### PR TITLE
feat: add report abuse guardrails

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -99,6 +99,9 @@ For off-box safety, sync the directory to S3 occasionally:
 
 - **Secrets**: the Postgres password is generated at first boot into
   `/opt/eastbrook/.env` (mode 600, gitignored). Nothing else to manage.
+- **Report metadata hashing**: set `REPORT_HASH_SECRET` in production so
+  report IP/user-agent/detail hashes cannot be compared against the deterministic
+  local/dev fallback.
 - **Username bans**: set `USERNAME_BANLIST_FILE=/opt/eastbrook/username-banlist.txt`
   to load blocked username terms from a private newline- or comma-separated
   file. `USERNAME_BANLIST` can also provide a comma-separated inline list.

--- a/server/db.ts
+++ b/server/db.ts
@@ -87,8 +87,46 @@ CREATE TABLE IF NOT EXISTS player_reports (
   reviewed_by_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
   review_note TEXT NOT NULL DEFAULT ''
 );
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'player';
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS report_kind TEXT NOT NULL DEFAULT 'player_report';
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS realm TEXT NOT NULL DEFAULT '${REALM.replace(/'/g, "''")}';
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS evidence JSONB NOT NULL DEFAULT '{}'::jsonb;
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS abuse_score INT NOT NULL DEFAULT 0;
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS abuse_reasons TEXT[] NOT NULL DEFAULT '{}';
+ALTER TABLE player_reports ADD COLUMN IF NOT EXISTS dedupe_key TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS player_reports_reported_status ON player_reports(reported_account_id, status, created_at DESC);
 CREATE INDEX IF NOT EXISTS player_reports_reporter_created ON player_reports(reporter_account_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS player_reports_open_system_abuse_dedupe
+  ON player_reports(dedupe_key)
+  WHERE status = 'open' AND source = 'system' AND report_kind = 'report_abuse' AND dedupe_key <> '';
+CREATE TABLE IF NOT EXISTS report_events (
+  id BIGSERIAL PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  realm TEXT NOT NULL DEFAULT '${REALM.replace(/'/g, "''")}',
+  reporter_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  reporter_character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  reporter_character_name TEXT NOT NULL DEFAULT '',
+  target_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  target_character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  target_character_name TEXT NOT NULL DEFAULT '',
+  reason TEXT NOT NULL DEFAULT '',
+  details_hash TEXT NOT NULL DEFAULT '',
+  details_length INT NOT NULL DEFAULT 0,
+  outcome TEXT NOT NULL,
+  player_report_id BIGINT REFERENCES player_reports(id) ON DELETE SET NULL,
+  ip_hash TEXT NOT NULL DEFAULT '',
+  user_agent_hash TEXT NOT NULL DEFAULT '',
+  abuse_score INT NOT NULL DEFAULT 0,
+  abuse_reasons TEXT[] NOT NULL DEFAULT '{}',
+  evidence JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS report_events_reporter_created ON report_events(reporter_account_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS report_events_target_created ON report_events(target_account_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS report_events_target_time ON report_events(target_account_id, created_at);
+CREATE INDEX IF NOT EXISTS report_events_reporter_target_created ON report_events(reporter_account_id, target_account_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS report_events_ip_created ON report_events(ip_hash, created_at DESC);
+CREATE INDEX IF NOT EXISTS report_events_outcome ON report_events(outcome);
+CREATE INDEX IF NOT EXISTS report_events_player_report ON report_events(player_report_id);
 CREATE TABLE IF NOT EXISTS account_moderation_actions (
   id BIGSERIAL PRIMARY KEY,
   account_id INT REFERENCES accounts(id) ON DELETE CASCADE,

--- a/server/main.ts
+++ b/server/main.ts
@@ -8,13 +8,13 @@ import {
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
   findCharacterReportTargetByName, topArenaRatings,
 } from './db';
-import { cleanReportReason, createPlayerReport } from './moderation_db';
+import { cleanReportReason, submitPlayerReportAttempt } from './moderation_db';
 import { resolveReportTarget } from './report_target';
 import {
   hashPassword, verifyPassword, newToken, validUsernameShape, offensiveName, validPassword, normalizeCharName,
 } from './auth';
 import { json, readBody } from './http_util';
-import { rateLimited } from './ratelimit';
+import { rateLimited, requestIp } from './ratelimit';
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
@@ -272,20 +272,25 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         reportTargetForPid: (pid) => game.reportTargetForPid(pid),
         findCharacterReportTargetByName,
       });
-      if (!resolved.ok) return json(res, resolved.status, { error: resolved.error });
-      try {
-        const report = await createPlayerReport({
-          reporterAccountId: accountId,
-          reporterCharacterId: reporter.id,
-          reporterCharacterName: reporter.name,
-          target: resolved.target,
-          reason,
-          details: body.details,
-        });
-        return json(res, 200, { ok: true, reportId: report.id });
-      } catch (err) {
-        return json(res, 400, { error: err instanceof Error ? err.message : 'could not submit report' });
-      }
+      const result = await submitPlayerReportAttempt({
+        reporterAccountId: accountId,
+        reporterCharacterId: reporter.id,
+        reporterCharacterName: reporter.name,
+        target: resolved.ok ? resolved.target : null,
+        reason,
+        details: body.details,
+        invalidTargetError: resolved.ok ? undefined : resolved.error,
+        invalidTargetStatus: resolved.ok ? undefined : resolved.status,
+        metadata: {
+          ip: requestIp(req),
+          userAgent: String(req.headers['user-agent'] ?? ''),
+          realm: REALM,
+          targetMethod: Number.isFinite(Number(body.targetPid)) ? 'pid' : typeof body.targetCharacterName === 'string' ? 'name' : 'unknown',
+        },
+      });
+      return result.ok
+        ? json(res, 200, { ok: true, reportId: result.reportId })
+        : json(res, result.status, { error: result.error });
     }
     if (req.method === 'GET' && url === '/api/project-stats') {
       const accountsCount = await getAccountsCount();

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -1,16 +1,50 @@
+import { createHmac } from 'node:crypto';
 import { pool } from './db';
+import { REALM } from './realm';
 
-export const REPORT_REASONS = ['harassment', 'spam', 'cheating', 'offensive_name_or_chat', 'other'] as const;
+export const PLAYER_REPORT_REASONS = ['harassment', 'spam', 'cheating', 'botting', 'offensive_name_or_chat', 'other'] as const;
+export const REPORT_REASONS = [...PLAYER_REPORT_REASONS, 'report_abuse'] as const;
+export type PlayerReportReason = typeof PLAYER_REPORT_REASONS[number];
 export type ReportReason = typeof REPORT_REASONS[number];
 export type ModerationAction = 'ignore' | 'suspend' | 'ban';
 
 const REPORT_DETAILS_MAX = 1000;
 const ACTION_REASON_MAX = 500;
 const DUPLICATE_REPORT_WINDOW_HOURS = 12;
+const REPORT_HASH_SECRET_FALLBACK = 'world-of-claudecraft-dev-report-hash-secret';
+const REPORT_SUBMISSION_LOCK_KEY = 0x57_4f_43_02; // "WOC\x02"
 
-export function cleanReportReason(value: unknown): ReportReason | null {
-  return typeof value === 'string' && REPORT_REASONS.includes(value as ReportReason)
-    ? value as ReportReason
+export const REPORT_RATE_LIMITS = {
+  rapidSubmitSeconds: 5,
+  reporterAcceptedPerHour: 5,
+  reporterAcceptedPerDay: 20,
+  ipAttemptsPerHour: 20,
+} as const;
+
+export const REPORT_ABUSE_SCORING = {
+  threshold: 100,
+  reporterSpamWindowMinutes: 10,
+  reporterSpamAttempts: 6,
+  reporterSpamDistinctTargets: 3,
+  rejectedWindowMinutes: 30,
+  rejectedAttempts: 4,
+  sameTargetWindowMinutes: 10,
+  sameTargetReports: 4,
+  linkedReporterCount: 3,
+  dedupeHours: 24,
+  scores: {
+    reporterSpam: 100,
+    repeatedRejected: 100,
+    sameTargetBurst: 40,
+    sharedIpCoordination: 80,
+    identicalDetailsCoordination: 80,
+    solicitation: 20,
+  },
+} as const;
+
+export function cleanReportReason(value: unknown): PlayerReportReason | null {
+  return typeof value === 'string' && PLAYER_REPORT_REASONS.includes(value as PlayerReportReason)
+    ? value as PlayerReportReason
     : null;
 }
 
@@ -24,47 +58,738 @@ export interface LiveReportTarget {
   characterName: string;
 }
 
+export interface ReportRequestMetadata {
+  ip?: string;
+  userAgent?: string;
+  realm?: string;
+  targetMethod?: 'pid' | 'name' | 'unknown';
+}
+
+export type ReportAttemptOutcome =
+  | 'accepted'
+  | 'duplicate'
+  | 'rate_limited'
+  | 'invalid_target'
+  | 'self_report'
+  | 'rejected';
+
+export interface ReportEventSummary {
+  id: number;
+  createdAt: string;
+  outcome: string;
+  reason: string;
+  reporterAccountId: number | null;
+  reporterCharacterName: string;
+  targetAccountId: number | null;
+  targetCharacterName: string;
+  detailsHash: string;
+  detailsLength: number;
+  ipHash: string;
+  userAgentHash: string;
+  abuseScore: number;
+  abuseReasons: string[];
+  evidence: Record<string, unknown>;
+}
+
+interface Queryable {
+  query(sql: string, params?: unknown[]): Promise<{ rows: any[]; rowCount?: number | null }>;
+}
+
+function hashSecret(): string {
+  if (process.env.REPORT_HASH_SECRET) return process.env.REPORT_HASH_SECRET;
+  return REPORT_HASH_SECRET_FALLBACK;
+}
+
+export function hashReportMetadata(value: unknown): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text) return '';
+  const secret = hashSecret();
+  return createHmac('sha256', secret || REPORT_HASH_SECRET_FALLBACK).update(text).digest('hex');
+}
+
+function reportAbuseBucket(now = Date.now()): string {
+  const hours = REPORT_ABUSE_SCORING.dedupeHours;
+  const ms = hours * 60 * 60 * 1000;
+  return String(Math.floor(now / ms));
+}
+
+function reasonLabels(reasons: string[]): string[] {
+  return [...new Set(reasons)].sort();
+}
+
 export async function createPlayerReport(input: {
   reporterAccountId: number;
   reporterCharacterId: number;
   reporterCharacterName: string;
   target: LiveReportTarget;
-  reason: ReportReason;
+  reason: PlayerReportReason;
   details: unknown;
 }): Promise<{ id: number }> {
-  if (input.reporterAccountId === input.target.accountId) {
-    throw new Error('cannot report yourself');
-  }
+  const result = await submitPlayerReportAttempt({
+    ...input,
+    metadata: {},
+  });
+  if (!result.ok) throw new Error(result.error);
+  return { id: result.reportId };
+}
+
+export type SubmitReportResult =
+  | { ok: true; reportId: number }
+  | { ok: false; status: number; error: string; outcome: ReportAttemptOutcome };
+
+export async function submitPlayerReportAttempt(input: {
+  reporterAccountId: number;
+  reporterCharacterId: number;
+  reporterCharacterName: string;
+  target: LiveReportTarget | null;
+  reason: PlayerReportReason;
+  details: unknown;
+  metadata: ReportRequestMetadata;
+  invalidTargetError?: string;
+  invalidTargetStatus?: number;
+}): Promise<SubmitReportResult> {
   const details = cleanText(input.details, REPORT_DETAILS_MAX);
-  const dup = await pool.query(
-    `SELECT id FROM player_reports
-     WHERE reporter_account_id = $1
-       AND reported_account_id = $2
-       AND status = 'open'
-       AND created_at > now() - ($3 || ' hours')::interval
-     LIMIT 1`,
-    [input.reporterAccountId, input.target.accountId, String(DUPLICATE_REPORT_WINDOW_HOURS)],
-  );
-  if (dup.rows[0]) throw new Error('you have already reported this player recently');
-  const res = await pool.query(
-    `INSERT INTO player_reports (
+  const realm = input.metadata.realm || REALM;
+  const detailsHash = hashReportMetadata(details);
+  const ipHash = hashReportMetadata(input.metadata.ip);
+  const userAgentHash = hashReportMetadata(input.metadata.userAgent);
+  const baseEvidence = {
+    realm,
+    targetMethod: input.metadata.targetMethod ?? 'unknown',
+    reporterCharacterName: input.reporterCharacterName,
+    targetCharacterName: input.target?.characterName ?? '',
+    reason: input.reason,
+    detailsHash,
+    detailsLength: details.length,
+    ipHashPresent: ipHash !== '',
+    userAgentHashPresent: userAgentHash !== '',
+  };
+
+  if (!input.target) {
+    const rejected = await recordRejectedReportAttempt(input, {
+      realm,
+      target: null,
+      detailsHash,
+      detailsLength: details.length,
+      ipHash,
+      userAgentHash,
+      baseEvidence,
+      rejectedOutcome: 'invalid_target',
+      rejectedStatus: input.invalidTargetStatus ?? 400,
+      rejectedError: input.invalidTargetError ?? 'invalid report target',
+      rejectedEvidence: { error: input.invalidTargetError ?? 'invalid report target' },
+    });
+    await runReportAbuseDetection(rejected.eventId, realm, input.reporterAccountId, null);
+    return rejected.result;
+  }
+
+  if (input.reporterAccountId === input.target.accountId) {
+    const rejected = await recordRejectedReportAttempt(input, {
+      realm,
+      target: input.target,
+      detailsHash,
+      detailsLength: details.length,
+      ipHash,
+      userAgentHash,
+      baseEvidence,
+      rejectedOutcome: 'self_report',
+      rejectedStatus: 400,
+      rejectedError: 'cannot report yourself',
+      rejectedEvidence: { targetAccountId: input.target.accountId },
+    });
+    await runReportAbuseDetection(rejected.eventId, realm, input.reporterAccountId, input.target.accountId);
+    return rejected.result;
+  }
+
+  const client = await pool.connect();
+  let result: SubmitReportResult;
+  let detectionEventId: number | null = null;
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock($1, $2)', [REPORT_SUBMISSION_LOCK_KEY, input.reporterAccountId]);
+    const duplicate = await client.query(
+      `SELECT id FROM player_reports
+       WHERE reporter_account_id = $1
+         AND reported_account_id = $2
+         AND status = 'open'
+         AND source = 'player'
+         AND report_kind = 'player_report'
+         AND created_at > now() - ($3 || ' hours')::interval
+       LIMIT 1`,
+      [input.reporterAccountId, input.target.accountId, String(DUPLICATE_REPORT_WINDOW_HOURS)],
+    );
+    if (duplicate.rows[0]) {
+      const rateLimit = await reportRateLimit(input.reporterAccountId, ipHash, realm, client);
+      if (rateLimit.limited) {
+        detectionEventId = await insertRateLimitedReportEvent(input, {
+          realm,
+          target: input.target,
+          detailsHash,
+          detailsLength: details.length,
+          ipHash,
+          userAgentHash,
+          baseEvidence,
+          rateLimit,
+        }, client);
+        result = { ok: false, status: 429, error: 'you are submitting reports too quickly', outcome: 'rate_limited' };
+      } else {
+        detectionEventId = await insertReportEvent({
+          realm,
+          reporterAccountId: input.reporterAccountId,
+          reporterCharacterId: input.reporterCharacterId,
+          reporterCharacterName: input.reporterCharacterName,
+          target: input.target,
+          reason: input.reason,
+          detailsHash,
+          detailsLength: details.length,
+          outcome: 'duplicate',
+          playerReportId: null,
+          ipHash,
+          userAgentHash,
+          evidence: { ...baseEvidence, duplicateReportId: Number(duplicate.rows[0].id) },
+        }, client);
+        result = { ok: false, status: 400, error: 'you have already reported this player recently', outcome: 'duplicate' };
+      }
+      await client.query('COMMIT');
+      await runReportAbuseDetection(detectionEventId, realm, input.reporterAccountId, input.target.accountId);
+      return result;
+    }
+
+    const rateLimit = await reportRateLimit(input.reporterAccountId, ipHash, realm, client);
+    if (rateLimit.limited) {
+      detectionEventId = await insertReportEvent({
+        realm,
+        reporterAccountId: input.reporterAccountId,
+        reporterCharacterId: input.reporterCharacterId,
+        reporterCharacterName: input.reporterCharacterName,
+        target: input.target,
+        reason: input.reason,
+        detailsHash,
+        detailsLength: details.length,
+        outcome: 'rate_limited',
+        playerReportId: null,
+        ipHash,
+        userAgentHash,
+        evidence: { ...baseEvidence, rateLimit },
+      }, client);
+      await client.query('COMMIT');
+      await runReportAbuseDetection(detectionEventId, realm, input.reporterAccountId, input.target.accountId);
+      return { ok: false, status: 429, error: 'you are submitting reports too quickly', outcome: 'rate_limited' };
+    }
+
+    const res = await client.query(
+      `INSERT INTO player_reports (
+         reporter_account_id, reporter_character_id, reporter_character_name,
+         reported_account_id, reported_character_id, reported_character_name,
+         reason, details, source, report_kind, realm, evidence
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'player','player_report',$9,$10::jsonb)
+       RETURNING id`,
+      [
+        input.reporterAccountId,
+        input.reporterCharacterId,
+        input.reporterCharacterName,
+        input.target.accountId,
+        input.target.characterId,
+        input.target.characterName,
+        input.reason,
+        details,
+        realm,
+        JSON.stringify({
+          ...baseEvidence,
+          targetAccountId: input.target.accountId,
+          targetCharacterId: input.target.characterId,
+        }),
+      ],
+    );
+    const reportId = Number(res.rows[0].id);
+    detectionEventId = await insertReportEvent({
+      realm,
+      reporterAccountId: input.reporterAccountId,
+      reporterCharacterId: input.reporterCharacterId,
+      reporterCharacterName: input.reporterCharacterName,
+      target: input.target,
+      reason: input.reason,
+      detailsHash,
+      detailsLength: details.length,
+      outcome: 'accepted',
+      playerReportId: reportId,
+      ipHash,
+      userAgentHash,
+      evidence: {
+        ...baseEvidence,
+        playerReportId: reportId,
+        targetAccountId: input.target.accountId,
+        targetCharacterId: input.target.characterId,
+      },
+    }, client);
+    await client.query('COMMIT');
+    await runReportAbuseDetection(detectionEventId, realm, input.reporterAccountId, input.target.accountId);
+    return { ok: true, reportId };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function insertRateLimitedReportEvent(input: {
+  reporterAccountId: number;
+  reporterCharacterId: number;
+  reporterCharacterName: string;
+  reason: PlayerReportReason;
+}, event: {
+  realm: string;
+  target: LiveReportTarget | null;
+  detailsHash: string;
+  detailsLength: number;
+  ipHash: string;
+  userAgentHash: string;
+  baseEvidence: Record<string, unknown>;
+  rateLimit: Record<string, unknown>;
+}, db: Queryable = pool): Promise<number> {
+  return insertReportEvent({
+    realm: event.realm,
+    reporterAccountId: input.reporterAccountId,
+    reporterCharacterId: input.reporterCharacterId,
+    reporterCharacterName: input.reporterCharacterName,
+    target: event.target,
+    reason: input.reason,
+    detailsHash: event.detailsHash,
+    detailsLength: event.detailsLength,
+    outcome: 'rate_limited',
+    playerReportId: null,
+    ipHash: event.ipHash,
+    userAgentHash: event.userAgentHash,
+    evidence: { ...event.baseEvidence, rateLimit: event.rateLimit },
+  }, db);
+}
+
+async function recordRejectedReportAttempt(input: {
+  reporterAccountId: number;
+  reporterCharacterId: number;
+  reporterCharacterName: string;
+  reason: PlayerReportReason;
+}, event: {
+  realm: string;
+  target: LiveReportTarget | null;
+  detailsHash: string;
+  detailsLength: number;
+  ipHash: string;
+  userAgentHash: string;
+  baseEvidence: Record<string, unknown>;
+  rejectedOutcome: Exclude<ReportAttemptOutcome, 'accepted' | 'rate_limited'>;
+  rejectedStatus: number;
+  rejectedError: string;
+  rejectedEvidence: Record<string, unknown>;
+}): Promise<{ eventId: number; result: SubmitReportResult }> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query('SELECT pg_advisory_xact_lock($1, $2)', [REPORT_SUBMISSION_LOCK_KEY, input.reporterAccountId]);
+    const rateLimit = await reportRateLimit(input.reporterAccountId, event.ipHash, event.realm, client);
+    let eventId: number;
+    let result: SubmitReportResult;
+    if (rateLimit.limited) {
+      eventId = await insertRateLimitedReportEvent(input, {
+        realm: event.realm,
+        target: event.target,
+        detailsHash: event.detailsHash,
+        detailsLength: event.detailsLength,
+        ipHash: event.ipHash,
+        userAgentHash: event.userAgentHash,
+        baseEvidence: event.baseEvidence,
+        rateLimit,
+      }, client);
+      result = { ok: false, status: 429, error: 'you are submitting reports too quickly', outcome: 'rate_limited' };
+    } else {
+      eventId = await insertReportEvent({
+        realm: event.realm,
+        reporterAccountId: input.reporterAccountId,
+        reporterCharacterId: input.reporterCharacterId,
+        reporterCharacterName: input.reporterCharacterName,
+        target: event.target,
+        reason: input.reason,
+        detailsHash: event.detailsHash,
+        detailsLength: event.detailsLength,
+        outcome: event.rejectedOutcome,
+        playerReportId: null,
+        ipHash: event.ipHash,
+        userAgentHash: event.userAgentHash,
+        evidence: { ...event.baseEvidence, ...event.rejectedEvidence },
+      }, client);
+      result = { ok: false, status: event.rejectedStatus, error: event.rejectedError, outcome: event.rejectedOutcome };
+    }
+    await client.query('COMMIT');
+    return { eventId, result };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function reportRateLimit(reporterAccountId: number, ipHash: string, realm: string, db: Queryable = pool): Promise<{
+  limited: boolean;
+  reason: string;
+  rapidAttempts: number;
+  reporterAcceptedHour: number;
+  reporterAcceptedDay: number;
+  ipAttemptsHour: number;
+}> {
+  const [rapid, reporterHour, reporterDay, ipHour] = await Promise.all([
+    db.query(
+      `SELECT count(*)::int AS count FROM report_events
+       WHERE realm = $1 AND reporter_account_id = $2 AND created_at > now() - ($3 || ' seconds')::interval`,
+      [realm, reporterAccountId, String(REPORT_RATE_LIMITS.rapidSubmitSeconds)],
+    ),
+    db.query(
+      `SELECT count(*)::int AS count FROM report_events
+       WHERE realm = $1 AND reporter_account_id = $2 AND outcome = 'accepted' AND created_at > now() - interval '1 hour'`,
+      [realm, reporterAccountId],
+    ),
+    db.query(
+      `SELECT count(*)::int AS count FROM report_events
+       WHERE realm = $1 AND reporter_account_id = $2 AND outcome = 'accepted' AND created_at > now() - interval '1 day'`,
+      [realm, reporterAccountId],
+    ),
+    ipHash
+      ? db.query(
+          `SELECT count(*)::int AS count FROM report_events
+           WHERE realm = $1 AND ip_hash = $2 AND created_at > now() - interval '1 hour'`,
+          [realm, ipHash],
+        )
+      : Promise.resolve({ rows: [{ count: 0 }] } as any),
+  ]);
+  const rapidAttempts = Number(rapid.rows[0]?.count ?? 0);
+  const reporterAcceptedHour = Number(reporterHour.rows[0]?.count ?? 0);
+  const reporterAcceptedDay = Number(reporterDay.rows[0]?.count ?? 0);
+  const ipAttemptsHour = Number(ipHour.rows[0]?.count ?? 0);
+  const reason =
+    rapidAttempts > 0 ? 'rapid_submit'
+    : reporterAcceptedHour >= REPORT_RATE_LIMITS.reporterAcceptedPerHour ? 'reporter_hour'
+    : reporterAcceptedDay >= REPORT_RATE_LIMITS.reporterAcceptedPerDay ? 'reporter_day'
+    : ipAttemptsHour >= REPORT_RATE_LIMITS.ipAttemptsPerHour ? 'ip_hour'
+    : '';
+  return { limited: reason !== '', reason, rapidAttempts, reporterAcceptedHour, reporterAcceptedDay, ipAttemptsHour };
+}
+
+async function insertReportEvent(input: {
+  realm: string;
+  reporterAccountId: number;
+  reporterCharacterId: number;
+  reporterCharacterName: string;
+  target: LiveReportTarget | null;
+  reason: PlayerReportReason;
+  detailsHash: string;
+  detailsLength: number;
+  outcome: ReportAttemptOutcome;
+  playerReportId: number | null;
+  ipHash: string;
+  userAgentHash: string;
+  evidence: Record<string, unknown>;
+}, db: Queryable = pool): Promise<number> {
+  const res = await db.query(
+    `INSERT INTO report_events (
+       realm,
        reporter_account_id, reporter_character_id, reporter_character_name,
-       reported_account_id, reported_character_id, reported_character_name,
-       reason, details
-     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+       target_account_id, target_character_id, target_character_name,
+       reason, details_hash, details_length, outcome, player_report_id,
+       ip_hash, user_agent_hash, evidence
+     ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15::jsonb)
      RETURNING id`,
     [
+      input.realm,
       input.reporterAccountId,
       input.reporterCharacterId,
       input.reporterCharacterName,
-      input.target.accountId,
-      input.target.characterId,
-      input.target.characterName,
+      input.target?.accountId ?? null,
+      input.target?.characterId ?? null,
+      input.target?.characterName ?? '',
       input.reason,
-      details,
+      input.detailsHash,
+      input.detailsLength,
+      input.outcome,
+      input.playerReportId,
+      input.ipHash,
+      input.userAgentHash,
+      JSON.stringify(input.evidence),
     ],
   );
-  return { id: Number(res.rows[0].id) };
+  return Number(res.rows[0].id);
+}
+
+async function runReportAbuseDetection(
+  eventId: number,
+  realm: string,
+  reporterAccountId: number,
+  targetAccountId: number | null,
+): Promise<void> {
+  try {
+    await detectReportAbuseForEvent(eventId, realm, reporterAccountId, targetAccountId);
+  } catch (err) {
+    console.error('report abuse detection failed:', err);
+  }
+}
+
+async function detectReportAbuseForEvent(
+  eventId: number,
+  realm: string,
+  reporterAccountId: number,
+  targetAccountId: number | null,
+): Promise<void> {
+  const reasons: string[] = [];
+  let score = 0;
+  let individualScore = 0;
+  const eventIds = new Set<number>([eventId]);
+  const evidence: Record<string, unknown> = { triggerEventId: eventId, realm };
+
+  const reporterStats = await pool.query(
+    `SELECT
+       count(*)::int AS attempts,
+       count(DISTINCT target_account_id)::int AS distinct_targets,
+       array_agg(id ORDER BY created_at DESC) AS event_ids
+     FROM report_events
+     WHERE realm = $1
+       AND reporter_account_id = $2
+       AND created_at > now() - ($3 || ' minutes')::interval`,
+    [realm, reporterAccountId, String(REPORT_ABUSE_SCORING.reporterSpamWindowMinutes)],
+  );
+  const reporterRow = reporterStats.rows[0] ?? {};
+  const reporterAttempts = Number(reporterRow.attempts ?? 0);
+  const distinctTargets = Number(reporterRow.distinct_targets ?? 0);
+  if (
+    reporterAttempts >= REPORT_ABUSE_SCORING.reporterSpamAttempts
+    && distinctTargets >= REPORT_ABUSE_SCORING.reporterSpamDistinctTargets
+  ) {
+    reasons.push('reporter_spam');
+    score += REPORT_ABUSE_SCORING.scores.reporterSpam;
+    individualScore += REPORT_ABUSE_SCORING.scores.reporterSpam;
+    evidence.reporterSpam = {
+      attempts: reporterAttempts,
+      distinctTargets,
+      windowMinutes: REPORT_ABUSE_SCORING.reporterSpamWindowMinutes,
+    };
+    for (const id of reporterRow.event_ids ?? []) eventIds.add(Number(id));
+  }
+
+  const rejectedStats = await pool.query(
+    `SELECT count(*)::int AS attempts, array_agg(id ORDER BY created_at DESC) AS event_ids
+     FROM report_events
+     WHERE realm = $1
+       AND reporter_account_id = $2
+       AND outcome IN ('duplicate', 'invalid_target', 'self_report', 'rate_limited', 'rejected')
+       AND created_at > now() - ($3 || ' minutes')::interval`,
+    [realm, reporterAccountId, String(REPORT_ABUSE_SCORING.rejectedWindowMinutes)],
+  );
+  const rejectedRow = rejectedStats.rows[0] ?? {};
+  const rejectedAttempts = Number(rejectedRow.attempts ?? 0);
+  if (rejectedAttempts >= REPORT_ABUSE_SCORING.rejectedAttempts) {
+    reasons.push('repeated_rejected_reports');
+    score += REPORT_ABUSE_SCORING.scores.repeatedRejected;
+    individualScore += REPORT_ABUSE_SCORING.scores.repeatedRejected;
+    evidence.rejectedReports = {
+      attempts: rejectedAttempts,
+      windowMinutes: REPORT_ABUSE_SCORING.rejectedWindowMinutes,
+    };
+    for (const id of rejectedRow.event_ids ?? []) eventIds.add(Number(id));
+  }
+
+  const solicitation = await pool.query(
+    `SELECT cl.id, cl.created_at
+     FROM chat_logs cl
+     JOIN characters c ON c.id = cl.character_id
+     WHERE cl.account_id = $1
+       AND cl.created_at > now() - ($2 || ' minutes')::interval
+       AND cl.message ~* $3
+       AND c.realm = $4
+     ORDER BY cl.created_at DESC
+     LIMIT 5`,
+    [
+      reporterAccountId,
+      String(REPORT_ABUSE_SCORING.sameTargetWindowMinutes),
+      '\\m(everyone|mass|all)\\M.{0,32}\\mreport\\M|\\mreport\\M.{1,32}\\m(now|them|him|her|everyone)\\M',
+      realm,
+    ],
+  );
+  let solicitationApplied = false;
+  const applySolicitationEvidence = () => {
+    if (solicitationApplied || score <= 0 || solicitation.rows.length === 0) return;
+    solicitationApplied = true;
+    reasons.push('recent_report_solicitation');
+    score += REPORT_ABUSE_SCORING.scores.solicitation;
+    individualScore += individualScore > 0 ? REPORT_ABUSE_SCORING.scores.solicitation : 0;
+    evidence.recentReportSolicitation = {
+      chatLogIds: solicitation.rows.map((row) => Number(row.id)),
+      windowMinutes: REPORT_ABUSE_SCORING.sameTargetWindowMinutes,
+    };
+  };
+
+  if (targetAccountId !== null) {
+    const burstRows = await pool.query(
+      `SELECT id, reporter_account_id, reporter_character_id, reporter_character_name,
+              target_account_id, target_character_name, ip_hash, details_hash, outcome
+       FROM report_events
+       WHERE realm = $1
+         AND target_account_id = $2
+         AND created_at > now() - ($3 || ' minutes')::interval
+       ORDER BY created_at DESC`,
+      [realm, targetAccountId, String(REPORT_ABUSE_SCORING.sameTargetWindowMinutes)],
+    );
+    const rows = burstRows.rows;
+    if (rows.length >= REPORT_ABUSE_SCORING.sameTargetReports) {
+      reasons.push('same_target_burst');
+      score += REPORT_ABUSE_SCORING.scores.sameTargetBurst;
+      const coordinationReasons = ['same_target_burst'];
+      let coordinationScore = REPORT_ABUSE_SCORING.scores.sameTargetBurst;
+      evidence.sameTargetBurst = {
+        targetAccountId,
+        reports: rows.length,
+        windowMinutes: REPORT_ABUSE_SCORING.sameTargetWindowMinutes,
+      };
+      for (const row of rows) eventIds.add(Number(row.id));
+
+      const linkedByIp = linkedReporters(rows, 'ip_hash');
+      const linkedByDetails = linkedReporters(rows, 'details_hash');
+      const linked = new Map<number, any>();
+      if (linkedByIp.length >= REPORT_ABUSE_SCORING.linkedReporterCount) {
+        reasons.push('shared_ip_coordination');
+        score += REPORT_ABUSE_SCORING.scores.sharedIpCoordination;
+        coordinationReasons.push('shared_ip_coordination');
+        coordinationScore += REPORT_ABUSE_SCORING.scores.sharedIpCoordination;
+        evidence.sharedIpReporterCount = linkedByIp.length;
+        for (const row of linkedByIp) linked.set(Number(row.reporter_account_id), row);
+      }
+      if (linkedByDetails.length >= REPORT_ABUSE_SCORING.linkedReporterCount) {
+        reasons.push('identical_details_coordination');
+        score += REPORT_ABUSE_SCORING.scores.identicalDetailsCoordination;
+        coordinationReasons.push('identical_details_coordination');
+        coordinationScore += REPORT_ABUSE_SCORING.scores.identicalDetailsCoordination;
+        evidence.identicalDetailsReporterCount = linkedByDetails.length;
+        for (const row of linkedByDetails) linked.set(Number(row.reporter_account_id), row);
+      }
+      if (linked.size > 0) {
+        applySolicitationEvidence();
+        if (evidence.recentReportSolicitation) {
+          coordinationReasons.push('recent_report_solicitation');
+          coordinationScore += REPORT_ABUSE_SCORING.scores.solicitation;
+        }
+        evidence.linkedReporterAccountIds = [...linked.keys()].sort((a, b) => a - b);
+        for (const row of linked.values()) {
+          await createReportAbuseCase({
+            realm,
+            reportedAccountId: Number(row.reporter_account_id),
+            reportedCharacterId: row.reporter_character_id === null ? null : Number(row.reporter_character_id),
+            reportedCharacterName: row.reporter_character_name ?? '',
+            score: coordinationScore,
+            reasons: reasonLabels(coordinationReasons),
+            signalFamily: 'coordination',
+            eventIds: [...eventIds],
+            evidence: {
+              triggerEventId: eventId,
+              realm,
+              sameTargetBurst: evidence.sameTargetBurst,
+              sharedIpReporterCount: evidence.sharedIpReporterCount,
+              identicalDetailsReporterCount: evidence.identicalDetailsReporterCount,
+              linkedReporterAccountIds: evidence.linkedReporterAccountIds,
+              recentReportSolicitation: evidence.recentReportSolicitation,
+              summary: 'Linked reporters submitted a same-target burst with shared report-abuse signals.',
+              originalTargetAccountId: targetAccountId,
+            },
+          });
+        }
+      }
+    }
+  }
+
+  applySolicitationEvidence();
+
+  const finalReasons = reasonLabels(reasons);
+  if (finalReasons.length > 0) {
+    await pool.query(
+      `UPDATE report_events SET abuse_score = $2, abuse_reasons = $3 WHERE id = $1`,
+      [eventId, score, finalReasons],
+    );
+  }
+  if (individualScore >= REPORT_ABUSE_SCORING.threshold) {
+    await createReportAbuseCase({
+      realm,
+      reportedAccountId: reporterAccountId,
+      reportedCharacterId: null,
+      reportedCharacterName: '',
+      score: individualScore,
+      reasons: finalReasons,
+      signalFamily: finalReasons.includes('reporter_spam') ? 'reporter_spam' : 'repeated_rejected',
+      eventIds: [...eventIds],
+      evidence: {
+        ...evidence,
+        summary: 'Reporter crossed deterministic report-abuse thresholds.',
+      },
+    });
+  }
+}
+
+function linkedReporters(rows: any[], field: 'ip_hash' | 'details_hash'): any[] {
+  const groups = new Map<string, any[]>();
+  for (const row of rows) {
+    const reporterAccountId = Number(row.reporter_account_id);
+    if (!Number.isFinite(reporterAccountId) || reporterAccountId <= 0) continue;
+    const key = String(row[field] ?? '');
+    if (!key) continue;
+    const group = groups.get(key) ?? [];
+    group.push(row);
+    groups.set(key, group);
+  }
+  let best: any[] = [];
+  for (const group of groups.values()) {
+    const unique = new Map<number, any>();
+    for (const row of group) unique.set(Number(row.reporter_account_id), row);
+    if (unique.size > best.length) best = [...unique.values()];
+  }
+  return best;
+}
+
+async function createReportAbuseCase(input: {
+  realm: string;
+  reportedAccountId: number;
+  reportedCharacterId: number | null;
+  reportedCharacterName: string;
+  score: number;
+  reasons: string[];
+  signalFamily: string;
+  eventIds: number[];
+  evidence: Record<string, unknown>;
+}): Promise<void> {
+  const dedupeKey = `report_abuse:${input.realm}:${input.reportedAccountId}:${reportAbuseBucket()}:${input.signalFamily}`;
+  await pool.query(
+    `INSERT INTO player_reports (
+       reporter_account_id, reporter_character_id, reporter_character_name,
+       reported_account_id, reported_character_id, reported_character_name,
+       reason, details, source, report_kind, realm, evidence, abuse_score, abuse_reasons, dedupe_key
+     ) VALUES (
+       NULL, NULL, 'System',
+       $1, $2, $3,
+       'report_abuse', $4, 'system', 'report_abuse', $5, $6::jsonb, $7, $8, $9
+     )
+     ON CONFLICT DO NOTHING`,
+    [
+      input.reportedAccountId,
+      input.reportedCharacterId,
+      input.reportedCharacterName,
+      'Automated report-abuse alert for moderator review.',
+      input.realm,
+      JSON.stringify({
+        ...input.evidence,
+        triggeredEventIds: input.eventIds.sort((a, b) => a - b),
+        abuseReasons: input.reasons,
+        abuseScore: input.score,
+      }),
+      input.score,
+      input.reasons,
+      dedupeKey,
+    ],
+  );
 }
 
 export interface ModerationQueueRow {
@@ -75,6 +800,10 @@ export interface ModerationQueueRow {
   openReports: number;
   latestReportAt: string;
   latestReason: string;
+  latestSource: string;
+  latestReportKind: string;
+  maxAbuseScore: number;
+  abuseReasons: string[];
   characterNames: string[];
   online: boolean;
 }
@@ -86,15 +815,20 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
        a.username,
        a.banned_at,
        a.suspended_until,
-       count(r.id)::int AS open_reports,
+       count(DISTINCT r.id)::int AS open_reports,
        max(r.created_at) AS latest_report_at,
        (array_agg(r.reason ORDER BY r.created_at DESC))[1] AS latest_reason,
+       (array_agg(r.source ORDER BY r.created_at DESC))[1] AS latest_source,
+       (array_agg(r.report_kind ORDER BY r.created_at DESC))[1] AS latest_report_kind,
+       max(r.abuse_score)::int AS max_abuse_score,
+       array_remove(array_agg(DISTINCT unnest_reason.reason), NULL::text) AS abuse_reasons,
        array_remove(array_agg(DISTINCT r.reported_character_name), '') AS character_names
      FROM player_reports r
      JOIN accounts a ON a.id = r.reported_account_id
+     LEFT JOIN LATERAL unnest(r.abuse_reasons) AS unnest_reason(reason) ON TRUE
      WHERE r.status = 'open'
      GROUP BY a.id
-     ORDER BY count(r.id) DESC, max(r.created_at) DESC`,
+     ORDER BY count(DISTINCT r.id) DESC, max(r.created_at) DESC`,
   );
   return res.rows.map((r): ModerationQueueRow => {
     const suspendedUntil = r.suspended_until ? new Date(r.suspended_until).toISOString() : null;
@@ -108,6 +842,10 @@ export async function moderationQueue(onlineAccountIds: Set<number>): Promise<Mo
       openReports: r.open_reports,
       latestReportAt: new Date(r.latest_report_at).toISOString(),
       latestReason: r.latest_reason,
+      latestSource: r.latest_source ?? 'player',
+      latestReportKind: r.latest_report_kind ?? 'player_report',
+      maxAbuseScore: Number(r.max_abuse_score ?? 0),
+      abuseReasons: r.abuse_reasons ?? [],
       characterNames: r.character_names ?? [],
       online: onlineAccountIds.has(r.account_id),
     };
@@ -123,6 +861,11 @@ export interface ReportDetail {
   reason: string;
   details: string;
   status: string;
+  source: string;
+  reportKind: string;
+  evidence: Record<string, unknown>;
+  abuseScore: number;
+  abuseReasons: string[];
   createdAt: string;
   reporterAccountId: number | null;
   reporterUsername: string | null;
@@ -132,6 +875,7 @@ export interface ReportDetail {
   reportedUsername: string;
   reportedCharacterId: number | null;
   reportedCharacterName: string;
+  relatedEvents: ReportEventSummary[];
   chatContext: { id: number; characterName: string; channel: string; message: string; createdAt: string }[];
 }
 
@@ -147,6 +891,23 @@ export async function moderationReportsForAccount(accountId: number): Promise<Re
   );
   const out: ReportDetail[] = [];
   for (const r of reports.rows) {
+    const evidence = objectEvidence(r.evidence);
+    const triggeredEventIds = Array.isArray(evidence.triggeredEventIds)
+      ? evidence.triggeredEventIds.map((id) => Number(id)).filter(Number.isFinite)
+      : [];
+    const eventParams: unknown[] = [Number(r.id), triggeredEventIds];
+    const events = await pool.query(
+      `SELECT id, created_at, outcome, reason,
+              reporter_account_id, reporter_character_name,
+              target_account_id, target_character_name,
+              details_hash, details_length, ip_hash, user_agent_hash,
+              abuse_score, abuse_reasons, evidence
+       FROM report_events
+       WHERE player_report_id = $1 OR id = ANY($2::bigint[])
+       ORDER BY created_at DESC
+       LIMIT 50`,
+      eventParams,
+    );
     const chat = await pool.query(
       `SELECT id, character_name, channel, message, created_at
        FROM chat_logs
@@ -160,6 +921,11 @@ export async function moderationReportsForAccount(accountId: number): Promise<Re
       reason: r.reason,
       details: r.details,
       status: r.status,
+      source: r.source ?? 'player',
+      reportKind: r.report_kind ?? 'player_report',
+      evidence,
+      abuseScore: Number(r.abuse_score ?? 0),
+      abuseReasons: r.abuse_reasons ?? [],
       createdAt: new Date(r.created_at).toISOString(),
       reporterAccountId: r.reporter_account_id,
       reporterUsername: r.reporter_username,
@@ -169,6 +935,23 @@ export async function moderationReportsForAccount(accountId: number): Promise<Re
       reportedUsername: r.reported_username,
       reportedCharacterId: r.reported_character_id,
       reportedCharacterName: r.reported_character_name,
+      relatedEvents: events.rows.map((event): ReportEventSummary => ({
+        id: Number(event.id),
+        createdAt: new Date(event.created_at).toISOString(),
+        outcome: event.outcome,
+        reason: event.reason,
+        reporterAccountId: event.reporter_account_id === null ? null : Number(event.reporter_account_id),
+        reporterCharacterName: event.reporter_character_name ?? '',
+        targetAccountId: event.target_account_id === null ? null : Number(event.target_account_id),
+        targetCharacterName: event.target_character_name ?? '',
+        detailsHash: event.details_hash ?? '',
+        detailsLength: Number(event.details_length ?? 0),
+        ipHash: event.ip_hash ?? '',
+        userAgentHash: event.user_agent_hash ?? '',
+        abuseScore: Number(event.abuse_score ?? 0),
+        abuseReasons: event.abuse_reasons ?? [],
+        evidence: objectEvidence(event.evidence),
+      })),
       chatContext: chat.rows.reverse().map((c) => ({
         id: Number(c.id),
         characterName: c.character_name,
@@ -179,6 +962,12 @@ export async function moderationReportsForAccount(accountId: number): Promise<Re
     });
   }
   return out;
+}
+
+function objectEvidence(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
 }
 
 export async function ignoreReport(reportId: number, adminAccountId: number, note: unknown): Promise<boolean> {

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -126,7 +126,7 @@ export function renderModerationQueue(rows: ModerationQueueRow[]): string {
       <td>${escapeHtml(r.username)}${r.online ? ' <span class="badge">online</span>' : ''}</td>
       <td>${r.characterNames.map(escapeHtml).join(', ') || '—'}</td>
       <td class="num">${r.openReports}</td>
-      <td>${escapeHtml(reasonLabel(r.latestReason))}</td>
+      <td>${reportKindBadge(r.latestSource, r.latestReportKind)} ${escapeHtml(reasonLabel(r.latestReason))}${r.maxAbuseScore > 0 ? ` <span class="badge warn">score ${r.maxAbuseScore}</span>` : ''}</td>
       <td>${fmtRelative(r.latestReportAt)}</td>
       <td>${statusBadge(r.status, r.suspendedUntil)}</td>
     </tr>`);
@@ -140,6 +140,20 @@ export function renderModerationQueue(rows: ModerationQueueRow[]): string {
 
 export function renderModerationDetail(d: ModerationAccountDetail): string {
   const reports = d.reports.map((r) => {
+    const evidence = renderEvidence(r.evidence);
+    const events = r.relatedEvents.length === 0
+      ? '<div class="empty">no related submission events</div>'
+      : `<table><thead><tr><th>Time</th><th>Outcome</th><th>Reporter</th><th>Target</th><th class="num">Score</th><th>Signals</th></tr></thead><tbody>${
+          r.relatedEvents.map((event) => `
+            <tr>
+              <td>${fmtDate(event.createdAt)}</td>
+              <td>${escapeHtml(event.outcome)}</td>
+              <td>${event.reporterAccountId ?? '—'} / ${escapeHtml(event.reporterCharacterName || 'unknown')}</td>
+              <td>${event.targetAccountId ?? '—'} / ${escapeHtml(event.targetCharacterName || 'unknown')}</td>
+              <td class="num">${event.abuseScore}</td>
+              <td>${event.abuseReasons.map(escapeHtml).join(', ') || '—'}</td>
+            </tr>`).join('')
+        }</tbody></table>`;
     const chat = r.chatContext.length === 0
       ? '<div class="empty">no recent chat from this character before the report</div>'
       : `<table><thead><tr><th>Time</th><th>Channel</th><th>Message</th></tr></thead><tbody>${
@@ -151,17 +165,21 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
             </tr>`).join('')
         }</tbody></table>`;
     return `<div class="mod-report panel" data-report-id="${r.id}">
-      <div class="panel-title">Report #${r.id} <span class="hint">${fmtDate(r.createdAt)}</span></div>
+      <div class="panel-title">Report #${r.id} ${reportKindBadge(r.source, r.reportKind)} <span class="hint">${fmtDate(r.createdAt)}</span></div>
       <div class="mod-report-meta">
         <div><b>Reporter:</b> ${escapeHtml(r.reporterUsername ?? 'unknown')} / ${escapeHtml(r.reporterCharacterName || 'unknown')}</div>
         <div><b>Reported:</b> ${escapeHtml(r.reportedUsername)} / ${escapeHtml(r.reportedCharacterName || 'unknown')}</div>
         <div><b>Reason:</b> ${escapeHtml(reasonLabel(r.reason))}</div>
+        <div><b>Abuse score:</b> ${r.abuseScore}${r.abuseReasons.length > 0 ? ` (${r.abuseReasons.map(escapeHtml).join(', ')})` : ''}</div>
       </div>
       <div class="mod-details">${escapeHtml(r.details || 'No extra details provided.')}</div>
+      ${evidence}
       <div class="mod-actions">
         <button data-ignore-report="${r.id}">Ignore</button>
         ${r.reportedCharacterId ? `<button data-force-rename-character="${r.reportedCharacterId}" data-character-name="${escapeHtml(r.reportedCharacterName)}">Force Name Change</button>` : ''}
       </div>
+      <h4>Related report submissions</h4>
+      ${events}
       <h4>Recent chat before this report</h4>
       ${chat}
     </div>`;
@@ -194,9 +212,31 @@ function reasonLabel(reason: string): string {
     harassment: 'Harassment / abuse',
     spam: 'Spam',
     cheating: 'Cheating / exploit',
+    botting: 'Botting / automation',
     offensive_name_or_chat: 'Offensive name or chat',
+    report_abuse: 'Report abuse',
     other: 'Other',
   } as Record<string, string>)[reason] ?? reason;
+}
+
+function reportKindBadge(source: string, kind: string): string {
+  if (source === 'system' || kind === 'report_abuse') {
+    return '<span class="badge warn">System: report abuse</span>';
+  }
+  return '';
+}
+
+function renderEvidence(evidence: Record<string, unknown>): string {
+  const entries = Object.entries(evidence).filter(([, value]) => value !== undefined && value !== null && value !== '');
+  if (entries.length === 0) return '';
+  return `<div class="mod-report-meta">${entries.slice(0, 12).map(([key, value]) => `
+    <div><b>${escapeHtml(key)}:</b> ${escapeHtml(formatEvidenceValue(value))}</div>`).join('')}</div>`;
+}
+
+function formatEvidenceValue(value: unknown): string {
+  if (Array.isArray(value)) return value.map((v) => typeof v === 'object' ? JSON.stringify(v) : String(v)).join(', ');
+  if (value && typeof value === 'object') return JSON.stringify(value);
+  return String(value);
 }
 
 function statusBadge(status: string, suspendedUntil: string | null): string {

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -111,6 +111,10 @@ export interface ModerationQueueRow {
   openReports: number;
   latestReportAt: string;
   latestReason: string;
+  latestSource: string;
+  latestReportKind: string;
+  maxAbuseScore: number;
+  abuseReasons: string[];
   characterNames: string[];
   online: boolean;
 }
@@ -120,6 +124,11 @@ export interface ReportDetail {
   reason: string;
   details: string;
   status: string;
+  source: string;
+  reportKind: string;
+  evidence: Record<string, unknown>;
+  abuseScore: number;
+  abuseReasons: string[];
   createdAt: string;
   reporterAccountId: number | null;
   reporterUsername: string | null;
@@ -129,6 +138,23 @@ export interface ReportDetail {
   reportedUsername: string;
   reportedCharacterId: number | null;
   reportedCharacterName: string;
+  relatedEvents: {
+    id: number;
+    createdAt: string;
+    outcome: string;
+    reason: string;
+    reporterAccountId: number | null;
+    reporterCharacterName: string;
+    targetAccountId: number | null;
+    targetCharacterName: string;
+    detailsHash: string;
+    detailsLength: number;
+    ipHash: string;
+    userAgentHash: string;
+    abuseScore: number;
+    abuseReasons: string[];
+    evidence: Record<string, unknown>;
+  }[];
   chatContext: {
     id: number;
     characterName: string;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2162,6 +2162,7 @@ export class Hud {
         <option value="harassment">Harassment / abuse</option>
         <option value="spam">Spam</option>
         <option value="cheating">Cheating / exploit</option>
+        <option value="botting">Botting / automation</option>
         <option value="offensive_name_or_chat">Offensive name or chat</option>
         <option value="other">Other</option>
       </select>
@@ -2191,7 +2192,7 @@ export class Hud {
       request
         .then(() => {
           el.style.display = 'none';
-          this.log(`Report submitted for ${name}.`, '#ffd100');
+          this.log(`Report received for ${name}. You can also ignore or block players who are disrupting your chat.`, '#ffd100');
         })
         .catch((err: unknown) => {
           submit.disabled = false;

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -179,6 +179,10 @@ describe('admin api auth', () => {
       openReports: 4,
       latestReportAt: new Date().toISOString(),
       latestReason: 'spam',
+      latestSource: 'system',
+      latestReportKind: 'report_abuse',
+      maxAbuseScore: 120,
+      abuseReasons: ['reporter_spam'],
       characterNames: ['Badactor'],
       online: true,
     }]);

--- a/tests/admin_tables.test.ts
+++ b/tests/admin_tables.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { renderModerationDetail, renderModerationQueue } from '../src/admin/tables';
+import type { ModerationAccountDetail, ModerationQueueRow } from '../src/admin/types';
+
+function accountDetail() {
+  return {
+    id: 9,
+    username: 'badactor',
+    createdAt: '2026-06-01T00:00:00Z',
+    lastLogin: null,
+    isAdmin: false,
+    playtimeSeconds: 0,
+    characters: [],
+    recentSessions: [],
+  };
+}
+
+describe('admin moderation tables', () => {
+  it('renders system report-abuse queue rows and detail evidence', () => {
+    const queueRow: ModerationQueueRow = {
+      accountId: 9,
+      username: 'badactor',
+      status: 'active',
+      suspendedUntil: null,
+      openReports: 1,
+      latestReportAt: '2026-06-13T00:00:00Z',
+      latestReason: 'report_abuse',
+      latestSource: 'system',
+      latestReportKind: 'report_abuse',
+      maxAbuseScore: 140,
+      abuseReasons: ['shared_ip_coordination'],
+      characterNames: ['Badactor'],
+      online: false,
+    };
+
+    const detail: ModerationAccountDetail = {
+      account: accountDetail(),
+      reports: [{
+        id: 55,
+        reason: 'report_abuse',
+        details: 'Automated report-abuse alert for moderator review.',
+        status: 'open',
+        source: 'system',
+        reportKind: 'report_abuse',
+        evidence: {
+          summary: 'Linked reporters submitted a same-target burst with shared report-abuse signals.',
+          linkedReporterAccountIds: [9, 10, 11],
+        },
+        abuseScore: 140,
+        abuseReasons: ['same_target_burst', 'shared_ip_coordination'],
+        createdAt: '2026-06-13T00:00:00Z',
+        reporterAccountId: null,
+        reporterUsername: null,
+        reporterCharacterId: null,
+        reporterCharacterName: 'System',
+        reportedAccountId: 9,
+        reportedUsername: 'badactor',
+        reportedCharacterId: 90,
+        reportedCharacterName: 'Badactor',
+        relatedEvents: [{
+          id: 501,
+          createdAt: '2026-06-13T00:00:00Z',
+          outcome: 'accepted',
+          reason: 'harassment',
+          reporterAccountId: 9,
+          reporterCharacterName: 'Badactor',
+          targetAccountId: 2,
+          targetCharacterName: 'Target',
+          detailsHash: 'abc',
+          detailsLength: 12,
+          ipHash: 'def',
+          userAgentHash: 'ghi',
+          abuseScore: 140,
+          abuseReasons: ['shared_ip_coordination'],
+          evidence: {},
+        }],
+        chatContext: [],
+      }],
+    };
+
+    expect(renderModerationQueue([queueRow])).toContain('System: report abuse');
+    const html = renderModerationDetail(detail);
+    expect(html).toContain('System: report abuse');
+    expect(html).toContain('shared_ip_coordination');
+    expect(html).toContain('Related report submissions');
+    expect(html).toContain('Linked reporters submitted');
+  });
+});

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -5,9 +5,11 @@ vi.mock('../server/db', () => ({
 }));
 
 import { pool } from '../server/db';
+import { REALM } from '../server/realm';
 import {
-  cleanReportReason, cleanText, createPlayerReport, forceCharacterRename, moderateAccount,
+  cleanReportReason, cleanText, createPlayerReport, forceCharacterRename, hashReportMetadata, moderateAccount,
   moderationQueue, moderationReportsForAccount,
+  submitPlayerReportAttempt,
 } from '../server/moderation_db';
 
 const query = vi.mocked(pool.query);
@@ -22,33 +24,73 @@ function clientStub() {
   return { query: cquery, release };
 }
 
+function connectClient(...results: any[]) {
+  const client = clientStub();
+  for (const result of results) {
+    client.query.mockResolvedValueOnce(result);
+  }
+  connect.mockResolvedValue(client as any);
+  return client;
+}
+
 beforeEach(() => {
   query.mockReset();
+  query.mockResolvedValue({ rows: [] } as any);
   connect.mockReset();
 });
 
 describe('moderation report helpers', () => {
   it('accepts only known report reasons and trims bounded text', () => {
     expect(cleanReportReason('spam')).toBe('spam');
+    expect(cleanReportReason('botting')).toBe('botting');
+    expect(cleanReportReason('report_abuse')).toBeNull();
     expect(cleanReportReason('bad')).toBeNull();
     expect(cleanText('  hello  ', 5)).toBe('hello');
     expect(cleanText('abcdef', 3)).toBe('abc');
+    expect(hashReportMetadata('203.0.113.9')).not.toContain('203.0.113.9');
   });
 
-  it('rejects self reports before writing', async () => {
-    await expect(createPlayerReport({
+  it('logs self reports before rejecting them', async () => {
+    const client = connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 123 }] },
+      { rows: [] }, // COMMIT
+    );
+
+    const result = await submitPlayerReportAttempt({
       reporterAccountId: 1,
       reporterCharacterId: 10,
       reporterCharacterName: 'Alice',
       target: { accountId: 1, characterId: 11, characterName: 'Alt' },
       reason: 'spam',
       details: 'same account',
-    })).rejects.toThrow(/yourself/);
-    expect(query).not.toHaveBeenCalled();
+      metadata: { ip: '203.0.113.8', userAgent: 'UnitTest/1.0', targetMethod: 'name' },
+    });
+
+    expect(result).toEqual({ ok: false, status: 400, error: 'cannot report yourself', outcome: 'self_report' });
+    expect(client.query.mock.calls[6][0]).toMatch(/INSERT INTO report_events/);
+    expect(client.query.mock.calls[6][1]).toContain('self_report');
+    expect(JSON.stringify(client.query.mock.calls[6][1])).not.toContain('203.0.113.8');
+    expect(JSON.stringify(client.query.mock.calls[6][1])).not.toContain('UnitTest/1.0');
   });
 
   it('rejects duplicate open reports in the recent window', async () => {
-    query.mockResolvedValueOnce({ rows: [{ id: 99 }] } as any);
+    const client = connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [{ id: 99 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 124 }] },
+      { rows: [] }, // COMMIT
+    );
+    query.mockResolvedValue({ rows: [{ attempts: 0, distinct_targets: 0, event_ids: [] }] } as any);
 
     await expect(createPlayerReport({
       reporterAccountId: 1,
@@ -58,6 +100,289 @@ describe('moderation report helpers', () => {
       reason: 'harassment',
       details: 'duplicate',
     })).rejects.toThrow(/already reported/);
+    expect(client.query.mock.calls[6][0]).toMatch(/INSERT INTO report_events/);
+    expect(client.query.mock.calls[6][1]).toContain('duplicate');
+  });
+
+  it('creates an accepted report and immutable submission event with hashed metadata', async () => {
+    const client = connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [] }, // duplicate
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 77 }] },
+      { rows: [{ id: 88 }] },
+      { rows: [] }, // COMMIT
+    );
+    query
+      .mockResolvedValueOnce({ rows: [{ attempts: 1, distinct_targets: 1, event_ids: [88] }] } as any)
+      .mockResolvedValueOnce({ rows: [{ attempts: 0, event_ids: [] }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 1,
+      reporterCharacterId: 10,
+      reporterCharacterName: 'Alice',
+      target: { accountId: 2, characterId: 20, characterName: 'Bob' },
+      reason: 'botting',
+      details: '  repeated pathing loop  ',
+      metadata: { ip: '203.0.113.7', userAgent: 'UnitTest/2.0', targetMethod: 'pid' },
+    });
+
+    expect(result).toEqual({ ok: true, reportId: 77 });
+    expect(client.query.mock.calls[7][0]).toMatch(/INSERT INTO player_reports/);
+    expect(client.query.mock.calls[8][0]).toMatch(/INSERT INTO report_events/);
+    const eventParams = JSON.stringify(client.query.mock.calls[8][1]);
+    expect(eventParams).toContain('accepted');
+    expect(eventParams).toContain('botting');
+    expect(eventParams).not.toContain('203.0.113.7');
+    expect(eventParams).not.toContain('UnitTest/2.0');
+  });
+
+  it('creates a deduped system report-abuse case when one reporter crosses spam thresholds', async () => {
+    connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [] }, // duplicate
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 201 }] },
+      { rows: [{ id: 301 }] },
+      { rows: [] }, // COMMIT
+    );
+    query
+      .mockResolvedValueOnce({ rows: [{ attempts: 6, distinct_targets: 3, event_ids: [301, 300, 299] }] } as any)
+      .mockResolvedValueOnce({ rows: [{ attempts: 0, event_ids: [] }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any) // update trigger event
+      .mockResolvedValueOnce({ rows: [] } as any); // system report insert
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 9,
+      reporterCharacterId: 90,
+      reporterCharacterName: 'Reporter',
+      target: { accountId: 20, characterId: 200, characterName: 'Target' },
+      reason: 'spam',
+      details: 'bad',
+      metadata: { ip: '203.0.113.9', userAgent: 'UnitTest/3.0', targetMethod: 'pid' },
+    });
+
+    expect(result).toEqual({ ok: true, reportId: 201 });
+    const systemInsert = query.mock.calls.find((call) => String(call[0]).includes("'report_abuse'"));
+    expect(systemInsert?.[0]).toMatch(/INSERT INTO player_reports/);
+    expect(systemInsert?.[1]).toEqual(expect.arrayContaining([9, null, '']));
+    expect(JSON.stringify(systemInsert?.[1])).toContain('reporter_spam');
+    const systemParams = systemInsert?.[1] as unknown[] | undefined;
+    expect(String(systemParams?.[systemParams.length - 1])).toContain(`report_abuse:${REALM}:9:`);
+    expect(JSON.stringify(systemInsert?.[1])).not.toContain('203.0.113.9');
+  });
+
+  it('does not fail an accepted report when post-commit abuse detection fails', async () => {
+    connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [] }, // duplicate
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 901 }] },
+      { rows: [{ id: 902 }] },
+      { rows: [] }, // COMMIT
+    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    query.mockRejectedValueOnce(new Error('detector down'));
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 21,
+      reporterCharacterId: 210,
+      reporterCharacterName: 'Reporter',
+      target: { accountId: 22, characterId: 220, characterName: 'Target' },
+      reason: 'spam',
+      details: 'accepted',
+      metadata: { ip: '203.0.113.21', userAgent: 'UnitTest/8.0', targetMethod: 'pid' },
+    });
+
+    expect(result).toEqual({ ok: true, reportId: 901 });
+    expect(errorSpy).toHaveBeenCalledWith('report abuse detection failed:', expect.any(Error));
+    errorSpy.mockRestore();
+  });
+
+  it('logs invalid targets when the reporter identity is known', async () => {
+    const client = connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 401 }] },
+      { rows: [] }, // COMMIT
+    );
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 1,
+      reporterCharacterId: 10,
+      reporterCharacterName: 'Alice',
+      target: null,
+      reason: 'spam',
+      details: 'missing target',
+      invalidTargetError: 'that player is no longer online',
+      invalidTargetStatus: 404,
+      metadata: { ip: '203.0.113.10', userAgent: 'UnitTest/4.0', targetMethod: 'pid' },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: 'that player is no longer online',
+      outcome: 'invalid_target',
+    });
+    expect(client.query.mock.calls[6][0]).toMatch(/INSERT INTO report_events/);
+    expect(client.query.mock.calls[6][1]).toContain('invalid_target');
+  });
+
+  it('runs abuse detection for repeated invalid-target submissions', async () => {
+    connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 801 }] },
+      { rows: [] }, // COMMIT
+    );
+    query
+      .mockResolvedValueOnce({ rows: [{ attempts: 1, distinct_targets: 0, event_ids: [801] }] } as any)
+      .mockResolvedValueOnce({ rows: [{ attempts: 4, event_ids: [801, 800, 799, 798] }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 7,
+      reporterCharacterId: 70,
+      reporterCharacterName: 'Reporter',
+      target: null,
+      reason: 'spam',
+      details: 'missing target',
+      invalidTargetError: 'that player could not be found',
+      invalidTargetStatus: 404,
+      metadata: { ip: '203.0.113.12', userAgent: 'UnitTest/7.0', targetMethod: 'name' },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.outcome).toBe('invalid_target');
+    const systemInsert = query.mock.calls.find((call) => String(call[0]).includes("'report_abuse'"));
+    expect(systemInsert?.[1]).toEqual(expect.arrayContaining([7, null, '']));
+    expect(JSON.stringify(systemInsert?.[1])).toContain('repeated_rejected_reports');
+  });
+
+  it('uses persisted report events for report cooldowns and logs rate-limited attempts', async () => {
+    const client = connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [] }, // duplicate
+      { rows: [{ count: 1 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 501 }] },
+      { rows: [] }, // COMMIT
+    );
+    query
+      .mockResolvedValueOnce({ rows: [{ attempts: 1, distinct_targets: 1, event_ids: [501] }] } as any)
+      .mockResolvedValueOnce({ rows: [{ attempts: 1, event_ids: [501] }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any);
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 1,
+      reporterCharacterId: 10,
+      reporterCharacterName: 'Alice',
+      target: { accountId: 2, characterId: 20, characterName: 'Bob' },
+      reason: 'spam',
+      details: 'too soon',
+      metadata: { ip: '203.0.113.11', userAgent: 'UnitTest/5.0', targetMethod: 'name' },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 429,
+      error: 'you are submitting reports too quickly',
+      outcome: 'rate_limited',
+    });
+    expect(client.query.mock.calls[3][0]).toMatch(/FROM report_events/);
+    expect(client.query.mock.calls[7][0]).toMatch(/INSERT INTO report_events/);
+    expect(client.query.mock.calls[7][1]).toContain('rate_limited');
+    expect(client.query.mock.calls.some((call) => String(call[0]).includes('INSERT INTO player_reports'))).toBe(false);
+  });
+
+  it('creates report-abuse cases for linked same-target reporters but not the original target', async () => {
+    const sharedIp = hashReportMetadata('198.51.100.1');
+    const sharedDetails = hashReportMetadata('same details');
+    connectClient(
+      { rows: [] }, // BEGIN
+      { rows: [] }, // advisory lock
+      { rows: [] }, // duplicate
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ count: 0 }] },
+      { rows: [{ id: 601 }] },
+      { rows: [{ id: 701 }] },
+      { rows: [] }, // COMMIT
+    );
+    query
+      .mockResolvedValueOnce({ rows: [{ attempts: 1, distinct_targets: 1, event_ids: [701] }] } as any)
+      .mockResolvedValueOnce({ rows: [{ attempts: 0, event_ids: [] }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
+      .mockResolvedValueOnce({ rows: [
+        {
+          id: 701, reporter_account_id: 11, reporter_character_id: 110, reporter_character_name: 'One',
+          target_account_id: 50, target_character_name: 'Target', ip_hash: sharedIp, details_hash: sharedDetails, outcome: 'accepted',
+        },
+        {
+          id: 700, reporter_account_id: 12, reporter_character_id: 120, reporter_character_name: 'Two',
+          target_account_id: 50, target_character_name: 'Target', ip_hash: sharedIp, details_hash: sharedDetails, outcome: 'accepted',
+        },
+        {
+          id: 699, reporter_account_id: 13, reporter_character_id: 130, reporter_character_name: 'Three',
+          target_account_id: 50, target_character_name: 'Target', ip_hash: sharedIp, details_hash: sharedDetails, outcome: 'accepted',
+        },
+        {
+          id: 698, reporter_account_id: 14, reporter_character_id: 140, reporter_character_name: 'Other',
+          target_account_id: 50, target_character_name: 'Target', ip_hash: hashReportMetadata('198.51.100.14'), details_hash: 'different', outcome: 'accepted',
+        },
+      ] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any) // linked reporter 11 system report
+      .mockResolvedValueOnce({ rows: [] } as any) // linked reporter 12 system report
+      .mockResolvedValueOnce({ rows: [] } as any) // linked reporter 13 system report
+      .mockResolvedValueOnce({ rows: [] } as any); // update trigger event
+
+    const result = await submitPlayerReportAttempt({
+      reporterAccountId: 11,
+      reporterCharacterId: 110,
+      reporterCharacterName: 'One',
+      target: { accountId: 50, characterId: 500, characterName: 'Target' },
+      reason: 'harassment',
+      details: 'same details',
+      metadata: { ip: '198.51.100.1', userAgent: 'UnitTest/6.0', targetMethod: 'pid' },
+    });
+
+    expect(result).toEqual({ ok: true, reportId: 601 });
+    const systemInserts = query.mock.calls.filter((call) => String(call[0]).includes("'report_abuse'"));
+    expect(systemInserts).toHaveLength(3);
+    expect(systemInserts.map((call) => (call[1] as unknown[])[0])).toEqual([11, 12, 13]);
+    expect(systemInserts.map((call) => (call[1] as unknown[])[0])).not.toContain(50);
+    expect(JSON.stringify(systemInserts.map((call) => call[1]))).toContain('shared_ip_coordination');
   });
 
   it('sorts moderation queue by open report count, recency, then online status', async () => {
@@ -99,6 +424,7 @@ describe('moderation report helpers', () => {
         reported_character_id: 20,
         reported_character_name: 'Bob',
       }] } as any)
+      .mockResolvedValueOnce({ rows: [] } as any)
       .mockResolvedValueOnce({ rows: [
         { id: 2, character_name: 'Bob', channel: 'say', message: 'second', created_at: '2026-06-12T23:59:00Z' },
         { id: 1, character_name: 'Bob', channel: 'say', message: 'first', created_at: '2026-06-12T23:58:00Z' },
@@ -107,7 +433,7 @@ describe('moderation report helpers', () => {
     const reports = await moderationReportsForAccount(2);
 
     expect(reports).toHaveLength(1);
-    expect(query.mock.calls[1][1]).toEqual([20, '2026-06-13T00:00:00Z']);
+    expect(query.mock.calls[2][1]).toEqual([20, '2026-06-13T00:00:00Z']);
     expect(reports[0].chatContext.map((c) => c.message)).toEqual(['first', 'second']);
   });
 


### PR DESCRIPTION
## Summary
- Adds persisted `report_events` for accepted and rejected report attempts, with hashed IP/user-agent/detail metadata and realm-scoped rate limits.
- Adds deterministic report-abuse detection for reporter spam, repeated rejected attempts, linked same-target bursts, identical-details/shared-IP coordination, and weak solicitation evidence.
- Creates deduped system `report_abuse` moderation cases for human review without automatically actioning the original report target.
- Updates the player report modal, admin moderation queue/detail rendering, schema migration, deployment notes, and focused regression coverage.

## Implementation Notes
- Report target resolution remains server-trusted through the existing resolver; client-supplied account/character IDs are still ignored.
- Valid report submissions serialize per reporter with a transaction-scoped advisory lock so duplicate checks, persisted rate limits, and event/report writes cannot race each other.
- Post-commit abuse detection is isolated from the player-facing report submission result; if alert generation fails, the accepted/rejected attempt remains recorded.
- System `report_abuse` rows use realm-aware dedupe keys and carry compact staff evidence rather than raw IP addresses or raw user-agent strings.

## Verification
- `npm test`; 36 files passed, 405 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.

## Risk
Moderation and persistence risk is medium because this extends the report schema and submission path. The migration is idempotent, old report rows keep default source/kind/evidence values, and automated report-abuse alerts only create moderation queue items for staff review.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
