### PR TITLE
fix: add server unavailable fallback page

### DIFF
--- a/public/server-unavailable.html
+++ b/public/server-unavailable.html
@@ -1,0 +1,148 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="refresh" content="30" />
+  <title>World of Claudecraft - Realm Unavailable</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --gold: #d7b56d;
+      --gold-soft: #f3dfaa;
+      --ink: #f7efe0;
+      --muted: #c4b899;
+      --panel: rgba(10, 13, 20, 0.72);
+      --line: rgba(215, 181, 109, 0.38);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html,
+    body {
+      min-height: 100%;
+      margin: 0;
+    }
+
+    body {
+      display: grid;
+      place-items: center;
+      overflow: hidden;
+      background:
+        linear-gradient(90deg, rgba(5, 7, 12, 0.82), rgba(5, 7, 12, 0.34) 52%, rgba(5, 7, 12, 0.86)),
+        radial-gradient(circle at 50% 34%, rgba(215, 181, 109, 0.14), transparent 34%),
+        #080b12 url("/loading-screen.jpg") center / cover no-repeat;
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      padding: 24px;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background:
+        linear-gradient(rgba(255, 255, 255, 0.025) 50%, rgba(0, 0, 0, 0.025) 50%),
+        radial-gradient(circle at 50% 88%, rgba(0, 0, 0, 0.5), transparent 42%);
+      background-size: 100% 4px, auto;
+      pointer-events: none;
+    }
+
+    main {
+      position: relative;
+      width: min(640px, 100%);
+      padding: clamp(28px, 5vw, 46px);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      box-shadow: 0 26px 90px rgba(0, 0, 0, 0.48), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+      text-align: center;
+      backdrop-filter: blur(10px);
+    }
+
+    .logo {
+      width: min(430px, 88%);
+      height: auto;
+      margin-bottom: clamp(22px, 4vw, 34px);
+      filter: drop-shadow(0 10px 28px rgba(0, 0, 0, 0.64));
+    }
+
+    .eyebrow {
+      margin: 0 0 10px;
+      color: var(--gold);
+      font-size: 12px;
+      font-weight: 700;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+
+    h1 {
+      margin: 0;
+      color: var(--gold-soft);
+      font-family: Georgia, "Times New Roman", serif;
+      font-size: clamp(34px, 7vw, 58px);
+      font-weight: 700;
+      line-height: 0.98;
+      text-shadow: 0 3px 18px rgba(0, 0, 0, 0.74);
+    }
+
+    p {
+      margin: 18px auto 0;
+      max-width: 470px;
+      color: var(--muted);
+      font-size: clamp(16px, 2.4vw, 18px);
+      line-height: 1.58;
+    }
+
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin-top: 28px;
+      padding: 10px 14px;
+      border: 1px solid rgba(215, 181, 109, 0.28);
+      border-radius: 999px;
+      background: rgba(0, 0, 0, 0.28);
+      color: #ead7a1;
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    .status::before {
+      content: "";
+      width: 9px;
+      height: 9px;
+      border-radius: 999px;
+      background: #d7b56d;
+      box-shadow: 0 0 0 5px rgba(215, 181, 109, 0.14), 0 0 18px rgba(215, 181, 109, 0.8);
+    }
+
+    @media (max-width: 560px) {
+      body {
+        padding: 16px;
+        background-position: center;
+      }
+
+      main {
+        padding: 26px 20px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main aria-labelledby="realm-title">
+    <img class="logo" src="/worldofclaudecraft-logo.png" alt="World of Claudecraft" />
+    <p class="eyebrow">Realm maintenance</p>
+    <h1 id="realm-title">The realm is temporarily unavailable.</h1>
+    <p>
+      We are restarting the game service and expect Claudemoon to return shortly.
+      This page will keep checking automatically.
+    </p>
+    <div class="status" aria-live="polite">Back soon</div>
+  </main>
+</body>
+</html>

--- a/tests/server_unavailable.test.ts
+++ b/tests/server_unavailable.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const html = readFileSync(new URL('../public/server-unavailable.html', import.meta.url), 'utf8');
+
+describe('server unavailable fallback page', () => {
+  it('uses branded static assets and clear downtime copy', () => {
+    expect(html).toContain('/loading-screen.jpg');
+    expect(html).toContain('/worldofclaudecraft-logo.png');
+    expect(html).toContain('The realm is temporarily unavailable.');
+    expect(html).toContain('Back soon');
+    expect(html).toContain('http-equiv="refresh" content="30"');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the game-repo half of #88.

- Adds a static branded fallback page at `public/server-unavailable.html`.
- Uses existing splash art (`loading-screen.jpg`) and logo (`worldofclaudecraft-logo.png`).
- Adds professional downtime copy and a 30-second auto-refresh for temporary upstream outages.
- Adds a regression test to catch missing fallback assets/copy.

## Verification

- `npx vitest run tests/server_unavailable.test.ts` — passed.
- `npm run build` — passed.
- Tested on dev behind nginx by stopping `eastbrook-game`; `https://dev.worldofclaudecraft.com/` returned `503` with the fallback page and the assets served directly from nginx.

Refs #88
