### PR TITLE
fix: use stable market owner keys

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -396,7 +396,9 @@ export class GameServer {
 
   join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
-    const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
+    const marketKey = `character:${characterId}`;
+    const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined, marketKey });
+    this.sim.claimMarketKey(name, marketKey);
     if (isGm) {
       // GM characters: invulnerable, and always at the level cap (the row is
       // created without state, so the first join levels them up)

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -170,6 +170,7 @@ export interface PlayerMeta {
   entityId: number;
   cls: PlayerClass;
   name: string;
+  marketKey: string;
   moveInput: MoveInput;
   inventory: InvSlot[];
   copper: number;
@@ -190,13 +191,13 @@ export interface PlayerMeta {
 // The World Market — a single shared, server-authoritative auction house run
 // by the Merchant NPC. Listings live in the sim (so offline play has a market
 // too and the rules are testable); the server persists them to Postgres.
-// Sellers are keyed by character name, which is globally unique, so proceeds
-// and returns reach the right player even while they are offline.
+// Online sellers are keyed by durable character identity; local/offline play
+// falls back to character name so existing saved markets remain usable.
 // ---------------------------------------------------------------------------
 
 export interface MarketListing {
   id: number;
-  sellerKey: string; // stable seller identity (character name); '' for house stock
+  sellerKey: string; // stable seller identity; '' for house stock
   sellerName: string; // display name
   itemId: string;
   count: number;
@@ -206,7 +207,7 @@ export interface MarketListing {
 }
 
 // Gold + items awaiting pickup at the Merchant (sale proceeds, expired
-// listings), keyed by seller name so an offline seller can collect later.
+// listings), keyed by the same seller identity as MarketListing.sellerKey.
 export interface MarketCollection {
   copper: number;
   items: InvSlot[];
@@ -416,7 +417,7 @@ export class Sim {
   // Players: join / leave / persistence
   // -------------------------------------------------------------------------
 
-  addPlayer(cls: PlayerClass, name: string, opts?: { autoEquip?: boolean; state?: CharacterState }): number {
+  addPlayer(cls: PlayerClass, name: string, opts?: { autoEquip?: boolean; state?: CharacterState; marketKey?: string }): number {
     // Characters saved inside a dungeon instance rejoin at its entrance —
     // their old instance is gone (or belongs to someone else) by now.
     let savedPos = opts?.state?.pos ?? null;
@@ -434,6 +435,7 @@ export class Sim {
       entityId: player.id,
       cls,
       name,
+      marketKey: opts?.marketKey ?? name,
       moveInput: emptyMoveInput(),
       inventory: [],
       copper: 0,
@@ -3955,9 +3957,9 @@ export class Sim {
     return !!m && dist2d(e.pos, m.pos) <= MARKET_RANGE;
   }
 
-  private metaByName(name: string): PlayerMeta | null {
-    if (!name) return null;
-    for (const m of this.players.values()) if (m.name === name) return m;
+  private metaByMarketKey(key: string): PlayerMeta | null {
+    if (!key) return null;
+    for (const m of this.players.values()) if (m.marketKey === key) return m;
     return null;
   }
 
@@ -3965,6 +3967,19 @@ export class Sim {
     let c = this.marketCollections.get(key);
     if (!c) { c = { copper: 0, items: [] }; this.marketCollections.set(key, c); }
     return c;
+  }
+
+  claimMarketKey(legacyKey: string, marketKey: string): void {
+    if (!legacyKey || !marketKey || legacyKey === marketKey) return;
+    for (const listing of this.marketListings) {
+      if (!listing.house && listing.sellerKey === legacyKey) listing.sellerKey = marketKey;
+    }
+    const legacyCollection = this.marketCollections.get(legacyKey);
+    if (!legacyCollection) return;
+    const collection = this.collectionFor(marketKey);
+    collection.copper += legacyCollection.copper;
+    collection.items.push(...legacyCollection.items.map((s) => ({ ...s })));
+    this.marketCollections.delete(legacyKey);
   }
 
   // The Merchant always keeps a little stock so the market is never empty —
@@ -4002,11 +4017,11 @@ export class Sim {
     const ask = Math.floor(price);
     if (!Number.isFinite(ask) || ask < MARKET_MIN_PRICE) { this.error(meta.entityId, 'Name a price of at least 1 copper.'); return; }
     if (ask > MARKET_MAX_PRICE) { this.error(meta.entityId, 'That price is beyond what the Merchant will broker.'); return; }
-    const mine = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
+    const mine = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.marketKey ? 1 : 0), 0);
     if (mine >= MARKET_MAX_LISTINGS) { this.error(meta.entityId, `You may keep at most ${MARKET_MAX_LISTINGS} goods on the market at once.`); return; }
     this.removeItem(itemId, want, meta.entityId); // escrow
     this.marketListings.push({
-      id: this.nextListingId++, sellerKey: meta.name, sellerName: meta.name,
+      id: this.nextListingId++, sellerKey: meta.marketKey, sellerName: meta.name,
       itemId, count: want, price: ask, expiresAt: this.time + MARKET_LISTING_DURATION, house: false,
     });
     this.emit({ type: 'loot', text: `Listed ${def.name}${want > 1 ? ' x' + want : ''} on the World Market for ${formatMoney(ask)}.`, pid: meta.entityId });
@@ -4025,7 +4040,7 @@ export class Sim {
     const listing = this.marketListings[idx];
     const def = ITEMS[listing.itemId];
     if (!def) { this.marketListings.splice(idx, 1); return; }
-    if (!listing.house && listing.sellerKey === meta.name) {
+    if (!listing.house && listing.sellerKey === meta.marketKey) {
       this.error(meta.entityId, 'That is your own listing — cancel it to reclaim it.');
       return;
     }
@@ -4036,7 +4051,7 @@ export class Sim {
       const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
       this.collectionFor(listing.sellerKey).copper += proceeds;
       this.marketListings.splice(idx, 1);
-      const sellerMeta = this.metaByName(listing.sellerKey);
+      const sellerMeta = this.metaByMarketKey(listing.sellerKey);
       if (sellerMeta) {
         this.emit({ type: 'loot', text: `${meta.name} bought your ${def.name} for ${formatMoney(listing.price)} — collect ${formatMoney(proceeds)} from the Merchant.`, pid: sellerMeta.entityId });
       }
@@ -4053,7 +4068,7 @@ export class Sim {
     const idx = this.marketListings.findIndex((l) => l.id === listingId);
     if (idx < 0) return;
     const listing = this.marketListings[idx];
-    if (listing.house || listing.sellerKey !== meta.name) { this.error(meta.entityId, 'That is not your listing.'); return; }
+    if (listing.house || listing.sellerKey !== meta.marketKey) { this.error(meta.entityId, 'That is not your listing.'); return; }
     this.marketListings.splice(idx, 1);
     this.addItem(listing.itemId, listing.count, meta.entityId);
     const def = ITEMS[listing.itemId];
@@ -4067,14 +4082,14 @@ export class Sim {
     if (!r) return;
     const { meta, e: p } = r;
     if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
-    const col = this.marketCollections.get(meta.name);
+    const col = this.marketCollections.get(meta.marketKey);
     if (!col || (col.copper <= 0 && col.items.length === 0)) { this.error(meta.entityId, 'You have nothing to collect.'); return; }
     if (col.copper > 0) {
       meta.copper += col.copper;
       this.emit({ type: 'loot', text: `You collect ${formatMoney(col.copper)} from the Merchant.`, pid: meta.entityId });
     }
     for (const s of col.items) this.addItem(s.itemId, s.count, meta.entityId);
-    this.marketCollections.delete(meta.name);
+    this.marketCollections.delete(meta.marketKey);
   }
 
   // Once a second: return expired player listings to their seller's collection.
@@ -4085,7 +4100,7 @@ export class Sim {
       if (l.house || this.time < l.expiresAt) continue;
       this.marketListings.splice(i, 1);
       this.collectionFor(l.sellerKey).items.push({ itemId: l.itemId, count: l.count });
-      const sellerMeta = this.metaByName(l.sellerKey);
+      const sellerMeta = this.metaByMarketKey(l.sellerKey);
       if (sellerMeta) {
         const def = ITEMS[l.itemId];
         this.emit({ type: 'log', text: `Your market listing of ${def?.name ?? l.itemId} expired and waits at the Merchant.`, color: '#caa472', pid: sellerMeta.entityId });
@@ -4107,10 +4122,10 @@ export class Sim {
     });
     const listings = sorted.slice(0, MARKET_WIRE_LIMIT).map((l) => ({
       id: l.id, sellerName: l.sellerName, itemId: l.itemId, count: l.count,
-      price: l.price, mine: !l.house && l.sellerKey === meta.name, house: l.house,
+      price: l.price, mine: !l.house && l.sellerKey === meta.marketKey, house: l.house,
     }));
-    const col = this.marketCollections.get(meta.name);
-    const myListingCount = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
+    const col = this.marketCollections.get(meta.marketKey);
+    const myListingCount = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.marketKey ? 1 : 0), 0);
     return {
       listings,
       collectionCopper: col?.copper ?? 0,

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -43,4 +43,37 @@ describe('GameServer sessions', () => {
     const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
     expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
   });
+
+  it('uses the durable character id for online market listings', () => {
+    const server = new GameServer();
+    server.sim.loadMarket({
+      listings: [
+        { id: 50, sellerKey: 'Seller', sellerName: 'Seller', itemId: 'bone_fragments', count: 1, price: 75, secondsLeft: 60 },
+      ],
+      collections: [
+        { key: 'Seller', copper: 25, items: [{ itemId: 'wolf_fang', count: 2 }] },
+      ],
+      nextListingId: 51,
+    });
+    const session = expectJoined(server.join(fakeWs(), 11, 101, 'Seller', 'warrior', null));
+    const merchant = [...server.sim.entities.values()].find((e) => e.templateId === 'the_merchant')!;
+    const player = server.sim.entities.get(session.pid)!;
+    player.pos = { ...merchant.pos };
+    player.prevPos = { ...player.pos };
+
+    expect(server.sim.players.get(session.pid)?.marketKey).toBe('character:101');
+    expect(server.sim.marketListings.find((l) => l.id === 50)).toMatchObject({
+      sellerKey: 'character:101',
+      sellerName: 'Seller',
+    });
+    expect(server.sim.marketInfoFor(session.pid)?.collectionCopper).toBe(25);
+    server.sim.addItem('wolf_fang', 1, session.pid);
+    server.sim.marketList('wolf_fang', 1, 100, session.pid);
+
+    expect(server.sim.marketListings.find((l) => l.sellerKey === 'character:101' && l.itemId === 'wolf_fang')).toMatchObject({
+      sellerName: 'Seller',
+      itemId: 'wolf_fang',
+      count: 1,
+    });
+  });
 });

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -169,6 +169,43 @@ describe('the World Market — the Merchant', () => {
     expect(info.collectionItems).toEqual([{ itemId: 'wolf_fang', count: 1 }]);
   });
 
+  it('keeps market ownership stable when the seller display name changes', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller', { marketKey: 'character:123' });
+    const buyer = sim.addPlayer('mage', 'Buyer', { marketKey: 'character:456' });
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 2, seller);
+    sim.players.get(buyer)!.copper = 1000;
+    sim.marketList('wolf_fang', 1, 100, seller);
+    sim.marketList('wolf_fang', 1, 200, seller);
+    const listingToCancel = sim.marketListings.find((l) => l.sellerKey === 'character:123' && l.price === 100)!;
+    const listingToBuy = sim.marketListings.find((l) => l.sellerKey === 'character:123' && l.price === 200)!;
+
+    sim.players.get(seller)!.name = 'Renamed';
+    sim.entities.get(seller)!.name = 'Renamed';
+    const oldNameOwner = sim.addPlayer('warrior', 'Seller', { marketKey: 'character:789' });
+    standAtMerchant(sim, oldNameOwner);
+    sim.events.length = 0;
+
+    sim.marketCancel(listingToCancel.id, oldNameOwner);
+    expect(errorsSince(sim).join(' ')).toMatch(/not your listing/i);
+    expect(sim.marketListings.some((l) => l.id === listingToCancel.id)).toBe(true);
+
+    sim.marketCancel(listingToCancel.id, seller);
+    expect(sim.countItem('wolf_fang', seller)).toBe(1);
+    expect(sim.marketListings.some((l) => l.id === listingToCancel.id)).toBe(false);
+
+    sim.marketBuy(listingToBuy.id, buyer);
+    sim.events.length = 0;
+    sim.marketCollect(oldNameOwner);
+    expect(errorsSince(sim).join(' ')).toMatch(/nothing to collect/i);
+    expect(copperOf(sim, oldNameOwner)).toBe(0);
+
+    sim.marketCollect(seller);
+    expect(copperOf(sim, seller)).toBe(190);
+  });
+
   it('refuses to deal with anyone who is not standing at the Merchant', () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');
@@ -209,18 +246,19 @@ describe('the World Market — the Merchant', () => {
 
   it('survives a save/load round-trip (persistence)', () => {
     const sim = makeWorld();
-    const seller = sim.addPlayer('warrior', 'Seller');
-    const buyer = sim.addPlayer('mage', 'Buyer');
+    const seller = sim.addPlayer('warrior', 'Seller', { marketKey: 'character:123' });
+    const buyer = sim.addPlayer('mage', 'Buyer', { marketKey: 'character:456' });
     standAtMerchant(sim, seller);
     standAtMerchant(sim, buyer);
     sim.addItem('wolf_fang', 3, seller);
     sim.players.get(buyer)!.copper = 1000;
     sim.marketList('wolf_fang', 1, 300, seller); // this one will sell -> collection gold
     sim.marketList('wolf_fang', 2, 150, seller); // this one stays listed
-    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'Seller' && l.count === 1)!.id, buyer);
+    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'character:123' && l.count === 1)!.id, buyer);
 
     const save = sim.serializeMarket();
     expect(save.listings.length).toBe(1); // only the unsold player listing (house excluded)
+    expect(save.listings[0]).toMatchObject({ sellerKey: 'character:123', sellerName: 'Seller' });
     expect(save.listings[0].secondsLeft).toBeGreaterThan(0);
 
     const sim2 = makeWorld();
@@ -229,12 +267,12 @@ describe('the World Market — the Merchant', () => {
 
     const loaded = sim2.marketListings.filter((l) => !l.house);
     expect(loaded.length).toBe(1);
-    expect(loaded[0]).toMatchObject({ sellerKey: 'Seller', itemId: 'wolf_fang', count: 2, price: 150 });
+    expect(loaded[0]).toMatchObject({ sellerKey: 'character:123', sellerName: 'Seller', itemId: 'wolf_fang', count: 2, price: 150 });
     expect(Number.isFinite(loaded[0].expiresAt)).toBe(true);
     // house stock is reseeded, not duplicated from the save
     expect(sim2.marketListings.filter((l) => l.house).length).toBe(houseBefore);
     // the waiting sale proceeds came across too
-    const col = (sim2 as unknown as { marketCollections: Map<string, { copper: number }> }).marketCollections.get('Seller');
+    const col = (sim2 as unknown as { marketCollections: Map<string, { copper: number }> }).marketCollections.get('character:123');
     expect(col?.copper).toBe(285); // 300 - 5%
     // new listings keep climbing past the loaded ids
     const seller2 = sim2.addPlayer('warrior', 'Seller');
@@ -243,5 +281,28 @@ describe('the World Market — the Merchant', () => {
     sim2.marketList('bone_fragments', 1, 50, seller2);
     const ids = sim2.marketListings.map((l) => l.id);
     expect(new Set(ids).size).toBe(ids.length); // no id collisions
+  });
+
+  it('loads old name-keyed market saves for local play', () => {
+    const sim = makeWorld();
+    sim.loadMarket({
+      listings: [
+        { id: 50, sellerKey: 'Seller', sellerName: 'Seller', itemId: 'wolf_fang', count: 1, price: 75, secondsLeft: 60 },
+      ],
+      collections: [
+        { key: 'Seller', copper: 25, items: [{ itemId: 'bone_fragments', count: 2 }] },
+      ],
+      nextListingId: 51,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+
+    expect(sim.marketInfoFor(seller)!.listings.find((l) => l.id === 50)).toMatchObject({
+      sellerName: 'Seller',
+      mine: true,
+    });
+    sim.marketCollect(seller);
+    expect(copperOf(sim, seller)).toBe(25);
+    expect(sim.countItem('bone_fragments', seller)).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- Uses a durable `character:<id>` market owner key for online World Market listings and collections instead of the mutable character display name.
- Keeps `sellerName` as readable display text, so market rows still show the seller name while ownership checks use the stable key.
- Claims existing name-keyed listings and collections to the durable key when the current online character joins, while offline/local saves continue to use the name fallback.

## Diagnosis
World Market ownership was stored under character names. A rename could leave escrowed goods or collection copper under the old name, and a later character with that old name could be treated as the owner.

## Implementation Notes
- `Sim.addPlayer()` now accepts an optional `marketKey`; local/offline callers omit it and keep the existing name-keyed behavior.
- `GameServer.join()` passes `character:<id>` and rewrites legacy name-keyed entries for that joining character before market interaction.
- Market list, buy, cancel, collect, `mine`, listing-count, and seller notification paths all compare against the stable market key.
- Saved market JSON remains the same shape; old name-keyed saves still load.

## Verification
- `npm test -- tests/market.test.ts tests/game_sessions.test.ts`; 2 files passed, 16 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:server`; passed.
- Full local gate after the review fix: `npm test` (35 files, 400 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.

## Real behavior proof
- Behavior addressed: renamed characters keep market ownership under a stable identity, and a different character with the old display name cannot cancel listings or collect proceeds already keyed to the durable owner.
- Environment tested: deterministic sim market tests and server session tests.
- Evidence after fix: online joins create and claim listings under `character:<id>`, stable-key listings survive display-name changes, old-name characters are rejected from cancel/collect, and old name-keyed local saves still load and collect.
- Not tested: manual browser or live multiplayer rename flow.

## Risk
This touches shared economy ownership and persisted market JSON. The JSON schema is unchanged, house listings are still excluded from saves, and legacy name-keyed entries are only rewritten when a current character joins with a known durable server id.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
