### PR TITLE
fix: clear banned_at when suspending so a ban can be downgraded

### DIFF
--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -229,9 +229,14 @@ export async function moderateAccount(input: {
         [input.accountId, reason],
       );
     } else {
+      // Suspending supersedes any standing ban (an admin downgrading a ban to a
+      // timed suspension). banned_at must be cleared here for the same reason
+      // the ban branch clears suspended_until — moderationStatusForAccount reads
+      // banned_at first, so a leftover ban would mask the suspension entirely
+      // and leave the account locked out forever.
       await client.query(
         `UPDATE accounts
-         SET suspended_until = $2, moderation_reason = $3
+         SET banned_at = NULL, suspended_until = $2, moderation_reason = $3
          WHERE id = $1`,
         [input.accountId, expiresAt!.toISOString(), reason],
       );

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -153,6 +153,29 @@ describe('moderation report helpers', () => {
     expect(client.release).toHaveBeenCalledTimes(1);
   });
 
+  it('clears the opposing lock flag so a ban and a suspension never both stand', async () => {
+    // Banning must clear any standing suspension; suspending must clear any
+    // standing ban. The latter matters because moderationStatusForAccount reads
+    // banned_at before suspended_until, so a leftover ban would silently mask a
+    // downgrade-to-suspension and keep the account locked out forever.
+    const banClient = clientStub();
+    connect.mockResolvedValueOnce(banClient as any);
+    await moderateAccount({ accountId: 2, adminAccountId: 1, action: 'ban', reason: 'cheating' });
+    const banUpdate = banClient.query.mock.calls.find((c) => /UPDATE accounts/.test(c[0]))![0];
+    expect(banUpdate).toMatch(/banned_at = now\(\)/);
+    expect(banUpdate).toMatch(/suspended_until = NULL/);
+
+    const suspendClient = clientStub();
+    connect.mockResolvedValueOnce(suspendClient as any);
+    await moderateAccount({
+      accountId: 2, adminAccountId: 1, action: 'suspend', reason: 'cooling off',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+    });
+    const suspendUpdate = suspendClient.query.mock.calls.find((c) => /UPDATE accounts/.test(c[0]))![0];
+    expect(suspendUpdate).toMatch(/banned_at = NULL/);
+    expect(suspendUpdate).toMatch(/suspended_until = \$2/);
+  });
+
   it('marks a character for forced rename and action-resolves its reports', async () => {
     query.mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any);
     const client = clientStub();


### PR DESCRIPTION
## Problem

`moderateAccount()` exposes two actions, `suspend` and `ban`, and there is no separate unban/reinstate endpoint (`server/admin.ts` only routes `.../(suspend|ban)`). So the only way an admin can soften a permanent ban into a timed suspension is to apply the `suspend` action to an already-banned account.

But the `suspend` branch never cleared `banned_at`:

```ts
// ban branch — clears the opposing flag ✅
SET banned_at = now(), suspended_until = NULL, ...
// suspend branch — left banned_at intact ❌
SET suspended_until = $2, moderation_reason = $3
```

`moderationStatusForAccount()` (`server/db.ts`) checks `banned_at` **before** `suspended_until`:

```ts
if (row.banned_at) return { locked: true, banned: true, ... };  // wins
const suspendedUntil = ...                                       // never reached
```

So a leftover `banned_at` silently masks the suspension. The account stays banned forever — the suspension's expiry never matters, and the WS auth gate (`main.ts`) keeps rejecting the login. The moderation queue also keeps showing the account as `banned` rather than `suspended`.

## Fix

Make the two actions symmetric — suspending clears `banned_at` just as banning clears `suspended_until`:

```ts
SET banned_at = NULL, suspended_until = $2, moderation_reason = $3
```

## Test

Adds a regression test asserting each action clears the opposing lock flag. Verified it fails on the old code (`expected 'UPDATE accounts SET suspended_until…' to match /banned_at = NULL/`) and passes with the fix. Full suite: 390 tests pass (the unrelated `homepage_foundation` suite fails identically on `main` due to a missing `DATABASE_URL` in the local env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)