### PR TITLE
feat: add food and drink action-bar shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -471,6 +471,7 @@
   #spellbook { left: 50%; top: 16%; transform: translateX(-50%); width: 430px; max-height: 64%; overflow-y: auto; }
   .spell-row { display: flex; gap: 10px; padding: 6px; border-radius: 4px; align-items: center; }
   .spell-row:hover { background: #ffffff0e; }
+  .spell-row[draggable="true"] { cursor: grab; }
   .spell-row .spell-name { font-size: 13px; color: #fff; font-family: var(--title-font); }
   .spell-row .spell-sub { font-size: 11px; color: #998d6a; }
   .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;

--- a/index.html
+++ b/index.html
@@ -320,6 +320,8 @@
   .action-btn:active { transform: translateY(1px); }
   .action-btn.empty { background: #0d0d13; cursor: default; box-shadow: inset 0 0 10px #000; }
   .action-btn .keybind { position: absolute; top: 1px; right: 3px; font-size: 9px; color: #ddd; font-family: var(--ui-font); }
+  .action-btn .item-count { position: absolute; right: 3px; bottom: 1px; min-width: 10px; text-align: right;
+    font-size: 10px; color: #fff; font-family: var(--ui-font); font-weight: bold; text-shadow: 1px 1px 2px #000; }
   .action-btn .cdtext { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
     font-size: 17px; color: var(--gold); text-shadow: 1px 1px 2px #000; }
   .action-btn .cd-overlay { position: absolute; left: 0; right: 0; bottom: 0; background: #000d; height: 0%; border-radius: 0 0 4px 4px; }

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,0 +1,16 @@
+export function placeAbilityOnSlot(
+  slotMap: readonly (string | null)[],
+  abilityId: string,
+  targetIndex: number,
+): (string | null)[] {
+  const next = slotMap.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  const sourceIndex = next.indexOf(abilityId);
+  if (sourceIndex === targetIndex) return next;
+  if (sourceIndex !== -1) {
+    [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+    return next;
+  }
+  next[targetIndex] = abilityId;
+  return next;
+}

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,16 +1,105 @@
+export type HotbarAction =
+  | { type: 'ability'; id: string }
+  | { type: 'item'; id: string }
+  | null;
+
+export const HOTBAR_ACTION_MIME = 'application/x-woc-hotbar-action';
+
+export function encodeHotbarAction(action: Exclude<HotbarAction, null>): string {
+  return JSON.stringify(action);
+}
+
+export function parseHotbarAction(
+  value: unknown,
+  abilityExists: (id: string) => boolean,
+  itemExists: (id: string) => boolean,
+): Exclude<HotbarAction, null> | null {
+  if (!value || typeof value !== 'object') return null;
+  const action = value as { type?: unknown; id?: unknown };
+  if (typeof action.id !== 'string') return null;
+  if (action.type === 'ability' && abilityExists(action.id)) return { type: 'ability', id: action.id };
+  if (action.type === 'item' && itemExists(action.id)) return { type: 'item', id: action.id };
+  return null;
+}
+
+export function parseHotbarActions(
+  value: unknown,
+  slots: number,
+  abilityExists: (id: string) => boolean,
+  itemExists: (id: string) => boolean,
+): HotbarAction[] {
+  const seenAbilities = new Set<string>();
+  return Array.from({ length: slots }, (_, i) => {
+    const raw = Array.isArray(value) ? value[i] : null;
+    const action = typeof raw === 'string'
+      ? (abilityExists(raw) ? { type: 'ability' as const, id: raw } : null)
+      : parseHotbarAction(raw, abilityExists, itemExists);
+    if (action?.type === 'ability') {
+      if (seenAbilities.has(action.id)) return null;
+      seenAbilities.add(action.id);
+    }
+    return action;
+  });
+}
+
 export function placeAbilityOnSlot(
-  slotMap: readonly (string | null)[],
+  actions: readonly HotbarAction[],
   abilityId: string,
   targetIndex: number,
-): (string | null)[] {
-  const next = slotMap.slice();
+): HotbarAction[] {
+  const next = actions.slice();
   if (targetIndex < 0 || targetIndex >= next.length) return next;
-  const sourceIndex = next.indexOf(abilityId);
+  const sourceIndex = next.findIndex((action) => action?.type === 'ability' && action.id === abilityId);
   if (sourceIndex === targetIndex) return next;
   if (sourceIndex !== -1) {
     [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
     return next;
   }
-  next[targetIndex] = abilityId;
+  next[targetIndex] = { type: 'ability', id: abilityId };
   return next;
+}
+
+export function placeItemOnSlot(
+  actions: readonly HotbarAction[],
+  itemId: string,
+  targetIndex: number,
+): HotbarAction[] {
+  const next = actions.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  next[targetIndex] = { type: 'item', id: itemId };
+  return next;
+}
+
+export function swapHotbarSlots(
+  actions: readonly HotbarAction[],
+  sourceIndex: number,
+  targetIndex: number,
+): HotbarAction[] {
+  const next = actions.slice();
+  if (
+    sourceIndex < 0 || sourceIndex >= next.length ||
+    targetIndex < 0 || targetIndex >= next.length ||
+    sourceIndex === targetIndex
+  ) return next;
+  [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+  return next;
+}
+
+export function syncHotbarActions(
+  actions: readonly HotbarAction[],
+  knownAbilityIds: readonly string[],
+): { actions: HotbarAction[]; changed: boolean } {
+  const known = new Set(knownAbilityIds);
+  const next = actions.map((action) => (
+    action?.type === 'ability' && !known.has(action.id) ? null : action
+  ));
+  let changed = next.some((action, i) => action !== actions[i]);
+  for (const id of knownAbilityIds) {
+    if (next.some((action) => action?.type === 'ability' && action.id === id)) continue;
+    const empty = next.indexOf(null);
+    if (empty === -1) continue;
+    next[empty] = { type: 'ability', id };
+    changed = true;
+  }
+  return { actions: next, changed };
 }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,6 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { placeAbilityOnSlot } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -66,7 +67,7 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragFromSlot: number | null = null;
+  private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -424,19 +425,19 @@ export class Hud {
         return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to swap the two keybinds;
+        // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
-          this.dragFromSlot = slot;
+          this.dragAbilityId = known.def.id;
           e.dataTransfer!.setData('text/plain', known.def.id);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragFromSlot === null || this.dragFromSlot === slot) return;
+          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
           e.preventDefault(); // required to permit the drop
           e.dataTransfer!.dropEffect = 'move';
           btn.classList.add('drop-target');
@@ -445,21 +446,24 @@ export class Hud {
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const from = this.dragFromSlot;
-          this.dragFromSlot = null;
-          if (from === null || from === slot) return;
-          const a = from - 1, b = slot - 1;
-          [this.slotMap[a], this.slotMap[b]] = [this.slotMap[b], this.slotMap[a]]; // swap; empty target = move
+          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
+          this.dragAbilityId = null;
+          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
+          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragFromSlot = null;
-          bar.querySelectorAll('.drop-target').forEach((el) => el.classList.remove('drop-target'));
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
       this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
+  }
+
+  private clearActionDropTargets(): void {
+    document.querySelectorAll('#actionbar .drop-target').forEach((el) => el.classList.remove('drop-target'));
   }
 
   // Repaint the keycap on every action button from the current bindings.
@@ -1927,8 +1931,20 @@ export class Hud {
       row.innerHTML = `<div class="spell-icon" style="background-image:url(${iconDataUrl('ability', abilityId)});${locked ? 'filter:grayscale(1) brightness(0.5)' : ''}"></div>
         <div><div class="spell-name" style="${locked ? 'color:#777' : ''}">${def.name}${known && known.rank > 1 ? ` <span style="color:#998d6a;font-size:11px">Rank ${known.rank}</span>` : ''}</div>
         <div class="spell-sub">${locked ? `Trainable at level ${def.learnLevel}` : describeCost(known!, sim)}</div></div>`;
-      if (known) this.attachTooltip(row, () => this.abilityTooltip(known));
-      else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
+      if (known) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          this.dragAbilityId = known.def.id;
+          e.dataTransfer!.setData('text/plain', known.def.id);
+          e.dataTransfer!.effectAllowed = 'move';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
+        });
+        this.attachTooltip(row, () => this.abilityTooltip(known));
+      } else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
       el.appendChild(row);
     }
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,7 +17,10 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
-import { placeAbilityOnSlot } from './hotbar';
+import {
+  encodeHotbarAction, HOTBAR_ACTION_MIME, HotbarAction, parseHotbarAction, parseHotbarActions,
+  placeAbilityOnSlot, placeItemOnSlot, swapHotbarSlots, syncHotbarActions,
+} from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -65,9 +68,9 @@ const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
 
 export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
-  private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
-  private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragAbilityId: string | null = null;
+  private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; countEl: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
+  private hotbarActions: HotbarAction[] = []; // index = barSlot-1
+  private dragAction: { action: Exclude<HotbarAction, null>; sourceIndex: number | null } | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -337,49 +340,59 @@ export class Hud {
   // Action bar
   // -------------------------------------------------------------------------
 
-  // The hotbar layout is a client-side remap over the learned abilities,
-  // keyed by ability id (known is class-ordered and shifts on level-up, so
-  // indices would not survive). Persisted per class+character.
+  // The hotbar layout is a client-side remap over learned abilities and item
+  // shortcuts. Abilities are keyed by id (known is class-ordered and shifts on
+  // level-up, so indices would not survive). Persisted per class+character.
   private slotMapKey(): string {
     return `woc_hotbar_${this.sim.cfg.playerClass}_${this.sim.player.name}`;
+  }
+
+  private isHotbarItemId(itemId: string): boolean {
+    const item = ITEMS[itemId];
+    return item?.kind === 'food' || item?.kind === 'drink';
   }
 
   private loadSlotMap(): void {
     let arr: unknown = null;
     try { arr = JSON.parse(localStorage.getItem(this.slotMapKey()) ?? 'null'); } catch { /* corrupt */ }
-    const seen = new Set<string>();
-    this.slotMap = Array.from({ length: Hud.BAR_ABILITY_SLOTS }, (_, i) => {
-      const v = Array.isArray(arr) ? arr[i] : null;
-      if (typeof v !== 'string' || !ABILITIES[v] || seen.has(v)) return null;
-      seen.add(v);
-      return v;
-    });
+    this.hotbarActions = parseHotbarActions(
+      arr,
+      Hud.BAR_ABILITY_SLOTS,
+      (id) => !!ABILITIES[id],
+      (id) => this.isHotbarItemId(id),
+    );
   }
 
   private saveSlotMap(): void {
-    try { localStorage.setItem(this.slotMapKey(), JSON.stringify(this.slotMap)); } catch { /* storage unavailable */ }
+    try { localStorage.setItem(this.slotMapKey(), JSON.stringify(this.hotbarActions)); } catch { /* storage unavailable */ }
   }
 
-  // Drop unlearned ids; place newly learned abilities in the first empty
-  // slot. With empty storage this reproduces the default class-order layout.
+  // Drop unlearned ability ids; place newly learned abilities in the first
+  // empty slot. Item shortcuts stay assigned even when their count reaches 0.
   private syncSlotMap(): void {
-    const ids = new Set(this.sim.known.map((k) => k.def.id));
-    let dirty = false;
-    for (let i = 0; i < this.slotMap.length; i++) {
-      const id = this.slotMap[i];
-      if (id !== null && !ids.has(id)) { this.slotMap[i] = null; dirty = true; }
-    }
-    for (const k of this.sim.known) {
-      if (this.slotMap.includes(k.def.id)) continue;
-      const empty = this.slotMap.indexOf(null);
-      if (empty !== -1) { this.slotMap[empty] = k.def.id; dirty = true; }
-    }
-    if (dirty) this.saveSlotMap();
+    const synced = syncHotbarActions(this.hotbarActions, this.sim.known.map((k) => k.def.id));
+    this.hotbarActions = synced.actions;
+    if (synced.changed) this.saveSlotMap();
+  }
+
+  private actionForSlot(barSlot: number): HotbarAction { // barSlot 1..11
+    return this.hotbarActions[barSlot - 1] ?? null;
   }
 
   abilityForSlot(barSlot: number): ResolvedAbility | null { // barSlot 1..11
-    const id = this.slotMap[barSlot - 1];
-    return id ? this.sim.known.find((k) => k.def.id === id) ?? null : null;
+    const action = this.actionForSlot(barSlot);
+    return action?.type === 'ability'
+      ? this.sim.known.find((k) => k.def.id === action.id) ?? null
+      : null;
+  }
+
+  private itemForSlot(barSlot: number): ItemDef | null {
+    const action = this.actionForSlot(barSlot);
+    return action?.type === 'item' ? ITEMS[action.id] ?? null : null;
+  }
+
+  private inventoryCount(itemId: string): number {
+    return this.sim.inventory.reduce((total, slot) => total + (slot.itemId === itemId ? slot.count : 0), 0);
   }
 
   // Shared entry point for hotbar clicks and the 1..0-= keybinds.
@@ -389,10 +402,31 @@ export class Hud {
       else this.sim.startAutoAttack();
       return;
     }
-    const known = this.abilityForSlot(barSlot);
-    // cast by ability id: the server validates against its own known list,
-    // so the client-side slot remap never desyncs slot semantics
-    if (known) this.sim.castAbility(known.def.id);
+    const action = this.actionForSlot(barSlot);
+    if (action?.type === 'ability') {
+      // cast by ability id: the server validates against its own known list,
+      // so the client-side slot remap never desyncs slot semantics
+      if (this.abilityForSlot(barSlot)) this.sim.castAbility(action.id);
+    } else if (action?.type === 'item' && this.isHotbarItemId(action.id)) {
+      if (this.tradeOpen) return;
+      this.sim.useItem(action.id);
+      if ($('#bags').style.display === 'block') this.renderBags();
+    }
+  }
+
+  private writeDraggedAction(dt: DataTransfer | null, action: Exclude<HotbarAction, null>): void {
+    if (!dt) return;
+    dt.setData(HOTBAR_ACTION_MIME, encodeHotbarAction(action));
+    dt.setData('text/plain', action.id);
+  }
+
+  private readDraggedAction(dt: DataTransfer | null): Exclude<HotbarAction, null> | null {
+    if (!dt) return null;
+    const raw = dt.getData(HOTBAR_ACTION_MIME);
+    if (!raw) return null;
+    let parsed: unknown = null;
+    try { parsed = JSON.parse(raw); } catch { return null; }
+    return parseHotbarAction(parsed, (id) => this.sim.known.some((k) => k.def.id === id), (id) => this.isHotbarItemId(id));
   }
 
   private buildActionBar(): void {
@@ -402,6 +436,8 @@ export class Hud {
       btn.className = 'action-btn empty';
       const label = document.createElement('span');
       label.className = 'icon-label';
+      const countEl = document.createElement('span');
+      countEl.className = 'item-count';
       const kb = document.createElement('span');
       kb.className = 'keybind';
       kb.textContent = this.keybinds.primaryLabel(`slot${i}`); // rebindable; refreshKeybindLabels keeps it current
@@ -409,7 +445,7 @@ export class Hud {
       cdOverlay.className = 'cd-overlay';
       const cdText = document.createElement('div');
       cdText.className = 'cdtext';
-      btn.append(label, kb, cdOverlay, cdText);
+      btn.append(label, countEl, kb, cdOverlay, cdText);
       const slot = i;
       // slot 0 is Attack for every class (auto-attack toggle — players
       // without right-click need a way in); the kit fills slots 1+
@@ -422,43 +458,57 @@ export class Hud {
           return '<div class="tt-title">Attack</div><div class="tt-sub">Toggle auto-attack on your target.<br>Right-clicking an enemy also attacks.</div>';
         }
         const known = this.abilityForSlot(slot);
-        return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
+        if (known) return this.abilityTooltip(known);
+        const item = this.itemForSlot(slot);
+        if (item) {
+          const count = this.inventoryCount(item.id);
+          return this.itemTooltip(item) + (count > 0 ? `<div class="tt-sub">In bags: ${count}</div>` : '<div class="tt-sub">None in bags</div>');
+        }
+        return '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to place or swap it;
+        // drag an action onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
-          const known = this.abilityForSlot(slot);
-          if (!known) { e.preventDefault(); return; }
-          this.dragAbilityId = known.def.id;
-          e.dataTransfer!.setData('text/plain', known.def.id);
+          const action = this.actionForSlot(slot);
+          if (!action) { e.preventDefault(); return; }
+          this.dragAction = { action, sourceIndex: slot - 1 };
+          this.writeDraggedAction(e.dataTransfer, action);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
+          const dragged = this.dragAction?.action ?? this.readDraggedAction(e.dataTransfer);
+          if (!dragged) return;
+          if (this.dragAction?.sourceIndex === slot - 1) return;
           e.preventDefault(); // required to permit the drop
-          e.dataTransfer!.dropEffect = 'move';
+          e.dataTransfer!.dropEffect = this.dragAction?.sourceIndex === null && dragged.type === 'item' ? 'copy' : 'move';
           btn.classList.add('drop-target');
         });
         btn.addEventListener('dragleave', () => btn.classList.remove('drop-target'));
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
-          this.dragAbilityId = null;
-          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
-          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
+          const dragged = this.dragAction ?? { action: this.readDraggedAction(e.dataTransfer), sourceIndex: null };
+          this.dragAction = null;
+          const action = dragged.action;
+          if (!action) return;
+          if (dragged.sourceIndex !== null) this.hotbarActions = swapHotbarSlots(this.hotbarActions, dragged.sourceIndex, slot - 1);
+          else if (action.type === 'ability' && this.sim.known.some((k) => k.def.id === action.id)) {
+            this.hotbarActions = placeAbilityOnSlot(this.hotbarActions, action.id, slot - 1);
+          } else if (action.type === 'item' && this.isHotbarItemId(action.id)) {
+            this.hotbarActions = placeItemOnSlot(this.hotbarActions, action.id, slot - 1);
+          }
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragAbilityId = null;
+          this.dragAction = null;
           this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
-      this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
+      this.abilityButtons.push({ btn, label, countEl, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
   }
 
@@ -569,7 +619,7 @@ export class Hud {
     // action bar
     const tgtDist = target && !target.dead ? dist2d(p.pos, target.pos) : null;
     const actionbar = $('#actionbar');
-    actionbar.classList.toggle('many-spells', this.slotMap.filter((id) => id !== null).length > 10);
+    actionbar.classList.toggle('many-spells', this.hotbarActions.filter((action) => action !== null).length > 10);
     for (let i = 0; i < this.abilityButtons.length; i++) {
       const ab = this.abilityButtons[i];
       if (i === 0) {
@@ -579,37 +629,58 @@ export class Hud {
           ab.lastIcon = '__attack';
           ab.label.style.backgroundImage = `url(${iconDataUrl('ability', 'attack')})`;
         }
+        ab.countEl.textContent = '';
         ab.cdOverlay.style.height = '0%';
         ab.cdText.textContent = '';
         ab.btn.classList.toggle('queued', !!p.autoAttack);
         ab.btn.classList.toggle('oor', tgtDist !== null && tgtDist > MELEE_RANGE);
         continue;
       }
+      const action = this.actionForSlot(i);
       const known = this.abilityForSlot(i);
-      if (!known) {
+      const item = this.itemForSlot(i);
+      if (!known && !item) {
         ab.btn.classList.add('empty');
+        ab.btn.classList.remove('unusable', 'oor', 'queued');
         if (ab.lastIcon !== '') {
           ab.lastIcon = '';
           ab.label.style.backgroundImage = '';
         }
+        ab.countEl.textContent = '';
         ab.cdOverlay.style.height = '0%';
         ab.cdText.textContent = '';
         continue;
       }
-      const a = known.def;
       ab.btn.classList.remove('empty');
+      if (item && action?.type === 'item') {
+        const iconKey = `item:${item.id}`;
+        if (ab.lastIcon !== iconKey) {
+          ab.lastIcon = iconKey;
+          ab.label.style.backgroundImage = `url(${iconDataUrl('item', item.id)})`;
+        }
+        const count = this.inventoryCount(item.id);
+        ab.countEl.textContent = String(count);
+        ab.cdOverlay.style.height = '0%';
+        ab.cdText.textContent = '';
+        ab.btn.classList.toggle('unusable', count <= 0 || p.dead);
+        ab.btn.classList.remove('oor', 'queued');
+        continue;
+      }
+      const a = known!.def;
       // set the painted icon once per slot change, not every frame
-      if (ab.lastIcon !== a.id) {
-        ab.lastIcon = a.id;
+      const iconKey = `ability:${a.id}`;
+      if (ab.lastIcon !== iconKey) {
+        ab.lastIcon = iconKey;
         ab.label.style.backgroundImage = `url(${iconDataUrl('ability', a.id)})`;
       }
+      ab.countEl.textContent = '';
       const cd = p.cooldowns.get(a.id) ?? 0;
       const gcdActive = !a.offGcd && p.gcdRemaining > 0;
       const shown = Math.max(cd, gcdActive ? p.gcdRemaining : 0);
       const denom = cd > 0 ? a.cooldown : GCD;
       ab.cdOverlay.style.height = shown > 0 ? `${Math.min(100, (shown / Math.max(0.01, denom)) * 100)}%` : '0%';
       ab.cdText.textContent = cd > 1 ? Math.ceil(cd).toString() : '';
-      ab.btn.classList.toggle('unusable', p.resource < known.cost);
+      ab.btn.classList.toggle('unusable', p.resource < known!.cost);
       const oor = a.requiresTarget && tgtDist !== null && tgtDist > (a.range > 0 ? a.range : MELEE_RANGE);
       ab.btn.classList.toggle('oor', !!oor);
       ab.btn.classList.toggle('queued', p.queuedOnSwing === a.id);
@@ -1838,6 +1909,20 @@ export class Hud {
           this.renderBags();
         }
       });
+      if (!this.tradeOpen && !this.vendorOpen && this.isHotbarItemId(s.itemId)) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          const action = { type: 'item' as const, id: s.itemId };
+          this.dragAction = { action, sourceIndex: null };
+          this.writeDraggedAction(e.dataTransfer, action);
+          e.dataTransfer!.effectAllowed = 'copy';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAction = null;
+          this.clearActionDropTargets();
+        });
+      }
       this.attachTooltip(row, () => {
         let extra = '';
         if (this.tradeOpen) extra = '<div class="tt-sub">Click to offer in trade</div>';
@@ -1934,13 +2019,14 @@ export class Hud {
       if (known) {
         row.draggable = true;
         row.addEventListener('dragstart', (e) => {
-          this.dragAbilityId = known.def.id;
-          e.dataTransfer!.setData('text/plain', known.def.id);
+          const action = { type: 'ability' as const, id: known.def.id };
+          this.dragAction = { action, sourceIndex: null };
+          this.writeDraggedAction(e.dataTransfer, action);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         row.addEventListener('dragend', () => {
-          this.dragAbilityId = null;
+          this.dragAction = null;
           this.clearActionDropTargets();
         });
         this.attachTooltip(row, () => this.abilityTooltip(known));
@@ -2618,6 +2704,7 @@ export class Hud {
         this.tradeWasOpen = false;
         this.stagedTrade = { items: [], copper: 0 };
         this.lastTradeSig = '';
+        if ($('#bags').style.display === 'block') this.renderBags();
       }
       return;
     }
@@ -2860,7 +2947,7 @@ export class Hud {
     this.settingsViewFooter();
   }
 
-  // Display name for an action row. Action-bar slots show the ability that
+  // Display name for an action row. Action-bar slots show the shortcut that
   // currently occupies them (slot 0 is always Attack); everything else uses
   // its registry label.
   private actionDisplayName(actionId: string, fallback: string): string {
@@ -2868,7 +2955,9 @@ export class Hud {
     const slot = Number(actionId.slice(4));
     if (slot === 0) return 'Attack';
     const known = this.abilityForSlot(slot);
-    return known ? known.def.name : fallback;
+    if (known) return known.def.name;
+    const item = this.itemForSlot(slot);
+    return item ? item.name : fallback;
   }
 
   private renderKeybinds(): void {

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { placeAbilityOnSlot } from '../src/ui/hotbar';
+
+describe('hotbar ability placement', () => {
+  it('places a spellbook ability onto the target action slot', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'polymorph', 1);
+
+    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
+    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+  });
+
+  it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
+
+    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,21 +1,119 @@
 import { describe, expect, it } from 'vitest';
-import { placeAbilityOnSlot } from '../src/ui/hotbar';
+import {
+  parseHotbarActions, placeAbilityOnSlot, placeItemOnSlot, syncHotbarActions,
+} from '../src/ui/hotbar';
 
-describe('hotbar ability placement', () => {
+const abilityIds = new Set(['fireball', 'frost_armor', 'arcane_intellect', 'polymorph', 'shared_id']);
+const itemIds = new Set(['baked_bread', 'spring_water', 'shared_id']);
+const abilityExists = (id: string) => abilityIds.has(id);
+const itemExists = (id: string) => itemIds.has(id);
+
+describe('hotbar action parsing', () => {
+  it('migrates legacy ability strings and drops duplicate abilities', () => {
+    const actions = parseHotbarActions(
+      ['fireball', 'frost_armor', 'fireball', 'baked_bread'],
+      5,
+      abilityExists,
+      itemExists,
+    );
+
+    expect(actions).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'frost_armor' },
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it('keeps item and ability actions distinct even when ids overlap', () => {
+    const actions = parseHotbarActions(
+      [{ type: 'ability', id: 'shared_id' }, { type: 'item', id: 'shared_id' }],
+      2,
+      abilityExists,
+      itemExists,
+    );
+
+    expect(actions).toEqual([
+      { type: 'ability', id: 'shared_id' },
+      { type: 'item', id: 'shared_id' },
+    ]);
+  });
+});
+
+describe('hotbar action placement', () => {
   it('places a spellbook ability onto the target action slot', () => {
-    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+    const slots = [
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'ability' as const, id: 'frost_armor' },
+      { type: 'ability' as const, id: 'arcane_intellect' },
+      null,
+    ];
 
     const next = placeAbilityOnSlot(slots, 'polymorph', 1);
 
-    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
-    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+    expect(next).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'polymorph' },
+      { type: 'ability', id: 'arcane_intellect' },
+      null,
+    ]);
+    expect(slots).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'frost_armor' },
+      { type: 'ability', id: 'arcane_intellect' },
+      null,
+    ]);
   });
 
   it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
-    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+    const slots = [
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'ability' as const, id: 'frost_armor' },
+      { type: 'ability' as const, id: 'arcane_intellect' },
+      null,
+    ];
 
     const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
 
-    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+    expect(next).toEqual([
+      { type: 'ability', id: 'arcane_intellect' },
+      { type: 'ability', id: 'frost_armor' },
+      { type: 'ability', id: 'fireball' },
+      null,
+    ]);
+  });
+
+  it('places a food item on an occupied action slot without removing other item shortcuts', () => {
+    const slots = [
+      { type: 'item' as const, id: 'baked_bread' },
+      { type: 'ability' as const, id: 'fireball' },
+      null,
+    ];
+
+    const next = placeItemOnSlot(slots, 'baked_bread', 1);
+
+    expect(next).toEqual([
+      { type: 'item', id: 'baked_bread' },
+      { type: 'item', id: 'baked_bread' },
+      null,
+    ]);
+  });
+
+  it('keeps item shortcuts when learned abilities resync', () => {
+    const slots = [
+      { type: 'item' as const, id: 'spring_water' },
+      { type: 'ability' as const, id: 'fireball' },
+      null,
+    ];
+
+    const synced = syncHotbarActions(slots, ['fireball', 'polymorph']);
+
+    expect(synced.actions).toEqual([
+      { type: 'item', id: 'spring_water' },
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'polymorph' },
+    ]);
+    expect(synced.changed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds typed hotbar actions so action-bar slots can represent abilities or food/drink item shortcuts without overloading raw ids.
- Lets players drag food and drink from bags onto action-bar slots and use them through the existing `IWorld.useItem(itemId)` path.
- Keeps missing or out-of-stock consumable shortcuts assigned, rendering them unavailable with a zero count until the item is reacquired.
- Clears action-bar drop highlights when spellbook or bag item drags are cancelled before drop.

## Implementation Notes
- Legacy ability-only hotbar storage migrates into typed ability actions and duplicate ability entries are still dropped.
- Item shortcuts are limited to `food` and `drink`; equipment, quest items, and vendor/trade bag interactions stay outside this PR.
- Consumable hotkeys are disabled while trade is open so keypresses do not consume items involved in an offer.

## Verification
- `npx vitest run tests/hotbar.test.ts tests/sim.test.ts`; 2 files passed, 48 tests passed.
- `npm test`; 36 files passed, 403 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `gh api repos/levy-street/world-of-claudecraft/compare/main...gndk:actionbar-consumables`; branch is 2 commits ahead, 0 behind, stacked on #123.

## Risk
- Touches persisted client hotbar storage. The parser accepts existing ability strings and writes typed actions after sync, so existing bars keep working while item shortcuts get an explicit representation.
- Item use remains server/sim-authoritative through the existing `useItem` command path; the HUD only stores and dispatches shortcuts.

## Notes
- Depends on #123 for spellbook-to-hotbar action placement, swap groundwork, and drag-cancel cleanup. The parent branch exists only in the fork, so this PR remains based on `main` with the dependency noted here.
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
