### PR TITLE
feat: add vendor item buyback

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,6 +491,8 @@
   .vendor-item:hover { background: #ffffff10; }
   .vendor-item .vi-name { font-size: 12px; flex: 1; }
   .vendor-item .vi-price { font-size: 11px; color: #ddd; }
+  .vendor-section-title { margin-top: 8px; padding-top: 7px; border-top: 1px solid #463a1c; color: var(--gold); font-family: var(--title-font); font-size: 12px; }
+  .vendor-empty { padding: 5px; font-size: 11px; color: #887c5c; }
   .vendor-hint { font-size: 11px; color: #c8b888; margin-top: 8px; border-top: 1px solid #463a1c; padding-top: 6px; }
 
   /* bags */

--- a/server/game.ts
+++ b/server/game.ts
@@ -632,6 +632,7 @@ export class GameServer {
       case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
       case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
       case 'sell': if (typeof msg.item === 'string') sim.sellItem(msg.item, pid); break;
+      case 'buyback': if (typeof msg.item === 'string') sim.buyBackItem(msg.item, pid); break;
       case 'release': sim.releaseSpirit(pid); break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;
@@ -912,6 +913,7 @@ export class GameServer {
       }
     };
     maybe('inv', meta.inventory);
+    maybe('buyback', meta.vendorBuyback);
     maybe('equip', meta.equipment);
     maybe('qlog', [...meta.questLog.values()]);
     maybe('qdone', [...meta.questsDone]);

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -209,6 +209,7 @@ export class ClientWorld implements IWorld {
   playerId = -1;
   moveInput: MoveInput = emptyMoveInput();
   inventory: InvSlot[] = [];
+  vendorBuyback: InvSlot[] = [];
   equipment: Partial<Record<EquipSlot, string>> = {};
   copper = 0;
   xp = 0;
@@ -496,6 +497,7 @@ export class ClientWorld implements IWorld {
       this.xp = s.xp ?? 0;
       this.copper = s.copper ?? 0;
       if (s.inv !== undefined) { this.inventory = s.inv; this.invChanged = true; }
+      if (s.buyback !== undefined) { this.vendorBuyback = s.buyback; this.invChanged = true; }
       if (s.equip !== undefined) this.equipment = s.equip;
       if (s.qlog !== undefined) this.questLog = new Map((s.qlog as QuestProgress[]).map((q) => [q.questId, q]));
       if (s.qdone !== undefined) this.questsDone = new Set(s.qdone);
@@ -600,6 +602,9 @@ export class ClientWorld implements IWorld {
   }
   sellItem(itemId: string): void {
     this.cmd({ cmd: 'sell', item: itemId });
+  }
+  buyBackItem(itemId: string): void {
+    this.cmd({ cmd: 'buyback', item: itemId });
   }
   releaseSpirit(): void {
     this.cmd({ cmd: 'release' });

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -58,6 +58,7 @@ const MARKET_MAX_PRICE = 5_000_000; // 500g ceiling — guards against overflow 
 const MARKET_CUT = 0.05; // the Merchant's cut on a completed sale (a gold sink)
 const MARKET_LISTING_DURATION = 48 * 3600; // sim-seconds an unsold listing lingers before returning
 const MARKET_WIRE_LIMIT = 120; // most listings shipped to one client at a time
+const VENDOR_BUYBACK_LIMIT = 12;
 const INSTANCE_EMPTY_TIMEOUT = 300; // seconds before an empty instance resets
 const HUNTER_RANGED_DEADZONE = 8;
 const MAX_CLIMB_SLOPE = 1.5; // rise/run above which a ground move is blocked (cliffs, world rim)
@@ -172,6 +173,7 @@ export interface PlayerMeta {
   name: string;
   moveInput: MoveInput;
   inventory: InvSlot[];
+  vendorBuyback: InvSlot[];
   copper: number;
   equipment: PlayerEquipment;
   xp: number;
@@ -234,6 +236,7 @@ export interface CharacterState {
   facing: number;
   equipment: PlayerEquipment;
   inventory: InvSlot[];
+  vendorBuyback?: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
   questsDone: string[];
   arenaRating?: number;
@@ -436,6 +439,7 @@ export class Sim {
       name,
       moveInput: emptyMoveInput(),
       inventory: [],
+      vendorBuyback: [],
       copper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
       xp: 0,
@@ -460,6 +464,7 @@ export class Sim {
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
       meta.inventory = s.inventory.map((i) => ({ ...i }));
+      meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
       for (const q of s.questLog) {
         if (q.state !== 'done') meta.questLog.set(q.questId, { questId: q.questId, counts: [...q.counts], state: q.state });
       }
@@ -538,6 +543,7 @@ export class Sim {
       facing: e.facing,
       equipment: { ...meta.equipment },
       inventory: meta.inventory.map((i) => ({ ...i })),
+      vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
       questLog: [...meta.questLog.values()].map((q) => ({ questId: q.questId, counts: [...q.counts], state: q.state })),
       questsDone: [...meta.questsDone],
       arenaRating: meta.arenaRating,
@@ -565,6 +571,9 @@ export class Sim {
   }
   get inventory(): InvSlot[] {
     return this.primary.inventory;
+  }
+  get vendorBuyback(): InvSlot[] {
+    return this.primary.vendorBuyback;
   }
   get equipment(): PlayerEquipment {
     return this.primary.equipment;
@@ -2858,6 +2867,23 @@ export class Sim {
     this.emit({ type: 'vendor', action: 'buy', itemId, pid: meta.entityId });
   }
 
+  private vendorInRange(p: Entity): boolean {
+    return [...this.entities.values()].some((e) =>
+      e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
+  }
+
+  private recordVendorBuyback(meta: PlayerMeta, itemId: string, count: number): void {
+    const existingIndex = meta.vendorBuyback.findIndex((s) => s.itemId === itemId);
+    if (existingIndex >= 0) {
+      const [existing] = meta.vendorBuyback.splice(existingIndex, 1);
+      existing.count += count;
+      meta.vendorBuyback.unshift(existing);
+    } else {
+      meta.vendorBuyback.unshift({ itemId, count });
+    }
+    while (meta.vendorBuyback.length > VENDOR_BUYBACK_LIMIT) meta.vendorBuyback.pop();
+  }
+
   sellItem(itemId: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
@@ -2865,15 +2891,32 @@ export class Sim {
     const def = ITEMS[itemId];
     if (!def || this.countItem(itemId, meta.entityId) <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
     if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
-    // mirror buyItem's gate: selling requires a vendor in interact range
-    const nearVendor = [...this.entities.values()].some((e) =>
-      e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
-    if (!nearVendor) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
+    if (!this.vendorInRange(p)) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
     if (def.kind === 'quest') { this.error(meta.entityId, 'You cannot sell quest items.'); return; }
     this.removeItem(itemId, 1, meta.entityId);
+    this.recordVendorBuyback(meta, itemId, 1);
     meta.copper += def.sellValue;
     this.emit({ type: 'vendor', action: 'sell', itemId, pid: meta.entityId });
     this.emit({ type: 'loot', text: `Sold ${def.name} for ${formatMoney(def.sellValue)}.`, pid: meta.entityId });
+  }
+
+  buyBackItem(itemId: string, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta, e: p } = r;
+    const def = ITEMS[itemId];
+    const slot = meta.vendorBuyback.find((s) => s.itemId === itemId);
+    if (!def || !slot || slot.count <= 0) { this.error(meta.entityId, 'That item is not available for buyback.'); return; }
+    if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
+    if (!this.vendorInRange(p)) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
+    if (meta.copper < def.sellValue) { this.error(meta.entityId, 'Not enough money.'); return; }
+    meta.copper -= def.sellValue;
+    slot.count -= 1;
+    if (slot.count <= 0) meta.vendorBuyback = meta.vendorBuyback.filter((s) => s !== slot);
+    this.addItemSilent(itemId, 1, meta);
+    this.onInventoryChangedForQuests(meta);
+    this.emit({ type: 'vendor', action: 'buyback', itemId, pid: meta.entityId });
+    this.emit({ type: 'loot', text: `Bought back ${def.name} for ${formatMoney(def.sellValue)}.`, pid: meta.entityId });
   }
 
   private addItemSilent(itemId: string, count: number, meta: PlayerMeta): void {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -481,7 +481,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'comboPoint'; points: number }
   | { type: 'playerDeath' }
   | { type: 'respawn' }
-  | { type: 'vendor'; action: 'buy' | 'sell'; itemId: string }
+  | { type: 'vendor'; action: 'buy' | 'sell' | 'buyback'; itemId: string }
   // say/yell are delivered only to players in range and carry the speaker's
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1149,7 +1149,7 @@ export class Hud {
         case 'comboPoint': break;
         case 'loot': {
           this.log(ev.text, '#7fdc4f');
-          if (ev.text.includes('loot') || ev.text.includes('Sold')) audio.coin();
+          if (ev.text.includes('loot') || ev.text.includes('Sold') || ev.text.includes('Bought back')) audio.coin();
           else audio.lootItem();
           if ($('#bags').style.display === 'block') this.renderBags();
           break;
@@ -1562,6 +1562,28 @@ export class Hud {
       this.attachTooltip(row, () => this.itemTooltip(item) + '<div class="tt-sub">Click to buy</div>');
       el.appendChild(row);
     }
+    const buybackTitle = document.createElement('div');
+    buybackTitle.className = 'vendor-section-title';
+    buybackTitle.textContent = 'Buyback';
+    el.appendChild(buybackTitle);
+    const buyback = this.sim.vendorBuyback.filter((s) => ITEMS[s.itemId] && s.count > 0);
+    if (buyback.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'vendor-empty';
+      empty.textContent = 'No items';
+      el.appendChild(empty);
+    }
+    for (const s of buyback) {
+      const item = ITEMS[s.itemId]!;
+      const row = document.createElement('div');
+      row.className = 'vendor-item';
+      row.innerHTML = `${this.itemIcon(item)}<span class="vi-name">${item.name}${s.count > 1 ? ` x${s.count}` : ''}</span><span class="vi-price">${this.moneyHtml(item.sellValue)}</span>`;
+      row.addEventListener('click', () => {
+        this.sim.buyBackItem(s.itemId);
+      });
+      this.attachTooltip(row, () => this.itemTooltip(item) + '<div class="tt-sub">Click to buy back</div>');
+      el.appendChild(row);
+    }
     const hint = document.createElement('div');
     hint.className = 'vendor-hint';
     hint.textContent = 'Click an item in your bags to sell it while this window is open.';
@@ -1802,6 +1824,7 @@ export class Hud {
   // carry inventory separately from the event frames that normally redraw).
   onInventoryChanged(): void {
     if ($('#bags').style.display === 'block') this.renderBags();
+    if (this.openVendorNpcId !== null) this.renderVendor();
   }
 
   renderBags(): void {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -143,6 +143,7 @@ export interface IWorld {
   player: Entity;
   moveInput: MoveInput;
   inventory: InvSlot[];
+  vendorBuyback: InvSlot[];
   equipment: Partial<Record<EquipSlot, string>>;
   copper: number;
   xp: number;
@@ -166,6 +167,7 @@ export interface IWorld {
   useItem(itemId: string): void;
   buyItem(npcId: number, itemId: string): void;
   sellItem(itemId: string): void;
+  buyBackItem(itemId: string): void;
   releaseSpirit(): void;
   chat(text: string): void;
   // social systems

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -468,6 +468,78 @@ describe('food, drink, vendor', () => {
     expect(sim.countItem('wolf_fang')).toBe(1);
   });
 
+  it('vendor buyback restores recently sold gear for the sale price', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('apprentice_staff', 1);
+
+    sim.sellItem('apprentice_staff');
+
+    expect(sim.countItem('apprentice_staff')).toBe(0);
+    expect(sim.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    expect(sim.copper).toBe(120);
+
+    sim.buyBackItem('apprentice_staff');
+
+    expect(sim.countItem('apprentice_staff')).toBe(1);
+    expect(sim.vendorBuyback).toEqual([]);
+    expect(sim.copper).toBe(0);
+  });
+
+  it('vendor buyback round-trips through saved character state', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('apprentice_staff', 1);
+    sim.sellItem('apprentice_staff');
+
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false });
+    const pid2 = sim2.addPlayer('warrior', 'Saved', { state });
+    const wilkes2 = [...sim2.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim2, wilkes2.pos.x + 2, wilkes2.pos.z);
+
+    expect(sim2.meta(pid2)!.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    sim2.buyBackItem('apprentice_staff', pid2);
+    expect(sim2.countItem('apprentice_staff', pid2)).toBe(1);
+    expect(sim2.meta(pid2)!.vendorBuyback).toEqual([]);
+  });
+
+  it('vendor buyback requires money and keeps only recent sold item groups', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false });
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('wolf_fang', 2);
+    sim.sellItem('wolf_fang');
+    sim.sellItem('wolf_fang');
+    expect(sim.vendorBuyback).toEqual([{ itemId: 'wolf_fang', count: 2 }]);
+    sim.copper = 0;
+
+    sim.buyBackItem('wolf_fang');
+
+    expect(sim.countItem('wolf_fang')).toBe(0);
+    expect(sim.vendorBuyback).toEqual([{ itemId: 'wolf_fang', count: 2 }]);
+    expect(sim.events).toContainEqual({ type: 'error', text: 'Not enough money.', pid: sim.player.id });
+
+    const itemIds = [
+      'bandit_bandana', 'tough_jerky', 'mudfin_scale', 'tallow_candle',
+      'spider_leg', 'bone_fragments', 'linen_scrap', 'baked_bread',
+      'spring_water', 'roasted_boar', 'worn_sword', 'hickory_shortstaff',
+      'apprentice_staff',
+    ];
+    for (const itemId of itemIds) {
+      sim.addItem(itemId, 1);
+      sim.sellItem(itemId);
+    }
+
+    expect(sim.vendorBuyback).toHaveLength(12);
+    expect(sim.vendorBuyback[0]).toEqual({ itemId: 'apprentice_staff', count: 1 });
+    expect(sim.vendorBuyback.some((s) => s.itemId === 'wolf_fang')).toBe(false);
+  });
+
   it('vendor buy rejects stale or invalid merchants with feedback', () => {
     const sim = makeSim('warrior');
     const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -15,7 +15,7 @@ vi.mock('../server/db', () => ({
 import { censorChatText, GameServer, ClientSession } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 
-const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
+const DELTA_KEYS = ['inv', 'buyback', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
 
 interface FakeClient {
   sent: any[];
@@ -52,6 +52,7 @@ function bareClient(pid: number): ClientWorld {
   c.playerId = pid;
   c.moveInput = {};
   c.inventory = [];
+  c.vendorBuyback = [];
   c.equipment = {};
   c.copper = 0;
   c.xp = 0;
@@ -141,6 +142,33 @@ describe('delta snapshots', () => {
     expect(snap.self.inv.some((s: any) => s.itemId === 'baked_bread')).toBe(true);
     expect(snap.self).not.toHaveProperty('qlog');
     expect(snap.self).not.toHaveProperty('stats');
+  });
+
+  it('mirrors vendor buyback deltas to the client', () => {
+    const wilkes = [...server.sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    const player = server.sim.entities.get(session.pid)!;
+    player.pos.x = wilkes.pos.x + 2;
+    player.pos.z = wilkes.pos.z;
+    player.prevPos = { ...player.pos };
+    server.sim.addItem('apprentice_staff', 1, session.pid);
+    broadcast(server);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.vendorBuyback).toEqual([]);
+    expect(client.consumeInventoryChanged()).toBe(true);
+
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'sell', item: 'apprentice_staff' }));
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self).toHaveProperty('buyback');
+    expect(snap.self.buyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+
+    const buybackOnly = { ...snap, self: { ...snap.self } };
+    delete buybackOnly.self.inv;
+    (client as any).applySnapshot(buybackOnly);
+    expect(client.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    expect(client.consumeInventoryChanged()).toBe(true);
   });
 
   it('quest commands force a quest-state resync even when rejected', () => {


### PR DESCRIPTION
## Summary
- Adds a vendor buyback list so recently sold items can be recovered for their original vendor sell value.
- Persists buyback entries in saved character state so accidental sales can still be undone after reconnects or reloads.
- Mirrors buyback entries through online snapshots and refreshes the open vendor panel when inventory or buyback deltas arrive.

## Diagnosis
Accidentally sold gear was removed from inventory and converted to copper with no recovery path. For quest rewards or newly acquired equipment, one misclick in the bag while a vendor was open could permanently discard the item.

## Implementation Notes
- The shared sim owns the sell, buyback, merchant-range, money, dead-player, and save/load rules, keeping offline and online behavior aligned.
- The vendor window now renders a Buyback section next to normal vendor stock. The online client treats buyback deltas as inventory-related UI changes so an open vendor panel redraws as snapshots arrive.
- Existing character saves load cleanly because `vendorBuyback` is optional and defaults to an empty list.

## Verification
- `npx vitest run tests/sim.test.ts -t vendor`; 8 tests passed, 37 skipped.
- `npx vitest run tests/snapshots.test.ts`; 13 tests passed.
- `npx tsc --noEmit`; passed before the review-fix sequence.
- `npm run build`; passed before the review-fix sequence and after the vendor-panel refresh fix.
- Full branch gate after the final persistence fix and polish: `npm test` (35 files, 401 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.
- `scripts/codex-review-gate --base origin/main`; clean for the final one-commit branch.

## Real behavior proof
- Behavior addressed: a player can accidentally sell newly earned gear and need a way to recover it from the vendor.
- Environment tested: deterministic sim vendor tests and online snapshot mirror tests.
- Evidence after fix: sold gear enters buyback at its sell value, round-trips through saved character state, reloads into a new sim, and can be bought back while near a vendor.
- Not tested: manual browser click-through of the vendor panel.

## Risk
This touches character save JSON, vendor transactions, and online inventory UI refresh. The saved field is optional for old characters, buyback is capped to recent item groups, and all money/range/death checks stay in the shared sim path.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
