### PR TITLE
docs: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Levy Street
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -249,3 +249,11 @@ scripts/      browser E2E + screenshot tour + multiplayer integration tests
 Names, quests and the zones are original; formulas and mechanics follow
 vanilla. World seed is fixed in `src/main.ts` so the world is the same place
 every visit.
+
+## License
+
+The code is [MIT licensed](LICENSE) — fork it, remix it, host your own world.
+
+The bundled third-party art assets (models, textures, HDRIs) remain under
+their own licenses — all CC0 public domain except the MIT water normal maps,
+as documented per pack in [CREDITS.md](CREDITS.md).

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "world-of-claudecraft",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "description": "World of Claudecraft — a WoW-Classic-style micro-MMO + headless RL training environment",
   "scripts": {


### PR DESCRIPTION
## Summary
Adds an MIT `LICENSE` file — the repo previously had none, so it defaulted to all-rights-reserved and nobody could legally remix it despite the open-source posture.

- `LICENSE` — MIT, copyright Levy Street
- `package.json` — `"license": "MIT"`
- `README.md` — License section clarifying that the code is MIT while the bundled third-party art assets (all CC0, plus MIT water normals) remain under their own licenses as documented per pack in [CREDITS.md](CREDITS.md)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)