### PR TITLE
fix: keep hud out of login shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,11 +530,6 @@
     display: none; align-items: center; justify-content: center; flex-direction: column; gap: 18px; z-index: 30; }
   #death-overlay h1 { color: #ddd; font-size: 44px; text-shadow: 2px 2px 8px #000; font-family: var(--title-font); }
   
-  /* Hide all other UI components while the start screen is visible to prevent keyboard focus leakage */
-  body:has(#start-screen:not([style*="display: none"])) #ui {
-    display: none !important;
-  }
-
   /* ---------- start screen ---------- */
   #start-screen {
     position: absolute;
@@ -1957,6 +1952,7 @@
   <canvas id="game-canvas"></canvas>
   <div id="nameplates"></div>
 
+  <template id="game-ui-template">
   <div id="ui">
     <div id="player-frame" class="unitframe">
       <div class="portrait-wrap">
@@ -2083,6 +2079,7 @@
   </div>
 
   <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  </template>
 
   <main id="start-screen">
     <h1 class="visually-hidden">World of Claudecraft</h1>

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,14 @@ function beginWorldEntry(): boolean {
   return true;
 }
 
+function mountGameUi(): void {
+  if (document.getElementById('ui')) return;
+  const template = document.getElementById('game-ui-template') as HTMLTemplateElement | null;
+  const startScreen = document.getElementById('start-screen');
+  if (!template || !startScreen) throw new Error('Game UI shell is missing.');
+  document.body.insertBefore(template.content.cloneNode(true), startScreen);
+}
+
 // ---------------------------------------------------------------------------
 // Shared game wiring (used by both offline sim and online world)
 // ---------------------------------------------------------------------------
@@ -90,6 +98,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     return;
   }
   setLoadingStatus('Entering the world…');
+  mountGameUi();
 
   const canvas = $('#game-canvas') as unknown as HTMLCanvasElement;
   const nameplates = $('#nameplates') as HTMLDivElement;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+function splitGameUiTemplate(): { templateHtml: string; liveHtml: string } {
+  const marker = '<template id="game-ui-template">';
+  const start = html.indexOf(marker);
+  const end = html.indexOf('</template>', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  const templateHtml = html.slice(start, end + '</template>'.length);
+  return {
+    templateHtml,
+    liveHtml: html.slice(0, start) + html.slice(end + '</template>'.length),
+  };
+}
+
+describe('client HTML shell', () => {
+  it('keeps game HUD controls out of the live startup DOM', () => {
+    const { liveHtml, templateHtml } = splitGameUiTemplate();
+
+    expect(templateHtml).toContain('id="ui"');
+    expect(templateHtml).toContain('Release Spirit');
+    expect(templateHtml).toContain('Combat Log');
+    expect(templateHtml).toContain('id="chat-input"');
+
+    expect(liveHtml).not.toContain('id="ui"');
+    expect(liveHtml).not.toContain('Release Spirit');
+    expect(liveHtml).not.toContain('Combat Log');
+    expect(liveHtml).not.toContain('id="chat-input"');
+  });
+});


### PR DESCRIPTION
## Summary
- Keeps game-only HUD controls out of the live login, realm, and character-select DOM while no world exists.
- Moves the static HUD/chat shell into an inert `game-ui-template` and mounts it only when `startGame` begins world entry.
- Adds a regression test that verifies Release Spirit, Combat Log, and chat input are absent from the live startup shell but still present in the game UI template.

## Diagnosis
The startup HTML mounted both the start flow and the game HUD at page load, then relied on CSS to hide the HUD while the start screen was visible. After restart, DOM/a11y inspection could still find game controls such as Release Spirit and Combat Log even while `window.__game` was unset.

## Verification
- `npx vitest run tests/client_shell.test.ts`; 1 test passed.
- `npx tsc --noEmit`.
- `npm run build`.
- Browser DOM check at initial mode select and login panel: `hasGame: false`, no live `#ui`, no live `#chat-input`, no Release Spirit or Combat Log text in rendered body.
- Browser offline-entry check: `hasGame: true`, live `#ui`, live `#chat-input`, player entered world without page errors.
- `VITEST_MAX_WORKERS=1 VITEST_TEST_TIMEOUT=10000 npm test`; 26 files and 326 tests passed during PR hygiene recovery from unrelated 5s suite timeout margins.
- Commit/polish gates also ran `npm run build:env`, `npm run build:server`, and `npm run build` successfully.

## Real behavior proof
- Behavior addressed: after restart, the login page DOM exposed game UI controls while `hasGame` was false.
- Environment tested: local Vite browser session with Puppeteer against mode select, login panel, and offline world entry.
- Evidence after fix: login/startup DOM has no live game HUD or chat input until world entry mounts the template.

## Risk
Low client-shell risk. The HUD markup is unchanged, but it is no longer live until world entry. The main risk is startup ordering for HUD queries; offline browser entry confirmed the template mounts before renderer/HUD wiring reads those elements.

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
