### PR TITLE
Block offensive account usernames

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -99,6 +99,9 @@ For off-box safety, sync the directory to S3 occasionally:
 
 - **Secrets**: the Postgres password is generated at first boot into
   `/opt/eastbrook/.env` (mode 600, gitignored). Nothing else to manage.
+- **Username bans**: set `USERNAME_BANLIST_FILE=/opt/eastbrook/username-banlist.txt`
+  to load blocked username terms from a private newline- or comma-separated
+  file. `USERNAME_BANLIST` can also provide a comma-separated inline list.
 - **Never** set `ALLOW_DEV_COMMANDS=1` in production — it enables the
   level/teleport cheats used by the test bots.
 - Health check: `curl -s localhost:8787/api/status` on the box returns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     environment:
       DATABASE_URL: postgres://eastbrook:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env. See .env.example.}@postgres:5432/eastbrook
       PORT: "8787"
+      USERNAME_BANLIST: ${USERNAME_BANLIST:-}
+      USERNAME_BANLIST_FILE: ${USERNAME_BANLIST_FILE:-}
     # loopback-only: the TLS reverse proxy (Caddy) is the public entrance
     ports:
       - "127.0.0.1:8787:8787"

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
 
 const SCRYPT_N = 16384, SCRYPT_R = 8, SCRYPT_P = 1, KEYLEN = 64;
@@ -29,8 +30,55 @@ export function newToken(): string {
   return randomBytes(32).toString('hex');
 }
 
+const CONFUSABLE_CHARS: Record<string, string> = {
+  '0': 'o',
+  '1': 'i',
+  '!': 'i',
+  '|': 'i',
+  '3': 'e',
+  '4': 'a',
+  '@': 'a',
+  '5': 's',
+  '$': 's',
+  '7': 't',
+  '+': 't',
+  '8': 'b',
+};
+
+function normalizedUsernameForCensorship(username: string): string {
+  return username
+    .toLowerCase()
+    .replace(/[0134578!|@$+]/g, (ch) => CONFUSABLE_CHARS[ch] ?? ch)
+    .replace(/[^a-z]/g, '');
+}
+
+function parseBanlist(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(/[\s,]+/)
+    .map((term) => normalizedUsernameForCensorship(term))
+    .filter((term) => term.length > 0);
+}
+
+function bannedUsernameTerms(): string[] {
+  const terms = parseBanlist(process.env.USERNAME_BANLIST);
+  const file = process.env.USERNAME_BANLIST_FILE;
+  if (!file) return terms;
+  try {
+    return terms.concat(parseBanlist(readFileSync(file, 'utf8')));
+  } catch (err) {
+    console.warn(`could not read USERNAME_BANLIST_FILE (${file}):`, err);
+    return terms;
+  }
+}
+
+export function offensiveUsername(u: unknown): boolean {
+  if (typeof u !== 'string') return false;
+  const normalized = normalizedUsernameForCensorship(u);
+  return bannedUsernameTerms().some((term) => normalized.includes(term));
+}
+
 export function validUsername(u: unknown): u is string {
-  return typeof u === 'string' && /^[A-Za-z0-9_]{3,24}$/.test(u);
+  return typeof u === 'string' && /^[A-Za-z0-9_]{3,24}$/.test(u) && !offensiveUsername(u);
 }
 
 export function validPassword(p: unknown): p is string {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,8 +1,11 @@
 import { EventEmitter } from 'node:events';
+import { rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
-import { validCharName } from '../server/auth';
+import { offensiveUsername, validCharName, validUsername } from '../server/auth';
 import { rateLimited, requestIp } from '../server/ratelimit';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
@@ -10,6 +13,23 @@ function fakeReq(headers: Record<string, string>, remoteAddress: string) {
   req.headers = headers;
   req.socket = { remoteAddress };
   return req;
+}
+
+function withUsernameBanlist(env: { inline?: string; file?: string }, test: () => void): void {
+  const prevInline = process.env.USERNAME_BANLIST;
+  const prevFile = process.env.USERNAME_BANLIST_FILE;
+  if (env.inline === undefined) delete process.env.USERNAME_BANLIST;
+  else process.env.USERNAME_BANLIST = env.inline;
+  if (env.file === undefined) delete process.env.USERNAME_BANLIST_FILE;
+  else process.env.USERNAME_BANLIST_FILE = env.file;
+  try {
+    test();
+  } finally {
+    if (prevInline === undefined) delete process.env.USERNAME_BANLIST;
+    else process.env.USERNAME_BANLIST = prevInline;
+    if (prevFile === undefined) delete process.env.USERNAME_BANLIST_FILE;
+    else process.env.USERNAME_BANLIST_FILE = prevFile;
+  }
 }
 
 describe('websocket authentication', () => {
@@ -108,5 +128,39 @@ describe('gm privilege boundaries', () => {
     const pid = target.addPlayer('warrior', 'Tester', { state });
 
     expect(target.entities.get(pid)?.gm).not.toBe(true);
+  });
+});
+
+describe('username censorship', () => {
+  it('allows normal account usernames that meet the shape rules', () => {
+    withUsernameBanlist({ inline: 'blockedterm' }, () => {
+      expect(validUsername('Eastbrook_123')).toBe(true);
+    });
+  });
+
+  it('rejects configured banned terms in new account usernames', () => {
+    withUsernameBanlist({ inline: 'blockedterm' }, () => {
+      expect(validUsername('blockedterm')).toBe(false);
+      expect(validUsername('xBLOCKEDTERMx')).toBe(false);
+    });
+  });
+
+  it('normalizes obvious separators and leetspeak before checking usernames', () => {
+    withUsernameBanlist({ inline: 'biga' }, () => {
+      expect(offensiveUsername('b_1_g_4')).toBe(true);
+      expect(validUsername('b_1_g_4')).toBe(false);
+    });
+  });
+
+  it('can load banned username terms from a configured file', () => {
+    const file = join(tmpdir(), `woc-banlist-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`);
+    writeFileSync(file, 'forbidden\n');
+    try {
+      withUsernameBanlist({ file }, () => {
+        expect(validUsername('forbidden')).toBe(false);
+      });
+    } finally {
+      rmSync(file, { force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- reject offensive account usernames using configurable banned terms instead of a hardcoded list
- support USERNAME_BANLIST and USERNAME_BANLIST_FILE, with simple leetspeak/separator normalization before matching
- pass the optional env settings through Docker Compose and document the private banlist file option
- add security tests covering allowed names, inline env bans, file-backed bans, and normalized variants

## Testing
- npm test -- tests/security.test.ts
- npm test