### PR TITLE
Spatial hash grid for entity radius queries (sim AI + snapshot broadcast)

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -350,6 +350,8 @@ export class GameServer {
             const p = sim.groundPos(msg.x, msg.z);
             e.pos = p;
             e.prevPos = { ...p };
+            sim.grid.update(e);
+            sim.playerGrid.update(e);
           }
         }
         break;
@@ -396,16 +398,15 @@ export class GameServer {
       const meta = this.sim.meta(session.pid);
       if (!p || !meta) continue;
       const ents: string[] = [];
-      for (const e of this.sim.entities.values()) {
-        if (e.id === session.pid) continue;
-        if (dist2d(p.pos, e.pos) > INTEREST_RADIUS) continue;
+      this.sim.grid.forEachInRadius(p.pos.x, p.pos.z, INTEREST_RADIUS, (e) => {
+        if (e.id === session.pid) return;
         let json = entJson.get(e.id);
         if (json === undefined) {
           json = JSON.stringify(wireEntity(e));
           entJson.set(e.id, json);
         }
         ents.push(json);
-      }
+      });
       this.sendRaw(session, `${head},"self":${this.selfWireJson(session, p, meta)},"ents":[${ents.join(',')}]}`);
     }
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7,6 +7,7 @@ import {
 import { resolvePosition } from './colliders';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
 import { Rng } from './rng';
+import { SpatialGrid } from './spatial';
 import { groundHeight, WATER_LEVEL } from './world';
 import {
   AbilityDef, AbilityEffect, Aura, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
@@ -156,6 +157,11 @@ export class Sim {
   tickCount = 0;
   entities = new Map<number, Entity>();
   players = new Map<number, PlayerMeta>(); // keyed by entity id
+  // spatial indexes for radius queries; re-bucketed at the end of each tick
+  // and kept roster-exact on spawn/despawn/teleport
+  readonly grid = new SpatialGrid();
+  readonly playerGrid = new SpatialGrid();
+  private engagedPids = new Set<number>();
   primaryId = -1; // the local/RL player in single-player contexts
   nextId = 1;
   events: SimEvent[] = [];
@@ -185,7 +191,7 @@ export class Sim {
     for (const npcDef of Object.values(NPCS)) {
       const safe = this.findSafePos(npcDef.pos.x, npcDef.pos.z, WATER_LEVEL + 0.6);
       const npc = createNpc(this.nextId++, npcDef, this.groundPos(safe.x, safe.z));
-      this.entities.set(npc.id, npc);
+      this.addEntity(npc);
     }
 
     // Mobs from camps
@@ -203,7 +209,7 @@ export class Sim {
         mob.facing = this.rng.range(-Math.PI, Math.PI);
         mob.prevFacing = mob.facing;
         mob.wanderTimer = this.rng.range(2, 10);
-        this.entities.set(mob.id, mob);
+        this.addEntity(mob);
       }
     }
 
@@ -211,7 +217,7 @@ export class Sim {
     for (const objDef of GROUND_OBJECTS) {
       for (const p of objDef.positions) {
         const obj = createGroundObject(this.nextId++, objDef.itemId, objDef.name, this.groundPos(p.x, p.z));
-        this.entities.set(obj.id, obj);
+        this.addEntity(obj);
       }
     }
 
@@ -222,7 +228,7 @@ export class Sim {
       door.dungeonId = dungeon.id;
       door.objectItemId = null;
       door.lootable = true; // interactable
-      this.entities.set(door.id, door);
+      this.addEntity(door);
       for (let i = 0; i < INSTANCE_SLOT_COUNT; i++) {
         this.instances.push({ dungeonId: dungeon.id, slot: i, partyKey: null, mobIds: [], exitId: null, emptyFor: 0 });
       }
@@ -231,6 +237,30 @@ export class Sim {
     if (!cfg.noPlayer) {
       this.addPlayer(this.cfg.playerClass, this.cfg.playerName, { autoEquip: this.cfg.autoEquip });
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Entity roster: every add/remove/teleport goes through these so the
+  // spatial indexes always match the entities map
+  // -------------------------------------------------------------------------
+
+  private addEntity(e: Entity): void {
+    this.entities.set(e.id, e);
+    this.grid.insert(e);
+    if (e.kind === 'player') this.playerGrid.insert(e);
+  }
+
+  private dropEntity(id: number): void {
+    const e = this.entities.get(id);
+    if (!e) return;
+    this.grid.remove(e);
+    if (e.kind === 'player') this.playerGrid.remove(e);
+    this.entities.delete(id);
+  }
+
+  private rebucket(e: Entity): void {
+    this.grid.update(e);
+    if (e.kind === 'player') this.playerGrid.update(e);
   }
 
   // -------------------------------------------------------------------------
@@ -249,7 +279,7 @@ export class Sim {
       ? this.groundPos(savedPos.x, savedPos.z)
       : this.groundPos(PLAYER_START.x, PLAYER_START.z);
     const player = createPlayer(this.nextId++, cls, startPos, name);
-    this.entities.set(player.id, player);
+    this.addEntity(player);
     const classDef = CLASSES[cls];
     const meta: PlayerMeta = {
       entityId: player.id,
@@ -324,7 +354,7 @@ export class Sim {
       const e = this.entities.get(other.entityId);
       if (e && e.targetId === pid) e.targetId = null;
     }
-    this.entities.delete(pid);
+    this.dropEntity(pid);
     this.players.delete(pid);
     if (this.primaryId === pid) this.primaryId = this.players.size > 0 ? [...this.players.keys()][0] : -1;
   }
@@ -530,18 +560,38 @@ export class Sim {
       }
     }
 
+    // one pass over the entities collects every player a mob is engaged
+    // with, instead of one full scan per player
+    this.engagedPids.clear();
+    for (const e of this.entities.values()) {
+      if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId !== null) {
+        this.engagedPids.add(e.aggroTargetId);
+      }
+    }
     for (const meta of this.players.values()) {
       const p = this.entities.get(meta.entityId);
-      if (p) this.updateCombatFlag(p);
+      if (p) p.inCombat = this.engagedPids.has(p.id) || p.combatTimer < 5;
     }
 
     this.updateDuels();
     this.updateTradesAndInvites();
     this.updateInstances();
 
+    // movement re-bucketing: queries during the next tick and the server's
+    // snapshot broadcast right after this one see fresh cells
+    this.grid.refresh(this.entities.values());
+    this.playerGrid.refresh(this.playerEntities());
+
     const out = this.events;
     this.events = [];
     return out;
+  }
+
+  private *playerEntities(): Iterable<Entity> {
+    for (const meta of this.players.values()) {
+      const e = this.entities.get(meta.entityId);
+      if (e) yield e;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -776,17 +826,6 @@ export class Sim {
       const meta = this.players.get(e.id);
       if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
     }
-  }
-
-  private updateCombatFlag(p: Entity): void {
-    let engaged = false;
-    for (const e of this.entities.values()) {
-      if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId === p.id) {
-        engaged = true;
-        break;
-      }
-    }
-    p.inCombat = engaged || p.combatTimer < 5;
   }
 
   // -------------------------------------------------------------------------
@@ -1341,9 +1380,9 @@ export class Sim {
 
   private mobsInRadius(pos: Vec3, radius: number): Entity[] {
     const out: Entity[] = [];
-    for (const e of this.entities.values()) {
-      if (e.kind === 'mob' && !e.dead && e.hostile && dist2d(pos, e.pos) <= radius) out.push(e);
-    }
+    this.grid.forEachInRadius(pos.x, pos.z, radius, (e) => {
+      if (e.kind === 'mob' && !e.dead && e.hostile) out.push(e);
+    });
     return out;
   }
 
@@ -1714,27 +1753,24 @@ export class Sim {
     mob.inCombat = true;
     if (social) {
       const pullRadius = MOBS[mob.templateId]?.family === 'murloc' ? 18 : 12;
-      for (const m of this.entities.values()) {
+      this.grid.forEachInRadius(mob.pos.x, mob.pos.z, pullRadius, (m, d2) => {
         if (m.kind === 'mob' && m.id !== mob.id && !m.dead && m.aiState === 'idle'
-          && m.templateId === mob.templateId && dist2d(m.pos, mob.pos) < pullRadius) {
+          && m.templateId === mob.templateId && d2 < pullRadius * pullRadius) {
           m.aiState = 'chase';
           m.aggroTargetId = target.id;
           m.inCombat = true;
         }
-      }
+      });
     }
   }
 
   private nearestLivingPlayer(pos: Vec3, maxDist: number): { e: Entity; d: number } | null {
     let best: Entity | null = null;
-    let bestD = maxDist;
-    for (const meta of this.players.values()) {
-      const e = this.entities.get(meta.entityId);
-      if (!e || e.dead) continue;
-      const d = dist2d(pos, e.pos);
-      if (d < bestD) { bestD = d; best = e; }
-    }
-    return best ? { e: best, d: bestD } : null;
+    let bestD2 = maxDist * maxDist;
+    this.playerGrid.forEachInRadius(pos.x, pos.z, maxDist, (e, d2) => {
+      if (!e.dead && d2 < bestD2) { bestD2 = d2; best = e; }
+    });
+    return best ? { e: best, d: Math.sqrt(bestD2) } : null;
   }
 
   private updateMob(mob: Entity): void {
@@ -1926,6 +1962,7 @@ export class Sim {
     mob.pos = { ...mob.spawnPos };
     mob.pos.y = groundHeight(mob.pos.x, mob.pos.z, this.cfg.seed);
     mob.prevPos = { ...mob.pos };
+    this.rebucket(mob);
     mob.hp = mob.maxHp;
     mob.auras = [];
     mob.aiState = 'idle';
@@ -1953,7 +1990,7 @@ export class Sim {
         if (e?.targetId === id) e.targetId = null;
         if (e?.comboTargetId === id) { e.comboTargetId = null; e.comboPoints = 0; }
       }
-      this.entities.delete(id);
+      this.dropEntity(id);
     }
     boss.summonedIds = [];
   }
@@ -1999,7 +2036,7 @@ export class Sim {
       const add = createMob(this.nextId++, template, level, pos);
       add.spawnPos = { ...boss.spawnPos }; // leashes with the boss; stays dead in instances
       add.tappedById = boss.tappedById;
-      this.entities.set(add.id, add);
+      this.addEntity(add);
       boss.summonedIds.push(add.id);
       inst?.mobIds.push(add.id);
       if (victim && !victim.dead && victim.kind === 'player') this.aggroMob(add, victim, false);
@@ -2026,12 +2063,10 @@ export class Sim {
     if (!r) return;
     const p = r.e;
     const candidates: { e: Entity; d: number }[] = [];
-    for (const e of this.entities.values()) {
-      if (e.kind !== 'mob' || e.dead || !e.hostile) continue;
-      const d = dist2d(p.pos, e.pos);
-      if (d > 40) continue;
-      candidates.push({ e, d });
-    }
+    this.grid.forEachInRadius(p.pos.x, p.pos.z, 40, (e, d2) => {
+      if (e.kind !== 'mob' || e.dead || !e.hostile) return;
+      candidates.push({ e, d: Math.sqrt(d2) });
+    });
     if (candidates.length === 0) return;
     candidates.sort((a, b) => a.d - b.d);
     const curIdx = candidates.findIndex((c) => c.e.id === p.targetId);
@@ -2044,13 +2079,12 @@ export class Sim {
     if (!r) return;
     const p = r.e;
     let best: Entity | null = null;
-    let bestD = 40;
-    for (const e of this.entities.values()) {
-      if (e.kind !== 'mob' || e.dead || !e.hostile) continue;
-      const d = dist2d(p.pos, e.pos);
-      if (d < bestD) { bestD = d; best = e; }
-    }
-    if (best) p.targetId = best.id;
+    let bestD2 = 40 * 40;
+    this.grid.forEachInRadius(p.pos.x, p.pos.z, 40, (e, d2) => {
+      if (e.kind !== 'mob' || e.dead || !e.hostile) return;
+      if (d2 < bestD2) { bestD2 = d2; best = e; }
+    });
+    if (best) p.targetId = (best as Entity).id;
   }
 
   // -------------------------------------------------------------------------
@@ -2251,25 +2285,28 @@ export class Sim {
     if (!r) return;
     const p = r.e;
     let bestCorpse: Entity | null = null;
-    let bestCorpseD = INTERACT_RANGE;
+    let bestCorpseD2 = INTERACT_RANGE * INTERACT_RANGE;
     let bestObj: Entity | null = null;
-    let bestObjD = INTERACT_RANGE;
+    let bestObjD2 = INTERACT_RANGE * INTERACT_RANGE;
     let bestNpc: Entity | null = null;
-    let bestNpcD = INTERACT_RANGE;
-    for (const e of this.entities.values()) {
-      const d = dist2d(p.pos, e.pos);
-      if (e.kind === 'mob' && e.lootable && d < bestCorpseD) { bestCorpse = e; bestCorpseD = d; }
-      if (e.kind === 'object' && e.lootable && d < bestObjD) { bestObj = e; bestObjD = d; }
-      if (e.kind === 'npc' && d < bestNpcD) { bestNpc = e; bestNpcD = d; }
-    }
-    if (bestCorpse) { this.lootCorpse(bestCorpse.id, p.id); return; }
-    if (bestObj) {
-      if (bestObj.templateId === 'dungeon_door' && bestObj.dungeonId) { this.enterDungeon(bestObj.dungeonId, p.id); return; }
-      if (bestObj.templateId === 'dungeon_exit') { this.leaveDungeon(p.id); return; }
-      this.pickUpObject(bestObj.id, p.id);
+    let bestNpcD2 = INTERACT_RANGE * INTERACT_RANGE;
+    this.grid.forEachInRadius(p.pos.x, p.pos.z, INTERACT_RANGE, (e, d2) => {
+      if (e.kind === 'mob' && e.lootable && d2 < bestCorpseD2) { bestCorpse = e; bestCorpseD2 = d2; }
+      if (e.kind === 'object' && e.lootable && d2 < bestObjD2) { bestObj = e; bestObjD2 = d2; }
+      if (e.kind === 'npc' && d2 < bestNpcD2) { bestNpc = e; bestNpcD2 = d2; }
+    });
+    // re-read through wider types: TS cannot see the closure assignments above
+    const corpse = bestCorpse as Entity | null;
+    const obj = bestObj as Entity | null;
+    const npc = bestNpc as Entity | null;
+    if (corpse) { this.lootCorpse(corpse.id, p.id); return; }
+    if (obj) {
+      if (obj.templateId === 'dungeon_door' && obj.dungeonId) { this.enterDungeon(obj.dungeonId, p.id); return; }
+      if (obj.templateId === 'dungeon_exit') { this.leaveDungeon(p.id); return; }
+      this.pickUpObject(obj.id, p.id);
       return;
     }
-    if (bestNpc) this.talkToNpc(bestNpc.id, p.id);
+    if (npc) this.talkToNpc(npc.id, p.id);
   }
 
   talkToNpc(npcId: number, pid?: number): void {
@@ -2415,6 +2452,7 @@ export class Sim {
     const graveyard = zoneAt(dungeon ? dungeon.doorPos.z : p.pos.z).graveyard;
     p.pos = this.groundPos(graveyard.x, graveyard.z);
     p.prevPos = { ...p.pos };
+    this.rebucket(p);
     p.facing = 0;
     p.auras = [];
     recalcPlayerStats(p, meta.cls, meta.equipment);
@@ -2884,6 +2922,7 @@ export class Sim {
     const p = r.e;
     p.pos = this.groundPos(origin.x + dungeon.entry.x, origin.z + dungeon.entry.z);
     p.prevPos = { ...p.pos };
+    this.rebucket(p);
     p.facing = 0;
     p.targetId = null;
     p.autoAttack = false;
@@ -2901,6 +2940,7 @@ export class Sim {
     if (!dungeon) return;
     p.pos = this.groundPos(dungeon.doorPos.x, dungeon.doorPos.z - 4);
     p.prevPos = { ...p.pos };
+    this.rebucket(p);
     p.targetId = null;
     p.autoAttack = false;
     this.emit({ type: 'log', text: dungeon.leaveText, color: '#b9f', pid: r.meta.entityId });
@@ -2926,7 +2966,7 @@ export class Sim {
       const mob = createMob(this.nextId++, template, level, this.groundPos(origin.x + spawn.x, origin.z + spawn.z));
       mob.facing = Math.PI; // face the entrance
       mob.prevFacing = mob.facing;
-      this.entities.set(mob.id, mob);
+      this.addEntity(mob);
       inst.mobIds.push(mob.id);
     }
     const exit = createGroundObject(this.nextId++, '', `${dungeon.name} Exit`, this.groundPos(origin.x + dungeon.exitOffset.x, origin.z + dungeon.exitOffset.z));
@@ -2934,7 +2974,7 @@ export class Sim {
     exit.dungeonId = dungeon.id;
     exit.objectItemId = null;
     exit.lootable = true;
-    this.entities.set(exit.id, exit);
+    this.addEntity(exit);
     inst.exitId = exit.id;
   }
 
@@ -2947,9 +2987,9 @@ export class Sim {
         if (e?.targetId === id) e.targetId = null;
         if (e?.comboTargetId === id) { e.comboTargetId = null; e.comboPoints = 0; }
       }
-      this.entities.delete(id);
+      this.dropEntity(id);
     }
-    if (inst.exitId !== null) this.entities.delete(inst.exitId);
+    if (inst.exitId !== null) this.dropEntity(inst.exitId);
     inst.partyKey = null;
     inst.mobIds = [];
     inst.exitId = null;

--- a/src/sim/spatial.ts
+++ b/src/sim/spatial.ts
@@ -1,0 +1,82 @@
+// Spatial hash grid over entity positions for radius queries that would
+// otherwise scan every entity. Cells are re-bucketed once per tick (gradual
+// movement) and kept exact on spawn/despawn/teleport, so queries always see
+// the same roster as the entities map.
+import { Entity } from './types';
+
+// shifts negative cell coordinates into the positive range before packing
+const OFFSET = 32768;
+
+export class SpatialGrid {
+  private cells = new Map<number, Entity[]>();
+  private where = new Map<number, number>(); // entity id -> occupied cell key
+
+  constructor(readonly cellSize = 32) {}
+
+  private keyAt(x: number, z: number): number {
+    return (Math.floor(x / this.cellSize) + OFFSET) * 65536 + (Math.floor(z / this.cellSize) + OFFSET);
+  }
+
+  insert(e: Entity): void {
+    const key = this.keyAt(e.pos.x, e.pos.z);
+    let list = this.cells.get(key);
+    if (!list) {
+      list = [];
+      this.cells.set(key, list);
+    }
+    list.push(e);
+    this.where.set(e.id, key);
+  }
+
+  remove(e: Entity): void {
+    const key = this.where.get(e.id);
+    if (key === undefined) return;
+    this.where.delete(e.id);
+    const list = this.cells.get(key);
+    if (!list) return;
+    const i = list.indexOf(e);
+    if (i >= 0) {
+      list[i] = list[list.length - 1];
+      list.pop();
+    }
+  }
+
+  // Re-bucket an entity whose position changed cells (movement, teleport).
+  update(e: Entity): void {
+    if (this.where.get(e.id) === this.keyAt(e.pos.x, e.pos.z)) return;
+    this.remove(e);
+    this.insert(e);
+  }
+
+  // Re-bucket entities that crossed a cell boundary since the last call.
+  // Most entities stay inside their 32-unit cell from one tick to the next,
+  // so this is a key comparison per entity and rarely any bucket work.
+  refresh(entities: Iterable<Entity>): void {
+    for (const e of entities) this.update(e);
+  }
+
+  // Visit every entity within `radius` of (x, z) in the ground plane,
+  // passing the squared 2D distance. The cell window is padded by one unit
+  // so entities that drifted since the last rebuild still fall inside it;
+  // the distance check itself uses current positions.
+  forEachInRadius(x: number, z: number, radius: number, fn: (e: Entity, d2: number) => void): void {
+    const cs = this.cellSize;
+    const minCx = Math.floor((x - radius - 1) / cs) + OFFSET;
+    const maxCx = Math.floor((x + radius + 1) / cs) + OFFSET;
+    const minCz = Math.floor((z - radius - 1) / cs) + OFFSET;
+    const maxCz = Math.floor((z + radius + 1) / cs) + OFFSET;
+    const r2 = radius * radius;
+    for (let cx = minCx; cx <= maxCx; cx++) {
+      for (let cz = minCz; cz <= maxCz; cz++) {
+        const list = this.cells.get(cx * 65536 + cz);
+        if (!list) continue;
+        for (const e of list) {
+          const dx = e.pos.x - x;
+          const dz = e.pos.z - z;
+          const d2 = dx * dx + dz * dz;
+          if (d2 <= r2) fn(e, d2);
+        }
+      }
+    }
+  }
+}

--- a/tests/spatial.test.ts
+++ b/tests/spatial.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SpatialGrid } from '../src/sim/spatial';
+import { Entity, dist2d } from '../src/sim/types';
+
+function bruteForceInRadius(sim: Sim, x: number, z: number, radius: number): Set<number> {
+  const out = new Set<number>();
+  for (const e of sim.entities.values()) {
+    if (dist2d({ x, y: 0, z }, e.pos) <= radius) out.add(e.id);
+  }
+  return out;
+}
+
+function gridInRadius(grid: SpatialGrid, x: number, z: number, radius: number): Set<number> {
+  const out = new Set<number>();
+  grid.forEachInRadius(x, z, radius, (e) => out.add(e.id));
+  return out;
+}
+
+describe('spatial grid', () => {
+  it('radius queries match a brute-force scan across the whole world', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior' });
+    // let mobs wander off their spawn points and the grid re-bucket them
+    for (let i = 0; i < 200; i++) sim.tick();
+
+    const probes: Array<[number, number, number]> = [];
+    for (let z = -1200; z <= 1200; z += 150) {
+      probes.push([60, z, 120], [200, z, 25], [350, z, 8]);
+    }
+    probes.push([900, 0, 120]); // dungeon strip
+    for (const [x, z, r] of probes) {
+      expect(gridInRadius(sim.grid, x, z, r)).toEqual(bruteForceInRadius(sim, x, z, r));
+    }
+  });
+
+  it('keeps the roster exact on spawn and despawn without a tick', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('mage', 'Gridtest');
+    const p = sim.entities.get(pid)!;
+    expect(gridInRadius(sim.grid, p.pos.x, p.pos.z, 5).has(pid)).toBe(true);
+    expect(gridInRadius(sim.playerGrid, p.pos.x, p.pos.z, 5).has(pid)).toBe(true);
+    sim.removePlayer(pid);
+    expect(gridInRadius(sim.grid, p.pos.x, p.pos.z, 5).has(pid)).toBe(false);
+    expect(gridInRadius(sim.playerGrid, p.pos.x, p.pos.z, 5).has(pid)).toBe(false);
+  });
+
+  it('re-buckets teleported entities immediately', () => {
+    const grid = new SpatialGrid();
+    const e = { id: 1, pos: { x: 0, y: 0, z: 0 } } as Entity;
+    grid.insert(e);
+    e.pos.x = 500;
+    e.pos.z = -700;
+    grid.update(e);
+    expect(gridInRadius(grid, 500, -700, 2).has(1)).toBe(true);
+    expect(gridInRadius(grid, 0, 0, 2).has(1)).toBe(false);
+  });
+
+  it('player combat flag matches per-player scan semantics', () => {
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior' });
+    const p = sim.entities.get(sim.primaryId)!;
+    // walk the player into a camp until something aggroes
+    let aggroed = false;
+    for (let i = 0; i < 4000 && !aggroed; i++) {
+      const meta = sim.players.get(sim.primaryId)!;
+      meta.moveInput.forward = true;
+      sim.tick();
+      for (const e of sim.entities.values()) {
+        if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId === p.id) {
+          aggroed = true;
+        }
+      }
+    }
+    expect(aggroed).toBe(true);
+    expect(p.inCombat).toBe(true);
+  });
+});


### PR DESCRIPTION
> **Stacked on #8** (delta snapshots) — this branch includes that commit because both rewrite `broadcastSnapshots()`. Review only the last commit (`Add a spatial hash grid…`) until #8 merges; after that this PR shows only its own diff.

## Problem

Several hot paths scanned the **full entity map** every time they needed entities near a point:

- `broadcastSnapshots()` — interest filtering iterated all entities **per client per 50ms tick**
- `mobsInRadius()` — every AoE effect application scanned the world
- social aggro pull in `aggroMob()`, `tabTarget`, `targetNearestEnemy`, `interact`
- the combat flag check was **O(players × entities)** per tick (full scan per player)

## Change

[src/sim/spatial.ts](src/sim/spatial.ts) adds a 32-unit cell **spatial hash grid**. The sim keeps two instances — all entities, and players only (for mob idle-aggro scans, where iterating a handful of co-located cells beats touching every mob cell). Key properties:

- **Roster-exact**: every spawn/despawn/teleport goes through `addEntity`/`dropEntity`/`rebucket` helpers (dungeon enter/leave, mob respawn, graveyard release, boss adds, instance cleanup, `dev_teleport`), so grid contents always match the entities map — no ghost results.
- **Cheap maintenance**: cells are refreshed incrementally at the end of each tick; an entity rarely crosses a 32-unit boundary between ticks, so the refresh is one key comparison per entity. (The first implementation rebuilt the grid from scratch each tick — that was a net **regression**, caught and fixed during benchmarking.)
- **Exact semantics**: queries do the same distance comparison as the code they replace (squared distance, same `<` / `<=` boundaries); the cell window is padded so entities that drifted since the last refresh are still found.
- The per-player combat-flag scan is replaced by **one pass** that collects every player a mob is engaged with into a `Set` — same semantics, O(entities) total instead of O(players × entities).

## Measured locally (M-series laptop, world of 321 entities)

| scenario | before | after |
|---|---|---|
| sim tick, 20 moving players | 0.627 ms/tick | 0.538 ms/tick (**−14%**) |
| headless RL bench, single player | 226 steps/s | 236 steps/s (**+4%**) |
| server CPU, 30 moving clients spread across zones | 11.3% | 9.6% (**−15%**) |
| server CPU, 10 idle co-located clients | ~12% | ~12% (unchanged) |

The idle co-located case is dominated by snapshot JSON serialization, not scanning — that's the next optimization (per-entity deltas), out of scope here. The grid's win grows with entity and player count: queries are O(local density) instead of O(world).

## Testing

- `vitest run`: **138/138** pass. New [tests/spatial.test.ts](tests/spatial.test.ts) asserts grid-vs-brute-force equivalence across ~50 probe points over the whole world after 200 ticks of wandering, roster exactness on spawn/despawn without a tick, immediate re-bucketing on teleport, and combat-flag semantics under real aggro.
- Live e2e against a real server + Postgres: `mp_integration.mjs` 26/26, `social_e2e.mjs` 10/10, `crypt_raid.mjs` 8/8 — the 5-player dungeon raid exercises instance spawn/despawn, enter/leave teleports, and boss add waves against the grid roster.