### PR TITLE
fix: run moderation writes on a pinned pooled client

### DIFF
--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -206,38 +206,45 @@ export async function moderateAccount(input: {
       throw new Error('suspension expiry must be in the future');
     }
   }
-  await pool.query('BEGIN');
+  // Pin a single pooled client so BEGIN/…/COMMIT run on the same connection and
+  // the moderation write is actually atomic. Issuing these through pool.query()
+  // can spread them across different connections, leaving a partially-applied
+  // action (e.g. account banned but audit row / report resolution missing).
+  const client = await pool.connect();
   try {
+    await client.query('BEGIN');
     if (input.action === 'ban') {
-      await pool.query(
+      await client.query(
         `UPDATE accounts
          SET banned_at = now(), suspended_until = NULL, moderation_reason = $2
          WHERE id = $1`,
         [input.accountId, reason],
       );
     } else {
-      await pool.query(
+      await client.query(
         `UPDATE accounts
          SET suspended_until = $2, moderation_reason = $3
          WHERE id = $1`,
         [input.accountId, expiresAt!.toISOString(), reason],
       );
     }
-    await pool.query(
+    await client.query(
       `INSERT INTO account_moderation_actions (account_id, admin_account_id, action, reason, expires_at)
        VALUES ($1, $2, $3, $4, $5)`,
       [input.accountId, input.adminAccountId, input.action, reason, expiresAt ? expiresAt.toISOString() : null],
     );
-    await pool.query(
+    await client.query(
       `UPDATE player_reports
        SET status = 'actioned', reviewed_at = now(), reviewed_by_account_id = $2, review_note = $3
        WHERE reported_account_id = $1 AND status = 'open'`,
       [input.accountId, input.adminAccountId, reason],
     );
-    await pool.query('COMMIT');
+    await client.query('COMMIT');
   } catch (err) {
-    await pool.query('ROLLBACK');
+    await client.query('ROLLBACK').catch(() => {});
     throw err;
+  } finally {
+    client.release();
   }
 }
 
@@ -251,24 +258,29 @@ export async function forceCharacterRename(input: {
   const character = await pool.query('SELECT account_id FROM characters WHERE id = $1', [input.characterId]);
   const accountId = character.rows[0]?.account_id;
   if (!accountId) throw new Error('character not found');
-  await pool.query('BEGIN');
+  // Pin a single pooled client so the whole transaction is atomic; see the note
+  // in moderateAccount above.
+  const client = await pool.connect();
   try {
-    await pool.query('UPDATE characters SET force_rename = TRUE WHERE id = $1', [input.characterId]);
-    await pool.query(
+    await client.query('BEGIN');
+    await client.query('UPDATE characters SET force_rename = TRUE WHERE id = $1', [input.characterId]);
+    await client.query(
       `INSERT INTO account_moderation_actions (account_id, admin_account_id, action, reason)
        VALUES ($1, $2, 'force_rename', $3)`,
       [accountId, input.adminAccountId, reason],
     );
-    await pool.query(
+    await client.query(
       `UPDATE player_reports
        SET status = 'actioned', reviewed_at = now(), reviewed_by_account_id = $2, review_note = $3
        WHERE reported_character_id = $1 AND status = 'open'`,
       [input.characterId, input.adminAccountId, reason],
     );
-    await pool.query('COMMIT');
+    await client.query('COMMIT');
     return { accountId };
   } catch (err) {
-    await pool.query('ROLLBACK');
+    await client.query('ROLLBACK').catch(() => {});
     throw err;
+  } finally {
+    client.release();
   }
 }

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../server/db', () => ({
-  pool: { query: vi.fn() },
+  pool: { query: vi.fn(), connect: vi.fn() },
 }));
 
 import { pool } from '../server/db';
@@ -11,9 +11,20 @@ import {
 } from '../server/moderation_db';
 
 const query = vi.mocked(pool.query);
+const connect = vi.mocked(pool.connect);
+
+// A pooled-client stub whose query()/release() calls we can inspect. Pinning a
+// single client for the whole transaction is what makes BEGIN/…/COMMIT atomic,
+// so the tests assert every transactional statement runs through this stub.
+function clientStub() {
+  const cquery = vi.fn().mockResolvedValue({ rows: [] } as any);
+  const release = vi.fn();
+  return { query: cquery, release };
+}
 
 beforeEach(() => {
   query.mockReset();
+  connect.mockReset();
 });
 
 describe('moderation report helpers', () => {
@@ -122,21 +133,40 @@ describe('moderation report helpers', () => {
   });
 
   it('marks a character for forced rename and action-resolves its reports', async () => {
-    query
-      .mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any)
-      .mockResolvedValueOnce({ rows: [] } as any)
-      .mockResolvedValueOnce({ rows: [] } as any)
-      .mockResolvedValueOnce({ rows: [] } as any)
-      .mockResolvedValueOnce({ rows: [] } as any)
-      .mockResolvedValueOnce({ rows: [] } as any);
+    query.mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any);
+    const client = clientStub();
+    connect.mockResolvedValue(client as any);
 
     const result = await forceCharacterRename({ characterId: 20, adminAccountId: 1, reason: 'offensive name' });
 
     expect(result).toEqual({ accountId: 2 });
-    expect(query.mock.calls[1][0]).toBe('BEGIN');
-    expect(query.mock.calls[2][0]).toMatch(/UPDATE characters SET force_rename = TRUE/);
-    expect(query.mock.calls[3][0]).toMatch(/account_moderation_actions/);
-    expect(query.mock.calls[4][0]).toMatch(/UPDATE player_reports/);
-    expect(query.mock.calls[5][0]).toBe('COMMIT');
+    // The whole transaction must run on one pinned client, not arbitrary pooled
+    // connections, otherwise BEGIN/…/COMMIT are not actually atomic.
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(client.query.mock.calls[0][0]).toBe('BEGIN');
+    expect(client.query.mock.calls[1][0]).toMatch(/UPDATE characters SET force_rename = TRUE/);
+    expect(client.query.mock.calls[2][0]).toMatch(/account_moderation_actions/);
+    expect(client.query.mock.calls[3][0]).toMatch(/UPDATE player_reports/);
+    expect(client.query.mock.calls[4][0]).toBe('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back on the pinned client and releases it when a statement fails', async () => {
+    query.mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any);
+    const client = clientStub();
+    client.query
+      .mockResolvedValueOnce({ rows: [] } as any) // BEGIN
+      .mockRejectedValueOnce(new Error('db down')) // first UPDATE fails
+      .mockResolvedValue({ rows: [] } as any); // ROLLBACK
+    connect.mockResolvedValue(client as any);
+
+    await expect(
+      forceCharacterRename({ characterId: 20, adminAccountId: 1, reason: 'offensive name' }),
+    ).rejects.toThrow(/db down/);
+
+    const stmts = client.query.mock.calls.map((c) => c[0]);
+    expect(stmts).toContain('ROLLBACK');
+    expect(stmts).not.toContain('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem

`moderateAccount` and `forceCharacterRename` in `server/moderation_db.ts` issued `BEGIN`, their `UPDATE`/`INSERT` statements, and `COMMIT`/`ROLLBACK` through `pool.query()`. With `pg`'s connection `Pool`, **each `pool.query()` call can check out a different physical connection**, so these statements were not guaranteed to run inside one transaction.

Consequences:

- **No atomicity.** If a statement fails partway (e.g. the `account_moderation_actions` insert throws), an earlier `UPDATE accounts SET banned_at = now()` may already be committed on its own connection — leaving the account banned but the audit row and report-resolution never written. The `ROLLBACK` may run on a different connection with no open transaction and do nothing.
- **Connection-state leak under concurrency.** `BEGIN` can land on connection A; a different request that borrows A before `COMMIT` inherits an open transaction.

These are security-sensitive moderation paths, so a partially-applied state matters.

## Fix

Pin a single client via `pool.connect()` for the whole transaction and `release()` it in `finally` — exactly the pattern already used in `server/db.ts` `ensureSchema()`. `ROLLBACK` is now best-effort (`.catch(() => {})`) so the original error always propagates.

## Tests

The existing `tests/moderation_db.test.ts` mocked `pool` as a single shared `query` fn and actually *asserted* the buggy `pool.query('BEGIN')` sequence, so it could not detect the cross-connection problem. Updated to:

- provide a `pool.connect()` stub returning a pinned client,
- assert every transactional statement (`BEGIN` → updates → `COMMIT`) runs through that one client and it is released,
- add a regression test that a mid-transaction failure issues `ROLLBACK` (never `COMMIT`) on the pinned client and still releases it.

Full suite: **326 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)