### PR TITLE
Add Ravenrift: ranked 5v5 capture-the-flag battleground

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ see each other in town. `Enter` opens chat.
 - **Duels**: right-click → *Challenge to a Duel*. 3-second countdown, fight
   until one side hits 1 hp — nobody dies, the winner is announced zone-wide.
   Running 60 yards away forfeits.
+- **Ravenrift** (5v5 ranked capture-the-flag): press `H` (or the ⚑ button) and
+  *Enter the Queue* — solo, or **group up to 5 and queue your whole party
+  together**. Matchmaking forms two balanced teams of five and drops you into a
+  walled, open-air battleground with two keeps. **Steal the enemy banner and
+  run it to your keep to score — first team to 5 captures wins.** Weave the
+  cover to lose pursuers, grab **Sprint Runes** at the flag sections for a burst
+  of speed, and respawn at your keep when you fall (no graveyard run). A
+  separate **squad Elo** ladder tracks wins/losses (`GET /api/squad/leaderboard`).
 - **Multiplayer rules**: classic tap rights (first player to damage a mob owns
   its loot/XP/quest credit — others get "You don't have permission to loot
   that."), mobs retarget the next attacker when their victim dies (no free
@@ -152,7 +160,7 @@ zone map.
 | `Tab` | cycle nearest enemies · left-click target · right-click attack/loot/talk |
 | `1`–`9`, `0`, `-`, `=` | action bar |
 | `F` | interact (loot corpse / pick up object / talk) |
-| `C` `P` `L` `M` `B` | character · spellbook · quest log · world map · bags |
+| `C` `P` `L` `M` `B` `H` | character · spellbook · quest log · world map · bags · battleground (Ravenrift) |
 | `V` / `R` / `Esc` | nameplates · autorun · close windows / clear target |
 
 ### Classic-fidelity checklist
@@ -234,6 +242,7 @@ node scripts/smoke_rogue.mjs    # rogue: combo points, eviscerate, vendor, eatin
 node scripts/visual_tour.mjs    # screenshot tour of the zone + UI into tmp/
 node scripts/mp_integration.mjs # 26-check API/WS/persistence suite (server running)
 node scripts/social_e2e.mjs     # trade + duel over the wire (ALLOW_DEV_COMMANDS=1)
+node scripts/squad_visual.mjs   # several clients queue + play Ravenrift 5v5 capture-the-flag (ALLOW_DEV_COMMANDS=1)
 node scripts/crypt_raid.mjs     # five bots clear the Hollow Crypt (ALLOW_DEV_COMMANDS=1)
 ```
 

--- a/index.html
+++ b/index.html
@@ -306,6 +306,47 @@
 
   /* map */
   #map-window { left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 14px; }
+
+  /* ---------- Ravenrift (5v5 capture the flag) ---------- */
+  .bg-sub { font-family: var(--title-font); color: var(--gold); font-size: 12px; margin: 12px 0 5px; border-bottom: 1px solid #463a1c; padding-bottom: 3px; }
+  .ladder-row { display: grid; grid-template-columns: 24px 1fr auto auto; gap: 8px; align-items: center;
+    font-size: 12px; padding: 3px 6px; border-radius: 4px; color: #e0d6b4; }
+  .ladder-row.me { background: #6aa6ff1f; outline: 1px solid #6aa6ff55; }
+  .ladder-row .rank { color: #998d6a; text-align: right; }
+  .ladder-row .lr-name { color: #cfe0ff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ladder-row .lr-rating { color: #7fb8ff; font-family: var(--title-font); }
+  .ladder-row .lr-wl { color: #8c8468; font-size: 10.5px; }
+  .ladder-empty { font-size: 11.5px; color: #8c8468; font-style: italic; padding: 4px 6px; }
+  #bg-window { left: 50%; top: 50%; transform: translate(-50%, -50%); width: 380px; padding: 14px; }
+  #bg-window .btn { width: 100%; margin: 4px 0 0; box-sizing: border-box; text-align: center; }
+  #bg-window .btn.leave { background: linear-gradient(#3a4a5a, #243140 55%, #1a2430); color: #cfe6ff; }
+  .bg-rank { display: flex; align-items: baseline; gap: 10px; margin: 2px 0 6px; }
+  .bg-rank .rating { font-family: var(--title-font); font-size: 30px; color: #7fb8ff; text-shadow: 0 0 10px #3a78d166, 1px 1px 2px #000; }
+  .bg-rank .wl { font-size: 12px; color: #cfc6a8; }
+  .bg-rank .wl b { color: #7fdc4f; } .bg-rank .wl i { color: #ff7a6a; font-style: normal; }
+  .bg-note { font-size: 11.5px; color: #b6ad8c; line-height: 1.45; margin: 4px 0 2px; font-family: Georgia, serif; }
+  .bg-queue-status { font-size: 12px; color: #7fd4ff; margin-top: 6px; text-align: center; }
+
+  /* in-match scoreboard: pinned top centre */
+  #bg-scoreboard { position: absolute; top: 8px; left: 50%; transform: translateX(-50%); display: none;
+    text-align: center; pointer-events: none; z-index: 18; min-width: 320px;
+    background: linear-gradient(#10131add, #080a0edd); border: 1px solid #3a4a66;
+    border-radius: 9px; padding: 6px 18px 8px; box-shadow: 0 2px 16px #000a; }
+  .bg-score-line { display: flex; align-items: center; justify-content: center; gap: 14px; font-family: var(--title-font); }
+  .bg-score-line .team { font-size: 13px; letter-spacing: 0.5px; }
+  .bg-score-line .crimson { color: #ff6a62; } .bg-score-line .azure { color: #6aa6ff; }
+  .bg-score-line .num { font-size: 26px; text-shadow: 1px 1px 2px #000; }
+  .bg-score-line .flag { font-size: 13px; }
+  .bg-score-line .flag.home { opacity: 0.45; } .bg-score-line .flag.carried { color: #ffd24a; }
+  .bg-score-line .flag.dropped { color: #ff9a3c; }
+  .bg-score-line .dash { color: #998d6a; font-size: 18px; }
+  .bg-caps { font-size: 10.5px; color: #9aa6b8; margin-top: 1px; letter-spacing: 0.4px; }
+  .bg-roster { display: flex; justify-content: center; gap: 5px; margin-top: 4px; flex-wrap: wrap; }
+  .bg-pip { width: 9px; height: 9px; border-radius: 50%; border: 1px solid #000; }
+  .bg-pip.dead { opacity: 0.3; }
+  .bg-pip.flag { box-shadow: 0 0 6px 1px #ffd24a; border-color: #ffd24a; }
+  .bg-respawn { position: absolute; left: 50%; top: 54%; transform: translate(-50%,-50%); text-align: center;
+    color: #ff8d7a; font-family: var(--title-font); font-size: 22px; text-shadow: 2px 2px 6px #000; }
   #map-canvas { border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; }
 
   /* ---------- options / game menu (Esc) ---------- */
@@ -538,6 +579,7 @@
           <button class="micro-btn" id="mm-quest" title="Quest Log">Q<span class="keybind">l</span></button>
           <button class="micro-btn" id="mm-map" title="World Map">M<span class="keybind">m</span></button>
           <button class="micro-btn" id="mm-bag" title="Bags">B<span class="keybind">b</span></button>
+          <button class="micro-btn" id="mm-bg" title="Ravenrift (5v5 Capture the Flag)">⚑<span class="keybind">h</span></button>
           <button class="micro-btn" id="mm-music" title="Toggle Music">♪</button>
         </div>
       </div>
@@ -562,6 +604,8 @@
     <div id="quest-log-window" class="window panel"></div>
     <div id="vendor-window" class="window panel"></div>
     <div id="map-window" class="window panel"><canvas id="map-canvas" width="560" height="560"></canvas></div>
+    <div id="bg-window" class="window panel"></div>
+    <div id="bg-scoreboard"></div>
     <div id="options-menu" class="window panel"></div>
     <div id="meters-window" class="panel">
       <div class="panel-title">

--- a/scripts/squad_visual.mjs
+++ b/scripts/squad_visual.mjs
@@ -1,0 +1,141 @@
+// Drives several real browser clients through Ravenrift, the 5v5 capture-the-flag
+// battleground: queue, a dev force-start (so a screenshot run needs fewer than
+// ten browsers), then a flag grab + capture + sprint rune. Screenshots -> tmp/.
+// Run the server first (serves the built client on :8787) with ALLOW_DEV_COMMANDS=1.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:8787';
+const N = Number(process.env.BG_CLIENTS ?? 6);
+fs.mkdirSync('tmp', { recursive: true });
+const uniq = Date.now().toString(36).slice(-5);
+// character names must be letters only — fold the timestamp's digits to letters
+const alpha = uniq.replace(/[0-9]/g, (d) => 'abcdefghij'[Number(d)]);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const errors = [];
+const CRIMSON = 0xd1413a, AZURE = 0x3a78d1;
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  protocolTimeout: 90000,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1280,760', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 760 },
+});
+
+async function login(page, charName, cls) {
+  page.on('pageerror', (e) => errors.push(`[${charName}] ` + e.message));
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await sleep(500);
+  await page.evaluate((u, p) => {
+    document.querySelector('#btn-online').click();
+    document.querySelector('#login-user').value = u;
+    document.querySelector('#login-pass').value = p;
+    document.querySelector('#btn-register').click();
+  }, `sq_${charName}_${uniq}`, 'hunter22');
+  await page.waitForFunction(() => document.querySelector('#charselect-panel')?.style.display === 'block', { timeout: 10000, polling: 200 });
+  await page.evaluate((name, cls) => {
+    document.querySelector('#new-char-name').value = name;
+    document.querySelector(`#charselect-panel .mini-class[data-class="${cls}"]`).click();
+    document.querySelector('#btn-create-char').click();
+  }, charName, cls);
+  await sleep(600);
+  await page.evaluate((name) => {
+    [...document.querySelectorAll('.char-row')].find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('button')?.click();
+  }, charName);
+  await page.waitForFunction(() => window.__game?.world?.entities?.size > 5, { timeout: 25000, polling: 500 });
+}
+
+const names = ['Ravven', 'Bryn', 'Cael', 'Dax', 'Eira', 'Finn', 'Gust', 'Hale', 'Ivo', 'Jor'];
+const classes = ['warrior', 'paladin', 'hunter', 'rogue', 'mage', 'priest', 'shaman', 'warlock', 'druid', 'warrior'];
+const pages = [];
+console.log(`logging in ${N} champions…`);
+for (let i = 0; i < N; i++) {
+  const pg = await browser.newPage();
+  try { await login(pg, names[i] + alpha, classes[i % classes.length]); pages.push(pg); }
+  catch (e) { console.log(`client ${i} (${names[i]}) failed to enter: ${e.message.slice(0, 60)}`); }
+}
+console.log(`${pages.length} in world`);
+const hero = pages[0];
+
+// sturdy fighters so the demo isn't over in one hit
+for (const pg of pages) await pg.evaluate(() => window.__game.online.cmd({ cmd: 'dev_level', level: 14 }));
+await sleep(800);
+
+// --- 1. the Ravenrift panel: squad rating, queue, ladder ---
+await hero.bringToFront();
+await hero.evaluate(() => window.__game.hud.toggleBg());
+await sleep(700);
+await hero.screenshot({ path: 'tmp/squad1_panel.png' });
+console.log('panel rendered:', await hero.evaluate(() => document.querySelector('#bg-window')?.style.display === 'block') ? 'OK' : 'FAIL');
+await hero.evaluate(() => window.__game.hud.toggleBg());
+
+// --- 2. queue everyone, then dev force-start the match ---
+for (const pg of pages) await pg.evaluate(() => window.__game.world.bgQueueJoin());
+await sleep(500);
+await hero.evaluate(() => window.__game.online.cmd({ cmd: 'dev_bg_start' }));
+await hero.waitForFunction(() => window.__game.world.bgInfo?.match != null, { timeout: 12000, polling: 200 });
+console.log('match started; my team:', await hero.evaluate(() => window.__game.world.bgInfo.match.myTeam));
+
+// establishing shot: float the hero to mid-field and pull the camera up/back
+const flagPos = async (pg, color) => pg.evaluate((c) => {
+  const f = [...window.__game.world.entities.values()].find((e) => e.templateId === 'bg_flag' && e.color === c);
+  return f ? { x: f.pos.x, z: f.pos.z } : null;
+}, color);
+const myTeam = await hero.evaluate(() => window.__game.world.bgInfo.match.myTeam);
+const myColor = myTeam === 0 ? CRIMSON : AZURE;
+const foeColor = myTeam === 0 ? AZURE : CRIMSON;
+let myFlag = await flagPos(hero, myColor);
+const center = myFlag ? { x: myFlag.x, z: myFlag.z + (myTeam === 0 ? 30 : -30) } : null;
+if (center) await hero.evaluate((c) => window.__game.online.cmd({ cmd: 'dev_teleport', x: c.x, z: c.z }), center);
+await hero.evaluate(() => { window.__game.input.camDist = 22; window.__game.input.camPitch = 0.78; });
+await sleep(3500); // let the battleground build + everyone settle
+await hero.bringToFront();
+await hero.screenshot({ path: 'tmp/squad2_field.png' });
+console.log('on the battleground:', await hero.evaluate(() => window.__game.world.player.pos.x > 3800) ? 'OK' : 'FAIL');
+
+// the fight only goes live after the form-up countdown — runes and captures
+// don't register until then
+await toActive(hero);
+console.log('battle live:', await hero.evaluate(() => window.__game.world.bgInfo?.match?.state) === 'active' ? 'OK' : 'still counting');
+
+// --- 3. sprint rune ---
+const rune = await hero.evaluate(() => {
+  const r = [...window.__game.world.entities.values()].find((e) => e.templateId === 'bg_rune');
+  return r ? { x: r.pos.x, z: r.pos.z } : null;
+});
+if (rune) {
+  await hero.evaluate((r) => window.__game.online.cmd({ cmd: 'dev_teleport', x: r.x, z: r.z + 1 }), rune);
+  await hero.evaluate(() => { window.__game.input.camDist = 10; window.__game.input.camPitch = 0.35; });
+  await sleep(1400);
+  await hero.screenshot({ path: 'tmp/squad3_rune.png' });
+  console.log('grabbed sprint rune:', await hero.evaluate(() => window.__game.world.player.auras?.some((a) => a.kind === 'buff_speed')) ? 'OK' : '(maybe)');
+}
+
+// --- 4. grab the enemy flag, run it home, score ---
+const enemyFlag = await flagPos(hero, foeColor);
+if (enemyFlag) {
+  await hero.evaluate((f) => window.__game.online.cmd({ cmd: 'dev_teleport', x: f.x, z: f.z }), enemyFlag);
+  await sleep(900);
+  await hero.evaluate(() => { window.__game.input.camDist = 11; window.__game.input.camPitch = 0.4; });
+  await sleep(400);
+  await hero.screenshot({ path: 'tmp/squad4_carry.png' });
+  console.log('carrying enemy flag:', await hero.evaluate(() => window.__game.world.bgInfo.match.players.find((p) => p.pid === window.__game.world.playerId)?.carrying) ? 'OK' : 'FAIL');
+  // run it back to my own stand
+  myFlag = await flagPos(hero, myColor);
+  if (myFlag) {
+    await hero.evaluate((f) => window.__game.online.cmd({ cmd: 'dev_teleport', x: f.x, z: f.z }), myFlag);
+    await sleep(1100);
+    await hero.bringToFront();
+    await hero.screenshot({ path: 'tmp/squad5_capture.png' });
+    console.log('score after capture:', await hero.evaluate(() => window.__game.world.bgInfo.match.scores.join('–')));
+  }
+}
+
+async function toActive(pg) {
+  await pg.waitForFunction(() => window.__game.world.bgInfo?.match?.state === 'active', { timeout: 14000, polling: 200 }).catch(() => {});
+}
+
+console.log(errors.length ? 'PAGE ERRORS:\n' + errors.slice(0, 6).join('\n') : 'no page errors');
+await browser.close();

--- a/server/db.ts
+++ b/server/db.ts
@@ -161,6 +161,40 @@ export async function isAdminAccount(accountId: number): Promise<boolean> {
 }
 
 // ---------------------------------------------------------------------------
+// Ravenrift 5v5 rankings: the all-time ladder. Ratings/records live inside each
+// character's state JSONB (no schema migration needed); only characters who
+// have actually played a match appear.
+// ---------------------------------------------------------------------------
+
+export interface SquadLeaderRow {
+  name: string;
+  class: PlayerClass;
+  level: number;
+  rating: number;
+  wins: number;
+  losses: number;
+}
+
+export async function topSquadRatings(limit = 20): Promise<SquadLeaderRow[]> {
+  const res = await pool.query(
+    `SELECT name, class, level,
+            COALESCE((state->>'squadRating')::int, 1500) AS rating,
+            COALESCE((state->>'squadWins')::int, 0)     AS wins,
+            COALESCE((state->>'squadLosses')::int, 0)   AS losses
+       FROM characters
+      WHERE state IS NOT NULL
+        AND COALESCE((state->>'squadWins')::int, 0) + COALESCE((state->>'squadLosses')::int, 0) > 0
+      ORDER BY rating DESC, wins DESC, name ASC
+      LIMIT $1`,
+    [Math.max(1, Math.min(100, limit))],
+  );
+  return res.rows.map((r) => ({
+    name: r.name, class: r.class, level: r.level,
+    rating: Number(r.rating), wins: Number(r.wins), losses: Number(r.losses),
+  }));
+}
+
+// ---------------------------------------------------------------------------
 // Play sessions: one row per character login, closed on logout. Powers the
 // admin dashboard's playtime / DAU / sessions-per-day metrics.
 // ---------------------------------------------------------------------------

--- a/server/game.ts
+++ b/server/game.ts
@@ -501,6 +501,10 @@ export class GameServer {
       case 'duel_req': if (typeof msg.id === 'number') sim.duelRequest(msg.id, pid); break;
       case 'duel_accept': sim.duelAccept(pid); break;
       case 'duel_decline': sim.duelDecline(pid); break;
+      // Ravenrift (5v5 capture-the-flag queue)
+      case 'bg_queue': sim.bgQueueJoin(pid); break;
+      case 'bg_leave': sim.bgQueueLeave(pid); break;
+      case 'dev_bg_start': if (process.env.ALLOW_DEV_COMMANDS === '1') sim.devStartBg(); break;
       // dev/ops commands, only when ALLOW_DEV_COMMANDS=1 (never in production)
       case 'dev_level': {
         if (process.env.ALLOW_DEV_COMMANDS === '1' && typeof msg.level === 'number') {
@@ -695,6 +699,7 @@ export class GameServer {
     maybe('party', this.partyWire(session.pid));
     maybe('trade', this.tradeWire(session.pid));
     maybe('duel', this.duelWire(session.pid));
+    maybe('bg', this.sim.bgInfoFor(session.pid));
     return extra === '' ? json : json.slice(0, -1) + extra + '}';
   }
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -5,7 +5,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import {
   ensureSchema, pool, createAccount, findAccount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
-  pruneChatLogs,
+  pruneChatLogs, topSquadRatings,
 } from './db';
 import { hashPassword, verifyPassword, newToken, validUsername, validPassword, validCharName } from './auth';
 import { json, readBody } from './http_util';
@@ -173,6 +173,10 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         players_online: game.clients.size,
         names: [...game.clients.values()].map((s) => s.name),
       });
+    }
+    if (req.method === 'GET' && url === '/api/squad/leaderboard') {
+      // public all-time Ravenrift 5v5 ladder
+      return json(res, 200, { leaders: await topSquadRatings(20) });
     }
     json(res, 404, { error: 'unknown endpoint' });
   } catch (err: any) {

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -13,7 +13,7 @@ const BASE_LOOK_SENS = 0.0045;
 export interface InputCallbacks {
   onTab(): void;
   onAbility(slot: number): void;
-  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters'): void;
+  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'battleground'): void;
   onClickPick(x: number, y: number, button: number): void;
 }
 
@@ -102,6 +102,7 @@ export class Input {
       case 'map': this.cb.onUiKey('map'); return;
       case 'nameplates': this.cb.onUiKey('nameplates'); return;
       case 'meters': this.cb.onUiKey('meters'); return;
+      case 'battleground': this.cb.onUiKey('battleground'); return;
       case 'chat': this.cb.onUiKey('chat'); return;
     }
   }

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -46,6 +46,7 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'bags', label: 'Bags', category: 'Interface', kind: 'edge', defaults: ['KeyB'] },
   { id: 'nameplates', label: 'Toggle Nameplates', category: 'Interface', kind: 'edge', defaults: ['KeyV'] },
   { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyN'] },
+  { id: 'battleground', label: 'Battleground (Ravenrift)', category: 'Interface', kind: 'edge', defaults: ['KeyH'] },
   { id: 'chat', label: 'Open Chat', category: 'Interface', kind: 'edge', defaults: ['Enter', 'NumpadEnter'] },
   // Action bar (slot 0 = Attack)
   ...SLOT_DEFAULTS.map((code, i): BindAction => ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         case 'map': hud.toggleMap(); break;
         case 'nameplates': renderer.showNameplates = !renderer.showNameplates; break;
         case 'meters': hud.toggleMeters(); break;
+        case 'battleground': hud.toggleBg(); break;
         case 'chat': openChat(); break;
         case 'escape':
           // close the topmost panel; if nothing was open, open the game menu

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -6,7 +6,7 @@ import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
-import type { DuelInfo, IWorld, PartyInfo, TradeInfo } from '../world_api';
+import type { BgInfo, DuelInfo, IWorld, PartyInfo, TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
 // REST
@@ -127,6 +127,7 @@ export class ClientWorld implements IWorld {
   partyInfo: PartyInfo | null = null;
   tradeInfo: TradeInfo | null = null;
   duelInfo: DuelInfo | null = null;
+  bgInfo: BgInfo | null = null;
   // snapshot interpolation
   lastSnapAt = 0;
   snapInterval = 50; // ms, adapts to measured cadence
@@ -378,6 +379,7 @@ export class ClientWorld implements IWorld {
       if (s.party !== undefined) this.partyInfo = s.party;
       if (s.trade !== undefined) this.tradeInfo = s.trade;
       if (s.duel !== undefined) this.duelInfo = s.duel;
+      if (s.bg !== undefined) this.bgInfo = s.bg;
       // camera follows server-side facing changes when not mouselooking
       if (prevSelfFacing !== undefined && this.mouselookFacing === null) {
         let d = e.facing - prevSelfFacing;
@@ -520,6 +522,12 @@ export class ClientWorld implements IWorld {
   }
   duelDecline(): void {
     this.cmd({ cmd: 'duel_decline' });
+  }
+  bgQueueJoin(): void {
+    this.cmd({ cmd: 'bg_queue' });
+  }
+  bgQueueLeave(): void {
+    this.cmd({ cmd: 'bg_leave' });
   }
   enterDungeon(dungeonId: string): void {
     this.cmd({ cmd: 'enter_dungeon', dungeon: dungeonId });

--- a/src/render/dungeon.ts
+++ b/src/render/dungeon.ts
@@ -20,6 +20,9 @@ import {
   CRYPT_LAYOUT, SANCTUM_LAYOUT, DUNGEON_WALL_X, TOMB_HD,
   DungeonLayout, GridPoint, WallStub,
 } from '../sim/dungeon_layout';
+import {
+  BASES, BG_HALF_X, BG_HALF_Z, COVER_CRATES, COVER_PILLARS, COVER_WALLS, SPEED_RUNES, TEAM_COLORS,
+} from '../sim/battleground_layout';
 
 const FLAME_EMISSIVE_HIGH = 2.2;
 // dungeon torch point lights: pumped + hung low so warm pools break up the
@@ -237,6 +240,134 @@ export class DungeonInteriors {
     this.emit(group, p);
     group.position.set(ox, 0, oz);
     this.scene.add(group);
+  }
+
+  // Ravenrift battleground: an open-air walled field built from the same kit —
+  // a tiled courtyard floor, perimeter + keep + cover walls, then procedural
+  // team banners, flag stands and glowing sprint-rune pads.
+  private bgMats: { pole?: THREE.Material; stone?: THREE.Material; cloth: Map<number, THREE.Material>; rune?: THREE.Material } = { cloth: new Map() };
+
+  buildBattleground(ox: number, oz: number): void {
+    const group = new THREE.Group();
+    const p = new Placements();
+    const quarter = Math.PI / 2;
+
+    // courtyard floor
+    for (let z = -BG_HALF_Z + 2; z <= BG_HALF_Z - 2; z += FLOOR_CELL) {
+      for (let x = -BG_HALF_X + 2; x <= BG_HALF_X - 2; x += FLOOR_CELL) {
+        const t = hash2(x * 1.31, z);
+        const kind = t < 0.66 ? 'floor_tile_large' : t < 0.8 ? 'floor_tile_large_rocks'
+          : t < 0.9 ? 'floor_dirt_large' : 'floor_dirt_large_rocky';
+        p.add(kind, x, FLOOR_Y, z, Math.floor(hash2(z, x) * 4) * quarter);
+      }
+    }
+    // perimeter ramparts
+    this.addWallRun(p, -BG_HALF_X, -BG_HALF_Z, -BG_HALF_X, BG_HALF_Z);
+    this.addWallRun(p, BG_HALF_X, -BG_HALF_Z, BG_HALF_X, BG_HALF_Z);
+    this.addWallRun(p, -BG_HALF_X, -BG_HALF_Z, BG_HALF_X, -BG_HALF_Z);
+    this.addWallRun(p, -BG_HALF_X, BG_HALF_Z, BG_HALF_X, BG_HALF_Z);
+    // keeps — a three-sided enclosure around each flag, open to the field
+    for (const base of BASES) {
+      const dir = base.team === 0 ? -1 : 1;
+      const backZ = base.flag.z + dir * 8;
+      const sideZ = base.flag.z + dir * 2;
+      this.addWallRun(p, -14, backZ, 14, backZ);
+      this.addWallRun(p, -14, sideZ - 6, -14, sideZ + 6);
+      this.addWallRun(p, 14, sideZ - 6, 14, sideZ + 6);
+    }
+    // central cover
+    for (const w of COVER_WALLS) {
+      if (Math.abs(w.hw - w.hd) < 2 && w.hw > 3) {
+        this.addWallRun(p, w.x - w.hw, w.z - w.hd, w.x + w.hw, w.z - w.hd);
+        this.addWallRun(p, w.x - w.hw, w.z + w.hd, w.x + w.hw, w.z + w.hd);
+        this.addWallRun(p, w.x - w.hw, w.z - w.hd, w.x - w.hw, w.z + w.hd);
+        this.addWallRun(p, w.x + w.hw, w.z - w.hd, w.x + w.hw, w.z + w.hd);
+      } else if (w.hd >= w.hw) {
+        this.addWallRun(p, w.x, w.z - w.hd, w.x, w.z + w.hd);
+      } else {
+        this.addWallRun(p, w.x - w.hw, w.z, w.x + w.hw, w.z);
+      }
+    }
+    for (const pl of COVER_PILLARS) p.add('pillar', pl.x, 0, pl.z, 0, [PILLAR_XZ_SCALE, MODULE_SCALE, PILLAR_XZ_SCALE]);
+    for (const c of COVER_CRATES) p.add(hash2(c.x, c.z) < 0.5 ? 'crates_stacked' : 'box_stacked', c.x, 0, c.z, hash2(c.z, c.x) * Math.PI, 1.0);
+    this.emit(group, p);
+
+    // team identity: banners flanking each keep + a glowing flag pedestal
+    for (const base of BASES) {
+      const color = TEAM_COLORS[base.team];
+      const facing = base.team === 0 ? 0 : Math.PI;
+      this.addBgBanner(group, base.banner.x - 9, base.banner.z, color, facing);
+      this.addBgBanner(group, base.banner.x + 9, base.banner.z, color, facing);
+      this.addBgFlagStand(group, base.flag.x, base.flag.z, color);
+    }
+    for (const rp of SPEED_RUNES) this.addBgRunePad(group, rp.x, rp.z);
+
+    group.position.set(ox, 0, oz);
+    this.scene.add(group);
+  }
+
+  // Tile 'wall' kit modules (8u long at MODULE_SCALE) along a segment.
+  private addWallRun(p: Placements, ax: number, az: number, bx: number, bz: number): void {
+    const dx = bx - ax, dz = bz - az;
+    const len = Math.hypot(dx, dz);
+    if (len < 0.1) return;
+    const n = Math.max(1, Math.round(len / 8));
+    const ry = Math.atan2(dx, dz) + Math.PI / 2;
+    for (let i = 0; i < n; i++) {
+      const t = (i + 0.5) / n;
+      p.add('wall', ax + dx * t, 0, az + dz * t, ry, MODULE_SCALE);
+    }
+  }
+
+  private bgMat(which: 'pole' | 'stone'): THREE.Material {
+    if (this.bgMats[which]) return this.bgMats[which]!;
+    const color = which === 'pole' ? 0x5a4636 : 0x8b8a86;
+    const mat = this.lowGfx
+      ? new THREE.MeshLambertMaterial({ color })
+      : new THREE.MeshStandardMaterial({ color, roughness: 0.9, metalness: 0 });
+    this.bgMats[which] = mat;
+    return mat;
+  }
+
+  private bgClothMat(color: number): THREE.Material {
+    let mat = this.bgMats.cloth.get(color);
+    if (!mat) {
+      mat = this.lowGfx
+        ? new THREE.MeshLambertMaterial({ color, side: THREE.DoubleSide })
+        : new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0, side: THREE.DoubleSide, emissive: color, emissiveIntensity: 0.25 });
+      this.bgMats.cloth.set(color, mat);
+    }
+    return mat;
+  }
+
+  private addBgBanner(group: THREE.Group, x: number, z: number, color: number, facing: number): void {
+    const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.13, 6.5, 6), this.bgMat('pole'));
+    pole.position.set(x, 3.25, z);
+    pole.castShadow = !this.lowGfx;
+    group.add(pole);
+    const cloth = new THREE.Mesh(new THREE.PlaneGeometry(2.6, 3.6), this.bgClothMat(color));
+    cloth.position.set(x, 4.4, z);
+    cloth.rotation.y = facing;
+    group.add(cloth);
+  }
+
+  private addBgFlagStand(group: THREE.Group, x: number, z: number, color: number): void {
+    const ped = new THREE.Mesh(new THREE.CylinderGeometry(1.5, 1.9, 0.7, 14), this.bgMat('stone'));
+    ped.position.set(x, 0.35, z);
+    ped.receiveShadow = !this.lowGfx;
+    group.add(ped);
+    this.addTorchGlow(group, x, z, color, 0.72, 1.3);
+  }
+
+  private addBgRunePad(group: THREE.Group, x: number, z: number): void {
+    this.addTorchGlow(group, x, z, 0xffd24a, 0.06, 1.1);
+    if (!this.bgMats.rune) {
+      this.bgMats.rune = new THREE.MeshBasicMaterial({ color: 0xffd24a, transparent: true, opacity: 0.7, blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide });
+    }
+    const ring = new THREE.Mesh(new THREE.RingGeometry(1.4, 1.9, 22).rotateX(-Math.PI / 2), this.bgMats.rune);
+    ring.position.set(x, 0.09, z);
+    ring.renderOrder = 1;
+    group.add(ring);
   }
 
   // Hollow Crypt and Sunken Bastion share interior 'crypt'; the origin x-band

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -4,7 +4,7 @@ import type { IWorld } from '../world_api';
 import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import {
   MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
-  instanceOrigin, INSTANCE_SLOT_COUNT,
+  instanceOrigin, INSTANCE_SLOT_COUNT, BG_SLOT_COUNT, battlegroundOrigin, isBgPos,
 } from '../sim/data';
 import type { BiomeId } from '../sim/types';
 import { AnimState, CharacterVisual, createCharacterVisual } from './characters';
@@ -407,6 +407,10 @@ export class Renderer {
   private crateMat: THREE.Material | null = null;
   private crateLidMat: THREE.Material | null = null;
   private sparkleMat: THREE.SpriteMaterial | null = null;
+  // Ravenrift flag/rune objects (shared caches; survive interest churn)
+  private bgPoleMat: THREE.Material | null = null;
+  private bgFlagMats = new Map<number, THREE.Material>();
+  private bgRuneMat: THREE.MeshBasicMaterial | null = null;
 
   private createView(e: Entity): void {
     const group = new THREE.Group();
@@ -471,6 +475,49 @@ export class Renderer {
       const glow = new THREE.PointLight(tint, 9, 15, 2);
       glow.position.y = 2.4;
       body!.add(glow);
+      objectMesh = body!;
+    } else if (e.kind === 'object' && e.templateId === 'bg_flag') {
+      // capture-the-flag banner: pole + team-coloured pennant, carried by runners
+      body = new THREE.Group();
+      height = 4.4;
+      this.bgPoleMat ??= new THREE.MeshLambertMaterial({ color: 0x4a3a2a });
+      const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.1, 4.2, 6), this.bgPoleMat);
+      pole.position.y = 2.1;
+      pole.castShadow = !this.lowGfx;
+      body!.add(pole);
+      let clothMat = this.bgFlagMats.get(e.color);
+      if (!clothMat) {
+        const m = new THREE.MeshBasicMaterial({ color: e.color, side: THREE.DoubleSide });
+        if (!this.lowGfx) m.color.multiplyScalar(1.4); // pop against the field via bloom
+        this.bgFlagMats.set(e.color, m);
+        clothMat = m;
+      }
+      const cloth = new THREE.Mesh(new THREE.PlaneGeometry(1.9, 1.25), clothMat);
+      cloth.position.set(0.95, 3.45, 0);
+      body!.add(cloth);
+      objectMesh = body!;
+    } else if (e.kind === 'object' && e.templateId === 'bg_rune') {
+      // speed powerup: a glowing ground glyph with a hovering ring
+      body = new THREE.Group();
+      height = 1.4;
+      if (!this.bgRuneMat) {
+        this.bgRuneMat = new THREE.MeshBasicMaterial({
+          color: e.color, transparent: true, opacity: 0.85, side: THREE.DoubleSide,
+          blending: THREE.AdditiveBlending, depthWrite: false,
+        });
+        if (!this.lowGfx) this.bgRuneMat.color.multiplyScalar(2);
+      }
+      const disc = new THREE.Mesh(new THREE.CircleGeometry(1.2, 22).rotateX(-Math.PI / 2), this.bgRuneMat);
+      disc.position.y = 0.12;
+      body!.add(disc);
+      const ring = new THREE.Mesh(new THREE.TorusGeometry(0.75, 0.13, 8, 18).rotateX(-Math.PI / 2), this.bgRuneMat);
+      ring.position.y = 0.85;
+      body!.add(ring);
+      if (!this.lowGfx) {
+        const l = new THREE.PointLight(e.color, 6, 9, 2);
+        l.position.y = 1.1;
+        body!.add(l);
+      }
       objectMesh = body!;
     } else if (e.kind === 'object') {
       body = new THREE.Group();
@@ -586,11 +633,16 @@ export class Renderer {
   // ---------------------------------------------------------------------
 
   private builtInteriors = new Set<string>();
-  private fogState: 'outdoor' | 'dungeon' | 'underwater' = 'outdoor';
+  private fogState: 'outdoor' | 'dungeon' | 'underwater' | 'battleground' = 'outdoor';
 
   private buildInterior(interior: string, ox: number, oz: number): void {
     this.dungeons ??= new DungeonInteriors(this.scene, this.lowGfx, this.flames, this.fireLights);
     this.dungeons.buildInterior(interior, ox, oz);
+  }
+
+  private buildBg(ox: number, oz: number): void {
+    this.dungeons ??= new DungeonInteriors(this.scene, this.lowGfx, this.flames, this.fireLights);
+    this.dungeons.buildBattleground(ox, oz);
   }
 
   // Outdoor fog presets per biome (high tier eases between them as the
@@ -607,8 +659,21 @@ export class Renderer {
   }
 
   private updateAmbience(px: number, camY: number, dt: number): void {
-    const inside = px > DUNGEON_X_THRESHOLD;
-    if (inside) {
+    const inBg = isBgPos(px);
+    const inside = px > DUNGEON_X_THRESHOLD && !inBg;
+    if (inBg) {
+      // build the Ravenrift battleground the player was matched into
+      const pz = this.sim.player.pos.z;
+      for (let i = 0; i < BG_SLOT_COUNT; i++) {
+        const key = `bg:${i}`;
+        if (this.builtInteriors.has(key)) continue;
+        const o = battlegroundOrigin(i);
+        if (Math.abs(px - o.x) < 220 && Math.abs(pz - o.z) < 200) {
+          this.builtInteriors.add(key);
+          this.buildBg(o.x, o.z);
+        }
+      }
+    } else if (inside) {
       // build the interior copy the player is standing in
       for (const dungeon of DUNGEON_LIST) {
         for (let i = 0; i < INSTANCE_SLOT_COUNT; i++) {
@@ -622,7 +687,9 @@ export class Renderer {
         }
       }
     }
-    const desired = inside ? 'dungeon' : camY < WATER_LEVEL - 0.05 ? 'underwater' : 'outdoor';
+    const desired = inBg ? 'battleground'
+      : inside ? 'dungeon'
+        : camY < WATER_LEVEL - 0.05 ? 'underwater' : 'outdoor';
     const fog = this.scene.fog as THREE.Fog;
     if (desired !== this.fogState) {
       this.fogState = desired;
@@ -634,6 +701,11 @@ export class Renderer {
         fog.color.setHex(0x17506e);
         fog.near = 2;
         fog.far = 48;
+      } else if (desired === 'battleground') {
+        // open-air, but a close haze hides the off-world void past the ramparts
+        fog.color.setHex(0xaecbe0);
+        fog.near = 50;
+        fog.far = 185;
       } else {
         const preset = this.outdoorFogPreset();
         fog.color.setHex(preset.color);

--- a/src/sim/battleground_layout.ts
+++ b/src/sim/battleground_layout.ts
@@ -1,0 +1,100 @@
+// Ravenrift — the 5v5 capture-the-flag battleground. Plain-data map geometry
+// (instance-local coordinates, y up, z along the length), the single source of
+// truth shared by BOTH the collider set (src/sim/colliders.ts) and the renderer
+// (src/render/battleground.ts), so what you fight around is what you see.
+// Sim layer: no three.js imports.
+import type { Collider } from './colliders';
+
+export type Team = 0 | 1; // 0 = Crimson (south, -z), 1 = Azure (north, +z)
+export const TEAM_NAMES = ['Crimson', 'Azure'] as const;
+export const TEAM_COLORS = [0xd1413a, 0x3a78d1] as const; // red, blue — flags/banners/blips
+
+// Field footprint. The play area is a walled rectangle; the two keeps sit at
+// the short ends with their flag at the heart of a three-sided enclosure.
+export const BG_HALF_X = 34;
+export const BG_HALF_Z = 60;
+export const BG_WALL_T = 1; // wall half-thickness (collider + module)
+export const BG_WALL_HEIGHT = 6;
+export const FLAG_Z = 48; // |z| of each team's flag stand
+
+export interface BaseDef {
+  team: Team;
+  flag: { x: number; z: number }; // flag home + capture point
+  spawns: { x: number; z: number }[]; // respawn ring behind the flag
+  banner: { x: number; z: number };
+}
+
+// Crimson keep opens toward +z (the field); Azure mirrors it on +z.
+export const BASES: BaseDef[] = [
+  {
+    team: 0,
+    flag: { x: 0, z: -FLAG_Z },
+    spawns: [{ x: -6, z: -54 }, { x: 0, z: -55 }, { x: 6, z: -54 }, { x: -3, z: -51 }, { x: 3, z: -51 }],
+    banner: { x: 0, z: -56 },
+  },
+  {
+    team: 1,
+    flag: { x: 0, z: FLAG_Z },
+    spawns: [{ x: 6, z: 54 }, { x: 0, z: 55 }, { x: -6, z: 54 }, { x: 3, z: 51 }, { x: -3, z: 51 }],
+    banner: { x: 0, z: 56 },
+  },
+];
+
+// Speed runes: one at each flag section plus two mid-field flanks. Stepping on
+// an active rune grants a sprint buff; it then recharges (see sim BG_RUNE_*).
+export const SPEED_RUNES: { x: number; z: number }[] = [
+  { x: 0, z: -36 }, // Crimson flag approach
+  { x: 0, z: 36 }, // Azure flag approach
+  { x: -24, z: 0 }, // west flank
+  { x: 24, z: 0 }, // east flank
+];
+
+// Central cover — staggered walls, a heart ruin, pillars and crate stacks that
+// break line of sight and carve out flanking lanes to weave enemies through.
+interface WallSeg { x: number; z: number; hw: number; hd: number; rot?: number }
+export const COVER_WALLS: WallSeg[] = [
+  { x: 0, z: 0, hw: 5, hd: 5 }, // heart ruin block
+  { x: -13, z: -16, hw: 1, hd: 8 }, // offset lane walls
+  { x: 13, z: 16, hw: 1, hd: 8 },
+  { x: 13, z: -16, hw: 1, hd: 5 },
+  { x: -13, z: 16, hw: 1, hd: 5 },
+  { x: -22, z: -30, hw: 6, hd: 1 }, // wing baffles near each base mouth
+  { x: 22, z: 30, hw: 6, hd: 1 },
+];
+export const COVER_PILLARS: { x: number; z: number }[] = [
+  { x: -18, z: -8 }, { x: 18, z: -8 }, { x: -18, z: 8 }, { x: 18, z: 8 },
+  { x: 0, z: -26 }, { x: 0, z: 26 },
+];
+export const COVER_CRATES: { x: number; z: number }[] = [
+  { x: -8, z: -32 }, { x: 8, z: 32 }, { x: 9, z: -22 }, { x: -9, z: 22 },
+];
+
+const PILLAR_R = 1.0;
+const CRATE_R = 0.8;
+
+/** Full BG collision set in instance-local coordinates. Flag stands and speed
+ *  runes are deliberately walkable (no collider). */
+export function battlegroundColliders(): Collider[] {
+  const out: Collider[] = [];
+  // perimeter
+  for (const sx of [-BG_HALF_X, BG_HALF_X]) {
+    out.push({ type: 'obb', x: sx, z: 0, hw: BG_WALL_T, hd: BG_HALF_Z, rot: 0 });
+  }
+  for (const sz of [-BG_HALF_Z, BG_HALF_Z]) {
+    out.push({ type: 'obb', x: 0, z: sz, hw: BG_HALF_X, hd: BG_WALL_T, rot: 0 });
+  }
+  // keeps: a three-sided enclosure around each flag, open toward centre
+  for (const base of BASES) {
+    const dir = base.team === 0 ? -1 : 1; // back wall is further from centre
+    const backZ = base.flag.z + dir * 8;
+    out.push({ type: 'obb', x: 0, z: backZ, hw: 14, hd: BG_WALL_T, rot: 0 });
+    for (const sx of [-14, 14]) {
+      out.push({ type: 'obb', x: sx, z: base.flag.z + dir * 2, hw: BG_WALL_T, hd: 6, rot: 0 });
+    }
+  }
+  // central cover
+  for (const w of COVER_WALLS) out.push({ type: 'obb', x: w.x, z: w.z, hw: w.hw, hd: w.hd, rot: w.rot ?? 0 });
+  for (const p of COVER_PILLARS) out.push({ type: 'circle', x: p.x, z: p.z, r: PILLAR_R });
+  for (const c of COVER_CRATES) out.push({ type: 'circle', x: c.x, z: c.z, r: CRATE_R });
+  return out;
+}

--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -1,6 +1,10 @@
 import { generateDecorations } from './world';
-import { DUNGEON_X_THRESHOLD, INSTANCE_SLOT_COUNT, PROPS, dungeonAt, instanceOrigin } from './data';
+import {
+  DUNGEON_X_THRESHOLD, INSTANCE_SLOT_COUNT, PROPS, bgOriginAt, dungeonAt,
+  instanceOrigin, isBgPos,
+} from './data';
 import { CRYPT_LAYOUT, SANCTUM_LAYOUT, layoutColliders } from './dungeon_layout';
+import { battlegroundColliders } from './battleground_layout';
 
 // Static world collision. Prop placement comes from the per-zone content
 // modules (merged into PROPS by sim/data.ts): the renderer builds its meshes
@@ -85,6 +89,7 @@ function staticWorldColliders(seed: number): Collider[] {
 // drift apart. The boss dais is walkable and deliberately has no collider.
 const CRYPT_COLLIDERS: Collider[] = layoutColliders(CRYPT_LAYOUT);
 const SANCTUM_COLLIDERS: Collider[] = layoutColliders(SANCTUM_LAYOUT);
+const BG_COLLIDERS: Collider[] = battlegroundColliders();
 
 // Interior collider sets keyed by DungeonDef.interior.
 const INTERIOR_COLLIDERS: Record<string, Collider[]> = {
@@ -194,6 +199,11 @@ function instanceLocal(x: number, z: number): { ox: number; oz: number; interior
 // Resolve a movement destination against all static geometry. Movers slide
 // along obstacles. `r` is the body radius.
 export function resolvePosition(seed: number, x: number, z: number, r = 0.5): { x: number; z: number } {
+  if (isBgPos(x)) {
+    const o = bgOriginAt(z);
+    const local = resolveAgainst(BG_COLLIDERS, x - o.x, z - o.z, r);
+    return { x: local.x + o.x, z: local.z + o.z };
+  }
   if (x > DUNGEON_X_THRESHOLD) {
     const { ox, oz, interior } = instanceLocal(x, z);
     const colliders = INTERIOR_COLLIDERS[interior] ?? CRYPT_COLLIDERS;

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -147,6 +147,37 @@ export function dungeonAt(x: number): DungeonDef | null {
   return dungeonByIndex(Math.round((x - 900) / 600));
 }
 
+// ---------------------------------------------------------------------------
+// Ravenrift — the 5v5 ranked capture-the-flag battleground. Its match instances
+// get their own far-off flat-ground x-band well past the dungeon bands (index
+// 0/1/2 sit at x 900/1500/2100); slots stack along z. Like dungeons, x beyond
+// DUNGEON_X_THRESHOLD means flat ground (world.groundHeight) and instance-local
+// collision (sim/colliders.ts).
+// ---------------------------------------------------------------------------
+
+export const BG_X = 4200; // battleground instances share this x
+export const BG_X_MIN = 3800; // x at/after this = a battleground instance
+export const BG_SLOT_COUNT = 3; // concurrent 5v5 matches the world can host
+const BG_Z0 = -1500;
+const BG_SLOT_SPACING = 300; // > the field footprint (~120yd) so slots never overlap
+
+export function battlegroundOrigin(slot: number): { x: number; z: number } {
+  return { x: BG_X, z: BG_Z0 + slot * BG_SLOT_SPACING };
+}
+
+export function isBgPos(x: number): boolean {
+  return x >= BG_X_MIN;
+}
+
+export function bgOriginAt(z: number): { x: number; z: number; slot: number } {
+  let best = 0, bestD = Infinity;
+  for (let i = 0; i < BG_SLOT_COUNT; i++) {
+    const d = Math.abs(z - battlegroundOrigin(i).z);
+    if (d < bestD) { bestD = d; best = i; }
+  }
+  const o = battlegroundOrigin(best);
+  return { x: o.x, z: o.z, slot: best };
+}
 // Legacy aliases for the Hollow Crypt (tests + scripts reference these).
 export const CRYPT_DOOR_POS = DUNGEONS.hollow_crypt.doorPos;
 export const CRYPT_ENTRY = DUNGEONS.hollow_crypt.entry;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,9 +1,11 @@
 import {
-  ABILITIES, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, dungeonAt,
+  ABILITIES, BG_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef,
+  battlegroundOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT,
   ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, REWARD_ARCHETYPE, abilitiesKnownAt, instanceOrigin,
   zoneAt,
 } from './data';
+import { BASES, SPEED_RUNES, TEAM_COLORS, TEAM_NAMES, type Team } from './battleground_layout';
 import { resolvePosition } from './colliders';
 import { findPath } from './pathfind';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
@@ -32,6 +34,23 @@ const OBJECT_RESPAWN = 30;
 const PARTY_MAX = 5;
 const PARTY_XP_RANGE = 80; // yards: members this close share kill xp/credit
 const DUEL_COUNTDOWN = 3;
+const BG_BASE_RATING = 1500; // every character starts here, unranked
+const BG_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
+const BG_K_FACTOR = 32; // Elo sensitivity per match
+const BG_LADDER_SIZE = 10; // live online standings shipped to clients
+// Ravenrift 5v5 capture-the-flag
+const BG_TEAM_SIZE = 5; // players per team — a full match is 5v5
+const BG_COUNTDOWN = 8; // pre-match gates: form up at your keep
+const BG_CAPS_TO_WIN = 5; // first team to this many flag captures wins
+const BG_MAX_DURATION = 900; // safety cap; a timed-out match resolves on score
+const BG_RESPAWN_DELAY = 6; // seconds dead before you respawn at your keep
+const BG_FLAG_RETURN_TIME = 12; // a dropped flag auto-returns home after this
+const BG_PICKUP_RADIUS = 2.5; // walk this close to grab a flag / return your own
+const BG_CAPTURE_RADIUS = 4; // carry the enemy flag this close to your stand to score
+const BG_RUNE_RADIUS = 2.5; // step this close to a speed rune to claim it
+const BG_RUNE_COOLDOWN = 22; // a claimed rune recharges over this
+const BG_RUNE_SPEED = 1.4; // sprint multiplier the rune grants
+const BG_RUNE_DURATION = 8; // seconds of haste per rune
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
 const YELL_RANGE = 100;
 const CHAT_BURST = 8; // messages a player may send back-to-back...
@@ -70,6 +89,54 @@ export interface DuelState {
   b: number;
   state: 'countdown' | 'active';
   timer: number; // countdown remaining / elapsed
+}
+
+// Standard Elo. Returns the points the winner gains (and the loser loses) for
+// an outright result; a draw moves each toward its expected score by half.
+export function eloDelta(winnerRating: number, loserRating: number, score = 1): number {
+  const expected = 1 / (1 + 10 ** ((loserRating - winnerRating) / 400));
+  return Math.round(BG_K_FACTOR * (score - expected));
+}
+
+// --- Ravenrift 5v5 capture-the-flag ---
+
+interface BgFlag {
+  team: 0 | 1; // home team
+  home: Vec3; // world-space stand position
+  pos: Vec3; // current world position (== carrier while carried)
+  state: 'home' | 'carried' | 'dropped';
+  carrier: number | null; // pid carrying the enemy flag
+  dropTimer: number; // counts down a dropped flag to its auto-return
+  entityId: number;
+}
+
+interface BgRune {
+  pos: Vec3; // world
+  active: boolean;
+  cooldown: number; // seconds until it recharges
+  entityId: number; // -1 while spent (the rune mesh despawns on cooldown)
+}
+
+// A live battleground. Two teams of pids, per-team scores, the two flags, the
+// speed runes, and the per-player return/respawn bookkeeping.
+export interface BgMatch {
+  id: number;
+  slot: number;
+  teams: [number[], number[]]; // pids, index = team
+  scores: [number, number];
+  flags: [BgFlag, BgFlag];
+  runes: BgRune[];
+  state: 'countdown' | 'active';
+  timer: number; // countdown remaining, then elapsed once active
+  ret: Map<number, { x: number; z: number; facing: number }>; // where each player queued from
+  respawn: Map<number, number>; // pid -> seconds until respawn (absent = alive)
+  ratingAvg: [number, number]; // team average rating at start, for Elo
+}
+
+// A queued group: a whole party (or a solo) that matchmaking keeps together.
+interface BgQueueGroup {
+  pids: number[];
+  ratingAvg: number;
 }
 
 export interface InstanceSlot {
@@ -122,6 +189,10 @@ export interface PlayerMeta {
   questsDone: Set<string>;
   counters: RewardCounters;
   autoEquip: boolean;
+  // Ravenrift 5v5 standing — persisted in CharacterState
+  squadRating: number;
+  squadWins: number;
+  squadLosses: number;
 }
 
 // Persistable character state (stored as JSONB server-side).
@@ -137,6 +208,9 @@ export interface CharacterState {
   inventory: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
   questsDone: string[];
+  squadRating?: number;
+  squadWins?: number;
+  squadLosses?: number;
 }
 
 // Pure quest-state computation, shared by the sim and the network client.
@@ -187,6 +261,12 @@ export class Sim {
   tradeInvites = new Map<number, { fromPid: number; expires: number }>();
   duels = new Map<number, DuelState>(); // pid -> shared duel (both pids)
   duelInvites = new Map<number, { fromPid: number; expires: number }>();
+  // Ravenrift: queued party-groups, live matches keyed by every member pid,
+  // and the set of busy battleground slots
+  bgQueue: BgQueueGroup[] = [];
+  bgMatches = new Map<number, BgMatch>();
+  private bgBusySlots = new Set<number>();
+  private nextBgMatchId = 1;
   // per-player chat token bucket (anti-spam); refilled lazily by sim time
   private chatTokens = new Map<number, { tokens: number; at: number }>();
   // dungeon instances
@@ -310,6 +390,9 @@ export class Sim {
       questsDone: new Set(),
       counters: freshCounters(),
       autoEquip: opts?.autoEquip ?? false,
+      squadRating: opts?.state?.squadRating ?? BG_BASE_RATING,
+      squadWins: opts?.state?.squadWins ?? 0,
+      squadLosses: opts?.state?.squadLosses ?? 0,
     };
     this.players.set(player.id, meta);
     if (this.primaryId === -1) this.primaryId = player.id;
@@ -354,6 +437,11 @@ export class Sim {
     if (trade) this.tradeCancel(pid);
     const duel = this.duels.get(pid);
     if (duel) this.endDuel(duel, duel.a === pid ? duel.b : duel.a);
+    // battleground: drop out of the queue, and leave any live match (the team
+    // fights on a player down)
+    this.bgDequeue(pid);
+    const bg = this.bgMatches.get(pid);
+    if (bg) this.bgRemovePlayer(bg, pid);
     this.partyInvites.delete(pid);
     this.tradeInvites.delete(pid);
     this.duelInvites.delete(pid);
@@ -391,6 +479,9 @@ export class Sim {
       inventory: meta.inventory.map((i) => ({ ...i })),
       questLog: [...meta.questLog.values()].map((q) => ({ questId: q.questId, counts: [...q.counts], state: q.state })),
       questsDone: [...meta.questsDone],
+      squadRating: meta.squadRating,
+      squadWins: meta.squadWins,
+      squadLosses: meta.squadLosses,
     };
   }
 
@@ -590,6 +681,7 @@ export class Sim {
     }
 
     this.updateDuels();
+    this.updateBg();
     this.updateTradesAndInvites();
     this.updateInstances();
 
@@ -1680,6 +1772,13 @@ export class Sim {
       e.chargeTargetId = null;
       e.chargePath = [];
       this.emit({ type: 'playerDeath', pid: e.id });
+      // in a battleground you don't run to a graveyard — drop any flag you were
+      // carrying and queue a timed respawn back at your keep
+      const bg = this.bgMatches.get(e.id);
+      if (bg && bg.state === 'active') {
+        this.bgDropFlagsHeldBy(bg, e, killer);
+        bg.respawn.set(e.id, BG_RESPAWN_DELAY);
+      }
       for (const m of this.entities.values()) {
         if (m.kind === 'mob' && !m.dead && m.aggroTargetId === e.id && m.aiState !== 'dead') {
           // turn on the next nearby attacker; go home only if nobody is left
@@ -2512,6 +2611,9 @@ export class Sim {
     if (!r) return;
     const { meta, e: p } = r;
     if (!p.dead) return;
+    // in a battleground the keep respawn is automatic and timed — releasing
+    // does nothing (you can't graveyard-walk out of the match)
+    if (this.bgMatches.has(p.id)) return;
     p.dead = false;
     // dying in a dungeon sends you to the graveyard of the zone its door is
     // in; dying outdoors, to your current zone's graveyard
@@ -2626,7 +2728,12 @@ export class Sim {
     if (target.kind === 'mob') return target.hostile;
     if (target.kind === 'player' && attacker.kind === 'player') {
       const duel = this.duels.get(attacker.id);
-      return !!duel && duel.state === 'active' && (duel.a === target.id || duel.b === target.id);
+      if (duel && duel.state === 'active' && (duel.a === target.id || duel.b === target.id)) return true;
+      // battleground: hostile to the other team, friendly to your own
+      const bg = this.bgMatches.get(attacker.id);
+      if (bg && bg.state === 'active' && this.bgMatches.get(target.id) === bg) {
+        return this.bgTeamOf(bg, attacker.id) !== this.bgTeamOf(bg, target.id);
+      }
     }
     return false;
   }
@@ -2835,6 +2942,492 @@ export class Sim {
 
   duelFor(pid: number): DuelState | null {
     return this.duels.get(pid) ?? null;
+  }
+
+  // A clean slate so the bout is decided by play, not by what each fighter
+  // walked in carrying: full health/resource, cooldowns and combat reset.
+  private resetForBg(e: Entity): void {
+    const meta = this.players.get(e.id);
+    if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
+    e.auras = [];
+    e.hp = e.maxHp;
+    e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
+    e.targetId = null;
+    e.autoAttack = false;
+    e.queuedOnSwing = null;
+    e.castingAbility = null;
+    e.castRemaining = 0;
+    e.channeling = false;
+    e.comboPoints = 0;
+    e.comboTargetId = null;
+    e.cooldowns.clear();
+    e.gcdRemaining = 0;
+    e.swingTimer = 0;
+    e.chargeTargetId = null;
+    e.chargePath = [];
+    e.combatTimer = 99;
+    e.inCombat = false;
+    e.sitting = false;
+    e.eating = null;
+    e.drinking = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Ravenrift — 5v5 ranked capture-the-flag battleground
+  // -------------------------------------------------------------------------
+
+  bgQueueJoin(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const id = r.meta.entityId;
+    if (this.bgMatches.has(id)) { this.error(id, 'You are already in a battleground.'); return; }
+    if (r.e.dead) { this.error(id, 'You cannot queue for Ravenrift while dead.'); return; }
+    if (r.e.pos.x > DUNGEON_X_THRESHOLD) { this.error(id, 'You cannot queue from inside an instance.'); return; }
+    // queue the whole party as one group (kept together by matchmaking); solo
+    // players queue alone. Any eligible member can put the party in.
+    const party = this.partyOf(id);
+    const members = party ? party.members.slice(0, BG_TEAM_SIZE) : [id];
+    if (this.bgGroupContaining(id)) {
+      this.emit({ type: 'bgQueued', position: this.bgQueueSize(), pid: id });
+      return;
+    }
+    for (const m of members) {
+      if (this.bgMatches.has(m) || this.bgGroupContaining(m)) { this.error(id, 'A party member is already queued or in a match.'); return; }
+    }
+    const ratingAvg = members.reduce((s, m) => s + (this.players.get(m)?.squadRating ?? BG_BASE_RATING), 0) / members.length;
+    this.bgQueue.push({ pids: [...members], ratingAvg });
+    for (const m of members) {
+      this.emit({ type: 'bgQueued', position: this.bgQueueSize(), pid: m });
+      this.emit({ type: 'log', text: party && members.length > 1
+        ? `Your party of ${members.length} joins the Ravenrift queue.`
+        : 'You join the Ravenrift queue. Need 10 champions to start a match…', color: '#7fd4ff', pid: m });
+    }
+  }
+
+  bgQueueLeave(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const group = this.bgGroupContaining(r.meta.entityId);
+    if (!group) return;
+    this.bgQueue = this.bgQueue.filter((g) => g !== group);
+    for (const m of group.pids) {
+      this.emit({ type: 'bgUnqueued', pid: m });
+      this.emit({ type: 'log', text: 'You leave the Ravenrift queue.', color: '#7fd4ff', pid: m });
+    }
+  }
+
+  private bgGroupContaining(pid: number): BgQueueGroup | null {
+    return this.bgQueue.find((g) => g.pids.includes(pid)) ?? null;
+  }
+
+  private bgDequeue(pid: number): boolean {
+    const group = this.bgGroupContaining(pid);
+    if (!group) return false;
+    group.pids = group.pids.filter((p) => p !== pid);
+    if (group.pids.length === 0) this.bgQueue = this.bgQueue.filter((g) => g !== group);
+    return true;
+  }
+
+  private bgQueueSize(): number {
+    return this.bgQueue.reduce((s, g) => s + g.pids.length, 0);
+  }
+
+  private freeBgSlot(): number | null {
+    for (let i = 0; i < BG_SLOT_COUNT; i++) if (!this.bgBusySlots.has(i)) return i;
+    return null;
+  }
+
+  bgTeamOf(match: BgMatch, pid: number): Team {
+    return match.teams[1].includes(pid) ? 1 : 0;
+  }
+
+  bgMatchFor(pid: number): BgMatch | null {
+    return this.bgMatches.get(pid) ?? null;
+  }
+
+  private updateBg(): void {
+    this.matchmakeBg();
+    const seen = new Set<BgMatch>();
+    for (const match of this.bgMatches.values()) {
+      if (seen.has(match)) continue;
+      seen.add(match);
+      if (match.state === 'countdown') {
+        const before = Math.ceil(match.timer);
+        match.timer -= DT;
+        const after = Math.ceil(match.timer);
+        if (after < before && after > 0) {
+          for (const mp of this.bgAll(match)) this.emit({ type: 'bgCountdown', seconds: after, pid: mp });
+        }
+        if (match.timer <= 0) {
+          match.state = 'active';
+          match.timer = 0;
+          for (const mp of this.bgAll(match)) {
+            const e = this.entities.get(mp);
+            if (e) this.resetForBg(e);
+            this.emit({ type: 'log', text: 'The Ravenrift battle begins — take their flag!', color: '#ff5a3c', pid: mp });
+            this.emit({ type: 'bgStart', pid: mp });
+          }
+        }
+        continue;
+      }
+      match.timer += DT;
+      this.bgTickRespawns(match);
+      this.bgTickRunes(match);
+      this.bgTickFlags(match);
+      if (match.timer >= BG_MAX_DURATION) {
+        const w = match.scores[0] === match.scores[1] ? null : match.scores[0] > match.scores[1] ? 0 : 1;
+        this.endBgMatch(match, w, 'timeout');
+      }
+    }
+  }
+
+  private bgAll(match: BgMatch): number[] {
+    return [...match.teams[0], ...match.teams[1]];
+  }
+
+  private bgEmitAll(match: BgMatch, ev: (pid: number) => SimEvent): void {
+    for (const mp of this.bgAll(match)) this.emit(ev(mp));
+  }
+
+  private matchmakeBg(): void {
+    let guard = BG_SLOT_COUNT + 1;
+    while (guard-- > 0) {
+      // drop members who went offline/died/left while waiting
+      for (const g of this.bgQueue) g.pids = g.pids.filter((p) => this.entities.get(p) && !this.entities.get(p)!.dead && !this.bgMatches.has(p));
+      this.bgQueue = this.bgQueue.filter((g) => g.pids.length > 0);
+      if (this.bgQueueSize() < BG_TEAM_SIZE * 2 || this.freeBgSlot() === null) return;
+      // greedily pack whole groups into two teams of five, balancing headcount
+      const groups = [...this.bgQueue].sort((a, b) => b.pids.length - a.pids.length);
+      const teams: [number[], number[]] = [[], []];
+      const used: BgQueueGroup[] = [];
+      for (const g of groups) {
+        const canA = teams[0].length + g.pids.length <= BG_TEAM_SIZE;
+        const canB = teams[1].length + g.pids.length <= BG_TEAM_SIZE;
+        let t = -1;
+        if (canA && canB) t = teams[0].length <= teams[1].length ? 0 : 1;
+        else if (canA) t = 0;
+        else if (canB) t = 1;
+        if (t < 0) continue;
+        teams[t].push(...g.pids);
+        used.push(g);
+      }
+      if (teams[0].length !== BG_TEAM_SIZE || teams[1].length !== BG_TEAM_SIZE) return; // can't form 5v5 yet
+      this.bgQueue = this.bgQueue.filter((g) => !used.includes(g));
+      this.startBgMatch(teams[0], teams[1]);
+    }
+  }
+
+  private startBgMatch(teamA: number[], teamB: number[]): void {
+    const slot = this.freeBgSlot();
+    if (slot === null) { this.bgQueue.unshift({ pids: [...teamA, ...teamB], ratingAvg: BG_BASE_RATING }); return; }
+    this.bgBusySlots.add(slot);
+    const origin = battlegroundOrigin(slot);
+    const ret = new Map<number, { x: number; z: number; facing: number }>();
+    for (const pid of [...teamA, ...teamB]) {
+      const e = this.entities.get(pid);
+      if (e) ret.set(pid, { x: e.pos.x, z: e.pos.z, facing: e.facing });
+    }
+    const flags: [BgFlag, BgFlag] = [0, 1].map((team) => {
+      const home = this.groundPos(origin.x + BASES[team].flag.x, origin.z + BASES[team].flag.z);
+      return { team: team as Team, home, pos: { ...home }, state: 'home' as const, carrier: null, dropTimer: 0, entityId: -1 };
+    }) as [BgFlag, BgFlag];
+    const runes: BgRune[] = SPEED_RUNES.map((rp) => ({
+      pos: this.groundPos(origin.x + rp.x, origin.z + rp.z), active: true, cooldown: 0, entityId: -1,
+    }));
+    const match: BgMatch = {
+      id: this.nextBgMatchId++, slot, teams: [teamA, teamB], scores: [0, 0], flags, runes,
+      state: 'countdown', timer: BG_COUNTDOWN, ret,
+      respawn: new Map(),
+      ratingAvg: [this.bgTeamAvg(teamA), this.bgTeamAvg(teamB)],
+    };
+    for (const pid of this.bgAll(match)) this.bgMatches.set(pid, match);
+    for (const flag of flags) this.bgSpawnFlagEntity(flag);
+    for (const rune of runes) this.bgSpawnRuneEntity(rune);
+    // seat each team at its keep
+    for (const team of [0, 1] as Team[]) {
+      match.teams[team].forEach((pid, i) => this.bgSpawnPlayer(match, pid, team, i));
+    }
+    for (const team of [0, 1] as Team[]) {
+      for (const pid of match.teams[team]) {
+        this.emit({ type: 'bgFound', team, pid });
+        this.emit({ type: 'bgCountdown', seconds: BG_COUNTDOWN, pid });
+        this.emit({ type: 'log', text: `Ravenrift: you fight for the ${TEAM_NAMES[team]}. First to ${BG_CAPS_TO_WIN} captures wins.`, color: '#7fd4ff', pid });
+      }
+    }
+  }
+
+  private bgTeamAvg(pids: number[]): number {
+    if (pids.length === 0) return BG_BASE_RATING;
+    return pids.reduce((s, p) => s + (this.players.get(p)?.squadRating ?? BG_BASE_RATING), 0) / pids.length;
+  }
+
+  // Place a player at one of their keep's spawn points (round-robin by index),
+  // healed and reset for the fight.
+  private bgSpawnPlayer(match: BgMatch, pid: number, team: Team, index: number): void {
+    const e = this.entities.get(pid);
+    if (!e) return;
+    const slot = match.slot;
+    const origin = battlegroundOrigin(slot);
+    const spawns = BASES[team].spawns;
+    const sp = spawns[index % spawns.length];
+    e.pos = this.groundPos(origin.x + sp.x, origin.z + sp.z);
+    e.prevPos = { ...e.pos };
+    e.facing = team === 0 ? 0 : Math.PI; // face the field
+    e.prevFacing = e.facing;
+    this.rebucket(e);
+    this.resetForBg(e);
+  }
+
+  private bgSpawnFlagEntity(flag: BgFlag): void {
+    const e = createGroundObject(this.nextId++, '', `${TEAM_NAMES[flag.team]} Flag`, { ...flag.pos });
+    e.templateId = 'bg_flag';
+    e.objectItemId = null;
+    e.lootable = false;
+    e.color = TEAM_COLORS[flag.team];
+    this.addEntity(e);
+    flag.entityId = e.id;
+  }
+
+  private bgSpawnRuneEntity(rune: BgRune): void {
+    const e = createGroundObject(this.nextId++, '', 'Sprint Rune', { ...rune.pos });
+    e.templateId = 'bg_rune';
+    e.objectItemId = null;
+    e.lootable = false;
+    e.color = 0xffd24a;
+    this.addEntity(e);
+    rune.entityId = e.id;
+  }
+
+  private bgTickRespawns(match: BgMatch): void {
+    for (const [pid, t] of [...match.respawn]) {
+      const left = t - DT;
+      if (left > 0) { match.respawn.set(pid, left); continue; }
+      match.respawn.delete(pid);
+      const e = this.entities.get(pid);
+      if (!e) continue;
+      e.dead = false;
+      const team = this.bgTeamOf(match, pid);
+      const idx = match.teams[team].indexOf(pid);
+      this.bgSpawnPlayer(match, pid, team, idx < 0 ? 0 : idx);
+      this.emit({ type: 'respawn', pid });
+    }
+  }
+
+  private bgTickRunes(match: BgMatch): void {
+    for (const rune of match.runes) {
+      if (!rune.active) {
+        rune.cooldown -= DT;
+        if (rune.cooldown <= 0) { rune.active = true; this.bgSpawnRuneEntity(rune); }
+        continue;
+      }
+      // first live player to step on it claims the sprint
+      for (const pid of this.bgAll(match)) {
+        const e = this.entities.get(pid);
+        if (!e || e.dead) continue;
+        if (dist2d(e.pos, rune.pos) <= BG_RUNE_RADIUS) {
+          this.applyAura(e, {
+            id: 'sprint_rune', name: 'Sprint', kind: 'buff_speed', value: BG_RUNE_SPEED,
+            remaining: BG_RUNE_DURATION, duration: BG_RUNE_DURATION, sourceId: e.id, school: 'physical',
+          });
+          rune.active = false;
+          rune.cooldown = BG_RUNE_COOLDOWN;
+          if (rune.entityId >= 0) { this.dropEntity(rune.entityId); rune.entityId = -1; }
+          this.emit({ type: 'log', text: 'You seize a Sprint Rune!', color: '#ffd24a', pid });
+          break;
+        }
+      }
+    }
+  }
+
+  private bgTickFlags(match: BgMatch): void {
+    for (const flag of match.flags) {
+      if (flag.state === 'carried') {
+        const carrier = flag.carrier !== null ? this.entities.get(flag.carrier) : null;
+        if (!carrier || carrier.dead || !this.bgMatches.has(flag.carrier!)) {
+          this.bgDropFlag(match, flag, carrier ?? null);
+        } else {
+          flag.pos = { ...carrier.pos };
+          this.bgSyncFlagEntity(flag);
+          // captured: carry the enemy flag home to your own stand
+          const carrierTeam = this.bgTeamOf(match, flag.carrier!);
+          const ownHome = match.flags[carrierTeam].home;
+          if (dist2d(carrier.pos, ownHome) <= BG_CAPTURE_RADIUS) {
+            this.bgCapture(match, flag, carrierTeam);
+          }
+        }
+        continue;
+      }
+      // home or dropped: enemies grab it, friends return a dropped one
+      for (const pid of this.bgAll(match)) {
+        const e = this.entities.get(pid);
+        if (!e || e.dead) continue;
+        const team = this.bgTeamOf(match, pid);
+        const d = dist2d(e.pos, flag.pos);
+        if (team !== flag.team && d <= BG_PICKUP_RADIUS && !this.bgIsCarrying(match, pid)) {
+          flag.state = 'carried'; flag.carrier = pid;
+          this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'taken', team: flag.team, byName: this.players.get(pid)?.name ?? '?', scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+          break;
+        }
+        if (team === flag.team && flag.state === 'dropped' && d <= BG_PICKUP_RADIUS) {
+          this.bgReturnFlag(match, flag, this.players.get(pid)?.name ?? '?');
+          break;
+        }
+      }
+      if (flag.state === 'dropped') {
+        flag.dropTimer -= DT;
+        if (flag.dropTimer <= 0) this.bgReturnFlag(match, flag, '');
+        else this.bgSyncFlagEntity(flag);
+      }
+    }
+  }
+
+  private bgIsCarrying(match: BgMatch, pid: number): boolean {
+    return match.flags.some((f) => f.carrier === pid);
+  }
+
+  private bgSyncFlagEntity(flag: BgFlag): void {
+    const e = this.entities.get(flag.entityId);
+    if (!e) return;
+    e.pos = { ...flag.pos };
+    e.prevPos = { ...flag.pos };
+    this.rebucket(e);
+  }
+
+  private bgCapture(match: BgMatch, flag: BgFlag, scoringTeam: Team): void {
+    const carrierName = flag.carrier !== null ? this.players.get(flag.carrier)?.name ?? '?' : '?';
+    match.scores[scoringTeam]++;
+    this.bgReturnFlag(match, flag, '', true); // the captured flag resets home
+    this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'captured', team: flag.team, byName: carrierName, scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+    if (match.scores[scoringTeam] >= BG_CAPS_TO_WIN) this.endBgMatch(match, scoringTeam, 'caps');
+  }
+
+  // Returns a flag to its stand. `silent` skips the event (capture emits its own).
+  private bgReturnFlag(match: BgMatch, flag: BgFlag, byName: string, silent = false): void {
+    flag.state = 'home'; flag.carrier = null; flag.dropTimer = 0;
+    flag.pos = { ...flag.home };
+    this.bgSyncFlagEntity(flag);
+    if (!silent) {
+      this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'returned', team: flag.team, byName, scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+    }
+  }
+
+  private bgDropFlag(match: BgMatch, flag: BgFlag, at: Entity | null): void {
+    const carrierName = flag.carrier !== null ? this.players.get(flag.carrier)?.name ?? '?' : '?';
+    flag.state = 'dropped'; flag.carrier = null; flag.dropTimer = BG_FLAG_RETURN_TIME;
+    if (at) flag.pos = { ...at.pos };
+    this.bgSyncFlagEntity(flag);
+    this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'dropped', team: flag.team, byName: carrierName, scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+  }
+
+  private bgDropFlagsHeldBy(match: BgMatch, e: Entity, _killer: Entity | null): void {
+    for (const flag of match.flags) {
+      if (flag.carrier === e.id) this.bgDropFlag(match, flag, e);
+    }
+  }
+
+  private bgRemovePlayer(match: BgMatch, pid: number): void {
+    for (const flag of match.flags) {
+      if (flag.carrier === pid) this.bgDropFlag(match, flag, this.entities.get(pid) ?? null);
+    }
+    const team = this.bgTeamOf(match, pid);
+    match.teams[team] = match.teams[team].filter((p) => p !== pid);
+    match.respawn.delete(pid);
+    match.ret.delete(pid);
+    this.bgMatches.delete(pid);
+    // a fully-vacated side ends the match in the other team's favour
+    if (match.teams[0].length === 0 || match.teams[1].length === 0) {
+      const winner = match.teams[0].length === 0 && match.teams[1].length === 0
+        ? null : match.teams[0].length === 0 ? 1 : 0;
+      this.endBgMatch(match, winner, 'forfeit');
+    }
+  }
+
+  // winnerTeam null = draw
+  private endBgMatch(match: BgMatch, winnerTeam: Team | null, _reason: 'caps' | 'timeout' | 'forfeit'): void {
+    for (const pid of this.bgAll(match)) this.bgMatches.delete(pid);
+    this.bgBusySlots.delete(match.slot);
+    for (const flag of match.flags) if (flag.entityId >= 0 && this.entities.has(flag.entityId)) this.dropEntity(flag.entityId);
+    for (const rune of match.runes) if (rune.entityId >= 0 && this.entities.has(rune.entityId)) this.dropEntity(rune.entityId);
+
+    const score0 = winnerTeam === null ? 0.5 : winnerTeam === 0 ? 1 : 0;
+    const delta0 = eloDelta(match.ratingAvg[0], match.ratingAvg[1], score0);
+    const delta1 = eloDelta(match.ratingAvg[1], match.ratingAvg[0], 1 - score0);
+    for (const team of [0, 1] as Team[]) {
+      const delta = team === 0 ? delta0 : delta1;
+      for (const pid of match.teams[team]) {
+        const meta = this.players.get(pid);
+        const e = this.entities.get(pid);
+        if (!meta) continue;
+        const before = meta.squadRating;
+        meta.squadRating = Math.max(BG_MIN_RATING, before + delta);
+        if (winnerTeam === null) { /* draw: no W/L */ }
+        else if (winnerTeam === team) meta.squadWins++;
+        else meta.squadLosses++;
+        this.emit({
+          type: 'bgEnd', pid, draw: winnerTeam === null, won: winnerTeam === team,
+          scoreCrimson: match.scores[0], scoreAzure: match.scores[1],
+          ratingBefore: before, ratingAfter: meta.squadRating,
+        });
+        // restore the fighter to where they queued from, healed and out of combat
+        if (e) {
+          const ret = match.ret.get(pid);
+          if (ret) { e.pos = this.groundPos(ret.x, ret.z); e.prevPos = { ...e.pos }; e.facing = ret.facing; this.rebucket(e); }
+          e.auras = []; e.dead = false;
+          recalcPlayerStats(e, meta.cls, meta.equipment);
+          e.hp = e.maxHp;
+          e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
+          e.targetId = null; e.autoAttack = false; e.castingAbility = null; e.channeling = false;
+          e.combatTimer = 99; e.inCombat = false;
+          this.emit({ type: 'respawn', pid });
+        }
+      }
+    }
+  }
+
+  // Live squad standings of rated players currently online, best first.
+  squadLadder(): import('../world_api').SquadLadderEntry[] {
+    const rows: import('../world_api').SquadLadderEntry[] = [];
+    for (const meta of this.players.values()) {
+      if (!this.entities.get(meta.entityId)) continue;
+      rows.push({ pid: meta.entityId, name: meta.name, cls: meta.cls, rating: meta.squadRating, wins: meta.squadWins, losses: meta.squadLosses });
+    }
+    rows.sort((x, y) => y.rating - x.rating || y.wins - x.wins);
+    return rows.slice(0, BG_LADDER_SIZE);
+  }
+
+  bgInfoFor(pid: number): import('../world_api').BgInfo | null {
+    const meta = this.players.get(pid);
+    if (!meta) return null;
+    const match = this.bgMatches.get(pid);
+    let matchInfo: import('../world_api').BgMatchInfo | null = null;
+    if (match) {
+      const myTeam = this.bgTeamOf(match, pid);
+      const flags = match.flags.map((f): import('../world_api').BgFlagInfo => ({
+        state: f.state,
+        carrierName: f.carrier !== null ? this.players.get(f.carrier)?.name ?? null : null,
+        carrierTeam: f.carrier !== null ? this.bgTeamOf(match, f.carrier) : null,
+      })) as [import('../world_api').BgFlagInfo, import('../world_api').BgFlagInfo];
+      const players: import('../world_api').BgPlayerInfo[] = [];
+      for (const team of [0, 1] as Team[]) {
+        for (const mp of match.teams[team]) {
+          const e = this.entities.get(mp);
+          const m = this.players.get(mp);
+          if (!e || !m) continue;
+          players.push({ pid: mp, name: m.name, cls: m.cls, team, carrying: this.bgIsCarrying(match, mp), dead: e.dead, hp: e.hp, mhp: e.maxHp });
+        }
+      }
+      matchInfo = {
+        state: match.state, myTeam, capsToWin: BG_CAPS_TO_WIN,
+        scores: [match.scores[0], match.scores[1]], flags, players,
+        respawnIn: Math.ceil(match.respawn.get(pid) ?? 0),
+      };
+    }
+    const group = this.bgGroupContaining(pid);
+    return {
+      rating: meta.squadRating, wins: meta.squadWins, losses: meta.squadLosses,
+      queued: group !== null, queueSize: this.bgQueueSize(), queuedParty: group?.pids.length ?? 1,
+      match: matchInfo, ladder: this.squadLadder(),
+    };
   }
 
   // -------------------------------------------------------------------------
@@ -3192,6 +3785,26 @@ export class Sim {
     if (!d) return null;
     const otherPid = d.a === this.primaryId ? d.b : d.a;
     return { otherPid, otherName: this.players.get(otherPid)?.name ?? '?', state: d.state };
+  }
+
+  get bgInfo(): import('../world_api').BgInfo | null {
+    return this.primaryId === -1 ? null : this.bgInfoFor(this.primaryId);
+  }
+
+  // Dev/test only: force-start a battleground from whoever is queued, split
+  // into two teams even if there aren't a full ten. Server-gated behind
+  // ALLOW_DEV_COMMANDS so it never runs in production.
+  devStartBg(): void {
+    const pids = this.bgQueue.flatMap((g) => g.pids).filter((p) => this.entities.get(p) && !this.bgMatches.has(p));
+    if (pids.length < 2) return;
+    const take = pids.slice(0, BG_TEAM_SIZE * 2);
+    const half = Math.ceil(take.length / 2);
+    const teamA = take.slice(0, half);
+    const teamB = take.slice(half);
+    this.bgQueue = this.bgQueue
+      .map((g) => ({ ...g, pids: g.pids.filter((p) => !take.includes(p)) }))
+      .filter((g) => g.pids.length > 0);
+    this.startBgMatch(teamA, teamB);
   }
 
   instanceSlotAt(pos: Vec3): number | null {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -468,6 +468,15 @@ export type SimEvent = { pid?: number } & (
   | { type: 'duelCountdown'; seconds: number }
   | { type: 'duelStart' }
   | { type: 'duelEnd'; winnerName: string; loserName: string }
+  // Ravenrift 5v5 capture-the-flag battleground
+  | { type: 'bgQueued'; position: number }
+  | { type: 'bgUnqueued' }
+  | { type: 'bgFound'; team: number }
+  | { type: 'bgCountdown'; seconds: number }
+  | { type: 'bgStart' }
+  // flag lifecycle: `team` is the flag that was acted on; `byName` the actor
+  | { type: 'bgFlag'; action: 'taken' | 'dropped' | 'returned' | 'captured'; team: number; byName: string; scoreCrimson: number; scoreAzure: number }
+  | { type: 'bgEnd'; won: boolean; draw: boolean; scoreCrimson: number; scoreAzure: number; ratingBefore: number; ratingAfter: number }
   | { type: 'heal2'; sourceId: number; targetId: number; amount: number; crit: boolean; ability: string }
   // visual-only cue for the renderer: spell projectiles, dot ticks, aoe novas
   | { type: 'spellfx'; sourceId: number; targetId: number; school: string; fx: 'projectile' | 'tick' | 'nova' }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -69,6 +69,11 @@ export class Hud {
   private tradeWasOpen = false;
   private lastTradeSig = '';
   private lastPartySig = '';
+  private lastBgSig = '';
+  private lastBgScoreSig = '';
+  // all-time ladder, fetched best-effort from the server (online only)
+  private bgAllTime: { name: string; class: string; level: number; rating: number; wins: number; losses: number }[] | null = null;
+  private bgLbFetchedAt = 0;
   private lastCombatEventAt = 0;
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
@@ -104,6 +109,7 @@ export class Hud {
     $('#mm-quest').addEventListener('click', () => this.toggleQuestLog());
     $('#mm-map').addEventListener('click', () => this.toggleMap());
     $('#mm-bag').addEventListener('click', () => this.toggleBags());
+    $('#mm-bg').addEventListener('click', () => this.toggleBg());
     const musicBtn = $('#mm-music');
     const styleMusicBtn = () => { musicBtn.style.color = music.enabled ? '#ffd100' : '#666'; };
     styleMusicBtn();
@@ -513,7 +519,21 @@ export class Hud {
     ($('#xpbar .fill') as HTMLElement).style.width = `${(xpFrac * 100).toFixed(1)}%`;
     $('#xpbar .label').textContent = p.level >= MAX_LEVEL ? 'MAX LEVEL' : `${sim.xp} / ${xpNeed} XP (${Math.floor(xpFrac * 100)}%)`;
 
-    $('#death-overlay').style.display = p.dead ? 'flex' : 'none';
+    // death overlay: a battleground death is a timed keep respawn, not a
+    // graveyard run — show the countdown and hide the release button
+    const bgRespawnIn = sim.bgInfo?.match?.respawnIn ?? 0;
+    const overlay = $('#death-overlay');
+    if (p.dead && bgRespawnIn > 0) {
+      overlay.style.display = 'flex';
+      $('#death-overlay h1').textContent = `Respawning at your keep in ${bgRespawnIn}…`;
+      $('#release-btn').style.display = 'none';
+    } else if (p.dead) {
+      overlay.style.display = 'flex';
+      $('#death-overlay h1').textContent = 'You have died.';
+      $('#release-btn').style.display = '';
+    } else {
+      overlay.style.display = 'none';
+    }
 
     // zone transitions: banner + welcome hint when crossing into a new band.
     // A ~5yd dead-band past the boundary stops a player straddling the border
@@ -551,8 +571,10 @@ export class Hud {
     this.updateQuestTracker();
     this.updatePartyFrames();
     this.updateTradeWindow();
+    this.updateBgScoreboard();
     this.updateMinimap();
     if ($('#map-window').style.display === 'block') this.updateMapWindow();
+    if ($('#bg-window').style.display === 'block') this.renderBgWindow();
     if (this.openLootMobId !== null) {
       const mob = sim.entities.get(this.openLootMobId);
       if (!mob || !mob.lootable || dist2d(p.pos, mob.pos) > 7) this.closeLoot();
@@ -718,6 +740,106 @@ export class Hud {
 
   toggleMeters(): void {
     this.meters.toggle();
+  }
+
+  // -------------------------------------------------------------------------
+  // Ravenrift — 5v5 capture-the-flag panel + in-match scoreboard
+  // -------------------------------------------------------------------------
+
+  toggleBg(): void {
+    const el = $('#bg-window');
+    if (el.style.display === 'block') { el.style.display = 'none'; return; }
+    el.style.display = 'block';
+    this.lastBgSig = '';
+    this.fetchBgLeaderboard();
+    this.renderBgWindow();
+  }
+
+  private fetchBgLeaderboard(): void {
+    const now = performance.now();
+    if (now - this.bgLbFetchedAt < 15000) return;
+    this.bgLbFetchedAt = now;
+    fetch('/api/squad/leaderboard')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (d && Array.isArray(d.leaders)) { this.bgAllTime = d.leaders; this.lastBgSig = ''; } })
+      .catch(() => { /* offline — live ladder only */ });
+  }
+
+  private renderBgWindow(): void {
+    const el = $('#bg-window');
+    const b = this.sim.bgInfo;
+    if (!b) {
+      el.innerHTML = `<div class="panel-title"><span>Ravenrift</span><span class="x-btn" data-close>✕</span></div>`
+        + `<div class="bg-note">Ravenrift is a ranked 5v5 capture-the-flag battleground for the live world. Play online, group up to 5, and queue together.</div>`;
+      el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; });
+      return;
+    }
+    const inMatch = b.match !== null;
+    const party = this.sim.partyInfo;
+    const partySize = party ? party.members.length : 1;
+    const ladderRow = (r: { pid?: number; name: string; cls?: string; class?: string; level?: number; rating: number; wins: number; losses: number }, i: number) => {
+      const me = (r.pid !== undefined && r.pid === this.sim.playerId) || r.name === this.sim.player.name;
+      const clsKey = (r.cls ?? r.class ?? '') as keyof typeof CLASSES;
+      const cls = CLASSES[clsKey]?.name ?? (r.cls ?? r.class ?? '');
+      return `<div class="ladder-row${me ? ' me' : ''}"><span class="rank">${i + 1}</span>`
+        + `<span class="lr-name" title="${r.name} — ${cls}">${r.name}</span>`
+        + `<span class="lr-rating">${r.rating}</span><span class="lr-wl">${r.wins}-${r.losses}</span></div>`;
+    };
+    const online = b.ladder.map(ladderRow).join('') || `<div class="ladder-empty">No squads ranked yet — be the first.</div>`;
+    this.fetchBgLeaderboard();
+    const allTimeRows = (this.bgAllTime ?? []).map(ladderRow).join('');
+    const allTime = this.bgAllTime && this.bgAllTime.length > 0 ? `<div class="bg-sub">Ladder — All-Time</div>${allTimeRows}` : '';
+
+    let action: string;
+    if (inMatch) {
+      action = `<div class="bg-queue-status">⚑ Battle in progress — ${b.match!.scores[0]}–${b.match!.scores[1]}.</div>`;
+    } else if (b.queued) {
+      action = `<button class="btn leave" data-act="leave">Leave Queue</button>`
+        + `<div class="bg-queue-status">Searching… ${b.queueSize}/10 in queue${b.queuedParty > 1 ? ` · party of ${b.queuedParty}` : ''}.</div>`;
+    } else {
+      action = `<button class="btn" data-act="queue">Enter the Queue${partySize > 1 ? ` (party of ${partySize})` : ''}</button>`
+        + `<div class="bg-note">Two teams of five. Steal the enemy banner and run it to your keep — first to 5 captures wins. Grab Sprint Runes to fly across the field, and weave the cover to lose your pursuers. Group up to bring your squad.</div>`;
+    }
+
+    const sig = JSON.stringify([b.rating, b.wins, b.losses, b.queued, b.queueSize, b.queuedParty, inMatch, partySize, b.ladder, this.bgAllTime]);
+    if (sig === this.lastBgSig) return;
+    this.lastBgSig = sig;
+    el.innerHTML = `<div class="panel-title"><span>Ravenrift <span style="color:#998d6a;font-size:11px">5v5 Capture the Flag</span></span><span class="x-btn" data-close>✕</span></div>`
+      + `<div class="bg-rank"><span class="rating">${b.rating}</span><span class="wl">Squad Rating · <b>${b.wins}</b> wins / <i>${b.losses}</i> losses</span></div>`
+      + action
+      + `<div class="bg-sub">Ladder — Online</div>${online}${allTime}`;
+    el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; });
+    el.querySelector('[data-act="queue"]')?.addEventListener('click', () => { this.sim.bgQueueJoin(); audio.click(); });
+    el.querySelector('[data-act="leave"]')?.addEventListener('click', () => { this.sim.bgQueueLeave(); audio.click(); });
+  }
+
+  // The pinned in-match scoreboard: team scores, flag states, your team's pips.
+  private updateBgScoreboard(): void {
+    const el = $('#bg-scoreboard');
+    const b = this.sim.bgInfo;
+    const m = b?.match ?? null;
+    if (!m) {
+      if (el.style.display !== 'none') { el.style.display = 'none'; this.lastBgScoreSig = ''; }
+      return;
+    }
+    const flagGlyph = (i: number) => {
+      const f = m.flags[i];
+      return `<span class="flag ${f.state} ${i === 0 ? 'crimson' : 'azure'}" title="${i === 0 ? 'Crimson' : 'Azure'} flag: ${f.state}${f.carrierName ? ' by ' + f.carrierName : ''}">⚑</span>`;
+    };
+    const pips = (team: number) => m.players.filter((p) => p.team === team)
+      .map((p) => `<div class="bg-pip${p.dead ? ' dead' : ''}${p.carrying ? ' flag' : ''}" style="background:${team === 0 ? '#ff6a62' : '#6aa6ff'}" title="${p.name}${p.dead ? ' (down)' : ''}${p.carrying ? ' — carrying!' : ''}"></div>`).join('');
+    const sig = JSON.stringify([m.scores, m.flags.map((f) => f.state + (f.carrierName ?? '')), m.players.map((p) => [p.dead, p.carrying]), m.state, m.myTeam]);
+    if (sig !== this.lastBgScoreSig) {
+      this.lastBgScoreSig = sig;
+      const youCrimson = m.myTeam === 0;
+      el.innerHTML = `<div class="bg-score-line">`
+        + `<span class="team crimson">${flagGlyph(0)} Crimson${youCrimson ? ' (you)' : ''}</span>`
+        + `<span class="num crimson">${m.scores[0]}</span><span class="dash">–</span><span class="num azure">${m.scores[1]}</span>`
+        + `<span class="team azure">Azure${!youCrimson ? ' (you)' : ''} ${flagGlyph(1)}</span></div>`
+        + `<div class="bg-caps">${m.state === 'countdown' ? 'FORM UP…' : `FIRST TO ${m.capsToWin} CAPTURES`}</div>`
+        + `<div class="bg-roster">${pips(0)}<span style="width:10px"></span>${pips(1)}</div>`;
+      el.style.display = 'block';
+    }
   }
 
   toggleMap(): void {
@@ -968,6 +1090,42 @@ export class Hud {
           this.combatLog(`${ev.winnerName} has defeated ${ev.loserName} in a duel.`, '#fa6');
           audio.duelEnd();
           break;
+        case 'bgQueued': this.log(`Queued for Ravenrift (${ev.position}/10).`, '#7fd4ff'); break;
+        case 'bgUnqueued': this.log('You leave the Ravenrift queue.', '#7fd4ff'); break;
+        case 'bgFound': {
+          const team = ev.team === 0 ? 'Crimson' : 'Azure';
+          this.showBanner(`Battle found — you fight for the ${team}!`);
+          audio.duelChallenge();
+          break;
+        }
+        case 'bgCountdown': this.showBanner(`Ravenrift begins in ${ev.seconds}…`); audio.duelCountdownTick(); break;
+        case 'bgStart': this.showBanner('Capture the flag!'); audio.duelStart(); break;
+        case 'bgFlag': {
+          const team = ev.team === 0 ? 'Crimson' : 'Azure';
+          const score = `${ev.scoreCrimson}–${ev.scoreAzure}`;
+          if (ev.action === 'captured') {
+            this.showBanner(`${ev.byName} captured the ${team} flag!  ${score}`);
+            this.combatLog(`${ev.byName} captured the ${team} flag. Score ${score}.`, '#ffd24a');
+            audio.questDone();
+          } else if (ev.action === 'taken') {
+            this.combatLog(`${ev.byName} has taken the ${team} flag!`, '#ff9a3c');
+          } else if (ev.action === 'dropped') {
+            this.combatLog(`The ${team} flag was dropped.`, '#cfc6a8');
+          } else {
+            this.combatLog(`The ${team} flag was returned.`, '#9fdc7f');
+          }
+          break;
+        }
+        case 'bgEnd': {
+          const delta = ev.ratingAfter - ev.ratingBefore;
+          const sign = delta >= 0 ? '+' : '';
+          const score = `${ev.scoreCrimson}–${ev.scoreAzure}`;
+          if (ev.draw) this.showBanner(`Ravenrift draw ${score} (${sign}${delta} rating)`);
+          else if (ev.won) { this.showBanner(`Victory!  Ravenrift ${score} — Rating ${ev.ratingAfter} (${sign}${delta})`); audio.duelEnd(); }
+          else { this.showBanner(`Defeat.  Ravenrift ${score} — Rating ${ev.ratingAfter} (${sign}${delta})`); audio.death(); }
+          this.combatLog(`Ravenrift ended ${score}. Squad rating ${ev.ratingAfter} (${sign}${delta}).`, ev.won ? '#7fdc4f' : '#ff7a6a');
+          break;
+        }
         case 'log': this.log(ev.text, ev.color ?? '#ccc'); break;
         case 'playerDeath': {
           this.log('You have died.', '#ff4444');
@@ -1917,7 +2075,7 @@ export class Hud {
       this.sim.tradeCancel();
       closed = true;
     }
-    for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window']) {
+    for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window', '#bg-window']) {
       const el = $(id);
       if (el.style.display === 'block') {
         el.style.display = 'none';

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -41,6 +41,53 @@ export interface DuelInfo {
   state: 'countdown' | 'active';
 }
 
+// ---- Ravenrift 5v5 capture-the-flag ----
+export interface SquadLadderEntry {
+  pid: number;
+  name: string;
+  cls: PlayerClass;
+  rating: number;
+  wins: number;
+  losses: number;
+}
+
+export interface BgFlagInfo {
+  state: 'home' | 'carried' | 'dropped';
+  carrierName: string | null;
+  carrierTeam: number | null; // which team is carrying it
+}
+
+export interface BgPlayerInfo {
+  pid: number;
+  name: string;
+  cls: PlayerClass;
+  team: number; // 0 = Crimson, 1 = Azure
+  carrying: boolean; // holding the enemy flag
+  dead: boolean;
+  hp: number;
+  mhp: number;
+}
+
+export interface BgMatchInfo {
+  state: 'countdown' | 'active';
+  myTeam: number;
+  capsToWin: number;
+  scores: [number, number]; // [Crimson, Azure]
+  flags: [BgFlagInfo, BgFlagInfo]; // index = flag's home team
+  players: BgPlayerInfo[];
+  respawnIn: number; // seconds until you respawn, 0 if alive
+}
+
+export interface BgInfo {
+  rating: number;
+  wins: number;
+  losses: number;
+  queued: boolean;
+  queueSize: number; // players waiting (across all groups)
+  queuedParty: number; // size of the party you queued with (1 = solo)
+  match: BgMatchInfo | null;
+  ladder: SquadLadderEntry[];
+}
 // The surface the renderer + HUD need from a game world. The offline `Sim`
 // satisfies this structurally; the online `ClientWorld` implements it by
 // mirroring server snapshots and sending commands over the socket.
@@ -80,6 +127,7 @@ export interface IWorld {
   partyInfo: PartyInfo | null;
   tradeInfo: TradeInfo | null;
   duelInfo: DuelInfo | null;
+  bgInfo: BgInfo | null;
   partyInvite(targetPid: number): void;
   partyAccept(): void;
   partyDecline(): void;
@@ -93,6 +141,8 @@ export interface IWorld {
   duelRequest(targetPid: number): void;
   duelAccept(): void;
   duelDecline(): void;
+  bgQueueJoin(): void;
+  bgQueueLeave(): void;
   enterDungeon(dungeonId: string): void;
   leaveDungeon(): void;
 }

--- a/tests/squad.test.ts
+++ b/tests/squad.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+import { isBgPos } from '../src/sim/data';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function tp(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos = { x, y: groundHeight(x, z, sim.cfg.seed), z };
+  e.prevPos = { ...e.pos };
+  (sim as any).rebucket(e);
+}
+
+// Ten solo players, queued, advanced one tick so matchmaking seats a 5v5.
+function tenInQueue(): { sim: Sim; pids: number[] } {
+  const sim = makeWorld();
+  const pids: number[] = [];
+  const classes = ['warrior', 'mage', 'priest', 'rogue', 'hunter'] as const;
+  for (let i = 0; i < 10; i++) {
+    const pid = sim.addPlayer(classes[i % 5], `P${i}`);
+    tp(sim, pid, (i % 5) * 2 - 4, -40);
+    pids.push(pid);
+  }
+  for (const pid of pids) sim.bgQueueJoin(pid);
+  sim.tick(); // matchmakeBg seats them
+  return { sim, pids };
+}
+
+function toActive(sim: Sim, match: any) {
+  for (let i = 0; i < 20 * 10 && match.state !== 'active'; i++) sim.tick();
+}
+
+describe('Ravenrift: queue + matchmaking', () => {
+  it('needs ten players; then forms two teams of five and seats them in a battleground', () => {
+    const sim = makeWorld();
+    const pids: number[] = [];
+    for (let i = 0; i < 9; i++) {
+      const pid = sim.addPlayer('warrior', `W${i}`);
+      tp(sim, pid, 0, -40);
+      pids.push(pid);
+      sim.bgQueueJoin(pid);
+    }
+    sim.tick();
+    expect(sim.bgMatchFor(pids[0])).toBe(null); // 9 isn't enough
+
+    const tenth = sim.addPlayer('mage', 'Tenth');
+    tp(sim, tenth, 0, -40);
+    sim.bgQueueJoin(tenth);
+    sim.tick();
+    const match = sim.bgMatchFor(pids[0])!;
+    expect(match).toBeTruthy();
+    expect(match.teams[0].length).toBe(5);
+    expect(match.teams[1].length).toBe(5);
+    // every fighter whisked onto the battleground sands
+    for (const pid of [...match.teams[0], ...match.teams[1]]) {
+      expect(isBgPos(sim.entities.get(pid)!.pos.x)).toBe(true);
+    }
+    expect(match.state).toBe('countdown');
+  });
+
+  it('keeps a queued party together on one team', () => {
+    const sim = makeWorld();
+    // a party of five
+    const leader = sim.addPlayer('warrior', 'Leader');
+    tp(sim, leader, 0, -40);
+    const party = [leader];
+    for (let i = 0; i < 4; i++) {
+      const m = sim.addPlayer('priest', `Mate${i}`);
+      tp(sim, m, 0, -40);
+      sim.partyInvite(m, leader);
+      sim.partyAccept(m);
+      party.push(m);
+    }
+    // plus five solos
+    const solos: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const s = sim.addPlayer('rogue', `Solo${i}`);
+      tp(sim, s, 0, -40);
+      solos.push(s);
+      sim.bgQueueJoin(s);
+    }
+    sim.bgQueueJoin(leader); // queues the whole party
+    sim.tick();
+    const match = sim.bgMatchFor(leader)!;
+    expect(match).toBeTruthy();
+    const teamOfLeader = match.teams[0].includes(leader) ? 0 : 1;
+    for (const m of party) expect(match.teams[teamOfLeader]).toContain(m);
+  });
+
+  it('refuses to queue from inside an instance', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'A');
+    tp(sim, a, 80, 88);
+    sim.enterCrypt(a);
+    sim.bgQueueJoin(a);
+    expect((sim as any).bgGroupContaining(a)).toBe(null);
+  });
+});
+
+describe('Ravenrift: flags + scoring', () => {
+  it('grab the enemy flag, run it home, score — first to five wins', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    expect(match.state).toBe('active');
+
+    const carrier = match.teams[0][0];
+    const azure = match.flags[1]; // team 0 captures the Azure flag
+    const crimsonHome = match.flags[0].home;
+
+    let ended: any = null;
+    for (let cap = 0; cap < 5 && !ended; cap++) {
+      // onto the enemy flag → pick it up
+      tp(sim, carrier, azure.home.x, azure.home.z);
+      sim.tick();
+      expect(match.flags[1].state).toBe('carried');
+      expect(match.flags[1].carrier).toBe(carrier);
+      // run it back to your own stand → capture
+      tp(sim, carrier, crimsonHome.x, crimsonHome.z);
+      const evs = sim.tick();
+      const end = evs.find((e) => e.type === 'bgEnd');
+      if (end) ended = end;
+      expect(match.scores[0]).toBe(cap + 1);
+      // captured flag resets home (unless the match just ended)
+      if (!ended) expect(match.flags[1].state).toBe('home');
+    }
+    expect(match.scores[0]).toBe(5);
+    expect(ended).toBeTruthy();
+    expect(ended.won).toBe(true); // from carrier's (team 0) perspective
+    expect(sim.bgMatchFor(carrier)).toBe(null); // cleaned up
+  });
+
+  it('dying drops the flag and queues a keep respawn (no graveyard run)', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const carrier = match.teams[0][0];
+    const azure = match.flags[1];
+    tp(sim, carrier, azure.home.x, azure.home.z);
+    sim.tick();
+    expect(match.flags[1].carrier).toBe(carrier);
+
+    const e = sim.entities.get(carrier)!;
+    (sim as any).dealDamage(null, e, 99999, false, 'physical', null, 'hit');
+    sim.tick();
+    expect(e.dead).toBe(true);
+    expect(match.flags[1].state).toBe('dropped'); // flag dropped where they fell
+    expect(match.respawn.has(carrier)).toBe(true); // timed respawn queued
+    // releasing does nothing in a battleground
+    sim.releaseSpirit(carrier);
+    expect(e.dead).toBe(true);
+  });
+
+  it('a dropped flag a teammate touches returns home', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const crimsonFlag = match.flags[0];
+    const enemy = match.teams[1][0]; // Azure steals the Crimson flag
+    tp(sim, enemy, crimsonFlag.home.x, crimsonFlag.home.z);
+    sim.tick();
+    expect(match.flags[0].state).toBe('carried');
+    // enemy dies, flag drops
+    (sim as any).dealDamage(null, sim.entities.get(enemy)!, 99999, false, 'physical', null, 'hit');
+    sim.tick();
+    expect(match.flags[0].state).toBe('dropped');
+    // a Crimson defender walks over their own dropped flag → instant return
+    const defender = match.teams[0][1];
+    const fe = sim.entities.get(match.flags[0].entityId)!;
+    tp(sim, defender, fe.pos.x, fe.pos.z);
+    sim.tick();
+    expect(match.flags[0].state).toBe('home');
+  });
+});
+
+describe('Ravenrift: speed runes + teams', () => {
+  it('stepping on a sprint rune grants haste and spends the rune', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const runner = match.teams[0][0];
+    const rune = match.runes[0];
+    expect(rune.active).toBe(true);
+    tp(sim, runner, rune.pos.x, rune.pos.z);
+    sim.tick();
+    const e = sim.entities.get(runner)!;
+    expect(e.auras.some((a) => a.kind === 'buff_speed' && a.value > 1)).toBe(true);
+    expect(match.runes[0].active).toBe(false); // consumed, now recharging
+  });
+
+  it('enemies are hostile, teammates are not', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const a = sim.entities.get(match.teams[0][0])!;
+    const mate = sim.entities.get(match.teams[0][1])!;
+    const foe = sim.entities.get(match.teams[1][0])!;
+    expect(sim.isHostileTo(a, foe)).toBe(true);
+    expect(sim.isHostileTo(a, mate)).toBe(false);
+  });
+});
+
+describe('Ravenrift: ranking + forfeit', () => {
+  it('a win moves both teams\' squad Elo and records W/L', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const winnerPid = match.teams[0][0];
+    const loserPid = match.teams[1][0];
+    const r0 = sim.meta(winnerPid)!.squadRating;
+    const rL = sim.meta(loserPid)!.squadRating;
+    const carrier = winnerPid;
+    const azure = match.flags[1];
+    const crimsonHome = match.flags[0].home;
+    for (let cap = 0; cap < 5; cap++) {
+      tp(sim, carrier, azure.home.x, azure.home.z); sim.tick();
+      tp(sim, carrier, crimsonHome.x, crimsonHome.z); sim.tick();
+    }
+    expect(sim.meta(winnerPid)!.squadRating).toBeGreaterThan(r0);
+    expect(sim.meta(loserPid)!.squadRating).toBeLessThan(rL);
+    expect(sim.meta(winnerPid)!.squadWins).toBe(1);
+    expect(sim.meta(loserPid)!.squadLosses).toBe(1);
+    // restored to the overworld where they queued
+    expect(isBgPos(sim.entities.get(winnerPid)!.pos.x)).toBe(false);
+  });
+
+  it('a team that fully disconnects forfeits the match', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const winners = [...match.teams[0]];
+    const r0 = sim.meta(winners[0])!.squadRating;
+    for (const pid of [...match.teams[1]]) sim.removePlayer(pid);
+    expect(sim.bgMatchFor(winners[0])).toBe(null);
+    expect(sim.meta(winners[0])!.squadRating).toBeGreaterThan(r0);
+    expect(sim.meta(winners[0])!.squadWins).toBe(1);
+  });
+
+  it('squad ladder sorts online players by squad rating', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Low');
+    const b = sim.addPlayer('mage', 'High');
+    sim.meta(a)!.squadRating = 1400;
+    sim.meta(b)!.squadRating = 1700;
+    expect(sim.squadLadder().map((r) => r.name)).toEqual(['High', 'Low']);
+  });
+
+  it('squad rating round-trips through CharacterState', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('druid', 'Keeper');
+    sim.meta(a)!.squadRating = 1633;
+    sim.meta(a)!.squadWins = 7;
+    const state = sim.serializeCharacter(a)!;
+    expect(state.squadRating).toBe(1633);
+    const sim2 = makeWorld();
+    const a2 = sim2.addPlayer('druid', 'Keeper', { state });
+    expect(sim2.meta(a2)!.squadRating).toBe(1633);
+    expect(sim2.meta(a2)!.squadWins).toBe(7);
+  });
+});


### PR DESCRIPTION
A team-based ranked mode: queue solo or as a party of up to 5, get matched into two teams of five on a walled open-air battleground, steal the enemy banner and run it to your keep — first to 5 captures wins. Weave the central cover to lose pursuers, grab Sprint Runes at the flag sections for a burst of speed, and respawn at your keep when you fall. A persistent squad Elo ladder tracks wins/losses; both teams' rating moves zero-sum on the result.

Built in the deterministic sim core, so it's testable and behaves identically online and offline. A far-off flat-ground instance band reuses the dungeon ground/collision path; battleground_layout.ts is the shared geometry (bases, flags, cover, rune pads) for both colliders and renderer. The open-air map is built from the same KayKit kit (courtyard floor, ramparts, keeps, cover) plus procedural team banners, flag stands, glowing rune pads, and dynamic flag/rune entities that follow their carriers.

Wired through IWorld, the online client, the server command/snapshot path, the HUD (Ravenrift panel + in-match scoreboard: scores, flag states, roster pips, keep-respawn overlay), input (H key + a rebindable action), and a /api/squad/leaderboard endpoint.

tests/squad.test.ts (12 tests): matchmaking incl. party-together and the instance guard, flag grab/capture/win, death-drops-flag + respawn, dropped-flag return, sprint runes, team hostility, team Elo, forfeit, ladder, persistence. scripts/squad_visual.mjs drives real clients through a match (dev force-start so a screenshot run needs fewer than ten browsers).

Verified: tsc clean, 246 tests pass, client + server build.