### PR TITLE
Fix walk-animation jitter with locomotion-state hysteresis

### DIFF
--- a/src/render/locomotion.ts
+++ b/src/render/locomotion.ts
@@ -1,0 +1,66 @@
+// Locomotion-state derivation for the character animation state machine,
+// factored out of the renderer so it can be reasoned about and tested without
+// a WebGL context. Render-space speed is sampled per frame and is noisy:
+// frame-time jitter, snapshot interpolation stalls, and vertical bob over
+// uneven terrain all make a steadily-walking entity momentarily read as
+// stopped. Without leeway that single-frame dip flips the anim state to idle
+// and resets the walk clip the next frame — visible leg jitter. So we enter
+// the moving state above a low speed, latch it for a grace window after speed
+// dips, smooth the cadence-driving speed, and hold the travel direction.
+
+export const MOVE_ENTER_SPEED = 0.4; // u/s above which an entity is "moving"
+export const MOVE_HOLD_TIME = 0.22; // s to keep "moving" latched after speed dips
+export const SPEED_SMOOTH_RATE = 12; // EMA rate for the cadence-driving speed
+const TELEPORT_SPEED = 25; // u/s above this is a snap, not locomotion
+
+/** Per-entity hysteresis state; the renderer keeps one of these per view. */
+export interface LocoTrack {
+  moveHold: number;
+  smoothSpeed: number;
+  movingBackwards: boolean;
+}
+
+export interface LocoState {
+  speed: number; // smoothed, for footstep cadence matching
+  moving: boolean;
+  backwards: boolean;
+}
+
+export function newLocoTrack(): LocoTrack {
+  return { moveHold: 0, smoothSpeed: 0, movingBackwards: false };
+}
+
+/**
+ * Advance the locomotion hysteresis by one frame.
+ * @param t      per-entity track (mutated in place)
+ * @param vx,vz  render-space horizontal displacement since last frame
+ * @param facing entity facing (radians, 0 = +Z) for backpedal detection
+ * @param dt     frame delta in seconds
+ */
+export function updateLocomotion(
+  t: LocoTrack, vx: number, vz: number, facing: number, dt: number,
+): LocoState {
+  const dist = Math.hypot(vx, vz);
+  let speed = dist / Math.max(dt, 1e-4);
+  if (speed > TELEPORT_SPEED) speed = 0; // teleport snap, not locomotion
+
+  if (speed > MOVE_ENTER_SPEED) t.moveHold = MOVE_HOLD_TIME;
+  else t.moveHold = Math.max(0, t.moveHold - dt);
+  const moving = t.moveHold > 0;
+
+  // smooth cadence speed; while latched-but-stalled keep the last value so
+  // footsteps don't lurch toward zero on a stalled frame
+  if (speed > MOVE_ENTER_SPEED || !moving) {
+    t.smoothSpeed += (speed - t.smoothSpeed) * Math.min(1, dt * SPEED_SMOOTH_RATE);
+  }
+
+  // only re-judge direction on frames with real displacement; a stalled frame
+  // keeps the last direction so walkBack doesn't flip to walk and reset
+  if (speed > MOVE_ENTER_SPEED && dist > 1e-6) {
+    t.movingBackwards = (vx * Math.sin(facing) + vz * Math.cos(facing)) / dist < -0.3;
+  } else if (!moving) {
+    t.movingBackwards = false;
+  }
+
+  return { speed: t.smoothSpeed, moving, backwards: moving && t.movingBackwards };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -8,6 +8,7 @@ import {
 } from '../sim/data';
 import type { BiomeId } from '../sim/types';
 import { AnimState, CharacterVisual, createCharacterVisual } from './characters';
+import { LocoTrack, newLocoTrack, updateLocomotion } from './locomotion';
 import { buildProps } from './props';
 import { plankTexture, sparkleTexture } from './textures';
 import { DungeonInteriors } from './dungeon';
@@ -83,6 +84,9 @@ interface EntityView {
   // render-space position last frame, for true u/s locomotion speed
   lastX: number;
   lastZ: number;
+  // locomotion-state hysteresis so a one-frame speed dip can't reset the
+  // walk clip (see locomotion.ts)
+  loco: LocoTrack;
 }
 
 function collectCasters(root: THREE.Object3D, into: THREE.Object3D[]): void {
@@ -533,6 +537,7 @@ export class Renderer {
       nameplate: np, nameEl, hpBar, hpFill, markerEl: marker, sparkle, objectMesh, portal,
       objectCasters, shadowOn: true, isFar: false,
       lastX: e.pos.x, lastZ: e.pos.z,
+      loco: newLocoTrack(),
     });
   }
 
@@ -796,20 +801,17 @@ export class Renderer {
       // distant rigs swap to the single-draw baked idle-pose mesh
       v.visual.setFar(v.isFar && active === v.visual);
 
-      // animation state machine inputs, derived from render-space motion
+      // animation state machine inputs, derived from render-space motion with
+      // hysteresis so a one-frame speed dip can't reset the walk clip
       const vx = x - v.lastX, vz = z - v.lastZ;
       v.lastX = x;
       v.lastZ = z;
-      const dist = Math.hypot(vx, vz);
-      let speed = dist / Math.max(dt, 1e-4);
-      if (speed > 25) speed = 0; // teleport snap, not locomotion
-      const moving = speed > 0.4;
-      const backwards = moving && dist > 1e-6
-        && (vx * Math.sin(facing) + vz * Math.cos(facing)) / dist < -0.3;
+      const loco = updateLocomotion(v.loco, vx, vz, facing, dt);
+      const moving = loco.moving;
       const st: AnimState = {
-        speed,
+        speed: loco.speed,
         moving,
-        backwards,
+        backwards: loco.backwards,
         dead: e.dead,
         casting: e.castingAbility !== null && !e.dead,
         swimming,

--- a/tests/locomotion.test.ts
+++ b/tests/locomotion.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MOVE_HOLD_TIME, newLocoTrack, updateLocomotion,
+} from '../src/render/locomotion';
+
+const FPS = 1 / 60;
+
+// steady forward walk: ~2.2 u/s gives ~0.0367u of travel per 60fps frame
+function walkStep(t: ReturnType<typeof newLocoTrack>, dt = FPS, speed = 2.2) {
+  return updateLocomotion(t, 0, speed * dt, 0, dt);
+}
+
+describe('locomotion hysteresis', () => {
+  it('a steady walk reports moving', () => {
+    const t = newLocoTrack();
+    let s = walkStep(t);
+    for (let i = 0; i < 30; i++) s = walkStep(t);
+    expect(s.moving).toBe(true);
+    expect(s.backwards).toBe(false);
+    expect(s.speed).toBeGreaterThan(1.5); // smoothed toward ~2.2
+  });
+
+  it('a single stalled frame mid-walk does NOT drop the moving state', () => {
+    const t = newLocoTrack();
+    for (let i = 0; i < 20; i++) walkStep(t);
+    // interpolation stall / terrain bob: one frame with zero horizontal travel
+    const stalled = updateLocomotion(t, 0, 0, 0, FPS);
+    expect(stalled.moving).toBe(true); // latched through the dip — no reset
+  });
+
+  it('several consecutive stalled frames within the grace window stay moving', () => {
+    const t = newLocoTrack();
+    for (let i = 0; i < 20; i++) walkStep(t);
+    // ~0.15s of stall, under MOVE_HOLD_TIME (0.22s)
+    let s = { moving: true } as ReturnType<typeof updateLocomotion>;
+    for (let i = 0; i < 9; i++) s = updateLocomotion(t, 0, 0, 0, FPS);
+    expect(9 * FPS).toBeLessThan(MOVE_HOLD_TIME);
+    expect(s.moving).toBe(true);
+  });
+
+  it('a genuine stop transitions to idle after the grace window', () => {
+    const t = newLocoTrack();
+    for (let i = 0; i < 20; i++) walkStep(t);
+    let s = updateLocomotion(t, 0, 0, 0, FPS);
+    // run well past the hold window with no movement
+    for (let i = 0; i < 30; i++) s = updateLocomotion(t, 0, 0, 0, FPS);
+    expect(s.moving).toBe(false);
+  });
+
+  it('keeps the backpedal direction through a stalled frame', () => {
+    const t = newLocoTrack();
+    // facing +Z (0); travel toward -Z is backwards
+    for (let i = 0; i < 10; i++) updateLocomotion(t, 0, -2.2 * FPS, 0, FPS);
+    const moving = updateLocomotion(t, 0, -2.2 * FPS, 0, FPS);
+    expect(moving.backwards).toBe(true);
+    // a stalled frame must not flip walkBack -> walk
+    const stalled = updateLocomotion(t, 0, 0, 0, FPS);
+    expect(stalled.moving).toBe(true);
+    expect(stalled.backwards).toBe(true);
+  });
+
+  it('treats a teleport snap as not moving', () => {
+    const t = newLocoTrack();
+    // 50u in one frame = 3000 u/s, far above the teleport cutoff
+    const s = updateLocomotion(t, 50, 0, 0, FPS);
+    expect(s.moving).toBe(false);
+  });
+
+  it('jitter scenario: alternating walk/stall frames never lose moving', () => {
+    const t = newLocoTrack();
+    walkStep(t);
+    let everStopped = false;
+    for (let i = 0; i < 60; i++) {
+      // every other frame stalls (worst-case interp/terrain noise)
+      const s = i % 2 === 0 ? updateLocomotion(t, 0, 0, 0, FPS) : walkStep(t);
+      if (!s.moving) everStopped = true;
+    }
+    expect(everStopped).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Player (and mob/NPC) characters jitter while walking — the legs twitch as if the walk animation keeps restarting. It does: the character animation state machine derives its `moving`/`speed` inputs from instantaneous per-frame render-space velocity (`moving = speed > 0.4`, with no leeway), and `fadeTo` calls `clip.reset()` on every state change. A single-frame speed dip — frame-time jitter, snapshot-interpolation stalls in online play, or vertical bob over uneven terrain — flips `moving` to false for one frame, which fades the rig to idle and then resets the walk clip from frame 0 the very next frame. Repeated, that reads as constant jitter.

## Fix

Extract the locomotion-state derivation out of the renderer's WebGL-bound loop into a pure, unit-testable helper (`src/render/locomotion.ts`) and give it hysteresis:

- **Latch `moving`** for a 0.22s grace window after speed drops below the enter threshold, so a brief stall can't drop the state and reset the clip.
- **Smooth the cadence-driving speed** (EMA) so footstep timeScale doesn't wobble frame to frame, and freeze it during a latched-but-stalled frame so it doesn't lurch toward zero.
- **Hold the travel direction** through stalled frames so a backpedaling player's `walkBack` doesn't momentarily flip to `walk` (which would also reset).

The renderer now just calls `updateLocomotion(view.loco, vx, vz, facing, dt)` per entity; behavior for genuine stops (idle after the grace window) and teleport snaps is unchanged.

## Testing

- New `tests/locomotion.test.ts` (7 cases) covers steady walk, single and multi-frame stalls within the grace window, genuine stop → idle, backpedal direction held through a stall, teleport-snap rejection, and a worst-case **alternating walk/stall frame sequence** that previously would have reset the clip every other frame — it now stays `moving` throughout.
- Full suite green: 211/211. `npm run build` compiles clean.

Note: this is a deterministic fix for the state-reset logic verified by unit tests; I haven't captured before/after video of the rig in-engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)