### PR TITLE
Block offensive names and add character deletion

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,6 +753,12 @@
   }
   .char-row .char-sub { color: var(--color-text-muted); font-size: 12px; flex: 1; }
   .char-row .btn { margin: 0; padding: 6px 12px; font-size: 11.5px; }
+  .char-row .char-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 0 0 auto;
+  }
   .char-row.online .char-name { color: var(--color-text-success); text-shadow: 0 0 8px rgba(127,220,79,0.3); }
   .char-row.rename-required .char-name { color: #ffbf66; }
   .char-row .rename-input {
@@ -1040,6 +1046,19 @@
     background: linear-gradient(180deg, #4a3a14 0%, #241c08 100%);
     color: var(--color-primary);
     border: 1px solid var(--color-border-default);
+  }
+  .btn-danger {
+    background: linear-gradient(180deg, #5a1714 0%, #250807 100%);
+    border: 1px solid #9f2d24;
+    color: #ffd0c8;
+  }
+  .btn-danger:hover:not(:disabled) {
+    border-color: #d64a3d;
+    color: #fff0ec;
+  }
+  .btn-danger:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
   }
   #btn-login {
     grid-column: span 2;
@@ -1503,6 +1522,48 @@
   .text-center-lg {
     text-align: center;
     margin-top: var(--spacing-lg);
+  }
+
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(0, 0, 0, 0.72);
+  }
+  .modal-backdrop[hidden] {
+    display: none;
+  }
+  .confirm-modal {
+    width: min(420px, 100%);
+    padding: 18px;
+  }
+  .confirm-modal h2 {
+    margin: 0 0 10px;
+    color: var(--color-text-light);
+    font-family: var(--font-heading);
+    font-size: 22px;
+  }
+  .confirm-modal p {
+    margin: 8px 0;
+    color: var(--color-text-muted);
+    line-height: 1.45;
+  }
+  .confirm-modal strong {
+    color: var(--color-primary);
+  }
+  .confirm-modal .auth-label {
+    display: block;
+    margin-top: 14px;
+  }
+  .confirm-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-sm);
+    margin-top: 14px;
   }
 
   /* ---------- Premium Class Details Panel ---------- */
@@ -2204,6 +2265,20 @@
             <canvas id="char-preview-canvas"></canvas>
           </div>
           <div id="online-class-details" class="class-details-panel" aria-live="polite"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="delete-character-modal" class="modal-backdrop" hidden>
+      <div class="confirm-modal panel auth-panel-premium" role="dialog" aria-modal="true" aria-labelledby="delete-character-title">
+        <h2 id="delete-character-title">Delete Character</h2>
+        <p>This permanently deletes <strong id="delete-character-name"></strong>. This cannot be undone.</p>
+        <label for="delete-character-confirm" class="auth-label">Type the character name to confirm</label>
+        <input id="delete-character-confirm" maxlength="16" autocomplete="off" />
+        <div id="delete-character-error" class="auth-error" aria-live="polite"></div>
+        <div class="confirm-actions">
+          <button type="button" class="btn btn-secondary" id="btn-cancel-delete-character">Cancel</button>
+          <button type="button" class="btn btn-danger" id="btn-confirm-delete-character" disabled>Delete Permanently</button>
         </div>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "world-of-claudecraft",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "n8ao": "^1.10.1",
+        "obscenity": "^0.4.6",
         "pg": "^8.21.0",
         "postprocessing": "^6.36.0",
         "three": "^0.165.0",
@@ -3890,6 +3892,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/obscenity": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/obscenity/-/obscenity-0.4.6.tgz",
+      "integrity": "sha512-pHk7kNN7j3L3zGhhGnwxjvXIGsPpLrcZl2r58fqWh/V/rH6b/dafscj2sMmAY+A/9/wPsocLmimgGk2DKeKsFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/obug": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "n8ao": "^1.10.1",
+    "obscenity": "^0.4.6",
     "pg": "^8.21.0",
     "postprocessing": "^6.36.0",
     "three": "^0.165.0",

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
+import { RegExpMatcher, englishDataset, englishRecommendedTransformers } from 'obscenity';
 
 const SCRYPT_N = 16384, SCRYPT_R = 8, SCRYPT_P = 1, KEYLEN = 64;
 
@@ -45,6 +46,11 @@ const CONFUSABLE_CHARS: Record<string, string> = {
   '8': 'b',
 };
 
+const profanityMatcher = new RegExpMatcher({
+  ...englishDataset.build(),
+  ...englishRecommendedTransformers,
+});
+
 function normalizedUsernameForCensorship(username: string): string {
   return username
     .toLowerCase()
@@ -72,13 +78,23 @@ function bannedUsernameTerms(): string[] {
 }
 
 export function offensiveUsername(u: unknown): boolean {
+  return offensiveName(u);
+}
+
+export function offensiveName(u: unknown): boolean {
   if (typeof u !== 'string') return false;
   const normalized = normalizedUsernameForCensorship(u);
-  return bannedUsernameTerms().some((term) => normalized.includes(term));
+  return profanityMatcher.hasMatch(u) ||
+    profanityMatcher.hasMatch(normalized) ||
+    bannedUsernameTerms().some((term) => normalized.includes(term));
 }
 
 export function validUsername(u: unknown): u is string {
-  return typeof u === 'string' && /^[A-Za-z0-9_]{3,24}$/.test(u) && !offensiveUsername(u);
+  return validUsernameShape(u) && !offensiveName(u);
+}
+
+export function validUsernameShape(u: unknown): u is string {
+  return typeof u === 'string' && /^[A-Za-z0-9_]{3,24}$/.test(u);
 }
 
 export function validPassword(p: unknown): p is string {
@@ -86,5 +102,9 @@ export function validPassword(p: unknown): p is string {
 }
 
 export function validCharName(n: unknown): n is string {
+  return validCharNameShape(n) && !offensiveName(n);
+}
+
+export function validCharNameShape(n: unknown): n is string {
   return typeof n === 'string' && /^[A-Za-z][A-Za-z' -]{1,15}$/.test(n);
 }

--- a/server/db.ts
+++ b/server/db.ts
@@ -253,7 +253,10 @@ export async function createCharacter(accountId: number, name: string, cls: Play
 }
 
 export async function deleteCharacter(accountId: number, characterId: number): Promise<boolean> {
-  const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2', [characterId, accountId]);
+  const res = await pool.query(
+    'DELETE FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3',
+    [characterId, accountId, REALM],
+  );
   return (res.rowCount ?? 0) > 0;
 }
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -10,7 +10,9 @@ import {
 } from './db';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
-import { hashPassword, verifyPassword, newToken, validUsername, validPassword, validCharName } from './auth';
+import {
+  hashPassword, verifyPassword, newToken, validUsernameShape, offensiveName, validPassword, validCharNameShape,
+} from './auth';
 import { json, readBody } from './http_util';
 import { rateLimited } from './ratelimit';
 import { handleAdminApi } from './admin';
@@ -24,6 +26,10 @@ const STATIC_DIR = path.join(__dirname, '..', 'dist');
 const CHAT_LOG_RETENTION_DAYS = Number(process.env.CHAT_LOG_RETENTION_DAYS ?? 90);
 
 const game = new GameServer();
+
+function normalizeDeleteConfirmation(name: unknown): string {
+  return typeof name === 'string' ? name.trim().toLowerCase() : '';
+}
 
 async function bearerAccount(req: http.IncomingMessage): Promise<number | null> {
   const auth = req.headers.authorization ?? '';
@@ -143,7 +149,8 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     }
     if (req.method === 'POST' && url === '/api/register') {
       const body = await readBody(req);
-      if (!validUsername(body.username)) return json(res, 400, { error: 'username must be 3-24 chars (letters, digits, _)' });
+      if (!validUsernameShape(body.username)) return json(res, 400, { error: 'username must be 3-24 chars (letters, digits, _)' });
+      if (offensiveName(body.username)) return json(res, 400, { error: 'username is not allowed' });
       if (!validPassword(body.password)) return json(res, 400, { error: 'password must be at least 6 chars' });
       const existing = await findAccount(body.username);
       if (existing) return json(res, 409, { error: 'username already taken' });
@@ -181,7 +188,8 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       }
       if (req.method === 'POST') {
         const body = await readBody(req);
-        if (!validCharName(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+        if (!validCharNameShape(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+        if (offensiveName(body.name)) return json(res, 400, { error: 'character name is not allowed' });
         const validClasses = ['warrior', 'paladin', 'hunter', 'rogue', 'priest', 'shaman', 'mage', 'warlock', 'druid'];
         if (!validClasses.includes(body.class)) return json(res, 400, { error: 'invalid class' });
         const chars = await listCharacters(accountId);
@@ -203,7 +211,8 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const accountId = await bearerActiveAccount(req, res);
       if (accountId === null) return;
       const body = await readBody(req);
-      if (!validCharName(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+      if (!validCharNameShape(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+      if (offensiveName(body.name)) return json(res, 400, { error: 'character name is not allowed' });
       try {
         const c = await renameCharacter(accountId, Number(renameMatch[1]), body.name);
         if (!c) return json(res, 404, { error: 'character not found' });
@@ -218,7 +227,17 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     if (req.method === 'DELETE' && delMatch) {
       const accountId = await bearerActiveAccount(req, res);
       if (accountId === null) return;
-      const ok = await deleteCharacter(accountId, Number(delMatch[1]));
+      const characterId = Number(delMatch[1]);
+      const body = await readBody(req);
+      const character = await getCharacter(accountId, characterId);
+      if (!character) return json(res, 404, { error: 'not found' });
+      if ([...game.clients.values()].some((s) => s.characterId === characterId)) {
+        return json(res, 400, { error: 'character is currently online' });
+      }
+      if (normalizeDeleteConfirmation(body.name) !== normalizeDeleteConfirmation(character.name)) {
+        return json(res, 400, { error: 'type the character name to confirm deletion' });
+      }
+      const ok = await deleteCharacter(accountId, characterId);
       return json(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'not found' });
     }
     if (req.method === 'GET' && url === '/api/realms') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { iconDataUrl } from './ui/icons';
 const WORLD_SEED = 20061; // fixed: World of Claudecraft is a persistent place
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
+let pendingDeleteCharacter: CharacterSummary | null = null;
 
 // ---------------------------------------------------------------------------
 // Loading screen (shown from "enter world" until the first frame renders)
@@ -583,6 +584,39 @@ function selectRealm(entry: import('./net/online').RealmEntry): void {
   void refreshCharacters();
 }
 
+function setDeleteCharacterError(message: string): void {
+  $('#delete-character-error').textContent = message;
+}
+
+function closeDeleteCharacterDialog(): void {
+  pendingDeleteCharacter = null;
+  const modal = $('#delete-character-modal');
+  const input = $('#delete-character-confirm') as HTMLInputElement;
+  const confirmBtn = $('#btn-confirm-delete-character') as HTMLButtonElement;
+  modal.setAttribute('hidden', '');
+  input.value = '';
+  confirmBtn.disabled = true;
+  setDeleteCharacterError('');
+}
+
+function normalizeDeleteConfirmation(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function openDeleteCharacterDialog(character: CharacterSummary): void {
+  pendingDeleteCharacter = character;
+  const modal = $('#delete-character-modal');
+  const nameEl = $('#delete-character-name');
+  const input = $('#delete-character-confirm') as HTMLInputElement;
+  const confirmBtn = $('#btn-confirm-delete-character') as HTMLButtonElement;
+  nameEl.textContent = character.name;
+  input.value = '';
+  confirmBtn.disabled = true;
+  setDeleteCharacterError('');
+  modal.removeAttribute('hidden');
+  input.focus();
+}
+
 async function refreshCharacters(): Promise<void> {
   const listEl = $('#char-list');
   listEl.innerHTML = '<li class="char-list-message">Loading…</li>';
@@ -603,8 +637,13 @@ async function refreshCharacters(): Promise<void> {
       row.innerHTML = `<span class="char-name">${c.name}</span>
         <span class="char-sub">Level ${c.level} ${c.class[0].toUpperCase()}${c.class.slice(1)}${c.online ? ' (in world)' : c.forceRename ? ' (rename required)' : ''}</span>
         ${c.forceRename
-          ? '<input class="rename-input" placeholder="New character name" maxlength="16" /><button class="btn rename-btn">Rename</button>'
-          : `<button class="btn" ${c.online ? 'disabled' : ''}>Enter World</button>`}`;
+          ? `<input class="rename-input" placeholder="New character name" maxlength="16" /><span class="char-actions"><button class="btn btn-danger delete-char-btn" ${c.online ? 'disabled' : ''}>Delete</button><button class="btn rename-btn">Rename</button></span>`
+          : `<span class="char-actions"><button class="btn btn-danger delete-char-btn" ${c.online ? 'disabled' : ''}>Delete</button><button class="btn enter-world-btn" ${c.online ? 'disabled' : ''}>Enter World</button></span>`}`;
+
+      row.querySelector('.delete-char-btn')!.addEventListener('click', (e) => {
+        e.stopPropagation();
+        openDeleteCharacterDialog(c);
+      });
 
       if (c.forceRename) {
         const input = row.querySelector('.rename-input') as HTMLInputElement;
@@ -619,7 +658,7 @@ async function refreshCharacters(): Promise<void> {
           }
         });
       } else {
-        row.querySelector('button')!.addEventListener('click', (e) => {
+        row.querySelector('.enter-world-btn')!.addEventListener('click', (e) => {
           e.stopPropagation();
           enterWorld(c);
         });
@@ -1446,6 +1485,44 @@ function wireStartScreens(): void {
     }
   });
   $('#btn-charselect-back').addEventListener('click', () => show('#login-panel'));
+
+  const deleteConfirmInput = $('#delete-character-confirm') as HTMLInputElement;
+  const deleteConfirmBtn = $('#btn-confirm-delete-character') as HTMLButtonElement;
+  const deleteCancelBtn = $('#btn-cancel-delete-character') as HTMLButtonElement;
+  const deleteModal = $('#delete-character-modal');
+
+  deleteConfirmInput.addEventListener('input', () => {
+    setDeleteCharacterError('');
+    deleteConfirmBtn.disabled = !pendingDeleteCharacter ||
+      normalizeDeleteConfirmation(deleteConfirmInput.value) !== normalizeDeleteConfirmation(pendingDeleteCharacter.name);
+  });
+  deleteConfirmInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !deleteConfirmBtn.disabled) {
+      e.preventDefault();
+      deleteConfirmBtn.click();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeDeleteCharacterDialog();
+    }
+  });
+  deleteCancelBtn.addEventListener('click', () => closeDeleteCharacterDialog());
+  deleteModal.addEventListener('click', (e) => {
+    if (e.target === deleteModal) closeDeleteCharacterDialog();
+  });
+  deleteConfirmBtn.addEventListener('click', async () => {
+    if (!pendingDeleteCharacter) return;
+    const target = pendingDeleteCharacter;
+    deleteConfirmBtn.disabled = true;
+    setDeleteCharacterError('');
+    try {
+      await api.deleteCharacter(target.id, deleteConfirmInput.value);
+      closeDeleteCharacterDialog();
+      await refreshCharacters();
+    } catch (err: any) {
+      setDeleteCharacterError(err.message);
+      deleteConfirmBtn.disabled = normalizeDeleteConfirmation(deleteConfirmInput.value) !== normalizeDeleteConfirmation(target.name);
+    }
+  });
 
   // Collapsible Controls Drawer toggle
   const controlsDrawer = $('#controls-drawer');

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -104,6 +104,20 @@ export class Api {
     return data;
   }
 
+  private async delete(path: string, body: unknown): Promise<any> {
+    const res = await fetch(this.base + path, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error ?? `request failed (${res.status})`);
+    return data;
+  }
+
   async register(username: string, password: string): Promise<void> {
     const data = await this.post('/api/register', { username, password });
     this.token = data.token;
@@ -128,6 +142,10 @@ export class Api {
 
   async renameCharacter(characterId: number, name: string): Promise<void> {
     await this.post(`/api/characters/${characterId}/rename`, { name });
+  }
+
+  async deleteCharacter(characterId: number, name: string): Promise<void> {
+    await this.delete(`/api/characters/${characterId}`, { name });
   }
 
   async reportPlayer(reporterCharacterId: number, targetPid: number, reason: string, details: string): Promise<void> {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
-import { offensiveUsername, validCharName, validUsername } from '../server/auth';
+import { offensiveName, offensiveUsername, validCharName, validUsername } from '../server/auth';
 import { rateLimited, requestIp } from '../server/ratelimit';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
@@ -186,6 +186,13 @@ describe('username censorship', () => {
     });
   });
 
+  it('rejects profanity detected by the built-in username filter', () => {
+    withUsernameBanlist({}, () => {
+      expect(offensiveName('fuuuck')).toBe(true);
+      expect(validUsername('fuuuck')).toBe(false);
+    });
+  });
+
   it('can load banned username terms from a configured file', () => {
     const file = join(tmpdir(), `woc-banlist-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`);
     writeFileSync(file, 'forbidden\n');
@@ -196,5 +203,25 @@ describe('username censorship', () => {
     } finally {
       rmSync(file, { force: true });
     }
+  });
+});
+
+describe('character name censorship', () => {
+  it('rejects profanity in character names', () => {
+    withUsernameBanlist({}, () => {
+      expect(validCharName('Fuuuck')).toBe(false);
+    });
+  });
+
+  it('normalizes separators before checking character names', () => {
+    withUsernameBanlist({ inline: 'biga' }, () => {
+      expect(validCharName('B I G A')).toBe(false);
+    });
+  });
+
+  it('applies configured banned username terms to character names too', () => {
+    withUsernameBanlist({ inline: 'gravecaller' }, () => {
+      expect(validCharName('Grave Caller')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
Summary

  - Add server-side profanity/slur blocking for account usernames and character
  names using `obscenity`
  - Keep existing custom `USERNAME_BANLIST` / `USERNAME_BANLIST_FILE` support and
  apply it to character names too
  - Split name validation errors so blocked content returns `username is not
  allowed` / `character name is not allowed`
  - Add character deletion from the character select screen
  - Require typed character-name confirmation before deletion
  - Enforce delete confirmation server-side, scoped to authenticated account and
  current realm
  - Prevent deletion of currently-online characters

Verification

  - `npm test`
  - `npm run build`
  - `npm audit --audit-level=moderate`
  - Local API smoke tested character delete:
    - wrong confirmation name is rejected
    - trimmed/case-insensitive matching confirmation deletes successfully
    
Data behavior

  Deleting a character removes the persistent character row, including saved
  gameplay state such as level, position, inventory, equipment, quests, and money.

  Related rows behave according to existing DB constraints:

  - Friends/blocks/guild membership cascade and are removed.
  - Play sessions, chat logs, and player reports are preserved for history/
  moderation, with character foreign keys set to `NULL`.
