### PR TITLE
feat: sell vendor item stacks

### DIFF
--- a/index.html
+++ b/index.html
@@ -1908,6 +1908,12 @@
     display: flex; flex-direction: column; gap: 10px; }
   .prompt { padding: 14px 18px; text-align: center; min-width: 300px; }
   .prompt .prompt-text { font-size: 13.5px; color: #e8e0c8; margin-bottom: 4px; font-family: Georgia, serif; }
+  .prompt .prompt-number {
+    width: 82px; margin: 8px 8px 6px 0; padding: 5px 7px; border: 1px solid #5d4a25;
+    border-radius: 3px; background: #08080d; color: #f4e6bd; font: 12px var(--ui-font);
+    text-align: center; box-shadow: inset 0 1px 3px #000;
+  }
+  .prompt .prompt-number:focus { outline: 1px solid var(--gold-dim); }
 
   /* ---------- trade window ---------- */
   #trade-window { left: 50%; top: 18%; transform: translateX(-50%); width: 460px; }

--- a/server/game.ts
+++ b/server/game.ts
@@ -631,7 +631,11 @@ export class GameServer {
       case 'equip': if (typeof msg.item === 'string') sim.equipItem(msg.item, pid); break;
       case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
       case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
-      case 'sell': if (typeof msg.item === 'string') sim.sellItem(msg.item, pid); break;
+      case 'sell':
+        if (typeof msg.item === 'string') {
+          sim.sellItem(msg.item, typeof msg.count === 'number' ? msg.count : undefined, pid);
+        }
+        break;
       case 'release': sim.releaseSpirit(pid); break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -598,8 +598,8 @@ export class ClientWorld implements IWorld {
   buyItem(npcId: number, itemId: string): void {
     this.cmd({ cmd: 'buy', npc: npcId, item: itemId });
   }
-  sellItem(itemId: string): void {
-    this.cmd({ cmd: 'sell', item: itemId });
+  sellItem(itemId: string, count?: number): void {
+    this.cmd({ cmd: 'sell', item: itemId, count });
   }
   releaseSpirit(): void {
     this.cmd({ cmd: 'release' });

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2858,22 +2858,26 @@ export class Sim {
     this.emit({ type: 'vendor', action: 'buy', itemId, pid: meta.entityId });
   }
 
-  sellItem(itemId: string, pid?: number): void {
+  sellItem(itemId: string, count = 1, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
     const { meta, e: p } = r;
     const def = ITEMS[itemId];
-    if (!def || this.countItem(itemId, meta.entityId) <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
+    const available = this.countItem(itemId, meta.entityId);
+    if (!def || available <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
     if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
+    const sellCount = Number.isFinite(count) ? Math.min(Math.floor(count), available) : 0;
+    if (sellCount <= 0) return;
     // mirror buyItem's gate: selling requires a vendor in interact range
     const nearVendor = [...this.entities.values()].some((e) =>
       e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
     if (!nearVendor) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
     if (def.kind === 'quest') { this.error(meta.entityId, 'You cannot sell quest items.'); return; }
-    this.removeItem(itemId, 1, meta.entityId);
-    meta.copper += def.sellValue;
+    this.removeItem(itemId, sellCount, meta.entityId);
+    const payout = def.sellValue * sellCount;
+    meta.copper += payout;
     this.emit({ type: 'vendor', action: 'sell', itemId, pid: meta.entityId });
-    this.emit({ type: 'loot', text: `Sold ${def.name} for ${formatMoney(def.sellValue)}.`, pid: meta.entityId });
+    this.emit({ type: 'loot', text: `Sold ${def.name}${sellCount > 1 ? ' x' + sellCount : ''} for ${formatMoney(payout)}.`, pid: meta.entityId });
   }
 
   private addItemSilent(itemId: string, count: number, meta: PlayerMeta): void {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1820,7 +1820,7 @@ export class Hud {
       row.className = 'bag-item';
       const qColor = QUALITY_COLOR[item.quality ?? 'common'] ?? '#fff';
       row.innerHTML = `${this.itemIcon(item)}<span style="color:${qColor}">${item.name}</span><span class="bi-count">${s.count > 1 ? 'x' + s.count : ''}</span>`;
-      row.addEventListener('click', () => {
+      row.addEventListener('click', (ev) => {
         if (this.tradeOpen) {
           this.addItemToTrade(s.itemId);
         } else if (this.marketOpen && this.marketTab === 'sell') {
@@ -1828,11 +1828,16 @@ export class Hud {
           this.marketSellItem = s.itemId;
           this.renderMarket();
         } else if (this.vendorOpen) {
-          this.sim.sellItem(s.itemId);
+          this.sellBagItem(s, ev);
         } else {
           this.sim.useItem(s.itemId);
           this.renderBags();
         }
+      });
+      row.addEventListener('contextmenu', (ev) => {
+        if (!this.vendorOpen || !ev.ctrlKey) return;
+        ev.preventDefault();
+        this.sellBagItem(s, ev);
       });
       this.attachTooltip(row, () => {
         let extra = '';
@@ -1851,6 +1856,54 @@ export class Hud {
     money.innerHTML = this.moneyHtml(sim.copper);
     el.appendChild(money);
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });
+  }
+
+  private sellBagItem(slot: InvSlot, ev: MouseEvent): void {
+    const count = Math.max(1, Math.floor(slot.count));
+    if (ev.ctrlKey || ev.metaKey) {
+      this.sim.sellItem(slot.itemId, count);
+    } else if (ev.shiftKey && count > 1) {
+      this.showSellQuantityPrompt(slot.itemId, count);
+    } else {
+      this.sim.sellItem(slot.itemId);
+    }
+  }
+
+  private showSellQuantityPrompt(itemId: string, maxCount: number): void {
+    document.querySelectorAll('.sell-quantity-prompt').forEach((el) => el.remove());
+    const item = ITEMS[itemId];
+    const stack = $('#prompt-stack');
+    const prompt = document.createElement('div');
+    prompt.className = 'prompt panel sell-quantity-prompt';
+    prompt.innerHTML = `<div class="prompt-text">Sell ${esc(item?.name ?? itemId)}</div>`;
+    const input = document.createElement('input');
+    input.className = 'prompt-number';
+    input.type = 'number';
+    input.min = '1';
+    input.max = String(maxCount);
+    input.step = '1';
+    input.value = '1';
+    const confirm = document.createElement('button');
+    confirm.className = 'btn';
+    confirm.textContent = 'Sell';
+    const cancel = document.createElement('button');
+    cancel.className = 'btn';
+    cancel.textContent = 'Cancel';
+    const close = () => prompt.remove();
+    const submit = () => {
+      const count = Math.max(1, Math.min(maxCount, Math.floor(Number(input.value) || 0)));
+      this.sim.sellItem(itemId, count);
+      close();
+    };
+    confirm.addEventListener('click', submit);
+    cancel.addEventListener('click', close);
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') submit();
+      else if (e.key === 'Escape') close();
+    });
+    prompt.append(input, confirm, cancel);
+    stack.appendChild(prompt);
+    window.setTimeout(() => { input.focus(); input.select(); }, 0);
   }
 
   // -------------------------------------------------------------------------

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -165,7 +165,7 @@ export interface IWorld {
   equipItem(itemId: string): void;
   useItem(itemId: string): void;
   buyItem(npcId: number, itemId: string): void;
-  sellItem(itemId: string): void;
+  sellItem(itemId: string, count?: number): void;
   releaseSpirit(): void;
   chat(text: string): void;
   // social systems

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -480,6 +480,36 @@ describe('food, drink, vendor', () => {
     expect(sim.countItem('baked_bread')).toBe(0);
     expect(sim.events).toContainEqual({ type: 'error', text: 'Too far away.', pid: sim.player.id });
   });
+
+  it('vendor sells stack quantities without exceeding what the player has', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('wolf_fang', 5);
+
+    sim.sellItem('wolf_fang', 3);
+
+    expect(sim.copper).toBe(12);
+    expect(sim.countItem('wolf_fang')).toBe(2);
+
+    sim.sellItem('wolf_fang', 99);
+
+    expect(sim.copper).toBe(20);
+    expect(sim.countItem('wolf_fang')).toBe(0);
+  });
+
+  it('vendor ignores invalid sell quantities', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('wolf_fang', 2);
+
+    sim.sellItem('wolf_fang', 0);
+    sim.sellItem('wolf_fang', -1);
+
+    expect(sim.copper).toBe(0);
+    expect(sim.countItem('wolf_fang')).toBe(2);
+  });
 });
 
 describe('leveling', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -131,6 +131,24 @@ describe('delta snapshots', () => {
     }
   });
 
+  it('sell command forwards bounded stack quantities', () => {
+    const player = server.sim.entities.get(session.pid)!;
+    const vendor = [...server.sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    player.pos = { ...vendor.pos, x: vendor.pos.x + 2 };
+    player.prevPos = { ...player.pos };
+    server.sim.addItem('wolf_fang', 5, session.pid);
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'sell', item: 'wolf_fang', count: 3 }));
+
+    expect(server.sim.meta(session.pid)?.copper).toBe(12);
+    expect(server.sim.countItem('wolf_fang', session.pid)).toBe(2);
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'sell', item: 'wolf_fang', count: 99 }));
+
+    expect(server.sim.meta(session.pid)?.copper).toBe(20);
+    expect(server.sim.countItem('wolf_fang', session.pid)).toBe(0);
+  });
+
   it('resends a heavy field once it changes', () => {
     broadcast(server);
     fc.sent.length = 0;


### PR DESCRIPTION
## Summary
- Adds vendor stack selling for the player feedback that selling more than one item at a time should be possible.
- Keeps normal bag clicks selling one item, Shift-click opening a quantity prompt, and Ctrl-click or Meta-click selling the full stack while a vendor is open.
- Carries the optional sell count through `IWorld`, `ClientWorld`, the server command handler, and the authoritative sim, where counts are clamped to a positive whole number no larger than the players stack.

## Implementation Notes
- The server only forwards numeric `count` values from client commands; invalid or missing counts fall back to one item.
- The sim owns the final sell quantity, payout, inventory removal, and vendor-range/quest-item validation for offline and online parity.

## Verification
- `npx vitest run tests/sim.test.ts -t vendor`; 1 file passed, 7 tests passed and 37 skipped.
- `npx vitest run tests/snapshots.test.ts -t "sell command"`; 1 file passed, 1 test passed and 12 skipped.
- `npx tsc --noEmit`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:vendor-sell-multiple-items`; branch is 1 commit ahead, 0 behind.

## Risk
- User-visible risk is limited to bag clicks while a vendor is open. The fallback path still sells one item, and the authoritative sim clamps all requested quantities.
- No manual browser click-through was run for the modifier interactions.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
