### PR TITLE
perf: reuse position objects in hot paths

### DIFF
--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -149,6 +149,12 @@ function wrapAngle(d: number): number {
   return d;
 }
 
+function copyPos(dst: { x: number; y: number; z: number }, src: { x: number; y: number; z: number }): void {
+  dst.x = src.x;
+  dst.y = src.y;
+  dst.z = src.z;
+}
+
 function blankEntity(id: number): Entity {
   return {
     id, kind: 'mob', templateId: '', name: '', level: 1,
@@ -349,7 +355,7 @@ export class ClientWorld implements IWorld {
         if (!hasIdentity) return null;
         e = blankEntity(w.id);
         e.pos = { x: w.x, y: w.y, z: w.z };
-        e.prevPos = { x: w.x, y: w.y, z: w.z };
+        copyPos(e.prevPos, e.pos);
         e.facing = w.f;
         e.prevFacing = w.f;
         this.entities.set(w.id, e);
@@ -393,11 +399,9 @@ export class ClientWorld implements IWorld {
         }
       }
       e.netUpdatedAt = now;
-      e.prevPos = {
-        x: e.prevPos.x + (e.pos.x - e.prevPos.x) * entAlpha,
-        y: e.prevPos.y + (e.pos.y - e.prevPos.y) * entAlpha,
-        z: e.prevPos.z + (e.pos.z - e.prevPos.z) * entAlpha,
-      };
+      e.prevPos.x = e.prevPos.x + (e.pos.x - e.prevPos.x) * entAlpha;
+      e.prevPos.y = e.prevPos.y + (e.pos.y - e.prevPos.y) * entAlpha;
+      e.prevPos.z = e.prevPos.z + (e.pos.z - e.prevPos.z) * entAlpha;
       e.prevFacing = e.prevFacing + wrapAngle(e.facing - e.prevFacing) * entFacingAlpha;
       e.pos.x = w.x; e.pos.y = w.y; e.pos.z = w.z;
       e.facing = w.f;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -167,6 +167,12 @@ export function computeQuestState(
   return 'available';
 }
 
+function copyPos(dst: { x: number; y: number; z: number }, src: { x: number; y: number; z: number }): void {
+  dst.x = src.x;
+  dst.y = src.y;
+  dst.z = src.z;
+}
+
 function freshCounters(): RewardCounters {
   return {
     damageDealt: 0, damageTaken: 0, kills: 0, deaths: 0, xpGained: 0,
@@ -577,7 +583,7 @@ export class Sim {
     this.tickCount++;
 
     for (const e of this.entities.values()) {
-      e.prevPos = { ...e.pos };
+      copyPos(e.prevPos, e.pos);
       e.prevFacing = e.facing;
     }
 


### PR DESCRIPTION
## Summary
- Reuses existing `prevPos` vector objects in `Sim.tick()` and `ClientWorld.applySnapshot()` instead of allocating fresh `{ x, y, z }` objects every tick or snapshot.
- Keeps movement state shapes and network payloads unchanged; newly observed client entities still keep distinct `pos` and `prevPos` objects.

## Implementation Notes
- Adds local `copyPos` helpers in the two touched files instead of introducing a shared utility for this narrow hot-path pattern.
- Leaves teleport, respawn, and other rare position reset assignments unchanged.

## Verification
- `npx vitest run tests/spatial.test.ts tests/locomotion.test.ts`; 2 files and 11 tests passed.
- `npx vitest run tests/interest.test.ts tests/snapshots.test.ts`; 2 files and 32 tests passed.
- `npx vitest run tests/spatial.test.ts tests/interest.test.ts tests/locomotion.test.ts tests/snapshots.test.ts`; 4 files and 43 tests passed.
- `npx vitest run tests/sim.test.ts tests/social.test.ts tests/fixes.test.ts`; 3 files and 91 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `scripts/committer "perf: reuse position objects in hot paths" src/sim/sim.ts src/net/online.ts`; configured full gate passed, including `npm test` with 25 files and 325 tests, typecheck, `build:env`, `build:server`, and client build.
- `python3 ~/.codex/skills/world-of-claudecraft-pr/scripts/polish_branch.py --subject "perf: reuse position objects in hot paths" --body-file <file>`; polished branch preserved #53 and reran the configured pre-commit gate.
- `scripts/codex-review-gate --base c7ddcbe`; clean.

## Risk
Low. The change mutates existing vector-like objects only where object identity is not part of the contract, and it does not change public types, deterministic gameplay rules, snapshot payloads, teleport behavior, or respawn behavior.

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
