### PR TITLE
feat: persist chat whispers

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,13 +340,20 @@
   #chatlog-tabs { display: flex; gap: 2px; margin-left: 6px; margin-bottom: -1px; position: relative; z-index: 2; }
   .chat-tab { height: 22px; padding: 0 12px; border: 1px solid #3a321d; border-bottom: none;
     border-radius: 6px 6px 0 0; background: linear-gradient(#1c1824, #0d0b13); color: #95886a;
-    cursor: pointer; font-family: var(--title-font); font-size: 12px; text-shadow: 1px 1px 1px #000; }
+    cursor: pointer; font-family: var(--title-font); font-size: 12px; text-shadow: 1px 1px 1px #000; position: relative; }
   .chat-tab.active { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#2a2436, #161220); }
+  .chat-tab.has-private { color: #ffb4ff; border-color: #b96cff; box-shadow: 0 0 8px #ff80ff66; }
+  .chat-tab.has-private::after { content: attr(data-private-count); position: absolute; top: -7px; right: -7px;
+    min-width: 15px; height: 15px; padding: 0 4px; border-radius: 8px; background: #ff80ff; color: #180018;
+    border: 1px solid #ffd6ff; font-family: var(--ui-font); font-size: 10px; font-weight: bold; line-height: 14px; text-shadow: none; }
   #chatlog-frame { height: 184px; padding: 0; overflow: hidden; border-radius: 0 6px 6px 6px; }
   .chat-pane { display: none; height: 100%; overflow-y: auto; overflow-x: hidden; padding: 7px 10px;
     font-size: 11px; line-height: 1.45; }
   .chat-pane.active { display: block; }
   .chat-pane div { text-shadow: 1px 1px 1px #000; overflow-wrap: break-word; user-select: text; }
+  .chat-time { color: #8d826c; margin-right: 2px; }
+  .chat-private { background: rgba(255, 128, 255, 0.08); border-left: 2px solid #ff80ff; margin-left: -6px; padding-left: 4px; }
+  .chat-private.incoming-private { box-shadow: inset 0 0 10px #ff80ff22; }
   .chat-player-name { cursor: context-menu; text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
   .chat-player-name:hover { filter: brightness(1.25); }
   .chat-pane::-webkit-scrollbar { width: 8px; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -337,6 +337,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   function openChat(): void {
     chatInput.style.display = 'block';
     chatInput.focus();
+    hud.onChatOpened();
   }
   chatInput.addEventListener('keydown', (e) => {
     e.stopPropagation();

--- a/src/ui/chat_history.ts
+++ b/src/ui/chat_history.ts
@@ -1,0 +1,96 @@
+export const CHAT_HISTORY_LIMIT = 200;
+
+export interface StoredChatEntry {
+  kind: 'from';
+  at: number;
+  color: string;
+  name: string;
+  text: string;
+  prefix: string;
+  separator: string;
+  isPrivate: boolean;
+  incomingPrivate: boolean;
+}
+
+type ChatStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+export function chatHistoryStorageKey(realm: string, playerName: string): string {
+  const realmName = realm.trim() || 'offline';
+  const normalized = playerName.trim() || 'player';
+  return `woc_chat_history_${encodeURIComponent(realmName)}_${encodeURIComponent(normalized)}`;
+}
+
+export function chatPrivateSeenStorageKey(realm: string, playerName: string): string {
+  const realmName = realm.trim() || 'offline';
+  const normalized = playerName.trim() || 'player';
+  return `woc_chat_private_seen_${encodeURIComponent(realmName)}_${encodeURIComponent(normalized)}`;
+}
+
+export function formatChatTimestamp(at: number): string {
+  const date = new Date(at);
+  const hh = String(date.getHours()).padStart(2, '0');
+  const mm = String(date.getMinutes()).padStart(2, '0');
+  return `[${hh}:${mm}]`;
+}
+
+export function readStoredChatHistory(storage: ChatStorage | null | undefined, key: string): StoredChatEntry[] {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isStoredChatEntry).slice(-CHAT_HISTORY_LIMIT);
+  } catch {
+    return [];
+  }
+}
+
+export function appendStoredChatHistory(
+  storage: ChatStorage | null | undefined,
+  key: string,
+  entry: StoredChatEntry,
+): void {
+  if (!storage) return;
+  try {
+    const entries = readStoredChatHistory(storage, key);
+    entries.push(entry);
+    storage.setItem(key, JSON.stringify(entries.slice(-CHAT_HISTORY_LIMIT)));
+  } catch {
+    // localStorage can throw in private browsing or when quota is full.
+  }
+}
+
+export function readChatPrivateSeenAt(storage: ChatStorage | null | undefined, key: string): number {
+  if (!storage) return 0;
+  try {
+    const value = Number(storage.getItem(key));
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function writeChatPrivateSeenAt(storage: ChatStorage | null | undefined, key: string, at: number): void {
+  if (!storage) return;
+  try {
+    storage.setItem(key, String(at));
+  } catch {
+    // localStorage can throw in private browsing or when quota is full.
+  }
+}
+
+function isStoredChatEntry(value: unknown): value is StoredChatEntry {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return row.kind === 'from'
+    && typeof row.at === 'number'
+    && Number.isFinite(row.at)
+    && typeof row.color === 'string'
+    && typeof row.name === 'string'
+    && typeof row.text === 'string'
+    && typeof row.prefix === 'string'
+    && typeof row.separator === 'string'
+    && typeof row.isPrivate === 'boolean'
+    && typeof row.incomingPrivate === 'boolean';
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,6 +17,10 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import {
+  appendStoredChatHistory, chatHistoryStorageKey, chatPrivateSeenStorageKey, formatChatTimestamp,
+  readChatPrivateSeenAt, readStoredChatHistory, writeChatPrivateSeenAt, type StoredChatEntry,
+} from './chat_history';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -62,6 +66,11 @@ const PARTY_RANGE_YD = 100;
 const ZONE_BANNER_DEADBAND = 5;
 const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
 
+interface ChatLogOptions {
+  isPrivate?: boolean;
+  incomingPrivate?: boolean;
+}
+
 export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
@@ -74,6 +83,7 @@ export class Hud {
   private keybindNote = '';
   private chatLogEl = $('#chatlog');
   private combatLogEl = $('#combatlog');
+  private chatTabEl = document.querySelector<HTMLButtonElement>('.chat-tab[data-log-tab="chat"]');
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
   private tooltipEl = $('#tooltip');
@@ -106,6 +116,11 @@ export class Hud {
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
   private ignoredChatNames = new Set<string>();
+  private chatHistoryKey = '';
+  private chatPrivateSeenKey = '';
+  private privateNoticeCount = 0;
+  private restoredChatRows: { entry: StoredChatEntry; el: HTMLElement; hiddenByFilter: boolean }[] = [];
+  private lastChatBlockSig = '';
   private socialTab: 'friends' | 'guild' | 'ignore' = 'friends';
   // split signatures: structural changes (tab, guild membership) rebuild the
   // whole panel; content-only changes (a friend's presence) refresh just the
@@ -122,8 +137,11 @@ export class Hud {
 
   constructor(private sim: IWorld, private renderer: Renderer, private keybinds: Keybinds) {
     this.ignoredChatNames = this.loadIgnoredChatNames();
+    this.chatHistoryKey = chatHistoryStorageKey(sim.realm, sim.player.name);
+    this.chatPrivateSeenKey = chatPrivateSeenStorageKey(sim.realm, sim.player.name);
     this.meters = new Meters(sim);
     this.bindLogTabs();
+    this.restoreChatHistory();
     this.loadSlotMap();
     this.buildActionBar();
     this.refreshKeybindLabels();
@@ -173,6 +191,7 @@ export class Hud {
         tabs.forEach((t) => t.classList.toggle('active', t === tab));
         $('#chatlog').classList.toggle('active', which === 'chat');
         $('#combatlog').classList.toggle('active', which === 'combat');
+        if (which === 'chat') this.clearPrivateNotice();
       });
     });
   }
@@ -651,6 +670,12 @@ export class Hud {
     const zone = inDungeon ? 'dungeon'
       : Math.hypot(p.pos.x - hub.x, p.pos.z - hub.z) < hub.radius + 10 ? 'town' : currentZone.biome;
     music.update(zone, inCombat);
+
+    const chatBlockSig = this.chatBlockSig();
+    if (chatBlockSig !== this.lastChatBlockSig) {
+      this.lastChatBlockSig = chatBlockSig;
+      this.applyRestoredChatFilters();
+    }
 
     this.updateQuestTracker();
     this.updatePartyFrames();
@@ -1176,13 +1201,16 @@ export class Hud {
           this.refreshGossip();
           break;
         case 'chat': {
-          if (this.isChatIgnored(ev.from)) break;
+          if (this.isChatSenderIgnored(ev.from)) break;
           switch (ev.channel) {
             case 'party': this.chatLogFrom(ev.from, ev.text, '#7fd4ff', '[Party] ', ': '); break;
             case 'yell': this.chatLogFrom(ev.from, ev.text, '#ff5040', '', ' yells: '); break;
             case 'whisper':
-              if (ev.to) this.chatLogFrom(ev.to, ev.text, '#ff80ff', 'To ', ': ');
-              else { this.chatLogFrom(ev.from, ev.text, '#ff80ff', '', ' whispers: '); audio.whisper(); }
+              if (ev.to) this.chatLogFrom(ev.to, ev.text, '#ff80ff', 'To ', ': ', { isPrivate: true });
+              else {
+                this.chatLogFrom(ev.from, ev.text, '#ff80ff', '', ' whispers: ', { isPrivate: true, incomingPrivate: true });
+                audio.whisper();
+              }
               break;
             case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
@@ -1316,23 +1344,130 @@ export class Hud {
     if (text) this.log(text, '#ffd100');
   }
 
-  private chatLogFrom(name: string, text: string, color: string, prefix: string, separator: string): void {
+  private chatLogFrom(name: string, text: string, color: string, prefix: string, separator: string, opts: ChatLogOptions = {}): void {
+    const entry: StoredChatEntry = {
+      kind: 'from',
+      at: Date.now(),
+      color,
+      name,
+      text,
+      prefix,
+      separator,
+      isPrivate: opts.isPrivate === true,
+      incomingPrivate: opts.incomingPrivate === true,
+    };
+    this.appendChatEntry(entry);
+    appendStoredChatHistory(this.chatStorage(), this.chatHistoryKey, entry);
+    if (entry.incomingPrivate) {
+      if (this.isChatLogVisible()) writeChatPrivateSeenAt(this.chatStorage(), this.chatPrivateSeenKey, entry.at);
+      else this.showPrivateNotice();
+    }
+  }
+
+  private restoreChatHistory(): void {
+    const storage = this.chatStorage();
+    const entries = readStoredChatHistory(storage, this.chatHistoryKey);
+    for (const entry of entries) {
+      const el = this.appendChatEntry(entry);
+      this.restoredChatRows.push({ entry, el, hiddenByFilter: false });
+    }
+    this.lastChatBlockSig = this.chatBlockSig();
+    this.applyRestoredChatFilters();
+    const seenAt = readChatPrivateSeenAt(storage, this.chatPrivateSeenKey);
+    const visibleEntries = this.restoredChatRows.filter((row) => row.el.isConnected).map((row) => row.entry);
+    const incomingPrivate = visibleEntries.filter((entry) => entry.incomingPrivate);
+    const latestPrivateAt = incomingPrivate.reduce((latest, entry) => Math.max(latest, entry.at), 0);
+    if (this.isChatLogVisible() && latestPrivateAt > seenAt) {
+      writeChatPrivateSeenAt(storage, this.chatPrivateSeenKey, latestPrivateAt);
+      return;
+    }
+    const unreadPrivate = incomingPrivate.filter((entry) => entry.at > seenAt).length;
+    if (unreadPrivate > 0) this.setPrivateNotice(unreadPrivate);
+  }
+
+  private chatStorage(): Storage | null {
+    try {
+      return window.localStorage;
+    } catch {
+      return null;
+    }
+  }
+
+  private isChatLogVisible(): boolean {
+    return this.chatLogEl.classList.contains('active') && this.chatLogEl.getClientRects().length > 0;
+  }
+
+  private appendChatEntry(entry: StoredChatEntry): HTMLElement {
     const wasNearBottom = this.chatLogEl.scrollHeight - this.chatLogEl.scrollTop - this.chatLogEl.clientHeight < 24;
     const div = document.createElement('div');
-    div.style.color = color;
-    if (prefix) div.append(document.createTextNode(prefix));
+    div.style.color = entry.color;
+    if (entry.isPrivate) div.classList.add('chat-private');
+    if (entry.incomingPrivate) div.classList.add('incoming-private');
+    const time = document.createElement('span');
+    time.className = 'chat-time';
+    time.textContent = `${formatChatTimestamp(entry.at)} `;
+    div.append(time);
+    if (entry.prefix) div.append(document.createTextNode(entry.prefix));
     const sender = document.createElement('span');
     sender.className = 'chat-player-name';
-    sender.textContent = name;
-    sender.title = `Right-click ${name}`;
+    sender.textContent = entry.name;
+    sender.title = `Right-click ${entry.name}`;
     sender.addEventListener('contextmenu', (ev) => {
       ev.preventDefault();
-      this.openChatPlayerContextMenu(name, ev.clientX, ev.clientY);
+      this.openChatPlayerContextMenu(entry.name, ev.clientX, ev.clientY);
     });
-    div.append(sender, document.createTextNode(`${separator}${text}`));
+    div.append(sender, document.createTextNode(`${entry.separator}${entry.text}`));
     this.chatLogEl.appendChild(div);
     while (this.chatLogEl.children.length > 200) this.chatLogEl.removeChild(this.chatLogEl.firstChild!);
     if (wasNearBottom) this.chatLogEl.scrollTop = this.chatLogEl.scrollHeight;
+    return div;
+  }
+
+  private chatBlockSig(): string {
+    const social = this.sim.socialInfo;
+    if (social !== null) return `online:${social.blocks.map((block) => block.name).sort().join('|')}`;
+    return `local:${[...this.ignoredChatNames].sort().join('|')}`;
+  }
+
+  private applyRestoredChatFilters(): void {
+    for (const row of this.restoredChatRows) {
+      const hidden = row.entry.prefix !== 'To ' && this.isChatSenderIgnored(row.entry.name);
+      if (hidden) {
+        if (row.el.isConnected) row.el.remove();
+        row.hiddenByFilter = true;
+      } else if (row.hiddenByFilter) {
+        if (!row.el.isConnected) {
+          this.chatLogEl.appendChild(row.el);
+          while (this.chatLogEl.children.length > 200) this.chatLogEl.removeChild(this.chatLogEl.firstChild!);
+        }
+        row.hiddenByFilter = false;
+      }
+    }
+  }
+
+  onChatOpened(): void {
+    if (this.isChatLogVisible()) this.clearPrivateNotice();
+  }
+
+  private showPrivateNotice(): void {
+    this.setPrivateNotice(this.privateNoticeCount + 1);
+  }
+
+  private setPrivateNotice(count: number): void {
+    if (!this.chatTabEl) return;
+    this.privateNoticeCount = Math.min(99, count);
+    this.chatTabEl.classList.add('has-private');
+    this.chatTabEl.dataset.privateCount = String(this.privateNoticeCount);
+    this.chatTabEl.title = `${this.privateNoticeCount} unread private message${this.privateNoticeCount === 1 ? '' : 's'}`;
+  }
+
+  private clearPrivateNotice(): void {
+    if (!this.chatTabEl) return;
+    this.privateNoticeCount = 0;
+    this.chatTabEl.classList.remove('has-private');
+    delete this.chatTabEl.dataset.privateCount;
+    this.chatTabEl.removeAttribute('title');
+    writeChatPrivateSeenAt(this.chatStorage(), this.chatPrivateSeenKey, Date.now());
   }
 
   private combatLog(text: string, color = '#ccc'): void {
@@ -2208,6 +2343,13 @@ export class Hud {
     return this.ignoredChatNames.has(this.chatIgnoreKey(name));
   }
 
+  private isChatSenderIgnored(name: string): boolean {
+    const social = this.sim.socialInfo;
+    return social !== null
+      ? social.blocks.some((block) => block.name === name)
+      : this.isChatIgnored(name);
+  }
+
   private loadIgnoredChatNames(): Set<string> {
     try {
       const raw = localStorage.getItem(IGNORED_CHAT_NAMES_KEY);
@@ -2233,6 +2375,8 @@ export class Hud {
       this.log(`Ignoring chat from ${name}.`, '#aaf');
     }
     this.saveIgnoredChatNames();
+    this.lastChatBlockSig = this.chatBlockSig();
+    this.applyRestoredChatFilters();
   }
 
   closeContextMenu(): void {

--- a/tests/chat_history.test.ts
+++ b/tests/chat_history.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_HISTORY_LIMIT,
+  appendStoredChatHistory,
+  chatHistoryStorageKey,
+  chatPrivateSeenStorageKey,
+  formatChatTimestamp,
+  readChatPrivateSeenAt,
+  readStoredChatHistory,
+  writeChatPrivateSeenAt,
+  type StoredChatEntry,
+} from '../src/ui/chat_history';
+
+class FakeStorage {
+  private values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function entry(text: string, at = Date.UTC(2026, 0, 2, 3, 4)): StoredChatEntry {
+  return {
+    kind: 'from',
+    at,
+    color: '#ff80ff',
+    name: 'Ardenn',
+    text,
+    prefix: '',
+    separator: ' whispers: ',
+    isPrivate: true,
+    incomingPrivate: true,
+  };
+}
+
+describe('chat history storage', () => {
+  it('uses a stable per-character storage key', () => {
+    expect(chatHistoryStorageKey(' Claudemoon ', ' Ardenn ')).toBe('woc_chat_history_Claudemoon_Ardenn');
+    expect(chatPrivateSeenStorageKey(' Claudemoon ', ' Ardenn ')).toBe('woc_chat_private_seen_Claudemoon_Ardenn');
+    expect(chatHistoryStorageKey('Claudemoon', 'Ardenn')).not.toBe(chatHistoryStorageKey('Claudemoon', 'ardenn'));
+    expect(chatHistoryStorageKey('Claudemoon', 'Ardenn')).not.toBe(chatHistoryStorageKey('Otherrealm', 'Ardenn'));
+    expect(chatHistoryStorageKey('', '')).toBe('woc_chat_history_offline_player');
+  });
+
+  it('keeps valid timestamped chat rows and ignores malformed rows', () => {
+    const storage = new FakeStorage();
+    const key = chatHistoryStorageKey('Claudemoon', 'Aleph');
+    storage.setItem(key, JSON.stringify([
+      entry('dungeon?'),
+      { kind: 'from', text: 'missing fields' },
+      'bad row',
+    ]));
+
+    expect(readStoredChatHistory(storage, key)).toEqual([entry('dungeon?')]);
+  });
+
+  it('appends chat rows while enforcing the visible chat limit', () => {
+    const storage = new FakeStorage();
+    const key = chatHistoryStorageKey('Claudemoon', 'Aleph');
+    for (let i = 0; i < CHAT_HISTORY_LIMIT + 3; i++) {
+      appendStoredChatHistory(storage, key, entry(`msg ${i}`, i));
+    }
+
+    const rows = readStoredChatHistory(storage, key);
+    expect(rows).toHaveLength(CHAT_HISTORY_LIMIT);
+    expect(rows[0].text).toBe('msg 3');
+    expect(rows.at(-1)?.text).toBe(`msg ${CHAT_HISTORY_LIMIT + 2}`);
+  });
+
+  it('formats local chat timestamps as compact clock labels', () => {
+    expect(formatChatTimestamp(new Date(2026, 0, 2, 3, 4).getTime())).toBe('[03:04]');
+  });
+
+  it('stores the last acknowledged private-message timestamp defensively', () => {
+    const storage = new FakeStorage();
+    const key = chatPrivateSeenStorageKey('Claudemoon', 'Aleph');
+
+    expect(readChatPrivateSeenAt(storage, key)).toBe(0);
+    writeChatPrivateSeenAt(storage, key, 1234);
+    expect(readChatPrivateSeenAt(storage, key)).toBe(1234);
+    storage.setItem(key, 'not a time');
+    expect(readChatPrivateSeenAt(storage, key)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Persists player-facing chat rows in localStorage keyed by realm and exact character name, with timestamps and the existing 200-row visible history cap.
- Restores chat rows when the HUD reloads so private messages remain visible after reasonable UI/browser reloads.
- Adds a private-message badge on the Chat tab for incoming whispers, restores it from unread persisted whispers, and clears it when the player opens Chat.

## Implementation Notes
- This is client-side HUD persistence only; shared sim/server-authoritative whisper routing and moderation chat logging remain unchanged.
- Chat storage is scoped by realm plus exact trimmed character name so same-name cross-realm characters and case-distinct names do not share history.
- System/combat-style HUD log lines stay transient; the persisted path is for chat-channel rows rendered through the chat log.
- Restored rows respect local and online ignore state, including block lists that arrive after HUD construction, and visible restored whispers are marked seen instead of badged unread.

## Verification
- `npx vitest run tests/chat_history.test.ts`
- `npx tsc --noEmit`
- `npm run build`
- Full configured gate after review fixes: `npm test` (36 files, 402 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Review gate clean for `main..HEAD`.

## Real behavior proof
- Behavior addressed: a private message was easy to miss because whispers only lived in transient HUD DOM.
- Environment tested: local HUD/storage regression tests and client build on the rebased branch.
- Evidence after fix: private rows are timestamped, persisted under the active realm/character key, restored on HUD startup, and incoming whispers raise a visible Chat-tab badge only when the chat pane is not visible.
- Not tested: live two-player whisper delivery in a running multiplayer server; existing chat routing behavior is unchanged.

## Risk
Low client-side persistence risk. Chat history is browser-local, capped at 200 rows per realm/character, and can still be lost if localStorage is unavailable or cleared. The main user-visible change is that private chat is more visible and survives UI reloads on the same browser profile.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
