### PR TITLE
fix: prevent rate-limit bypass under load and repair failing db test suite

### DIFF
--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -66,6 +66,18 @@ export function rateLimited(req: http.IncomingMessage, maxPerMinute = 20): boole
   const list = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
   const updated = [...list, now];
   attempts.set(ip, updated);
-  if (attempts.size > MAX_TRACKED_IPS) attempts.clear(); // memory backstop
+  // Memory backstop: when the map grows too large, evict entries whose window
+  // has fully expired rather than clearing everything. A blanket clear() would
+  // also wipe the counter we just recorded, so every IP would perpetually see
+  // a single attempt and rate limiting would silently stop working under load.
+  if (attempts.size > MAX_TRACKED_IPS) {
+    for (const [key, times] of attempts) {
+      if (key === ip) continue;
+      if (times.length === 0 || times[times.length - 1] <= windowStart) {
+        attempts.delete(key);
+      }
+      if (attempts.size <= MAX_TRACKED_IPS) break;
+    }
+  }
   return updated.length > maxPerMinute;
 }

--- a/tests/homepage_foundation.test.ts
+++ b/tests/homepage_foundation.test.ts
@@ -1,4 +1,12 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from "vitest";
+
+// db.ts requires DATABASE_URL at import time (it throws otherwise). Stub it
+// before the import below so the module loads; pool.query is spied per-test
+// so no real connection is ever opened.
+vi.hoisted(() => {
+  process.env.DATABASE_URL ??= "postgres://test/test";
+});
+
 import { pool, getAccountsCount } from "../server/db";
 import { t, setLanguage, getLanguage } from "../src/ui/i18n";
 import { Api } from "../src/net/online";

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -110,6 +110,29 @@ describe('rate-limit client IP selection', () => {
     // ...while another player behind the same proxy is unaffected
     expect(rateLimited(fakeReq({ 'x-forwarded-for': '198.51.100.201' }, '172.18.0.1'))).toBe(false);
   });
+
+  it('keeps limiting a persistent attacker after the memory backstop evicts', () => {
+    // A persistent attacker keeps hammering one endpoint while the IP map is
+    // pushed past its backstop threshold by churning many one-off IPs. The
+    // backstop must evict expired one-off entries, NOT wipe the attacker's
+    // live counter — otherwise flooding the map silently disables rate limiting.
+    const attacker = '203.0.113.250';
+    let limited = false;
+    for (let i = 0; i < 25; i++) {
+      limited = rateLimited(fakeReq({ 'x-forwarded-for': attacker }, '172.18.0.1'));
+    }
+    expect(limited).toBe(true);
+
+    // Churn past MAX_TRACKED_IPS (10_000) distinct clients to trip the backstop.
+    for (let i = 0; i < 10_050; i++) {
+      const a = (i >> 8) & 0xff;
+      const b = i & 0xff;
+      rateLimited(fakeReq({ 'x-forwarded-for': `100.64.${a}.${b}` }, '172.18.0.1'));
+    }
+
+    // The attacker's counter must survive eviction and stay limited.
+    expect(rateLimited(fakeReq({ 'x-forwarded-for': attacker }, '172.18.0.1'))).toBe(true);
+  });
 });
 
 describe('malformed websocket frames cannot crash the server', () => {


### PR DESCRIPTION
## Summary

Two distinct bugs found while scanning the server code for defects.

### 1. Rate-limit bypass under load (`server/ratelimit.ts`) — security

The in-memory limiter's memory backstop called `attempts.clear()` once the IP map exceeded `MAX_TRACKED_IPS` (10,000):

```ts
attempts.set(ip, updated);
if (attempts.size > MAX_TRACKED_IPS) attempts.clear(); // memory backstop
return updated.length > maxPerMinute;
```

`clear()` wipes **every** counter, including the entry just recorded. Past that threshold every request sees `updated.length === 1`, so `rateLimited()` always returns `false` — brute-force protection on `/api/login`, `/api/register`, and `/admin/api/login` silently stops working. Because direct internet clients are keyed by their real (varying) public source IP, an attacker can intentionally inflate the map past the threshold to disable rate limiting.

**Fix:** evict only entries whose sliding window has fully expired, never the live counters.

### 2. Test suite fails to collect (`tests/homepage_foundation.test.ts`)

The file imported `server/db` without stubbing `DATABASE_URL`. `db.ts` throws at module-load time when it's unset, so the entire suite failed to collect. The sibling db tests (`character_db.test.ts`, `db_search.test.ts`) already use a `vi.hoisted` stub; this applies the same pattern.

## Testing

- Added a regression test that floods the limiter past `MAX_TRACKED_IPS` and asserts a persistent attacker stays rate-limited.
- Full suite now: **35 files / 398 tests pass** (previously 34/35 with `homepage_foundation` failing to collect).
- `npm run build:server` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)