### PR TITLE
feat: add who command

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -41,6 +41,7 @@ const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
+const WHO_RESULT_LIMIT = 50;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
 
@@ -62,6 +63,7 @@ export interface ClientSession {
   // character ids this player has ignored; chat from them is dropped before
   // delivery. Loaded from the DB on join, kept in sync by social commands.
   blockedIds: Set<number>;
+  blockListLoaded: boolean;
   // name of the last player to whisper this session, for WoW's /r reply
   lastWhisperFrom: string | null;
   // serialized form of each delta self field as last sent to this client;
@@ -116,6 +118,14 @@ interface WireAura {
   kind: string;
   rem: number;
   dur: number;
+}
+
+interface WhoRosterRow {
+  name: string;
+  cls: string;
+  level: number;
+  zone: string;
+  status: PresenceStatus;
 }
 
 // Identity fields rarely change, so they ride only in "full" records: on an
@@ -410,6 +420,7 @@ export class GameServer {
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
       blockedIds: new Set(),
+      blockListLoaded: false,
       lastWhisperFrom: null,
       lastSent: {},
       sentEnts: new Map(),
@@ -439,6 +450,7 @@ export class GameServer {
   private async initSocial(session: ClientSession): Promise<void> {
     try {
       session.blockedIds = new Set(await this.socialDb.blockedIds(session.characterId));
+      session.blockListLoaded = true;
     } catch (err) {
       console.error('failed to load block list:', err);
     }
@@ -637,6 +649,10 @@ export class GameServer {
         if (typeof msg.text !== 'string') break;
         if (!this.consumeChatToken(session)) break;
         const text = msg.text.trim();
+        if (/^\/who(?:\s|$)/i.test(text)) {
+          this.sendWhoRoster(session);
+          break;
+        }
         // guild and officer chat are persistent + cross-zone, so they live in
         // the server's SocialService rather than the sim (no guild concept)
         const gm = /^\/(?:gu|guild)\s+([\s\S]+)$/i.exec(text);
@@ -1061,6 +1077,60 @@ export class GameServer {
       this.send(session, { t: 'events', list: [{ type: 'error', text: 'You are sending messages too quickly. Slow down.' }] });
     }
     return false;
+  }
+
+  private sendWhoRoster(session: ClientSession): void {
+    if (!session.blockListLoaded) {
+      this.send(session, { t: 'events', list: [{ type: 'error', text: 'Your ignore list is still loading. Try /who again in a moment.' }] });
+      return;
+    }
+    const rows = this.whoRosterFor(session);
+    const total = rows.length;
+    const list: { type: 'log'; text: string; color: string }[] = [{
+      type: 'log',
+      text: `Who: ${total} ${total === 1 ? 'player' : 'players'} online on ${REALM}.`,
+      color: '#7fd4ff',
+    }];
+    for (const row of rows.slice(0, WHO_RESULT_LIMIT)) {
+      const status = row.status === 'online' ? '' : ` (${row.status})`;
+      list.push({
+        type: 'log',
+        text: `${row.name} - level ${row.level} ${row.cls} - ${row.zone}${status}`,
+        color: '#c9b27a',
+      });
+    }
+    if (total > WHO_RESULT_LIMIT) {
+      list.push({
+        type: 'log',
+        text: `...and ${total - WHO_RESULT_LIMIT} more.`,
+        color: '#998d6a',
+      });
+    }
+    this.send(session, { t: 'events', list });
+  }
+
+  private whoRosterFor(viewer: ClientSession): WhoRosterRow[] {
+    const rows: WhoRosterRow[] = [];
+    for (const session of this.clients.values()) {
+      if (!this.canShowInWho(viewer, session)) continue;
+      const e = this.sim.entities.get(session.pid);
+      const meta = this.sim.meta(session.pid);
+      if (!e || !meta) continue;
+      rows.push({
+        name: session.name,
+        cls: meta.cls,
+        level: e.level,
+        ...this.presenceOf(session),
+      });
+    }
+    return rows.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private canShowInWho(viewer: ClientSession, candidate: ClientSession): boolean {
+    if (!candidate.blockListLoaded) return false;
+    if (viewer.blockedIds.has(candidate.characterId)) return false;
+    if (candidate.characterId !== viewer.characterId && candidate.blockedIds.has(viewer.characterId)) return false;
+    return true;
   }
 
   private broadcastSystem(text: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3179,6 +3179,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/who(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, 'The /who roster is available in online play.');
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -126,6 +126,19 @@ describe('chat channels', () => {
     expect(events.some((e) => e.type === 'error' && e.text.includes('/dance'))).toBe(true);
   });
 
+  it('/who explains that the roster is online-only in offline sim play', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/who', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'The /who roster is available in online play.',
+    }));
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -14,6 +14,7 @@ vi.mock('../server/db', () => ({
 
 import { censorChatText, GameServer, ClientSession } from '../server/game';
 import { ClientWorld } from '../src/net/online';
+import type { PlayerClass } from '../src/sim/types';
 
 const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
 
@@ -34,10 +35,18 @@ function lastSnap(sent: any[]): any {
   return null;
 }
 
-function joinServer(server: GameServer, fc: FakeClient, characterId: number, name: string): ClientSession {
-  const session = server.join(fc.ws, characterId, characterId, name, 'warrior', null);
+function joinServer(server: GameServer, fc: FakeClient, characterId: number, name: string, cls: PlayerClass = 'warrior'): ClientSession {
+  const session = server.join(fc.ws, characterId, characterId, name, cls, null);
   if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
   return session;
+}
+
+function eventTexts(sent: any[]): string[] {
+  return sent
+    .flatMap((msg) => msg.t === 'events' ? msg.list : [])
+    .filter((ev) => ev.type === 'log' || ev.type === 'error')
+    .map((ev) => ev.text);
 }
 
 function broadcast(server: GameServer): void {
@@ -273,6 +282,75 @@ describe('chat moderation', () => {
       warn.mockRestore();
       rmSync(dir, { force: true, recursive: true });
     }
+  });
+});
+
+describe('/who command', () => {
+  it('lists online players with class, level, realm, and zone metadata', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph', 'warrior');
+    const fc2 = fakeWs();
+    const other = joinServer(server, fc2, 2, 'Bet', 'mage');
+    server.sim.setPlayerLevel(7, other.pid);
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    const text = eventTexts(fc.sent).join('\n');
+    expect(text).toContain('Who: 2 players online on Claudemoon.');
+    expect(text).toContain('Aleph - level 1 warrior - Eastbrook Vale');
+    expect(text).toContain('Bet - level 7 mage - Eastbrook Vale');
+  });
+
+  it('hides ignored players and players who ignored the requester', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph');
+    const fcIgnored = fakeWs();
+    const ignored = joinServer(server, fcIgnored, 2, 'Bet');
+    const fcBlocking = fakeWs();
+    const blocking = joinServer(server, fcBlocking, 3, 'Gimel');
+    self.blockedIds = new Set([ignored.characterId]);
+    blocking.blockedIds = new Set([self.characterId]);
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    const text = eventTexts(fc.sent).join('\n');
+    expect(text).toContain('Who: 1 player online on Claudemoon.');
+    expect(text).toContain('Aleph - level 1 warrior - Eastbrook Vale');
+    expect(text).not.toContain('Bet');
+    expect(text).not.toContain('Gimel');
+  });
+
+  it('waits for the requester ignore list before showing online players', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph');
+    joinServer(server, fakeWs(), 2, 'Bet');
+    self.blockListLoaded = false;
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    expect(eventTexts(fc.sent)).toContain('Your ignore list is still loading. Try /who again in a moment.');
+  });
+
+  it('omits players whose own ignore list is still loading', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph');
+    const pending = joinServer(server, fakeWs(), 2, 'Bet');
+    pending.blockListLoaded = false;
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    const text = eventTexts(fc.sent).join('\n');
+    expect(text).toContain('Who: 1 player online on Claudemoon.');
+    expect(text).toContain('Aleph - level 1 warrior - Eastbrook Vale');
+    expect(text).not.toContain('Bet');
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds an online `/who` chat command for issue #106 so players can discover who is currently online.
- Returns a server-authoritative roster with player name, level, class, realm, zone, and activity status when applicable.
- Respects ignore/block privacy in both directions and fails closed while ignore lists are still loading.
- Adds an offline fallback message instead of treating `/who` as an unknown command in offline play.

## Implementation Notes
- The roster is built from live server sessions at request time, so no persistent state or snapshot payload changes are needed.
- `/who` output is delivered only to the requester as system log rows and capped to 50 visible entries.
- Candidates are hidden if the requester ignores them, if they ignore the requester, or if their own ignore list has not finished loading.

## Verification
- `npx vitest run tests/snapshots.test.ts tests/chat.test.ts`; 30 tests passed.
- `npx tsc --noEmit`; passed.
- Full closeout gate after the final logic: `npm test` (402 tests passed), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.

## Risk
Low multiplayer/server risk. The command is read-only, does not alter persistence or simulation state, and uses existing session/block-list state. The main user-visible change is a new chat command in online play.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
