### PR TITLE
fix: clarify quest and vendor rejection feedback

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -1022,9 +1022,8 @@ export class GameServer {
     }
   }
 
-  // the web client applies quest commands optimistically; force the next
-  // snapshot to carry quest state even when the command changed nothing,
-  // so a rejected command still converges back to the server's truth
+  // force the next snapshot to carry quest state even when a quest command
+  // changed nothing, so stale client UI converges back to the server's truth
   private resyncQuests(session: ClientSession): void {
     delete session.lastSent.qlog;
     delete session.lastSent.qdone;

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1,6 +1,6 @@
 // Online play: REST auth client + WebSocket world mirror.
 
-import { NPCS, QUESTS, abilitiesKnownAt } from '../sim/data';
+import { NPCS, abilitiesKnownAt } from '../sim/data';
 import { computeQuestState, ResolvedAbility } from '../sim/sim';
 import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
@@ -210,6 +210,7 @@ export class ClientWorld implements IWorld {
   // inventory deltas arrive in snapshots, separate from the event frames the
   // HUD redraws on — the frame loop polls this so open panels re-render
   private invChanged = false;
+  private pendingQuestCommands = new Map<string, 'accept' | 'turnin'>();
   private mouselookFacing: number | null = null;
   private sendTimer: number | undefined;
 
@@ -277,8 +278,12 @@ export class ClientWorld implements IWorld {
     this.ws.send(JSON.stringify(msg));
   }
 
+  private canSendCommand(): boolean {
+    return this.connected && this.ws.readyState === WebSocket.OPEN;
+  }
+
   private cmd(payload: Record<string, unknown>): void {
-    if (!this.connected || this.ws.readyState !== WebSocket.OPEN) return;
+    if (!this.canSendCommand()) return;
     this.ws.send(JSON.stringify({ t: 'cmd', ...payload }));
   }
 
@@ -466,6 +471,7 @@ export class ClientWorld implements IWorld {
       if (s.equip !== undefined) this.equipment = s.equip;
       if (s.qlog !== undefined) this.questLog = new Map((s.qlog as QuestProgress[]).map((q) => [q.questId, q]));
       if (s.qdone !== undefined) this.questsDone = new Set(s.qdone);
+      if (s.qlog !== undefined || s.qdone !== undefined) this.pendingQuestCommands?.clear();
       this.known = abilitiesKnownAt(this.cfg.playerClass, e.level);
       if (s.party !== undefined) this.partyInfo = s.party;
       if (s.trade !== undefined) this.tradeInfo = s.trade;
@@ -490,7 +496,12 @@ export class ClientWorld implements IWorld {
   // -----------------------------------------------------------------------
 
   questState(questId: string): QuestState {
-    return computeQuestState(questId, this.questLog, this.questsDone, this.player.level);
+    const state = computeQuestState(questId, this.questLog, this.questsDone, this.player.level);
+    const pending = this.pendingQuestCommands?.get(questId);
+    if ((pending === 'accept' && state === 'available') || (pending === 'turnin' && state === 'ready')) {
+      return 'active';
+    }
+    return state;
   }
 
   consumeInventoryChanged(): boolean {
@@ -535,21 +546,14 @@ export class ClientWorld implements IWorld {
   pickUpObject(id: number): void {
     this.cmd({ cmd: 'pickup', id });
   }
-  // Quest commands update local state optimistically so the dialog can't be
-  // re-used in the window before the next server snapshot lands. The server
-  // remains authoritative; the following snapshot overwrites this state.
   acceptQuest(questId: string): void {
-    const quest = QUESTS[questId];
-    if (quest && !this.questLog.has(questId) && !this.questsDone.has(questId)) {
-      this.questLog.set(questId, { questId, counts: quest.objectives.map(() => 0), state: 'active' });
-    }
+    if (!this.canSendCommand()) return;
+    this.pendingQuestCommands.set(questId, 'accept');
     this.cmd({ cmd: 'accept', quest: questId });
   }
   turnInQuest(questId: string): void {
-    if (this.questLog.get(questId)?.state === 'ready') {
-      this.questLog.delete(questId);
-      this.questsDone.add(questId);
-    }
+    if (!this.canSendCommand()) return;
+    this.pendingQuestCommands.set(questId, 'turnin');
     this.cmd({ cmd: 'turnin', quest: questId });
   }
   abandonQuest(questId: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2697,7 +2697,12 @@ export class Sim {
     const { meta, e: p } = r;
     const npc = this.entities.get(npcId);
     const def = ITEMS[itemId];
-    if (!npc || npc.kind !== 'npc' || !npc.vendorItems.includes(itemId) || !def?.buyValue) return;
+    if (!npc || npc.kind !== 'npc' || npc.vendorItems.length === 0) {
+      this.error(meta.entityId, 'That merchant is not available.');
+      return;
+    }
+    if (!npc.vendorItems.includes(itemId)) { this.error(meta.entityId, 'That item is not sold here.'); return; }
+    if (!def?.buyValue) { this.error(meta.entityId, 'That item is not for sale.'); return; }
     if (dist2d(p.pos, npc.pos) > INTERACT_RANGE + 2) { this.error(meta.entityId, 'Too far away.'); return; }
     if (meta.copper < def.buyValue) { this.error(meta.entityId, 'Not enough money.'); return; }
     meta.copper -= def.buyValue;
@@ -2710,7 +2715,8 @@ export class Sim {
     if (!r) return;
     const { meta, e: p } = r;
     const def = ITEMS[itemId];
-    if (!def || this.countItem(itemId, meta.entityId) <= 0 || p.dead) return;
+    if (!def || this.countItem(itemId, meta.entityId) <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
+    if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
     // mirror buyItem's gate: selling requires a vendor in interact range
     const nearVendor = [...this.entities.values()].some((e) =>
       e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
@@ -2855,12 +2861,30 @@ export class Sim {
     return computeQuestState(questId, r.meta.questLog, r.meta.questsDone, r.e.level);
   }
 
+  private questNpcFor(questId: string, role: 'giver' | 'turnIn', p: Entity): { npc: Entity | null; tooFar: boolean } {
+    const quest = QUESTS[questId];
+    const templateId = role === 'giver' ? quest.giverNpcId : quest.turnInNpcId;
+    let sawNpc = false;
+    for (const e of this.entities.values()) {
+      if (e.kind !== 'npc' || e.templateId !== templateId) continue;
+      sawNpc = true;
+      if (dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2) return { npc: e, tooFar: false };
+    }
+    return { npc: null, tooFar: sawNpc };
+  }
+
   acceptQuest(questId: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
-    const { meta } = r;
-    if (this.questState(questId, meta.entityId) !== 'available') return;
     const quest = QUESTS[questId];
+    const { meta, e: p } = r;
+    if (!quest) { this.error(meta.entityId, 'That quest is not available.'); return; }
+    if (this.questState(questId, meta.entityId) !== 'available') { this.error(meta.entityId, 'That quest is not available.'); return; }
+    const nearby = this.questNpcFor(questId, 'giver', p);
+    if (!nearby.npc) {
+      this.error(meta.entityId, nearby.tooFar ? 'Too far away.' : 'That quest giver is not nearby.');
+      return;
+    }
     meta.questLog.set(questId, { questId, counts: quest.objectives.map(() => 0), state: 'active' });
     this.emit({ type: 'questAccepted', questId, pid: meta.entityId });
     this.emit({ type: 'log', text: `Quest accepted: ${quest.name}`, color: '#ff0', pid: meta.entityId });
@@ -2880,11 +2904,16 @@ export class Sim {
     const r = this.resolve(pid);
     if (!r) return;
     const { meta, e: p } = r;
-    const qp = meta.questLog.get(questId);
-    if (!qp || qp.state !== 'ready') return;
     const quest = QUESTS[questId];
-    const npc = [...this.entities.values()].find((e) => e.kind === 'npc' && e.templateId === quest.turnInNpcId);
-    if (!npc || dist2d(p.pos, npc.pos) > INTERACT_RANGE + 2) { this.error(meta.entityId, 'Too far away.'); return; }
+    if (!quest) { this.error(meta.entityId, 'That quest is not available.'); return; }
+    const qp = meta.questLog.get(questId);
+    if (!qp) { this.error(meta.entityId, 'That quest is not in your log.'); return; }
+    if (qp.state !== 'ready') { this.error(meta.entityId, 'That quest is not complete.'); return; }
+    const nearby = this.questNpcFor(questId, 'turnIn', p);
+    if (!nearby.npc) {
+      this.error(meta.entityId, nearby.tooFar ? 'Too far away.' : 'That quest turn-in is not nearby.');
+      return;
+    }
 
     for (const obj of quest.objectives) {
       if (obj.type === 'collect' && obj.itemId) this.removeItem(obj.itemId, obj.count, meta.entityId);

--- a/tests/bandwidth.test.ts
+++ b/tests/bandwidth.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed.
 vi.mock('../server/db', () => ({
-  pool: { query: vi.fn() },
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
@@ -89,5 +89,5 @@ describe('crowd bandwidth', () => {
     );
 
     expect(newBytes).toBeLessThan(legacyBytes * 0.5);
-  });
+  }, 30000);
 });

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -23,6 +23,8 @@ function teleportTo(sim: Sim, x: number, z: number, pid?: number) {
 describe('quest lifecycle', () => {
   it('a turned-in quest cannot be accepted again', () => {
     const sim = makeSim();
+    const redbrook = [...sim.entities.values()].find((e) => e.templateId === 'marshal_redbrook')!;
+    teleportTo(sim, redbrook.pos.x + 2, redbrook.pos.z + 2);
     sim.acceptQuest('q_wolves');
     expect(sim.questState('q_wolves')).toBe('active');
 
@@ -30,8 +32,6 @@ describe('quest lifecycle', () => {
     qp.counts[0] = 8;
     qp.state = 'ready';
 
-    const redbrook = [...sim.entities.values()].find((e) => e.templateId === 'marshal_redbrook')!;
-    teleportTo(sim, redbrook.pos.x + 2, redbrook.pos.z + 2);
     sim.turnInQuest('q_wolves');
     expect(sim.questState('q_wolves')).toBe('done');
     expect(sim.questLog.has('q_wolves')).toBe(false);

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -465,6 +465,19 @@ describe('food, drink, vendor', () => {
     expect(sim.copper).toBe(79);
     expect(sim.countItem('wolf_fang')).toBe(1);
   });
+
+  it('vendor buy rejects stale or invalid merchants with feedback', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 40, wilkes.pos.z);
+    sim.copper = 100;
+    sim.events = [];
+
+    sim.buyItem(wilkes.id, 'baked_bread');
+
+    expect(sim.countItem('baked_bread')).toBe(0);
+    expect(sim.events).toContainEqual({ type: 'error', text: 'Too far away.', pid: sim.player.id });
+  });
 });
 
 describe('leveling', () => {
@@ -524,6 +537,22 @@ describe('quests', () => {
     sim.interact();
     expect(sim.questState('q_boars')).toBe('done');
     expect(sim.countItem('boar_hide')).toBe(0);
+  });
+
+  it('quest accept and turn-in reject stale out-of-range dialogs with feedback', () => {
+    const sim = makeSim('warrior');
+    teleportTo(sim, 0, -40);
+    sim.events = [];
+
+    sim.acceptQuest('q_wolves');
+    expect(sim.questState('q_wolves')).toBe('available');
+    expect(sim.events).toContainEqual({ type: 'error', text: 'Too far away.', pid: sim.player.id });
+
+    sim.events = [];
+    sim.questLog.set('q_wolves', { questId: 'q_wolves', counts: [8], state: 'ready' });
+    sim.turnInQuest('q_wolves');
+    expect(sim.questState('q_wolves')).toBe('ready');
+    expect(sim.events).toContainEqual({ type: 'error', text: 'Too far away.', pid: sim.player.id });
   });
 
   it('ground objects can only be picked up with the quest active', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -55,6 +55,7 @@ function bareClient(pid: number): ClientWorld {
   c.known = [];
   c.questLog = new Map();
   c.questsDone = new Set();
+  c.pendingQuestCommands = new Map();
   c.partyInfo = null;
   c.tradeInfo = null;
   c.duelInfo = null;
@@ -134,8 +135,8 @@ describe('delta snapshots', () => {
     broadcast(server);
     fc.sent.length = 0;
     // unknown quest: the sim rejects it and quest state does not change, but
-    // the next snapshot must still carry quest fields so the client's
-    // optimistic update converges back to the server's truth
+    // the next snapshot must still carry quest fields so stale client UI
+    // converges back to the server's truth
     server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'accept', quest: 'no_such_quest' }));
     broadcast(server);
     const snap = lastSnap(fc.sent);
@@ -221,6 +222,30 @@ describe('chat moderation', () => {
 });
 
 describe('client-side delta merge', () => {
+  it('does not apply optimistic quest accept or completion state', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    try {
+      client.acceptQuest('q_wolves');
+      expect(client.questLog.has('q_wolves')).toBe(false);
+      expect(client.questState('q_wolves')).toBe('active');
+      expect(sent).toContainEqual({ t: 'cmd', cmd: 'accept', quest: 'q_wolves' });
+
+      (client as any).pendingQuestCommands.clear();
+      client.questLog.set('q_wolves', { questId: 'q_wolves', counts: [8], state: 'ready' });
+      client.turnInQuest('q_wolves');
+      expect(client.questLog.has('q_wolves')).toBe(true);
+      expect(client.questsDone.has('q_wolves')).toBe(false);
+      expect(client.questState('q_wolves')).toBe('active');
+      expect(sent).toContainEqual({ t: 'cmd', cmd: 'turnin', quest: 'q_wolves' });
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
   it('keeps previous structures when delta fields are omitted', () => {
     const server = new GameServer();
     const fc = fakeWs();


### PR DESCRIPTION
## Summary
- Adds explicit rejection feedback for stale quest and vendor actions, including out-of-range quest accepts, quest turn-ins, and vendor buys/sells.
- Keeps quest accept/turn-in validation in the authoritative sim path, so offline and online behavior use the same NPC proximity rules.
- Removes optimistic online quest success mutations while suppressing repeat dialog actions until the server's authoritative quest snapshot arrives.
- Keeps the no-Postgres bandwidth test mock returning empty row sets so social snapshot side work stays quiet during the full suite.

## Diagnosis
The online client previously marked quest accepts and completions locally before the server confirmed them. When the server later rejected the command for range or stale state, the snapshot restored truth, but the dialog could briefly look successful. Some sim rejection paths also returned without player-facing feedback, which made server rejections hard to distinguish from UI glitches.

## Implementation Notes
- `Sim.acceptQuest` and `Sim.turnInQuest` now require the correct nearby quest NPC and emit clear errors when the request is stale, out of range, unavailable, incomplete, or not in the log.
- Online quest commands now track a small pending-command state instead of editing `questLog` or `questsDone`; pending actions hide the repeat offer/turn-in until the next authoritative quest snapshot clears them.
- Vendor buy/sell guards now emit explicit errors for stale merchants, unavailable items, missing inventory, dead players, range, and money failures.

## Verification
- `npm test`; 25 test files passed, 328 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.

## Risk
User-visible quest and vendor rejection text changes, but the authority boundary is stricter: success still only comes from the shared/server-authoritative sim state. The online pending-command state is cleared by quest snapshots, so rejected commands converge back to server truth without leaving local quest state mutated.

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
