### PR TITLE
fix: diminish repeated arena roots

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -188,7 +188,7 @@ function blankEntity(id: number): Entity {
     attackPower: 0, rangedPower: 0, critChance: 0.05, dodgeChance: 0.05, moveSpeed: 7, hostile: false,
     targetId: null, autoAttack: false, swingTimer: 0,
     inCombat: false, combatTimer: 99,
-    auras: [], castingAbility: null, castRemaining: 0, castTotal: 0,
+    auras: [], ccDr: new Map(), castingAbility: null, castRemaining: 0, castTotal: 0,
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, savedMana: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -12,7 +12,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     attackPower: 0, rangedPower: 0, critChance: 0.05, dodgeChance: 0.05, moveSpeed: 7, hostile: false,
     targetId: null, autoAttack: false, swingTimer: 0,
     inCombat: false, combatTimer: 99,
-    auras: [], castingAbility: null, castRemaining: 0, castTotal: 0,
+    auras: [], ccDr: new Map(), castingAbility: null, castRemaining: 0, castTotal: 0,
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, savedMana: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -17,7 +17,7 @@ import {
 import { groundHeight, WATER_LEVEL } from './world';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
-  CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
+  CONSUME_TICKS, CrowdControlDrCategory, DT, Entity, EquipSlot, GCD,
   INTERACT_RANGE, InvSlot, MELEE_RANGE, MAX_LEVEL,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
@@ -44,6 +44,8 @@ const ARENA_BASE_RATING = 1500; // every character starts here, unranked
 const ARENA_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
 const ARENA_K_FACTOR = 32; // Elo sensitivity per match
 const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
+const PVP_CC_DR_RESET = 18; // seconds before a repeated PvP CC category is fresh again
+const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
 const YELL_RANGE = 100;
 const CHAT_BURST = 8; // messages a player may send back-to-back...
@@ -1558,11 +1560,7 @@ export class Sim {
         }
         case 'root': {
           if (!target || target.dead) break;
-          this.applyAura(target, {
-            id: ability.id + '_root', name: ability.name, kind: 'root',
-            remaining: eff.duration, duration: eff.duration, value: 0,
-            sourceId: p.id, school: ability.school,
-          });
+          this.applyRootAura(p, target, ability.name, ability.id + '_root', eff.duration, ability.school);
           this.enterCombat(p, target);
           break;
         }
@@ -1621,15 +1619,11 @@ export class Sim {
         }
         case 'aoeRoot': {
           this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: ability.school, fx: 'nova' });
-          for (const m of this.mobsInRadius(p.pos, eff.radius)) {
+          for (const m of this.hostilesInRadius(p, p.pos, eff.radius)) {
             const dmg = this.rng.range(eff.min, eff.max);
             this.dealDamage(p, m, Math.round(dmg), false, ability.school, ability.name, 'hit');
-            if (!m.dead) {
-              this.applyAura(m, {
-                id: ability.id + '_root', name: ability.name, kind: 'root',
-                remaining: eff.duration, duration: eff.duration, value: 0,
-                sourceId: p.id, school: ability.school,
-              });
+            if (!m.dead && this.isHostileTo(p, m)) {
+              this.applyRootAura(p, m, ability.name, ability.id + '_root', eff.duration, ability.school);
             }
           }
           break;
@@ -1759,10 +1753,44 @@ export class Sim {
     }
   }
 
+  private applyRootAura(source: Entity, target: Entity, name: string, id: string, duration: number, school: Aura['school']): void {
+    const remaining = this.diminishedCrowdControlDuration(source, target, 'root', duration);
+    if (remaining === null) return;
+    this.applyAura(target, {
+      id, name, kind: 'root',
+      remaining, duration: remaining, value: 0,
+      sourceId: source.id, school,
+    });
+  }
+
+  private diminishedCrowdControlDuration(
+    source: Entity,
+    target: Entity,
+    category: CrowdControlDrCategory,
+    duration: number,
+  ): number | null {
+    if (source.kind !== 'player' || target.kind !== 'player' || !this.isHostileTo(source, target)) {
+      return duration;
+    }
+    const existing = target.ccDr.get(category);
+    const stage = existing && existing.resetAt > this.time ? existing.stage : 0;
+    if (stage >= PVP_CC_DR_MULTIPLIERS.length) return null;
+    target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + PVP_CC_DR_RESET });
+    return duration * PVP_CC_DR_MULTIPLIERS[stage];
+  }
+
   private mobsInRadius(pos: Vec3, radius: number): Entity[] {
     const out: Entity[] = [];
     this.grid.forEachInRadius(pos.x, pos.z, radius, (e) => {
       if (e.kind === 'mob' && !e.dead && e.hostile) out.push(e);
+    });
+    return out;
+  }
+
+  private hostilesInRadius(source: Entity, pos: Vec3, radius: number): Entity[] {
+    const out: Entity[] = [];
+    this.grid.forEachInRadius(pos.x, pos.z, radius, (e) => {
+      if (e.id !== source.id && !e.dead && this.isHostileTo(source, e)) out.push(e);
     });
     return out;
   }
@@ -2114,6 +2142,7 @@ export class Sim {
     e.dead = true;
     e.hp = 0;
     e.auras = [];
+    e.ccDr.clear();
     e.castingAbility = null;
     this.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
 
@@ -3148,6 +3177,7 @@ export class Sim {
     this.rebucket(p);
     p.facing = 0;
     p.auras = [];
+    p.ccDr.clear();
     recalcPlayerStats(p, meta.cls, meta.equipment);
     p.hp = p.maxHp;
     p.resource = p.resourceType === 'mana' ? p.maxResource : p.resourceType === 'energy' ? 100 : 0;
@@ -3485,6 +3515,7 @@ export class Sim {
     const eb = this.entities.get(duel.b);
     // stop the combatants from swinging at each other
     for (const e of [ea, eb]) {
+      if (e) e.ccDr.clear();
       if (e && e.targetId !== null && (e.targetId === duel.a || e.targetId === duel.b)) {
         e.autoAttack = false;
       }
@@ -3662,6 +3693,7 @@ export class Sim {
     const meta = this.players.get(e.id);
     if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
     e.auras = [];
+    e.ccDr.clear();
     e.hp = e.maxHp;
     e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
     e.targetId = null;
@@ -3731,6 +3763,7 @@ export class Sim {
       this.rebucket(e);
       if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
       e.auras = [];
+      e.ccDr.clear();
       e.dead = false;
       e.hp = e.maxHp;
       e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -51,6 +51,13 @@ export interface Aura {
   stacks?: number; // sunder armor: applications stack up to the effect's cap
 }
 
+export type CrowdControlDrCategory = 'root';
+
+export interface CrowdControlDrState {
+  stage: number;
+  resetAt: number;
+}
+
 export interface Stats {
   str: number;
   agi: number;
@@ -400,6 +407,7 @@ export interface Entity {
   inCombat: boolean;
   combatTimer: number; // time since last combat event
   auras: Aura[];
+  ccDr: Map<CrowdControlDrCategory, CrowdControlDrState>;
   castingAbility: string | null;
   castRemaining: number;
   castTotal: number;

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Sim, eloDelta } from '../src/sim/sim';
 import { groundHeight } from '../src/sim/world';
 import { isArenaPos } from '../src/sim/data';
+import type { PlayerClass } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -16,16 +17,29 @@ function teleport(sim: Sim, pid: number, x: number, z: number) {
 }
 
 // Queue two players and advance one tick so matchmaking seats them.
-function queueDuo(): { sim: Sim; a: number; b: number } {
+function queueDuo(aClass: PlayerClass = 'warrior', bClass: PlayerClass = 'mage'): { sim: Sim; a: number; b: number } {
   const sim = makeWorld();
-  const a = sim.addPlayer('warrior', 'Aleph');
-  const b = sim.addPlayer('mage', 'Bet');
+  const a = sim.addPlayer(aClass, 'Aleph');
+  const b = sim.addPlayer(bClass, 'Bet');
   teleport(sim, a, 0, -40);
   teleport(sim, b, 6, -40);
   sim.arenaQueueJoin(a);
   sim.arenaQueueJoin(b);
   sim.tick(); // updateArena() matchmakes the pair
   return { sim, a, b };
+}
+
+function face(sim: Sim, pid: number, targetId: number) {
+  const e = sim.entities.get(pid)!;
+  const t = sim.entities.get(targetId)!;
+  e.facing = Math.atan2(t.pos.x - e.pos.x, t.pos.z - e.pos.z);
+}
+
+function finishCast(sim: Sim, pid: number) {
+  for (let i = 0; i < 20 * 4; i++) {
+    sim.tick();
+    if (!sim.entities.get(pid)!.castingAbility) return;
+  }
 }
 
 // Run the countdown out so the bout goes live.
@@ -229,5 +243,66 @@ describe('arena: forfeit + persistence', () => {
     sim.meta(c)!.arenaRating = 1600;
     const ladder = sim.arenaLadder();
     expect(ladder.map((r) => r.name)).toEqual(['High', 'Mid', 'Low']);
+  });
+});
+
+describe('arena: crowd control diminishing returns', () => {
+  it('shortens repeated roots on the same arena target, then resets', () => {
+    const { sim, a, b } = queueDuo('druid', 'warrior');
+    startBout(sim);
+    const druid = sim.entities.get(a)!;
+    const warrior = sim.entities.get(b)!;
+    (sim as any).rng.chance = () => true;
+    sim.setPlayerLevel(8, a);
+    druid.pos.x = warrior.pos.x;
+    druid.pos.z = warrior.pos.z - 8;
+    druid.targetId = b;
+    face(sim, a, b);
+
+    const castRoot = () => {
+      druid.resource = druid.maxResource;
+      druid.gcdRemaining = 0;
+      sim.castAbility('entangling_roots', a);
+      finishCast(sim, a);
+    };
+
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(12);
+    warrior.auras = [];
+
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(6);
+    warrior.auras = [];
+
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(3);
+    warrior.auras = [];
+
+    castRoot();
+    expect(warrior.auras.some((aura) => aura.kind === 'root')).toBe(false);
+
+    for (let i = 0; i < 20 * 18; i++) sim.tick();
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(12);
+  });
+
+  it('lets Frost Nova root arena opponents through the same root category', () => {
+    const { sim, a, b } = queueDuo();
+    startBout(sim);
+    const warrior = sim.entities.get(a)!;
+    const mage = sim.entities.get(b)!;
+    sim.setPlayerLevel(10, b);
+    mage.pos.x = warrior.pos.x;
+    mage.pos.z = warrior.pos.z - 4;
+    mage.facing = 0;
+
+    sim.castAbility('frost_nova', b);
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(8);
+    warrior.auras = [];
+    mage.gcdRemaining = 0;
+    mage.cooldowns.clear();
+
+    sim.castAbility('frost_nova', b);
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(4);
   });
 });


### PR DESCRIPTION
## Summary
- Add PvP-only root diminishing returns so repeated arena roots land at full, half, quarter, then immune until the category resets.
- Route single-target roots and Frost Nova roots through the same root category while leaving normal PvE root behavior unchanged.
- Cover repeated Entangling Roots and Frost Nova rooting an arena opponent in the arena regression suite.

## Diagnosis
Repeated position-freeze effects in 1v1 arena could keep landing at full strength. That made root chaining harder to answer than the classic MMO expectation that repeated crowd control against the same PvP target falls off within a short window.

## Implementation Notes
- The DR state is transient runtime combat state on entities, not persisted character state.
- The rule applies only when both source and target are hostile players, so PvE roots keep their authored duration.
- Frost Nova now scans hostile entities in radius, which lets it affect arena opponents without making non-hostile nearby players valid targets.

## Verification
- `npx vitest run tests/arena.test.ts -t "crowd control diminishing returns"`; 2 tests passed.
- `npx vitest run tests/arena.test.ts`; 14 tests passed.
- `npx tsc --noEmit`; passed.
- Full local gate: `npm test` (399 tests passed), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.

## Real behavior proof
- Behavior addressed: release arena feedback that repeated position-freeze abilities could chain control too long.
- Environment tested: local deterministic sim arena tests.
- Evidence after fix: repeated arena roots diminish from 12s to 6s to 3s to immunity, then return to full duration after the reset window.
- Not tested: live two-client browser arena match.

## Risk
Gameplay-balance risk is limited to active player-vs-player root control. The change intentionally makes Frost Nova able to root hostile arena opponents, and the tests cover that behavior through the same root DR category.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
