### PR TITLE
fix: harden rate limiter and repair broken test suite loading

### DIFF
--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -56,7 +56,10 @@ export function requestIp(req: http.IncomingMessage): string {
   for (let i = chain.length - 1; i >= 0; i--) {
     if (!isTrustedProxy(chain[i])) return chain[i];
   }
-  return chain[0] ?? remote;
+  // Every hop was a trusted proxy (or the header was empty). The leftmost
+  // chain entry is client-supplied and spoofable, so fall back to the
+  // unspoofable socket peer instead of trusting chain[0].
+  return remote;
 }
 
 export function rateLimited(req: http.IncomingMessage, maxPerMinute = 20): boolean {
@@ -66,6 +69,15 @@ export function rateLimited(req: http.IncomingMessage, maxPerMinute = 20): boole
   const list = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
   const updated = [...list, now];
   attempts.set(ip, updated);
-  if (attempts.size > MAX_TRACKED_IPS) attempts.clear(); // memory backstop
+  // Memory backstop: prune entries whose windows have fully expired rather
+  // than clearing the whole map. Wiping every entry would reset the live
+  // windows of legitimate clients too, letting an attacker who churns through
+  // many distinct IP keys periodically flush the limiter for everyone.
+  if (attempts.size > MAX_TRACKED_IPS) {
+    for (const [key, times] of attempts) {
+      if (key === ip) continue;
+      if (times.every((t) => t <= windowStart)) attempts.delete(key);
+    }
+  }
   return updated.length > maxPerMinute;
 }

--- a/tests/homepage_foundation.test.ts
+++ b/tests/homepage_foundation.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+
+// db.ts requires DATABASE_URL at import time; set it before importing so the
+// module loads. The accounts-count test spies on pool.query and never opens a
+// real connection.
+vi.hoisted(() => {
+  process.env.DATABASE_URL = "postgres://test/test";
+});
 import { pool, getAccountsCount } from "../server/db";
 import { t, setLanguage, getLanguage } from "../src/ui/i18n";
 import { Api } from "../src/net/online";

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -110,6 +110,13 @@ describe('rate-limit client IP selection', () => {
     // ...while another player behind the same proxy is unaffected
     expect(rateLimited(fakeReq({ 'x-forwarded-for': '198.51.100.201' }, '172.18.0.1'))).toBe(false);
   });
+
+  it('falls back to the socket peer, not the spoofable leftmost hop, when every forwarded hop is trusted', () => {
+    // All hops are private/trusted, so there is no untrusted client to resolve.
+    // The leftmost entry is client-supplied; we must use the real socket peer.
+    const req = fakeReq({ 'x-forwarded-for': '10.0.0.9, 172.18.0.1' }, '172.18.0.5');
+    expect(requestIp(req)).toBe('172.18.0.5');
+  });
 });
 
 describe('malformed websocket frames cannot crash the server', () => {


### PR DESCRIPTION
## Summary

Three high-confidence bugs found while scanning the codebase for defects.

### 1. Rate limiter wiped all clients' windows on its memory backstop
`server/ratelimit.ts` called `attempts.clear()` once the tracking map exceeded `MAX_TRACKED_IPS`, erasing **every** IP's sliding window — including legitimate clients mid-window. An attacker who churns through many distinct forwarded-IP keys (the resolved key is attacker-controllable once behind the trusted proxy) could force repeated full flushes, effectively disabling the limiter for everyone. Now we prune only **fully-expired** windows, keeping memory bounded without resetting live limits.

### 2. `requestIp()` fell back to the spoofable leftmost X-Forwarded-For hop
When every hop in the chain was trusted, `requestIp()` returned `chain[0]` — the leftmost, fully client-supplied value. That contradicts the file's own documented threat model ("everything left of [the first untrusted hop] is client-supplied and spoofable"). It now falls back to the unspoofable socket peer (`remote`).

### 3. A whole test suite failed to load
`tests/homepage_foundation.test.ts` imports `server/db.ts`, which throws at **module load** when `DATABASE_URL` is unset — crashing the entire suite before any test ran. Added the `vi.hoisted()` `DATABASE_URL` stub already used by the other db-touching tests (the test only spies on `pool.query`, never connecting).

## Testing
- Added a regression test for the forwarded-IP fallback.
- Full suite: **398 passing / 35 files** (previously 389 passing with 1 suite that couldn't load).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)