### PR TITLE
Add report action to chat player context menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,6 +279,8 @@
     font-size: 11px; line-height: 1.45; }
   .chat-pane.active { display: block; }
   .chat-pane div { text-shadow: 1px 1px 1px #000; overflow-wrap: break-word; user-select: text; }
+  .chat-player-name { cursor: context-menu; text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  .chat-player-name:hover { filter: brightness(1.25); }
   .chat-pane::-webkit-scrollbar { width: 8px; }
   .chat-pane::-webkit-scrollbar-track { background: #0b0b10; }
   .chat-pane::-webkit-scrollbar-thumb { background: #4a3d1d; border-radius: 4px; }

--- a/server/db.ts
+++ b/server/db.ts
@@ -230,6 +230,20 @@ export async function getCharacter(accountId: number, characterId: number): Prom
   return res.rows[0] ?? null;
 }
 
+export async function findCharacterReportTargetByName(name: string): Promise<{ accountId: number; characterId: number; characterName: string } | null> {
+  const term = name.trim();
+  if (!term) return null;
+  const res = await pool.query(
+    `SELECT account_id, id, name
+     FROM characters
+     WHERE realm = $1 AND lower(name) = lower($2)
+     LIMIT 1`,
+    [REALM, term],
+  );
+  const row = res.rows[0];
+  return row ? { accountId: Number(row.account_id), characterId: Number(row.id), characterName: row.name } : null;
+}
+
 export async function createCharacter(accountId: number, name: string, cls: PlayerClass): Promise<CharacterRow> {
   const res = await pool.query(
     'INSERT INTO characters (account_id, name, class, realm) VALUES ($1, $2, $3, $4) RETURNING id, account_id, name, class, level, state, is_gm, force_rename',

--- a/server/main.ts
+++ b/server/main.ts
@@ -6,8 +6,10 @@ import {
   ensureSchema, pool, createAccount, findAccount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
+  findCharacterReportTargetByName,
 } from './db';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
+import { resolveReportTarget } from './report_target';
 import { hashPassword, verifyPassword, newToken, validUsername, validPassword, validCharName } from './auth';
 import { json, readBody } from './http_util';
 import { rateLimited } from './ratelimit';
@@ -240,20 +242,22 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const reason = cleanReportReason(body.reason);
       if (!reason) return json(res, 400, { error: 'choose a report reason' });
       const reporterCharacterId = Number(body.reporterCharacterId);
-      const targetPid = Number(body.targetPid);
-      if (!Number.isFinite(reporterCharacterId) || !Number.isFinite(targetPid)) {
+      if (!Number.isFinite(reporterCharacterId)) {
         return json(res, 400, { error: 'invalid report target' });
       }
       const reporter = await getCharacter(accountId, reporterCharacterId);
       if (!reporter) return json(res, 404, { error: 'reporting character not found' });
-      const target = game.reportTargetForPid(targetPid);
-      if (!target) return json(res, 404, { error: 'that player is no longer online' });
+      const resolved = await resolveReportTarget(body, {
+        reportTargetForPid: (pid) => game.reportTargetForPid(pid),
+        findCharacterReportTargetByName,
+      });
+      if (!resolved.ok) return json(res, resolved.status, { error: resolved.error });
       try {
         const report = await createPlayerReport({
           reporterAccountId: accountId,
           reporterCharacterId: reporter.id,
           reporterCharacterName: reporter.name,
-          target,
+          target: resolved.target,
           reason,
           details: body.details,
         });

--- a/server/report_target.ts
+++ b/server/report_target.ts
@@ -1,0 +1,33 @@
+import type { LiveReportTarget } from './moderation_db';
+
+export interface ReportTargetResolvers {
+  reportTargetForPid(pid: number): LiveReportTarget | null;
+  findCharacterReportTargetByName(name: string): Promise<LiveReportTarget | null>;
+}
+
+export type ResolveReportTargetResult =
+  | { ok: true; target: LiveReportTarget }
+  | { ok: false; status: number; error: string };
+
+export async function resolveReportTarget(
+  body: Record<string, unknown>,
+  resolvers: ReportTargetResolvers,
+): Promise<ResolveReportTargetResult> {
+  const targetPid = Number(body.targetPid);
+  if (Number.isFinite(targetPid)) {
+    const target = resolvers.reportTargetForPid(targetPid);
+    return target
+      ? { ok: true, target }
+      : { ok: false, status: 404, error: 'that player is no longer online' };
+  }
+
+  const name = typeof body.targetCharacterName === 'string' ? body.targetCharacterName.trim() : '';
+  if (name) {
+    const target = await resolvers.findCharacterReportTargetByName(name);
+    return target
+      ? { ok: true, target }
+      : { ok: false, status: 404, error: 'that player could not be found' };
+  }
+
+  return { ok: false, status: 400, error: 'invalid report target' };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -181,6 +181,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   if (online) {
     hud.attachReporting({
       submit: (targetPid, reason, details) => api.reportPlayer(online.characterId, targetPid, reason, details),
+      submitByName: (targetName, reason, details) => api.reportPlayerByName(online.characterId, targetName, reason, details),
     });
   }
 

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -133,6 +133,10 @@ export class Api {
   async reportPlayer(reporterCharacterId: number, targetPid: number, reason: string, details: string): Promise<void> {
     await this.post('/api/reports', { reporterCharacterId, targetPid, reason, details });
   }
+
+  async reportPlayerByName(reporterCharacterId: number, targetCharacterName: string, reason: string, details: string): Promise<void> {
+    await this.post('/api/reports', { reporterCharacterId, targetCharacterName, reason, details });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -15,6 +15,7 @@ import { music } from '../game/music';
 import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
+import { chatPlayerContextActions } from './player_context_menu';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -27,6 +28,7 @@ export interface OptionsHooks {
 
 export interface ReportHooks {
   submit(targetPid: number, reason: string, details: string): Promise<void>;
+  submitByName?(targetName: string, reason: string, details: string): Promise<void>;
 }
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
@@ -976,16 +978,16 @@ export class Hud {
         case 'chat': {
           if (this.isChatIgnored(ev.from)) break;
           switch (ev.channel) {
-            case 'party': this.log(`[Party] ${ev.from}: ${ev.text}`, '#7fd4ff'); break;
-            case 'yell': this.log(`${ev.from} yells: ${ev.text}`, '#ff5040'); break;
+            case 'party': this.chatLogFrom(ev.from, ev.text, '#7fd4ff', '[Party] ', ': '); break;
+            case 'yell': this.chatLogFrom(ev.from, ev.text, '#ff5040', '', ' yells: '); break;
             case 'whisper':
-              if (ev.to) this.log(`To ${ev.to}: ${ev.text}`, '#ff80ff');
-              else { this.log(`${ev.from} whispers: ${ev.text}`, '#ff80ff'); audio.whisper(); }
+              if (ev.to) this.chatLogFrom(ev.to, ev.text, '#ff80ff', 'To ', ': ');
+              else { this.chatLogFrom(ev.from, ev.text, '#ff80ff', '', ' whispers: '); audio.whisper(); }
               break;
-            case 'general': this.log(`[General] ${ev.from}: ${ev.text}`, '#ffc864'); break;
-            case 'guild': this.log(`[Guild] ${ev.from}: ${ev.text}`, '#40d264'); break;
-            case 'officer': this.log(`[Officer] ${ev.from}: ${ev.text}`, '#4ce0c0'); break;
-            default: this.log(`${ev.from} says: ${ev.text}`, '#f0ead8'); break;
+            case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
+            case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
+            case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
+            default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
           if ((ev.channel === 'say' || ev.channel === 'yell') && ev.entityId !== undefined) {
             this.renderer.showChatBubble(ev.entityId, ev.text, ev.channel === 'yell');
@@ -1069,6 +1071,25 @@ export class Hud {
 
   log(text: string, color = '#ccc'): void {
     this.appendLog(this.chatLogEl, text, color);
+  }
+
+  private chatLogFrom(name: string, text: string, color: string, prefix: string, separator: string): void {
+    const wasNearBottom = this.chatLogEl.scrollHeight - this.chatLogEl.scrollTop - this.chatLogEl.clientHeight < 24;
+    const div = document.createElement('div');
+    div.style.color = color;
+    if (prefix) div.append(document.createTextNode(prefix));
+    const sender = document.createElement('span');
+    sender.className = 'chat-player-name';
+    sender.textContent = name;
+    sender.title = `Right-click ${name}`;
+    sender.addEventListener('contextmenu', (ev) => {
+      ev.preventDefault();
+      this.openChatPlayerContextMenu(name, ev.clientX, ev.clientY);
+    });
+    div.append(sender, document.createTextNode(`${separator}${text}`));
+    this.chatLogEl.appendChild(div);
+    while (this.chatLogEl.children.length > 200) this.chatLogEl.removeChild(this.chatLogEl.firstChild!);
+    if (wasNearBottom) this.chatLogEl.scrollTop = this.chatLogEl.scrollHeight;
   }
 
   private combatLog(text: string, color = '#ccc'): void {
@@ -1599,14 +1620,68 @@ export class Hud {
         else if (act === 'ignore') {
           if (online) { ignored ? this.sim.blockRemove(name) : this.sim.blockAdd(name); }
           else this.toggleChatIgnore(name);
-        } else if (act === 'report') this.openReportWindow(pid, name);
+        } else if (act === 'report') this.openReportWindow({ pid, name });
         else if (act === 'kick') this.sim.partyKick(pid);
       });
     });
   }
 
-  private openReportWindow(pid: number, name: string): void {
+  private openChatPlayerContextMenu(name: string, x: number, y: number): void {
+    const el = $('#ctx-menu');
+    const online = this.sim.socialInfo !== null;
+    const social = this.sim.socialInfo;
+    const isFriend = !!social?.friends.some((f) => f.name === name);
+    const canGuildInvite = !!social?.guild && social.guild.rank !== 'member';
+    const alreadyGuilded = !!social?.guild?.members.some((m) => m.name === name);
+    const ignored = online
+      ? !!social?.blocks.some((b) => b.name === name)
+      : this.isChatIgnored(name);
+    const actions = chatPlayerContextActions({
+      playerName: name,
+      selfName: this.sim.player.name,
+      online,
+      isFriend,
+      ignored,
+      canGuildInvite,
+      alreadyGuilded,
+      canReport: !!this.reportHooks?.submitByName,
+    });
+    el.innerHTML = `<div class="ctx-title">${esc(name)}</div>`
+      + actions.map((a) => `<div class="ctx-item" data-act="${a.id}">${esc(a.label)}</div>`).join('');
+    el.style.left = `${Math.min(window.innerWidth - 170, x)}px`;
+    el.style.top = `${Math.min(window.innerHeight - 240, y)}px`;
+    el.style.display = 'block';
+    el.querySelectorAll('.ctx-item').forEach((item) => {
+      item.addEventListener('click', () => {
+        const act = (item as HTMLElement).dataset.act;
+        el.style.display = 'none';
+        const livePid = this.playerPidByName(name);
+        if (act === 'whisper') this.startWhisper(name);
+        else if (act === 'invite') {
+          if (livePid !== null) this.sim.partyInvite(livePid);
+          else this.showError('That player is not nearby.');
+        } else if (act === 'friend') this.sim.friendAdd(name);
+        else if (act === 'unfriend') this.sim.friendRemove(name);
+        else if (act === 'ginvite') this.sim.guildInvite(name);
+        else if (act === 'ignore') {
+          if (online) { ignored ? this.sim.blockRemove(name) : this.sim.blockAdd(name); }
+          else this.toggleChatIgnore(name);
+        } else if (act === 'report') this.openReportWindow({ name });
+      });
+    });
+  }
+
+  private playerPidByName(name: string): number | null {
+    const wanted = name.toLowerCase();
+    for (const e of this.sim.entities.values()) {
+      if (e.kind === 'player' && e.name.toLowerCase() === wanted) return e.id;
+    }
+    return null;
+  }
+
+  private openReportWindow(target: { pid?: number; name: string }): void {
     if (!this.reportHooks) return;
+    const { pid, name } = target;
     const el = $('#report-window');
     el.innerHTML = `
       <div class="panel-title">Report ${esc(name)}<button data-close>×</button></div>
@@ -1634,7 +1709,14 @@ export class Hud {
       const reason = ($('#report-reason') as HTMLSelectElement).value;
       const details = ($('#report-details') as HTMLTextAreaElement).value;
       submit.disabled = true;
-      this.reportHooks!.submit(pid, reason, details)
+      const request = pid !== undefined
+        ? this.reportHooks!.submit(pid, reason, details)
+        : this.reportHooks!.submitByName?.(name, reason, details);
+      if (!request) {
+        $('#report-error').textContent = 'Could not submit report.';
+        return;
+      }
+      request
         .then(() => {
           el.style.display = 'none';
           this.log(`Report submitted for ${name}.`, '#ffd100');

--- a/src/ui/player_context_menu.ts
+++ b/src/ui/player_context_menu.ts
@@ -1,0 +1,44 @@
+export type PlayerContextActionId =
+  | 'whisper'
+  | 'invite'
+  | 'friend'
+  | 'unfriend'
+  | 'ginvite'
+  | 'ignore'
+  | 'report'
+  | 'close';
+
+export interface PlayerContextAction {
+  id: PlayerContextActionId;
+  label: string;
+}
+
+export interface ChatPlayerContextState {
+  playerName: string;
+  selfName: string;
+  online: boolean;
+  isFriend: boolean;
+  ignored: boolean;
+  canGuildInvite: boolean;
+  alreadyGuilded: boolean;
+  canReport: boolean;
+}
+
+export function chatPlayerContextActions(state: ChatPlayerContextState): PlayerContextAction[] {
+  const samePlayer = state.playerName.toLowerCase() === state.selfName.toLowerCase();
+  const actions: PlayerContextAction[] = [];
+
+  if (!samePlayer) {
+    actions.push({ id: 'whisper', label: 'Whisper' });
+    actions.push({ id: 'invite', label: 'Invite to Party' });
+    if (state.online) {
+      actions.push({ id: state.isFriend ? 'unfriend' : 'friend', label: state.isFriend ? 'Remove Friend' : 'Add Friend' });
+    }
+    if (state.canGuildInvite && !state.alreadyGuilded) actions.push({ id: 'ginvite', label: 'Invite to Guild' });
+    actions.push({ id: 'ignore', label: `${state.ignored ? 'Unignore' : 'Ignore'}${state.online ? '' : ' Chat'}` });
+    if (state.canReport) actions.push({ id: 'report', label: 'Report Player' });
+  }
+
+  actions.push({ id: 'close', label: 'Cancel' });
+  return actions;
+}

--- a/tests/chat_context_menu.test.ts
+++ b/tests/chat_context_menu.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { chatPlayerContextActions } from '../src/ui/player_context_menu';
+
+describe('chat player context menu', () => {
+  it('offers social and report actions from chat names without live-only actions', () => {
+    const actions = chatPlayerContextActions({
+      playerName: 'Badmage',
+      selfName: 'Adventurer',
+      online: true,
+      isFriend: false,
+      ignored: false,
+      canGuildInvite: true,
+      alreadyGuilded: false,
+      canReport: true,
+    });
+
+    expect(actions.map((a) => a.id)).toEqual([
+      'whisper',
+      'invite',
+      'friend',
+      'ginvite',
+      'ignore',
+      'report',
+      'close',
+    ]);
+    expect(actions.map((a) => a.id)).not.toContain('trade');
+    expect(actions.map((a) => a.id)).not.toContain('duel');
+  });
+
+  it('does not allow reporting yourself from chat', () => {
+    const actions = chatPlayerContextActions({
+      playerName: 'Adventurer',
+      selfName: 'Adventurer',
+      online: true,
+      isFriend: false,
+      ignored: false,
+      canGuildInvite: false,
+      alreadyGuilded: false,
+      canReport: true,
+    });
+
+    expect(actions.map((a) => a.id)).not.toContain('report');
+  });
+});

--- a/tests/report_target.test.ts
+++ b/tests/report_target.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveReportTarget } from '../server/report_target';
+
+describe('report target resolution', () => {
+  it('resolves chat reports by server-side character name', async () => {
+    const target = { accountId: 22, characterId: 44, characterName: 'Badmage' };
+    const findCharacterReportTargetByName = vi.fn().mockResolvedValue(target);
+
+    await expect(resolveReportTarget(
+      { targetCharacterName: ' Badmage ' },
+      { reportTargetForPid: vi.fn(), findCharacterReportTargetByName },
+    )).resolves.toEqual({ ok: true, target });
+
+    expect(findCharacterReportTargetByName).toHaveBeenCalledWith('Badmage');
+  });
+
+  it('keeps live pid reports for world right-click actions', async () => {
+    const target = { accountId: 22, characterId: 44, characterName: 'Badmage' };
+    const reportTargetForPid = vi.fn().mockReturnValue(target);
+
+    await expect(resolveReportTarget(
+      { targetPid: 123 },
+      { reportTargetForPid, findCharacterReportTargetByName: vi.fn() },
+    )).resolves.toEqual({ ok: true, target });
+
+    expect(reportTargetForPid).toHaveBeenCalledWith(123);
+  });
+
+  it('rejects unknown chat names without trusting client-supplied ids', async () => {
+    await expect(resolveReportTarget(
+      { targetCharacterName: 'Nobody', targetAccountId: 999, targetCharacterId: 888 },
+      { reportTargetForPid: vi.fn(), findCharacterReportTargetByName: vi.fn().mockResolvedValue(null) },
+    )).resolves.toEqual({ ok: false, status: 404, error: 'that player could not be found' });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds right-click context menus to player names in chat.
- Allows reporting players from chat by resolving character names server-side within the current realm.
- Keeps Trade and Challenge to Duel limited to live world/player context menus.

## Why
Players could report someone from the world/party context menu, but not from chat. Chat is often where abusive behavior appears, and those reports should not depend on the reported player being nearby as a live entity.

## Testing
- `npm test -- tests/report_target.test.ts tests/chat_context_menu.test.ts`
- `npm test -- tests/moderation_db.test.ts tests/chat_log.test.ts tests/chat.test.ts tests/report_target.test.ts tests/chat_context_menu.test.ts`
- `npm test -- --testTimeout=15000` — 25 files, 325 tests passed
- `npm run build:server`
- `npm run build`
- `git diff --check`

## Local Playtest
- Verified locally from `http://localhost:8791/`.
- Confirmed chat sender right-click menu includes Report and excludes Trade / Challenge to Duel.
