### PR TITLE
fix: cleanse hostile npc control auras

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -15,7 +15,7 @@ import {
 } from './threat';
 import { groundHeight, WATER_LEVEL } from './world';
 import {
-  AbilityDef, AbilityEffect, Aura, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
+  AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
   CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
   INTERACT_RANGE, InvSlot, MELEE_RANGE, MAX_LEVEL,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
@@ -58,6 +58,13 @@ const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_GROWL_INTERVAL = 8; // controlled pets can tank by forcing attention
+const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+]);
+
+function isRejectedFriendlyNpcAura(aura: Aura): boolean {
+  return FRIENDLY_NPC_REJECTED_AURA_KINDS.has(aura.kind);
+}
 
 export interface Party {
   id: number;
@@ -599,6 +606,8 @@ export class Sim {
       if (e.kind === 'mob') {
         this.updateMob(e);
         this.updateAuras(e);
+      } else if (e.kind === 'npc') {
+        this.cleanseFriendlyNpcAuras(e);
       } else if (e.kind === 'object') {
         if (!e.lootable) {
           e.respawnTimer -= DT;
@@ -894,6 +903,15 @@ export class Sim {
       const nv = v - DT;
       if (nv <= 0) p.cooldowns.delete(k);
       else p.cooldowns.set(k, nv);
+    }
+  }
+
+  private cleanseFriendlyNpcAuras(e: Entity): void {
+    for (let i = e.auras.length - 1; i >= 0; i--) {
+      const aura = e.auras[i];
+      if (!isRejectedFriendlyNpcAura(aura)) continue;
+      e.auras.splice(i, 1);
+      this.emit({ type: 'aura', targetId: e.id, name: aura.name, gained: false });
     }
   }
 
@@ -1614,6 +1632,7 @@ export class Sim {
   }
 
   private applyAura(target: Entity, aura: Aura): void {
+    if (target.kind === 'npc' && isRejectedFriendlyNpcAura(aura)) return;
     const existing = target.auras.findIndex((a) => a.id === aura.id && a.sourceId === aura.sourceId);
     if (existing >= 0) target.auras.splice(existing, 1);
     target.auras.push(aura);

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -272,6 +272,21 @@ describe('quest npc roles', () => {
     for (let i = 0; i < 10 && sim.questState('q_fenbridge_muster') !== 'active'; i++) sim.talkToNpc(aldric.id);
     expect(sim.questState('q_fenbridge_muster')).toBe('active');
   });
+
+  it('cleanses hostile control auras from quest NPCs', () => {
+    const sim = makeSim('mage');
+    const redbrook = [...sim.entities.values()].find((e) => e.templateId === 'marshal_redbrook')!;
+    redbrook.auras.push({
+      id: 'polymorph', name: 'Polymorph', kind: 'polymorph',
+      remaining: 15, duration: 15, value: 0, tickInterval: 1, tickTimer: 1,
+      sourceId: sim.playerId, school: 'arcane', breaksOnDamage: true,
+    });
+
+    const events = sim.tick();
+
+    expect(redbrook.auras.some((a) => a.kind === 'polymorph')).toBe(false);
+    expect(events).toContainEqual({ type: 'aura', targetId: redbrook.id, name: 'Polymorph', gained: false });
+  });
 });
 
 describe('warrior charge', () => {


### PR DESCRIPTION
## Summary
- Prevents hostile control and debuff auras from sticking to friendly NPC entities.
- Cleanses rejected NPC aura state during ticks so already-bad live state recovers.
- Covers Marshal Redbrook with a regression test for the observed Polymorph case.

## Diagnosis
Live gameplay showed Marshal Redbrook carrying a Polymorph aura. Friendly quest NPCs shared the normal aura application path with combat targets, so hostile crowd-control state could persist on NPCs that new players need for quest flow.

## Implementation Notes
- Defines the rejected hostile NPC aura kinds once and uses the same policy for new aura application and tick-time cleanup.
- Emits the existing aura-loss event when cleanup removes an already-applied rejected aura.

## Verification
- `npx vitest run tests/fixes.test.ts`
- `npx tsc --noEmit`
- `npm test`
- `npm run build:env`
- `npm run build:server`
- `npm run build`

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
