### PR TITLE
Delta snapshots: skip unchanged self state, serialize entities once per tick

### DIFF
--- a/scripts/crypt_raid.mjs
+++ b/scripts/crypt_raid.mjs
@@ -26,6 +26,14 @@ async function api(path, body, token) {
   return { status: res.status, body: await res.json().catch(() => ({})) };
 }
 
+// heavy self fields (inventory, quests, party, ...) arrive only when they
+// changed; an absent field means "same as the previous snapshot"
+const DELTA_SELF_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
+function mergeSelf(prev, next) {
+  if (prev) for (const k of DELTA_SELF_KEYS) if (!(k in next)) next[k] = prev[k];
+  return next;
+}
+
 class Bot {
   constructor(name, cls) {
     this.name = name;
@@ -51,8 +59,8 @@ class Bot {
         const msg = JSON.parse(String(data));
         if (msg.t === 'hello') { this.pid = msg.pid; clearTimeout(to); resolve(); }
         else if (msg.t === 'snap') {
-          this.self = msg.self;
-          this.ents = new Map([[msg.self.id, msg.self], ...msg.ents.map((e) => [e.id, e])]);
+          this.self = mergeSelf(this.self, msg.self);
+          this.ents = new Map([[this.self.id, this.self], ...msg.ents.map((e) => [e.id, e])]);
         } else if (msg.t === 'events') this.events.push(...msg.list);
       });
       this.ws.on('error', reject);

--- a/scripts/mp_integration.mjs
+++ b/scripts/mp_integration.mjs
@@ -25,6 +25,14 @@ async function api(path, opts = {}, token = null) {
   return { status: res.status, body };
 }
 
+// heavy self fields (inventory, quests, party, ...) arrive only when they
+// changed; an absent field means "same as the previous snapshot"
+const DELTA_SELF_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
+function mergeSelf(prev, next) {
+  if (prev) for (const k of DELTA_SELF_KEYS) if (!(k in next)) next[k] = prev[k];
+  return next;
+}
+
 class Client {
   constructor() {
     this.snapshots = [];
@@ -48,8 +56,8 @@ class Client {
           clearTimeout(timeout);
           resolve(msg);
         } else if (msg.t === 'snap') {
-          this.self = msg.self;
-          this.entities = new Map([[msg.self.id, msg.self], ...msg.ents.map((e) => [e.id, e])]);
+          this.self = mergeSelf(this.self, msg.self);
+          this.entities = new Map([[this.self.id, this.self], ...msg.ents.map((e) => [e.id, e])]);
         } else if (msg.t === 'events') {
           this.events.push(...msg.list);
         } else if (msg.t === 'error') {

--- a/scripts/social_e2e.mjs
+++ b/scripts/social_e2e.mjs
@@ -21,6 +21,14 @@ async function api(path, body, token) {
   return { status: res.status, body: await res.json().catch(() => ({})) };
 }
 
+// heavy self fields (inventory, quests, party, ...) arrive only when they
+// changed; an absent field means "same as the previous snapshot"
+const DELTA_SELF_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
+function mergeSelf(prev, next) {
+  if (prev) for (const k of DELTA_SELF_KEYS) if (!(k in next)) next[k] = prev[k];
+  return next;
+}
+
 class Bot {
   constructor(name, cls) { this.name = name; this.cls = cls; this.self = null; this.events = []; }
   async join() {
@@ -35,7 +43,7 @@ class Bot {
       this.ws.on('message', (data) => {
         const msg = JSON.parse(String(data));
         if (msg.t === 'hello') { this.pid = msg.pid; clearTimeout(to); resolve(); }
-        else if (msg.t === 'snap') this.self = msg.self;
+        else if (msg.t === 'snap') this.self = mergeSelf(this.self, msg.self);
         else if (msg.t === 'events') this.events.push(...msg.list);
       });
       this.ws.on('error', reject);

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,5 +1,6 @@
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
+import type { PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { saveCharacterState, openPlaySession, closePlaySession } from './db';
@@ -21,6 +22,9 @@ export interface ClientSession {
   alive: boolean;
   joinedAt: number;
   dbSessionId: number | null; // play_sessions row, set once the insert lands
+  // serialized form of each delta self field as last sent to this client;
+  // a field is omitted from a snapshot while its serialization is unchanged
+  lastSent: Record<string, string>;
 }
 
 export interface AdminServerStats {
@@ -150,6 +154,7 @@ export class GameServer {
     const session: ClientSession = {
       ws, accountId, characterId, pid, name,
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
+      lastSent: {},
     };
     this.clients.set(pid, session);
     this.peakOnline = Math.max(this.peakOnline, this.clients.size);
@@ -291,9 +296,9 @@ export class GameServer {
       case 'interact': sim.interact(pid); break;
       case 'loot': if (typeof msg.id === 'number') sim.lootCorpse(msg.id, pid); break;
       case 'pickup': if (typeof msg.id === 'number') sim.pickUpObject(msg.id, pid); break;
-      case 'accept': if (typeof msg.quest === 'string') sim.acceptQuest(msg.quest, pid); break;
-      case 'turnin': if (typeof msg.quest === 'string') sim.turnInQuest(msg.quest, pid); break;
-      case 'abandon': if (typeof msg.quest === 'string') sim.abandonQuest(msg.quest, pid); break;
+      case 'accept': if (typeof msg.quest === 'string') { sim.acceptQuest(msg.quest, pid); this.resyncQuests(session); } break;
+      case 'turnin': if (typeof msg.quest === 'string') { sim.turnInQuest(msg.quest, pid); this.resyncQuests(session); } break;
+      case 'abandon': if (typeof msg.quest === 'string') { sim.abandonQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'equip': if (typeof msg.item === 'string') sim.equipItem(msg.item, pid); break;
       case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
       case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
@@ -368,48 +373,75 @@ export class GameServer {
   // -------------------------------------------------------------------------
 
   private broadcastSnapshots(): void {
+    if (this.clients.size === 0) return;
+    // each entity is serialized at most once per tick, shared by every
+    // recipient whose interest area contains it
+    const entJson = new Map<number, string>();
+    const head = `{"t":"snap","tick":${this.sim.tickCount},"time":${round2(this.sim.time)}`;
     for (const session of this.clients.values()) {
       const p = this.sim.entities.get(session.pid);
       const meta = this.sim.meta(session.pid);
       if (!p || !meta) continue;
-      const ents: Record<string, unknown>[] = [];
+      const ents: string[] = [];
       for (const e of this.sim.entities.values()) {
         if (e.id === session.pid) continue;
         if (dist2d(p.pos, e.pos) > INTEREST_RADIUS) continue;
-        ents.push(wireEntity(e));
+        let json = entJson.get(e.id);
+        if (json === undefined) {
+          json = JSON.stringify(wireEntity(e));
+          entJson.set(e.id, json);
+        }
+        ents.push(json);
       }
-      const selfWire = wireEntity(p);
-      Object.assign(selfWire, {
-        res: Math.round(p.resource * 10) / 10,
-        mres: p.maxResource,
-        rtype: p.resourceType,
-        xp: meta.xp,
-        copper: meta.copper,
-        inv: meta.inventory,
-        equip: meta.equipment,
-        qlog: [...meta.questLog.values()],
-        qdone: [...meta.questsDone],
-        cds: Object.fromEntries([...p.cooldowns.entries()].map(([k, v]) => [k, round2(v)])),
-        gcd: round2(p.gcdRemaining),
-        combo: p.comboPoints,
-        comboTgt: p.comboTargetId,
-        target: p.targetId,
-        auto: p.autoAttack,
-        queued: p.queuedOnSwing,
-        stats: p.stats,
-        ap: p.attackPower,
-        crit: p.critChance,
-        dodge: p.dodgeChance,
-        weapon: p.weapon,
-        eat: p.eating ? { remaining: round2(p.eating.remaining) } : null,
-        drk: p.drinking ? { remaining: round2(p.drinking.remaining) } : null,
-        opUntil: p.overpowerUntil > this.sim.time ? 1 : 0,
-        party: this.partyWire(session.pid),
-        trade: this.tradeWire(session.pid),
-        duel: this.duelWire(session.pid),
-      });
-      this.send(session, { t: 'snap', tick: this.sim.tickCount, time: round2(this.sim.time), self: selfWire, ents });
+      this.sendRaw(session, `${head},"self":${this.selfWireJson(session, p, meta)},"ents":[${ents.join(',')}]}`);
     }
+  }
+
+  private selfWireJson(session: ClientSession, p: Entity, meta: PlayerMeta): string {
+    const self = wireEntity(p);
+    Object.assign(self, {
+      res: Math.round(p.resource * 10) / 10,
+      mres: p.maxResource,
+      rtype: p.resourceType,
+      xp: meta.xp,
+      copper: meta.copper,
+      gcd: round2(p.gcdRemaining),
+      combo: p.comboPoints,
+      comboTgt: p.comboTargetId,
+      target: p.targetId,
+      auto: p.autoAttack,
+      queued: p.queuedOnSwing,
+      ap: p.attackPower,
+      crit: p.critChance,
+      dodge: p.dodgeChance,
+      eat: p.eating ? { remaining: round2(p.eating.remaining) } : null,
+      drk: p.drinking ? { remaining: round2(p.drinking.remaining) } : null,
+      opUntil: p.overpowerUntil > this.sim.time ? 1 : 0,
+    });
+    const json = JSON.stringify(self);
+    // heavy, rarely-changing fields ride along only when their serialized
+    // form differs from what this session last received; the client treats
+    // an absent field as "unchanged" (a fresh session always gets them all)
+    const sent = session.lastSent;
+    let extra = '';
+    const maybe = (key: string, value: unknown): void => {
+      const s = JSON.stringify(value ?? null);
+      if (sent[key] !== s) {
+        sent[key] = s;
+        extra += `,"${key}":${s}`;
+      }
+    };
+    maybe('inv', meta.inventory);
+    maybe('equip', meta.equipment);
+    maybe('qlog', [...meta.questLog.values()]);
+    maybe('qdone', [...meta.questsDone]);
+    maybe('cds', Object.fromEntries([...p.cooldowns.entries()].map(([k, v]) => [k, round2(v)])));
+    maybe('stats', p.stats);
+    maybe('weapon', p.weapon);
+    maybe('party', this.partyWire(session.pid));
+    maybe('trade', this.tradeWire(session.pid));
+    maybe('duel', this.duelWire(session.pid));
+    return extra === '' ? json : json.slice(0, -1) + extra + '}';
   }
 
   private partyWire(pid: number): unknown {
@@ -485,9 +517,21 @@ export class GameServer {
     }
   }
 
+  // the web client applies quest commands optimistically; force the next
+  // snapshot to carry quest state even when the command changed nothing,
+  // so a rejected command still converges back to the server's truth
+  private resyncQuests(session: ClientSession): void {
+    delete session.lastSent.qlog;
+    delete session.lastSent.qdone;
+  }
+
   private send(session: ClientSession, obj: unknown): void {
+    this.sendRaw(session, JSON.stringify(obj));
+  }
+
+  private sendRaw(session: ClientSession, payload: string): void {
     if (session.ws.readyState === 1) {
-      session.ws.send(JSON.stringify(obj));
+      session.ws.send(payload);
     }
   }
 }

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -293,7 +293,9 @@ export class ClientWorld implements IWorld {
       e.resource = s.res;
       e.maxResource = s.mres;
       e.resourceType = s.rtype;
-      e.cooldowns = new Map(Object.entries(s.cds ?? {}).map(([k, v]) => [k, Number(v)]));
+      // delta fields: the server omits them while unchanged, so only the
+      // snapshots that carry them rebuild the local structures
+      if (s.cds !== undefined) e.cooldowns = new Map(Object.entries(s.cds).map(([k, v]) => [k, Number(v)]));
       e.gcdRemaining = s.gcd ?? 0;
       e.comboPoints = s.combo ?? 0;
       e.comboTargetId = s.comboTgt ?? null;
@@ -313,14 +315,14 @@ export class ClientWorld implements IWorld {
         : null;
       this.xp = s.xp ?? 0;
       this.copper = s.copper ?? 0;
-      this.inventory = s.inv ?? [];
-      this.equipment = s.equip ?? {};
-      this.questLog = new Map((s.qlog ?? []).map((q: QuestProgress) => [q.questId, q]));
-      this.questsDone = new Set(s.qdone ?? []);
+      if (s.inv !== undefined) this.inventory = s.inv;
+      if (s.equip !== undefined) this.equipment = s.equip;
+      if (s.qlog !== undefined) this.questLog = new Map((s.qlog as QuestProgress[]).map((q) => [q.questId, q]));
+      if (s.qdone !== undefined) this.questsDone = new Set(s.qdone);
       this.known = abilitiesKnownAt(this.cfg.playerClass, e.level);
-      this.partyInfo = s.party ?? null;
-      this.tradeInfo = s.trade ?? null;
-      this.duelInfo = s.duel ?? null;
+      if (s.party !== undefined) this.partyInfo = s.party;
+      if (s.trade !== undefined) this.tradeInfo = s.trade;
+      if (s.duel !== undefined) this.duelInfo = s.duel;
       // camera follows server-side facing changes when not mouselooking
       if (prevSelfFacing !== undefined && this.mouselookFacing === null) {
         let d = e.facing - prevSelfFacing;

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; snapshot logic is under test.
+vi.mock('../server/db', () => ({
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+}));
+
+import { GameServer, ClientSession } from '../server/game';
+import { ClientWorld } from '../src/net/online';
+
+const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
+
+interface FakeClient {
+  sent: any[];
+  ws: any;
+}
+
+function fakeWs(): FakeClient {
+  const sent: any[] = [];
+  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+}
+
+function lastSnap(sent: any[]): any {
+  for (let i = sent.length - 1; i >= 0; i--) {
+    if (sent[i].t === 'snap') return sent[i];
+  }
+  return null;
+}
+
+function joinServer(server: GameServer, fc: FakeClient, characterId: number, name: string): ClientSession {
+  const session = server.join(fc.ws, characterId, characterId, name, 'warrior', null);
+  if ('error' in session) throw new Error(session.error);
+  return session;
+}
+
+function broadcast(server: GameServer): void {
+  (server as any).broadcastSnapshots();
+}
+
+// A ClientWorld without the WebSocket plumbing, to drive applySnapshot directly.
+function bareClient(pid: number): ClientWorld {
+  const c: any = Object.create(ClientWorld.prototype);
+  c.cfg = { seed: 20061, playerClass: 'warrior' };
+  c.entities = new Map();
+  c.playerId = pid;
+  c.moveInput = {};
+  c.inventory = [];
+  c.equipment = {};
+  c.copper = 0;
+  c.xp = 0;
+  c.known = [];
+  c.questLog = new Map();
+  c.questsDone = new Set();
+  c.partyInfo = null;
+  c.tradeInfo = null;
+  c.duelInfo = null;
+  c.lastSnapAt = 0;
+  c.snapInterval = 50;
+  c.pendingFacingDelta = 0;
+  c.connected = true;
+  c.eventQueue = [];
+  c.mouselookFacing = null;
+  return c;
+}
+
+describe('delta snapshots', () => {
+  let server: GameServer;
+  let fc: FakeClient;
+  let session: ClientSession;
+
+  beforeEach(() => {
+    server = new GameServer();
+    fc = fakeWs();
+    session = joinServer(server, fc, 1, 'Testa');
+  });
+
+  it('first snapshot carries the full self state', () => {
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap).not.toBeNull();
+    for (const key of DELTA_KEYS) {
+      expect(snap.self, `self.${key} missing from first snapshot`).toHaveProperty(key);
+    }
+    expect(snap.self.party).toBeNull();
+    expect(snap.self.trade).toBeNull();
+    expect(Array.isArray(snap.self.inv)).toBe(true);
+    expect(Array.isArray(snap.ents)).toBe(true);
+  });
+
+  it('omits unchanged heavy fields from subsequent snapshots', () => {
+    broadcast(server);
+    fc.sent.length = 0;
+    server.sim.tick();
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    for (const key of DELTA_KEYS) {
+      expect(snap.self, `self.${key} resent although unchanged`).not.toHaveProperty(key);
+    }
+    // the always-on fields are still present every snapshot
+    for (const key of ['x', 'z', 'hp', 'mhp', 'res', 'gcd', 'xp', 'copper', 'target']) {
+      expect(snap.self).toHaveProperty(key);
+    }
+  });
+
+  it('resends a heavy field once it changes', () => {
+    broadcast(server);
+    fc.sent.length = 0;
+    server.sim.addItem('baked_bread', 2, session.pid);
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self).toHaveProperty('inv');
+    expect(snap.self.inv.some((s: any) => s.itemId === 'baked_bread')).toBe(true);
+    expect(snap.self).not.toHaveProperty('qlog');
+    expect(snap.self).not.toHaveProperty('stats');
+  });
+
+  it('quest commands force a quest-state resync even when rejected', () => {
+    broadcast(server);
+    fc.sent.length = 0;
+    // unknown quest: the sim rejects it and quest state does not change, but
+    // the next snapshot must still carry quest fields so the client's
+    // optimistic update converges back to the server's truth
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'accept', quest: 'no_such_quest' }));
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self).toHaveProperty('qlog');
+    expect(snap.self).toHaveProperty('qdone');
+    expect(snap.self).not.toHaveProperty('inv');
+  });
+
+  it('each client gets full state on its own first snapshot', () => {
+    broadcast(server);
+    const fc2 = fakeWs();
+    joinServer(server, fc2, 2, 'Testb');
+    broadcast(server);
+    const snapNew = lastSnap(fc2.sent);
+    for (const key of DELTA_KEYS) {
+      expect(snapNew.self, `self.${key} missing for fresh session`).toHaveProperty(key);
+    }
+    // the veteran session still gets deltas only
+    const snapOld = lastSnap(fc.sent);
+    expect(snapOld.self).not.toHaveProperty('inv');
+    // both players spawn together, so each sees the other in ents
+    expect(snapNew.ents.some((e: any) => e.id === session.pid)).toBe(true);
+  });
+});
+
+describe('client-side delta merge', () => {
+  it('keeps previous structures when delta fields are omitted', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
+    const client = bareClient(session.pid);
+
+    server.sim.addItem('conjured_water', 1, session.pid);
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.inventory.length).toBeGreaterThan(0);
+    const invRef = client.inventory;
+    const qlogRef = client.questLog;
+    const qdoneRef = client.questsDone;
+    const cdsRef = client.player.cooldowns;
+
+    fc.sent.length = 0;
+    server.sim.tick();
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    // omitted fields neither reset nor get rebuilt
+    expect(client.inventory).toBe(invRef);
+    expect(client.questLog).toBe(qlogRef);
+    expect(client.questsDone).toBe(qdoneRef);
+    expect(client.player.cooldowns).toBe(cdsRef);
+
+    fc.sent.length = 0;
+    server.sim.addItem('baked_bread', 1, session.pid);
+    broadcast(server);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.inventory).not.toBe(invRef);
+    expect(client.inventory.some((s) => s.itemId === 'baked_bread')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`broadcastSnapshots()` did two redundant things on every 50ms tick:

1. **Per-recipient serialization** — every visible entity went through `wireEntity()` + `JSON.stringify` once *per client*, so co-located players multiplied the serialization cost (O(entities × clients)).
2. **Full self state every tick** — inventory, equipment, quest log, completed quests, cooldowns, stats, weapon, party/trade/duel were resent 20×/s even when nothing changed. The client then rebuilt its `Map`s/`Set`s from scratch on every snapshot, churning GC in the browser.

## Change

**Server** ([server/game.ts](server/game.ts)):
- Entity wire JSON is cached per tick in a `Map<id, string>` and shared by all recipients whose interest radius contains that entity — serialization becomes O(entities + clients).
- Heavy self fields (`inv`, `equip`, `qlog`, `qdone`, `cds`, `stats`, `weapon`, `party`, `trade`, `duel`) ride along **only when their serialized form differs** from what that session last received. Absent = unchanged. A fresh session (join/reconnect) always gets a full snapshot.
- Quest commands (`accept`/`turnin`/`abandon`) clear the `qlog`/`qdone` signatures so the next snapshot always carries quest state — the web client applies quest commands optimistically, and this guarantees convergence back to server truth even when the command is rejected.

**Client** ([src/net/online.ts](src/net/online.ts)):
- Delta fields are applied only when present, so cooldown/quest `Map`s and `Set`s are no longer rebuilt 20×/s while unchanged. (`stats`/`weapon` already had merge semantics via `?? e.stats`.)

**Bot scripts** (`scripts/mp_integration.mjs`, `social_e2e.mjs`, `crypt_raid.mjs`): merge delta fields the same way (`mergeSelf`).

The wire format stays JSON and backward-compatible in shape; only the "always present" guarantee for the heavy self fields changed to "present when changed, full on first snapshot".

## Measured locally

20Hz, two mid-game characters (level 12, stacked bags), 15s window:

| metric | before | after |
|---|---|---|
| self payload per snapshot | 926 B | 323 B (−65%) |
| server CPU, 10 co-located idle clients | 12.9% | 8.4% (−35%) |

Total snapshot size near spawn only drops ~4% because the `ents` array dominates there — per-entity deltas / interest-grid are the natural follow-up and intentionally out of scope here.

## Testing

- `vitest run`: **134/134** pass, including 6 new tests in [tests/snapshots.test.ts](tests/snapshots.test.ts) covering: full first snapshot, omission of unchanged fields, resend-on-change, quest resync after rejected command, full resend for a fresh session, and client-side merge keeping previous structures (reference-identity asserted).
- Live e2e against a real server + Postgres: `mp_integration.mjs` 26/26, `social_e2e.mjs` 10/10 (trade/duel exercise the delta fields), `crypt_raid.mjs` 8/8 (5-player party, dungeon boss, party deltas under combat load).