### PR TITLE
feat: add Google Analytics (gtag.js) to the game page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,14 +6,18 @@
 <title>World of Claudecraft</title>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='13' font-size='13'>⚔️</text></svg>" />
 <link rel="preload" as="image" href="/loading-screen.jpg" />
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-BR5Z7GT7C2"></script>
+<!-- Google tag (gtag.js) — skipped on localhost so dev sessions don't pollute analytics -->
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-BR5Z7GT7C2');
+  if (!['localhost', '127.0.0.1', '[::1]'].includes(location.hostname)) {
+    const s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=G-BR5Z7GT7C2';
+    document.head.appendChild(s);
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function(){ dataLayer.push(arguments); };
+    gtag('js', new Date());
+    gtag('config', 'G-BR5Z7GT7C2');
+  }
 </script>
 <style>
   :root {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
 <title>World of Claudecraft</title>
 <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><text y='13' font-size='13'>⚔️</text></svg>" />
 <link rel="preload" as="image" href="/loading-screen.jpg" />
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-BR5Z7GT7C2"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-BR5Z7GT7C2');
+</script>
 <style>
   :root {
     --gold: #ffd100;


### PR DESCRIPTION
Adds the standard gtag.js snippet (measurement ID `G-BR5Z7GT7C2`) to the `<head>` of `index.html`, covering the start screen and the game.

Notes:
- Verified the server sets no Content-Security-Policy headers, so the googletagmanager.com script loads fine.
- Not added to `admin.html` (internal ops page — would pollute the data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)