### PR TITLE
fix: confirm friend/ignore membership before reporting removal

### DIFF
--- a/server/social.ts
+++ b/server/social.ts
@@ -215,6 +215,8 @@ export class SocialService {
   async friendRemove(actor: SocialActor, name: string): Promise<void> {
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
     if (!target) { this.err(actor.characterId, `No character named '${name}' on your friends list.`); return; }
+    const friends = await this.db.listFriends(actor.characterId);
+    if (!friends.some((f) => f.id === target.id)) { this.err(actor.characterId, `${target.name} is not on your friends list.`); return; }
     await this.db.removeFriend(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} removed from friends.`);
     this.push(actor.characterId);
@@ -257,6 +259,8 @@ export class SocialService {
   async blockRemove(actor: SocialActor, name: string): Promise<void> {
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
     if (!target) { this.err(actor.characterId, `No character named '${name}' on your ignore list.`); return; }
+    const blocks = await this.db.listBlocks(actor.characterId);
+    if (!blocks.some((b) => b.id === target.id)) { this.err(actor.characterId, `${target.name} is not on your ignore list.`); return; }
     await this.db.removeBlock(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} is no longer ignored.`);
     this.tx.onBlocksChanged(actor.characterId, await this.db.blockedIds(actor.characterId));

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -203,6 +203,12 @@ describe('friends', () => {
     expect((await h.svc.snapshot(1)).friends).toHaveLength(0);
   });
 
+  it('does not claim success when removing someone who is not a friend', async () => {
+    await h.svc.friendRemove(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/not on your friends list/i);
+    expect(h.tx.textFor(1).join()).not.toMatch(/removed from friends/i);
+  });
+
   it('notifies watching friends when a character comes online', async () => {
     // 1 has 2 on their friends list; 2 logs in
     await h.svc.friendAdd(h.actor(1), 'Bet');
@@ -237,6 +243,12 @@ describe('ignore / block', () => {
     await h.svc.blockRemove(h.actor(1), 'Bet');
     expect((await h.svc.snapshot(1)).blocks).toHaveLength(0);
     expect(h.tx.blockSets.get(1)).toEqual([]);
+  });
+
+  it('does not claim success when unignoring someone who is not ignored', async () => {
+    await h.svc.blockRemove(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/not on your ignore list/i);
+    expect(h.tx.textFor(1).join()).not.toMatch(/no longer ignored/i);
   });
 
   it('refuses to block yourself', async () => {


### PR DESCRIPTION
## Problem

`SocialService.friendRemove` and `SocialService.blockRemove` (`server/social.ts`) resolve the target by name, then call `removeFriend` / `removeBlock` **unconditionally** and always report success.

Because the underlying `DELETE ... WHERE` statements are idempotent (deleting a non-matching row is a harmless no-op), the service never distinguishes "removed an actual friend" from "removed nothing". The result is misleading feedback:

- `/removefriend SomeStranger` → *"SomeStranger removed from friends."* (even though they never were a friend)
- `/unignore SomeStranger` → *"SomeStranger is no longer ignored."* (even though they were never ignored)

This is inconsistent with the add paths, which already guard against duplicates (`friendAdd` / `blockAdd` report *"... is already your friend / already ignored"*).

## Fix

Read the friends / ignore list first and verify the target is actually on it. If not, surface an accurate error (*"X is not on your friends list."* / *"X is not on your ignore list."*) instead of a false confirmation. The DB layer is unchanged — only the user-facing feedback is corrected.

## Tests

Added negative-case coverage for both paths in `tests/social_system.test.ts`. Verified the new tests fail without the fix and pass with it. Full suite: 391 tests pass (the unrelated `homepage_foundation` suite still requires `DATABASE_URL`, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)