### PR TITLE
perf: index game sessions by character id

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -264,6 +264,7 @@ export function censorChatText(text: string): string {
 export class GameServer {
   sim: Sim;
   clients = new Map<number, ClientSession>(); // by pid
+  private readonly sessionsByCharacterId = new Map<number, ClientSession>();
   readonly chatLog = new ChatLogger(insertChatLogs);
   private readonly socialDb = new PgSocialDb(pool);
   readonly social: SocialService;
@@ -291,8 +292,7 @@ export class GameServer {
   }
 
   private sessionByCharacterId(id: number): ClientSession | null {
-    for (const s of this.clients.values()) if (s.characterId === id) return s;
-    return null;
+    return this.sessionsByCharacterId.get(id) ?? null;
   }
 
   private sessionByName(name: string): ClientSession | null {
@@ -381,9 +381,7 @@ export class GameServer {
   // -------------------------------------------------------------------------
 
   join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false): ClientSession | { error: string } {
-    for (const c of this.clients.values()) {
-      if (c.characterId === characterId) return { error: 'character already in world' };
-    }
+    if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
     if (isGm) {
       // GM characters: invulnerable, and always at the level cap (the row is
@@ -403,6 +401,7 @@ export class GameServer {
       sentEnts: new Map(),
     };
     this.clients.set(pid, session);
+    this.sessionsByCharacterId.set(characterId, session);
     this.peakOnline = Math.max(this.peakOnline, this.clients.size);
     openPlaySession(accountId, characterId, name)
       .then((id) => { session.dbSessionId = id; })
@@ -437,6 +436,7 @@ export class GameServer {
   async leave(session: ClientSession, reason: string): Promise<void> {
     if (!this.clients.has(session.pid)) return;
     this.clients.delete(session.pid);
+    this.sessionsByCharacterId.delete(session.characterId);
     this.social.forget(session.characterId);
     // delete from clients first so friends see them as offline in the notice
     void this.social.announcePresence({ characterId: session.characterId, name: session.name }, false)

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+}));
+
+import { GameServer, type ClientSession } from '../server/game';
+
+function fakeWs() {
+  return {
+    readyState: 1,
+    send: vi.fn(),
+    close: vi.fn(),
+  } as any;
+}
+
+function expectJoined(result: ClientSession | { error: string }): ClientSession {
+  if ('error' in result) throw new Error(result.error);
+  return result;
+}
+
+describe('GameServer sessions', () => {
+  it('keeps the character-id session index coherent across join, duplicate join, leave, and rejoin', async () => {
+    const server = new GameServer();
+    const first = expectJoined(server.join(fakeWs(), 11, 101, 'Indexa', 'warrior', null));
+    const second = expectJoined(server.join(fakeWs(), 12, 102, 'Indexb', 'warrior', null));
+
+    expect((server as any).sessionByCharacterId(101)).toBe(first);
+    expect((server as any).sessionByCharacterId(102)).toBe(second);
+    expect(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null)).toEqual({
+      error: 'character already in world',
+    });
+
+    await server.leave(first, 'test');
+
+    expect((server as any).sessionByCharacterId(101)).toBeNull();
+    expect((server as any).sessionByCharacterId(102)).toBe(second);
+
+    const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
+    expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
+  });
+});


### PR DESCRIPTION
## Summary
- Maintain a `GameServer` session index keyed by stable character id while preserving the existing pid-keyed client map.
- Use the character-id index for duplicate-login checks and social transport presence/delivery lookups, avoiding a scan over every online session per roster row or guild member.
- Add regression coverage for duplicate join rejection, leave cleanup, and rejoining the same character id.

## Implementation Notes
- The index is updated in the same join/leave lifecycle path as `clients`, keeping pid ownership unchanged for snapshot and WebSocket behavior.
- `SocialService` and the wire protocol remain unchanged; the optimization stays inside `GameServer`'s transport boundary.

## Verification
- `npx vitest run tests/social_system.test.ts tests/snapshots.test.ts`; 2 files, 38 tests passed.
- `npx vitest run tests/game_sessions.test.ts tests/snapshots.test.ts`; 2 files, 10 tests passed.
- `npx vitest run tests/social_system.test.ts tests/snapshots.test.ts tests/interest.test.ts`; 3 files, 61 tests passed.
- `npx tsc --noEmit`; passed with no TypeScript errors.
- `npm run build:server`; passed.
- `scripts/committer "perf: index game sessions by character id" server/game.ts tests/game_sessions.test.ts`; full closeout gate passed: `npm test` 26 files, 326 tests passed; `npx tsc --noEmit`; `npm run build:env`; `npm run build:server`; `npm run build`.

## Risk
Low. The change is server-local and preserves the existing session ownership model; the main risk is stale index entries, covered by the join/leave/rejoin regression test.

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
