### PR TITLE
feat: Max-Level XP Overflow & post-cap progression

### DIFF
--- a/docs/prd/max-level-xp-overflow.md
+++ b/docs/prd/max-level-xp-overflow.md
@@ -1,0 +1,284 @@
+# PRD — Max-Level XP Overflow & Post-Cap Progression
+
+| | |
+|---|---|
+| **Status** | Draft / Proposed |
+| **Owner** | TBD |
+| **Created** | 2026-06-14 |
+| **Source demand** | Discord `#feature-requests` — starshadowx2 ("xp gained after max level still counted… like RuneScape level 99 → 200m xp"), endorsed by Zyzz Jobs. 💯-reacted; #2 most-loved remaining request. |
+| **Related systems** | Leveling (`src/sim/sim.ts`, `src/sim/types.ts`), character persistence (`server/db.ts`), HUD XP bar (`src/ui/hud.ts`) |
+| **Companion PRD** | `docs/prd/talents-and-specializations.md` |
+
+---
+
+## 1. Summary
+
+Today, when a character hits the level cap (20) all further XP is discarded. This PRD adds **post-cap progression**: XP keeps counting forever into a 64-bit lifetime counter, drives a cosmetic **virtual level** (so the bar keeps "leveling up"), and feeds a **leaderboard + milestone cosmetic rewards**. The intent is **retention and bragging rights, not power** — at a level-20 cap, post-cap power gain would break balance, so this system is deliberately horizontal/cosmetic.
+
+This is the **RuneScape model** (level cap stays, XP continues to a counter, virtual levels are cosmetic, the grind is leaderboard- and prestige-driven), with **WoW's post-cap reward cadence** (Paragon-style milestone rewards, Honor-style uncapped prestige levels) layered on top.
+
+---
+
+## 2. Background & motivation
+
+### 2.1 Player demand
+The request appeared organically in `#feature-requests` and drew reactions. The ask is specifically the RuneScape pattern: *"sorta like how in Runescape there's level 99 but you can still go up to 200m xp."*
+
+### 2.2 Why it matters
+- The current behavior is actively bad: max-level players gain **nothing** from combat. `grantXp()` returns early at cap and any overflow is zeroed. There is no reason to keep playing a maxed character outside of new content.
+- It is a **very high love-to-effort ratio** feature. The leveling system is small and self-contained; the foundation lands in well under a day.
+- It establishes patterns (a new persisted progression field, a leaderboard endpoint) reused by other systems.
+
+---
+
+## 3. How it works in the reference games (full breakdown)
+
+### 3.1 WoW XP & leveling (baseline)
+- **XP earned from:** kills (scaled by mob level vs player level), quests (dominant source), exploration/discovery (one-time chunks), gathering.
+- **Rested XP:** accumulates while logged out (faster in inns/cities), grants ×2 kill XP until drained, max ≈ 1.5 levels of stored bonus. Quests/exploration advance the rested marker but do not consume it.
+- **XP-to-next curve:** a tuned (non-cleanly-exponential, modern WoW even non-monotonic) curve, rounded to the nearest 100.
+- **At cap:** XP gain **stops** and quest XP converts to gold. **WoW has no native XP overflow** — this is the key research finding. The "keep earning" feeling comes entirely from the post-cap systems below.
+
+### 3.2 WoW post-cap systems (the reward-cadence reference)
+- **Paragon levels:** after maxing a reputation, a bar refills every fixed chunk (+10,000) and dumps a reward cache (gold, currency, RNG cosmetics). Clean "infinite repeatable bar with milestone rewards" pattern.
+- **Artifact Power (Legion) / Azerite (BfA):** literally a *second XP bar that never ends*, unlocking traits/levels, paced by a throttle knob (Artifact Knowledge multiplier / weekly auto-reduction) so the curve never balloons for returners.
+- **Honor levels (PvP):** **uncapped, account-wide "prestige" levels** with cosmetic milestone rewards (e.g. a mount at Honor Level 500). The closest analog to uncapped prestige + cosmetics.
+- **Renown (Shadowlands/DF):** time-gated reputation track with cosmetic milestones, framed account-wide for permanence.
+
+### 3.3 RuneScape model (the literal request)
+- **Cap = level 99 (13,034,431 XP)** per skill, but **XP continues to a 200,000,000 cap.** (Their 200M ceiling is an accident of 32-bit storage — *we use 64-bit and never need an artificial cap.*)
+- **Virtual levels:** computed from continued XP (99 → 120 standard, → 150 elite, ≈126 at 200M). **Purely cosmetic, no gameplay effect.**
+- **XP curve:** each level ≈ 10.4% more than the last (roughly doubles every 7 levels).
+- **Recognition:** skill capes at 99, master capes at virtual 120, eight cosmetic 200M skill icons, and **public hiscores/leaderboards** — the entire endgame grind is leaderboard + cosmetic driven.
+
+### 3.4 Design synthesis for a level-20 cap
+Because the cap is low, post-cap XP is **purely retention/flex**. Recommended stack:
+1. **Lifetime XP counter (64-bit)** — foundation + leaderboard sort key.
+2. **Virtual levels** computed from it — bar keeps "leveling," zero new content.
+3. **Paragon-style milestone rewards** on a *flat* XP interval (rewards never dry up) — cosmetic only.
+4. *(Optional)* **Prestige** — opt-in hard reset of the level-20 bar for a prestige rank/badge.
+
+---
+
+## 4. Current state in the codebase
+
+> **Re-verified against `fix/discord-bug-batch` (PR #131) on top of Release v0.4, 2026-06-14.** Line numbers below reflect the post-v0.4 tree (sim.ts and hud.ts grew substantially). Since v0.4, **arena (Ashen Coliseum), the World Market, and i18n all merged** — relevant because (a) the leaderboard UI must route strings through i18n, and (b) post-cap activities now include arena/market.
+
+| Concern | Location | Notes |
+|---|---|---|
+| XP discard at cap | `src/sim/sim.ts:2238` | `if (p.level >= MAX_LEVEL) meta.xp = 0;` — **the discard to replace** |
+| Early return at cap (no XP granted) | `src/sim/sim.ts:2224` | `if (!p || p.level >= MAX_LEVEL) return;` — **must change** |
+| Party-member XP gate at cap | `src/sim/sim.ts:2214` | `if (xpGain > 0 && mE.level < MAX_LEVEL) this.grantXp(...)` — **second cap-gate to update** |
+| XP grant + level-up loop | `src/sim/sim.ts:2222-2238` | `grantXp()`; while-loop already carries overflow between levels |
+| Quest XP grant | `src/sim/sim.ts:3131` | `this.grantXp(quest.xpReward, meta)` — also flows through the cap gate |
+| XP table / cap / `xpForLevel()` | `src/sim/types.ts:562-569` | `XP_TABLE`, `MAX_LEVEL = 20` |
+| Mob XP value + level-diff scaling | `src/sim/types.ts:582` | `mobXpValue()` — reduces XP for out-leveled mobs (anti-farm) |
+| Character state (persisted) | `src/sim/sim.ts:236` | `interface CharacterState { level, xp, … }` |
+| `PlayerMeta` (runtime) | `src/sim/sim.ts:178` | holds `xp`, would hold `lifetimeXp` at runtime |
+| Serialize | `src/sim/sim.ts:536` | `serializeCharacter()` |
+| Deserialize | `src/sim/sim.ts:428` | `addPlayer(cls, name, { state })` (level clamp at `:465`) |
+| DB schema | `server/db.ts:36-45` | `state JSONB` (line 42) — **no migration needed for new fields** |
+| DB save fn | `server/db.ts:315` | `saveCharacterState(characterId, level, state)` |
+| Autosave | `server/game.ts:38, 382-384` | 30s interval (`AUTOSAVE_SECONDS`) |
+| Command switch (for prestige cmd) | `server/game.ts:616-617` | `switch (msg.cmd)`; copy a `case` like `:619`/`:629` |
+| XP bar render / update | `src/ui/hud.ts:513, 657-658` | ticks at `:513`; update + `MAX LEVEL` label at `:657-658` |
+| XP / levelup toast events | `src/ui/hud.ts:1177-1182` | `case 'xp'` / `case 'levelup'` |
+| Character sheet | `src/ui/hud.ts:1907-1910` | `toggleChar()` / `renderChar()` |
+| i18n string helper | `src/ui/i18n.ts:1886` | `t(key)` — **all new UI strings must register here** |
+| Settings | `src/game/settings.ts:5` | `GameSettings` (for optional `showOverflowXp` toggle) |
+| Dev set-level helper | `src/sim/sim.ts:685` | `setPlayerLevel()` (gated by `ALLOW_DEV_COMMANDS`) |
+
+**Gap:** no lifetime XP, no virtual levels, no leaderboard, no prestige, no milestone rewards. Combat at cap yields nothing (gated in **two** places — `:2224` solo and `:2214` party).
+
+---
+
+## 5. Goals & non-goals
+
+### Goals
+- Max-level characters earn and retain XP indefinitely.
+- A cosmetic virtual level keeps the XP bar progressing past cap.
+- A global leaderboard ranks players by lifetime XP.
+- Cosmetic milestone rewards (titles/borders/icons) at fixed thresholds.
+- Anti-farm: trivial low-level mobs cannot be farmed for cheap leaderboard rank.
+- Zero power creep at a level-20 cap.
+
+### Non-goals
+- No stat/power rewards from post-cap XP (explicitly out of scope to protect balance).
+- No raising the actual level cap (separate effort; see `feature/expansion-levels-1-20`).
+- No rested-XP rework (can be a follow-up).
+- No trading/selling of lifetime XP or prestige.
+
+---
+
+## 6. Functional requirements
+
+### 6.1 Lifetime XP counter
+- **FR-1.1** Add `lifetimeXp: number` to `CharacterState`, serialized/deserialized through the existing JSONB blob (no migration).
+- **FR-1.2** Use a 64-bit-safe integer. JS `number` is safe to 2^53; document the invariant and add a guard/log if a single character ever approaches it (effectively never, but explicit).
+- **FR-1.3** Every XP award (kill/quest/explore) adds to both the level bar (until cap) and `lifetimeXp` (always). After cap, only `lifetimeXp` grows.
+- **FR-1.4** Update **all three** cap gates so XP still accrues to `lifetimeXp` at cap: the solo early-return (`sim.ts:2224`), the party-member gate (`sim.ts:2214`), and the discard (`sim.ts:2238` → route remainder to `lifetimeXp` instead of zeroing).
+- **FR-1.5** Pre-cap, `lifetimeXp` is the running total of all XP ever earned (so the leaderboard is meaningful for leveling players too).
+
+### 6.2 Virtual levels
+- **FR-2.1** Add `virtualLevel(lifetimeXp): number` next to `xpForLevel()` in `types.ts`. Extend the curve past level 20 with a defined formula (e.g. continue the existing `XP_TABLE` slope, or a RuneScape-style ~10% step). Cache the threshold table.
+- **FR-2.2** Below cap, virtual level == actual level. At/after cap, virtual level = 20 + extra levels computed from post-cap lifetime XP.
+- **FR-2.3** Crossing a virtual level fires a cosmetic banner + sound (reuse the `levelup` toast path) reading e.g. "Virtual Level 27!".
+- **FR-2.4** Virtual level has **no mechanical effect** (no stats, abilities, or gating).
+
+### 6.3 XP bar & character sheet UI
+- **FR-3.1** Post-cap, the XP bar shows virtual-level progress (fills toward next virtual level) instead of a static "MAX LEVEL".
+- **FR-3.2** Post-cap bar is visually distinct (prestige/gold tint) to signal the threshold was crossed.
+- **FR-3.3** Bar label post-cap: `Lv 20 (+7)  ·  1,284,500 total XP  ·  62% to next`.
+- **FR-3.4** Character sheet (`hud.ts:1408`) shows `Total XP`, `Virtual Level`, and current prestige rank (if enabled).
+
+### 6.4 Leaderboard
+- **FR-4.1** Server endpoint `GET /api/leaderboard?metric=lifetimeXp&realm=<realm>&limit=100` returning ranked `{ rank, name, class, level, virtualLevel, lifetimeXp }`.
+- **FR-4.2** Query is indexed and **cached server-side** with periodic refresh (follow the chat-censor caching pattern, PR #85). Never computed per request under load.
+- **FR-4.3** Realm-scoped by default (consistent with realm isolation, PR #34), with an optional global view.
+- **FR-4.4** Client leaderboard panel (model on quest-log two-column panel, `hud.ts:1482`), bound to a key and/or a button in the social panel.
+- **FR-4.5** Highlight the viewing player's own rank even if outside the visible top-N.
+
+### 6.5 Milestone cosmetic rewards
+- **FR-5.1** Define milestone thresholds (in lifetime XP or virtual level) granting cosmetic rewards: titles, name-plate borders/colors, and/or character-sheet badges.
+- **FR-5.2** Milestones are persisted (`unlockedMilestones: string[]` in `CharacterState`) and surfaced in the character sheet.
+- **FR-5.3** Milestone unlock fires a celebratory banner.
+- **FR-5.4** Rewards are strictly cosmetic.
+
+### 6.6 (Optional / Phase 4) Prestige
+- **FR-6.1** Opt-in "Prestige" action at cap: resets the level-20 XP *bar* to 0 (does not touch `lifetimeXp`), increments `prestigeRank`.
+- **FR-6.2** Prestige rank shown as a star/number by the character name and in the leaderboard.
+- **FR-6.3** Prestige is cosmetic-only; no power, no loss of abilities/talents/gear.
+- **FR-6.4** Confirmation dialog explaining exactly what does/doesn't change.
+
+### 6.7 Anti-farm & integrity
+- **FR-7.1** Retain `mobXpValue()` level-diff scaling post-cap so out-leveled mobs grant trivial XP.
+- **FR-7.2** Lifetime XP and virtual level are computed **server-side** (authoritative `Sim`); client display is derived only.
+- **FR-7.3** Consider a per-source cap or diminishing returns for repeatable XP exploits (flag during design; depends on existing quest/kill economy).
+
+---
+
+## 7. Data model & schema changes
+
+```ts
+// src/sim/sim.ts — CharacterState (JSONB blob; no DB migration)
+interface CharacterState {
+  level: number;
+  xp: number;                  // current level-bar XP
+  lifetimeXp: number;          // NEW — monotonic, never reset
+  prestigeRank?: number;       // NEW (Phase 4) — opt-in
+  unlockedMilestones?: string[]; // NEW — cosmetic milestone ids
+  // …existing fields…
+}
+```
+
+- `characters.level` column stays as-is (used for listing). Virtual level is computed, not stored.
+- No SQL migration: all new fields live in the existing `state JSONB`.
+- Leaderboard may add a generated/denormalized column or a cached materialized view of `lifetimeXp` for query performance (decide in design; JSONB extraction with an index is acceptable at current scale).
+
+---
+
+## 8. API / command surface
+
+- **Read:** `GET /api/leaderboard` (see FR-4.1). No new client→sim *command* needed for the counter (it's a passive consequence of existing XP grants).
+- **Prestige (Phase 4):** new command `prestige` wired through `IWorld` (`src/world_api.ts:86`) → client `cmd()` (`src/net/online.ts:280`) → server switch (`server/game.ts:585`) → `Sim.prestige(pid)`. Follow the existing `castAbility`/`turnin` pattern exactly.
+- **Events:** extend the existing `levelup`/`xp` event payloads (or add `virtualLevelUp`, `milestoneUnlocked`) emitted from `Sim` and handled in `hud.ts:937`.
+
+---
+
+## 9. UI / UX specification
+
+- **XP bar (primary surface):** reuse existing element (`index.html:2018`, `hud.ts:564`). Pre-cap unchanged. Post-cap: gold/prestige fill, virtual-level label, hover tooltip shows total XP + rank.
+- **Character sheet:** add a "Progression" row group: Total XP, Virtual Level, Prestige Rank, unlocked milestone badges.
+- **Leaderboard panel:** two-column quest-log-style window; tabs for Realm/Global; sticky "your rank" row.
+- **Banners/toasts:** virtual level-up and milestone unlock reuse `showBanner()` + `audio.levelUp()`.
+- **Settings:** add `showOverflowXp` toggle to `GameSettings` (`src/game/settings.ts:5`) surfaced in the options menu for players who want the classic "MAX LEVEL" text.
+- **i18n (new constraint):** all new UI strings (bar labels, leaderboard headers, milestone names, prestige dialog) must be registered in `src/ui/i18n.ts` and rendered via `t(key)` (`:1886`) — the game shipped multilingual support in v0.4. Do not hardcode display strings.
+- **Accessibility/clarity:** the prestige confirmation must be unambiguous about what is and isn't reset.
+
+---
+
+## 10. Performance requirements
+
+- **PR-1** Counter cost is one integer add per XP event — negligible.
+- **PR-2** Virtual level is computed from a cached threshold table; O(log n) lookup or direct formula. Never recompute per frame.
+- **PR-3** Leaderboard is the only sensitive path: cache server-side, refresh on an interval (e.g. 30–60s), serve from cache. Index the sort key.
+- **PR-4** No additions to the combat hot path or per-tick simulation.
+
+---
+
+## 11. Gameplay & balance design
+
+- **Cosmetic-only** at a level-20 cap. No stats, no power. This is the core balance guarantee.
+- **Reward cadence:** prefer fixed-interval milestones (Paragon-style) over an asymptotic curve so rewards never fully dry up. Decide the interval vs. RuneScape-style ever-increasing curve during design (tradeoff: grind feel vs. long-tail).
+- **Retention drivers (ranked):** leaderboard > cosmetic milestones/titles > prestige badges. Power gains intentionally excluded.
+- **Account-wide framing (stretch):** an account-level lifetime XP total makes alt play feel permanent (WoW Warband pattern).
+
+---
+
+## 12. Phasing
+
+| Phase | Scope | Est. |
+|---|---|---|
+| **1 — Overflow counter** | `lifetimeXp` persisted; stop discarding/early-return; show Total XP in sheet + bar hover | XS (~0.5 day) |
+| **2 — Virtual levels** | `virtualLevel()`, bar keeps filling, post-cap banner + sound, distinct bar styling, settings toggle | S (~1 day) |
+| **3 — Leaderboard + cosmetics** | server endpoint + cache, leaderboard panel, milestone titles/borders | M (~2–3 days) |
+| **4 — Prestige (optional)** | opt-in reset, prestige rank, confirmation UX | S–M |
+
+---
+
+## 13. Testing strategy
+
+### 13.1 Unit / snapshot (`tests/`)
+- New `tests/xp.test.ts`: mid-level carry (regression — already works), at-cap XP routes to `lifetimeXp` (not gold/zero), virtual-level boundaries, level-diff scaling still gates trivial mobs, prestige resets bar but not `lifetimeXp`.
+- Snapshot the XP-bar label states (pre-cap, at-cap, post-cap).
+
+### 13.2 Local manual testing
+1. `ALLOW_DEV_COMMANDS=1`; use `setPlayerLevel()` (`sim.ts:555`) to jump to 20.
+2. Kill mobs → confirm `lifetimeXp` grows and virtual level increments (today it's discarded — this is the headline regression check).
+3. Log out/in → confirm persistence via `serializeCharacter` + autosave.
+4. Hit `/api/leaderboard` → confirm ranking, realm scoping, and cache behavior.
+5. Trigger a milestone → confirm banner + persisted unlock.
+6. (Phase 4) Prestige → confirm bar resets, `lifetimeXp` and gear/talents untouched.
+
+### 13.3 Multiplayer correctness
+- Verify lifetime XP/virtual level compute in the authoritative `Sim` and reach the client only via snapshot/events (test the `ClientWorld` online path, not just offline).
+
+---
+
+## 14. Telemetry / metrics
+
+- Track: % of max-level characters earning post-cap XP weekly, median post-cap virtual level, leaderboard page views, milestone unlock counts, prestige adoption.
+- Success signal: increased session count/length for max-level characters after launch.
+
+---
+
+## 15. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Players expect power from post-cap XP | Clear cosmetic-only messaging; lean on leaderboard/cosmetics for motivation |
+| XP farming for leaderboard | Retain level-diff scaling; consider per-source diminishing returns |
+| Leaderboard query cost at scale | Server-side cache + indexed sort key |
+| Curve feels like an endless grind | Fixed-interval milestone rewards so progress is always visible |
+| Integer growth | 64-bit-safe handling; guard/log near 2^53 (practically unreachable) |
+
+---
+
+## 16. Open questions
+
+1. Virtual-level curve: continue current `XP_TABLE` slope, or adopt RuneScape-style ~10%/level growth?
+2. Milestone cadence: fixed interval vs. increasing — and what cosmetics exactly (titles, borders, nameplate icons)?
+3. Is prestige in scope for v1, or a fast-follow?
+4. Leaderboard scope: realm-only, global, and/or account-wide totals?
+5. Should rested XP be reworked alongside this, or deferred?
+
+---
+
+## 17. Acceptance criteria
+
+- A level-20 character killing mobs sees `lifetimeXp` and virtual level increase, persisted across logout.
+- The XP bar visibly progresses past cap with distinct styling and accurate labels.
+- `/api/leaderboard` returns correct, cached, realm-scoped rankings; the client panel renders them and highlights the viewer.
+- At least one cosmetic milestone unlocks, persists, and is shown on the character sheet.
+- No measurable change to combat-tick performance; no power gain at any virtual level.
+- (If Phase 4 shipped) Prestige resets the bar only, increments rank, and is fully reversible in understanding via the confirmation dialog.

--- a/index.html
+++ b/index.html
@@ -300,11 +300,14 @@
   #bottom-bar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 6px; text-align: center; }
   #xpbar { width: 612px; height: 10px; background: #14101e; border: 1px solid #000; outline: 1px solid #3a3148;
     margin: 0 auto 4px; position: relative; border-radius: 2px; overflow: hidden; }
-  #xpbar .fill { height: 100%; width: 0%; background: linear-gradient(#b85eff, #6a1bb0); }
+  #xpbar .fill { height: 100%; width: 0%; background: linear-gradient(#b85eff, #6a1bb0); transition: background .3s; }
   #xpbar .ticks { position: absolute; inset: 0; display: flex; }
   #xpbar .ticks i { flex: 1; border-right: 1px solid #00000055; }
   #xpbar .label { position: absolute; inset: 0; font-size: 9px; color: #fff; text-align: center; line-height: 10px; text-shadow: 1px 1px 1px #000; opacity: 0; transition: opacity .15s; }
   #xpbar:hover .label { opacity: 1; }
+  /* Post-cap overflow bar (Max-Level XP Overflow): gold/prestige tint. */
+  #xpbar.overflow { outline-color: #b8902a; box-shadow: 0 0 6px #f5c84355; }
+  #xpbar.overflow .fill { background: linear-gradient(#ffe27a, #d99a1c); }
   #actionbar-row { display: flex; align-items: flex-end; gap: 8px; }
   /* xp bar stacks directly on the action bar; the taller side-button
      column must not push it up (it used to float ~150px above the bar) */
@@ -484,6 +487,41 @@
   .ql-item { padding: 4px 6px; font-size: 12px; color: #d8c89a; cursor: pointer; border-radius: 3px; font-family: var(--title-font); }
   .ql-item:hover, .ql-item.sel { background: #ffffff14; color: var(--gold); }
   .ql-detail { flex: 1; font-size: 12px; max-height: 380px; overflow-y: auto; }
+
+  /* post-cap progression: character-sheet block + milestone badges */
+  .char-progression { margin-top: 10px; border-top: 1px solid #463a1c; padding-top: 8px; }
+  .cp-title { font-family: var(--title-font); color: var(--gold); font-size: 12px; letter-spacing: .4px; margin-bottom: 4px; }
+  .char-progression .cp-stats { border-top: none; margin-top: 0; padding-top: 0; }
+  .cp-milestones { font-size: 11.5px; color: #b9ac82; margin-top: 6px; display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
+  .cp-none { color: #7c7256; font-style: italic; }
+  .ms-badge { display: inline-block; font-size: 10.5px; padding: 1px 7px; border-radius: 8px; font-family: var(--title-font);
+    border: 1px solid #b8902a; color: #ffe27a; background: #2a210c; }
+  .ms-badge.ms-border { border-color: #c97bff; color: #e6c8ff; background: #2a1838; }
+  .cp-actions { margin-top: 8px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .cp-actions .btn[disabled] { opacity: 0.45; cursor: not-allowed; filter: grayscale(0.5); pointer-events: none; }
+  .cp-hint { font-size: 11px; color: #b9ac82; }
+
+  /* lifetime-XP leaderboard panel (modeled on the quest-log window) */
+  #leaderboard-window { left: 50%; top: 12%; transform: translateX(-50%); width: 480px; max-height: 70%; display: none; }
+  .lb-body { margin-top: 8px; max-height: 56vh; overflow-y: auto; }
+  .lb-loading, .lb-empty { font-size: 12px; color: #b9ac82; padding: 10px 4px; text-align: center; }
+  .lb-row { display: grid; grid-template-columns: 44px 1fr 44px 48px 96px; align-items: center; gap: 6px; padding: 4px 8px; font-size: 12px; border-radius: 3px; }
+  .lb-row:nth-child(odd) { background: #ffffff08; }
+  .lb-head { color: var(--gold); font-family: var(--title-font); font-size: 11px; letter-spacing: .3px; background: none; border-bottom: 1px solid #463a1c; }
+  .lb-rank { text-align: center; color: #d8c89a; }
+  .lb-name { color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .lb-lvl, .lb-vlvl { text-align: center; color: #cfc6a8; }
+  .lb-xp { text-align: right; color: #ffe27a; }
+  .lb-row.lb-mine { background: #f5c84322; outline: 1px solid #b8902a; }
+  .lb-you { color: #b8902a; font-size: 10px; }
+  .lb-prestige { color: #ffd100; font-size: 10px; }
+  .lb-sticky { position: sticky; bottom: 0; margin-top: 6px; border-top: 1px solid #463a1c; background: #160f08; padding-top: 4px; }
+
+  /* generic confirm dialog (prestige) */
+  #confirm-dialog { left: 50%; top: 50%; transform: translate(-50%, -50%); width: 360px; padding: 14px; z-index: 60; }
+  #confirm-dialog .cd-body { font-size: 12.5px; line-height: 1.55; color: #e8e0c8; margin: 10px 0; }
+  #confirm-dialog .cd-actions { display: flex; justify-content: flex-end; gap: 8px; }
+  #confirm-dialog .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }
 
   /* vendor */
   #vendor-window { left: 50%; top: 16%; transform: translateX(-50%); width: 400px; max-height: 68%; overflow-y: auto; }
@@ -1074,6 +1112,57 @@
     box-shadow: inset 0 0 8px #000;
     margin-top: var(--spacing-xs);
   }
+
+  /* Home-page global leaderboard (Max-Level XP Overflow) */
+  .hs-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-lg);
+    max-width: 720px;
+  }
+  .hs-leaderboard {
+    width: 100%;
+    margin-top: var(--spacing-sm);
+    text-align: left;
+  }
+  .hs-loading, .hs-empty, .hs-error {
+    color: var(--color-text-light);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    text-align: center;
+    padding: 18px 0;
+  }
+  .hs-error { color: #e08a7a; }
+  .hs-row {
+    display: grid;
+    grid-template-columns: 48px 1fr 120px 56px 64px 120px;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 12px;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    color: var(--color-text-light);
+    border-radius: var(--radius-sm);
+  }
+  .hs-row:nth-child(even) { background: rgba(255, 255, 255, 0.035); }
+  .hs-head {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 11px;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--color-border-default);
+    background: none !important;
+  }
+  .hs-rank { text-align: center; font-weight: 700; color: var(--color-primary-dim); }
+  .hs-row.hs-top .hs-rank { color: #ffd86b; text-shadow: 0 0 8px #f5c84366; }
+  .hs-name { color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .hs-realm, .hs-lvl, .hs-vlvl { color: var(--color-text-muted, #b9ac82); }
+  .hs-lvl, .hs-vlvl { text-align: center; }
+  .hs-xp { text-align: right; color: #ffe27a; font-variant-numeric: tabular-nums; }
+  .hs-prestige { color: #ffd100; font-size: 11px; margin-right: 4px; }
 
   /* Wiki view with integrated Controls Guide */
   .wiki-container-layout {
@@ -3249,6 +3338,7 @@
           <button class="micro-btn" id="mm-map" title="World Map">M<span class="keybind">m</span></button>
           <button class="micro-btn" id="mm-bag" title="Bags">B<span class="keybind">b</span></button>
           <button class="micro-btn" id="mm-arena" title="Ashen Coliseum (1v1 Arena)">⚔<span class="keybind">g</span></button>
+          <button class="micro-btn" id="mm-leaderboard" title="Leaderboard (Lifetime XP)">🏆<span class="keybind">k</span></button>
           <button class="micro-btn" id="mm-music" title="Toggle Music">♪</button>
         </div>
         <div id="meters-window" class="panel">
@@ -3294,6 +3384,7 @@
       <canvas id="map-canvas" width="560" height="560"></canvas>
     </div>
     <div id="arena-window" class="window panel"></div>
+    <div id="leaderboard-window" class="window panel"></div>
     <div id="market-window" class="window panel"></div>
     <div id="arena-status"></div>
     <div id="options-menu" class="window panel"></div>
@@ -3569,15 +3660,17 @@
       </section>
 
       <section id="highscores-view" class="view-section" hidden aria-hidden="true">
-        <div class="parchment-panel skeleton-panel">
+        <div class="parchment-panel hs-panel">
           <div class="skeleton-icon-wrapper">
             <svg viewBox="0 0 24 24" class="skeleton-svg-icon" aria-hidden="true">
               <path fill="currentColor" d="M12 2C11.5 2 6 4 6 4V10C6 14.41 9.59 18 12 18.5C14.41 18 18 14.41 18 10V4C18 4 12.5 2 12 2M12 16.5C10.32 15.5 8 12.78 8 10V5.37L12 3.91L16 5.37V10C16 12.78 13.68 15.5 12 16.5Z"/>
             </svg>
           </div>
           <h2 class="skeleton-title" data-i18n="highscores.title">High Scores Leaderboard</h2>
-          <p class="skeleton-desc" data-i18n="highscores.desc">Track the realm's greatest champions and compare your progress.</p>
-          <div class="coming-soon-badge" data-i18n="comingSoon.placeholder">Coming Soon...</div>
+          <p class="skeleton-desc" data-i18n="game.leaderboard.globalSubtitle">Top champions across all realms</p>
+          <div id="hs-leaderboard" class="hs-leaderboard" aria-live="polite">
+            <div class="hs-loading" data-i18n="game.leaderboard.loading">Loading rankings…</div>
+          </div>
         </div>
       </section>
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -44,6 +44,13 @@ CREATE TABLE IF NOT EXISTS characters (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS characters_account ON characters(account_id);
+-- Max-Level XP Overflow leaderboard: indexed lifetime-XP sort key. The first
+-- index serves the realm-scoped in-game panel; the second serves the global
+-- (cross-realm) home-page board.
+CREATE INDEX IF NOT EXISTS characters_lifetime_xp
+  ON characters (realm, ((state->>'lifetimeXp')::bigint) DESC);
+CREATE INDEX IF NOT EXISTS characters_lifetime_xp_global
+  ON characters (((state->>'lifetimeXp')::bigint) DESC);
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS suspended_until TIMESTAMPTZ;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS banned_at TIMESTAMPTZ;
@@ -355,6 +362,56 @@ export async function topArenaRatings(limit = 20): Promise<ArenaLeaderRow[]> {
   return res.rows.map((r) => ({
     name: r.name, class: r.class, level: r.level,
     rating: Number(r.rating), wins: Number(r.wins), losses: Number(r.losses),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Lifetime-XP leaderboard (Max-Level XP Overflow). Ranks characters by the
+// `lifetimeXp` stored in their state JSONB. Realm-scoped (FR-4.3) and backed by
+// the `characters_lifetime_xp` index. Read through the server-side cache in
+// main.ts — never run per request under load.
+// ---------------------------------------------------------------------------
+
+export interface LifetimeXpLeaderRow {
+  name: string;
+  class: PlayerClass;
+  level: number;
+  realm: string;
+  lifetimeXp: number;
+  prestigeRank: number;
+}
+
+// `global: true` ranks across every realm (for the home-page board); otherwise
+// it is scoped to this process's realm (the in-game panel). Both paths sort on
+// the indexed lifetime-XP expression and are read through the main.ts cache.
+export async function topLifetimeXp(limit = 100, opts: { global?: boolean } = {}): Promise<LifetimeXpLeaderRow[]> {
+  const cap = Math.max(1, Math.min(100, limit));
+  const res = opts.global
+    ? await pool.query(
+        `SELECT name, class, level, realm,
+                COALESCE((state->>'lifetimeXp')::bigint, 0) AS lifetime_xp,
+                COALESCE((state->>'prestigeRank')::int, 0)  AS prestige_rank
+           FROM characters
+          WHERE state IS NOT NULL
+            AND COALESCE((state->>'lifetimeXp')::bigint, 0) > 0
+          ORDER BY lifetime_xp DESC, level DESC, name ASC
+          LIMIT $1`,
+        [cap],
+      )
+    : await pool.query(
+        `SELECT name, class, level, realm,
+                COALESCE((state->>'lifetimeXp')::bigint, 0) AS lifetime_xp,
+                COALESCE((state->>'prestigeRank')::int, 0)  AS prestige_rank
+           FROM characters
+          WHERE realm = $1 AND state IS NOT NULL
+            AND COALESCE((state->>'lifetimeXp')::bigint, 0) > 0
+          ORDER BY lifetime_xp DESC, level DESC, name ASC
+          LIMIT $2`,
+        [REALM, cap],
+      );
+  return res.rows.map((r) => ({
+    name: r.name, class: r.class, level: r.level, realm: r.realm,
+    lifetimeXp: Number(r.lifetime_xp), prestigeRank: Number(r.prestige_rank),
   }));
 }
 

--- a/server/game.ts
+++ b/server/game.ts
@@ -706,6 +706,9 @@ export class GameServer {
       // arena (Ashen Coliseum 1v1 queue)
       case 'arena_queue': sim.arenaQueueJoin(pid); break;
       case 'arena_leave': sim.arenaQueueLeave(pid); break;
+
+      // post-cap cosmetic prestige (Max-Level XP Overflow, Phase 4)
+      case 'prestige': sim.prestige(pid); break;
       // World Market (the Merchant's auction house)
       case 'market_list':
         if (typeof msg.item === 'string' && typeof msg.count === 'number' && typeof msg.price === 'number') {
@@ -884,6 +887,8 @@ export class GameServer {
       mres: p.maxResource,
       rtype: p.resourceType,
       xp: meta.xp,
+      lxp: meta.lifetimeXp,
+      prk: meta.prestigeRank,
       copper: meta.copper,
       gcd: round2(p.gcdRemaining),
       combo: p.comboPoints,
@@ -915,6 +920,7 @@ export class GameServer {
     maybe('equip', meta.equipment);
     maybe('qlog', [...meta.questLog.values()]);
     maybe('qdone', [...meta.questsDone]);
+    maybe('milestones', [...meta.unlockedMilestones]);
     maybe('cds', Object.fromEntries([...p.cooldowns.entries()].map(([k, v]) => [k, round2(v)])));
     maybe('stats', p.stats);
     maybe('weapon', p.weapon);

--- a/server/main.ts
+++ b/server/main.ts
@@ -6,8 +6,10 @@ import {
   ensureSchema, pool, createAccount, findAccount, getAccountsCount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
-  findCharacterReportTargetByName, topArenaRatings,
+  findCharacterReportTargetByName, topArenaRatings, topLifetimeXp,
 } from './db';
+import { virtualLevel } from '../src/sim/types';
+import type { LeaderboardEntry } from '../src/world_api';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
 import {
@@ -26,6 +28,48 @@ const STATIC_DIR = path.join(__dirname, '..', 'dist');
 const CHAT_LOG_RETENTION_DAYS = Number(process.env.CHAT_LOG_RETENTION_DAYS ?? 90);
 
 const game = new GameServer();
+
+// ---------------------------------------------------------------------------
+// Lifetime-XP leaderboard cache (Max-Level XP Overflow, FR-4.2 / PR-3).
+// Same shape as the chat-censor memoization: compute once, serve from memory,
+// refresh on an interval. The query is never run per request under load — at
+// most once per LEADERBOARD_TTL_MS, plus the boot warm-up below.
+// ---------------------------------------------------------------------------
+const LEADERBOARD_TTL_MS = 30_000;
+const LEADERBOARD_SIZE = 100;
+// One cache per scope: 'realm' for the in-game panel, 'global' for the
+// cross-realm home-page board.
+const leaderboardCache: Record<'realm' | 'global', { at: number; entries: LeaderboardEntry[] } | null> = {
+  realm: null,
+  global: null,
+};
+
+async function refreshLeaderboard(scope: 'realm' | 'global'): Promise<LeaderboardEntry[]> {
+  const rows = await topLifetimeXp(LEADERBOARD_SIZE, { global: scope === 'global' });
+  const entries: LeaderboardEntry[] = rows.map((r, i) => ({
+    rank: i + 1,
+    name: r.name,
+    cls: r.class,
+    level: r.level,
+    virtualLevel: virtualLevel(r.lifetimeXp),
+    lifetimeXp: r.lifetimeXp,
+    prestigeRank: r.prestigeRank,
+    ...(scope === 'global' ? { realm: r.realm } : {}),
+  }));
+  leaderboardCache[scope] = { at: Date.now(), entries };
+  return entries;
+}
+
+async function getLeaderboard(scope: 'realm' | 'global'): Promise<LeaderboardEntry[]> {
+  const cached = leaderboardCache[scope];
+  if (cached && Date.now() - cached.at < LEADERBOARD_TTL_MS) return cached.entries;
+  try {
+    return await refreshLeaderboard(scope);
+  } catch (err) {
+    console.error(`leaderboard refresh failed (${scope}):`, err);
+    return cached?.entries ?? [];
+  }
+}
 
 function normalizeDeleteConfirmation(name: unknown): string {
   return typeof name === 'string' ? name.trim().toLowerCase() : '';
@@ -307,6 +351,18 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       // public all-time Ashen Coliseum ladder (top rated characters)
       return json(res, 200, { leaders: await topArenaRatings(20) });
     }
+    if (req.method === 'GET' && url === '/api/leaderboard') {
+      // lifetime-XP leaderboard (Max-Level XP Overflow), served from the
+      // in-memory cache. metric is fixed to lifetimeXp. ?scope=global ranks
+      // across every realm (home page); default is this process's realm (the
+      // in-game panel). Optional ?limit=N (1..100). `url` is the path only, so
+      // the query string is parsed from req.url.
+      const params = new URLSearchParams((req.url ?? '').split('?')[1] ?? '');
+      const scope: 'realm' | 'global' = params.get('scope') === 'global' ? 'global' : 'realm';
+      const limit = Math.max(1, Math.min(LEADERBOARD_SIZE, Number(params.get('limit')) || LEADERBOARD_SIZE));
+      const entries = await getLeaderboard(scope);
+      return json(res, 200, { realm: REALM, scope, metric: 'lifetimeXp', leaders: entries.slice(0, limit) });
+    }
     json(res, 404, { error: 'unknown endpoint' });
   } catch (err: any) {
     console.error('api error:', err);
@@ -339,6 +395,14 @@ async function main(): Promise<void> {
   setInterval(() => {
     void pruneChatLogs(CHAT_LOG_RETENTION_DAYS).catch((err) => console.error('chat log prune failed:', err));
   }, 24 * 3600 * 1000).unref();
+  // keep both leaderboard caches warm so the first viewer never waits on the
+  // query and it never recomputes per request (PR-3)
+  const warmLeaderboards = () => {
+    void refreshLeaderboard('realm').catch((err) => console.error('leaderboard refresh failed (realm):', err));
+    void refreshLeaderboard('global').catch((err) => console.error('leaderboard refresh failed (global):', err));
+  };
+  warmLeaderboards();
+  setInterval(warmLeaderboards, LEADERBOARD_TTL_MS).unref();
   console.log('database ready');
 
   const server = http.createServer((req, res) => {

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -15,7 +15,7 @@ const TOUCH_LOOK_PITCH_RATE = 2.2;
 export interface InputCallbacks {
   onTab(): void;
   onAbility(slot: number): void;
-  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena'): void;
+  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena' | 'leaderboard'): void;
   onClickPick(x: number, y: number, button: number): void;
 }
 
@@ -148,6 +148,7 @@ export class Input {
       case 'meters': this.cb.onUiKey('meters'); return;
       case 'social': this.cb.onUiKey('social'); return;
       case 'arena': this.cb.onUiKey('arena'); return;
+      case 'leaderboard': this.cb.onUiKey('leaderboard'); return;
       case 'chat': this.cb.onUiKey('chat'); return;
     }
   }

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -48,6 +48,7 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyN'] },
   { id: 'social', label: 'Friends & Guild', category: 'Interface', kind: 'edge', defaults: ['KeyO'] },
   { id: 'arena', label: 'Arena (Ashen Coliseum)', category: 'Interface', kind: 'edge', defaults: ['KeyG'] },
+  { id: 'leaderboard', label: 'Leaderboard', category: 'Interface', kind: 'edge', defaults: ['KeyK'] },
   { id: 'chat', label: 'Open Chat', category: 'Interface', kind: 'edge', defaults: ['Enter', 'NumpadEnter'] },
   // Action bar (slot 0 = Attack)
   ...SLOT_DEFAULTS.map((code, i): BindAction => ({

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -9,6 +9,7 @@ export interface GameSettings {
   brightness: number;   // tone-mapping exposure multiplier
   renderScale: number;  // resolution multiplier on top of the device pixel ratio
   fullscreen: number;   // 0/1 browser fullscreen preference
+  showOverflowXp: number; // 1 = show post-cap virtual-level overflow bar (default), 0 = classic "MAX LEVEL"
 }
 
 interface Range { min: number; max: number; def: number }
@@ -23,6 +24,9 @@ export const SETTING_RANGES: Record<keyof GameSettings, Range> = {
   brightness: { min: 0.6, max: 1.5, def: 1 },
   renderScale: { min: 0.5, max: 1, def: 1 },
   fullscreen: { min: 0, max: 1, def: 1 },
+  // on by default: post-cap players see their overflow/virtual-level bar; turn
+  // off for the classic static "MAX LEVEL" text (Max-Level XP Overflow)
+  showOverflowXp: { min: 0, max: 1, def: 1 },
 };
 
 const STORE_KEY = 'woc_settings';

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,7 +9,8 @@ import { audio } from './game/audio';
 import { music } from './game/music';
 import { handlePickedEntity } from './game/interactions';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
-import type { IWorld } from './world_api';
+import type { IWorld, LeaderboardEntry } from './world_api';
+import { formatXp } from './ui/xp_bar';
 import { assetsReady } from './render/assets/preload';
 import { CharacterPreview } from './render/characters';
 import { DT, INTERACT_RANGE, PlayerClass, dist2d } from './sim/types';
@@ -369,6 +370,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         case 'meters': hud.toggleMeters(); break;
         case 'social': hud.toggleSocial(); break;
         case 'arena': hud.toggleArena(); break;
+        case 'leaderboard': hud.toggleLeaderboard(); break;
         case 'chat': openChat(); break;
         case 'escape':
           // close the topmost panel; if nothing was open, open the game menu
@@ -1464,6 +1466,50 @@ async function loadProjectStats(): Promise<void> {
   }
 }
 
+// Home-page global (cross-realm) lifetime-XP leaderboard. Server computes the
+// virtual level + ranking; this only renders. Re-fetched each time the High
+// Scores view is opened (the server caches, so this is cheap).
+let highscoresLoading = false;
+async function loadHighscores(): Promise<void> {
+  const host = $('#hs-leaderboard');
+  if (!host || highscoresLoading) return;
+  highscoresLoading = true;
+  host.innerHTML = `<div class="hs-loading">${t('game.leaderboard.loading')}</div>`;
+  let rows: LeaderboardEntry[] = [];
+  try {
+    rows = await api.leaderboard('global', 100);
+  } catch {
+    host.innerHTML = `<div class="hs-error">${t('game.leaderboard.retry')}</div>`;
+    highscoresLoading = false;
+    return;
+  }
+  highscoresLoading = false;
+  if (rows.length === 0) {
+    host.innerHTML = `<div class="hs-empty">${t('game.leaderboard.empty')}</div>`;
+    return;
+  }
+  const esc = (s: string): string => s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+  const head = `<div class="hs-row hs-head">`
+    + `<span class="hs-rank">${t('game.leaderboard.rank')}</span>`
+    + `<span class="hs-name">${t('game.leaderboard.name')}</span>`
+    + `<span class="hs-realm">${t('game.leaderboard.realmCol')}</span>`
+    + `<span class="hs-lvl">${t('game.leaderboard.level')}</span>`
+    + `<span class="hs-vlvl">${t('game.leaderboard.vlevel')}</span>`
+    + `<span class="hs-xp">${t('game.leaderboard.lifetimeXp')}</span></div>`;
+  const body = rows.map((r) => {
+    const cls = CLASSES[r.cls];
+    const star = r.prestigeRank > 0 ? `<span class="hs-prestige" title="${t('game.prestige.rank')} ${r.prestigeRank}">★${r.prestigeRank}</span>` : '';
+    return `<div class="hs-row${r.rank <= 3 ? ' hs-top' : ''}">`
+      + `<span class="hs-rank">${r.rank}</span>`
+      + `<span class="hs-name"${cls ? ` title="${esc(cls.name)}"` : ''}>${star}${esc(r.name)}</span>`
+      + `<span class="hs-realm">${esc(r.realm ?? '')}</span>`
+      + `<span class="hs-lvl">${r.level}</span>`
+      + `<span class="hs-vlvl">${r.virtualLevel}</span>`
+      + `<span class="hs-xp">${formatXp(r.lifetimeXp)}</span></div>`;
+  }).join('');
+  host.innerHTML = head + body;
+}
+
 function wireStartScreens(): void {
   // Initial page translation and stats load
   translatePage();
@@ -2002,7 +2048,10 @@ function wireStartScreens(): void {
     show('#mode-select');
   });
 
-  setupNavBtn(navBtnHighscores, '#highscores-view');
+  setupNavBtn(navBtnHighscores, '#highscores-view', () => {
+    switchMainView('#highscores-view');
+    void loadHighscores();
+  });
   setupNavBtn(navBtnWiki, '#wiki-view');
   setupNavBtn(navBtnNews, '#news-view');
   setupNavBtn(navBtnDownload, '#download-view');

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -6,7 +6,7 @@ import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
-import type { ArenaInfo, CharacterSearchResult, DuelInfo, IWorld, MarketInfo, PartyInfo, SocialInfo, TradeInfo } from '../world_api';
+import type { ArenaInfo, CharacterSearchResult, DuelInfo, IWorld, LeaderboardEntry, MarketInfo, PartyInfo, SocialInfo, TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
 // REST
@@ -159,6 +159,16 @@ export class Api {
   async projectStats(): Promise<{ accounts_created: number; players_online: number; realm: string }> {
     return this.get('/api/project-stats');
   }
+
+  // Lifetime-XP leaderboard for the home page. 'global' ranks across all realms.
+  async leaderboard(scope: 'realm' | 'global' = 'global', limit = 100): Promise<LeaderboardEntry[]> {
+    try {
+      const data = await this.get(`/api/leaderboard?scope=${scope}&metric=lifetimeXp&limit=${limit}`);
+      return data.leaders ?? [];
+    } catch {
+      return [];
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +222,10 @@ export class ClientWorld implements IWorld {
   equipment: Partial<Record<EquipSlot, string>> = {};
   copper = 0;
   xp = 0;
+  // Post-cap progression (Max-Level XP Overflow), mirrored from snapshot self.
+  lifetimeXp = 0;
+  prestigeRank = 0;
+  unlockedMilestones: string[] = [];
   known: ResolvedAbility[] = [];
   questLog = new Map<string, QuestProgress>();
   questsDone = new Set<string>();
@@ -494,6 +508,9 @@ export class ClientWorld implements IWorld {
         ? { itemId: '', kind: 'drink', hpPer2s: 0, manaPer2s: 0, remaining: s.drk.remaining }
         : null;
       this.xp = s.xp ?? 0;
+      this.lifetimeXp = s.lxp ?? 0;
+      this.prestigeRank = s.prk ?? 0;
+      if (s.milestones !== undefined) this.unlockedMilestones = s.milestones;
       this.copper = s.copper ?? 0;
       if (s.inv !== undefined) { this.inventory = s.inv; this.invChanged = true; }
       if (s.equip !== undefined) this.equipment = s.equip;
@@ -696,6 +713,18 @@ export class ClientWorld implements IWorld {
   }
   leaveDungeon(): void {
     this.cmd({ cmd: 'leave_dungeon' });
+  }
+  async leaderboard(): Promise<LeaderboardEntry[]> {
+    try {
+      const res = await fetch(`${this.base}/api/leaderboard?metric=lifetimeXp&limit=100`);
+      if (!res.ok) return [];
+      return (await res.json()).leaders ?? [];
+    } catch {
+      return [];
+    }
+  }
+  prestige(): void {
+    this.cmd({ cmd: 'prestige' });
   }
   // legacy aliases kept for older scripts
   enterCrypt(): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -15,6 +15,7 @@ import {
   TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatModifier, topThreatValue,
 } from './threat';
 import { groundHeight, WATER_LEVEL } from './world';
+import type { LeaderboardEntry } from '../world_api';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
   CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
@@ -22,6 +23,7 @@ import {
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
   rageFromDealing, rageFromTaking, spellHitChance, xpForLevel,
+  MILESTONES, virtualLevel, xpToReachLevel, canPrestige,
 } from './types';
 
 const LEASH_DISTANCE = 45;
@@ -175,6 +177,13 @@ export interface PlayerMeta {
   copper: number;
   equipment: PlayerEquipment;
   xp: number;
+  // Post-cap progression (Max-Level XP Overflow). `lifetimeXp` is the monotonic
+  // 64-bit-safe total of all XP ever earned — it keeps growing at the cap and is
+  // the leaderboard sort key + virtual-level source. `prestigeRank` and
+  // `unlockedMilestones` are cosmetic-only. All persisted in CharacterState.
+  lifetimeXp: number;
+  prestigeRank: number;
+  unlockedMilestones: Set<string>;
   known: ResolvedAbility[];
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;
@@ -227,6 +236,11 @@ export interface MarketSave {
 export interface CharacterState {
   level: number;
   xp: number;
+  // Post-cap progression. All optional so characters saved before the Max-Level
+  // XP Overflow system load cleanly (addPlayer backfills lifetimeXp from level).
+  lifetimeXp?: number;
+  prestigeRank?: number;
+  unlockedMilestones?: string[];
   copper: number;
   hp: number;
   resource: number;
@@ -439,6 +453,9 @@ export class Sim {
       copper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
       xp: 0,
+      lifetimeXp: 0,
+      prestigeRank: 0,
+      unlockedMilestones: new Set(),
       known: [],
       questLog: new Map(),
       questsDone: new Set(),
@@ -457,6 +474,12 @@ export class Sim {
       player.facing = s.facing;
       player.prevFacing = s.facing;
       meta.xp = s.xp;
+      // Backfill lifetimeXp for pre-overflow saves from the level they reached
+      // plus their current bar progress, so the leaderboard is meaningful for
+      // existing characters from day one.
+      meta.lifetimeXp = s.lifetimeXp ?? (xpToReachLevel(player.level) + Math.max(0, s.xp));
+      meta.prestigeRank = s.prestigeRank ?? 0;
+      if (s.unlockedMilestones) for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
       meta.inventory = s.inventory.map((i) => ({ ...i }));
@@ -531,6 +554,9 @@ export class Sim {
     return {
       level: e.level,
       xp: meta.xp,
+      lifetimeXp: meta.lifetimeXp,
+      prestigeRank: meta.prestigeRank,
+      unlockedMilestones: [...meta.unlockedMilestones],
       copper: meta.copper,
       hp: e.hp,
       resource: e.resource,
@@ -580,6 +606,36 @@ export class Sim {
   }
   set xp(v: number) {
     this.primary.xp = v;
+  }
+  get lifetimeXp(): number {
+    return this.primary.lifetimeXp;
+  }
+  get prestigeRank(): number {
+    return this.primary.prestigeRank;
+  }
+  get unlockedMilestones(): string[] {
+    return [...this.primary.unlockedMilestones];
+  }
+  // Offline leaderboard: rank the players the local sim knows about by lifetime
+  // XP. Online play overrides this with the cached, realm-scoped server query.
+  leaderboard(): Promise<LeaderboardEntry[]> {
+    const rows = [...this.players.values()]
+      .map((m) => {
+        const e = this.entities.get(m.entityId);
+        return e ? { meta: m, e } : null;
+      })
+      .filter((x): x is { meta: PlayerMeta; e: Entity } => x !== null)
+      .sort((a, b) => b.meta.lifetimeXp - a.meta.lifetimeXp || b.e.level - a.e.level || a.meta.name.localeCompare(b.meta.name))
+      .map(({ meta, e }, i) => ({
+        rank: i + 1,
+        name: meta.name,
+        cls: meta.cls,
+        level: e.level,
+        virtualLevel: virtualLevel(meta.lifetimeXp),
+        lifetimeXp: meta.lifetimeXp,
+        prestigeRank: meta.prestigeRank,
+      }));
+    return Promise.resolve(rows);
   }
   get known(): ResolvedAbility[] {
     return this.primary.known;
@@ -677,6 +733,10 @@ export class Sim {
     const r = this.resolve(pid);
     if (!r) return;
     r.e.level = Math.max(1, Math.min(MAX_LEVEL, level));
+    // Keep lifetimeXp consistent with the level so post-cap progression starts
+    // from a sane baseline (virtualLevel never falls below the real level). Only
+    // ever raises it — lifetimeXp is monotonic.
+    r.meta.lifetimeXp = Math.max(r.meta.lifetimeXp, xpToReachLevel(r.e.level));
     recalcPlayerStats(r.e, r.meta.cls, r.meta.equipment);
     r.e.hp = r.e.maxHp;
     if (r.e.resourceType === 'mana') r.e.resource = r.e.maxResource;
@@ -2189,8 +2249,11 @@ export class Sim {
         for (const member of eligible) {
           const mE = this.entities.get(member.entityId);
           if (!mE) continue;
+          // mobXpValue keeps the level-diff (anti-farm) scaling; grantXp now
+          // routes the award to lifetimeXp even at the cap, so the party gate no
+          // longer blocks max-level members — it just forwards every positive award.
           const xpGain = Math.round((mobXpValue(e.level, mE.level) * eliteMult * bonus) / eligible.length);
-          if (xpGain > 0 && mE.level < MAX_LEVEL) this.grantXp(xpGain, member);
+          if (xpGain > 0) this.grantXp(xpGain, member);
           this.onMobKilledForQuests(e, member);
         }
         this.rollLoot(e, meta);
@@ -2200,10 +2263,19 @@ export class Sim {
 
   grantXp(amount: number, meta: PlayerMeta = this.primary): void {
     const p = this.entities.get(meta.entityId);
-    if (!p || p.level >= MAX_LEVEL) return;
-    meta.xp += amount;
+    if (!p || amount <= 0) return;
+    // Lifetime XP accrues for EVERY award, including at the cap — this is what
+    // makes post-cap progression work. It feeds the virtual level, the
+    // leaderboard, and cosmetic milestones. The level bar below only advances
+    // while under the cap; once capped the remainder lives on in lifetimeXp
+    // rather than being discarded to gold/zero (FR-1.4).
+    this.accrueLifetimeXp(amount, meta, p);
     meta.counters.xpGained += amount;
     this.emit({ type: 'xp', amount, pid: p.id });
+
+    if (p.level >= MAX_LEVEL) return; // bar frozen at cap; lifetimeXp already credited
+
+    meta.xp += amount;
     while (p.level < MAX_LEVEL && meta.xp >= xpForLevel(p.level)) {
       meta.xp -= xpForLevel(p.level);
       p.level++;
@@ -2214,7 +2286,59 @@ export class Sim {
       this.emit({ type: 'levelup', level: p.level, pid: p.id });
       this.refreshKnownAbilities(meta, true);
     }
+    // Dinged to cap mid-grant: clear the leftover from the BAR. It is not lost —
+    // the full award was already added to lifetimeXp above (FR-1.4).
     if (p.level >= MAX_LEVEL) meta.xp = 0;
+  }
+
+  // Add to the monotonic lifetime counter, emitting cosmetic virtual-level-up
+  // events past the cap and unlocking any newly crossed milestones. Cheap: one
+  // add plus an O(log n) table lookup, never touched on the per-tick hot path.
+  private accrueLifetimeXp(amount: number, meta: PlayerMeta, p: Entity): void {
+    const atCap = p.level >= MAX_LEVEL;
+    const beforeVL = atCap ? virtualLevel(meta.lifetimeXp) : 0;
+    meta.lifetimeXp += amount;
+    // 64-bit-safe invariant: JS numbers are exact to 2^53. A single character
+    // reaching this is effectively impossible, but clamp + log if it ever does.
+    if (meta.lifetimeXp >= Number.MAX_SAFE_INTEGER) {
+      meta.lifetimeXp = Number.MAX_SAFE_INTEGER;
+      console.warn(`lifetimeXp for ${meta.name} hit the 2^53 ceiling and was clamped`);
+    }
+    if (atCap) {
+      const afterVL = virtualLevel(meta.lifetimeXp);
+      for (let v = beforeVL + 1; v <= afterVL; v++) {
+        this.emit({ type: 'virtualLevelUp', level: v, pid: p.id });
+      }
+    }
+    this.checkMilestones(meta, p);
+  }
+
+  // Unlock any cosmetic milestone whose lifetime-XP threshold was just crossed.
+  private checkMilestones(meta: PlayerMeta, p: Entity): void {
+    for (const m of MILESTONES) {
+      if (meta.lifetimeXp >= m.lifetimeXp && !meta.unlockedMilestones.has(m.id)) {
+        meta.unlockedMilestones.add(m.id);
+        this.emit({ type: 'milestoneUnlocked', milestoneId: m.id, pid: p.id });
+      }
+    }
+  }
+
+  // Opt-in cosmetic prestige (Phase 4): only at the cap. Resets the level XP
+  // bar, bumps the prestige rank for a badge by the name + on the leaderboard,
+  // and deliberately leaves lifetimeXp, level, gear, talents, and learned
+  // abilities untouched — strictly cosmetic, zero power change (FR-6.1/6.3).
+  prestige(pid?: number): boolean {
+    const r = this.resolve(pid);
+    if (!r) return false;
+    // Authoritative anti-abuse gate: must be at the cap AND have earned a full
+    // prestige bar of post-cap XP since the last rank. This caps prestigeRank at
+    // what lifetimeXp supports, so spamming the `prestige` command (e.g. from a
+    // hacked client) can never inflate the rank beyond XP actually earned.
+    if (!canPrestige(r.e.level, r.meta.lifetimeXp, r.meta.prestigeRank)) return false;
+    r.meta.xp = 0;
+    r.meta.prestigeRank += 1;
+    this.emit({ type: 'log', pid: r.e.id, text: `You have prestiged! Prestige Rank ${r.meta.prestigeRank}.`, color: '#ffd100' });
+    return true;
   }
 
   private rollLoot(mob: Entity, meta: PlayerMeta): void {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -468,6 +468,10 @@ export type SimEvent = { pid?: number } & (
   | { type: 'death'; entityId: number; killerId: number }
   | { type: 'xp'; amount: number }
   | { type: 'levelup'; level: number }
+  // post-cap cosmetic progression (Max-Level XP Overflow): crossing a virtual
+  // level past the cap, and unlocking a cosmetic lifetime-XP milestone
+  | { type: 'virtualLevelUp'; level: number }
+  | { type: 'milestoneUnlocked'; milestoneId: string }
   | { type: 'learnAbility'; abilityId: string; rank: number }
   | { type: 'loot'; text: string }
   | { type: 'error'; text: string }
@@ -563,6 +567,113 @@ export const MAX_LEVEL = 20;
 
 export function xpForLevel(level: number): number {
   return XP_TABLE[Math.min(level - 1, XP_TABLE.length - 1)];
+}
+
+// ---------------------------------------------------------------------------
+// Post-cap progression — "Max-Level XP Overflow" (see docs/prd/…).
+//
+// At the level cap, XP keeps accruing into a 64-bit lifetime counter that
+// drives a cosmetic *virtual level* so the XP bar keeps "leveling" forever.
+// The threshold table below is the cumulative lifetime XP needed to reach each
+// virtual level. Real levels 1..20 reuse XP_TABLE exactly (so below the cap
+// `virtualLevel(lifetimeXp) === level`); past the cap the per-level cost keeps
+// growing geometrically (RuneScape-style ~10%/level) so the grind has a long
+// tail but the bar always visibly moves. Built once and cached.
+// ---------------------------------------------------------------------------
+
+const POSTCAP_GROWTH = 1.1; // each virtual level past the cap costs ~10% more
+export const MAX_VIRTUAL_LEVEL = 200; // table bound; far beyond any reachable lifetime total
+
+// VLEVEL_CUM[v] = total lifetime XP required to *reach* virtual level v.
+// VLEVEL_CUM[1] = 0; index 0 is unused padding.
+const VLEVEL_CUM: number[] = (() => {
+  const cum: number[] = [0, 0];
+  let total = 0;
+  // real levels: 1→2 … 19→20 come straight from XP_TABLE
+  for (let lvl = 1; lvl < MAX_LEVEL; lvl++) {
+    total += XP_TABLE[lvl - 1];
+    cum[lvl + 1] = total;
+  }
+  // post-cap: continue from the 20→21 step, growing geometrically
+  let step = XP_TABLE[MAX_LEVEL - 1];
+  for (let lvl = MAX_LEVEL; lvl < MAX_VIRTUAL_LEVEL; lvl++) {
+    total += Math.round(step);
+    cum[lvl + 1] = total;
+    step *= POSTCAP_GROWTH;
+  }
+  return cum;
+})();
+
+// Total lifetime XP needed to reach a given (virtual or real) level. Used to
+// backfill `lifetimeXp` for characters saved before the counter existed.
+export function xpToReachLevel(level: number): number {
+  return VLEVEL_CUM[Math.max(1, Math.min(MAX_VIRTUAL_LEVEL, Math.floor(level)))];
+}
+
+// Cosmetic virtual level for a lifetime-XP total. Below the cap this equals the
+// real level; at/after the cap it climbs past MAX_LEVEL. O(log n) over the
+// cached table — never recomputed per frame, never per combat tick.
+export function virtualLevel(lifetimeXp: number): number {
+  const xp = Math.max(0, lifetimeXp);
+  let lo = 1, hi = MAX_VIRTUAL_LEVEL;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (VLEVEL_CUM[mid] <= xp) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+// Progress within the current virtual level: how much lifetime XP into it, and
+// how much that level costs in total. Pre-cap callers use the level bar instead.
+export function virtualLevelProgress(lifetimeXp: number): { level: number; into: number; span: number } {
+  const level = virtualLevel(lifetimeXp);
+  const floor = VLEVEL_CUM[level];
+  const next = VLEVEL_CUM[Math.min(level + 1, MAX_VIRTUAL_LEVEL)];
+  const span = Math.max(1, next - floor);
+  return { level, into: Math.max(0, Math.min(span, lifetimeXp - floor)), span };
+}
+
+// Cosmetic lifetime-XP milestones (Paragon-style). Strictly cosmetic — they
+// grant titles / nameplate borders, never power. Ordered by threshold.
+export interface MilestoneDef {
+  id: string;
+  lifetimeXp: number;
+  kind: 'title' | 'border';
+}
+export const MILESTONES: MilestoneDef[] = [
+  { id: 'veteran', lifetimeXp: 250_000, kind: 'title' },
+  { id: 'champion', lifetimeXp: 500_000, kind: 'title' },
+  { id: 'paragon', lifetimeXp: 1_000_000, kind: 'border' },
+  { id: 'mythic', lifetimeXp: 2_500_000, kind: 'border' },
+  { id: 'eternal', lifetimeXp: 5_000_000, kind: 'title' },
+];
+
+// Prestige cost. Each prestige rank requires a full level-cap bar's worth of
+// post-cap lifetime XP, so prestige rank is a pure function of XP actually
+// earned past the cap. This is the anti-abuse guard: the prestige command can't
+// be spammed from a hacked client to inflate the (leaderboard-visible) rank —
+// the server caps rank at maxPrestigeRank(lifetimeXp) regardless of how many
+// prestige commands arrive.
+export const PRESTIGE_XP_PER_RANK = xpForLevel(MAX_LEVEL); // = 23,200
+
+// Highest prestige rank the given lifetime XP can support (post-cap XP / cost).
+export function maxPrestigeRank(lifetimeXp: number): number {
+  const earned = lifetimeXp - xpToReachLevel(MAX_LEVEL);
+  return earned <= 0 ? 0 : Math.floor(earned / PRESTIGE_XP_PER_RANK);
+}
+
+// Authoritative prestige eligibility: at the cap, and with enough unspent
+// post-cap XP for the next rank. Used server-side (enforced) and client-side
+// (to enable/disable the button — display only).
+export function canPrestige(level: number, lifetimeXp: number, prestigeRank: number): boolean {
+  return level >= MAX_LEVEL && prestigeRank < maxPrestigeRank(lifetimeXp);
+}
+
+// Lifetime XP still needed before the next prestige rank unlocks (0 if ready).
+export function xpUntilNextPrestige(lifetimeXp: number, prestigeRank: number): number {
+  const target = xpToReachLevel(MAX_LEVEL) + (prestigeRank + 1) * PRESTIGE_XP_PER_RANK;
+  return Math.max(0, target - lifetimeXp);
 }
 
 // Zero-difference band: how many levels below you a mob stops giving XP.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -8,7 +8,10 @@ import {
 } from '../sim/data';
 import type { ZoneDef } from '../sim/data';
 import type { InvSlot } from '../sim/types';
-import { AbilityEffect, CONSUME_DURATION, Entity, GCD, ItemDef, SimEvent, dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE } from '../sim/types';
+import { AbilityEffect, CONSUME_DURATION, Entity, GCD, ItemDef, SimEvent, dist2d, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige } from '../sim/types';
+import type { LeaderboardEntry } from '../world_api';
+import { xpBarView, formatXp } from './xp_bar';
+import { t } from './i18n';
 import { terrainHeight, WATER_LEVEL, roadDistance } from '../sim/world';
 import { Meters } from './meters';
 import { audio } from '../game/audio';
@@ -151,6 +154,7 @@ export class Hud {
     $('#mm-bag').addEventListener('click', () => this.toggleBags());
     $('#social-fab').addEventListener('click', () => this.toggleSocial());
     $('#mm-arena').addEventListener('click', () => this.toggleArena());
+    $('#mm-leaderboard').addEventListener('click', () => this.toggleLeaderboard());
     const musicBtn = $('#mm-music');
     const styleMusicBtn = () => { musicBtn.style.color = music.enabled ? '#ffd100' : '#666'; };
     styleMusicBtn();
@@ -611,11 +615,13 @@ export class Hud {
       ab.btn.classList.toggle('queued', p.queuedOnSwing === a.id);
     }
 
-    // xp bar
-    const xpNeed = xpForLevel(p.level);
-    const xpFrac = p.level >= MAX_LEVEL ? 1 : sim.xp / xpNeed;
-    ($('#xpbar .fill') as HTMLElement).style.width = `${(xpFrac * 100).toFixed(1)}%`;
-    $('#xpbar .label').textContent = p.level >= MAX_LEVEL ? 'MAX LEVEL' : `${sim.xp} / ${xpNeed} XP (${Math.floor(xpFrac * 100)}%)`;
+    // xp bar — pre-cap shows the level bar; post-cap fills toward the next
+    // virtual level (Max-Level XP Overflow), with distinct prestige/gold styling.
+    const showOverflow = (this.optionsHooks?.settings.get('showOverflowXp') ?? 1) >= 0.5;
+    const bar = xpBarView({ level: p.level, xp: sim.xp, lifetimeXp: sim.lifetimeXp, showOverflow });
+    ($('#xpbar .fill') as HTMLElement).style.width = `${(bar.fillFrac * 100).toFixed(1)}%`;
+    $('#xpbar .label').textContent = bar.label;
+    $('#xpbar').classList.toggle('overflow', bar.postCap);
 
     $('#death-overlay').style.display = p.dead ? 'flex' : 'none';
 
@@ -1142,6 +1148,20 @@ export class Hud {
         case 'levelup': {
           this.showBanner(`Level ${ev.level}!`);
           this.log(`You have reached level ${ev.level}!`, '#ffd100');
+          audio.levelUp();
+          break;
+        }
+        case 'virtualLevelUp': {
+          // cosmetic post-cap "level up" — reuses the levelup banner + sound
+          this.showBanner(`${t('game.progression.virtualLevelUp')} ${ev.level}!`);
+          this.log(`${t('game.progression.virtualLevelUp')} ${ev.level}!`, '#ffd100');
+          audio.levelUp();
+          break;
+        }
+        case 'milestoneUnlocked': {
+          const name = this.milestoneName(ev.milestoneId);
+          this.showBanner(`${t('game.milestone.unlocked')}: ${name}`);
+          this.log(`${t('game.milestone.unlocked')}: ${name}`, '#ffd100');
           audio.levelUp();
           break;
         }
@@ -1880,7 +1900,9 @@ export class Hud {
       <span>Intellect: <b>${p.stats.int}</b></span><span>Crit Chance: <b>${(p.critChance * 100).toFixed(1)}%</b></span>
       <span>Spirit: <b>${p.stats.spi}</b></span><span>Dodge: <b>${(p.dodgeChance * 100).toFixed(1)}%</b></span>
     </div>`;
+    html += this.progressionHtml(p.level);
     el.innerHTML = html;
+    el.querySelector('[data-act="prestige"]')?.addEventListener('click', () => this.openPrestigeDialog());
     const col = el.querySelector('#equip-col')!;
     const slots: { key: 'mainhand' | 'chest' | 'legs' | 'feet'; name: string }[] = [
       { key: 'mainhand', name: 'Main Hand' },
@@ -1900,6 +1922,127 @@ export class Hud {
       col.appendChild(row);
     }
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });
+  }
+
+  // -------------------------------------------------------------------------
+  // Post-cap progression (Max-Level XP Overflow): character-sheet block,
+  // milestone badges, prestige dialog, and the lifetime-XP leaderboard panel.
+  // -------------------------------------------------------------------------
+
+  private milestoneName(id: string): string {
+    switch (id) {
+      case 'veteran': return t('game.milestone.veteran');
+      case 'champion': return t('game.milestone.champion');
+      case 'paragon': return t('game.milestone.paragon');
+      case 'mythic': return t('game.milestone.mythic');
+      case 'eternal': return t('game.milestone.eternal');
+      default: return id;
+    }
+  }
+
+  // The "Progression" group on the character sheet: total XP, virtual level,
+  // prestige rank (when prestiged), unlocked milestone badges, and — at the cap
+  // — the opt-in Prestige button.
+  private progressionHtml(level: number): string {
+    const sim = this.sim;
+    const vlevel = virtualLevel(sim.lifetimeXp);
+    const unlocked = new Set(sim.unlockedMilestones);
+    const badges = MILESTONES.filter((m) => unlocked.has(m.id))
+      .map((m) => `<span class="ms-badge ms-${m.kind}">${this.milestoneName(m.id)}</span>`)
+      .join('');
+    let html = `<div class="cp-title">${t('game.progression.heading')}</div>`;
+    html += `<div class="char-stats cp-stats">
+      <span>${t('game.progression.totalXp')}: <b>${formatXp(sim.lifetimeXp)}</b></span>
+      <span>${t('game.progression.virtualLevel')}: <b>${vlevel}</b></span>`;
+    if (sim.prestigeRank > 0) html += `<span>${t('game.progression.prestigeRank')}: <b>★ ${sim.prestigeRank}</b></span>`;
+    html += `</div>`;
+    html += `<div class="cp-milestones"><span class="cp-ms-label">${t('game.progression.milestones')}:</span> ${badges || `<span class="cp-none">${t('game.progression.none')}</span>`}</div>`;
+    if (level >= MAX_LEVEL) {
+      // The button reflects the server's authoritative prestige gate (post-cap
+      // XP earned). It's disabled — and the requirement shown — until eligible;
+      // the server re-checks regardless, so a forged click does nothing.
+      const ready = canPrestige(level, sim.lifetimeXp, sim.prestigeRank);
+      html += `<div class="cp-actions"><button class="btn" data-act="prestige"${ready ? '' : ' disabled'}>${t('game.prestige.action')}${sim.prestigeRank > 0 ? ` (★ ${sim.prestigeRank})` : ''}</button>`;
+      if (!ready) html += `<span class="cp-hint">${formatXp(xpUntilNextPrestige(sim.lifetimeXp, sim.prestigeRank))} ${t('game.prestige.needXp')}</span>`;
+      html += `</div>`;
+    }
+    return `<div class="char-progression">${html}</div>`;
+  }
+
+  private openPrestigeDialog(): void {
+    const p = this.sim.player;
+    // Mirror the server's gate; the server enforces it authoritatively anyway.
+    if (!canPrestige(p.level, this.sim.lifetimeXp, this.sim.prestigeRank)) {
+      this.showError(p.level < MAX_LEVEL
+        ? t('game.prestige.needCap')
+        : `${formatXp(xpUntilNextPrestige(this.sim.lifetimeXp, this.sim.prestigeRank))} ${t('game.prestige.needXp')}`);
+      return;
+    }
+    this.confirmDialog(
+      t('game.prestige.title'),
+      t('game.prestige.body'),
+      t('game.prestige.confirm'),
+      t('game.prestige.cancel'),
+      () => { this.sim.prestige(); audio.click(); },
+    );
+  }
+
+  // Minimal modal confirm dialog (reuses the .window/.panel chrome). Used by the
+  // prestige flow; built on demand and removed on dismiss.
+  private confirmDialog(title: string, body: string, okText: string, cancelText: string, onOk: () => void): void {
+    document.getElementById('confirm-dialog')?.remove();
+    const el = document.createElement('div');
+    el.id = 'confirm-dialog';
+    el.className = 'window panel';
+    el.style.display = 'block';
+    el.innerHTML = `<div class="panel-title"><span>${title}</span><span class="x-btn" data-cancel>✕</span></div>`
+      + `<div class="cd-body">${body}</div>`
+      + `<div class="cd-actions"><button class="btn" data-cancel>${cancelText}</button><button class="btn cd-ok" data-ok>${okText}</button></div>`;
+    document.body.appendChild(el);
+    const close = () => el.remove();
+    el.querySelectorAll('[data-cancel]').forEach((b) => b.addEventListener('click', () => { audio.click(); close(); }));
+    el.querySelector('[data-ok]')?.addEventListener('click', () => { close(); onOk(); });
+  }
+
+  toggleLeaderboard(): void {
+    const el = $('#leaderboard-window');
+    if (el.style.display === 'block') { el.style.display = 'none'; this.hideTooltip(); return; }
+    el.style.display = 'block';
+    void this.renderLeaderboard();
+  }
+
+  async renderLeaderboard(): Promise<void> {
+    const el = $('#leaderboard-window');
+    const myName = this.sim.player.name;
+    el.innerHTML = `<div class="panel-title"><span>${t('game.leaderboard.title')} <span style="color:#998d6a;font-size:11px">${t('game.leaderboard.subtitle')}${this.sim.realm ? ` &middot; ${this.sim.realm}` : ''}</span></span><span class="x-btn" data-close>✕</span></div>`
+      + `<div class="lb-body"><div class="lb-loading">${t('game.leaderboard.loading')}</div></div>`;
+    el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; });
+
+    let rows: LeaderboardEntry[] = [];
+    try { rows = await this.sim.leaderboard(); } catch { rows = []; }
+    // panel may have been closed while the fetch was in flight
+    if (el.style.display !== 'block') return;
+    const body = el.querySelector('.lb-body')!;
+    if (rows.length === 0) {
+      body.innerHTML = `<div class="lb-empty">${t('game.leaderboard.empty')}</div>`;
+      return;
+    }
+    const header = `<div class="lb-row lb-head"><span class="lb-rank">${t('game.leaderboard.rank')}</span><span class="lb-name">${t('game.leaderboard.name')}</span><span class="lb-lvl">${t('game.leaderboard.level')}</span><span class="lb-vlvl">${t('game.leaderboard.vlevel')}</span><span class="lb-xp">${t('game.leaderboard.lifetimeXp')}</span></div>`;
+    const rowHtml = (r: LeaderboardEntry, mine: boolean): string => {
+      const cls = CLASSES[r.cls];
+      const star = r.prestigeRank > 0 ? `<span class="lb-prestige" title="${t('game.prestige.rank')} ${r.prestigeRank}">★${r.prestigeRank}</span> ` : '';
+      const title = cls ? ` title="${cls.name}"` : '';
+      return `<div class="lb-row${mine ? ' lb-mine' : ''}"><span class="lb-rank">${r.rank}</span>`
+        + `<span class="lb-name"${title}>${star}${r.name}${mine ? ` <span class="lb-you">(${t('game.leaderboard.you')})</span>` : ''}</span>`
+        + `<span class="lb-lvl">${r.level}</span><span class="lb-vlvl">${r.virtualLevel}</span><span class="lb-xp">${formatXp(r.lifetimeXp)}</span></div>`;
+    };
+    const mineIndex = rows.findIndex((r) => r.name === myName);
+    let html = header + rows.map((r) => rowHtml(r, r.name === myName)).join('');
+    // sticky "your standing" row when the viewer is outside the visible list
+    if (mineIndex === -1) {
+      html += `<div class="lb-sticky"><div class="lb-row lb-mine"><span class="lb-rank">—</span><span class="lb-name">${myName} <span class="lb-you">(${t('game.leaderboard.you')})</span></span><span class="lb-lvl">${this.sim.player.level}</span><span class="lb-vlvl">${virtualLevel(this.sim.lifetimeXp)}</span><span class="lb-xp">${formatXp(this.sim.lifetimeXp)}</span></div></div>`;
+    }
+    body.innerHTML = html;
   }
 
   // -------------------------------------------------------------------------
@@ -2818,9 +2961,10 @@ export class Hud {
     this.settingSlider(body, 'Brightness', 'brightness');
     this.settingSlider(body, 'Render Quality', 'renderScale');
     this.settingToggle(body, 'Fullscreen', 'fullscreen');
+    this.settingToggle(body, t('game.settings.showOverflowXp'), 'showOverflowXp');
     const note = document.createElement('div');
     note.className = 'set-note';
-    note.textContent = 'Lower Camera Speed for a calmer mouselook. Render Quality below 100% boosts FPS on weaker machines.';
+    note.textContent = 'Lower Camera Speed for a calmer mouselook. Render Quality below 100% boosts FPS on weaker machines. Show Overflow XP keeps the XP bar filling past the level cap.';
     $('#options-menu').appendChild(note);
     this.settingsViewFooter();
   }
@@ -2943,7 +3087,9 @@ export class Hud {
       closed = true;
     }
     if (this.marketOpen) { this.closeMarket(); closed = true; }
-    for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window', '#report-window', '#arena-window']) {
+    const confirmEl = document.getElementById('confirm-dialog');
+    if (confirmEl) { confirmEl.remove(); closed = true; }
+    for (const id of ['#quest-dialog', '#loot-window', '#vendor-window', '#bags', '#char-window', '#spellbook', '#quest-log-window', '#map-window', '#report-window', '#arena-window', '#leaderboard-window']) {
       const el = $(id);
       if (el.style.display === 'block') {
         el.style.display = 'none';

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -12,7 +12,70 @@ export type Leaves<T, D extends number = 5> = [D] extends [never]
   ? { [K in keyof T]-?: Join<K, Leaves<T[K], Prev[D]>> }[keyof T]
   : "";
 
+// In-game HUD strings for the Max-Level XP Overflow / post-cap progression
+// system. The in-game HUD shipped English-only; these are registered here so
+// they route through t() per the i18n constraint. Every locale references this
+// same English object (translations are a follow-up), which keeps the
+// `: typeof en` shape exact across all languages.
+export const gameStrings = {
+  xp: {
+    suffix: "XP",
+    maxLevel: "MAX LEVEL",
+    totalXp: "total XP",
+    lv: "Lv",
+    toNext: "to next",
+  },
+  progression: {
+    heading: "Progression",
+    totalXp: "Total XP",
+    virtualLevel: "Virtual Level",
+    prestigeRank: "Prestige Rank",
+    milestones: "Milestones",
+    none: "None yet",
+    virtualLevelUp: "Virtual Level",
+  },
+  leaderboard: {
+    title: "Leaderboard",
+    subtitle: "Lifetime XP",
+    rank: "Rank",
+    name: "Name",
+    realmCol: "Realm",
+    level: "Lvl",
+    vlevel: "V.Lvl",
+    lifetimeXp: "Lifetime XP",
+    yourRank: "Your Standing",
+    empty: "No champions yet — be the first to make your mark.",
+    loading: "Loading rankings…",
+    unranked: "Unranked",
+    you: "You",
+    globalSubtitle: "Top champions across all realms",
+    retry: "Could not load the leaderboard. Try again.",
+  },
+  milestone: {
+    unlocked: "Milestone Unlocked",
+    veteran: "Veteran",
+    champion: "Champion",
+    paragon: "Paragon",
+    mythic: "Mythic",
+    eternal: "Eternal",
+  },
+  prestige: {
+    action: "Prestige",
+    title: "Prestige Character",
+    body: "Prestige raises your Prestige Rank by 1 and resets your level XP bar. It does NOT change your level, gear, talents, abilities, or your lifetime XP and leaderboard standing — it is a cosmetic flex only.",
+    confirm: "Prestige",
+    cancel: "Cancel",
+    rank: "Prestige",
+    needCap: "You must be at the level cap to prestige.",
+    needXp: "more lifetime XP to prestige",
+  },
+  settings: {
+    showOverflowXp: "Show Overflow XP",
+  },
+};
+
 export const en = {
+  game: gameStrings,
   nav: {
     home: "Home",
     play: "Play",
@@ -143,6 +206,7 @@ export const en = {
 };
 
 export const es: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Inicio",
     play: "Jugar",
@@ -273,6 +337,7 @@ export const es: typeof en = {
 };
 
 export const es_ES: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Inicio",
     play: "Jugar",
@@ -403,6 +468,7 @@ export const es_ES: typeof en = {
 };
 
 export const fr_FR: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Accueil",
     play: "Jouer",
@@ -533,6 +599,7 @@ export const fr_FR: typeof en = {
 };
 
 export const fr_CA: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Accueil",
     play: "Jouer",
@@ -663,6 +730,7 @@ export const fr_CA: typeof en = {
 };
 
 export const en_CA: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Home",
     play: "Play",
@@ -793,6 +861,7 @@ export const en_CA: typeof en = {
 };
 
 export const it_IT: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Pagina principale",
     play: "Gioca",
@@ -923,6 +992,7 @@ export const it_IT: typeof en = {
 };
 
 export const de_DE: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Startseite",
     play: "Spielen",
@@ -1053,6 +1123,7 @@ export const de_DE: typeof en = {
 };
 
 export const zh_CN: typeof en = {
+  game: gameStrings,
   nav: {
     home: "首页",
     play: "开始游戏",
@@ -1183,6 +1254,7 @@ export const zh_CN: typeof en = {
 };
 
 export const zh_TW: typeof en = {
+  game: gameStrings,
   nav: {
     home: "首頁",
     play: "開始遊戲",
@@ -1313,6 +1385,7 @@ export const zh_TW: typeof en = {
 };
 
 export const ko_KR: typeof en = {
+  game: gameStrings,
   nav: {
     home: "홈",
     play: "플레이",
@@ -1443,6 +1516,7 @@ export const ko_KR: typeof en = {
 };
 
 export const ja_JP: typeof en = {
+  game: gameStrings,
   nav: {
     home: "ホーム",
     play: "プレイ",
@@ -1573,6 +1647,7 @@ export const ja_JP: typeof en = {
 };
 
 export const pt_BR: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Início",
     play: "Jogar",
@@ -1703,6 +1778,7 @@ export const pt_BR: typeof en = {
 };
 
 export const ru_RU: typeof en = {
+  game: gameStrings,
   nav: {
     home: "Главная",
     play: "Играть",

--- a/src/ui/xp_bar.ts
+++ b/src/ui/xp_bar.ts
@@ -1,0 +1,65 @@
+// Pure derivation of the XP-bar visual state for the Max-Level XP Overflow
+// system. Kept UI-framework-free (no DOM) so the label states can be snapshot
+// tested directly. All display strings route through i18n's t().
+
+import { MAX_LEVEL, virtualLevelProgress, xpForLevel } from '../sim/types';
+import { t } from './i18n';
+
+export interface XpBarInput {
+  level: number;
+  xp: number; // current level-bar XP (server-authoritative)
+  lifetimeXp: number; // monotonic lifetime total (server-authoritative)
+  showOverflow: boolean; // settings toggle; false → classic "MAX LEVEL"
+}
+
+export interface XpBarView {
+  fillFrac: number; // 0..1 width of the fill
+  label: string; // hover label
+  postCap: boolean; // true → distinct prestige/gold styling
+}
+
+// Thousands-separated integer (locale-independent grouping so snapshots are
+// stable across machines).
+export function formatXp(n: number): string {
+  return Math.floor(Math.max(0, n)).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+export function xpBarView(input: XpBarInput): XpBarView {
+  const { level, xp, lifetimeXp, showOverflow } = input;
+  const atCap = level >= MAX_LEVEL;
+
+  if (!atCap) {
+    const need = xpForLevel(level);
+    const frac = need > 0 ? xp / need : 0;
+    return {
+      fillFrac: clamp01(frac),
+      label: `${formatXp(xp)} / ${formatXp(need)} ${t('game.xp.suffix')} (${Math.floor(frac * 100)}%)`,
+      postCap: false,
+    };
+  }
+
+  // At the cap with overflow disabled: classic full bar, but still surface the
+  // lifetime total on hover so the counter is never hidden entirely.
+  if (!showOverflow) {
+    return {
+      fillFrac: 1,
+      label: `${t('game.xp.maxLevel')}  ·  ${formatXp(lifetimeXp)} ${t('game.xp.totalXp')}`,
+      postCap: false,
+    };
+  }
+
+  // At/after the cap with overflow on: fill toward the next virtual level.
+  const prog = virtualLevelProgress(lifetimeXp);
+  const extra = prog.level - MAX_LEVEL;
+  const pct = Math.floor((prog.into / prog.span) * 100);
+  // FR-3.3 format: "Lv 20 (+7)  ·  1,284,500 total XP  ·  62% to next"
+  const label =
+    `${t('game.xp.lv')} ${MAX_LEVEL} (+${extra})  ·  ` +
+    `${formatXp(lifetimeXp)} ${t('game.xp.totalXp')}  ·  ` +
+    `${pct}% ${t('game.xp.toNext')}`;
+  return { fillFrac: clamp01(prog.into / prog.span), label, postCap: true };
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -81,6 +81,19 @@ export interface CharacterSearchResult {
   level: number;
 }
 
+// One ranked row of the lifetime-XP leaderboard (Max-Level XP Overflow). Always
+// computed server-side; the client only displays it.
+export interface LeaderboardEntry {
+  rank: number;
+  name: string;
+  cls: PlayerClass;
+  level: number;
+  virtualLevel: number;
+  lifetimeXp: number;
+  prestigeRank: number;
+  realm?: string; // present on the global (cross-realm) home-page board
+}
+
 export interface ArenaLadderEntry {
   pid: number;
   name: string;
@@ -146,6 +159,11 @@ export interface IWorld {
   equipment: Partial<Record<EquipSlot, string>>;
   copper: number;
   xp: number;
+  // Post-cap progression (Max-Level XP Overflow). All server-authoritative;
+  // the client renders these as-is and derives virtual level from lifetimeXp.
+  lifetimeXp: number;
+  prestigeRank: number;
+  unlockedMilestones: string[];
   known: ResolvedAbility[];
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;
@@ -216,4 +234,8 @@ export interface IWorld {
   marketCollect(): void;
   enterDungeon(dungeonId: string): void;
   leaveDungeon(): void;
+  // Post-cap progression: the realm-scoped lifetime-XP leaderboard, and the
+  // opt-in cosmetic prestige action (Phase 4).
+  leaderboard(): Promise<LeaderboardEntry[]>;
+  prestige(): void;
 }

--- a/tests/xp.test.ts
+++ b/tests/xp.test.ts
@@ -1,0 +1,465 @@
+// Max-Level XP Overflow & Post-Cap Progression.
+//
+// Covers the PRD's testing strategy: at-cap XP routes to lifetimeXp (not
+// gold/zero) for both the solo and party paths, mid-level carry still works,
+// virtual-level boundaries, level-diff anti-farm still gates trivial mobs,
+// prestige resets the bar but not lifetimeXp, persistence round-trips, the
+// XP-bar label states (pre-cap / at-cap / post-cap), and the online
+// (ClientWorld) snapshot path — not just offline.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so the online-path test needs no Postgres (mirrors
+// snapshots.test.ts). Hoisted by vitest, so it applies to server/game below.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+}));
+
+import { Sim, CharacterState } from '../src/sim/sim';
+import {
+  MAX_LEVEL, MILESTONES, mobXpValue, virtualLevel, virtualLevelProgress,
+  xpForLevel, xpToReachLevel, zeroDiff,
+  PRESTIGE_XP_PER_RANK, maxPrestigeRank, canPrestige, xpUntilNextPrestige,
+} from '../src/sim/types';
+import { xpBarView, formatXp } from '../src/ui/xp_bar';
+import { GameServer } from '../server/game';
+import { ClientWorld } from '../src/net/online';
+import { terrainHeight } from '../src/sim/world';
+
+function makeSim(cls: 'warrior' | 'mage' | 'rogue' = 'warrior', seed = 42): Sim {
+  return new Sim({ seed, playerClass: cls, autoEquip: true });
+}
+
+function nearestMob(sim: Sim) {
+  const p = sim.player;
+  let best: any = null, bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    const dx = p.pos.x - e.pos.x, dz = p.pos.z - e.pos.z;
+    const d = Math.hypot(dx, dz);
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  return best;
+}
+
+function teleport(sim: Sim, e: any, x: number, z: number) {
+  e.pos.x = x; e.pos.z = z; e.pos.y = terrainHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+// -------------------------------------------------------------------------
+// Pure curve functions
+// -------------------------------------------------------------------------
+
+describe('virtual-level curve', () => {
+  it('below the cap, virtual level equals the real level', () => {
+    for (let level = 1; level <= MAX_LEVEL; level++) {
+      // lifetime XP to *reach* this level, plus a little into the bar
+      const lifetime = xpToReachLevel(level) + (level < MAX_LEVEL ? Math.floor(xpForLevel(level) / 2) : 0);
+      expect(virtualLevel(lifetime)).toBe(level);
+    }
+  });
+
+  it('xpToReachLevel is monotonic and matches XP_TABLE pre-cap', () => {
+    expect(xpToReachLevel(1)).toBe(0);
+    expect(xpToReachLevel(2)).toBe(xpForLevel(1));
+    expect(xpToReachLevel(3)).toBe(xpForLevel(1) + xpForLevel(2));
+    for (let l = 1; l < 40; l++) {
+      expect(xpToReachLevel(l + 1)).toBeGreaterThan(xpToReachLevel(l));
+    }
+  });
+
+  it('virtual level climbs past the cap on lifetime XP boundaries', () => {
+    // exactly at the cap threshold → virtual 20, one XP short → still 19's band? no: 20
+    expect(virtualLevel(xpToReachLevel(20))).toBe(20);
+    expect(virtualLevel(xpToReachLevel(21))).toBe(21);
+    expect(virtualLevel(xpToReachLevel(21) - 1)).toBe(20);
+    expect(virtualLevel(xpToReachLevel(27))).toBe(27);
+    expect(virtualLevel(xpToReachLevel(27) + 1)).toBe(27);
+    expect(virtualLevel(xpToReachLevel(28) - 1)).toBe(27);
+  });
+
+  it('post-cap levels cost progressively more (geometric grind)', () => {
+    const step21 = xpToReachLevel(22) - xpToReachLevel(21);
+    const step20 = xpToReachLevel(21) - xpToReachLevel(20);
+    const step30 = xpToReachLevel(31) - xpToReachLevel(30);
+    expect(step21).toBeGreaterThan(step20);
+    expect(step30).toBeGreaterThan(step21);
+  });
+
+  it('virtualLevelProgress reports position within the current virtual level', () => {
+    const base = xpToReachLevel(25);
+    const span = xpToReachLevel(26) - xpToReachLevel(25);
+    const prog = virtualLevelProgress(base + Math.floor(span / 2));
+    expect(prog.level).toBe(25);
+    expect(prog.span).toBe(span);
+    expect(prog.into).toBeCloseTo(Math.floor(span / 2), -1);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Solo cap-gate: at-cap XP routes to lifetimeXp, never gold/zero
+// -------------------------------------------------------------------------
+
+describe('solo grantXp at the cap', () => {
+  it('accrues lifetimeXp at the cap instead of discarding it', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    expect(sim.player.level).toBe(MAX_LEVEL);
+    const before = sim.lifetimeXp;
+    sim.grantXp(5000);
+    expect(sim.lifetimeXp).toBe(before + 5000);
+    // the level bar stays frozen — no power, no de-level, no level-up
+    expect(sim.player.level).toBe(MAX_LEVEL);
+    expect(sim.xp).toBe(0);
+  });
+
+  it('keeps accruing across many post-cap awards (overflow never resets)', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    let expected = sim.lifetimeXp;
+    for (let i = 0; i < 50; i++) { sim.grantXp(1000); expected += 1000; }
+    expect(sim.lifetimeXp).toBe(expected);
+    expect(virtualLevel(sim.lifetimeXp)).toBeGreaterThan(MAX_LEVEL);
+  });
+
+  it('a level-up into the cap keeps the overflow remainder in lifetimeXp', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL - 1); // level 19
+    const lifeBefore = sim.lifetimeXp;
+    const need = xpForLevel(MAX_LEVEL - 1); // 19 → 20
+    sim.grantXp(need + 7777); // dings to 20 with a big overflow remainder
+    expect(sim.player.level).toBe(MAX_LEVEL);
+    expect(sim.xp).toBe(0); // bar cleared on reaching cap…
+    expect(sim.lifetimeXp).toBe(lifeBefore + need + 7777); // …but nothing was lost
+  });
+
+  it('emits a virtual-level-up event when crossing a virtual level past cap', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.events.length = 0;
+    sim.grantXp(xpToReachLevel(22)); // jump well past the cap
+    const vlevels = sim.events.filter((e) => e.type === 'virtualLevelUp').map((e: any) => e.level);
+    expect(vlevels).toContain(21);
+    expect(vlevels).toContain(22);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Mid-level carry (regression — must keep working)
+// -------------------------------------------------------------------------
+
+describe('pre-cap leveling regression', () => {
+  it('carries overflow XP between levels', () => {
+    const sim = makeSim('warrior');
+    sim.grantXp(xpForLevel(1) + xpForLevel(2) + 10);
+    expect(sim.player.level).toBe(3);
+    expect(sim.xp).toBe(10); // carry preserved
+  });
+
+  it('lifetimeXp tracks the running total and matches virtual level pre-cap', () => {
+    const sim = makeSim('warrior');
+    sim.grantXp(xpForLevel(1) + xpForLevel(2) + 10);
+    // total earned = sum of crossed levels + carry = xpToReachLevel(3) + 10
+    expect(sim.lifetimeXp).toBe(xpToReachLevel(3) + 10);
+    expect(virtualLevel(sim.lifetimeXp)).toBe(sim.player.level);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Party cap-gate: a max-level party member still accrues lifetimeXp
+// -------------------------------------------------------------------------
+
+describe('party grantXp at the cap', () => {
+  it('a capped party member accrues lifetimeXp from a shared kill', () => {
+    const sim = makeSim('warrior');
+    const p1 = sim.playerId;
+    const p2 = sim.addPlayer('warrior', 'Bjorn');
+    sim.partyInvite(p2, p1);
+    sim.partyAccept(p2);
+    sim.setPlayerLevel(MAX_LEVEL, p1);
+    sim.setPlayerLevel(MAX_LEVEL, p2);
+
+    const wolf = nearestMob(sim);
+    wolf.level = MAX_LEVEL; // make it worth XP for level-20 killers (anti-gray)
+    const e1 = sim.entities.get(p1)!;
+    const e2 = sim.entities.get(p2)!;
+    teleport(sim, e1, wolf.pos.x, wolf.pos.z);
+    teleport(sim, e2, wolf.pos.x, wolf.pos.z);
+
+    const m2 = sim.meta(p2)!;
+    const before2 = m2.lifetimeXp;
+    wolf.hp = 1;
+    (sim as any).dealDamage(e1, wolf, 9999, false, 'physical', 'Test', 'hit');
+
+    expect(wolf.dead).toBe(true);
+    expect(m2.lifetimeXp).toBeGreaterThan(before2); // capped member still earns
+    expect(e2.level).toBe(MAX_LEVEL); // …with no level/power change
+    expect(m2.xp).toBe(0);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Anti-farm: level-diff scaling still zeroes trivial mobs
+// -------------------------------------------------------------------------
+
+describe('anti-farm level-diff scaling', () => {
+  it('gray mobs grant zero XP even post-cap', () => {
+    // a level-20 player vs a far-lower mob: beyond the zero-diff band → 0
+    expect(zeroDiff(MAX_LEVEL)).toBe(8);
+    expect(mobXpValue(MAX_LEVEL - zeroDiff(MAX_LEVEL), MAX_LEVEL)).toBe(0);
+    expect(mobXpValue(3, MAX_LEVEL)).toBe(0);
+  });
+
+  it('a zero award is a no-op on lifetimeXp', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    const before = sim.lifetimeXp;
+    sim.grantXp(0);
+    sim.grantXp(mobXpValue(3, MAX_LEVEL)); // gray → 0
+    expect(sim.lifetimeXp).toBe(before);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Milestones
+// -------------------------------------------------------------------------
+
+describe('cosmetic milestones', () => {
+  it('unlocks, emits, and persists the first milestone', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    const first = MILESTONES[0];
+    sim.events.length = 0;
+    sim.grantXp(first.lifetimeXp + 1);
+    expect(sim.unlockedMilestones).toContain(first.id);
+    expect(sim.events.some((e: any) => e.type === 'milestoneUnlocked' && e.milestoneId === first.id)).toBe(true);
+  });
+
+  it('does not re-unlock a milestone already earned', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.grantXp(MILESTONES[0].lifetimeXp + 1);
+    sim.events.length = 0;
+    sim.grantXp(1000);
+    expect(sim.events.some((e: any) => e.type === 'milestoneUnlocked')).toBe(false);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Prestige (Phase 4): resets the bar, not lifetimeXp; cap-gated; cosmetic
+// -------------------------------------------------------------------------
+
+describe('prestige', () => {
+  it('resets the level bar and bumps rank but never lifetimeXp', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.grantXp(800_000); // build a real lifetime total
+    const m = sim.meta(sim.playerId)!;
+    m.xp = 123; // simulate stray bar XP to prove the reset clears it
+    const lifeBefore = sim.lifetimeXp;
+    const ok = sim.prestige();
+    expect(ok).toBe(true);
+    expect(sim.xp).toBe(0); // bar reset
+    expect(sim.prestigeRank).toBe(1); // rank incremented
+    expect(sim.lifetimeXp).toBe(lifeBefore); // lifetime untouched
+    expect(sim.player.level).toBe(MAX_LEVEL); // no de-level / power loss
+  });
+
+  it('is refused below the cap', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(10);
+    expect(sim.prestige()).toBe(false);
+    expect(sim.prestigeRank).toBe(0);
+  });
+});
+
+describe('prestige anti-abuse gate (server-locked rank)', () => {
+  it('refuses prestige at the cap with no post-cap XP earned', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL); // lifetimeXp == cap threshold, nothing earned past it
+    expect(maxPrestigeRank(sim.lifetimeXp)).toBe(0);
+    expect(sim.prestige()).toBe(false);
+    expect(sim.prestigeRank).toBe(0);
+  });
+
+  it('caps rank at earned post-cap XP — spamming the command cannot inflate it', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    // earn exactly 3 prestige bars of post-cap XP
+    sim.grantXp(PRESTIGE_XP_PER_RANK * 3);
+    const allowed = maxPrestigeRank(sim.lifetimeXp);
+    expect(allowed).toBe(3);
+    // simulate a hacked client hammering the prestige command 100×
+    let successes = 0;
+    for (let i = 0; i < 100; i++) if (sim.prestige()) successes++;
+    expect(successes).toBe(3);          // only as many as the earned XP supports
+    expect(sim.prestigeRank).toBe(3);   // never beyond the XP-backed cap
+    expect(sim.lifetimeXp).toBeGreaterThanOrEqual(xpToReachLevel(MAX_LEVEL)); // lifetime untouched by prestige
+  });
+
+  it('unlocks the next rank only after earning another full bar', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.grantXp(PRESTIGE_XP_PER_RANK);     // exactly one bar
+    expect(sim.prestige()).toBe(true);     // rank 1
+    expect(sim.prestige()).toBe(false);    // no XP left for rank 2
+    expect(sim.prestigeRank).toBe(1);
+    expect(xpUntilNextPrestige(sim.lifetimeXp, sim.prestigeRank)).toBe(PRESTIGE_XP_PER_RANK);
+    sim.grantXp(PRESTIGE_XP_PER_RANK);     // earn another bar
+    expect(canPrestige(MAX_LEVEL, sim.lifetimeXp, sim.prestigeRank)).toBe(true);
+    expect(sim.prestige()).toBe(true);     // rank 2
+    expect(sim.prestigeRank).toBe(2);
+  });
+
+  it('canPrestige is false below the cap regardless of lifetime XP', () => {
+    expect(canPrestige(MAX_LEVEL - 1, 9_999_999, 0)).toBe(false);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Persistence round-trip + legacy backfill
+// -------------------------------------------------------------------------
+
+describe('persistence', () => {
+  it('round-trips lifetimeXp, prestigeRank, and milestones', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(MAX_LEVEL);
+    sim.grantXp(MILESTONES[0].lifetimeXp + 5);
+    sim.prestige();
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.lifetimeXp).toBeGreaterThan(0);
+    expect(state.prestigeRank).toBe(1);
+    expect(state.unlockedMilestones).toContain(MILESTONES[0].id);
+
+    const sim2 = makeSim('warrior');
+    const pid = sim2.addPlayer('warrior', 'Reload', { state });
+    const m = sim2.meta(pid)!;
+    expect(m.lifetimeXp).toBe(state.lifetimeXp);
+    expect(m.prestigeRank).toBe(1);
+    expect([...m.unlockedMilestones]).toContain(MILESTONES[0].id);
+  });
+
+  it('backfills lifetimeXp for characters saved before the counter existed', () => {
+    const sim = makeSim('warrior');
+    // a legacy save: level + bar XP, but no lifetimeXp field
+    const legacy = sim.serializeCharacter(sim.playerId)!;
+    const state: CharacterState = { ...legacy, level: 12, xp: 500 };
+    delete (state as any).lifetimeXp;
+    const sim2 = makeSim('warrior');
+    const pid = sim2.addPlayer('warrior', 'Legacy', { state });
+    const m = sim2.meta(pid)!;
+    expect(m.lifetimeXp).toBe(xpToReachLevel(12) + 500);
+  });
+});
+
+// -------------------------------------------------------------------------
+// XP-bar label snapshots (pre-cap / at-cap / post-cap)
+// -------------------------------------------------------------------------
+
+describe('xp-bar label states', () => {
+  it('pre-cap shows the level bar', () => {
+    const v = xpBarView({ level: 5, xp: 1000, lifetimeXp: 0, showOverflow: true });
+    expect(v.postCap).toBe(false);
+    expect(v.label).toBe('1,000 / 2,800 XP (35%)');
+  });
+
+  it('at-cap with overflow shows the virtual-level bar starting at +0', () => {
+    const v = xpBarView({ level: MAX_LEVEL, xp: 0, lifetimeXp: xpToReachLevel(MAX_LEVEL), showOverflow: true });
+    expect(v.postCap).toBe(true);
+    expect(v.label).toBe(`Lv 20 (+0)  ·  ${formatXp(xpToReachLevel(MAX_LEVEL))} total XP  ·  0% to next`);
+  });
+
+  it('post-cap shows virtual level, total, and percent to next', () => {
+    const lifetime = xpToReachLevel(27); // start of virtual level 27
+    const v = xpBarView({ level: MAX_LEVEL, xp: 0, lifetimeXp: lifetime, showOverflow: true });
+    expect(v.postCap).toBe(true);
+    expect(v.label).toBe(`Lv 20 (+7)  ·  ${formatXp(lifetime)} total XP  ·  0% to next`);
+  });
+
+  it('post-cap fill fraction advances within the virtual level', () => {
+    const base = xpToReachLevel(27);
+    const span = xpToReachLevel(28) - xpToReachLevel(27);
+    const v = xpBarView({ level: MAX_LEVEL, xp: 0, lifetimeXp: base + Math.floor(span * 0.5), showOverflow: true });
+    expect(v.fillFrac).toBeCloseTo(0.5, 1);
+    expect(v.label).toMatch(/Lv 20 \(\+7\)  ·  .* total XP  ·  \d+% to next/);
+  });
+
+  it('classic "MAX LEVEL" when overflow display is turned off', () => {
+    const v = xpBarView({ level: MAX_LEVEL, xp: 0, lifetimeXp: xpToReachLevel(25), showOverflow: false });
+    expect(v.postCap).toBe(false);
+    expect(v.label).toBe(`MAX LEVEL  ·  ${formatXp(xpToReachLevel(25))} total XP`);
+  });
+});
+
+// -------------------------------------------------------------------------
+// Online path: the values flow through the snapshot to the ClientWorld, and
+// the client derives virtual level for display (server stays authoritative).
+// -------------------------------------------------------------------------
+
+function bareClient(pid: number): ClientWorld {
+  const c: any = Object.create(ClientWorld.prototype);
+  c.cfg = { seed: 20061, playerClass: 'warrior' };
+  c.entities = new Map();
+  c.playerId = pid;
+  c.moveInput = {};
+  c.inventory = [];
+  c.equipment = {};
+  c.copper = 0;
+  c.xp = 0;
+  c.lifetimeXp = 0;
+  c.prestigeRank = 0;
+  c.unlockedMilestones = [];
+  c.known = [];
+  c.questLog = new Map();
+  c.questsDone = new Set();
+  c.pendingQuestCommands = new Map();
+  c.partyInfo = null;
+  c.tradeInfo = null;
+  c.duelInfo = null;
+  c.lastSnapAt = 0;
+  c.snapInterval = 50;
+  c.pendingFacingDelta = 0;
+  c.connected = true;
+  c.eventQueue = [];
+  c.mouselookFacing = null;
+  return c;
+}
+
+describe('online ClientWorld path', () => {
+  let server: GameServer;
+
+  beforeEach(() => {
+    server = new GameServer();
+  });
+
+  it('post-cap lifetimeXp and prestige reach the client via snapshot', () => {
+    const fc = { sent: [] as any[], ws: { readyState: 1, send: (p: string) => fc.sent.push(JSON.parse(p)) } };
+    const session = server.join(fc.ws as any, 1, 1, 'Hilda', 'warrior', null);
+    if ('error' in session) throw new Error(session.error);
+
+    server.sim.setPlayerLevel(MAX_LEVEL, session.pid);
+    server.sim.grantXp(xpToReachLevel(23), server.sim.meta(session.pid)!);
+    server.sim.prestige(session.pid);
+
+    (server as any).broadcastSnapshots();
+    const snap = [...fc.sent].reverse().find((m) => m.t === 'snap');
+    expect(snap).toBeTruthy();
+    expect(snap.self.lxp).toBe(server.sim.meta(session.pid)!.lifetimeXp);
+    expect(snap.self.prk).toBe(1);
+
+    const serverLifetime = server.sim.meta(session.pid)!.lifetimeXp;
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(snap);
+    expect(client.lifetimeXp).toBe(serverLifetime);
+    expect(client.prestigeRank).toBe(1);
+    // the client derives the cosmetic virtual level for display — identical to
+    // what the authoritative sim computes, and past the cap
+    expect(virtualLevel(client.lifetimeXp)).toBe(virtualLevel(serverLifetime));
+    expect(virtualLevel(client.lifetimeXp)).toBeGreaterThan(MAX_LEVEL);
+    expect(client.player.level).toBe(MAX_LEVEL);
+  });
+});


### PR DESCRIPTION
## Max-Level XP Overflow & Post-Cap Progression

Implements `docs/prd/max-level-xp-overflow.md`: RuneScape-style post-cap progression at the level-20 cap. **Cosmetic only — zero power creep**, fully server-authoritative.

### What's in it
- **Lifetime XP counter** (64-bit-safe) persisted in the `CharacterState` JSONB blob. All three cap-gates now accrue XP to `lifetimeXp` at the cap instead of discarding it; mob level-diff anti-farm scaling is preserved.
- **Virtual levels** — `virtualLevel()` + cached threshold table in `types.ts` (== real level below cap, climbs past it). Gold "overflow" XP bar with the PRD label format (`Lv 20 (+7) · 1,284,500 total XP · 62% to next`), a virtual-level-up banner + sound, and a `showOverflowXp` settings toggle.
- **Leaderboard** — `GET /api/leaderboard?scope=realm|global&limit=N`, indexed + server-cached with periodic refresh. In-game realm panel (bound to **K** / 🏆 button, viewer self-highlighted) and a **global cross-realm board on the home page** (replaces the "Coming Soon" High Scores placeholder).
- **Cosmetic milestones** (titles/borders) persisted in `unlockedMilestones`, shown on the character sheet with an unlock banner.
- **Prestige** (opt-in, cap-only) — resets the level bar, increments `prestigeRank`; leaves `lifetimeXp`/level/gear/talents/abilities untouched.

### Deployment — nothing to configure
- **No DB migration** — all new fields live in the existing `state JSONB`.
- **No new env vars.**
- The two leaderboard indexes are created idempotently in `ensureSchema()` at boot (same pattern as every other index), so deploy is just merge → deploy.

### Security (server-locked, audited)
- `pid` is always derived from the authenticated session — a client can only affect its own character.
- No command carries an XP/level/lifetime amount; XP only flows from server-computed kills (anti-farm intact) and quest rewards. Client `lifetimeXp`/`prestigeRank` are display-only snapshot mirrors; DB state is written only by the server.
- **Prestige rank is gated by post-cap XP earned** (`canPrestige`/`maxPrestigeRank`) so the `prestige` command can't be spammed to inflate the leaderboard badge — verified with a raw-WebSocket abuse test (spam ×50 + forged `grantXp`/`setLifetimeXp` → no change).
- Dev commands remain gated behind `ALLOW_DEV_COMMANDS` (off by default).

### Testing
- **427 tests pass** (incl. 30 new in `tests/xp.test.ts`: sim cap-gates solo + party, mid-level carry, virtual-level boundaries, anti-farm, prestige + anti-abuse gate, persistence round-trip, XP-bar label snapshots, and the online `ClientWorld` snapshot path). `npm run build`, `build:server`, and `build:env` all green; `tsc --noEmit` clean.
- **Browser E2E verified**: home-page global board, in-game realm panel + self-highlight, two-account cross-functionality, overflow bar, char sheet, prestige flow + gate, and persistence across logout. No console errors.

Branch is rebased onto `main` (feature-only commit, no unrelated changes) and merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
