### PR TITLE
fix(test): set DATABASE_URL before db import in homepage_foundation test

### DIFF
--- a/tests/homepage_foundation.test.ts
+++ b/tests/homepage_foundation.test.ts
@@ -1,4 +1,12 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+
+// db.ts requires DATABASE_URL at import time; set a dummy value before the
+// hoisted import runs so the module loads. Queries are spied on the real pool
+// (see below), so no actual connection is ever opened.
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test/test";
+});
+
 import { pool, getAccountsCount } from "../server/db";
 import { t, setLanguage, getLanguage } from "../src/ui/i18n";
 import { Api } from "../src/net/online";


### PR DESCRIPTION
## Problem

`npm test` currently fails: the `tests/homepage_foundation.test.ts` suite errors out at load time with:

```
Error: DATABASE_URL is required. For local dev, copy .env.example to .env and run through docker compose.
 ❯ server/db.ts:16:11
```

`server/db.ts` throws at **module-load time** when `DATABASE_URL` is unset. Because the test statically imports `{ pool, getAccountsCount }` from it, the whole suite fails to load (0 tests collected, suite-level error) — so CI is red.

## Fix

Set a dummy `DATABASE_URL` via `vi.hoisted()` *before* the hoisted `server/db` import runs — the same pattern already used in `tests/db_search.test.ts` and `tests/character_db.test.ts`.

The test spies on the real `pool.query`, so no actual database connection is ever opened; the connection string only needs to be present for the module to load.

## Verification

- Before: `Test Files  1 failed | 34 passed (35)`
- After: `Test Files  35 passed (35)` / `Tests  397 passed (397)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)