### PR TITLE
fix: refresh character window after equipping from bags

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1802,6 +1802,7 @@ export class Hud {
   // carry inventory separately from the event frames that normally redraw).
   onInventoryChanged(): void {
     if ($('#bags').style.display === 'block') this.renderBags();
+    this.renderCharIfOpen();
   }
 
   renderBags(): void {
@@ -1832,6 +1833,7 @@ export class Hud {
         } else {
           this.sim.useItem(s.itemId);
           this.renderBags();
+          this.renderCharIfOpen();
         }
       });
       this.attachTooltip(row, () => {
@@ -1851,6 +1853,10 @@ export class Hud {
     money.innerHTML = this.moneyHtml(sim.copper);
     el.appendChild(money);
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });
+  }
+
+  private renderCharIfOpen(): void {
+    if ($('#char-window').style.display === 'block') this.renderChar();
   }
 
   // -------------------------------------------------------------------------

--- a/tests/hud_inventory.test.ts
+++ b/tests/hud_inventory.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Hud } from '../src/ui/hud';
+
+type Listener = () => void;
+
+class FakeElement {
+  id = '';
+  className = '';
+  style: Record<string, string> = {};
+  parent: FakeElement | null = null;
+  children: FakeElement[] = [];
+  private html = '';
+  private text = '';
+  private listeners = new Map<string, Listener[]>();
+
+  set innerHTML(value: string) {
+    this.html = value;
+    this.text = stripTags(value);
+    this.children = [];
+    if (value.includes('id="equip-col"')) {
+      const equipCol = new FakeElement();
+      equipCol.id = 'equip-col';
+      this.appendChild(equipCol);
+    }
+  }
+
+  get innerHTML(): string {
+    return this.html;
+  }
+
+  set textContent(value: string | null) {
+    this.text = value ?? '';
+    this.html = this.text;
+    this.children = [];
+  }
+
+  get textContent(): string {
+    return this.text + this.children.map((child) => child.textContent).join('');
+  }
+
+  appendChild(child: FakeElement): FakeElement {
+    child.parent = this;
+    this.children.push(child);
+    return child;
+  }
+
+  append(...nodes: FakeElement[]): void {
+    for (const node of nodes) this.appendChild(node);
+  }
+
+  querySelector(selector: string): FakeElement | null {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const matches: FakeElement[] = [];
+    const visit = (el: FakeElement) => {
+      if (matchesSelector(el, selector)) matches.push(el);
+      for (const child of el.children) visit(child);
+    };
+    for (const child of this.children) visit(child);
+    return matches;
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  click(): void {
+    for (const listener of this.listeners.get('click') ?? []) listener();
+  }
+}
+
+function stripTags(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
+function matchesSelector(el: FakeElement, selector: string): boolean {
+  if (selector.startsWith('#')) return el.id === selector.slice(1);
+  if (selector.startsWith('.')) return el.className.split(/\s+/).includes(selector.slice(1));
+  if (selector === '[data-close]') return el.innerHTML.includes('data-close');
+  return false;
+}
+
+function installDocument(elements: Map<string, FakeElement>): void {
+  (globalThis as any).document = {
+    body: { classList: { contains: () => false } },
+    createElement: () => new FakeElement(),
+    querySelector: (selector: string) => {
+      if (selector.startsWith('#')) return elements.get(selector.slice(1)) ?? null;
+      for (const el of elements.values()) {
+        const match = el.querySelector(selector);
+        if (match) return match;
+      }
+      return null;
+    },
+  };
+}
+
+function panelText(id: string): string {
+  return ((document.querySelector(`#${id}`) as unknown as FakeElement).textContent ?? '').replace(/\s+/g, ' ');
+}
+
+describe('HUD inventory panels', () => {
+  const previousDocument = (globalThis as any).document;
+
+  beforeEach(() => {
+    const elements = new Map<string, FakeElement>();
+    for (const id of ['bags', 'char-window']) {
+      const el = new FakeElement();
+      el.id = id;
+      el.style.display = 'block';
+      elements.set(id, el);
+    }
+    installDocument(elements);
+  });
+
+  afterEach(() => {
+    (globalThis as any).document = previousDocument;
+  });
+
+  it('refreshes the open character window after equipping an item from bags', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', playerName: 'Tester' });
+    sim.addItem('redbrook_blade', 1);
+    // Keep every paperdoll slot occupied so this unit test does not need the
+    // canvas-backed empty-slot icon renderer.
+    sim.equipment.legs = 'quilted_trousers';
+    sim.equipment.feet = 'oiled_boots';
+
+    const hud = Object.create(Hud.prototype) as any;
+    hud.sim = sim;
+    (hud as any).openVendorNpcId = null;
+    (hud as any).itemIcon = (item: { name: string }) => `<img alt="${item.name}">`;
+    (hud as any).attachTooltip = () => {};
+
+    hud.renderChar();
+    hud.renderBags();
+
+    expect(panelText('char-window')).toContain('Worn Shortsword');
+
+    const bagItem = document.querySelector('#bags')!.querySelector('.bag-item') as unknown as FakeElement;
+    bagItem.click();
+
+    expect(sim.equipment.mainhand).toBe('redbrook_blade');
+    expect(panelText('bags')).toContain('Worn Shortsword');
+    expect(panelText('char-window')).toContain('Redbrook Militia Blade');
+    expect(panelText('char-window')).not.toContain('Worn Shortsword');
+  });
+});


### PR DESCRIPTION
## Summary
- Refreshes the character/equipped-items window immediately after using an item from bags when that window is already open.
- Covers the reported stale paperdoll behavior with a focused HUD regression test.

## Diagnosis
Bag item clicks called `sim.useItem()` and then rebuilt only the bags panel. Equipping succeeded in the sim and the bag contents updated, but the already-open character window kept its previous paperdoll and stat markup until it was closed and reopened.

## Verification
- `npx vitest run tests/hud_inventory.test.ts`; 1 file passed, 1 test passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:refresh-character-window-on-equip`; branch is 1 commit ahead, 0 behind, changing only `src/ui/hud.ts` and `tests/hud_inventory.test.ts`.

## Real behavior proof
- Behavior addressed: equipping gear from bags while the character/equipped-items window is open left the visible equipment/stats stale.
- Environment tested: local HUD regression test on the rebased branch.
- Evidence after fix: the regression test clicks the rendered bag item and verifies the open character window shows the newly equipped item immediately.

## Risk
Low UI-only refresh risk. The sim equipment and inventory transitions are unchanged; the patch only rebuilds the character panel when it is already open.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
