### PR TITLE
docs: add the missing .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,29 @@
+# World of Claudecraft server configuration — copy to .env and edit:
+#   cp .env.example .env
+# The game server loads .env automatically; docker compose reads it too.
+
+# Postgres password for the eastbrook database (docker compose requires it).
+# Make it long and random for anything reachable from the internet.
+POSTGRES_PASSWORD=change-me
+
+# Connection string the game server uses. Only needed when running
+# `npm run server` outside docker — compose builds its own from
+# POSTGRES_PASSWORD. The dev database from `npm run db:up` listens on
+# 127.0.0.1:5433; keep this password in sync with POSTGRES_PASSWORD.
+DATABASE_URL=postgres://eastbrook:change-me@127.0.0.1:5433/eastbrook
+
+# HTTP + WebSocket port for the game server (default 8787).
+#PORT=8787
+
+# How many days of chat logs to keep (default 90; 0 = keep forever).
+#CHAT_LOG_RETENTION_DAYS=90
+
+# Comma-separated reverse-proxy IPs whose X-Forwarded-For header is trusted
+# when rate-limiting. Default trusts loopback + private ranges, which is
+# right for the compose + local reverse proxy setup; pin an explicit list
+# if your proxy connects from elsewhere.
+#TRUSTED_PROXY_IPS=
+
+# DANGER: enables the level/teleport/item cheat commands used by the test
+# bots (scripts/crypt_raid.mjs etc). Never set this on a public server.
+#ALLOW_DEV_COMMANDS=1

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ __pycache__/
 # environment / secrets
 .env
 .env.*
+!.env.example
 
 # editor & OS noise
 .DS_Store


### PR DESCRIPTION
The README's first instruction is `cp .env.example .env` and docker-compose errors with "See .env.example" — but the file was never in the repo. Turns out `.gitignore`'s `.env.*` pattern was ignoring `.env.example` itself, so it could never be committed.

This PR:
- adds `!.env.example` to .gitignore
- adds `.env.example` documenting every env var the server reads: `POSTGRES_PASSWORD`, `DATABASE_URL` (with the dev :5433 connection string), and optional `PORT`, `TRUSTED_PROXY_IPS` (from #3), `ALLOW_DEV_COMMANDS` (with a danger warning), and `CHAT_LOG_RETENTION_DAYS` (lands with #17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)