### PR TITLE
feat: expose quest grouping metadata

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1,9 +1,9 @@
 // Online play: REST auth client + WebSocket world mirror.
 
 import { NPCS, abilitiesKnownAt } from '../sim/data';
-import { computeQuestState, ResolvedAbility } from '../sim/sim';
+import { computeQuestInfo, computeQuestState, ResolvedAbility } from '../sim/sim';
 import {
-  Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
+  Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestInfo, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
 import type { ArenaInfo, CharacterSearchResult, DuelInfo, IWorld, MarketInfo, PartyInfo, SocialInfo, TradeInfo } from '../world_api';
@@ -532,6 +532,13 @@ export class ClientWorld implements IWorld {
       return 'active';
     }
     return state;
+  }
+
+  questInfo(questId: string): QuestInfo {
+    return {
+      ...computeQuestInfo(questId, this.questLog, this.questsDone, this.player.level),
+      state: this.questState(questId),
+    };
   }
 
   consumeInventoryChanged(): boolean {

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -42,6 +42,8 @@ export const MOBS: Record<string, MobTemplate> = {
   ...ZONE1_MOBS, ...ZONE2_MOBS, ...ZONE3_MOBS, ...DUNGEON_MOBS,
 };
 
+export const DUNGEON_MOB_IDS = new Set(Object.keys(DUNGEON_MOBS));
+
 export const NPCS: Record<string, NpcDef> = {
   ...ZONE1_NPCS, ...ZONE2_NPCS, ...ZONE3_NPCS,
 };

--- a/src/sim/obs.ts
+++ b/src/sim/obs.ts
@@ -83,7 +83,7 @@ export function applyAction(sim: Sim, action: number): void {
 const NEARBY_MOBS = 5;
 
 export function obsSize(): number {
-  return 16 + ABILITY_SLOTS * 2 + 9 + NEARBY_MOBS * 6 + 5 + QUEST_ORDER.length * 2;
+  return 16 + ABILITY_SLOTS * 2 + 9 + NEARBY_MOBS * 6 + 5 + QUEST_ORDER.length * 3;
 }
 
 export function encodeObs(sim: Sim): number[] {
@@ -177,9 +177,10 @@ export function encodeObs(sim: Sim): number[] {
     obs.push(0, 1.5, 0, 0, 0);
   }
 
-  // --- quests (10 x 2 = 20) ---
+  // --- quests (QUEST_ORDER.length x 3) ---
   for (const qid of QUEST_ORDER) {
-    const state = sim.questState(qid);
+    const info = sim.questInfo(qid);
+    const state = info.state;
     obs.push(state === 'done' ? 1 : state === 'ready' ? 0.66 : state === 'active' ? 0.33 : 0);
     const qp = sim.questLog.get(qid);
     if (qp) {
@@ -190,6 +191,7 @@ export function encodeObs(sim: Sim): number[] {
     } else {
       obs.push(state === 'done' ? 1 : 0);
     }
+    obs.push(info.suggestedPlayers ? clamp(info.suggestedPlayers / 5, 0, 1) : 0);
   }
 
   return obs;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,6 +1,6 @@
 import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
-  DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
+  DUNGEON_MOB_IDS, DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
   ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, REWARD_ARCHETYPE, abilitiesKnownAt, instanceOrigin,
   zoneAt,
 } from './data';
@@ -19,7 +19,7 @@ import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
   CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
   INTERACT_RANGE, InvSlot, MELEE_RANGE, MAX_LEVEL,
-  MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
+  MoveInput, PlayerClass, QuestInfo, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
   rageFromDealing, rageFromTaking, spellHitChance, xpForLevel,
 } from './types';
@@ -256,6 +256,31 @@ export function computeQuestState(
   if (quest.requiresQuest && !questsDone.has(quest.requiresQuest)) return 'unavailable';
   if (quest.minLevel && playerLevel < quest.minLevel) return 'unavailable';
   return 'available';
+}
+
+export function computeQuestInfo(
+  questId: string,
+  questLog: Map<string, QuestProgress>,
+  questsDone: Set<string>,
+  playerLevel: number,
+): QuestInfo {
+  const state = computeQuestState(questId, questLog, questsDone, playerLevel);
+  const quest = QUESTS[questId];
+  if (!quest) return { questId, state, suggestedPlayers: null, elite: false, dungeon: false };
+  let elite = false;
+  let dungeon = false;
+  for (const obj of quest.objectives) {
+    if (!obj.targetMobId) continue;
+    if (MOBS[obj.targetMobId]?.elite) elite = true;
+    if (DUNGEON_MOB_IDS.has(obj.targetMobId)) dungeon = true;
+  }
+  return {
+    questId,
+    state,
+    suggestedPlayers: quest.suggestedPlayers ?? null,
+    elite,
+    dungeon,
+  };
 }
 
 function copyPos(dst: { x: number; y: number; z: number }, src: { x: number; y: number; z: number }): void {
@@ -3007,6 +3032,12 @@ export class Sim {
     const r = this.resolve(pid);
     if (!r) return 'unavailable';
     return computeQuestState(questId, r.meta.questLog, r.meta.questsDone, r.e.level);
+  }
+
+  questInfo(questId: string, pid?: number): QuestInfo {
+    const r = this.resolve(pid);
+    if (!r) return { questId, state: 'unavailable', suggestedPlayers: null, elite: false, dungeon: false };
+    return computeQuestInfo(questId, r.meta.questLog, r.meta.questsDone, r.e.level);
   }
 
   private questNpcFor(questId: string, role: 'giver' | 'turnIn', p: Entity): { npc: Entity | null; tooFar: boolean } {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -339,6 +339,14 @@ export interface QuestDef {
 
 export type QuestState = 'unavailable' | 'available' | 'active' | 'ready' | 'done';
 
+export interface QuestInfo {
+  questId: string;
+  state: QuestState;
+  suggestedPlayers: number | null;
+  elite: boolean;
+  dungeon: boolean;
+}
+
 export interface QuestProgress {
   questId: string;
   counts: number[]; // per objective

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -1,4 +1,4 @@
-import type { Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, ResourceType } from './sim/types';
+import type { Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestInfo, QuestProgress, QuestState, ResourceType } from './sim/types';
 import type { ResolvedAbility } from './sim/sim';
 
 export interface PartyMemberInfo {
@@ -150,6 +150,7 @@ export interface IWorld {
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;
   questState(questId: string): QuestState;
+  questInfo(questId: string): QuestInfo;
   castAbility(abilityId: string): void;
   castAbilityBySlot(slot: number): void;
   targetEntity(id: number | null): void;

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -5,7 +5,7 @@ import {
   type SimEvent, dist2d, MAX_LEVEL, xpForLevel, mobXpValue, rageConversion, rageFromDealing,
   spellHitChance, meleeMissChance,
 } from '../src/sim/types';
-import { QUESTS, abilitiesKnownAt } from '../src/sim/data';
+import { QUESTS, QUEST_ORDER, abilitiesKnownAt } from '../src/sim/data';
 import { terrainHeight } from '../src/sim/world';
 
 function makeSim(cls: 'warrior' | 'mage' | 'rogue' = 'warrior', seed = 42) {
@@ -600,6 +600,38 @@ describe('RL interface', () => {
       expect(Number.isFinite(v)).toBe(true);
       expect(Math.abs(v)).toBeLessThanOrEqual(2);
     }
+  });
+
+  it('exposes quest grouping metadata through world state and observations', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(20);
+    sim.questsDone.add('q_bones');
+    sim.questsDone.add('q_whispers');
+    sim.questsDone.add('q_rite');
+
+    expect(sim.questInfo('q_hollow')).toMatchObject({
+      state: 'available',
+      suggestedPlayers: 5,
+      elite: true,
+      dungeon: true,
+    });
+    expect(sim.questInfo('q_crushers')).toMatchObject({
+      suggestedPlayers: 3,
+      elite: true,
+      dungeon: false,
+    });
+    expect(sim.questInfo('q_wolves')).toMatchObject({
+      suggestedPlayers: null,
+      elite: false,
+      dungeon: false,
+    });
+
+    const obs = encodeObs(sim);
+    const questBase = obsSize() - QUEST_ORDER.length * 3;
+    const hollowIndex = QUEST_ORDER.indexOf('q_hollow');
+    const wolvesIndex = QUEST_ORDER.indexOf('q_wolves');
+    expect(obs[questBase + hollowIndex * 3 + 2]).toBe(1);
+    expect(obs[questBase + wolvesIndex * 3 + 2]).toBe(0);
   });
 
   it('actions execute without error and sim stays finite', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -287,6 +287,7 @@ describe('client-side delta merge', () => {
       client.acceptQuest('q_wolves');
       expect(client.questLog.has('q_wolves')).toBe(false);
       expect(client.questState('q_wolves')).toBe('active');
+      expect(client.questInfo('q_wolves').state).toBe('active');
       expect(sent).toContainEqual({ t: 'cmd', cmd: 'accept', quest: 'q_wolves' });
 
       (client as any).pendingQuestCommands.clear();
@@ -295,10 +296,26 @@ describe('client-side delta merge', () => {
       expect(client.questLog.has('q_wolves')).toBe(true);
       expect(client.questsDone.has('q_wolves')).toBe(false);
       expect(client.questState('q_wolves')).toBe('active');
+      expect(client.questInfo('q_wolves').state).toBe('active');
       expect(sent).toContainEqual({ t: 'cmd', cmd: 'turnin', quest: 'q_wolves' });
     } finally {
       (globalThis as any).WebSocket = oldWebSocket;
     }
+  });
+
+  it('computes quest grouping metadata on the client mirror', () => {
+    const client = bareClient(1);
+    client.entities.set(1, { id: 1, level: 20 } as any);
+    client.questsDone.add('q_bones');
+    client.questsDone.add('q_whispers');
+    client.questsDone.add('q_rite');
+
+    expect(client.questInfo('q_hollow')).toMatchObject({
+      state: 'available',
+      suggestedPlayers: 5,
+      elite: true,
+      dungeon: true,
+    });
   });
 
   it('keeps previous structures when delta fields are omitted', () => {


### PR DESCRIPTION
## Summary
- Exposes `questInfo()` on the shared world API so offline `Sim` and online `ClientWorld` report quest state together with `suggestedPlayers`, `elite`, and `dungeon` metadata.
- Adds a normalized per-quest `suggestedPlayers` observation value so agents can distinguish true group content from hard normal quests without inferring from level or route difficulty.
- Derives `elite` from objective mob templates and `dungeon` from dungeon mob content, keeping the metadata source-owned and deterministic.

## Implementation Notes
- Existing `questState()` behavior is unchanged for HUD, renderer, and quest flow callers.
- `ClientWorld.questInfo()` uses the same pending-command state as `questState()` so online dialogs do not briefly drift while awaiting authoritative quest snapshots.
- No snapshot, persistence, or server schema changes are needed because the online client already computes quest state from shared quest definitions.

## Verification
- `npx vitest run tests/sim.test.ts tests/snapshots.test.ts` (2 files, 56 tests)
- `npx tsc --noEmit`
- Full configured gate after review fix: `npm test` (35 files, 399 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Review gate clean for `main..HEAD`.

## Risk
- Observation vector size increases by one value per quest. `obsSize()` and regression coverage were updated with the new layout.
- Grouping flags are exposed as read-only metadata from static content, so gameplay authority and quest progression remain unchanged.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
