### PR TITLE
Fix v0.3 character select layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1312,7 +1312,7 @@
   #btn-toggle-controls {
     grid-row: 3;
     grid-column: 1;
-    margin-top: 28px;
+    margin-top: 12px;
     background: linear-gradient(180deg, #1b1b26 0%, #0d0d14 100%);
     color: var(--color-primary-dim);
     border: 1px solid var(--color-border-default);
@@ -1872,35 +1872,42 @@
     #offline-select {
       width: min(1160px, 96vw) !important;
       max-width: none !important;
-      height: 640px; /* Enforce stable container height */
+      height: min(640px, calc(100vh - 190px));
+      min-height: 520px;
       box-sizing: border-box;
       display: flex;
       flex-direction: column;
+      overflow: hidden;
     }
 
     #charselect-panel .auth-title,
     #offline-select .auth-title {
-      margin-bottom: var(--spacing-md);
+      margin-bottom: var(--spacing-sm);
       flex-shrink: 0;
     }
 
     .charselect-layout {
       display: grid;
       grid-template-columns: 1.1fr 0.9fr;
-      gap: 32px;
+      gap: 28px;
       flex-grow: 1;
-      height: calc(100% - 60px); /* Fill the rest of the stable panel height minus title */
+      min-height: 0;
       align-items: stretch;
     }
 
     .charselect-col-left {
       height: 100%;
       justify-content: space-between;
+      min-height: 0;
+    }
+
+    .charselect-col-right {
+      min-height: 0;
     }
 
     #charselect-panel #char-list {
-      max-height: 180px;
-      flex-grow: 0;
+      max-height: 112px;
+      flex: 0 0 auto;
     }
 
     #charselect-panel .char-create,


### PR DESCRIPTION
## Summary
- Makes the character select panels viewport-aware instead of fixed-height on desktop.
- Tightens vertical spacing so the controls button no longer overlaps the character select panel on shorter screens.
- Keeps the preview/details layout scrollable within the panel.

## Verification
- `npm run build`
- `git diff --check`