### PR TITLE
perf: bound and dedupe autosaves

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -36,6 +36,7 @@ const QUARTER_RATE_DIVISOR = 4;
 const WIRE_CACHE_SWEEP_TICKS = 1200;
 const EVENT_RADIUS = 90;
 const AUTOSAVE_SECONDS = 30;
+const SAVE_CONCURRENCY = 4;
 const CHAT_RATE_BURST = 5;
 const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
@@ -285,6 +286,7 @@ export class GameServer {
   private lastWireSweepTick = 0;
   private interval: NodeJS.Timeout | null = null;
   private saveTimer = 0;
+  private saveAllInFlight: Promise<void> | null = null;
   private readonly startedAt = Date.now();
   private peakOnline = 0;
   private tickMsAvg = 0;
@@ -473,9 +475,31 @@ export class GameServer {
   }
 
   async saveAll(reason: string): Promise<void> {
-    for (const session of this.clients.values()) {
-      await this.saveCharacter(session).catch((err) => console.error(`${reason} failed for ${session.name}:`, err));
+    while (this.saveAllInFlight) {
+      const inFlight = this.saveAllInFlight;
+      if (reason !== 'shutdown') return;
+      await inFlight;
     }
+    const run = this.saveAllSnapshot(reason);
+    this.saveAllInFlight = run;
+    try {
+      await run;
+    } finally {
+      if (this.saveAllInFlight === run) this.saveAllInFlight = null;
+    }
+  }
+
+  private async saveAllSnapshot(reason: string): Promise<void> {
+    const sessions = [...this.clients.values()];
+    let next = 0;
+    const worker = async () => {
+      for (;;) {
+        const session = sessions[next++];
+        if (!session) return;
+        await this.saveCharacter(session).catch((err) => console.error(`${reason} failed for ${session.name}:`, err));
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(SAVE_CONCURRENCY, sessions.length) }, worker));
   }
 
   // The World Market is shared global state, persisted as a single JSONB blob.

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -13,6 +13,7 @@ vi.mock('../server/db', () => ({
 }));
 
 import { censorChatText, GameServer, ClientSession } from '../server/game';
+import { saveCharacterState } from '../server/db';
 import { ClientWorld } from '../src/net/online';
 
 const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
@@ -273,6 +274,68 @@ describe('chat moderation', () => {
       warn.mockRestore();
       rmSync(dir, { force: true, recursive: true });
     }
+  });
+});
+
+describe('autosaves', () => {
+  beforeEach(() => {
+    vi.mocked(saveCharacterState).mockReset();
+    vi.mocked(saveCharacterState).mockResolvedValue(undefined);
+  });
+
+  it('skips overlapping saveAll runs while saving each current session once', async () => {
+    const server = new GameServer();
+    joinServer(server, fakeWs(), 1, 'Testa');
+    joinServer(server, fakeWs(), 2, 'Testb');
+    joinServer(server, fakeWs(), 3, 'Testc');
+
+    let resolveFirstSave!: () => void;
+    const firstSave = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    vi.mocked(saveCharacterState).mockImplementationOnce(() => firstSave);
+
+    const firstRun = server.saveAll('test');
+    await vi.waitFor(() => {
+      expect(saveCharacterState).toHaveBeenCalledTimes(3);
+    });
+
+    await server.saveAll('test');
+    expect(saveCharacterState).toHaveBeenCalledTimes(3);
+
+    resolveFirstSave();
+    await firstRun;
+
+    const savedCharacterIds = vi.mocked(saveCharacterState).mock.calls.map((call) => call[0]);
+    expect(savedCharacterIds.sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it('waits for an active autosave before running the shutdown save pass', async () => {
+    const server = new GameServer();
+    joinServer(server, fakeWs(), 1, 'Testa');
+    joinServer(server, fakeWs(), 2, 'Testb');
+
+    let resolveFirstSave!: () => void;
+    const firstSave = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    vi.mocked(saveCharacterState).mockImplementationOnce(() => firstSave);
+
+    const autosave = server.saveAll('autosave');
+    await vi.waitFor(() => {
+      expect(saveCharacterState).toHaveBeenCalledTimes(2);
+    });
+
+    const shutdown = server.saveAll('shutdown');
+    await Promise.resolve();
+    expect(saveCharacterState).toHaveBeenCalledTimes(2);
+
+    resolveFirstSave();
+    await autosave;
+    await shutdown;
+
+    const savedCharacterIds = vi.mocked(saveCharacterState).mock.calls.map((call) => call[0]);
+    expect(savedCharacterIds.sort((a, b) => a - b)).toEqual([1, 1, 2, 2]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Bulk autosaves now snapshot connected sessions before starting database writes and process them with bounded concurrency.
- Ordinary overlapping `saveAll()` calls return while an existing bulk save is in flight, avoiding duplicate autosave pressure under slow persistence.
- Shutdown saves wait for any active autosave and then run their own final save pass, preserving graceful shutdown persistence.

## Diagnosis
The autosave interval launched `saveAll("autosave")` without tracking whether a previous bulk save was still running. `saveAll()` also awaited each session sequentially while iterating the live client map, so slow database writes could trail live state and overlapping intervals could enqueue duplicate persistence work.

## Implementation Notes
- `saveAll()` owns the in-flight guard; direct `saveCharacter()` calls, including logout saves, remain independent.
- The save pass copies `this.clients.values()` before awaiting database work.
- Per-session save failures are still caught and logged with the save reason and session name so one failure does not reject the whole pass.

## Verification
- `npm test`; 35 files passed, 399 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:plan-005-autosaves-autosave-seconds-connected-characters`; branch is 1 commit ahead, 0 behind, changing only `server/game.ts` and `tests/snapshots.test.ts`.

## Risk
Persistence behavior is operationally sensitive. The tests cover overlap dedupe and the shutdown final-save case, and the implementation keeps logout saves outside the bulk-save guard.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
