### PR TITLE
fix: stabilize mobile joystick pointers

### DIFF
--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -57,11 +57,36 @@ export class MobileControls {
     this.moveJoystick.addEventListener('pointermove', (e) => this.onMoveMove(e));
     this.moveJoystick.addEventListener('pointerup', (e) => this.onMoveEnd(e));
     this.moveJoystick.addEventListener('pointercancel', (e) => this.onMoveEnd(e));
+    this.moveJoystick.addEventListener('lostpointercapture', (e) => this.onMoveEnd(e));
 
     this.cameraJoystick.addEventListener('pointerdown', (e) => this.onCameraDown(e));
     this.cameraJoystick.addEventListener('pointermove', (e) => this.onCameraMove(e));
     this.cameraJoystick.addEventListener('pointerup', (e) => this.onCameraEnd(e));
     this.cameraJoystick.addEventListener('pointercancel', (e) => this.onCameraEnd(e));
+    this.cameraJoystick.addEventListener('lostpointercapture', (e) => this.onCameraEnd(e));
+
+    window.addEventListener('pointermove', (e) => {
+      this.onMoveMove(e);
+      this.onCameraMove(e);
+    });
+    window.addEventListener('pointerup', (e) => {
+      this.onMoveEnd(e);
+      this.onCameraEnd(e);
+    });
+    window.addEventListener('pointercancel', (e) => {
+      this.onMoveEnd(e);
+      this.onCameraEnd(e);
+    });
+    window.addEventListener('blur', () => {
+      this.releaseMove();
+      this.releaseCamera();
+    });
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') {
+        this.releaseMove();
+        this.releaseCamera();
+      }
+    });
 
     this.bindButton('mobile-attack-nearest', () => this.callbacks.onAttackNearest());
     this.bindButton('mobile-target', () => this.callbacks.onTarget());
@@ -148,6 +173,13 @@ export class MobileControls {
   }
 
   private releaseMove(): void {
+    if (this.joyPointer !== null) {
+      try {
+        if (this.moveJoystick?.hasPointerCapture?.(this.joyPointer)) {
+          this.moveJoystick.releasePointerCapture(this.joyPointer);
+        }
+      } catch { /* capture may already be gone on mobile browser gesture changes */ }
+    }
     this.joyPointer = null;
     this.input.clearTouchMove();
     if (this.moveStick) this.moveStick.style.transform = '';
@@ -183,6 +215,13 @@ export class MobileControls {
   }
 
   private releaseCamera(): void {
+    if (this.lookPointer !== null) {
+      try {
+        if (this.cameraJoystick?.hasPointerCapture?.(this.lookPointer)) {
+          this.cameraJoystick.releasePointerCapture(this.lookPointer);
+        }
+      } catch { /* capture may already be gone on mobile browser gesture changes */ }
+    }
     this.lookPointer = null;
     this.input.setTouchLook(false);
     this.input.setTouchLookVector({ x: 0, y: 0 });

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { isPhoneTouchDevice, mapJoystickVector, mapLookVector } from '../src/game/mobile_controls';
+import { afterEach, describe, expect, it } from 'vitest';
+import { isPhoneTouchDevice, mapJoystickVector, mapLookVector, MobileControls } from '../src/game/mobile_controls';
+import type { Input, TouchMoveInput } from '../src/game/input';
 
 describe('mapJoystickVector', () => {
   it('returns neutral inside the deadzone', () => {
@@ -45,5 +46,186 @@ describe('mapLookVector', () => {
     const v = mapLookVector(0.45, -0.25);
     expect(v.x).toBeCloseTo(0.36);
     expect(v.y).toBeCloseTo(-0.2);
+  });
+});
+
+class FakeClassList {
+  private values = new Set<string>();
+
+  add(...names: string[]): void {
+    for (const name of names) this.values.add(name);
+  }
+
+  remove(...names: string[]): void {
+    for (const name of names) this.values.delete(name);
+  }
+
+  contains(name: string): boolean {
+    return this.values.has(name);
+  }
+
+  toggle(name: string, force?: boolean): boolean {
+    const next = force ?? !this.values.has(name);
+    if (next) this.values.add(name);
+    else this.values.delete(name);
+    return next;
+  }
+}
+
+class FakeElement extends EventTarget {
+  classList = new FakeClassList();
+  style = { transform: '' };
+  private captured = new Set<number>();
+
+  constructor(private rect = { left: 0, top: 0, width: 100, height: 100 }) {
+    super();
+  }
+
+  getBoundingClientRect(): DOMRect {
+    return this.rect as DOMRect;
+  }
+
+  setPointerCapture(pointerId: number): void {
+    this.captured.add(pointerId);
+  }
+
+  releasePointerCapture(pointerId: number): void {
+    this.captured.delete(pointerId);
+  }
+
+  hasPointerCapture(pointerId: number): boolean {
+    return this.captured.has(pointerId);
+  }
+
+  closest(): Element | null {
+    return null;
+  }
+}
+
+class FakeMediaQueryList extends EventTarget {
+  matches = true;
+}
+
+const previousGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+};
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'document', { value: previousGlobals.document, configurable: true });
+  Object.defineProperty(globalThis, 'window', { value: previousGlobals.window, configurable: true });
+});
+
+function installMobileControlDom(): { moveJoystick: FakeElement; cameraJoystick: FakeElement; windowTarget: EventTarget } {
+  const elements = new Map<string, FakeElement>([
+    ['mobile-controls', new FakeElement()],
+    ['mobile-move-joystick', new FakeElement()],
+    ['mobile-move-stick', new FakeElement()],
+    ['mobile-camera-joystick', new FakeElement()],
+    ['mobile-camera-stick', new FakeElement()],
+  ]);
+  const body = new FakeElement();
+  const documentTarget = new EventTarget();
+  const windowTarget = new EventTarget() as EventTarget & { matchMedia(query: string): FakeMediaQueryList };
+  windowTarget.matchMedia = () => new FakeMediaQueryList();
+
+  const documentFake = documentTarget as EventTarget & {
+    body: FakeElement;
+    getElementById(id: string): FakeElement | null;
+  };
+  documentFake.body = body;
+  documentFake.getElementById = (id: string) => elements.get(id) ?? null;
+
+  Object.defineProperty(globalThis, 'document', { value: documentFake, configurable: true });
+  Object.defineProperty(globalThis, 'window', { value: windowTarget, configurable: true });
+
+  return {
+    moveJoystick: elements.get('mobile-move-joystick')!,
+    cameraJoystick: elements.get('mobile-camera-joystick')!,
+    windowTarget,
+  };
+}
+
+function pointerEvent(type: string, init: { pointerId: number; clientX?: number; clientY?: number }): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperties(event, {
+    pointerId: { value: init.pointerId },
+    clientX: { value: init.clientX ?? 0 },
+    clientY: { value: init.clientY ?? 0 },
+  });
+  return event;
+}
+
+describe('MobileControls pointer lifecycle', () => {
+  it('clears movement when the active pointer ends outside the joystick element', () => {
+    const { moveJoystick, windowTarget } = installMobileControlDom();
+    let lastMove: TouchMoveInput | null = null;
+    let clearCount = 0;
+    const input = {
+      setTouchMove: (move: TouchMoveInput) => { lastMove = move; },
+      clearTouchMove: () => { clearCount += 1; lastMove = null; },
+      setTouchLook: () => {},
+      setTouchLookVector: () => {},
+    } as unknown as Input;
+    const noop = () => {};
+
+    new MobileControls(input, {
+      onAttackNearest: noop,
+      onTarget: noop,
+      onInteract: noop,
+      onChat: noop,
+      onMenu: noop,
+      onSocial: noop,
+      onArena: noop,
+      onSpellbook: noop,
+      onMeters: noop,
+      onMap: noop,
+    }).start();
+
+    moveJoystick.dispatchEvent(pointerEvent('pointerdown', { pointerId: 4, clientX: 100, clientY: 50 }));
+
+    expect(lastMove).toEqual({ forward: false, back: false, strafeLeft: false, strafeRight: true });
+
+    windowTarget.dispatchEvent(pointerEvent('pointerup', { pointerId: 4 }));
+
+    expect(clearCount).toBe(1);
+    expect(lastMove).toBeNull();
+  });
+
+  it('keeps updating camera look when the active pointer moves outside the joystick element', () => {
+    const { cameraJoystick, windowTarget } = installMobileControlDom();
+    let touchLookActive = false;
+    let lastLook = { x: 0, y: 0 };
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: (active: boolean) => { touchLookActive = active; },
+      setTouchLookVector: (look: { x: number; y: number }) => { lastLook = look; },
+    } as unknown as Input;
+    const noop = () => {};
+
+    new MobileControls(input, {
+      onAttackNearest: noop,
+      onTarget: noop,
+      onInteract: noop,
+      onChat: noop,
+      onMenu: noop,
+      onSocial: noop,
+      onArena: noop,
+      onSpellbook: noop,
+      onMeters: noop,
+      onMap: noop,
+    }).start();
+
+    cameraJoystick.dispatchEvent(pointerEvent('pointerdown', { pointerId: 9, clientX: 50, clientY: 50 }));
+    windowTarget.dispatchEvent(pointerEvent('pointermove', { pointerId: 9, clientX: 100, clientY: 50 }));
+
+    expect(touchLookActive).toBe(true);
+    expect(lastLook).toEqual({ x: 0.8, y: 0 });
+
+    windowTarget.dispatchEvent(pointerEvent('pointercancel', { pointerId: 9 }));
+
+    expect(touchLookActive).toBe(false);
+    expect(lastLook).toEqual({ x: 0, y: 0 });
   });
 });


### PR DESCRIPTION
## Summary
- Keeps mobile move and camera joysticks tracking the active pointer after a thumb leaves the visible joystick element.
- Clears stuck movement/look state when Chrome sends pointer release, pointer cancel, lost capture, blur, or hidden-page events outside the joystick element.
- Adds focused regression coverage for movement release and camera rotation continuing outside the joystick element.

## Diagnosis
The mobile controls captured pointer input on each joystick, but the lifecycle handlers only listened on the joystick elements themselves. If mobile Chrome delivered the active pointer's move or release outside that element, the previous move/look vector could stay latched, making the joystick appear stuck in one direction or unable to rotate.

## Verification
- `npx vitest run tests/mobile_controls.test.ts`; 1 file passed, 8 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- Full local gate passed: `npm test` (35 files, 399 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.

## Real behavior proof
- Behavior addressed: mobile Chrome feedback after release 0.4 reported the joystick sometimes locking to one direction or failing to rotate.
- Environment tested: focused pointer-lifecycle regression tests for the mobile control code.
- Not tested: manual mobile Chrome gameplay was not run locally.

## Risk
Low client-input risk. The change is limited to mobile joystick pointer lifecycle handling and preserves the existing joystick vector mapping, combat controls, simulation, server authority, and desktop input paths.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
