### PR TITLE
fix: expose quest log on mobile controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -3710,6 +3710,7 @@
         <button class="mobile-btn" id="mobile-arena" title="Arena" aria-label="Arena">⚔<span class="mobile-label">Arena</span></button>
         <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu">☰<span class="mobile-label">Menu</span></button>
         <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot">✦<span class="mobile-label">Use</span></button>
+        <button class="mobile-btn" id="mobile-quest" title="Quest Log" aria-label="Quest Log">!<span class="mobile-label">Quests</span></button>
         <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook">✹<span class="mobile-label">Spellbook</span></button>
         <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters">▦<span class="mobile-label">Meters</span></button>
         <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map">◇<span class="mobile-label">Map</span></button>

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -12,6 +12,7 @@ export interface MobileControlCallbacks {
   onMenu(): void;
   onSocial(): void;
   onArena(): void;
+  onQuestLog(): void;
   onSpellbook(): void;
   onMeters(): void;
   onMap(): void;
@@ -70,6 +71,7 @@ export class MobileControls {
     this.bindButton('mobile-menu', () => this.callbacks.onMenu());
     this.bindButton('mobile-social', () => this.callbacks.onSocial());
     this.bindButton('mobile-arena', () => this.callbacks.onArena());
+    this.bindButton('mobile-quest', () => this.callbacks.onQuestLog());
     this.bindButton('mobile-spellbook', () => this.callbacks.onSpellbook());
     this.bindButton('mobile-meters', () => this.callbacks.onMeters());
     this.bindButton('mobile-map', () => this.callbacks.onMap());

--- a/src/main.ts
+++ b/src/main.ts
@@ -390,6 +390,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     },
     onSocial: () => hud.toggleSocial(),
     onArena: () => hud.toggleArena(),
+    onQuestLog: () => hud.toggleQuestLog(),
     onSpellbook: () => hud.toggleSpellbook(),
     onMeters: () => hud.toggleMeters(),
     onMap: () => hud.toggleMap(),

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -30,4 +30,10 @@ describe('client HTML shell', () => {
     expect(liveHtml).not.toContain('Combat Log');
     expect(liveHtml).not.toContain('id="chat-input"');
   });
+
+  it('offers the quest log in the mobile controls drawer', () => {
+    expect(html).toContain('id="mobile-extra-controls"');
+    expect(html).toContain('id="mobile-quest"');
+    expect(html).toContain('aria-label="Quest Log"');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a Quests button to the mobile More drawer so touch players can open the Quest Log from the mobile HUD.
- Wires the new control through the existing mobile controls callback path to `hud.toggleQuestLog()`.
- Adds static shell coverage so the mobile drawer keeps exposing the Quest Log entry point.

## Diagnosis
Mobile mode hides the desktop side-button column, including the Quest Log button. In landscape mobile mode the quest tracker is also hidden to keep the play area clear, so accepted quest details had no obvious touch-HUD entry point.

## Verification
- `npx vitest run tests/client_shell.test.ts tests/mobile_controls.test.ts`; 8 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- `npm test`; 398 tests passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- Mobile landscape browser check opened offline play, verified the Quests drawer button was visible, and confirmed tapping it opened the Quest Log.

## Real behavior proof
- Behavior addressed: after release 0.4, mobile players reported that quests did not seem to appear.
- Environment tested: local offline browser session at a mobile landscape viewport.
- Evidence after fix: the mobile More drawer exposed Quests, and tapping it opened the Quest Log panel.

## Risk
Low client-side HUD risk. The change only adds a mobile button that calls the existing Quest Log toggle; quest state, simulation, persistence, and desktop controls are unchanged.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
