### PR TITLE
Add admin account moderation controls

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -95,6 +95,16 @@
   tr.detail-row > td { background: #0d0d14; padding: 12px 16px; white-space: normal; }
   .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
   .detail-grid h4 { font-family: var(--title-font); color: var(--gold-dim); margin-bottom: 6px; font-size: 13px; }
+  .detail-row button {
+    padding: 4px 8px;
+    background: #1a1410;
+    color: #c9b27a;
+    border: 1px solid #463a1c;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .detail-row button:hover { color: #fff; border-color: var(--gold-dim); }
   @media (max-width: 800px) { .detail-grid { grid-template-columns: 1fr; } }
 
   /* ---------- controls ---------- */
@@ -124,6 +134,24 @@
   }
   .mod-actions button:hover, .mod-account-actions button:hover { color: #fff; border-color: var(--gold-dim); }
   .mod-account-actions input { padding: 6px 8px; background: #11111a; border: 1px solid var(--border); border-radius: 4px; color: var(--text); }
+  .account-admin-controls {
+    align-items: stretch;
+    padding: 10px;
+    background: #090910;
+    border: 1px solid #2a2414;
+    border-radius: 4px;
+  }
+  .account-status {
+    flex: 1 0 100%;
+    color: #c9b27a;
+    font-size: 12px;
+  }
+  .account-status .hint {
+    color: var(--text-dim);
+    margin-left: 8px;
+  }
+  .account-mod-reason { min-width: 300px; flex: 1 1 300px; }
+  .account-custom-expiry { width: 190px; }
   #mod-reason { min-width: 300px; flex: 1 1 300px; }
   #mod-custom-expiry { width: 190px; }
   .mod-confirm { display: none; margin: 10px 0; padding: 10px; border: 1px solid #8a6f2d; border-radius: 4px; background: #171207; }
@@ -133,8 +161,30 @@
   .mod-confirm dt { color: var(--text-dim); }
   .mod-confirm dd { color: var(--text); }
   .mod-confirm .confirm-actions { display: flex; gap: 8px; margin-top: 10px; }
-  .mod-confirm button { padding: 5px 10px; background: #1a1410; color: #c9b27a; border: 1px solid #463a1c; border-radius: 3px; cursor: pointer; }
-  .mod-confirm .danger { border-color: #b34a3a; color: #ff7a5e; }
+  .mod-confirm button {
+    min-width: 78px;
+    padding: 6px 12px;
+    background: linear-gradient(#2a2112, #15100b);
+    color: #e8d8a8;
+    border: 1px solid #6f5a2a;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1.1;
+  }
+  .mod-confirm button:hover { color: #fff; border-color: var(--gold-dim); }
+  .mod-confirm button:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 2px;
+  }
+  .mod-confirm button[data-confirm-moderation] {
+    color: var(--gold);
+    border-color: var(--gold-dim);
+  }
+  .mod-confirm .danger {
+    border-color: #b34a3a;
+    color: #ff7a5e;
+  }
 </style>
 </head>
 <body>

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -84,10 +84,13 @@ export async function handleAdminApi(
     const accountId = await adminAccountId(req);
     if (accountId === null) return fail(res, 401, 'admin authentication required');
 
-    const actionMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/(suspend|ban)$/.exec(path);
+    const actionMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/(suspend|ban|unban)$/.exec(path);
     if (req.method === 'POST' && actionMatch) {
       const targetAccountId = Number(actionMatch[1]);
-      const action = actionMatch[2] as 'suspend' | 'ban';
+      const action = actionMatch[2] as 'suspend' | 'ban' | 'unban';
+      if (action !== 'unban' && await isAdminAccount(targetAccountId)) {
+        return fail(res, 400, 'admin accounts cannot be suspended or banned');
+      }
       const body = await readBody(req);
       try {
         await moderateAccount({
@@ -97,8 +100,10 @@ export async function handleAdminApi(
           reason: body.reason,
           expiresAt: body.expiresAt,
         });
-        const statusText = action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
-        game.disconnectAccount(targetAccountId, statusText);
+        if (action !== 'unban') {
+          const statusText = action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
+          game.disconnectAccount(targetAccountId, statusText);
+        }
         return ok(res, { ok: true });
       } catch (err) {
         return fail(res, 400, err instanceof Error ? err.message : 'moderation action failed');

--- a/server/admin_db.ts
+++ b/server/admin_db.ts
@@ -107,6 +107,8 @@ export interface AdminAccountRow {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
   characterCount: number;
   maxLevel: number;
   playtimeSeconds: number;
@@ -125,6 +127,7 @@ export async function listAccounts(search: string, page: number, limit: number):
   const [rows, total] = await Promise.all([
     pool.query(
       `SELECT a.id, a.username, a.created_at, a.last_login, a.is_admin,
+              a.banned_at, a.suspended_until,
               count(c.id)::int AS character_count,
               COALESCE(max(c.level), 0)::int AS max_level,
               COALESCE((SELECT sum(EXTRACT(EPOCH FROM (COALESCE(s.ended_at, now()) - s.started_at)))
@@ -146,6 +149,8 @@ export async function listAccounts(search: string, page: number, limit: number):
       createdAt: r.created_at,
       lastLogin: r.last_login,
       isAdmin: r.is_admin,
+      bannedAt: r.banned_at,
+      suspendedUntil: r.suspended_until,
       characterCount: r.character_count,
       maxLevel: r.max_level,
       playtimeSeconds: Number(r.playtime_seconds),
@@ -226,6 +231,9 @@ export interface AccountDetail {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
+  moderationReason: string;
   playtimeSeconds: number;
   characters: {
     id: number;
@@ -250,7 +258,8 @@ export interface AccountDetail {
 export async function accountDetail(accountId: number): Promise<AccountDetail | null> {
   const [account, characters, sessions] = await Promise.all([
     pool.query(
-      `SELECT id, username, created_at, last_login, is_admin,
+      `SELECT id, username, created_at, last_login, is_admin, banned_at, suspended_until,
+              COALESCE(moderation_reason, '') AS moderation_reason,
               COALESCE((SELECT sum(EXTRACT(EPOCH FROM (COALESCE(s.ended_at, now()) - s.started_at)))
                         FROM play_sessions s WHERE s.account_id = accounts.id), 0)::bigint AS playtime_seconds
        FROM accounts WHERE id = $1`,
@@ -279,6 +288,9 @@ export async function accountDetail(accountId: number): Promise<AccountDetail | 
     createdAt: a.created_at,
     lastLogin: a.last_login,
     isAdmin: a.is_admin,
+    bannedAt: a.banned_at,
+    suspendedUntil: a.suspended_until,
+    moderationReason: a.moderation_reason,
     playtimeSeconds: Number(a.playtime_seconds),
     characters: characters.rows.map((c) => ({
       id: c.id,

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -2,7 +2,7 @@ import { pool } from './db';
 
 export const REPORT_REASONS = ['harassment', 'spam', 'cheating', 'offensive_name_or_chat', 'other'] as const;
 export type ReportReason = typeof REPORT_REASONS[number];
-export type ModerationAction = 'ignore' | 'suspend' | 'ban';
+export type ModerationAction = 'ignore' | 'suspend' | 'ban' | 'unban';
 
 const REPORT_DETAILS_MAX = 1000;
 const ACTION_REASON_MAX = 500;
@@ -194,7 +194,7 @@ export async function ignoreReport(reportId: number, adminAccountId: number, not
 export async function moderateAccount(input: {
   accountId: number;
   adminAccountId: number;
-  action: 'suspend' | 'ban';
+  action: 'suspend' | 'ban' | 'unban';
   reason: unknown;
   expiresAt?: unknown;
 }): Promise<void> {
@@ -218,6 +218,13 @@ export async function moderateAccount(input: {
       await client.query(
         `UPDATE accounts
          SET banned_at = now(), suspended_until = NULL, moderation_reason = $2
+         WHERE id = $1`,
+        [input.accountId, reason],
+      );
+    } else if (input.action === 'unban') {
+      await client.query(
+        `UPDATE accounts
+         SET banned_at = NULL, suspended_until = NULL, moderation_reason = $2
          WHERE id = $1`,
         [input.accountId, reason],
       );

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -32,7 +32,7 @@ const charactersState: TableState = { page: 1, search: '', sort: 'level', dir: '
 let liveTimer: number | null = null;
 let activityTimer: number | null = null;
 let activePage: 'overview' | 'moderation' = 'overview';
-let pendingModerationAction: { endpoint: string; body: unknown; accountId: number } | null = null;
+let pendingModerationAction: { endpoint: string; body: unknown; accountId: number; source: 'account' | 'moderation' } | null = null;
 
 // ---------------------------------------------------------------------------
 // Auth flow
@@ -180,10 +180,22 @@ async function toggleAccountDetail(row: HTMLTableRowElement, accountId: number):
     const detail = await apiGet<AccountDetail>(`/admin/api/accounts/${accountId}`);
     const detailRow = document.createElement('tr');
     detailRow.className = 'detail-row';
-    detailRow.innerHTML = `<td colspan="7">${renderAccountDetail(detail)}</td>`;
+    detailRow.innerHTML = `<td colspan="7">${renderAccountDetail(detail, true)}</td>`;
     row.after(detailRow);
   } catch (err) {
     if (!handleAuthFailure(err)) console.error('account detail failed:', err);
+  }
+}
+
+async function refreshOpenAccountDetail(accountId: number): Promise<void> {
+  const row = document.querySelector<HTMLTableRowElement>(`#accounts tr.clickable[data-account-id="${CSS.escape(String(accountId))}"]`);
+  const detailRow = row?.nextElementSibling;
+  if (!row || !detailRow?.classList.contains('detail-row')) return;
+  try {
+    const detail = await apiGet<AccountDetail>(`/admin/api/accounts/${accountId}`);
+    detailRow.innerHTML = `<td colspan="7">${renderAccountDetail(detail, true)}</td>`;
+  } catch (err) {
+    if (!handleAuthFailure(err)) console.error('account detail refresh failed:', err);
   }
 }
 
@@ -203,11 +215,13 @@ function showModerationConfirm(opts: {
   endpoint: string;
   body: unknown;
   accountId: number;
+  source: 'account' | 'moderation';
+  confirmEl: HTMLElement;
   danger?: boolean;
 }): void {
-  pendingModerationAction = { endpoint: opts.endpoint, body: opts.body, accountId: opts.accountId };
-  const el = $('mod-confirm');
-  el.className = 'mod-confirm show';
+  pendingModerationAction = { endpoint: opts.endpoint, body: opts.body, accountId: opts.accountId, source: opts.source };
+  const el = opts.confirmEl;
+  el.className = `mod-confirm show${el.classList.contains('account-mod-confirm') ? ' account-mod-confirm' : ''}`;
   el.innerHTML = `
     <h4>${escapeHtml(opts.title)}</h4>
     <dl>${opts.rows.map((r) => `<dt>${escapeHtml(r.label)}</dt><dd>${escapeHtml(r.value)}</dd>`).join('')}</dl>
@@ -216,6 +230,168 @@ function showModerationConfirm(opts: {
       <button data-cancel-moderation>Cancel</button>
     </div>`;
   el.scrollIntoView({ block: 'nearest' });
+}
+
+function moderationReasonInput(target: HTMLElement): HTMLInputElement | null {
+  const detailRow = target.closest('.detail-row');
+  return (detailRow?.querySelector('.account-mod-reason') as HTMLInputElement | null) ??
+    ($('mod-reason') as HTMLInputElement | null);
+}
+
+function moderationCustomExpiryInput(target: HTMLElement): HTMLInputElement | null {
+  const detailRow = target.closest('.detail-row');
+  return (detailRow?.querySelector('.account-custom-expiry') as HTMLInputElement | null) ??
+    ($('mod-custom-expiry') as HTMLInputElement | null);
+}
+
+function moderationConfirmEl(target: HTMLElement): HTMLElement {
+  const detailRow = target.closest('.detail-row');
+  return (detailRow?.querySelector('.account-mod-confirm') as HTMLElement | null) ?? $('mod-confirm');
+}
+
+async function finishModerationAction(): Promise<void> {
+  const pending = pendingModerationAction;
+  if (!pending) return;
+  await apiPost(pending.endpoint, pending.body);
+  pendingModerationAction = null;
+  void refreshAccounts();
+  void refreshModeration();
+  if (pending.source === 'account' && Number.isFinite(pending.accountId)) {
+    await refreshOpenAccountDetail(pending.accountId);
+  } else {
+    await openModerationAccount(pending.accountId);
+  }
+}
+
+function handleModerationActionClick(e: Event, source: 'account' | 'moderation'): boolean {
+  const target = e.target as HTMLElement;
+  const confirmEl = moderationConfirmEl(target);
+  if (target.closest('[data-cancel-moderation]')) {
+    pendingModerationAction = null;
+    confirmEl.className = `mod-confirm${confirmEl.classList.contains('account-mod-confirm') ? ' account-mod-confirm' : ''}`;
+    confirmEl.innerHTML = '';
+    return true;
+  }
+  if (target.closest('[data-confirm-moderation]')) {
+    void finishModerationAction()
+      .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'moderation action failed'); });
+    return true;
+  }
+  const actionWrap = target.closest('[data-action-account-id]') as HTMLElement | null;
+  const detailWrap = target.closest('.mod-detail') as HTMLElement | null;
+  const accountId = Number((actionWrap ?? detailWrap?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
+  const note = (moderationReasonInput(target)?.value ?? '').trim();
+  const requireNote = (): boolean => {
+    if (note) return true;
+    window.alert('Enter a moderator note / reason first.');
+    return false;
+  };
+  const forceRenameBtn = target.closest('button[data-force-rename-character]') as HTMLButtonElement | null;
+  if (forceRenameBtn) {
+    if (!requireNote()) return true;
+    const characterId = Number(forceRenameBtn.dataset.forceRenameCharacter);
+    const characterName = forceRenameBtn.dataset.characterName ?? `#${characterId}`;
+    showModerationConfirm({
+      title: 'Confirm forced name change',
+      rows: [
+        { label: 'Character', value: characterName },
+        { label: 'Action', value: 'Require player to choose a new character name before entering the world.' },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/characters/${characterId}/force-rename`,
+      body: { reason: note },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  if (!actionWrap) return false;
+  const suspendBtn = target.closest('button[data-suspend-hours]') as HTMLButtonElement | null;
+  if (suspendBtn) {
+    if (!requireNote()) return true;
+    const hours = Number(suspendBtn.dataset.suspendHours);
+    const expiresAt = new Date(Date.now() + hours * 3600 * 1000).toISOString();
+    showModerationConfirm({
+      title: 'Confirm suspension',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Temporary account lockout' },
+        { label: 'Length', value: `${hours} hour${hours === 1 ? '' : 's'}` },
+        { label: 'Until', value: new Date(expiresAt).toLocaleString() },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
+      body: { reason: note, expiresAt },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  const customSuspend = target.closest('button[data-suspend-custom]') as HTMLButtonElement | null;
+  if (customSuspend) {
+    if (!requireNote()) return true;
+    const raw = moderationCustomExpiryInput(target)?.value ?? '';
+    const expiry = raw ? new Date(raw) : null;
+    if (!expiry || !Number.isFinite(expiry.getTime())) {
+      window.alert('Choose a custom suspension expiry.');
+      return true;
+    }
+    showModerationConfirm({
+      title: 'Confirm custom suspension',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Temporary account lockout' },
+        { label: 'Until', value: expiry.toLocaleString() },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
+      body: { reason: note, expiresAt: expiry.toISOString() },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  const banBtn = target.closest('button[data-ban-account]') as HTMLButtonElement | null;
+  if (banBtn) {
+    if (!requireNote()) return true;
+    showModerationConfirm({
+      title: 'Confirm ban',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Permanent account lockout' },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/ban`,
+      body: { reason: note },
+      accountId,
+      source,
+      confirmEl,
+      danger: true,
+    });
+    return true;
+  }
+  const unbanBtn = target.closest('button[data-unban-account]') as HTMLButtonElement | null;
+  if (unbanBtn) {
+    if (!requireNote()) return true;
+    showModerationConfirm({
+      title: 'Confirm unban',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Restore account login access' },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/unban`,
+      body: { reason: note },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -262,7 +438,13 @@ function wireEvents(): void {
   });
 
   $('accounts').addEventListener('click', (e) => {
-    const row = (e.target as HTMLElement).closest('tr.clickable') as HTMLTableRowElement | null;
+    const target = e.target as HTMLElement;
+    const isAccountModClick = target.closest('.account-admin-controls, .account-mod-confirm, button[data-force-rename-character]');
+    if (isAccountModClick && handleModerationActionClick(e, 'account')) {
+      e.stopPropagation();
+      return;
+    }
+    const row = target.closest('tr.clickable') as HTMLTableRowElement | null;
     const accountId = Number(row?.dataset.accountId);
     if (row && Number.isFinite(accountId)) void toggleAccountDetail(row, accountId);
   });
@@ -275,24 +457,6 @@ function wireEvents(): void {
 
   $('moderation-detail').addEventListener('click', (e) => {
     const target = e.target as HTMLElement;
-    if (target.closest('[data-cancel-moderation]')) {
-      pendingModerationAction = null;
-      $('mod-confirm').className = 'mod-confirm';
-      $('mod-confirm').innerHTML = '';
-      return;
-    }
-    if (target.closest('[data-confirm-moderation]')) {
-      const pending = pendingModerationAction;
-      if (!pending) return;
-      void apiPost(pending.endpoint, pending.body)
-        .then(() => {
-          pendingModerationAction = null;
-          void refreshModeration();
-          void openModerationAccount(pending.accountId);
-        })
-        .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'moderation action failed'); });
-      return;
-    }
     const ignoreBtn = target.closest('button[data-ignore-report]') as HTMLButtonElement | null;
     if (ignoreBtn) {
       const reportId = Number(ignoreBtn.dataset.ignoreReport);
@@ -306,93 +470,7 @@ function wireEvents(): void {
         .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'ignore failed'); });
       return;
     }
-    const actionWrap = target.closest('[data-action-account-id]') as HTMLElement | null;
-    const detailWrap = target.closest('.mod-detail') as HTMLElement | null;
-    const accountId = Number((actionWrap ?? detailWrap?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
-    const note = (($('mod-reason') as HTMLInputElement | null)?.value ?? '').trim();
-    const requireNote = (): boolean => {
-      if (note) return true;
-      window.alert('Enter a moderator note / reason first.');
-      return false;
-    };
-    const forceRenameBtn = target.closest('button[data-force-rename-character]') as HTMLButtonElement | null;
-    if (forceRenameBtn) {
-      if (!requireNote()) return;
-      const characterId = Number(forceRenameBtn.dataset.forceRenameCharacter);
-      const characterName = forceRenameBtn.dataset.characterName ?? `#${characterId}`;
-      showModerationConfirm({
-        title: 'Confirm forced name change',
-        rows: [
-          { label: 'Character', value: characterName },
-          { label: 'Action', value: 'Require player to choose a new character name before entering the world.' },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/characters/${characterId}/force-rename`,
-        body: { reason: note },
-        accountId,
-      });
-      return;
-    }
-    if (!actionWrap) return;
-    const suspendBtn = target.closest('button[data-suspend-hours]') as HTMLButtonElement | null;
-    if (suspendBtn) {
-      if (!requireNote()) return;
-      const hours = Number(suspendBtn.dataset.suspendHours);
-      const expiresAt = new Date(Date.now() + hours * 3600 * 1000).toISOString();
-      showModerationConfirm({
-        title: 'Confirm suspension',
-        rows: [
-          { label: 'Account', value: `#${accountId}` },
-          { label: 'Action', value: 'Temporary account lockout' },
-          { label: 'Length', value: `${hours} hour${hours === 1 ? '' : 's'}` },
-          { label: 'Until', value: new Date(expiresAt).toLocaleString() },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
-        body: { reason: note, expiresAt },
-        accountId,
-      });
-      return;
-    }
-    const customSuspend = target.closest('button[data-suspend-custom]') as HTMLButtonElement | null;
-    if (customSuspend) {
-      if (!requireNote()) return;
-      const raw = ($('mod-custom-expiry') as HTMLInputElement).value;
-      const expiry = raw ? new Date(raw) : null;
-      if (!expiry || !Number.isFinite(expiry.getTime())) {
-        window.alert('Choose a custom suspension expiry.');
-        return;
-      }
-      showModerationConfirm({
-        title: 'Confirm custom suspension',
-        rows: [
-          { label: 'Account', value: `#${accountId}` },
-          { label: 'Action', value: 'Temporary account lockout' },
-          { label: 'Until', value: expiry.toLocaleString() },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
-        body: { reason: note, expiresAt: expiry.toISOString() },
-        accountId,
-      });
-      return;
-    }
-    const banBtn = target.closest('button[data-ban-account]') as HTMLButtonElement | null;
-    if (banBtn) {
-      if (!requireNote()) return;
-      showModerationConfirm({
-        title: 'Confirm ban',
-        rows: [
-          { label: 'Account', value: `#${accountId}` },
-          { label: 'Action', value: 'Permanent account lockout' },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/accounts/${accountId}/ban`,
-        body: { reason: note },
-        accountId,
-        danger: true,
-      });
-    }
+    handleModerationActionClick(e, 'moderation');
   });
 
   $('characters').addEventListener('click', (e) => {

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -33,7 +33,7 @@ export function renderAccountsTable(rows: AccountRow[]): string {
   const body = rows.map((a) => `
     <tr class="clickable" data-account-id="${a.id}">
       <td class="num">${a.id}</td>
-      <td>${escapeHtml(a.username)}${a.isAdmin ? ' <span class="badge">admin</span>' : ''}</td>
+      <td>${escapeHtml(a.username)}${a.isAdmin ? ' <span class="badge">admin</span>' : ''} ${accountStatusBadge(a)}</td>
       <td class="num">${a.characterCount}</td>
       <td class="num">${a.maxLevel}</td>
       <td class="num">${fmtDuration(a.playtimeSeconds)}</td>
@@ -49,10 +49,25 @@ export function renderAccountsTable(rows: AccountRow[]): string {
   </table>`;
 }
 
-export function renderAccountDetail(d: AccountDetail): string {
+function accountStatusBadge(a: { bannedAt: string | null; suspendedUntil: string | null }): string {
+  if (a.bannedAt) return '<span class="badge bad">banned</span>';
+  const suspendedUntil = a.suspendedUntil ? new Date(a.suspendedUntil) : null;
+  if (suspendedUntil && suspendedUntil.getTime() > Date.now()) return '<span class="badge warn">suspended</span>';
+  return '';
+}
+
+function accountStatusDetail(d: AccountDetail): string {
+  const activeSuspension = d.suspendedUntil !== null && new Date(d.suspendedUntil).getTime() > Date.now();
+  if (d.bannedAt) return `<span class="badge bad">banned</span> <span class="hint">since ${fmtDate(d.bannedAt)}</span>`;
+  if (activeSuspension) return `<span class="badge warn">suspended until ${fmtDate(d.suspendedUntil)}</span>`;
+  return '<span class="badge">active</span>';
+}
+
+export function renderAccountDetail(d: AccountDetail, includeAdminControls = false): string {
+  const canModerateAccount = includeAdminControls && !d.isAdmin;
   const chars = d.characters.length === 0
     ? '<div class="empty">no characters</div>'
-    : `<table><thead><tr><th>Name</th><th>Class</th><th class="num">Lvl</th><th class="num">XP</th><th class="num">Money</th><th class="num">Pos</th><th>Last played</th></tr></thead><tbody>${
+    : `<table><thead><tr><th>Name</th><th>Class</th><th class="num">Lvl</th><th class="num">XP</th><th class="num">Money</th><th class="num">Pos</th><th>Last played</th>${canModerateAccount ? '<th>Actions</th>' : ''}</tr></thead><tbody>${
         d.characters.map((c) => `
           <tr>
             <td>${escapeHtml(c.name)}</td>
@@ -62,6 +77,7 @@ export function renderAccountDetail(d: AccountDetail): string {
             <td class="num">${fmtCopper(c.copper)}</td>
             <td class="num">${c.pos ? `${Math.round(c.pos.x)}, ${Math.round(c.pos.z)}` : '—'}</td>
             <td>${fmtRelative(c.updatedAt)}</td>
+            ${canModerateAccount ? `<td><button data-force-rename-character="${c.id}" data-character-name="${escapeHtml(c.name)}">Force Name Change</button></td>` : ''}
           </tr>`).join('')
       }</tbody></table>`;
   const sessions = d.recentSessions.length === 0
@@ -74,10 +90,31 @@ export function renderAccountDetail(d: AccountDetail): string {
             <td class="num">${s.endedAt ? fmtDuration(s.seconds) : 'online now'}</td>
           </tr>`).join('')
       }</tbody></table>`;
-  return `<div class="detail-grid">
+  const accountStatus = accountStatusDetail(d);
+  const accountActionButtons = d.bannedAt ? `
+      <button data-unban-account="1">Unban</button>` : `
+      <button data-suspend-hours="1">Suspend 1h</button>
+      <button data-suspend-hours="24">Suspend 24h</button>
+      <button data-suspend-hours="72">Suspend 3d</button>
+      <button data-suspend-hours="168">Suspend 7d</button>
+      <button data-suspend-hours="720">Suspend 30d</button>
+      <input class="account-custom-expiry" type="datetime-local" />
+      <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-ban-account="1" class="danger">Ban</button>`;
+  const adminControls = canModerateAccount ? `
+    <div class="account-admin-controls mod-account-actions" data-action-account-id="${d.id}">
+      <div class="account-status"><b>Status:</b> ${accountStatus}${d.moderationReason ? ` <span class="hint">reason: ${escapeHtml(d.moderationReason)}</span>` : ''}</div>
+      <input class="account-mod-reason" placeholder="Moderator note / reason" maxlength="500" />
+      ${accountActionButtons}
+    </div>
+    <div class="mod-confirm account-mod-confirm"></div>` : includeAdminControls ? `
+    <div class="account-admin-controls">
+      <div class="account-status"><b>Status:</b> <span class="badge">admin</span> ${accountStatus}</div>
+    </div>` : '';
+  return `<div class="account-detail" data-action-account-id="${d.id}">${adminControls}<div class="detail-grid">
     <div><h4>Characters</h4>${chars}</div>
     <div><h4>Recent sessions — total playtime ${fmtDuration(d.playtimeSeconds)}</h4>${sessions}</div>
-  </div>`;
+  </div></div>`;
 }
 
 export function renderCharactersTable(rows: CharacterRow[], sort: string, dir: string): string {
@@ -166,6 +203,16 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
       ${chat}
     </div>`;
   }).join('');
+  const moderationAccountButtons = d.account.bannedAt ? `
+      <button data-unban-account="1">Unban</button>` : `
+      <button data-suspend-hours="1">Suspend 1h</button>
+      <button data-suspend-hours="24">Suspend 24h</button>
+      <button data-suspend-hours="72">Suspend 3d</button>
+      <button data-suspend-hours="168">Suspend 7d</button>
+      <button data-suspend-hours="720">Suspend 30d</button>
+      <input id="mod-custom-expiry" type="datetime-local" />
+      <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-ban-account="1">Ban</button>`;
   return `<div class="mod-detail">
     <div class="panel-title">
       <span>${escapeHtml(d.account.username)}</span>
@@ -174,14 +221,7 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
     ${renderAccountDetail(d.account)}
     <div class="mod-account-actions" data-action-account-id="${d.account.id}">
       <input id="mod-reason" placeholder="Moderator note / reason" maxlength="500" />
-      <button data-suspend-hours="1">Suspend 1h</button>
-      <button data-suspend-hours="24">Suspend 24h</button>
-      <button data-suspend-hours="72">Suspend 3d</button>
-      <button data-suspend-hours="168">Suspend 7d</button>
-      <button data-suspend-hours="720">Suspend 30d</button>
-      <input id="mod-custom-expiry" type="datetime-local" />
-      <button data-suspend-custom="1">Suspend Custom</button>
-      <button data-ban-account="1">Ban</button>
+      ${moderationAccountButtons}
     </div>
     <div id="mod-confirm" class="mod-confirm"></div>
     <h4>Open reports</h4>

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -51,6 +51,8 @@ export interface AccountRow {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
   characterCount: number;
   maxLevel: number;
   playtimeSeconds: number;
@@ -82,6 +84,9 @@ export interface AccountDetail {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
+  moderationReason: string;
   playtimeSeconds: number;
   characters: {
     id: number;

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -196,6 +196,7 @@ describe('admin api auth', () => {
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9, username: 'badactor', createdAt: '', lastLogin: null, isAdmin: false,
+      bannedAt: null, suspendedUntil: null, moderationReason: '',
       playtimeSeconds: 0, characters: [], recentSessions: [],
     });
     vi.mocked(moderationReportsForAccount).mockResolvedValue([]);
@@ -225,7 +226,7 @@ describe('admin api auth', () => {
 
   it('suspends and disconnects an account', async () => {
     vi.mocked(accountForToken).mockResolvedValue(7);
-    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
     const expiresAt = new Date(Date.now() + 3600_000).toISOString();
@@ -243,7 +244,7 @@ describe('admin api auth', () => {
 
   it('bans and disconnects an account', async () => {
     vi.mocked(accountForToken).mockResolvedValue(7);
-    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
 
@@ -256,6 +257,40 @@ describe('admin api auth', () => {
     expect(res.statusCode).toBe(200);
     expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'ban', reason: 'severe abuse', expiresAt: undefined });
     expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account has been banned.');
+  });
+
+  it('unbans without disconnecting the account', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(moderateAccount).mockResolvedValue();
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/unban', body: { reason: 'appeal accepted' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'unban', reason: 'appeal accepted', expiresAt: undefined });
+    expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects suspending or banning admin accounts', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/ban', body: { reason: 'bad admin' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/admin accounts cannot/);
+    expect(moderateAccount).not.toHaveBeenCalled();
+    expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
   });
 
   it('forces a character rename and disconnects that account', async () => {

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -132,6 +132,27 @@ describe('moderation report helpers', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('unbans accounts and writes an audit action in one transaction', async () => {
+    const client = clientStub();
+    connect.mockResolvedValue(client as any);
+
+    await moderateAccount({
+      accountId: 2,
+      adminAccountId: 1,
+      action: 'unban',
+      reason: 'appeal accepted',
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(client.query.mock.calls[0][0]).toBe('BEGIN');
+    expect(client.query.mock.calls[1][0]).toMatch(/SET banned_at = NULL, suspended_until = NULL/);
+    expect(client.query.mock.calls[1][1]).toEqual([2, 'appeal accepted']);
+    expect(client.query.mock.calls[2][0]).toMatch(/account_moderation_actions/);
+    expect(client.query.mock.calls[2][1]).toEqual([2, 1, 'unban', 'appeal accepted', null]);
+    expect(client.query.mock.calls[4][0]).toBe('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
   it('marks a character for forced rename and action-resolves its reports', async () => {
     query.mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any);
     const client = clientStub();


### PR DESCRIPTION
## Summary
  - Adds expanded admin controls from the Accounts table.
  - Shows account characters, recent sessions, status, and moderation actions.
  - Allows admins to suspend, ban, unban, and force character name changes from account details.
  - Shows banned/suspended state in the Accounts list and expanded account panel.
  - Prevents suspending or banning admin accounts server-side.

  ## Testing
  - npm test
  - npm run build

  ## Notes
  - Ban/suspend actions remain server-enforced and disconnect affected accounts.
  - Unban clears account lock state without disconnecting.
  - Moderator notes are required for account actions.