### PR TITLE
UI/UX improvements: XP bar placement, hotbar drag-and-drop, quest fixes, Charge rework

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,6 +147,9 @@
   #xpbar .label { position: absolute; inset: 0; font-size: 9px; color: #fff; text-align: center; line-height: 10px; text-shadow: 1px 1px 1px #000; opacity: 0; transition: opacity .15s; }
   #xpbar:hover .label { opacity: 1; }
   #actionbar-row { display: flex; align-items: flex-end; gap: 8px; }
+  /* xp bar stacks directly on the action bar; the taller side-button
+     column must not push it up (it used to float ~150px above the bar) */
+  #actionbar-stack { display: flex; flex-direction: column; }
   #actionbar { display: flex; gap: 4px; padding: 6px; }
   .action-btn { width: 46px; height: 46px; position: relative; border: 2px solid #4a3d1d; border-radius: 6px;
     background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); color: #fff; cursor: pointer;
@@ -164,6 +167,8 @@
   .action-btn.unusable .icon-label { filter: grayscale(1) brightness(0.5); }
   .action-btn.oor .icon-label { filter: brightness(0.55) saturate(0.4); }
   .action-btn.queued { border-color: #fff; box-shadow: 0 0 9px #ffd100cc, inset 0 1px 0 #ffffff18; }
+  .action-btn:not(.empty)[draggable="true"] { cursor: grab; }
+  .action-btn.drop-target { border-color: #7fd1ff; box-shadow: 0 0 8px #7fd1ff88; }
   #side-buttons { display: flex; flex-direction: column; gap: 4px; padding-bottom: 6px; }
   .micro-btn { width: 34px; height: 30px; border: 2px solid #4a3d1d; border-radius: 5px;
     background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); color: #d8c89a; cursor: pointer;
@@ -490,9 +495,11 @@
     <div id="quest-tracker"></div>
 
     <div id="bottom-bar">
-      <div id="xpbar"><div class="fill"></div><div class="ticks"></div><div class="label"></div></div>
       <div id="actionbar-row">
-        <div id="actionbar" class="panel"></div>
+        <div id="actionbar-stack">
+          <div id="xpbar"><div class="fill"></div><div class="ticks"></div><div class="label"></div></div>
+          <div id="actionbar" class="panel"></div>
+        </div>
         <div id="side-buttons">
           <button class="micro-btn" id="mm-char" title="Character Info">C<span class="keybind">c</span></button>
           <button class="micro-btn" id="mm-spell" title="Spellbook">S<span class="keybind">p</span></button>

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,15 +119,8 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   const input = new Input(canvas, {
     onTab: () => world.tabTarget(),
     // slot 0 (key 1) is Attack for every class — auto-attack without needing
-    // right-click; the remaining keys map onto the class kit shifted by one
-    onAbility: (slot) => {
-      if (slot === 0) {
-        if (world.player.autoAttack) world.stopAutoAttack();
-        else world.startAutoAttack();
-      } else {
-        world.castAbilityBySlot(slot - 1);
-      }
-    },
+    // right-click; keys and clicks share the Hud's remappable slot layout
+    onAbility: (slot) => hud.castSlot(slot),
     onUiKey: (key) => {
       switch (key) {
         case 'interact': interactKey(); break;
@@ -245,6 +238,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     net.setMouselookFacing(mouselook ? input.camYaw : null);
     net.pendingFacingDelta = 0; // superseded by the interpolated follow below
     hud.handleEvents(net.drainEvents());
+    if (net.consumeInventoryChanged()) hud.onInventoryChanged();
     const alpha = net.lastSnapAt > 0
       ? Math.min(1.25, (performance.now() - net.lastSnapAt) / Math.max(20, net.snapInterval))
       : 1;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -102,6 +102,7 @@ function blankEntity(id: number): Entity {
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1,
+    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     spawnPos: { x: 0, y: 0, z: 0 }, wanderTarget: null, wanderTimer: 0,
@@ -136,6 +137,9 @@ export class ClientWorld implements IWorld {
 
   private ws: WebSocket;
   private eventQueue: SimEvent[] = [];
+  // inventory deltas arrive in snapshots, separate from the event frames the
+  // HUD redraws on — the frame loop polls this so open panels re-render
+  private invChanged = false;
   private mouselookFacing: number | null = null;
   private sendTimer: number | undefined;
 
@@ -335,7 +339,7 @@ export class ClientWorld implements IWorld {
         : null;
       this.xp = s.xp ?? 0;
       this.copper = s.copper ?? 0;
-      if (s.inv !== undefined) this.inventory = s.inv;
+      if (s.inv !== undefined) { this.inventory = s.inv; this.invChanged = true; }
       if (s.equip !== undefined) this.equipment = s.equip;
       if (s.qlog !== undefined) this.questLog = new Map((s.qlog as QuestProgress[]).map((q) => [q.questId, q]));
       if (s.qdone !== undefined) this.questsDone = new Set(s.qdone);
@@ -364,6 +368,12 @@ export class ClientWorld implements IWorld {
 
   questState(questId: string): QuestState {
     return computeQuestState(questId, this.questLog, this.questsDone, this.player.level);
+  }
+
+  consumeInventoryChanged(): boolean {
+    const v = this.invChanged;
+    this.invChanged = false;
+    return v;
   }
 
   castAbility(abilityId: string): void {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3,7 +3,7 @@ import { Entity, SimEvent } from '../sim/types';
 import type { IWorld } from '../world_api';
 import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import {
-  MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST,
+  MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
   instanceOrigin, INSTANCE_SLOT_COUNT,
 } from '../sim/data';
 import type { BiomeId } from '../sim/types';
@@ -1018,11 +1018,15 @@ export class Renderer {
         v.hpBar.style.display = 'none';
         let marker = '';
         let cls = '';
+        // role-aware: '!' only at the quest's giver, '?' only at its turn-in
+        // NPC (gray while in progress), matching the gossip dialog
         for (const qid of e.questIds) {
+          const quest = QUESTS[qid];
+          if (!quest) continue;
           const st = sim.questState(qid);
-          if (st === 'ready') { marker = '?'; cls = 'ready'; break; }
-          if (st === 'available') { marker = '!'; cls = 'avail'; }
-          else if (st === 'active' && !marker) { marker = '?'; cls = 'active'; }
+          if (st === 'ready' && quest.turnInNpcId === e.templateId) { marker = '?'; cls = 'ready'; break; }
+          if (st === 'available' && quest.giverNpcId === e.templateId) { marker = '!'; cls = 'avail'; }
+          else if (st === 'active' && quest.turnInNpcId === e.templateId && !marker) { marker = '?'; cls = 'active'; }
         }
         v.markerEl.textContent = marker;
         v.markerEl.className = 'np-marker ' + cls;

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -347,7 +347,7 @@ export const ZONE1_QUESTS: Record<string, QuestDef> = {
     id: 'q_gravecallers_trail', name: "The Gravecaller's Trail",
     giverNpcId: 'brother_aldric', turnInNpcId: 'brother_aldric',
     text: 'Morthen is dead, yet a question gnaws at me: a sect that hid for a century does not spend itself on one village chapel. He kept a grimoire — his rites, his correspondence. If anything of it survives, it lies in the vestry of the ruined chapel above the crypt. Search the ruin and bring me whatever remains of his writings, $N.',
-    completionText: 'Morthen wrote to a \'Mistcaller\' in the southern fen. The sect is not dead, $N — it has merely been patient.',
+    completionText: 'Morthen wrote to a \'Mistcaller\' in the northern fen. The sect is not dead, $N — it has merely been patient.',
     objectives: [{ type: 'collect', itemId: 'morthen_grimoire', count: 1, label: "Morthen's Grimoire" }],
     xpReward: 900, copperReward: 400, itemRewards: {},
     requiresQuest: 'q_hollow',

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -1,5 +1,5 @@
 // Zone 2 — Mirefen Marsh (levels 6-13). Brother Aldric follows the
-// Gravecaller trail south of the causeway: drowned dead rise from the fen,
+// Gravecaller trail north of the causeway: drowned dead rise from the fen,
 // trolls dig into barrow-mounds, and Vael the Mistcaller waits in the
 // Sunken Bastion.
 
@@ -216,7 +216,7 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
   q_fenbridge_muster: {
     id: 'q_fenbridge_muster', name: 'Muster at Fenbridge',
     giverNpcId: 'brother_aldric', turnInNpcId: 'warden_fenwick',
-    text: "Morthen's writings named a master in the southern marsh — a 'Mistcaller.' Now Warden Fenwick has sounded the muster horn at Fenbridge, and I do not believe in coincidence, $N. Take the causeway south, pull the muster order from the gatepost, and present it to the Warden.",
+    text: "Morthen's writings named a master in the northern marsh — a 'Mistcaller.' Now Warden Fenwick has sounded the muster horn at Fenbridge, and I do not believe in coincidence, $N. Take the causeway north, pull the muster order from the gatepost, and present it to the Warden.",
     completionText: "Aldric's seal, is it? Then you'll do. The fen has been swallowing my patrols whole, and I need every blade that floats.",
     objectives: [{ type: 'collect', itemId: 'fen_muster_order', count: 1, label: 'Fenbridge Muster Order' }],
     xpReward: 300, copperReward: 200, itemRewards: {},
@@ -310,7 +310,7 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
   q_drowned_censers: {
     id: 'q_drowned_censers', name: 'Censers from the Deep',
     giverNpcId: 'brother_aldric_fen', turnInNpcId: 'brother_aldric_fen',
-    text: 'South of the widow lake stands a chapel that drowned with its congregation when the marsh rose. The dead there carry rusted censers — funerary ones, the kind swung at a Gravecaller rite. Gather 4 from the chapel yard and I will read what rite was sung over that water.',
+    text: 'North of the widow lake stands a chapel that drowned with its congregation when the marsh rose. The dead there carry rusted censers — funerary ones, the kind swung at a Gravecaller rite. Gather 4 from the chapel yard and I will read what rite was sung over that water.',
     completionText: "As I feared. These censers burned grave-ash, not incense. Someone consecrated that chapel to the drowning — and the rite is signed 'Voss.'",
     objectives: [{ type: 'collect', itemId: 'rusted_censer', count: 4, label: 'Rusted Censer' }],
     xpReward: 1300, copperReward: 500, itemRewards: {},
@@ -358,7 +358,7 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
   q_cult_camp: {
     id: 'q_cult_camp', name: 'Robes in the Reeds',
     giverNpcId: 'scout_maren', turnInNpcId: 'scout_maren',
-    text: "There — south past the third lake, where the mist never lifts. Grey robes, grey banners: Gravecallers, camped in the open like they already own the fen. They have stopped hiding, $N, which means they think they have already won. Prove them wrong. Cut down 12 of their cultists.",
+    text: "There — north past the third lake, where the mist never lifts. Grey robes, grey banners: Gravecallers, camped in the open like they already own the fen. They have stopped hiding, $N, which means they think they have already won. Prove them wrong. Cut down 12 of their cultists.",
     completionText: 'Twelve robes face-down in the mud. Now they know the fen watches back.',
     objectives: [{ type: 'kill', targetMobId: 'gravecaller_cultist', count: 12, label: 'Gravecaller Cultist slain' }],
     xpReward: 1800, copperReward: 700, itemRewards: {},
@@ -379,7 +379,7 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
   q_deacon: {
     id: 'q_deacon', name: 'The Deacon of the Mire',
     giverNpcId: 'warden_fenwick', turnInNpcId: 'warden_fenwick',
-    text: 'So a deacon of the Gravecallers stands at the heart of that camp, singing my drowned wardens up out of the lakes to serve him. His hymn ends today. Take the camp road south, $N, and put Deacon Voss in the ground — deep enough that nobody sings HIM back up.',
+    text: 'So a deacon of the Gravecallers stands at the heart of that camp, singing my drowned wardens up out of the lakes to serve him. His hymn ends today. Take the camp road north, $N, and put Deacon Voss in the ground — deep enough that nobody sings HIM back up.',
     completionText: "Voss is dead and the mist over the camp is already thinning. You have broken their voice in the fen — now only the Bastion remains.",
     objectives: [{ type: 'kill', targetMobId: 'deacon_voss', count: 1, label: 'Deacon Voss slain' }],
     xpReward: 2200, copperReward: 1000,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -16,6 +16,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1,
+    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     spawnPos: { ...pos }, wanderTarget: null, wanderTimer: 0,

--- a/src/sim/pathfind.ts
+++ b/src/sim/pathfind.ts
@@ -1,0 +1,142 @@
+import { isBlocked } from './colliders';
+import { groundHeight } from './world';
+
+// Local A* over a 1-yard grid, used for short forced moves (warrior Charge).
+// The search window is the start/goal bounding box plus a margin, so cost
+// stays tiny (Charge range is ~25yd). Cells are blocked by static colliders,
+// deep water, and uphill steps too steep to climb; the caller supplies those
+// thresholds so they can't drift from the movement rules in sim.ts.
+
+export interface PathOpts {
+  seed: number;
+  bodyRadius: number;
+  maxClimbSlope: number; // rise/run above which an uphill step is a wall
+  minGround: number; // ground below this height is impassable (deep water)
+}
+
+const CELL = 1; // yards
+const MARGIN = 8; // yards of slack around the start/goal bounding box
+const MAX_SPAN = 64; // cells per axis; beyond this fall back to a straight line
+
+// Returns world-space waypoints from `from` to `to`, excluding the start and
+// ending exactly at `to`. Falls back to [to] (straight line) when the window
+// is too large, the goal is unreachable, or start and goal share a cell.
+export function findPath(
+  from: { x: number; z: number }, to: { x: number; z: number }, o: PathOpts,
+): { x: number; z: number }[] {
+  const minX = Math.min(from.x, to.x) - MARGIN;
+  const minZ = Math.min(from.z, to.z) - MARGIN;
+  const W = Math.ceil((Math.max(from.x, to.x) + MARGIN - minX) / CELL);
+  const H = Math.ceil((Math.max(from.z, to.z) + MARGIN - minZ) / CELL);
+  if (W > MAX_SPAN || H > MAX_SPAN) return [{ x: to.x, z: to.z }];
+  const cx = (gx: number) => minX + (gx + 0.5) * CELL;
+  const cz = (gz: number) => minZ + (gz + 0.5) * CELL;
+  const toCell = (x: number, z: number) => ({
+    gx: Math.min(W - 1, Math.max(0, Math.floor((x - minX) / CELL))),
+    gz: Math.min(H - 1, Math.max(0, Math.floor((z - minZ) / CELL))),
+  });
+  const start = toCell(from.x, from.z);
+  const goal = toCell(to.x, to.z);
+  const startIdx = start.gz * W + start.gx;
+  const goalIdx = goal.gz * W + goal.gx;
+  if (startIdx === goalIdx) return [{ x: to.x, z: to.z }];
+
+  // lazy per-cell caches: walkability and ground height
+  const walk = new Int8Array(W * H); // 0 unknown, 1 walkable, -1 blocked
+  const height = new Float64Array(W * H).fill(NaN);
+  const groundAt = (i: number): number => {
+    if (Number.isNaN(height[i])) height[i] = groundHeight(cx(i % W), cz((i / W) | 0), o.seed);
+    return height[i];
+  };
+  const walkable = (i: number): boolean => {
+    if (walk[i] === 0) {
+      // the start and goal cells are always traversable: the mover is already
+      // standing on one, and the slide in resolvePosition owns the last yard
+      const ok = i === startIdx || i === goalIdx
+        || (groundAt(i) >= o.minGround && !isBlocked(o.seed, cx(i % W), cz((i / W) | 0), o.bodyRadius));
+      walk[i] = ok ? 1 : -1;
+    }
+    return walk[i] === 1;
+  };
+
+  const gScore = new Float64Array(W * H).fill(Infinity);
+  const cameFrom = new Int32Array(W * H).fill(-1);
+  // binary min-heap of [fScore, idx]
+  const heap: number[][] = [];
+  const heapPush = (item: number[]) => {
+    heap.push(item);
+    let i = heap.length - 1;
+    while (i > 0) {
+      const par = (i - 1) >> 1;
+      if (heap[par][0] <= heap[i][0]) break;
+      [heap[par], heap[i]] = [heap[i], heap[par]];
+      i = par;
+    }
+  };
+  const heapPop = (): number[] => {
+    const top = heap[0];
+    const last = heap.pop()!;
+    if (heap.length > 0) {
+      heap[0] = last;
+      let i = 0;
+      for (;;) {
+        const l = i * 2 + 1, r = l + 1;
+        let m = i;
+        if (l < heap.length && heap[l][0] < heap[m][0]) m = l;
+        if (r < heap.length && heap[r][0] < heap[m][0]) m = r;
+        if (m === i) break;
+        [heap[m], heap[i]] = [heap[i], heap[m]];
+        i = m;
+      }
+    }
+    return top;
+  };
+  const octile = (gx: number, gz: number): number => {
+    const dx = Math.abs(gx - goal.gx), dz = Math.abs(gz - goal.gz);
+    return (Math.max(dx, dz) + (Math.SQRT2 - 1) * Math.min(dx, dz)) * CELL;
+  };
+
+  gScore[startIdx] = 0;
+  heapPush([octile(start.gx, start.gz), startIdx]);
+  let found = false;
+  while (heap.length > 0) {
+    const [, cur] = heapPop();
+    if (cur === goalIdx) { found = true; break; }
+    const gx = cur % W, gz = (cur / W) | 0;
+    const hCur = groundAt(cur);
+    for (let dz = -1; dz <= 1; dz++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        if (dx === 0 && dz === 0) continue;
+        const nx = gx + dx, nz = gz + dz;
+        if (nx < 0 || nx >= W || nz < 0 || nz >= H) continue;
+        const n = nz * W + nx;
+        if (!walkable(n)) continue;
+        // diagonals only when both orthogonal cells are clear (no corner clipping)
+        if (dx !== 0 && dz !== 0 && (!walkable(gz * W + nx) || !walkable(nz * W + gx))) continue;
+        const stepLen = (dx !== 0 && dz !== 0 ? Math.SQRT2 : 1) * CELL;
+        const rise = groundAt(n) - hCur;
+        if (rise > 0 && rise / stepLen > o.maxClimbSlope) continue;
+        const g = gScore[cur] + stepLen;
+        if (g < gScore[n]) {
+          gScore[n] = g;
+          cameFrom[n] = cur;
+          heapPush([g + octile(nx, nz), n]);
+        }
+      }
+    }
+  }
+  if (!found) return [{ x: to.x, z: to.z }];
+
+  // reconstruct, dropping collinear interior points
+  const cells: number[] = [];
+  for (let i = goalIdx; i !== -1; i = cameFrom[i]) cells.push(i);
+  cells.reverse();
+  const path: { x: number; z: number }[] = [];
+  for (let k = 1; k < cells.length - 1; k++) {
+    const dirIn = cells[k] - cells[k - 1];
+    const dirOut = cells[k + 1] - cells[k];
+    if (dirIn !== dirOut) path.push({ x: cx(cells[k] % W), z: cz((cells[k] / W) | 0) });
+  }
+  path.push({ x: to.x, z: to.z });
+  return path;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5,6 +5,7 @@ import {
   zoneAt,
 } from './data';
 import { resolvePosition } from './colliders';
+import { findPath } from './pathfind';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
 import { Rng } from './rng';
 import { SpatialGrid } from './spatial';
@@ -45,6 +46,9 @@ const SWIM_DEPTH = 0.8; // ground this far under the water line = deep water
 const SWIM_SPEED_MULT = 0.65;
 const DOOR_TRIGGER_RADIUS = 2.0; // walking this close to a dungeon door teleports you
 const BODY_RADIUS = 0.5;
+const CHARGE_SPEED_MULT = 3; // warrior charge runs at 3x normal speed
+const CHARGE_MAX_DURATION = 3; // seconds before a blocked charge gives up
+const CHARGE_ARRIVE_RANGE = MELEE_RANGE - 1; // stop inside melee range
 
 export interface Party {
   id: number;
@@ -639,7 +643,58 @@ export class Sim {
       && e.pos.y <= SWIM_SURFACE_Y + 0.15;
   }
 
+  private findChargePath(p: Entity, target: Entity): Vec3[] {
+    return findPath(p.pos, target.pos, {
+      seed: this.cfg.seed,
+      bodyRadius: BODY_RADIUS,
+      maxClimbSlope: MAX_CLIMB_SLOPE,
+      minGround: WATER_LEVEL - SWIM_DEPTH,
+    }).map((w) => ({ x: w.x, y: 0, z: w.z }));
+  }
+
+  // Charge in flight: forced movement toward the target along the pathfound
+  // route. Returns true while it owns the player's movement this tick.
+  private updateChargeMovement(p: Entity): boolean {
+    if (p.chargeTargetId === null) return false;
+    const target = this.entities.get(p.chargeTargetId);
+    p.chargeTimeLeft -= DT;
+    const done = (arrived: boolean): boolean => {
+      p.chargeTargetId = null;
+      p.chargePath = [];
+      if (target) p.facing = angleTo(p.pos, target.pos);
+      if (arrived) this.startAutoAttack(p.id);
+      return true;
+    };
+    if (!target || target.dead || p.chargeTimeLeft <= 0 || this.isRooted(p)) return done(false);
+    if (dist2d(p.pos, target.pos) <= CHARGE_ARRIVE_RANGE) return done(true);
+    if (p.sitting) this.standUp(p);
+    // re-route when the target has run well away from where the path ends
+    const pathEnd = p.chargePath[p.chargePath.length - 1];
+    if (!pathEnd || dist2d(pathEnd, target.pos) > 4) p.chargePath = this.findChargePath(p, target);
+    // steer at the next waypoint; the final leg homes on the live target
+    while (p.chargePath.length > 1 && dist2d(p.pos, p.chargePath[0]) < 1) p.chargePath.shift();
+    const wp = p.chargePath.length > 1 ? p.chargePath[0] : target.pos;
+    p.facing = angleTo(p.pos, wp);
+    const step = Math.min(RUN_SPEED * CHARGE_SPEED_MULT * DT, Math.max(0.01, dist2d(p.pos, wp)));
+    const nx = p.pos.x + Math.sin(p.facing) * step;
+    const nz = p.pos.z + Math.cos(p.facing) * step;
+    // deep water and cliffs end the charge early rather than dragging the player in
+    const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
+    const h1 = groundHeight(nx, nz, this.cfg.seed);
+    if (h1 < WATER_LEVEL - SWIM_DEPTH) return done(false);
+    if (h1 > h0 && (h1 - h0) / step > MAX_CLIMB_SLOPE) return done(false);
+    const resolved = resolvePosition(this.cfg.seed, nx, nz, BODY_RADIUS);
+    p.pos.x = resolved.x;
+    p.pos.z = resolved.z;
+    p.pos.y = groundHeight(resolved.x, resolved.z, this.cfg.seed);
+    p.vy = 0;
+    p.onGround = true;
+    p.fallStartY = p.pos.y;
+    return true;
+  }
+
   private updatePlayerMovement(p: Entity, meta: PlayerMeta): void {
+    if (this.updateChargeMovement(p)) return;
     const inp = meta.moveInput;
     // Convention: facing f points along (sin f, cos f); the camera sits behind
     // the player, so screen-right is the world vector (-cos f, sin f).
@@ -1349,15 +1404,13 @@ export class Sim {
         }
         case 'charge': {
           if (!target) break;
-          const ang = angleTo(target.pos, p.pos);
-          const nx = target.pos.x + Math.sin(ang) * 2.5;
-          const nz = target.pos.z + Math.cos(ang) * 2.5;
-          p.pos.x = nx; p.pos.z = nz;
-          p.pos.y = groundHeight(nx, nz, this.cfg.seed);
-          p.facing = angleTo(p.pos, target.pos);
+          // the stun effect in the same ability lands this tick; the player
+          // then runs the route at charge speed instead of teleporting
+          p.chargeTargetId = target.id;
+          p.chargeTimeLeft = CHARGE_MAX_DURATION;
+          p.chargePath = this.findChargePath(p, target);
           if (p.resourceType === 'rage') p.resource = Math.min(p.maxResource, p.resource + 9);
           this.enterCombat(p, target);
-          this.startAutoAttack(p.id);
           break;
         }
       }
@@ -1624,6 +1677,8 @@ export class Sim {
       e.eating = null;
       e.drinking = null;
       e.sitting = false;
+      e.chargeTargetId = null;
+      e.chargePath = [];
       this.emit({ type: 'playerDeath', pid: e.id });
       for (const m of this.entities.values()) {
         if (m.kind === 'mob' && !m.dead && m.aggroTargetId === e.id && m.aiState !== 'dead') {
@@ -2334,7 +2389,7 @@ export class Sim {
       }
     }
     for (const qid of npc.questIds) {
-      if (this.questState(qid, meta.entityId) === 'available') {
+      if (QUESTS[qid].giverNpcId === npc.templateId && this.questState(qid, meta.entityId) === 'available') {
         this.acceptQuest(qid, meta.entityId);
         return;
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -391,6 +391,10 @@ export interface Entity {
   comboPoints: number;
   comboTargetId: number | null;
   overpowerUntil: number; // sim-time until which overpower is usable
+  // warrior charge: forced run toward the target along a pathfound route
+  chargeTargetId: number | null;
+  chargeTimeLeft: number; // seconds; failsafe so a blocked charge can't run forever
+  chargePath: Vec3[]; // waypoints consumed front-to-back; last leg homes on the live target
   sitting: boolean;
   eating: Consuming | null;
   drinking: Consuming | null;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -30,7 +30,10 @@ const ZONE_BANNER_DEADBAND = 5;
 const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
 
 export class Hud {
+  private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
+  private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
+  private dragFromSlot: number | null = null;
   private chatLogEl = $('#chatlog');
   private combatLogEl = $('#combatlog');
   private errorEl = $('#error-msg');
@@ -62,6 +65,7 @@ export class Hud {
     this.ignoredChatNames = this.loadIgnoredChatNames();
     this.meters = new Meters(sim);
     this.bindLogTabs();
+    this.loadSlotMap();
     this.buildActionBar();
     this.buildXpTicks();
     $('#pf-name').textContent = sim.player.name;
@@ -217,6 +221,64 @@ export class Hud {
   // Action bar
   // -------------------------------------------------------------------------
 
+  // The hotbar layout is a client-side remap over the learned abilities,
+  // keyed by ability id (known is class-ordered and shifts on level-up, so
+  // indices would not survive). Persisted per class+character.
+  private slotMapKey(): string {
+    return `woc_hotbar_${this.sim.cfg.playerClass}_${this.sim.player.name}`;
+  }
+
+  private loadSlotMap(): void {
+    let arr: unknown = null;
+    try { arr = JSON.parse(localStorage.getItem(this.slotMapKey()) ?? 'null'); } catch { /* corrupt */ }
+    const seen = new Set<string>();
+    this.slotMap = Array.from({ length: Hud.BAR_ABILITY_SLOTS }, (_, i) => {
+      const v = Array.isArray(arr) ? arr[i] : null;
+      if (typeof v !== 'string' || !ABILITIES[v] || seen.has(v)) return null;
+      seen.add(v);
+      return v;
+    });
+  }
+
+  private saveSlotMap(): void {
+    try { localStorage.setItem(this.slotMapKey(), JSON.stringify(this.slotMap)); } catch { /* storage unavailable */ }
+  }
+
+  // Drop unlearned ids; place newly learned abilities in the first empty
+  // slot. With empty storage this reproduces the default class-order layout.
+  private syncSlotMap(): void {
+    const ids = new Set(this.sim.known.map((k) => k.def.id));
+    let dirty = false;
+    for (let i = 0; i < this.slotMap.length; i++) {
+      const id = this.slotMap[i];
+      if (id !== null && !ids.has(id)) { this.slotMap[i] = null; dirty = true; }
+    }
+    for (const k of this.sim.known) {
+      if (this.slotMap.includes(k.def.id)) continue;
+      const empty = this.slotMap.indexOf(null);
+      if (empty !== -1) { this.slotMap[empty] = k.def.id; dirty = true; }
+    }
+    if (dirty) this.saveSlotMap();
+  }
+
+  abilityForSlot(barSlot: number): ResolvedAbility | null { // barSlot 1..11
+    const id = this.slotMap[barSlot - 1];
+    return id ? this.sim.known.find((k) => k.def.id === id) ?? null : null;
+  }
+
+  // Shared entry point for hotbar clicks and the 1..0-= keybinds.
+  castSlot(barSlot: number): void {
+    if (barSlot === 0) {
+      if (this.sim.player.autoAttack) this.sim.stopAutoAttack();
+      else this.sim.startAutoAttack();
+      return;
+    }
+    const known = this.abilityForSlot(barSlot);
+    // cast by ability id: the server validates against its own known list,
+    // so the client-side slot remap never desyncs slot semantics
+    if (known) this.sim.castAbility(known.def.id);
+  }
+
   private buildActionBar(): void {
     const bar = $('#actionbar');
     const keybinds = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '='];
@@ -238,20 +300,49 @@ export class Hud {
       // without right-click need a way in); the kit fills slots 1+
       btn.addEventListener('click', () => {
         audio.click();
-        if (slot === 0) {
-          if (this.sim.player.autoAttack) this.sim.stopAutoAttack();
-          else this.sim.startAutoAttack();
-        } else {
-          this.sim.castAbilityBySlot(slot - 1);
-        }
+        this.castSlot(slot);
       });
       this.attachTooltip(btn, () => {
         if (slot === 0) {
           return '<div class="tt-title">Attack</div><div class="tt-sub">Toggle auto-attack on your target.<br>Right-clicking an enemy also attacks.</div>';
         }
-        const known = this.sim.known[slot - 1];
+        const known = this.abilityForSlot(slot);
         return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
       });
+      if (slot >= 1) {
+        // drag an ability onto another slot to swap the two keybinds;
+        // slot 0 (Attack) stays fixed
+        btn.draggable = true;
+        btn.addEventListener('dragstart', (e) => {
+          const known = this.abilityForSlot(slot);
+          if (!known) { e.preventDefault(); return; }
+          this.dragFromSlot = slot;
+          e.dataTransfer!.setData('text/plain', known.def.id);
+          e.dataTransfer!.effectAllowed = 'move';
+          this.hideTooltip();
+        });
+        btn.addEventListener('dragover', (e) => {
+          if (this.dragFromSlot === null || this.dragFromSlot === slot) return;
+          e.preventDefault(); // required to permit the drop
+          e.dataTransfer!.dropEffect = 'move';
+          btn.classList.add('drop-target');
+        });
+        btn.addEventListener('dragleave', () => btn.classList.remove('drop-target'));
+        btn.addEventListener('drop', (e) => {
+          e.preventDefault();
+          btn.classList.remove('drop-target');
+          const from = this.dragFromSlot;
+          this.dragFromSlot = null;
+          if (from === null || from === slot) return;
+          const a = from - 1, b = slot - 1;
+          [this.slotMap[a], this.slotMap[b]] = [this.slotMap[b], this.slotMap[a]]; // swap; empty target = move
+          this.saveSlotMap();
+        });
+        btn.addEventListener('dragend', () => {
+          this.dragFromSlot = null;
+          bar.querySelectorAll('.drop-target').forEach((el) => el.classList.remove('drop-target'));
+        });
+      }
       bar.appendChild(btn);
       this.abilityButtons.push({ btn, label, cdOverlay, cdText, lastIcon: '' });
     }
@@ -270,6 +361,7 @@ export class Hud {
     const sim = this.sim;
     const p = sim.player;
     this.meters.update();
+    this.syncSlotMap(); // picks up newly learned abilities mid-session
 
     // player frame
     $('#pf-level').textContent = String(p.level);
@@ -363,7 +455,7 @@ export class Hud {
         ab.btn.classList.toggle('oor', tgtDist !== null && tgtDist > MELEE_RANGE);
         continue;
       }
-      const known = sim.known[i - 1];
+      const known = this.abilityForSlot(i);
       if (!known) {
         ab.btn.classList.add('empty');
         if (ab.lastIcon !== '') {
@@ -555,8 +647,8 @@ export class Hud {
       const mx = S / 2 + dx, my = S / 2 + dz;
       if ((mx - S / 2) ** 2 + (my - S / 2) ** 2 > (S / 2 - 7) ** 2) continue;
       if (e.kind === 'npc') {
-        const hasAvail = e.questIds.some((q) => this.sim.questState(q) === 'available');
-        const hasReady = e.questIds.some((q) => this.sim.questState(q) === 'ready');
+        const hasAvail = e.questIds.some((q) => QUESTS[q].giverNpcId === e.templateId && this.sim.questState(q) === 'available');
+        const hasReady = e.questIds.some((q) => QUESTS[q].turnInNpcId === e.templateId && this.sim.questState(q) === 'ready');
         ctx.fillStyle = '#ffd100';
         ctx.font = 'bold 11px Georgia';
         ctx.fillText(hasReady ? '?' : hasAvail ? '!' : '•', mx - 2, my + 3);
@@ -677,8 +769,8 @@ export class Hud {
       if (e.kind !== 'npc') continue;
       if (e.pos.z < zone.zMin || e.pos.z >= zone.zMax) continue;
       const { mx, my } = toMap(e.pos.x, e.pos.z);
-      const hasAvail = e.questIds.some((q) => this.sim.questState(q) === 'available');
-      const hasReady = e.questIds.some((q) => this.sim.questState(q) === 'ready');
+      const hasAvail = e.questIds.some((q) => QUESTS[q].giverNpcId === e.templateId && this.sim.questState(q) === 'available');
+      const hasReady = e.questIds.some((q) => QUESTS[q].turnInNpcId === e.templateId && this.sim.questState(q) === 'ready');
       if (hasAvail || hasReady) {
         ctx.fillStyle = '#ffd100';
         ctx.font = 'bold 15px Georgia';
@@ -943,13 +1035,19 @@ export class Hud {
     this.openGossipNpcId = npc.id;
     const el = $('#quest-dialog');
     const def = NPCS[npc.templateId];
-    const interesting = npc.questIds.filter((q) => ['available', 'active', 'ready'].includes(this.sim.questState(q)));
+    // accepted-but-unfinished quests are tracked in the quest log; the NPC
+    // only offers new quests (at the giver) and turn-ins (at the turn-in NPC)
+    const interesting = npc.questIds.filter((q) => {
+      const st = this.sim.questState(q);
+      return (st === 'available' && QUESTS[q].giverNpcId === npc.templateId)
+        || (st === 'ready' && QUESTS[q].turnInNpcId === npc.templateId);
+    });
     let html = `<div class="panel-title"><span>${npc.name}<span style="color:#998d6a;font-size:11px"> &lt;${def?.title ?? ''}&gt;</span></span><span class="x-btn" data-close>✕</span></div>`;
     html += `<div class="qd-text">"${(def?.greeting ?? 'Greetings.').replace('$C', CLASSES[this.sim.cfg.playerClass].name.toLowerCase())}"</div>`;
     if (interesting.length > 0) {
       for (const qid of interesting) {
         const st = this.sim.questState(qid);
-        const icon = st === 'ready' ? '<span class="gold">?</span> ' : st === 'available' ? '<span class="gold">!</span> ' : '<span style="color:#999">…</span> ';
+        const icon = st === 'ready' ? '<span class="gold">?</span> ' : '<span class="gold">!</span> ';
         html += `<div class="qd-list-item" data-quest="${qid}">${icon}${QUESTS[qid].name}</div>`;
       }
     }
@@ -1131,6 +1229,12 @@ export class Hud {
     this.renderBags();
     el.style.display = 'block';
     audio.bagOpen();
+  }
+
+  // Called when an authoritative inventory delta lands (online snapshots
+  // carry inventory separately from the event frames that normally redraw).
+  onInventoryChanged(): void {
+    if ($('#bags').style.display === 'block') this.renderBags();
   }
 
   renderBags(): void {

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { Entity, dist2d } from '../src/sim/types';
-import { CRYPT_DOOR_POS, DUNGEON_X_THRESHOLD, LAKE, MOBS } from '../src/sim/data';
+import { CRYPT_DOOR_POS, DUNGEON_X_THRESHOLD, LAKE, MOBS, NPCS, QUESTS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { groundHeight, WATER_LEVEL } from '../src/sim/world';
 import { isBlocked, resolvePosition } from '../src/sim/colliders';
@@ -244,6 +244,79 @@ describe('boss loot and encounter resets', () => {
     sim.sellItem('wolf_fang');
     expect(sim.countItem('wolf_fang')).toBe(1);
     expect(sim.copper).toBe(copperBefore);
+  });
+});
+
+describe('quest npc roles', () => {
+  it('every quest is listed in the questIds of its giver and turn-in NPCs', () => {
+    // the gossip dialog and markers filter by role, so a quest whose giver
+    // does not list it would be unobtainable
+    for (const quest of Object.values(QUESTS)) {
+      expect(NPCS[quest.giverNpcId]?.questIds, `${quest.id} giver ${quest.giverNpcId}`).toContain(quest.id);
+      expect(NPCS[quest.turnInNpcId]?.questIds, `${quest.id} turn-in ${quest.turnInNpcId}`).toContain(quest.id);
+    }
+  });
+
+  it('interacting with the turn-in NPC does not auto-accept an available quest', () => {
+    const sim = makeSim();
+    (sim as any).grantXp(99999); // well past minLevel 6 for q_fenbridge_muster
+    expect(sim.questState('q_fenbridge_muster')).toBe('available');
+    const warden = [...sim.entities.values()].find((e) => e.templateId === 'warden_fenwick')!;
+    teleportTo(sim, warden.pos.x + 2, warden.pos.z);
+    sim.talkToNpc(warden.id);
+    expect(sim.questState('q_fenbridge_muster')).toBe('available');
+    const aldric = [...sim.entities.values()].find((e) => e.templateId === 'brother_aldric')!;
+    teleportTo(sim, aldric.pos.x + 2, aldric.pos.z);
+    // talkToNpc accepts one available quest per interaction and aldric
+    // offers several — keep talking until the muster order is taken
+    for (let i = 0; i < 10 && sim.questState('q_fenbridge_muster') !== 'active'; i++) sim.talkToNpc(aldric.id);
+    expect(sim.questState('q_fenbridge_muster')).toBe('active');
+  });
+});
+
+describe('warrior charge', () => {
+  function chargeSetup() {
+    const sim = makeSim();
+    (sim as any).grantXp(99999); // learn charge (level 4)
+    const p = sim.player;
+    const wolf = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'forest_wolf' && !e.dead)!;
+    teleportTo(sim, wolf.pos.x - 18, wolf.pos.z);
+    p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
+    sim.targetEntity(wolf.id);
+    return { sim, p, wolf };
+  }
+
+  it('stuns the target immediately and does not teleport', () => {
+    const { sim, p, wolf } = chargeSetup();
+    const before = dist2d(p.pos, wolf.pos);
+    sim.castAbility('charge');
+    expect(wolf.auras.some((a) => a.kind === 'stun')).toBe(true);
+    // still roughly where we started — the run happens over the next ticks
+    expect(dist2d(p.pos, wolf.pos)).toBeGreaterThan(before - 2);
+    expect(p.chargeTargetId).toBe(wolf.id);
+  });
+
+  it('runs to melee range at roughly 3x speed and starts attacking', () => {
+    const { sim, p, wolf } = chargeSetup();
+    sim.castAbility('charge');
+    const start = { ...p.pos };
+    // 10 ticks = 0.5s; at 21 yd/s a clear run covers ~10.5yd, far beyond
+    // the 3.5yd a normal run would manage
+    for (let i = 0; i < 10; i++) sim.tick();
+    expect(dist2d(start, p.pos)).toBeGreaterThan(7);
+    for (let i = 0; i < 50 && p.chargeTargetId !== null; i++) sim.tick();
+    expect(p.chargeTargetId).toBe(null);
+    expect(dist2d(p.pos, wolf.pos)).toBeLessThanOrEqual(5);
+    expect(p.autoAttack).toBe(true);
+  });
+
+  it('gives up cleanly when the target dies mid-charge', () => {
+    const { sim, p, wolf } = chargeSetup();
+    sim.castAbility('charge');
+    sim.tick();
+    wolf.dead = true;
+    sim.tick();
+    expect(p.chargeTargetId).toBe(null);
   });
 });
 


### PR DESCRIPTION
Six UI/UX improvements from a playtest session, aimed at making the game easier to read and interact with.

## Changes

### 1. XP bar sits directly above the action bar
The XP bar floated ~150px above the hotbar because `#actionbar-row`'s height is set by the ~206px-tall side-button column, and the bar sat above the whole row. It's now wrapped with the action bar in an `#actionbar-stack` column — 4px above the slots, edge-aligned (both are 612px), WoW-classic style.

### 2. Bags update immediately when selling to a vendor
The bag panel only re-rendered on *event* messages, but inventory data arrives in a separate *snapshot* message with no re-render hook — when a frame landed between the two, the bag UI stayed stale until reopened. Snapshot `inv` deltas now set a flag that the frame loop consumes to re-render the open bag panel. Also fixes the same staleness for loot, buys, and trades.

### 3. Quest dialogs and markers are role-aware
- NPC gossip no longer lists accepted-but-unfinished quests — only new quests (`!`) and turn-ins (`?`).
- All quest indicators (dialog, minimap, world map, nameplates) now check giver vs turn-in role, so a split-NPC quest can no longer show "Accept" at its turn-in NPC (where turning up at the wrong NPC produced a "Too far away." error).
- `talkToNpc` auto-accept gets the same giver check.
- New test asserts every quest is listed in the `questIds` of both its giver and turn-in NPC, so role filtering can't orphan content.

### 4. Hotbar drag-and-drop
Abilities can be dragged between hotbar slots to reassign keybinds (swap when the target is occupied; slot 1 Attack stays fixed). The layout is an ability-id-keyed map persisted to localStorage per class+character — newly learned abilities fill the first empty slot instead of shifting the layout (previously a mid-list unlock re-shuffled the bar). Casts now go by ability id, which the server already fully validates, so there are no protocol or server changes and the headless/RL slot semantics are untouched.

### 5. Corrected inverted compass directions in quest text
Verified against world coordinates (+z is north; Eastbrook z=0, Fenbridge z=300): the Fenbridge muster quest now says "northern marsh / take the causeway north", and the preceding quest's "southern fen" is fixed. The same inverted-compass slip affected three more Mirefen strings (the Drowned Chapel is north of the widow lake, the cult camp is north of the third lake, and the camp road runs north) — all corrected, and directions that were already right (e.g. "south spans" of the causeway as seen from Fenbridge) are untouched.

### 6. Warrior Charge: stun + run instead of teleport
Charge no longer teleports the player. The 1s stun still lands instantly at cast; the player then runs to the target at 3x run speed along a pathfound route (new `src/sim/pathfind.ts`: a local A* over a 1-yard grid bounded to the charge area, reusing the existing collider/water/cliff rules — the codebase previously had no pathfinding). The charge re-routes if the target flees, slides off obstacles, refuses deep water and cliffs, times out after 3s, and starts auto-attack on arrival. It lives in the shared sim, so it's server-authoritative in multiplayer with no netcode changes.

## Testing
- 182/182 tests pass, including new coverage: charge stuns immediately without teleporting, covers ground at ~3x run speed and lands in melee with auto-attack, cancels cleanly if the target dies; turn-in NPCs don't auto-accept; quest/NPC content invariant.
- Verified in headless Chrome against the dev server: XP bar geometry (4px above the action bar, edge-aligned), and a simulated drag swapped two hotbar slots and persisted the layout, with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)