### PR TITLE
feat: return structured item command results

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
-import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
+import { CommandResult, DT, Entity, SimEvent, dist2d } from '../src/sim/types';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
@@ -623,15 +623,31 @@ export class GameServer {
       case 'attack': sim.startAutoAttack(pid); break;
       case 'stopattack': sim.stopAutoAttack(pid); break;
       case 'interact': sim.interact(pid); break;
-      case 'loot': if (typeof msg.id === 'number') sim.lootCorpse(msg.id, pid); break;
+      case 'loot':
+        this.sendCommandResult(session, msg, typeof msg.id === 'number'
+          ? sim.lootCorpse(msg.id, pid)
+          : this.commandFailure('invalid_command', 'Invalid loot command.'));
+        break;
       case 'pickup': if (typeof msg.id === 'number') sim.pickUpObject(msg.id, pid); break;
       case 'accept': if (typeof msg.quest === 'string') { sim.acceptQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'turnin': if (typeof msg.quest === 'string') { sim.turnInQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'abandon': if (typeof msg.quest === 'string') { sim.abandonQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'equip': if (typeof msg.item === 'string') sim.equipItem(msg.item, pid); break;
-      case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
-      case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
-      case 'sell': if (typeof msg.item === 'string') sim.sellItem(msg.item, pid); break;
+      case 'use':
+        this.sendCommandResult(session, msg, typeof msg.item === 'string'
+          ? sim.useItem(msg.item, pid)
+          : this.commandFailure('invalid_command', 'Invalid use command.'));
+        break;
+      case 'buy':
+        this.sendCommandResult(session, msg, typeof msg.npc === 'number' && typeof msg.item === 'string'
+          ? sim.buyItem(msg.npc, msg.item, pid)
+          : this.commandFailure('invalid_command', 'Invalid buy command.'));
+        break;
+      case 'sell':
+        this.sendCommandResult(session, msg, typeof msg.item === 'string'
+          ? sim.sellItem(msg.item, pid)
+          : this.commandFailure('invalid_command', 'Invalid sell command.'));
+        break;
       case 'release': sim.releaseSpirit(pid); break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;
@@ -1074,6 +1090,15 @@ export class GameServer {
   private resyncQuests(session: ClientSession): void {
     delete session.lastSent.qlog;
     delete session.lastSent.qdone;
+  }
+
+  private commandFailure(reason: string, serverMessage: string): CommandResult {
+    return { ok: false, reason, serverMessage, changedItems: [], changedCopper: 0 };
+  }
+
+  private sendCommandResult(session: ClientSession, msg: any, result: CommandResult): void {
+    if (typeof msg.rid !== 'number') return;
+    this.send(session, { t: 'cmdResult', rid: msg.rid, result });
   }
 
   private send(session: ClientSession, obj: unknown): void {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -3,7 +3,7 @@
 import { NPCS, abilitiesKnownAt } from '../sim/data';
 import { computeQuestState, ResolvedAbility } from '../sim/sim';
 import {
-  Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
+  CommandResult, Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
 import type { ArenaInfo, CharacterSearchResult, DuelInfo, IWorld, MarketInfo, PartyInfo, SocialInfo, TradeInfo } from '../world_api';
@@ -237,6 +237,8 @@ export class ClientWorld implements IWorld {
   private readonly token: string;
   private readonly base: string;
   private eventQueue: SimEvent[] = [];
+  private nextCommandRequestId = 1;
+  private pendingCommandResults = new Map<number, { resolve: (result: CommandResult) => void; timeout: number }>();
   // inventory deltas arrive in snapshots, separate from the event frames the
   // HUD redraws on — the frame loop polls this so open panels re-render
   private invChanged = false;
@@ -262,6 +264,7 @@ export class ClientWorld implements IWorld {
     this.ws.onclose = () => {
       this.connected = false;
       clearInterval(this.sendTimer);
+      this.resolvePendingCommandResults(this.commandFailure('disconnected', 'Connection to the server was lost.'));
       this.onDisconnect?.('Connection to the server was lost.');
     };
     // input stream at sim rate
@@ -271,6 +274,7 @@ export class ClientWorld implements IWorld {
   close(): void {
     clearInterval(this.sendTimer);
     this.ws.onclose = null;
+    this.resolvePendingCommandResults(this.commandFailure('closed', 'Connection closed.'));
     this.ws.close();
   }
 
@@ -317,6 +321,57 @@ export class ClientWorld implements IWorld {
     this.ws.send(JSON.stringify({ t: 'cmd', ...payload }));
   }
 
+  private cmdWithResult(payload: Record<string, unknown>): Promise<CommandResult> {
+    if (!this.connected || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.resolve(this.commandFailure('not_connected', 'Not connected.'));
+    }
+    const rid = this.nextCommandRequestId++;
+    return new Promise((resolve) => {
+      const timeout = window.setTimeout(() => {
+        this.pendingCommandResults.delete(rid);
+        resolve(this.commandFailure('timeout', 'No server response.'));
+      }, 5000);
+      this.pendingCommandResults.set(rid, { resolve, timeout });
+      this.ws.send(JSON.stringify({ t: 'cmd', rid, ...payload }));
+    });
+  }
+
+  private commandFailure(reason: string, serverMessage: string): CommandResult {
+    return { ok: false, reason, serverMessage, changedItems: [], changedCopper: 0 };
+  }
+
+  private normalizeCommandResult(result: any): CommandResult {
+    if (typeof result !== 'object' || result === null) {
+      return this.commandFailure('invalid_result', 'Invalid server response.');
+    }
+    const changedItems = Array.isArray(result.changedItems)
+      ? result.changedItems.flatMap((item: any) => {
+        if (typeof item?.itemId !== 'string') return [];
+        return [{
+          itemId: item.itemId,
+          before: Number(item.before) || 0,
+          after: Number(item.after) || 0,
+          delta: Number(item.delta) || 0,
+        }];
+      })
+      : [];
+    return {
+      ok: result.ok === true,
+      reason: typeof result.reason === 'string' ? result.reason : 'unknown',
+      serverMessage: typeof result.serverMessage === 'string' ? result.serverMessage : '',
+      changedItems,
+      changedCopper: Number(result.changedCopper) || 0,
+    };
+  }
+
+  private resolvePendingCommandResults(result: CommandResult): void {
+    for (const [rid, pending] of this.pendingCommandResults) {
+      window.clearTimeout(pending.timeout);
+      pending.resolve(result);
+      this.pendingCommandResults.delete(rid);
+    }
+  }
+
   private onMessage(raw: string): void {
     let msg: any;
     try {
@@ -338,6 +393,15 @@ export class ClientWorld implements IWorld {
     }
     if (msg.t === 'events') {
       for (const ev of msg.list) this.eventQueue.push(ev as SimEvent);
+      return;
+    }
+    if (msg.t === 'cmdResult') {
+      const rid = typeof msg.rid === 'number' ? msg.rid : -1;
+      const pending = this.pendingCommandResults.get(rid);
+      if (!pending) return;
+      window.clearTimeout(pending.timeout);
+      this.pendingCommandResults.delete(rid);
+      pending.resolve(this.normalizeCommandResult(msg.result));
       return;
     }
     if (msg.t === 'social') {
@@ -570,8 +634,8 @@ export class ClientWorld implements IWorld {
   interact(): void {
     this.cmd({ cmd: 'interact' });
   }
-  lootCorpse(id: number): void {
-    this.cmd({ cmd: 'loot', id });
+  lootCorpse(id: number): Promise<CommandResult> {
+    return this.cmdWithResult({ cmd: 'loot', id });
   }
   pickUpObject(id: number): void {
     this.cmd({ cmd: 'pickup', id });
@@ -592,14 +656,14 @@ export class ClientWorld implements IWorld {
   equipItem(itemId: string): void {
     this.cmd({ cmd: 'equip', item: itemId });
   }
-  useItem(itemId: string): void {
-    this.cmd({ cmd: 'use', item: itemId });
+  useItem(itemId: string): Promise<CommandResult> {
+    return this.cmdWithResult({ cmd: 'use', item: itemId });
   }
-  buyItem(npcId: number, itemId: string): void {
-    this.cmd({ cmd: 'buy', npc: npcId, item: itemId });
+  buyItem(npcId: number, itemId: string): Promise<CommandResult> {
+    return this.cmdWithResult({ cmd: 'buy', npc: npcId, item: itemId });
   }
-  sellItem(itemId: string): void {
-    this.cmd({ cmd: 'sell', item: itemId });
+  sellItem(itemId: string): Promise<CommandResult> {
+    return this.cmdWithResult({ cmd: 'sell', item: itemId });
   }
   releaseSpirit(): void {
     this.cmd({ cmd: 'release' });

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -17,7 +17,7 @@ import {
 import { groundHeight, WATER_LEVEL } from './world';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
-  CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
+  CONSUME_TICKS, CommandResult, DT, Entity, EquipSlot, GCD,
   INTERACT_RANGE, InvSlot, MELEE_RANGE, MAX_LEVEL,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
@@ -2793,6 +2793,40 @@ export class Sim {
     this.onInventoryChangedForQuests(meta);
   }
 
+  private emptyCommandResult(ok: boolean, reason: string, serverMessage: string): CommandResult {
+    return { ok, reason, serverMessage, changedItems: [], changedCopper: 0 };
+  }
+
+  private inventoryCounts(meta: PlayerMeta): Map<string, number> {
+    const counts = new Map<string, number>();
+    for (const slot of meta.inventory) counts.set(slot.itemId, (counts.get(slot.itemId) ?? 0) + slot.count);
+    return counts;
+  }
+
+  private commandResult(
+    meta: PlayerMeta,
+    beforeItems: Map<string, number>,
+    beforeCopper: number,
+    ok: boolean,
+    reason: string,
+    serverMessage: string,
+  ): CommandResult {
+    const afterItems = this.inventoryCounts(meta);
+    const itemIds = new Set([...beforeItems.keys(), ...afterItems.keys()]);
+    const changedItems = [...itemIds].sort().flatMap((itemId) => {
+      const before = beforeItems.get(itemId) ?? 0;
+      const after = afterItems.get(itemId) ?? 0;
+      return before === after ? [] : [{ itemId, before, after, delta: after - before }];
+    });
+    return {
+      ok,
+      reason,
+      serverMessage,
+      changedItems,
+      changedCopper: meta.copper - beforeCopper,
+    };
+  }
+
   equipItem(itemId: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
@@ -2813,15 +2847,27 @@ export class Sim {
     this.emit({ type: 'log', text: `Equipped ${def.name}.`, color: '#8f8', pid: meta.entityId });
   }
 
-  useItem(itemId: string, pid?: number): void {
+  useItem(itemId: string, pid?: number): CommandResult {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return this.emptyCommandResult(false, 'invalid_player', 'Player not found.');
     const { meta, e: p } = r;
     const def = ITEMS[itemId];
-    if (!def || this.countItem(itemId, meta.entityId) <= 0 || p.dead) return;
+    if (!def) return this.emptyCommandResult(false, 'unknown_item', 'That item does not exist.');
+    if (this.countItem(itemId, meta.entityId) <= 0) return this.emptyCommandResult(false, 'missing_item', "You don't have that item.");
+    if (p.dead) return this.emptyCommandResult(false, 'dead', "You can't do that while dead.");
+    const beforeItems = this.inventoryCounts(meta);
+    const beforeCopper = meta.copper;
     if (def.kind === 'food' || def.kind === 'drink') {
-      if (p.inCombat) { this.error(meta.entityId, "You can't do that while in combat."); return; }
-      if (this.isSwimming(p)) { this.error(meta.entityId, "You can't do that while swimming."); return; }
+      if (p.inCombat) {
+        const msg = "You can't do that while in combat.";
+        this.error(meta.entityId, msg);
+        return this.commandResult(meta, beforeItems, beforeCopper, false, 'in_combat', msg);
+      }
+      if (this.isSwimming(p)) {
+        const msg = "You can't do that while swimming.";
+        this.error(meta.entityId, msg);
+        return this.commandResult(meta, beforeItems, beforeCopper, false, 'swimming', msg);
+      }
       this.removeItem(itemId, 1, meta.entityId);
       p.sitting = true;
       // food and drink occupy separate slots, so you can do both at once
@@ -2833,47 +2879,101 @@ export class Sim {
         manaPer2s: def.drinkMana ? Math.round(def.drinkMana / CONSUME_TICKS) : 0,
         remaining: CONSUME_DURATION,
       };
-      this.emit({ type: 'log', text: def.kind === 'food' ? 'You sit down to eat.' : 'You sit down to drink.', color: '#999', pid: meta.entityId });
+      const msg = def.kind === 'food' ? 'You sit down to eat.' : 'You sit down to drink.';
+      this.emit({ type: 'log', text: msg, color: '#999', pid: meta.entityId });
+      return this.commandResult(meta, beforeItems, beforeCopper, true, 'used', msg);
     } else if (def.kind === 'weapon' || def.kind === 'armor') {
+      if (def.requiredClass && !def.requiredClass.includes(meta.cls)) {
+        const msg = 'You cannot equip that.';
+        this.error(meta.entityId, msg);
+        return this.commandResult(meta, beforeItems, beforeCopper, false, 'wrong_class', msg);
+      }
       this.equipItem(itemId, meta.entityId);
+      return this.commandResult(meta, beforeItems, beforeCopper, true, 'equipped', `Equipped ${def.name}.`);
     }
+    return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_usable', 'That item cannot be used.');
   }
 
-  buyItem(npcId: number, itemId: string, pid?: number): void {
+  buyItem(npcId: number, itemId: string, pid?: number): CommandResult {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return this.emptyCommandResult(false, 'invalid_player', 'Player not found.');
     const { meta, e: p } = r;
     const npc = this.entities.get(npcId);
     const def = ITEMS[itemId];
+    const beforeItems = this.inventoryCounts(meta);
+    const beforeCopper = meta.copper;
     if (!npc || npc.kind !== 'npc' || npc.vendorItems.length === 0) {
-      this.error(meta.entityId, 'That merchant is not available.');
-      return;
+      const msg = 'That merchant is not available.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_vendor', msg);
     }
-    if (!npc.vendorItems.includes(itemId)) { this.error(meta.entityId, 'That item is not sold here.'); return; }
-    if (!def?.buyValue) { this.error(meta.entityId, 'That item is not for sale.'); return; }
-    if (dist2d(p.pos, npc.pos) > INTERACT_RANGE + 2) { this.error(meta.entityId, 'Too far away.'); return; }
-    if (meta.copper < def.buyValue) { this.error(meta.entityId, 'Not enough money.'); return; }
+    if (!npc.vendorItems.includes(itemId)) {
+      const msg = 'That item is not sold here.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_sold', msg);
+    }
+    if (!def?.buyValue) {
+      const msg = 'That item is not for sale.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_purchasable', msg);
+    }
+    if (dist2d(p.pos, npc.pos) > INTERACT_RANGE + 2) {
+      const msg = 'Too far away.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'too_far', msg);
+    }
+    if (meta.copper < def.buyValue) {
+      const msg = 'Not enough money.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_enough_money', msg);
+    }
     meta.copper -= def.buyValue;
     this.addItem(itemId, 1, meta.entityId);
     this.emit({ type: 'vendor', action: 'buy', itemId, pid: meta.entityId });
+    return this.commandResult(meta, beforeItems, beforeCopper, true, 'bought', `Bought ${def.name}.`);
   }
 
-  sellItem(itemId: string, pid?: number): void {
+  sellItem(itemId: string, pid?: number): CommandResult {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return this.emptyCommandResult(false, 'invalid_player', 'Player not found.');
     const { meta, e: p } = r;
     const def = ITEMS[itemId];
-    if (!def || this.countItem(itemId, meta.entityId) <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
-    if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
+    const beforeItems = this.inventoryCounts(meta);
+    const beforeCopper = meta.copper;
+    if (!def) {
+      const msg = 'That item does not exist.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'unknown_item', msg);
+    }
+    if (this.countItem(itemId, meta.entityId) <= 0) {
+      const msg = "You don't have that item.";
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'missing_item', msg);
+    }
+    if (p.dead) {
+      const msg = "You can't do that while dead.";
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'dead', msg);
+    }
     // mirror buyItem's gate: selling requires a vendor in interact range
     const nearVendor = [...this.entities.values()].some((e) =>
       e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
-    if (!nearVendor) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
-    if (def.kind === 'quest') { this.error(meta.entityId, 'You cannot sell quest items.'); return; }
+    if (!nearVendor) {
+      const msg = 'There is no merchant nearby.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'no_merchant', msg);
+    }
+    if (def.kind === 'quest') {
+      const msg = 'You cannot sell quest items.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'quest_item', msg);
+    }
     this.removeItem(itemId, 1, meta.entityId);
     meta.copper += def.sellValue;
     this.emit({ type: 'vendor', action: 'sell', itemId, pid: meta.entityId });
-    this.emit({ type: 'loot', text: `Sold ${def.name} for ${formatMoney(def.sellValue)}.`, pid: meta.entityId });
+    const msg = `Sold ${def.name} for ${formatMoney(def.sellValue)}.`;
+    this.emit({ type: 'loot', text: msg, pid: meta.entityId });
+    return this.commandResult(meta, beforeItems, beforeCopper, true, 'sold', msg);
   }
 
   private addItemSilent(itemId: string, count: number, meta: PlayerMeta): void {
@@ -2900,21 +3000,29 @@ export class Sim {
   // Interaction: looting, quest NPCs, ground objects
   // -------------------------------------------------------------------------
 
-  lootCorpse(mobId: number, pid?: number): void {
+  lootCorpse(mobId: number, pid?: number): CommandResult {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return this.emptyCommandResult(false, 'invalid_player', 'Player not found.');
     const { meta, e: p } = r;
     const mob = this.entities.get(mobId);
-    if (!mob || !mob.lootable || !mob.loot) return;
+    const beforeItems = this.inventoryCounts(meta);
+    const beforeCopper = meta.copper;
+    if (!mob || !mob.lootable || !mob.loot) return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_lootable', 'There is nothing to loot.');
     if (mob.tappedById !== null && mob.tappedById !== meta.entityId) {
       // party members of the tapper share loot rights
       const tapperParty = this.partyOf(mob.tappedById);
       if (!tapperParty || !tapperParty.members.includes(meta.entityId)) {
-        this.error(meta.entityId, "You don't have permission to loot that.");
-        return;
+        const msg = "You don't have permission to loot that.";
+        this.error(meta.entityId, msg);
+        return this.commandResult(meta, beforeItems, beforeCopper, false, 'not_allowed', msg);
       }
     }
-    if (dist2d(p.pos, mob.pos) > INTERACT_RANGE) { this.error(meta.entityId, 'Too far away.'); return; }
+    if (dist2d(p.pos, mob.pos) > INTERACT_RANGE) {
+      const msg = 'Too far away.';
+      this.error(meta.entityId, msg);
+      return this.commandResult(meta, beforeItems, beforeCopper, false, 'too_far', msg);
+    }
+    const itemCount = mob.loot.items.reduce((sum, slot) => sum + slot.count, 0);
     if (mob.loot.copper > 0) {
       meta.copper += mob.loot.copper;
       meta.counters.lootCopper += mob.loot.copper;
@@ -2925,6 +3033,10 @@ export class Sim {
     mob.lootable = false;
     mob.corpseTimer = Math.min(mob.corpseTimer, 4);
     if (p.targetId === mobId) p.targetId = null;
+    const pieces = [];
+    if (meta.copper !== beforeCopper) pieces.push(formatMoney(meta.copper - beforeCopper));
+    if (itemCount > 0) pieces.push(`${itemCount} item${itemCount === 1 ? '' : 's'}`);
+    return this.commandResult(meta, beforeItems, beforeCopper, true, 'looted', pieces.length > 0 ? `Looted ${pieces.join(' and ')}.` : 'Looted corpse.');
   }
 
   pickUpObject(objId: number, pid?: number): void {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -91,6 +91,21 @@ export interface InvSlot {
   count: number;
 }
 
+export interface CommandItemChange {
+  itemId: string;
+  before: number;
+  after: number;
+  delta: number;
+}
+
+export interface CommandResult {
+  ok: boolean;
+  reason: string;
+  serverMessage: string;
+  changedItems: CommandItemChange[];
+  changedCopper: number;
+}
+
 export interface LootEntry {
   itemId?: string;
   copper?: number;

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -1,4 +1,4 @@
-import type { Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, ResourceType } from './sim/types';
+import type { CommandResult, Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, ResourceType } from './sim/types';
 import type { ResolvedAbility } from './sim/sim';
 
 export interface PartyMemberInfo {
@@ -133,6 +133,8 @@ export interface MarketInfo {
   myListingCount: number; // how many active listings the viewer already has
 }
 
+export type CommandResultLike = CommandResult | Promise<CommandResult>;
+
 // The surface the renderer + HUD need from a game world. The offline `Sim`
 // satisfies this structurally; the online `ClientWorld` implements it by
 // mirroring server snapshots and sending commands over the socket.
@@ -157,15 +159,15 @@ export interface IWorld {
   startAutoAttack(): void;
   stopAutoAttack(): void;
   interact(): void;
-  lootCorpse(id: number): void;
+  lootCorpse(id: number): CommandResultLike;
   pickUpObject(id: number): void;
   acceptQuest(questId: string): void;
   turnInQuest(questId: string): void;
   abandonQuest(questId: string): void;
   equipItem(itemId: string): void;
-  useItem(itemId: string): void;
-  buyItem(npcId: number, itemId: string): void;
-  sellItem(itemId: string): void;
+  useItem(itemId: string): CommandResultLike;
+  buyItem(npcId: number, itemId: string): CommandResultLike;
+  sellItem(itemId: string): CommandResultLike;
   releaseSpirit(): void;
   chat(text: string): void;
   // social systems

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -454,16 +454,48 @@ describe('food, drink, vendor', () => {
     expect(sim.player.resource).toBeGreaterThan(before);
   });
 
+  it('use item returns a structured inventory result', () => {
+    const sim = makeSim('warrior');
+    sim.addItem('baked_bread', 1);
+    const result = sim.useItem('baked_bread');
+    expect(result).toMatchObject({
+      ok: true,
+      reason: 'used',
+      serverMessage: 'You sit down to eat.',
+      changedCopper: 0,
+    });
+    expect(result.changedItems).toEqual([
+      { itemId: 'baked_bread', before: 1, after: 0, delta: -1 },
+    ]);
+  });
+
   it('vendor buys and sells', () => {
     const sim = makeSim('warrior');
     const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
     teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
     sim.copper = 100;
-    sim.buyItem(wilkes.id, 'baked_bread');
+    const buy = sim.buyItem(wilkes.id, 'baked_bread');
+    expect(buy).toMatchObject({
+      ok: true,
+      reason: 'bought',
+      changedCopper: -25,
+    });
+    expect(buy.changedItems).toEqual([
+      { itemId: 'baked_bread', before: 0, after: 1, delta: 1 },
+    ]);
     expect(sim.countItem('baked_bread')).toBe(1);
     expect(sim.copper).toBe(75);
     sim.addItem('wolf_fang', 2);
-    sim.sellItem('wolf_fang');
+    const sell = sim.sellItem('wolf_fang');
+    expect(sell).toMatchObject({
+      ok: true,
+      reason: 'sold',
+      serverMessage: 'Sold Cracked Wolf Fang for 4c.',
+      changedCopper: 4,
+    });
+    expect(sell.changedItems).toEqual([
+      { itemId: 'wolf_fang', before: 2, after: 1, delta: -1 },
+    ]);
     expect(sim.copper).toBe(79);
     expect(sim.countItem('wolf_fang')).toBe(1);
   });
@@ -475,10 +507,36 @@ describe('food, drink, vendor', () => {
     sim.copper = 100;
     sim.events = [];
 
-    sim.buyItem(wilkes.id, 'baked_bread');
+    const result = sim.buyItem(wilkes.id, 'baked_bread');
 
+    expect(result).toMatchObject({
+      ok: false,
+      reason: 'too_far',
+      serverMessage: 'Too far away.',
+      changedCopper: 0,
+      changedItems: [],
+    });
     expect(sim.countItem('baked_bread')).toBe(0);
     expect(sim.events).toContainEqual({ type: 'error', text: 'Too far away.', pid: sim.player.id });
+  });
+
+  it('loot corpse returns structured item and copper changes', () => {
+    const sim = makeSim('warrior');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    teleportTo(sim, wolf.pos.x + 2, wolf.pos.z);
+    wolf.lootable = true;
+    wolf.loot = { copper: 12, items: [{ itemId: 'wolf_fang', count: 2 }] };
+    const result = sim.lootCorpse(wolf.id);
+    expect(result).toMatchObject({
+      ok: true,
+      reason: 'looted',
+      changedCopper: 12,
+    });
+    expect(result.changedItems).toEqual([
+      { itemId: 'wolf_fang', before: 0, after: 2, delta: 2 },
+    ]);
+    expect(wolf.lootable).toBe(false);
+    expect(wolf.loot).toBe(null);
   });
 });
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -157,6 +157,29 @@ describe('delta snapshots', () => {
     expect(snap.self).not.toHaveProperty('inv');
   });
 
+  it('returns structured results for item commands with a request id', () => {
+    const wilkes = [...server.sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    const player = server.sim.entities.get(session.pid)!;
+    const pos = server.sim.groundPos(wilkes.pos.x + 2, wilkes.pos.z);
+    player.pos = { ...pos };
+    player.prevPos = { ...pos };
+    server.sim.meta(session.pid)!.copper = 100;
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'buy', rid: 42, npc: wilkes.id, item: 'baked_bread' }));
+
+    expect(fc.sent).toContainEqual({
+      t: 'cmdResult',
+      rid: 42,
+      result: {
+        ok: true,
+        reason: 'bought',
+        serverMessage: 'Bought Freshly Baked Bread.',
+        changedItems: [{ itemId: 'baked_bread', before: 0, after: 1, delta: 1 }],
+        changedCopper: -25,
+      },
+    });
+  });
+
   it('each client gets full state on its own first snapshot', () => {
     broadcast(server);
     const fc2 = fakeWs();


### PR DESCRIPTION
## Summary
- Adds structured command results for `useItem`, `buyItem`, `sellItem`, and `lootCorpse`.
- Returns explicit success/failure metadata plus item and copper deltas so controllers do not need to infer outcomes by polling state or parsing chat/log text.
- Carries the same result contract through the offline sim, `IWorld`, the online client mirror, and authoritative server command replies.

## Implementation Notes
- The shared sim remains the source of truth for item/vendor/loot state transitions and computes the before/after inventory and copper diff.
- Online commands with request ids receive `cmdResult` replies from `GameServer`; `ClientWorld` resolves those to the same `CommandResult` shape used offline.
- Rebased onto current `main` while preserving current vendor rejection feedback and adding structured failure metadata for those paths.

## Verification
- `npx vitest run tests/sim.test.ts tests/snapshots.test.ts` (2 files, 57 tests)
- `npx tsc --noEmit`
- `npm run build:server`
- `npm run build`
- Review gate clean for `main..HEAD`.

## Risk
- Online callers receive results asynchronously, while offline callers receive them synchronously through the same `IWorld` return type union. Existing fire-and-forget UI callers can ignore the returned value.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
