### PR TITLE
feat: expose start flow state transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1074,6 +1074,21 @@
     box-shadow: inset 0 0 8px #000;
     margin-top: var(--spacing-xs);
   }
+  #start-flow-status {
+    max-width: min(520px, 88vw);
+    padding: 6px 12px;
+    border: 1px solid rgba(200, 168, 56, 0.38);
+    border-radius: var(--radius-sm);
+    background: rgba(5, 5, 9, 0.62);
+    color: var(--color-primary-dim);
+    font-family: var(--font-heading);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    line-height: 1.4;
+    text-align: center;
+    text-shadow: 1px 1px 2px #000;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.38);
+  }
 
   /* Wiki view with integrated Controls Guide */
   .wiki-container-layout {
@@ -1930,7 +1945,7 @@
 
   /* ---------- Collapsible Controls Drawer ---------- */
   #btn-toggle-controls {
-    grid-row: 3;
+    grid-row: 4;
     grid-column: 1;
     margin-top: 12px;
     background: linear-gradient(180deg, #1b1b26 0%, #0d0d14 100%);
@@ -3177,7 +3192,7 @@
   }
 </style>
 </head>
-<body>
+<body data-start-flow-state="mode-select" data-active-start-panel="#mode-select" data-has-game="false">
   <canvas id="game-canvas"></canvas>
   <div id="nameplates"></div>
 
@@ -3316,7 +3331,7 @@
   <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
   </template>
 
-  <main id="start-screen">
+  <main id="start-screen" data-start-flow-state="mode-select" data-active-start-panel="#mode-select" data-has-game="false">
     <!-- Keep the backdrop here at the top level so it spans the entire screen behind content -->
     <div id="start-screen-backdrop" aria-hidden="true">
       <div class="portal-ring"></div>
@@ -3674,6 +3689,7 @@
     </div>
 
     <footer class="homepage-footer">
+      <div id="start-flow-status" aria-live="polite">Choose online or offline play.</div>
       <div class="footer-social-row">
         <a class="social-link" href="https://github.com/levy-street/world-of-claudecraft" target="_blank" rel="noopener noreferrer">
           <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { assetsReady } from './render/assets/preload';
 import { CharacterPreview } from './render/characters';
 import { DT, INTERACT_RANGE, PlayerClass, dist2d } from './sim/types';
 import { togglePasswordVisibility, syncInputAriaState, validateForm, handleKeyboardActivation, validateCharacterName } from './ui/auth_utils';
+import { startFlowStatusText, StartFlowPanel, StartFlowSnapshot, StartFlowState } from './ui/start_flow_state';
 import { CLASSES, ABILITIES } from './sim/content/classes';
 import { iconDataUrl } from './ui/icons';
 import { getLanguage, setLanguage, t, SupportedLanguage } from './ui/i18n';
@@ -207,6 +208,37 @@ function requestPreferredFullscreen(): void {
     return;
   }
   if (new Settings().get('fullscreen') >= 0.5) requestBrowserFullscreen();
+}
+
+function setOptionalDataset(el: HTMLElement, key: string, value: string | number | undefined): void {
+  if (value === undefined || value === '') delete el.dataset[key];
+  else el.dataset[key] = String(value);
+}
+
+function setStartFlowState(
+  state: StartFlowState,
+  panel: StartFlowPanel,
+  details: Partial<Omit<StartFlowSnapshot, 'state' | 'panel' | 'hasGame'>> = {},
+): void {
+  const snapshot: StartFlowSnapshot = {
+    state,
+    panel,
+    hasGame: Boolean((window as any).__game),
+    ...details,
+  };
+  const status = document.querySelector('#start-flow-status') as HTMLElement | null;
+  const startScreen = document.querySelector('#start-screen') as HTMLElement | null;
+  const targets = [document.body, startScreen].filter((el): el is HTMLElement => Boolean(el));
+  for (const target of targets) {
+    target.dataset.startFlowState = snapshot.state;
+    target.dataset.activeStartPanel = snapshot.panel;
+    target.dataset.hasGame = snapshot.hasGame ? 'true' : 'false';
+    setOptionalDataset(target, 'startFlowRealm', snapshot.realm);
+    setOptionalDataset(target, 'startFlowUsername', snapshot.username);
+    setOptionalDataset(target, 'startFlowCharacterCount', snapshot.characterCount);
+  }
+  if (status) status.textContent = startFlowStatusText(snapshot);
+  (window as any).__wocStartFlow = snapshot;
 }
 
 // ---------------------------------------------------------------------------
@@ -561,6 +593,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   requestAnimationFrame(() => requestAnimationFrame(() => hideLoadingScreen()));
 
   (window as any).__game = { sim: world, world, renderer, input, hud, online };
+  setStartFlowState('game-ready', 'none', { realm: api.realm || undefined });
 }
 
 // ---------------------------------------------------------------------------
@@ -591,6 +624,20 @@ const api = new Api();
 let activeTransitionTimeout: number | null = null;
 let activeTransitionCleanup: (() => void) | null = null;
 let characterPreview: CharacterPreview | null = null;
+let authRequestId = 0;
+let realmListRequestId = 0;
+let characterListRequestId = 0;
+
+function stateForPanel(panel: StartFlowPanel): StartFlowState {
+  switch (panel) {
+    case '#mode-select': return 'mode-select';
+    case '#login-panel': return 'login';
+    case '#realm-panel': return 'realm-list';
+    case '#charselect-panel': return 'character-select';
+    case '#offline-select': return 'offline-select';
+    case 'none': return 'game-ready';
+  }
+}
 
 function updatePreviewContainer(panelId: string): void {
   if (!characterPreview) return;
@@ -719,6 +766,10 @@ function show(el: string): void {
   if (document.activeElement instanceof HTMLInputElement || document.activeElement instanceof HTMLTextAreaElement) {
     document.activeElement.blur();
   }
+  setStartFlowState(stateForPanel(el as StartFlowPanel), el as StartFlowPanel, {
+    username: api.username ?? undefined,
+    realm: api.realm || undefined,
+  });
 
   // Reset currently rendered classes to force re-render/animation when opening a panel
   currentlyRenderedClass['offline-class-details'] = null;
@@ -845,6 +896,7 @@ function realmPopulation(online: boolean, players: number): { label: string; cls
 // the chosen realm). We remember the last realm and jump straight to its
 // characters, with a "Change Realm" button back to this list.
 async function enterRealmFlow(): Promise<void> {
+  setStartFlowState('realm-loading', '#realm-panel', { username: api.username ?? undefined });
   const dir = await api.realms();
   $('#realm-list-user').textContent = api.username ? `${api.username}` : '';
   const remembered = localStorage.getItem(LAST_REALM_KEY);
@@ -854,9 +906,16 @@ async function enterRealmFlow(): Promise<void> {
 }
 
 function showRealmList(dir?: import('./net/online').RealmDirectory): void {
+  const requestId = ++realmListRequestId;
   show('#realm-panel');
   const listEl = $('#realm-list');
+  const isCurrentRequest = () => requestId === realmListRequestId
+    && document.body.dataset.activeStartPanel === '#realm-panel';
   const render = (d: import('./net/online').RealmDirectory) => {
+    if (!isCurrentRequest()) return;
+    setStartFlowState(d.realms.length === 0 ? 'realm-empty' : 'realm-list', '#realm-panel', {
+      username: api.username ?? undefined,
+    });
     if (d.realms.length === 0) { listEl.innerHTML = '<div class="realm-loading">No realms available.</div>'; return; }
     // recommend the lowest-population online realm (WoW nudges new players there)
     listEl.innerHTML = d.realms.map((r) => {
@@ -878,6 +937,7 @@ function showRealmList(dir?: import('./net/online').RealmDirectory): void {
     let bestPlayers = Infinity, bestName = '';
     void Promise.all(d.realms.map(async (r) => {
       const st = await api.realmStatus(r.url || '');
+      if (!isCurrentRequest()) return;
       const row = listEl.querySelector(`.realm-row[data-name="${CSS.escape(r.name)}"]`) as HTMLElement | null;
       if (!row) return;
       const pop = realmPopulation(st.online, st.players);
@@ -888,19 +948,29 @@ function showRealmList(dir?: import('./net/online').RealmDirectory): void {
       row.classList.toggle('offline', !st.online);
       if (st.online && st.players < bestPlayers) { bestPlayers = st.players; bestName = r.name; }
     })).then(() => {
+      if (!isCurrentRequest()) return;
       const recRow = bestName ? listEl.querySelector(`.realm-row[data-name="${CSS.escape(bestName)}"]`) : null;
       recRow?.querySelector('[data-rec]')?.removeAttribute('hidden');
     });
   };
   if (dir) render(dir);
-  else { listEl.innerHTML = '<div class="realm-loading">Loading realms…</div>'; void api.realms().then(render); }
+  else {
+    setStartFlowState('realm-loading', '#realm-panel', { username: api.username ?? undefined });
+    listEl.innerHTML = '<div class="realm-loading">Loading realms…</div>';
+    void api.realms().then(render);
+  }
 }
 
 function selectRealm(entry: import('./net/online').RealmEntry): void {
+  realmListRequestId += 1;
   api.setRealm(entry.url);
   api.realm = entry.name;
   localStorage.setItem(LAST_REALM_KEY, entry.name);
   show('#charselect-panel');
+  setStartFlowState('character-loading', '#charselect-panel', {
+    username: api.username ?? undefined,
+    realm: api.realm,
+  });
   void refreshCharacters();
 }
 
@@ -945,14 +1015,37 @@ async function refreshCharacters(): Promise<void> {
     btn.classList.toggle('active', on);
     btn.setAttribute('aria-selected', String(on));
   });
+  const requestId = ++characterListRequestId;
+  const requestRealm = api.realm;
   const listEl = $('#char-list');
+  if (document.body.dataset.activeStartPanel !== '#charselect-panel') return;
+  setStartFlowState('character-loading', '#charselect-panel', {
+    username: api.username ?? undefined,
+    realm: api.realm || undefined,
+  });
   listEl.innerHTML = '<li class="char-list-message">Loading…</li>';
   try {
     const chars = await api.characters();
+    if (
+      requestId !== characterListRequestId
+      || document.body.dataset.activeStartPanel !== '#charselect-panel'
+      || api.realm !== requestRealm
+    ) return;
     if (api.realm) $('#charselect-realm').textContent = `Realm: ${api.realm}`;
     listEl.innerHTML = '';
     if (chars.length === 0) {
+      setStartFlowState('character-empty', '#charselect-panel', {
+        username: api.username ?? undefined,
+        realm: api.realm || undefined,
+        characterCount: 0,
+      });
       listEl.innerHTML = '<li class="char-list-message">No characters yet (create one below).</li>';
+    } else {
+      setStartFlowState('character-select', '#charselect-panel', {
+        username: api.username ?? undefined,
+        realm: api.realm || undefined,
+        characterCount: chars.length,
+      });
     }
     for (const c of chars) {
       const row = document.createElement('li');
@@ -1026,6 +1119,16 @@ async function refreshCharacters(): Promise<void> {
       firstRow.click();
     }
   } catch (err: any) {
+    if (
+      requestId !== characterListRequestId
+      || document.body.dataset.activeStartPanel !== '#charselect-panel'
+      || api.realm !== requestRealm
+    ) return;
+    setStartFlowState('character-error', '#charselect-panel', {
+      username: api.username ?? undefined,
+      realm: api.realm || undefined,
+      error: err.message,
+    });
     listEl.innerHTML = `<li class="char-list-message char-list-error">${err.message}</li>`;
   }
 }
@@ -1054,6 +1157,10 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     if (!(await prepareWorldEntry())) return;
     audio.init();
     music.init();
+    setStartFlowState('world-connecting', '#charselect-panel', {
+      username: api.username ?? undefined,
+      realm: api.realm || undefined,
+    });
     enterLoadingState('Connecting to realm…');
   } finally {
     if (!hasBegunWorldEntry && button) {
@@ -1643,15 +1750,20 @@ function wireStartScreens(): void {
 
   // login
   const doAuth = async (mode: 'login' | 'register') => {
+    const requestId = ++authRequestId;
     const username = ($('#login-user') as unknown as HTMLInputElement).value.trim();
     const password = ($('#login-pass') as unknown as HTMLInputElement).value;
     loginError('');
+    setStartFlowState('authenticating', '#login-panel', { username });
     try {
       if (mode === 'login') await api.login(username, password);
       else await api.register(username, password);
+      if (requestId !== authRequestId || document.body.dataset.activeStartPanel !== '#login-panel') return;
       $('#charselect-user').textContent = api.username ?? '';
       await enterRealmFlow();
     } catch (err: any) {
+      if (requestId !== authRequestId || document.body.dataset.activeStartPanel !== '#login-panel') return;
+      setStartFlowState('login', '#login-panel', { username });
       loginError(err.message);
     }
   };
@@ -2094,6 +2206,8 @@ function wireStartScreens(): void {
       characterPreview.setClass(cls);
     }
   });
+
+  setStartFlowState('mode-select', '#mode-select');
 }
 
 wireStartScreens();

--- a/src/ui/start_flow_state.ts
+++ b/src/ui/start_flow_state.ts
@@ -1,0 +1,71 @@
+export type StartFlowPanel =
+  | '#mode-select'
+  | '#login-panel'
+  | '#realm-panel'
+  | '#charselect-panel'
+  | '#offline-select'
+  | 'none';
+
+export type StartFlowState =
+  | 'mode-select'
+  | 'login'
+  | 'authenticating'
+  | 'realm-loading'
+  | 'realm-list'
+  | 'realm-empty'
+  | 'offline-select'
+  | 'character-loading'
+  | 'character-empty'
+  | 'character-select'
+  | 'character-error'
+  | 'world-connecting'
+  | 'game-ready';
+
+export interface StartFlowSnapshot {
+  state: StartFlowState;
+  panel: StartFlowPanel;
+  hasGame: boolean;
+  username?: string;
+  realm?: string;
+  characterCount?: number;
+  error?: string;
+}
+
+function realmSuffix(realm: string | undefined): string {
+  return realm ? ` on ${realm}` : '';
+}
+
+export function startFlowStatusText(snapshot: StartFlowSnapshot): string {
+  switch (snapshot.state) {
+    case 'mode-select':
+      return 'Choose online or offline play.';
+    case 'login':
+      return 'Online: enter your account details.';
+    case 'authenticating':
+      return 'Online: signing in...';
+    case 'realm-loading':
+      return 'Online: loading realms...';
+    case 'realm-list':
+      return snapshot.username ? `Online: ${snapshot.username}, choose a realm.` : 'Online: choose a realm.';
+    case 'realm-empty':
+      return 'Online: no realms are available.';
+    case 'offline-select':
+      return 'Offline: create a local character.';
+    case 'character-loading':
+      return `Online: loading characters${realmSuffix(snapshot.realm)}...`;
+    case 'character-empty':
+      return `Online: no characters${realmSuffix(snapshot.realm)} yet.`;
+    case 'character-select':
+      if (snapshot.characterCount === 1) return `Online: 1 character available${realmSuffix(snapshot.realm)}.`;
+      if (typeof snapshot.characterCount === 'number') {
+        return `Online: ${snapshot.characterCount} characters available${realmSuffix(snapshot.realm)}.`;
+      }
+      return `Online: characters available${realmSuffix(snapshot.realm)}.`;
+    case 'character-error':
+      return snapshot.error ? `Online: could not load characters: ${snapshot.error}` : 'Online: could not load characters.';
+    case 'world-connecting':
+      return `Online: entering the world${realmSuffix(snapshot.realm)}...`;
+    case 'game-ready':
+      return 'World ready.';
+  }
+}

--- a/tests/start_flow_state.test.ts
+++ b/tests/start_flow_state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { startFlowStatusText } from '../src/ui/start_flow_state';
+
+describe('startFlowStatusText', () => {
+  it('names the auth transition while login is in flight', () => {
+    expect(startFlowStatusText({
+      state: 'authenticating',
+      panel: '#login-panel',
+      hasGame: false,
+    })).toBe('Online: signing in...');
+  });
+
+  it('includes the selected realm while characters are loading', () => {
+    expect(startFlowStatusText({
+      state: 'character-loading',
+      panel: '#charselect-panel',
+      hasGame: false,
+      realm: 'Azeroth',
+    })).toBe('Online: loading characters on Azeroth...');
+  });
+
+  it('distinguishes an empty character list from a hidden or blank panel', () => {
+    expect(startFlowStatusText({
+      state: 'character-empty',
+      panel: '#charselect-panel',
+      hasGame: false,
+      realm: 'Azeroth',
+      characterCount: 0,
+    })).toBe('Online: no characters on Azeroth yet.');
+  });
+
+  it('reports character load failures without implying the game has started', () => {
+    expect(startFlowStatusText({
+      state: 'character-error',
+      panel: '#charselect-panel',
+      hasGame: false,
+      error: 'not authenticated',
+    })).toBe('Online: could not load characters: not authenticated');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an explicit start-flow state surface for login, auth-in-flight, realm loading/list/empty, character loading/empty/select/error, world connecting, and game-ready.
- Mirrors the state to a visible `#start-flow-status`, `body`/`#start-screen` data attributes, and `window.__wocStartFlow` so loaded-but-not-in-game states can be inspected directly.
- Guards late auth, realm, and character-load completions so stale async responses do not move the UI back to an old state after navigation.
- Preserves the current homepage/footer layout and mobile character-select tabs after rebasing.

## Diagnosis
The start screen previously hid and showed panels directly while async login, realm, and character APIs updated text after completion. A loaded page could therefore have no `__game`, hidden login fields, and pending character data without a durable visible or machine-readable explanation of the current flow.

## Implementation Notes
- `src/ui/start_flow_state.ts` centralizes the state names and status text.
- `src/main.ts` updates the observable state around existing panel transitions and async boundaries without changing server auth, persistence, or game authority.
- Request ids and active-panel checks prevent late auth, realm, or character responses from overwriting the current state after the user navigates away.

## Verification
- `npx vitest run tests/start_flow_state.test.ts`; 1 file passed, 4 tests passed.
- `npm test`; 36 files passed, 401 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:chat-login-character-select-transitions-could`; branch is 1 commit ahead, 0 behind.

## Real behavior proof
- Behavior addressed: loaded page, login, realm, and character-select confusion when the game has not started yet.
- Environment tested: local unit/type/build verification on the rebased branch.
- Not tested: manual browser smoke pass after the homepage-layout rebase.

## Risk
Client-only observability change. It does not alter server auth, persistence, character data, or world simulation behavior. The async guards reduce stale UI-state risk by ignoring responses that no longer belong to the active panel/request.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
