### PR TITLE
Add in-game community invite links

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
   .chat-pane::-webkit-scrollbar-thumb { background: #4a3d1d; border-radius: 4px; }
 
   /* ---------- quest tracker ---------- */
-  #quest-tracker { position: absolute; right: 14px; top: 210px; width: 240px; font-size: 12px;
+  #quest-tracker { position: absolute; right: 14px; top: 262px; width: 240px; font-size: 12px;
     color: var(--gold); text-shadow: 1px 1px 2px #000; pointer-events: none; }
   #quest-tracker .qt-header { font-family: var(--title-font); font-size: 14px; border-bottom: 1px solid #ffd10044; margin-bottom: 4px; padding-bottom: 2px; }
   #quest-tracker .qt-title { font-weight: bold; margin-top: 8px; font-family: var(--title-font); }
@@ -225,6 +225,18 @@
   #minimap-wrap { position: absolute; right: 12px; top: 10px; width: 170px; text-align: center; }
   #zone-label { font-size: 13px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 3px #000; margin-bottom: 3px; letter-spacing: 0.5px; }
   #minimap { border-radius: 50%; border: 4px solid var(--border); outline: 1px solid #000; box-shadow: 0 0 14px #000c, inset 0 0 20px #0008; }
+
+  /* ---------- community HUD ---------- */
+  #community-hud { position: absolute; right: 12px; top: 208px; width: 170px; padding: 7px; display: flex; gap: 6px; z-index: 18; }
+  .community-link { flex: 1; min-width: 0; height: 34px; display: inline-flex; align-items: center; justify-content: center; gap: 0;
+    color: #d8d9ff; text-decoration: none; border: 1px solid #3e4672; border-radius: 6px;
+    background: linear-gradient(180deg, #202238ee, #0d0e18ee); box-shadow: inset 0 1px 0 #ffffff16, 0 2px 8px #0008;
+    font-size: 0; font-weight: bold; text-shadow: 1px 1px 1px #000; transition: color .15s, border-color .15s, transform .15s; }
+  .community-link:hover { color: #fff; border-color: #7f8cff; transform: translateY(-1px); }
+  .community-link.github { color: #e4e4ea; border-color: #4a4a58; }
+  .community-link.github:hover { border-color: var(--gold-dim); }
+  .community-link svg { width: 17px; height: 17px; flex: none; display: block; }
+  .community-link span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* ---------- windows ---------- */
   .window { position: absolute; display: none; padding: 12px; z-index: 20; }
@@ -451,6 +463,13 @@
   #target-frame.elite .portrait { border-color: var(--gold); box-shadow: 0 0 12px #ffd10066, 0 2px 8px #000c; }
   #tf-elite-tag { font-size: 9px; color: var(--gold); font-family: var(--title-font); letter-spacing: 1px; text-align: center; display: none; }
   #target-frame.elite #tf-elite-tag { display: block; }
+
+  @media (max-width: 760px) {
+    #community-hud { top: 208px; width: 146px; padding: 6px; gap: 5px; }
+    .community-link { height: 32px; }
+    .community-link svg { width: 17px; height: 17px; }
+    #quest-tracker { top: 260px; right: 12px; width: 190px; }
+  }
 </style>
 </head>
 <body>
@@ -497,6 +516,17 @@
     <div id="minimap-wrap">
       <div id="zone-label">Eastbrook Vale</div>
       <canvas id="minimap" width="162" height="162"></canvas>
+    </div>
+
+    <div id="community-hud" class="panel" aria-label="Community links">
+      <a class="community-link discord" href="https://discord.gg/GjhnUsBtw" target="_blank" rel="noopener noreferrer" title="Join the Discord" aria-label="Join the Discord community">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.32 4.37A19.8 19.8 0 0 0 15.36 2.8a13.66 13.66 0 0 0-.64 1.32 18.47 18.47 0 0 0-5.45 0 13.02 13.02 0 0 0-.65-1.32 19.73 19.73 0 0 0-4.96 1.58C.53 9.03-.32 13.56.1 18.02a19.9 19.9 0 0 0 6.08 3.08c.49-.67.93-1.38 1.3-2.13-.72-.27-1.41-.6-2.06-.98.17-.13.34-.26.5-.4a14.16 14.16 0 0 0 12.16 0c.16.14.33.27.5.4-.65.39-1.34.72-2.07.99.38.74.81 1.45 1.31 2.12a19.86 19.86 0 0 0 6.08-3.08c.5-5.17-.85-9.66-3.58-13.65ZM8.02 15.28c-1.18 0-2.15-1.08-2.15-2.41 0-1.33.95-2.42 2.15-2.42 1.2 0 2.17 1.1 2.15 2.42 0 1.33-.95 2.41-2.15 2.41Zm7.96 0c-1.18 0-2.15-1.08-2.15-2.41 0-1.33.95-2.42 2.15-2.42 1.2 0 2.17 1.1 2.15 2.42 0 1.33-.95 2.41-2.15 2.41Z"/></svg>
+        <span>Discord</span>
+      </a>
+      <a class="community-link github" href="https://github.com/levy-street/world-of-claudecraft" target="_blank" rel="noopener noreferrer" title="View GitHub" aria-label="View World of Claudecraft on GitHub">
+        <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        <span>GitHub</span>
+      </a>
     </div>
 
     <div id="quest-tracker"></div>


### PR DESCRIPTION
## Summary
- Add an in-game floating community HUD panel below the minimap
- Link to the Discord community and GitHub repository with icon-only buttons
- Shift the quest tracker down so the new HUD panel does not overlap existing UI

## Testing
- npm run build
