### PR TITLE
test: cover quest giver range for accept

### DIFF
--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -44,6 +44,20 @@ describe('quest lifecycle', () => {
     expect(zoneWelcomeText(starterZone, (questId) => sim.questState(questId))).toBeNull();
   });
 
+  it('accepting a quest directly requires standing near the giver', () => {
+    const sim = makeSim();
+    teleportTo(sim, 0, -40);
+
+    sim.acceptQuest('q_wolves');
+    expect(sim.questState('q_wolves')).toBe('available');
+    expect(sim.questLog.has('q_wolves')).toBe(false);
+
+    const redbrook = [...sim.entities.values()].find((e) => e.templateId === 'marshal_redbrook')!;
+    teleportTo(sim, redbrook.pos.x + 2, redbrook.pos.z);
+    sim.acceptQuest('q_wolves');
+    expect(sim.questState('q_wolves')).toBe('active');
+  });
+
   it('a turned-in quest cannot be accepted again', () => {
     const sim = makeSim();
     const redbrook = [...sim.entities.values()].find((e) => e.templateId === 'marshal_redbrook')!;
@@ -55,6 +69,7 @@ describe('quest lifecycle', () => {
     qp.counts[0] = 8;
     qp.state = 'ready';
 
+    teleportTo(sim, redbrook.pos.x + 2, redbrook.pos.z + 2);
     sim.turnInQuest('q_wolves');
     expect(sim.questState('q_wolves')).toBe('done');
     expect(sim.questLog.has('q_wolves')).toBe(false);

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -157,6 +157,20 @@ describe('delta snapshots', () => {
     expect(snap.self).not.toHaveProperty('inv');
   });
 
+  it('rejected distant quest accepts resync the authoritative quest state', () => {
+    broadcast(server);
+    fc.sent.length = 0;
+    const player = server.sim.entities.get(session.pid)!;
+    player.pos.x = 0;
+    player.pos.z = -40;
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'accept', quest: 'q_wolves' }));
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.qlog).toEqual([]);
+    expect(snap.self.qdone).toEqual([]);
+  });
+
   it('each client gets full state on its own first snapshot', () => {
     broadcast(server);
     const fc2 = fakeWs();


### PR DESCRIPTION
## Summary
- Adds regression coverage for direct quest acceptance while out of range of the quest giver.
- Preserves snapshot coverage for the authoritative rejection path.
- Drops the unrelated chat-censor cache commit that had been present on the stale branch.

## Why
Current `main` already contains the shared quest-giver range check. This branch now keeps the regression evidence isolated so the rule remains covered without reintroducing obsolete implementation changes.

## Verification
- `npx vitest run tests/fixes.test.ts tests/snapshots.test.ts`; 2 files passed, 37 tests passed.
- `npm test`; 35 files passed, 399 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:quest-accept-range`; branch is 1 commit ahead, 0 behind, changing only `tests/fixes.test.ts` and `tests/snapshots.test.ts`.

## Risk
Low test-only risk. The branch no longer changes sim behavior because the authority check is already present on `main`.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
