### PR TITLE
Add player reporting and moderation admin tools

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -61,11 +61,16 @@
   /* ---------- layout ---------- */
   #app { display: none; max-width: 1200px; margin: 0 auto; padding: 18px 18px 60px; }
   #app.authed { display: block; }
-  header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 18px; }
+  header { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 10px; }
   header h1 { font-family: var(--title-font); color: var(--gold); font-size: 22px; text-shadow: 1px 1px 2px #000; }
   header .who { font-size: 12px; color: var(--text-dim); }
   header button { margin-left: 12px; padding: 4px 10px; background: #1a1410; color: #c9b27a; border: 1px solid #463a1c; border-radius: 3px; cursor: pointer; }
   header button:hover { color: #fff; border-color: var(--gold-dim); }
+  #admin-tabs { display: flex; gap: 6px; margin-bottom: 18px; border-bottom: 1px solid #2a2414; }
+  .admin-tab { padding: 7px 12px; background: #100d0b; color: #c9b27a; border: 1px solid #463a1c; border-bottom: none; border-radius: 4px 4px 0 0; cursor: pointer; font-family: var(--title-font); }
+  .admin-tab.active { color: var(--gold); border-color: var(--gold-dim); background: #20180d; }
+  .admin-page { display: none; }
+  .admin-page.active { display: block; }
   section { margin-bottom: 18px; }
 
   /* ---------- stat cards ---------- */
@@ -85,6 +90,8 @@
   td.num, th.num { text-align: right; }
   .empty { color: var(--text-dim); padding: 14px 8px; font-style: italic; }
   .badge { display: inline-block; padding: 1px 6px; border-radius: 3px; font-size: 11px; border: 1px solid var(--gold-dim); color: var(--gold); }
+  .badge.warn { border-color: #c98c36; color: #ffbf66; }
+  .badge.bad { border-color: #b34a3a; color: #ff7a5e; }
   tr.detail-row > td { background: #0d0d14; padding: 12px 16px; white-space: normal; }
   .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
   .detail-grid h4 { font-family: var(--title-font); color: var(--gold-dim); margin-bottom: 6px; font-size: 13px; }
@@ -105,6 +112,29 @@
   .chart .bar { fill: #c8a838; }
   .chart .bar:hover { fill: #ffd100; }
   .chart .axis { fill: var(--text-dim); font-size: 9px; }
+
+  /* ---------- moderation ---------- */
+  #moderation-detail { margin-top: 12px; }
+  .mod-report { margin-top: 12px; }
+  .mod-report-meta { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 6px 12px; font-size: 12px; color: #c9b27a; }
+  .mod-details { margin: 10px 0; padding: 10px; background: #0d0d14; border: 1px solid #2a2414; border-radius: 4px; white-space: pre-wrap; }
+  .mod-actions, .mod-account-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin: 10px 0; }
+  .mod-actions button, .mod-account-actions button {
+    padding: 5px 10px; background: #1a1410; color: #c9b27a; border: 1px solid #463a1c; border-radius: 3px; cursor: pointer;
+  }
+  .mod-actions button:hover, .mod-account-actions button:hover { color: #fff; border-color: var(--gold-dim); }
+  .mod-account-actions input { padding: 6px 8px; background: #11111a; border: 1px solid var(--border); border-radius: 4px; color: var(--text); }
+  #mod-reason { min-width: 300px; flex: 1 1 300px; }
+  #mod-custom-expiry { width: 190px; }
+  .mod-confirm { display: none; margin: 10px 0; padding: 10px; border: 1px solid #8a6f2d; border-radius: 4px; background: #171207; }
+  .mod-confirm.show { display: block; }
+  .mod-confirm h4 { font-family: var(--title-font); color: var(--gold); margin-bottom: 6px; }
+  .mod-confirm dl { display: grid; grid-template-columns: 90px 1fr; gap: 4px 8px; font-size: 12px; }
+  .mod-confirm dt { color: var(--text-dim); }
+  .mod-confirm dd { color: var(--text); }
+  .mod-confirm .confirm-actions { display: flex; gap: 8px; margin-top: 10px; }
+  .mod-confirm button { padding: 5px 10px; background: #1a1410; color: #c9b27a; border: 1px solid #463a1c; border-radius: 3px; cursor: pointer; }
+  .mod-confirm .danger { border-color: #b34a3a; color: #ff7a5e; }
 </style>
 </head>
 <body>
@@ -126,29 +156,44 @@
       <div class="who">signed in as <span id="who-name"></span><button id="logout">Sign out</button></div>
     </header>
 
-    <section id="stats"></section>
+    <nav id="admin-tabs">
+      <button class="admin-tab active" data-admin-page="overview">Overview</button>
+      <button class="admin-tab" data-admin-page="moderation">Moderation</button>
+    </nav>
 
-    <section class="panel">
-      <div class="panel-title">Players online <span class="hint">refreshes every 5s</span></div>
-      <div id="online"></div>
-    </section>
+    <main id="page-overview" class="admin-page active">
+      <section id="stats"></section>
 
-    <section id="charts"></section>
+      <section class="panel">
+        <div class="panel-title">Players online <span class="hint">refreshes every 5s</span></div>
+        <div id="online"></div>
+      </section>
 
-    <section class="panel">
-      <div class="panel-title">Accounts</div>
-      <div class="controls">
-        <input id="account-search" placeholder="Search username…" />
-        <div class="pager" id="accounts-pager"></div>
-      </div>
-      <div id="accounts"></div>
-    </section>
+      <section id="charts"></section>
 
-    <section class="panel">
-      <div class="panel-title">Characters <span class="hint">click a column to sort</span></div>
-      <div class="controls"><div class="pager" id="characters-pager"></div></div>
-      <div id="characters"></div>
-    </section>
+      <section class="panel">
+        <div class="panel-title">Accounts</div>
+        <div class="controls">
+          <input id="account-search" placeholder="Search username…" />
+          <div class="pager" id="accounts-pager"></div>
+        </div>
+        <div id="accounts"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-title">Characters <span class="hint">click a column to sort</span></div>
+        <div class="controls"><div class="pager" id="characters-pager"></div></div>
+        <div id="characters"></div>
+      </section>
+    </main>
+
+    <main id="page-moderation" class="admin-page">
+      <section class="panel">
+        <div class="panel-title">Moderation <span class="hint">highest open report counts first</span></div>
+        <div id="moderation"></div>
+        <div id="moderation-detail"></div>
+      </section>
+    </main>
   </div>
 
   <script type="module" src="/src/admin/main.ts"></script>

--- a/index.html
+++ b/index.html
@@ -195,6 +195,16 @@
   .chat-pane::-webkit-scrollbar { width: 8px; }
   .chat-pane::-webkit-scrollbar-track { background: #0b0b10; }
   .chat-pane::-webkit-scrollbar-thumb { background: #4a3d1d; border-radius: 4px; }
+  #report-window { width: 320px; z-index: 95; }
+  #report-window .panel-title { display: flex; justify-content: space-between; align-items: center; }
+  #report-window [data-close] { background: transparent; border: 0; color: #c9b27a; cursor: pointer; font-size: 16px; }
+  .report-label { display: block; color: #c9b27a; font-size: 12px; margin: 8px 0 4px; }
+  #report-window select, #report-window textarea {
+    width: 100%; background: #101018; border: 1px solid #4a3d1d; border-radius: 4px; color: #e8d8a8; padding: 6px;
+  }
+  #report-window textarea { height: 96px; resize: none; }
+  .report-error { min-height: 16px; color: #ff7a5e; font-size: 12px; margin-top: 6px; }
+  .report-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
 
   /* ---------- quest tracker ---------- */
   #quest-tracker { position: absolute; right: 14px; top: 210px; width: 240px; font-size: 12px;
@@ -424,6 +434,8 @@
   .char-row .char-sub { color: #998d6a; font-size: 11px; flex: 1; }
   .char-row .btn { margin: 0; padding: 4px 10px; font-size: 11px; }
   .char-row.online .char-name { color: #7fdc4f; }
+  .char-row.rename-required .char-name { color: #ffbf66; }
+  .char-row .rename-input { width: 150px; padding: 5px 7px; background: #101018; border: 1px solid #4a3d1d; border-radius: 4px; color: #e8d8a8; }
   .char-create { margin-top: 14px; border-top: 1px solid #463a1c; padding-top: 10px; }
   .mini-class-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; margin-bottom: 8px; }
   .mini-class { text-align: center; padding: 7px 2px; border: 2px solid #4a3d1d; border-radius: 5px;
@@ -563,6 +575,7 @@
     <div id="vendor-window" class="window panel"></div>
     <div id="map-window" class="window panel"><canvas id="map-canvas" width="560" height="560"></canvas></div>
     <div id="options-menu" class="window panel"></div>
+    <div id="report-window" class="window panel"></div>
     <div id="meters-window" class="panel">
       <div class="panel-title">
         <span class="mt-tabs">

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -7,6 +7,9 @@ import {
   overviewCounts, registrationsByDay, sessionsByDay, classDistribution, levelDistribution,
   listAccounts, listCharacters, accountDetail,
 } from './admin_db';
+import {
+  forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount,
+} from './moderation_db';
 import type { GameServer } from './game';
 
 // Admin API: everything under /admin/api/*. Auth is a bearer token whose
@@ -78,10 +81,52 @@ export async function handleAdminApi(
       return await handleLogin(req, res);
     }
 
-    if (req.method !== 'GET') return fail(res, 405, 'method not allowed');
-
     const accountId = await adminAccountId(req);
     if (accountId === null) return fail(res, 401, 'admin authentication required');
+
+    const actionMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/(suspend|ban)$/.exec(path);
+    if (req.method === 'POST' && actionMatch) {
+      const targetAccountId = Number(actionMatch[1]);
+      const action = actionMatch[2] as 'suspend' | 'ban';
+      const body = await readBody(req);
+      try {
+        await moderateAccount({
+          accountId: targetAccountId,
+          adminAccountId: accountId,
+          action,
+          reason: body.reason,
+          expiresAt: body.expiresAt,
+        });
+        const statusText = action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
+        game.disconnectAccount(targetAccountId, statusText);
+        return ok(res, { ok: true });
+      } catch (err) {
+        return fail(res, 400, err instanceof Error ? err.message : 'moderation action failed');
+      }
+    }
+    const ignoreMatch = /^\/admin\/api\/moderation\/reports\/(\d+)\/ignore$/.exec(path);
+    if (req.method === 'POST' && ignoreMatch) {
+      const body = await readBody(req);
+      const ignored = await ignoreReport(Number(ignoreMatch[1]), accountId, body.note);
+      return ignored ? ok(res, { ok: true }) : fail(res, 404, 'open report not found');
+    }
+    const forceRenameMatch = /^\/admin\/api\/moderation\/characters\/(\d+)\/force-rename$/.exec(path);
+    if (req.method === 'POST' && forceRenameMatch) {
+      const body = await readBody(req);
+      try {
+        const result = await forceCharacterRename({
+          characterId: Number(forceRenameMatch[1]),
+          adminAccountId: accountId,
+          reason: body.reason,
+        });
+        game.disconnectAccount(result.accountId, 'A moderator requires one of your characters to be renamed.');
+        return ok(res, { ok: true });
+      } catch (err) {
+        return fail(res, 400, err instanceof Error ? err.message : 'force rename failed');
+      }
+    }
+
+    if (req.method !== 'GET') return fail(res, 405, 'method not allowed');
 
     if (path === '/admin/api/overview') {
       const counts = await overviewCounts();
@@ -103,6 +148,19 @@ export async function handleAdminApi(
       const { page, limit } = parsePageParams(url.searchParams);
       const search = (url.searchParams.get('search') ?? '').slice(0, 64);
       return ok(res, await listAccounts(search, page, limit));
+    }
+    if (path === '/admin/api/moderation/queue') {
+      return ok(res, { rows: await moderationQueue(game.liveAccountIds()) });
+    }
+    const moderationAccountMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)$/.exec(path);
+    if (moderationAccountMatch) {
+      const id = Number(moderationAccountMatch[1]);
+      const [detail, reports] = await Promise.all([
+        accountDetail(id),
+        moderationReportsForAccount(id),
+      ]);
+      if (!detail) return fail(res, 404, 'account not found');
+      return ok(res, { account: detail, reports });
     }
     const detailMatch = /^\/admin\/api\/accounts\/(\d+)$/.exec(path);
     if (detailMatch) {

--- a/server/db.ts
+++ b/server/db.ts
@@ -43,7 +43,11 @@ CREATE TABLE IF NOT EXISTS characters (
 );
 CREATE INDEX IF NOT EXISTS characters_account ON characters(account_id);
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS suspended_until TIMESTAMPTZ;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS banned_at TIMESTAMPTZ;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS moderation_reason TEXT;
 ALTER TABLE characters ADD COLUMN IF NOT EXISTS is_gm BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS force_rename BOOLEAN NOT NULL DEFAULT FALSE;
 CREATE TABLE IF NOT EXISTS play_sessions (
   id SERIAL PRIMARY KEY,
   account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
@@ -65,6 +69,34 @@ CREATE TABLE IF NOT EXISTS chat_logs (
 );
 CREATE INDEX IF NOT EXISTS chat_logs_created ON chat_logs(created_at);
 CREATE INDEX IF NOT EXISTS chat_logs_character ON chat_logs(character_id, created_at);
+CREATE TABLE IF NOT EXISTS player_reports (
+  id BIGSERIAL PRIMARY KEY,
+  reporter_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  reporter_character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  reporter_character_name TEXT NOT NULL DEFAULT '',
+  reported_account_id INT REFERENCES accounts(id) ON DELETE CASCADE,
+  reported_character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  reported_character_name TEXT NOT NULL DEFAULT '',
+  reason TEXT NOT NULL,
+  details TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'open',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  reviewed_at TIMESTAMPTZ,
+  reviewed_by_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  review_note TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS player_reports_reported_status ON player_reports(reported_account_id, status, created_at DESC);
+CREATE INDEX IF NOT EXISTS player_reports_reporter_created ON player_reports(reporter_account_id, created_at DESC);
+CREATE TABLE IF NOT EXISTS account_moderation_actions (
+  id BIGSERIAL PRIMARY KEY,
+  account_id INT REFERENCES accounts(id) ON DELETE CASCADE,
+  admin_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  action TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS account_moderation_actions_account ON account_moderation_actions(account_id, created_at DESC);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -75,6 +107,14 @@ export interface AccountRow {
   id: number;
   username: string;
   password_hash: string;
+}
+
+export interface AccountModerationStatus {
+  locked: boolean;
+  banned: boolean;
+  suspendedUntil: string | null;
+  reason: string;
+  message: string;
 }
 
 export async function createAccount(username: string, passwordHash: string): Promise<AccountRow> {
@@ -109,6 +149,38 @@ export async function accountForToken(token: string): Promise<number | null> {
   return res.rows[0]?.account_id ?? null;
 }
 
+export async function moderationStatusForAccount(accountId: number): Promise<AccountModerationStatus> {
+  const res = await pool.query(
+    `SELECT banned_at, suspended_until, moderation_reason
+     FROM accounts WHERE id = $1`,
+    [accountId],
+  );
+  const row = res.rows[0];
+  if (!row) {
+    return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '' };
+  }
+  if (row.banned_at) {
+    return {
+      locked: true,
+      banned: true,
+      suspendedUntil: null,
+      reason: row.moderation_reason ?? '',
+      message: 'This account has been banned.',
+    };
+  }
+  const suspendedUntil = row.suspended_until ? new Date(row.suspended_until) : null;
+  if (suspendedUntil && suspendedUntil.getTime() > Date.now()) {
+    return {
+      locked: true,
+      banned: false,
+      suspendedUntil: suspendedUntil.toISOString(),
+      reason: row.moderation_reason ?? '',
+      message: `This account is suspended until ${suspendedUntil.toUTCString()}.`,
+    };
+  }
+  return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '' };
+}
+
 export interface CharacterRow {
   id: number;
   account_id: number;
@@ -117,11 +189,12 @@ export interface CharacterRow {
   level: number;
   state: CharacterState | null;
   is_gm: boolean;
+  force_rename: boolean;
 }
 
 export async function listCharacters(accountId: number): Promise<CharacterRow[]> {
   const res = await pool.query(
-    'SELECT id, account_id, name, class, level, state, is_gm FROM characters WHERE account_id = $1 ORDER BY id',
+    'SELECT id, account_id, name, class, level, state, is_gm, force_rename FROM characters WHERE account_id = $1 ORDER BY id',
     [accountId],
   );
   return res.rows;
@@ -129,7 +202,7 @@ export async function listCharacters(accountId: number): Promise<CharacterRow[]>
 
 export async function getCharacter(accountId: number, characterId: number): Promise<CharacterRow | null> {
   const res = await pool.query(
-    'SELECT id, account_id, name, class, level, state, is_gm FROM characters WHERE id = $1 AND account_id = $2',
+    'SELECT id, account_id, name, class, level, state, is_gm, force_rename FROM characters WHERE id = $1 AND account_id = $2',
     [characterId, accountId],
   );
   return res.rows[0] ?? null;
@@ -137,7 +210,7 @@ export async function getCharacter(accountId: number, characterId: number): Prom
 
 export async function createCharacter(accountId: number, name: string, cls: PlayerClass): Promise<CharacterRow> {
   const res = await pool.query(
-    'INSERT INTO characters (account_id, name, class) VALUES ($1, $2, $3) RETURNING id, account_id, name, class, level, state, is_gm',
+    'INSERT INTO characters (account_id, name, class) VALUES ($1, $2, $3) RETURNING id, account_id, name, class, level, state, is_gm, force_rename',
     [accountId, name, cls],
   );
   return res.rows[0];
@@ -146,6 +219,17 @@ export async function createCharacter(accountId: number, name: string, cls: Play
 export async function deleteCharacter(accountId: number, characterId: number): Promise<boolean> {
   const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2', [characterId, accountId]);
   return (res.rowCount ?? 0) > 0;
+}
+
+export async function renameCharacter(accountId: number, characterId: number, name: string): Promise<CharacterRow | null> {
+  const res = await pool.query(
+    `UPDATE characters
+     SET name = $3, force_rename = FALSE, updated_at = now()
+     WHERE id = $1 AND account_id = $2
+     RETURNING id, account_id, name, class, level, state, is_gm, force_rename`,
+    [characterId, accountId, name],
+  );
+  return res.rows[0] ?? null;
 }
 
 export async function saveCharacterState(characterId: number, level: number, state: CharacterState): Promise<void> {

--- a/server/game.ts
+++ b/server/game.ts
@@ -405,6 +405,26 @@ export class GameServer {
     return players.sort((a, b) => b.sessionSeconds - a.sessionSeconds);
   }
 
+  liveAccountIds(): Set<number> {
+    return new Set([...this.clients.values()].map((s) => s.accountId));
+  }
+
+  reportTargetForPid(pid: number): { accountId: number; characterId: number; characterName: string } | null {
+    const session = this.clients.get(pid);
+    return session
+      ? { accountId: session.accountId, characterId: session.characterId, characterName: session.name }
+      : null;
+  }
+
+  disconnectAccount(accountId: number, reason: string): void {
+    for (const session of [...this.clients.values()]) {
+      if (session.accountId !== accountId) continue;
+      this.send(session, { t: 'error', error: reason });
+      try { session.ws.close(); } catch { /* connection already closing */ }
+      void this.leave(session, 'moderation action');
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Input & commands
   // -------------------------------------------------------------------------

--- a/server/main.ts
+++ b/server/main.ts
@@ -5,8 +5,9 @@ import { WebSocketServer, WebSocket } from 'ws';
 import {
   ensureSchema, pool, createAccount, findAccount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
-  pruneChatLogs,
+  pruneChatLogs, moderationStatusForAccount, renameCharacter,
 } from './db';
+import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { hashPassword, verifyPassword, newToken, validUsername, validPassword, validCharName } from './auth';
 import { json, readBody } from './http_util';
 import { rateLimited } from './ratelimit';
@@ -26,6 +27,20 @@ async function bearerAccount(req: http.IncomingMessage): Promise<number | null> 
   const m = /^Bearer ([a-f0-9]{64})$/.exec(auth);
   if (!m) return null;
   return accountForToken(m[1]);
+}
+
+async function bearerActiveAccount(req: http.IncomingMessage, res: http.ServerResponse): Promise<number | null> {
+  const accountId = await bearerAccount(req);
+  if (accountId === null) {
+    json(res, 401, { error: 'not authenticated' });
+    return null;
+  }
+  const status = await moderationStatusForAccount(accountId);
+  if (status.locked) {
+    json(res, 403, { error: status.message });
+    return null;
+  }
+  return accountId;
 }
 
 const MIME: Record<string, string> = {
@@ -125,20 +140,23 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (!account || !(await verifyPassword(String(body.password ?? ''), account.password_hash))) {
         return json(res, 401, { error: 'invalid username or password' });
       }
+      const status = await moderationStatusForAccount(account.id);
+      if (status.locked) return json(res, 403, { error: status.message });
       await touchLogin(account.id);
       const token = newToken();
       await saveToken(token, account.id);
       return json(res, 200, { token, username: account.username });
     }
     if (url === '/api/characters') {
-      const accountId = await bearerAccount(req);
-      if (accountId === null) return json(res, 401, { error: 'not authenticated' });
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
       if (req.method === 'GET') {
         const chars = await listCharacters(accountId);
         return json(res, 200, {
           characters: chars.map((c) => ({
             id: c.id, name: c.name, class: c.class, level: c.level,
             online: [...game.clients.values()].some((s) => s.characterId === c.id),
+            forceRename: c.force_rename,
           })),
         });
       }
@@ -151,7 +169,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         if (chars.length >= 10) return json(res, 400, { error: 'character limit reached' });
         try {
           const c = await createCharacter(accountId, body.name, body.class);
-          return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level });
+          return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
         } catch (err: any) {
           if (String(err?.message).includes('unique') || err?.code === '23505') {
             return json(res, 409, { error: 'that name is taken' });
@@ -161,11 +179,57 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       }
     }
     const delMatch = /^\/api\/characters\/(\d+)$/.exec(url);
+    const renameMatch = /^\/api\/characters\/(\d+)\/rename$/.exec(url);
+    if (req.method === 'POST' && renameMatch) {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      const body = await readBody(req);
+      if (!validCharName(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+      try {
+        const c = await renameCharacter(accountId, Number(renameMatch[1]), body.name);
+        if (!c) return json(res, 404, { error: 'character not found' });
+        return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
+      } catch (err: any) {
+        if (String(err?.message).includes('unique') || err?.code === '23505') {
+          return json(res, 409, { error: 'that name is taken' });
+        }
+        throw err;
+      }
+    }
     if (req.method === 'DELETE' && delMatch) {
-      const accountId = await bearerAccount(req);
-      if (accountId === null) return json(res, 401, { error: 'not authenticated' });
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
       const ok = await deleteCharacter(accountId, Number(delMatch[1]));
       return json(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'not found' });
+    }
+    if (req.method === 'POST' && url === '/api/reports') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      const body = await readBody(req);
+      const reason = cleanReportReason(body.reason);
+      if (!reason) return json(res, 400, { error: 'choose a report reason' });
+      const reporterCharacterId = Number(body.reporterCharacterId);
+      const targetPid = Number(body.targetPid);
+      if (!Number.isFinite(reporterCharacterId) || !Number.isFinite(targetPid)) {
+        return json(res, 400, { error: 'invalid report target' });
+      }
+      const reporter = await getCharacter(accountId, reporterCharacterId);
+      if (!reporter) return json(res, 404, { error: 'reporting character not found' });
+      const target = game.reportTargetForPid(targetPid);
+      if (!target) return json(res, 404, { error: 'that player is no longer online' });
+      try {
+        const report = await createPlayerReport({
+          reporterAccountId: accountId,
+          reporterCharacterId: reporter.id,
+          reporterCharacterName: reporter.name,
+          target,
+          reason,
+          details: body.details,
+        });
+        return json(res, 200, { ok: true, reportId: report.id });
+      } catch (err) {
+        return json(res, 400, { error: err instanceof Error ? err.message : 'could not submit report' });
+      }
     }
     if (req.method === 'GET' && url === '/api/status') {
       return json(res, 200, {
@@ -252,9 +316,20 @@ async function main(): Promise<void> {
       ws.close();
       return;
     }
+    const status = await moderationStatusForAccount(accountId);
+    if (status.locked) {
+      ws.send(JSON.stringify({ t: 'error', error: status.message }));
+      ws.close();
+      return;
+    }
     const character = await getCharacter(accountId, characterId);
     if (!character) {
       ws.send(JSON.stringify({ t: 'error', error: 'no such character' }));
+      ws.close();
+      return;
+    }
+    if (character.force_rename) {
+      ws.send(JSON.stringify({ t: 'error', error: 'This character must be renamed before entering the world.' }));
       ws.close();
       return;
     }

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -1,0 +1,274 @@
+import { pool } from './db';
+
+export const REPORT_REASONS = ['harassment', 'spam', 'cheating', 'offensive_name_or_chat', 'other'] as const;
+export type ReportReason = typeof REPORT_REASONS[number];
+export type ModerationAction = 'ignore' | 'suspend' | 'ban';
+
+const REPORT_DETAILS_MAX = 1000;
+const ACTION_REASON_MAX = 500;
+const DUPLICATE_REPORT_WINDOW_HOURS = 12;
+
+export function cleanReportReason(value: unknown): ReportReason | null {
+  return typeof value === 'string' && REPORT_REASONS.includes(value as ReportReason)
+    ? value as ReportReason
+    : null;
+}
+
+export function cleanText(value: unknown, max: number): string {
+  return typeof value === 'string' ? value.trim().slice(0, max) : '';
+}
+
+export interface LiveReportTarget {
+  accountId: number;
+  characterId: number;
+  characterName: string;
+}
+
+export async function createPlayerReport(input: {
+  reporterAccountId: number;
+  reporterCharacterId: number;
+  reporterCharacterName: string;
+  target: LiveReportTarget;
+  reason: ReportReason;
+  details: unknown;
+}): Promise<{ id: number }> {
+  if (input.reporterAccountId === input.target.accountId) {
+    throw new Error('cannot report yourself');
+  }
+  const details = cleanText(input.details, REPORT_DETAILS_MAX);
+  const dup = await pool.query(
+    `SELECT id FROM player_reports
+     WHERE reporter_account_id = $1
+       AND reported_account_id = $2
+       AND status = 'open'
+       AND created_at > now() - ($3 || ' hours')::interval
+     LIMIT 1`,
+    [input.reporterAccountId, input.target.accountId, String(DUPLICATE_REPORT_WINDOW_HOURS)],
+  );
+  if (dup.rows[0]) throw new Error('you have already reported this player recently');
+  const res = await pool.query(
+    `INSERT INTO player_reports (
+       reporter_account_id, reporter_character_id, reporter_character_name,
+       reported_account_id, reported_character_id, reported_character_name,
+       reason, details
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+     RETURNING id`,
+    [
+      input.reporterAccountId,
+      input.reporterCharacterId,
+      input.reporterCharacterName,
+      input.target.accountId,
+      input.target.characterId,
+      input.target.characterName,
+      input.reason,
+      details,
+    ],
+  );
+  return { id: Number(res.rows[0].id) };
+}
+
+export interface ModerationQueueRow {
+  accountId: number;
+  username: string;
+  status: 'active' | 'suspended' | 'banned';
+  suspendedUntil: string | null;
+  openReports: number;
+  latestReportAt: string;
+  latestReason: string;
+  characterNames: string[];
+  online: boolean;
+}
+
+export async function moderationQueue(onlineAccountIds: Set<number>): Promise<ModerationQueueRow[]> {
+  const res = await pool.query(
+    `SELECT
+       a.id AS account_id,
+       a.username,
+       a.banned_at,
+       a.suspended_until,
+       count(r.id)::int AS open_reports,
+       max(r.created_at) AS latest_report_at,
+       (array_agg(r.reason ORDER BY r.created_at DESC))[1] AS latest_reason,
+       array_remove(array_agg(DISTINCT r.reported_character_name), '') AS character_names
+     FROM player_reports r
+     JOIN accounts a ON a.id = r.reported_account_id
+     WHERE r.status = 'open'
+     GROUP BY a.id
+     ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
+  );
+  return res.rows.map((r) => {
+    const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
+    const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    return {
+      accountId: r.account_id,
+      username: r.username,
+      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      suspendedUntil,
+      openReports: r.open_reports,
+      latestReportAt: new Date(r.latest_report_at).toISOString(),
+      latestReason: r.latest_reason,
+      characterNames: r.character_names ?? [],
+      online: onlineAccountIds.has(r.account_id),
+    };
+  }).sort((a, b) => (
+    b.openReports - a.openReports
+    || new Date(b.latestReportAt).getTime() - new Date(a.latestReportAt).getTime()
+    || Number(b.online) - Number(a.online)
+  ));
+}
+
+export interface ReportDetail {
+  id: number;
+  reason: string;
+  details: string;
+  status: string;
+  createdAt: string;
+  reporterAccountId: number | null;
+  reporterUsername: string | null;
+  reporterCharacterId: number | null;
+  reporterCharacterName: string;
+  reportedAccountId: number;
+  reportedUsername: string;
+  reportedCharacterId: number | null;
+  reportedCharacterName: string;
+  chatContext: { id: number; characterName: string; channel: string; message: string; createdAt: string }[];
+}
+
+export async function moderationReportsForAccount(accountId: number): Promise<ReportDetail[]> {
+  const reports = await pool.query(
+    `SELECT r.*, reporter.username AS reporter_username, reported.username AS reported_username
+     FROM player_reports r
+     LEFT JOIN accounts reporter ON reporter.id = r.reporter_account_id
+     JOIN accounts reported ON reported.id = r.reported_account_id
+     WHERE r.reported_account_id = $1 AND r.status = 'open'
+     ORDER BY r.created_at DESC`,
+    [accountId],
+  );
+  const out: ReportDetail[] = [];
+  for (const r of reports.rows) {
+    const chat = await pool.query(
+      `SELECT id, character_name, channel, message, created_at
+       FROM chat_logs
+       WHERE character_id = $1 AND created_at <= $2
+       ORDER BY created_at DESC
+       LIMIT 50`,
+      [r.reported_character_id, r.created_at],
+    );
+    out.push({
+      id: Number(r.id),
+      reason: r.reason,
+      details: r.details,
+      status: r.status,
+      createdAt: new Date(r.created_at).toISOString(),
+      reporterAccountId: r.reporter_account_id,
+      reporterUsername: r.reporter_username,
+      reporterCharacterId: r.reporter_character_id,
+      reporterCharacterName: r.reporter_character_name,
+      reportedAccountId: r.reported_account_id,
+      reportedUsername: r.reported_username,
+      reportedCharacterId: r.reported_character_id,
+      reportedCharacterName: r.reported_character_name,
+      chatContext: chat.rows.reverse().map((c) => ({
+        id: Number(c.id),
+        characterName: c.character_name,
+        channel: c.channel,
+        message: c.message,
+        createdAt: new Date(c.created_at).toISOString(),
+      })),
+    });
+  }
+  return out;
+}
+
+export async function ignoreReport(reportId: number, adminAccountId: number, note: unknown): Promise<boolean> {
+  const res = await pool.query(
+    `UPDATE player_reports
+     SET status = 'ignored', reviewed_at = now(), reviewed_by_account_id = $2, review_note = $3
+     WHERE id = $1 AND status = 'open'`,
+    [reportId, adminAccountId, cleanText(note, ACTION_REASON_MAX)],
+  );
+  return (res.rowCount ?? 0) > 0;
+}
+
+export async function moderateAccount(input: {
+  accountId: number;
+  adminAccountId: number;
+  action: 'suspend' | 'ban';
+  reason: unknown;
+  expiresAt?: unknown;
+}): Promise<void> {
+  const reason = cleanText(input.reason, ACTION_REASON_MAX);
+  if (!reason) throw new Error('moderation reason is required');
+  let expiresAt: Date | null = null;
+  if (input.action === 'suspend') {
+    expiresAt = new Date(String(input.expiresAt ?? ''));
+    if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= Date.now()) {
+      throw new Error('suspension expiry must be in the future');
+    }
+  }
+  await pool.query('BEGIN');
+  try {
+    if (input.action === 'ban') {
+      await pool.query(
+        `UPDATE accounts
+         SET banned_at = now(), suspended_until = NULL, moderation_reason = $2
+         WHERE id = $1`,
+        [input.accountId, reason],
+      );
+    } else {
+      await pool.query(
+        `UPDATE accounts
+         SET suspended_until = $2, moderation_reason = $3
+         WHERE id = $1`,
+        [input.accountId, expiresAt!.toISOString(), reason],
+      );
+    }
+    await pool.query(
+      `INSERT INTO account_moderation_actions (account_id, admin_account_id, action, reason, expires_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [input.accountId, input.adminAccountId, input.action, reason, expiresAt ? expiresAt.toISOString() : null],
+    );
+    await pool.query(
+      `UPDATE player_reports
+       SET status = 'actioned', reviewed_at = now(), reviewed_by_account_id = $2, review_note = $3
+       WHERE reported_account_id = $1 AND status = 'open'`,
+      [input.accountId, input.adminAccountId, reason],
+    );
+    await pool.query('COMMIT');
+  } catch (err) {
+    await pool.query('ROLLBACK');
+    throw err;
+  }
+}
+
+export async function forceCharacterRename(input: {
+  characterId: number;
+  adminAccountId: number;
+  reason: unknown;
+}): Promise<{ accountId: number }> {
+  const reason = cleanText(input.reason, ACTION_REASON_MAX);
+  if (!reason) throw new Error('moderation reason is required');
+  const character = await pool.query('SELECT account_id FROM characters WHERE id = $1', [input.characterId]);
+  const accountId = character.rows[0]?.account_id;
+  if (!accountId) throw new Error('character not found');
+  await pool.query('BEGIN');
+  try {
+    await pool.query('UPDATE characters SET force_rename = TRUE WHERE id = $1', [input.characterId]);
+    await pool.query(
+      `INSERT INTO account_moderation_actions (account_id, admin_account_id, action, reason)
+       VALUES ($1, $2, 'force_rename', $3)`,
+      [accountId, input.adminAccountId, reason],
+    );
+    await pool.query(
+      `UPDATE player_reports
+       SET status = 'actioned', reviewed_at = now(), reviewed_by_account_id = $2, review_note = $3
+       WHERE reported_character_id = $1 AND status = 'open'`,
+      [input.characterId, input.adminAccountId, reason],
+    );
+    await pool.query('COMMIT');
+    return { accountId };
+  } catch (err) {
+    await pool.query('ROLLBACK');
+    throw err;
+  }
+}

--- a/src/admin/api.ts
+++ b/src/admin/api.ts
@@ -60,3 +60,14 @@ export async function apiGet<T>(path: string): Promise<T> {
   const res = await fetch(path, { headers: { Authorization: `Bearer ${token}` } });
   return parseEnvelope<T>(res);
 }
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const token = getToken();
+  if (!token) throw new ApiError(401, 'not signed in');
+  const res = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  return parseEnvelope<T>(res);
+}

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -1,10 +1,14 @@
-import { apiGet, apiLogin, clearSession, getAdminName, getToken, ApiError } from './api';
+import { apiGet, apiLogin, apiPost, clearSession, getAdminName, getToken, ApiError } from './api';
 import { barChart, chartPanel } from './charts';
 import { escapeHtml, fmtBytes, fmtDuration } from './format';
 import {
-  renderAccountDetail, renderAccountsTable, renderCharactersTable, renderOnlineTable, renderPager,
+  renderAccountDetail, renderAccountsTable, renderCharactersTable, renderModerationDetail,
+  renderModerationQueue, renderOnlineTable, renderPager,
 } from './tables';
-import type { AccountDetail, AccountRow, Activity, CharacterRow, LivePlayer, Overview, Paginated } from './types';
+import type {
+  AccountDetail, AccountRow, Activity, CharacterRow, LivePlayer, ModerationAccountDetail,
+  ModerationQueueRow, Overview, Paginated,
+} from './types';
 
 const LIVE_REFRESH_MS = 5_000;
 const ACTIVITY_REFRESH_MS = 60_000;
@@ -27,6 +31,8 @@ const accountsState: TableState = { page: 1, search: '', sort: 'id', dir: 'desc'
 const charactersState: TableState = { page: 1, search: '', sort: 'level', dir: 'desc' };
 let liveTimer: number | null = null;
 let activityTimer: number | null = null;
+let activePage: 'overview' | 'moderation' = 'overview';
+let pendingModerationAction: { endpoint: string; body: unknown; accountId: number } | null = null;
 
 // ---------------------------------------------------------------------------
 // Auth flow
@@ -54,9 +60,29 @@ async function showApp(): Promise<void> {
   $('app').classList.add('authed');
   $('who-name').textContent = getAdminName();
   await refreshLive();
-  await Promise.all([refreshActivity(), refreshAccounts(), refreshCharacters()]);
+  await Promise.all([refreshActivity(), refreshModeration(), refreshAccounts(), refreshCharacters()]);
   liveTimer = window.setInterval(() => void refreshLive(), LIVE_REFRESH_MS);
   activityTimer = window.setInterval(() => void refreshActivity(), ACTIVITY_REFRESH_MS);
+}
+
+async function refreshModeration(): Promise<void> {
+  try {
+    const data = await apiGet<{ rows: ModerationQueueRow[] }>('/admin/api/moderation/queue');
+    $('moderation').innerHTML = renderModerationQueue(data.rows);
+  } catch (err) {
+    if (!handleAuthFailure(err)) $('moderation').innerHTML = '<div class="empty">failed to load moderation queue</div>';
+  }
+}
+
+function showPage(page: 'overview' | 'moderation'): void {
+  activePage = page;
+  document.querySelectorAll<HTMLButtonElement>('.admin-tab').forEach((tab) => {
+    tab.classList.toggle('active', tab.dataset.adminPage === page);
+  });
+  document.querySelectorAll<HTMLElement>('.admin-page').forEach((el) => {
+    el.classList.toggle('active', el.id === `page-${page}`);
+  });
+  if (page === 'moderation') void refreshModeration();
 }
 
 // ---------------------------------------------------------------------------
@@ -161,6 +187,37 @@ async function toggleAccountDetail(row: HTMLTableRowElement, accountId: number):
   }
 }
 
+async function openModerationAccount(accountId: number): Promise<void> {
+  $('moderation-detail').innerHTML = '<div class="empty">loading report context…</div>';
+  try {
+    const detail = await apiGet<ModerationAccountDetail>(`/admin/api/moderation/accounts/${accountId}`);
+    $('moderation-detail').innerHTML = renderModerationDetail(detail);
+  } catch (err) {
+    if (!handleAuthFailure(err)) $('moderation-detail').innerHTML = '<div class="empty">failed to load report context</div>';
+  }
+}
+
+function showModerationConfirm(opts: {
+  title: string;
+  rows: { label: string; value: string }[];
+  endpoint: string;
+  body: unknown;
+  accountId: number;
+  danger?: boolean;
+}): void {
+  pendingModerationAction = { endpoint: opts.endpoint, body: opts.body, accountId: opts.accountId };
+  const el = $('mod-confirm');
+  el.className = 'mod-confirm show';
+  el.innerHTML = `
+    <h4>${escapeHtml(opts.title)}</h4>
+    <dl>${opts.rows.map((r) => `<dt>${escapeHtml(r.label)}</dt><dd>${escapeHtml(r.value)}</dd>`).join('')}</dl>
+    <div class="confirm-actions">
+      <button data-confirm-moderation ${opts.danger ? 'class="danger"' : ''}>Confirm</button>
+      <button data-cancel-moderation>Cancel</button>
+    </div>`;
+  el.scrollIntoView({ block: 'nearest' });
+}
+
 // ---------------------------------------------------------------------------
 // Event wiring
 // ---------------------------------------------------------------------------
@@ -179,6 +236,12 @@ function wireEvents(): void {
   });
 
   $('logout').addEventListener('click', () => showLogin());
+
+  $('admin-tabs').addEventListener('click', (e) => {
+    const tab = (e.target as HTMLElement).closest<HTMLButtonElement>('.admin-tab');
+    const page = tab?.dataset.adminPage;
+    if (page === 'overview' || page === 'moderation') showPage(page);
+  });
 
   let searchTimer: number | null = null;
   $('account-search').addEventListener('input', (e) => {
@@ -202,6 +265,134 @@ function wireEvents(): void {
     const row = (e.target as HTMLElement).closest('tr.clickable') as HTMLTableRowElement | null;
     const accountId = Number(row?.dataset.accountId);
     if (row && Number.isFinite(accountId)) void toggleAccountDetail(row, accountId);
+  });
+
+  $('moderation').addEventListener('click', (e) => {
+    const row = (e.target as HTMLElement).closest('tr[data-moderation-account-id]') as HTMLTableRowElement | null;
+    const accountId = Number(row?.dataset.moderationAccountId);
+    if (row && Number.isFinite(accountId)) void openModerationAccount(accountId);
+  });
+
+  $('moderation-detail').addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-cancel-moderation]')) {
+      pendingModerationAction = null;
+      $('mod-confirm').className = 'mod-confirm';
+      $('mod-confirm').innerHTML = '';
+      return;
+    }
+    if (target.closest('[data-confirm-moderation]')) {
+      const pending = pendingModerationAction;
+      if (!pending) return;
+      void apiPost(pending.endpoint, pending.body)
+        .then(() => {
+          pendingModerationAction = null;
+          void refreshModeration();
+          void openModerationAccount(pending.accountId);
+        })
+        .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'moderation action failed'); });
+      return;
+    }
+    const ignoreBtn = target.closest('button[data-ignore-report]') as HTMLButtonElement | null;
+    if (ignoreBtn) {
+      const reportId = Number(ignoreBtn.dataset.ignoreReport);
+      const note = (($('mod-reason') as HTMLInputElement | null)?.value ?? '').trim();
+      void apiPost(`/admin/api/moderation/reports/${reportId}/ignore`, { note })
+        .then(() => {
+          const accountId = Number((ignoreBtn.closest('.mod-detail')?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
+          void refreshModeration();
+          if (Number.isFinite(accountId)) void openModerationAccount(accountId);
+        })
+        .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'ignore failed'); });
+      return;
+    }
+    const actionWrap = target.closest('[data-action-account-id]') as HTMLElement | null;
+    const detailWrap = target.closest('.mod-detail') as HTMLElement | null;
+    const accountId = Number((actionWrap ?? detailWrap?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
+    const note = (($('mod-reason') as HTMLInputElement | null)?.value ?? '').trim();
+    const requireNote = (): boolean => {
+      if (note) return true;
+      window.alert('Enter a moderator note / reason first.');
+      return false;
+    };
+    const forceRenameBtn = target.closest('button[data-force-rename-character]') as HTMLButtonElement | null;
+    if (forceRenameBtn) {
+      if (!requireNote()) return;
+      const characterId = Number(forceRenameBtn.dataset.forceRenameCharacter);
+      const characterName = forceRenameBtn.dataset.characterName ?? `#${characterId}`;
+      showModerationConfirm({
+        title: 'Confirm forced name change',
+        rows: [
+          { label: 'Character', value: characterName },
+          { label: 'Action', value: 'Require player to choose a new character name before entering the world.' },
+          { label: 'Reason', value: note },
+        ],
+        endpoint: `/admin/api/moderation/characters/${characterId}/force-rename`,
+        body: { reason: note },
+        accountId,
+      });
+      return;
+    }
+    if (!actionWrap) return;
+    const suspendBtn = target.closest('button[data-suspend-hours]') as HTMLButtonElement | null;
+    if (suspendBtn) {
+      if (!requireNote()) return;
+      const hours = Number(suspendBtn.dataset.suspendHours);
+      const expiresAt = new Date(Date.now() + hours * 3600 * 1000).toISOString();
+      showModerationConfirm({
+        title: 'Confirm suspension',
+        rows: [
+          { label: 'Account', value: `#${accountId}` },
+          { label: 'Action', value: 'Temporary account lockout' },
+          { label: 'Length', value: `${hours} hour${hours === 1 ? '' : 's'}` },
+          { label: 'Until', value: new Date(expiresAt).toLocaleString() },
+          { label: 'Reason', value: note },
+        ],
+        endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
+        body: { reason: note, expiresAt },
+        accountId,
+      });
+      return;
+    }
+    const customSuspend = target.closest('button[data-suspend-custom]') as HTMLButtonElement | null;
+    if (customSuspend) {
+      if (!requireNote()) return;
+      const raw = ($('mod-custom-expiry') as HTMLInputElement).value;
+      const expiry = raw ? new Date(raw) : null;
+      if (!expiry || !Number.isFinite(expiry.getTime())) {
+        window.alert('Choose a custom suspension expiry.');
+        return;
+      }
+      showModerationConfirm({
+        title: 'Confirm custom suspension',
+        rows: [
+          { label: 'Account', value: `#${accountId}` },
+          { label: 'Action', value: 'Temporary account lockout' },
+          { label: 'Until', value: expiry.toLocaleString() },
+          { label: 'Reason', value: note },
+        ],
+        endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
+        body: { reason: note, expiresAt: expiry.toISOString() },
+        accountId,
+      });
+      return;
+    }
+    const banBtn = target.closest('button[data-ban-account]') as HTMLButtonElement | null;
+    if (banBtn) {
+      if (!requireNote()) return;
+      showModerationConfirm({
+        title: 'Confirm ban',
+        rows: [
+          { label: 'Account', value: `#${accountId}` },
+          { label: 'Action', value: 'Permanent account lockout' },
+          { label: 'Reason', value: note },
+        ],
+        endpoint: `/admin/api/moderation/accounts/${accountId}/ban`,
+        body: { reason: note },
+        accountId,
+        danger: true,
+      });
+    }
   });
 
   $('characters').addEventListener('click', (e) => {

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -1,5 +1,5 @@
 import { escapeHtml, fmtCopper, fmtDate, fmtDuration, fmtRelative } from './format';
-import type { AccountDetail, AccountRow, CharacterRow, LivePlayer } from './types';
+import type { AccountDetail, AccountRow, CharacterRow, LivePlayer, ModerationAccountDetail, ModerationQueueRow } from './types';
 
 // Pure HTML-string renderers for the dashboard tables. All dynamic values go
 // through escapeHtml — usernames and character names are player-controlled.
@@ -117,4 +117,90 @@ export function renderPager(total: number, page: number, limit: number): string 
     <button data-page="${page - 1}" ${page <= 1 ? 'disabled' : ''}>‹ prev</button>
     <span>page ${page} / ${pages} — ${total} total</span>
     <button data-page="${page + 1}" ${page >= pages ? 'disabled' : ''}>next ›</button>`;
+}
+
+export function renderModerationQueue(rows: ModerationQueueRow[]): string {
+  if (rows.length === 0) return '<div class="empty">no open reports</div>';
+  const body = rows.map((r) => `
+    <tr class="clickable" data-moderation-account-id="${r.accountId}">
+      <td>${escapeHtml(r.username)}${r.online ? ' <span class="badge">online</span>' : ''}</td>
+      <td>${r.characterNames.map(escapeHtml).join(', ') || '—'}</td>
+      <td class="num">${r.openReports}</td>
+      <td>${escapeHtml(reasonLabel(r.latestReason))}</td>
+      <td>${fmtRelative(r.latestReportAt)}</td>
+      <td>${statusBadge(r.status, r.suspendedUntil)}</td>
+    </tr>`);
+  return `<table>
+    <thead><tr>
+      <th>Account</th><th>Characters</th><th class="num">Open Reports</th><th>Latest Reason</th><th>Latest</th><th>Status</th>
+    </tr></thead>
+    <tbody>${body.join('')}</tbody>
+  </table>`;
+}
+
+export function renderModerationDetail(d: ModerationAccountDetail): string {
+  const reports = d.reports.map((r) => {
+    const chat = r.chatContext.length === 0
+      ? '<div class="empty">no recent chat from this character before the report</div>'
+      : `<table><thead><tr><th>Time</th><th>Channel</th><th>Message</th></tr></thead><tbody>${
+          r.chatContext.map((c) => `
+            <tr>
+              <td>${fmtDate(c.createdAt)}</td>
+              <td>${escapeHtml(c.channel)}</td>
+              <td><b>${escapeHtml(c.characterName)}:</b> ${escapeHtml(c.message)}</td>
+            </tr>`).join('')
+        }</tbody></table>`;
+    return `<div class="mod-report panel" data-report-id="${r.id}">
+      <div class="panel-title">Report #${r.id} <span class="hint">${fmtDate(r.createdAt)}</span></div>
+      <div class="mod-report-meta">
+        <div><b>Reporter:</b> ${escapeHtml(r.reporterUsername ?? 'unknown')} / ${escapeHtml(r.reporterCharacterName || 'unknown')}</div>
+        <div><b>Reported:</b> ${escapeHtml(r.reportedUsername)} / ${escapeHtml(r.reportedCharacterName || 'unknown')}</div>
+        <div><b>Reason:</b> ${escapeHtml(reasonLabel(r.reason))}</div>
+      </div>
+      <div class="mod-details">${escapeHtml(r.details || 'No extra details provided.')}</div>
+      <div class="mod-actions">
+        <button data-ignore-report="${r.id}">Ignore</button>
+        ${r.reportedCharacterId ? `<button data-force-rename-character="${r.reportedCharacterId}" data-character-name="${escapeHtml(r.reportedCharacterName)}">Force Name Change</button>` : ''}
+      </div>
+      <h4>Recent chat before this report</h4>
+      ${chat}
+    </div>`;
+  }).join('');
+  return `<div class="mod-detail">
+    <div class="panel-title">
+      <span>${escapeHtml(d.account.username)}</span>
+      <span class="hint">account #${d.account.id}</span>
+    </div>
+    ${renderAccountDetail(d.account)}
+    <div class="mod-account-actions" data-action-account-id="${d.account.id}">
+      <input id="mod-reason" placeholder="Moderator note / reason" maxlength="500" />
+      <button data-suspend-hours="1">Suspend 1h</button>
+      <button data-suspend-hours="24">Suspend 24h</button>
+      <button data-suspend-hours="72">Suspend 3d</button>
+      <button data-suspend-hours="168">Suspend 7d</button>
+      <button data-suspend-hours="720">Suspend 30d</button>
+      <input id="mod-custom-expiry" type="datetime-local" />
+      <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-ban-account="1">Ban</button>
+    </div>
+    <div id="mod-confirm" class="mod-confirm"></div>
+    <h4>Open reports</h4>
+    ${reports || '<div class="empty">no open reports for this account</div>'}
+  </div>`;
+}
+
+function reasonLabel(reason: string): string {
+  return ({
+    harassment: 'Harassment / abuse',
+    spam: 'Spam',
+    cheating: 'Cheating / exploit',
+    offensive_name_or_chat: 'Offensive name or chat',
+    other: 'Other',
+  } as Record<string, string>)[reason] ?? reason;
+}
+
+function statusBadge(status: string, suspendedUntil: string | null): string {
+  if (status === 'banned') return '<span class="badge bad">banned</span>';
+  if (status === 'suspended') return `<span class="badge warn">suspended until ${fmtDate(suspendedUntil)}</span>`;
+  return '<span class="badge">active</span>';
 }

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -102,3 +102,43 @@ export interface AccountDetail {
     seconds: number;
   }[];
 }
+
+export interface ModerationQueueRow {
+  accountId: number;
+  username: string;
+  status: 'active' | 'suspended' | 'banned';
+  suspendedUntil: string | null;
+  openReports: number;
+  latestReportAt: string;
+  latestReason: string;
+  characterNames: string[];
+  online: boolean;
+}
+
+export interface ReportDetail {
+  id: number;
+  reason: string;
+  details: string;
+  status: string;
+  createdAt: string;
+  reporterAccountId: number | null;
+  reporterUsername: string | null;
+  reporterCharacterId: number | null;
+  reporterCharacterName: string;
+  reportedAccountId: number;
+  reportedUsername: string;
+  reportedCharacterId: number | null;
+  reportedCharacterName: string;
+  chatContext: {
+    id: number;
+    characterName: string;
+    channel: string;
+    message: string;
+    createdAt: string;
+  }[];
+}
+
+export interface ModerationAccountDetail {
+  account: AccountDetail;
+  reports: ReportDetail[];
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,6 +169,11 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     settings,
     onSettingChange: (key, value) => applySetting(key, value),
   });
+  if (online) {
+    hud.attachReporting({
+      submit: (targetPid, reason, details) => api.reportPlayer(online.characterId, targetPid, reason, details),
+    });
+  }
 
   function interactKey(): void {
     const p = world.player;
@@ -337,11 +342,26 @@ async function refreshCharacters(): Promise<void> {
     }
     for (const c of chars) {
       const row = document.createElement('div');
-      row.className = 'char-row' + (c.online ? ' online' : '');
+      row.className = 'char-row' + (c.online ? ' online' : '') + (c.forceRename ? ' rename-required' : '');
       row.innerHTML = `<span class="char-name">${c.name}</span>
-        <span class="char-sub">Level ${c.level} ${c.class[0].toUpperCase()}${c.class.slice(1)}${c.online ? ' — in world' : ''}</span>
-        <button class="btn" ${c.online ? 'disabled' : ''}>Enter World</button>`;
-      row.querySelector('button')!.addEventListener('click', () => enterWorld(c));
+        <span class="char-sub">Level ${c.level} ${c.class[0].toUpperCase()}${c.class.slice(1)}${c.online ? ' — in world' : c.forceRename ? ' — rename required' : ''}</span>
+        ${c.forceRename
+          ? '<input class="rename-input" placeholder="New character name" maxlength="16" /><button class="btn rename-btn">Rename</button>'
+          : `<button class="btn" ${c.online ? 'disabled' : ''}>Enter World</button>`}`;
+      if (c.forceRename) {
+        const input = row.querySelector('.rename-input') as HTMLInputElement;
+        row.querySelector('.rename-btn')!.addEventListener('click', async () => {
+          $('#charselect-error').textContent = '';
+          try {
+            await api.renameCharacter(c.id, input.value.trim());
+            await refreshCharacters();
+          } catch (err: any) {
+            $('#charselect-error').textContent = err.message;
+          }
+        });
+      } else {
+        row.querySelector('button')!.addEventListener('click', () => enterWorld(c));
+      }
       listEl.appendChild(row);
     }
   } catch (err: any) {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -18,6 +18,7 @@ export interface CharacterSummary {
   class: PlayerClass;
   level: number;
   online: boolean;
+  forceRename: boolean;
 }
 
 export function buildWebSocketUrl(protocol: string, host: string): string {
@@ -74,6 +75,14 @@ export class Api {
 
   async createCharacter(name: string, cls: PlayerClass): Promise<void> {
     await this.post('/api/characters', { name, class: cls });
+  }
+
+  async renameCharacter(characterId: number, name: string): Promise<void> {
+    await this.post(`/api/characters/${characterId}/rename`, { name });
+  }
+
+  async reportPlayer(reporterCharacterId: number, targetPid: number, reason: string, details: string): Promise<void> {
+    await this.post('/api/reports', { reporterCharacterId, targetPid, reason, details });
   }
 }
 
@@ -134,6 +143,7 @@ export class ClientWorld implements IWorld {
   pendingFacingDelta = 0;
   connected = false;
   onDisconnect: ((reason: string) => void) | null = null;
+  readonly characterId: number;
 
   private ws: WebSocket;
   private eventQueue: SimEvent[] = [];
@@ -144,6 +154,7 @@ export class ClientWorld implements IWorld {
   private sendTimer: number | undefined;
 
   constructor(token: string, characterId: number, cls: PlayerClass) {
+    this.characterId = characterId;
     this.cfg = { seed: 20061, playerClass: cls };
     this.ws = new WebSocket(buildWebSocketUrl(location.protocol, location.host));
     this.ws.onopen = () => {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2645,6 +2645,22 @@ export class Sim {
     return partyId !== undefined ? this.parties.get(partyId) ?? null : null;
   }
 
+  private hasActiveInvite(map: Map<number, { fromPid: number; expires: number }>, targetPid: number): boolean {
+    const invite = map.get(targetPid);
+    if (!invite) return false;
+    if (invite.expires < this.time) {
+      map.delete(targetPid);
+      return false;
+    }
+    return true;
+  }
+
+  private hasPendingSocialInvite(targetPid: number): boolean {
+    return this.hasActiveInvite(this.partyInvites, targetPid)
+      || this.hasActiveInvite(this.tradeInvites, targetPid)
+      || this.hasActiveInvite(this.duelInvites, targetPid);
+  }
+
   partyInvite(targetPid: number, pid?: number): void {
     const r = this.resolve(pid);
     const target = this.players.get(targetPid);
@@ -2654,6 +2670,7 @@ export class Sim {
     if (myParty && myParty.leader !== r.meta.entityId) { this.error(r.meta.entityId, 'Only the party leader may invite.'); return; }
     if (myParty && myParty.members.length >= PARTY_MAX) { this.error(r.meta.entityId, 'Your party is full.'); return; }
     if (this.partyOf(targetPid)) { this.error(r.meta.entityId, `${target.name} is already in a party.`); return; }
+    if (this.hasPendingSocialInvite(targetPid)) { this.error(r.meta.entityId, `${target.name} already has a pending invitation.`); return; }
     this.partyInvites.set(targetPid, { fromPid: r.meta.entityId, expires: this.time + 30 });
     this.emit({ type: 'partyInvite', fromPid: r.meta.entityId, fromName: r.meta.name, pid: targetPid });
     this.emit({ type: 'log', text: `You have invited ${target.name} to your party.`, color: '#aaf', pid: r.meta.entityId });
@@ -2742,6 +2759,7 @@ export class Sim {
     if (targetPid === r.meta.entityId) return;
     if (this.duels.has(r.meta.entityId) || this.duels.has(targetPid)) { this.error(r.meta.entityId, 'A duel is already in progress.'); return; }
     if (dist2d(r.e.pos, targetE.pos) > 30) { this.error(r.meta.entityId, 'Target is too far away.'); return; }
+    if (this.hasPendingSocialInvite(targetPid)) { this.error(r.meta.entityId, `${target.name} already has a pending invitation.`); return; }
     this.duelInvites.set(targetPid, { fromPid: r.meta.entityId, expires: this.time + 30 });
     this.emit({ type: 'duelRequest', fromPid: r.meta.entityId, fromName: r.meta.name, pid: targetPid });
     this.emit({ type: 'log', text: `You have challenged ${target.name} to a duel.`, color: '#fa6', pid: r.meta.entityId });
@@ -2849,6 +2867,7 @@ export class Sim {
     if (targetPid === r.meta.entityId) return;
     if (this.trades.has(r.meta.entityId) || this.trades.has(targetPid)) { this.error(r.meta.entityId, 'A trade is already in progress.'); return; }
     if (dist2d(r.e.pos, targetE.pos) > TRADE_RANGE) { this.error(r.meta.entityId, 'Target is too far away to trade.'); return; }
+    if (this.hasPendingSocialInvite(targetPid)) { this.error(r.meta.entityId, `${target.name} already has a pending invitation.`); return; }
     this.tradeInvites.set(targetPid, { fromPid: r.meta.entityId, expires: this.time + 30 });
     this.emit({ type: 'tradeRequest', fromPid: r.meta.entityId, fromName: r.meta.name, pid: targetPid });
     this.emit({ type: 'log', text: `You have requested to trade with ${target.name}.`, color: '#8df', pid: r.meta.entityId });

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -25,7 +25,17 @@ export interface OptionsHooks {
   onSettingChange(key: keyof GameSettings, value: number): void;
 }
 
+export interface ReportHooks {
+  submit(targetPid: number, reason: string, details: string): Promise<void>;
+}
+
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
+const esc = (value: unknown): string => String(value ?? '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
 
 const FAMILY_GLYPH: Record<string, string> = {
   beast: '🐾', humanoid: '🗡️', murloc: '🐟', spider: '🕷️', kobold: '⛏️', undead: '💀',
@@ -46,6 +56,7 @@ export class Hud {
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
   private dragFromSlot: number | null = null;
   private optionsHooks: OptionsHooks | null = null;
+  private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
   private capturingKey: { action: string; index: number } | null = null; // binding awaiting a key
   private keybindNote = '';
@@ -1493,11 +1504,12 @@ export class Hud {
     const isLeader = party?.leader === this.sim.playerId;
     const isMember = !!party?.members.some((m) => m.pid === pid);
     const ignored = this.isChatIgnored(name);
-    let html = `<div class="ctx-title">${name}</div>`;
+    let html = `<div class="ctx-title">${esc(name)}</div>`;
     if (!isMember) html += `<div class="ctx-item" data-act="invite">Invite to Party</div>`;
     html += `<div class="ctx-item" data-act="trade">Trade</div>`;
     html += `<div class="ctx-item" data-act="duel">Challenge to a Duel</div>`;
     html += `<div class="ctx-item" data-act="ignore">${ignored ? 'Unignore' : 'Ignore'} Chat</div>`;
+    if (this.reportHooks && pid !== this.sim.playerId) html += `<div class="ctx-item" data-act="report">Report Player</div>`;
     if (isLeader && isMember && pid !== this.sim.playerId) html += `<div class="ctx-item" data-act="kick">Remove from Party</div>`;
     html += `<div class="ctx-item" data-act="close">Cancel</div>`;
     el.innerHTML = html;
@@ -1512,8 +1524,50 @@ export class Hud {
         else if (act === 'trade') this.sim.tradeRequest(pid);
         else if (act === 'duel') this.sim.duelRequest(pid);
         else if (act === 'ignore') this.toggleChatIgnore(name);
+        else if (act === 'report') this.openReportWindow(pid, name);
         else if (act === 'kick') this.sim.partyKick(pid);
       });
+    });
+  }
+
+  private openReportWindow(pid: number, name: string): void {
+    if (!this.reportHooks) return;
+    const el = $('#report-window');
+    el.innerHTML = `
+      <div class="panel-title">Report ${esc(name)}<button data-close>×</button></div>
+      <label class="report-label">Reason</label>
+      <select id="report-reason">
+        <option value="harassment">Harassment / abuse</option>
+        <option value="spam">Spam</option>
+        <option value="cheating">Cheating / exploit</option>
+        <option value="offensive_name_or_chat">Offensive name or chat</option>
+        <option value="other">Other</option>
+      </select>
+      <label class="report-label">Details</label>
+      <textarea id="report-details" maxlength="1000" placeholder="What happened?"></textarea>
+      <div class="report-error" id="report-error"></div>
+      <div class="report-actions">
+        <button class="btn" id="report-submit">Submit Report</button>
+        <button class="btn" data-close>Cancel</button>
+      </div>`;
+    el.style.left = `${Math.max(12, Math.min(window.innerWidth - 340, window.innerWidth / 2 - 160))}px`;
+    el.style.top = `${Math.max(20, Math.min(window.innerHeight - 300, window.innerHeight / 2 - 150))}px`;
+    el.style.display = 'block';
+    el.querySelectorAll('[data-close]').forEach((btn) => btn.addEventListener('click', () => { el.style.display = 'none'; }));
+    const submit = $('#report-submit') as HTMLButtonElement;
+    submit.addEventListener('click', () => {
+      const reason = ($('#report-reason') as HTMLSelectElement).value;
+      const details = ($('#report-details') as HTMLTextAreaElement).value;
+      submit.disabled = true;
+      this.reportHooks!.submit(pid, reason, details)
+        .then(() => {
+          el.style.display = 'none';
+          this.log(`Report submitted for ${name}.`, '#ffd100');
+        })
+        .catch((err: unknown) => {
+          submit.disabled = false;
+          $('#report-error').textContent = err instanceof Error ? err.message : 'Could not submit report.';
+        });
     });
   }
 
@@ -1679,6 +1733,10 @@ export class Hud {
 
   attachOptions(hooks: OptionsHooks): void {
     this.optionsHooks = hooks;
+  }
+
+  attachReporting(hooks: ReportHooks): void {
+    this.reportHooks = hooks;
   }
 
   get optionsOpen(): boolean {
@@ -1917,7 +1975,7 @@ export class Hud {
       this.sim.tradeCancel();
       closed = true;
     }
-    for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window']) {
+    for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window', '#report-window']) {
       const el = $(id);
       if (el.style.display === 'block') {
         el.style.display = 'none';

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -24,10 +24,18 @@ vi.mock('../server/admin_db', async () => {
     accountDetail: vi.fn(),
   };
 });
+vi.mock('../server/moderation_db', () => ({
+  forceCharacterRename: vi.fn(),
+  moderationQueue: vi.fn(),
+  moderationReportsForAccount: vi.fn(),
+  ignoreReport: vi.fn(),
+  moderateAccount: vi.fn(),
+}));
 
 import { handleAdminApi, parsePageParams } from '../server/admin';
 import { accountForToken, isAdminAccount, findAccount } from '../server/db';
-import { overviewCounts, listAccounts, escapeLike } from '../server/admin_db';
+import { overviewCounts, listAccounts, accountDetail, escapeLike } from '../server/admin_db';
+import { forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount } from '../server/moderation_db';
 
 const VALID_TOKEN = 'a'.repeat(64);
 
@@ -62,6 +70,8 @@ const fakeGame: any = {
     simEntities: 40, rssBytes: 1, heapUsedBytes: 1,
   }),
   liveSessions: () => [],
+  liveAccountIds: () => new Set([9]),
+  disconnectAccount: vi.fn(),
 };
 
 beforeEach(() => {
@@ -124,8 +134,10 @@ describe('admin api auth', () => {
   });
 
   it('rejects non-GET methods on data endpoints', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
     const res = fakeRes();
-    await handleAdminApi(fakeReq({ method: 'DELETE', url: '/admin/api/accounts' }), res, fakeGame);
+    await handleAdminApi(fakeReq({ method: 'DELETE', token: VALID_TOKEN, url: '/admin/api/accounts' }), res, fakeGame);
 
     expect(res.statusCode).toBe(405);
   });
@@ -154,6 +166,113 @@ describe('admin api auth', () => {
 
     expect(listAccounts).toHaveBeenCalledWith('bob', 2, 50);
     expect(res.statusCode).toBe(200);
+  });
+
+  it('serves the moderation queue to admins with online account context', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(moderationQueue).mockResolvedValue([{
+      accountId: 9,
+      username: 'badactor',
+      status: 'active',
+      suspendedUntil: null,
+      openReports: 4,
+      latestReportAt: new Date().toISOString(),
+      latestReason: 'spam',
+      characterNames: ['Badactor'],
+      online: true,
+    }]);
+    const res = fakeRes();
+
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/moderation/queue' }), res, fakeGame);
+
+    expect(res.statusCode).toBe(200);
+    expect(moderationQueue).toHaveBeenCalledWith(new Set([9]));
+    expect(res.body.data.rows[0].openReports).toBe(4);
+  });
+
+  it('loads moderation account detail with open reports', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(accountDetail).mockResolvedValue({
+      id: 9, username: 'badactor', createdAt: '', lastLogin: null, isAdmin: false,
+      playtimeSeconds: 0, characters: [], recentSessions: [],
+    });
+    vi.mocked(moderationReportsForAccount).mockResolvedValue([]);
+    const res = fakeRes();
+
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9' }), res, fakeGame);
+
+    expect(res.statusCode).toBe(200);
+    expect(moderationReportsForAccount).toHaveBeenCalledWith(9);
+  });
+
+  it('ignores an open report', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(ignoreReport).mockResolvedValue(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/reports/55/ignore', body: { note: 'no issue' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(ignoreReport).toHaveBeenCalledWith(55, 7, 'no issue');
+  });
+
+  it('suspends and disconnects an account', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(moderateAccount).mockResolvedValue();
+    const res = fakeRes();
+    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/suspend', body: { reason: 'abuse', expiresAt } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'suspend', reason: 'abuse', expiresAt });
+    expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account is suspended.');
+  });
+
+  it('bans and disconnects an account', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(moderateAccount).mockResolvedValue();
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/ban', body: { reason: 'severe abuse' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'ban', reason: 'severe abuse', expiresAt: undefined });
+    expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account has been banned.');
+  });
+
+  it('forces a character rename and disconnects that account', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(forceCharacterRename).mockResolvedValue({ accountId: 9 });
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/characters/42/force-rename', body: { reason: 'bad name' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(forceCharacterRename).toHaveBeenCalledWith({ characterId: 42, adminAccountId: 7, reason: 'bad name' });
+    expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'A moderator requires one of your characters to be renamed.');
   });
 });
 

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn() },
+}));
+
+import { pool } from '../server/db';
+import {
+  cleanReportReason, cleanText, createPlayerReport, forceCharacterRename, moderateAccount,
+  moderationQueue, moderationReportsForAccount,
+} from '../server/moderation_db';
+
+const query = vi.mocked(pool.query);
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('moderation report helpers', () => {
+  it('accepts only known report reasons and trims bounded text', () => {
+    expect(cleanReportReason('spam')).toBe('spam');
+    expect(cleanReportReason('bad')).toBeNull();
+    expect(cleanText('  hello  ', 5)).toBe('hello');
+    expect(cleanText('abcdef', 3)).toBe('abc');
+  });
+
+  it('rejects self reports before writing', async () => {
+    await expect(createPlayerReport({
+      reporterAccountId: 1,
+      reporterCharacterId: 10,
+      reporterCharacterName: 'Alice',
+      target: { accountId: 1, characterId: 11, characterName: 'Alt' },
+      reason: 'spam',
+      details: 'same account',
+    })).rejects.toThrow(/yourself/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('rejects duplicate open reports in the recent window', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 99 }] } as any);
+
+    await expect(createPlayerReport({
+      reporterAccountId: 1,
+      reporterCharacterId: 10,
+      reporterCharacterName: 'Alice',
+      target: { accountId: 2, characterId: 20, characterName: 'Bob' },
+      reason: 'harassment',
+      details: 'duplicate',
+    })).rejects.toThrow(/already reported/);
+  });
+
+  it('sorts moderation queue by open report count, recency, then online status', async () => {
+    query.mockResolvedValueOnce({ rows: [
+      {
+        account_id: 2, username: 'offline-two', banned_at: null, suspended_until: null,
+        open_reports: 2, latest_report_at: '2026-06-01T00:00:00Z', latest_reason: 'spam', character_names: ['B'],
+      },
+      {
+        account_id: 3, username: 'online-two', banned_at: null, suspended_until: null,
+        open_reports: 2, latest_report_at: '2026-05-01T00:00:00Z', latest_reason: 'spam', character_names: ['C'],
+      },
+      {
+        account_id: 4, username: 'one', banned_at: null, suspended_until: null,
+        open_reports: 1, latest_report_at: '2026-06-10T00:00:00Z', latest_reason: 'other', character_names: ['D'],
+      },
+    ] } as any);
+
+    const rows = await moderationQueue(new Set([3]));
+
+    expect(rows.map((r) => r.accountId)).toEqual([2, 3, 4]);
+    expect(rows[1].online).toBe(true);
+  });
+
+  it('loads per-report chat context before each report timestamp', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{
+        id: 7,
+        reason: 'harassment',
+        details: 'bad chat',
+        status: 'open',
+        created_at: '2026-06-13T00:00:00Z',
+        reporter_account_id: 1,
+        reporter_username: 'alice',
+        reporter_character_id: 10,
+        reporter_character_name: 'Alice',
+        reported_account_id: 2,
+        reported_username: 'bob',
+        reported_character_id: 20,
+        reported_character_name: 'Bob',
+      }] } as any)
+      .mockResolvedValueOnce({ rows: [
+        { id: 2, character_name: 'Bob', channel: 'say', message: 'second', created_at: '2026-06-12T23:59:00Z' },
+        { id: 1, character_name: 'Bob', channel: 'say', message: 'first', created_at: '2026-06-12T23:58:00Z' },
+      ] } as any);
+
+    const reports = await moderationReportsForAccount(2);
+
+    expect(reports).toHaveLength(1);
+    expect(query.mock.calls[1][1]).toEqual([20, '2026-06-13T00:00:00Z']);
+    expect(reports[0].chatContext.map((c) => c.message)).toEqual(['first', 'second']);
+  });
+
+  it('rejects suspension expiry values that are not in the future', async () => {
+    await expect(moderateAccount({
+      accountId: 2,
+      adminAccountId: 1,
+      action: 'suspend',
+      reason: 'test',
+      expiresAt: '2020-01-01T00:00:00Z',
+    })).rejects.toThrow(/future/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('requires a moderation reason for suspend and ban actions', async () => {
+    await expect(moderateAccount({
+      accountId: 2,
+      adminAccountId: 1,
+      action: 'ban',
+      reason: '   ',
+    })).rejects.toThrow(/reason/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('marks a character for forced rename and action-resolves its reports', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = await forceCharacterRename({ characterId: 20, adminAccountId: 1, reason: 'offensive name' });
+
+    expect(result).toEqual({ accountId: 2 });
+    expect(query.mock.calls[1][0]).toBe('BEGIN');
+    expect(query.mock.calls[2][0]).toMatch(/UPDATE characters SET force_rename = TRUE/);
+    expect(query.mock.calls[3][0]).toMatch(/account_moderation_actions/);
+    expect(query.mock.calls[4][0]).toMatch(/UPDATE player_reports/);
+    expect(query.mock.calls[5][0]).toBe('COMMIT');
+  });
+});

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -218,6 +218,40 @@ describe('parties', () => {
     expect(sim.partyOf(b)).toBe(null);
   });
 
+  it('does not replace a pending party invite', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('priest', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.partyInvite(b, a);
+    sim.partyInvite(b, c);
+    sim.partyAccept(b);
+    expect(sim.partyOf(a)?.members).toEqual([a, b]);
+    expect(sim.partyOf(c)).toBe(null);
+  });
+
+  it('allows a new party invite after decline or expiry', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('priest', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.partyInvite(b, a);
+    sim.partyDecline(b);
+    sim.partyInvite(b, c);
+    sim.partyAccept(b);
+    expect(sim.partyOf(c)?.members).toEqual([c, b]);
+    expect(sim.partyOf(a)).toBe(null);
+
+    const d = sim.addPlayer('mage', 'Dalet');
+    const e = sim.addPlayer('warrior', 'Heh');
+    sim.partyInvite(d, a);
+    for (let i = 0; i < 20 * 31; i++) sim.tick();
+    sim.partyInvite(d, e);
+    sim.partyAccept(d);
+    expect(sim.partyOf(e)?.members).toEqual([e, d]);
+    expect(sim.partyOf(a)).toBe(null);
+  });
+
   it('party members share kill xp with the group bonus and quest credit', () => {
     const { sim, a, b } = makeDuo();
     // both accept the wolf quest
@@ -318,6 +352,47 @@ describe('duels', () => {
     expect(eb.dead).toBe(false);
     expect(sim.duelFor(a)).toBe(null);
   });
+
+  it('does not replace a pending duel challenge', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    teleport(sim, c, 6, -40);
+    sim.duelRequest(b, a);
+    sim.duelRequest(b, c);
+    sim.duelAccept(b);
+    expect(sim.duelFor(a)?.a).toBe(a);
+    expect(sim.duelFor(a)?.b).toBe(b);
+    expect(sim.duelFor(c)).toBe(null);
+  });
+
+  it('blocks other social invites until a pending duel is answered or expires', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    teleport(sim, c, 6, -40);
+    sim.duelRequest(b, a);
+    sim.partyInvite(b, c);
+    sim.duelDecline(b);
+    sim.partyInvite(b, c);
+    sim.partyAccept(b);
+    expect(sim.partyOf(c)?.members).toEqual([c, b]);
+    expect(sim.duelFor(a)).toBe(null);
+
+    const d = sim.addPlayer('priest', 'Dalet');
+    teleport(sim, d, 9, -40);
+    sim.duelRequest(d, a);
+    for (let i = 0; i < 20 * 31; i++) sim.tick();
+    sim.partyInvite(d, c);
+    sim.partyAccept(d);
+    expect(sim.partyOf(c)?.members).toContain(d);
+  });
 });
 
 describe('trading', () => {
@@ -347,6 +422,21 @@ describe('trading', () => {
     expect(sim.countItem('baked_bread', b)).toBe(0);
     expect(sim.meta(a)!.copper).toBe(100 - 30 + 10);
     expect(sim.meta(b)!.copper).toBe(50 - 10 + 30);
+  });
+
+  it('does not replace a pending trade request', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 3, -40);
+    teleport(sim, c, 6, -40);
+    sim.tradeRequest(b, a);
+    sim.tradeRequest(b, c);
+    sim.tradeAccept(b);
+    expect(sim.tradeFor(a)).toBeTruthy();
+    expect(sim.tradeFor(c)).toBe(null);
   });
 
   it('trade cancels when players walk apart', () => {


### PR DESCRIPTION
## Summary
- Adds in-game player reporting and routes reports into the admin dashboard moderation view.
- Adds moderation queue/detail views with report counts, reporter context, recent chat context, ignore/suspend/ban actions, and forced character rename.
- Adds account lock enforcement plus social invite lockout so party/duel/trade prompts cannot be overwritten while pending.

## Evidence
- Local admin panel loaded with seeded reports for queue/detail testing.
- Dev deployment smoke test loaded the game successfully and confirmed hashed media assets under `/media/...` loaded correctly.
- Browser reload showed media served from disk cache for hashed assets.

## Tests
- `npm test -- --run tests/admin.test.ts tests/moderation_db.test.ts`
- `npm test -- --run tests/social.test.ts`
- `npm test -- --testTimeout=15000`
- `npm run build`
- `npm run build:server`
- `git diff --check`

Closes #29