### PR TITLE
fix: normalize character names server-side instead of trusting the client

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -88,3 +88,15 @@ export function validPassword(p: unknown): p is string {
 export function validCharName(n: unknown): n is string {
   return typeof n === 'string' && /^[A-Za-z][A-Za-z' -]{1,15}$/.test(n);
 }
+
+// Server-side canonical form for a character name: trim the ends and collapse
+// any interior whitespace run to a single space. The browser already trims
+// before sending, but the server is the authority — a direct API client must
+// not be able to store a padded name (e.g. "Bob "), which would then fail to
+// match the typed, unpadded form in findCharacterByName. Returns the cleaned
+// name, or null if it is not a valid character name once normalized.
+export function normalizeCharName(n: unknown): string | null {
+  if (typeof n !== 'string') return null;
+  const cleaned = n.trim().replace(/\s+/g, ' ');
+  return validCharName(cleaned) ? cleaned : null;
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -10,7 +10,7 @@ import {
 } from './db';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
-import { hashPassword, verifyPassword, newToken, validUsername, validPassword, validCharName } from './auth';
+import { hashPassword, verifyPassword, newToken, validUsername, validPassword, normalizeCharName } from './auth';
 import { json, readBody } from './http_util';
 import { rateLimited } from './ratelimit';
 import { handleAdminApi } from './admin';
@@ -181,13 +181,14 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       }
       if (req.method === 'POST') {
         const body = await readBody(req);
-        if (!validCharName(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+        const name = normalizeCharName(body.name);
+        if (name === null) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
         const validClasses = ['warrior', 'paladin', 'hunter', 'rogue', 'priest', 'shaman', 'mage', 'warlock', 'druid'];
         if (!validClasses.includes(body.class)) return json(res, 400, { error: 'invalid class' });
         const chars = await listCharacters(accountId);
         if (chars.length >= 10) return json(res, 400, { error: 'character limit reached' });
         try {
-          const c = await createCharacter(accountId, body.name, body.class);
+          const c = await createCharacter(accountId, name, body.class);
           return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
         } catch (err: any) {
           if (String(err?.message).includes('unique') || err?.code === '23505') {
@@ -203,9 +204,10 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const accountId = await bearerActiveAccount(req, res);
       if (accountId === null) return;
       const body = await readBody(req);
-      if (!validCharName(body.name)) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
+      const name = normalizeCharName(body.name);
+      if (name === null) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
       try {
-        const c = await renameCharacter(accountId, Number(renameMatch[1]), body.name);
+        const c = await renameCharacter(accountId, Number(renameMatch[1]), name);
         if (!c) return json(res, 404, { error: 'character not found' });
         return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
       } catch (err: any) {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
-import { offensiveUsername, validCharName, validUsername } from '../server/auth';
+import { normalizeCharName, offensiveUsername, validCharName, validUsername } from '../server/auth';
 import { rateLimited, requestIp } from '../server/ratelimit';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
@@ -143,6 +143,36 @@ describe('malformed websocket frames cannot crash the server', () => {
 
   it('still accepts a well-formed object frame', () => {
     expect(parseFrame(JSON.stringify({ t: 'input', mi: { f: 1 } }))).toEqual({ t: 'input', mi: { f: 1 } });
+  });
+});
+
+describe('character name normalization', () => {
+  // The server is the authority: it must not trust the browser to strip
+  // whitespace. A direct API client could otherwise store padded names that
+  // then become un-befriendable (findCharacterByName won't match the typed,
+  // unpadded form).
+  it('trims surrounding whitespace and collapses interior runs', () => {
+    expect(normalizeCharName('  Bob  Smith ')).toBe('Bob Smith');
+    expect(normalizeCharName('Thrall')).toBe('Thrall');
+    expect(normalizeCharName('Bob \t Smith')).toBe('Bob Smith');
+  });
+
+  it('returns null for names that are invalid even after normalizing', () => {
+    expect(normalizeCharName('  ')).toBeNull();
+    expect(normalizeCharName('A')).toBeNull(); // too short
+    expect(normalizeCharName('123Adventurer')).toBeNull();
+    expect(normalizeCharName(42)).toBeNull();
+  });
+
+  it('preserves valid punctuation while normalizing whitespace', () => {
+    expect(normalizeCharName("  Kael'thas ")).toBe("Kael'thas");
+    expect(normalizeCharName('Rexxar-Misha')).toBe('Rexxar-Misha');
+  });
+
+  it('a normalized name always passes validCharName', () => {
+    const n = normalizeCharName('  Bob  Smith ');
+    expect(n).not.toBeNull();
+    expect(validCharName(n)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

The browser trims character names before sending them, but the server is the real authority and was storing `body.name` **raw**. Because `validCharName`'s regex `^[A-Za-z][A-Za-z' -]{1,15}$` includes a space in its character class, a direct (non-browser) `POST /api/characters` or `POST /api/characters/:id/rename` could persist a padded name like `"Bob "`.

Such a name then fails to match the typed, unpadded form in `findCharacterByName`:
- the exact-match query (`name = $1`) misses, and
- the case-insensitive fallback (`lower(name) = lower($1)`) misses too (`'bob' != 'bob '`).

The result: that character is **un-befriendable / un-ignorable** via `/friend`, `/ignore`, guild invites, etc., and renders with stray trailing whitespace.

## Fix

- Add `normalizeCharName(n)` in `server/auth.ts`: trims the ends, collapses interior whitespace runs to a single space, then validates the normalized form (returns the clean name or `null`).
- The create and rename endpoints in `server/main.ts` now store the **normalized** name rather than the raw input.

This moves name normalization to the server boundary instead of trusting the client to do it.

## Testing

- Added unit coverage in `tests/security.test.ts` (`character name normalization`) — written test-first (red → green).
- Full suite: **329 passed** (was 325).

🤖 Generated with [Claude Code](https://claude.com/claude-code)