### PR TITLE
fix: bound rate limiter memory under a single-IP flood

### DIFF
--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -64,8 +64,21 @@ export function rateLimited(req: http.IncomingMessage, maxPerMinute = 20): boole
   const now = Date.now();
   const windowStart = now - WINDOW_MS;
   const list = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
-  const updated = [...list, now];
-  attempts.set(ip, updated);
+  // Once the window is full this request is over the limit, and we never need
+  // more than `maxPerMinute` timestamps to decide. Stop appending past that so
+  // a sustained flood from a single IP can't grow its array without bound —
+  // otherwise the limiter's own memory scales with attack volume, defeating
+  // the point. The remaining timestamps age out, throttling a flooder to the
+  // intended ~maxPerMinute rate.
+  const limited = list.length >= maxPerMinute;
+  if (!limited) list.push(now);
+  attempts.set(ip, list);
   if (attempts.size > MAX_TRACKED_IPS) attempts.clear(); // memory backstop
-  return updated.length > maxPerMinute;
+  return limited;
+}
+
+// Test/observability helper: how many timestamps are currently retained for an
+// IP. Used to assert the per-IP window stays bounded under a flood.
+export function trackedHitCount(ip: string): number {
+  return attempts.get(ip)?.length ?? 0;
 }

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
 import { offensiveUsername, validCharName, validUsername } from '../server/auth';
-import { rateLimited, requestIp } from '../server/ratelimit';
+import { rateLimited, requestIp, trackedHitCount } from '../server/ratelimit';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
   const req: any = new EventEmitter();
@@ -109,6 +109,17 @@ describe('rate-limit client IP selection', () => {
     expect(aliceLimited).toBe(true);
     // ...while another player behind the same proxy is unaffected
     expect(rateLimited(fakeReq({ 'x-forwarded-for': '198.51.100.201' }, '172.18.0.1'))).toBe(false);
+  });
+
+  it('keeps a flooding IP from growing the limiter unbounded', () => {
+    // A single IP hammering far past the limit must not retain a timestamp per
+    // request — the limiter's memory has to stay bounded or it becomes its own
+    // DoS amplifier. We never need more than `maxPerMinute` timestamps to keep
+    // returning "limited", so the retained window caps there.
+    const flood = fakeReq({ 'x-forwarded-for': '203.0.113.250' }, '172.18.0.1');
+    for (let i = 0; i < 1000; i++) rateLimited(flood, 20);
+    expect(rateLimited(flood, 20)).toBe(true);
+    expect(trackedHitCount('203.0.113.250')).toBeLessThanOrEqual(20);
   });
 });
 


### PR DESCRIPTION
## Problem

`rateLimited()` in `server/ratelimit.ts` appends a timestamp to the per-IP array on **every** call — including when that IP is already over the limit:

```js
const list = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
const updated = [...list, now];   // always appends, even while flooding
attempts.set(ip, updated);
if (attempts.size > MAX_TRACKED_IPS) attempts.clear();
return updated.length > maxPerMinute;
```

The `MAX_TRACKED_IPS` backstop only caps the *number of distinct IPs*, not the size of any single IP's array. So one source flooding at high volume drives that array to one entry per request — **the limiter's own memory scales with attack volume, defeating its purpose as a DoS safeguard.**

## Fix

A sliding-window limiter never needs more than `maxPerMinute` timestamps to decide: once that many sit in the window, the next request is over the limit no matter how many more arrive. So stop appending past that point. The retained timestamps age out naturally, throttling a sustained flooder to the intended ~`maxPerMinute` rate — with bounded memory.

Behaviour is unchanged for legitimate traffic (the existing `rate-limits forwarded clients independently` test still passes); only the unbounded-growth path under flood changes.

## Test

Adds a regression test asserting the retained per-IP window stays `<= maxPerMinute` after a 1000-request flood from one IP. Against the old code this count would be ~1001.

- `npx vitest run` → 327 passed
- One pre-existing, unrelated `tsc` error in `moderation_db.ts` (present on `main`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)