### PR TITLE
test: cover full action bar spell replacement

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,6 +471,7 @@
   #spellbook { left: 50%; top: 16%; transform: translateX(-50%); width: 430px; max-height: 64%; overflow-y: auto; }
   .spell-row { display: flex; gap: 10px; padding: 6px; border-radius: 4px; align-items: center; }
   .spell-row:hover { background: #ffffff0e; }
+  .spell-row[draggable="true"] { cursor: grab; }
   .spell-row .spell-name { font-size: 13px; color: #fff; font-family: var(--title-font); }
   .spell-row .spell-sub { font-size: 11px; color: #998d6a; }
   .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,0 +1,16 @@
+export function placeAbilityOnSlot(
+  slotMap: readonly (string | null)[],
+  abilityId: string,
+  targetIndex: number,
+): (string | null)[] {
+  const next = slotMap.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  const sourceIndex = next.indexOf(abilityId);
+  if (sourceIndex === targetIndex) return next;
+  if (sourceIndex !== -1) {
+    [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+    return next;
+  }
+  next[targetIndex] = abilityId;
+  return next;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,6 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { placeAbilityOnSlot } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -66,7 +67,7 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragFromSlot: number | null = null;
+  private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -424,19 +425,19 @@ export class Hud {
         return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to swap the two keybinds;
+        // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
-          this.dragFromSlot = slot;
+          this.dragAbilityId = known.def.id;
           e.dataTransfer!.setData('text/plain', known.def.id);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragFromSlot === null || this.dragFromSlot === slot) return;
+          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
           e.preventDefault(); // required to permit the drop
           e.dataTransfer!.dropEffect = 'move';
           btn.classList.add('drop-target');
@@ -445,21 +446,24 @@ export class Hud {
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const from = this.dragFromSlot;
-          this.dragFromSlot = null;
-          if (from === null || from === slot) return;
-          const a = from - 1, b = slot - 1;
-          [this.slotMap[a], this.slotMap[b]] = [this.slotMap[b], this.slotMap[a]]; // swap; empty target = move
+          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
+          this.dragAbilityId = null;
+          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
+          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragFromSlot = null;
-          bar.querySelectorAll('.drop-target').forEach((el) => el.classList.remove('drop-target'));
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
       this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
+  }
+
+  private clearActionDropTargets(): void {
+    document.querySelectorAll('#actionbar .drop-target').forEach((el) => el.classList.remove('drop-target'));
   }
 
   // Repaint the keycap on every action button from the current bindings.
@@ -1927,8 +1931,20 @@ export class Hud {
       row.innerHTML = `<div class="spell-icon" style="background-image:url(${iconDataUrl('ability', abilityId)});${locked ? 'filter:grayscale(1) brightness(0.5)' : ''}"></div>
         <div><div class="spell-name" style="${locked ? 'color:#777' : ''}">${def.name}${known && known.rank > 1 ? ` <span style="color:#998d6a;font-size:11px">Rank ${known.rank}</span>` : ''}</div>
         <div class="spell-sub">${locked ? `Trainable at level ${def.learnLevel}` : describeCost(known!, sim)}</div></div>`;
-      if (known) this.attachTooltip(row, () => this.abilityTooltip(known));
-      else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
+      if (known) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          this.dragAbilityId = known.def.id;
+          e.dataTransfer!.setData('text/plain', known.def.id);
+          e.dataTransfer!.effectAllowed = 'move';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
+        });
+        this.attachTooltip(row, () => this.abilityTooltip(known));
+      } else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
       el.appendChild(row);
     }
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { placeAbilityOnSlot } from '../src/ui/hotbar';
+
+describe('hotbar ability placement', () => {
+  it('places a spellbook ability onto the target action slot', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'polymorph', 1);
+
+    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
+    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+  });
+
+  it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
+
+    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { CLASSES } from '../src/sim/content/classes';
 import { placeAbilityOnSlot } from '../src/ui/hotbar';
 
 describe('hotbar ability placement', () => {
@@ -17,5 +18,26 @@ describe('hotbar ability placement', () => {
     const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
 
     expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+
+  it('places the mage overflow spell onto a full non-Attack action bar', () => {
+    const barSlots = 11;
+    const mageAbilities = CLASSES.mage.abilities;
+    const slots = mageAbilities.slice(0, barSlots);
+    const targetIndex = 4;
+    const displacedAbility = slots[targetIndex];
+
+    expect(slots).toHaveLength(barSlots);
+    expect(mageAbilities[barSlots]).toBe('ice_barrier');
+    expect(slots).not.toContain('ice_barrier');
+
+    const next = placeAbilityOnSlot(slots, 'ice_barrier', targetIndex);
+    const occupied = next.filter((id) => id !== null);
+
+    expect(next[targetIndex]).toBe('ice_barrier');
+    expect(next).not.toContain(displacedAbility);
+    expect(occupied).toHaveLength(barSlots);
+    expect(new Set(occupied).size).toBe(occupied.length);
+    expect(slots).toEqual(mageAbilities.slice(0, barSlots));
   });
 });


### PR DESCRIPTION
## Summary
- Adds regression coverage for issue #97's full non-Attack action bar case.
- Uses the real mage kit: the first 11 abilities fill the bar and `ice_barrier` is placed onto an occupied slot through the hotbar helper.
- Verifies the bar remains full and no duplicate ability ids are introduced.

## Why
Mage currently has 12 abilities while the non-Attack action bar has 11 slots. The overflow spell case needs explicit coverage so learned spell placement stays covered when the bar is already full.

## Verification
- `npx vitest run tests/hotbar.test.ts`; 1 file passed, 3 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:test-full-actionbar-new-spell`; branch is 2 commits ahead, 0 behind, stacked on #123.

## Notes
- Depends on #123 for the `placeAbilityOnSlot` helper, spellbook-to-hotbar placement support, and spellbook drag-cancel cleanup. The parent branch exists only in the fork, so this PR remains based on `main` with the dependency noted here.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.