### PR TITLE
Tune mob reset and social pull behavior

### DIFF
--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { ...pos }, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -26,6 +26,8 @@ import {
 
 const LEASH_DISTANCE = 45;
 const DUNGEON_LEASH_DISTANCE = 70;
+const SOCIAL_PULL_RADIUS = 5;
+const MURLOC_SOCIAL_PULL_RADIUS = 8;
 const CORPSE_DURATION = 60;
 const EVADE_SPEED_MULT = 1.6;
 const BACKPEDAL_MULT = 0.65;
@@ -1753,6 +1755,8 @@ export class Sim {
     if (existing >= 0) target.auras.splice(existing, 1);
     target.auras.push(aura);
     this.emit({ type: 'aura', targetId: target.id, name: aura.name, gained: true });
+    const source = this.entities.get(aura.sourceId);
+    this.refreshMobLeashFromAction(source ?? null, target);
     if (target.kind === 'player') {
       const meta = this.players.get(target.id);
       if (meta) recalcPlayerStats(target, meta.cls, meta.equipment);
@@ -2052,6 +2056,7 @@ export class Sim {
     }
 
     if (source && source.id !== target.id) this.enterCombat(source, target);
+    this.refreshMobLeashFromAction(source, target);
 
     // classic threat: damage (and the ability's flat bonus) lands on the mob's
     // hate table, scaled by the attacker's stance/form modifiers
@@ -2263,9 +2268,15 @@ export class Sim {
   // Mob AI
   // -------------------------------------------------------------------------
 
+  private refreshMobLeashFromAction(source: Entity | null, target: Entity): void {
+    if (!source || source.id === target.id || target.kind !== 'mob' || target.ownerId !== null || target.dead) return;
+    if (source.kind !== 'player' && source.ownerId === null) return;
+    target.leashAnchor = { ...target.pos };
+  }
+
   // When a mob's target dies/leaves it swings to its next-highest-threat
-  // attacker; with an empty hate table it falls back to the nearest living
-  // player, and failing that it goes home.
+  // attacker. With no living threat left, it evades home instead of grabbing a
+  // nearby bystander who never acted on the mob.
   private retargetMob(mob: Entity): void {
     const next = this.highestThreatTarget(mob);
     if (next) {
@@ -2274,16 +2285,8 @@ export class Sim {
       mob.inCombat = true;
       return;
     }
-    const near = this.nearestLivingPlayer(mob.pos, 35);
-    if (near) {
-      addThreat(mob, near.e.id, 1);
-      mob.aggroTargetId = near.e.id;
-      mob.aiState = 'chase';
-      mob.inCombat = true;
-    } else {
-      mob.aggroTargetId = null;
-      mob.aiState = 'evade';
-    }
+    mob.aggroTargetId = null;
+    mob.aiState = 'evade';
   }
 
   /** Highest-threat living attacker on the table; prunes stale entries. */
@@ -2336,15 +2339,17 @@ export class Sim {
     mob.aiState = 'chase';
     mob.aggroTargetId = target.id;
     mob.inCombat = true;
+    mob.leashAnchor = { ...mob.pos };
     addThreat(mob, target.id, 1); // seed the hate table so taunts/heals have a baseline
     if (social) {
-      const pullRadius = MOBS[mob.templateId]?.family === 'murloc' ? 18 : 12;
+      const pullRadius = MOBS[mob.templateId]?.family === 'murloc' ? MURLOC_SOCIAL_PULL_RADIUS : SOCIAL_PULL_RADIUS;
       this.grid.forEachInRadius(mob.pos.x, mob.pos.z, pullRadius, (m, d2) => {
         if (m.kind === 'mob' && m.id !== mob.id && !m.dead && m.hostile && m.aiState === 'idle' && m.ownerId === null
           && m.templateId === mob.templateId && d2 < pullRadius * pullRadius) {
           m.aiState = 'chase';
           m.aggroTargetId = target.id;
           m.inCombat = true;
+          m.leashAnchor = { ...m.pos };
           addThreat(m, target.id, 1);
         }
       });
@@ -2438,10 +2443,12 @@ export class Sim {
           break;
         }
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
-        if (dist2d(mob.pos, mob.spawnPos) > leash) {
+        const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
+        if (dist2d(mob.pos, leashAnchor) > leash) {
           mob.aiState = 'evade';
           mob.aggroTargetId = null;
           clearThreat(mob);
+          mob.leashAnchor = null;
           break;
         }
         const d = dist2d(mob.pos, target.pos);
@@ -2492,6 +2499,7 @@ export class Sim {
           mob.auras = [];
           mob.inCombat = false;
           mob.tappedById = null;
+          mob.leashAnchor = null;
           clearThreat(mob);
           this.despawnSummonedAdds(mob);
           mob.firedSummons = 0;
@@ -2631,6 +2639,7 @@ export class Sim {
     mob.aiState = 'idle';
     mob.aggroTargetId = null;
     mob.inCombat = false;
+    mob.leashAnchor = null;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -437,6 +437,7 @@ export interface Entity {
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active
   spawnPos: Vec3;
+  leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   wanderTarget: Vec3 | null;
   wanderTimer: number;
   aggroTargetId: number | null;

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -233,6 +233,56 @@ describe('combat', () => {
     expect(wolf.hp).toBe(wolf.maxHp);
   });
 
+  it('hostile actions refresh the mob leash anchor for kiting', () => {
+    const sim = makeSim('warrior');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    wolf.maxHp = 5000;
+    wolf.hp = 5000;
+    wolf.pos.x = wolf.spawnPos.x + 50;
+    wolf.pos.z = wolf.spawnPos.z;
+    wolf.pos.y = terrainHeight(wolf.pos.x, wolf.pos.z, sim.cfg.seed);
+    wolf.prevPos = { ...wolf.pos };
+    teleportTo(sim, wolf.pos.x + 2, wolf.pos.z);
+
+    (sim as any).dealDamage(sim.player, wolf, 1, false, 'physical', 'Test', 'hit', true);
+    sim.tick();
+
+    expect(dist2d(wolf.pos, wolf.spawnPos)).toBeGreaterThan(45);
+    expect(wolf.aiState).not.toBe('evade');
+    expect(wolf.leashAnchor).not.toBeNull();
+  });
+
+  it('social pulls only very close same-template mobs', () => {
+    const sim = makeSim('warrior');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    const otherWolf = [...sim.entities.values()].find((e: any) => e.kind === 'mob' && e.id !== wolf.id && e.templateId === 'forest_wolf') as any;
+    wolf.pos = { ...wolf.spawnPos };
+    otherWolf.pos = { x: wolf.pos.x + 6, y: wolf.pos.y, z: wolf.pos.z };
+    otherWolf.prevPos = { ...otherWolf.pos };
+    (sim as any).rebucket(wolf);
+    (sim as any).rebucket(otherWolf);
+    teleportTo(sim, wolf.pos.x + 2, wolf.pos.z);
+
+    (sim as any).aggroMob(wolf, sim.player, true);
+
+    expect(otherWolf.aiState).toBe('idle');
+
+    const murloc = nearestMob(sim, 'mudfin_murloc');
+    const otherMurloc = [...sim.entities.values()].find((e: any) => e.kind === 'mob' && e.id !== murloc.id && e.templateId === 'mudfin_murloc') as any;
+    murloc.aiState = 'idle';
+    otherMurloc.aiState = 'idle';
+    murloc.pos = { ...murloc.spawnPos };
+    otherMurloc.pos = { x: murloc.pos.x + 9, y: murloc.pos.y, z: murloc.pos.z };
+    otherMurloc.prevPos = { ...otherMurloc.pos };
+    (sim as any).rebucket(murloc);
+    (sim as any).rebucket(otherMurloc);
+    teleportTo(sim, murloc.pos.x + 2, murloc.pos.z);
+
+    (sim as any).aggroMob(murloc, sim.player, true);
+
+    expect(otherMurloc.aiState).toBe('idle');
+  });
+
   it('dead mobs respawn', () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', respawnSeconds: 2 });
     const wolf = nearestMob(sim, 'forest_wolf');

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -232,6 +232,18 @@ describe('classic pull-over rules (110% melee / 130% ranged)', () => {
     // the dead player dropped off the table entirely
     expect(wolf.threat.has(a.id)).toBe(false);
   });
+
+  it('when the target dies the mob evades instead of attacking a bystander with no threat', () => {
+    const { sim, a, b, wolf } = aggroSetup();
+    teleport(sim, b, wolf.pos.x + 2, wolf.pos.z + 2);
+
+    (sim as any).dealDamage(wolf, a, 99999, false, 'physical', null, 'hit', true);
+
+    expect(a.dead).toBe(true);
+    expect(wolf.threat.has(b.id)).toBe(false);
+    expect(wolf.aggroTargetId).not.toBe(b.id);
+    expect(wolf.aiState).toBe('evade');
+  });
 });
 
 describe('taunt and growl', () => {


### PR DESCRIPTION
 ## Summary
  - Prevents mobs from retargeting uninvolved bystanders when their target dies.
  - Mobs now evade/reset when no living threat remains.
  - Hostile player/pet actions refresh a mob leash anchor, allowing kiting while still preserving home spawn.
  - Reduces social pull radius to 5 yards for same-template mobs and 8 yards for murlocs.
  - Adds coverage for bystander retargeting, leash refresh, and tighter social pulls.