### PR TITLE
fix: allow dragging spellbook abilities to hotbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,6 +471,7 @@
   #spellbook { left: 50%; top: 16%; transform: translateX(-50%); width: 430px; max-height: 64%; overflow-y: auto; }
   .spell-row { display: flex; gap: 10px; padding: 6px; border-radius: 4px; align-items: center; }
   .spell-row:hover { background: #ffffff0e; }
+  .spell-row[draggable="true"] { cursor: grab; }
   .spell-row .spell-name { font-size: 13px; color: #fff; font-family: var(--title-font); }
   .spell-row .spell-sub { font-size: 11px; color: #998d6a; }
   .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,0 +1,16 @@
+export function placeAbilityOnSlot(
+  slotMap: readonly (string | null)[],
+  abilityId: string,
+  targetIndex: number,
+): (string | null)[] {
+  const next = slotMap.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  const sourceIndex = next.indexOf(abilityId);
+  if (sourceIndex === targetIndex) return next;
+  if (sourceIndex !== -1) {
+    [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+    return next;
+  }
+  next[targetIndex] = abilityId;
+  return next;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,6 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { placeAbilityOnSlot } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -66,7 +67,7 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragFromSlot: number | null = null;
+  private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -424,19 +425,19 @@ export class Hud {
         return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to swap the two keybinds;
+        // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
-          this.dragFromSlot = slot;
+          this.dragAbilityId = known.def.id;
           e.dataTransfer!.setData('text/plain', known.def.id);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragFromSlot === null || this.dragFromSlot === slot) return;
+          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
           e.preventDefault(); // required to permit the drop
           e.dataTransfer!.dropEffect = 'move';
           btn.classList.add('drop-target');
@@ -445,21 +446,24 @@ export class Hud {
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const from = this.dragFromSlot;
-          this.dragFromSlot = null;
-          if (from === null || from === slot) return;
-          const a = from - 1, b = slot - 1;
-          [this.slotMap[a], this.slotMap[b]] = [this.slotMap[b], this.slotMap[a]]; // swap; empty target = move
+          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
+          this.dragAbilityId = null;
+          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
+          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragFromSlot = null;
-          bar.querySelectorAll('.drop-target').forEach((el) => el.classList.remove('drop-target'));
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
       this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
+  }
+
+  private clearActionDropTargets(): void {
+    document.querySelectorAll('#actionbar .drop-target').forEach((el) => el.classList.remove('drop-target'));
   }
 
   // Repaint the keycap on every action button from the current bindings.
@@ -1927,8 +1931,20 @@ export class Hud {
       row.innerHTML = `<div class="spell-icon" style="background-image:url(${iconDataUrl('ability', abilityId)});${locked ? 'filter:grayscale(1) brightness(0.5)' : ''}"></div>
         <div><div class="spell-name" style="${locked ? 'color:#777' : ''}">${def.name}${known && known.rank > 1 ? ` <span style="color:#998d6a;font-size:11px">Rank ${known.rank}</span>` : ''}</div>
         <div class="spell-sub">${locked ? `Trainable at level ${def.learnLevel}` : describeCost(known!, sim)}</div></div>`;
-      if (known) this.attachTooltip(row, () => this.abilityTooltip(known));
-      else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
+      if (known) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          this.dragAbilityId = known.def.id;
+          e.dataTransfer!.setData('text/plain', known.def.id);
+          e.dataTransfer!.effectAllowed = 'move';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
+        });
+        this.attachTooltip(row, () => this.abilityTooltip(known));
+      } else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
       el.appendChild(row);
     }
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { placeAbilityOnSlot } from '../src/ui/hotbar';
+
+describe('hotbar ability placement', () => {
+  it('places a spellbook ability onto the target action slot', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'polymorph', 1);
+
+    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
+    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+  });
+
+  it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
+
+    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});


### PR DESCRIPTION
## Summary
- Lets learned spellbook abilities be dragged onto action-bar slots, including abilities that overflow the visible bar layout.
- Keeps existing slot-to-slot swapping behavior and swaps instead of duplicating when the dragged spell is already on the bar.
- Clears action-bar drop highlights when a spellbook drag is cancelled before drop.
- Adds focused hotbar placement tests for spellbook placement and duplicate-free swaps.

Addresses the full-bar/new-spell replacement portion of #97. Clearing action-bar slots and placing consumables or food on the bar remain out of scope for this PR.

## Diagnosis
Players could rearrange abilities already on the bar, but spellbook rows were display-only and action slots only accepted drag state from another action slot. Learned abilities beyond the current bar layout had no working path onto a preferred slot. Spellbook-originated drag cancellation also needed to clear action-slot hover state because its drag-end handler is separate from action-button drag-end handling.

## Verification
- `npx vitest run tests/hotbar.test.ts`; 1 file passed, 2 tests passed.
- `npm test`; 36 files passed, 399 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:swap-abilities`; branch is 1 commit ahead, 0 behind, changing only `index.html`, `src/ui/hotbar.ts`, `src/ui/hud.ts`, and `tests/hotbar.test.ts`.

## Risk
Low client-side UI risk. The hotbar remap remains client-local and still sends ability ids through the existing server-authoritative cast validation path.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
