### PR TITLE
Fix quest reward preview/turn-in mismatch (#98)

### DIFF
--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -86,6 +86,15 @@ export const REWARD_ARCHETYPE: Record<PlayerClass, PlayerClass> = {
   mage: 'mage', priest: 'mage', warlock: 'mage', druid: 'mage',
 };
 
+// Resolve the item a quest awards a given class: a class-specific reward if the
+// quest lists one, else the reward for the class's archetype (rewards are
+// authored per archetype — warrior/rogue/mage). The dialog preview and the
+// turn-in grant MUST both call this so what the player is shown matches what
+// they receive. Returns undefined when the quest has no item reward.
+export function questRewardItem(quest: QuestDef, cls: PlayerClass): string | undefined {
+  return quest.itemRewards[cls] ?? quest.itemRewards[REWARD_ARCHETYPE[cls]];
+}
+
 // Vanilla group XP multipliers by party size (1-5).
 export const GROUP_XP_BONUS = [1, 1, 1.166, 1.3, 1.43];
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,7 +1,7 @@
 import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
-  ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, REWARD_ARCHETYPE, abilitiesKnownAt, instanceOrigin,
+  ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, questRewardItem, abilitiesKnownAt, instanceOrigin,
   zoneAt,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
@@ -3074,7 +3074,7 @@ export class Sim {
       meta.copper += quest.copperReward;
       this.emit({ type: 'loot', text: `You receive ${formatMoney(quest.copperReward)}.`, pid: meta.entityId });
     }
-    const rewardItem = quest.itemRewards[meta.cls] ?? quest.itemRewards[REWARD_ARCHETYPE[meta.cls]];
+    const rewardItem = questRewardItem(quest, meta.cls);
     if (rewardItem) this.addItem(rewardItem, 1, meta.entityId);
     this.grantXp(quest.xpReward, meta);
     this.emit({ type: 'questDone', questId, pid: meta.entityId });

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -3,7 +3,7 @@ import type { IWorld, MarketInfo } from '../world_api';
 import { Renderer } from '../render/renderer';
 import {
   ABILITIES, CLASSES, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, MOBS, NPCS, QUESTS,
-  WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z, ZONES, dungeonAt, zoneAt,
+  WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_X, WORLD_MIN_Z, ZONES, dungeonAt, questRewardItem, zoneAt,
   zoneWelcomeText,
 } from '../sim/data';
 import type { ZoneDef } from '../sim/data';
@@ -1443,7 +1443,7 @@ export class Hud {
     }
     html += `<div class="qd-sub">Rewards</div>`;
     html += `<div class="qd-obj">${quest.xpReward} experience &nbsp; ${this.moneyHtml(quest.copperReward)}</div>`;
-    const rewardItem = quest.itemRewards[this.sim.cfg.playerClass];
+    const rewardItem = questRewardItem(quest, this.sim.cfg.playerClass);
     if (rewardItem) {
       const item = ITEMS[rewardItem];
       html += `<div class="qd-reward-row" data-reward>${this.itemIcon(item)}<span style="color:${QUALITY_COLOR[item.quality ?? 'common'] ?? '#fff'};font-size:12px">${item.name}</span></div>`;

--- a/tests/quest_rewards.test.ts
+++ b/tests/quest_rewards.test.ts
@@ -1,0 +1,35 @@
+// Quest reward resolution must be identical between the quest-dialog preview
+// (hud.ts) and the turn-in grant (sim.ts). Both now route through the shared
+// questRewardItem() resolver so they cannot drift apart again. Regression test
+// for the "preview shows no item but turn-in grants the archetype item" bug
+// (e.g. a priest, a mage-archetype class, seeing an empty reward preview yet
+// receiving the staff at turn-in).
+import { describe, expect, it } from 'vitest';
+import { QUESTS, REWARD_ARCHETYPE, questRewardItem } from '../src/sim/data';
+import { ALL_CLASSES } from '../src/sim/types';
+
+describe('quest reward resolution', () => {
+  it('resolver matches the turn-in fallback formula for every quest and class', () => {
+    for (const quest of Object.values(QUESTS)) {
+      for (const cls of ALL_CLASSES) {
+        // This is exactly the resolution sim.ts uses when granting the reward.
+        const granted = quest.itemRewards[cls] ?? quest.itemRewards[REWARD_ARCHETYPE[cls]];
+        expect(questRewardItem(quest, cls)).toBe(granted);
+      }
+    }
+  });
+
+  it('shows the archetype reward for non-archetype classes (the reported bug)', () => {
+    // Find a quest that only lists archetype-keyed rewards (warrior/rogue/mage)
+    // and verify a non-archetype class such as priest still previews an item.
+    for (const quest of Object.values(QUESTS)) {
+      const priestReward = questRewardItem(quest, 'priest');
+      const mageReward = questRewardItem(quest, 'mage');
+      // priest is a mage-archetype class, so its reward must equal the mage's
+      // whenever the quest has no priest-specific override.
+      if (quest.itemRewards.priest === undefined) {
+        expect(priestReward).toBe(mageReward);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #98. The quest-dialog **reward preview** and the **turn-in grant** resolved the awarded item differently, so players could be shown no reward (or the wrong one) yet receive an item at turn-in — matching the Discord report that "the staff reward became better than what the quest originally displayed."

## Root cause
Quest item rewards are authored per **archetype** (`warrior`/`rogue`/`mage`):
```ts
itemRewards: { warrior: 'gravecaller_blade', rogue: 'widowfang_dirk', mage: 'gravecaller_staff' }
```
The turn-in path resolved with a `REWARD_ARCHETYPE` fallback:
```ts
// src/sim/sim.ts (turn-in)
quest.itemRewards[meta.cls] ?? quest.itemRewards[REWARD_ARCHETYPE[meta.cls]]
```
but the preview did a raw lookup with **no fallback**:
```ts
// src/ui/hud.ts (preview)
quest.itemRewards[this.sim.cfg.playerClass]
```
For any non-archetype class (priest, paladin, shaman, hunter, warlock, druid) `itemRewards[cls]` is `undefined`, so the preview showed **no item** while turn-in still granted the archetype item. A priest (mage-archetype) saw an empty reward but received the mage staff.

## Fix
Extract a single resolver `questRewardItem(quest, cls)` in `src/sim/data.ts` and call it from **both** the turn-in (`sim.ts`) and the preview (`hud.ts`), so the two paths can no longer drift.

## Tests
Adds `tests/quest_rewards.test.ts`:
- the resolver matches the turn-in fallback formula for **every quest × every class**;
- non-archetype classes (e.g. priest) preview their archetype reward.

Full suite passes (the only failing test is the pre-existing `homepage_foundation` test, which requires a live `DATABASE_URL` and is unrelated). `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)