### PR TITLE
Add a game options menu: key bindings, graphics, and audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,14 @@
     background: linear-gradient(#2c2c3a, #15151f); color: #ffd9a0; border-color: #4a3d1d; }
   .kb-key.capturing { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd100aa; }
   .kb-note { font-size: 11px; color: #b9ac82; margin: 2px 0 6px; min-height: 14px; line-height: 1.4; }
+  .set-rows { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
+  .set-row { display: grid; grid-template-columns: 120px 1fr 48px; align-items: center; gap: 10px; padding: 3px 6px; }
+  .set-name { font-size: 12.5px; color: #e8e0c8; }
+  .set-slider { width: 100%; accent-color: var(--gold); cursor: pointer; }
+  .set-val { font-size: 12px; color: #ffd9a0; text-align: right; font-variant-numeric: tabular-nums; }
+  .set-toggle { margin: 0; padding: 3px 14px; }
+  .set-toggle.off { filter: grayscale(0.6) brightness(0.8); }
+  .set-note { font-size: 11px; color: #b9ac82; margin: 6px 0 2px; line-height: 1.4; }
 
   /* tooltip */
   #tooltip { position: absolute; display: none; z-index: 100; pointer-events: none; max-width: 280px;

--- a/index.html
+++ b/index.html
@@ -309,19 +309,21 @@
   #map-canvas { border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; }
 
   /* ---------- options / game menu (Esc) ---------- */
-  #options-menu { left: 50%; top: 50%; transform: translate(-50%, -50%); width: 360px;
-    max-height: 80%; overflow-y: auto; z-index: 40; }
+  #options-menu { left: 50%; top: 50%; transform: translate(-50%, -50%); width: 420px;
+    max-height: 82%; overflow-y: auto; z-index: 40; }
   .opt-list { display: flex; flex-direction: column; gap: 8px; align-items: stretch; padding: 4px 0; }
   .opt-btn { margin: 0; text-align: center; }
-  .kb-rows { display: flex; flex-direction: column; gap: 3px; margin-bottom: 8px; }
-  .kb-row { display: flex; align-items: center; justify-content: space-between;
-    gap: 10px; padding: 3px 6px; border-radius: 4px; }
-  .kb-row:nth-child(odd) { background: #ffffff0a; }
+  .kb-rows { display: flex; flex-direction: column; gap: 2px; margin-bottom: 8px; }
+  .kb-cat { font-family: var(--title-font); color: var(--gold); font-size: 12px; letter-spacing: 0.5px;
+    text-transform: uppercase; margin: 8px 0 2px; border-bottom: 1px solid #463a1c; padding-bottom: 2px; }
+  .kb-row { display: grid; grid-template-columns: 1fr 78px 78px; align-items: center;
+    gap: 6px; padding: 2px 6px; border-radius: 4px; }
+  .kb-row:nth-of-type(odd) { background: #ffffff0a; }
   .kb-name { font-size: 12.5px; color: #e8e0c8; }
-  .kb-key { margin: 0; min-width: 84px; text-align: center; padding: 4px 8px; font-size: 12px;
+  .kb-key { margin: 0; text-align: center; padding: 3px 6px; font-size: 12px;
     background: linear-gradient(#2c2c3a, #15151f); color: #ffd9a0; border-color: #4a3d1d; }
   .kb-key.capturing { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd100aa; }
-  .kb-note { font-size: 11px; color: #b9ac82; margin: 4px 0 2px; min-height: 14px; }
+  .kb-note { font-size: 11px; color: #b9ac82; margin: 2px 0 6px; min-height: 14px; line-height: 1.4; }
 
   /* tooltip */
   #tooltip { position: absolute; display: none; z-index: 100; pointer-events: none; max-width: 280px;

--- a/index.html
+++ b/index.html
@@ -308,6 +308,21 @@
   #map-window { left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 14px; }
   #map-canvas { border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; }
 
+  /* ---------- options / game menu (Esc) ---------- */
+  #options-menu { left: 50%; top: 50%; transform: translate(-50%, -50%); width: 360px;
+    max-height: 80%; overflow-y: auto; z-index: 40; }
+  .opt-list { display: flex; flex-direction: column; gap: 8px; align-items: stretch; padding: 4px 0; }
+  .opt-btn { margin: 0; text-align: center; }
+  .kb-rows { display: flex; flex-direction: column; gap: 3px; margin-bottom: 8px; }
+  .kb-row { display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; padding: 3px 6px; border-radius: 4px; }
+  .kb-row:nth-child(odd) { background: #ffffff0a; }
+  .kb-name { font-size: 12.5px; color: #e8e0c8; }
+  .kb-key { margin: 0; min-width: 84px; text-align: center; padding: 4px 8px; font-size: 12px;
+    background: linear-gradient(#2c2c3a, #15151f); color: #ffd9a0; border-color: #4a3d1d; }
+  .kb-key.capturing { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd100aa; }
+  .kb-note { font-size: 11px; color: #b9ac82; margin: 4px 0 2px; min-height: 14px; }
+
   /* tooltip */
   #tooltip { position: absolute; display: none; z-index: 100; pointer-events: none; max-width: 280px;
     padding: 8px 10px; font-size: 12px; line-height: 1.5; }
@@ -537,6 +552,7 @@
     <div id="quest-log-window" class="window panel"></div>
     <div id="vendor-window" class="window panel"></div>
     <div id="map-window" class="window panel"><canvas id="map-canvas" width="560" height="560"></canvas></div>
+    <div id="options-menu" class="window panel"></div>
     <div id="meters-window" class="panel">
       <div class="panel-title">
         <span class="mt-tabs">
@@ -636,7 +652,7 @@
 
     <div id="controls-hint">
       <b>WASD</b> move &middot; <b>A/D</b> turn, <b>Q/E</b> strafe &middot; <b>right-drag</b> mouselook &middot; <b>left-drag</b> orbit camera &middot; wheel zoom &middot; <b>Space</b> jump<br/>
-      <b>Tab</b> target &middot; <b>1-9,0</b> abilities &middot; <b>F</b> interact/loot &middot; <b>C</b> character &middot; <b>P</b> spellbook &middot; <b>L</b> quest log &middot; <b>M</b> map &middot; <b>B</b> bags &middot; <b>V</b> nameplates &middot; <b>R</b> autorun &middot; <b>Enter</b> chat
+      <b>Tab</b> target &middot; <b>1-9,0</b> abilities &middot; <b>F</b> interact/loot &middot; <b>C</b> character &middot; <b>P</b> spellbook &middot; <b>L</b> quest log &middot; <b>M</b> map &middot; <b>B</b> bags &middot; <b>V</b> nameplates &middot; <b>R</b> autorun &middot; <b>Enter</b> chat &middot; <b>Esc</b> menu (rebind keys)
     </div>
 
     <div id="social-links">

--- a/src/game/audio.ts
+++ b/src/game/audio.ts
@@ -1,16 +1,29 @@
 // Procedural WebAudio sound effects — no audio files.
 
+const SFX_BASE_GAIN = 0.32; // master level at full volume
+
 export class GameAudio {
   private ctx: AudioContext | null = null;
   private master: GainNode | null = null;
   private noiseBuf: AudioBuffer | null = null;
+  private vol = 1; // 0..1, set from the settings menu (applied to the master gain)
+
+  /** Set SFX volume (0..1). Safe before init(); applied when the context exists. */
+  setVolume(v: number): void {
+    this.vol = Math.min(1, Math.max(0, v));
+    if (this.master) this.master.gain.value = SFX_BASE_GAIN * this.vol;
+  }
+
+  get volume(): number {
+    return this.vol;
+  }
 
   init(): void {
     if (this.ctx) return;
     try {
       this.ctx = new AudioContext();
       this.master = this.ctx.createGain();
-      this.master.gain.value = 0.32;
+      this.master.gain.value = SFX_BASE_GAIN * this.vol;
       this.master.connect(this.ctx.destination);
       const len = this.ctx.sampleRate;
       this.noiseBuf = this.ctx.createBuffer(1, len, this.ctx.sampleRate);

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -6,6 +6,10 @@
 
 import { Keybinds, actionKind } from './keybinds';
 
+// the camera sensitivity that used to be hard-coded in onMouseMove; the
+// settings slider scales this (cameraSpeed 1.0 reproduces the old feel)
+const BASE_LOOK_SENS = 0.0045;
+
 export interface InputCallbacks {
   onTab(): void;
   onAbility(slot: number): void;
@@ -29,6 +33,9 @@ export class Input {
   // one-shot key capture for the rebind UI: the next keydown is delivered here
   // (Escape cancels with null) instead of being dispatched as an action
   private captureCb: ((code: string | null) => void) | null = null;
+  // mouse-look sensitivity, in radians per pixel of drag; the old fixed value
+  // was BASE_LOOK_SENS — setCameraSpeed scales it from the settings menu
+  private lookSensitivity = BASE_LOOK_SENS;
 
   constructor(private canvas: HTMLCanvasElement, private cb: InputCallbacks, private keybinds: Keybinds) {
     window.addEventListener('keydown', (e) => this.onKeyDown(e));
@@ -47,6 +54,11 @@ export class Input {
   /** Capture the next keypress (for the rebind UI) instead of acting on it. */
   captureNextKey(cb: (code: string | null) => void): void {
     this.captureCb = cb;
+  }
+
+  /** Scale mouse-look sensitivity. 1.0 = the original fixed speed. */
+  setCameraSpeed(mult: number): void {
+    this.lookSensitivity = BASE_LOOK_SENS * mult;
   }
 
   private onKeyDown(e: KeyboardEvent): void {
@@ -119,8 +131,8 @@ export class Input {
     if (!this.leftDown && !this.rightDown) return;
     const mx = e.movementX ?? 0, my = e.movementY ?? 0;
     this.dragDistance += Math.abs(mx) + Math.abs(my);
-    this.camYaw -= mx * 0.0045;
-    this.camPitch = Math.min(1.35, Math.max(-0.4, this.camPitch + my * 0.0045));
+    this.camYaw -= mx * this.lookSensitivity;
+    this.camPitch = Math.min(1.35, Math.max(-0.4, this.camPitch + my * this.lookSensitivity));
   }
 
   readMoveInput(): {

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -1,7 +1,10 @@
 // WoW-style input: WASD + A/D keyboard turn, Q/E strafe, space jump,
 // left-drag orbits the camera, right-drag mouselooks (turns the character),
-// both buttons run forward, wheel zooms, Tab targets, 1-9/0/-/= cast,
-// C/P/L/M/B windows, V nameplates, F interacts, R autorun.
+// both buttons run forward, wheel zooms, Tab targets, action-bar keys cast
+// (player-rebindable, see Keybinds), C/P/L/M/B windows, V nameplates,
+// F interacts, R autorun.
+
+import { Keybinds } from './keybinds';
 
 export interface InputCallbacks {
   onTab(): void;
@@ -9,11 +12,6 @@ export interface InputCallbacks {
   onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters'): void;
   onClickPick(x: number, y: number, button: number): void;
 }
-
-const ABILITY_KEYS: Record<string, number> = {
-  Digit1: 0, Digit2: 1, Digit3: 2, Digit4: 3, Digit5: 4, Digit6: 5,
-  Digit7: 6, Digit8: 7, Digit9: 8, Digit0: 9, Minus: 10, Equal: 11,
-};
 
 export class Input {
   keys = new Set<string>();
@@ -23,10 +21,16 @@ export class Input {
   camPitch = 0.32;
   camDist = 12;
   autorun = false;
+  // while true, readMoveInput reports neutral — set when a modal (the options
+  // menu) is open so held WASD doesn't drive the character behind it
+  suspendMovement = false;
   private dragDistance = 0;
   private downButton = -1;
+  // one-shot key capture for the rebind UI: the next keydown is delivered here
+  // (Escape cancels with null) instead of being dispatched as an action
+  private captureCb: ((code: string | null) => void) | null = null;
 
-  constructor(private canvas: HTMLCanvasElement, private cb: InputCallbacks) {
+  constructor(private canvas: HTMLCanvasElement, private cb: InputCallbacks, private keybinds: Keybinds) {
     window.addEventListener('keydown', (e) => this.onKeyDown(e));
     window.addEventListener('keyup', (e) => { this.keys.delete(e.code); });
     window.addEventListener('blur', () => { this.keys.clear(); this.leftDown = false; this.rightDown = false; });
@@ -40,12 +44,26 @@ export class Input {
     canvas.addEventListener('contextmenu', (e) => e.preventDefault());
   }
 
+  /** Capture the next keypress (for the rebind UI) instead of acting on it. */
+  captureNextKey(cb: (code: string | null) => void): void {
+    this.captureCb = cb;
+  }
+
   private onKeyDown(e: KeyboardEvent): void {
     if (e.repeat) return;
+    // rebind capture intercepts everything (incl. action/UI keys); Escape cancels
+    if (this.captureCb) {
+      e.preventDefault();
+      const cb = this.captureCb;
+      this.captureCb = null;
+      cb(e.code === 'Escape' ? null : e.code);
+      return;
+    }
     const tag = (document.activeElement?.tagName ?? '').toLowerCase();
     if (tag === 'input' || tag === 'textarea') return;
-    if (ABILITY_KEYS[e.code] !== undefined) {
-      this.cb.onAbility(ABILITY_KEYS[e.code]);
+    const slot = this.keybinds.slotForCode(e.code);
+    if (slot !== null) {
+      this.cb.onAbility(slot);
       return;
     }
     switch (e.code) {
@@ -102,6 +120,9 @@ export class Input {
     forward: boolean; back: boolean; turnLeft: boolean; turnRight: boolean;
     strafeLeft: boolean; strafeRight: boolean; jump: boolean;
   } {
+    if (this.suspendMovement) {
+      return { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
+    }
     const k = this.keys;
     const bothButtons = this.leftDown && this.rightDown;
     const mouselook = this.rightDown;

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -4,7 +4,7 @@
 // (player-rebindable, see Keybinds), C/P/L/M/B windows, V nameplates,
 // F interacts, R autorun.
 
-import { Keybinds } from './keybinds';
+import { Keybinds, actionKind } from './keybinds';
 
 export interface InputCallbacks {
   onTab(): void;
@@ -61,30 +61,37 @@ export class Input {
     }
     const tag = (document.activeElement?.tagName ?? '').toLowerCase();
     if (tag === 'input' || tag === 'textarea') return;
-    const slot = this.keybinds.slotForCode(e.code);
-    if (slot !== null) {
-      this.cb.onAbility(slot);
+    // Escape always opens/closes the game menu — never rebindable
+    if (e.code === 'Escape') { this.cb.onUiKey('escape'); return; }
+    if (e.code === 'Tab') e.preventDefault(); // keep Tab from moving DOM focus in-game
+    const action = this.keybinds.actionForCode(e.code);
+    if (action === null) return;
+    if (actionKind(action) === 'held') {
+      // movement: just record the key; readMoveInput polls it each frame
+      this.keys.add(e.code);
+      if (action === 'forward' || action === 'back') this.autorun = false;
       return;
     }
-    switch (e.code) {
-      case 'Tab':
-        e.preventDefault();
-        this.cb.onTab();
-        return;
-      case 'KeyF': this.cb.onUiKey('interact'); return;
-      case 'KeyB': this.cb.onUiKey('bags'); return;
-      case 'KeyC': this.cb.onUiKey('char'); return;
-      case 'KeyP': this.cb.onUiKey('spellbook'); return;
-      case 'KeyL': this.cb.onUiKey('questlog'); return;
-      case 'KeyM': this.cb.onUiKey('map'); return;
-      case 'KeyV': this.cb.onUiKey('nameplates'); return;
-      case 'KeyN': this.cb.onUiKey('meters'); return;
-      case 'Enter': case 'NumpadEnter': this.cb.onUiKey('chat'); return;
-      case 'Escape': this.cb.onUiKey('escape'); return;
-      case 'NumLock': case 'KeyR': this.autorun = !this.autorun; return;
+    this.dispatchEdge(action);
+  }
+
+  // Fire a one-shot (edge) action by id. Action-bar slots route to onAbility;
+  // the rest map to the targeting/interface callbacks; autorun is internal.
+  private dispatchEdge(action: string): void {
+    if (action.startsWith('slot')) { this.cb.onAbility(Number(action.slice(4))); return; }
+    switch (action) {
+      case 'autorun': this.autorun = !this.autorun; return;
+      case 'target': this.cb.onTab(); return;
+      case 'interact': this.cb.onUiKey('interact'); return;
+      case 'bags': this.cb.onUiKey('bags'); return;
+      case 'char': this.cb.onUiKey('char'); return;
+      case 'spellbook': this.cb.onUiKey('spellbook'); return;
+      case 'questlog': this.cb.onUiKey('questlog'); return;
+      case 'map': this.cb.onUiKey('map'); return;
+      case 'nameplates': this.cb.onUiKey('nameplates'); return;
+      case 'meters': this.cb.onUiKey('meters'); return;
+      case 'chat': this.cb.onUiKey('chat'); return;
     }
-    this.keys.add(e.code);
-    if (['KeyW', 'KeyS', 'ArrowUp', 'ArrowDown'].includes(e.code)) this.autorun = false;
   }
 
   private onMouseDown(e: MouseEvent): void {
@@ -124,17 +131,19 @@ export class Input {
       return { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
     }
     const k = this.keys;
+    const held = (id: string) => this.keybinds.codesForAction(id).some((c) => k.has(c));
     const bothButtons = this.leftDown && this.rightDown;
     const mouselook = this.rightDown;
-    const forward = k.has('KeyW') || k.has('ArrowUp') || bothButtons || this.autorun;
-    const back = k.has('KeyS') || k.has('ArrowDown');
-    const aHeld = k.has('KeyA') || k.has('ArrowLeft');
-    const dHeld = k.has('KeyD') || k.has('ArrowRight');
-    const strafeLeft = k.has('KeyQ') || (mouselook && aHeld);
-    const strafeRight = k.has('KeyE') || (mouselook && dHeld);
+    // A/D (turn) double as strafe while mouselooking, matching WoW; Q/E always strafe
+    const aHeld = held('turnLeft');
+    const dHeld = held('turnRight');
+    const forward = held('forward') || bothButtons || this.autorun;
+    const back = held('back');
+    const strafeLeft = held('strafeLeft') || (mouselook && aHeld);
+    const strafeRight = held('strafeRight') || (mouselook && dHeld);
     const turnLeft = !mouselook && aHeld;
     const turnRight = !mouselook && dHeld;
-    const jump = k.has('Space');
+    const jump = held('jump');
     return { forward, back, turnLeft, turnRight, strafeLeft, strafeRight, jump };
   }
 }

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -1,30 +1,73 @@
-// Player-rebindable action-bar hotkeys. The 12 action slots (slot 0 is the
-// Attack / auto-attack toggle, slots 1-11 the ability bar) each map to a
-// KeyboardEvent.code. Input dispatches a keypress to a slot via slotForCode;
-// the HUD renders the per-slot label via keyLabel. Bindings persist globally
-// (not per character) in localStorage. This module is pure — no DOM — so the
-// conflict and persistence logic is unit-testable.
+// Player-rebindable controls. Every bindable game action — movement, camera,
+// targeting, interface windows, and the 12 action-bar slots — lives in one
+// registry, and the Keybinds map holds up to two KeyboardEvent.codes per
+// action (primary + secondary, e.g. W and ArrowUp both Move Forward). Input
+// dispatches edge actions and polls held (movement) actions through this map;
+// the HUD renders the rebind menu and action-bar keycaps from it. Bindings
+// persist globally in localStorage. Pure (no DOM) so the conflict/persistence
+// logic is unit-testable.
+//
+// Escape is deliberately NOT a bindable action: it always opens/closes the
+// game menu, so it stays out of the registry and is refused by bind().
 
-export const ACTION_SLOTS = 12; // bar slots 0..11
-const STORE_KEY = 'woc_keybinds';
+export type BindKind = 'held' | 'edge';
 
-// slot 0..11 -> default code; matches the original hard-coded 1..0,-,= bar
-const DEFAULT_CODES: string[] = [
-  'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6',
-  'Digit7', 'Digit8', 'Digit9', 'Digit0', 'Minus', 'Equal',
+export interface BindAction {
+  id: string;
+  label: string;
+  category: string;
+  kind: BindKind;
+  defaults: string[]; // 1 or 2 codes; index 0 = primary, 1 = secondary
+}
+
+export const ACTION_BAR_SLOTS = 12; // slot 0 is Attack, 1..11 the ability bar
+
+const SLOT_DEFAULTS = ['Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6',
+  'Digit7', 'Digit8', 'Digit9', 'Digit0', 'Minus', 'Equal'];
+
+export const BIND_ACTIONS: BindAction[] = [
+  // Movement / camera — polled every frame (held)
+  { id: 'forward', label: 'Move Forward', category: 'Movement', kind: 'held', defaults: ['KeyW', 'ArrowUp'] },
+  { id: 'back', label: 'Move Backward', category: 'Movement', kind: 'held', defaults: ['KeyS', 'ArrowDown'] },
+  { id: 'turnLeft', label: 'Turn Left', category: 'Movement', kind: 'held', defaults: ['KeyA', 'ArrowLeft'] },
+  { id: 'turnRight', label: 'Turn Right', category: 'Movement', kind: 'held', defaults: ['KeyD', 'ArrowRight'] },
+  { id: 'strafeLeft', label: 'Strafe Left', category: 'Movement', kind: 'held', defaults: ['KeyQ'] },
+  { id: 'strafeRight', label: 'Strafe Right', category: 'Movement', kind: 'held', defaults: ['KeyE'] },
+  { id: 'jump', label: 'Jump', category: 'Movement', kind: 'held', defaults: ['Space'] },
+  { id: 'autorun', label: 'Toggle Autorun', category: 'Movement', kind: 'edge', defaults: ['KeyR'] },
+  // Targeting / interaction
+  { id: 'target', label: 'Target Nearest Enemy', category: 'Targeting', kind: 'edge', defaults: ['Tab'] },
+  { id: 'interact', label: 'Interact / Loot', category: 'Targeting', kind: 'edge', defaults: ['KeyF'] },
+  // Interface windows
+  { id: 'char', label: 'Character', category: 'Interface', kind: 'edge', defaults: ['KeyC'] },
+  { id: 'spellbook', label: 'Spellbook', category: 'Interface', kind: 'edge', defaults: ['KeyP'] },
+  { id: 'questlog', label: 'Quest Log', category: 'Interface', kind: 'edge', defaults: ['KeyL'] },
+  { id: 'map', label: 'World Map', category: 'Interface', kind: 'edge', defaults: ['KeyM'] },
+  { id: 'bags', label: 'Bags', category: 'Interface', kind: 'edge', defaults: ['KeyB'] },
+  { id: 'nameplates', label: 'Toggle Nameplates', category: 'Interface', kind: 'edge', defaults: ['KeyV'] },
+  { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyN'] },
+  { id: 'chat', label: 'Open Chat', category: 'Interface', kind: 'edge', defaults: ['Enter', 'NumpadEnter'] },
+  // Action bar (slot 0 = Attack)
+  ...SLOT_DEFAULTS.map((code, i): BindAction => ({
+    id: `slot${i}`,
+    label: i === 0 ? 'Attack' : `Action Bar ${i + 1}`,
+    category: 'Action Bar',
+    kind: 'edge',
+    defaults: [code],
+  })),
 ];
 
-// Core movement / camera / system keys that must keep working — binding an
-// action onto these would break basic control (e.g. W would move AND cast),
-// so the rebind UI refuses them.
-const RESERVED = new Set<string>([
-  'KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyQ', 'KeyE',
-  'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
-  'Space', 'Tab', 'Escape', 'Enter', 'NumpadEnter',
-]);
+const ACTION_BY_ID = new Map(BIND_ACTIONS.map((a) => [a.id, a]));
+export const BIND_CATEGORIES = [...new Set(BIND_ACTIONS.map((a) => a.category))];
+const STORE_KEY = 'woc_keybinds';
+const SLOTS_PER_ACTION = 2; // primary + secondary
+
+export function actionKind(id: string): BindKind | null {
+  return ACTION_BY_ID.get(id)?.kind ?? null;
+}
 
 export function isReservedCode(code: string): boolean {
-  return RESERVED.has(code);
+  return code === 'Escape'; // the game-menu key is never rebindable
 }
 
 // e.code -> short on-screen label (matches the keycap shown on the action bar)
@@ -39,6 +82,8 @@ export function keyLabel(code: string | null): string {
     Backslash: '\\', Semicolon: ';', Quote: "'", Comma: ',', Period: '.', Slash: '/',
     Space: 'Space', Tab: 'Tab', Enter: 'Enter', Escape: 'Esc',
     ArrowUp: '↑', ArrowDown: '↓', ArrowLeft: '←', ArrowRight: '→',
+    ShiftLeft: 'LShift', ShiftRight: 'RShift', ControlLeft: 'LCtrl', ControlRight: 'RCtrl',
+    AltLeft: 'LAlt', AltRight: 'RAlt', CapsLock: 'Caps',
     NumpadAdd: 'Num+', NumpadSubtract: 'Num-', NumpadMultiply: 'Num*',
     NumpadDivide: 'Num/', NumpadDecimal: 'Num.', NumpadEnter: 'NumEnter',
   };
@@ -46,70 +91,106 @@ export function keyLabel(code: string | null): string {
 }
 
 export class Keybinds {
-  // index = slot, value = e.code, or null when the slot has no key
-  private codes: (string | null)[] = [];
+  // actionId -> [primary, secondary] codes (either may be null)
+  private map = new Map<string, (string | null)[]>();
 
   constructor() {
     this.load();
   }
 
+  private defaults(): Map<string, (string | null)[]> {
+    const m = new Map<string, (string | null)[]>();
+    for (const a of BIND_ACTIONS) {
+      m.set(a.id, [a.defaults[0] ?? null, a.defaults[1] ?? null]);
+    }
+    return m;
+  }
+
   private load(): void {
+    this.map = this.defaults();
     let stored: unknown = null;
     try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
-    const seen = new Set<string>();
-    this.codes = DEFAULT_CODES.map((def, i) => {
-      const v = Array.isArray(stored) ? stored[i] : undefined;
-      // accept a stored code only if it's a string and not already claimed by
-      // an earlier slot; missing/invalid entries fall back to the default
-      const code = v === null ? null : (typeof v === 'string' ? v : def);
-      if (code !== null && seen.has(code)) return null;
-      if (code !== null) seen.add(code);
-      return code;
-    });
+    if (!stored || typeof stored !== 'object') return;
+    // Apply stored codes over the defaults, but only for known actions and
+    // never letting one code land on two actions (first writer keeps it).
+    const claimed = new Set<string>();
+    for (const a of BIND_ACTIONS) {
+      const entry = (stored as Record<string, unknown>)[a.id];
+      const slots: (string | null)[] = [null, null];
+      for (let i = 0; i < SLOTS_PER_ACTION; i++) {
+        const v = Array.isArray(entry) ? entry[i] : undefined;
+        if (typeof v === 'string' && !claimed.has(v) && !isReservedCode(v)) {
+          slots[i] = v;
+          claimed.add(v);
+        } else {
+          slots[i] = null;
+        }
+      }
+      this.map.set(a.id, slots);
+    }
   }
 
   private save(): void {
-    try { localStorage.setItem(STORE_KEY, JSON.stringify(this.codes)); } catch { /* storage unavailable */ }
+    const obj: Record<string, (string | null)[]> = {};
+    for (const [id, codes] of this.map) obj[id] = codes;
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(obj)); } catch { /* storage unavailable */ }
   }
 
-  /** Slot a keypress should trigger, or null if the code is unbound. */
-  slotForCode(code: string): number | null {
-    const i = this.codes.indexOf(code);
-    return i === -1 ? null : i;
+  /** The action a keypress should trigger, or null if the code is unbound. */
+  actionForCode(code: string): string | null {
+    for (const [id, codes] of this.map) {
+      if (codes.includes(code)) return id;
+    }
+    return null;
   }
 
-  codeForSlot(slot: number): string | null {
-    return this.codes[slot] ?? null;
+  /** Non-null codes bound to an action (for held-key polling). */
+  codesForAction(id: string): string[] {
+    return (this.map.get(id) ?? []).filter((c): c is string => c !== null);
   }
 
-  label(slot: number): string {
-    return keyLabel(this.codes[slot] ?? null);
+  codeAt(id: string, index: number): string | null {
+    return this.map.get(id)?.[index] ?? null;
+  }
+
+  labelAt(id: string, index: number): string {
+    return keyLabel(this.codeAt(id, index));
+  }
+
+  /** Primary (or, if unset, secondary) label — used for action-bar keycaps. */
+  primaryLabel(id: string): string {
+    const codes = this.map.get(id) ?? [];
+    return keyLabel(codes[0] ?? codes[1] ?? null);
   }
 
   /**
-   * Bind a key to a slot. A reserved key is rejected (returns false, no
-   * change). Binding a key already held by another slot clears it there
-   * first (WoW-style), so a code is never on two slots.
+   * Bind a code to (action, index). Reserved keys are refused (returns false).
+   * The code is first removed from wherever else it lives so it is never on
+   * two actions at once (WoW-style).
    */
-  bind(slot: number, code: string): boolean {
-    if (slot < 0 || slot >= ACTION_SLOTS) return false;
+  bind(id: string, index: number, code: string): boolean {
+    const codes = this.map.get(id);
+    if (!codes || index < 0 || index >= SLOTS_PER_ACTION) return false;
     if (isReservedCode(code)) return false;
-    const existing = this.codes.indexOf(code);
-    if (existing !== -1 && existing !== slot) this.codes[existing] = null;
-    this.codes[slot] = code;
+    for (const [otherId, otherCodes] of this.map) {
+      for (let i = 0; i < otherCodes.length; i++) {
+        if (otherCodes[i] === code && !(otherId === id && i === index)) otherCodes[i] = null;
+      }
+    }
+    codes[index] = code;
     this.save();
     return true;
   }
 
-  /** Clear a slot's binding (the action stays clickable, just no hotkey). */
-  clear(slot: number): void {
-    if (slot < 0 || slot >= ACTION_SLOTS) return;
-    this.codes[slot] = null;
+  clear(id: string, index: number): void {
+    const codes = this.map.get(id);
+    if (!codes || index < 0 || index >= SLOTS_PER_ACTION) return;
+    codes[index] = null;
     this.save();
   }
 
   reset(): void {
-    this.codes = DEFAULT_CODES.slice();
+    this.map = this.defaults();
     this.save();
   }
 }

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -1,0 +1,115 @@
+// Player-rebindable action-bar hotkeys. The 12 action slots (slot 0 is the
+// Attack / auto-attack toggle, slots 1-11 the ability bar) each map to a
+// KeyboardEvent.code. Input dispatches a keypress to a slot via slotForCode;
+// the HUD renders the per-slot label via keyLabel. Bindings persist globally
+// (not per character) in localStorage. This module is pure — no DOM — so the
+// conflict and persistence logic is unit-testable.
+
+export const ACTION_SLOTS = 12; // bar slots 0..11
+const STORE_KEY = 'woc_keybinds';
+
+// slot 0..11 -> default code; matches the original hard-coded 1..0,-,= bar
+const DEFAULT_CODES: string[] = [
+  'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5', 'Digit6',
+  'Digit7', 'Digit8', 'Digit9', 'Digit0', 'Minus', 'Equal',
+];
+
+// Core movement / camera / system keys that must keep working — binding an
+// action onto these would break basic control (e.g. W would move AND cast),
+// so the rebind UI refuses them.
+const RESERVED = new Set<string>([
+  'KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyQ', 'KeyE',
+  'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight',
+  'Space', 'Tab', 'Escape', 'Enter', 'NumpadEnter',
+]);
+
+export function isReservedCode(code: string): boolean {
+  return RESERVED.has(code);
+}
+
+// e.code -> short on-screen label (matches the keycap shown on the action bar)
+export function keyLabel(code: string | null): string {
+  if (!code) return '';
+  if (/^Digit\d$/.test(code)) return code.slice(5);
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3);
+  if (/^F\d{1,2}$/.test(code)) return code;
+  if (/^Numpad\d$/.test(code)) return 'Num' + code.slice(6);
+  const named: Record<string, string> = {
+    Minus: '-', Equal: '=', Backquote: '`', BracketLeft: '[', BracketRight: ']',
+    Backslash: '\\', Semicolon: ';', Quote: "'", Comma: ',', Period: '.', Slash: '/',
+    Space: 'Space', Tab: 'Tab', Enter: 'Enter', Escape: 'Esc',
+    ArrowUp: '↑', ArrowDown: '↓', ArrowLeft: '←', ArrowRight: '→',
+    NumpadAdd: 'Num+', NumpadSubtract: 'Num-', NumpadMultiply: 'Num*',
+    NumpadDivide: 'Num/', NumpadDecimal: 'Num.', NumpadEnter: 'NumEnter',
+  };
+  return named[code] ?? code;
+}
+
+export class Keybinds {
+  // index = slot, value = e.code, or null when the slot has no key
+  private codes: (string | null)[] = [];
+
+  constructor() {
+    this.load();
+  }
+
+  private load(): void {
+    let stored: unknown = null;
+    try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
+    const seen = new Set<string>();
+    this.codes = DEFAULT_CODES.map((def, i) => {
+      const v = Array.isArray(stored) ? stored[i] : undefined;
+      // accept a stored code only if it's a string and not already claimed by
+      // an earlier slot; missing/invalid entries fall back to the default
+      const code = v === null ? null : (typeof v === 'string' ? v : def);
+      if (code !== null && seen.has(code)) return null;
+      if (code !== null) seen.add(code);
+      return code;
+    });
+  }
+
+  private save(): void {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(this.codes)); } catch { /* storage unavailable */ }
+  }
+
+  /** Slot a keypress should trigger, or null if the code is unbound. */
+  slotForCode(code: string): number | null {
+    const i = this.codes.indexOf(code);
+    return i === -1 ? null : i;
+  }
+
+  codeForSlot(slot: number): string | null {
+    return this.codes[slot] ?? null;
+  }
+
+  label(slot: number): string {
+    return keyLabel(this.codes[slot] ?? null);
+  }
+
+  /**
+   * Bind a key to a slot. A reserved key is rejected (returns false, no
+   * change). Binding a key already held by another slot clears it there
+   * first (WoW-style), so a code is never on two slots.
+   */
+  bind(slot: number, code: string): boolean {
+    if (slot < 0 || slot >= ACTION_SLOTS) return false;
+    if (isReservedCode(code)) return false;
+    const existing = this.codes.indexOf(code);
+    if (existing !== -1 && existing !== slot) this.codes[existing] = null;
+    this.codes[slot] = code;
+    this.save();
+    return true;
+  }
+
+  /** Clear a slot's binding (the action stays clickable, just no hotkey). */
+  clear(slot: number): void {
+    if (slot < 0 || slot >= ACTION_SLOTS) return;
+    this.codes[slot] = null;
+    this.save();
+  }
+
+  reset(): void {
+    this.codes = DEFAULT_CODES.slice();
+    this.save();
+  }
+}

--- a/src/game/music.ts
+++ b/src/game/music.ts
@@ -318,9 +318,27 @@ export class MusicDirector {
   private zone: MusicZone | null = null;
   private combat = false;
   private _enabled = (typeof localStorage === 'undefined') ? true : localStorage.getItem(STORAGE_KEY) !== '0';
+  private _vol = 1; // 0..1 volume, set from the settings menu
 
   get enabled(): boolean {
     return this._enabled;
+  }
+
+  // master gain target given the enabled flag and volume (base level 0.15)
+  private masterTarget(): number {
+    return this._enabled ? 0.15 * this._vol : 0;
+  }
+
+  /** Set music volume (0..1). Safe before init(); applied to the master gain. */
+  setVolume(v: number): void {
+    this._vol = Math.min(1, Math.max(0, v));
+    if (this.ctx && this.master) {
+      this.master.gain.setTargetAtTime(this.masterTarget(), this.ctx.currentTime, 0.2);
+    }
+  }
+
+  get volume(): number {
+    return this._vol;
   }
 
   init(): void {
@@ -332,7 +350,7 @@ export class MusicDirector {
     }
     const ctx = this.ctx;
     this.master = ctx.createGain();
-    this.master.gain.value = this._enabled ? 0.15 : 0;
+    this.master.gain.value = this.masterTarget();
     this.master.connect(ctx.destination);
 
     // generated hall impulse response
@@ -376,7 +394,7 @@ export class MusicDirector {
       localStorage.setItem(STORAGE_KEY, on ? '1' : '0');
     } catch { /* private mode */ }
     if (this.ctx && this.master) {
-      this.master.gain.setTargetAtTime(on ? 0.15 : 0, this.ctx.currentTime, 0.3);
+      this.master.gain.setTargetAtTime(this.masterTarget(), this.ctx.currentTime, 0.3);
     }
   }
 

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -1,0 +1,77 @@
+// Player-adjustable game settings (camera, audio, graphics) surfaced in the
+// Esc options menu. Pure + persisted to localStorage; main.ts applies each
+// value to the live subsystem (Input / GameAudio / MusicDirector / Renderer).
+
+export interface GameSettings {
+  cameraSpeed: number;  // mouse-look sensitivity multiplier (1 = the old fixed speed)
+  sfxVolume: number;    // 0..1
+  musicVolume: number;  // 0..1
+  brightness: number;   // tone-mapping exposure multiplier
+  renderScale: number;  // resolution multiplier on top of the device pixel ratio
+}
+
+interface Range { min: number; max: number; def: number }
+
+// Camera default is 0.7: the old fixed speed (1.0) was near the top of the
+// reasonable range and drew complaints, so out of the box it's calmer while
+// the slider still reaches 1.25 for players who liked it fast.
+export const SETTING_RANGES: Record<keyof GameSettings, Range> = {
+  cameraSpeed: { min: 0.25, max: 1.25, def: 0.7 },
+  sfxVolume: { min: 0, max: 1, def: 0.8 },
+  musicVolume: { min: 0, max: 1, def: 0.8 },
+  brightness: { min: 0.6, max: 1.5, def: 1 },
+  renderScale: { min: 0.5, max: 1, def: 1 },
+};
+
+const STORE_KEY = 'woc_settings';
+const KEYS = Object.keys(SETTING_RANGES) as (keyof GameSettings)[];
+
+function clampSetting(key: keyof GameSettings, v: number): number {
+  const r = SETTING_RANGES[key];
+  if (!Number.isFinite(v)) return r.def;
+  return Math.min(r.max, Math.max(r.min, v));
+}
+
+export class Settings {
+  private values: GameSettings;
+
+  constructor() {
+    this.values = this.load();
+  }
+
+  private load(): GameSettings {
+    let stored: unknown = null;
+    try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
+    const out = {} as GameSettings;
+    for (const key of KEYS) {
+      const raw = stored && typeof stored === 'object' ? (stored as Record<string, unknown>)[key] : undefined;
+      out[key] = typeof raw === 'number' ? clampSetting(key, raw) : SETTING_RANGES[key].def;
+    }
+    return out;
+  }
+
+  private save(): void {
+    try { localStorage.setItem(STORE_KEY, JSON.stringify(this.values)); } catch { /* storage unavailable */ }
+  }
+
+  get<K extends keyof GameSettings>(key: K): GameSettings[K] {
+    return this.values[key];
+  }
+
+  all(): GameSettings {
+    return { ...this.values };
+  }
+
+  /** Clamp + store a value; returns the value actually applied. */
+  set<K extends keyof GameSettings>(key: K, value: number): number {
+    const v = clampSetting(key, value);
+    this.values[key] = v;
+    this.save();
+    return v;
+  }
+
+  reset(): void {
+    for (const key of KEYS) this.values[key] = SETTING_RANGES[key].def;
+    this.save();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Sim } from './sim/sim';
 import { Renderer } from './render/renderer';
 import { Input } from './game/input';
 import { Keybinds } from './game/keybinds';
+import { Settings, GameSettings } from './game/settings';
 import { Hud } from './ui/hud';
 import { audio } from './game/audio';
 import { music } from './game/music';
@@ -86,6 +87,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   const nameplates = $('#nameplates') as HTMLDivElement;
 
   const keybinds = new Keybinds();
+  const settings = new Settings();
   let renderer!: Renderer;
   let hud!: Hud;
   try {
@@ -144,11 +146,28 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   }, keybinds);
   input.camYaw = world.player.facing;
 
-  // the options menu drives logout + key-capture, both of which need refs that
-  // only exist now (input) or are page-level (reload returns to the start menu)
+  // apply a setting to its live subsystem (also used to apply all on startup)
+  function applySetting(key: keyof GameSettings, value: number): void {
+    const v = settings.set(key, value);
+    switch (key) {
+      case 'cameraSpeed': input.setCameraSpeed(v); break;
+      case 'sfxVolume': audio.setVolume(v); break;
+      case 'musicVolume': music.setVolume(v); break;
+      case 'brightness': renderer.setBrightness(v); break;
+      case 'renderScale': renderer.setRenderScale(v); break;
+    }
+  }
+  // apply persisted settings to the freshly-built subsystems
+  const saved = settings.all();
+  for (const k of Object.keys(saved) as (keyof GameSettings)[]) applySetting(k, saved[k]);
+
+  // the options menu drives logout + key-capture + settings, all of which need
+  // refs that only exist now (input/renderer) or are page-level (reload)
   hud.attachOptions({
     logout: () => location.reload(),
     captureKey: (cb) => input.captureNextKey(cb),
+    settings,
+    onSettingChange: (key, value) => applySetting(key, value),
   });
 
   function interactKey(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import { Sim } from './sim/sim';
 import { Renderer } from './render/renderer';
 import { Input } from './game/input';
+import { Keybinds } from './game/keybinds';
 import { Hud } from './ui/hud';
 import { audio } from './game/audio';
 import { music } from './game/music';
@@ -84,11 +85,12 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   const canvas = $('#game-canvas') as unknown as HTMLCanvasElement;
   const nameplates = $('#nameplates') as HTMLDivElement;
 
+  const keybinds = new Keybinds();
   let renderer!: Renderer;
   let hud!: Hud;
   try {
     renderer = new Renderer(world, canvas, nameplates);
-    hud = new Hud(world, renderer);
+    hud = new Hud(world, renderer, keybinds);
   } catch (err) {
     // e.g. WebGL context creation failure — surface it instead of leaving the
     // loading screen up forever
@@ -133,13 +135,21 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         case 'meters': hud.toggleMeters(); break;
         case 'chat': openChat(); break;
         case 'escape':
-          if (!hud.closeAll()) world.targetEntity(null);
+          // close the topmost panel; if nothing was open, open the game menu
+          if (!hud.closeAll()) hud.toggleOptionsMenu();
           break;
       }
     },
     onClickPick: (x, y, button) => handlePick(x, y, button),
-  });
+  }, keybinds);
   input.camYaw = world.player.facing;
+
+  // the options menu drives logout + key-capture, both of which need refs that
+  // only exist now (input) or are page-level (reload returns to the start menu)
+  hud.attachOptions({
+    logout: () => location.reload(),
+    captureKey: (cb) => input.captureNextKey(cb),
+  });
 
   function interactKey(): void {
     const p = world.player;
@@ -209,6 +219,10 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     let frameDt = (now - last) / 1000;
     last = now;
     if (frameDt > 0.25) frameDt = 0.25;
+
+    // freeze movement while the game menu is up so WASD doesn't walk the
+    // character behind it (other windows stay non-modal, as before)
+    input.suspendMovement = hud.isModalOpen();
 
     const mouselook = input.rightDown && !world.player.dead;
 

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -104,6 +104,9 @@ export class Renderer {
   camPitch = 0.32;
   camDist = 12;
   showNameplates = true;
+  // settings-menu graphics knobs (applied live)
+  private renderScale = 1; // resolution multiplier on top of the device pixel ratio
+  private baseExposure = 1.12; // tone-mapping exposure at brightness 1.0
   private tmpV = new THREE.Vector3();
   private tmpV2 = new THREE.Vector3();
   // floating /say-/yell bubbles, keyed by speaker entity id
@@ -152,7 +155,7 @@ export class Renderer {
     this.webgl.shadowMap.enabled = !LOW_GFX;
     this.webgl.shadowMap.type = THREE.PCFSoftShadowMap;
     this.webgl.toneMapping = THREE.ACESFilmicToneMapping; // OutputPass reads this on the composer path
-    this.webgl.toneMappingExposure = 1.12;
+    this.webgl.toneMappingExposure = this.baseExposure;
     this.camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 950);
 
     this.scene.fog = new THREE.Fog(0xa6c6e0, 130, 470);
@@ -329,17 +332,33 @@ export class Renderer {
     window.addEventListener('resize', () => {
       this.camera.aspect = window.innerWidth / window.innerHeight;
       this.camera.updateProjectionMatrix();
-      // dragging between monitors changes devicePixelRatio: refresh it before
-      // resizing so the canvas/composer/vfx don't keep the old DPI
-      const ratio = Math.min(window.devicePixelRatio, GFX.pixelRatioCap);
-      this.webgl.setPixelRatio(ratio);
-      this.webgl.setSize(window.innerWidth, window.innerHeight);
-      if (this.post) {
-        this.post.composer.setPixelRatio(ratio);
-        this.post.setSize(window.innerWidth, window.innerHeight);
-      }
-      this.vfx.setViewportScale(this.webgl.domElement.clientHeight * this.webgl.getPixelRatio(), 60);
+      this.applyResolution();
     });
+  }
+
+  // Push the current device pixel ratio (× renderScale, still capped by the
+  // tier) to the renderer, composer, and vfx. Shared by resize and the
+  // render-scale setting so a window resize never drops the chosen scale.
+  private applyResolution(): void {
+    const ratio = Math.min(window.devicePixelRatio, GFX.pixelRatioCap) * this.renderScale;
+    this.webgl.setPixelRatio(ratio);
+    this.webgl.setSize(window.innerWidth, window.innerHeight);
+    if (this.post) {
+      this.post.composer.setPixelRatio(ratio);
+      this.post.setSize(window.innerWidth, window.innerHeight);
+    }
+    this.vfx.setViewportScale(this.webgl.domElement.clientHeight * this.webgl.getPixelRatio(), 60);
+  }
+
+  /** Tone-mapping exposure multiplier (1.0 = the default look). */
+  setBrightness(mult: number): void {
+    this.webgl.toneMappingExposure = this.baseExposure * mult;
+  }
+
+  /** Resolution multiplier on top of the device pixel ratio (0.5..1). */
+  setRenderScale(scale: number): void {
+    this.renderScale = Math.min(1, Math.max(0.5, scale));
+    this.applyResolution();
   }
 
   // Visual reactions to sim events (called by the HUD for every event,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -13,6 +13,13 @@ import { Meters } from './meters';
 import { audio } from '../game/audio';
 import { music } from '../game/music';
 import { iconDataUrl, QUALITY_COLOR } from './icons';
+import { Keybinds, ACTION_SLOTS, isReservedCode, keyLabel } from '../game/keybinds';
+
+// hooks main wires after Input exists (the options menu drives both)
+export interface OptionsHooks {
+  logout(): void;
+  captureKey(cb: (code: string | null) => void): void;
+}
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
 
@@ -31,9 +38,13 @@ const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
 
 export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
-  private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
+  private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
   private dragFromSlot: number | null = null;
+  private optionsHooks: OptionsHooks | null = null;
+  private optionsView: 'main' | 'keybinds' = 'main';
+  private capturingSlot: number | null = null; // action slot awaiting a key
+  private keybindNote = '';
   private chatLogEl = $('#chatlog');
   private combatLogEl = $('#combatlog');
   private errorEl = $('#error-msg');
@@ -61,12 +72,13 @@ export class Hud {
 
   private meters: Meters;
 
-  constructor(private sim: IWorld, private renderer: Renderer) {
+  constructor(private sim: IWorld, private renderer: Renderer, private keybinds: Keybinds) {
     this.ignoredChatNames = this.loadIgnoredChatNames();
     this.meters = new Meters(sim);
     this.bindLogTabs();
     this.loadSlotMap();
     this.buildActionBar();
+    this.refreshKeybindLabels();
     this.buildXpTicks();
     $('#pf-name').textContent = sim.player.name;
     this.drawPortrait($('#pf-portrait') as unknown as HTMLCanvasElement, CLASS_GLYPH[sim.cfg.playerClass], CLASSES[sim.cfg.playerClass].color);
@@ -281,7 +293,6 @@ export class Hud {
 
   private buildActionBar(): void {
     const bar = $('#actionbar');
-    const keybinds = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-', '='];
     for (let i = 0; i < 12; i++) {
       const btn = document.createElement('button');
       btn.className = 'action-btn empty';
@@ -289,7 +300,7 @@ export class Hud {
       label.className = 'icon-label';
       const kb = document.createElement('span');
       kb.className = 'keybind';
-      kb.textContent = keybinds[i];
+      kb.textContent = this.keybinds.label(i); // rebindable; refreshKeybindLabels keeps it current
       const cdOverlay = document.createElement('div');
       cdOverlay.className = 'cd-overlay';
       const cdText = document.createElement('div');
@@ -344,7 +355,14 @@ export class Hud {
         });
       }
       bar.appendChild(btn);
-      this.abilityButtons.push({ btn, label, cdOverlay, cdText, lastIcon: '' });
+      this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
+    }
+  }
+
+  // Repaint the keycap on every action button from the current bindings.
+  private refreshKeybindLabels(): void {
+    for (let i = 0; i < this.abilityButtons.length; i++) {
+      this.abilityButtons[i].keybindEl.textContent = this.keybinds.label(i);
     }
   }
 
@@ -1652,11 +1670,135 @@ export class Hud {
   }
 
   // -------------------------------------------------------------------------
+  // Options menu (Esc) + hotkey rebinding
+  // -------------------------------------------------------------------------
+
+  attachOptions(hooks: OptionsHooks): void {
+    this.optionsHooks = hooks;
+  }
+
+  get optionsOpen(): boolean {
+    return $('#options-menu').style.display === 'block';
+  }
+
+  // True while a menu that should pause character movement is up.
+  isModalOpen(): boolean {
+    return this.optionsOpen;
+  }
+
+  toggleOptionsMenu(): void {
+    if (this.optionsOpen) { this.closeOptions(); return; }
+    this.optionsView = 'main';
+    this.capturingSlot = null;
+    this.keybindNote = '';
+    this.renderOptions();
+    $('#options-menu').style.display = 'block';
+    audio.click();
+  }
+
+  closeOptions(): void {
+    $('#options-menu').style.display = 'none';
+    this.capturingSlot = null;
+    this.hideTooltip();
+  }
+
+  private renderOptions(): void {
+    if (this.optionsView === 'keybinds') { this.renderKeybinds(); return; }
+    const el = $('#options-menu');
+    el.innerHTML = `<div class="panel-title"><span>Game Menu</span><span class="x-btn" data-close>✕</span></div>`;
+    const list = document.createElement('div');
+    list.className = 'opt-list';
+    const add = (text: string, onClick: () => void) => {
+      const b = document.createElement('button');
+      b.className = 'btn opt-btn';
+      b.textContent = text;
+      b.addEventListener('click', () => { audio.click(); onClick(); });
+      list.appendChild(b);
+    };
+    add('Key Bindings', () => { this.optionsView = 'keybinds'; this.keybindNote = ''; this.renderOptions(); });
+    add('Logout', () => this.optionsHooks?.logout());
+    add('Return to Game', () => this.closeOptions());
+    el.appendChild(list);
+    el.querySelector('[data-close]')?.addEventListener('click', () => this.closeOptions());
+  }
+
+  // Label shown for an action slot in the rebind list: slot 0 is Attack, the
+  // rest show whatever ability currently occupies that bar slot.
+  private slotActionName(slot: number): string {
+    if (slot === 0) return 'Attack';
+    const known = this.abilityForSlot(slot);
+    return known ? known.def.name : `Slot ${slot + 1}`;
+  }
+
+  private renderKeybinds(): void {
+    const el = $('#options-menu');
+    el.innerHTML = `<div class="panel-title"><span>Key Bindings</span><span class="x-btn" data-close>✕</span></div>`;
+    const rows = document.createElement('div');
+    rows.className = 'kb-rows';
+    for (let slot = 0; slot < ACTION_SLOTS; slot++) {
+      const row = document.createElement('div');
+      row.className = 'kb-row';
+      const name = document.createElement('span');
+      name.className = 'kb-name';
+      name.textContent = this.slotActionName(slot);
+      const key = document.createElement('button');
+      key.className = 'btn kb-key' + (this.capturingSlot === slot ? ' capturing' : '');
+      key.textContent = this.capturingSlot === slot ? 'press a key…' : (this.keybinds.label(slot) || '—');
+      key.addEventListener('click', () => this.beginCapture(slot));
+      row.append(name, key);
+      rows.appendChild(row);
+    }
+    el.appendChild(rows);
+    const note = document.createElement('div');
+    note.className = 'kb-note';
+    note.textContent = this.keybindNote || 'Click a key, then press the key to bind. Esc cancels.';
+    el.appendChild(note);
+    const reset = document.createElement('button');
+    reset.className = 'btn';
+    reset.textContent = 'Reset to Defaults';
+    reset.addEventListener('click', () => {
+      audio.click();
+      this.keybinds.reset();
+      this.capturingSlot = null;
+      this.keybindNote = 'Bindings reset to defaults.';
+      this.refreshKeybindLabels();
+      this.renderKeybinds();
+    });
+    const back = document.createElement('button');
+    back.className = 'btn';
+    back.textContent = 'Back';
+    back.addEventListener('click', () => { audio.click(); this.optionsView = 'main'; this.capturingSlot = null; this.renderOptions(); });
+    el.append(reset, back);
+    el.querySelector('[data-close]')?.addEventListener('click', () => this.closeOptions());
+  }
+
+  private beginCapture(slot: number): void {
+    if (!this.optionsHooks) return;
+    this.capturingSlot = slot;
+    this.keybindNote = `Press a key for "${this.slotActionName(slot)}"…`;
+    this.renderKeybinds();
+    this.optionsHooks.captureKey((code) => {
+      this.capturingSlot = null;
+      if (code === null) {
+        this.keybindNote = 'Rebinding cancelled.';
+      } else if (isReservedCode(code)) {
+        this.keybindNote = `${keyLabel(code)} is reserved for movement and can't be bound.`;
+      } else if (this.keybinds.bind(slot, code)) {
+        this.keybindNote = `Bound "${this.slotActionName(slot)}" to ${keyLabel(code)}.`;
+        this.refreshKeybindLabels();
+      }
+      // re-render only if the menu is still open (player may have closed it)
+      if (this.optionsOpen) this.renderKeybinds();
+    });
+  }
+
+  // -------------------------------------------------------------------------
 
   // Closes the topmost UI. Returns true if something was closed.
   closeAll(): boolean {
     let closed = false;
     this.closeContextMenu();
+    if (this.optionsOpen) { this.closeOptions(); return true; }
     if (this.tradeOpen) {
       this.sim.tradeCancel();
       closed = true;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -14,11 +14,15 @@ import { audio } from '../game/audio';
 import { music } from '../game/music';
 import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
+import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 
-// hooks main wires after Input exists (the options menu drives both)
+// hooks main wires after Input exists (the options menu drives input, audio,
+// graphics, and logout, all of which live outside the HUD)
 export interface OptionsHooks {
   logout(): void;
   captureKey(cb: (code: string | null) => void): void;
+  settings: Settings;
+  onSettingChange(key: keyof GameSettings, value: number): void;
 }
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
@@ -42,7 +46,7 @@ export class Hud {
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
   private dragFromSlot: number | null = null;
   private optionsHooks: OptionsHooks | null = null;
-  private optionsView: 'main' | 'keybinds' = 'main';
+  private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
   private capturingKey: { action: string; index: number } | null = null; // binding awaiting a key
   private keybindNote = '';
   private chatLogEl = $('#chatlog');
@@ -1704,6 +1708,8 @@ export class Hud {
 
   private renderOptions(): void {
     if (this.optionsView === 'keybinds') { this.renderKeybinds(); return; }
+    if (this.optionsView === 'graphics') { this.renderGraphics(); return; }
+    if (this.optionsView === 'audio') { this.renderAudio(); return; }
     const el = $('#options-menu');
     el.innerHTML = `<div class="panel-title"><span>Game Menu</span><span class="x-btn" data-close>✕</span></div>`;
     const list = document.createElement('div');
@@ -1715,11 +1721,104 @@ export class Hud {
       b.addEventListener('click', () => { audio.click(); onClick(); });
       list.appendChild(b);
     };
-    add('Key Bindings', () => { this.optionsView = 'keybinds'; this.keybindNote = ''; this.renderOptions(); });
+    const goto = (view: 'keybinds' | 'graphics' | 'audio') => { this.optionsView = view; this.keybindNote = ''; this.renderOptions(); };
+    add('Key Bindings', () => goto('keybinds'));
+    add('Graphics', () => goto('graphics'));
+    add('Audio', () => goto('audio'));
     add('Logout', () => this.optionsHooks?.logout());
     add('Return to Game', () => this.closeOptions());
     el.appendChild(list);
     el.querySelector('[data-close]')?.addEventListener('click', () => this.closeOptions());
+  }
+
+  // A labelled slider bound to a numeric setting; live-applies via the hook.
+  private settingSlider(parent: HTMLElement, label: string, key: keyof GameSettings): void {
+    const hooks = this.optionsHooks;
+    if (!hooks) return;
+    const r = SETTING_RANGES[key];
+    const row = document.createElement('div');
+    row.className = 'set-row';
+    const name = document.createElement('span');
+    name.className = 'set-name';
+    name.textContent = label;
+    const slider = document.createElement('input');
+    slider.type = 'range';
+    slider.className = 'set-slider';
+    slider.min = String(r.min);
+    slider.max = String(r.max);
+    slider.step = '0.05';
+    slider.value = String(hooks.settings.get(key));
+    const val = document.createElement('span');
+    val.className = 'set-val';
+    const pct = () => `${Math.round(hooks.settings.get(key) * 100)}%`;
+    val.textContent = pct();
+    slider.addEventListener('input', () => {
+      hooks.onSettingChange(key, Number(slider.value));
+      val.textContent = pct();
+    });
+    row.append(name, slider, val);
+    parent.appendChild(row);
+  }
+
+  private settingsViewShell(title: string): HTMLElement {
+    const el = $('#options-menu');
+    el.innerHTML = `<div class="panel-title"><span>${title}</span><span class="x-btn" data-close>✕</span></div>`;
+    const body = document.createElement('div');
+    body.className = 'set-rows';
+    el.appendChild(body);
+    return body;
+  }
+
+  private settingsViewFooter(): void {
+    const el = $('#options-menu');
+    const reset = document.createElement('button');
+    reset.className = 'btn';
+    reset.textContent = 'Reset to Defaults';
+    reset.addEventListener('click', () => {
+      audio.click();
+      this.optionsHooks?.settings.reset();
+      // re-apply every setting to its subsystem, then redraw the view
+      const all = this.optionsHooks?.settings.all();
+      if (all) for (const k of Object.keys(all) as (keyof GameSettings)[]) this.optionsHooks?.onSettingChange(k, all[k]);
+      this.renderOptions();
+    });
+    const back = document.createElement('button');
+    back.className = 'btn';
+    back.textContent = 'Back';
+    back.addEventListener('click', () => { audio.click(); this.optionsView = 'main'; this.renderOptions(); });
+    el.append(reset, back);
+    el.querySelector('[data-close]')?.addEventListener('click', () => this.closeOptions());
+  }
+
+  private renderGraphics(): void {
+    const body = this.settingsViewShell('Graphics');
+    this.settingSlider(body, 'Camera Speed', 'cameraSpeed');
+    this.settingSlider(body, 'Brightness', 'brightness');
+    this.settingSlider(body, 'Render Quality', 'renderScale');
+    const note = document.createElement('div');
+    note.className = 'set-note';
+    note.textContent = 'Lower Camera Speed for a calmer mouselook. Render Quality below 100% boosts FPS on weaker machines.';
+    $('#options-menu').appendChild(note);
+    this.settingsViewFooter();
+  }
+
+  private renderAudio(): void {
+    const body = this.settingsViewShell('Audio');
+    this.settingSlider(body, 'Sound Effects', 'sfxVolume');
+    this.settingSlider(body, 'Music Volume', 'musicVolume');
+    const row = document.createElement('div');
+    row.className = 'set-row';
+    const name = document.createElement('span');
+    name.className = 'set-name';
+    name.textContent = 'Music';
+    const toggle = document.createElement('button');
+    toggle.className = 'btn set-toggle';
+    const sync = () => { toggle.textContent = music.enabled ? 'On' : 'Off'; toggle.classList.toggle('off', !music.enabled); };
+    sync();
+    toggle.addEventListener('click', () => { audio.click(); music.setEnabled(!music.enabled); sync(); });
+    row.append(name, toggle);
+    body.appendChild(row);
+    this.settingsViewFooter();
   }
 
   // Display name for an action row. Action-bar slots show the ability that

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -13,7 +13,7 @@ import { Meters } from './meters';
 import { audio } from '../game/audio';
 import { music } from '../game/music';
 import { iconDataUrl, QUALITY_COLOR } from './icons';
-import { Keybinds, ACTION_SLOTS, isReservedCode, keyLabel } from '../game/keybinds';
+import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 
 // hooks main wires after Input exists (the options menu drives both)
 export interface OptionsHooks {
@@ -43,7 +43,7 @@ export class Hud {
   private dragFromSlot: number | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private optionsView: 'main' | 'keybinds' = 'main';
-  private capturingSlot: number | null = null; // action slot awaiting a key
+  private capturingKey: { action: string; index: number } | null = null; // binding awaiting a key
   private keybindNote = '';
   private chatLogEl = $('#chatlog');
   private combatLogEl = $('#combatlog');
@@ -300,7 +300,7 @@ export class Hud {
       label.className = 'icon-label';
       const kb = document.createElement('span');
       kb.className = 'keybind';
-      kb.textContent = this.keybinds.label(i); // rebindable; refreshKeybindLabels keeps it current
+      kb.textContent = this.keybinds.primaryLabel(`slot${i}`); // rebindable; refreshKeybindLabels keeps it current
       const cdOverlay = document.createElement('div');
       cdOverlay.className = 'cd-overlay';
       const cdText = document.createElement('div');
@@ -362,7 +362,7 @@ export class Hud {
   // Repaint the keycap on every action button from the current bindings.
   private refreshKeybindLabels(): void {
     for (let i = 0; i < this.abilityButtons.length; i++) {
-      this.abilityButtons[i].keybindEl.textContent = this.keybinds.label(i);
+      this.abilityButtons[i].keybindEl.textContent = this.keybinds.primaryLabel(`slot${i}`);
     }
   }
 
@@ -1689,7 +1689,7 @@ export class Hud {
   toggleOptionsMenu(): void {
     if (this.optionsOpen) { this.closeOptions(); return; }
     this.optionsView = 'main';
-    this.capturingSlot = null;
+    this.capturingKey = null;
     this.keybindNote = '';
     this.renderOptions();
     $('#options-menu').style.display = 'block';
@@ -1698,7 +1698,7 @@ export class Hud {
 
   closeOptions(): void {
     $('#options-menu').style.display = 'none';
-    this.capturingSlot = null;
+    this.capturingKey = null;
     this.hideTooltip();
   }
 
@@ -1722,44 +1722,58 @@ export class Hud {
     el.querySelector('[data-close]')?.addEventListener('click', () => this.closeOptions());
   }
 
-  // Label shown for an action slot in the rebind list: slot 0 is Attack, the
-  // rest show whatever ability currently occupies that bar slot.
-  private slotActionName(slot: number): string {
+  // Display name for an action row. Action-bar slots show the ability that
+  // currently occupies them (slot 0 is always Attack); everything else uses
+  // its registry label.
+  private actionDisplayName(actionId: string, fallback: string): string {
+    if (!actionId.startsWith('slot')) return fallback;
+    const slot = Number(actionId.slice(4));
     if (slot === 0) return 'Attack';
     const known = this.abilityForSlot(slot);
-    return known ? known.def.name : `Slot ${slot + 1}`;
+    return known ? known.def.name : fallback;
   }
 
   private renderKeybinds(): void {
     const el = $('#options-menu');
     el.innerHTML = `<div class="panel-title"><span>Key Bindings</span><span class="x-btn" data-close>✕</span></div>`;
-    const rows = document.createElement('div');
-    rows.className = 'kb-rows';
-    for (let slot = 0; slot < ACTION_SLOTS; slot++) {
-      const row = document.createElement('div');
-      row.className = 'kb-row';
-      const name = document.createElement('span');
-      name.className = 'kb-name';
-      name.textContent = this.slotActionName(slot);
-      const key = document.createElement('button');
-      key.className = 'btn kb-key' + (this.capturingSlot === slot ? ' capturing' : '');
-      key.textContent = this.capturingSlot === slot ? 'press a key…' : (this.keybinds.label(slot) || '—');
-      key.addEventListener('click', () => this.beginCapture(slot));
-      row.append(name, key);
-      rows.appendChild(row);
-    }
-    el.appendChild(rows);
     const note = document.createElement('div');
     note.className = 'kb-note';
-    note.textContent = this.keybindNote || 'Click a key, then press the key to bind. Esc cancels.';
+    note.textContent = this.keybindNote || 'Click a key cell, then press a key to bind it. Esc cancels. Each action has a primary and an alternate key.';
     el.appendChild(note);
+    const rows = document.createElement('div');
+    rows.className = 'kb-rows';
+    for (const category of BIND_CATEGORIES) {
+      const header = document.createElement('div');
+      header.className = 'kb-cat';
+      header.textContent = category;
+      rows.appendChild(header);
+      for (const action of BIND_ACTIONS.filter((a) => a.category === category)) {
+        const row = document.createElement('div');
+        row.className = 'kb-row';
+        const name = document.createElement('span');
+        name.className = 'kb-name';
+        name.textContent = this.actionDisplayName(action.id, action.label);
+        row.appendChild(name);
+        for (let index = 0; index < 2; index++) {
+          const capturing = this.capturingKey?.action === action.id && this.capturingKey?.index === index;
+          const key = document.createElement('button');
+          key.className = 'btn kb-key' + (capturing ? ' capturing' : '');
+          key.textContent = capturing ? '…' : (this.keybinds.labelAt(action.id, index) || '—');
+          key.title = index === 0 ? 'Primary' : 'Alternate';
+          key.addEventListener('click', () => this.beginCapture(action.id, index, action.label));
+          row.appendChild(key);
+        }
+        rows.appendChild(row);
+      }
+    }
+    el.appendChild(rows);
     const reset = document.createElement('button');
     reset.className = 'btn';
     reset.textContent = 'Reset to Defaults';
     reset.addEventListener('click', () => {
       audio.click();
       this.keybinds.reset();
-      this.capturingSlot = null;
+      this.capturingKey = null;
       this.keybindNote = 'Bindings reset to defaults.';
       this.refreshKeybindLabels();
       this.renderKeybinds();
@@ -1767,24 +1781,25 @@ export class Hud {
     const back = document.createElement('button');
     back.className = 'btn';
     back.textContent = 'Back';
-    back.addEventListener('click', () => { audio.click(); this.optionsView = 'main'; this.capturingSlot = null; this.renderOptions(); });
+    back.addEventListener('click', () => { audio.click(); this.optionsView = 'main'; this.capturingKey = null; this.renderOptions(); });
     el.append(reset, back);
     el.querySelector('[data-close]')?.addEventListener('click', () => this.closeOptions());
   }
 
-  private beginCapture(slot: number): void {
+  private beginCapture(actionId: string, index: number, fallbackLabel: string): void {
     if (!this.optionsHooks) return;
-    this.capturingSlot = slot;
-    this.keybindNote = `Press a key for "${this.slotActionName(slot)}"…`;
+    const name = this.actionDisplayName(actionId, fallbackLabel);
+    this.capturingKey = { action: actionId, index };
+    this.keybindNote = `Press a key for "${name}"…`;
     this.renderKeybinds();
     this.optionsHooks.captureKey((code) => {
-      this.capturingSlot = null;
+      this.capturingKey = null;
       if (code === null) {
         this.keybindNote = 'Rebinding cancelled.';
       } else if (isReservedCode(code)) {
-        this.keybindNote = `${keyLabel(code)} is reserved for movement and can't be bound.`;
-      } else if (this.keybinds.bind(slot, code)) {
-        this.keybindNote = `Bound "${this.slotActionName(slot)}" to ${keyLabel(code)}.`;
+        this.keybindNote = `${keyLabel(code)} is reserved and can't be bound.`;
+      } else if (this.keybinds.bind(actionId, index, code)) {
+        this.keybindNote = `Bound "${name}" to ${keyLabel(code)}.`;
         this.refreshKeybindLabels();
       }
       // re-render only if the menu is still open (player may have closed it)

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Keybinds, isReservedCode, keyLabel } from '../src/game/keybinds';
+
+// minimal localStorage stub (the test env is plain node, no DOM)
+function installStorage(): void {
+  const map = new Map<string, string>();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => { map.set(k, v); },
+    removeItem: (k: string) => { map.delete(k); },
+    clear: () => map.clear(),
+  };
+}
+
+beforeEach(() => installStorage());
+
+describe('keyLabel', () => {
+  it('maps codes to short keycaps', () => {
+    expect(keyLabel('Digit1')).toBe('1');
+    expect(keyLabel('Digit0')).toBe('0');
+    expect(keyLabel('Minus')).toBe('-');
+    expect(keyLabel('Equal')).toBe('=');
+    expect(keyLabel('KeyR')).toBe('R');
+    expect(keyLabel('F5')).toBe('F5');
+    expect(keyLabel('Numpad3')).toBe('Num3');
+    expect(keyLabel('Space')).toBe('Space');
+    expect(keyLabel(null)).toBe('');
+  });
+});
+
+describe('reserved keys', () => {
+  it('flags movement/system keys', () => {
+    for (const c of ['KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyQ', 'KeyE', 'Space', 'Tab', 'Escape', 'Enter']) {
+      expect(isReservedCode(c), c).toBe(true);
+    }
+    for (const c of ['Digit1', 'KeyR', 'F1', 'Minus']) {
+      expect(isReservedCode(c), c).toBe(false);
+    }
+  });
+});
+
+describe('Keybinds', () => {
+  it('starts on the default 1..0,-,= layout', () => {
+    const kb = new Keybinds();
+    expect(kb.codeForSlot(0)).toBe('Digit1');
+    expect(kb.label(0)).toBe('1'); // slot 0 = Attack, key "1"
+    expect(kb.codeForSlot(9)).toBe('Digit0');
+    expect(kb.label(10)).toBe('-');
+    expect(kb.label(11)).toBe('=');
+    expect(kb.slotForCode('Digit1')).toBe(0);
+    expect(kb.slotForCode('Equal')).toBe(11);
+    expect(kb.slotForCode('KeyZ')).toBe(null);
+  });
+
+  it('binds a key to a slot, including the Attack slot', () => {
+    const kb = new Keybinds();
+    expect(kb.bind(0, 'KeyR')).toBe(true); // rebind Attack off "1"
+    expect(kb.slotForCode('KeyR')).toBe(0);
+    expect(kb.label(0)).toBe('R');
+    expect(kb.slotForCode('Digit1')).toBe(null); // its old key is now free
+  });
+
+  it('rejects reserved keys and leaves the slot unchanged', () => {
+    const kb = new Keybinds();
+    expect(kb.bind(2, 'KeyW')).toBe(false);
+    expect(kb.codeForSlot(2)).toBe('Digit3'); // default intact
+  });
+
+  it('clears a conflicting binding from its old slot (no duplicates)', () => {
+    const kb = new Keybinds();
+    // bind slot 3 to slot 0's default key
+    expect(kb.bind(3, 'Digit1')).toBe(true);
+    expect(kb.slotForCode('Digit1')).toBe(3);
+    expect(kb.codeForSlot(0)).toBe(null); // stolen from slot 0
+  });
+
+  it('clear() removes a slot binding', () => {
+    const kb = new Keybinds();
+    kb.clear(4);
+    expect(kb.codeForSlot(4)).toBe(null);
+    expect(kb.label(4)).toBe('');
+    expect(kb.slotForCode('Digit5')).toBe(null);
+  });
+
+  it('reset() restores defaults', () => {
+    const kb = new Keybinds();
+    kb.bind(0, 'KeyR');
+    kb.clear(5);
+    kb.reset();
+    expect(kb.codeForSlot(0)).toBe('Digit1');
+    expect(kb.codeForSlot(5)).toBe('Digit6');
+  });
+
+  it('persists across instances', () => {
+    const a = new Keybinds();
+    a.bind(0, 'KeyR');
+    a.bind(1, 'KeyF');
+    const b = new Keybinds(); // reloads from the same storage
+    expect(b.slotForCode('KeyR')).toBe(0);
+    expect(b.slotForCode('KeyF')).toBe(1);
+  });
+
+  it('drops duplicate codes when loading corrupt storage', () => {
+    // two slots claim the same code — the later one must lose it on load
+    localStorage.setItem('woc_keybinds', JSON.stringify(['KeyR', 'KeyR', 'Digit3']));
+    const kb = new Keybinds();
+    expect(kb.slotForCode('KeyR')).toBe(0); // first wins
+    expect(kb.codeForSlot(1)).toBe(null); // duplicate dropped
+  });
+});

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { Keybinds, isReservedCode, keyLabel } from '../src/game/keybinds';
+import {
+  Keybinds, BIND_ACTIONS, BIND_CATEGORIES, actionKind, isReservedCode, keyLabel,
+} from '../src/game/keybinds';
 
 // minimal localStorage stub (the test env is plain node, no DOM)
 function installStorage(): void {
@@ -17,94 +19,142 @@ beforeEach(() => installStorage());
 describe('keyLabel', () => {
   it('maps codes to short keycaps', () => {
     expect(keyLabel('Digit1')).toBe('1');
-    expect(keyLabel('Digit0')).toBe('0');
     expect(keyLabel('Minus')).toBe('-');
     expect(keyLabel('Equal')).toBe('=');
     expect(keyLabel('KeyR')).toBe('R');
     expect(keyLabel('F5')).toBe('F5');
     expect(keyLabel('Numpad3')).toBe('Num3');
     expect(keyLabel('Space')).toBe('Space');
+    expect(keyLabel('ArrowUp')).toBe('↑');
     expect(keyLabel(null)).toBe('');
   });
 });
 
+describe('registry', () => {
+  it('classifies movement as held and the rest as edge', () => {
+    expect(actionKind('forward')).toBe('held');
+    expect(actionKind('jump')).toBe('held');
+    expect(actionKind('autorun')).toBe('edge');
+    expect(actionKind('target')).toBe('edge');
+    expect(actionKind('slot0')).toBe('edge');
+    expect(actionKind('nope')).toBe(null);
+  });
+
+  it('covers the expected categories and 12 action-bar slots', () => {
+    expect(BIND_CATEGORIES).toContain('Movement');
+    expect(BIND_CATEGORIES).toContain('Action Bar');
+    expect(BIND_ACTIONS.filter((a) => a.category === 'Action Bar').length).toBe(12);
+  });
+});
+
 describe('reserved keys', () => {
-  it('flags movement/system keys', () => {
-    for (const c of ['KeyW', 'KeyA', 'KeyS', 'KeyD', 'KeyQ', 'KeyE', 'Space', 'Tab', 'Escape', 'Enter']) {
-      expect(isReservedCode(c), c).toBe(true);
-    }
-    for (const c of ['Digit1', 'KeyR', 'F1', 'Minus']) {
+  it('reserves only Escape (everything else is rebindable now)', () => {
+    expect(isReservedCode('Escape')).toBe(true);
+    for (const c of ['KeyW', 'Space', 'Tab', 'Enter', 'Digit1', 'KeyR']) {
       expect(isReservedCode(c), c).toBe(false);
     }
   });
 });
 
-describe('Keybinds', () => {
-  it('starts on the default 1..0,-,= layout', () => {
+describe('Keybinds defaults', () => {
+  it('resolves default movement, system, and action-bar keys to actions', () => {
     const kb = new Keybinds();
-    expect(kb.codeForSlot(0)).toBe('Digit1');
-    expect(kb.label(0)).toBe('1'); // slot 0 = Attack, key "1"
-    expect(kb.codeForSlot(9)).toBe('Digit0');
-    expect(kb.label(10)).toBe('-');
-    expect(kb.label(11)).toBe('=');
-    expect(kb.slotForCode('Digit1')).toBe(0);
-    expect(kb.slotForCode('Equal')).toBe(11);
-    expect(kb.slotForCode('KeyZ')).toBe(null);
+    expect(kb.actionForCode('KeyW')).toBe('forward');
+    expect(kb.actionForCode('ArrowUp')).toBe('forward'); // secondary default
+    expect(kb.actionForCode('KeyD')).toBe('turnRight');
+    expect(kb.actionForCode('Space')).toBe('jump');
+    expect(kb.actionForCode('Tab')).toBe('target');
+    expect(kb.actionForCode('KeyB')).toBe('bags');
+    expect(kb.actionForCode('Digit1')).toBe('slot0'); // Attack
+    expect(kb.actionForCode('Equal')).toBe('slot11');
+    expect(kb.actionForCode('KeyJ')).toBe(null);
   });
 
-  it('binds a key to a slot, including the Attack slot', () => {
+  it('exposes primary/secondary codes and labels', () => {
     const kb = new Keybinds();
-    expect(kb.bind(0, 'KeyR')).toBe(true); // rebind Attack off "1"
-    expect(kb.slotForCode('KeyR')).toBe(0);
-    expect(kb.label(0)).toBe('R');
-    expect(kb.slotForCode('Digit1')).toBe(null); // its old key is now free
+    expect(kb.codeAt('forward', 0)).toBe('KeyW');
+    expect(kb.codeAt('forward', 1)).toBe('ArrowUp');
+    expect(kb.codesForAction('forward')).toEqual(['KeyW', 'ArrowUp']);
+    expect(kb.primaryLabel('slot0')).toBe('1');
+    expect(kb.labelAt('forward', 1)).toBe('↑');
+  });
+});
+
+describe('binding', () => {
+  it('rebinds the Attack slot off "1"', () => {
+    const kb = new Keybinds();
+    expect(kb.bind('slot0', 0, 'KeyR')).toBe(true);
+    expect(kb.actionForCode('KeyR')).toBe('slot0');
+    expect(kb.primaryLabel('slot0')).toBe('R');
+    expect(kb.actionForCode('Digit1')).toBe(null); // old key freed
   });
 
-  it('rejects reserved keys and leaves the slot unchanged', () => {
+  it('rebinds a movement key', () => {
     const kb = new Keybinds();
-    expect(kb.bind(2, 'KeyW')).toBe(false);
-    expect(kb.codeForSlot(2)).toBe('Digit3'); // default intact
+    expect(kb.bind('jump', 0, 'KeyJ')).toBe(true);
+    expect(kb.actionForCode('KeyJ')).toBe('jump');
+    expect(kb.actionForCode('Space')).toBe(null);
   });
 
-  it('clears a conflicting binding from its old slot (no duplicates)', () => {
+  it('binds a secondary key without disturbing the primary', () => {
     const kb = new Keybinds();
-    // bind slot 3 to slot 0's default key
-    expect(kb.bind(3, 'Digit1')).toBe(true);
-    expect(kb.slotForCode('Digit1')).toBe(3);
-    expect(kb.codeForSlot(0)).toBe(null); // stolen from slot 0
+    expect(kb.bind('slot1', 1, 'KeyZ')).toBe(true);
+    expect(kb.codeAt('slot1', 0)).toBe('Digit2');
+    expect(kb.codeAt('slot1', 1)).toBe('KeyZ');
+    expect(kb.actionForCode('KeyZ')).toBe('slot1');
   });
 
-  it('clear() removes a slot binding', () => {
+  it('rejects the reserved Escape key', () => {
     const kb = new Keybinds();
-    kb.clear(4);
-    expect(kb.codeForSlot(4)).toBe(null);
-    expect(kb.label(4)).toBe('');
-    expect(kb.slotForCode('Digit5')).toBe(null);
+    expect(kb.bind('jump', 0, 'Escape')).toBe(false);
+    expect(kb.codeAt('jump', 0)).toBe('Space');
+  });
+
+  it('clears a conflicting code from another action (cross-category)', () => {
+    const kb = new Keybinds();
+    // steal W (forward's primary) for the bags window
+    expect(kb.bind('bags', 0, 'KeyW')).toBe(true);
+    expect(kb.actionForCode('KeyW')).toBe('bags');
+    expect(kb.codeAt('forward', 0)).toBe(null); // primary stolen
+    expect(kb.actionForCode('ArrowUp')).toBe('forward'); // alternate still drives forward
+  });
+
+  it('clear() removes one binding slot', () => {
+    const kb = new Keybinds();
+    kb.clear('forward', 1);
+    expect(kb.codesForAction('forward')).toEqual(['KeyW']);
+    expect(kb.actionForCode('ArrowUp')).toBe(null);
   });
 
   it('reset() restores defaults', () => {
     const kb = new Keybinds();
-    kb.bind(0, 'KeyR');
-    kb.clear(5);
+    kb.bind('slot0', 0, 'KeyR');
+    kb.clear('jump', 0);
     kb.reset();
-    expect(kb.codeForSlot(0)).toBe('Digit1');
-    expect(kb.codeForSlot(5)).toBe('Digit6');
+    expect(kb.actionForCode('Digit1')).toBe('slot0');
+    expect(kb.actionForCode('Space')).toBe('jump');
   });
+});
 
-  it('persists across instances', () => {
+describe('persistence', () => {
+  it('round-trips bindings across instances', () => {
     const a = new Keybinds();
-    a.bind(0, 'KeyR');
-    a.bind(1, 'KeyF');
-    const b = new Keybinds(); // reloads from the same storage
-    expect(b.slotForCode('KeyR')).toBe(0);
-    expect(b.slotForCode('KeyF')).toBe(1);
+    a.bind('slot0', 0, 'KeyR');
+    a.bind('jump', 0, 'KeyJ');
+    const b = new Keybinds();
+    expect(b.actionForCode('KeyR')).toBe('slot0');
+    expect(b.actionForCode('KeyJ')).toBe('jump');
+    expect(b.actionForCode('Space')).toBe(null);
   });
 
   it('drops duplicate codes when loading corrupt storage', () => {
-    // two slots claim the same code — the later one must lose it on load
-    localStorage.setItem('woc_keybinds', JSON.stringify(['KeyR', 'KeyR', 'Digit3']));
+    // two actions claim KeyR — the later one must lose it on load
+    localStorage.setItem('woc_keybinds', JSON.stringify({
+      slot0: ['KeyR', null],
+      slot1: ['KeyR', null],
+    }));
     const kb = new Keybinds();
-    expect(kb.slotForCode('KeyR')).toBe(0); // first wins
-    expect(kb.codeForSlot(1)).toBe(null); // duplicate dropped
+    expect(kb.actionForCode('KeyR')).toBe('slot0');
+    expect(kb.codeAt('slot1', 0)).toBe(null);
   });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Settings, SETTING_RANGES } from '../src/game/settings';
+
+function installStorage(): void {
+  const map = new Map<string, string>();
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => { map.set(k, v); },
+    removeItem: (k: string) => { map.delete(k); },
+    clear: () => map.clear(),
+  };
+}
+
+beforeEach(() => installStorage());
+
+describe('Settings', () => {
+  it('starts at the documented defaults (camera calmer than the old 1.0)', () => {
+    const s = new Settings();
+    expect(s.get('cameraSpeed')).toBe(SETTING_RANGES.cameraSpeed.def);
+    expect(s.get('cameraSpeed')).toBeLessThan(1); // addresses the "too fast" complaint
+    expect(s.get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
+    expect(s.get('renderScale')).toBe(1);
+  });
+
+  it('clamps out-of-range values to the slider bounds', () => {
+    const s = new Settings();
+    expect(s.set('cameraSpeed', 99)).toBe(SETTING_RANGES.cameraSpeed.max);
+    expect(s.set('cameraSpeed', -5)).toBe(SETTING_RANGES.cameraSpeed.min);
+    expect(s.set('sfxVolume', 0.5)).toBe(0.5);
+  });
+
+  it('ignores non-finite input, keeping a valid value', () => {
+    const s = new Settings();
+    s.set('brightness', NaN);
+    expect(Number.isFinite(s.get('brightness'))).toBe(true);
+  });
+
+  it('persists across instances', () => {
+    const a = new Settings();
+    a.set('cameraSpeed', 0.4);
+    a.set('musicVolume', 0.2);
+    const b = new Settings();
+    expect(b.get('cameraSpeed')).toBe(0.4);
+    expect(b.get('musicVolume')).toBe(0.2);
+  });
+
+  it('falls back to defaults for missing/corrupt keys', () => {
+    localStorage.setItem('woc_settings', JSON.stringify({ cameraSpeed: 0.5 }));
+    const s = new Settings();
+    expect(s.get('cameraSpeed')).toBe(0.5);
+    expect(s.get('brightness')).toBe(SETTING_RANGES.brightness.def); // missing -> default
+  });
+
+  it('reset() restores every default', () => {
+    const s = new Settings();
+    s.set('cameraSpeed', 1.2);
+    s.set('renderScale', 0.5);
+    s.reset();
+    expect(s.get('cameraSpeed')).toBe(SETTING_RANGES.cameraSpeed.def);
+    expect(s.get('renderScale')).toBe(SETTING_RANGES.renderScale.def);
+  });
+
+  it('all() returns an independent snapshot', () => {
+    const s = new Settings();
+    const snap = s.all();
+    snap.cameraSpeed = 99;
+    expect(s.get('cameraSpeed')).not.toBe(99);
+  });
+});


### PR DESCRIPTION
## What

Adds a game menu opened with **Esc** containing **Logout** and three settings screens:

- **Key Bindings** — rebind *any* control (movement, camera, targeting, interface windows, and all 12 action-bar slots, including the Attack toggle that was stuck on `1`).
- **Graphics** — Camera Speed, Brightness, Render Quality.
- **Audio** — Sound Effects volume, Music volume, Music on/off.

All settings apply live and persist across sessions. **Camera speed** is the headline ask: the old mouselook sensitivity was near the top of the reasonable range and drew complaints, so the default is now calmer (0.7×) and adjustable from 0.25× to 1.25×.

## Why

Controls and AV were entirely hard-coded — a static `code → slot` table and `switch` for keys, direct `keys.has('KeyW')` for movement, a fixed `0.0045` mouselook sensitivity, and fixed audio gains. There was no in-game settings UI.

## How

- **`src/game/keybinds.ts` (new, pure):** one `BIND_ACTIONS` registry of every bindable action, tagged by category and kind (`held` polled movement vs `edge` one-shot), each with up to two codes (so `W` and `↑` both Move Forward). `actionForCode` drives edge dispatch; `codesForAction` drives held polling. Binding clears the code from any other action (no duplicates). Only **Escape** is reserved. Persisted to localStorage.
- **`src/game/settings.ts` (new, pure):** persisted `GameSettings` (cameraSpeed, sfxVolume, musicVolume, brightness, renderScale) with per-key clamp ranges, defaults, and reset.
- **Runtime setters:** `Input.setCameraSpeed` scales the formerly-hard-coded mouselook sensitivity; `GameAudio.setVolume` / `MusicDirector.setVolume` scale their master gains (safe before audio-context init); `Renderer.setBrightness` (tone-mapping exposure) and `setRenderScale` (pixel ratio) via a shared `applyResolution()` so a window resize preserves the chosen scale. (Full quality-tier switching is intentionally out of scope — the tier is baked into materials/composer/shadow maps at construction.)
- **`src/game/input.ts`:** resolves each keypress to a registry action (held → record for polling, edge → dispatch); `readMoveInput` polls movement through the bindings, preserving mouselook turn→strafe. Adds `captureNextKey()` for the rebind UI and `suspendMovement` so WASD doesn't drive the character while the menu is open.
- **`src/ui/hud.ts`:** one `#options-menu` window with main / Key Bindings / Graphics / Audio views; live-applying sliders, the categorized rebind list (primary + alternate key per action, action-bar rows showing the live ability name), conflict/reserved feedback, and Reset to Defaults.
- **`src/main.ts`:** constructs `Keybinds` + `Settings`, applies persisted settings on startup, and wires `Esc` → close-topmost-panel-or-open-menu, `Logout` → reload, key capture, and per-setting application.

Behavior change: `Esc` with nothing open now opens the game menu (was: clear target; left-clicking empty ground still clears target).

## Testing

- **Unit (pure logic):** `tests/keybinds.test.ts` (15) and `tests/settings.test.ts` (7) — registry/defaults, two-key binds, cross-category conflict-clear, reserved Escape, clamping, persistence round-trips, corrupt-storage fallback, reset. Full suite green: **226/226**. `npm run build` clean.
- **In-browser (headless Chrome):**
  - *Key bindings:* rebinding **Move Forward** `W→T` makes holding `T` drive movement and `W` go dead (the polled/held path); rebinding **Bags** `B→G` routes the edge action; menu shows all four categories (30 rows); rebinds persist with the alternate key preserved.
  - *Settings:* default **camera speed loads at 0.7**; the slider drives the live `input` sensitivity down to 0.25×; **Brightness** changes `toneMappingExposure`; Graphics/Audio views render with working sliders + a Music toggle; all values persist to `woc_settings`. No console errors.

Note: verified via DOM automation + unit tests, not a recorded play session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)