### PR TITLE
fix: gate starter zone hint on quest state

### DIFF
--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -31,6 +31,7 @@ export const ZONE1_ZONE: ZoneDef = {
     { x: 80, z: 80, label: 'Fallen Chapel' },
   ],
   welcome: 'Find Marshal Redbrook in town — he has work for you.',
+  welcomeQuestId: 'q_wolves',
 };
 
 // ---------------------------------------------------------------------------

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -6,7 +6,7 @@
 
 import type {
   CampDef, DungeonDef, GroundObjectDef, ItemDef, MobTemplate, NpcDef,
-  PlayerClass, QuestDef, ZoneDef, ZonePropsDef,
+  PlayerClass, QuestDef, QuestState, ZoneDef, ZonePropsDef,
 } from './types';
 import { BASE_ITEMS } from './content/items';
 import {
@@ -112,6 +112,11 @@ export function zoneAt(z: number): ZoneDef {
     if (z < zone.zMax) return zone;
   }
   return ZONES[ZONES.length - 1];
+}
+
+export function zoneWelcomeText(zone: ZoneDef, questState: (questId: string) => QuestState): string | null {
+  if (zone.welcomeQuestId && questState(zone.welcomeQuestId) !== 'available') return null;
+  return zone.welcome;
 }
 
 // Legacy single-zone exports (zone 1) — still referenced by tests and the

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -274,6 +274,7 @@ export interface ZoneDef {
   lakes: { x: number; z: number; radius: number }[];
   pois: { x: number; z: number; label: string }[];
   welcome: string; // chat-log hint shown on first entry
+  welcomeQuestId?: string; // only show the hint while this quest is available
 }
 
 export interface BuildingDef {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4,6 +4,7 @@ import { Renderer } from '../render/renderer';
 import {
   ABILITIES, CLASSES, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, MOBS, NPCS, QUESTS,
   WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z, ZONES, dungeonAt, zoneAt,
+  zoneWelcomeText,
 } from '../sim/data';
 import type { ZoneDef } from '../sim/data';
 import type { InvSlot } from '../sim/types';
@@ -140,7 +141,7 @@ export class Hud {
     this.lastZoneId = startZone.id;
     this.showBanner(startZone.name);
     this.log(`Welcome to ${startZone.name}!`, '#ffd100');
-    this.log(startZone.welcome, '#ffd100');
+    this.logZoneWelcome(startZone);
   }
 
   private bindLogTabs(): void {
@@ -583,7 +584,7 @@ export class Hud {
         if (this.lastZoneId !== '') {
           this.showBanner(currentZone.name);
           this.log(`Entering ${currentZone.name}.`, '#ffd100');
-          this.log(currentZone.welcome, '#ffd100');
+          this.logZoneWelcome(currentZone);
         }
         this.lastZoneId = currentZone.id;
       }
@@ -1071,6 +1072,11 @@ export class Hud {
 
   log(text: string, color = '#ccc'): void {
     this.appendLog(this.chatLogEl, text, color);
+  }
+
+  private logZoneWelcome(zone: ZoneDef): void {
+    const text = zoneWelcomeText(zone, (questId) => this.sim.questState(questId));
+    if (text) this.log(text, '#ffd100');
   }
 
   private chatLogFrom(name: string, text: string, color: string, prefix: string, separator: string): void {

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { Entity, dist2d } from '../src/sim/types';
-import { CRYPT_DOOR_POS, DUNGEON_X_THRESHOLD, LAKE, MOBS, NPCS, QUESTS } from '../src/sim/data';
+import { CRYPT_DOOR_POS, DUNGEON_X_THRESHOLD, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { groundHeight, WATER_LEVEL } from '../src/sim/world';
 import { isBlocked, resolvePosition } from '../src/sim/colliders';
@@ -21,6 +21,28 @@ function teleportTo(sim: Sim, x: number, z: number, pid?: number) {
 }
 
 describe('quest lifecycle', () => {
+  it('stops showing the Redbrook starter hint after the first quest is accepted', () => {
+    const sim = makeSim();
+    const starterZone = zoneAt(sim.player.pos.z);
+
+    expect(zoneWelcomeText(starterZone, (questId) => sim.questState(questId)))
+      .toBe('Find Marshal Redbrook in town — he has work for you.');
+
+    sim.acceptQuest('q_wolves');
+    expect(zoneWelcomeText(starterZone, (questId) => sim.questState(questId))).toBeNull();
+
+    const qp = sim.questLog.get('q_wolves')!;
+    qp.counts[0] = 8;
+    qp.state = 'ready';
+
+    const redbrook = [...sim.entities.values()].find((e) => e.templateId === 'marshal_redbrook')!;
+    teleportTo(sim, redbrook.pos.x + 2, redbrook.pos.z + 2);
+    sim.turnInQuest('q_wolves');
+
+    expect(sim.questState('q_wolves')).toBe('done');
+    expect(zoneWelcomeText(starterZone, (questId) => sim.questState(questId))).toBeNull();
+  });
+
   it('a turned-in quest cannot be accepted again', () => {
     const sim = makeSim();
     sim.acceptQuest('q_wolves');


### PR DESCRIPTION
## Summary
- Stops the Eastbrook Vale Redbrook starter hint from repeating after the player accepts or completes `q_wolves`.
- Adds an optional `welcomeQuestId` gate for zone welcome text while preserving ungated welcome text for other zones.
- Covers the hint before quest acceptance, after acceptance, and after turn-in.

## Diagnosis
The HUD logged each zone's welcome hint unconditionally on startup and zone entry. That made the starter quest prompt keep reappearing even after the player had already moved past the Redbrook quest step.

## Implementation Notes
- Centralizes zone welcome visibility in `zoneWelcomeText` so startup and zone-entry logging use the same quest-state rule.
- Keeps the zone schema backward-compatible by making `welcomeQuestId` optional.

## Verification
- `npx vitest run tests/fixes.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npm run build:env`
- `npm run build:server`
- `npm run build`

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
