### PR TITLE
Add the Merchant and a player-driven World Market

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,45 @@
 
   /* map */
   #map-window { left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 14px; }
+
+  /* ---------- The World Market (the Merchant's auction house) ---------- */
+  #market-window { left: 50%; top: 12%; transform: translateX(-50%); width: 470px; max-height: 76%; display: flex; flex-direction: column; }
+  .mkt-tabs { display: flex; gap: 4px; margin: 2px 0 8px; }
+  .mkt-tab { flex: 1; text-align: center; font-family: var(--title-font); font-size: 12px; color: #cabb8c;
+    padding: 5px 4px; border-radius: 4px 4px 0 0; cursor: pointer; background: #ffffff08; border-bottom: 2px solid transparent; }
+  .mkt-tab:hover { background: #ffffff14; color: #ffe6a8; }
+  .mkt-tab.sel { color: var(--gold); background: #ffffff16; border-bottom-color: #cc9a3c; }
+  .mkt-tab .pip { color: #9fdc7f; font-size: 10.5px; }
+  #market-body { overflow-y: auto; flex: 1; min-height: 80px; }
+  .mkt-note { font-size: 11.5px; color: #b6ad8c; line-height: 1.45; margin: 2px 0 8px; font-family: Georgia, serif; }
+  .mkt-row { display: grid; grid-template-columns: 30px 1fr auto auto; gap: 9px; align-items: center;
+    padding: 5px 6px; border-radius: 4px; font-size: 12px; }
+  .mkt-row:hover { background: #ffffff0d; }
+  .mkt-row .mkt-name { overflow: hidden; }
+  .mkt-row .mkt-name .nm { display: block; }
+  .mkt-row .mkt-name .seller { font-size: 10.5px; color: #8c8468; }
+  .mkt-row .mkt-name .seller.house { color: #d4af37; }
+  .mkt-row .mkt-price { font-size: 11.5px; color: #ffe6a8; white-space: nowrap; text-align: right; }
+  .mkt-btn { font-family: var(--title-font); font-size: 11px; cursor: pointer; border-radius: 4px; padding: 4px 11px;
+    border: 1px solid #5a4a18; background: linear-gradient(#3a6a28, #244a18 60%, #1a3812); color: #d6ffc8; white-space: nowrap; }
+  .mkt-btn:hover { filter: brightness(1.18); }
+  .mkt-btn.cancel { background: linear-gradient(#6a3a18, #4a2810 60%, #381c0c); color: #ffd8b8; }
+  .mkt-empty { font-size: 12px; color: #887c5c; font-style: italic; padding: 10px 6px; text-align: center; }
+  .mkt-sell-pick { display: flex; gap: 10px; align-items: center; padding: 8px; border: 1px dashed #5a4a2a; border-radius: 6px; margin-bottom: 10px; }
+  .mkt-sell-pick.empty { color: #998d6a; font-size: 12px; justify-content: center; font-style: italic; }
+  .mkt-sell-pick .ps-name { font-size: 13px; }
+  .mkt-price-form { display: flex; flex-direction: column; gap: 9px; }
+  .mkt-price-row { display: flex; gap: 8px; align-items: center; font-size: 12px; color: #cabb8c; }
+  .mkt-price-row label { width: 64px; }
+  .mkt-price-row .coininput { width: 56px; background: #120d07; border: 1px solid #5a4a2a; color: #ffe6a8;
+    border-radius: 4px; padding: 4px 6px; font-family: var(--ui-font, inherit); font-size: 12px; }
+  .mkt-coin-tag { color: #998d6a; font-size: 11px; margin-right: 6px; }
+  .mkt-list-btn { font-family: var(--title-font); font-size: 13px; cursor: pointer; border-radius: 5px; padding: 8px;
+    border: 1px solid #5a4a18; background: linear-gradient(#5a4a18, #3a2f0d 55%, #2a2208); color: #ffe6a8; margin-top: 4px; }
+  .mkt-list-btn:hover { filter: brightness(1.15); }
+  .mkt-list-btn:disabled { opacity: 0.5; cursor: default; filter: none; }
+  .mkt-collect { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    padding: 8px; background: #ffffff0a; border-radius: 6px; margin-bottom: 8px; }
   #map-canvas { border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; }
 
   /* ---------- options / game menu (Esc) ---------- */
@@ -562,6 +601,7 @@
     <div id="quest-log-window" class="window panel"></div>
     <div id="vendor-window" class="window panel"></div>
     <div id="map-window" class="window panel"><canvas id="map-canvas" width="560" height="560"></canvas></div>
+    <div id="market-window" class="window panel"></div>
     <div id="options-menu" class="window panel"></div>
     <div id="meters-window" class="panel">
       <div class="panel-title">

--- a/scripts/market_mp_e2e.mjs
+++ b/scripts/market_mp_e2e.mjs
@@ -1,0 +1,140 @@
+// Online World Market end-to-end over real WebSockets, in two phases:
+//   node scripts/market_mp_e2e.mjs sell    -> two clients: seller lists, buyer
+//     sees it across the wire, earns coin at the vendor, buys it; seller (still
+//     online) is credited and collects. Seller leaves one item listed.
+//   node scripts/market_mp_e2e.mjs verify   -> after a server restart, the
+//     seller reconnects and the still-listed item is present (DB persistence).
+// Needs the game server up (:8787) with ALLOW_DEV_COMMANDS=1. A fixed MKT_UNIQ
+// env keeps the account/char names stable across the two phases.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:8787';
+const PHASE = process.argv[2] ?? 'sell';
+const UNIQ = process.env.MKT_UNIQ ?? 'demo';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fails = [];
+const check = (c, m) => { console.log(`${c ? 'OK  ' : 'FAIL'}  ${m}`); if (!c) fails.push(m); };
+const SELLER = `Sellwyn${UNIQ}`;
+const BUYER = `Buyrum${UNIQ}`;
+const PASS = 'hunter22';
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH, headless: 'new', protocolTimeout: 60000,
+  args: ['--no-sandbox', '--window-size=1280,760', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 760 },
+});
+
+async function enter(page, charName, cls, mode) {
+  page.on('pageerror', (e) => fails.push(`[${charName}] ` + e.message));
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await sleep(700);
+  await page.evaluate((u, p, btn) => {
+    document.querySelector('#btn-online').click();
+    document.querySelector('#login-user').value = u;
+    document.querySelector('#login-pass').value = p;
+    document.querySelector(btn).click();
+  }, `mkt_${charName}`, PASS, mode === 'register' ? '#btn-register' : '#btn-login');
+  await page.waitForFunction(() => document.querySelector('#charselect-panel')?.style.display === 'block', { timeout: 9000, polling: 200 });
+  if (mode === 'register') {
+    await page.evaluate((name, cls) => {
+      document.querySelector('#new-char-name').value = name;
+      document.querySelector(`#charselect-panel .mini-class[data-class="${cls}"]`).click();
+      document.querySelector('#btn-create-char').click();
+    }, charName, cls);
+    await sleep(700);
+  }
+  await page.evaluate((name) => {
+    [...document.querySelectorAll('.char-row')].find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('button')?.click();
+  }, charName);
+  await page.waitForFunction(() => window.__game?.world?.entities?.size > 5, { timeout: 20000, polling: 500 });
+  await sleep(500);
+}
+
+// teleport to the Merchant (dev) and wait until the server streams the market
+async function goToMerchant(page) {
+  await page.evaluate(() => {
+    const w = window.__game.world;
+    const m = [...w.entities.values()].find((e) => e.templateId === 'the_merchant');
+    window.__MKT = { x: m.pos.x, z: m.pos.z };
+    window.__game.online.cmd({ cmd: 'dev_teleport', x: m.pos.x, z: m.pos.z - 3 });
+  });
+  await page.waitForFunction(() => window.__game.world.marketInfo !== null, { timeout: 8000, polling: 150 });
+}
+
+if (PHASE === 'sell') {
+  const seller = await browser.newPage();
+  const buyer = await browser.newPage();
+  await enter(seller, SELLER, 'warrior', 'register');
+  await enter(buyer, BUYER, 'mage', 'register');
+  await goToMerchant(seller);
+
+  // seller lists two items: the boots will sell, the candle stays for the
+  // persistence phase
+  await seller.evaluate(() => {
+    window.__game.online.cmd({ cmd: 'dev_give', item: 'oiled_boots', count: 1 });
+    window.__game.online.cmd({ cmd: 'dev_give', item: 'tallow_candle', count: 1 });
+  });
+  await sleep(500);
+  await seller.evaluate(() => {
+    window.__game.world.marketList('oiled_boots', 1, 400);
+    window.__game.world.marketList('tallow_candle', 1, 250);
+  });
+  await sleep(500);
+
+  // buyer walks up and should see the seller's listings over the wire
+  await goToMerchant(buyer);
+  await buyer.evaluate(() => window.__game.hud.openMarket());
+  await sleep(500);
+  const seen = await buyer.evaluate((sellerName) => {
+    const ls = window.__game.world.marketInfo.listings.filter((l) => l.sellerName === sellerName);
+    return { count: ls.length, boots: ls.find((l) => l.itemId === 'oiled_boots') ?? null };
+  }, SELLER);
+  check(seen.count >= 2, `buyer sees the seller's ${seen.count} listings across the wire`);
+  await buyer.screenshot({ path: 'tmp/market_mp_buyer_sees.png' });
+
+  // buyer earns coin at Trader Wilkes, then buys the boots
+  await buyer.evaluate(() => window.__game.online.cmd({ cmd: 'dev_give', item: 'militia_vest', count: 5 }));
+  await sleep(400);
+  await buyer.evaluate(() => window.__game.online.cmd({ cmd: 'dev_teleport', x: -7, z: 3 })); // Trader Wilkes
+  await sleep(600);
+  await buyer.evaluate(() => { for (let i = 0; i < 5; i++) window.__game.world.sellItem('militia_vest'); });
+  await sleep(600);
+  const purse = await buyer.evaluate(() => window.__game.world.copper);
+  check(purse >= 400, `buyer earned coin at the vendor (${purse}c)`);
+  await goToMerchant(buyer);
+  await buyer.evaluate((id) => window.__game.world.marketBuy(id), seen.boots.id);
+  await sleep(700);
+  const bought = await buyer.evaluate(() => window.__game.sim.countItem ? null : null); // sim not on client
+  const buyerHasBoots = await buyer.evaluate(() => window.__game.world.inventory.some((s) => s.itemId === 'oiled_boots'));
+  check(buyerHasBoots, 'buyer received the Oiled Leather Boots over the wire');
+
+  // the seller, still online, was credited — collect it
+  await sleep(500);
+  const owed = await seller.evaluate(() => window.__game.world.marketInfo?.collectionCopper ?? 0);
+  check(owed === Math.floor(400 * 0.95), `seller is owed ${owed}c (400c sale less 5% cut)`);
+  await seller.evaluate(() => window.__game.hud.openMarket());
+  await sleep(300);
+  const before = await seller.evaluate(() => window.__game.world.copper);
+  await seller.evaluate(() => window.__game.world.marketCollect());
+  await sleep(600);
+  const after = await seller.evaluate(() => window.__game.world.copper);
+  check(after === before + owed, `seller collected ${owed}c into the purse (${before} -> ${after})`);
+} else {
+  // verify phase: reconnect the seller after a server restart
+  const seller = await browser.newPage();
+  await enter(seller, SELLER, 'warrior', 'login');
+  await goToMerchant(seller);
+  await seller.evaluate(() => window.__game.hud.openMarket());
+  await sleep(500);
+  const persisted = await seller.evaluate((sellerName) =>
+    window.__game.world.marketInfo.listings.some((l) => l.sellerName === sellerName && l.itemId === 'tallow_candle'), SELLER);
+  check(persisted, 'the still-listed Tallow Candle survived the server restart (DB persistence)');
+  await seller.screenshot({ path: 'tmp/market_mp_persisted.png' });
+}
+
+await browser.close();
+console.log(fails.length === 0 ? `\nPHASE "${PHASE}" PASSED` : `\n${fails.length} CHECK(S) FAILED:\n - ` + fails.join('\n - '));
+process.exit(fails.length === 0 ? 0 : 1);

--- a/scripts/market_visual.mjs
+++ b/scripts/market_visual.mjs
@@ -1,0 +1,149 @@
+// Visual + functional walkthrough of the World Market (the Merchant's auction
+// house). Boots the offline game in a headless browser, then drives the REAL
+// HUD + Sim: browse the Merchant's stock and other adventurers' listings, buy
+// an item, list one of your own, have another adventurer buy it, and collect
+// the proceeds. Screenshots land in tmp/. Run with `npm run dev` already up
+// (or it is started for you by the npm pretest wrapper / CI).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fails = [];
+const check = (cond, msg) => { console.log(`${cond ? 'OK  ' : 'FAIL'}  ${msg}`); if (!cond) fails.push(msg); };
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => fails.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE-ERR:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(200);
+await page.click('.class-card[data-class="warrior"]');
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 5, { timeout: 20000, polling: 200 });
+await sleep(1500);
+
+// --- set the scene: stand at the Merchant; stock the market from several
+// adventurers so it reads like a living world market; fill the player's bags
+// and purse so they can both buy and sell. -----------------------------------
+const scene = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const merchant = [...sim.entities.values()].find((e) => e.templateId === 'the_merchant');
+  const at = (e, x, z) => { const p = sim.groundPos(x, z); e.pos = p; e.prevPos = { ...p }; };
+
+  // the player steps up to the Merchant, facing him
+  const me = sim.player;
+  at(me, merchant.pos.x, merchant.pos.z - 3.2);
+  me.facing = 0; me.prevFacing = 0;
+  sim.players.get(me.id).copper = 50000; // 5g to shop with
+  sim.addItem('oiled_boots', 1);   // a green to list
+  sim.addItem('spider_leg', 4);    // some junk
+
+  // other adventurers consign goods to the market
+  const others = [['Brena', 'mage'], ['Tovrin', 'rogue'], ['Sella', 'priest']];
+  const ids = {};
+  for (const [name, cls] of others) {
+    const pid = sim.addPlayer(cls, name);
+    ids[name] = pid;
+    const e = sim.entities.get(pid);
+    at(e, merchant.pos.x + (Math.random() * 4 - 2), merchant.pos.z + 2 + Math.random() * 2);
+    sim.players.get(pid).copper = 100000;
+  }
+  sim.addItem('keen_dirk', 1, ids.Brena); sim.marketList('keen_dirk', 1, 4200, ids.Brena);
+  sim.addItem('roasted_boar', 5, ids.Tovrin); sim.marketList('roasted_boar', 5, 900, ids.Tovrin);
+  sim.addItem('greyjaw_pelt_cloak', 1, ids.Sella); sim.marketList('greyjaw_pelt_cloak', 1, 2600, ids.Sella);
+  sim.addItem('wolf_fang', 3, ids.Tovrin); sim.marketList('wolf_fang', 3, 120, ids.Tovrin);
+
+  return { merchant: !!merchant, name: me.name, buyerId: ids.Brena, listings: sim.marketListings.length };
+});
+check(scene.merchant, 'the Merchant exists in Eastbrook');
+check(scene.listings >= 8, `market has stock (${scene.listings} listings: house + adventurers)`);
+
+// 1) the Merchant standing at his World Market stall in the square
+await page.evaluate(() => { window.__game.input.camDist = 7.5; window.__game.input.camPitch = 0.32; });
+await sleep(900);
+await page.screenshot({ path: 'tmp/market_01_merchant.png' });
+
+// 2) open the market — the Browse tab, full of listings
+await page.evaluate(() => window.__game.hud.openMarket());
+await sleep(500);
+const browseRows = await page.evaluate(() => document.querySelectorAll('#market-body .mkt-row').length);
+check(browseRows >= 8, `Browse tab shows ${browseRows} listings`);
+await page.screenshot({ path: 'tmp/market_02_browse.png' });
+
+// 3) buy another adventurer's listing outright (click a real Buy button) and
+// confirm coin + goods move. Keen Dirk is Brena's and uniquely named.
+const beforeBuy = await page.evaluate(() => {
+  const dirk = window.__game.world.marketInfo.listings.find((l) => l.itemId === 'keen_dirk');
+  return { copper: window.__game.world.copper, dirk: window.__game.sim.countItem('keen_dirk'), price: dirk.price, seller: dirk.sellerName };
+});
+await page.evaluate(() => {
+  const row = [...document.querySelectorAll('#market-body .mkt-row')].find((r) => /Keen Dirk/.test(r.textContent) && /Buy/.test(r.textContent));
+  row.querySelector('.mkt-btn').click();
+});
+await sleep(600);
+const afterBuy = await page.evaluate(() => ({ copper: window.__game.world.copper, dirk: window.__game.sim.countItem('keen_dirk') }));
+check(afterBuy.copper === beforeBuy.copper - beforeBuy.price, `buyer paid ${beforeBuy.price}c for ${beforeBuy.seller}'s Keen Dirk (${beforeBuy.copper} -> ${afterBuy.copper})`);
+check(afterBuy.dirk === beforeBuy.dirk + 1, `buyer received the Keen Dirk (${beforeBuy.dirk} -> ${afterBuy.dirk})`);
+await page.screenshot({ path: 'tmp/market_03_bought.png' });
+
+// 4) Sell tab: pick an item from the bags and see the listing form
+await page.evaluate(() => {
+  document.querySelector('#market-window [data-tab="sell"]').click();
+  const row = [...document.querySelectorAll('#bags .bag-item')].find((r) => /Oiled Leather Boots/.test(r.textContent));
+  row.click();
+});
+await sleep(400);
+const sellForm = await page.evaluate(() => !!document.querySelector('#mkt-g'));
+check(sellForm, 'Sell tab shows the price form for the chosen item');
+await page.screenshot({ path: 'tmp/market_04_sell.png' });
+
+// 5) list it for 4s, then Browse shows it as mine (Reclaim)
+await page.evaluate(() => {
+  document.querySelector('#mkt-g').value = '0';
+  document.querySelector('#mkt-s').value = '4';
+  document.querySelector('#mkt-c').value = '0';
+  document.querySelector('.mkt-list-btn').click();
+});
+await sleep(600);
+const listed = await page.evaluate(() => {
+  window.__game.hud.openMarket(); // back to Browse
+  const mine = window.__game.world.marketInfo.listings.find((l) => l.mine && l.itemId === 'oiled_boots');
+  return { id: mine?.id ?? null, escrowed: window.__game.sim.countItem('oiled_boots') === 0 };
+});
+check(listed.id !== null, 'my Oiled Leather Boots are now listed on the market');
+check(listed.escrowed, 'the listed item left my bags (held in escrow)');
+await sleep(300);
+await page.screenshot({ path: 'tmp/market_05_listed.png' });
+
+// 6) another adventurer buys my listing; collect the proceeds (price less the cut)
+await page.evaluate((info) => {
+  window.__game.sim.marketBuy(info.id, info.buyerId);
+}, { id: listed.id, buyerId: scene.buyerId });
+await sleep(400);
+await page.evaluate(() => document.querySelector('#market-window [data-tab="collect"]').click());
+await sleep(400);
+const collectible = await page.evaluate(() => window.__game.world.marketInfo.collectionCopper);
+check(collectible === Math.floor(400 * 0.95), `proceeds waiting to collect: ${collectible}c (4s = 400c listing, less 5% cut = 380c)`);
+await page.screenshot({ path: 'tmp/market_06_collect.png' });
+
+// collect it into the purse
+const purseBefore = await page.evaluate(() => window.__game.world.copper);
+await page.evaluate(() => document.querySelector('#market-body .mkt-list-btn').click());
+await sleep(500);
+const purseAfter = await page.evaluate(() => window.__game.world.copper);
+check(purseAfter === purseBefore + collectible, `collected ${collectible}c into the purse (${purseBefore} -> ${purseAfter})`);
+await page.screenshot({ path: 'tmp/market_07_collected.png' });
+
+await browser.close();
+console.log(fails.length === 0 ? '\nALL MARKET CHECKS PASSED' : `\n${fails.length} CHECK(S) FAILED:\n - ` + fails.join('\n - '));
+process.exit(fails.length === 0 ? 0 : 1);

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,5 +1,5 @@
 import { Pool } from 'pg';
-import type { CharacterState } from '../src/sim/sim';
+import type { CharacterState, MarketSave } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
 import type { ChatLogRow } from './chat_log';
 
@@ -65,6 +65,11 @@ CREATE TABLE IF NOT EXISTS chat_logs (
 );
 CREATE INDEX IF NOT EXISTS chat_logs_created ON chat_logs(created_at);
 CREATE INDEX IF NOT EXISTS chat_logs_character ON chat_logs(character_id, created_at);
+CREATE TABLE IF NOT EXISTS world_state (
+  key TEXT PRIMARY KEY,
+  data JSONB NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -158,6 +163,33 @@ export async function saveCharacterState(characterId: number, level: number, sta
 export async function isAdminAccount(accountId: number): Promise<boolean> {
   const res = await pool.query('SELECT is_admin FROM accounts WHERE id = $1', [accountId]);
   return res.rows[0]?.is_admin === true;
+}
+
+// ---------------------------------------------------------------------------
+// World state: a tiny key→JSONB store for shared, global game state that isn't
+// tied to one character. The World Market (the Merchant's auction house) lives
+// here under the 'market' key — listings + per-seller collections.
+// ---------------------------------------------------------------------------
+
+export async function loadWorldState<T>(key: string): Promise<T | null> {
+  const res = await pool.query('SELECT data FROM world_state WHERE key = $1', [key]);
+  return (res.rows[0]?.data as T) ?? null;
+}
+
+export async function saveWorldState(key: string, data: unknown): Promise<void> {
+  await pool.query(
+    `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
+     ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+    [key, JSON.stringify(data)],
+  );
+}
+
+export async function loadMarketState(): Promise<MarketSave | null> {
+  return loadWorldState<MarketSave>('market');
+}
+
+export async function saveMarketState(save: MarketSave): Promise<void> {
+  await saveWorldState('market', save);
 }
 
 // ---------------------------------------------------------------------------

--- a/server/game.ts
+++ b/server/game.ts
@@ -4,7 +4,7 @@ import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
-import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs } from './db';
+import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, loadMarketState, saveMarketState } from './db';
 import { ChatLogger } from './chat_log';
 
 const WORLD_SEED = 20061;
@@ -277,6 +277,7 @@ export class GameServer {
       if (this.saveTimer >= AUTOSAVE_SECONDS) {
         this.saveTimer = 0;
         void this.saveAll('autosave');
+        void this.saveMarket();
       }
     }, 50);
   }
@@ -347,6 +348,23 @@ export class GameServer {
   async saveAll(reason: string): Promise<void> {
     for (const session of this.clients.values()) {
       await this.saveCharacter(session).catch((err) => console.error(`${reason} failed for ${session.name}:`, err));
+    }
+  }
+
+  // The World Market is shared global state, persisted as a single JSONB blob.
+  async loadMarket(): Promise<void> {
+    try {
+      this.sim.loadMarket(await loadMarketState());
+    } catch (err) {
+      console.error('failed to load world market:', err);
+    }
+  }
+
+  async saveMarket(): Promise<void> {
+    try {
+      await saveMarketState(this.sim.serializeMarket());
+    } catch (err) {
+      console.error('failed to save world market:', err);
     }
   }
 
@@ -501,6 +519,15 @@ export class GameServer {
       case 'duel_req': if (typeof msg.id === 'number') sim.duelRequest(msg.id, pid); break;
       case 'duel_accept': sim.duelAccept(pid); break;
       case 'duel_decline': sim.duelDecline(pid); break;
+      // World Market (the Merchant's auction house)
+      case 'market_list':
+        if (typeof msg.item === 'string' && typeof msg.count === 'number' && typeof msg.price === 'number') {
+          sim.marketList(msg.item, msg.count, msg.price, pid);
+        }
+        break;
+      case 'market_buy': if (typeof msg.id === 'number') sim.marketBuy(msg.id, pid); break;
+      case 'market_cancel': if (typeof msg.id === 'number') sim.marketCancel(msg.id, pid); break;
+      case 'market_collect': sim.marketCollect(pid); break;
       // dev/ops commands, only when ALLOW_DEV_COMMANDS=1 (never in production)
       case 'dev_level': {
         if (process.env.ALLOW_DEV_COMMANDS === '1' && typeof msg.level === 'number') {
@@ -695,6 +722,9 @@ export class GameServer {
     maybe('party', this.partyWire(session.pid));
     maybe('trade', this.tradeWire(session.pid));
     maybe('duel', this.duelWire(session.pid));
+    // market info is null unless the player is standing at the Merchant, so it
+    // only rides the wire for players actually browsing the World Market
+    maybe('market', this.sim.marketInfoFor(session.pid));
     return extra === '' ? json : json.slice(0, -1) + extra + '}';
   }
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -202,6 +202,7 @@ async function main(): Promise<void> {
   if (orphans > 0) console.log(`closed ${orphans} orphaned play session(s) from a previous run`);
   const pruned = await pruneChatLogs(CHAT_LOG_RETENTION_DAYS);
   if (pruned > 0) console.log(`pruned ${pruned} chat log row(s) older than ${CHAT_LOG_RETENTION_DAYS} days`);
+  await game.loadMarket();
   setInterval(() => {
     void pruneChatLogs(CHAT_LOG_RETENTION_DAYS).catch((err) => console.error('chat log prune failed:', err));
   }, 24 * 3600 * 1000).unref();
@@ -310,6 +311,7 @@ async function main(): Promise<void> {
     console.log('shutting down: saving characters...');
     game.stop();
     await game.saveAll('shutdown');
+    await game.saveMarket();
     await game.endAllPlaySessions();
     await game.chatLog.stop();
     await pool.end();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -6,7 +6,7 @@ import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
-import type { DuelInfo, IWorld, PartyInfo, TradeInfo } from '../world_api';
+import type { DuelInfo, IWorld, MarketInfo, PartyInfo, TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
 // REST
@@ -127,6 +127,7 @@ export class ClientWorld implements IWorld {
   partyInfo: PartyInfo | null = null;
   tradeInfo: TradeInfo | null = null;
   duelInfo: DuelInfo | null = null;
+  marketInfo: MarketInfo | null = null;
   // snapshot interpolation
   lastSnapAt = 0;
   snapInterval = 50; // ms, adapts to measured cadence
@@ -378,6 +379,7 @@ export class ClientWorld implements IWorld {
       if (s.party !== undefined) this.partyInfo = s.party;
       if (s.trade !== undefined) this.tradeInfo = s.trade;
       if (s.duel !== undefined) this.duelInfo = s.duel;
+      if (s.market !== undefined) this.marketInfo = s.market;
       // camera follows server-side facing changes when not mouselooking
       if (prevSelfFacing !== undefined && this.mouselookFacing === null) {
         let d = e.facing - prevSelfFacing;
@@ -520,6 +522,18 @@ export class ClientWorld implements IWorld {
   }
   duelDecline(): void {
     this.cmd({ cmd: 'duel_decline' });
+  }
+  marketList(itemId: string, count: number, price: number): void {
+    this.cmd({ cmd: 'market_list', item: itemId, count, price });
+  }
+  marketBuy(listingId: number): void {
+    this.cmd({ cmd: 'market_buy', id: listingId });
+  }
+  marketCancel(listingId: number): void {
+    this.cmd({ cmd: 'market_cancel', id: listingId });
+  }
+  marketCollect(): void {
+    this.cmd({ cmd: 'market_collect' });
   }
   enterDungeon(dungeonId: string): void {
     this.cmd({ cmd: 'enter_dungeon', dungeon: dungeonId });

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -145,6 +145,14 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
 // ---------------------------------------------------------------------------
 
 export const ZONE1_NPCS: Record<string, NpcDef> = {
+  the_merchant: {
+    id: 'the_merchant', name: 'The Merchant', title: 'Keeper of the World Market',
+    // centerpiece of the square, just north of the well, facing the approach
+    pos: { x: 0, z: 9.5 }, facing: Math.PI, color: 0xd4af37,
+    questIds: [],
+    market: true,
+    greeting: 'Welcome to the World Market, $C. Buy from every adventurer in the realm — or set out your own wares and let coin find you.',
+  },
   marshal_redbrook: {
     id: 'marshal_redbrook', name: 'Marshal Redbrook', title: 'Town Marshal',
     pos: { x: 4, z: 6 }, facing: Math.PI, color: 0xb7950b,
@@ -462,6 +470,7 @@ export const ZONE1_PROPS: ZonePropsDef = {
   stalls: [
     { x: -8.5, z: 3, rot: Math.PI / 2, r: 1.7 },
     { x: 9.5, z: 17.5, rot: -2.7, r: 1.7 }, // Smith Haldren's smithy stall
+    { x: 0, z: 11.5, rot: Math.PI, r: 1.8 }, // The Merchant's World Market stall
   ],
   mines: [{ x: -88, z: -68, rot: 0.8 }],
   docks: [{ x: -64, z: 60, rot: -2.2, hutLocal: { x: 2.8, z: 2.4, hw: 1.7, hd: 1.5 } }],

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -38,6 +38,14 @@ const CHAT_BURST = 8; // messages a player may send back-to-back...
 const CHAT_REFILL = 2; // ...then this many more per second (caps spam amplifiers)
 const DUEL_FORFEIT_DISTANCE = 60;
 const TRADE_RANGE = 10;
+// The World Market (the Merchant's auction house)
+const MARKET_RANGE = INTERACT_RANGE + 2; // you must stand at the Merchant to deal
+const MARKET_MAX_LISTINGS = 12; // active player listings per seller
+const MARKET_MIN_PRICE = 1; // copper
+const MARKET_MAX_PRICE = 5_000_000; // 500g ceiling — guards against overflow / fat-finger
+const MARKET_CUT = 0.05; // the Merchant's cut on a completed sale (a gold sink)
+const MARKET_LISTING_DURATION = 48 * 3600; // sim-seconds an unsold listing lingers before returning
+const MARKET_WIRE_LIMIT = 120; // most listings shipped to one client at a time
 const INSTANCE_EMPTY_TIMEOUT = 300; // seconds before an empty instance resets
 const HUNTER_RANGED_DEADZONE = 8;
 const MAX_CLIMB_SLOPE = 1.5; // rise/run above which a ground move is blocked (cliffs, world rim)
@@ -124,6 +132,41 @@ export interface PlayerMeta {
   autoEquip: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// The World Market — a single shared, server-authoritative auction house run
+// by the Merchant NPC. Listings live in the sim (so offline play has a market
+// too and the rules are testable); the server persists them to Postgres.
+// Sellers are keyed by character name, which is globally unique, so proceeds
+// and returns reach the right player even while they are offline.
+// ---------------------------------------------------------------------------
+
+export interface MarketListing {
+  id: number;
+  sellerKey: string; // stable seller identity (character name); '' for house stock
+  sellerName: string; // display name
+  itemId: string;
+  count: number;
+  price: number; // total copper buyout for the whole stack
+  expiresAt: number; // sim.time seconds; Infinity for the Merchant's own stock
+  house: boolean; // the Merchant's standing stock: never expires, never depletes, pays no one
+}
+
+// Gold + items awaiting pickup at the Merchant (sale proceeds, expired
+// listings), keyed by seller name so an offline seller can collect later.
+export interface MarketCollection {
+  copper: number;
+  items: InvSlot[];
+}
+
+// Persistable market state. `secondsLeft` is stored instead of an absolute
+// expiry because sim.time resets to 0 each server boot — on load it becomes
+// `this.time + secondsLeft`, so a restart never silently expires everything.
+export interface MarketSave {
+  listings: { id: number; sellerKey: string; sellerName: string; itemId: string; count: number; price: number; secondsLeft: number }[];
+  collections: { key: string; copper: number; items: InvSlot[] }[];
+  nextListingId: number;
+}
+
 // Persistable character state (stored as JSONB server-side).
 export interface CharacterState {
   level: number;
@@ -191,6 +234,12 @@ export class Sim {
   private chatTokens = new Map<number, { tokens: number; at: number }>();
   // dungeon instances
   instances: InstanceSlot[] = [];
+  // the World Market: one shared listing book, per-seller collections keyed by
+  // character name, and the Merchant entity these are anchored to
+  marketListings: MarketListing[] = [];
+  private marketCollections = new Map<string, MarketCollection>();
+  private nextListingId = 1;
+  private merchantId = -1;
 
   constructor(cfg: SimConfig) {
     this.cfg = {
@@ -207,7 +256,9 @@ export class Sim {
       const safe = this.findSafePos(npcDef.pos.x, npcDef.pos.z, WATER_LEVEL + 0.6);
       const npc = createNpc(this.nextId++, npcDef, this.groundPos(safe.x, safe.z));
       this.addEntity(npc);
+      if (npcDef.market) this.merchantId = npc.id; // the World Market is anchored here
     }
+    this.seedHouseListings();
 
     // Mobs from camps
     for (const camp of CAMPS) {
@@ -592,6 +643,7 @@ export class Sim {
     this.updateDuels();
     this.updateTradesAndInvites();
     this.updateInstances();
+    this.updateMarket();
 
     // movement re-bucketing: queries during the next tick and the server's
     // snapshot broadcast right after this one see fresh cells
@@ -2994,6 +3046,225 @@ export class Sim {
   }
 
   // -------------------------------------------------------------------------
+  // The World Market — the Merchant's auction house
+  // -------------------------------------------------------------------------
+
+  private merchantEntity(): Entity | null {
+    const e = this.entities.get(this.merchantId);
+    return e && e.kind === 'npc' ? e : null;
+  }
+
+  private nearMerchant(e: Entity): boolean {
+    const m = this.merchantEntity();
+    return !!m && dist2d(e.pos, m.pos) <= MARKET_RANGE;
+  }
+
+  private metaByName(name: string): PlayerMeta | null {
+    if (!name) return null;
+    for (const m of this.players.values()) if (m.name === name) return m;
+    return null;
+  }
+
+  private collectionFor(key: string): MarketCollection {
+    let c = this.marketCollections.get(key);
+    if (!c) { c = { copper: 0, items: [] }; this.marketCollections.set(key, c); }
+    return c;
+  }
+
+  // The Merchant always keeps a little stock so the market is never empty —
+  // standing consignments that never expire, never deplete, and pay no one.
+  private seedHouseListings(): void {
+    const stock: { itemId: string; count: number; price: number }[] = [
+      { itemId: 'roasted_boar', count: 5, price: 700 },
+      { itemId: 'spring_water', count: 5, price: 160 },
+      { itemId: 'oiled_boots', count: 1, price: 1900 },
+      { itemId: 'quilted_trousers', count: 1, price: 2400 },
+      { itemId: 'greyjaw_pelt_cloak', count: 1, price: 2900 },
+    ];
+    for (const s of stock) {
+      if (!ITEMS[s.itemId]) continue;
+      this.marketListings.push({
+        id: this.nextListingId++, sellerKey: '', sellerName: 'The Merchant',
+        itemId: s.itemId, count: s.count, price: s.price, expiresAt: Infinity, house: true,
+      });
+    }
+  }
+
+  // List a stack from your bags for sale. The goods are escrowed (pulled from
+  // your bags immediately) and held by the Merchant until bought or reclaimed.
+  marketList(itemId: string, count: number, price: number, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta, e: p } = r;
+    if (p.dead) return;
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You must bring your goods to the Merchant.'); return; }
+    const def = ITEMS[itemId];
+    if (!def) return;
+    if (def.kind === 'quest') { this.error(meta.entityId, 'The Merchant will not broker quest items.'); return; }
+    const want = Math.max(1, Math.floor(count));
+    if (this.countItem(itemId, meta.entityId) < want) { this.error(meta.entityId, 'You do not have that many to sell.'); return; }
+    const ask = Math.floor(price);
+    if (!Number.isFinite(ask) || ask < MARKET_MIN_PRICE) { this.error(meta.entityId, 'Name a price of at least 1 copper.'); return; }
+    if (ask > MARKET_MAX_PRICE) { this.error(meta.entityId, 'That price is beyond what the Merchant will broker.'); return; }
+    const mine = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
+    if (mine >= MARKET_MAX_LISTINGS) { this.error(meta.entityId, `You may keep at most ${MARKET_MAX_LISTINGS} goods on the market at once.`); return; }
+    this.removeItem(itemId, want, meta.entityId); // escrow
+    this.marketListings.push({
+      id: this.nextListingId++, sellerKey: meta.name, sellerName: meta.name,
+      itemId, count: want, price: ask, expiresAt: this.time + MARKET_LISTING_DURATION, house: false,
+    });
+    this.emit({ type: 'loot', text: `Listed ${def.name}${want > 1 ? ' x' + want : ''} on the World Market for ${formatMoney(ask)}.`, pid: meta.entityId });
+  }
+
+  // Buy a listing outright. Coin leaves the buyer, goods enter their bags, and
+  // the seller's proceeds (less the Merchant's cut) wait in their collection.
+  marketBuy(listingId: number, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta, e: p } = r;
+    if (p.dead) return;
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
+    const idx = this.marketListings.findIndex((l) => l.id === listingId);
+    if (idx < 0) { this.error(meta.entityId, 'That listing is no longer available.'); return; }
+    const listing = this.marketListings[idx];
+    const def = ITEMS[listing.itemId];
+    if (!def) { this.marketListings.splice(idx, 1); return; }
+    if (!listing.house && listing.sellerKey === meta.name) {
+      this.error(meta.entityId, 'That is your own listing — cancel it to reclaim it.');
+      return;
+    }
+    if (meta.copper < listing.price) { this.error(meta.entityId, 'You cannot afford that.'); return; }
+    meta.copper -= listing.price;
+    this.addItem(listing.itemId, listing.count, meta.entityId);
+    if (!listing.house) {
+      const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
+      this.collectionFor(listing.sellerKey).copper += proceeds;
+      this.marketListings.splice(idx, 1);
+      const sellerMeta = this.metaByName(listing.sellerKey);
+      if (sellerMeta) {
+        this.emit({ type: 'loot', text: `${meta.name} bought your ${def.name} for ${formatMoney(listing.price)} — collect ${formatMoney(proceeds)} from the Merchant.`, pid: sellerMeta.entityId });
+      }
+    }
+    this.emit({ type: 'loot', text: `Bought ${def.name}${listing.count > 1 ? ' x' + listing.count : ''} for ${formatMoney(listing.price)}.`, pid: meta.entityId });
+  }
+
+  // Reclaim your own listing; the escrowed goods go straight back to your bags.
+  marketCancel(listingId: number, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta, e: p } = r;
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
+    const idx = this.marketListings.findIndex((l) => l.id === listingId);
+    if (idx < 0) return;
+    const listing = this.marketListings[idx];
+    if (listing.house || listing.sellerKey !== meta.name) { this.error(meta.entityId, 'That is not your listing.'); return; }
+    this.marketListings.splice(idx, 1);
+    this.addItem(listing.itemId, listing.count, meta.entityId);
+    const def = ITEMS[listing.itemId];
+    this.emit({ type: 'loot', text: `Reclaimed ${def?.name ?? listing.itemId}${listing.count > 1 ? ' x' + listing.count : ''} from the market.`, pid: meta.entityId });
+  }
+
+  // Take everything waiting for you at the Merchant: sale gold and any items
+  // returned from expired listings.
+  marketCollect(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta, e: p } = r;
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
+    const col = this.marketCollections.get(meta.name);
+    if (!col || (col.copper <= 0 && col.items.length === 0)) { this.error(meta.entityId, 'You have nothing to collect.'); return; }
+    if (col.copper > 0) {
+      meta.copper += col.copper;
+      this.emit({ type: 'loot', text: `You collect ${formatMoney(col.copper)} from the Merchant.`, pid: meta.entityId });
+    }
+    for (const s of col.items) this.addItem(s.itemId, s.count, meta.entityId);
+    this.marketCollections.delete(meta.name);
+  }
+
+  // Once a second: return expired player listings to their seller's collection.
+  private updateMarket(): void {
+    if (this.tickCount % 20 !== 0) return;
+    for (let i = this.marketListings.length - 1; i >= 0; i--) {
+      const l = this.marketListings[i];
+      if (l.house || this.time < l.expiresAt) continue;
+      this.marketListings.splice(i, 1);
+      this.collectionFor(l.sellerKey).items.push({ itemId: l.itemId, count: l.count });
+      const sellerMeta = this.metaByName(l.sellerKey);
+      if (sellerMeta) {
+        const def = ITEMS[l.itemId];
+        this.emit({ type: 'log', text: `Your market listing of ${def?.name ?? l.itemId} expired and waits at the Merchant.`, color: '#caa472', pid: sellerMeta.entityId });
+      }
+    }
+  }
+
+  marketInfoFor(pid: number): import('../world_api').MarketInfo | null {
+    const meta = this.players.get(pid);
+    const e = this.entities.get(pid);
+    if (!meta || !e) return null;
+    // the World Market is a place you visit — only stream it while standing by
+    // the Merchant, which also bounds the per-snapshot wire cost
+    if (!this.nearMerchant(e)) return null;
+    const sorted = [...this.marketListings].sort((a, b) => {
+      const na = ITEMS[a.itemId]?.name ?? a.itemId;
+      const nb = ITEMS[b.itemId]?.name ?? b.itemId;
+      return na.localeCompare(nb) || a.price - b.price;
+    });
+    const listings = sorted.slice(0, MARKET_WIRE_LIMIT).map((l) => ({
+      id: l.id, sellerName: l.sellerName, itemId: l.itemId, count: l.count,
+      price: l.price, mine: !l.house && l.sellerKey === meta.name, house: l.house,
+    }));
+    const col = this.marketCollections.get(meta.name);
+    const myListingCount = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
+    return {
+      listings,
+      collectionCopper: col?.copper ?? 0,
+      collectionItems: col ? col.items.map((s) => ({ ...s })) : [],
+      cutPct: Math.round(MARKET_CUT * 100),
+      maxListings: MARKET_MAX_LISTINGS,
+      myListingCount,
+    };
+  }
+
+  // Persist only player listings + collections; house stock is reseeded each
+  // boot so content edits take effect. secondsLeft survives the time reset.
+  serializeMarket(): MarketSave {
+    return {
+      listings: this.marketListings.filter((l) => !l.house).map((l) => ({
+        id: l.id, sellerKey: l.sellerKey, sellerName: l.sellerName, itemId: l.itemId,
+        count: l.count, price: l.price,
+        secondsLeft: Number.isFinite(l.expiresAt) ? Math.max(0, Math.round(l.expiresAt - this.time)) : MARKET_LISTING_DURATION,
+      })),
+      collections: [...this.marketCollections.entries()].map(([key, c]) => ({
+        key, copper: c.copper, items: c.items.map((s) => ({ ...s })),
+      })),
+      nextListingId: this.nextListingId,
+    };
+  }
+
+  loadMarket(save: MarketSave | null | undefined): void {
+    if (!save) return;
+    for (const l of save.listings ?? []) {
+      if (!l || typeof l.itemId !== 'string' || !ITEMS[l.itemId]) continue;
+      this.marketListings.push({
+        id: l.id, sellerKey: String(l.sellerKey ?? ''), sellerName: String(l.sellerName ?? l.sellerKey ?? '?'),
+        itemId: l.itemId, count: Math.max(1, l.count | 0),
+        price: Math.max(MARKET_MIN_PRICE, Math.min(MARKET_MAX_PRICE, Math.floor(l.price) || MARKET_MIN_PRICE)),
+        expiresAt: this.time + (Number.isFinite(l.secondsLeft) ? Math.max(0, l.secondsLeft) : MARKET_LISTING_DURATION),
+        house: false,
+      });
+    }
+    for (const c of save.collections ?? []) {
+      if (!c || typeof c.key !== 'string') continue;
+      this.marketCollections.set(c.key, {
+        copper: Math.max(0, Math.floor(c.copper) || 0),
+        items: (c.items ?? []).filter((s) => s && ITEMS[s.itemId]).map((s) => ({ itemId: s.itemId, count: Math.max(1, s.count | 0) })),
+      });
+    }
+    const maxId = this.marketListings.reduce((m, l) => Math.max(m, l.id + 1), 1);
+    this.nextListingId = Math.max(this.nextListingId, save.nextListingId ?? 1, maxId);
+  }
+
+  // -------------------------------------------------------------------------
   // Dungeons: party-instanced elite content (the Hollow Crypt and friends)
   // -------------------------------------------------------------------------
 
@@ -3192,6 +3463,10 @@ export class Sim {
     if (!d) return null;
     const otherPid = d.a === this.primaryId ? d.b : d.a;
     return { otherPid, otherName: this.players.get(otherPid)?.name ?? '?', state: d.state };
+  }
+
+  get marketInfo(): import('../world_api').MarketInfo | null {
+    return this.primaryId === -1 ? null : this.marketInfoFor(this.primaryId);
   }
 
   instanceSlotAt(pos: Vec3): number | null {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -210,6 +210,9 @@ export interface NpcDef {
   color: number;
   questIds: string[];
   vendorItems?: string[];
+  // The Merchant: talking to this NPC opens the player-driven World Market
+  // (auction house) instead of a fixed vendor stock.
+  market?: boolean;
   greeting: string;
 }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1,5 +1,5 @@
 import { formatMoney, ResolvedAbility } from '../sim/sim';
-import type { IWorld } from '../world_api';
+import type { IWorld, MarketInfo } from '../world_api';
 import { Renderer } from '../render/renderer';
 import {
   ABILITIES, CLASSES, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, MOBS, NPCS, QUESTS,
@@ -69,6 +69,11 @@ export class Hud {
   private tradeWasOpen = false;
   private lastTradeSig = '';
   private lastPartySig = '';
+  // World Market (the Merchant's auction house)
+  private marketOpen = false;
+  private marketTab: 'browse' | 'sell' | 'collect' = 'browse';
+  private marketSellItem: string | null = null; // bag item staged for listing
+  private lastMarketSig = '';
   private lastCombatEventAt = 0;
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
@@ -560,6 +565,10 @@ export class Hud {
     if (this.openVendorNpcId !== null) {
       const npc = sim.entities.get(this.openVendorNpcId);
       if (!npc || dist2d(p.pos, npc.pos) > 8) this.closeVendor();
+    }
+    if (this.marketOpen) {
+      if (!this.nearbyMarketNpc()) this.closeMarket();
+      else this.refreshMarket();
     }
   }
 
@@ -1076,6 +1085,9 @@ export class Hud {
     if (npc.vendorItems.length > 0) {
       html += `<div class="qd-list-item" data-vendor="1"><span style="color:#9fdc7f">$</span> Let me browse your goods.</div>`;
     }
+    if (def?.market) {
+      html += `<div class="qd-list-item" data-market="1"><span style="color:#ffd24a">⚖</span> Show me the World Market.</div>`;
+    }
     el.innerHTML = html;
     el.querySelectorAll('[data-quest]').forEach((item) => {
       item.addEventListener('click', () => this.renderQuestDetail(npc, (item as HTMLElement).dataset.quest!));
@@ -1083,6 +1095,10 @@ export class Hud {
     el.querySelector('[data-vendor]')?.addEventListener('click', () => {
       this.closeQuestDialog();
       this.openVendor(npc.id);
+    });
+    el.querySelector('[data-market]')?.addEventListener('click', () => {
+      this.closeQuestDialog();
+      this.openMarket();
     });
     el.querySelector('[data-close]')?.addEventListener('click', () => this.closeQuestDialog());
     el.style.display = 'block';
@@ -1242,6 +1258,210 @@ export class Hud {
   }
 
   // -------------------------------------------------------------------------
+  // The World Market — the Merchant's auction house
+  // -------------------------------------------------------------------------
+
+  openMarket(): void {
+    this.marketOpen = true;
+    this.marketTab = 'browse';
+    this.marketSellItem = null;
+    this.lastMarketSig = '';
+    this.renderMarket();
+    $('#market-window').style.display = 'flex';
+    // bags ride alongside so you can click items straight onto the Sell tab
+    this.renderBags();
+    $('#bags').style.display = 'block';
+    audio.bagOpen();
+  }
+
+  closeMarket(): void {
+    if (!this.marketOpen) return;
+    this.marketOpen = false;
+    this.marketSellItem = null;
+    $('#market-window').style.display = 'none';
+    this.hideTooltip();
+    if ($('#bags').style.display === 'block') this.renderBags();
+  }
+
+  get marketWindowOpen(): boolean {
+    return this.marketOpen;
+  }
+
+  private nearbyMarketNpc(): Entity | null {
+    const p = this.sim.player;
+    for (const e of this.sim.entities.values()) {
+      if (e.kind === 'npc' && NPCS[e.templateId]?.market && dist2d(p.pos, e.pos) <= 8) return e;
+    }
+    return null;
+  }
+
+  private bagCount(itemId: string): number {
+    return this.sim.inventory.filter((s) => s.itemId === itemId).reduce((n, s) => n + s.count, 0);
+  }
+
+  private renderMarket(): void {
+    const el = $('#market-window');
+    this.hideTooltip();
+    const info = this.sim.marketInfo;
+    const collectN = info ? (info.collectionCopper > 0 ? 1 : 0) + info.collectionItems.length : 0;
+    const tab = (id: typeof this.marketTab, label: string, pip = '') =>
+      `<div class="mkt-tab${this.marketTab === id ? ' sel' : ''}" data-tab="${id}">${label}${pip}</div>`;
+    el.innerHTML =
+      `<div class="panel-title"><span>The World Market <span style="color:#998d6a;font-size:11px">— the Merchant's exchange</span></span><span class="x-btn" data-close>✕</span></div>`
+      + `<div class="mkt-tabs">`
+      + tab('browse', 'Browse')
+      + tab('sell', 'Sell')
+      + tab('collect', 'Collect', collectN > 0 ? ` <span class="pip">(${collectN})</span>` : '')
+      + `</div>`
+      + `<div id="market-body"></div>`;
+    el.querySelector('[data-close]')?.addEventListener('click', () => this.closeMarket());
+    el.querySelectorAll('[data-tab]').forEach((t) => {
+      t.addEventListener('click', () => {
+        const next = (t as HTMLElement).dataset.tab as typeof this.marketTab;
+        if (next === this.marketTab) return;
+        this.marketTab = next;
+        this.lastMarketSig = '';
+        audio.click();
+        this.renderMarket();
+      });
+    });
+    this.renderMarketContent(info);
+  }
+
+  // Per-frame: refresh the live lists (Browse/Collect) when they change. The
+  // Sell tab holds typed inputs, so it is only rebuilt on explicit actions.
+  private refreshMarket(): void {
+    if (!this.marketOpen || this.marketTab === 'sell') return;
+    const info = this.sim.marketInfo;
+    const collectN = info ? (info.collectionCopper > 0 ? 1 : 0) + info.collectionItems.length : 0;
+    const sig = JSON.stringify([this.marketTab, info?.listings, info?.collectionCopper, info?.collectionItems]);
+    if (sig === this.lastMarketSig) return;
+    this.lastMarketSig = sig;
+    const collectTab = $('#market-window').querySelector('[data-tab="collect"]');
+    if (collectTab) collectTab.innerHTML = `Collect${collectN > 0 ? ` <span class="pip">(${collectN})</span>` : ''}`;
+    this.renderMarketContent(info);
+  }
+
+  private renderMarketContent(info: MarketInfo | null): void {
+    const body = document.getElementById('market-body');
+    if (!body) return;
+    if (!info) { body.innerHTML = `<div class="mkt-empty">Step up to the Merchant to deal.</div>`; return; }
+    if (this.marketTab === 'browse') this.renderMarketBrowse(body, info);
+    else if (this.marketTab === 'sell') this.renderMarketSell(body, info);
+    else this.renderMarketCollect(body, info);
+  }
+
+  private renderMarketBrowse(body: HTMLElement, info: MarketInfo): void {
+    if (info.listings.length === 0) {
+      body.innerHTML = `<div class="mkt-empty">The market is quiet. Be the first — list something on the Sell tab.</div>`;
+      return;
+    }
+    body.innerHTML = `<div class="mkt-note">Goods listed by adventurers across the realm. Click Buy to purchase a stack outright.</div>`;
+    for (const l of info.listings) {
+      const item = ITEMS[l.itemId];
+      if (!item) continue;
+      const qColor = QUALITY_COLOR[item.quality ?? 'common'] ?? '#fff';
+      const row = document.createElement('div');
+      row.className = 'mkt-row';
+      const each = l.count > 1 ? `<br><span class="seller">${formatMoney(Math.ceil(l.price / l.count))} each</span>` : '';
+      row.innerHTML =
+        `${this.itemIcon(item)}`
+        + `<span class="mkt-name"><span class="nm" style="color:${qColor}">${item.name}${l.count > 1 ? ' <span style="color:#ccc">x' + l.count + '</span>' : ''}</span>`
+        + `<span class="seller${l.house ? ' house' : ''}">${l.house ? "Merchant's stock" : l.sellerName}</span></span>`
+        + `<span class="mkt-price">${this.moneyHtml(l.price)}${each}</span>`;
+      const btn = document.createElement('button');
+      btn.className = 'mkt-btn' + (l.mine ? ' cancel' : '');
+      btn.textContent = l.mine ? 'Reclaim' : 'Buy';
+      btn.addEventListener('click', () => {
+        if (l.mine) this.sim.marketCancel(l.id);
+        else this.sim.marketBuy(l.id);
+        audio.click();
+      });
+      row.appendChild(btn);
+      this.attachTooltip(row, () => this.itemTooltip(item));
+      body.appendChild(row);
+    }
+  }
+
+  private renderMarketSell(body: HTMLElement, info: MarketInfo): void {
+    body.innerHTML = `<div class="mkt-note">List goods from your bags. The Merchant takes a ${info.cutPct}% cut when an item sells. You are using ${info.myListingCount}/${info.maxListings} listing slots.</div>`;
+    const item = this.marketSellItem ? ITEMS[this.marketSellItem] : null;
+    const have = this.marketSellItem ? this.bagCount(this.marketSellItem) : 0;
+    const pick = document.createElement('div');
+    if (!item || have <= 0) {
+      pick.className = 'mkt-sell-pick empty';
+      pick.textContent = 'Click an item in your bags to choose what to sell.';
+      body.appendChild(pick);
+      return;
+    }
+    const qColor = QUALITY_COLOR[item.quality ?? 'common'] ?? '#fff';
+    pick.className = 'mkt-sell-pick';
+    pick.innerHTML = `${this.itemIcon(item)}<span class="ps-name" style="color:${qColor}">${item.name}</span>`;
+    body.appendChild(pick);
+
+    const form = document.createElement('div');
+    form.className = 'mkt-price-form';
+    const qtyRow = have > 1
+      ? `<div class="mkt-price-row"><label>Quantity</label><input class="coininput" id="mkt-qty" type="number" min="1" max="${have}" value="1"> <span class="mkt-coin-tag">of ${have}</span></div>`
+      : '';
+    // a gentle starting ask: a few times vendor value, never below 1c
+    const suggested = Math.max(1, item.buyValue ?? Math.max(1, item.sellValue) * 4);
+    const g = Math.floor(suggested / 10000), s = Math.floor((suggested % 10000) / 100), c = suggested % 100;
+    form.innerHTML = qtyRow
+      + `<div class="mkt-price-row"><label>Price each</label>`
+      + `<input class="coininput" id="mkt-g" type="number" min="0" value="${g}"><span class="mkt-coin-tag">g</span>`
+      + `<input class="coininput" id="mkt-s" type="number" min="0" max="99" value="${s}"><span class="mkt-coin-tag">s</span>`
+      + `<input class="coininput" id="mkt-c" type="number" min="0" max="99" value="${c}"><span class="mkt-coin-tag">c</span></div>`;
+    body.appendChild(form);
+
+    const listBtn = document.createElement('button');
+    listBtn.className = 'mkt-list-btn';
+    listBtn.textContent = 'List on the World Market';
+    listBtn.addEventListener('click', () => {
+      const qty = have > 1 ? Math.max(1, Math.min(have, parseInt(($('#mkt-qty') as HTMLInputElement)?.value || '1', 10) || 1)) : 1;
+      const gg = Math.max(0, parseInt(($('#mkt-g') as HTMLInputElement)?.value || '0', 10) || 0);
+      const ss = Math.max(0, parseInt(($('#mkt-s') as HTMLInputElement)?.value || '0', 10) || 0);
+      const cc = Math.max(0, parseInt(($('#mkt-c') as HTMLInputElement)?.value || '0', 10) || 0);
+      const each = gg * 10000 + ss * 100 + cc;
+      if (each < 1) { this.showError('Name a price of at least 1 copper.'); return; }
+      this.sim.marketList(this.marketSellItem!, qty, each * qty);
+      this.marketSellItem = null;
+      audio.coin();
+      this.renderMarket(); // the next snapshot echoes the new bags + listings
+    });
+    body.appendChild(listBtn);
+  }
+
+  private renderMarketCollect(body: HTMLElement, info: MarketInfo): void {
+    if (info.collectionCopper <= 0 && info.collectionItems.length === 0) {
+      body.innerHTML = `<div class="mkt-empty">Nothing waiting. Sale proceeds and expired listings collect here.</div>`;
+      return;
+    }
+    body.innerHTML = `<div class="mkt-note">Earnings and returned goods the Merchant is holding for you.</div>`;
+    if (info.collectionCopper > 0) {
+      const row = document.createElement('div');
+      row.className = 'mkt-collect';
+      row.innerHTML = `<span>Sale proceeds</span><span class="mkt-price">${this.moneyHtml(info.collectionCopper)}</span>`;
+      body.appendChild(row);
+    }
+    for (const s of info.collectionItems) {
+      const item = ITEMS[s.itemId];
+      if (!item) continue;
+      const qColor = QUALITY_COLOR[item.quality ?? 'common'] ?? '#fff';
+      const row = document.createElement('div');
+      row.className = 'mkt-collect';
+      row.innerHTML = `<span style="display:flex;gap:8px;align-items:center">${this.itemIcon(item)}<span style="color:${qColor}">${item.name}${s.count > 1 ? ' x' + s.count : ''}</span></span>`;
+      this.attachTooltip(row, () => this.itemTooltip(item));
+      body.appendChild(row);
+    }
+    const btn = document.createElement('button');
+    btn.className = 'mkt-list-btn';
+    btn.textContent = 'Collect All';
+    btn.addEventListener('click', () => { this.sim.marketCollect(); audio.coin(); });
+    body.appendChild(btn);
+  }
+
+  // -------------------------------------------------------------------------
   // Bags
   // -------------------------------------------------------------------------
 
@@ -1278,6 +1498,10 @@ export class Hud {
       row.addEventListener('click', () => {
         if (this.tradeOpen) {
           this.addItemToTrade(s.itemId);
+        } else if (this.marketOpen && this.marketTab === 'sell') {
+          if (item.kind === 'quest') { this.showError('The Merchant will not broker quest items.'); return; }
+          this.marketSellItem = s.itemId;
+          this.renderMarket();
         } else if (this.vendorOpen) {
           this.sim.sellItem(s.itemId);
         } else {
@@ -1288,6 +1512,7 @@ export class Hud {
       this.attachTooltip(row, () => {
         let extra = '';
         if (this.tradeOpen) extra = '<div class="tt-sub">Click to offer in trade</div>';
+        else if (this.marketOpen && this.marketTab === 'sell') extra = item.kind === 'quest' ? '<div class="tt-sub">Cannot be sold on the market</div>' : '<div class="tt-sub">Click to put on the market</div>';
         else if (this.vendorOpen) extra = '<div class="tt-sub">Click to sell</div>';
         else if (item.kind === 'weapon' || item.kind === 'armor') extra = '<div class="tt-sub">Click to equip</div>';
         else if (item.kind === 'food' || item.kind === 'drink') extra = '<div class="tt-sub">Click to consume</div>';
@@ -1917,6 +2142,7 @@ export class Hud {
       this.sim.tradeCancel();
       closed = true;
     }
+    if (this.marketOpen) { this.closeMarket(); closed = true; }
     for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window']) {
       const el = $(id);
       if (el.style.display === 'block') {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -41,6 +41,32 @@ export interface DuelInfo {
   state: 'countdown' | 'active';
 }
 
+// ---------------------------------------------------------------------------
+// The World Market (the Merchant's auction house). Listings are global and
+// shared by every player; collections are the per-player gold + items waiting
+// to be picked up (sale proceeds, expired/returned listings).
+// ---------------------------------------------------------------------------
+
+export interface MarketListingView {
+  id: number;
+  sellerName: string;
+  itemId: string;
+  count: number;
+  price: number; // total copper buyout for the whole stack
+  mine: boolean; // the viewer is the seller (offer them Cancel, not Buy)
+  house: boolean; // the Merchant's own standing stock
+}
+
+export interface MarketInfo {
+  listings: MarketListingView[];
+  collectionCopper: number; // proceeds waiting to be collected
+  collectionItems: InvSlot[]; // returned/expired items waiting to be collected
+  cutPct: number; // the Merchant's cut on a sale, as a percentage
+  maxListings: number; // per-seller active-listing cap
+  myListingCount: number; // how many active listings the viewer already has
+}
+
+
 // The surface the renderer + HUD need from a game world. The offline `Sim`
 // satisfies this structurally; the online `ClientWorld` implements it by
 // mirroring server snapshots and sending commands over the socket.
@@ -80,6 +106,7 @@ export interface IWorld {
   partyInfo: PartyInfo | null;
   tradeInfo: TradeInfo | null;
   duelInfo: DuelInfo | null;
+  marketInfo: MarketInfo | null;
   partyInvite(targetPid: number): void;
   partyAccept(): void;
   partyDecline(): void;
@@ -93,6 +120,11 @@ export interface IWorld {
   duelRequest(targetPid: number): void;
   duelAccept(): void;
   duelDecline(): void;
+  // World Market
+  marketList(itemId: string, count: number, price: number): void;
+  marketBuy(listingId: number): void;
+  marketCancel(listingId: number): void;
+  marketCollect(): void;
   enterDungeon(dungeonId: string): void;
   leaveDungeon(): void;
 }

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function merchant(sim: Sim): Entity {
+  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') return e;
+  throw new Error('the Merchant was not spawned');
+}
+
+// stand a player right on the Merchant so the proximity gate passes
+function standAtMerchant(sim: Sim, pid: number) {
+  const m = merchant(sim);
+  const e = sim.entities.get(pid)!;
+  e.pos.x = m.pos.x; e.pos.z = m.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function copperOf(sim: Sim, pid: number): number {
+  return sim.players.get(pid)!.copper;
+}
+
+function errorsSince(sim: Sim): string[] {
+  return sim.events.filter((e) => e.type === 'error').map((e) => (e as { text: string }).text);
+}
+
+describe('the World Market — the Merchant', () => {
+  it('spawns a single Merchant who keeps standing house stock', () => {
+    const sim = makeWorld();
+    const merchants = [...sim.entities.values()].filter((e) => e.templateId === 'the_merchant');
+    expect(merchants.length).toBe(1);
+    const house = sim.marketListings.filter((l) => l.house);
+    expect(house.length).toBeGreaterThan(0);
+    expect(house.every((l) => l.expiresAt === Infinity && l.sellerKey === '')).toBe(true);
+  });
+
+  it('lists a stack from a seller\'s bags into escrow', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 3, seller);
+    sim.events.length = 0;
+
+    sim.marketList('wolf_fang', 2, 100, seller);
+
+    expect(errorsSince(sim)).toEqual([]);
+    expect(sim.countItem('wolf_fang', seller)).toBe(1); // 2 escrowed
+    const mine = sim.marketListings.filter((l) => l.sellerKey === 'Seller');
+    expect(mine.length).toBe(1);
+    expect(mine[0]).toMatchObject({ itemId: 'wolf_fang', count: 2, price: 100, house: false });
+    expect(Number.isFinite(mine[0].expiresAt)).toBe(true);
+  });
+
+  it('completes a sale: coin and goods move, seller keeps proceeds less the cut', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 2, seller);
+    sim.players.get(buyer)!.copper = 1000;
+    sim.marketList('wolf_fang', 2, 100, seller);
+    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    sim.events.length = 0;
+
+    sim.marketBuy(listing.id, buyer);
+
+    expect(errorsSince(sim)).toEqual([]);
+    expect(copperOf(sim, buyer)).toBe(900);
+    expect(sim.countItem('wolf_fang', buyer)).toBe(2);
+    expect(sim.marketListings.some((l) => l.id === listing.id)).toBe(false);
+    // 5% cut: seller is owed 95, waiting to be collected
+    const info = sim.marketInfoFor(seller)!;
+    expect(info.collectionCopper).toBe(95);
+  });
+
+  it('collecting moves waiting gold into the seller\'s purse', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.players.get(buyer)!.copper = 500;
+    sim.marketList('wolf_fang', 1, 200, seller);
+    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'Seller')!.id, buyer);
+    expect(copperOf(sim, seller)).toBe(0);
+
+    sim.marketCollect(seller);
+
+    expect(copperOf(sim, seller)).toBe(190); // 200 - 5%
+    expect(sim.marketInfoFor(seller)!.collectionCopper).toBe(0);
+  });
+
+  it('forbids buying your own listing, but lets you reclaim it', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.players.get(seller)!.copper = 10000;
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    sim.events.length = 0;
+
+    sim.marketBuy(listing.id, seller);
+    expect(errorsSince(sim).join(' ')).toMatch(/your own listing/i);
+    expect(copperOf(sim, seller)).toBe(10000); // unchanged
+
+    sim.marketCancel(listing.id, seller);
+    expect(sim.countItem('wolf_fang', seller)).toBe(1); // back in bags
+    expect(sim.marketListings.some((l) => l.id === listing.id)).toBe(false);
+  });
+
+  it('rejects a purchase the buyer cannot afford', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.players.get(buyer)!.copper = 50;
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    sim.events.length = 0;
+
+    sim.marketBuy(listing.id, buyer);
+    expect(errorsSince(sim).join(' ')).toMatch(/afford/i);
+    expect(copperOf(sim, buyer)).toBe(50);
+    expect(sim.marketListings.some((l) => l.id === listing.id)).toBe(true);
+  });
+
+  it('buying house stock never depletes it and pays no one', () => {
+    const sim = makeWorld();
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, buyer);
+    const house = sim.marketListings.find((l) => l.house)!;
+    sim.players.get(buyer)!.copper = house.price + 1000;
+    sim.marketBuy(house.id, buyer);
+    // the listing is still on the board and the buyer received the goods
+    expect(sim.marketListings.some((l) => l.id === house.id)).toBe(true);
+    expect(sim.countItem(house.itemId, buyer)).toBeGreaterThanOrEqual(house.count);
+    expect(copperOf(sim, buyer)).toBe(1000);
+  });
+
+  it('returns expired listings to the seller\'s collection', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    listing.expiresAt = sim.time - 1; // force it past due
+    for (let i = 0; i < 20; i++) sim.tick(); // updateMarket runs once a second
+
+    expect(sim.marketListings.some((l) => l.id === listing.id)).toBe(false);
+    const info = sim.marketInfoFor(seller)!;
+    expect(info.collectionItems).toEqual([{ itemId: 'wolf_fang', count: 1 }]);
+  });
+
+  it('refuses to deal with anyone who is not standing at the Merchant', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    teleport(sim, seller, 200, 200);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.events.length = 0;
+
+    sim.marketList('wolf_fang', 1, 100, seller);
+    expect(errorsSince(sim).join(' ')).toMatch(/Merchant/i);
+    expect(sim.countItem('wolf_fang', seller)).toBe(1); // nothing escrowed
+    expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+    expect(sim.marketInfoFor(seller)).toBeNull(); // not streamed when far
+  });
+
+  it('will not broker quest items', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('boar_hide', 1, seller); // a quest item
+    sim.events.length = 0;
+    sim.marketList('boar_hide', 1, 100, seller);
+    expect(errorsSince(sim).join(' ')).toMatch(/quest items/i);
+    expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+  });
+
+  it('caps how many listings one seller may keep', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 20, seller);
+    for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 10, seller);
+    expect(sim.marketInfoFor(seller)!.myListingCount).toBe(12);
+    sim.events.length = 0;
+    sim.marketList('wolf_fang', 1, 10, seller); // one too many
+    expect(errorsSince(sim).join(' ')).toMatch(/at most/i);
+    expect(sim.marketListings.filter((l) => l.sellerKey === 'Seller').length).toBe(12);
+  });
+
+  it('survives a save/load round-trip (persistence)', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 3, seller);
+    sim.players.get(buyer)!.copper = 1000;
+    sim.marketList('wolf_fang', 1, 300, seller); // this one will sell -> collection gold
+    sim.marketList('wolf_fang', 2, 150, seller); // this one stays listed
+    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'Seller' && l.count === 1)!.id, buyer);
+
+    const save = sim.serializeMarket();
+    expect(save.listings.length).toBe(1); // only the unsold player listing (house excluded)
+    expect(save.listings[0].secondsLeft).toBeGreaterThan(0);
+
+    const sim2 = makeWorld();
+    const houseBefore = sim2.marketListings.length;
+    sim2.loadMarket(save);
+
+    const loaded = sim2.marketListings.filter((l) => !l.house);
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]).toMatchObject({ sellerKey: 'Seller', itemId: 'wolf_fang', count: 2, price: 150 });
+    expect(Number.isFinite(loaded[0].expiresAt)).toBe(true);
+    // house stock is reseeded, not duplicated from the save
+    expect(sim2.marketListings.filter((l) => l.house).length).toBe(houseBefore);
+    // the waiting sale proceeds came across too
+    const col = (sim2 as unknown as { marketCollections: Map<string, { copper: number }> }).marketCollections.get('Seller');
+    expect(col?.copper).toBe(285); // 300 - 5%
+    // new listings keep climbing past the loaded ids
+    const seller2 = sim2.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim2, seller2);
+    sim2.addItem('bone_fragments', 1, seller2);
+    sim2.marketList('bone_fragments', 1, 50, seller2);
+    const ids = sim2.marketListings.map((l) => l.id);
+    expect(new Set(ids).size).toBe(ids.length); // no id collisions
+  });
+});


### PR DESCRIPTION
Introduces "The Merchant," a single NPC in Eastbrook's square who opens a World Market — an auction house where players list items for sale and buy each other's goods.

Mechanics (in the shared deterministic Sim, so offline play has it too and the server stays authoritative):
- List a stack from your bags (escrowed), Buy a listing outright, Reclaim your own, and Collect proceeds/returns at the Merchant.
- Sellers are keyed by their globally-unique character name, so proceeds and expired listings reach them even while offline (collected on their next visit). A 5% Merchant's cut is a gold sink; listings expire back to the seller; per-seller listing cap and price guardrails.
- House stock keeps the market non-empty.

Online: market state persists to Postgres in a new world_state table (loaded on boot, saved on autosave + shutdown). Listing info rides the snapshot only while a player stands at the Merchant. ClientWorld mirrors it and sends the list/buy/cancel/collect commands.

UI: a three-tab World Market panel (Browse / Sell / Collect) reachable from the Merchant's gossip; click a bag item to stage it for sale.

Tests: tests/market.test.ts (list/buy/cancel/collect, the cut, expiry, proximity, per-seller cap, house stock, save/load round-trip). Visual + e2e walkthroughs in scripts/market_visual.mjs and scripts/market_mp_e2e.mjs.

