### PR TITLE
feat: add presence notice chat setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
   .kb-key.capturing { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd100aa; }
   .kb-note { font-size: 11px; color: #b9ac82; margin: 2px 0 6px; min-height: 14px; line-height: 1.4; }
   .set-rows { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
-  .set-row { display: grid; grid-template-columns: 120px 1fr 48px; align-items: center; gap: 10px; padding: 3px 6px; }
+  .set-row { display: grid; grid-template-columns: 140px 1fr 68px; align-items: center; gap: 10px; padding: 3px 6px; }
   .set-name { font-size: 12.5px; color: #e8e0c8; }
   .set-slider { width: 100%; accent-color: var(--gold); cursor: pointer; }
   .set-val { font-size: 12px; color: #ffd9a0; text-align: right; font-variant-numeric: tabular-nums; }

--- a/server/game.ts
+++ b/server/game.ts
@@ -429,7 +429,7 @@ export class GameServer {
       cls,
       realm: REALM,
     });
-    this.broadcastSystem(`${name} has entered World of Claudecraft.`);
+    this.broadcastSystem(`${name} has entered World of Claudecraft.`, 'presence');
     void this.initSocial(session);
     return session;
   }
@@ -460,7 +460,7 @@ export class GameServer {
     }
     await this.saveCharacter(session).catch((err) => console.error('save on leave failed:', err));
     this.sim.removePlayer(session.pid);
-    this.broadcastSystem(`${session.name} has left the world. (${reason})`);
+    this.broadcastSystem(`${session.name} has left the world. (${reason})`, 'presence');
   }
 
   async saveCharacter(session: ClientSession): Promise<void> {
@@ -1063,9 +1063,9 @@ export class GameServer {
     return false;
   }
 
-  private broadcastSystem(text: string): void {
+  private broadcastSystem(text: string, kind?: Extract<SimEvent, { type: 'log' }>['kind']): void {
     for (const session of this.clients.values()) {
-      this.send(session, { t: 'events', list: [{ type: 'log', text, color: '#ffd100' }] });
+      this.send(session, { t: 'events', list: [{ type: 'log', text, color: '#ffd100', kind }] });
     }
   }
 

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -1,6 +1,6 @@
-// Player-adjustable game settings (camera, audio, graphics) surfaced in the
+// Player-adjustable game settings (camera, audio, graphics, interface) surfaced in the
 // Esc options menu. Pure + persisted to localStorage; main.ts applies each
-// value to the live subsystem (Input / GameAudio / MusicDirector / Renderer).
+// value to the live subsystem (Input / GameAudio / MusicDirector / Renderer / HUD).
 
 export interface GameSettings {
   cameraSpeed: number;  // mouse-look sensitivity multiplier (1 = the old fixed speed)
@@ -9,6 +9,7 @@ export interface GameSettings {
   brightness: number;   // tone-mapping exposure multiplier
   renderScale: number;  // resolution multiplier on top of the device pixel ratio
   fullscreen: number;   // 0/1 browser fullscreen preference
+  showPresenceNotices: number; // 0/1: show player enter/leave chat notices
 }
 
 interface Range { min: number; max: number; def: number }
@@ -23,6 +24,7 @@ export const SETTING_RANGES: Record<keyof GameSettings, Range> = {
   brightness: { min: 0.6, max: 1.5, def: 1 },
   renderScale: { min: 0.5, max: 1, def: 1 },
   fullscreen: { min: 0, max: 1, def: 1 },
+  showPresenceNotices: { min: 0, max: 1, def: 1 },
 };
 
 const STORE_KEY = 'woc_settings';

--- a/src/main.ts
+++ b/src/main.ts
@@ -406,6 +406,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       case 'brightness': renderer.setBrightness(v); break;
       case 'renderScale': renderer.setRenderScale(v); break;
       case 'fullscreen': v >= 0.5 ? requestPreferredFullscreen() : exitBrowserFullscreen(); break;
+      case 'showPresenceNotices': break;
     }
   }
   // apply persisted settings to the freshly-built subsystems

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -509,7 +509,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'spellfx'; sourceId: number; targetId: number; school: string; fx: 'projectile' | 'tick' | 'nova' }
   // entityId (when set) anchors the log to that entity so the server only
   // delivers it to nearby players; anchorless logs broadcast server-wide
-  | { type: 'log'; text: string; color?: string; entityId?: number }
+  | { type: 'log'; text: string; color?: string; entityId?: number; kind?: 'presence' }
 );
 
 export interface MoveInput {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -69,7 +69,7 @@ export class Hud {
   private dragFromSlot: number | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
-  private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
+  private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' | 'interface' = 'main';
   private capturingKey: { action: string; index: number } | null = null; // binding awaiting a key
   private keybindNote = '';
   private chatLogEl = $('#chatlog');
@@ -1278,7 +1278,9 @@ export class Hud {
           }
           break;
         }
-        case 'log': this.log(ev.text, ev.color ?? '#ccc'); break;
+        case 'log':
+          if (this.shouldDisplayLog(ev)) this.log(ev.text, ev.color ?? '#ccc');
+          break;
         case 'playerDeath': {
           this.log('You have died.', '#ff4444');
           audio.death();
@@ -1314,6 +1316,10 @@ export class Hud {
   private logZoneWelcome(zone: ZoneDef): void {
     const text = zoneWelcomeText(zone, (questId) => this.sim.questState(questId));
     if (text) this.log(text, '#ffd100');
+  }
+
+  private shouldDisplayLog(ev: Extract<SimEvent, { type: 'log' }>): boolean {
+    return ev.kind !== 'presence' || (this.optionsHooks?.settings.get('showPresenceNotices') ?? 1) >= 0.5;
   }
 
   private chatLogFrom(name: string, text: string, color: string, prefix: string, separator: string): void {
@@ -2705,6 +2711,7 @@ export class Hud {
     if (this.optionsView === 'keybinds') { this.renderKeybinds(); return; }
     if (this.optionsView === 'graphics') { this.renderGraphics(); return; }
     if (this.optionsView === 'audio') { this.renderAudio(); return; }
+    if (this.optionsView === 'interface') { this.renderInterface(); return; }
     const el = $('#options-menu');
     el.innerHTML = `<div class="panel-title"><span>Game Menu</span><span class="x-btn" data-close>✕</span></div>`;
     const list = document.createElement('div');
@@ -2716,8 +2723,9 @@ export class Hud {
       b.addEventListener('click', () => { audio.click(); onClick(); });
       list.appendChild(b);
     };
-    const goto = (view: 'keybinds' | 'graphics' | 'audio') => { this.optionsView = view; this.keybindNote = ''; this.renderOptions(); };
+    const goto = (view: 'keybinds' | 'graphics' | 'audio' | 'interface') => { this.optionsView = view; this.keybindNote = ''; this.renderOptions(); };
     add('Key Bindings', () => goto('keybinds'));
+    add('Interface', () => goto('interface'));
     add('Graphics', () => goto('graphics'));
     add('Audio', () => goto('audio'));
     add('Logout', () => this.optionsHooks?.logout());
@@ -2755,7 +2763,7 @@ export class Hud {
     parent.appendChild(row);
   }
 
-  private settingToggle(parent: HTMLElement, label: string, key: keyof GameSettings): void {
+  private settingToggle(parent: HTMLElement, label: string, key: keyof GameSettings, onText = 'On', offText = 'Off'): void {
     const hooks = this.optionsHooks;
     if (!hooks) return;
     const row = document.createElement('div');
@@ -2763,11 +2771,12 @@ export class Hud {
     const name = document.createElement('span');
     name.className = 'set-name';
     name.textContent = label;
+    const spacer = document.createElement('span');
     const toggle = document.createElement('button');
     toggle.className = 'btn set-toggle';
     const sync = () => {
       const on = hooks.settings.get(key) >= 0.5;
-      toggle.textContent = on ? 'On' : 'Off';
+      toggle.textContent = on ? onText : offText;
       toggle.classList.toggle('off', !on);
       toggle.setAttribute('aria-pressed', String(on));
     };
@@ -2778,7 +2787,7 @@ export class Hud {
       hooks.onSettingChange(key, next);
       sync();
     });
-    row.append(name, toggle);
+    row.append(name, spacer, toggle);
     parent.appendChild(row);
   }
 
@@ -2834,13 +2843,20 @@ export class Hud {
     const name = document.createElement('span');
     name.className = 'set-name';
     name.textContent = 'Music';
+    const spacer = document.createElement('span');
     const toggle = document.createElement('button');
     toggle.className = 'btn set-toggle';
     const sync = () => { toggle.textContent = music.enabled ? 'On' : 'Off'; toggle.classList.toggle('off', !music.enabled); };
     sync();
     toggle.addEventListener('click', () => { audio.click(); music.setEnabled(!music.enabled); sync(); });
-    row.append(name, toggle);
+    row.append(name, spacer, toggle);
     body.appendChild(row);
+    this.settingsViewFooter();
+  }
+
+  private renderInterface(): void {
+    const body = this.settingsViewShell('Interface');
+    this.settingToggle(body, 'Player Enter/Leave', 'showPresenceNotices', 'Shown', 'Hidden');
     this.settingsViewFooter();
   }
 

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -21,6 +21,7 @@ describe('Settings', () => {
     expect(s.get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
     expect(s.get('renderScale')).toBe(1);
     expect(s.get('fullscreen')).toBe(1);
+    expect(s.get('showPresenceNotices')).toBe(1);
   });
 
   it('clamps out-of-range values to the slider bounds', () => {
@@ -29,6 +30,8 @@ describe('Settings', () => {
     expect(s.set('cameraSpeed', -5)).toBe(SETTING_RANGES.cameraSpeed.min);
     expect(s.set('sfxVolume', 0.5)).toBe(0.5);
     expect(s.set('fullscreen', -1)).toBe(0);
+    expect(s.set('showPresenceNotices', -1)).toBe(0);
+    expect(s.set('showPresenceNotices', 2)).toBe(1);
   });
 
   it('ignores non-finite input, keeping a valid value', () => {
@@ -42,10 +45,12 @@ describe('Settings', () => {
     a.set('cameraSpeed', 0.4);
     a.set('musicVolume', 0.2);
     a.set('fullscreen', 0);
+    a.set('showPresenceNotices', 0);
     const b = new Settings();
     expect(b.get('cameraSpeed')).toBe(0.4);
     expect(b.get('musicVolume')).toBe(0.2);
     expect(b.get('fullscreen')).toBe(0);
+    expect(b.get('showPresenceNotices')).toBe(0);
   });
 
   it('falls back to defaults for missing/corrupt keys', () => {
@@ -54,6 +59,7 @@ describe('Settings', () => {
     expect(s.get('cameraSpeed')).toBe(0.5);
     expect(s.get('brightness')).toBe(SETTING_RANGES.brightness.def); // missing -> default
     expect(s.get('fullscreen')).toBe(SETTING_RANGES.fullscreen.def);
+    expect(s.get('showPresenceNotices')).toBe(1);
   });
 
   it('reset() restores every default', () => {
@@ -61,10 +67,12 @@ describe('Settings', () => {
     s.set('cameraSpeed', 1.2);
     s.set('renderScale', 0.5);
     s.set('fullscreen', 0);
+    s.set('showPresenceNotices', 0);
     s.reset();
     expect(s.get('cameraSpeed')).toBe(SETTING_RANGES.cameraSpeed.def);
     expect(s.get('renderScale')).toBe(SETTING_RANGES.renderScale.def);
     expect(s.get('fullscreen')).toBe(SETTING_RANGES.fullscreen.def);
+    expect(s.get('showPresenceNotices')).toBe(1);
   });
 
   it('all() returns an independent snapshot', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -175,6 +175,31 @@ describe('delta snapshots', () => {
 });
 
 describe('chat moderation', () => {
+  it('marks world enter and leave notices as presence logs', async () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    joinServer(server, fc, 1, 'Testa');
+    fc.sent.length = 0;
+
+    const fc2 = fakeWs();
+    const session2 = joinServer(server, fc2, 2, 'Testb');
+    let events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'log',
+      kind: 'presence',
+      text: expect.stringContaining('has entered World of Claudecraft'),
+    }));
+
+    fc.sent.length = 0;
+    await server.leave(session2, 'disconnected');
+    events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'log',
+      kind: 'presence',
+      text: expect.stringContaining('has left the world'),
+    }));
+  });
+
   it('rate-limits chat bursts per connected client before cooldown', () => {
     const server = new GameServer();
     const fc = fakeWs();


### PR DESCRIPTION
## Summary
- Presence notifications can crowd out player chat when players connect or disconnect; the Esc menu now has an Interface setting to show or hide those notices.
- Server join/leave system logs are tagged with `kind: "presence"`, and the HUD filters only that log kind so normal chat and other gameplay logs still appear.
- The setting is persisted with the existing `woc_settings` store and defaults to shown, preserving current behavior until the player hides it.
- The rebased options menu keeps the current fullscreen setting and preserves the existing three-column settings layout.

## Implementation Notes
- Reuses the numeric settings store for the toggle (`1` shown, `0` hidden) and renders it as a compact button in the Interface submenu.
- The event tag is additive on `log` events; untagged logs continue through the existing chat log path.

## Verification
- `npx vitest run tests/settings.test.ts tests/snapshots.test.ts`; 2 files passed, 20 tests passed.
- `npm test`; 35 files passed, 398 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:hide-presence-chat-notices`; branch is 1 commit ahead, 0 behind.

## Risk
Low user-visible risk: the default remains current behavior. The setting only filters a client-side log category and does not change server authority, persistence, or chat delivery. No manual browser gameplay pass was run; coverage is focused tests plus production builds.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
