### PR TITLE
Add browser fullscreen setting

### DIFF
--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -8,6 +8,7 @@ export interface GameSettings {
   musicVolume: number;  // 0..1
   brightness: number;   // tone-mapping exposure multiplier
   renderScale: number;  // resolution multiplier on top of the device pixel ratio
+  fullscreen: number;   // 0/1 browser fullscreen preference
 }
 
 interface Range { min: number; max: number; def: number }
@@ -21,6 +22,7 @@ export const SETTING_RANGES: Record<keyof GameSettings, Range> = {
   musicVolume: { min: 0, max: 1, def: 0.8 },
   brightness: { min: 0.6, max: 1.5, def: 1 },
   renderScale: { min: 0.5, max: 1, def: 1 },
+  fullscreen: { min: 0, max: 1, def: 1 },
 };
 
 const STORE_KEY = 'woc_settings';

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,48 @@ const WORLD_SEED = 20061; // fixed: World of Claudecraft is a persistent place
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
 
+type FullscreenDocument = Document & {
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => Promise<void> | void;
+};
+
+type FullscreenElement = HTMLElement & {
+  webkitRequestFullscreen?: () => Promise<void> | void;
+};
+
+function currentFullscreenElement(): Element | null {
+  const doc = document as FullscreenDocument;
+  return document.fullscreenElement ?? doc.webkitFullscreenElement ?? null;
+}
+
+function requestBrowserFullscreen(): void {
+  if (currentFullscreenElement()) return;
+  const root = document.documentElement as FullscreenElement;
+  const request = root.requestFullscreen?.bind(root) ?? root.webkitRequestFullscreen?.bind(root);
+  if (!request) return;
+  try {
+    const result = request();
+    if (result instanceof Promise) void result.catch(() => {});
+  } catch {
+    // Browsers can reject fullscreen outside a direct user gesture.
+  }
+}
+
+function exitBrowserFullscreen(): void {
+  if (!currentFullscreenElement()) return;
+  const doc = document as FullscreenDocument;
+  try {
+    const result = document.exitFullscreen?.() ?? doc.webkitExitFullscreen?.();
+    if (result instanceof Promise) void result.catch(() => {});
+  } catch {
+    // Fullscreen exit can also reject while the document is changing state.
+  }
+}
+
+function requestPreferredFullscreen(): void {
+  if (new Settings().get('fullscreen') >= 0.5) requestBrowserFullscreen();
+}
+
 // ---------------------------------------------------------------------------
 // Loading screen (shown from "enter world" until the first frame renders)
 // ---------------------------------------------------------------------------
@@ -164,6 +206,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       case 'musicVolume': music.setVolume(v); break;
       case 'brightness': renderer.setBrightness(v); break;
       case 'renderScale': renderer.setRenderScale(v); break;
+      case 'fullscreen': v >= 0.5 ? requestBrowserFullscreen() : exitBrowserFullscreen(); break;
     }
   }
   // apply persisted settings to the freshly-built subsystems
@@ -319,6 +362,7 @@ function sanitizeOfflineName(raw: string): string {
 }
 
 function startOffline(playerClass: PlayerClass, name: string): void {
+  requestPreferredFullscreen();
   if (!beginWorldEntry()) return;
   const sim = new Sim({ seed: WORLD_SEED, playerClass, playerName: name });
   void startGame(sim, sim, null);
@@ -680,6 +724,7 @@ function fatalOverlay(message: string): void {
 }
 
 function enterWorld(c: CharacterSummary): void {
+  requestPreferredFullscreen();
   if (!beginWorldEntry()) return;
   audio.init();
   music.init();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2283,6 +2283,33 @@ export class Hud {
     parent.appendChild(row);
   }
 
+  private settingToggle(parent: HTMLElement, label: string, key: keyof GameSettings): void {
+    const hooks = this.optionsHooks;
+    if (!hooks) return;
+    const row = document.createElement('div');
+    row.className = 'set-row';
+    const name = document.createElement('span');
+    name.className = 'set-name';
+    name.textContent = label;
+    const toggle = document.createElement('button');
+    toggle.className = 'btn set-toggle';
+    const sync = () => {
+      const on = hooks.settings.get(key) >= 0.5;
+      toggle.textContent = on ? 'On' : 'Off';
+      toggle.classList.toggle('off', !on);
+      toggle.setAttribute('aria-pressed', String(on));
+    };
+    sync();
+    toggle.addEventListener('click', () => {
+      audio.click();
+      const next = hooks.settings.get(key) >= 0.5 ? 0 : 1;
+      hooks.onSettingChange(key, next);
+      sync();
+    });
+    row.append(name, toggle);
+    parent.appendChild(row);
+  }
+
   private settingsViewShell(title: string): HTMLElement {
     const el = $('#options-menu');
     el.innerHTML = `<div class="panel-title"><span>${title}</span><span class="x-btn" data-close>✕</span></div>`;
@@ -2318,6 +2345,7 @@ export class Hud {
     this.settingSlider(body, 'Camera Speed', 'cameraSpeed');
     this.settingSlider(body, 'Brightness', 'brightness');
     this.settingSlider(body, 'Render Quality', 'renderScale');
+    this.settingToggle(body, 'Fullscreen', 'fullscreen');
     const note = document.createElement('div');
     note.className = 'set-note';
     note.textContent = 'Lower Camera Speed for a calmer mouselook. Render Quality below 100% boosts FPS on weaker machines.';

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -20,6 +20,7 @@ describe('Settings', () => {
     expect(s.get('cameraSpeed')).toBeLessThan(1); // addresses the "too fast" complaint
     expect(s.get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
     expect(s.get('renderScale')).toBe(1);
+    expect(s.get('fullscreen')).toBe(1);
   });
 
   it('clamps out-of-range values to the slider bounds', () => {
@@ -27,6 +28,7 @@ describe('Settings', () => {
     expect(s.set('cameraSpeed', 99)).toBe(SETTING_RANGES.cameraSpeed.max);
     expect(s.set('cameraSpeed', -5)).toBe(SETTING_RANGES.cameraSpeed.min);
     expect(s.set('sfxVolume', 0.5)).toBe(0.5);
+    expect(s.set('fullscreen', -1)).toBe(0);
   });
 
   it('ignores non-finite input, keeping a valid value', () => {
@@ -39,9 +41,11 @@ describe('Settings', () => {
     const a = new Settings();
     a.set('cameraSpeed', 0.4);
     a.set('musicVolume', 0.2);
+    a.set('fullscreen', 0);
     const b = new Settings();
     expect(b.get('cameraSpeed')).toBe(0.4);
     expect(b.get('musicVolume')).toBe(0.2);
+    expect(b.get('fullscreen')).toBe(0);
   });
 
   it('falls back to defaults for missing/corrupt keys', () => {
@@ -49,15 +53,18 @@ describe('Settings', () => {
     const s = new Settings();
     expect(s.get('cameraSpeed')).toBe(0.5);
     expect(s.get('brightness')).toBe(SETTING_RANGES.brightness.def); // missing -> default
+    expect(s.get('fullscreen')).toBe(SETTING_RANGES.fullscreen.def);
   });
 
   it('reset() restores every default', () => {
     const s = new Settings();
     s.set('cameraSpeed', 1.2);
     s.set('renderScale', 0.5);
+    s.set('fullscreen', 0);
     s.reset();
     expect(s.get('cameraSpeed')).toBe(SETTING_RANGES.cameraSpeed.def);
     expect(s.get('renderScale')).toBe(SETTING_RANGES.renderScale.def);
+    expect(s.get('fullscreen')).toBe(SETTING_RANGES.fullscreen.def);
   });
 
   it('all() returns an independent snapshot', () => {


### PR DESCRIPTION
## Summary
- Add a persisted Fullscreen setting that defaults on for new players
- Request browser fullscreen from the Enter World/offline start click path when the saved preference is enabled
- Add a Graphics settings toggle that enters/exits fullscreen and remembers the last selected state

## Verification
- npm test -- --run
- npm run build

Note: browser fullscreen support depends on the user's browser Fullscreen API implementation; unsupported/rejected requests fail silently and the toggle remains persisted.