### PR TITLE
fix: allow clearing action-bar slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,6 +471,7 @@
   #spellbook { left: 50%; top: 16%; transform: translateX(-50%); width: 430px; max-height: 64%; overflow-y: auto; }
   .spell-row { display: flex; gap: 10px; padding: 6px; border-radius: 4px; align-items: center; }
   .spell-row:hover { background: #ffffff0e; }
+  .spell-row[draggable="true"] { cursor: grab; }
   .spell-row .spell-name { font-size: 13px; color: #fff; font-family: var(--title-font); }
   .spell-row .spell-sub { font-size: 11px; color: #998d6a; }
   .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,0 +1,16 @@
+export function placeAbilityOnSlot(
+  slotMap: readonly (string | null)[],
+  abilityId: string,
+  targetIndex: number,
+): (string | null)[] {
+  const next = slotMap.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  const sourceIndex = next.indexOf(abilityId);
+  if (sourceIndex === targetIndex) return next;
+  if (sourceIndex !== -1) {
+    [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+    return next;
+  }
+  next[targetIndex] = abilityId;
+  return next;
+}

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -14,3 +14,27 @@ export function placeAbilityOnSlot(
   next[targetIndex] = abilityId;
   return next;
 }
+
+export function clearHotbarSlot(
+  slotMap: readonly (string | null)[],
+  targetIndex: number,
+): (string | null)[] {
+  if (targetIndex < 0 || targetIndex >= slotMap.length) return [...slotMap];
+  return slotMap.map((slot, index) => index === targetIndex ? null : slot);
+}
+
+export function syncHotbarSlotMap(
+  slotMap: readonly (string | null)[],
+  knownAbilityIds: readonly string[],
+  autoPlaceAbilityIds: ReadonlySet<string>,
+): (string | null)[] {
+  const known = new Set(knownAbilityIds);
+  const next = slotMap.map((id) => id !== null && !known.has(id) ? null : id);
+  for (const id of knownAbilityIds) {
+    if (next.includes(id) || !autoPlaceAbilityIds.has(id)) continue;
+    const empty = next.indexOf(null);
+    if (empty === -1) break;
+    next[empty] = id;
+  }
+  return next;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,7 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
-import { placeAbilityOnSlot } from './hotbar';
+import { clearHotbarSlot, placeAbilityOnSlot, syncHotbarSlotMap } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -67,6 +67,8 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
+  private loadedSlotMapFromStorage = false;
+  private knownAbilityIdsAtLastSlotSync: Set<string> | null = null;
   private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
@@ -347,6 +349,7 @@ export class Hud {
   private loadSlotMap(): void {
     let arr: unknown = null;
     try { arr = JSON.parse(localStorage.getItem(this.slotMapKey()) ?? 'null'); } catch { /* corrupt */ }
+    this.loadedSlotMapFromStorage = Array.isArray(arr);
     const seen = new Set<string>();
     this.slotMap = Array.from({ length: Hud.BAR_ABILITY_SLOTS }, (_, i) => {
       const v = Array.isArray(arr) ? arr[i] : null;
@@ -363,18 +366,23 @@ export class Hud {
   // Drop unlearned ids; place newly learned abilities in the first empty
   // slot. With empty storage this reproduces the default class-order layout.
   private syncSlotMap(): void {
-    const ids = new Set(this.sim.known.map((k) => k.def.id));
-    let dirty = false;
-    for (let i = 0; i < this.slotMap.length; i++) {
-      const id = this.slotMap[i];
-      if (id !== null && !ids.has(id)) { this.slotMap[i] = null; dirty = true; }
+    const knownAbilityIds = this.sim.known.map((k) => k.def.id);
+    const autoPlaceAbilityIds = new Set<string>();
+    if (this.knownAbilityIdsAtLastSlotSync === null) {
+      if (!this.loadedSlotMapFromStorage) {
+        for (const id of knownAbilityIds) autoPlaceAbilityIds.add(id);
+      }
+    } else {
+      for (const id of knownAbilityIds) {
+        if (!this.knownAbilityIdsAtLastSlotSync.has(id)) autoPlaceAbilityIds.add(id);
+      }
     }
-    for (const k of this.sim.known) {
-      if (this.slotMap.includes(k.def.id)) continue;
-      const empty = this.slotMap.indexOf(null);
-      if (empty !== -1) { this.slotMap[empty] = k.def.id; dirty = true; }
+    const next = syncHotbarSlotMap(this.slotMap, knownAbilityIds, autoPlaceAbilityIds);
+    if (next.some((id, i) => id !== this.slotMap[i])) {
+      this.slotMap = next;
+      this.saveSlotMap();
     }
-    if (dirty) this.saveSlotMap();
+    this.knownAbilityIdsAtLastSlotSync = new Set(knownAbilityIds);
   }
 
   abilityForSlot(barSlot: number): ResolvedAbility | null { // barSlot 1..11
@@ -422,12 +430,32 @@ export class Hud {
           return '<div class="tt-title">Attack</div><div class="tt-sub">Toggle auto-attack on your target.<br>Right-clicking an enemy also attacks.</div>';
         }
         const known = this.abilityForSlot(slot);
-        return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
+        return known
+          ? this.abilityTooltip(known) + '<div class="tt-sub">Shift-right-click or Shift-Delete to clear</div>'
+          : '<div class="tt-sub">Empty slot<br>Shift-right-click or Shift-Delete to clear</div>';
       });
       if (slot >= 1) {
         // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
+        const clearSlot = () => {
+          this.slotMap = clearHotbarSlot(this.slotMap, slot - 1);
+          this.saveSlotMap();
+          btn.classList.add('empty');
+          btn.classList.remove('drop-target', 'oor', 'queued', 'unusable');
+          this.hideTooltip();
+        };
+        btn.addEventListener('contextmenu', (e) => {
+          if (!e.shiftKey) return;
+          e.preventDefault();
+          clearSlot();
+        });
+        btn.addEventListener('keydown', (e) => {
+          if (!e.shiftKey || (e.key !== 'Delete' && e.key !== 'Backspace')) return;
+          e.preventDefault();
+          e.stopPropagation();
+          clearSlot();
+        });
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
@@ -588,6 +616,7 @@ export class Hud {
       const known = this.abilityForSlot(i);
       if (!known) {
         ab.btn.classList.add('empty');
+        ab.btn.classList.remove('oor', 'queued', 'unusable');
         if (ab.lastIcon !== '') {
           ab.lastIcon = '';
           ab.label.style.backgroundImage = '';

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,6 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { placeAbilityOnSlot } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -66,7 +67,7 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragFromSlot: number | null = null;
+  private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -424,19 +425,19 @@ export class Hud {
         return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to swap the two keybinds;
+        // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
-          this.dragFromSlot = slot;
+          this.dragAbilityId = known.def.id;
           e.dataTransfer!.setData('text/plain', known.def.id);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragFromSlot === null || this.dragFromSlot === slot) return;
+          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
           e.preventDefault(); // required to permit the drop
           e.dataTransfer!.dropEffect = 'move';
           btn.classList.add('drop-target');
@@ -445,21 +446,24 @@ export class Hud {
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const from = this.dragFromSlot;
-          this.dragFromSlot = null;
-          if (from === null || from === slot) return;
-          const a = from - 1, b = slot - 1;
-          [this.slotMap[a], this.slotMap[b]] = [this.slotMap[b], this.slotMap[a]]; // swap; empty target = move
+          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
+          this.dragAbilityId = null;
+          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
+          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragFromSlot = null;
-          bar.querySelectorAll('.drop-target').forEach((el) => el.classList.remove('drop-target'));
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
       this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
+  }
+
+  private clearActionDropTargets(): void {
+    document.querySelectorAll('#actionbar .drop-target').forEach((el) => el.classList.remove('drop-target'));
   }
 
   // Repaint the keycap on every action button from the current bindings.
@@ -1927,8 +1931,20 @@ export class Hud {
       row.innerHTML = `<div class="spell-icon" style="background-image:url(${iconDataUrl('ability', abilityId)});${locked ? 'filter:grayscale(1) brightness(0.5)' : ''}"></div>
         <div><div class="spell-name" style="${locked ? 'color:#777' : ''}">${def.name}${known && known.rank > 1 ? ` <span style="color:#998d6a;font-size:11px">Rank ${known.rank}</span>` : ''}</div>
         <div class="spell-sub">${locked ? `Trainable at level ${def.learnLevel}` : describeCost(known!, sim)}</div></div>`;
-      if (known) this.attachTooltip(row, () => this.abilityTooltip(known));
-      else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
+      if (known) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          this.dragAbilityId = known.def.id;
+          e.dataTransfer!.setData('text/plain', known.def.id);
+          e.dataTransfer!.effectAllowed = 'move';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
+        });
+        this.attachTooltip(row, () => this.abilityTooltip(known));
+      } else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
       el.appendChild(row);
     }
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { placeAbilityOnSlot } from '../src/ui/hotbar';
+
+describe('hotbar ability placement', () => {
+  it('places a spellbook ability onto the target action slot', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'polymorph', 1);
+
+    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
+    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+  });
+
+  it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
+
+    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { placeAbilityOnSlot } from '../src/ui/hotbar';
+import { clearHotbarSlot, placeAbilityOnSlot, syncHotbarSlotMap } from '../src/ui/hotbar';
 
 describe('hotbar ability placement', () => {
   it('places a spellbook ability onto the target action slot', () => {
@@ -17,5 +17,58 @@ describe('hotbar ability placement', () => {
     const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
 
     expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});
+
+describe('hotbar slot clearing', () => {
+  it('clears an occupied slot', () => {
+    const slotMap = ['fireball', 'frostbolt', null];
+
+    expect(clearHotbarSlot(slotMap, 1)).toEqual(['fireball', null, null]);
+  });
+
+  it('leaves an empty slot stable', () => {
+    const slotMap = ['fireball', null, 'blink'];
+
+    expect(clearHotbarSlot(slotMap, 1)).toEqual(['fireball', null, 'blink']);
+  });
+
+  it('does not mutate the input array', () => {
+    const slotMap = ['fireball', 'frostbolt', null];
+
+    clearHotbarSlot(slotMap, 1);
+
+    expect(slotMap).toEqual(['fireball', 'frostbolt', null]);
+  });
+
+  it('ignores out-of-range slots', () => {
+    const slotMap = ['fireball', 'frostbolt', null];
+
+    expect(clearHotbarSlot(slotMap, -1)).toEqual(slotMap);
+    expect(clearHotbarSlot(slotMap, 3)).toEqual(slotMap);
+  });
+});
+
+describe('hotbar slot sync', () => {
+  it('preserves a missing already-known ability as a cleared slot', () => {
+    const slots = ['fireball', null, 'blink'];
+
+    expect(syncHotbarSlotMap(slots, ['fireball', 'frostbolt', 'blink'], new Set())).toEqual(slots);
+  });
+
+  it('places a newly learned ability into the first empty slot', () => {
+    const slots = ['fireball', null, 'blink'];
+
+    expect(syncHotbarSlotMap(slots, ['fireball', 'frostbolt', 'blink'], new Set(['frostbolt']))).toEqual([
+      'fireball',
+      'frostbolt',
+      'blink',
+    ]);
+  });
+
+  it('drops abilities that are no longer known', () => {
+    const slots = ['fireball', 'frostbolt', 'blink'];
+
+    expect(syncHotbarSlotMap(slots, ['fireball', 'blink'], new Set())).toEqual(['fireball', null, 'blink']);
   });
 });


### PR DESCRIPTION
## Summary
- Allows players to intentionally clear action-bar slots 1..11 while keeping slot 0 as the fixed Attack button.
- Persists cleared slots through the existing hotbar localStorage path so `syncSlotMap()` does not immediately refill already-known abilities.
- Keeps this client-side and limited to action-bar slot layout; no consumable or server casting behavior changes are included.

## Diagnosis
The hotbar already represented empty slots as `null`, but the sync path treated every missing known ability as a candidate to refill the first empty slot. That made an intentional clear indistinguishable from an uninitialized or newly learned ability.

## Implementation Notes
- Adds pure hotbar helpers for clearing and syncing slot maps.
- Tracks whether the layout came from storage and which abilities were known at the previous sync, so default layouts and newly learned abilities still auto-place while cleared existing abilities stay empty.
- Adds Shift-right-click plus Shift-Delete/Backspace clear gestures for non-Attack action slots, with handled key events stopped before reaching game bindings.

## Verification
- `npm test`; 36 files passed, 406 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:actionbar-clear-slots`; branch is 2 commits ahead, 0 behind, stacked on #123.

## Risk
The clear gesture is modified to reduce accidental clears, and slot 0 remains outside the clearable slot map. Browser smoke testing was not run; coverage is focused on the pure slot-map behavior plus TypeScript/build checks.

## Notes
- Depends on #123 for the shared hotbar helper, spellbook placement behavior, and spellbook drag-cancel cleanup. The parent branch exists only in the fork, so this PR remains based on `main` with the dependency noted here.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
