### PR TITLE
fix: await guild broadcasts so members reliably receive updates

### DIFF
--- a/server/social.ts
+++ b/server/social.ts
@@ -417,8 +417,8 @@ export class SocialService {
     }
     if (targetMembership.rank === rank) { this.err(actor.characterId, `${target.name} is already ${RANK_LABEL[rank]}.`); return; }
     await this.db.setGuildRank(target.id, rank);
-    this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${target.name} is now ${RANK_LABEL[rank]}.`, color: '#40ff7f' }]);
-    this.pushGuild(membership.guildId);
+    await this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${target.name} is now ${RANK_LABEL[rank]}.`, color: '#40ff7f' }]);
+    await this.pushGuild(membership.guildId);
   }
 
   async guildChat(actor: SocialActor, rawText: string): Promise<boolean> {
@@ -447,18 +447,16 @@ export class SocialService {
   }
 
   // Deliver events to every online member of a guild.
-  private broadcastGuild(guildId: number, events: SocialEvent[]): void {
-    void this.db.guildMembers(guildId).then((members) => {
-      for (const m of members) {
-        if (this.tx.isOnline(m.id)) this.tx.deliver(m.id, events);
-      }
-    });
+  private async broadcastGuild(guildId: number, events: SocialEvent[]): Promise<void> {
+    const members = await this.db.guildMembers(guildId);
+    for (const m of members) {
+      if (this.tx.isOnline(m.id)) this.tx.deliver(m.id, events);
+    }
   }
 
-  private pushGuild(guildId: number): void {
-    void this.db.guildMembers(guildId).then((members) => {
-      for (const m of members) if (this.tx.isOnline(m.id)) this.push(m.id);
-    });
+  private async pushGuild(guildId: number): Promise<void> {
+    const members = await this.db.guildMembers(guildId);
+    for (const m of members) if (this.tx.isOnline(m.id)) this.push(m.id);
   }
 
   // Drop a character's pending invite when they disconnect.

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -301,6 +301,21 @@ describe('guilds', () => {
     expect(h.tx.eventsFor(3).some((e) => e.type === 'guildInvite')).toBe(true);
   });
 
+  it('awaits the rank-change broadcast so members reliably receive it', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    h.tx.clear();
+    // Force the member lookup that broadcastGuild/pushGuild depend on to resolve
+    // on a later macrotask. If guildSetRank fails to await the broadcast, the
+    // promote notice will not have been delivered by the time the call resolves.
+    const realMembers = h.db.guildMembers.bind(h.db);
+    h.db.guildMembers = (guildId: number) =>
+      new Promise((resolve) => { setTimeout(() => { void realMembers(guildId).then(resolve); }, 0); });
+    await h.svc.guildSetRank(h.actor(1), 'Bet', 'officer');
+    expect(h.tx.textFor(2).join()).toMatch(/Bet is now Officer/);
+  });
+
   it('expires a stale invite', async () => {
     await h.svc.guildCreate(h.actor(1), 'Knights');
     await h.svc.guildInvite(h.actor(1), 'Bet');


### PR DESCRIPTION
## Summary

`broadcastGuild` and `pushGuild` in `server/social.ts` were typed `void` but did their member lookup and event delivery via a fire-and-forget `void this.db.guildMembers(...).then(...)`. Most call sites already wrote `await this.broadcastGuild(...)`, but **awaiting a `void` return is a no-op**, so the async work was never actually awaited. `guildSetRank` didn't even attempt to await it.

The result: guild events (joins, promotions, kicks, leaves, guild chat) could be lost or delivered out of order. If a member's online/offline state changed — or the request handler returned and unwound — between scheduling the `.then()` and the deferred `guildMembers()` lookup resolving, the delivery could simply be missed. The failure is silent: TypeScript permits `await` on a non-promise, so there's no type error and no runtime error.

## Fix

- Make `broadcastGuild` and `pushGuild` `async` (return `Promise<void>`), so every existing `await` call site becomes meaningful.
- Add the two missing `await`s in `guildSetRank`.

## Test

Adds a regression test that forces the member lookup to resolve on a later macrotask and asserts the promote notice has been delivered by the time `guildSetRank` resolves. It **fails before the fix** and **passes after**. Full suite: 326 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)