### PR TITLE
feat: friends, guilds, blocks & WoW-style realms

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,23 @@ DATABASE_URL=postgres://eastbrook:change-me@127.0.0.1:5433/eastbrook
 # absolute /opt/eastbrook path in production.
 EASTBROOK_MEDIA_DIR=./media-cache
 
+# Realm (world/shard) this process serves (default "Claudemoon"). Characters,
+# friends, guilds, and presence are all scoped to it. To run multiple isolated
+# realms, start one process per realm — same DATABASE_URL, a different
+# REALM_NAME and PORT each — e.g. REALM_NAME=Ironforge PORT=8788. Letters,
+# digits, spaces, and ' _ - up to 24 chars; invalid values fall back to default.
+#REALM_NAME=Claudemoon
+
+# Type of this process's own realm (Normal | PvP | RP | RP-PvP). Default Normal.
+# Only used for the single-realm default directory; multi-realm uses REALMS.
+#REALM_TYPE=Normal
+
+# Optional realm directory powering the client's WoW-style Realm List screen.
+# Comma-separated `Name=https://origin=Type` entries (Type optional → Normal);
+# every realm process should advertise the same list. Unset → a single
+# same-origin realm. Cross-origin realms here are also the CORS allowlist.
+#REALMS=Claudemoon=https://claudemoon.example.com=Normal,Ironforge=https://ironforge.example.com=PvP
+
 # How many days of chat logs to keep (default 90; 0 = keep forever).
 #CHAT_LOG_RETENTION_DAYS=90
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -105,6 +105,15 @@ For off-box safety, sync the directory to S3 occasionally:
 - **Chat censorship**: set `CHAT_CENSOR_FILE=/opt/eastbrook/chat-censor.txt`
   to mask configured terms from a private newline- or comma-separated file.
   `CHAT_CENSOR_LIST` can also provide a comma-separated inline list.
+- **Realms (horizontal scaling)**: each server process serves one realm,
+  set by `REALM_NAME` (default `Claudemoon`). To add a realm, run another
+  process against the **same** `DATABASE_URL` with a different `REALM_NAME`
+  and `PORT` (e.g. behind its own vhost or compose service). Characters,
+  friends, guilds, and presence are realm-scoped, so the worlds are fully
+  isolated — players on different realms can't see, whisper, friend, or
+  guild each other. Concurrent boots serialize their schema setup behind a
+  Postgres advisory lock, so starting several at once is safe. Character and
+  guild names remain globally unique across realms.
 - **Never** set `ALLOW_DEV_COMMANDS=1` in production — it enables the
   level/teleport cheats used by the test bots.
 - Health check: `curl -s localhost:8787/api/status` on the box returns

--- a/index.html
+++ b/index.html
@@ -304,6 +304,60 @@
   .coin.s { background: radial-gradient(circle at 35% 30%, #e8e8e8, #888); }
   .coin.c { background: radial-gradient(circle at 35% 30%, #e8a87a, #8b4513); }
 
+  /* social: friends / guild / ignore */
+  #social-window { right: 12px; bottom: 12px; width: 348px; height: 560px; max-height: calc(100vh - 24px);
+    display: none; flex-direction: column; }
+  #social-window.open { display: flex; }
+  /* friends launcher, pinned bottom-right; hidden while the panel is open */
+  #social-fab { position: absolute; right: 16px; bottom: 16px; width: 46px; height: 46px; border-radius: 8px;
+    display: flex; align-items: center; justify-content: center; cursor: pointer; z-index: 18; padding: 0;
+    background: radial-gradient(circle at 36% 30%, #2c2538, #14101c); border: 2px solid #6f5a2a;
+    box-shadow: 0 3px 10px #000b, inset 0 0 10px #0007; color: #e0c89a; transition: color .12s, border-color .12s, transform .12s; }
+  #social-fab:hover { color: var(--gold); border-color: var(--gold); transform: translateY(-1px); }
+  #social-fab svg { width: 22px; height: 22px; fill: currentColor; }
+  #social-window.open ~ #social-fab { display: none; }
+  .soc-realm-tag { color: #7fd4ff; font-size: 11px; font-weight: 400; }
+  .soc-tabs { display: flex; gap: 4px; margin: 6px 0 8px; flex: none; }
+  .soc-tab { flex: 1; padding: 7px 0; font-size: 13px; font-family: var(--title-font); color: #d8c89a; cursor: pointer;
+    background: #1a1410; border: 1px solid #463a1c; border-radius: 4px; text-align: center; }
+  .soc-tab:hover { color: var(--gold); }
+  .soc-tab.on { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#2a2436, #161220); }
+  .soc-body { overflow-y: auto; flex: 1; min-height: 80px; }
+  .soc-row { display: flex; align-items: center; gap: 8px; font-size: 13px; padding: 6px 6px; border-radius: 4px; }
+  .soc-row:hover { background: #ffffff10; }
+  .soc-dot { width: 10px; height: 10px; border-radius: 50%; flex: none; background: #555; box-shadow: 0 0 4px #0008; }
+  .soc-dot.on { background: #46d246; box-shadow: 0 0 5px #46d246aa; }
+  .soc-dot.combat { background: #ff5040; box-shadow: 0 0 5px #ff5040aa; }
+  .soc-dot.dungeon { background: #c98bff; box-shadow: 0 0 5px #c98bffaa; }
+  .soc-dot.dead { background: #888; }
+  .soc-name { color: #f0ead8; font-weight: 600; }
+  .soc-name.soc-link { cursor: pointer; }
+  .soc-name.soc-link:hover { color: #ff80ff; text-decoration: underline; }
+  .soc-name .rank { color: #c9b27a; font-weight: 400; font-size: 10px; margin-left: 4px; }
+  .soc-meta { color: #998d6a; font-size: 11px; margin-left: auto; text-align: right; line-height: 1.25; }
+  .soc-meta .zone { color: #7fd4ff; }
+  .soc-actions { display: flex; gap: 5px; margin-left: 6px; }
+  .soc-x { color: #e0c89a; cursor: pointer; font-size: 15px; line-height: 1; min-width: 26px; height: 26px;
+    display: inline-flex; align-items: center; justify-content: center; padding: 0 5px;
+    border: 1px solid #5a4a26; border-radius: 4px; background: #221a10; }
+  .soc-x:hover { color: #fff0b0; border-color: #8a6f34; background: #2e2416; }
+  .soc-notice { flex: none; display: none; font-size: 11px; padding: 5px 7px; margin-top: 6px; border-radius: 4px; }
+  .soc-notice.err { color: #ffb0a0; background: #3a1512; border: 1px solid #6e2a1e; }
+  .soc-notice.ok { color: #bfe8a0; background: #16280f; border: 1px solid #2f5a22; }
+  .soc-add { display: flex; gap: 6px; margin-top: 8px; flex: none; position: relative; }
+  .soc-add.soc-leave { justify-content: flex-end; }
+  .soc-add input { flex: 1; background: #120f0c; border: 1px solid #463a1c; border-radius: 4px; color: #f0ead8; padding: 5px 7px; font-size: 12px; }
+  .soc-add .btn { margin: 0; padding: 5px 12px; font-size: 11px; }
+  .soc-suggest { position: absolute; left: 0; right: 0; bottom: calc(100% + 3px); display: none; z-index: 30;
+    background: #14110d; border: 1px solid #6f5a2a; border-radius: 5px; max-height: 210px; overflow-y: auto;
+    box-shadow: 0 -6px 18px #000a; }
+  .soc-sugg-item { display: flex; align-items: center; gap: 8px; padding: 7px 9px; cursor: pointer; font-size: 13px; }
+  .soc-sugg-item:hover, .soc-sugg-item.active { background: #2f2740; }
+  .soc-sugg-item.active { box-shadow: inset 2px 0 0 var(--gold); }
+  .soc-empty { color: #887c5c; font-size: 12px; padding: 10px 6px; text-align: center; }
+  .soc-guild-head { font-family: var(--title-font); color: var(--gold); font-size: 15px; padding: 2px 4px 6px; }
+  .soc-guild-head .gm { color: #998d6a; font-size: 11px; }
+
   /* map */
   #map-window { left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 14px; }
   #map-canvas { border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; }
@@ -415,6 +469,29 @@
   .mode-card h2 { font-family: var(--title-font); color: var(--gold); font-size: 22px; margin-bottom: 10px; }
   .mode-card p { font-size: 11.5px; color: #9aa4b8; line-height: 1.55; }
   .auth-panel { width: 360px; padding: 16px; }
+  .cs-realm { font-size: 11px; color: #7fd4ff; font-family: var(--title-font); letter-spacing: 0.3px; }
+  .btn.btn-small { padding: 4px 10px; font-size: 11px; margin: 0 0 10px; }
+  /* WoW-style realm list */
+  #realm-panel { width: 440px; }
+  #realm-list { margin: 8px 0 12px; max-height: 50vh; overflow-y: auto; border: 1px solid #463a1c; border-radius: 5px; }
+  .realm-loading { padding: 16px; text-align: center; color: #887c5c; font-size: 13px; }
+  .realm-row { display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 10px;
+    padding: 9px 12px; cursor: pointer; border-bottom: 1px solid #2a2418; }
+  .realm-row:last-child { border-bottom: none; }
+  .realm-row:hover { background: #ffffff10; }
+  .realm-row.sel { background: linear-gradient(#2a2436, #161220); box-shadow: inset 3px 0 0 var(--gold); }
+  .realm-row.offline { opacity: 0.55; }
+  .realm-name { font-family: var(--title-font); font-size: 15px; color: #f0ead8; }
+  .realm-name .rn-chars { color: #7fd4ff; font-size: 11px; margin-left: 8px; }
+  .realm-name .rn-rec { color: #40d264; font-size: 10px; margin-left: 6px; border: 1px solid #2f5a22; border-radius: 3px; padding: 0 4px; }
+  .realm-sub { font-size: 11px; color: #998d6a; margin-top: 2px; }
+  .realm-type { font-size: 11px; color: #c9b27a; font-family: var(--title-font); }
+  .realm-pop { font-size: 12px; font-family: var(--title-font); min-width: 64px; text-align: right; }
+  .realm-pop.low { color: #46d246; }
+  .realm-pop.med { color: #ffd100; }
+  .realm-pop.high { color: #ff9030; }
+  .realm-pop.full { color: #ff5040; }
+  .realm-pop.offline { color: #888; }
   .auth-panel input { display: block; width: 100%; margin-bottom: 10px; background: #0d0d14; color: #e8d8a8;
     border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; padding: 8px 12px;
     font-size: 14px; font-family: var(--title-font); user-select: text; }
@@ -563,6 +640,10 @@
     <div id="vendor-window" class="window panel"></div>
     <div id="map-window" class="window panel"><canvas id="map-canvas" width="560" height="560"></canvas></div>
     <div id="options-menu" class="window panel"></div>
+    <div id="social-window" class="window panel"></div>
+    <button id="social-fab" title="Friends &amp; Guild (O)" aria-label="Friends &amp; Guild">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3zm-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3zm0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5zm8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5z"/></svg>
+    </button>
     <div id="meters-window" class="panel">
       <div class="panel-title">
         <span class="mt-tabs">
@@ -591,7 +672,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (/y yell, /w name whisper, /g general, /p party)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
 
   <div id="start-screen">
     <img id="title-logo" src="/worldofclaudecraft-logo.png" alt="World of Claudecraft" />
@@ -622,8 +703,15 @@
       </div>
     </div>
 
+    <div id="realm-panel" class="panel auth-panel" style="display:none">
+      <div class="panel-title"><span>Realm List</span><span id="realm-list-user" class="cs-realm"></span></div>
+      <div id="realm-list"><div class="realm-loading">Loading realms…</div></div>
+      <button class="btn" id="btn-realm-back">Back</button>
+    </div>
+
     <div id="charselect-panel" class="panel auth-panel" style="display:none">
-      <div class="panel-title"><span>Characters — <span id="charselect-user" class="gold"></span></span></div>
+      <div class="panel-title"><span>Characters — <span id="charselect-user" class="gold"></span></span><span id="charselect-realm" class="cs-realm"></span></div>
+      <button class="btn btn-small" id="btn-change-realm">Change Realm</button>
       <div id="char-list"></div>
       <div class="char-create">
         <div class="qd-sub">Create a character</div>
@@ -662,7 +750,7 @@
 
     <div id="controls-hint">
       <b>WASD</b> move &middot; <b>A/D</b> turn, <b>Q/E</b> strafe &middot; <b>right-drag</b> mouselook &middot; <b>left-drag</b> orbit camera &middot; wheel zoom &middot; <b>Space</b> jump<br/>
-      <b>Tab</b> target &middot; <b>1-9,0</b> abilities &middot; <b>F</b> interact/loot &middot; <b>C</b> character &middot; <b>P</b> spellbook &middot; <b>L</b> quest log &middot; <b>M</b> map &middot; <b>B</b> bags &middot; <b>V</b> nameplates &middot; <b>R</b> autorun &middot; <b>Enter</b> chat &middot; <b>Esc</b> menu (rebind keys)
+      <b>Tab</b> target &middot; <b>1-9,0</b> abilities &middot; <b>F</b> interact/loot &middot; <b>C</b> character &middot; <b>P</b> spellbook &middot; <b>L</b> quest log &middot; <b>M</b> map &middot; <b>B</b> bags &middot; <b>O</b> friends &middot; <b>V</b> nameplates &middot; <b>R</b> autorun &middot; <b>Enter</b> chat &middot; <b>Esc</b> menu (rebind keys)
     </div>
 
     <div id="social-links">

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:down": "docker compose down",
     "build:server": "esbuild server/main.ts --bundle --platform=node --format=cjs --external:pg-native --external:bufferutil --external:utf-8-validate --outfile=dist-server/server.cjs",
     "server": "npm run build:server && node dist-server/server.cjs",
+    "realms": "npm run build:server && node scripts/dev-realms.mjs",
     "admin:grant": "node scripts/grant_admin.mjs"
   },
   "dependencies": {

--- a/scripts/dev-realms.mjs
+++ b/scripts/dev-realms.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Run several realms locally so you can exercise the WoW-style realm picker.
+//
+//   npm run realms            # build the server, then launch the realms below
+//
+// Each realm is a separate process (process-per-realm) sharing the one local
+// database from .env. They all advertise the same REALMS directory, so the
+// client served by any of them lists and can switch to the others. Connect to
+// the first realm's port in your browser. Ctrl-C stops them all.
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+// Edit this list to add/remove local realms. type: Normal | PvP | RP | RP-PvP
+const REALMS = [
+  { name: 'Claudemoon', port: 8787, type: 'Normal' },
+  { name: 'Ironforge', port: 8788, type: 'PvP' },
+  { name: 'Stormhaven', port: 8789, type: 'RP' },
+];
+
+const SERVER = 'dist-server/server.cjs';
+if (!existsSync(SERVER)) {
+  console.error(`Missing ${SERVER}. Run \`npm run build:server\` first (or use \`npm run realms\`).`);
+  process.exit(1);
+}
+
+const directory = REALMS.map((r) => `${r.name}=http://localhost:${r.port}=${r.type}`).join(',');
+const COLORS = ['36', '35', '33', '32', '34', '31']; // ansi fg per realm
+const children = [];
+
+for (const [i, realm] of REALMS.entries()) {
+  const child = spawn(process.execPath, [SERVER], {
+    env: { ...process.env, REALM_NAME: realm.name, REALM_TYPE: realm.type, PORT: String(realm.port), REALMS: directory },
+    stdio: ['inherit', 'pipe', 'pipe'],
+  });
+  const tag = `\x1b[${COLORS[i % COLORS.length]}m[${realm.name}:${realm.port}]\x1b[0m`;
+  const pipe = (stream, dest) => stream.on('data', (b) => {
+    for (const line of String(b).split('\n')) if (line.trim()) dest.write(`${tag} ${line}\n`);
+  });
+  pipe(child.stdout, process.stdout);
+  pipe(child.stderr, process.stderr);
+  child.on('exit', (code) => {
+    console.error(`${tag} exited (${code}). Shutting the cluster down.`);
+    shutdown();
+  });
+  children.push(child);
+}
+
+console.log(`\nLaunched ${REALMS.length} realms. Open http://localhost:${REALMS[0].port} and pick a realm.\n`);
+
+let stopping = false;
+function shutdown() {
+  if (stopping) return;
+  stopping = true;
+  for (const c of children) { try { c.kill('SIGTERM'); } catch { /* already gone */ } }
+  setTimeout(() => process.exit(0), 500);
+}
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,6 +2,8 @@ import { Pool } from 'pg';
 import type { CharacterState } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
 import type { ChatLogRow } from './chat_log';
+import { SOCIAL_SCHEMA } from './social_db';
+import { REALM } from './realm';
 
 try {
   process.loadEnvFile?.();
@@ -68,7 +70,24 @@ CREATE INDEX IF NOT EXISTS chat_logs_character ON chat_logs(character_id, create
 `;
 
 export async function ensureSchema(): Promise<void> {
-  await pool.query(SCHEMA);
+  // In the process-per-realm model several server processes boot against the
+  // same database at once. Their idempotent CREATE/ALTER statements would
+  // otherwise deadlock when run concurrently, so serialize schema setup behind
+  // a transaction-scoped advisory lock (auto-released on COMMIT). The lock key
+  // is an arbitrary constant shared by every process.
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock($1)', [0x57_4f_43_01]); // "WOC\x01"
+    await client.query(SCHEMA);
+    await client.query(SOCIAL_SCHEMA);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 export interface AccountRow {
@@ -119,26 +138,29 @@ export interface CharacterRow {
   is_gm: boolean;
 }
 
+// Character reads/writes are scoped to this process's realm: an account may
+// hold characters on several realms (each served by its own process), but a
+// process only ever lists, loads, or creates characters on its own realm.
 export async function listCharacters(accountId: number): Promise<CharacterRow[]> {
   const res = await pool.query(
-    'SELECT id, account_id, name, class, level, state, is_gm FROM characters WHERE account_id = $1 ORDER BY id',
-    [accountId],
+    'SELECT id, account_id, name, class, level, state, is_gm FROM characters WHERE account_id = $1 AND realm = $2 ORDER BY id',
+    [accountId, REALM],
   );
   return res.rows;
 }
 
 export async function getCharacter(accountId: number, characterId: number): Promise<CharacterRow | null> {
   const res = await pool.query(
-    'SELECT id, account_id, name, class, level, state, is_gm FROM characters WHERE id = $1 AND account_id = $2',
-    [characterId, accountId],
+    'SELECT id, account_id, name, class, level, state, is_gm FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3',
+    [characterId, accountId, REALM],
   );
   return res.rows[0] ?? null;
 }
 
 export async function createCharacter(accountId: number, name: string, cls: PlayerClass): Promise<CharacterRow> {
   const res = await pool.query(
-    'INSERT INTO characters (account_id, name, class) VALUES ($1, $2, $3) RETURNING id, account_id, name, class, level, state, is_gm',
-    [accountId, name, cls],
+    'INSERT INTO characters (account_id, name, class, realm) VALUES ($1, $2, $3, $4) RETURNING id, account_id, name, class, level, state, is_gm',
+    [accountId, name, cls, REALM],
   );
   return res.rows[0];
 }
@@ -146,6 +168,39 @@ export async function createCharacter(accountId: number, name: string, cls: Play
 export async function deleteCharacter(accountId: number, characterId: number): Promise<boolean> {
   const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2', [characterId, accountId]);
   return (res.rowCount ?? 0) > 0;
+}
+
+// How many characters this account has on each realm — deliberately NOT
+// realm-scoped, so the realm-list screen can show "N characters" per realm
+// like WoW. Keyed by realm name.
+export async function characterCountsByRealm(accountId: number): Promise<Record<string, number>> {
+  const res = await pool.query(
+    'SELECT realm, count(*)::int AS n FROM characters WHERE account_id = $1 GROUP BY realm',
+    [accountId],
+  );
+  const out: Record<string, number> = {};
+  for (const r of res.rows) out[r.realm] = r.n;
+  return out;
+}
+
+export interface CharacterSearchRow {
+  name: string;
+  cls: PlayerClass;
+  level: number;
+}
+
+// Realm-scoped username typeahead: case-insensitive prefix match, capped.
+// Wildcards in the input are escaped so they can't widen the match.
+export async function searchCharacters(prefix: string, limit = 8): Promise<CharacterSearchRow[]> {
+  const term = prefix.trim();
+  if (!term) return [];
+  const escaped = term.replace(/[\\%_]/g, (m) => `\\${m}`);
+  const res = await pool.query(
+    `SELECT name, class AS cls, level FROM characters
+     WHERE realm = $1 AND name ILIKE $2 ESCAPE '\\' ORDER BY name LIMIT $3`,
+    [REALM, `${escaped}%`, Math.min(20, Math.max(1, limit))],
+  );
+  return res.rows;
 }
 
 export async function saveCharacterState(characterId: number, level: number, state: CharacterState): Promise<void> {

--- a/server/game.ts
+++ b/server/game.ts
@@ -4,8 +4,12 @@ import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
-import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs } from './db';
+import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool } from './db';
 import { ChatLogger } from './chat_log';
+import { SocialService } from './social';
+import type { Presence, PresenceStatus, SocialActor, SocialEvent, SocialTransport } from './social';
+import { PgSocialDb } from './social_db';
+import { REALM } from './realm';
 
 const WORLD_SEED = 20061;
 // Interest management: the client renders entities out to 80yd, so new
@@ -54,6 +58,11 @@ export interface ClientSession {
   chatLastRateError: number;
   chatRateViolations: number;
   chatCooldownUntil: number;
+  // character ids this player has ignored; chat from them is dropped before
+  // delivery. Loaded from the DB on join, kept in sync by social commands.
+  blockedIds: Set<number>;
+  // name of the last player to whisper this session, for WoW's /r reply
+  lastWhisperFrom: string | null;
   // serialized form of each delta self field as last sent to this client;
   // a field is omitted from a snapshot while its serialization is unchanged
   lastSent: Record<string, string>;
@@ -190,6 +199,10 @@ function round2(v: number): number {
   return Math.round(v * 100) / 100;
 }
 
+function logSocialErr(err: unknown): void {
+  console.error('social command failed:', err);
+}
+
 const CONFUSABLE_CHARS: Record<string, string> = {
   '0': 'o',
   '1': 'i',
@@ -244,6 +257,8 @@ export class GameServer {
   sim: Sim;
   clients = new Map<number, ClientSession>(); // by pid
   readonly chatLog = new ChatLogger(insertChatLogs);
+  private readonly socialDb = new PgSocialDb(pool);
+  readonly social: SocialService;
   private wireCache = new Map<number, EntityWireCache>();
   private lastWireSweepTick = 0;
   private interval: NodeJS.Timeout | null = null;
@@ -254,6 +269,76 @@ export class GameServer {
 
   constructor() {
     this.sim = new Sim({ seed: WORLD_SEED, playerClass: 'warrior', noPlayer: true });
+    this.social = new SocialService(this.socialDb, this.socialTransport());
+  }
+
+  // -------------------------------------------------------------------------
+  // Social presence/transport: bridges the persistent SocialService to the
+  // live client map + sim. Keyed by character id (stable across sessions),
+  // not pid (per-login).
+  // -------------------------------------------------------------------------
+
+  private actorFor(session: ClientSession): SocialActor {
+    return { characterId: session.characterId, name: session.name };
+  }
+
+  private sessionByCharacterId(id: number): ClientSession | null {
+    for (const s of this.clients.values()) if (s.characterId === id) return s;
+    return null;
+  }
+
+  private sessionByName(name: string): ClientSession | null {
+    const wanted = name.trim();
+    let ci: ClientSession | null = null;
+    let ciCount = 0;
+    const lower = wanted.toLowerCase();
+    for (const s of this.clients.values()) {
+      if (s.name === wanted) return s; // exact case wins
+      if (s.name.toLowerCase() === lower) { ci = s; ciCount++; }
+    }
+    return ciCount === 1 ? ci : null;
+  }
+
+  // Live location + activity of an online character, for friend/guild rosters.
+  private presenceOf(session: ClientSession): Presence {
+    const e = this.sim.entities.get(session.pid);
+    if (!e) return { zone: 'Unknown', status: 'online' };
+    let status: PresenceStatus = 'online';
+    if (e.dead) status = 'dead';
+    else if (e.dungeonId) status = 'dungeon';
+    else if (e.inCombat) status = 'combat';
+    const zone = e.dungeonId ? (DUNGEONS[e.dungeonId]?.name ?? e.dungeonId) : zoneAt(e.pos.z).name;
+    return { zone, status };
+  }
+
+  private socialTransport(): SocialTransport {
+    const actor = (s: ClientSession): SocialActor => ({ characterId: s.characterId, name: s.name });
+    return {
+      byCharacterId: (id) => { const s = this.sessionByCharacterId(id); return s ? actor(s) : null; },
+      byName: (name) => { const s = this.sessionByName(name); return s ? actor(s) : null; },
+      isOnline: (id) => this.sessionByCharacterId(id) !== null,
+      locationOf: (id) => { const s = this.sessionByCharacterId(id); return s ? this.presenceOf(s) : null; },
+      deliver: (id, events) => {
+        const s = this.sessionByCharacterId(id);
+        if (s) this.send(s, { t: 'events', list: events });
+      },
+      pushSnapshot: (id) => { void this.sendSocialSnapshot(id); },
+      onBlocksChanged: (id, ids) => {
+        const s = this.sessionByCharacterId(id);
+        if (s) s.blockedIds = new Set(ids);
+      },
+    };
+  }
+
+  private async sendSocialSnapshot(charId: number): Promise<void> {
+    const session = this.sessionByCharacterId(charId);
+    if (!session) return;
+    try {
+      const snap = await this.social.snapshot(charId);
+      this.send(session, { t: 'social', ...snap });
+    } catch (err) {
+      console.error('social snapshot failed:', err);
+    }
   }
 
   start(): void {
@@ -304,6 +389,8 @@ export class GameServer {
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
+      blockedIds: new Set(),
+      lastWhisperFrom: null,
       lastSent: {},
       sentEnts: new Map(),
     };
@@ -319,14 +406,33 @@ export class GameServer {
       seed: this.sim.cfg.seed,
       name,
       cls,
+      realm: REALM,
     });
     this.broadcastSystem(`${name} has entered World of Claudecraft.`);
+    void this.initSocial(session);
     return session;
+  }
+
+  // Load the player's block list, send their friends/ignore/guild panel, and
+  // let friends + guildmates know they've come online.
+  private async initSocial(session: ClientSession): Promise<void> {
+    try {
+      session.blockedIds = new Set(await this.socialDb.blockedIds(session.characterId));
+    } catch (err) {
+      console.error('failed to load block list:', err);
+    }
+    await this.sendSocialSnapshot(session.characterId);
+    await this.social.announcePresence({ characterId: session.characterId, name: session.name }, true)
+      .catch((err) => console.error('presence announce failed:', err));
   }
 
   async leave(session: ClientSession, reason: string): Promise<void> {
     if (!this.clients.has(session.pid)) return;
     this.clients.delete(session.pid);
+    this.social.forget(session.characterId);
+    // delete from clients first so friends see them as offline in the notice
+    void this.social.announcePresence({ characterId: session.characterId, name: session.name }, false)
+      .catch((err) => console.error('presence announce failed:', err));
     if (session.dbSessionId !== null) {
       void closePlaySession(session.dbSessionId).catch((err) => console.error('failed to close play session:', err));
     }
@@ -471,16 +577,37 @@ export class GameServer {
       case 'chat': {
         if (typeof msg.text !== 'string') break;
         if (!this.consumeChatToken(session)) break;
-        const sent = sim.chat(censorChatText(msg.text), pid);
-        if (sent) {
-          this.chatLog.log({
-            accountId: session.accountId,
-            characterId: session.characterId,
-            characterName: session.name,
-            channel: sent.channel,
-            message: sent.message,
-          });
+        const text = msg.text.trim();
+        // guild and officer chat are persistent + cross-zone, so they live in
+        // the server's SocialService rather than the sim (no guild concept)
+        const gm = /^\/(?:gu|guild)\s+([\s\S]+)$/i.exec(text);
+        const om = gm ? null : /^\/(?:o|officer)\s+([\s\S]+)$/i.exec(text);
+        if (gm || om) {
+          const channel = gm ? 'guild' : 'officer';
+          const body = censorChatText((gm ?? om!)[1]);
+          const route = gm ? this.social.guildChat(this.actorFor(session), body)
+            : this.social.officerChat(this.actorFor(session), body);
+          void route.then((sent) => {
+            if (sent) {
+              this.chatLog.log({
+                accountId: session.accountId, characterId: session.characterId,
+                characterName: session.name, channel, message: body.trim().slice(0, 200),
+              });
+            }
+          }).catch((err) => console.error(`${channel} chat failed:`, err));
+          break;
         }
+        // WoW /r: reply to whoever last whispered you
+        const rm = /^\/(?:r|reply)\s+([\s\S]+)$/i.exec(text);
+        if (rm) {
+          if (!session.lastWhisperFrom) {
+            this.send(session, { t: 'events', list: [{ type: 'error', text: 'No one has whispered you recently.' }] });
+            break;
+          }
+          this.logChat(session, sim.chat(`/w ${session.lastWhisperFrom} ${censorChatText(rm[1])}`, pid));
+          break;
+        }
+        this.logChat(session, sim.chat(censorChatText(msg.text), pid));
         break;
       }
       // party
@@ -501,6 +628,22 @@ export class GameServer {
       case 'duel_req': if (typeof msg.id === 'number') sim.duelRequest(msg.id, pid); break;
       case 'duel_accept': sim.duelAccept(pid); break;
       case 'duel_decline': sim.duelDecline(pid); break;
+      // social: friends / ignore / guild (persistent, account-scoped)
+      case 'friend_add': if (typeof msg.name === 'string') void this.social.friendAdd(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'friend_remove': if (typeof msg.name === 'string') void this.social.friendRemove(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'block_add': if (typeof msg.name === 'string') void this.social.blockAdd(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'block_remove': if (typeof msg.name === 'string') void this.social.blockRemove(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'social_refresh': void this.sendSocialSnapshot(session.characterId); break;
+      case 'guild_create': if (typeof msg.name === 'string') void this.social.guildCreate(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'guild_invite': if (typeof msg.name === 'string') void this.social.guildInvite(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'guild_accept': void this.social.guildAccept(this.actorFor(session)).catch(logSocialErr); break;
+      case 'guild_decline': this.social.guildDecline(this.actorFor(session)); break;
+      case 'guild_leave': void this.social.guildLeave(this.actorFor(session)).catch(logSocialErr); break;
+      case 'guild_kick': if (typeof msg.name === 'string') void this.social.guildKick(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'guild_promote': if (typeof msg.name === 'string') void this.social.guildSetRank(this.actorFor(session), msg.name, 'officer').catch(logSocialErr); break;
+      case 'guild_demote': if (typeof msg.name === 'string') void this.social.guildSetRank(this.actorFor(session), msg.name, 'member').catch(logSocialErr); break;
+      case 'guild_transfer': if (typeof msg.name === 'string') void this.social.guildTransferLeader(this.actorFor(session), msg.name).catch(logSocialErr); break;
+      case 'guild_disband': void this.social.guildDisband(this.actorFor(session)).catch(logSocialErr); break;
       // dev/ops commands, only when ALLOW_DEV_COMMANDS=1 (never in production)
       case 'dev_level': {
         if (process.env.ALLOW_DEV_COMMANDS === '1' && typeof msg.level === 'number') {
@@ -745,8 +888,18 @@ export class GameServer {
       if (!p) continue;
       const mine: SimEvent[] = [];
       for (const ev of events) {
+        // ignore list: drop chat originating from a character this player has
+        // blocked, before it ever reaches their client
+        if (ev.type === 'chat' && session.blockedIds.size > 0 && this.isBlockedSender(session, ev.fromPid)) continue;
         if (ev.pid !== undefined) {
-          if (ev.pid === session.pid) mine.push(ev);
+          if (ev.pid === session.pid) {
+            mine.push(ev);
+            // remember the last person to whisper us, for /r reply (the
+            // recipient copy of a whisper has no `to`; the sender echo does)
+            if (ev.type === 'chat' && ev.channel === 'whisper' && ev.to === undefined && ev.fromPid !== session.pid) {
+              session.lastWhisperFrom = ev.from;
+            }
+          }
           continue;
         }
         // world events: only those near this player
@@ -757,12 +910,32 @@ export class GameServer {
     }
   }
 
+  // Maps a chat event's source pid to its character id and checks the
+  // recipient's ignore set. Self-echoes (fromPid === own pid) are never
+  // blocked so you always see your own messages.
+  private isBlockedSender(recipient: ClientSession, fromPid: number): boolean {
+    if (fromPid === recipient.pid) return false;
+    const sender = this.clients.get(fromPid);
+    return sender ? recipient.blockedIds.has(sender.characterId) : false;
+  }
+
   private eventAnchor(ev: SimEvent): { x: number; y: number; z: number } | null {
     let id: number | undefined;
     if ('targetId' in ev && typeof ev.targetId === 'number') id = ev.targetId;
     else if ('entityId' in ev && typeof ev.entityId === 'number') id = ev.entityId;
     if (id === undefined) return null; // chat/log etc: broadcast
     return this.sim.entities.get(id)?.pos ?? null;
+  }
+
+  private logChat(session: ClientSession, sent: import('../src/sim/sim').SentChat | null): void {
+    if (!sent) return;
+    this.chatLog.log({
+      accountId: session.accountId,
+      characterId: session.characterId,
+      characterName: session.name,
+      channel: sent.channel,
+      message: sent.message,
+    });
   }
 
   private consumeChatToken(session: ClientSession): boolean {

--- a/server/main.ts
+++ b/server/main.ts
@@ -5,13 +5,14 @@ import { WebSocketServer, WebSocket } from 'ws';
 import {
   ensureSchema, pool, createAccount, findAccount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
-  pruneChatLogs,
+  pruneChatLogs, searchCharacters, characterCountsByRealm,
 } from './db';
 import { hashPassword, verifyPassword, newToken, validUsername, validPassword, validCharName } from './auth';
 import { json, readBody } from './http_util';
 import { rateLimited } from './ratelimit';
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
+import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
 import { cacheControlFor, etagFor, isNotModified } from './static_cache';
 
 const PORT = Number(process.env.PORT ?? 8787);
@@ -102,6 +103,21 @@ function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void 
 // REST API
 // ---------------------------------------------------------------------------
 
+// Cross-realm CORS: a client served by one realm may call another realm's API
+// after switching realms in the picker. Only the configured realm origins are
+// allowed; auth is via bearer token (no cookies), so reflecting these specific
+// origins is safe.
+function maybeCors(req: http.IncomingMessage, res: http.ServerResponse): void {
+  const origin = req.headers.origin;
+  if (typeof origin === 'string' && REALM_ORIGINS.has(origin)) {
+    res.setHeader('Access-Control-Allow-Origin', origin);
+    res.setHeader('Vary', 'Origin');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+    res.setHeader('Access-Control-Max-Age', '600');
+  }
+}
+
 async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   const url = (req.url ?? '').split('?')[0];
   try {
@@ -136,6 +152,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (req.method === 'GET') {
         const chars = await listCharacters(accountId);
         return json(res, 200, {
+          realm: REALM,
           characters: chars.map((c) => ({
             id: c.id, name: c.name, class: c.class, level: c.level,
             online: [...game.clients.values()].some((s) => s.characterId === c.id),
@@ -167,9 +184,24 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const ok = await deleteCharacter(accountId, Number(delMatch[1]));
       return json(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'not found' });
     }
+    if (req.method === 'GET' && url === '/api/realms') {
+      // optionally authenticated: with a token we also return how many
+      // characters the account has on each realm (for the realm-list screen)
+      const accountId = await bearerAccount(req);
+      const characters = accountId !== null ? await characterCountsByRealm(accountId) : {};
+      return json(res, 200, { current: REALM, realms: REALM_DIRECTORY, characters });
+    }
+    if (req.method === 'GET' && url === '/api/search') {
+      const accountId = await bearerAccount(req);
+      if (accountId === null) return json(res, 401, { error: 'not authenticated' });
+      const q = new URL(req.url ?? '/', 'http://localhost').searchParams.get('q') ?? '';
+      const results = q.trim().length >= 1 ? await searchCharacters(q, 8) : [];
+      return json(res, 200, { results });
+    }
     if (req.method === 'GET' && url === '/api/status') {
       return json(res, 200, {
         ok: true,
+        realm: REALM,
         players_online: game.clients.size,
         names: [...game.clients.values()].map((s) => s.name),
       });
@@ -209,6 +241,9 @@ async function main(): Promise<void> {
 
   const server = http.createServer((req, res) => {
     const url = req.url ?? '';
+    const isApi = url.startsWith('/api/') || url.startsWith('/admin/api/');
+    if (isApi) maybeCors(req, res);
+    if (req.method === 'OPTIONS' && isApi) { res.writeHead(204); res.end(); return; }
     if (url.startsWith('/admin/api/')) void handleAdminApi(req, res, game);
     else if (url.startsWith('/api/')) void handleApi(req, res);
     else serveStatic(req, res);

--- a/server/realm.ts
+++ b/server/realm.ts
@@ -1,0 +1,73 @@
+// The realm (world/shard) this server process serves. In the process-per-realm
+// model each instance hosts exactly one realm — set REALM_NAME per deployment
+// (e.g. a Caddy vhost or compose service per realm), all pointing at the same
+// database. Characters, friends, guilds, and presence are all scoped to this
+// value, so two processes with different REALM_NAME share a DB yet form fully
+// isolated worlds. Defaults to a single realm for local dev / single-shard prod.
+
+export const DEFAULT_REALM_NAME = 'Claudemoon';
+
+export function resolveRealm(rawName: string | undefined): string {
+  const raw = (rawName ?? '').trim();
+  // realm names are short, human display strings (letters, digits, spaces, a
+  // couple of punctuation marks à la "Area 52" / "Mal'Ganis"); fall back rather
+  // than boot a process with a nonsense realm
+  if (raw && raw.length <= 24 && /^[A-Za-z0-9][A-Za-z0-9 '_-]*$/.test(raw)) return raw;
+  return DEFAULT_REALM_NAME;
+}
+
+export const REALM = resolveRealm(process.env.REALM_NAME);
+
+// WoW realm types. Normal == PvE.
+export type RealmType = 'Normal' | 'PvP' | 'RP' | 'RP-PvP';
+const REALM_TYPES: readonly RealmType[] = ['Normal', 'PvP', 'RP', 'RP-PvP'];
+
+function resolveRealmType(raw: string | undefined): RealmType {
+  const t = (raw ?? '').trim();
+  return (REALM_TYPES as readonly string[]).includes(t) ? (t as RealmType) : 'Normal';
+}
+
+// This process's own realm type (used for the single-realm default directory).
+export const REALM_TYPE: RealmType = resolveRealmType(process.env.REALM_TYPE);
+
+export interface RealmEntry {
+  name: string;
+  // origin a client should connect to for this realm (e.g.
+  // "https://ironforge.example.com"); '' means "same origin as this page",
+  // used for the single-realm default
+  url: string;
+  type: RealmType;
+}
+
+// The realm directory drives the client's WoW-style realm-list screen.
+// Configure it with REALMS as a comma-separated list of `Name=https://host=Type`
+// entries (Type optional, defaults Normal), e.g.
+//   REALMS="Claudemoon=https://claudemoon.example.com=Normal,Ironforge=https://ironforge.example.com=PvP"
+// Every realm process shares the same DATABASE_URL and serves the same
+// directory, so a client on any of them can discover and switch to the others.
+// Unset → a single same-origin realm (this process), i.e. no cross-realm UI.
+function parseRealms(raw: string | undefined): RealmEntry[] {
+  const out: RealmEntry[] = [];
+  for (const part of (raw ?? '').split(',')) {
+    const seg = part.trim();
+    if (!seg) continue;
+    const fields = seg.split('=').map((s) => s.trim());
+    if (fields.length < 2) continue;
+    const name = resolveRealm(fields[0]);
+    let url = fields[1];
+    if (url && !/^https?:\/\/[^/]+$/.test(url.replace(/\/+$/, ''))) continue; // must be a bare origin
+    url = url.replace(/\/+$/, '');
+    if (out.some((e) => e.name === name)) continue;
+    out.push({ name, url, type: resolveRealmType(fields[2]) });
+  }
+  return out;
+}
+
+export const REALM_DIRECTORY: RealmEntry[] = (() => {
+  const parsed = parseRealms(process.env.REALMS);
+  return parsed.length > 0 ? parsed : [{ name: REALM, url: '', type: REALM_TYPE }];
+})();
+
+// Cross-origin requests from these realm origins are allowed (CORS), so a
+// client served by one realm can call another realm's API after switching.
+export const REALM_ORIGINS: ReadonlySet<string> = new Set(REALM_DIRECTORY.map((r) => r.url).filter(Boolean));

--- a/server/social.ts
+++ b/server/social.ts
@@ -1,0 +1,472 @@
+// Persistent social systems: friends, ignore/block lists, and guilds.
+//
+// Unlike parties/duels/trades (which live in the ephemeral Sim, keyed by
+// transient entity ids), these outlive a play session and are keyed by
+// character id. The business logic here is deliberately decoupled from both
+// Postgres and the WebSocket layer: it talks to a `SocialDb` (so tests can use
+// an in-memory fake) and a `SocialTransport` (so it can deliver messages to
+// whoever happens to be online without knowing about sockets). game.ts wires
+// the real Postgres + socket implementations in.
+
+export type GuildRank = 'leader' | 'officer' | 'member';
+
+// Where a character is and what they're doing, for friend/guild rosters.
+// `realm` is the world/shard the character lives on (stored per character so
+// it survives logout and is ready for future cross-realm play); `zone` and
+// `status` are only meaningful while the character is online.
+export type PresenceStatus = 'online' | 'combat' | 'dungeon' | 'dead';
+
+export interface Presence {
+  zone: string;
+  status: PresenceStatus;
+}
+
+export interface CharRef {
+  id: number;
+  name: string;
+}
+
+export interface CharInfo extends CharRef {
+  cls: string;
+  level: number;
+  realm: string;
+}
+
+export interface FriendEntry extends CharInfo {
+  online: boolean;
+  zone?: string;
+  status?: PresenceStatus;
+}
+
+export interface GuildMemberEntry extends CharInfo {
+  rank: GuildRank;
+  online: boolean;
+  zone?: string;
+  status?: PresenceStatus;
+}
+
+export interface GuildView {
+  id: number;
+  name: string;
+  rank: GuildRank;
+  members: GuildMemberEntry[];
+}
+
+export interface SocialSnapshot {
+  friends: FriendEntry[];
+  blocks: CharRef[];
+  guild: GuildView | null;
+}
+
+// Storage abstraction. The Postgres implementation lives in social_db.ts; the
+// tests provide an in-memory one. Every method is keyed by character id.
+export interface SocialDb {
+  findCharacterByName(name: string): Promise<CharInfo | null>;
+  getCharacter(id: number): Promise<CharInfo | null>;
+  // friends (one-directional, WoW-classic style: no acceptance needed)
+  addFriend(charId: number, friendId: number): Promise<void>;
+  removeFriend(charId: number, friendId: number): Promise<void>;
+  listFriends(charId: number): Promise<CharInfo[]>;
+  whoFriended(charId: number): Promise<number[]>; // reverse lookup
+  // blocks (one-directional ignore)
+  addBlock(charId: number, blockedId: number): Promise<void>;
+  removeBlock(charId: number, blockedId: number): Promise<void>;
+  listBlocks(charId: number): Promise<CharRef[]>;
+  blockedIds(charId: number): Promise<number[]>;
+  // guilds (a character belongs to at most one)
+  createGuild(name: string): Promise<number>; // returns guild id; throws on duplicate name
+  deleteGuild(id: number): Promise<void>;
+  guildMembership(charId: number): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null>;
+  addGuildMember(guildId: number, charId: number, rank: GuildRank): Promise<void>;
+  removeGuildMember(charId: number): Promise<void>;
+  setGuildRank(charId: number, rank: GuildRank): Promise<void>;
+  guildMembers(guildId: number): Promise<(CharInfo & { rank: GuildRank })[]>;
+}
+
+export interface SocialActor {
+  characterId: number;
+  name: string;
+}
+
+// Presence + delivery, provided by game.ts. Keeps this module ignorant of
+// sockets and the live client map.
+export interface SocialTransport {
+  byCharacterId(id: number): SocialActor | null;
+  byName(name: string): SocialActor | null;
+  isOnline(id: number): boolean;
+  // where an online character is and what they're doing (null if offline);
+  // game.ts derives this from the live sim entity
+  locationOf(id: number): Presence | null;
+  // deliver gameplay events to a character if they are online
+  deliver(characterId: number, events: SocialEvent[]): void;
+  // re-send the full social panel state to a character if online
+  pushSnapshot(characterId: number): void;
+  // a character's block set changed; refresh the in-memory chat filter
+  onBlocksChanged(characterId: number, blockedIds: number[]): void;
+}
+
+export type SocialEvent =
+  | { type: 'log'; text: string; color?: string }
+  | { type: 'error'; text: string }
+  | { type: 'chat'; from: string; text: string; channel: 'guild' | 'officer' }
+  | { type: 'guildInvite'; fromName: string; guildName: string };
+
+const FRIEND_LIMIT = 50;
+const BLOCK_LIMIT = 50;
+const GUILD_MEMBER_LIMIT = 100;
+const GUILD_INVITE_TTL_MS = 60_000;
+const GUILD_MESSAGE_MAX = 200;
+
+export function validateGuildName(name: string): string | null {
+  const trimmed = String(name ?? '').trim();
+  if (trimmed.length < 3 || trimmed.length > 24) return null;
+  // letters and single interior spaces only — keeps the channel header tidy
+  if (!/^[A-Za-z][A-Za-z ]*[A-Za-z]$/.test(trimmed)) return null;
+  if (/\s{2,}/.test(trimmed)) return null;
+  return trimmed;
+}
+
+const RANK_LABEL: Record<GuildRank, string> = { leader: 'Guild Master', officer: 'Officer', member: 'Member' };
+
+export class SocialService {
+  private pendingGuildInvites = new Map<number, { guildId: number; guildName: string; fromName: string; expiresAt: number }>();
+
+  constructor(
+    private readonly db: SocialDb,
+    private readonly tx: SocialTransport,
+    private readonly now: () => number = () => Date.now(),
+  ) {}
+
+  // -------------------------------------------------------------------------
+  // Snapshot (drives the client Social panel)
+  // -------------------------------------------------------------------------
+
+  async snapshot(charId: number): Promise<SocialSnapshot> {
+    const [friends, blocks, membership] = await Promise.all([
+      this.db.listFriends(charId),
+      this.db.listBlocks(charId),
+      this.db.guildMembership(charId),
+    ]);
+    let guild: GuildView | null = null;
+    if (membership) {
+      const members = await this.db.guildMembers(membership.guildId);
+      guild = {
+        id: membership.guildId,
+        name: membership.guildName,
+        rank: membership.rank,
+        members: members
+          .map((m) => ({ ...m, ...this.presence(m.id) }))
+          .sort((a, b) => rankOrder(a.rank) - rankOrder(b.rank) || a.name.localeCompare(b.name)),
+      };
+    }
+    return {
+      friends: friends
+        .map((f) => ({ ...f, ...this.presence(f.id) }))
+        .sort((a, b) => Number(b.online) - Number(a.online) || a.name.localeCompare(b.name)),
+      blocks,
+      guild,
+    };
+  }
+
+  // Collapse a character's online presence into the fields a roster row needs.
+  private presence(charId: number): { online: boolean; zone?: string; status?: PresenceStatus } {
+    const loc = this.tx.locationOf(charId);
+    return loc ? { online: true, zone: loc.zone, status: loc.status } : { online: false };
+  }
+
+  private push(charId: number): void {
+    this.tx.pushSnapshot(charId);
+  }
+
+  private err(charId: number, text: string): void {
+    this.tx.deliver(charId, [{ type: 'error', text }]);
+  }
+
+  private info(charId: number, text: string, color = '#aaf'): void {
+    this.tx.deliver(charId, [{ type: 'log', text, color }]);
+  }
+
+  // Resolve a target character by name for a friend/block/invite action,
+  // reporting the right error to the actor. Returns null on failure.
+  private async resolveTarget(actor: SocialActor, name: string): Promise<CharInfo | null> {
+    const wanted = String(name ?? '').trim();
+    if (!wanted) { this.err(actor.characterId, 'Specify a character name.'); return null; }
+    const target = await this.db.findCharacterByName(wanted);
+    if (!target) { this.err(actor.characterId, `No character named '${wanted}' exists.`); return null; }
+    return target;
+  }
+
+  // -------------------------------------------------------------------------
+  // Friends
+  // -------------------------------------------------------------------------
+
+  async friendAdd(actor: SocialActor, name: string): Promise<void> {
+    const target = await this.resolveTarget(actor, name);
+    if (!target) return;
+    if (target.id === actor.characterId) { this.err(actor.characterId, 'You cannot befriend yourself.'); return; }
+    const friends = await this.db.listFriends(actor.characterId);
+    if (friends.some((f) => f.id === target.id)) { this.err(actor.characterId, `${target.name} is already your friend.`); return; }
+    if (friends.length >= FRIEND_LIMIT) { this.err(actor.characterId, 'Your friends list is full.'); return; }
+    await this.db.addFriend(actor.characterId, target.id);
+    this.info(actor.characterId, `${target.name} added to friends.`);
+    this.push(actor.characterId);
+  }
+
+  async friendRemove(actor: SocialActor, name: string): Promise<void> {
+    const target = await this.db.findCharacterByName(String(name ?? '').trim());
+    if (!target) { this.err(actor.characterId, `No character named '${name}' on your friends list.`); return; }
+    await this.db.removeFriend(actor.characterId, target.id);
+    this.info(actor.characterId, `${target.name} removed from friends.`);
+    this.push(actor.characterId);
+  }
+
+  // Called by game.ts when a character logs in/out, so friends watching them
+  // see a come-online / go-offline notice (and refresh their panel).
+  async announcePresence(actor: SocialActor, online: boolean): Promise<void> {
+    const watchers = await this.db.whoFriended(actor.characterId);
+    for (const watcherId of watchers) {
+      if (!this.tx.isOnline(watcherId)) continue;
+      this.tx.deliver(watcherId, [{
+        type: 'log',
+        text: online ? `${actor.name} has come online.` : `${actor.name} has gone offline.`,
+        color: '#7fd4ff',
+      }]);
+      this.push(watcherId);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Blocks / ignore
+  // -------------------------------------------------------------------------
+
+  async blockAdd(actor: SocialActor, name: string): Promise<void> {
+    const target = await this.resolveTarget(actor, name);
+    if (!target) return;
+    if (target.id === actor.characterId) { this.err(actor.characterId, 'You cannot ignore yourself.'); return; }
+    const blocks = await this.db.listBlocks(actor.characterId);
+    if (blocks.some((b) => b.id === target.id)) { this.err(actor.characterId, `${target.name} is already ignored.`); return; }
+    if (blocks.length >= BLOCK_LIMIT) { this.err(actor.characterId, 'Your ignore list is full.'); return; }
+    await this.db.addBlock(actor.characterId, target.id);
+    // ignoring someone also drops them from your friends list
+    await this.db.removeFriend(actor.characterId, target.id);
+    this.info(actor.characterId, `${target.name} is now ignored.`);
+    this.tx.onBlocksChanged(actor.characterId, await this.db.blockedIds(actor.characterId));
+    this.push(actor.characterId);
+  }
+
+  async blockRemove(actor: SocialActor, name: string): Promise<void> {
+    const target = await this.db.findCharacterByName(String(name ?? '').trim());
+    if (!target) { this.err(actor.characterId, `No character named '${name}' on your ignore list.`); return; }
+    await this.db.removeBlock(actor.characterId, target.id);
+    this.info(actor.characterId, `${target.name} is no longer ignored.`);
+    this.tx.onBlocksChanged(actor.characterId, await this.db.blockedIds(actor.characterId));
+    this.push(actor.characterId);
+  }
+
+  // -------------------------------------------------------------------------
+  // Guilds
+  // -------------------------------------------------------------------------
+
+  async guildCreate(actor: SocialActor, rawName: string): Promise<void> {
+    const name = validateGuildName(rawName);
+    if (!name) { this.err(actor.characterId, 'Guild names are 3-24 letters (spaces allowed).'); return; }
+    if (await this.db.guildMembership(actor.characterId)) { this.err(actor.characterId, 'You are already in a guild.'); return; }
+    let guildId: number;
+    try {
+      guildId = await this.db.createGuild(name);
+    } catch {
+      this.err(actor.characterId, `A guild named '${name}' already exists.`);
+      return;
+    }
+    await this.db.addGuildMember(guildId, actor.characterId, 'leader');
+    this.info(actor.characterId, `You found the guild <${name}>! You are its Guild Master.`, '#40ff7f');
+    this.push(actor.characterId);
+  }
+
+  async guildInvite(actor: SocialActor, name: string): Promise<void> {
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    if (membership.rank === 'member') { this.err(actor.characterId, 'Only officers and the Guild Master may invite.'); return; }
+    const target = await this.resolveTarget(actor, name);
+    if (!target) return;
+    if (target.id === actor.characterId) { this.err(actor.characterId, 'You are already in the guild.'); return; }
+    if (!this.tx.isOnline(target.id)) { this.err(actor.characterId, `${target.name} must be online to be invited.`); return; }
+    if (await this.db.guildMembership(target.id)) { this.err(actor.characterId, `${target.name} is already in a guild.`); return; }
+    const members = await this.db.guildMembers(membership.guildId);
+    if (members.length >= GUILD_MEMBER_LIMIT) { this.err(actor.characterId, 'Your guild is full.'); return; }
+    this.pendingGuildInvites.set(target.id, {
+      guildId: membership.guildId,
+      guildName: membership.guildName,
+      fromName: actor.name,
+      expiresAt: this.now() + GUILD_INVITE_TTL_MS,
+    });
+    this.tx.deliver(target.id, [{ type: 'guildInvite', fromName: actor.name, guildName: membership.guildName }]);
+    this.info(actor.characterId, `You have invited ${target.name} to the guild.`);
+  }
+
+  async guildAccept(actor: SocialActor): Promise<void> {
+    const invite = this.pendingGuildInvites.get(actor.characterId);
+    this.pendingGuildInvites.delete(actor.characterId);
+    if (!invite || invite.expiresAt < this.now()) { this.err(actor.characterId, 'The guild invitation has expired.'); return; }
+    if (await this.db.guildMembership(actor.characterId)) { this.err(actor.characterId, 'You are already in a guild.'); return; }
+    const members = await this.db.guildMembers(invite.guildId);
+    if (members.length === 0) { this.err(actor.characterId, 'That guild no longer exists.'); return; }
+    if (members.length >= GUILD_MEMBER_LIMIT) { this.err(actor.characterId, 'That guild is full.'); return; }
+    await this.db.addGuildMember(invite.guildId, actor.characterId, 'member');
+    await this.broadcastGuild(invite.guildId, [{ type: 'log', text: `${actor.name} has joined the guild.`, color: '#40ff7f' }]);
+    await this.pushGuild(invite.guildId);
+  }
+
+  guildDecline(actor: SocialActor): void {
+    this.pendingGuildInvites.delete(actor.characterId);
+  }
+
+  async guildLeave(actor: SocialActor): Promise<void> {
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    const members = await this.db.guildMembers(membership.guildId);
+    const others = members.filter((m) => m.id !== actor.characterId);
+    // WoW rule: the Guild Master cannot quit while others remain — they must
+    // hand leadership over (Promote to Guild Master) or disband the guild.
+    if (membership.rank === 'leader' && others.length > 0) {
+      this.err(actor.characterId, 'As Guild Master you must promote a new leader or disband the guild before leaving.');
+      return;
+    }
+    await this.db.removeGuildMember(actor.characterId);
+    if (others.length === 0) {
+      // last member out: the guild ceases to exist
+      await this.db.deleteGuild(membership.guildId);
+      this.info(actor.characterId, `You have left <${membership.guildName}>. The guild has disbanded.`, '#ffd100');
+    } else {
+      await this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${actor.name} has left the guild.`, color: '#ffd100' }]);
+      this.info(actor.characterId, `You have left <${membership.guildName}>.`);
+      await this.pushGuild(membership.guildId);
+    }
+    this.push(actor.characterId);
+  }
+
+  // WoW /gleader: hand the Guild Master title to another member. The former
+  // leader steps down to Officer.
+  async guildTransferLeader(actor: SocialActor, name: string): Promise<void> {
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    if (membership.rank !== 'leader') { this.err(actor.characterId, 'Only the Guild Master may promote a new leader.'); return; }
+    const target = await this.db.findCharacterByName(String(name ?? '').trim());
+    if (!target || target.id === actor.characterId) { this.err(actor.characterId, `No such guild member '${name}'.`); return; }
+    const targetMembership = await this.db.guildMembership(target.id);
+    if (!targetMembership || targetMembership.guildId !== membership.guildId) {
+      this.err(actor.characterId, `${target.name} is not in your guild.`); return;
+    }
+    await this.db.setGuildRank(target.id, 'leader');
+    await this.db.setGuildRank(actor.characterId, 'officer');
+    await this.broadcastGuild(membership.guildId, [
+      { type: 'log', text: `${target.name} is now the Guild Master of <${membership.guildName}>.`, color: '#ffd100' },
+    ]);
+    await this.pushGuild(membership.guildId);
+  }
+
+  // WoW /gdisband: the Guild Master dissolves the entire guild.
+  async guildDisband(actor: SocialActor): Promise<void> {
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    if (membership.rank !== 'leader') { this.err(actor.characterId, 'Only the Guild Master may disband the guild.'); return; }
+    const members = await this.db.guildMembers(membership.guildId);
+    await this.db.deleteGuild(membership.guildId);
+    for (const m of members) {
+      if (this.tx.isOnline(m.id)) {
+        this.info(m.id, `<${membership.guildName}> has been disbanded.`, '#ffd100');
+        this.push(m.id);
+      }
+    }
+  }
+
+  async guildKick(actor: SocialActor, name: string): Promise<void> {
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    if (membership.rank === 'member') { this.err(actor.characterId, 'Only officers and the Guild Master may remove members.'); return; }
+    const target = await this.db.findCharacterByName(String(name ?? '').trim());
+    if (!target) { this.err(actor.characterId, `No character named '${name}'.`); return; }
+    if (target.id === actor.characterId) { this.err(actor.characterId, 'Use Leave Guild to remove yourself.'); return; }
+    const targetMembership = await this.db.guildMembership(target.id);
+    if (!targetMembership || targetMembership.guildId !== membership.guildId) {
+      this.err(actor.characterId, `${target.name} is not in your guild.`); return;
+    }
+    if (targetMembership.rank === 'leader') { this.err(actor.characterId, 'You cannot remove the Guild Master.'); return; }
+    if (targetMembership.rank === 'officer' && membership.rank !== 'leader') {
+      this.err(actor.characterId, 'Only the Guild Master may remove an officer.'); return;
+    }
+    await this.db.removeGuildMember(target.id);
+    if (this.tx.isOnline(target.id)) {
+      this.info(target.id, `You have been removed from <${membership.guildName}>.`, '#ffd100');
+      this.push(target.id);
+    }
+    await this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${target.name} has been removed from the guild by ${actor.name}.`, color: '#ffd100' }]);
+    await this.pushGuild(membership.guildId);
+  }
+
+  async guildSetRank(actor: SocialActor, name: string, rank: GuildRank): Promise<void> {
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    if (membership.rank !== 'leader') { this.err(actor.characterId, 'Only the Guild Master may change ranks.'); return; }
+    if (rank === 'leader') { this.err(actor.characterId, 'Use a guild transfer to hand over leadership.'); return; }
+    const target = await this.db.findCharacterByName(String(name ?? '').trim());
+    if (!target || target.id === actor.characterId) { this.err(actor.characterId, `No such guild member '${name}'.`); return; }
+    const targetMembership = await this.db.guildMembership(target.id);
+    if (!targetMembership || targetMembership.guildId !== membership.guildId) {
+      this.err(actor.characterId, `${target.name} is not in your guild.`); return;
+    }
+    if (targetMembership.rank === rank) { this.err(actor.characterId, `${target.name} is already ${RANK_LABEL[rank]}.`); return; }
+    await this.db.setGuildRank(target.id, rank);
+    this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${target.name} is now ${RANK_LABEL[rank]}.`, color: '#40ff7f' }]);
+    this.pushGuild(membership.guildId);
+  }
+
+  async guildChat(actor: SocialActor, rawText: string): Promise<boolean> {
+    const text = String(rawText ?? '').trim().slice(0, GUILD_MESSAGE_MAX);
+    if (!text) return false;
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return false; }
+    await this.broadcastGuild(membership.guildId, [{ type: 'chat', from: actor.name, text, channel: 'guild' }]);
+    return true;
+  }
+
+  // WoW officer chat (/o): officers + Guild Master only, delivered to the same.
+  async officerChat(actor: SocialActor, rawText: string): Promise<boolean> {
+    const text = String(rawText ?? '').trim().slice(0, GUILD_MESSAGE_MAX);
+    if (!text) return false;
+    const membership = await this.db.guildMembership(actor.characterId);
+    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return false; }
+    if (membership.rank === 'member') { this.err(actor.characterId, 'Only officers and the Guild Master can use officer chat.'); return false; }
+    const members = await this.db.guildMembers(membership.guildId);
+    for (const m of members) {
+      if ((m.rank === 'officer' || m.rank === 'leader') && this.tx.isOnline(m.id)) {
+        this.tx.deliver(m.id, [{ type: 'chat', from: actor.name, text, channel: 'officer' }]);
+      }
+    }
+    return true;
+  }
+
+  // Deliver events to every online member of a guild.
+  private broadcastGuild(guildId: number, events: SocialEvent[]): void {
+    void this.db.guildMembers(guildId).then((members) => {
+      for (const m of members) {
+        if (this.tx.isOnline(m.id)) this.tx.deliver(m.id, events);
+      }
+    });
+  }
+
+  private pushGuild(guildId: number): void {
+    void this.db.guildMembers(guildId).then((members) => {
+      for (const m of members) if (this.tx.isOnline(m.id)) this.push(m.id);
+    });
+  }
+
+  // Drop a character's pending invite when they disconnect.
+  forget(charId: number): void {
+    this.pendingGuildInvites.delete(charId);
+  }
+}
+
+function rankOrder(rank: GuildRank): number {
+  return rank === 'leader' ? 0 : rank === 'officer' ? 1 : 2;
+}

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -1,0 +1,177 @@
+// Postgres-backed SocialDb. The schema is appended to the main ensureSchema()
+// run in db.ts. All relationships are keyed by character id; the realm column
+// on `characters` scopes a character to a world/shard (one realm today, but
+// stored now so cross-realm friends/guilds need no migration later).
+
+import type { Pool } from 'pg';
+import type { CharInfo, CharRef, GuildRank, SocialDb } from './social';
+import { REALM } from './realm';
+
+// kept as an alias for the schema's column default; the live realm is REALM
+export const DEFAULT_REALM = REALM;
+
+export const SOCIAL_SCHEMA = `
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS realm TEXT NOT NULL DEFAULT '${DEFAULT_REALM.replace(/'/g, "''")}';
+CREATE INDEX IF NOT EXISTS characters_realm ON characters(realm);
+-- WoW: character names are unique per realm, not globally. Relax the original
+-- global unique on characters.name to a (realm, name) composite. This is a
+-- constraint relaxation, so existing globally-unique rows always satisfy it.
+ALTER TABLE characters DROP CONSTRAINT IF EXISTS characters_name_key;
+CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_name ON characters(realm, name);
+
+CREATE TABLE IF NOT EXISTS friendships (
+  character_id INT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  friend_id INT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (character_id, friend_id),
+  CHECK (character_id <> friend_id)
+);
+CREATE INDEX IF NOT EXISTS friendships_friend ON friendships(friend_id);
+
+CREATE TABLE IF NOT EXISTS blocks (
+  character_id INT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  blocked_id INT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (character_id, blocked_id),
+  CHECK (character_id <> blocked_id)
+);
+
+CREATE TABLE IF NOT EXISTS guilds (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  realm TEXT NOT NULL DEFAULT '${DEFAULT_REALM.replace(/'/g, "''")}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- guild names are likewise unique per realm
+ALTER TABLE guilds DROP CONSTRAINT IF EXISTS guilds_name_key;
+CREATE UNIQUE INDEX IF NOT EXISTS guilds_realm_name ON guilds(realm, name);
+
+CREATE TABLE IF NOT EXISTS guild_members (
+  character_id INT PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+  guild_id INT NOT NULL REFERENCES guilds(id) ON DELETE CASCADE,
+  rank TEXT NOT NULL DEFAULT 'member',
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS guild_members_guild ON guild_members(guild_id);
+`;
+
+const CHAR_COLS = 'id, name, class AS cls, level, realm';
+
+export class PgSocialDb implements SocialDb {
+  constructor(private readonly pool: Pool) {}
+
+  async findCharacterByName(name: string): Promise<CharInfo | null> {
+    // scoped to this realm: you can only friend/ignore/invite characters that
+    // live on the same world as you. exact case wins; otherwise an unambiguous
+    // case-insensitive match
+    const exact = await this.pool.query(`SELECT ${CHAR_COLS} FROM characters WHERE name = $1 AND realm = $2`, [name, REALM]);
+    if (exact.rows[0]) return exact.rows[0];
+    const ci = await this.pool.query(`SELECT ${CHAR_COLS} FROM characters WHERE lower(name) = lower($1) AND realm = $2 LIMIT 2`, [name, REALM]);
+    return ci.rows.length === 1 ? ci.rows[0] : null;
+  }
+
+  async getCharacter(id: number): Promise<CharInfo | null> {
+    const res = await this.pool.query(`SELECT ${CHAR_COLS} FROM characters WHERE id = $1 AND realm = $2`, [id, REALM]);
+    return res.rows[0] ?? null;
+  }
+
+  async addFriend(charId: number, friendId: number): Promise<void> {
+    await this.pool.query(
+      'INSERT INTO friendships (character_id, friend_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [charId, friendId],
+    );
+  }
+
+  async removeFriend(charId: number, friendId: number): Promise<void> {
+    await this.pool.query('DELETE FROM friendships WHERE character_id = $1 AND friend_id = $2', [charId, friendId]);
+  }
+
+  async listFriends(charId: number): Promise<CharInfo[]> {
+    const res = await this.pool.query(
+      `SELECT c.id, c.name, c.class AS cls, c.level, c.realm
+       FROM friendships f JOIN characters c ON c.id = f.friend_id
+       WHERE f.character_id = $1 ORDER BY c.name`,
+      [charId],
+    );
+    return res.rows;
+  }
+
+  async whoFriended(charId: number): Promise<number[]> {
+    const res = await this.pool.query('SELECT character_id FROM friendships WHERE friend_id = $1', [charId]);
+    return res.rows.map((r) => r.character_id);
+  }
+
+  async addBlock(charId: number, blockedId: number): Promise<void> {
+    await this.pool.query(
+      'INSERT INTO blocks (character_id, blocked_id) VALUES ($1, $2) ON CONFLICT DO NOTHING',
+      [charId, blockedId],
+    );
+  }
+
+  async removeBlock(charId: number, blockedId: number): Promise<void> {
+    await this.pool.query('DELETE FROM blocks WHERE character_id = $1 AND blocked_id = $2', [charId, blockedId]);
+  }
+
+  async listBlocks(charId: number): Promise<CharRef[]> {
+    const res = await this.pool.query(
+      `SELECT c.id, c.name FROM blocks b JOIN characters c ON c.id = b.blocked_id
+       WHERE b.character_id = $1 ORDER BY c.name`,
+      [charId],
+    );
+    return res.rows;
+  }
+
+  async blockedIds(charId: number): Promise<number[]> {
+    const res = await this.pool.query('SELECT blocked_id FROM blocks WHERE character_id = $1', [charId]);
+    return res.rows.map((r) => r.blocked_id);
+  }
+
+  async createGuild(name: string): Promise<number> {
+    const res = await this.pool.query(
+      'INSERT INTO guilds (name, realm) VALUES ($1, $2) RETURNING id',
+      [name, DEFAULT_REALM],
+    );
+    return res.rows[0].id;
+  }
+
+  async deleteGuild(id: number): Promise<void> {
+    await this.pool.query('DELETE FROM guilds WHERE id = $1', [id]);
+  }
+
+  async guildMembership(charId: number): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null> {
+    const res = await this.pool.query(
+      `SELECT gm.guild_id, g.name AS guild_name, gm.rank
+       FROM guild_members gm JOIN guilds g ON g.id = gm.guild_id
+       WHERE gm.character_id = $1`,
+      [charId],
+    );
+    const row = res.rows[0];
+    return row ? { guildId: row.guild_id, guildName: row.guild_name, rank: row.rank } : null;
+  }
+
+  async addGuildMember(guildId: number, charId: number, rank: GuildRank): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO guild_members (guild_id, character_id, rank) VALUES ($1, $2, $3)
+       ON CONFLICT (character_id) DO NOTHING`,
+      [guildId, charId, rank],
+    );
+  }
+
+  async removeGuildMember(charId: number): Promise<void> {
+    await this.pool.query('DELETE FROM guild_members WHERE character_id = $1', [charId]);
+  }
+
+  async setGuildRank(charId: number, rank: GuildRank): Promise<void> {
+    await this.pool.query('UPDATE guild_members SET rank = $2 WHERE character_id = $1', [charId, rank]);
+  }
+
+  async guildMembers(guildId: number): Promise<(CharInfo & { rank: GuildRank })[]> {
+    const res = await this.pool.query(
+      `SELECT c.id, c.name, c.class AS cls, c.level, c.realm, gm.rank
+       FROM guild_members gm JOIN characters c ON c.id = gm.character_id
+       WHERE gm.guild_id = $1 ORDER BY gm.joined_at`,
+      [guildId],
+    );
+    return res.rows;
+  }
+}

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -13,7 +13,7 @@ const BASE_LOOK_SENS = 0.0045;
 export interface InputCallbacks {
   onTab(): void;
   onAbility(slot: number): void;
-  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters'): void;
+  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social'): void;
   onClickPick(x: number, y: number, button: number): void;
 }
 
@@ -102,6 +102,7 @@ export class Input {
       case 'map': this.cb.onUiKey('map'); return;
       case 'nameplates': this.cb.onUiKey('nameplates'); return;
       case 'meters': this.cb.onUiKey('meters'); return;
+      case 'social': this.cb.onUiKey('social'); return;
       case 'chat': this.cb.onUiKey('chat'); return;
     }
   }

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -46,6 +46,7 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'bags', label: 'Bags', category: 'Interface', kind: 'edge', defaults: ['KeyB'] },
   { id: 'nameplates', label: 'Toggle Nameplates', category: 'Interface', kind: 'edge', defaults: ['KeyV'] },
   { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyN'] },
+  { id: 'social', label: 'Friends & Guild', category: 'Interface', kind: 'edge', defaults: ['KeyO'] },
   { id: 'chat', label: 'Open Chat', category: 'Interface', kind: 'edge', defaults: ['Enter', 'NumpadEnter'] },
   // Action bar (slot 0 = Attack)
   ...SLOT_DEFAULTS.map((code, i): BindAction => ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         case 'map': hud.toggleMap(); break;
         case 'nameplates': renderer.showNameplates = !renderer.showNameplates; break;
         case 'meters': hud.toggleMeters(); break;
+        case 'social': hud.toggleSocial(); break;
         case 'chat': openChat(); break;
         case 'escape':
           // close the topmost panel; if nothing was open, open the game menu
@@ -316,7 +317,7 @@ function startOffline(playerClass: PlayerClass, name: string): void {
 const api = new Api();
 
 function show(el: string): void {
-  for (const id of ['#mode-select', '#login-panel', '#charselect-panel']) {
+  for (const id of ['#mode-select', '#login-panel', '#realm-panel', '#charselect-panel']) {
     $(id).style.display = id === el ? 'block' : 'none';
   }
 }
@@ -326,11 +327,87 @@ function loginError(text: string): void {
   el.textContent = text;
 }
 
+const LAST_REALM_KEY = 'woc_last_realm';
+
+// WoW population bands, derived from the realm's current online count (WoW's
+// own labels are relative to peak; current count is a fair local stand-in).
+function realmPopulation(online: boolean, players: number): { label: string; cls: string } {
+  if (!online) return { label: 'Offline', cls: 'offline' };
+  if (players >= 80) return { label: 'Full', cls: 'full' };
+  if (players >= 40) return { label: 'High', cls: 'high' };
+  if (players >= 15) return { label: 'Medium', cls: 'med' };
+  return { label: 'Low', cls: 'low' };
+}
+
+// After login WoW drops you onto a Realm List screen (then character select for
+// the chosen realm). We remember the last realm and jump straight to its
+// characters, with a "Change Realm" button back to this list.
+async function enterRealmFlow(): Promise<void> {
+  const dir = await api.realms();
+  $('#realm-list-user').textContent = api.username ? `${api.username}` : '';
+  const remembered = localStorage.getItem(LAST_REALM_KEY);
+  const auto = dir.realms.find((r) => r.name === remembered);
+  if (auto) { selectRealm(auto); return; }
+  showRealmList(dir);
+}
+
+function showRealmList(dir?: import('./net/online').RealmDirectory): void {
+  show('#realm-panel');
+  const listEl = $('#realm-list');
+  const render = (d: import('./net/online').RealmDirectory) => {
+    if (d.realms.length === 0) { listEl.innerHTML = '<div class="realm-loading">No realms available.</div>'; return; }
+    // recommend the lowest-population online realm (WoW nudges new players there)
+    listEl.innerHTML = d.realms.map((r) => {
+      const chars = d.characters[r.name] ?? 0;
+      const charTag = chars > 0 ? `<span class="rn-chars">${chars} character${chars === 1 ? '' : 's'}</span>` : '';
+      return `<div class="realm-row" data-name="${r.name}" data-url="${r.url}">
+        <div><div class="realm-name">${r.name}${charTag}<span class="rn-rec" data-rec hidden>Recommended</span></div>
+          <div class="realm-sub" data-sub>Checking status…</div></div>
+        <div class="realm-type">${r.type}</div>
+        <div class="realm-pop offline" data-pop>—</div>
+      </div>`;
+    }).join('');
+    listEl.querySelectorAll('.realm-row').forEach((row) => row.addEventListener('click', () => {
+      const name = (row as HTMLElement).dataset.name!;
+      const entry = d.realms.find((r) => r.name === name);
+      if (entry) selectRealm(entry);
+    }));
+    // live status per realm
+    let bestPlayers = Infinity, bestName = '';
+    void Promise.all(d.realms.map(async (r) => {
+      const st = await api.realmStatus(r.url || '');
+      const row = listEl.querySelector(`.realm-row[data-name="${CSS.escape(r.name)}"]`) as HTMLElement | null;
+      if (!row) return;
+      const pop = realmPopulation(st.online, st.players);
+      const popEl = row.querySelector('[data-pop]') as HTMLElement;
+      popEl.textContent = pop.label;
+      popEl.className = `realm-pop ${pop.cls}`;
+      (row.querySelector('[data-sub]') as HTMLElement).textContent = st.online ? `${st.players} online now` : 'Realm is down';
+      row.classList.toggle('offline', !st.online);
+      if (st.online && st.players < bestPlayers) { bestPlayers = st.players; bestName = r.name; }
+    })).then(() => {
+      const recRow = bestName ? listEl.querySelector(`.realm-row[data-name="${CSS.escape(bestName)}"]`) : null;
+      recRow?.querySelector('[data-rec]')?.removeAttribute('hidden');
+    });
+  };
+  if (dir) render(dir);
+  else { listEl.innerHTML = '<div class="realm-loading">Loading realms…</div>'; void api.realms().then(render); }
+}
+
+function selectRealm(entry: import('./net/online').RealmEntry): void {
+  api.setRealm(entry.url);
+  api.realm = entry.name;
+  localStorage.setItem(LAST_REALM_KEY, entry.name);
+  show('#charselect-panel');
+  void refreshCharacters();
+}
+
 async function refreshCharacters(): Promise<void> {
   const listEl = $('#char-list');
   listEl.innerHTML = '<div style="color:#887c5c;font-size:12px">Loading…</div>';
   try {
     const chars = await api.characters();
+    if (api.realm) $('#charselect-realm').textContent = `Realm: ${api.realm}`;
     listEl.innerHTML = '';
     if (chars.length === 0) {
       listEl.innerHTML = '<div style="color:#887c5c;font-size:12px;padding:6px 0">No characters yet — create one below.</div>';
@@ -369,7 +446,7 @@ function enterWorld(c: CharacterSummary): void {
   audio.init();
   music.init();
   showLoadingScreen('Connecting to realm…');
-  const world = new ClientWorld(api.token!, c.id, c.class);
+  const world = new ClientWorld(api.token!, c.id, c.class, api.base);
   // wait for hello + first snapshot so the world starts populated
   const waitStart = Date.now();
   const poll = setInterval(() => {
@@ -417,8 +494,7 @@ function wireStartScreens(): void {
       if (mode === 'login') await api.login(username, password);
       else await api.register(username, password);
       $('#charselect-user').textContent = api.username ?? '';
-      show('#charselect-panel');
-      await refreshCharacters();
+      await enterRealmFlow();
     } catch (err: any) {
       loginError(err.message);
     }
@@ -429,6 +505,8 @@ function wireStartScreens(): void {
     if ((e as KeyboardEvent).key === 'Enter') void doAuth('login');
   });
   $('#btn-login-back').addEventListener('click', () => show('#mode-select'));
+  $('#btn-realm-back').addEventListener('click', () => show('#mode-select'));
+  $('#btn-change-realm').addEventListener('click', () => showRealmList());
 
   // character creation
   document.querySelectorAll('#charselect-panel .mini-class').forEach((el) => {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -6,7 +6,7 @@ import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
-import type { DuelInfo, IWorld, PartyInfo, TradeInfo } from '../world_api';
+import type { CharacterSearchResult, DuelInfo, IWorld, PartyInfo, SocialInfo, TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
 // REST
@@ -29,12 +29,59 @@ export function buildWebSocketAuthMessage(token: string, characterId: number): {
   return { t: 'auth', token, character: characterId };
 }
 
+export type RealmType = 'Normal' | 'PvP' | 'RP' | 'RP-PvP';
+
+export interface RealmEntry {
+  name: string;
+  url: string;
+  type: RealmType;
+}
+
+export interface RealmDirectory {
+  current: string;
+  realms: RealmEntry[];
+  characters: Record<string, number>; // realm name -> how many characters you have
+}
+
 export class Api {
   token: string | null = null;
   username: string | null = null;
+  realm: string | null = null;
+  // base origin for realm-scoped calls (characters, search, ws). '' = the page
+  // origin; set to another realm's origin when the player picks a realm
+  base = '';
+
+  setRealm(url: string): void {
+    this.base = url || '';
+  }
+
+  // The realm directory is always read from the page's own server. Sending the
+  // token (when logged in) also returns per-realm character counts.
+  async realms(): Promise<RealmDirectory> {
+    try {
+      const res = await fetch('/api/realms', { headers: this.token ? { Authorization: `Bearer ${this.token}` } : {} });
+      if (!res.ok) return { current: '', realms: [], characters: {} };
+      const d = await res.json();
+      return { current: d.current ?? '', realms: d.realms ?? [], characters: d.characters ?? {} };
+    } catch {
+      return { current: '', realms: [], characters: {} };
+    }
+  }
+
+  // Live status for a realm (population + reachability), for the realm picker.
+  async realmStatus(url: string): Promise<{ online: boolean; players: number }> {
+    try {
+      const res = await fetch(`${url}/api/status`, { signal: AbortSignal.timeout(3000) });
+      if (!res.ok) return { online: false, players: 0 };
+      const d = await res.json();
+      return { online: true, players: d.players_online ?? 0 };
+    } catch {
+      return { online: false, players: 0 };
+    }
+  }
 
   private async post(path: string, body: unknown): Promise<any> {
-    const res = await fetch(path, {
+    const res = await fetch(this.base + path, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -48,7 +95,7 @@ export class Api {
   }
 
   private async get(path: string): Promise<any> {
-    const res = await fetch(path, {
+    const res = await fetch(this.base + path, {
       headers: this.token ? { Authorization: `Bearer ${this.token}` } : {},
     });
     const data = await res.json().catch(() => ({}));
@@ -69,7 +116,9 @@ export class Api {
   }
 
   async characters(): Promise<CharacterSummary[]> {
-    return (await this.get('/api/characters')).characters;
+    const data = await this.get('/api/characters');
+    if (typeof data.realm === 'string') this.realm = data.realm;
+    return data.characters;
   }
 
   async createCharacter(name: string, cls: PlayerClass): Promise<void> {
@@ -127,6 +176,10 @@ export class ClientWorld implements IWorld {
   partyInfo: PartyInfo | null = null;
   tradeInfo: TradeInfo | null = null;
   duelInfo: DuelInfo | null = null;
+  socialInfo: SocialInfo | null = null;
+  realm = '';
+  // bumped whenever a fresh social snapshot lands, so an open panel re-renders
+  private socialDirty = false;
   // snapshot interpolation
   lastSnapAt = 0;
   snapInterval = 50; // ms, adapts to measured cadence
@@ -136,6 +189,8 @@ export class ClientWorld implements IWorld {
   onDisconnect: ((reason: string) => void) | null = null;
 
   private ws: WebSocket;
+  private readonly token: string;
+  private readonly base: string;
   private eventQueue: SimEvent[] = [];
   // inventory deltas arrive in snapshots, separate from the event frames the
   // HUD redraws on — the frame loop polls this so open panels re-render
@@ -143,9 +198,16 @@ export class ClientWorld implements IWorld {
   private mouselookFacing: number | null = null;
   private sendTimer: number | undefined;
 
-  constructor(token: string, characterId: number, cls: PlayerClass) {
+  constructor(token: string, characterId: number, cls: PlayerClass, base = '') {
+    this.token = token;
+    this.base = base;
     this.cfg = { seed: 20061, playerClass: cls };
-    this.ws = new WebSocket(buildWebSocketUrl(location.protocol, location.host));
+    // when a realm was picked, connect to that realm's origin; otherwise the
+    // page's own host
+    const wsUrl = base
+      ? base.replace(/^http/, 'ws') + '/ws'
+      : buildWebSocketUrl(location.protocol, location.host);
+    this.ws = new WebSocket(wsUrl);
     this.ws.onopen = () => {
       this.ws.send(JSON.stringify(buildWebSocketAuthMessage(token, characterId)));
     };
@@ -214,6 +276,7 @@ export class ClientWorld implements IWorld {
     if (msg.t === 'hello') {
       this.playerId = msg.pid;
       this.cfg.seed = msg.seed;
+      if (typeof msg.realm === 'string') this.realm = msg.realm;
       this.connected = true;
       return;
     }
@@ -226,9 +289,20 @@ export class ClientWorld implements IWorld {
       for (const ev of msg.list) this.eventQueue.push(ev as SimEvent);
       return;
     }
+    if (msg.t === 'social') {
+      this.socialInfo = { friends: msg.friends ?? [], blocks: msg.blocks ?? [], guild: msg.guild ?? null };
+      this.socialDirty = true;
+      return;
+    }
     if (msg.t === 'snap') {
       this.applySnapshot(msg);
     }
+  }
+
+  consumeSocialChanged(): boolean {
+    const v = this.socialDirty;
+    this.socialDirty = false;
+    return v;
   }
 
   private applySnapshot(snap: any): void {
@@ -520,6 +594,32 @@ export class ClientWorld implements IWorld {
   }
   duelDecline(): void {
     this.cmd({ cmd: 'duel_decline' });
+  }
+  // persistent social (resolved server-side by character name)
+  friendAdd(name: string): void { this.cmd({ cmd: 'friend_add', name }); }
+  friendRemove(name: string): void { this.cmd({ cmd: 'friend_remove', name }); }
+  blockAdd(name: string): void { this.cmd({ cmd: 'block_add', name }); }
+  blockRemove(name: string): void { this.cmd({ cmd: 'block_remove', name }); }
+  guildCreate(name: string): void { this.cmd({ cmd: 'guild_create', name }); }
+  guildInvite(name: string): void { this.cmd({ cmd: 'guild_invite', name }); }
+  guildAccept(): void { this.cmd({ cmd: 'guild_accept' }); }
+  guildDecline(): void { this.cmd({ cmd: 'guild_decline' }); }
+  guildLeave(): void { this.cmd({ cmd: 'guild_leave' }); }
+  guildKick(name: string): void { this.cmd({ cmd: 'guild_kick', name }); }
+  guildPromote(name: string): void { this.cmd({ cmd: 'guild_promote', name }); }
+  guildDemote(name: string): void { this.cmd({ cmd: 'guild_demote', name }); }
+  guildTransfer(name: string): void { this.cmd({ cmd: 'guild_transfer', name }); }
+  guildDisband(): void { this.cmd({ cmd: 'guild_disband' }); }
+  async searchCharacters(query: string): Promise<CharacterSearchResult[]> {
+    const q = query.trim();
+    if (!q) return [];
+    try {
+      const res = await fetch(`${this.base}/api/search?q=${encodeURIComponent(q)}`, { headers: { Authorization: `Bearer ${this.token}` } });
+      if (!res.ok) return [];
+      return (await res.json()).results ?? [];
+    } catch {
+      return [];
+    }
   }
   enterDungeon(dungeonId: string): void {
     this.cmd({ cmd: 'enter_dungeon', dungeon: dungeonId });

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2773,6 +2773,27 @@ export class Sim {
     }
   }
 
+  // Persistent social systems (friends / ignore / guilds) require an account
+  // and database, so they only exist in online play. The offline Sim satisfies
+  // the IWorld surface with inert stubs.
+  realm = '';
+  socialInfo: null = null;
+  friendAdd(_name: string): void {}
+  friendRemove(_name: string): void {}
+  blockAdd(_name: string): void {}
+  blockRemove(_name: string): void {}
+  guildCreate(_name: string): void {}
+  guildInvite(_name: string): void {}
+  guildAccept(): void {}
+  guildDecline(): void {}
+  guildLeave(): void {}
+  guildKick(_name: string): void {}
+  guildPromote(_name: string): void {}
+  guildDemote(_name: string): void {}
+  guildTransfer(_name: string): void {}
+  guildDisband(): void {}
+  searchCharacters(_query: string): Promise<import('../world_api').CharacterSearchResult[]> { return Promise.resolve([]); }
+
   private updateDuels(): void {
     const seen = new Set<DuelState>();
     for (const duel of this.duels.values()) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -460,8 +460,11 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
+  // a guild invitation from an online guild officer/leader; resolved by name
+  // server-side so it carries no pid
+  | { type: 'guildInvite'; fromName: string; guildName: string }
   | { type: 'tradeRequest'; fromPid: number; fromName: string }
   | { type: 'tradeDone' }
   | { type: 'duelRequest'; fromPid: number; fromName: string }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -73,6 +73,17 @@ export class Hud {
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
   private ignoredChatNames = new Set<string>();
+  private socialTab: 'friends' | 'guild' | 'ignore' = 'friends';
+  // split signatures: structural changes (tab, guild membership) rebuild the
+  // whole panel; content-only changes (a friend's presence) refresh just the
+  // list, so an open typeahead / half-typed name survives a snapshot
+  private lastSocialStruct = '';
+  private lastSocialContent = '';
+  private socialNotice: { text: string; error: boolean } | null = null;
+  private socialSuggestTimer: number | undefined;
+  // current typeahead state: which input, its results, and the keyboard-
+  // highlighted row (-1 = none), so Enter/Arrow keys can pick a suggestion
+  private socialSuggest: { field: string; items: { name: string; cls: string; level: number }[]; index: number } = { field: '', items: [], index: -1 };
 
   private meters: Meters;
 
@@ -104,6 +115,7 @@ export class Hud {
     $('#mm-quest').addEventListener('click', () => this.toggleQuestLog());
     $('#mm-map').addEventListener('click', () => this.toggleMap());
     $('#mm-bag').addEventListener('click', () => this.toggleBags());
+    $('#social-fab').addEventListener('click', () => this.toggleSocial());
     const musicBtn = $('#mm-music');
     const styleMusicBtn = () => { musicBtn.style.color = music.enabled ? '#ffd100' : '#666'; };
     styleMusicBtn();
@@ -553,6 +565,17 @@ export class Hud {
     this.updateTradeWindow();
     this.updateMinimap();
     if ($('#map-window').style.display === 'block') this.updateMapWindow();
+    if ($('#social-window').classList.contains('open')) {
+      const struct = this.socialStructSig();
+      if (struct !== this.lastSocialStruct) {
+        this.lastSocialStruct = struct;
+        this.lastSocialContent = JSON.stringify(this.sim.socialInfo);
+        this.renderSocial();
+      } else {
+        const content = JSON.stringify(this.sim.socialInfo);
+        if (content !== this.lastSocialContent) { this.lastSocialContent = content; this.refreshSocialList(); }
+      }
+    }
     if (this.openLootMobId !== null) {
       const mob = sim.entities.get(this.openLootMobId);
       if (!mob || !mob.lootable || dist2d(p.pos, mob.pos) > 7) this.closeLoot();
@@ -920,6 +943,8 @@ export class Hud {
               else { this.log(`${ev.from} whispers: ${ev.text}`, '#ff80ff'); audio.whisper(); }
               break;
             case 'general': this.log(`[General] ${ev.from}: ${ev.text}`, '#ffc864'); break;
+            case 'guild': this.log(`[Guild] ${ev.from}: ${ev.text}`, '#40d264'); break;
+            case 'officer': this.log(`[Officer] ${ev.from}: ${ev.text}`, '#4ce0c0'); break;
             default: this.log(`${ev.from} says: ${ev.text}`, '#f0ead8'); break;
           }
           if ((ev.channel === 'say' || ev.channel === 'yell') && ev.entityId !== undefined) {
@@ -945,6 +970,11 @@ export class Hud {
           audio.questAccept();
           this.showPrompt(`<b>${ev.fromName}</b> invites you to join their party.`, 'Join Party',
             () => this.sim.partyAccept(), () => this.sim.partyDecline());
+          break;
+        case 'guildInvite':
+          audio.questAccept();
+          this.showPrompt(`<b>${ev.fromName}</b> invites you to join <span class="gold">&lt;${ev.guildName}&gt;</span>.`, 'Join Guild',
+            () => this.sim.guildAccept(), () => this.sim.guildDecline());
           break;
         case 'tradeRequest':
           audio.click();
@@ -1492,17 +1522,28 @@ export class Hud {
     const party = this.sim.partyInfo;
     const isLeader = party?.leader === this.sim.playerId;
     const isMember = !!party?.members.some((m) => m.pid === pid);
-    const ignored = this.isChatIgnored(name);
+    // online play exposes persistent friends/ignore/guild; offline falls back
+    // to the client-only chat ignore stored in localStorage
+    const online = this.sim.socialInfo !== null;
+    const social = this.sim.socialInfo;
+    const isFriend = !!social?.friends.some((f) => f.name === name);
+    const inGuildWithInvite = !!social?.guild && social.guild.rank !== 'member';
+    const alreadyGuilded = !!social?.guild?.members.some((m) => m.name === name);
+    const ignored = online
+      ? !!social?.blocks.some((b) => b.name === name)
+      : this.isChatIgnored(name);
     let html = `<div class="ctx-title">${name}</div>`;
     if (!isMember) html += `<div class="ctx-item" data-act="invite">Invite to Party</div>`;
     html += `<div class="ctx-item" data-act="trade">Trade</div>`;
     html += `<div class="ctx-item" data-act="duel">Challenge to a Duel</div>`;
-    html += `<div class="ctx-item" data-act="ignore">${ignored ? 'Unignore' : 'Ignore'} Chat</div>`;
+    if (online) html += `<div class="ctx-item" data-act="${isFriend ? 'unfriend' : 'friend'}">${isFriend ? 'Remove Friend' : 'Add Friend'}</div>`;
+    if (inGuildWithInvite && !alreadyGuilded) html += `<div class="ctx-item" data-act="ginvite">Invite to Guild</div>`;
+    html += `<div class="ctx-item" data-act="ignore">${ignored ? 'Unignore' : 'Ignore'}${online ? '' : ' Chat'}</div>`;
     if (isLeader && isMember && pid !== this.sim.playerId) html += `<div class="ctx-item" data-act="kick">Remove from Party</div>`;
     html += `<div class="ctx-item" data-act="close">Cancel</div>`;
     el.innerHTML = html;
     el.style.left = `${Math.min(window.innerWidth - 170, x)}px`;
-    el.style.top = `${Math.min(window.innerHeight - 200, y)}px`;
+    el.style.top = `${Math.min(window.innerHeight - 240, y)}px`;
     el.style.display = 'block';
     el.querySelectorAll('.ctx-item').forEach((item) => {
       item.addEventListener('click', () => {
@@ -1511,8 +1552,13 @@ export class Hud {
         if (act === 'invite') this.sim.partyInvite(pid);
         else if (act === 'trade') this.sim.tradeRequest(pid);
         else if (act === 'duel') this.sim.duelRequest(pid);
-        else if (act === 'ignore') this.toggleChatIgnore(name);
-        else if (act === 'kick') this.sim.partyKick(pid);
+        else if (act === 'friend') this.sim.friendAdd(name);
+        else if (act === 'unfriend') this.sim.friendRemove(name);
+        else if (act === 'ginvite') this.sim.guildInvite(name);
+        else if (act === 'ignore') {
+          if (online) { ignored ? this.sim.blockRemove(name) : this.sim.blockAdd(name); }
+          else this.toggleChatIgnore(name);
+        } else if (act === 'kick') this.sim.partyKick(pid);
       });
     });
   }
@@ -1554,6 +1600,314 @@ export class Hud {
 
   closeContextMenu(): void {
     $('#ctx-menu').style.display = 'none';
+  }
+
+  // -------------------------------------------------------------------------
+  // Social panel: friends / guild / ignore (online play)
+  // -------------------------------------------------------------------------
+
+  toggleSocial(): void {
+    const el = $('#social-window');
+    if (el.classList.contains('open')) { el.classList.remove('open'); return; }
+    el.classList.add('open');
+    this.socialNotice = null;
+    this.lastSocialStruct = this.socialStructSig();
+    this.lastSocialContent = JSON.stringify(this.sim.socialInfo);
+    this.renderSocial();
+  }
+
+  // structural identity of the panel: which tab, online or not, and the guild
+  // membership/rank (which changes the footer). Content within a tab — a
+  // friend's zone, the roster — doesn't count, so it can refresh in place.
+  private socialStructSig(): string {
+    const g = this.sim.socialInfo?.guild;
+    return `${this.socialTab}|${this.sim.socialInfo !== null}|${g?.id ?? 0}|${g?.rank ?? ''}`;
+  }
+
+  // Full rebuild: title, tabs, body, notice, and the tab's footer (with its
+  // typeahead). Used on open, tab switch, and guild-membership changes.
+  private renderSocial(): void {
+    const el = $('#social-window');
+    if (!el.classList.contains('open')) return;
+    const tab = this.socialTab;
+    const online = this.sim.socialInfo !== null;
+    const realmTag = online && this.sim.realm ? ` <span class="soc-realm-tag">— ${esc(this.sim.realm)}</span>` : '';
+    el.innerHTML = `<div class="panel-title"><span>Social${realmTag}</span><span class="x-btn" data-close>✕</span></div>`
+      + `<div class="soc-tabs">`
+      + `<div class="soc-tab ${tab === 'friends' ? 'on' : ''}" data-tab="friends">Friends</div>`
+      + `<div class="soc-tab ${tab === 'guild' ? 'on' : ''}" data-tab="guild">Guild</div>`
+      + `<div class="soc-tab ${tab === 'ignore' ? 'on' : ''}" data-tab="ignore">Ignore</div>`
+      + `</div>`
+      + `<div class="soc-body"></div>`
+      + `<div class="soc-notice"></div>`
+      + (online ? this.socialFooter() : '');
+    this.wireSocialChrome(el);
+    this.refreshSocialList();
+    this.renderSocialNotice();
+  }
+
+  // Lighter refresh: just the list inside the current tab, leaving the footer
+  // (and any half-typed name / open suggestions) untouched.
+  private refreshSocialList(): void {
+    const body = $('#social-window').querySelector('.soc-body') as HTMLElement | null;
+    if (!body) return;
+    const online = this.sim.socialInfo !== null;
+    body.innerHTML = !online
+      ? `<div class="soc-empty">Friends, guilds, and ignore lists are available in online play.</div>`
+      : this.socialTab === 'friends' ? this.friendsHtml()
+        : this.socialTab === 'guild' ? this.guildHtml()
+          : this.ignoreHtml();
+    this.wireSocialRows(body);
+  }
+
+  private friendsHtml(): string {
+    const friends = this.sim.socialInfo?.friends ?? [];
+    if (friends.length === 0) return `<div class="soc-empty">No friends yet. Search for someone by name below.</div>`;
+    return friends.map((f) => {
+      const dot = f.online ? (f.status ?? 'online') : 'off';
+      const meta = f.online
+        ? `<span class="zone">${esc(f.zone ?? '')}</span><br>${statusLabel(f.status)}`
+        : 'Offline';
+      const name = f.online
+        ? `<span class="soc-name soc-link" data-whisper="${esc(f.name)}" title="Whisper ${esc(f.name)}">${esc(f.name)}</span>`
+        : `<span class="soc-name">${esc(f.name)}</span>`;
+      const whisper = f.online ? `<span class="soc-x" data-whisper="${esc(f.name)}" title="Whisper ${esc(f.name)}">✉</span>` : '';
+      return `<div class="soc-row">`
+        + `<span class="soc-dot ${dot === 'off' ? '' : dot}"></span>`
+        + `<span>${name}<br><span class="soc-meta">Lvl ${f.level} ${cap(f.cls)}</span></span>`
+        + `<span class="soc-meta">${meta}</span>`
+        + `<span class="soc-actions">${whisper}<span class="soc-x" data-act="unfriend" data-name="${esc(f.name)}" title="Remove ${esc(f.name)} from friends">✕</span></span>`
+        + `</div>`;
+    }).join('');
+  }
+
+  private ignoreHtml(): string {
+    const blocks = this.sim.socialInfo?.blocks ?? [];
+    if (blocks.length === 0) return `<div class="soc-empty">Your ignore list is empty.</div>`;
+    return blocks.map((b) => `<div class="soc-row">`
+      + `<span class="soc-name">${esc(b.name)}</span>`
+      + `<span class="soc-actions" style="margin-left:auto"><span class="soc-x" data-act="unblock" data-name="${esc(b.name)}" title="Stop ignoring ${esc(b.name)}">✕</span></span>`
+      + `</div>`).join('');
+  }
+
+  private guildHtml(): string {
+    const guild = this.sim.socialInfo?.guild ?? null;
+    if (!guild) return `<div class="soc-empty">You are not in a guild. Found one below, or get invited by an existing guild.</div>`;
+    const me = guild.rank;
+    const head = `<div class="soc-guild-head">&lt;${esc(guild.name)}&gt; <span class="gm">— you are ${rankLabel(me)} &middot; ${guild.members.length} member${guild.members.length === 1 ? '' : 's'}</span></div>`;
+    const rows = guild.members.map((m) => {
+      const dot = m.online ? (m.status ?? 'online') : 'off';
+      const meta = m.online ? `<span class="zone">${esc(m.zone ?? '')}</span>` : 'Offline';
+      const self = m.name === this.sim.player.name;
+      const nameInner = `${esc(m.name)}<span class="rank">${rankLabel(m.rank)}</span>`;
+      const name = m.online && !self
+        ? `<span class="soc-name soc-link" data-whisper="${esc(m.name)}" title="Whisper ${esc(m.name)}">${nameInner}</span>`
+        : `<span class="soc-name">${nameInner}</span>`;
+      let actions = m.online && !self ? `<span class="soc-x" data-whisper="${esc(m.name)}" title="Whisper ${esc(m.name)}">✉</span>` : '';
+      if (!self && me === 'leader') actions += `<span class="soc-x" data-act="gtransfer" data-name="${esc(m.name)}" title="Make ${esc(m.name)} Guild Master">♛</span>`;
+      if (!self && me === 'leader' && m.rank === 'member') actions += `<span class="soc-x" data-act="promote" data-name="${esc(m.name)}" title="Promote ${esc(m.name)} to officer">▲</span>`;
+      if (!self && me === 'leader' && m.rank === 'officer') actions += `<span class="soc-x" data-act="demote" data-name="${esc(m.name)}" title="Demote ${esc(m.name)} to member">▼</span>`;
+      // leaders may remove members + officers; officers may remove only members
+      const canKick = !self && ((me === 'leader' && m.rank !== 'leader') || (me === 'officer' && m.rank === 'member'));
+      if (canKick) actions += `<span class="soc-x" data-act="gkick" data-name="${esc(m.name)}" title="Remove ${esc(m.name)} from guild">✕</span>`;
+      return `<div class="soc-row">`
+        + `<span class="soc-dot ${dot === 'off' ? '' : dot}"></span>`
+        + `<span>${name}<br><span class="soc-meta">Lvl ${m.level} ${cap(m.cls)}</span></span>`
+        + `<span class="soc-meta">${meta}</span>`
+        + (actions ? `<span class="soc-actions">${actions}</span>` : '')
+        + `</div>`;
+    }).join('');
+    return head + rows;
+  }
+
+  // The add/action row changes with the tab (and guild membership). Inputs
+  // tagged data-suggest get the username typeahead.
+  private socialFooter(): string {
+    if (this.socialTab === 'friends') return this.addRow('friend', 'friend-add', 'Search to add a friend…', 'Add', 16, true);
+    if (this.socialTab === 'ignore') return this.addRow('ignore', 'block-add', 'Search to ignore…', 'Ignore', 16, true);
+    const guild = this.sim.socialInfo?.guild ?? null;
+    if (!guild) return this.addRow('gname', 'guild-create', 'Name your new guild', 'Found', 24, false);
+    let foot = '';
+    if (guild.rank !== 'member') foot += this.addRow('ginvite', 'guild-invite', 'Search to invite…', 'Invite', 16, true);
+    // WoW: a Guild Master with other members can't just leave — they disband
+    // (or hand over leadership via the ♛ action). Everyone else can leave.
+    foot += guild.rank === 'leader' && guild.members.length > 1
+      ? `<div class="soc-add soc-leave"><button class="btn" data-act="guild-disband">Disband Guild</button></div>`
+      : `<div class="soc-add soc-leave"><button class="btn" data-act="guild-leave">Leave Guild</button></div>`;
+    return foot;
+  }
+
+  private addRow(field: string, act: string, placeholder: string, label: string, maxlen: number, suggest: boolean): string {
+    return `<div class="soc-add">`
+      + (suggest ? `<div class="soc-suggest" data-for="${field}"></div>` : '')
+      + `<input maxlength="${maxlen}" placeholder="${placeholder}" data-field="${field}"${suggest ? ' data-suggest="1"' : ''} autocomplete="off" spellcheck="false"/>`
+      + `<button class="btn" data-act="${act}">${label}</button></div>`;
+  }
+
+  // Wire the parts that survive a content refresh: close, tabs, footer + search.
+  private wireSocialChrome(el: HTMLElement): void {
+    el.querySelector('[data-close]')?.addEventListener('click', () => this.toggleSocial());
+    el.querySelectorAll('.soc-tab').forEach((t) => t.addEventListener('click', () => {
+      this.socialTab = (t as HTMLElement).dataset.tab as 'friends' | 'guild' | 'ignore';
+      this.socialNotice = null;
+      this.lastSocialStruct = this.socialStructSig();
+      this.renderSocial();
+    }));
+    const field = (sel: string): string => (el.querySelector(`input[data-field="${sel}"]`) as HTMLInputElement | null)?.value.trim() ?? '';
+    const submit = (act: string | undefined): void => {
+      if (act === 'friend-add') void this.socialResolveAndAct('friend', field('friend'));
+      else if (act === 'block-add') void this.socialResolveAndAct('ignore', field('ignore'));
+      else if (act === 'guild-invite') void this.socialResolveAndAct('ginvite', field('ginvite'));
+      else if (act === 'guild-create') { const n = field('gname'); if (n) { this.sim.guildCreate(n); this.clearSocialInput('gname'); } }
+      else if (act === 'guild-leave') this.sim.guildLeave();
+      else if (act === 'guild-disband') this.showPrompt('Disband your guild? This cannot be undone.', 'Disband', () => this.sim.guildDisband(), () => { /* keep */ });
+    };
+    el.querySelectorAll('.soc-add .btn').forEach((b) => b.addEventListener('click', () => submit((b as HTMLElement).dataset.act)));
+    // Enter-to-submit only for plain inputs (the guild name). Search inputs get
+    // richer keyboard handling — arrows + Enter to pick a suggestion — below.
+    el.querySelectorAll('.soc-add input:not([data-suggest])').forEach((inp) => inp.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key !== 'Enter') return;
+      submit((inp.parentElement?.querySelector('.btn') as HTMLElement | null)?.dataset.act);
+    }));
+    this.wireSuggest(el);
+  }
+
+  // Wire per-row actions (re-run on every list refresh).
+  private wireSocialRows(scope: HTMLElement): void {
+    scope.querySelectorAll('.soc-x').forEach((x) => x.addEventListener('click', () => {
+      const act = (x as HTMLElement).dataset.act;
+      const name = (x as HTMLElement).dataset.name ?? '';
+      if (act === 'unfriend') this.sim.friendRemove(name);
+      else if (act === 'unblock') this.sim.blockRemove(name);
+      else if (act === 'gkick') this.sim.guildKick(name);
+      else if (act === 'promote') this.sim.guildPromote(name);
+      else if (act === 'demote') this.sim.guildDemote(name);
+      else if (act === 'gtransfer') this.showPrompt(`Make <b>${esc(name)}</b> the Guild Master? You will step down to Officer.`, 'Promote', () => this.sim.guildTransfer(name), () => { /* keep */ });
+    }));
+    scope.querySelectorAll('[data-whisper]').forEach((w) => w.addEventListener('click', () => {
+      this.startWhisper((w as HTMLElement).dataset.whisper ?? '');
+    }));
+  }
+
+  private suggestKind(field: string): 'friend' | 'ignore' | 'ginvite' {
+    return field === 'friend' ? 'friend' : field === 'ignore' ? 'ignore' : 'ginvite';
+  }
+
+  // Username typeahead: debounced search against same-realm characters, with
+  // arrow-key navigation and Enter to pick the highlighted name.
+  private wireSuggest(el: HTMLElement): void {
+    el.querySelectorAll('input[data-suggest]').forEach((node) => {
+      const input = node as HTMLInputElement;
+      const field = input.dataset.field ?? '';
+      input.addEventListener('input', () => {
+        const q = input.value.trim();
+        window.clearTimeout(this.socialSuggestTimer);
+        if (!q) { this.renderSuggest(field, []); return; }
+        this.socialSuggestTimer = window.setTimeout(async () => {
+          const results = await this.sim.searchCharacters(q);
+          this.renderSuggest(field, results.filter((r) => r.name !== this.sim.player.name).slice(0, 8));
+        }, 160);
+      });
+      input.addEventListener('keydown', (e) => {
+        const ke = e as KeyboardEvent;
+        const open = this.socialSuggest.field === field && this.socialSuggest.items.length > 0;
+        if (ke.key === 'ArrowDown' && open) { ke.preventDefault(); this.moveSuggest(field, 1); }
+        else if (ke.key === 'ArrowUp' && open) { ke.preventDefault(); this.moveSuggest(field, -1); }
+        else if (ke.key === 'Escape' && open) { ke.preventDefault(); this.renderSuggest(field, []); }
+        else if (ke.key === 'Enter') {
+          ke.preventDefault();
+          const picked = open && this.socialSuggest.index >= 0 ? this.socialSuggest.items[this.socialSuggest.index].name : input.value;
+          void this.socialResolveAndAct(this.suggestKind(field), picked);
+        }
+      });
+      // let a suggestion's mousedown fire before blur clears the list
+      input.addEventListener('blur', () => window.setTimeout(() => this.renderSuggest(field, []), 150));
+    });
+  }
+
+  private renderSuggest(field: string, results: { name: string; cls: string; level: number }[]): void {
+    const box = $('#social-window').querySelector(`.soc-suggest[data-for="${field}"]`) as HTMLElement | null;
+    if (!box) return;
+    this.socialSuggest = { field, items: results, index: -1 };
+    if (results.length === 0) { box.style.display = 'none'; box.innerHTML = ''; return; }
+    const kind = this.suggestKind(field);
+    box.innerHTML = results.map((r, i) =>
+      `<div class="soc-sugg-item" data-i="${i}" data-name="${esc(r.name)}"><span class="soc-name">${esc(r.name)}</span><span class="soc-meta">Lvl ${r.level} ${cap(r.cls)}</span></div>`).join('');
+    box.style.display = 'block';
+    box.querySelectorAll('.soc-sugg-item').forEach((it) => {
+      it.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        void this.socialResolveAndAct(kind, (it as HTMLElement).dataset.name ?? '');
+      });
+      it.addEventListener('mousemove', () => { this.socialSuggest.index = Number((it as HTMLElement).dataset.i); this.highlightSuggest(field); });
+    });
+  }
+
+  private moveSuggest(field: string, delta: number): void {
+    const n = this.socialSuggest.items.length;
+    if (n === 0) return;
+    // start at the top when nothing is highlighted yet, then wrap
+    this.socialSuggest.index = this.socialSuggest.index < 0
+      ? (delta > 0 ? 0 : n - 1)
+      : (this.socialSuggest.index + delta + n) % n;
+    this.highlightSuggest(field);
+  }
+
+  private highlightSuggest(field: string): void {
+    const box = $('#social-window').querySelector(`.soc-suggest[data-for="${field}"]`) as HTMLElement | null;
+    if (!box) return;
+    box.querySelectorAll('.soc-sugg-item').forEach((it) => {
+      const on = Number((it as HTMLElement).dataset.i) === this.socialSuggest.index;
+      it.classList.toggle('active', on);
+      if (on) (it as HTMLElement).scrollIntoView({ block: 'nearest' });
+    });
+  }
+
+  // Authoritative existence check (realm-scoped) before acting, so we can give
+  // clear inline "no such player" feedback instead of a silent failure.
+  private async socialResolveAndAct(kind: 'friend' | 'ignore' | 'ginvite', rawName: string): Promise<void> {
+    const name = rawName.trim();
+    if (!name) return;
+    const results = await this.sim.searchCharacters(name);
+    const exact = results.find((r) => r.name.toLowerCase() === name.toLowerCase());
+    if (!exact) {
+      this.setSocialNotice(`No player named “${name}” on ${this.sim.realm || 'this realm'}.`, true);
+      return;
+    }
+    if (exact.name === this.sim.player.name) { this.setSocialNotice('That is you!', true); return; }
+    if (kind === 'friend') { this.sim.friendAdd(exact.name); this.setSocialNotice(`Added ${exact.name} to your friends.`, false); this.clearSocialInput('friend'); }
+    else if (kind === 'ignore') { this.sim.blockAdd(exact.name); this.setSocialNotice(`Now ignoring ${exact.name}.`, false); this.clearSocialInput('ignore'); }
+    else { this.sim.guildInvite(exact.name); this.setSocialNotice(`Invited ${exact.name} to your guild.`, false); this.clearSocialInput('ginvite'); }
+    this.renderSuggest(kind, []);
+  }
+
+  private clearSocialInput(field: string): void {
+    const inp = $('#social-window').querySelector(`input[data-field="${field}"]`) as HTMLInputElement | null;
+    if (inp) inp.value = '';
+  }
+
+  private setSocialNotice(text: string, error: boolean): void {
+    this.socialNotice = { text, error };
+    this.renderSocialNotice();
+  }
+
+  private renderSocialNotice(): void {
+    const box = $('#social-window').querySelector('.soc-notice') as HTMLElement | null;
+    if (!box) return;
+    if (!this.socialNotice) { box.style.display = 'none'; box.textContent = ''; return; }
+    box.textContent = this.socialNotice.text;
+    box.className = 'soc-notice' + (this.socialNotice.error ? ' err' : ' ok');
+    box.style.display = 'block';
+  }
+
+  // Open the chat bar pre-filled with a whisper to this player (WoW-style DM).
+  private startWhisper(name: string): void {
+    if (!name || name === this.sim.player.name) return;
+    const input = $('#chat-input') as unknown as HTMLInputElement;
+    input.value = `/w ${name} `;
+    input.style.display = 'block';
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
   }
 
   // -------------------------------------------------------------------------
@@ -1913,6 +2267,8 @@ export class Hud {
     let closed = false;
     this.closeContextMenu();
     if (this.optionsOpen) { this.closeOptions(); return true; }
+    const socialEl = $('#social-window');
+    if (socialEl.classList.contains('open')) { socialEl.classList.remove('open'); closed = true; }
     if (this.tradeOpen) {
       this.sim.tradeCancel();
       closed = true;
@@ -1940,6 +2296,27 @@ function describeCost(known: ResolvedAbility, sim: IWorld): string {
   parts.push(known.def.channel ? 'Channeled' : known.castTime > 0 ? `${known.castTime}s cast` : 'Instant');
   if (known.def.cooldown > 0) parts.push(`${known.def.cooldown}s cooldown`);
   return parts.join(' · ');
+}
+
+function esc(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
+}
+
+function cap(s: string): string {
+  return s ? s[0].toUpperCase() + s.slice(1) : s;
+}
+
+function statusLabel(status: string | undefined): string {
+  switch (status) {
+    case 'combat': return 'In Combat';
+    case 'dungeon': return 'In Dungeon';
+    case 'dead': return 'Dead';
+    default: return 'Online';
+  }
+}
+
+function rankLabel(rank: string): string {
+  return rank === 'leader' ? 'Guild Master' : rank === 'officer' ? 'Officer' : 'Member';
 }
 
 function shade(hex: string, amt: number): string {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -41,6 +41,45 @@ export interface DuelInfo {
   state: 'countdown' | 'active';
 }
 
+// Persistent social state, mirrored from the server's SocialService. Mirrors
+// server/social.ts shapes; kept here so the HUD has no server-side imports.
+export type PresenceStatus = 'online' | 'combat' | 'dungeon' | 'dead';
+export type GuildRank = 'leader' | 'officer' | 'member';
+
+export interface FriendInfo {
+  id: number;
+  name: string;
+  cls: string;
+  level: number;
+  realm: string;
+  online: boolean;
+  zone?: string;
+  status?: PresenceStatus;
+}
+
+export interface GuildMemberInfo extends FriendInfo {
+  rank: GuildRank;
+}
+
+export interface GuildInfo {
+  id: number;
+  name: string;
+  rank: GuildRank;
+  members: GuildMemberInfo[];
+}
+
+export interface SocialInfo {
+  friends: FriendInfo[];
+  blocks: { id: number; name: string }[];
+  guild: GuildInfo | null;
+}
+
+export interface CharacterSearchResult {
+  name: string;
+  cls: string;
+  level: number;
+}
+
 // The surface the renderer + HUD need from a game world. The offline `Sim`
 // satisfies this structurally; the online `ClientWorld` implements it by
 // mirroring server snapshots and sending commands over the socket.
@@ -93,6 +132,26 @@ export interface IWorld {
   duelRequest(targetPid: number): void;
   duelAccept(): void;
   duelDecline(): void;
+  // the realm (world/shard) this character lives on; '' in offline play
+  realm: string;
+  // persistent social: friends, ignore/block, guilds (online play only)
+  socialInfo: SocialInfo | null;
+  friendAdd(name: string): void;
+  friendRemove(name: string): void;
+  blockAdd(name: string): void;
+  blockRemove(name: string): void;
+  guildCreate(name: string): void;
+  guildInvite(name: string): void;
+  guildAccept(): void;
+  guildDecline(): void;
+  guildLeave(): void;
+  guildKick(name: string): void;
+  guildPromote(name: string): void;
+  guildDemote(name: string): void;
+  guildTransfer(name: string): void;
+  guildDisband(): void;
+  // realm-scoped username typeahead for friend/ignore/guild search
+  searchCharacters(query: string): Promise<CharacterSearchResult[]>;
   enterDungeon(dungeonId: string): void;
   leaveDungeon(): void;
 }

--- a/tests/bandwidth.test.ts
+++ b/tests/bandwidth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed.
 vi.mock('../server/db', () => ({
+  pool: { query: vi.fn() },
   saveCharacterState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../server/db', () => ({
+  pool: { query: vi.fn() },
   insertChatLogs: vi.fn(async () => {}),
   saveCharacterState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),

--- a/tests/interest.test.ts
+++ b/tests/interest.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed; interest logic is under test.
 vi.mock('../server/db', () => ({
+  pool: { query: vi.fn() },
   saveCharacterState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed; snapshot logic is under test.
 vi.mock('../server/db', () => ({
+  pool: { query: vi.fn() },
   saveCharacterState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -1,0 +1,409 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  SocialService, validateGuildName,
+  type CharInfo, type CharRef, type GuildRank, type Presence,
+  type SocialDb, type SocialEvent, type SocialTransport,
+} from '../server/social';
+import { resolveRealm } from '../server/realm';
+
+// ---------------------------------------------------------------------------
+// In-memory fakes — let us exercise the full SocialService logic (friends,
+// ignore, guilds, presence, chat routing) without Postgres or sockets.
+// ---------------------------------------------------------------------------
+
+class FakeDb implements SocialDb {
+  private chars = new Map<number, CharInfo>();
+  private friends = new Map<number, Set<number>>();
+  private blocks = new Map<number, Set<number>>();
+  private guilds = new Map<number, string>();
+  private members = new Map<number, { guildId: number; rank: GuildRank }>();
+  private nextGuildId = 1;
+
+  addChar(id: number, name: string, cls = 'warrior', level = 10, realm = 'Claudemoon'): void {
+    this.chars.set(id, { id, name, cls, level, realm });
+  }
+
+  async findCharacterByName(name: string): Promise<CharInfo | null> {
+    const trimmed = name.trim();
+    const exact = [...this.chars.values()].find((c) => c.name === trimmed);
+    if (exact) return exact;
+    const ci = [...this.chars.values()].filter((c) => c.name.toLowerCase() === trimmed.toLowerCase());
+    return ci.length === 1 ? ci[0] : null;
+  }
+  async getCharacter(id: number): Promise<CharInfo | null> { return this.chars.get(id) ?? null; }
+
+  async addFriend(c: number, f: number): Promise<void> { (this.friends.get(c) ?? this.friends.set(c, new Set()).get(c)!).add(f); }
+  async removeFriend(c: number, f: number): Promise<void> { this.friends.get(c)?.delete(f); }
+  async listFriends(c: number): Promise<CharInfo[]> {
+    return [...(this.friends.get(c) ?? [])].map((id) => this.chars.get(id)!).filter(Boolean);
+  }
+  async whoFriended(c: number): Promise<number[]> {
+    return [...this.friends.entries()].filter(([, set]) => set.has(c)).map(([id]) => id);
+  }
+
+  async addBlock(c: number, b: number): Promise<void> { (this.blocks.get(c) ?? this.blocks.set(c, new Set()).get(c)!).add(b); }
+  async removeBlock(c: number, b: number): Promise<void> { this.blocks.get(c)?.delete(b); }
+  async listBlocks(c: number): Promise<CharRef[]> {
+    return [...(this.blocks.get(c) ?? [])].map((id) => { const ch = this.chars.get(id)!; return { id: ch.id, name: ch.name }; });
+  }
+  async blockedIds(c: number): Promise<number[]> { return [...(this.blocks.get(c) ?? [])]; }
+
+  async createGuild(name: string): Promise<number> {
+    if ([...this.guilds.values()].some((n) => n.toLowerCase() === name.toLowerCase())) throw new Error('duplicate guild');
+    const id = this.nextGuildId++;
+    this.guilds.set(id, name);
+    return id;
+  }
+  async deleteGuild(id: number): Promise<void> {
+    this.guilds.delete(id);
+    for (const [cid, m] of [...this.members]) if (m.guildId === id) this.members.delete(cid);
+  }
+  async guildMembership(c: number): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null> {
+    const m = this.members.get(c);
+    return m ? { guildId: m.guildId, guildName: this.guilds.get(m.guildId)!, rank: m.rank } : null;
+  }
+  async addGuildMember(guildId: number, c: number, rank: GuildRank): Promise<void> {
+    if (!this.members.has(c)) this.members.set(c, { guildId, rank });
+  }
+  async removeGuildMember(c: number): Promise<void> { this.members.delete(c); }
+  async setGuildRank(c: number, rank: GuildRank): Promise<void> { const m = this.members.get(c); if (m) m.rank = rank; }
+  async guildMembers(guildId: number): Promise<(CharInfo & { rank: GuildRank })[]> {
+    return [...this.members.entries()]
+      .filter(([, m]) => m.guildId === guildId)
+      .map(([cid, m]) => ({ ...this.chars.get(cid)!, rank: m.rank }));
+  }
+}
+
+class FakeTransport implements SocialTransport {
+  online = new Set<number>();
+  presence = new Map<number, Presence>();
+  delivered = new Map<number, SocialEvent[]>();
+  snapshotCount = new Map<number, number>();
+  blockSets = new Map<number, number[]>();
+
+  constructor(private db: FakeDb) {}
+
+  setOnline(id: number, p: Presence = { zone: 'Mirewood', status: 'online' }): void {
+    this.online.add(id);
+    this.presence.set(id, p);
+  }
+  setOffline(id: number): void { this.online.delete(id); this.presence.delete(id); }
+
+  charCache = new Map<number, CharInfo>();
+  byCharacterId(id: number) {
+    const c = this.online.has(id) ? this.charCache.get(id) ?? null : null;
+    return c ? { characterId: c.id, name: c.name } : null;
+  }
+  byName(_name: string) { return null; }
+  isOnline(id: number): boolean { return this.online.has(id); }
+  locationOf(id: number): Presence | null { return this.online.has(id) ? this.presence.get(id) ?? null : null; }
+  deliver(id: number, events: SocialEvent[]): void {
+    const arr = this.delivered.get(id) ?? [];
+    arr.push(...events);
+    this.delivered.set(id, arr);
+  }
+  pushSnapshot(id: number): void { this.snapshotCount.set(id, (this.snapshotCount.get(id) ?? 0) + 1); }
+  onBlocksChanged(id: number, ids: number[]): void { this.blockSets.set(id, ids); }
+
+  eventsFor(id: number): SocialEvent[] { return this.delivered.get(id) ?? []; }
+  errorsFor(id: number): string[] { return this.eventsFor(id).filter((e) => e.type === 'error').map((e: any) => e.text); }
+  textFor(id: number): string[] { return this.eventsFor(id).filter((e) => e.type === 'log' || e.type === 'chat').map((e: any) => e.text ?? ''); }
+  clear(): void { this.delivered.clear(); this.snapshotCount.clear(); }
+}
+
+// Test harness: characters 1..N, with helpers to flip presence.
+function setup() {
+  const db = new FakeDb();
+  const tx = new FakeTransport(db);
+  let clock = 1000;
+  const svc = new SocialService(db, tx, () => clock);
+  const actors = new Map<number, { characterId: number; name: string }>();
+  const add = (id: number, name: string, opts: { cls?: string; level?: number } = {}) => {
+    db.addChar(id, name, opts.cls, opts.level);
+    tx.charCache.set(id, { id, name, cls: opts.cls ?? 'warrior', level: opts.level ?? 10, realm: 'Claudemoon' });
+    actors.set(id, { characterId: id, name });
+  };
+  return {
+    db, tx, svc, actors, add,
+    actor: (id: number) => actors.get(id)!,
+    advance: (ms: number) => { clock += ms; },
+  };
+}
+
+describe('resolveRealm', () => {
+  it('accepts realm-style display names', () => {
+    expect(resolveRealm('Claudemoon')).toBe('Claudemoon');
+    expect(resolveRealm('Area 52')).toBe('Area 52');
+    expect(resolveRealm("Mal'Ganis")).toBe("Mal'Ganis");
+    expect(resolveRealm('  Ironforge  ')).toBe('Ironforge');
+  });
+  it('falls back to the default for empty or invalid names', () => {
+    expect(resolveRealm(undefined)).toBe('Claudemoon');
+    expect(resolveRealm('')).toBe('Claudemoon');
+    expect(resolveRealm('x'.repeat(25))).toBe('Claudemoon');
+    expect(resolveRealm('drop;table')).toBe('Claudemoon');
+  });
+});
+
+describe('validateGuildName', () => {
+  it('accepts 3-24 letters with single interior spaces', () => {
+    expect(validateGuildName('Knights')).toBe('Knights');
+    expect(validateGuildName('  Iron Vanguard ')).toBe('Iron Vanguard');
+  });
+  it('rejects too short, too long, digits, and doubled spaces', () => {
+    expect(validateGuildName('ab')).toBeNull();
+    expect(validateGuildName('x'.repeat(25))).toBeNull();
+    expect(validateGuildName('Team99')).toBeNull();
+    expect(validateGuildName('Iron  Vanguard')).toBeNull();
+  });
+});
+
+describe('friends', () => {
+  let h: ReturnType<typeof setup>;
+  beforeEach(() => { h = setup(); h.add(1, 'Aleph'); h.add(2, 'Bet'); });
+
+  it('adds a friend and reflects it in the snapshot', async () => {
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    const snap = await h.svc.snapshot(1);
+    expect(snap.friends.map((f) => f.name)).toEqual(['Bet']);
+    expect(h.tx.errorsFor(1)).toHaveLength(0);
+  });
+
+  it('shows online friends first, with zone and status', async () => {
+    h.add(3, 'Gimel');
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    await h.svc.friendAdd(h.actor(1), 'Gimel');
+    h.tx.setOnline(3, { zone: 'Hollow Crypt', status: 'dungeon' });
+    const snap = await h.svc.snapshot(1);
+    expect(snap.friends[0].name).toBe('Gimel');
+    expect(snap.friends[0].online).toBe(true);
+    expect(snap.friends[0].zone).toBe('Hollow Crypt');
+    expect(snap.friends[0].status).toBe('dungeon');
+    expect(snap.friends[1].online).toBe(false);
+    expect(snap.friends[1].zone).toBeUndefined();
+  });
+
+  it('refuses self-friending and duplicates', async () => {
+    await h.svc.friendAdd(h.actor(1), 'Aleph');
+    expect(h.tx.errorsFor(1).join()).toMatch(/yourself/i);
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    h.tx.clear();
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/already your friend/i);
+  });
+
+  it('errors on an unknown name', async () => {
+    await h.svc.friendAdd(h.actor(1), 'Nobody');
+    expect(h.tx.errorsFor(1).join()).toMatch(/No character named/i);
+  });
+
+  it('removes a friend', async () => {
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    await h.svc.friendRemove(h.actor(1), 'Bet');
+    expect((await h.svc.snapshot(1)).friends).toHaveLength(0);
+  });
+
+  it('notifies watching friends when a character comes online', async () => {
+    // 1 has 2 on their friends list; 2 logs in
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    h.tx.setOnline(1);
+    h.tx.clear();
+    await h.svc.announcePresence(h.actor(2), true);
+    expect(h.tx.textFor(1).join()).toMatch(/Bet has come online/);
+    expect(h.tx.snapshotCount.get(1)).toBe(1);
+  });
+});
+
+describe('ignore / block', () => {
+  let h: ReturnType<typeof setup>;
+  beforeEach(() => { h = setup(); h.add(1, 'Aleph'); h.add(2, 'Bet'); });
+
+  it('blocks a player and surfaces the updated block set to the transport', async () => {
+    await h.svc.blockAdd(h.actor(1), 'Bet');
+    expect((await h.svc.snapshot(1)).blocks.map((b) => b.name)).toEqual(['Bet']);
+    expect(h.tx.blockSets.get(1)).toEqual([2]);
+  });
+
+  it('blocking someone also removes them from friends', async () => {
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    await h.svc.blockAdd(h.actor(1), 'Bet');
+    const snap = await h.svc.snapshot(1);
+    expect(snap.friends).toHaveLength(0);
+    expect(snap.blocks.map((b) => b.name)).toEqual(['Bet']);
+  });
+
+  it('unblocks and clears the transport block set', async () => {
+    await h.svc.blockAdd(h.actor(1), 'Bet');
+    await h.svc.blockRemove(h.actor(1), 'Bet');
+    expect((await h.svc.snapshot(1)).blocks).toHaveLength(0);
+    expect(h.tx.blockSets.get(1)).toEqual([]);
+  });
+
+  it('refuses to block yourself', async () => {
+    await h.svc.blockAdd(h.actor(1), 'Aleph');
+    expect(h.tx.errorsFor(1).join()).toMatch(/yourself/i);
+  });
+});
+
+describe('guilds', () => {
+  let h: ReturnType<typeof setup>;
+  beforeEach(() => {
+    h = setup();
+    h.add(1, 'Aleph'); h.add(2, 'Bet'); h.add(3, 'Gimel');
+    h.tx.setOnline(1); h.tx.setOnline(2); h.tx.setOnline(3);
+  });
+
+  it('creates a guild with the founder as leader', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Iron Vanguard');
+    const snap = await h.svc.snapshot(1);
+    expect(snap.guild?.name).toBe('Iron Vanguard');
+    expect(snap.guild?.rank).toBe('leader');
+    expect(snap.guild?.members.map((m) => m.name)).toEqual(['Aleph']);
+  });
+
+  it('rejects an invalid or duplicate guild name', async () => {
+    await h.svc.guildCreate(h.actor(1), 'no');
+    expect(h.tx.errorsFor(1).join()).toMatch(/3-24 letters/);
+    await h.svc.guildCreate(h.actor(1), 'Iron Vanguard');
+    h.tx.clear();
+    await h.svc.guildCreate(h.actor(2), 'iron vanguard');
+    expect(h.tx.errorsFor(2).join()).toMatch(/already exists/i);
+  });
+
+  it('invites, accepts, and broadcasts the join to all members', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(true);
+    await h.svc.guildAccept(h.actor(2));
+    const snap = await h.svc.snapshot(2);
+    expect(snap.guild?.name).toBe('Knights');
+    expect(snap.guild?.rank).toBe('member');
+    // leader saw the join broadcast
+    expect(h.tx.textFor(1).join()).toMatch(/Bet has joined the guild/);
+  });
+
+  it('only officers and leaders may invite', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    h.tx.clear();
+    await h.svc.guildInvite(h.actor(2), 'Gimel'); // Bet is a plain member
+    expect(h.tx.errorsFor(2).join()).toMatch(/officers and the Guild Master/i);
+  });
+
+  it('promotes a member to officer who can then invite', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    await h.svc.guildSetRank(h.actor(1), 'Bet', 'officer');
+    expect((await h.svc.snapshot(2)).guild?.rank).toBe('officer');
+    await h.svc.guildInvite(h.actor(2), 'Gimel');
+    expect(h.tx.eventsFor(3).some((e) => e.type === 'guildInvite')).toBe(true);
+  });
+
+  it('expires a stale invite', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    h.advance(61_000);
+    await h.svc.guildAccept(h.actor(2));
+    expect(h.tx.errorsFor(2).join()).toMatch(/expired/i);
+    expect((await h.svc.snapshot(2)).guild).toBeNull();
+  });
+
+  it('routes guild chat only to guild members', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    h.tx.clear();
+    const ok = await h.svc.guildChat(h.actor(1), 'hello guild');
+    expect(ok).toBe(true);
+    expect(h.tx.eventsFor(1).some((e) => e.type === 'chat' && e.channel === 'guild' && e.text === 'hello guild')).toBe(true);
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'chat' && e.text === 'hello guild')).toBe(true);
+    expect(h.tx.eventsFor(3)).toHaveLength(0); // Gimel is not in the guild
+  });
+
+  it('blocks guild chat from a non-member', async () => {
+    const ok = await h.svc.guildChat(h.actor(1), 'anyone there?');
+    expect(ok).toBe(false);
+    expect(h.tx.errorsFor(1).join()).toMatch(/not in a guild/i);
+  });
+
+  it('forbids the Guild Master from leaving while members remain (WoW rule)', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    h.tx.clear();
+    await h.svc.guildLeave(h.actor(1));
+    expect(h.tx.errorsFor(1).join()).toMatch(/promote a new leader or disband/i);
+    expect((await h.svc.snapshot(1)).guild?.rank).toBe('leader'); // still GM
+  });
+
+  it('transfers leadership explicitly, stepping the old leader down to officer', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    await h.svc.guildTransferLeader(h.actor(1), 'Bet');
+    expect((await h.svc.snapshot(2)).guild?.rank).toBe('leader');
+    expect((await h.db.guildMembership(1))?.rank).toBe('officer');
+    // now the former leader (an officer) may leave normally
+    await h.svc.guildLeave(h.actor(1));
+    expect(await h.db.guildMembership(1)).toBeNull();
+  });
+
+  it('lets the Guild Master disband the whole guild', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    h.tx.clear();
+    await h.svc.guildDisband(h.actor(1));
+    expect((await h.svc.snapshot(1)).guild).toBeNull();
+    expect((await h.svc.snapshot(2)).guild).toBeNull();
+    expect(h.tx.textFor(2).join()).toMatch(/disbanded/i);
+  });
+
+  it('only officers+leader send and receive officer chat', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2)); // Bet is a plain member
+    h.tx.clear();
+    // a member can't use officer chat
+    expect(await h.svc.officerChat(h.actor(2), 'secret')).toBe(false);
+    expect(h.tx.errorsFor(2).join()).toMatch(/officers and the Guild Master/i);
+    // promote Bet, then officer chat reaches both officers/leader
+    await h.svc.guildSetRank(h.actor(1), 'Bet', 'officer');
+    h.tx.clear();
+    expect(await h.svc.officerChat(h.actor(1), 'officers only')).toBe(true);
+    expect(h.tx.eventsFor(1).some((e) => e.type === 'chat' && e.channel === 'officer' && e.text === 'officers only')).toBe(true);
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'chat' && e.channel === 'officer')).toBe(true);
+  });
+
+  it('disbands the guild when the last member leaves', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildLeave(h.actor(1));
+    expect((await h.svc.snapshot(1)).guild).toBeNull();
+    // a fresh create of the same name must now succeed
+    await h.svc.guildCreate(h.actor(2), 'Knights');
+    expect((await h.svc.snapshot(2)).guild?.name).toBe('Knights');
+  });
+
+  it('lets a leader kick a member but not the reverse', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    h.tx.clear();
+    await h.svc.guildKick(h.actor(2), 'Aleph'); // member can't kick
+    expect(h.tx.errorsFor(2).join()).toMatch(/officers and the Guild Master/i);
+    await h.svc.guildKick(h.actor(1), 'Bet'); // leader can
+    expect((await h.svc.snapshot(2)).guild).toBeNull();
+    expect(h.tx.textFor(2).join()).toMatch(/removed from/i);
+  });
+
+  it('prevents joining two guilds at once', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildCreate(h.actor(2), 'Raiders');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    h.tx.clear();
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/already in a guild/i);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a persistent **social system** and **WoW-style realms**, scoped to what was requested in #feature-requests (friends + blocked users), plus the guild/chat and realm groundwork raised in that thread.

All social state is **server-layer and character-scoped** (the ephemeral sim is keyed by transient entity ids and has no persistence/identity), decoupled from Postgres and the socket layer so the logic is unit-testable.

### Friends
- Add/remove by name, online presence (zone + status: **online / in combat / in dungeon / dead**), "has come online" notices, **whisper a friend from the list**, realm-scoped username **typeahead** (arrow-keys + Enter to pick).
- One-directional and silent — matching WoW's in-game character friends list (the mutual request/accept flow is Battle.net friends, a separate system we deliberately don't add).

### Blocked / ignore
- Server-enforced: chat from a blocked player is dropped **before delivery**; blocking also removes them from friends.

### Guilds
- Create, invite (accept/decline), ranks (leader / officer / member), promote/demote, kick, guild chat (`/gu`), **officer chat (`/o`)**, explicit **leader transfer + disband** (the Guild Master can't silently leave). Plus **`/r` reply-to-whisper**.

### Realms (process-per-realm)
- WoW-style **Realm List screen**: name, type (Normal/PvP/RP/RP-PvP), population (Low/Medium/High/Full, colour-coded from live count), your character count, "Recommended", and a **Change Realm** button.
- **Per-realm character + guild names** (`(realm, name)` composite unique — a safe relaxation of the old global unique, applied behind the boot advisory lock). One global account, characters per realm, per-realm character cap.
- `REALMS` directory env (`Name=origin=Type`) + cross-realm CORS gated to those origins. `npm run realms` runs a local multi-realm cluster.

### UI
- Bottom-right **friends launcher** button; Social panel (Friends / Guild / Ignore) with presence dots, inline feedback, and realm in the header.
- `social` is a **rebindable keybind** (default **O**) and shown in the controls hint.

## Architecture / data
- New `server/{social,social_db,realm}.ts`; realm-scoped DB queries; one schema migration to `(realm, name)` uniqueness (relaxation → existing rows always satisfy it).
- Concurrent realm boots serialise schema setup behind a Postgres advisory lock.
- No new dependencies.

## Testing
- `tests/social_system.test.ts` (friends, blocks, guild flows incl. officer chat / transfer / disband, realm + guild-name validation). **263 tests pass**, `tsc` clean, client + server build.
- Verified live in a browser: realm list (multiple realms + status), realm selection + Change Realm, Social panel, typeahead + keyboard select, whisper-from-list, per-realm names, friends launcher.

## Notes / deliberate non-goals
- **No voice or proximity chat** (per the thread).
- **Friends/guildmates are not drawn on the map** — WoW only marks party/raid members (which this repo already does on the minimap); friend/guild map dots are add-on territory in WoW, so they're intentionally omitted.
- Realm population labels derive from current online count (WoW's are relative to 7-day peak) — same labels/colours, tunable bands.
- Names kept globally-unique→per-realm; no other migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
