### PR TITLE
feat: party-visible target markers (#105)

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,6 +215,12 @@
   .np-marker.ready { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }
   .np-marker.active { color: #b9b9b9; }
   .np-marker.loot { color: var(--gold); font-size: 14px; }
+  /* party raid/target marker — floats above the name; display toggled in JS so
+     it reserves no vertical space when absent. Drop-shadow adds a dark halo on
+     top of the icon's baked outline for legibility against the bright world. */
+  .np-raidmark { width: 30px; height: 30px; margin: 0 auto 1px; background-size: contain;
+    background-repeat: no-repeat; background-position: center;
+    filter: drop-shadow(0 0 2px #000) drop-shadow(0 1px 1px #000); }
 
   /* ---------- chat bubbles (/say, /yell) ---------- */
   .chat-bubble { position: absolute; left: 0; top: 0; max-width: 220px; pointer-events: none;
@@ -1902,6 +1908,8 @@
   #ctx-menu .ctx-title { font-family: var(--title-font); color: var(--gold); font-size: 13px; padding: 3px 8px; border-bottom: 1px solid #463a1c; margin-bottom: 4px; }
   #ctx-menu .ctx-item { padding: 5px 10px; font-size: 12.5px; color: #e8d8a8; cursor: pointer; border-radius: 4px; }
   #ctx-menu .ctx-item:hover { background: #ffffff18; color: #fff; }
+  #ctx-menu .ctx-mark { display: inline-block; width: 18px; height: 18px; vertical-align: middle;
+    margin-right: 8px; background-size: contain; background-repeat: no-repeat; background-position: center; }
 
   /* ---------- prompts (invite/trade/duel) ---------- */
   #prompt-stack { position: absolute; left: 50%; top: 34%; transform: translateX(-50%); z-index: 80;

--- a/server/game.ts
+++ b/server/game.ts
@@ -675,6 +675,9 @@ export class GameServer {
       case 'pdecline': sim.partyDecline(pid); break;
       case 'pleave': sim.partyLeave(pid); break;
       case 'pkick': if (typeof msg.id === 'number') sim.partyKick(msg.id, pid); break;
+      // raid/target markers
+      case 'setMarker': if (typeof msg.id === 'number' && typeof msg.marker === 'number') sim.setMarker(msg.id, msg.marker, pid); break;
+      case 'clearMarker': if (typeof msg.id === 'number') sim.clearMarker(msg.id, pid); break;
       // trade
       case 'trade_req': if (typeof msg.id === 'number') sim.tradeRequest(msg.id, pid); break;
       case 'trade_accept': sim.tradeAccept(pid); break;
@@ -919,6 +922,7 @@ export class GameServer {
     maybe('stats', p.stats);
     maybe('weapon', p.weapon);
     maybe('party', this.partyWire(session.pid));
+    maybe('marks', this.markersWire(session.pid));
     maybe('trade', this.tradeWire(session.pid));
     maybe('duel', this.duelWire(session.pid));
     maybe('arena', this.sim.arenaInfoFor(session.pid));
@@ -943,6 +947,14 @@ export class GameServer {
         } : null;
       }).filter(Boolean),
     };
+  }
+
+  // Raid markers the player's party can see, as { entityId: markerId }; null
+  // when the player is in no party. Pure read — the sim owns marker cleanup.
+  private markersWire(pid: number): unknown {
+    const party = this.sim.partyOf(pid);
+    if (!party) return null;
+    return this.sim.markersFor(pid);
   }
 
   private tradeWire(pid: number): unknown {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -221,6 +221,7 @@ export class ClientWorld implements IWorld {
   socialInfo: SocialInfo | null = null;
   arenaInfo: ArenaInfo | null = null;
   marketInfo: MarketInfo | null = null;
+  markers: Record<number, number> = {}; // entityId -> markerId, mirrored from the self-wire
   realm = '';
   // bumped whenever a fresh social snapshot lands, so an open panel re-renders
   private socialDirty = false;
@@ -502,6 +503,7 @@ export class ClientWorld implements IWorld {
       if (s.qlog !== undefined || s.qdone !== undefined) this.pendingQuestCommands?.clear();
       this.known = abilitiesKnownAt(this.cfg.playerClass, e.level);
       if (s.party !== undefined) this.partyInfo = s.party;
+      if (s.marks !== undefined) this.markers = s.marks ?? {}; // null = cleared (no party/disband)
       if (s.trade !== undefined) this.tradeInfo = s.trade;
       if (s.duel !== undefined) this.duelInfo = s.duel;
       if (s.arena !== undefined) this.arenaInfo = s.arena;
@@ -622,6 +624,16 @@ export class ClientWorld implements IWorld {
   }
   partyKick(targetPid: number): void {
     this.cmd({ cmd: 'pkick', id: targetPid });
+  }
+  // raid/target markers
+  markerFor(entityId: number): number | null {
+    return this.markers[entityId] ?? null;
+  }
+  setMarker(entityId: number, markerId: number): void {
+    this.cmd({ cmd: 'setMarker', id: entityId, marker: markerId });
+  }
+  clearMarker(entityId: number): void {
+    this.cmd({ cmd: 'clearMarker', id: entityId });
   }
   tradeRequest(targetPid: number): void {
     this.cmd({ cmd: 'trade_req', id: targetPid });

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -22,6 +22,7 @@ import { buildWater, WaterView } from './water';
 import { buildClouds, buildSky, SkyView } from './sky';
 import { buildFoliage, FoliageView } from './foliage';
 import { shouldRenderStealthGhost } from './stealth';
+import { raidMarkerDataUrl } from '../ui/icons';
 
 const NAMEPLATE_RANGE = 55;
 // Entities further than this from the player are hidden entirely: their rigs
@@ -76,6 +77,7 @@ interface EntityView {
   hpBar: HTMLDivElement;
   hpFill: HTMLDivElement;
   markerEl: HTMLDivElement;
+  raidMarkEl: HTMLDivElement; // party raid/target marker, above the name
   sparkle?: THREE.Sprite; // ground objects
   objectMesh?: THREE.Object3D;
   portal?: THREE.Mesh; // dungeon door swirl
@@ -560,6 +562,9 @@ export class Renderer {
     // nameplate
     const np = document.createElement('div');
     np.className = 'nameplate';
+    const raidMark = document.createElement('div');
+    raidMark.className = 'np-raidmark';
+    raidMark.style.display = 'none';
     const marker = document.createElement('div');
     marker.className = 'np-marker';
     const nameEl = document.createElement('div');
@@ -570,7 +575,7 @@ export class Renderer {
     const hpFill = document.createElement('div');
     hpFill.className = 'np-hpfill';
     hpBar.appendChild(hpFill);
-    np.append(marker, nameEl, hpBar);
+    np.append(raidMark, marker, nameEl, hpBar);
     this.nameplateLayer.appendChild(np);
 
     // object views gate their own casters; character shadows live in visual
@@ -578,7 +583,7 @@ export class Renderer {
     if (!visual) collectCasters(group, objectCasters);
     this.views.set(e.id, {
       group, visual, sheepVisual: null, bearVisual: null, height, clickTarget,
-      nameplate: np, nameEl, hpBar, hpFill, markerEl: marker, sparkle, objectMesh, portal,
+      nameplate: np, nameEl, hpBar, hpFill, markerEl: marker, raidMarkEl: raidMark, sparkle, objectMesh, portal,
       objectCasters, shadowOn: true, isFar: false,
       lastX: e.pos.x, lastZ: e.pos.z,
       loco: newLocoTrack(),
@@ -1071,6 +1076,15 @@ export class Renderer {
       const sy = (-this.tmpV.y * 0.5 + 0.5) * h;
       v.nameplate.style.display = '';
       v.nameplate.style.transform = `translate(${sx.toFixed(0)}px, ${sy.toFixed(0)}px) translate(-50%, -100%)`;
+
+      // party raid/target marker (only mobs are markable, so this is null elsewhere)
+      const raidMark = this.sim.markerFor(e.id);
+      if (raidMark !== null) {
+        v.raidMarkEl.style.backgroundImage = `url(${raidMarkerDataUrl(raidMark)})`;
+        v.raidMarkEl.style.display = '';
+      } else {
+        v.raidMarkEl.style.display = 'none';
+      }
 
       if (e.kind === 'object') {
         // dungeon doorways announce themselves

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -303,6 +303,9 @@ export class Sim {
   partyByPid = new Map<number, number>(); // pid -> party id
   partyInvites = new Map<number, { fromPid: number; expires: number }>(); // invitee pid -> invite
   nextPartyId = 1;
+  // raid/target markers: partyId -> (enemy entityId -> markerId 0..7). A
+  // cosmetic, party-scoped overlay — never read by tick()/obs/persistence.
+  partyMarkers = new Map<number, Map<number, number>>();
   trades = new Map<number, TradeSession>(); // pid -> shared session (both pids point at it)
   tradeInvites = new Map<number, { fromPid: number; expires: number }>();
   duels = new Map<number, DuelState>(); // pid -> shared duel (both pids)
@@ -400,6 +403,7 @@ export class Sim {
   }
 
   private dropEntity(id: number): void {
+    this.clearEntityMarker(id); // a despawned entity keeps no raid marker
     const e = this.entities.get(id);
     if (!e) return;
     this.grid.remove(e);
@@ -1826,6 +1830,7 @@ export class Sim {
     target.lootable = false;
     target.wanderTarget = null;
     clearThreat(target);
+    this.clearEntityMarker(target.id); // a tamed pet is no longer a markable enemy
     // it's friendly now: nobody keeps swinging at it, other mobs forget it
     for (const other of this.players.values()) {
       const e = this.entities.get(other.entityId);
@@ -2116,6 +2121,10 @@ export class Sim {
     e.auras = [];
     e.castingAbility = null;
     this.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
+
+    // a dead mob keeps no raid marker — respawnMob reuses the same entity id,
+    // so a stale mark would otherwise reappear on the respawn
+    if (e.kind === 'mob') this.clearEntityMarker(e.id);
 
     // the dead drop off every hate table (and any taunt lock on them)
     for (const m of this.entities.values()) {
@@ -3366,6 +3375,7 @@ export class Sim {
         this.emit({ type: 'log', text: 'Your party has disbanded.', color: '#aaf', pid: mPid });
       }
       this.parties.delete(party.id);
+      this.partyMarkers.delete(party.id);
     } else if (party.leader === pid) {
       party.leader = party.members[0];
       const newLeader = this.players.get(party.leader);
@@ -3373,6 +3383,62 @@ export class Sim {
         this.emit({ type: 'log', text: `${newLeader?.name ?? 'Someone'} is now the party leader.`, color: '#aaf', pid: mPid });
       }
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Raid markers (party-scoped target markers)
+  // -------------------------------------------------------------------------
+
+  // Every mark visible to the actor's party, as { entityId: markerId }. Empty
+  // when the actor is not in a party. Pure read — cleanup happens on the
+  // death/despawn/disband hooks, never here.
+  markersFor(pid: number): Record<number, number> {
+    const party = this.partyOf(pid);
+    if (!party) return {};
+    const marks = this.partyMarkers.get(party.id);
+    if (!marks) return {};
+    const out: Record<number, number> = {};
+    for (const [eid, mid] of marks) out[eid] = mid;
+    return out;
+  }
+
+  setMarker(entityId: number, markerId: number, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const party = this.partyOf(r.meta.entityId);
+    if (!party) { this.error(r.meta.entityId, 'You must be in a party to use raid markers.'); return; }
+    if (!Number.isInteger(markerId) || markerId < 0 || markerId > 7) return;
+    // markable: a live, wild, hostile mob (not players, NPCs, corpses, or pets)
+    const target = this.entities.get(entityId);
+    if (!target || target.kind !== 'mob' || target.dead || !target.hostile || target.ownerId !== null) return;
+    let marks = this.partyMarkers.get(party.id);
+    if (!marks) { marks = new Map(); this.partyMarkers.set(party.id, marks); }
+    // re-applying the same symbol to the same mob toggles it off
+    if (marks.get(entityId) === markerId) { marks.delete(entityId); return; }
+    // a symbol is unique within the party: take it off whatever held it
+    for (const [eid, mid] of marks) { if (mid === markerId) marks.delete(eid); }
+    marks.set(entityId, markerId);
+  }
+
+  clearMarker(entityId: number, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const party = this.partyOf(r.meta.entityId);
+    if (!party) return;
+    this.partyMarkers.get(party.id)?.delete(entityId);
+  }
+
+  // The local player's view of one entity's mark (for the renderer). Direct
+  // lookup, no per-call allocation.
+  markerFor(entityId: number): number | null {
+    const party = this.partyOf(this.primaryId);
+    if (!party) return null;
+    return this.partyMarkers.get(party.id)?.get(entityId) ?? null;
+  }
+
+  // Strip an entity's mark from every party — used when it dies or despawns.
+  private clearEntityMarker(entityId: number): void {
+    for (const marks of this.partyMarkers.values()) marks.delete(entityId);
   }
 
   // -------------------------------------------------------------------------

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -13,7 +13,7 @@ import { terrainHeight, WATER_LEVEL, roadDistance } from '../sim/world';
 import { Meters } from './meters';
 import { audio } from '../game/audio';
 import { music } from '../game/music';
-import { iconDataUrl, QUALITY_COLOR } from './icons';
+import { iconDataUrl, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_NAMES } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
@@ -141,6 +141,11 @@ export class Hud {
       const t = tid !== null ? this.sim.entities.get(tid) : null;
       if (t && t.kind === 'player' && t.id !== this.sim.playerId) {
         this.openContextMenu(t.id, t.name, (ev as MouseEvent).clientX, (ev as MouseEvent).clientY);
+      } else if (t && t.kind === 'mob' && !t.dead && t.hostile && t.ownerId === null && this.sim.partyInfo) {
+        // classic WoW: right-click an enemy's unit frame to set a raid marker.
+        // Mirror Sim.setMarker's markable criteria (live wild hostile mob) so the
+        // menu never appears for a pet/non-hostile mob where it would be a no-op.
+        this.openMarkerMenu(t.id, t.name, (ev as MouseEvent).clientX, (ev as MouseEvent).clientY);
       }
     });
     $('#mm-char').addEventListener('click', () => this.toggleChar());
@@ -2094,6 +2099,34 @@ export class Hud {
           else this.toggleChatIgnore(name);
         } else if (act === 'report') this.openReportWindow({ pid, name });
         else if (act === 'kick') this.sim.partyKick(pid);
+      });
+    });
+  }
+
+  // Raid/target marker picker for an enemy, opened from its target unit frame.
+  // Party-only (markers are a coordination feature); shows the 8 symbols with a
+  // check on the one currently on this mob, plus Clear and Cancel.
+  openMarkerMenu(entityId: number, name: string, x: number, y: number): void {
+    if (!this.sim.partyInfo) return;
+    const el = $('#ctx-menu');
+    const current = this.sim.markerFor(entityId);
+    let html = `<div class="ctx-title">${esc(name)}</div>`;
+    for (let i = 0; i < RAID_MARKER_NAMES.length; i++) {
+      const check = current === i ? ' ✓' : '';
+      html += `<div class="ctx-item" data-act="m${i}"><span class="ctx-mark" style="background-image:url(${raidMarkerDataUrl(i)})"></span>${RAID_MARKER_NAMES[i]}${check}</div>`;
+    }
+    html += `<div class="ctx-item" data-act="clear">Clear Marker</div>`;
+    html += `<div class="ctx-item" data-act="close">Cancel</div>`;
+    el.innerHTML = html;
+    el.style.left = `${Math.min(window.innerWidth - 170, x)}px`;
+    el.style.top = `${Math.min(window.innerHeight - 340, y)}px`;
+    el.style.display = 'block';
+    el.querySelectorAll('.ctx-item').forEach((item) => {
+      item.addEventListener('click', () => {
+        const act = (item as HTMLElement).dataset.act;
+        el.style.display = 'none';
+        if (act === 'clear') this.sim.clearMarker(entityId);
+        else if (act && act.startsWith('m')) this.sim.setMarker(entityId, Number(act.slice(1)));
       });
     });
   }

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1326,3 +1326,112 @@ export function iconDataUrl(kind: IconKind, id: string, size: number = DEFAULT_I
   urlCache.set(key, url);
   return url;
 }
+
+// ---------------------------------------------------------------------------
+// Raid / target markers (issue #105)
+//
+// Eight classic symbols (indexed 0..7) drawn flat and bold on a transparent
+// canvas — a dark outline behind each colored shape keeps them legible while
+// floating above mobs in the bright overworld. Unlike ability icons these have
+// no frame/background; contrast comes from the baked outline (+ a CSS shadow).
+// ---------------------------------------------------------------------------
+
+export const RAID_MARKER_NAMES = ['Star', 'Circle', 'Diamond', 'Triangle', 'Moon', 'Square', 'Cross', 'Skull'] as const;
+export const RAID_MARKER_COUNT = RAID_MARKER_NAMES.length;
+const RAID_MARKER_FILL = ['#ffe23a', '#ff8a2a', '#d24bff', '#37d72c', '#cfe6ff', '#23b5ff', '#ff3b30', '#f4f4f4'];
+const RAID_MARKER_OUTLINE = '#0d0d12';
+const RAID_MARKER_PX = 64;
+const raidMarkerCache = new Map<number, string>();
+
+function raidStarPath(ctx: Ctx): void {
+  ctx.beginPath();
+  for (let i = 0; i < 10; i++) {
+    const rr = i % 2 === 0 ? 42 : 17;
+    const a = -Math.PI / 2 + (i * Math.PI) / 5;
+    const x = Math.cos(a) * rr, y = Math.sin(a) * rr;
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+}
+
+function raidSkullPath(ctx: Ctx): void {
+  ctx.beginPath();
+  ctx.arc(0, -10, 30, Math.PI, 0, false); // cranium dome
+  ctx.lineTo(30, 6);
+  ctx.quadraticCurveTo(30, 20, 16, 23);
+  ctx.lineTo(13, 35);
+  ctx.quadraticCurveTo(0, 41, -13, 35); // chin
+  ctx.lineTo(-16, 23);
+  ctx.quadraticCurveTo(-30, 20, -30, 6);
+  ctx.closePath();
+}
+
+// Outline a single closed path, then fill it — the centered stroke leaves a
+// crisp dark border once the fill paints over its inner half.
+function raidStrokeFill(ctx: Ctx, fill: string): void {
+  ctx.lineJoin = 'round';
+  ctx.lineWidth = 9;
+  ctx.strokeStyle = RAID_MARKER_OUTLINE;
+  ctx.stroke();
+  ctx.fillStyle = fill;
+  ctx.fill();
+}
+
+function drawRaidMarker(ctx: Ctx, idx: number): void {
+  const fill = RAID_MARKER_FILL[idx] ?? '#ffffff';
+  switch (idx) {
+    case 0: // star
+      raidStarPath(ctx); raidStrokeFill(ctx, fill); break;
+    case 1: // circle
+      ctx.beginPath(); ctx.arc(0, 0, 37, 0, TAU); raidStrokeFill(ctx, fill); break;
+    case 2: // diamond
+      ctx.beginPath(); ctx.moveTo(0, -42); ctx.lineTo(38, 0); ctx.lineTo(0, 42); ctx.lineTo(-38, 0); ctx.closePath();
+      raidStrokeFill(ctx, fill); break;
+    case 3: // triangle
+      ctx.beginPath(); ctx.moveTo(0, -40); ctx.lineTo(38, 32); ctx.lineTo(-38, 32); ctx.closePath();
+      raidStrokeFill(ctx, fill); break;
+    case 4: { // moon — a dark crescent with a slightly inset colored one on top
+      const crescent = (outerR: number, carveX: number, carveR: number): void => {
+        ctx.beginPath();
+        ctx.arc(-4, 0, outerR, 0, TAU, false);
+        ctx.arc(carveX, 0, carveR, 0, TAU, true); // opposite winding carves a bite
+      };
+      crescent(40, 20, 40); ctx.fillStyle = RAID_MARKER_OUTLINE; ctx.fill();
+      crescent(34, 23, 40); ctx.fillStyle = fill; ctx.fill();
+      break;
+    }
+    case 5: // square
+      ctx.beginPath(); ctx.rect(-34, -34, 68, 68); raidStrokeFill(ctx, fill); break;
+    case 6: // cross (X) — two round-capped bars, wide dark pass then colored pass
+      ctx.lineCap = 'round';
+      ctx.beginPath(); ctx.moveTo(-28, -28); ctx.lineTo(28, 28); ctx.moveTo(28, -28); ctx.lineTo(-28, 28);
+      ctx.lineWidth = 28; ctx.strokeStyle = RAID_MARKER_OUTLINE; ctx.stroke();
+      ctx.lineWidth = 16; ctx.strokeStyle = fill; ctx.stroke();
+      break;
+    case 7: // skull
+      raidSkullPath(ctx); raidStrokeFill(ctx, fill);
+      ctx.fillStyle = RAID_MARKER_OUTLINE;
+      ctx.beginPath(); ctx.ellipse(-12, -7, 8, 9, 0, 0, TAU); ctx.fill(); // left eye
+      ctx.beginPath(); ctx.ellipse(12, -7, 8, 9, 0, 0, TAU); ctx.fill(); // right eye
+      ctx.beginPath(); ctx.moveTo(0, 3); ctx.lineTo(5, 14); ctx.lineTo(-5, 14); ctx.closePath(); ctx.fill(); // nose
+      break;
+    default:
+      ctx.beginPath(); ctx.arc(0, 0, 36, 0, TAU); raidStrokeFill(ctx, fill);
+  }
+}
+
+// Cached transparent-background PNG data URL for raid marker `idx` (0..7).
+export function raidMarkerDataUrl(idx: number): string {
+  const cached = raidMarkerCache.get(idx);
+  if (cached) return cached;
+  const canvas = document.createElement('canvas');
+  canvas.width = RAID_MARKER_PX;
+  canvas.height = RAID_MARKER_PX;
+  const ctx = canvas.getContext('2d')!;
+  ctx.scale(RAID_MARKER_PX / 100, RAID_MARKER_PX / 100);
+  ctx.translate(50, 50);
+  drawRaidMarker(ctx, idx);
+  const url = canvas.toDataURL();
+  raidMarkerCache.set(idx, url);
+  return url;
+}

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -179,6 +179,10 @@ export interface IWorld {
   partyDecline(): void;
   partyLeave(): void;
   partyKick(targetPid: number): void;
+  // raid/target markers (party-scoped): markerId 0..7, null = no mark
+  markerFor(entityId: number): number | null;
+  setMarker(entityId: number, markerId: number): void;
+  clearMarker(entityId: number): void;
   tradeRequest(targetPid: number): void;
   tradeAccept(): void;
   tradeSetOffer(items: InvSlot[], copper: number): void;

--- a/tests/markers.test.ts
+++ b/tests/markers.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The server self-wire tests pull in server/game.ts, which imports the db
+// layer — mock it so no Postgres is required (vi.mock is hoisted).
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+}));
+
+import { Sim } from '../src/sim/sim';
+import { GameServer } from '../server/game';
+import type { Entity } from '../src/sim/types';
+
+// Raid marker ids (0..7), WoW order: Star, Circle, Diamond, Triangle, Moon,
+// Square, Cross, Skull.
+const STAR = 0;
+const SKULL = 7;
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+// Wild, live, hostile mobs are spawned from CAMPS in the Sim constructor.
+function liveMobs(sim: Sim, n: number): Entity[] {
+  const mobs = [...sim.entities.values()].filter(
+    (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null,
+  );
+  if (mobs.length < n) throw new Error(`test needs ${n} mobs, found ${mobs.length}`);
+  return mobs.slice(0, n);
+}
+
+// Build a party led by pids[0] with the rest as members.
+function makeParty(sim: Sim, ...pids: number[]): void {
+  for (let i = 1; i < pids.length; i++) {
+    sim.partyInvite(pids[i], pids[0]);
+    sim.partyAccept(pids[i]);
+  }
+}
+
+describe('target markers — sim layer', () => {
+  it('a marker set by one party member is visible to the whole party, not outsiders', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel'); // outsider
+    makeParty(sim, a, b);
+    const [mob] = liveMobs(sim, 1);
+
+    sim.setMarker(mob.id, SKULL, a);
+
+    expect(sim.markersFor(a)).toEqual({ [mob.id]: SKULL });
+    expect(sim.markersFor(b)).toEqual({ [mob.id]: SKULL });
+    expect(sim.markersFor(c)).toEqual({}); // outsider sees nothing
+  });
+
+  it('two separate parties can mark the same mob independently', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    const d = sim.addPlayer('priest', 'Dalet');
+    makeParty(sim, a, b);
+    makeParty(sim, c, d);
+    const [mob] = liveMobs(sim, 1);
+
+    sim.setMarker(mob.id, SKULL, a);
+    sim.setMarker(mob.id, STAR, c);
+
+    expect(sim.markersFor(a)[mob.id]).toBe(SKULL);
+    expect(sim.markersFor(c)[mob.id]).toBe(STAR);
+  });
+
+  it('a symbol is unique within a party — re-assigning it moves it off the old mob', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    makeParty(sim, a, b);
+    const [mob1, mob2] = liveMobs(sim, 2);
+
+    sim.setMarker(mob1.id, SKULL, a);
+    sim.setMarker(mob2.id, SKULL, b); // same symbol, different mob
+
+    expect(sim.markersFor(a)).toEqual({ [mob2.id]: SKULL }); // moved, not duplicated
+  });
+
+  it('re-applying the same symbol to the same mob toggles it off', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    makeParty(sim, a, b);
+    const [mob] = liveMobs(sim, 1);
+
+    sim.setMarker(mob.id, SKULL, a);
+    sim.setMarker(mob.id, SKULL, a); // toggle
+
+    expect(sim.markersFor(a)).toEqual({});
+  });
+
+  it('clearMarker removes a mark for the party', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    makeParty(sim, a, b);
+    const [mob] = liveMobs(sim, 1);
+
+    sim.setMarker(mob.id, SKULL, a);
+    sim.clearMarker(mob.id, b);
+
+    expect(sim.markersFor(a)).toEqual({});
+    expect(sim.markersFor(b)).toEqual({});
+  });
+
+  describe('validation', () => {
+    it('does nothing when the actor has no party', () => {
+      const sim = makeWorld();
+      const lone = sim.addPlayer('warrior', 'Aleph');
+      const [mob] = liveMobs(sim, 1);
+
+      sim.setMarker(mob.id, SKULL, lone);
+
+      expect(sim.markersFor(lone)).toEqual({});
+    });
+
+    it('rejects out-of-range and non-integer marker ids', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+      const [mob] = liveMobs(sim, 1);
+
+      sim.setMarker(mob.id, 8, a);
+      sim.setMarker(mob.id, -1, a);
+      sim.setMarker(mob.id, 1.5, a);
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+
+    it('refuses to mark a non-mob (e.g. a player)', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+
+      sim.setMarker(b, SKULL, a); // b is a player entity
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+
+    it('refuses to mark a dead mob', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+      const [mob] = liveMobs(sim, 1);
+      mob.dead = true;
+
+      sim.setMarker(mob.id, SKULL, a);
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+
+    it('refuses to mark an owned pet/summon (ownerId set)', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+      const [mob] = liveMobs(sim, 1);
+      mob.ownerId = b; // now a controlled pet, not a wild enemy
+
+      sim.setMarker(mob.id, SKULL, a);
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+  });
+
+  describe('lifecycle cleanup', () => {
+    it('clears a mark when the marked mob dies (so it cannot reappear on respawn)', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+      const [mob] = liveMobs(sim, 1);
+
+      sim.setMarker(mob.id, SKULL, a);
+      // respawnMob reuses the same entity id, so the mark must be cleared on death
+      (sim as unknown as { handleDeath(e: Entity, killer: Entity | null): void }).handleDeath(mob, null);
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+
+    it('clears a mark when the marked entity despawns', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+      const [mob] = liveMobs(sim, 1);
+
+      sim.setMarker(mob.id, SKULL, a);
+      (sim as unknown as { dropEntity(id: number): void }).dropEntity(mob.id);
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+
+    it('clears a mark when the marked mob is tamed into a pet', () => {
+      const sim = makeWorld();
+      const hunter = sim.addPlayer('hunter', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, hunter, b);
+      const wolf = [...sim.entities.values()].find(
+        (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null && e.templateId === 'forest_wolf',
+      );
+      if (!wolf) throw new Error('expected a tameable forest_wolf in the overworld');
+      const hunterE = sim.entities.get(hunter)!;
+      hunterE.level = 20; // out-level the wolf so taming is permitted
+
+      sim.setMarker(wolf.id, SKULL, hunter);
+      expect(sim.markersFor(hunter)).toEqual({ [wolf.id]: SKULL });
+
+      (sim as unknown as { completeTame(p: Entity, target: Entity): void }).completeTame(hunterE, wolf);
+
+      expect(wolf.ownerId).toBe(hunter); // it really became a pet
+      expect(sim.markersFor(hunter)).toEqual({}); // and the stale mark is gone
+    });
+  });
+
+  describe('party lifecycle', () => {
+    it('marks survive a non-fatal member departure', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      const c = sim.addPlayer('rogue', 'Gimel');
+      makeParty(sim, a, b, c);
+      const [mob] = liveMobs(sim, 1);
+
+      sim.setMarker(mob.id, SKULL, a);
+      sim.partyLeave(c); // party still has a + b
+
+      expect(sim.markersFor(a)).toEqual({ [mob.id]: SKULL });
+    });
+
+    it('clears all marks when the party disbands', () => {
+      const sim = makeWorld();
+      const a = sim.addPlayer('warrior', 'Aleph');
+      const b = sim.addPlayer('mage', 'Bet');
+      makeParty(sim, a, b);
+      const [mob] = liveMobs(sim, 1);
+
+      sim.setMarker(mob.id, SKULL, a);
+      sim.partyLeave(b); // drops to 1 member -> disband
+
+      expect(sim.markersFor(a)).toEqual({});
+    });
+  });
+});
+
+describe('target markers — server self-wire', () => {
+  function fakeWs() {
+    const sent: any[] = [];
+    return { sent, ws: { readyState: 1, send: (p: string) => sent.push(JSON.parse(p)) } };
+  }
+  function lastSnap(sent: any[]): any {
+    for (let i = sent.length - 1; i >= 0; i--) if (sent[i].t === 'snap') return sent[i];
+    return null;
+  }
+  function serverMob(server: GameServer): Entity {
+    const mob = [...server.sim.entities.values()].find(
+      (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null,
+    );
+    if (!mob) throw new Error('no wild mob in server sim');
+    return mob;
+  }
+  function join(server: GameServer, fc: { ws: any }, id: number, name: string) {
+    const s = server.join(fc.ws, id, id, name, 'warrior', null);
+    if ('error' in s) throw new Error(s.error);
+    return s;
+  }
+  function cmd(server: GameServer, session: unknown, payload: object) {
+    server.handleMessage(session as never, JSON.stringify({ t: 'cmd', ...payload }));
+  }
+
+  it('delivers a mark to the whole party via the self-wire, and not to outsiders', () => {
+    const server = new GameServer();
+    const fcA = fakeWs(); const sA = join(server, fcA, 1, 'Aleph');
+    const fcB = fakeWs(); const sB = join(server, fcB, 2, 'Bet');
+    const fcC = fakeWs(); join(server, fcC, 3, 'Gimel'); // outsider, never in a party
+    cmd(server, sA, { cmd: 'pinvite', id: sB.pid });
+    cmd(server, sB, { cmd: 'paccept' });
+    const mob = serverMob(server);
+
+    cmd(server, sA, { cmd: 'setMarker', id: mob.id, marker: SKULL });
+    (server as unknown as { broadcastSnapshots(): void }).broadcastSnapshots();
+
+    expect(lastSnap(fcA.sent).self.marks).toEqual({ [mob.id]: SKULL });
+    expect(lastSnap(fcB.sent).self.marks).toEqual({ [mob.id]: SKULL });
+    expect(lastSnap(fcC.sent).self.marks).toBeNull(); // no party -> null on the wire
+  });
+
+  it('sends a clear (null) when the party disbands', () => {
+    const server = new GameServer();
+    const fcA = fakeWs(); const sA = join(server, fcA, 1, 'Aleph');
+    const fcB = fakeWs(); const sB = join(server, fcB, 2, 'Bet');
+    cmd(server, sA, { cmd: 'pinvite', id: sB.pid });
+    cmd(server, sB, { cmd: 'paccept' });
+    const mob = serverMob(server);
+    cmd(server, sA, { cmd: 'setMarker', id: mob.id, marker: SKULL });
+    (server as unknown as { broadcastSnapshots(): void }).broadcastSnapshots();
+    expect(lastSnap(fcA.sent).self.marks).toEqual({ [mob.id]: SKULL });
+
+    cmd(server, sB, { cmd: 'pleave' }); // drops party to 1 -> disband
+    (server as unknown as { broadcastSnapshots(): void }).broadcastSnapshots();
+
+    expect(lastSnap(fcA.sent).self.marks).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #105.

Adds WoW-style **party-visible target markers** (raid markers). Right-click an enemy's **target unit frame** to assign one of the 8 classic symbols — Star, Circle, Diamond, Triangle, Moon, Square, Cross, Skull — and it floats above that mob's nameplate for **everyone in your party**. Re-pick the same symbol on the same mob to clear it, or use **Clear Marker**.

## How it works

| Concern | Approach |
|---|---|
| **State** | A party-scoped overlay on the `Sim`: `partyMarkers: Map<partyId, Map<entityId, markerId>>`. Purely cosmetic — never read by `tick()`, `encodeObs()`, rewards, threat, targeting, or persistence, so the deterministic sim / headless RL env is untouched. |
| **Delivery** | Rides the per-recipient **self-wire** (`maybe('marks', markersWire(pid))`), the same channel as party/trade/duel state. This keeps markers **party-private** — a field on the per-entity snapshot would leak to every nearby viewer, since that wire cache is serialized once per entity and shared across observers. |
| **Semantics** | A symbol is unique within a party (re-assigning it moves it); re-applying it to the same mob toggles it off. Only live, wild, hostile mobs are markable (no players/NPCs/corpses/pets). |
| **Lifecycle** | Markers clear on mob **death** (overworld `respawnMob` reuses the entity id, so a stale mark would otherwise reappear on the respawn), on **despawn**, when a marked mob is **tamed** into a pet, and on party **disband**. |
| **Icons** | Drawn procedurally on canvas (matching the existing icon pipeline) — no asset files. |

## Files

- `src/sim/sim.ts` — `partyMarkers` + `setMarker`/`clearMarker`/`markersFor`/`markerFor`; cleanup hooks in `handleDeath`, `dropEntity`, `completeTame`, and party disband.
- `src/world_api.ts` — `markerFor`/`setMarker`/`clearMarker` on `IWorld` (offline `Sim` + online `ClientWorld` both satisfy it).
- `server/game.ts` — `setMarker`/`clearMarker` command dispatch + a pure `markersWire(pid)` into the self-wire.
- `src/net/online.ts` — client command methods + self-wire decode (`null` = cleared).
- `src/ui/icons.ts` — the 8 procedural marker icons + `raidMarkerDataUrl(idx)`.
- `src/render/renderer.ts` — a dedicated `.np-raidmark` element above each nameplate (hidden when absent, so layout never shifts).
- `src/ui/hud.ts` — `openMarkerMenu()` wired to the target-portrait right-click for mob targets.
- `index.html` — marker + menu CSS.
- `tests/markers.test.ts` — new.

## Verification

- **`npm test`** — full suite green, **17 new marker tests**: sim-layer party scope (members see / outsiders don't), two parties marking the same mob independently, symbol uniqueness + toggle, validation (no party / bad id / non-mob / dead / pet), lifecycle (death, despawn, tame), party lifecycle (member leave vs disband), and server self-wire delivery (party-only + clear-on-disband).
- **`npm run build`**, **`npm run build:server`**, **`npm run build:env`** — all pass; `tsc --noEmit` clean.
- Marker icons verified visually (rendered at overhead size on grass/dark/stone backgrounds).
- Diff reviewed by Codex (GPT-5.5); its one finding — clearing a mark when a marked beast is tamed — is fixed and covered by a test.

## Notes / possible follow-ups

- **Assignment is mouse-only** (right-click the target portrait), mirroring the existing player context menu. Modifier-key binds for markers could be a follow-up.
- Markers ride nameplate visibility (shown when the nameplate is shown). Always-on rendering regardless of nameplate settings could be a follow-up if desired.
- I verified the sim + server self-wire paths with unit tests and the icons visually; a live 2-client playtest of the in-world menu/render is still worth a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
