### PR TITLE
fix: escape untrusted player names to prevent stored XSS

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -918,14 +918,14 @@ export class Hud {
       const me = r.pid === myPid;
       const cls = CLASSES[r.cls]?.name ?? r.cls;
       return `<div class="ladder-row${me ? ' me' : ''}"><span class="rank">${i + 1}</span>`
-        + `<span class="lr-name" title="${r.name} — ${cls}">${r.name}</span>`
+        + `<span class="lr-name" title="${esc(r.name)} — ${esc(cls)}">${esc(r.name)}</span>`
         + `<span class="lr-rating">${r.rating}</span>`
         + `<span class="lr-wl">${r.wins}-${r.losses}</span></div>`;
     }).join('') || `<div class="ladder-empty">No challengers ranked yet — be the first.</div>`;
 
     let action: string;
     if (inMatch) {
-      action = `<div class="arena-queue-status">⚔ Match in progress vs ${a.match!.oppName}.</div>`;
+      action = `<div class="arena-queue-status">⚔ Match in progress vs ${esc(a.match!.oppName)}.</div>`;
     } else if (a.queued) {
       action = `<button class="btn leave" data-act="leave">Leave Queue</button>`
         + `<div class="arena-queue-status">Searching for an opponent… (${a.queueSize} in queue)</div>`;
@@ -939,7 +939,7 @@ export class Hud {
       const me = r.name === this.sim.player.name;
       const cls = CLASSES[r.class as keyof typeof CLASSES]?.name ?? r.class;
       return `<div class="ladder-row${me ? ' me' : ''}"><span class="rank">${i + 1}</span>`
-        + `<span class="lr-name" title="${r.name} — Lv ${r.level} ${cls}">${r.name}</span>`
+        + `<span class="lr-name" title="${esc(r.name)} — Lv ${r.level} ${esc(cls)}">${esc(r.name)}</span>`
         + `<span class="lr-rating">${r.rating}</span>`
         + `<span class="lr-wl">${r.wins}-${r.losses}</span></div>`;
     }).join('');
@@ -979,7 +979,7 @@ export class Hud {
     if (sig !== this.lastArenaStatusSig) {
       this.lastArenaStatusSig = sig;
       const cls = CLASSES[m.oppClass]?.name ?? m.oppClass;
-      el.innerHTML = `<div class="as-vs">⚔ VS <span class="opp">${m.oppName}</span> <span style="color:#b6ad8c;font-size:11px">Lv ${m.oppLevel} ${cls}</span></div>`
+      el.innerHTML = `<div class="as-vs">⚔ VS <span class="opp">${esc(m.oppName)}</span> <span style="color:#b6ad8c;font-size:11px">Lv ${m.oppLevel} ${esc(cls)}</span></div>`
         + `<div class="as-timer">${label}</div>`;
       el.style.display = 'block';
     }
@@ -1692,7 +1692,7 @@ export class Hud {
       row.innerHTML =
         `${this.itemIcon(item)}`
         + `<span class="mkt-name"><span class="nm" style="color:${qColor}">${item.name}${l.count > 1 ? ' <span style="color:#ccc">x' + l.count + '</span>' : ''}</span>`
-        + `<span class="seller${l.house ? ' house' : ''}">${l.house ? "Merchant's stock" : l.sellerName}</span></span>`
+        + `<span class="seller${l.house ? ' house' : ''}">${l.house ? "Merchant's stock" : esc(l.sellerName)}</span></span>`
         + `<span class="mkt-price">${this.moneyHtml(l.price)}${each}</span>`;
       const btn = document.createElement('button');
       btn.className = 'mkt-btn' + (l.mine ? ' cancel' : '');
@@ -2620,7 +2620,7 @@ export class Hud {
       return `<div class="trade-item${mine ? ' mine' : ''}" data-item="${mine ? s.itemId : ''}">${this.itemIcon(item)}<span>${item?.name ?? s.itemId}${s.count > 1 ? ' x' + s.count : ''}</span></div>`;
     };
     el.innerHTML = `
-      <div class="panel-title"><span>Trade with ${info.otherName}</span><span class="x-btn" data-close>✕</span></div>
+      <div class="panel-title"><span>Trade with ${esc(info.otherName)}</span><span class="x-btn" data-close>✕</span></div>
       <div class="trade-cols">
         <div class="trade-col ${info.myAccepted ? 'accepted' : ''}">
           <h4>Your offer</h4>
@@ -2628,7 +2628,7 @@ export class Hud {
           <div class="trade-money">Money: <input id="trade-copper" type="number" min="0" value="${this.stagedTrade.copper}" /> copper</div>
         </div>
         <div class="trade-col ${info.theirAccepted ? 'accepted' : ''}">
-          <h4>${info.otherName}'s offer</h4>
+          <h4>${esc(info.otherName)}'s offer</h4>
           <div class="trade-items">${info.theirOffer.items.map((s) => itemRow(s, false)).join('') || '<div style="color:#665c40;font-size:11px;padding:4px">Nothing offered yet</div>'}</div>
           <div class="trade-money">Money: <span class="gold">${formatMoney(info.theirOffer.copper)}</span></div>
         </div>


### PR DESCRIPTION
## Summary

Several HUD surfaces interpolate server-provided **player/character names** directly into `innerHTML` without escaping. Because a player fully controls their own character name, a name containing markup such as `<img src=x onerror=...>` is **stored** server-side and then executed in the browser of anyone who views that player — a stored XSS affecting other users (arena opponents, trade partners, market browsers).

The repo already has the correct defense — the `esc()` helper at `src/ui/hud.ts:36` — and uses it consistently for player names in context menus, the social panel, and reports. These call sites simply omitted it. This PR applies `esc()` to the missing spots (covering both visible text and `title`/attribute contexts).

## Affected surfaces (now escaped)

- **Arena ladder** (online + all-time) — name and class, in both the visible text and the `title` attribute
- **Arena status** — "Match in progress vs …" and the VS match banner
- **Trade window** — partner name in the panel title and the offer heading
- **World Market** — seller name in each listing row

## Risk / compatibility

- No behavior change for well-formed names.
- Minimal, isolated diff (7 lines in `src/ui/hud.ts`).
- `npx tsc --noEmit` passes; full `vitest` suite passes (389 tests). The lone unrelated failure — `tests/homepage_foundation.test.ts` — is pre-existing and caused by `server/db.ts` requiring `DATABASE_URL` at import; it fails identically on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)