### PR TITLE
fix: keep hud out of login shell

### DIFF
--- a/index.html
+++ b/index.html
@@ -530,11 +530,6 @@
     display: none; align-items: center; justify-content: center; flex-direction: column; gap: 18px; z-index: 30; }
   #death-overlay h1 { color: #ddd; font-size: 44px; text-shadow: 2px 2px 8px #000; font-family: var(--title-font); }
   
-  /* Hide all other UI components while the start screen is visible to prevent keyboard focus leakage */
-  body:has(#start-screen:not([style*="display: none"])) #ui {
-    display: none !important;
-  }
-
   /* ---------- start screen ---------- */
   #start-screen {
     position: absolute;
@@ -1957,6 +1952,7 @@
   <canvas id="game-canvas"></canvas>
   <div id="nameplates"></div>
 
+  <template id="game-ui-template">
   <div id="ui">
     <div id="player-frame" class="unitframe">
       <div class="portrait-wrap">
@@ -2083,6 +2079,7 @@
   </div>
 
   <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  </template>
 
   <main id="start-screen">
     <h1 class="visually-hidden">World of Claudecraft</h1>

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,6 +70,14 @@ function beginWorldEntry(): boolean {
   return true;
 }
 
+function mountGameUi(): void {
+  if (document.getElementById('ui')) return;
+  const template = document.getElementById('game-ui-template') as HTMLTemplateElement | null;
+  const startScreen = document.getElementById('start-screen');
+  if (!template || !startScreen) throw new Error('Game UI shell is missing.');
+  document.body.insertBefore(template.content.cloneNode(true), startScreen);
+}
+
 // ---------------------------------------------------------------------------
 // Shared game wiring (used by both offline sim and online world)
 // ---------------------------------------------------------------------------
@@ -90,6 +98,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     return;
   }
   setLoadingStatus('Entering the world…');
+  mountGameUi();
 
   const canvas = $('#game-canvas') as unknown as HTMLCanvasElement;
   const nameplates = $('#nameplates') as HTMLDivElement;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+
+function splitGameUiTemplate(): { templateHtml: string; liveHtml: string } {
+  const marker = '<template id="game-ui-template">';
+  const start = html.indexOf(marker);
+  const end = html.indexOf('</template>', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  const templateHtml = html.slice(start, end + '</template>'.length);
+  return {
+    templateHtml,
+    liveHtml: html.slice(0, start) + html.slice(end + '</template>'.length),
+  };
+}
+
+describe('client HTML shell', () => {
+  it('keeps game HUD controls out of the live startup DOM', () => {
+    const { liveHtml, templateHtml } = splitGameUiTemplate();
+
+    expect(templateHtml).toContain('id="ui"');
+    expect(templateHtml).toContain('Release Spirit');
+    expect(templateHtml).toContain('Combat Log');
+    expect(templateHtml).toContain('id="chat-input"');
+
+    expect(liveHtml).not.toContain('id="ui"');
+    expect(liveHtml).not.toContain('Release Spirit');
+    expect(liveHtml).not.toContain('Combat Log');
+    expect(liveHtml).not.toContain('id="chat-input"');
+  });
+});


### PR DESCRIPTION
## Summary

Release-targeted integration of #68.

- Keeps game-only HUD controls out of the live login, realm, and character-select DOM while no world exists.
- Moves the static HUD/chat shell into an inert `game-ui-template` and mounts it only when world entry begins.
- Preserves the release/v0.4 startup/mobile flow while applying the HUD-template fix.
- Adds a regression test that verifies Release Spirit, Combat Log, and chat input are absent from the live startup shell but still present in the game UI template.

## Verification

- `npx vitest run tests/client_shell.test.ts` — passed.
- `npm run build` — passed.
- Local release integration was run on `http://127.0.0.1:5173/`; server health returned `ok`.

Original PR: #68
