### PR TITLE
feat: add agent movement input channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,14 @@ node scripts/arena_visual.mjs   # two clients queue + fight a ranked 1v1 in the 
 node scripts/crypt_raid.mjs     # five bots clear the Hollow Crypt (ALLOW_DEV_COMMANDS=1)
 ```
 
+Browser agents can drive movement through `window.__game.controller` instead
+of simulating held keys. Use `controller.move({ forward: true }, facingRadians)`
+or compact websocket flags such as `{ f: 1, sr: 1 }`; call
+`controller.face(facingRadians)` to update facing without changing movement and
+`controller.stop()` to return to real keyboard input. Online play sends the
+same input frame to the server, which accepts only boolean/`1` movement flags
+and finite facing values.
+
 Layout:
 
 ```

--- a/server/game.ts
+++ b/server/game.ts
@@ -3,6 +3,7 @@ import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
+import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
@@ -600,16 +601,10 @@ export class GameServer {
       const meta = sim.meta(pid);
       const e = sim.entities.get(pid);
       if (!meta || !e) return;
-      const mi = msg.mi ?? {};
-      meta.moveInput.forward = !!mi.f;
-      meta.moveInput.back = !!mi.b;
-      meta.moveInput.turnLeft = !!mi.tl;
-      meta.moveInput.turnRight = !!mi.tr;
-      meta.moveInput.strafeLeft = !!mi.sl;
-      meta.moveInput.strafeRight = !!mi.sr;
-      meta.moveInput.jump = !!mi.j;
-      if (typeof msg.facing === 'number' && isFinite(msg.facing) && !e.dead) {
-        e.facing = msg.facing;
+      const { moveInput, facing } = parseMoveInputFrame(msg);
+      Object.assign(meta.moveInput, moveInput);
+      if (facing !== null && !e.dead) {
+        e.facing = facing;
       }
       return;
     }

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -5,6 +5,8 @@
 // F interacts, R autorun.
 
 import { Keybinds, actionKind } from './keybinds';
+import { sanitizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
+import type { MoveInput } from '../sim/types';
 
 // the camera sensitivity that used to be hard-coded in onMouseMove; the
 // settings slider scales this (cameraSpeed 1.0 reproduces the old feel)
@@ -42,6 +44,8 @@ export class Input {
   // one-shot key capture for the rebind UI: the next keydown is delivered here
   // (Escape cancels with null) instead of being dispatched as an action
   private captureCb: ((code: string | null) => void) | null = null;
+  private controllerMoveInput: MoveInput | null = null;
+  private controllerFacing: number | null = null;
   // mouse-look sensitivity, in radians per pixel of drag; the old fixed value
   // was BASE_LOOK_SENS — setCameraSpeed scales it from the settings menu
   private lookSensitivity = BASE_LOOK_SENS;
@@ -103,6 +107,24 @@ export class Input {
 
   isMouselookActive(): boolean {
     return this.rightDown || this.touchLookActive;
+  }
+
+  setControllerMoveInput(input: unknown, facing?: unknown): void {
+    this.controllerMoveInput = sanitizeMoveInput(input);
+    if (arguments.length > 1) this.controllerFacing = sanitizeMoveFacing(facing);
+  }
+
+  setControllerFacing(facing: unknown): void {
+    this.controllerFacing = sanitizeMoveFacing(facing);
+  }
+
+  clearControllerMoveInput(): void {
+    this.controllerMoveInput = null;
+    this.controllerFacing = null;
+  }
+
+  controllerFacingOverride(): number | null {
+    return this.controllerFacing;
   }
 
   private onKeyDown(e: KeyboardEvent): void {
@@ -181,13 +203,11 @@ export class Input {
     this.camPitch = Math.min(1.35, Math.max(-0.4, this.camPitch + my * this.lookSensitivity));
   }
 
-  readMoveInput(): {
-    forward: boolean; back: boolean; turnLeft: boolean; turnRight: boolean;
-    strafeLeft: boolean; strafeRight: boolean; jump: boolean;
-  } {
+  readMoveInput(): MoveInput {
     if (this.suspendMovement) {
       return { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
     }
+    if (this.controllerMoveInput) return { ...this.controllerMoveInput };
     const k = this.keys;
     const held = (id: string) => this.keybinds.codesForAction(id).some((c) => k.has(c));
     const bothButtons = this.leftDown && this.rightDown;

--- a/src/main.ts
+++ b/src/main.ts
@@ -516,13 +516,15 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     input.updateTouchLook(frameDt);
 
     const mouselook = input.isMouselookActive() && !world.player.dead;
+    const controllerFacing = input.controllerFacingOverride();
+    const movementFacing = !world.player.dead ? (mouselook ? input.camYaw : controllerFacing) : null;
 
     if (offlineSim) {
       acc += frameDt;
       while (acc >= DT) {
         const mi = input.readMoveInput();
         Object.assign(offlineSim.moveInput, mi);
-        if (mouselook) offlineSim.player.facing = input.camYaw;
+        if (movementFacing !== null) offlineSim.player.facing = movementFacing;
         const events = offlineSim.tick();
         hud.handleEvents(events);
         acc -= DT;
@@ -532,7 +534,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       renderer.camYaw = input.camYaw;
       renderer.camPitch = input.camPitch;
       renderer.camDist = input.camDist;
-      renderer.sync(acc / DT, frameDt, mouselook ? input.camYaw : null);
+      renderer.sync(acc / DT, frameDt, movementFacing);
       hud.update();
       return;
     }
@@ -540,7 +542,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     // online: inputs stream on a timer inside ClientWorld; here we mirror state
     const net = online!;
     Object.assign(net.moveInput, input.readMoveInput());
-    net.setMouselookFacing(mouselook ? input.camYaw : null);
+    net.setMouselookFacing(movementFacing);
     net.pendingFacingDelta = 0; // superseded by the interpolated follow below
     hud.handleEvents(net.drainEvents());
     if (net.consumeInventoryChanged()) hud.onInventoryChanged();
@@ -553,14 +555,22 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     renderer.camYaw = input.camYaw;
     renderer.camPitch = input.camPitch;
     renderer.camDist = input.camDist;
-    renderer.sync(alpha, frameDt, mouselook ? input.camYaw : null);
+    renderer.sync(alpha, frameDt, movementFacing);
     hud.update();
   }
   requestAnimationFrame(frame);
   // cut to the game only once the first frame is actually on screen
   requestAnimationFrame(() => requestAnimationFrame(() => hideLoadingScreen()));
 
-  (window as any).__game = { sim: world, world, renderer, input, hud, online };
+  const controller = {
+    move(moveInput: unknown, facing?: unknown) {
+      if (arguments.length > 1) input.setControllerMoveInput(moveInput, facing);
+      else input.setControllerMoveInput(moveInput);
+    },
+    face(facing: unknown) { input.setControllerFacing(facing); },
+    stop() { input.clearControllerMoveInput(); },
+  };
+  (window as any).__game = { sim: world, world, renderer, input, hud, online, controller };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -6,6 +6,7 @@ import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
+import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
 import type { ArenaInfo, CharacterSearchResult, DuelInfo, IWorld, MarketInfo, PartyInfo, SocialInfo, TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
@@ -284,8 +285,13 @@ export class ClientWorld implements IWorld {
     return out;
   }
 
-  setMouselookFacing(facing: number | null): void {
-    this.mouselookFacing = facing;
+  setMoveInput(input: unknown, facing?: unknown): void {
+    Object.assign(this.moveInput, sanitizeMoveInput(input));
+    if (arguments.length > 1) this.setMouselookFacing(facing);
+  }
+
+  setMouselookFacing(facing: unknown): void {
+    this.mouselookFacing = normalizeMoveFacing(facing);
   }
 
   // -----------------------------------------------------------------------

--- a/src/sim/move_input.ts
+++ b/src/sim/move_input.ts
@@ -1,0 +1,51 @@
+import { MoveInput, emptyMoveInput } from './types';
+
+const MOVE_FIELDS = [
+  ['forward', 'f'],
+  ['back', 'b'],
+  ['turnLeft', 'tl'],
+  ['turnRight', 'tr'],
+  ['strafeLeft', 'sl'],
+  ['strafeRight', 'sr'],
+  ['jump', 'j'],
+] as const;
+const MAX_FACING_MAGNITUDE = 1000;
+
+type MoveField = typeof MOVE_FIELDS[number][0];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isMoveFlag(value: unknown): boolean {
+  return value === true || value === 1;
+}
+
+export function sanitizeMoveInput(raw: unknown): MoveInput {
+  const input = emptyMoveInput();
+  if (!isRecord(raw)) return input;
+  for (const [field, compact] of MOVE_FIELDS) {
+    input[field as MoveField] = isMoveFlag(raw[field]) || isMoveFlag(raw[compact]);
+  }
+  return input;
+}
+
+export function sanitizeMoveFacing(raw: unknown): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw) && Math.abs(raw) <= MAX_FACING_MAGNITUDE
+    ? raw
+    : null;
+}
+
+export function normalizeMoveFacing(raw: unknown): number | null {
+  return typeof raw === 'number' && Number.isFinite(raw)
+    ? Math.atan2(Math.sin(raw), Math.cos(raw))
+    : null;
+}
+
+export function parseMoveInputFrame(raw: unknown): { moveInput: MoveInput; facing: number | null } {
+  if (!isRecord(raw)) return { moveInput: emptyMoveInput(), facing: null };
+  return {
+    moveInput: sanitizeMoveInput(raw.mi),
+    facing: sanitizeMoveFacing(raw.facing),
+  };
+}

--- a/tests/move_input.test.ts
+++ b/tests/move_input.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { Input } from '../src/game/input';
+import { Keybinds } from '../src/game/keybinds';
+import { ClientWorld } from '../src/net/online';
+import { normalizeMoveFacing, parseMoveInputFrame, sanitizeMoveInput } from '../src/sim/move_input';
+
+describe('movement input sanitizing', () => {
+  it('accepts compact websocket flags and long controller flags', () => {
+    expect(sanitizeMoveInput({ f: 1, turnRight: true, sr: 1 })).toEqual({
+      forward: true,
+      back: false,
+      turnLeft: false,
+      turnRight: true,
+      strafeLeft: false,
+      strafeRight: true,
+      jump: false,
+    });
+  });
+
+  it('rejects truthy non-protocol values and non-finite facing', () => {
+    const parsed = parseMoveInputFrame({
+      t: 'input',
+      mi: { f: '1', b: {}, tl: true, tr: 1, sl: 0, sr: false, j: 'true' },
+      facing: Infinity,
+    });
+
+    expect(parsed.moveInput).toEqual({
+      forward: false,
+      back: false,
+      turnLeft: true,
+      turnRight: true,
+      strafeLeft: false,
+      strafeRight: false,
+      jump: false,
+    });
+    expect(parsed.facing).toBeNull();
+  });
+
+  it('preserves accumulated finite facing values', () => {
+    const parsed = parseMoveInputFrame({ t: 'input', mi: {}, facing: Math.PI * 3 });
+
+    expect(parsed.facing).toBeCloseTo(Math.PI * 3);
+  });
+
+  it('rejects huge finite facing values', () => {
+    const parsed = parseMoveInputFrame({ t: 'input', mi: {}, facing: 1e9 });
+
+    expect(parsed.facing).toBeNull();
+  });
+
+  it('normalizes accumulated local yaw without looping', () => {
+    expect(normalizeMoveFacing(Math.PI * 401)).toBeCloseTo(Math.PI);
+    expect(normalizeMoveFacing(Number.POSITIVE_INFINITY)).toBeNull();
+  });
+});
+
+describe('agent movement channel', () => {
+  it('lets controller movement win over held keyboard state without mutating the stored intent', () => {
+    const input: any = Object.create(Input.prototype);
+    input.keys = new Set<string>();
+    input.leftDown = false;
+    input.rightDown = false;
+    input.autorun = false;
+    input.suspendMovement = false;
+    input.keybinds = new Keybinds();
+    input.controllerMoveInput = null;
+    input.controllerFacing = null;
+    input.touchMove = { forward: false, back: false, strafeLeft: false, strafeRight: false };
+
+    input.keys.add('KeyW');
+    expect(input.readMoveInput().forward).toBe(true);
+
+    input.setControllerMoveInput({ strafeLeft: true }, 8);
+    input.setControllerMoveInput({ forward: true });
+
+    expect(input.controllerFacingOverride()).toBe(8);
+
+    const first = input.readMoveInput();
+    first.forward = false;
+
+    expect(input.readMoveInput()).toEqual({
+      forward: true,
+      back: false,
+      turnLeft: false,
+      turnRight: false,
+      strafeLeft: false,
+      strafeRight: false,
+      jump: false,
+    });
+    expect(input.controllerFacingOverride()).toBe(8);
+
+    input.clearControllerMoveInput();
+    expect(input.readMoveInput().forward).toBe(true);
+    expect(input.controllerFacingOverride()).toBeNull();
+  });
+
+  it('sanitizes ClientWorld movement before it reaches the websocket sender', () => {
+    const client: any = Object.create(ClientWorld.prototype);
+    client.moveInput = {
+      forward: false,
+      back: false,
+      turnLeft: false,
+      turnRight: false,
+      strafeLeft: false,
+      strafeRight: false,
+      jump: false,
+    };
+    client.mouselookFacing = null;
+
+    client.setMoveInput({ f: '1', forward: true, sr: 1, jump: 'yes' }, Number.NaN);
+
+    expect(client.moveInput).toEqual({
+      forward: true,
+      back: false,
+      turnLeft: false,
+      turnRight: false,
+      strafeLeft: false,
+      strafeRight: true,
+      jump: false,
+    });
+    expect(client.mouselookFacing).toBeNull();
+
+    client.setMouselookFacing(Math.PI * 401);
+
+    expect(client.mouselookFacing).toBeCloseTo(Math.PI);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an official browser controller channel at `window.__game.controller` so agents can drive movement and facing without simulating held keyboard state.
- Reuses the existing online input stream and server-authoritative sim path, so agent movement still goes through validated movement flags, server facing handling, collision, roots, stuns, and other normal movement rules.
- Documents the controller surface in `README.md` and covers the input sanitizer, controller override behavior, and online facing handling in `tests/move_input.test.ts`.

## Implementation Notes
- `src/sim/move_input.ts` centralizes movement/facing parsing for the client and server.
- The server accepts only boolean/`1` movement flags and rejects non-finite or absurd facing payloads.
- The online client normalizes accumulated local yaw before sending it, while the browser controller preserves omitted facing values across `controller.move(...)` calls.
- Rebased onto current `main` and kept the mobile touch-look movement path integrated with controller-facing overrides.

## Verification
- `npm test -- tests/move_input.test.ts`
- `npx tsc --noEmit`
- `npm run build:env`
- `npm run build:server`
- `npm run build`
- Review gate clean for `main..HEAD`.

## Real behavior proof
- Behavior addressed: movement/input control for agents no longer has to fight the browser frame loop that rebuilds movement from real key state.
- Environment tested: local unit/type/build verification on the rebased branch.
- Not tested: manual browser gameplay session for the controller surface.

## Risk
- The new controller API is exposed on the existing debug `window.__game` surface and can only feed the same movement input/facing path used by normal online play.
- Server-side validation rejects malformed flags and unsafe facing values before touching sim state.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
