### PR TITLE
ci: add build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'dev-*'
+      - 'release/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Test and build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Build headless environment
+        run: npm run build:env
+
+      - name: Build server
+        run: npm run build:server
+
+      - name: Build client
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds GitHub Actions coverage for pull requests, pushes to `main`, `dev-*`, and `release/**`, plus manual runs.
- Runs the contributor baseline in CI: `npm ci`, the test suite, typecheck, and the headless env, server, and client builds on Node 22.

## Why
The repository had no CI guard for the build/test baseline, so broken tests, typecheck, or builds could reach contributors before GitHub reported them.

## Implementation Notes
- Uses `actions/checkout@v6` and `actions/setup-node@v6`; latest v6 releases were checked on 2026-06-14.
- Keeps workflow permissions read-only with `contents: read`.

## Verification
- `npm ci`; installed exact dependencies and reported 0 vulnerabilities.
- `npm test`; 35 files passed, 397 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:codex-add-ci-build-test-workflow`; branch is 1 commit ahead, 0 behind, changing only `.github/workflows/ci.yml`.

## Risk
Low CI-only risk. The workflow uses the repository baseline commands and read-only repository permissions.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
