### PR TITLE
docs: fix Gravecaller typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Brother Aldric's storyline continues past *The Restless Dead*: **Whispers
 Below** (find the Gravecaller's sigil at the ruined chapel) → **The Binding
 Rite** (gather Blessed Tallow from the kobold dig and Ghostly Essence from
 the restless dead) → **Into the Hollow** (*suggested players: 5*) — kill
-Morthen the Gravecaaller at the bottom of the crypt beneath the chapel.
+Morthen the Gravecaller at the bottom of the crypt beneath the chapel.
 
 - The crypt door at the Fallen Chapel teleports your **party into its own
   private instance copy** (6 slots; instances reset after 5 minutes empty).


### PR DESCRIPTION
One-character fix: "Gravecaaller" → "Gravecaller" in the Hollow Crypt section.

(Also serves as a live open PR to verify the review UI — please leave open for a few minutes before merging.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)