### PR TITLE
fix: support friendly spell targets

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -789,10 +789,42 @@ export class Sim {
   private effectiveArmor(e: Entity): number {
     let armor = e.stats.armor;
     for (const a of e.auras) {
+      if (e.kind !== 'player' && a.kind === 'buff_armor') armor += a.value;
       if (a.kind === 'sunder') armor -= a.value * (a.stacks ?? 1);
     }
     return Math.max(0, armor);
   }
+
+  private effectiveAttackPower(e: Entity): number {
+    let attackPower = e.attackPower;
+    if (e.kind !== 'player') {
+      for (const a of e.auras) {
+        if (a.kind === 'buff_ap') attackPower += a.value;
+      }
+    }
+    return attackPower;
+  }
+
+  private nonPlayerAuraHp(aura: Aura): number {
+    if (aura.kind === 'buff_sta') return aura.value * 10;
+    if (aura.kind === 'buff_allstats') return aura.value * 10;
+    return 0;
+  }
+
+  private applyNonPlayerStatAura(target: Entity, aura: Aura, direction: 1 | -1): void {
+    if (target.kind === 'player') return;
+    const hpDelta = this.nonPlayerAuraHp(aura) * direction;
+    if (hpDelta === 0) return;
+    const hpFrac = target.maxHp > 0 ? target.hp / target.maxHp : 1;
+    target.maxHp = Math.max(1, target.maxHp + hpDelta);
+    target.hp = target.dead ? 0 : Math.max(1, Math.min(target.maxHp, Math.round(target.maxHp * hpFrac)));
+  }
+
+  private clearNonPlayerStatAuras(target: Entity): void {
+    if (target.kind === 'player') return;
+    for (const aura of target.auras) this.applyNonPlayerStatAura(target, aura, -1);
+  }
+
   // swing interval multiplier: >1 = slower (thunder clap), haste divides
   private swingIntervalMult(e: Entity): number {
     let m = 1;
@@ -1061,6 +1093,7 @@ export class Sim {
       }
       if (a.remaining <= 0) {
         e.auras.splice(i, 1);
+        this.applyNonPlayerStatAura(e, a, -1);
         this.emit({ type: 'aura', targetId: e.id, name: a.name, gained: false });
         if (a.kind.startsWith('buff') || a.kind.startsWith('form')) statsDirty = true;
       }
@@ -1439,7 +1472,7 @@ export class Sim {
         }
         case 'finisherDamage': {
           if (!target || spentCombo <= 0) break;
-          let dmg = eff.base + eff.perCombo * spentCombo + this.rng.range(0, eff.variance) + (p.attackPower / 14);
+          let dmg = eff.base + eff.perCombo * spentCombo + this.rng.range(0, eff.variance) + (this.effectiveAttackPower(p) / 14);
           const crit = this.rng.chance(p.critChance);
           if (crit) dmg *= 2;
           dmg *= 1 - armorReduction(this.effectiveArmor(target), p.level);
@@ -1750,8 +1783,12 @@ export class Sim {
   private applyAura(target: Entity, aura: Aura): void {
     if (target.kind === 'npc' && isRejectedFriendlyNpcAura(aura)) return;
     const existing = target.auras.findIndex((a) => a.id === aura.id && a.sourceId === aura.sourceId);
-    if (existing >= 0) target.auras.splice(existing, 1);
+    if (existing >= 0) {
+      this.applyNonPlayerStatAura(target, target.auras[existing], -1);
+      target.auras.splice(existing, 1);
+    }
     target.auras.push(aura);
+    this.applyNonPlayerStatAura(target, aura, 1);
     this.emit({ type: 'aura', targetId: target.id, name: aura.name, gained: true });
     if (target.kind === 'player') {
       const meta = this.players.get(target.id);
@@ -1843,6 +1880,8 @@ export class Sim {
   /** Dismissal, owner logout, or pet respawn: the beast goes back to the wild
    *  and walks home. Mobs that were fighting it forget it. */
   private releasePetToWild(pet: Entity): void {
+    this.clearNonPlayerStatAuras(pet);
+    pet.auras = [];
     pet.ownerId = null;
     pet.petTauntTimer = 0;
     pet.hostile = true;
@@ -1959,7 +1998,7 @@ export class Sim {
     // weapon imbues (seals, rockbiter) add flat damage to every swing
     let imbueBonus = 0;
     for (const a of attacker.auras) if (a.kind === 'imbue') imbueBonus += a.value;
-    let dmg = (this.rng.range(attacker.weapon.min, attacker.weapon.max) + (attacker.attackPower / 14) * attacker.weapon.speed) * mult + bonus + imbueBonus;
+    let dmg = (this.rng.range(attacker.weapon.min, attacker.weapon.max) + (this.effectiveAttackPower(attacker) / 14) * attacker.weapon.speed) * mult + bonus + imbueBonus;
     const critChance = Math.max(0.005, attacker.critChance - Math.max(0, target.level - attacker.level) * 0.002);
     const crit = this.rng.chance(critChance);
     if (crit) dmg *= 2;
@@ -2113,6 +2152,7 @@ export class Sim {
   private handleDeath(e: Entity, killer: Entity | null): void {
     e.dead = true;
     e.hp = 0;
+    this.clearNonPlayerStatAuras(e);
     e.auras = [];
     e.castingAbility = null;
     this.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
@@ -2515,7 +2555,7 @@ export class Sim {
       this.emit({ type: 'damage', sourceId: mob.id, targetId: target.id, amount: 0, crit: false, school: 'physical', ability: null, kind: 'dodge' });
       return;
     }
-    let dmg = this.rng.range(mob.weapon.min, mob.weapon.max);
+    let dmg = this.rng.range(mob.weapon.min, mob.weapon.max) + (this.effectiveAttackPower(mob) / 14) * mob.weapon.speed;
     const crit = this.rng.chance(0.05);
     if (crit) dmg *= 2;
     const enrage = MOBS[mob.templateId]?.enrage;
@@ -2616,6 +2656,7 @@ export class Sim {
   }
 
   private respawnMob(mob: Entity): void {
+    this.clearNonPlayerStatAuras(mob);
     mob.dead = false;
     mob.lootable = false;
     mob.loot = null;
@@ -3260,8 +3301,12 @@ export class Sim {
   }
 
   private isFriendlyTo(caster: Entity, target: Entity): boolean {
-    if (target.kind !== 'player') return false;
-    return !this.isHostileTo(caster, target);
+    if (target.kind === 'player') return !this.isHostileTo(caster, target);
+    if (target.kind === 'mob' && target.ownerId !== null) {
+      const owner = this.entities.get(target.ownerId);
+      return !!owner && owner.kind === 'player' && !this.isHostileTo(caster, owner);
+    }
+    return false;
   }
 
   // -------------------------------------------------------------------------

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -71,6 +71,28 @@ describe('nine classes', () => {
     expect(p.hp).toBe(hpBefore); // fully soaked
   });
 
+  it('friendly target spells can affect selected players', () => {
+    const sim = makeWorld();
+    const priestId = sim.addPlayer('priest', 'Healer');
+    const priest = sim.entities.get(priestId)!;
+    const allyId = sim.addPlayer('warrior', 'Ally');
+    const ally = sim.entities.get(allyId)!;
+    teleport(sim, priestId, ally.pos.x + 5, ally.pos.z);
+    sim.setPlayerLevel(6, priestId);
+    priest.resource = priest.maxResource;
+    ally.hp = 20;
+
+    sim.targetEntity(ally.id, priestId);
+    sim.castAbility('lesser_heal', priestId);
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    expect(ally.hp).toBeGreaterThan(20);
+
+    for (let i = 0; i < 25; i++) sim.tick();
+    sim.castAbility('power_word_shield', priestId);
+    sim.tick();
+    expect(ally.auras.some((a) => a.kind === 'absorb')).toBe(true);
+  });
+
   it('renew ticks healing over time', () => {
     const sim = new Sim({ seed: 42, playerClass: 'priest' });
     sim.setPlayerLevel(8);

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -387,6 +387,55 @@ describe('hunter pets', () => {
     expect(sim.petOf(sim.playerId)).toBe(wolf);
   });
 
+  it('friendly target spells can affect controlled pets', () => {
+    const { sim, wolf: pet } = tamedSetup();
+    const druidId = sim.addPlayer('druid', 'Druid');
+    const druid = sim.entities.get(druidId)!;
+    teleport(sim, druid, pet.pos.x + 5, pet.pos.z);
+    druid.resource = druid.maxResource;
+    const armorBefore = (sim as any).effectiveArmor(pet);
+
+    sim.targetEntity(pet.id, druidId);
+    sim.castAbility('mark_of_the_wild', druidId);
+    expect(pet.auras.some((a) => a.id === 'mark_of_the_wild')).toBe(true);
+    expect((sim as any).effectiveArmor(pet)).toBeGreaterThan(armorBefore);
+
+    const priestId = sim.addPlayer('priest', 'Priest');
+    const priest = sim.entities.get(priestId)!;
+    teleport(sim, priest, pet.pos.x + 6, pet.pos.z);
+    priest.resource = priest.maxResource;
+    const maxHpBefore = pet.maxHp;
+    sim.targetEntity(pet.id, priestId);
+    sim.castAbility('power_word_fortitude', priestId);
+    expect(pet.maxHp).toBeGreaterThan(maxHpBefore);
+
+    const paladinId = sim.addPlayer('paladin', 'Paladin');
+    const paladin = sim.entities.get(paladinId)!;
+    sim.setPlayerLevel(4, paladinId);
+    teleport(sim, paladin, pet.pos.x + 7, pet.pos.z);
+    paladin.resource = paladin.maxResource;
+    const attackPowerBefore = (sim as any).effectiveAttackPower(pet);
+    sim.targetEntity(pet.id, paladinId);
+    sim.castAbility('blessing_of_might', paladinId);
+    expect((sim as any).effectiveAttackPower(pet)).toBeGreaterThan(attackPowerBefore);
+
+    pet.hp = pet.maxHp - 40;
+    const damagedHp = pet.hp;
+    for (let i = 0; i < 20 * 2; i++) sim.tick();
+    sim.castAbility('healing_touch', druidId);
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+
+    expect(pet.hp).toBeGreaterThan(damagedHp);
+
+    (sim as any).dealDamage(null, pet, pet.hp, false, 'physical', 'test', 'hit');
+    expect(pet.dead).toBe(true);
+    expect(pet.auras).toHaveLength(0);
+    expect(pet.maxHp).toBe(maxHpBefore);
+    (sim as any).respawnMob(pet);
+    expect(pet.auras).toHaveLength(0);
+    expect(pet.maxHp).toBe(maxHpBefore);
+  });
+
   it('the pet assists against attackers, growls, and builds its own threat', () => {
     const { sim, wolf: pet } = tamedSetup();
     const boar = nearestMob(sim, 'wild_boar');
@@ -408,10 +457,21 @@ describe('hunter pets', () => {
 
   it('dismiss releases the pet back to the wild', () => {
     const { sim, wolf } = tamedSetup();
+    const priestId = sim.addPlayer('priest', 'Priest');
+    const priest = sim.entities.get(priestId)!;
+    teleport(sim, priest, wolf.pos.x + 5, wolf.pos.z);
+    priest.resource = priest.maxResource;
+    const maxHpBefore = wolf.maxHp;
+    sim.targetEntity(wolf.id, priestId);
+    sim.castAbility('power_word_fortitude', priestId);
+    expect(wolf.maxHp).toBeGreaterThan(maxHpBefore);
+
     for (let i = 0; i < 25; i++) sim.tick();
     sim.castAbility('dismiss_pet');
     expect(wolf.ownerId).toBe(null);
     expect(wolf.hostile).toBe(true);
+    expect(wolf.auras).toHaveLength(0);
+    expect(wolf.maxHp).toBe(maxHpBefore);
     expect(sim.petOf(sim.playerId)).toBe(null);
   });
 


### PR DESCRIPTION
## Summary
- Addresses #133 by covering friendly-target spells on selected friendly players and completing the same behavior for controlled pets.
- Keeps existing player-friendly targeting explicit with regression coverage for healing and shielding another selected player.
- Allows controlled pets to resolve as friendly spell targets when their owner is friendly to the caster, and makes pet-targeted armor, stamina, and attack-power buffs affect the pet stats they advertise.
- Cleans up pet stat-buff deltas when auras are replaced, expire, the pet dies, respawns, or is dismissed back to the wild.

## Diagnosis
Friendly-target abilities already resolved selected friendly players before falling back to self, but that behavior was not covered by a focused regression. Controlled pets were non-hostile mob entities, so selected pets fell outside the friendly-target predicate; once pet targeting was allowed, pet stat buffs needed explicit non-player stat handling so buffs did real gameplay work and did not leak into wild mob state.

## Verification
- `npx vitest run tests/social.test.ts tests/threat.test.ts`; 2 files passed, 60 tests passed.
- `npx tsc --noEmit`; passed.
- Full local verification on the final branch: `npm test` (35 files passed, 399 tests passed), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.

## Risk
This changes shared sim targeting and pet stat handling. Friendly player targeting remains the existing non-hostile player path, now covered by tests. The new pet scope is limited to controlled pets whose owner is friendly to the caster; wild mobs and NPCs remain outside friendly spell targeting, and pet stat buffs are reversed on cleanup paths covered by regression tests.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
