### PR TITLE
fix: malformed websocket frame crashed the whole server

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -269,6 +269,10 @@ export class GameServer {
   }
 
   private dispatchMessage(session: ClientSession, msg: any): void {
+    // JSON.parse returns null / numbers / strings / arrays for valid JSON that
+    // isn't an object — `null` in particular threw on `msg.t`. Drop anything
+    // that isn't a plain object before touching its fields.
+    if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) return;
     const sim = this.sim;
     const pid = session.pid;
     if (msg.t === 'input') {

--- a/server/main.ts
+++ b/server/main.ts
@@ -296,6 +296,18 @@ async function main(): Promise<void> {
   };
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
+
+  // Last-resort net: one player's request must never crash the process and
+  // disconnect everyone. handleMessage already guards itself, but any future
+  // uncaught throw in a timer or async path would otherwise be fatal. Log and
+  // keep serving — a live world staying up beats a clean crash-loop. Genuinely
+  // fatal startup errors are still handled by main().catch() below.
+  process.on('uncaughtException', (err) => {
+    console.error('uncaughtException (kept alive):', err);
+  });
+  process.on('unhandledRejection', (reason) => {
+    console.error('unhandledRejection (kept alive):', reason);
+  });
 }
 
 main().catch((err) => {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -92,6 +92,40 @@ describe('rate-limit client IP selection', () => {
   });
 });
 
+describe('malformed websocket frames cannot crash the server', () => {
+  // Mirrors the guard in GameServer.dispatchMessage. Regression for the outage
+  // where a WS frame containing the literal `null` reached `msg.t`: JSON.parse
+  // returns null for valid-but-non-object JSON (also numbers/strings/arrays),
+  // and `null.t` threw an uncaught TypeError that killed the whole process,
+  // disconnecting every player.
+  function parseFrame(raw: string): Record<string, unknown> | null {
+    let msg: any;
+    try {
+      msg = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) return null;
+    return msg;
+  }
+
+  it('rejects null / primitives / arrays / unparseable frames', () => {
+    for (const raw of ['null', 'false', '0', '"hello"', '[1,2,3]', '{bad', '']) {
+      expect(parseFrame(raw)).toBeNull();
+    }
+  });
+
+  it('reading .t on every rejected frame never throws', () => {
+    for (const raw of ['null', 'false', '0', '"hello"', '[1,2,3]', '{bad', '']) {
+      expect(() => parseFrame(raw)?.t).not.toThrow();
+    }
+  });
+
+  it('still accepts a well-formed object frame', () => {
+    expect(parseFrame(JSON.stringify({ t: 'input', mi: { f: 1 } }))).toEqual({ t: 'input', mi: { f: 1 } });
+  });
+});
+
 describe('gm privilege boundaries', () => {
   it('normal character names cannot create reserved GM-style names', () => {
     expect(validCharName('GM01')).toBe(false);


### PR DESCRIPTION
## Outage
A WebSocket frame containing the literal `null` took the entire game server down, crash-looping it and disconnecting all ~90 players. `JSON.parse('null')` returns `null` (valid JSON, no throw), then `msg.t` threw `TypeError: Cannot read properties of null` — uncaught, fatal to the process.

It surfaced at peak and looked like a capacity wall, but the box was at **load 0.02** while crash-looping — it's a deterministic null-deref, not load.

## Fix (defense in depth)
- `dispatchMessage` drops any non-object payload (null/number/string/array) before reading fields
- process-level `uncaughtException`/`unhandledRejection` nets — `main`'s existing per-message try/catch only covers `handleMessage`; an uncaught throw in a timer or async path could still kill everyone
- regression test covering null / primitive / array / garbage frames

## Test plan
- [x] full suite green (156) + `tsc` clean (validated against the equivalent change in the working tree)
- [ ] post-deploy: confirm the server ignores a `null` frame instead of crashing (live check)

🚨 Deploying immediately — active outage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)