### PR TITLE
fix: return 409 (not 500) on a racing duplicate registration

### DIFF
--- a/server/http_util.ts
+++ b/server/http_util.ts
@@ -6,6 +6,16 @@ export function json(res: http.ServerResponse, status: number, body: unknown): v
   res.end(data);
 }
 
+// A Postgres unique-constraint violation (SQLSTATE 23505). The REST layer maps
+// this to 409 Conflict: the pre-insert existence check (e.g. findAccount) is
+// inherently TOCTOU, so the UNIQUE index is the real guard. When a racing
+// request wins the insert, this lets us return "already taken" instead of a
+// generic 500. The message fallback covers driver/test errors without a code.
+export function isUniqueViolation(err: unknown): boolean {
+  const e = err as { code?: unknown; message?: unknown } | null;
+  return e?.code === '23505' || (typeof e?.message === 'string' && e.message.includes('unique'));
+}
+
 export function readBody(req: http.IncomingMessage): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = '';

--- a/server/main.ts
+++ b/server/main.ts
@@ -13,7 +13,7 @@ import { resolveReportTarget } from './report_target';
 import {
   hashPassword, verifyPassword, newToken, validUsernameShape, offensiveName, validPassword, normalizeCharName,
 } from './auth';
-import { json, readBody } from './http_util';
+import { json, readBody, isUniqueViolation } from './http_util';
 import { rateLimited, authThrottled, recordAuthFailure, clearAuthFailures } from './ratelimit';
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
@@ -154,7 +154,16 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (!validPassword(body.password)) return json(res, 400, { error: 'password must be at least 6 chars' });
       const existing = await findAccount(body.username);
       if (existing) return json(res, 409, { error: 'username already taken' });
-      const account = await createAccount(body.username, await hashPassword(body.password));
+      let account;
+      try {
+        account = await createAccount(body.username, await hashPassword(body.password));
+      } catch (err: any) {
+        // a concurrent registration can win the insert after our findAccount
+        // check; the username UNIQUE index is the real guard. Surface it as a
+        // 409 like the duplicate path above, not a generic 500.
+        if (isUniqueViolation(err)) return json(res, 409, { error: 'username already taken' });
+        throw err;
+      }
       const token = newToken();
       await saveToken(token, account.id);
       return json(res, 200, { token, username: account.username });
@@ -207,9 +216,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
           const c = await createCharacter(accountId, name, body.class);
           return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
         } catch (err: any) {
-          if (String(err?.message).includes('unique') || err?.code === '23505') {
-            return json(res, 409, { error: 'that name is taken' });
-          }
+          if (isUniqueViolation(err)) return json(res, 409, { error: 'that name is taken' });
           throw err;
         }
       }
@@ -228,9 +235,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         if (!c) return json(res, 404, { error: 'character not found' });
         return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
       } catch (err: any) {
-        if (String(err?.message).includes('unique') || err?.code === '23505') {
-          return json(res, 409, { error: 'that name is taken' });
-        }
+        if (isUniqueViolation(err)) return json(res, 409, { error: 'that name is taken' });
         throw err;
       }
     }

--- a/tests/http_util.test.ts
+++ b/tests/http_util.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'vitest';
 import type * as http from 'node:http';
-import { readBody } from '../server/http_util';
+import { readBody, isUniqueViolation } from '../server/http_util';
 
 // Minimal IncomingMessage stand-in: an emitter that records whether the
 // request was destroyed so we can assert readBody stops reading the socket.
@@ -53,5 +53,25 @@ describe('readBody', () => {
     await expect(promise).rejects.toThrow('body too large');
     // Late chunks arriving after the abort must not be appended or throw.
     expect(() => req.emit('data', 'y'.repeat(1024 * 1024))).not.toThrow();
+  });
+});
+
+describe('isUniqueViolation', () => {
+  it('matches a Postgres unique-constraint error by SQLSTATE code', () => {
+    // what node-postgres throws for a UNIQUE index conflict
+    const err = Object.assign(new Error('duplicate key value violates unique constraint "accounts_username_key"'), { code: '23505' });
+    expect(isUniqueViolation(err)).toBe(true);
+  });
+
+  it('matches by message when no code is present', () => {
+    expect(isUniqueViolation(new Error('unique constraint failed'))).toBe(true);
+  });
+
+  it('ignores unrelated errors and non-errors', () => {
+    expect(isUniqueViolation(Object.assign(new Error('connection reset'), { code: '08006' }))).toBe(false);
+    expect(isUniqueViolation(new Error('boom'))).toBe(false);
+    expect(isUniqueViolation(null)).toBe(false);
+    expect(isUniqueViolation(undefined)).toBe(false);
+    expect(isUniqueViolation('nope')).toBe(false);
   });
 });


### PR DESCRIPTION
## What

`POST /api/register` returns a generic `500 internal error` (instead of `409`) when a duplicate username slips past the pre-insert `findAccount()` check and hits the `accounts.username` UNIQUE index.

## Why it happens

The handler does:

```ts
const existing = await findAccount(body.username);
if (existing) return json(res, 409, { error: 'username already taken' });
const account = await createAccount(...); // can throw 23505 on a race
```

That existence check is **TOCTOU** — two near-simultaneous signups for the same name both pass it, and the second `INSERT` is rejected by the UNIQUE index (Postgres SQLSTATE `23505`). Register never caught that error, so it fell through to the generic `catch` and returned `500`.

The sibling handlers in the same file — character create and rename — already translate the identical violation into a `409`. Register was the lone gap.

## Fix

- Catch the unique violation in `register` and return the same `409 "username already taken"` as the pre-check path.
- Extract the previously-triplicated `err.code === '23505' || message.includes('unique')` test into a single `isUniqueViolation()` helper in `http_util.ts`, and reuse it at all three call sites.

## Tests

Added unit tests for `isUniqueViolation` in `tests/http_util.test.ts` (matches by SQLSTATE code, by message fallback, and rejects unrelated/non-errors). `npx tsc --noEmit` and `npm run build:server` are clean; the `http_util` suite passes (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)