### PR TITLE
fix: preserve arena countdown buffs

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3569,7 +3569,7 @@ export class Sim {
         if (match.timer <= 0) {
           match.state = 'active';
           match.timer = 0;
-          for (const e of [ea, eb]) this.resetForArena(e);
+          for (const e of [ea, eb]) this.readyArenaFighter(e, { clearPrep: false });
           for (const mPid of [match.a, match.b]) {
             this.emit({ type: 'log', text: 'Fight!', color: '#ff5a3c', pid: mPid });
             this.emit({ type: 'arenaStart', pid: mPid });
@@ -3659,9 +3659,16 @@ export class Sim {
   // A clean slate so the bout is decided by play, not by what each fighter
   // walked in carrying: full health/resource, cooldowns and combat reset.
   private resetForArena(e: Entity): void {
+    this.readyArenaFighter(e, { clearPrep: true });
+  }
+
+  private readyArenaFighter(e: Entity, opts: { clearPrep: boolean }): void {
+    if (opts.clearPrep) {
+      e.auras = [];
+      e.cooldowns.clear();
+    }
     const meta = this.players.get(e.id);
     if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
-    e.auras = [];
     e.hp = e.maxHp;
     e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
     e.targetId = null;
@@ -3672,7 +3679,6 @@ export class Sim {
     e.channeling = false;
     e.comboPoints = 0;
     e.comboTargetId = null;
-    e.cooldowns.clear();
     e.gcdRemaining = 0;
     e.swingTimer = 0;
     e.chargeTargetId = null;

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -129,6 +129,19 @@ describe('arena: a full bout', () => {
     expect(eb.hp).toBe(eb.maxHp);
   });
 
+  it('keeps buffs cast during the countdown when the fight starts', () => {
+    const { sim, b } = queueDuo();
+    const mage = sim.entities.get(b)!;
+
+    sim.castAbility('frost_armor', b);
+    expect(mage.auras.some((aura) => aura.id === 'frost_armor')).toBe(true);
+
+    startBout(sim);
+
+    expect(sim.arenaMatchFor(b)!.state).toBe('active');
+    expect(mage.auras.some((aura) => aura.id === 'frost_armor')).toBe(true);
+  });
+
   it('ends at 1 health: winner declared, ratings move, nobody dies, both returned', () => {
     const { sim, a, b } = queueDuo();
     startBout(sim);


### PR DESCRIPTION
## Summary
- Keeps buffs cast during the Ashen Coliseum countdown active when the bout starts.
- Preserves the existing arena entry cleanup so outside-world carry-in auras and cooldowns are still cleared when fighters are matched.
- Adds regression coverage for a countdown-cast buff surviving the transition to the active fight.

## Diagnosis
Arena matchmaking reset fighters when they entered the arena, then reused the same reset when the countdown reached zero. That second reset removed buffs players intentionally cast during the prep timer, making the countdown hard to use for normal pre-fight setup.

## Implementation Notes
- Splits arena fighter preparation into an entry cleanup path and a start-of-fight ready path.
- The start transition still restores health/resource and clears combat/casting state, but no longer clears countdown prep auras or cooldowns.

## Verification
- `npx vitest run tests/arena.test.ts`; 13 tests passed.
- `npx tsc --noEmit`; passed.
- Full PR-mode closeout gate with `DATABASE_URL=postgres://test/test`: `npm test` (398 tests passed), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.

## Risk
Low gameplay risk. The arena still clears outside-world state at match entry and still cleans up after the bout; the change only preserves actions taken during the built-in countdown.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
