### PR TITLE
feat: high-visibility party indicators for minimap and party frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -1271,12 +1271,23 @@
 
   /* ---------- party frames ---------- */
   #party-frames { position: absolute; left: 12px; top: 92px; display: flex; flex-direction: column; gap: 6px; }
-  .party-frame { width: 170px; padding: 4px 8px; cursor: pointer; }
-  .party-frame .pfm-name { font-size: 11.5px; font-family: var(--title-font); color: #7fb8ff; display: flex; justify-content: space-between; }
+  .party-frame { --cls: #7fb8ff; width: 170px; padding: 4px 8px 5px; cursor: pointer;
+    border-left: 3px solid var(--cls); transition: opacity 0.2s ease, box-shadow 0.2s ease; }
+  .party-frame .pfm-name { font-size: 12px; font-family: var(--title-font); display: flex;
+    justify-content: space-between; align-items: center; gap: 6px; }
+  .party-frame .pfm-id { color: var(--cls); letter-spacing: 0.3px; overflow: hidden;
+    text-overflow: ellipsis; white-space: nowrap; text-shadow: 1px 1px 1px #000; }
+  .party-frame .pfm-meta { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
   .party-frame .pfm-name .lead { color: var(--gold); font-size: 10px; }
+  .party-frame .pf-badge { font-size: 10px; line-height: 1; filter: drop-shadow(0 0 2px #000); }
+  .party-frame .pf-badge.combat { animation: pf-combat-pulse 1s ease-in-out infinite; }
   .party-frame .bar { height: 9px; margin-top: 2px; }
-  .party-frame.dead .pfm-name { color: #888; }
-  .party-frame:hover { outline: 1px solid var(--gold-dim); }
+  .party-frame.combat { box-shadow: 0 0 7px #e74c3c99; }
+  .party-frame.dead { opacity: 0.7; }
+  .party-frame.dead .pfm-id { color: #888 !important; text-shadow: none; }
+  .party-frame.oor { opacity: 0.45; }
+  .party-frame:hover { outline: 1px solid var(--gold-dim); opacity: 1; }
+  @keyframes pf-combat-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
   #party-leave { font-size: 10px; padding: 2px 8px; margin: 0; }
 
   /* ---------- context menu ---------- */

--- a/server/game.ts
+++ b/server/game.ts
@@ -892,7 +892,7 @@ export class GameServer {
         return meta && e ? {
           pid: mPid, name: meta.name, cls: meta.cls, level: e.level,
           hp: e.hp, mhp: e.maxHp, res: Math.round(e.resource), mres: e.maxResource, rtype: e.resourceType,
-          x: round2(e.pos.x), z: round2(e.pos.z), dead: e.dead ? 1 : 0,
+          x: round2(e.pos.x), z: round2(e.pos.z), dead: e.dead ? 1 : 0, inCombat: e.inCombat ? 1 : 0,
         } : null;
       }).filter(Boolean),
     };

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3655,7 +3655,7 @@ export class Sim {
         return meta && e ? [{
           pid: mPid, name: meta.name, cls: meta.cls, level: e.level,
           hp: e.hp, mhp: e.maxHp, res: Math.round(e.resource), mres: e.maxResource, rtype: e.resourceType,
-          x: e.pos.x, z: e.pos.z, dead: e.dead ? 1 : 0,
+          x: e.pos.x, z: e.pos.z, dead: e.dead ? 1 : 0, inCombat: e.inCombat ? 1 : 0,
         }] : [];
       }),
     };

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -48,6 +48,15 @@ const CLASS_GLYPH: Record<string, string> = {
   shaman: '🌩️', mage: '🔮', warlock: '🕯️', druid: '🐻',
 };
 
+// Classic class colors (CLASSES[cls].color is a 0xRRGGBB number) as a CSS
+// string, used to color-code party members on the minimap and in the frames.
+const classCss = (cls: string): string =>
+  '#' + ((CLASSES as Record<string, { color: number }>)[cls]?.color ?? 0x5fa8ff).toString(16).padStart(6, '0');
+
+// Party frames dim and the minimap pins members to the rim once they pass
+// this range (yards) — just inside the server's ~120 yd interest scope.
+const PARTY_RANGE_YD = 100;
+
 // yards past a zone boundary before the crossing banner/welcome commits
 const ZONE_BANNER_DEADBAND = 5;
 const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
@@ -755,18 +764,52 @@ export class Hud {
         ctx.fillRect(mx - 1.5, my - 1.5, 3, 3);
       }
     }
-    // party members as bright blue blips
+    // Party members: class-colored markers. On-map allies are discs that
+    // scale up the closer they are (proximity scaling); allies past the rim
+    // are pinned to the edge as arrows pointing the way to regroup.
     const party = this.sim.partyInfo;
     if (party) {
-      ctx.fillStyle = '#5fa8ff';
+      const R = S / 2 - 7;
       for (const m of party.members) {
         if (m.pid === p.id) continue;
-        const mx = S / 2 - (m.x - p.pos.x) * pxPerYard;
-        const my = S / 2 - (m.z - p.pos.z) * pxPerYard;
-        if ((mx - S / 2) ** 2 + (my - S / 2) ** 2 > (S / 2 - 7) ** 2) continue;
-        ctx.beginPath();
-        ctx.arc(mx, my, 3, 0, Math.PI * 2);
-        ctx.fill();
+        const dx = -(m.x - p.pos.x) * pxPerYard; // +X is map-left
+        const dz = -(m.z - p.pos.z) * pxPerYard;
+        const dist = Math.hypot(dx, dz);
+        const offMap = dist > R;
+        const ang = Math.atan2(dz, dx);
+        const color = m.dead ? '#9a9a9a' : classCss(m.cls);
+        ctx.save();
+        if (offMap) {
+          // edge-anchored arrow pointing outward toward the off-screen ally
+          ctx.translate(S / 2 + Math.cos(ang) * R, S / 2 + Math.sin(ang) * R);
+          ctx.rotate(ang);
+          ctx.fillStyle = color;
+          ctx.strokeStyle = '#000';
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.moveTo(6, 0); ctx.lineTo(-4, 4.5); ctx.lineTo(-4, -4.5);
+          ctx.closePath();
+          ctx.fill();
+          ctx.stroke();
+        } else {
+          // proximity scaling: ~6px adjacent down to ~3px near the rim
+          const r = 6 - (dist / R) * 3;
+          ctx.translate(S / 2 + dx, S / 2 + dz);
+          ctx.fillStyle = color;
+          ctx.strokeStyle = '#000';
+          ctx.lineWidth = 1.5;
+          ctx.beginPath();
+          ctx.arc(0, 0, r, 0, Math.PI * 2);
+          ctx.fill();
+          ctx.stroke();
+          if (!m.dead) { // bright inner pip so members pop against terrain
+            ctx.fillStyle = '#ffffffcc';
+            ctx.beginPath();
+            ctx.arc(0, 0, Math.max(1, r * 0.35), 0, Math.PI * 2);
+            ctx.fill();
+          }
+        }
+        ctx.restore();
       }
     }
     ctx.translate(S / 2, S / 2);
@@ -1546,17 +1589,28 @@ export class Hud {
       this.lastPartySig = '';
       return;
     }
-    const others = info.members.filter((m) => m.pid !== this.sim.playerId);
-    const sig = others.map((m) => `${m.pid}:${m.hp}/${m.mhp}:${m.res}:${m.dead}:${m.level}`).join('|') + `L${info.leader}`;
+    const p = this.sim.player;
+    const others = info.members.map((m) => ({
+      ...m,
+      oor: !m.dead && Math.hypot(m.x - p.pos.x, m.z - p.pos.z) > PARTY_RANGE_YD,
+    })).filter((m) => m.pid !== this.sim.playerId);
+    // include combat/range state so the frames rebuild when a badge changes
+    const sig = others.map((m) => `${m.pid}:${m.hp}/${m.mhp}:${m.res}:${m.dead}:${m.inCombat}:${m.oor ? 1 : 0}:${m.level}`).join('|') + `L${info.leader}`;
     if (sig === this.lastPartySig) return;
     this.lastPartySig = sig;
     el.innerHTML = '';
     for (const m of others) {
       const frame = document.createElement('div');
-      frame.className = 'party-frame panel' + (m.dead ? ' dead' : '');
+      frame.className = 'party-frame panel'
+        + (m.dead ? ' dead' : m.inCombat ? ' combat' : '')
+        + (m.oor ? ' oor' : '');
+      frame.style.setProperty('--cls', classCss(m.cls));
       const resClass = m.rtype === 'rage' ? 'rage' : m.rtype === 'energy' ? 'energy' : 'mana';
+      const badge = m.dead ? '<span class="pf-badge dead" title="Dead">💀</span>'
+        : m.inCombat ? '<span class="pf-badge combat" title="In combat">⚔️</span>' : '';
+      const range = m.oor ? '<span class="pf-badge oor" title="Out of range">⤢</span>' : '';
       frame.innerHTML = `
-        <div class="pfm-name"><span>${CLASS_GLYPH[m.cls] ?? ''} ${m.name}</span><span class="lead">${info.leader === m.pid ? '★' : ''} ${m.level}</span></div>
+        <div class="pfm-name"><span class="pfm-id">${CLASS_GLYPH[m.cls] ?? ''} ${m.name}</span><span class="pfm-meta">${badge}${range}<span class="lead">${info.leader === m.pid ? '★' : ''}${m.level}</span></span></div>
         <div class="bar hp"><div class="bar-fill" style="transform:scaleX(${(m.hp / Math.max(1, m.mhp)).toFixed(3)})"></div></div>
         <div class="bar ${resClass}"><div class="bar-fill" style="transform:scaleX(${(m.res / Math.max(1, m.mres)).toFixed(3)})"></div></div>`;
       frame.addEventListener('click', () => this.sim.targetEntity(m.pid));

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -14,6 +14,7 @@ export interface PartyMemberInfo {
   x: number;
   z: number;
   dead: number;
+  inCombat: number;
 }
 
 export interface PartyInfo {

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -253,6 +253,27 @@ describe('parties', () => {
     expect(sim.partyOf(a)).toBe(null);
   });
 
+  it('partyInfo reports per-member combat state for the UI badges', () => {
+    const { sim, a, b } = makeDuo();
+    // out of combat by default
+    const before = sim.partyInfo!.members.find((m) => m.pid === b)!;
+    expect(before.inCombat).toBe(0);
+    // engaging a member flips its flag in the next info read
+    sim.entities.get(b)!.inCombat = true;
+    const after = sim.partyInfo!.members.find((m) => m.pid === b)!;
+    expect(after.inCombat).toBe(1);
+    // and the dead flag stays independent of combat
+    expect(after.dead).toBe(0);
+  });
+
+  it('partyInfo carries member position so the minimap can place them', () => {
+    const { sim, a, b } = makeDuo();
+    teleport(sim, b, 17, -23);
+    const info = sim.partyInfo!.members.find((m) => m.pid === b)!;
+    expect(info.x).toBeCloseTo(17, 3);
+    expect(info.z).toBeCloseTo(-23, 3);
+  });
+
   it('party members share kill xp with the group bonus and quest credit', () => {
     const { sim, a, b } = makeDuo();
     // both accept the wolf quest


### PR DESCRIPTION
## Summary
- Reworks the minimap party markers from uniform blue blips into class-colored markers: on-map allies are discs that scale up the closer they are (proximity scaling), and allies past the rim are pinned to the edge as arrows pointing the way to regroup instead of being culled off-screen.
- Adds live status to the party frames: a class-colored name with a class-colored left accent border, an in-combat badge (pulsing crossed swords), a death badge (skull), and an out-of-range fade once a member is past 100 yd.
- Plumbs a per-member `inCombat` flag through `PartyMemberInfo`, the offline `Sim.partyInfo` getter, and the server `partyWire`, so the combat badge works the same offline and online.

## Tests
- `npm test` — 267 pass, including new coverage that `partyInfo` reports per-member combat state and member position for the markers.
- `npx tsc --noEmit`
- `npm run build`

Closes #47