### PR TITLE
fix: scope deleteCharacter to the current realm

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -253,7 +253,7 @@ export async function createCharacter(accountId: number, name: string, cls: Play
 }
 
 export async function deleteCharacter(accountId: number, characterId: number): Promise<boolean> {
-  const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2', [characterId, accountId]);
+  const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3', [characterId, accountId, REALM]);
   return (res.rowCount ?? 0) > 0;
 }
 

--- a/tests/character_db.test.ts
+++ b/tests/character_db.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// db.ts builds a pg Pool and requires DATABASE_URL at import time; stub both so
+// the module loads and every query goes through a spy we can assert against.
+const { query } = vi.hoisted(() => ({ query: vi.fn() }));
+vi.hoisted(() => {
+  process.env.DATABASE_URL = 'postgres://test/test';
+});
+vi.mock('pg', () => ({
+  Pool: function Pool() {
+    return { query };
+  },
+}));
+
+import { deleteCharacter } from '../server/db';
+import { REALM } from '../server/realm';
+
+beforeEach(() => {
+  query.mockReset();
+});
+
+describe('deleteCharacter', () => {
+  it('scopes the delete to the current realm so cross-realm characters are safe', async () => {
+    query.mockResolvedValueOnce({ rowCount: 1 } as any);
+
+    await deleteCharacter(7, 42);
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/realm/i);
+    expect(params).toContain(REALM);
+    // id + account + realm — the same three predicates getCharacter/renameCharacter use
+    expect(params).toEqual(expect.arrayContaining([42, 7, REALM]));
+  });
+
+  it('reports whether a row was actually deleted', async () => {
+    query.mockResolvedValueOnce({ rowCount: 0 } as any);
+    expect(await deleteCharacter(7, 42)).toBe(false);
+
+    query.mockResolvedValueOnce({ rowCount: 1 } as any);
+    expect(await deleteCharacter(7, 42)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`deleteCharacter` only matched on `id` + `account_id`, unlike every other character query — `listCharacters`, `getCharacter`, and `renameCharacter` all additionally scope by `realm`. In the documented process-per-realm model (multiple realm processes sharing one `DATABASE_URL`), an account that owns characters across more than one realm could delete a character belonging to a **different** realm than the one the serving process hosts.

This restores the per-realm isolation invariant that the rest of the character API already enforces.

```diff
-  const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2', [characterId, accountId]);
+  const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3', [characterId, accountId, REALM]);
```

## Why it matters

`server/realm.ts` documents that "Characters, friends, guilds, and presence are all scoped to this value, so two processes with different `REALM_NAME` share a DB yet form fully isolated worlds." The missing `realm` predicate on delete broke that isolation for a cross-realm account.

## Testing

- Added `tests/character_db.test.ts`, which mocks the `pg` pool (matching the existing `moderation_db.test.ts` style) and asserts the delete query is realm-scoped and includes `REALM` in its parameters.
- Full suite: **327 tests passing**.
- Typecheck introduces no new errors (one pre-existing error in `moderation_db.ts` is unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)