### PR TITLE
fix: make guild creation and joins atomic (#149)

### DIFF
--- a/server/social.ts
+++ b/server/social.ts
@@ -74,10 +74,13 @@ export interface SocialDb {
   listBlocks(charId: number): Promise<CharRef[]>;
   blockedIds(charId: number): Promise<number[]>;
   // guilds (a character belongs to at most one)
-  createGuild(name: string): Promise<number>; // returns guild id; throws on duplicate name
+  // create the guild and seat its leader in one transaction, so a racing or
+  // duplicate create packet can never orphan a leaderless guild
+  createGuildWithLeader(name: string, leaderId: number): Promise<{ guildId: number } | { error: 'name_taken' | 'already_in_guild' }>;
   deleteGuild(id: number): Promise<void>;
   guildMembership(charId: number): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null>;
-  addGuildMember(guildId: number, charId: number, rank: GuildRank): Promise<void>;
+  // seat a member atomically, enforcing the cap under concurrent accepts
+  addGuildMemberAtomic(guildId: number, charId: number, rank: GuildRank, limit: number): Promise<'ok' | 'full' | 'already_member' | 'no_guild'>;
   removeGuildMember(charId: number): Promise<void>;
   setGuildRank(charId: number, rank: GuildRank): Promise<void>;
   guildMembers(guildId: number): Promise<(CharInfo & { rank: GuildRank })[]>;
@@ -270,15 +273,13 @@ export class SocialService {
   async guildCreate(actor: SocialActor, rawName: string): Promise<void> {
     const name = validateGuildName(rawName);
     if (!name) { this.err(actor.characterId, 'Guild names are 3-24 letters (spaces allowed).'); return; }
-    if (await this.db.guildMembership(actor.characterId)) { this.err(actor.characterId, 'You are already in a guild.'); return; }
-    let guildId: number;
-    try {
-      guildId = await this.db.createGuild(name);
-    } catch {
-      this.err(actor.characterId, `A guild named '${name}' already exists.`);
+    const result = await this.db.createGuildWithLeader(name, actor.characterId);
+    if ('error' in result) {
+      this.err(actor.characterId, result.error === 'name_taken'
+        ? `A guild named '${name}' already exists.`
+        : 'You are already in a guild.');
       return;
     }
-    await this.db.addGuildMember(guildId, actor.characterId, 'leader');
     this.info(actor.characterId, `You found the guild <${name}>! You are its Guild Master.`, '#40ff7f');
     this.push(actor.characterId);
   }
@@ -308,11 +309,10 @@ export class SocialService {
     const invite = this.pendingGuildInvites.get(actor.characterId);
     this.pendingGuildInvites.delete(actor.characterId);
     if (!invite || invite.expiresAt < this.now()) { this.err(actor.characterId, 'The guild invitation has expired.'); return; }
-    if (await this.db.guildMembership(actor.characterId)) { this.err(actor.characterId, 'You are already in a guild.'); return; }
-    const members = await this.db.guildMembers(invite.guildId);
-    if (members.length === 0) { this.err(actor.characterId, 'That guild no longer exists.'); return; }
-    if (members.length >= GUILD_MEMBER_LIMIT) { this.err(actor.characterId, 'That guild is full.'); return; }
-    await this.db.addGuildMember(invite.guildId, actor.characterId, 'member');
+    const result = await this.db.addGuildMemberAtomic(invite.guildId, actor.characterId, 'member', GUILD_MEMBER_LIMIT);
+    if (result === 'no_guild') { this.err(actor.characterId, 'That guild no longer exists.'); return; }
+    if (result === 'already_member') { this.err(actor.characterId, 'You are already in a guild.'); return; }
+    if (result === 'full') { this.err(actor.characterId, 'That guild is full.'); return; }
     await this.broadcastGuild(invite.guildId, [{ type: 'log', text: `${actor.name} has joined the guild.`, color: '#40ff7f' }]);
     await this.pushGuild(invite.guildId);
   }

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -128,12 +128,36 @@ export class PgSocialDb implements SocialDb {
     return res.rows.map((r) => r.blocked_id);
   }
 
-  async createGuild(name: string): Promise<number> {
-    const res = await this.pool.query(
-      'INSERT INTO guilds (name, realm) VALUES ($1, $2) RETURNING id',
-      [name, DEFAULT_REALM],
-    );
-    return res.rows[0].id;
+  async createGuildWithLeader(name: string, leaderId: number): Promise<{ guildId: number } | { error: 'name_taken' | 'already_in_guild' }> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      let guildId: number;
+      try {
+        const res = await client.query('INSERT INTO guilds (name, realm) VALUES ($1, $2) RETURNING id', [name, DEFAULT_REALM]);
+        guildId = res.rows[0].id;
+      } catch (err) {
+        await client.query('ROLLBACK');
+        if ((err as { code?: string }).code === '23505') return { error: 'name_taken' }; // unique (realm, name)
+        throw err;
+      }
+      // guild_members.character_id is the PK, so this seats the leader only if
+      // they are not already in a guild; 0 rows => roll the new guild back so no
+      // orphaned, leaderless guild is left behind.
+      const mem = await client.query(
+        `INSERT INTO guild_members (guild_id, character_id, rank) VALUES ($1, $2, 'leader')
+         ON CONFLICT (character_id) DO NOTHING`,
+        [guildId, leaderId],
+      );
+      if (mem.rowCount === 0) { await client.query('ROLLBACK'); return { error: 'already_in_guild' }; }
+      await client.query('COMMIT');
+      return { guildId };
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   async deleteGuild(id: number): Promise<void> {
@@ -151,12 +175,35 @@ export class PgSocialDb implements SocialDb {
     return row ? { guildId: row.guild_id, guildName: row.guild_name, rank: row.rank } : null;
   }
 
-  async addGuildMember(guildId: number, charId: number, rank: GuildRank): Promise<void> {
-    await this.pool.query(
-      `INSERT INTO guild_members (guild_id, character_id, rank) VALUES ($1, $2, $3)
-       ON CONFLICT (character_id) DO NOTHING`,
-      [guildId, charId, rank],
-    );
+  async addGuildMemberAtomic(guildId: number, charId: number, rank: GuildRank, limit: number): Promise<'ok' | 'full' | 'already_member' | 'no_guild'> {
+    const client = await this.pool.connect();
+    try {
+      await client.query('BEGIN');
+      // lock the guild row so concurrent accepts serialize — without this the
+      // count-then-insert races and N pending invitees can all pass the cap.
+      const g = await client.query('SELECT id FROM guilds WHERE id = $1 FOR UPDATE', [guildId]);
+      if (g.rowCount === 0) { await client.query('ROLLBACK'); return 'no_guild'; }
+      const existing = await client.query('SELECT 1 FROM guild_members WHERE character_id = $1', [charId]);
+      if ((existing.rowCount ?? 0) > 0) { await client.query('ROLLBACK'); return 'already_member'; }
+      const cnt = await client.query('SELECT count(*)::int AS n FROM guild_members WHERE guild_id = $1', [guildId]);
+      if (cnt.rows[0].n >= limit) { await client.query('ROLLBACK'); return 'full'; }
+      // ON CONFLICT guards the gap between the membership check above and this
+      // insert: if the character joined a guild concurrently, the character_id
+      // PK conflicts -> 0 rows -> report already_member instead of throwing.
+      const ins = await client.query(
+        `INSERT INTO guild_members (guild_id, character_id, rank) VALUES ($1, $2, $3)
+         ON CONFLICT (character_id) DO NOTHING`,
+        [guildId, charId, rank],
+      );
+      if (ins.rowCount === 0) { await client.query('ROLLBACK'); return 'already_member'; }
+      await client.query('COMMIT');
+      return 'ok';
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
   }
 
   async removeGuildMember(charId: number): Promise<void> {

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -48,11 +48,13 @@ class FakeDb implements SocialDb {
   }
   async blockedIds(c: number): Promise<number[]> { return [...(this.blocks.get(c) ?? [])]; }
 
-  async createGuild(name: string): Promise<number> {
-    if ([...this.guilds.values()].some((n) => n.toLowerCase() === name.toLowerCase())) throw new Error('duplicate guild');
+  async createGuildWithLeader(name: string, leaderId: number): Promise<{ guildId: number } | { error: 'name_taken' | 'already_in_guild' }> {
+    if ([...this.guilds.values()].some((n) => n.toLowerCase() === name.toLowerCase())) return { error: 'name_taken' };
+    if (this.members.has(leaderId)) return { error: 'already_in_guild' };
     const id = this.nextGuildId++;
     this.guilds.set(id, name);
-    return id;
+    this.members.set(leaderId, { guildId: id, rank: 'leader' });
+    return { guildId: id };
   }
   async deleteGuild(id: number): Promise<void> {
     this.guilds.delete(id);
@@ -62,8 +64,13 @@ class FakeDb implements SocialDb {
     const m = this.members.get(c);
     return m ? { guildId: m.guildId, guildName: this.guilds.get(m.guildId)!, rank: m.rank } : null;
   }
-  async addGuildMember(guildId: number, c: number, rank: GuildRank): Promise<void> {
-    if (!this.members.has(c)) this.members.set(c, { guildId, rank });
+  async addGuildMemberAtomic(guildId: number, c: number, rank: GuildRank, limit: number): Promise<'ok' | 'full' | 'already_member' | 'no_guild'> {
+    if (!this.guilds.has(guildId)) return 'no_guild';
+    if (this.members.has(c)) return 'already_member';
+    const count = [...this.members.values()].filter((m) => m.guildId === guildId).length;
+    if (count >= limit) return 'full';
+    this.members.set(c, { guildId, rank });
+    return 'ok';
   }
   async removeGuildMember(c: number): Promise<void> { this.members.delete(c); }
   async setGuildRank(c: number, rank: GuildRank): Promise<void> { const m = this.members.get(c); if (m) m.rank = rank; }
@@ -72,6 +79,7 @@ class FakeDb implements SocialDb {
       .filter(([, m]) => m.guildId === guildId)
       .map(([cid, m]) => ({ ...this.chars.get(cid)!, rank: m.rank }));
   }
+  guildCount(): number { return this.guilds.size; } // test helper: detect orphaned guilds
 }
 
 class FakeTransport implements SocialTransport {
@@ -420,5 +428,54 @@ describe('guilds', () => {
     h.tx.clear();
     await h.svc.guildInvite(h.actor(1), 'Bet');
     expect(h.tx.errorsFor(1).join()).toMatch(/already in a guild/i);
+  });
+});
+
+describe('guild atomicity (#149)', () => {
+  let h: ReturnType<typeof setup>;
+  beforeEach(() => {
+    h = setup();
+    h.add(1, 'Aleph'); h.add(2, 'Bet');
+    h.tx.setOnline(1); h.tx.setOnline(2);
+  });
+
+  it('two racing guild_create packets from one character leave no orphan guild', async () => {
+    // Both calls pass the "are you already in a guild?" check before either
+    // writes its member row. The non-atomic flow created two guilds and orphaned
+    // the leaderless second one; the atomic create must produce exactly one.
+    await Promise.all([
+      h.svc.guildCreate(h.actor(1), 'Iron Vanguard'),
+      h.svc.guildCreate(h.actor(1), 'Storm Wardens'),
+    ]);
+    expect(h.db.guildCount()).toBe(1);
+    const snap = await h.svc.snapshot(1);
+    expect(snap.guild?.rank).toBe('leader');
+    expect(snap.guild?.members.map((m) => m.name)).toEqual(['Aleph']);
+  });
+
+  it('refuses to create a second guild when already in one (no orphan)', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    h.tx.clear();
+    await h.svc.guildCreate(h.actor(1), 'Raiders');
+    expect(h.tx.errorsFor(1).join()).toMatch(/already in a guild/i);
+    expect(h.db.guildCount()).toBe(1);
+  });
+
+  it('guildAccept surfaces a full guild reported by the atomic add', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    h.db.addGuildMemberAtomic = async () => 'full';
+    await h.svc.guildAccept(h.actor(2));
+    expect(h.tx.errorsFor(2).join()).toMatch(/full/i);
+    expect((await h.svc.snapshot(2)).guild).toBeNull();
+  });
+
+  it('guildAccept surfaces a vanished guild reported by the atomic add', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    h.db.addGuildMemberAtomic = async () => 'no_guild';
+    await h.svc.guildAccept(h.actor(2));
+    expect(h.tx.errorsFor(2).join()).toMatch(/no longer exists/i);
+    expect((await h.svc.snapshot(2)).guild).toBeNull();
   });
 });


### PR DESCRIPTION
Closes #149.

The guild create and join flows did a read-check and a separate write with no transaction, so concurrent or duplicate packets (double-click, duplicate WS messages — forwarded directly in `game.ts`) race:

- **Orphaned guilds** — two `guild_create` packets from one character both pass the "are you already in a guild?" check; both `createGuild` succeed, but the second `addGuildMember` hits `ON CONFLICT (character_id) DO NOTHING`, leaving a **leaderless, memberless guild row** no normal flow can disband (plus name squatting).
- **Member-cap bypass** — the `< 100` check in `guildAccept` and the later insert aren't atomic, so N pending invitees can each pass the check and then all insert, pushing the guild over `GUILD_MEMBER_LIMIT`.

## Fix

Move both invariants into atomic DB methods and delete the racy primitives:

- **`createGuildWithLeader(name, leaderId)`** — inserts the guild and seats its leader in one transaction. If the founder is already guilded (the `guild_members.character_id` PK conflicts → 0 rows) or the name is taken (`23505` on the unique `(realm, name)` index), it **rolls back** so no orphan guild is left behind. Returns `{ guildId }` or `{ error: 'name_taken' | 'already_in_guild' }`.
- **`addGuildMemberAtomic(guildId, charId, rank, limit)`** — `SELECT ... FOR UPDATE` on the guild row so concurrent accepts serialize, then checks membership + count and inserts under that lock. The insert itself is `ON CONFLICT (character_id) DO NOTHING` so a character who joins another guild between the check and the insert resolves to `already_member` rather than throwing. Returns `ok | full | already_member | no_guild`.
- `guildCreate` / `guildAccept` now call these; the old `createGuild` / `addGuildMember` primitives are removed (so the racy pattern can't be reintroduced).

## Files

- `server/social_db.ts` — `createGuildWithLeader`, `addGuildMemberAtomic` (transactional; replace `createGuild`/`addGuildMember`).
- `server/social.ts` — `SocialDb` interface + `guildCreate`/`guildAccept` rewritten.
- `tests/social_system.test.ts` — `FakeDb` updated + new atomicity tests.

## Verification

- **`npm test`** — full suite green; new tests in `social_system.test.ts`: two racing `guildCreate` calls leave exactly one guild (no orphan), creating while already guilded is rejected with no orphan, and `guildAccept` surfaces `full` / no-longer-exists. (`Promise.all` reproduces the interleave against the in-memory `FakeDb`.)
- `tsc --noEmit` clean; `npm run build:server` passes.
- Diff reviewed by Codex (GPT-5.5); its finding — translate the insert-time PK conflict to `already_member` — is incorporated (the `ON CONFLICT` guard above).
- **Note:** the DB-level atomicity itself (`FOR UPDATE`, transaction rollback) is review-validated — the test harness mocks the DB layer, matching how the existing `moderation_db` transaction fix (#65) is covered. Bug confirmed present in current `main` before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
