### PR TITLE
fix(tests): stub DATABASE_URL so homepage_foundation suite loads

### DIFF
--- a/tests/homepage_foundation.test.ts
+++ b/tests/homepage_foundation.test.ts
@@ -1,4 +1,12 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+
+// db.ts requires DATABASE_URL at import time (it throws otherwise). The db
+// helper tests below spy on the real `pool.query`, so we only need a dummy
+// connection string present before the module loads — set it in a hoisted
+// block so it runs ahead of the hoisted import graph.
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test/test";
+});
 import { pool, getAccountsCount } from "../server/db";
 import { t, setLanguage, getLanguage } from "../src/ui/i18n";
 import { Api } from "../src/net/online";


### PR DESCRIPTION
## Problem

`tests/homepage_foundation.test.ts` imports `pool`/`getAccountsCount` from `server/db.ts`. That module evaluates `DATABASE_URL ?? (() => { throw … })()` **at import time**, so when `DATABASE_URL` is unset the whole suite fails to load before any test runs.

Reproduce on a clean checkout (no `.env`):

```
$ npx vitest run
 ❯ tests/homepage_foundation.test.ts (0 test)
 FAIL  tests/homepage_foundation.test.ts
 Error: DATABASE_URL is required. …
 Test Files  1 failed | 34 passed (35)
      Tests  389 passed (389)
```

The suite's 8 tests (i18n, `getAccountsCount`, `Api.projectStats`) never execute.

## Fix

The two other db-touching suites already guard against this. `tests/db_search.test.ts` sets a dummy connection string inside a `vi.hoisted()` block so it runs ahead of the hoisted import graph. This applies the same pattern.

Because these tests spy on the **real** `pool.query` (`vi.spyOn(pool, "query")`) rather than mocking `pg`, all that's needed is a connection string present at import time — the pool is constructed but never connects. `??=` preserves a real `DATABASE_URL` when one is provided (e.g. CI with a live DB).

## Verification

```
 Test Files  35 passed (35)
      Tests  397 passed (397)
```

`npx tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)