### PR TITLE
fix: stealthed player no longer shields visible allies from mob aggro

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2399,15 +2399,23 @@ export class Sim {
     switch (mob.aiState) {
       case 'idle': {
         const template = MOBS[mob.templateId];
-        const nearest = this.nearestLivingPlayer(mob.pos, 25);
-        if (nearest) {
-          let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - nearest.e.level) * 1.5));
+        // Evaluate every nearby player against ITS OWN effective radius, not
+        // just the single closest one. A stealthed player standing closer
+        // shrinks only its own detectability and must not mask a visible
+        // groupmate who is well inside the normal aggro radius.
+        let detected: Entity | null = null;
+        let detectedD = Infinity;
+        this.playerGrid.forEachInRadius(mob.pos.x, mob.pos.z, 25, (e, d2) => {
+          if (e.dead) return;
+          let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - e.level) * 1.5));
           // stealthed rogues are harder to detect, relative to observer level
-          if (nearest.e.auras.some((a) => a.kind === 'stealth')) radius = stealthDetectionRadius(mob, nearest.e, radius);
-          if (nearest.d < radius) {
-            this.aggroMob(mob, nearest.e, true);
-            break;
-          }
+          if (e.auras.some((a) => a.kind === 'stealth')) radius = stealthDetectionRadius(mob, e, radius);
+          const d = Math.sqrt(d2);
+          if (d < radius && d < detectedD) { detected = e; detectedD = d; }
+        });
+        if (detected) {
+          this.aggroMob(mob, detected, true);
+          break;
         }
         mob.wanderTimer -= DT;
         if (mob.wanderTimer <= 0) {

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -343,6 +343,32 @@ describe('rogue stealth', () => {
     expect(wolf.aiState).not.toBe('idle');
   });
 
+  it('a closer stealthed player does not shield a visible ally from aggro', () => {
+    // Regression: the idle-mob check only evaluated the single NEAREST player.
+    // A stealthed player standing closest shrank the detection radius and, being
+    // nearest, was the only candidate considered — so a visible groupmate well
+    // inside the normal aggro radius was silently ignored.
+    const sim = new Sim({ seed: 42, playerClass: 'rogue', noPlayer: true });
+    const rogue = sim.entities.get(sim.addPlayer('rogue', 'Sneak'))!;
+    const warrior = sim.entities.get(sim.addPlayer('warrior', 'Visible'))!;
+    sim.setPlayerLevel(5, rogue.id);
+    sim.setPlayerLevel(5, warrior.id);
+    const wolf = nearestMob(sim, 'forest_wolf', rogue);
+    wolf.wanderTarget = null;
+    // equal levels: no level-difference radius skew (forest_wolf aggroRadius 10,
+    // shrunk to ~2.5 while stealthed)
+    wolf.level = 5;
+    // rogue is NEAREST (4yd) but stealthed and outside its shrunk radius;
+    // the warrior is visible at 6yd, well inside the wolf's 10yd aggro radius
+    teleport(sim, rogue, wolf.pos.x + 4, wolf.pos.z);
+    teleport(sim, warrior, wolf.pos.x + 6, wolf.pos.z);
+    sim.castAbility('stealth', rogue.id);
+    expect(rogue.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    for (let i = 0; i < 20 && wolf.aiState === 'idle'; i++) sim.tick();
+    expect(wolf.aiState).not.toBe('idle');
+    expect(wolf.aggroTargetId).toBe(warrior.id);
+  });
+
   it('cannot stealth in combat; acting breaks stealth; ambush requires it', () => {
     const sim = makeSim('rogue');
     sim.setPlayerLevel(16);


### PR DESCRIPTION
## Problem

Idle mobs decide whether to aggro by looking at **only the single nearest living player** (`src/sim/sim.ts`, `updateMob` → `idle` case). `nearestLivingPlayer` is stealth-agnostic, so when a stealthed rogue stands closest to a mob:

1. The rogue is the **only** candidate the mob evaluates, and
2. `stealthDetectionRadius` shrinks the detection radius for that rogue (e.g. a Forest Wolf's 10yd radius collapses to ~2.5yd at equal level).

The result: a fully **visible** groupmate standing well inside the mob's normal aggro radius — but slightly farther than the stealthed rogue — is **never evaluated**, so the mob stays idle. A scout/rogue opening in front of the group effectively "shields" everyone behind them from aggro.

## Fix

Evaluate **every** player within range against **its own** effective radius (stealth shrinks only that player's detectability), and aggro the closest player that is actually detected. This reuses the existing `playerGrid.forEachInRadius` spatial index, so there is no added scan cost.

## Test

Added a regression test in `tests/threat.test.ts` (`rogue stealth` block): a stealthed rogue at 4yd (outside its shrunk radius) no longer prevents a visible warrior at 6yd (inside the 10yd aggro radius) from pulling the mob.

- Fails before the fix (mob stays `idle`), passes after.
- Full suite green (390 tests; the lone `homepage_foundation` failure is a pre-existing `DATABASE_URL`-required env issue, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)