### PR TITLE
Chat channels + bubbles, more SFX, instant bag refresh after trade, movement-jitter fix (issue #10)

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,13 @@
   .np-marker.active { color: #b9b9b9; }
   .np-marker.loot { color: var(--gold); font-size: 14px; }
 
+  /* ---------- chat bubbles (/say, /yell) ---------- */
+  .chat-bubble { position: absolute; left: 0; top: 0; max-width: 220px; pointer-events: none;
+    background: rgba(252, 250, 240, 0.93); color: #1d1610; border: 1px solid #8a7a55;
+    border-radius: 10px; padding: 4px 9px; font-size: 12px; line-height: 1.3;
+    text-align: center; overflow-wrap: break-word; will-change: transform; z-index: 21; }
+  .chat-bubble.yell { font-weight: bold; color: #7a1408; border-color: #c43a2a; }
+
   /* ---------- unit frames ---------- */
   .unitframe { position: absolute; top: 12px; display: flex; gap: 0; align-items: center; }
   #player-frame { left: 12px; }
@@ -151,14 +158,21 @@
   .micro-btn:hover { border-color: var(--gold); color: #fff; }
   .micro-btn .keybind { position: absolute; bottom: -1px; right: 2px; font-size: 8px; color: #998; }
 
-  /* ---------- combat log ---------- */
-  #combatlog-wrap { position: absolute; left: 12px; bottom: 8px; width: 350px; }
-  #combatlog-header { font-family: var(--title-font); font-size: 12px; color: #cdb877;
-    background: linear-gradient(#2a2436, #161220); border: 1px solid #463a1c; border-bottom: none;
-    border-radius: 6px 6px 0 0; padding: 3px 10px; width: 130px; text-shadow: 1px 1px 1px #000; }
-  #combatlog { height: 148px; overflow: hidden; font-size: 11px; padding: 6px 9px; line-height: 1.45;
-    border-radius: 0 6px 6px 6px; display: flex; flex-direction: column; justify-content: flex-end; }
-  #combatlog div { text-shadow: 1px 1px 1px #000; }
+  /* ---------- chat frame ---------- */
+  #chatlog-wrap { position: absolute; left: 12px; bottom: 8px; width: 370px; }
+  #chatlog-tabs { display: flex; gap: 2px; margin-left: 6px; margin-bottom: -1px; position: relative; z-index: 2; }
+  .chat-tab { height: 22px; padding: 0 12px; border: 1px solid #3a321d; border-bottom: none;
+    border-radius: 6px 6px 0 0; background: linear-gradient(#1c1824, #0d0b13); color: #95886a;
+    cursor: pointer; font-family: var(--title-font); font-size: 12px; text-shadow: 1px 1px 1px #000; }
+  .chat-tab.active { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#2a2436, #161220); }
+  #chatlog-frame { height: 184px; padding: 0; overflow: hidden; border-radius: 0 6px 6px 6px; }
+  .chat-pane { display: none; height: 100%; overflow-y: auto; overflow-x: hidden; padding: 7px 10px;
+    font-size: 11px; line-height: 1.45; scrollbar-width: thin; scrollbar-color: #6f5a2a #0b0b10; }
+  .chat-pane.active { display: block; }
+  .chat-pane div { text-shadow: 1px 1px 1px #000; overflow-wrap: break-word; user-select: text; }
+  .chat-pane::-webkit-scrollbar { width: 8px; }
+  .chat-pane::-webkit-scrollbar-track { background: #0b0b10; }
+  .chat-pane::-webkit-scrollbar-thumb { background: #4a3d1d; border-radius: 4px; }
 
   /* ---------- quest tracker ---------- */
   #quest-tracker { position: absolute; right: 14px; top: 210px; width: 240px; font-size: 12px;
@@ -367,7 +381,7 @@
   .mini-class.sel { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd10055; }
 
   /* ---------- chat ---------- */
-  #chat-input { position: absolute; left: 12px; bottom: 168px; width: 350px; display: none; z-index: 25;
+  #chat-input { position: absolute; left: 12px; bottom: 204px; width: 370px; display: none; z-index: 25;
     background: #0d0d14ee; color: #e8e8e8; border: 2px solid var(--border); outline: 1px solid #000;
     border-radius: 4px; padding: 7px 10px; font-size: 13px; user-select: text; }
 
@@ -476,9 +490,15 @@
       </div>
     </div>
 
-    <div id="combatlog-wrap">
-      <div id="combatlog-header">Combat Log</div>
-      <div id="combatlog" class="panel"></div>
+    <div id="chatlog-wrap">
+      <div id="chatlog-tabs">
+        <button class="chat-tab active" data-log-tab="chat">Chat</button>
+        <button class="chat-tab" data-log-tab="combat">Combat Log</button>
+      </div>
+      <div id="chatlog-frame" class="panel">
+        <div id="chatlog" class="chat-pane active"></div>
+        <div id="combatlog" class="chat-pane"></div>
+      </div>
     </div>
 
     <div id="quest-dialog" class="window panel"></div>
@@ -517,7 +537,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (Enter to send, Esc to cancel)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/y yell, /w name whisper, /g general, /p party)" autocomplete="off" />
 
   <div id="start-screen">
     <img id="title-logo" src="/worldofclaudecraft-logo.png" alt="World of Claudecraft" />

--- a/scripts/chat_e2e.mjs
+++ b/scripts/chat_e2e.mjs
@@ -1,0 +1,118 @@
+// Chat-channel e2e against a running game server (+ postgres).
+// Requires ALLOW_DEV_COMMANDS=1 on the server (dev_teleport positions the
+// two clients at exact distances for the range checks).
+import WebSocket from 'ws';
+
+const BASE = process.env.SERVER_URL ?? 'http://localhost:8787';
+const WS_BASE = BASE.replace(/^http/, 'ws');
+let pass = 0, fail = 0;
+
+function check(name, cond, extra = '') {
+  if (cond) { pass++; console.log(`OK   ${name}`); }
+  else { fail++; console.log(`FAIL ${name} ${extra}`); }
+}
+
+async function api(path, body, token) {
+  const res = await fetch(BASE + path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+class Client {
+  constructor() {
+    this.events = [];
+    this.pid = -1;
+  }
+  connect(token, characterId) {
+    return new Promise((resolve, reject) => {
+      this.ws = new WebSocket(`${WS_BASE}/ws`);
+      const to = setTimeout(() => reject(new Error('connect timeout')), 8000);
+      this.ws.on('message', (data) => {
+        const msg = JSON.parse(String(data));
+        if (msg.t === 'hello') { this.pid = msg.pid; clearTimeout(to); resolve(); }
+        else if (msg.t === 'events') this.events.push(...msg.list);
+      });
+      this.ws.on('open', () => this.ws.send(JSON.stringify({ t: 'auth', token, character: characterId })));
+      this.ws.on('error', reject);
+    });
+  }
+  cmd(p) { this.ws.send(JSON.stringify({ t: 'cmd', ...p })); }
+  chats() { return this.events.filter((e) => e.type === 'chat'); }
+  clear() { this.events = []; }
+  close() { this.ws?.close(); }
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const uniq = Date.now().toString(36);
+const alpha = uniq.replace(/[0-9]/g, (d) => 'abcdefghij'[Number(d)]).slice(-6);
+
+async function main() {
+  const r1 = await api('/api/register', { username: `chat_${uniq}_a`, password: 'hunter22' });
+  const r2 = await api('/api/register', { username: `chat_${uniq}_b`, password: 'hunter22' });
+  const c1 = await api('/api/characters', { name: `Saya${alpha}`, class: 'warrior' }, r1.token);
+  const c2 = await api('/api/characters', { name: `Heara${alpha}`, class: 'mage' }, r2.token);
+  const a = new Client();
+  const b = new Client();
+  await a.connect(r1.token, c1.id);
+  await b.connect(r2.token, c2.id);
+
+  // co-located: bare text is /say and B hears it (with speaker entity id)
+  a.cmd({ cmd: 'dev_teleport', x: 50, z: -40 });
+  b.cmd({ cmd: 'dev_teleport', x: 55, z: -40 });
+  await sleep(300);
+  b.clear(); a.clear();
+  a.cmd({ cmd: 'chat', text: 'hello neighbor' });
+  await sleep(300);
+  let got = b.chats().find((e) => e.text === 'hello neighbor');
+  check('say heard in range', !!got && got.channel === 'say' && got.entityId === a.pid);
+  check('speaker hears own say', a.chats().some((e) => e.text === 'hello neighbor'));
+
+  // B walks out of say range (25) but stays within yell range (100)
+  b.cmd({ cmd: 'dev_teleport', x: 110, z: -40 });
+  await sleep(300);
+  b.clear(); a.clear();
+  a.cmd({ cmd: 'chat', text: 'too far for say' });
+  a.cmd({ cmd: 'chat', text: '/y YELLING NOW' });
+  await sleep(400);
+  check('say not heard out of range', !b.chats().some((e) => e.text === 'too far for say'));
+  got = b.chats().find((e) => e.text === 'YELLING NOW');
+  check('yell heard at 60 units', !!got && got.channel === 'yell');
+
+  // B leaves yell range; /g still reaches everyone
+  b.cmd({ cmd: 'dev_teleport', x: 60, z: -900 });
+  await sleep(300);
+  b.clear(); a.clear();
+  a.cmd({ cmd: 'chat', text: '/y nobody hears this' });
+  a.cmd({ cmd: 'chat', text: '/g world news' });
+  await sleep(400);
+  check('yell not heard across the world', !b.chats().some((e) => e.text === 'nobody hears this'));
+  got = b.chats().find((e) => e.text === 'world news');
+  check('general reaches everyone', !!got && got.channel === 'general');
+
+  // whisper: routed to the target only, echo to the sender, third parties blind
+  b.clear(); a.clear();
+  a.cmd({ cmd: 'chat', text: `/w Heara${alpha} psst` });
+  await sleep(400);
+  got = b.chats().find((e) => e.channel === 'whisper');
+  check('whisper reaches target across the world', !!got && got.text === 'psst' && got.from === `Saya${alpha}`);
+  const echo = a.chats().find((e) => e.channel === 'whisper');
+  check('sender gets whisper echo with to-name', !!echo && echo.to === `Heara${alpha}`);
+
+  // unknown whisper target and unknown command produce errors, not chat
+  a.clear();
+  a.cmd({ cmd: 'chat', text: '/w Nobodyxyz hi' });
+  a.cmd({ cmd: 'chat', text: '/dance' });
+  await sleep(400);
+  check('unknown whisper target errors', a.events.some((e) => e.type === 'error' && e.text.includes('Nobodyxyz')));
+  check('unknown command errors', a.events.some((e) => e.type === 'error' && e.text.includes('/dance')));
+  check('no chat leaked for bad commands', a.chats().length === 0);
+
+  a.close(); b.close();
+  console.log(`\n${pass} passed, ${fail} failed`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/ws_security_e2e.mjs
+++ b/scripts/ws_security_e2e.mjs
@@ -1,0 +1,31 @@
+// Regression check: an oversized pre-auth ws frame must NOT crash the server.
+import WebSocket from 'ws';
+
+const BASE = process.env.SERVER_URL ?? 'http://localhost:8787';
+const WS_BASE = BASE.replace(/^http/, 'ws');
+
+const before = await fetch(BASE + '/api/status').then((r) => r.ok).catch(() => false);
+if (!before) { console.log('FAIL server not up before test'); process.exit(1); }
+
+// connect and immediately send a >16KB frame as the very first message
+await new Promise((resolve) => {
+  const ws = new WebSocket(`${WS_BASE}/ws`);
+  ws.on('open', () => {
+    ws.send('x'.repeat(64 * 1024));
+    setTimeout(() => { try { ws.close(); } catch {} resolve(); }, 600);
+  });
+  ws.on('error', () => resolve()); // server closing us is fine
+  ws.on('close', () => resolve());
+});
+
+await new Promise((r) => setTimeout(r, 500));
+const after = await fetch(BASE + '/api/status').then((r) => r.ok).catch(() => false);
+console.log(after ? 'OK   server survived oversized pre-auth frame' : 'FAIL server crashed on oversized frame');
+
+// and a normal client can still connect afterwards
+const r = await fetch(BASE + '/api/register', {
+  method: 'POST', headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ username: 'dos_' + Date.now().toString(36), password: 'hunter22' }),
+}).then((x) => x.json()).catch(() => ({}));
+console.log(r.token ? 'OK   server still serving requests' : 'FAIL server unresponsive after attack');
+process.exit(after && r.token ? 0 : 1);

--- a/server/main.ts
+++ b/server/main.ts
@@ -206,7 +206,10 @@ async function main(): Promise<void> {
     else serveStatic(req, res);
   });
 
-  const wss = new WebSocketServer({ noServer: true });
+  // cap frame size: the largest legitimate client message is a small JSON
+  // command; without this the ws default (~100 MiB) lets one socket force a
+  // huge allocation + parse before any field-level validation runs
+  const wss = new WebSocketServer({ noServer: true, maxPayload: 16 * 1024 });
   server.on('upgrade', (req, socket, head) => {
     const url = new URL(req.url ?? '/', 'http://localhost');
     if (url.pathname !== '/ws') {
@@ -272,6 +275,15 @@ async function main(): Promise<void> {
       ws.send(JSON.stringify({ t: 'error', error: 'authentication timed out' }));
       ws.close();
     }, 10_000);
+
+    // Pre-auth socket errors (e.g. a first frame over maxPayload, which ws
+    // surfaces as an 'error' event) would otherwise be an unhandled exception
+    // and crash the process. Tear the connection down quietly instead. The
+    // post-auth game.leave handler is attached separately once joined.
+    ws.on('error', () => {
+      clearTimeout(authTimer);
+      try { ws.close(); } catch { /* already closing */ }
+    });
 
     ws.once('message', (data) => {
       clearTimeout(authTimer);

--- a/src/game/audio.ts
+++ b/src/game/audio.ts
@@ -141,6 +141,43 @@ export class GameAudio {
   sheep(): void {
     this.tone(620, 0.4, 0.13, 'sawtooth', 0, 520);
   }
+
+  bagOpen(): void {
+    // leather flap + soft clasp
+    this.noise(0.09, 1400, 0.16, 0.7);
+    this.tone(660, 0.05, 0.06, 'triangle', 0.03);
+  }
+
+  bagClose(): void {
+    this.noise(0.08, 900, 0.14, 0.7);
+    this.tone(440, 0.05, 0.06, 'triangle', 0.01);
+  }
+
+  whisper(): void {
+    this.tone(1175, 0.09, 0.09, 'sine');
+    this.tone(1568, 0.12, 0.07, 'sine', 0.07);
+  }
+
+  duelChallenge(): void {
+    // war horn: two rising fifths
+    this.tone(196, 0.35, 0.2, 'sawtooth');
+    this.tone(294, 0.45, 0.2, 'sawtooth', 0.18);
+  }
+
+  duelCountdownTick(): void {
+    this.tone(880, 0.07, 0.12, 'square');
+  }
+
+  duelStart(): void {
+    // gong + cymbal wash
+    this.tone(220, 0.7, 0.28, 'triangle', 0, 110);
+    this.noise(0.4, 3000, 0.14, 0.5, 'highpass');
+  }
+
+  duelEnd(): void {
+    this.tone(392, 0.18, 0.18, 'triangle');
+    this.tone(523, 0.3, 0.18, 'triangle', 0.12);
+  }
 }
 
 export const audio = new GameAudio();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -81,6 +81,12 @@ export class Api {
 // World mirror
 // ---------------------------------------------------------------------------
 
+function wrapAngle(d: number): number {
+  while (d > Math.PI) d -= 2 * Math.PI;
+  while (d < -Math.PI) d += 2 * Math.PI;
+  return d;
+}
+
 function blankEntity(id: number): Entity {
   return {
     id, kind: 'mob', templateId: '', name: '', level: 1,
@@ -223,6 +229,13 @@ export class ClientWorld implements IWorld {
 
   private applySnapshot(snap: any): void {
     const now = performance.now();
+    // the interpolation alpha the render loop reached on its last frame
+    // (same formula and caps as main.ts); used below to re-anchor the new
+    // interpolation segment at the pose currently on screen
+    const contAlpha = this.lastSnapAt > 0
+      ? Math.min(1.25, (now - this.lastSnapAt) / Math.max(20, this.snapInterval))
+      : 1;
+    const contFacingAlpha = Math.min(1, contAlpha);
     if (this.lastSnapAt > 0) {
       const gap = now - this.lastSnapAt;
       if (gap > 5 && gap < 500) this.snapInterval = this.snapInterval * 0.9 + gap * 0.1;
@@ -254,9 +267,16 @@ export class ClientWorld implements IWorld {
         }
         this.entities.set(w.id, e);
       }
-      // interpolation bases
-      e.prevPos = { ...e.pos };
-      e.prevFacing = e.facing;
+      // interpolation bases: re-anchor at the pose the renderer last drew,
+      // not at the previous server pose — when a frame extrapolated past the
+      // last snapshot, restarting from the server pose snapped entities
+      // backwards every snapshot (visible rubber-banding while running)
+      e.prevPos = {
+        x: e.prevPos.x + (e.pos.x - e.prevPos.x) * contAlpha,
+        y: e.prevPos.y + (e.pos.y - e.prevPos.y) * contAlpha,
+        z: e.prevPos.z + (e.pos.z - e.prevPos.z) * contAlpha,
+      };
+      e.prevFacing = e.prevFacing + wrapAngle(e.facing - e.prevFacing) * contFacingAlpha;
       e.pos.x = w.x; e.pos.y = w.y; e.pos.z = w.z;
       e.facing = w.f;
       e.level = w.lv;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -106,6 +106,8 @@ export class Renderer {
   showNameplates = true;
   private tmpV = new THREE.Vector3();
   private tmpV2 = new THREE.Vector3();
+  // floating /say-/yell bubbles, keyed by speaker entity id
+  private chatBubbles = new Map<number, { el: HTMLDivElement; until: number }>();
   private sun: THREE.DirectionalLight;
   private hemi!: THREE.HemisphereLight;
   private sky!: THREE.Mesh;
@@ -902,6 +904,7 @@ export class Renderer {
     this.updateGodRays();
 
     this.updateNameplates();
+    this.updateChatBubbles();
     if (this.post) this.post.render();
     else this.webgl.render(this.scene, this.camera);
   }
@@ -1034,6 +1037,51 @@ export class Renderer {
         v.markerEl.textContent = e.lootable ? '$' : elite && !e.dead ? '◆' : '';
         v.markerEl.className = 'np-marker loot';
       }
+    }
+  }
+
+  // Hang a speech bubble over an entity's head; it follows the entity and
+  // fades out after a few seconds (longer for longer messages).
+  showChatBubble(entityId: number, text: string, yell: boolean): void {
+    let b = this.chatBubbles.get(entityId);
+    if (!b) {
+      const el = document.createElement('div');
+      el.className = 'chat-bubble';
+      this.nameplateLayer.appendChild(el);
+      b = { el, until: 0 };
+      this.chatBubbles.set(entityId, b);
+    }
+    b.el.textContent = text; // textContent: chat is player input, never HTML
+    b.el.classList.toggle('yell', yell);
+    // wall-clock ttl: sim/render time can run slower than real time under
+    // frame-delta clamping, which would keep bubbles up too long
+    b.until = performance.now() + 1000 * Math.min(10, 3.5 + text.length * 0.045);
+  }
+
+  private updateChatBubbles(): void {
+    if (this.chatBubbles.size === 0) return;
+    const w = window.innerWidth, h = window.innerHeight;
+    const now = performance.now();
+    for (const [id, b] of this.chatBubbles) {
+      const e = this.sim.entities.get(id);
+      const v = e ? this.views.get(id) : undefined;
+      if (!e || !v || now >= b.until) {
+        b.el.remove();
+        this.chatBubbles.delete(id);
+        continue;
+      }
+      // culled rigs (beyond ENTITY_DRAW_RANGE) stop updating group.position,
+      // so a yell from 80–100u away would hang frozen over empty terrain —
+      // fall back to the live entity position when the rig isn't being drawn
+      if (v.group.visible) this.tmpV.copy(v.group.position);
+      else this.tmpV.set(e.pos.x, e.pos.y, e.pos.z);
+      this.tmpV.y += v.height * e.scale + 1.0;
+      this.tmpV.project(this.camera);
+      if (this.tmpV.z > 1) { b.el.style.display = 'none'; continue; }
+      b.el.style.display = '';
+      const sx = (this.tmpV.x * 0.5 + 0.5) * w;
+      const sy = (-this.tmpV.y * 0.5 + 0.5) * h;
+      b.el.style.transform = `translate(${sx.toFixed(0)}px, ${sy.toFixed(0)}px) translate(-50%, -100%)`;
     }
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -31,6 +31,10 @@ const OBJECT_RESPAWN = 30;
 const PARTY_MAX = 5;
 const PARTY_XP_RANGE = 80; // yards: members this close share kill xp/credit
 const DUEL_COUNTDOWN = 3;
+const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
+const YELL_RANGE = 100;
+const CHAT_BURST = 8; // messages a player may send back-to-back...
+const CHAT_REFILL = 2; // ...then this many more per second (caps spam amplifiers)
 const DUEL_FORFEIT_DISTANCE = 60;
 const TRADE_RANGE = 10;
 const INSTANCE_EMPTY_TIMEOUT = 300; // seconds before an empty instance resets
@@ -174,6 +178,8 @@ export class Sim {
   tradeInvites = new Map<number, { fromPid: number; expires: number }>();
   duels = new Map<number, DuelState>(); // pid -> shared duel (both pids)
   duelInvites = new Map<number, { fromPid: number; expires: number }>();
+  // per-player chat token bucket (anti-spam); refilled lazily by sim time
+  private chatTokens = new Map<number, { tokens: number; at: number }>();
   // dungeon instances
   instances: InstanceSlot[] = [];
 
@@ -356,6 +362,7 @@ export class Sim {
     }
     this.dropEntity(pid);
     this.players.delete(pid);
+    this.chatTokens.delete(pid);
     if (this.primaryId === pid) this.primaryId = this.players.size > 0 ? [...this.players.keys()][0] : -1;
   }
 
@@ -2464,14 +2471,58 @@ export class Sim {
     this.emit({ type: 'respawn', pid: meta.entityId });
   }
 
+  // Token-bucket throttle: returns false (and notifies the player once) when
+  // they are out of chat tokens. Keeps /g and /w from being spam amplifiers.
+  private chatAllowed(pid: number): boolean {
+    let b = this.chatTokens.get(pid);
+    if (!b) { b = { tokens: CHAT_BURST, at: this.time }; this.chatTokens.set(pid, b); }
+    b.tokens = Math.min(CHAT_BURST, b.tokens + (this.time - b.at) * CHAT_REFILL);
+    b.at = this.time;
+    if (b.tokens < 1) return false;
+    b.tokens -= 1;
+    return true;
+  }
+
   chat(text: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
-    let clean = text.trim().slice(0, 200);
-    if (!clean) return;
+    const raw = text.trim().slice(0, 200);
+    if (!raw) return;
+    if (!this.chatAllowed(r.meta.entityId)) {
+      this.error(r.meta.entityId, 'You are sending messages too quickly.');
+      return;
+    }
+
+    // "/w name message" — private whisper to an online player
+    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
+    if (wm) {
+      const targetName = wm[1];
+      const msg = wm[2].trim();
+      if (!msg) return;
+      // exact case wins outright; otherwise a case-insensitive match is used
+      // only when unambiguous, so 'Bet' and 'bet' can't silently intercept
+      // each other's whispers
+      let target: PlayerMeta | null = null;
+      const ciMatches: PlayerMeta[] = [];
+      const wanted = targetName.toLowerCase();
+      for (const meta of this.players.values()) {
+        if (meta.name === targetName) { target = meta; break; }
+        if (meta.name.toLowerCase() === wanted) ciMatches.push(meta);
+      }
+      if (!target) {
+        if (ciMatches.length === 1) target = ciMatches[0];
+        else if (ciMatches.length > 1) { this.error(r.meta.entityId, `Several players match '${targetName}'. Use exact capitalization.`); return; }
+      }
+      if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return; }
+      if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return; }
+      this.emit({ type: 'chat', from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
+      this.emit({ type: 'chat', from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
+      return;
+    }
+
     // "/p message" goes to the party channel
-    if (clean.startsWith('/p ') || clean.startsWith('/party ')) {
-      clean = clean.replace(/^\/p(arty)? /, '').trim();
+    if (/^\/p(arty)?\s/i.test(raw)) {
+      const clean = raw.replace(/^\/p(arty)?\s+/i, '').trim();
       if (!clean) return;
       const party = this.partyOf(r.meta.entityId);
       if (!party) { this.error(r.meta.entityId, 'You are not in a party.'); return; }
@@ -2480,7 +2531,28 @@ export class Sim {
       }
       return;
     }
-    this.emit({ type: 'chat', from: r.meta.name, text: clean, channel: 'say' });
+
+    // "/g message" — world-wide general channel (no pid = broadcast to all)
+    if (/^\/g(eneral)?\s/i.test(raw)) {
+      const clean = raw.replace(/^\/g(eneral)?\s+/i, '').trim();
+      if (clean) this.emit({ type: 'chat', from: r.meta.name, text: clean, channel: 'general' });
+      return;
+    }
+
+    // bare text and "/s" are local say; "/y" carries further — both are
+    // delivered per-player by range and carry the speaker for chat bubbles
+    let channel: 'say' | 'yell' = 'say';
+    let clean = raw;
+    if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
+    else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return; }
+    if (!clean) return;
+    const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
+    for (const meta of this.players.values()) {
+      const e = this.entities.get(meta.entityId);
+      if (!e || dist2d(r.e.pos, e.pos) > range) continue;
+      this.emit({ type: 'chat', from: r.meta.name, text: clean, channel, entityId: r.e.id, pid: meta.entityId });
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -2658,6 +2730,7 @@ export class Sim {
           duel.state = 'active';
           for (const dPid of [duel.a, duel.b]) {
             this.emit({ type: 'log', text: 'The duel has begun!', color: '#fa6', pid: dPid });
+            this.emit({ type: 'duelStart', pid: dPid });
           }
         }
         continue;
@@ -2802,6 +2875,7 @@ export class Sim {
     }
     for (const tPid of [session.a, session.b]) {
       this.emit({ type: 'log', text: 'Trade complete.', color: '#8df', pid: tPid });
+      this.emit({ type: 'tradeDone', pid: tPid });
     }
     this.closeTrade(session);
   }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -447,11 +447,17 @@ export type SimEvent = { pid?: number } & (
   | { type: 'playerDeath' }
   | { type: 'respawn' }
   | { type: 'vendor'; action: 'buy' | 'sell'; itemId: string }
-  | { type: 'chat'; from: string; text: string; channel?: 'say' | 'party' }
+  // say/yell are delivered only to players in range and carry the speaker's
+  // entity id so the client can hang a chat bubble over their head; whisper
+  // goes to the target (and echoes to the sender with `to` set); general is
+  // a world-wide broadcast
+  | { type: 'chat'; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   | { type: 'tradeRequest'; fromPid: number; fromName: string }
+  | { type: 'tradeDone' }
   | { type: 'duelRequest'; fromPid: number; fromName: string }
   | { type: 'duelCountdown'; seconds: number }
+  | { type: 'duelStart' }
   | { type: 'duelEnd'; winnerName: string; loserName: string }
   | { type: 'heal2'; sourceId: number; targetId: number; amount: number; crit: boolean; ability: string }
   // visual-only cue for the renderer: spell projectiles, dot ticks, aoe novas

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -30,7 +30,8 @@ const ZONE_BANNER_DEADBAND = 5;
 
 export class Hud {
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
-  private logEl = $('#combatlog');
+  private chatLogEl = $('#chatlog');
+  private combatLogEl = $('#combatlog');
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
   private tooltipEl = $('#tooltip');
@@ -57,6 +58,7 @@ export class Hud {
 
   constructor(private sim: IWorld, private renderer: Renderer) {
     this.meters = new Meters(sim);
+    this.bindLogTabs();
     this.buildActionBar();
     this.buildXpTicks();
     $('#pf-name').textContent = sim.player.name;
@@ -91,6 +93,18 @@ export class Hud {
     this.showBanner(startZone.name);
     this.log(`Welcome to ${startZone.name}!`, '#ffd100');
     this.log(startZone.welcome, '#ffd100');
+  }
+
+  private bindLogTabs(): void {
+    const tabs = document.querySelectorAll<HTMLButtonElement>('.chat-tab');
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const which = tab.dataset.logTab;
+        tabs.forEach((t) => t.classList.toggle('active', t === tab));
+        $('#chatlog').classList.toggle('active', which === 'chat');
+        $('#combatlog').classList.toggle('active', which === 'combat');
+      });
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -707,7 +721,7 @@ export class Hud {
           if (ev.kind === 'miss' || ev.kind === 'dodge') {
             this.fct(tgt, ev.kind === 'miss' ? 'Miss' : 'Dodge', isPlayerTarget ? '#bbb' : '#fff', false);
             if (isPlayerSource) {
-              this.log(`Your ${ev.ability ?? 'attack'} ${ev.kind === 'miss' ? 'misses' : 'is dodged by'} ${tgt.name}.`, '#ccc');
+              this.combatLog(`Your ${ev.ability ?? 'attack'} ${ev.kind === 'miss' ? 'misses' : 'is dodged by'} ${tgt.name}.`, '#ccc');
               audio.meleeMiss();
             }
             break;
@@ -715,14 +729,14 @@ export class Hud {
           if (isPlayerSource && !isPlayerTarget) {
             const color = ev.ability ? '#ffe97a' : '#fff';
             this.fct(tgt, `${ev.amount}${ev.crit ? '!' : ''}`, color, ev.crit);
-            this.log(`Your ${ev.ability ?? 'attack'} hits ${tgt.name} for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, ev.ability ? '#ffe97a' : '#eee');
+            this.combatLog(`Your ${ev.ability ?? 'attack'} hits ${tgt.name} for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, ev.ability ? '#ffe97a' : '#eee');
             if (ev.school === 'fire') audio.fire();
             else if (ev.school === 'frost') audio.frost();
             else if (ev.school === 'arcane') audio.arcane();
             else audio.meleeHit(ev.crit);
           } else if (isPlayerTarget) {
             this.fct(tgt, `-${ev.amount}`, '#ff5544', ev.crit);
-            this.log(`${src?.name ?? 'Something'} hits you for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, '#ff8877');
+            this.combatLog(`${src?.name ?? 'Something'} hits you for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, '#ff8877');
             audio.hitTaken();
           }
           break;
@@ -735,7 +749,7 @@ export class Hud {
         }
         case 'death': {
           const e = sim.entities.get(ev.entityId);
-          if (e && ev.entityId !== sim.playerId) this.log(`${e.name} dies.`, '#aaa');
+          if (e && ev.entityId !== sim.playerId) this.combatLog(`${e.name} dies.`, '#aaa');
           break;
         }
         case 'xp': {
@@ -779,16 +793,32 @@ export class Hud {
           audio.questDone();
           this.refreshGossip();
           break;
-        case 'chat':
-          if (ev.channel === 'party') this.log(`[Party] ${ev.from}: ${ev.text}`, '#7fd4ff');
-          else this.log(`[${ev.from}]: ${ev.text}`, '#9adcf0');
+        case 'chat': {
+          switch (ev.channel) {
+            case 'party': this.log(`[Party] ${ev.from}: ${ev.text}`, '#7fd4ff'); break;
+            case 'yell': this.log(`${ev.from} yells: ${ev.text}`, '#ff5040'); break;
+            case 'whisper':
+              if (ev.to) this.log(`To ${ev.to}: ${ev.text}`, '#ff80ff');
+              else { this.log(`${ev.from} whispers: ${ev.text}`, '#ff80ff'); audio.whisper(); }
+              break;
+            case 'general': this.log(`[General] ${ev.from}: ${ev.text}`, '#ffc864'); break;
+            default: this.log(`${ev.from} says: ${ev.text}`, '#f0ead8'); break;
+          }
+          if ((ev.channel === 'say' || ev.channel === 'yell') && ev.entityId !== undefined) {
+            this.renderer.showChatBubble(ev.entityId, ev.text, ev.channel === 'yell');
+          }
+          break;
+        }
+        case 'tradeDone':
+          if ($('#bags').style.display === 'block') this.renderBags();
+          audio.coin();
           break;
         case 'heal2': {
           const tgt = sim.entities.get(ev.targetId);
           if (tgt && ev.amount > 0) {
             this.fct(tgt, `+${ev.amount}${ev.crit ? '!' : ''}`, '#3ce63c', ev.crit);
             if (ev.sourceId === sim.playerId) {
-              this.log(`Your ${ev.ability} heals ${ev.targetId === sim.playerId ? 'you' : tgt.name} for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, '#7fdc4f');
+              this.combatLog(`Your ${ev.ability} heals ${ev.targetId === sim.playerId ? 'you' : tgt.name} for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, '#7fdc4f');
             }
           }
           break;
@@ -804,17 +834,21 @@ export class Hud {
             () => this.sim.tradeAccept(), () => { /* let it expire */ });
           break;
         case 'duelRequest':
-          audio.aggro();
+          audio.duelChallenge();
           this.showPrompt(`<b>${ev.fromName}</b> has challenged you to a duel!`, 'Accept Duel',
             () => this.sim.duelAccept(), () => this.sim.duelDecline());
           break;
         case 'duelCountdown':
           this.showBanner(`Duel begins in ${ev.seconds}…`);
+          audio.duelCountdownTick();
+          break;
+        case 'duelStart':
+          audio.duelStart();
           break;
         case 'duelEnd':
           this.showBanner(`${ev.winnerName} has defeated ${ev.loserName} in a duel!`);
-          this.log(`${ev.winnerName} has defeated ${ev.loserName} in a duel.`, '#fa6');
-          audio.levelUp();
+          this.combatLog(`${ev.winnerName} has defeated ${ev.loserName} in a duel.`, '#fa6');
+          audio.duelEnd();
           break;
         case 'log': this.log(ev.text, ev.color ?? '#ccc'); break;
         case 'playerDeath': {
@@ -835,9 +869,9 @@ export class Hud {
           const tgt = sim.entities.get(ev.targetId);
           if (ev.name === 'Polymorph' && ev.gained) audio.sheep();
           if (ev.targetId === sim.playerId) {
-            this.log(ev.gained ? `You gain ${ev.name}.` : `${ev.name} fades from you.`, '#d8a0d8');
+            this.combatLog(ev.gained ? `You gain ${ev.name}.` : `${ev.name} fades from you.`, '#d8a0d8');
           } else if (tgt && ev.gained) {
-            this.log(`${tgt.name} is afflicted by ${ev.name}.`, '#d8a0d8');
+            this.combatLog(`${tgt.name} is afflicted by ${ev.name}.`, '#d8a0d8');
           }
           break;
         }
@@ -846,11 +880,21 @@ export class Hud {
   }
 
   log(text: string, color = '#ccc'): void {
+    this.appendLog(this.chatLogEl, text, color);
+  }
+
+  private combatLog(text: string, color = '#ccc'): void {
+    this.appendLog(this.combatLogEl, text, color);
+  }
+
+  private appendLog(el: HTMLElement, text: string, color: string): void {
+    const wasNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
     const div = document.createElement('div');
     div.textContent = text;
     div.style.color = color;
-    this.logEl.appendChild(div);
-    while (this.logEl.children.length > 11) this.logEl.removeChild(this.logEl.firstChild!);
+    el.appendChild(div);
+    while (el.children.length > 200) el.removeChild(el.firstChild!);
+    if (wasNearBottom) el.scrollTop = el.scrollHeight;
   }
 
   private fct(target: Entity, text: string, color: string, crit: boolean): void {
@@ -1079,9 +1123,10 @@ export class Hud {
 
   toggleBags(): void {
     const el = $('#bags');
-    if (el.style.display === 'block') { el.style.display = 'none'; this.hideTooltip(); return; }
+    if (el.style.display === 'block') { el.style.display = 'none'; this.hideTooltip(); audio.bagClose(); return; }
     this.renderBags();
     el.style.display = 'block';
+    audio.bagOpen();
   }
 
   renderBags(): void {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { ClientWorld } from '../src/net/online';
+import { SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function chatEvents(events: SimEvent[]): Extract<SimEvent, { type: 'chat' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'chat' }> => e.type === 'chat');
+}
+
+describe('chat channels', () => {
+  it('say reaches only players within SAY_RANGE and carries the speaker', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const near = sim.addPlayer('mage', 'Bet');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, near, 10, -40);  // within 25
+    teleport(sim, far, 60, -40);   // beyond 25
+    sim.tick();
+
+    sim.chat('Hello there', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((m) => m.channel === 'say' && m.entityId === a && m.text === 'Hello there')).toBe(true);
+    const pids = msgs.map((m) => m.pid).sort();
+    expect(pids).toContain(a);     // speaker hears themselves
+    expect(pids).toContain(near);
+    expect(pids).not.toContain(far);
+  });
+
+  it('yell carries further than say but not world-wide', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const mid = sim.addPlayer('mage', 'Bet');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, mid, 60, -40);   // beyond say(25), within yell(100)
+    teleport(sim, far, 0, -400);   // beyond yell
+    sim.tick();
+
+    sim.chat('/y Over here!', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((m) => m.channel === 'yell' && m.text === 'Over here!')).toBe(true);
+    const pids = msgs.map((m) => m.pid);
+    expect(pids).toContain(mid);
+    expect(pids).not.toContain(far);
+  });
+
+  it('whisper reaches only the target plus a sender echo', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 0, -900);     // whisper ignores distance
+    teleport(sim, c, 2, -40);
+    sim.tick();
+
+    sim.chat('/w bet psst, secret', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs).toHaveLength(2);
+    const toTarget = msgs.find((m) => m.pid === b)!;
+    expect(toTarget.channel).toBe('whisper');
+    expect(toTarget.from).toBe('Aleph');
+    expect(toTarget.text).toBe('psst, secret');
+    expect(toTarget.to).toBeUndefined();
+    const echo = msgs.find((m) => m.pid === a)!;
+    expect(echo.to).toBe('Bet');
+    expect(msgs.some((m) => m.pid === c)).toBe(false);
+  });
+
+  it('whisper to an unknown player errors instead of leaking text', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/w nobody hello?', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.text.includes('nobody'))).toBe(true);
+  });
+
+  it('whispering yourself is rejected', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/w aleph echo echo', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
+
+  it('general is a single world-wide broadcast without a pid', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const far = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, far, 0, -900);
+    sim.tick();
+
+    sim.chat('/g LFG crypt', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].channel).toBe('general');
+    expect(msgs[0].pid).toBeUndefined(); // no pid = routed to everyone
+    expect(msgs[0].text).toBe('LFG crypt');
+  });
+
+  it('unknown slash commands error instead of being said out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/dance', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.text.includes('/dance'))).toBe(true);
+  });
+
+  it('exact-case whisper wins over a case-variant squatter', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const squatter = sim.addPlayer('mage', 'bet'); // joins first, lowercase
+    const real = sim.addPlayer('rogue', 'Bet');    // the intended target
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/w Bet exact match', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.pid !== a);
+    expect(toTarget!.pid).toBe(real);
+    expect(toTarget!.pid).not.toBe(squatter);
+  });
+
+  it('ambiguous case-insensitive whisper is refused, not misdelivered', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    sim.addPlayer('rogue', 'bet');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/w BET ambiguous', a); // matches neither exactly
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && /capitalization/i.test(e.text))).toBe(true);
+  });
+
+  it('throttles a chat flood after the burst is spent', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    let delivered = 0;
+    let throttled = false;
+    for (let i = 0; i < 40; i++) {
+      sim.chat('/g spam ' + i, a);
+      const events = sim.tick(); // ~0.05s of refill per tick
+      if (events.some((e) => e.type === 'chat')) delivered++;
+      if (events.some((e) => e.type === 'error' && /too quickly/i.test(e.text))) throttled = true;
+    }
+    expect(throttled).toBe(true);
+    // 40 messages over ~2s of sim time: burst(8) + refill(2/s) is far below 40
+    expect(delivered).toBeLessThan(20);
+  });
+
+  it('party channel still works and stays private to the party', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 2, -40);
+    teleport(sim, outsider, 4, -40);
+    sim.tick();
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    sim.tick();
+
+    sim.chat('/p inv pls', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((m) => m.channel === 'party')).toBe(true);
+    const pids = msgs.map((m) => m.pid);
+    expect(pids).toContain(a);
+    expect(pids).toContain(b);
+    expect(pids).not.toContain(outsider);
+  });
+});
+
+describe('trade completion event', () => {
+  it('emits tradeDone to both sides when the trade executes', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    sim.addItem('wolf_fang', 1, a);
+    sim.tick();
+
+    sim.tradeRequest(b, a);
+    sim.tradeAccept(b);
+    sim.tradeSetOffer([{ itemId: 'wolf_fang', count: 1 }], 0, a);
+    sim.tradeConfirm(a);
+    sim.tradeConfirm(b);
+    const events = sim.tick();
+    const done = events.filter((e) => e.type === 'tradeDone');
+    expect(done.map((e) => e.pid).sort()).toEqual([a, b].sort());
+  });
+});
+
+describe('snapshot interpolation continuity', () => {
+  function bareClient(pid: number): any {
+    const c: any = Object.create(ClientWorld.prototype);
+    c.cfg = { seed: 42, playerClass: 'warrior' };
+    c.entities = new Map();
+    c.playerId = pid;
+    c.inventory = [];
+    c.equipment = {};
+    c.copper = 0; c.xp = 0;
+    c.known = [];
+    c.questLog = new Map();
+    c.questsDone = new Set();
+    c.partyInfo = null; c.tradeInfo = null; c.duelInfo = null;
+    c.lastSnapAt = 0;
+    c.snapInterval = 50;
+    c.pendingFacingDelta = 0;
+    c.connected = true;
+    c.eventQueue = [];
+    c.mouselookFacing = null;
+    return c;
+  }
+
+  const wire = (id: number, x: number) => ({
+    id, k: 'player', tid: 'warrior', nm: 'Runner', lv: 1,
+    x, y: 0, z: 0, f: 0, hp: 100, mhp: 100,
+  });
+
+  it('re-anchors prevPos at the rendered pose instead of the last server pose', () => {
+    const c = bareClient(7);
+    const self = (x: number) => ({
+      ...wire(7, x), res: 0, mres: 100, rtype: 'mana', xp: 0, copper: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {}, gcd: 0,
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    });
+    c.applySnapshot({ t: 'snap', tick: 1, time: 0, self: self(0), ents: [] });
+    const e = c.entities.get(7);
+    // second snapshot lands: the player moved server-side from x=0 to x=10
+    c.applySnapshot({ t: 'snap', tick: 2, time: 0.05, self: self(10), ents: [] });
+    // third snapshot from x=10 to x=20: prevPos must sit on the segment the
+    // renderer was drawing (between 0 and 10, or slightly past 10 when the
+    // frame extrapolated) — never reset all the way back to the old pose
+    // unless no time passed at all
+    c.applySnapshot({ t: 'snap', tick: 3, time: 0.1, self: self(20), ents: [] });
+    expect(e.pos.x).toBe(20);
+    expect(e.prevPos.x).toBeGreaterThanOrEqual(0);
+    expect(e.prevPos.x).toBeLessThanOrEqual(12.5); // <= 1.25 extrapolation cap
+    // and the interpolation target is always ahead of the anchor
+    expect(e.prevPos.x).toBeLessThan(e.pos.x);
+  });
+});


### PR DESCRIPTION
Closes most of the TODO list in #10. Each item below was built, unit-tested, and exercised against a live server; a multi-agent adversarial review pass caught three issues in my first cut (all fixed, see **Hardening**).

## Chat — channels with range
- `/say` (range 25, the default for bare text), `/yell` (range 100), `/w <name>` whisper, `/g` general (world-wide), `/p` party (was already there).
- **say/yell are delivered only to players in range** and carry the speaker's entity id (for bubbles). **whisper** reaches the target plus a sender echo. **general** is a single broadcast. Unknown commands / bad whisper targets return an error instead of being said out loud.
- Per-player **token-bucket throttle** (burst 8, 2/sec) so the new global/whisper channels can't be turned into spam amplifiers.
- Whisper name lookup prefers an **exact-case** match and refuses an ambiguous case-insensitive one, so `Bet` and `bet` can't intercept each other's private messages.

## Chat bubbles over heads
- Floating `/say` and `/yell` speech bubbles above the speaker (yell is styled bolder/red), with a wall-clock TTL that scales with message length. Bubbles for speakers past the render-cull distance fall back to the live entity position instead of freezing in mid-air. `textContent` only — chat is never injected as HTML.

## Sound effects
- New procedural sounds: bag open/close, whisper chime, duel challenge horn, countdown ticks, duel-start gong, duel end. (Previously the duel had no audio and bags were silent.) Added `duelStart` and `tradeDone` sim events to drive them.

## Trade
- `tradeDone` refreshes an open bag window the instant a trade completes, so received items appear **without** reopening the bags (the bug called out in the issue).

## Movement jitter
- The client now re-anchors snapshot interpolation at the pose actually on screen (same alpha + 1.25 extrapolation cap the render loop uses) instead of the last server pose. That removes the back-and-forth rubber-banding while running/jumping forward.

## Hardening (from the review pass)
- Cap WebSocket frames at 16 KB and attach a **pre-auth error listener**, so an oversized first frame closes that one socket instead of crashing the process (without the listener `maxPayload` turns a memory-exhaustion vector into a one-frame remote crash).

## Testing
- `tests/chat.test.ts` — 13 cases: per-channel range, whisper routing + case handling, throttle, `tradeDone`, interpolation continuity. Full suite **141 passing**, `tsc` clean, client + server build.
- Live e2e against a real server + Postgres: `chat_e2e.mjs` 11/11 (channel ranges, whisper echo, error paths), `ws_security_e2e.mjs` (oversized-frame resilience), plus existing `mp_integration` 26/26 and `social_e2e` 10/10.
- Browser-verified (puppeteer): bubbles render over heads for say & yell, the remote player sees them, yell styling applies, and they expire.

The RL/headless action space doesn't include chat, so the throttle has no effect on training.