### PR TITLE
perf: cache chat censor terms

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -240,16 +240,29 @@ function parseCensorList(raw: string | undefined): string[] {
     .filter((term) => term.length > 0);
 }
 
+let censorCacheKey: string | null = null;
+let censorCacheTerms: string[] = [];
+
 function configuredChatCensorTerms(): string[] {
-  const terms = parseCensorList(process.env.CHAT_CENSOR_LIST);
-  const file = process.env.CHAT_CENSOR_FILE;
-  if (!file) return terms;
+  const rawList = process.env.CHAT_CENSOR_LIST ?? '';
+  const file = process.env.CHAT_CENSOR_FILE ?? '';
+  const cacheKey = `${rawList}\0${file}`;
+  if (cacheKey === censorCacheKey) return censorCacheTerms;
+
+  const terms = parseCensorList(rawList);
+  if (!file) {
+    censorCacheTerms = terms;
+    censorCacheKey = cacheKey;
+    return censorCacheTerms;
+  }
   try {
-    return terms.concat(parseCensorList(readFileSync(file, 'utf8')));
+    censorCacheTerms = terms.concat(parseCensorList(readFileSync(file, 'utf8')));
   } catch (err) {
     console.warn(`could not read CHAT_CENSOR_FILE (${file}):`, err);
     return terms;
   }
+  censorCacheKey = cacheKey;
+  return censorCacheTerms;
 }
 
 export function censorChatText(text: string): string {

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed; snapshot logic is under test.
@@ -67,16 +70,25 @@ function bareClient(pid: number): ClientWorld {
   return c;
 }
 
-function withChatCensorList(list: string | undefined, test: () => void): void {
+function withChatCensorConfig(list: string | undefined, file: string | undefined, test: () => void): void {
   const prev = process.env.CHAT_CENSOR_LIST;
+  const prevFile = process.env.CHAT_CENSOR_FILE;
   if (list === undefined) delete process.env.CHAT_CENSOR_LIST;
   else process.env.CHAT_CENSOR_LIST = list;
+  if (file === undefined) delete process.env.CHAT_CENSOR_FILE;
+  else process.env.CHAT_CENSOR_FILE = file;
   try {
     test();
   } finally {
     if (prev === undefined) delete process.env.CHAT_CENSOR_LIST;
     else process.env.CHAT_CENSOR_LIST = prev;
+    if (prevFile === undefined) delete process.env.CHAT_CENSOR_FILE;
+    else process.env.CHAT_CENSOR_FILE = prevFile;
   }
+}
+
+function withChatCensorList(list: string | undefined, test: () => void): void {
+  withChatCensorConfig(list, undefined, test);
 }
 
 describe('delta snapshots', () => {
@@ -217,6 +229,49 @@ describe('chat moderation', () => {
         text: 'hello ***********',
       }));
     });
+  });
+
+  it('caches file-backed censor terms until censor env changes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claudecraft-censor-'));
+    const firstFile = join(dir, 'first.txt');
+    const secondFile = join(dir, 'second.txt');
+    writeFileSync(firstFile, 'fileterm\n');
+    writeFileSync(secondFile, 'otherterm\n');
+
+    try {
+      withChatCensorConfig(undefined, firstFile, () => {
+        expect(censorChatText('fileterm again')).toBe('******** again');
+        writeFileSync(firstFile, 'changedterm\n');
+        expect(censorChatText('fileterm changedterm')).toBe('******** changedterm');
+
+        process.env.CHAT_CENSOR_FILE = secondFile;
+        expect(censorChatText('fileterm otherterm')).toBe('fileterm *********');
+
+        delete process.env.CHAT_CENSOR_FILE;
+        expect(censorChatText('otherterm')).toBe('otherterm');
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('retries file-backed censor terms after a failed read', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claudecraft-censor-missing-'));
+    const missingFile = join(dir, 'missing.txt');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      withChatCensorConfig(undefined, missingFile, () => {
+        expect(censorChatText('laterterm')).toBe('laterterm');
+        expect(warn).toHaveBeenCalledOnce();
+
+        writeFileSync(missingFile, 'laterterm\n');
+        expect(censorChatText('laterterm')).toBe('*********');
+      });
+    } finally {
+      warn.mockRestore();
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Cache parsed chat censor terms by `CHAT_CENSOR_LIST` and `CHAT_CENSOR_FILE` so normal chat sends do not synchronously reread the censor file.
- Preserve list-only and file-backed moderation behavior, including retrying and warning after failed file reads instead of caching failures.
- Add file-backed cache coverage for unchanged env config, env changes, and a missing censor file that appears later.

## Why
Every chat command calls `censorChatText()`. When `CHAT_CENSOR_FILE` is configured, the old path synchronously read the file on every message, putting filesystem I/O on the chat hot path.

## Verification
- `npx vitest run tests/snapshots.test.ts`; 11 tests passed.
- `npx vitest run tests/snapshots.test.ts tests/chat.test.ts`; 24 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:server`; passed.
- `scripts/committer "fix: retry failed chat censor file reads" server/game.ts tests/snapshots.test.ts`; full configured gate passed, including `npm test` with 327 tests, `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, `npm run build`, and local Codex review.
- `python3 ~/.codex/skills/world-of-claudecraft-pr/scripts/polish_branch.py --subject "perf: cache chat censor terms" --body-file /tmp/cache-chat-censor-commit-body.md`; full configured gate passed with 327 tests and rebuilt env/server/client bundles.
- `scripts/codex-review-gate --base origin/codex-typecheck-failure-in-moderationqueue-instead`; clean for the final polished contribution.

## Risk
Low operational risk. Successful file-backed censor terms now refresh only when relevant environment values change; failed file reads still retry so a repaired file at the same path can take effect without changing env config.

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
