### PR TITLE
fix: silence mob leash reset chat

### DIFF
--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2294,7 +2294,6 @@ export class Sim {
           mob.aiState = 'evade';
           mob.aggroTargetId = null;
           clearThreat(mob);
-          this.emit({ type: 'log', text: mob.name + ' returns home.', color: '#999', entityId: mob.id });
           break;
         }
         const d = dist2d(mob.pos, target.pos);

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { applyAction, encodeObs, obsSize, ACTIONS } from '../src/sim/obs';
 import {
-  dist2d, MAX_LEVEL, xpForLevel, mobXpValue, rageConversion, rageFromDealing,
+  type SimEvent, dist2d, MAX_LEVEL, xpForLevel, mobXpValue, rageConversion, rageFromDealing,
   spellHitChance, meleeMissChance,
 } from '../src/sim/types';
 import { QUESTS, abilitiesKnownAt } from '../src/sim/data';
@@ -222,11 +222,13 @@ describe('combat', () => {
     teleportTo(sim, wolf.spawnPos.x + 100, wolf.spawnPos.z + 100);
     sim.stopAutoAttack();
     let evaded = false;
+    const leashEvents: SimEvent[] = [];
     for (let i = 0; i < 20 * 30 && !evaded; i++) {
-      sim.tick();
+      leashEvents.push(...sim.tick());
       if (wolf.aiState === 'evade' || wolf.aiState === 'idle') evaded = true;
     }
     expect(evaded).toBe(true);
+    expect(leashEvents.some((e) => e.type === 'log' && e.text.endsWith(' returns home.'))).toBe(false);
     for (let i = 0; i < 20 * 30 && wolf.aiState !== 'idle'; i++) sim.tick();
     expect(wolf.hp).toBe(wolf.maxHp);
   });


### PR DESCRIPTION
## Summary
- Stops mob leash resets from posting player-visible `returns home` log lines during normal evade recovery.
- Keeps the existing evade and reset behavior covered while asserting the chat log stays quiet.

## Diagnosis
The leash-distance path emitted a log event whenever a mob entered evade. In normal play, every mob that lost aggro could add another reset line to the shared game chat.

## Verification
- `npx vitest run tests/sim.test.ts`
- `npx tsc --noEmit`
- `npm test`
- `npm run build:env`
- `npm run build:server`
- `npm run build`

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
