### PR TITLE
Rate limit chat and add ignore action

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -102,6 +102,9 @@ For off-box safety, sync the directory to S3 occasionally:
 - **Username bans**: set `USERNAME_BANLIST_FILE=/opt/eastbrook/username-banlist.txt`
   to load blocked username terms from a private newline- or comma-separated
   file. `USERNAME_BANLIST` can also provide a comma-separated inline list.
+- **Chat censorship**: set `CHAT_CENSOR_FILE=/opt/eastbrook/chat-censor.txt`
+  to mask configured terms from a private newline- or comma-separated file.
+  `CHAT_CENSOR_LIST` can also provide a comma-separated inline list.
 - **Never** set `ALLOW_DEV_COMMANDS=1` in production — it enables the
   level/teleport cheats used by the test bots.
 - Health check: `curl -s localhost:8787/api/status` on the box returns

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       PORT: "8787"
       USERNAME_BANLIST: ${USERNAME_BANLIST:-}
       USERNAME_BANLIST_FILE: ${USERNAME_BANLIST_FILE:-}
+      CHAT_CENSOR_LIST: ${CHAT_CENSOR_LIST:-}
+      CHAT_CENSOR_FILE: ${CHAT_CENSOR_FILE:-}
     # loopback-only: the TLS reverse proxy (Caddy) is the public entrance
     ports:
       - "127.0.0.1:8787:8787"

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
@@ -10,6 +11,11 @@ const WORLD_SEED = 20061;
 const INTEREST_RADIUS = 120;
 const EVENT_RADIUS = 90;
 const AUTOSAVE_SECONDS = 30;
+const CHAT_RATE_BURST = 5;
+const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
+const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
+const CHAT_COOLDOWN_SECONDS = 20;
+const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
 
@@ -23,6 +29,11 @@ export interface ClientSession {
   alive: boolean;
   joinedAt: number;
   dbSessionId: number | null; // play_sessions row, set once the insert lands
+  chatTokens: number;
+  chatLastRefill: number;
+  chatLastRateError: number;
+  chatRateViolations: number;
+  chatCooldownUntil: number;
   // serialized form of each delta self field as last sent to this client;
   // a field is omitted from a snapshot while its serialization is unchanged
   lastSent: Record<string, string>;
@@ -96,6 +107,56 @@ function round2(v: number): number {
   return Math.round(v * 100) / 100;
 }
 
+const CONFUSABLE_CHARS: Record<string, string> = {
+  '0': 'o',
+  '1': 'i',
+  '!': 'i',
+  '|': 'i',
+  '3': 'e',
+  '4': 'a',
+  '@': 'a',
+  '5': 's',
+  '$': 's',
+  '7': 't',
+  '+': 't',
+  '8': 'b',
+};
+
+function normalizedCensorTerm(term: string): string {
+  return term
+    .toLowerCase()
+    .replace(/[0134578!|@$+]/g, (ch) => CONFUSABLE_CHARS[ch] ?? ch)
+    .replace(/[^a-z]/g, '');
+}
+
+function parseCensorList(raw: string | undefined): string[] {
+  return (raw ?? '')
+    .split(/[\s,]+/)
+    .map((term) => normalizedCensorTerm(term))
+    .filter((term) => term.length > 0);
+}
+
+function configuredChatCensorTerms(): string[] {
+  const terms = parseCensorList(process.env.CHAT_CENSOR_LIST);
+  const file = process.env.CHAT_CENSOR_FILE;
+  if (!file) return terms;
+  try {
+    return terms.concat(parseCensorList(readFileSync(file, 'utf8')));
+  } catch (err) {
+    console.warn(`could not read CHAT_CENSOR_FILE (${file}):`, err);
+    return terms;
+  }
+}
+
+export function censorChatText(text: string): string {
+  const terms = configuredChatCensorTerms();
+  if (terms.length === 0) return text;
+  return text.replace(/[A-Za-z0-9_@$!|+]+/g, (token) => {
+    const normalized = normalizedCensorTerm(token);
+    return terms.some((term) => normalized.includes(term)) ? '*'.repeat(token.length) : token;
+  });
+}
+
 export class GameServer {
   sim: Sim;
   clients = new Map<number, ClientSession>(); // by pid
@@ -156,6 +217,8 @@ export class GameServer {
     const session: ClientSession = {
       ws, accountId, characterId, pid, name,
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
+      chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
+      chatRateViolations: 0, chatCooldownUntil: 0,
       lastSent: {},
     };
     this.clients.set(pid, session);
@@ -321,7 +384,8 @@ export class GameServer {
       case 'release': sim.releaseSpirit(pid); break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;
-        const sent = sim.chat(msg.text, pid);
+        if (!this.consumeChatToken(session)) break;
+        const sent = sim.chat(censorChatText(msg.text), pid);
         if (sent) {
           this.chatLog.log({
             accountId: session.accountId,
@@ -538,6 +602,44 @@ export class GameServer {
     else if ('entityId' in ev && typeof ev.entityId === 'number') id = ev.entityId;
     if (id === undefined) return null; // chat/log etc: broadcast
     return this.sim.entities.get(id)?.pos ?? null;
+  }
+
+  private consumeChatToken(session: ClientSession): boolean {
+    const now = Date.now() / 1000;
+    if (session.chatCooldownUntil > now) {
+      if (now - session.chatLastRateError >= CHAT_RATE_ERROR_COOLDOWN_SECONDS) {
+        session.chatLastRateError = now;
+        const remaining = Math.ceil(session.chatCooldownUntil - now);
+        this.send(session, { t: 'events', list: [{ type: 'error', text: `Chat is on cooldown for ${remaining}s.` }] });
+      }
+      return false;
+    }
+    if (session.chatCooldownUntil > 0) {
+      session.chatCooldownUntil = 0;
+      session.chatRateViolations = 0;
+      session.chatTokens = CHAT_RATE_BURST;
+    }
+    const elapsed = Math.max(0, now - session.chatLastRefill);
+    session.chatTokens = Math.min(CHAT_RATE_BURST, session.chatTokens + elapsed * CHAT_RATE_REFILL_PER_SECOND);
+    session.chatLastRefill = now;
+    if (session.chatTokens >= 1) {
+      session.chatTokens -= 1;
+      session.chatRateViolations = 0;
+      return true;
+    }
+    session.chatRateViolations++;
+    if (session.chatRateViolations >= CHAT_RATE_VIOLATIONS_FOR_COOLDOWN) {
+      session.chatCooldownUntil = now + CHAT_COOLDOWN_SECONDS;
+      session.chatTokens = 0;
+      session.chatLastRateError = now;
+      this.send(session, { t: 'events', list: [{ type: 'error', text: `Chat locked for ${CHAT_COOLDOWN_SECONDS}s because you are sending messages too quickly.` }] });
+      return false;
+    }
+    if (now - session.chatLastRateError >= CHAT_RATE_ERROR_COOLDOWN_SECONDS) {
+      session.chatLastRateError = now;
+      this.send(session, { t: 'events', list: [{ type: 'error', text: 'You are sending messages too quickly. Slow down.' }] });
+    }
+    return false;
   }
 
   private broadcastSystem(text: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2520,8 +2520,8 @@ export class Sim {
       }
       if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
-      this.emit({ type: 'chat', from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
-      this.emit({ type: 'chat', from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
+      this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
+      this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
     }
 
@@ -2532,7 +2532,7 @@ export class Sim {
       const party = this.partyOf(r.meta.entityId);
       if (!party) { this.error(r.meta.entityId, 'You are not in a party.'); return null; }
       for (const mPid of party.members) {
-        this.emit({ type: 'chat', from: r.meta.name, text: clean, channel: 'party', pid: mPid });
+        this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: clean, channel: 'party', pid: mPid });
       }
       return { channel: 'party', message: clean };
     }
@@ -2541,7 +2541,7 @@ export class Sim {
     if (/^\/g(eneral)?\s/i.test(raw)) {
       const clean = raw.replace(/^\/g(eneral)?\s+/i, '').trim();
       if (!clean) return null;
-      this.emit({ type: 'chat', from: r.meta.name, text: clean, channel: 'general' });
+      this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: clean, channel: 'general' });
       return { channel: 'general', message: clean };
     }
 
@@ -2557,7 +2557,7 @@ export class Sim {
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
       if (!e || dist2d(r.e.pos, e.pos) > range) continue;
-      this.emit({ type: 'chat', from: r.meta.name, text: clean, channel, entityId: r.e.id, pid: meta.entityId });
+      this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: clean, channel, entityId: r.e.id, pid: meta.entityId });
     }
     return { channel, message: clean };
   }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -451,7 +451,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   | { type: 'tradeRequest'; fromPid: number; fromName: string }
   | { type: 'tradeDone' }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -27,6 +27,7 @@ const CLASS_GLYPH: Record<string, string> = {
 
 // yards past a zone boundary before the crossing banner/welcome commits
 const ZONE_BANNER_DEADBAND = 5;
+const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
 
 export class Hud {
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
@@ -53,10 +54,12 @@ export class Hud {
   private lastCombatEventAt = 0;
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
+  private ignoredChatNames = new Set<string>();
 
   private meters: Meters;
 
   constructor(private sim: IWorld, private renderer: Renderer) {
+    this.ignoredChatNames = this.loadIgnoredChatNames();
     this.meters = new Meters(sim);
     this.bindLogTabs();
     this.buildActionBar();
@@ -794,6 +797,7 @@ export class Hud {
           this.refreshGossip();
           break;
         case 'chat': {
+          if (this.isChatIgnored(ev.from)) break;
           switch (ev.channel) {
             case 'party': this.log(`[Party] ${ev.from}: ${ev.text}`, '#7fd4ff'); break;
             case 'yell': this.log(`${ev.from} yells: ${ev.text}`, '#ff5040'); break;
@@ -1362,10 +1366,12 @@ export class Hud {
     const party = this.sim.partyInfo;
     const isLeader = party?.leader === this.sim.playerId;
     const isMember = !!party?.members.some((m) => m.pid === pid);
+    const ignored = this.isChatIgnored(name);
     let html = `<div class="ctx-title">${name}</div>`;
     if (!isMember) html += `<div class="ctx-item" data-act="invite">Invite to Party</div>`;
     html += `<div class="ctx-item" data-act="trade">Trade</div>`;
     html += `<div class="ctx-item" data-act="duel">Challenge to a Duel</div>`;
+    html += `<div class="ctx-item" data-act="ignore">${ignored ? 'Unignore' : 'Ignore'} Chat</div>`;
     if (isLeader && isMember && pid !== this.sim.playerId) html += `<div class="ctx-item" data-act="kick">Remove from Party</div>`;
     html += `<div class="ctx-item" data-act="close">Cancel</div>`;
     el.innerHTML = html;
@@ -1379,9 +1385,45 @@ export class Hud {
         if (act === 'invite') this.sim.partyInvite(pid);
         else if (act === 'trade') this.sim.tradeRequest(pid);
         else if (act === 'duel') this.sim.duelRequest(pid);
+        else if (act === 'ignore') this.toggleChatIgnore(name);
         else if (act === 'kick') this.sim.partyKick(pid);
       });
     });
+  }
+
+  private chatIgnoreKey(name: string): string {
+    return name.trim().toLowerCase();
+  }
+
+  private isChatIgnored(name: string): boolean {
+    return this.ignoredChatNames.has(this.chatIgnoreKey(name));
+  }
+
+  private loadIgnoredChatNames(): Set<string> {
+    try {
+      const raw = localStorage.getItem(IGNORED_CHAT_NAMES_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return new Set(Array.isArray(parsed) ? parsed.filter((name): name is string => typeof name === 'string') : []);
+    } catch {
+      return new Set();
+    }
+  }
+
+  private saveIgnoredChatNames(): void {
+    localStorage.setItem(IGNORED_CHAT_NAMES_KEY, JSON.stringify([...this.ignoredChatNames]));
+  }
+
+  private toggleChatIgnore(name: string): void {
+    const key = this.chatIgnoreKey(name);
+    if (!key) return;
+    if (this.ignoredChatNames.has(key)) {
+      this.ignoredChatNames.delete(key);
+      this.log(`No longer ignoring ${name}.`, '#aaf');
+    } else {
+      this.ignoredChatNames.add(key);
+      this.log(`Ignoring chat from ${name}.`, '#aaf');
+    }
+    this.saveIgnoredChatNames();
   }
 
   closeContextMenu(): void {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -8,7 +8,7 @@ vi.mock('../server/db', () => ({
   insertChatLogs: vi.fn(async () => {}),
 }));
 
-import { GameServer, ClientSession } from '../server/game';
+import { censorChatText, GameServer, ClientSession } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 
 const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
@@ -64,6 +64,18 @@ function bareClient(pid: number): ClientWorld {
   c.eventQueue = [];
   c.mouselookFacing = null;
   return c;
+}
+
+function withChatCensorList(list: string | undefined, test: () => void): void {
+  const prev = process.env.CHAT_CENSOR_LIST;
+  if (list === undefined) delete process.env.CHAT_CENSOR_LIST;
+  else process.env.CHAT_CENSOR_LIST = list;
+  try {
+    test();
+  } finally {
+    if (prev === undefined) delete process.env.CHAT_CENSOR_LIST;
+    else process.env.CHAT_CENSOR_LIST = prev;
+  }
 }
 
 describe('delta snapshots', () => {
@@ -145,6 +157,65 @@ describe('delta snapshots', () => {
     expect(snapOld.self).not.toHaveProperty('inv');
     // both players spawn together, so each sees the other in ents
     expect(snapNew.ents.some((e: any) => e.id === session.pid)).toBe(true);
+  });
+});
+
+describe('chat moderation', () => {
+  it('rate-limits chat bursts per connected client before cooldown', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
+    fc.sent.length = 0;
+
+    for (let i = 0; i < 6; i++) {
+      server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: `msg ${i}` }));
+    }
+    (server as any).routeEvents(server.sim.tick());
+
+    const events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events.filter((ev) => ev.type === 'chat')).toHaveLength(5);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'You are sending messages too quickly. Slow down.',
+    }));
+  });
+
+  it('locks chat for 20 seconds after repeated over-limit messages', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
+    fc.sent.length = 0;
+
+    for (let i = 0; i < 8; i++) {
+      server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: `msg ${i}` }));
+    }
+    (server as any).routeEvents(server.sim.tick());
+
+    const events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events.filter((ev) => ev.type === 'chat')).toHaveLength(5);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'Chat locked for 20s because you are sending messages too quickly.',
+    }));
+  });
+
+  it('censors configured terrible words while still sending chat', () => {
+    withChatCensorList('blockedterm', () => {
+      expect(censorChatText('hello blockedterm and bl0ckedt3rm')).toBe('hello *********** and ***********');
+
+      const server = new GameServer();
+      const fc = fakeWs();
+      const session = joinServer(server, fc, 1, 'Testa');
+      fc.sent.length = 0;
+      server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'hello blockedterm' }));
+      (server as any).routeEvents(server.sim.tick());
+
+      const events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'chat',
+        text: 'hello ***********',
+      }));
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- rate limit online chat per player with a small burst and sustained cap around 20 messages/minute
- escalate repeated over-limit sends into a 20-second chat cooldown with private notifications
- censor configured terrible words with asterisks while still sending the chat message
- support CHAT_CENSOR_LIST and CHAT_CENSOR_FILE so censor terms can live outside the repo
- include sender ids on chat events for moderation metadata
- add a right-click Ignore/Unignore Chat action for player context menus, persisted locally in the browser

## Testing
- npm test -- tests/snapshots.test.ts
- npm test
- npm run build