### PR TITLE
fix: tamed beasts respawn hostile instead of stuck neutral

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2192,7 +2192,7 @@ export class Sim {
     if (social) {
       const pullRadius = MOBS[mob.templateId]?.family === 'murloc' ? 18 : 12;
       this.grid.forEachInRadius(mob.pos.x, mob.pos.z, pullRadius, (m, d2) => {
-        if (m.kind === 'mob' && m.id !== mob.id && !m.dead && m.aiState === 'idle' && m.ownerId === null
+        if (m.kind === 'mob' && m.id !== mob.id && !m.dead && m.hostile && m.aiState === 'idle' && m.ownerId === null
           && m.templateId === mob.templateId && d2 < pullRadius * pullRadius) {
           m.aiState = 'chase';
           m.aggroTargetId = target.id;
@@ -2474,6 +2474,7 @@ export class Sim {
     mob.loot = null;
     mob.tappedById = null;
     mob.ownerId = null; // a dead pet returns to the wild at its old camp
+    mob.hostile = true; // ...and is wild again: a tamed beast must not respawn neutral
     mob.pos = { ...mob.spawnPos };
     mob.pos.y = groundHeight(mob.pos.x, mob.pos.z, this.cfg.seed);
     mob.prevPos = { ...mob.pos };

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -415,6 +415,34 @@ describe('hunter pets', () => {
     expect(sim.petOf(sim.playerId)).toBe(null);
   });
 
+  it('a tamed beast that dies respawns hostile, not a grey unattackable zombie', () => {
+    // Regression: respawnMob cleared ownerId ("back to the wild") but left
+    // hostile=false, so any tamed-then-killed beast respawned permanently
+    // neutral — grey on the unit frame and rejected with "Invalid attack target".
+    const sim = new Sim({ seed: 42, playerClass: 'hunter', respawnSeconds: 2, autoEquip: true });
+    sim.setPlayerLevel(10);
+    const wolf = nearestMob(sim, 'forest_wolf');
+    teleport(sim, sim.player, wolf.pos.x + 5, wolf.pos.z);
+    sim.targetEntity(wolf.id);
+    sim.player.facing = Math.atan2(wolf.pos.x - sim.player.pos.x, wolf.pos.z - sim.player.pos.z);
+    sim.castAbility('tame_beast');
+    for (let i = 0; i < 20 * 7; i++) sim.tick(); // 6s cast
+    expect(wolf.ownerId).toBe(sim.playerId);
+    expect(wolf.hostile).toBe(false); // tamed pets are neutral
+
+    // the pet falls in combat and its corpse respawns at its old camp
+    const boar = nearestMob(sim, 'wild_boar');
+    wolf.hp = 1;
+    hit(sim, boar, wolf, 9999);
+    for (let i = 0; i < 20 * 5 && !wolf.dead; i++) sim.tick();
+    expect(wolf.dead).toBe(true);
+
+    for (let i = 0; i < 20 * 10 && wolf.dead; i++) sim.tick();
+    expect(wolf.dead).toBe(false);
+    expect(wolf.ownerId).toBe(null); // back to the wild
+    expect(wolf.hostile).toBe(true); // ...and attackable again
+  });
+
   it('tame validation: too-high level and elites are refused', () => {
     const sim = makeSim('hunter');
     sim.setPlayerLevel(10);


### PR DESCRIPTION
## Problem

Players reported being attacked by mobs they could not attack back because the game rejected the attack with "Invalid attack target." The root cause is that tamed beasts are set `hostile = false`, and when the pet later dies and respawns, `respawnMob` clears `ownerId` but did not restore `hostile = true`.

## Fix

- Restore `hostile = true` when a mob respawns back into the wild.
- Prevent non-hostile mobs from being pulled into social "call for help" aggro.
- Add a regression test covering tame -> death -> respawn -> hostile again.

## Verification

Carried forward from #87:
- Full suite: 326/326 passing.
- Typecheck clean for changed files; one unrelated pre-existing `server/moderation_db.ts` error remained.

This reopens the already-merged release fix against `main` so it can go live there.

Original PR: #87
