### PR TITLE
perf: index character typeahead search

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -284,7 +284,7 @@ export async function searchCharacters(prefix: string, limit = 8): Promise<Chara
   const escaped = term.replace(/[\\%_]/g, (m) => `\\${m}`);
   const res = await pool.query(
     `SELECT name, class AS cls, level FROM characters
-     WHERE realm = $1 AND name ILIKE $2 ESCAPE '\\' ORDER BY name LIMIT $3`,
+     WHERE realm = $1 AND lower(name) LIKE lower($2) ESCAPE '\\' ORDER BY name LIMIT $3`,
     [REALM, `${escaped}%`, Math.min(20, Math.max(1, limit))],
   );
   return res.rows;

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -96,13 +96,14 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
      GROUP BY a.id
      ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
   );
-  return res.rows.map((r) => {
+  return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
     const activeSuspension = suspendedUntil !== null && new Date(suspendedUntil).getTime() > Date.now();
+    const status: ModerationQueueRow['status'] = r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active';
     return {
       accountId: r.account_id,
       username: r.username,
-      status: r.banned_at ? 'banned' : activeSuspension ? 'suspended' : 'active',
+      status,
       suspendedUntil,
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -18,6 +18,8 @@ CREATE INDEX IF NOT EXISTS characters_realm ON characters(realm);
 -- constraint relaxation, so existing globally-unique rows always satisfy it.
 ALTER TABLE characters DROP CONSTRAINT IF EXISTS characters_name_key;
 CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_name ON characters(realm, name);
+CREATE INDEX IF NOT EXISTS characters_realm_lower_name_prefix
+  ON characters (realm, lower(name) text_pattern_ops);
 
 CREATE TABLE IF NOT EXISTS friendships (
   character_id INT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,

--- a/tests/db_search.test.ts
+++ b/tests/db_search.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => {
+  process.env.DATABASE_URL ??= 'postgres://test/test';
+  return { query: vi.fn() };
+});
+
+vi.mock('pg', () => ({
+  Pool: vi.fn(function Pool() {
+    return { query: dbMock.query };
+  }),
+}));
+
+import { searchCharacters } from '../server/db';
+import { SOCIAL_SCHEMA } from '../server/social_db';
+
+beforeEach(() => {
+  dbMock.query.mockReset();
+});
+
+describe('character typeahead search', () => {
+  it('creates a realm-scoped lower-name prefix index', () => {
+    expect(SOCIAL_SCHEMA).toContain('CREATE INDEX IF NOT EXISTS characters_realm_lower_name_prefix');
+    expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name) text_pattern_ops)');
+  });
+
+  it('uses the lower-name prefix predicate and preserves wildcard escaping', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [{ name: 'Al%_', cls: 'mage', level: 12 }] });
+
+    await expect(searchCharacters('  Al%_  ', 99)).resolves.toEqual([{ name: 'Al%_', cls: 'mage', level: 12 }]);
+
+    const [sql, params] = dbMock.query.mock.calls[0];
+    expect(sql).toContain('lower(name) LIKE lower($2)');
+    expect(sql).toContain("ESCAPE '\\'");
+    expect(sql).toContain('ORDER BY name LIMIT $3');
+    expect(params).toEqual([expect.any(String), 'Al\\%\\_%', 20]);
+  });
+
+  it('keeps the search limit clamped to at least one', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await searchCharacters('Bet', 0);
+
+    expect(dbMock.query.mock.calls[0][1][2]).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an idempotent `characters_realm_lower_name_prefix` index on `(realm, lower(name) text_pattern_ops)` for realm-scoped case-insensitive prefix lookup.
- Updates character typeahead search to use `lower(name) LIKE lower($2)` so the query predicate matches the expression index while preserving wildcard escaping, ordering, limit clamping, and response shape.
- Adds a Postgres-free regression test for the schema/index string, SQL predicate, escaped `%` and `_`, and the 1..20 search limit clamp.

## Why
The social UI typeahead search was realm-scoped and prefix-bounded, but `ILIKE` could not use the available plain realm/name indexes for case-insensitive prefixes. Larger character tables could degrade into scanning names within a realm.

## Verification
- `npx vitest run tests/db_search.test.ts`; 1 file, 3 tests passed.
- `npx vitest run tests/admin.test.ts tests/social_system.test.ts`; 2 files, 46 tests passed.
- `npx tsc --noEmit`; exit 0.
- `npm run build:server`; exit 0.
- `scripts/committer "perf: index character typeahead search" server/social_db.ts server/db.ts tests/db_search.test.ts`; full closeout gate passed: `npm test` 26 files / 328 tests, `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, `npm run build`, and local Codex review clean.
- `python3 ~/.codex/skills/world-of-claudecraft-pr/scripts/polish_branch.py --subject "perf: index character typeahead search" --body-file <commit-body-file>`; refreshed the stacked branch and reran the full pre-commit gate successfully.
- `scripts/codex-review-gate --base main`; local Codex review clean for `main..HEAD` after branch polish.

## Risk
This adds an index through the existing idempotent schema path. The `/api/search` response shape and limit behavior are unchanged; the main operational cost is the normal one-time index build on existing character rows.

## Notes
- Depends on #53 for the current `main` typecheck baseline.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
