### PR TITLE
fix: scope arena leaderboard to the current realm

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -346,11 +346,12 @@ export async function topArenaRatings(limit = 20): Promise<ArenaLeaderRow[]> {
             COALESCE((state->>'arenaWins')::int, 0)     AS wins,
             COALESCE((state->>'arenaLosses')::int, 0)   AS losses
        FROM characters
-      WHERE state IS NOT NULL
+      WHERE realm = $1
+        AND state IS NOT NULL
         AND COALESCE((state->>'arenaWins')::int, 0) + COALESCE((state->>'arenaLosses')::int, 0) > 0
       ORDER BY rating DESC, wins DESC, name ASC
-      LIMIT $1`,
-    [Math.max(1, Math.min(100, limit))],
+      LIMIT $2`,
+    [REALM, Math.max(1, Math.min(100, limit))],
   );
   return res.rows.map((r) => ({
     name: r.name, class: r.class, level: r.level,

--- a/tests/arena_db.test.ts
+++ b/tests/arena_db.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => {
+  process.env.DATABASE_URL ??= 'postgres://test/test';
+  return { query: vi.fn() };
+});
+
+vi.mock('pg', () => ({
+  Pool: vi.fn(function Pool() {
+    return { query: dbMock.query };
+  }),
+}));
+
+import { topArenaRatings } from '../server/db';
+import { REALM } from '../server/realm';
+
+beforeEach(() => {
+  dbMock.query.mockReset();
+});
+
+describe('arena leaderboard', () => {
+  it('scopes the ladder to the current realm', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await topArenaRatings();
+
+    const [sql, params] = dbMock.query.mock.calls[0];
+    // The ladder reads from the shared `characters` table; without a realm
+    // predicate it would leak rankings from every other realm's process.
+    expect(sql).toContain('WHERE realm = $1');
+    expect(params[0]).toBe(REALM);
+  });
+
+  it('clamps the limit and binds it after the realm parameter', async () => {
+    dbMock.query.mockResolvedValueOnce({ rows: [] });
+
+    await topArenaRatings(999);
+
+    const [sql, params] = dbMock.query.mock.calls[0];
+    expect(sql).toContain('LIMIT $2');
+    expect(params).toEqual([REALM, 100]);
+  });
+
+  it('coerces numeric rating/record fields from JSONB strings', async () => {
+    dbMock.query.mockResolvedValueOnce({
+      rows: [{ name: 'Thrall', class: 'shaman', level: 60, rating: '1832', wins: '12', losses: '3' }],
+    });
+
+    await expect(topArenaRatings(5)).resolves.toEqual([
+      { name: 'Thrall', class: 'shaman', level: 60, rating: 1832, wins: 12, losses: 3 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

`topArenaRatings` (the Ashen Coliseum all-time ladder) queries the shared `characters` table **without a `realm` predicate**:

```sql
FROM characters
WHERE state IS NOT NULL
  AND COALESCE((state->>'arenaWins')::int, 0) + COALESCE((state->>'arenaLosses')::int, 0) > 0
```

In the process-per-realm model (`server/db.ts:225` — "a process only ever lists, loads, or creates characters on its own realm"), every other character read is realm-scoped: `getCharacter`, `searchCharacters`, `renameCharacter`, `deleteCharacter`, etc. The arena leaderboard was the lone exception.

## Impact

With more than one realm sharing a database, each realm's ladder shows ranked characters from **all** realms — cross-realm data leakage and an incorrect leaderboard (players see opponents they can never face). Invisible in single-realm dev/test, surfaces the moment a second realm exists.

## Fix

Add `WHERE realm = $1` and bind `REALM`, shifting the limit bind to `$2`. One-line behavioral change, consistent with every sibling query.

## Tests

New `tests/arena_db.test.ts` (mirrors the existing `tests/db_search.test.ts` pg-mock pattern):
- asserts the query is realm-scoped and binds `REALM` first
- verifies limit clamping binds after the realm param
- covers JSONB string→number coercion of rating/record fields

Verified the new tests **fail on the pre-fix query** and pass after. Full suite: 392 tests pass; `tsc --noEmit` clean. (The unrelated pre-existing `homepage_foundation.test.ts` DATABASE_URL failure exists on `main` independently of this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)