### PR TITLE
fix: narrow moderation queue status type

### DIFF
--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),


### PR DESCRIPTION
## Summary
- Fixes the `npx tsc --noEmit` failure in `moderationQueue` by keeping the computed account status inside the admin API row union.
- Annotates the queue mapper return type so the moderation row contract is checked where SQL rows are converted.

## Diagnosis
The computed `status` value widened to `string` inside the object literal even though `ModerationQueueRow.status` only accepts `active`, `suspended`, or `banned`.

## Verification
- `npx tsc --noEmit`
- `npx vitest run tests/moderation_db.test.ts tests/admin.test.ts`
- `npm test`
- `npm run build:env`
- `npm run build:server`
- `npm run build`

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
