### PR TITLE
Fix trade item-duplication exploit + harden trade/message input handling

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -260,6 +260,15 @@ export class GameServer {
     } catch {
       return;
     }
+    // a malformed payload must never take down the server for everyone
+    try {
+      this.dispatchMessage(session, msg);
+    } catch (err) {
+      console.error(`bad message from ${session.name} (cmd: ${String(msg?.cmd ?? msg?.t)}):`, err);
+    }
+  }
+
+  private dispatchMessage(session: ClientSession, msg: any): void {
     const sim = this.sim;
     const pid = session.pid;
     if (msg.t === 'input') {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2709,6 +2709,8 @@ export class Sim {
     // the offered total per item is checked, not each slot in isolation
     const merged = new Map<string, number>();
     for (const slot of items.slice(0, 6)) {
+      // slots come straight off the wire — reject anything malformed
+      if (!slot || typeof slot.itemId !== 'string' || !Number.isFinite(slot.count)) continue;
       const count = Math.max(1, Math.floor(slot.count));
       const def = ITEMS[slot.itemId];
       if (!def || def.kind === 'quest') continue; // quest items are soulbound-ish

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2705,14 +2705,19 @@ export class Sim {
     if (!r) return;
     const session = this.trades.get(r.meta.entityId);
     if (!session) return;
-    // validate the offer against the player's bags
-    const cleaned: InvSlot[] = [];
+    // validate the offer against the player's bags; merge duplicate slots so
+    // the offered total per item is checked, not each slot in isolation
+    const merged = new Map<string, number>();
     for (const slot of items.slice(0, 6)) {
       const count = Math.max(1, Math.floor(slot.count));
       const def = ITEMS[slot.itemId];
       if (!def || def.kind === 'quest') continue; // quest items are soulbound-ish
-      if (this.countItem(slot.itemId, r.meta.entityId) < count) continue;
-      cleaned.push({ itemId: slot.itemId, count });
+      merged.set(slot.itemId, (merged.get(slot.itemId) ?? 0) + count);
+    }
+    const cleaned: InvSlot[] = [];
+    for (const [itemId, count] of merged) {
+      if (this.countItem(itemId, r.meta.entityId) < count) continue;
+      cleaned.push({ itemId, count });
     }
     const offer = { items: cleaned, copper: Math.max(0, Math.min(Math.floor(copper), r.meta.copper)) };
     if (session.a === r.meta.entityId) session.offerA = offer;
@@ -2737,8 +2742,8 @@ export class Sim {
     const valid =
       session.offerA.copper <= metaA.copper &&
       session.offerB.copper <= metaB.copper &&
-      session.offerA.items.every((s) => this.countItem(s.itemId, session.a) >= s.count) &&
-      session.offerB.items.every((s) => this.countItem(s.itemId, session.b) >= s.count);
+      this.offerCovered(session.offerA.items, session.a) &&
+      this.offerCovered(session.offerB.items, session.b);
     if (!valid) {
       for (const tPid of [session.a, session.b]) this.error(tPid, 'Trade failed: items or money no longer available.');
       this.closeTrade(session);
@@ -2770,6 +2775,17 @@ export class Sim {
       this.emit({ type: 'log', text: 'Trade cancelled.', color: '#8df', pid: tPid });
     }
     this.closeTrade(session);
+  }
+
+  // true when the player's bags cover the offered totals per item, summing
+  // duplicate slots — a per-slot check would let duplicates each pass alone
+  private offerCovered(items: InvSlot[], pid: number): boolean {
+    const totals = new Map<string, number>();
+    for (const s of items) totals.set(s.itemId, (totals.get(s.itemId) ?? 0) + s.count);
+    for (const [itemId, count] of totals) {
+      if (this.countItem(itemId, pid) < count) return false;
+    }
+    return true;
   }
 
   private closeTrade(session: TradeSession): void {

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -389,6 +389,35 @@ describe('trading', () => {
     expect(sim.meta(b)!.copper).toBe(50);
   });
 
+  it('malformed offer slots are rejected, not crashed or duplicated', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    sim.addItem('wolf_fang', 5, a);
+    sim.tradeRequest(b, a);
+    sim.tradeAccept(b);
+    // garbage straight off the wire: null slot, non-numeric and non-finite counts
+    const junk = [
+      null,
+      { itemId: 'wolf_fang', count: 'lots' },
+      { itemId: 'wolf_fang', count: NaN },
+      { itemId: 'wolf_fang', count: Infinity },
+      { count: 3 },
+      { itemId: 'wolf_fang', count: 2 },
+    ] as any;
+    // must not throw, and only the one valid slot survives
+    expect(() => sim.tradeSetOffer(junk, 0, a)).not.toThrow();
+    expect(sim.tradeFor(a)!.offerA.items).toEqual([{ itemId: 'wolf_fang', count: 2 }]);
+    sim.tradeConfirm(a);
+    sim.tradeConfirm(b);
+    expect(sim.tradeFor(a)).toBe(null);
+    // no NaN corruption: totals are conserved
+    expect(sim.countItem('wolf_fang', a)).toBe(3);
+    expect(sim.countItem('wolf_fang', b)).toBe(2);
+  });
+
   it('duplicate slots within the bags merge and trade normally', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -363,6 +363,51 @@ describe('trading', () => {
     expect(sim.tradeFor(a)).toBe(null);
   });
 
+  it('duplicate offer slots cannot duplicate items', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    sim.addItem('wolf_fang', 5, a);
+    sim.meta(a)!.copper = 100;
+    sim.meta(b)!.copper = 50;
+    sim.tradeRequest(b, a);
+    sim.tradeAccept(b);
+    // exploit attempt: 6 duplicate slots, each individually covered by the bags
+    const dup = Array.from({ length: 6 }, () => ({ itemId: 'wolf_fang', count: 5 }));
+    sim.tradeSetOffer(dup, 0, a);
+    // the merged total (30) exceeds the bags (5), so the offer must be rejected
+    expect(sim.tradeFor(a)!.offerA.items.length).toBe(0);
+    sim.tradeConfirm(a);
+    sim.tradeConfirm(b);
+    expect(sim.tradeFor(a)).toBe(null);
+    expect(sim.countItem('wolf_fang', a)).toBe(5);
+    expect(sim.countItem('wolf_fang', b)).toBe(0);
+    expect(sim.countItem('wolf_fang', a) + sim.countItem('wolf_fang', b)).toBe(5);
+    expect(sim.meta(a)!.copper).toBe(100);
+    expect(sim.meta(b)!.copper).toBe(50);
+  });
+
+  it('duplicate slots within the bags merge and trade normally', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    sim.addItem('wolf_fang', 5, a);
+    sim.tradeRequest(b, a);
+    sim.tradeAccept(b);
+    // two slots of 2 totals 4, within the 5 held — merged into one slot of 4
+    sim.tradeSetOffer([{ itemId: 'wolf_fang', count: 2 }, { itemId: 'wolf_fang', count: 2 }], 0, a);
+    expect(sim.tradeFor(a)!.offerA.items).toEqual([{ itemId: 'wolf_fang', count: 4 }]);
+    sim.tradeConfirm(a);
+    sim.tradeConfirm(b);
+    expect(sim.tradeFor(a)).toBe(null);
+    expect(sim.countItem('wolf_fang', a)).toBe(1);
+    expect(sim.countItem('wolf_fang', b)).toBe(4);
+  });
+
   it('quest items cannot be traded', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
This PR fixes a server-authoritative item-duplication exploit in the trade system and adds two defense-in-depth hardenings around untrusted client input. All three issues are present on `main` today.

## 1. Trade item duplication (the exploit)

`tradeSetOffer` (`src/sim/sim.ts`) validated each offered slot **independently** against the live inventory and never summed duplicate `itemId` slots.

1. A client sends `trade_offer` with N duplicate slots of the same item — e.g. 6× `{itemId: 'gold_bar', count: 5}` while holding only 5. The server handler (`server/game.ts`) only checks `Array.isArray(msg.items)`, no dedup.
2. Each slot passes `countItem('gold_bar') < 5` → false, so all 6 land in the offer.
3. `tradeConfirm`'s final validation repeats the same per-slot `.every(...)` check and passes for the same reason.
4. The swap loop runs once per slot: `removeItem` is clamped to what's available (stops at 0), but `addItem` credits unconditionally. Sender loses 5, recipient gains 30 — **25 items created from nothing**. With a second account this is free infinite duplication.

**Fix:** `tradeSetOffer` now merges duplicate slots per `itemId` (summing counts) before validating, and checks the **cumulative** offered count against the bags. The 6-slot cap and the existing filters (unknown defs, quest items) are unchanged; legitimate split offers still work (they merge into one slot). `tradeConfirm`'s final pre-swap validation goes through a new `offerCovered` helper that also sums per-item totals, as defense-in-depth.

## 2. A single malformed message could crash the whole server (DoS)

`handleMessage` (`server/game.ts`) only wrapped `JSON.parse` in try/catch. Any throw inside a command handler propagated to the `ws.on('message')` listener and became an uncaught exception — taking down the entire Node process and **every connected player**, not just the offender. A `trade_offer` with `items:[null]` is enough: it reaches `tradeSetOffer` and dereferences `null`.

**Fix:** the command dispatch is now wrapped so a malformed payload is logged and dropped for that one client only.

## 3. Trade slots trusted their shape

`tradeSetOffer` trusted slot shape, but the server only verifies `Array.isArray(msg.items)`. A `null` element threw (see #2); a non-finite `count` (e.g. `count:{}` or `"x"` → `NaN`) passed the `countItem < NaN` check (always false) and reached `addItem(NaN)`, **corrupting the recipient's stack into `NaN`** — a griefing vector even without the crash.

**Fix:** each slot is rejected unless it is an object with a string `itemId` and a finite `count`.

## Tests

Added to the `trading` block in `tests/social.test.ts`:

- **`duplicate offer slots cannot duplicate items`** — reproduces the attack: A holds exactly 5, offers 6 duplicate `{item, 5}` slots, both confirm; asserts the offer is rejected, totals stay 5, B never receives 30, copper untouched.
- **`malformed offer slots are rejected, not crashed or duplicated`** — null slot + non-numeric/`NaN`/`Infinity` counts + a slot missing `itemId`; asserts no throw, only the one valid slot survives, and totals are conserved (no `NaN` corruption).
- **`duplicate slots within the bags merge and trade normally`** — ensures legitimate duplicate slots whose total fits the inventory still trade (2+2 of 5 held → one slot of 4).

`npm test`: 131/131 passing (incl. all pre-existing trade tests). `tsc --noEmit` clean.