### PR TITLE
fix: make economy persistence ordered and atomic

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -319,6 +319,38 @@ export async function saveCharacterState(characterId: number, level: number, sta
   );
 }
 
+export interface CharacterStateWrite {
+  characterId: number;
+  level: number;
+  state: CharacterState;
+}
+
+export async function saveEconomyState(characters: CharacterStateWrite[], market: MarketSave | null): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    for (const character of characters) {
+      await client.query(
+        'UPDATE characters SET level = $2, state = $3, updated_at = now() WHERE id = $1',
+        [character.characterId, character.level, JSON.stringify(character.state)],
+      );
+    }
+    if (market !== null) {
+      await client.query(
+        `INSERT INTO world_state (key, data, updated_at) VALUES ($1, $2, now())
+         ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+        ['market', JSON.stringify(market)],
+      );
+    }
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 export async function isAdminAccount(accountId: number): Promise<boolean> {
   const res = await pool.query('SELECT is_admin FROM accounts WHERE id = $1', [accountId]);
   return res.rows[0]?.is_admin === true;

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,11 +1,12 @@
 import { readFileSync } from 'node:fs';
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
-import type { PlayerMeta } from '../src/sim/sim';
+import type { EconomyMutation, MarketSave, PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
-import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
+import { saveCharacterState, saveEconomyState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
+import type { CharacterStateWrite } from './db';
 import { ChatLogger } from './chat_log';
 import { SocialService } from './social';
 import type { Presence, PresenceStatus, SocialActor, SocialEvent, SocialTransport } from './social';
@@ -278,6 +279,9 @@ export class GameServer {
   sim: Sim;
   clients = new Map<number, ClientSession>(); // by pid
   private readonly sessionsByCharacterId = new Map<number, ClientSession>();
+  private readonly characterSaveQueues = new Map<number, Promise<void>>();
+  private marketSaveQueue: Promise<void> = Promise.resolve();
+  private economySaveQueue: Promise<void> = Promise.resolve();
   readonly chatLog = new ChatLogger(insertChatLogs);
   private readonly socialDb = new PgSocialDb(pool);
   readonly social: SocialService;
@@ -466,10 +470,31 @@ export class GameServer {
   async saveCharacter(session: ClientSession): Promise<void> {
     const state = this.sim.serializeCharacter(session.pid);
     const e = this.sim.entities.get(session.pid);
+    const characterId = session.characterId;
     if (state && e) {
-      await saveCharacterState(session.characterId, e.level, state);
-      session.lastSave = Date.now();
+      const level = e.level;
+      await this.enqueueCharacterSave(characterId, async () => {
+        await saveCharacterState(characterId, level, state);
+        session.lastSave = Date.now();
+      });
     }
+  }
+
+  private enqueueCharacterSave(characterId: number, task: () => Promise<void>): Promise<void> {
+    const prior = this.characterSaveQueues.get(characterId) ?? Promise.resolve();
+    const current = prior.then(task);
+    const tail = current
+      .catch((err) => console.error(`character save failed for ${characterId}:`, err))
+      .then(() => undefined);
+    this.trackCharacterSaveTail(characterId, tail);
+    return tail;
+  }
+
+  private trackCharacterSaveTail(characterId: number, tail: Promise<void>): void {
+    this.characterSaveQueues.set(characterId, tail);
+    void tail.finally(() => {
+      if (this.characterSaveQueues.get(characterId) === tail) this.characterSaveQueues.delete(characterId);
+    });
   }
 
   async saveAll(reason: string): Promise<void> {
@@ -488,11 +513,54 @@ export class GameServer {
   }
 
   async saveMarket(): Promise<void> {
-    try {
-      await saveMarketState(this.sim.serializeMarket());
-    } catch (err) {
-      console.error('failed to save world market:', err);
+    const save = this.sim.serializeMarket();
+    await this.enqueueMarketSave(async () => {
+      await saveMarketState(save);
+    });
+  }
+
+  private enqueueMarketSave(task: () => Promise<void>): Promise<void> {
+    const current = this.marketSaveQueue.then(task);
+    this.marketSaveQueue = current
+      .catch((err) => console.error('failed to save world market:', err))
+      .then(() => undefined);
+    return this.marketSaveQueue;
+  }
+
+  private persistEconomyMutation(mutation: EconomyMutation | null): void {
+    if (!mutation) return;
+    const characters: CharacterStateWrite[] = [];
+    const seenCharacterIds = new Set<number>();
+    for (const pid of mutation.characterPids) {
+      const session = this.clients.get(pid);
+      const entity = this.sim.entities.get(pid);
+      const state = this.sim.serializeCharacter(pid);
+      if (!session || !entity || !state || seenCharacterIds.has(session.characterId)) continue;
+      seenCharacterIds.add(session.characterId);
+      characters.push({ characterId: session.characterId, level: entity.level, state });
     }
+    const market = mutation.marketChanged ? this.sim.serializeMarket() : null;
+    if (characters.length === 0 && market === null) return;
+    void this.enqueueEconomySave(
+      characters.map((c) => c.characterId),
+      market,
+      async () => saveEconomyState(characters, market),
+    );
+  }
+
+  private enqueueEconomySave(characterIds: number[], market: MarketSave | null, task: () => Promise<void>): Promise<void> {
+    const ids = [...new Set(characterIds)].sort((a, b) => a - b);
+    const waits = ids.map((id) => this.characterSaveQueues.get(id) ?? Promise.resolve());
+    if (market !== null) waits.push(this.marketSaveQueue);
+    waits.push(this.economySaveQueue);
+    const current = Promise.all(waits).then(task);
+    const tail = current
+      .catch((err) => console.error('failed to save economy transfer:', err))
+      .then(() => undefined);
+    this.economySaveQueue = tail;
+    for (const id of ids) this.trackCharacterSaveTail(id, tail);
+    if (market !== null) this.marketSaveQueue = tail;
+    return tail;
   }
 
   // Close every open play_sessions row; called on graceful shutdown so the
@@ -596,6 +664,7 @@ export class GameServer {
     if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) return;
     const sim = this.sim;
     const pid = session.pid;
+    if (this.clients.get(pid) !== session) return;
     if (msg.t === 'input') {
       const meta = sim.meta(pid);
       const e = sim.entities.get(pid);
@@ -681,7 +750,15 @@ export class GameServer {
       case 'trade_offer':
         if (Array.isArray(msg.items)) sim.tradeSetOffer(msg.items, Number(msg.copper) || 0, pid);
         break;
-      case 'trade_confirm': sim.tradeConfirm(pid); break;
+      case 'trade_confirm': {
+        const trade = sim.tradeFor(pid);
+        if (trade && (!this.clients.has(trade.a) || !this.clients.has(trade.b))) {
+          sim.tradeCancel(pid);
+          break;
+        }
+        this.persistEconomyMutation(sim.tradeConfirm(pid));
+        break;
+      }
       case 'trade_cancel': sim.tradeCancel(pid); break;
       // duels
       case 'duel_req': if (typeof msg.id === 'number') sim.duelRequest(msg.id, pid); break;
@@ -709,12 +786,12 @@ export class GameServer {
       // World Market (the Merchant's auction house)
       case 'market_list':
         if (typeof msg.item === 'string' && typeof msg.count === 'number' && typeof msg.price === 'number') {
-          sim.marketList(msg.item, msg.count, msg.price, pid);
+          this.persistEconomyMutation(sim.marketList(msg.item, msg.count, msg.price, pid));
         }
         break;
-      case 'market_buy': if (typeof msg.id === 'number') sim.marketBuy(msg.id, pid); break;
-      case 'market_cancel': if (typeof msg.id === 'number') sim.marketCancel(msg.id, pid); break;
-      case 'market_collect': sim.marketCollect(pid); break;
+      case 'market_buy': if (typeof msg.id === 'number') this.persistEconomyMutation(sim.marketBuy(msg.id, pid)); break;
+      case 'market_cancel': if (typeof msg.id === 'number') this.persistEconomyMutation(sim.marketCancel(msg.id, pid)); break;
+      case 'market_collect': this.persistEconomyMutation(sim.marketCollect(pid)); break;
       // dev/ops commands, only when ALLOW_DEV_COMMANDS=1 (never in production)
       case 'dev_level': {
         if (process.env.ALLOW_DEV_COMMANDS === '1' && typeof msg.level === 'number') {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -221,6 +221,11 @@ export interface MarketSave {
   nextListingId: number;
 }
 
+export interface EconomyMutation {
+  characterPids: number[];
+  marketChanged: boolean;
+}
+
 // Persistable character state (stored as JSONB server-side). The arena fields
 // are optional so characters saved before the Ashen Coliseum existed load
 // cleanly (addPlayer falls back to the unranked defaults).
@@ -3849,18 +3854,18 @@ export class Sim {
     session.acceptedB = false;
   }
 
-  tradeConfirm(pid?: number): void {
+  tradeConfirm(pid?: number): EconomyMutation | null {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return null;
     const session = this.trades.get(r.meta.entityId);
-    if (!session) return;
+    if (!session) return null;
     if (session.a === r.meta.entityId) session.acceptedA = true;
     else session.acceptedB = true;
-    if (!(session.acceptedA && session.acceptedB)) return;
+    if (!(session.acceptedA && session.acceptedB)) return null;
 
     const metaA = this.players.get(session.a);
     const metaB = this.players.get(session.b);
-    if (!metaA || !metaB) { this.tradeCancel(session.a); return; }
+    if (!metaA || !metaB) { this.tradeCancel(session.a); return null; }
     // final validation before the atomic swap
     const valid =
       session.offerA.copper <= metaA.copper &&
@@ -3870,7 +3875,7 @@ export class Sim {
     if (!valid) {
       for (const tPid of [session.a, session.b]) this.error(tPid, 'Trade failed: items or money no longer available.');
       this.closeTrade(session);
-      return;
+      return null;
     }
     // swap
     metaA.copper = metaA.copper - session.offerA.copper + session.offerB.copper;
@@ -3888,6 +3893,7 @@ export class Sim {
       this.emit({ type: 'tradeDone', pid: tPid });
     }
     this.closeTrade(session);
+    return { characterPids: [session.a, session.b], marketChanged: false };
   }
 
   tradeCancel(pid?: number): void {
@@ -3988,93 +3994,102 @@ export class Sim {
 
   // List a stack from your bags for sale. The goods are escrowed (pulled from
   // your bags immediately) and held by the Merchant until bought or reclaimed.
-  marketList(itemId: string, count: number, price: number, pid?: number): void {
+  marketList(itemId: string, count: number, price: number, pid?: number): EconomyMutation | null {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return null;
     const { meta, e: p } = r;
-    if (p.dead) return;
-    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You must bring your goods to the Merchant.'); return; }
+    if (p.dead) return null;
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You must bring your goods to the Merchant.'); return null; }
     const def = ITEMS[itemId];
-    if (!def) return;
-    if (def.kind === 'quest') { this.error(meta.entityId, 'The Merchant will not broker quest items.'); return; }
+    if (!def) return null;
+    if (def.kind === 'quest') { this.error(meta.entityId, 'The Merchant will not broker quest items.'); return null; }
     const want = Math.max(1, Math.floor(count));
-    if (this.countItem(itemId, meta.entityId) < want) { this.error(meta.entityId, 'You do not have that many to sell.'); return; }
+    if (this.countItem(itemId, meta.entityId) < want) { this.error(meta.entityId, 'You do not have that many to sell.'); return null; }
     const ask = Math.floor(price);
-    if (!Number.isFinite(ask) || ask < MARKET_MIN_PRICE) { this.error(meta.entityId, 'Name a price of at least 1 copper.'); return; }
-    if (ask > MARKET_MAX_PRICE) { this.error(meta.entityId, 'That price is beyond what the Merchant will broker.'); return; }
+    if (!Number.isFinite(ask) || ask < MARKET_MIN_PRICE) { this.error(meta.entityId, 'Name a price of at least 1 copper.'); return null; }
+    if (ask > MARKET_MAX_PRICE) { this.error(meta.entityId, 'That price is beyond what the Merchant will broker.'); return null; }
     const mine = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
-    if (mine >= MARKET_MAX_LISTINGS) { this.error(meta.entityId, `You may keep at most ${MARKET_MAX_LISTINGS} goods on the market at once.`); return; }
+    if (mine >= MARKET_MAX_LISTINGS) { this.error(meta.entityId, `You may keep at most ${MARKET_MAX_LISTINGS} goods on the market at once.`); return null; }
     this.removeItem(itemId, want, meta.entityId); // escrow
     this.marketListings.push({
       id: this.nextListingId++, sellerKey: meta.name, sellerName: meta.name,
       itemId, count: want, price: ask, expiresAt: this.time + MARKET_LISTING_DURATION, house: false,
     });
     this.emit({ type: 'loot', text: `Listed ${def.name}${want > 1 ? ' x' + want : ''} on the World Market for ${formatMoney(ask)}.`, pid: meta.entityId });
+    return { characterPids: [meta.entityId], marketChanged: true };
   }
 
   // Buy a listing outright. Coin leaves the buyer, goods enter their bags, and
   // the seller's proceeds (less the Merchant's cut) wait in their collection.
-  marketBuy(listingId: number, pid?: number): void {
+  marketBuy(listingId: number, pid?: number): EconomyMutation | null {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return null;
     const { meta, e: p } = r;
-    if (p.dead) return;
-    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
+    if (p.dead) return null;
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return null; }
     const idx = this.marketListings.findIndex((l) => l.id === listingId);
-    if (idx < 0) { this.error(meta.entityId, 'That listing is no longer available.'); return; }
+    if (idx < 0) { this.error(meta.entityId, 'That listing is no longer available.'); return null; }
     const listing = this.marketListings[idx];
     const def = ITEMS[listing.itemId];
-    if (!def) { this.marketListings.splice(idx, 1); return; }
+    if (!def) {
+      this.marketListings.splice(idx, 1);
+      return { characterPids: [], marketChanged: true };
+    }
     if (!listing.house && listing.sellerKey === meta.name) {
       this.error(meta.entityId, 'That is your own listing — cancel it to reclaim it.');
-      return;
+      return null;
     }
-    if (meta.copper < listing.price) { this.error(meta.entityId, 'You cannot afford that.'); return; }
+    if (meta.copper < listing.price) { this.error(meta.entityId, 'You cannot afford that.'); return null; }
     meta.copper -= listing.price;
     this.addItem(listing.itemId, listing.count, meta.entityId);
+    let marketChanged = false;
     if (!listing.house) {
       const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
       this.collectionFor(listing.sellerKey).copper += proceeds;
       this.marketListings.splice(idx, 1);
+      marketChanged = true;
       const sellerMeta = this.metaByName(listing.sellerKey);
       if (sellerMeta) {
         this.emit({ type: 'loot', text: `${meta.name} bought your ${def.name} for ${formatMoney(listing.price)} — collect ${formatMoney(proceeds)} from the Merchant.`, pid: sellerMeta.entityId });
       }
     }
     this.emit({ type: 'loot', text: `Bought ${def.name}${listing.count > 1 ? ' x' + listing.count : ''} for ${formatMoney(listing.price)}.`, pid: meta.entityId });
+    return { characterPids: [meta.entityId], marketChanged };
   }
 
   // Reclaim your own listing; the escrowed goods go straight back to your bags.
-  marketCancel(listingId: number, pid?: number): void {
+  marketCancel(listingId: number, pid?: number): EconomyMutation | null {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return null;
     const { meta, e: p } = r;
-    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return null; }
     const idx = this.marketListings.findIndex((l) => l.id === listingId);
-    if (idx < 0) return;
+    if (idx < 0) return null;
     const listing = this.marketListings[idx];
-    if (listing.house || listing.sellerKey !== meta.name) { this.error(meta.entityId, 'That is not your listing.'); return; }
+    if (listing.house || listing.sellerKey !== meta.name) { this.error(meta.entityId, 'That is not your listing.'); return null; }
     this.marketListings.splice(idx, 1);
     this.addItem(listing.itemId, listing.count, meta.entityId);
     const def = ITEMS[listing.itemId];
     this.emit({ type: 'loot', text: `Reclaimed ${def?.name ?? listing.itemId}${listing.count > 1 ? ' x' + listing.count : ''} from the market.`, pid: meta.entityId });
+    return { characterPids: [meta.entityId], marketChanged: true };
   }
 
   // Take everything waiting for you at the Merchant: sale gold and any items
   // returned from expired listings.
-  marketCollect(pid?: number): void {
+  marketCollect(pid?: number): EconomyMutation | null {
     const r = this.resolve(pid);
-    if (!r) return;
+    if (!r) return null;
     const { meta, e: p } = r;
-    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
+    if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return null; }
     const col = this.marketCollections.get(meta.name);
-    if (!col || (col.copper <= 0 && col.items.length === 0)) { this.error(meta.entityId, 'You have nothing to collect.'); return; }
+    if (!col || (col.copper <= 0 && col.items.length === 0)) { this.error(meta.entityId, 'You have nothing to collect.'); return null; }
     if (col.copper > 0) {
       meta.copper += col.copper;
       this.emit({ type: 'loot', text: `You collect ${formatMoney(col.copper)} from the Merchant.`, pid: meta.entityId });
     }
     for (const s of col.items) this.addItem(s.itemId, s.count, meta.entityId);
     this.marketCollections.delete(meta.name);
+    return { characterPids: [meta.entityId], marketChanged: true };
   }
 
   // Once a second: return expired player listings to their seller's collection.

--- a/tests/bandwidth.test.ts
+++ b/tests/bandwidth.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
+  saveEconomyState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
   insertChatLogs: vi.fn(async () => {}),

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -4,6 +4,7 @@ vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   insertChatLogs: vi.fn(async () => {}),
   saveCharacterState: vi.fn(async () => {}),
+  saveEconomyState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
 }));

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -1,14 +1,20 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Entity } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
 
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
+  saveEconomyState: vi.fn(async () => {}),
+  loadMarketState: vi.fn(async () => null),
+  saveMarketState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
   insertChatLogs: vi.fn(async () => {}),
 }));
 
 import { GameServer, type ClientSession } from '../server/game';
+import { saveCharacterState, saveEconomyState, saveMarketState } from '../server/db';
 
 function fakeWs() {
   return {
@@ -23,7 +29,86 @@ function expectJoined(result: ClientSession | { error: string }): ClientSession 
   return result;
 }
 
+function command(cmd: string, extra: Record<string, unknown> = {}): string {
+  return JSON.stringify({ t: 'cmd', cmd, ...extra });
+}
+
+function teleport(server: GameServer, pid: number, x: number, z: number): void {
+  const e = server.sim.entities.get(pid);
+  if (!e) throw new Error('missing entity');
+  e.pos.x = x;
+  e.pos.z = z;
+  e.pos.y = groundHeight(x, z, server.sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function merchant(server: GameServer): Entity {
+  for (const e of server.sim.entities.values()) if (e.templateId === 'the_merchant') return e;
+  throw new Error('the Merchant was not spawned');
+}
+
+function standAtMerchant(server: GameServer, pid: number): void {
+  const m = merchant(server);
+  teleport(server, pid, m.pos.x, m.pos.z);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('GameServer sessions', () => {
+  it('serializes overlapping saves for the same character', async () => {
+    const server = new GameServer();
+    const session = expectJoined(server.join(fakeWs(), 11, 101, 'Saver', 'warrior', null));
+    let releaseFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    vi.mocked(saveCharacterState).mockImplementationOnce(async () => {
+      await firstStarted;
+    });
+
+    const firstSave = server.saveCharacter(session);
+    await vi.waitFor(() => expect(saveCharacterState).toHaveBeenCalledTimes(1));
+
+    const meta = server.sim.meta(session.pid);
+    if (!meta) throw new Error('missing player meta');
+    meta.copper += 37;
+    const secondSave = server.saveCharacter(session);
+
+    await Promise.resolve();
+    expect(saveCharacterState).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    await Promise.all([firstSave, secondSave]);
+
+    expect(saveCharacterState).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(saveCharacterState).mock.calls[1][2].copper).toBe(meta.copper);
+  });
+
+  it('serializes overlapping market saves', async () => {
+    const server = new GameServer();
+    let releaseFirst!: () => void;
+    const firstStarted = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    vi.mocked(saveMarketState).mockImplementationOnce(async () => {
+      await firstStarted;
+    });
+
+    const firstSave = server.saveMarket();
+    await vi.waitFor(() => expect(saveMarketState).toHaveBeenCalledTimes(1));
+    const secondSave = server.saveMarket();
+
+    await Promise.resolve();
+    expect(saveMarketState).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    await Promise.all([firstSave, secondSave]);
+
+    expect(saveMarketState).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps the character-id session index coherent across join, duplicate join, leave, and rejoin', async () => {
     const server = new GameServer();
     const first = expectJoined(server.join(fakeWs(), 11, 101, 'Indexa', 'warrior', null));
@@ -42,5 +127,180 @@ describe('GameServer sessions', () => {
 
     const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
     expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
+  });
+
+  it('persists completed trades as one economy transaction with both characters', async () => {
+    const server = new GameServer();
+    const a = expectJoined(server.join(fakeWs(), 11, 101, 'Tradera', 'warrior', null));
+    const b = expectJoined(server.join(fakeWs(), 12, 102, 'Traderb', 'mage', null));
+    teleport(server, a.pid, 0, -40);
+    teleport(server, b.pid, 3, -40);
+    server.sim.addItem('wolf_fang', 2, a.pid);
+    server.sim.addItem('baked_bread', 1, b.pid);
+    server.sim.meta(a.pid)!.copper = 100;
+    server.sim.meta(b.pid)!.copper = 50;
+
+    server.handleMessage(a, command('trade_req', { id: b.pid }));
+    server.handleMessage(b, command('trade_accept'));
+    server.handleMessage(a, command('trade_offer', { items: [{ itemId: 'wolf_fang', count: 2 }], copper: 30 }));
+    server.handleMessage(b, command('trade_offer', { items: [{ itemId: 'baked_bread', count: 1 }], copper: 10 }));
+    server.handleMessage(a, command('trade_confirm'));
+    expect(saveEconomyState).not.toHaveBeenCalled();
+
+    server.handleMessage(b, command('trade_confirm'));
+    await vi.waitFor(() => expect(saveEconomyState).toHaveBeenCalledTimes(1));
+
+    const [characters, market] = vi.mocked(saveEconomyState).mock.calls[0];
+    expect(characters.map((c) => c.characterId).sort((x, y) => x - y)).toEqual([101, 102]);
+    expect(characters.find((c) => c.characterId === 101)?.state.copper).toBe(80);
+    expect(characters.find((c) => c.characterId === 102)?.state.copper).toBe(70);
+    expect(market).toBeNull();
+  });
+
+  it('does not persist a completed trade when one character snapshot is missing', async () => {
+    const server = new GameServer();
+    const a = expectJoined(server.join(fakeWs(), 11, 101, 'Tradera', 'warrior', null));
+    const b = expectJoined(server.join(fakeWs(), 12, 102, 'Traderb', 'mage', null));
+    teleport(server, a.pid, 0, -40);
+    teleport(server, b.pid, 3, -40);
+    server.sim.addItem('wolf_fang', 1, a.pid);
+
+    server.handleMessage(a, command('trade_req', { id: b.pid }));
+    server.handleMessage(b, command('trade_accept'));
+    server.handleMessage(a, command('trade_offer', { items: [{ itemId: 'wolf_fang', count: 1 }], copper: 0 }));
+    server.handleMessage(a, command('trade_confirm'));
+    server.clients.delete(b.pid);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      server.handleMessage(b, command('trade_confirm'));
+      await Promise.resolve();
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(saveEconomyState).not.toHaveBeenCalled();
+  });
+
+  it('cancels trade confirmation before mutation when the peer session is missing', async () => {
+    const server = new GameServer();
+    const a = expectJoined(server.join(fakeWs(), 11, 101, 'Tradera', 'warrior', null));
+    const b = expectJoined(server.join(fakeWs(), 12, 102, 'Traderb', 'mage', null));
+    teleport(server, a.pid, 0, -40);
+    teleport(server, b.pid, 3, -40);
+    server.sim.addItem('wolf_fang', 1, a.pid);
+
+    server.handleMessage(a, command('trade_req', { id: b.pid }));
+    server.handleMessage(b, command('trade_accept'));
+    server.handleMessage(a, command('trade_offer', { items: [{ itemId: 'wolf_fang', count: 1 }], copper: 0 }));
+    server.handleMessage(b, command('trade_confirm'));
+    server.clients.delete(b.pid);
+
+    server.handleMessage(a, command('trade_confirm'));
+    await Promise.resolve();
+
+    expect(saveEconomyState).not.toHaveBeenCalled();
+    expect(server.sim.tradeFor(a.pid)).toBeNull();
+    expect(server.sim.countItem('wolf_fang', a.pid)).toBe(1);
+  });
+
+  it('persists successful market listings with seller state and market state', async () => {
+    const server = new GameServer();
+    const seller = expectJoined(server.join(fakeWs(), 11, 101, 'Seller', 'warrior', null));
+    standAtMerchant(server, seller.pid);
+    server.sim.addItem('wolf_fang', 2, seller.pid);
+
+    server.handleMessage(seller, command('market_list', { item: 'wolf_fang', count: 2, price: 100 }));
+    await vi.waitFor(() => expect(saveEconomyState).toHaveBeenCalledTimes(1));
+
+    const [characters, market] = vi.mocked(saveEconomyState).mock.calls[0];
+    expect(characters.map((c) => c.characterId)).toEqual([101]);
+    expect(characters[0].state.inventory).not.toContainEqual({ itemId: 'wolf_fang', count: 2 });
+    expect(market?.listings).toHaveLength(1);
+    expect(market?.listings[0]).toMatchObject({ sellerKey: 'Seller', itemId: 'wolf_fang', count: 2, price: 100 });
+  });
+
+  it('persists player market buys with buyer state and market state', async () => {
+    const server = new GameServer();
+    const seller = expectJoined(server.join(fakeWs(), 11, 101, 'Seller', 'warrior', null));
+    const buyer = expectJoined(server.join(fakeWs(), 12, 102, 'Buyer', 'mage', null));
+    standAtMerchant(server, seller.pid);
+    standAtMerchant(server, buyer.pid);
+    server.sim.addItem('wolf_fang', 1, seller.pid);
+    server.sim.meta(buyer.pid)!.copper = 500;
+    server.sim.marketList('wolf_fang', 1, 100, seller.pid);
+    const listing = server.sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    vi.mocked(saveEconomyState).mockClear();
+
+    server.handleMessage(buyer, command('market_buy', { id: listing.id }));
+    await vi.waitFor(() => expect(saveEconomyState).toHaveBeenCalledTimes(1));
+
+    const [characters, market] = vi.mocked(saveEconomyState).mock.calls[0];
+    expect(characters.map((c) => c.characterId)).toEqual([102]);
+    expect(characters[0].state.copper).toBe(400);
+    expect(characters[0].state.inventory).toContainEqual({ itemId: 'wolf_fang', count: 1 });
+    expect(market?.listings).toHaveLength(0);
+    expect(market?.collections).toContainEqual({ key: 'Seller', copper: 95, items: [] });
+  });
+
+  it('does not persist a market mutation when the acting character snapshot is missing', async () => {
+    const server = new GameServer();
+    const seller = expectJoined(server.join(fakeWs(), 11, 101, 'Seller', 'warrior', null));
+    standAtMerchant(server, seller.pid);
+    server.sim.addItem('wolf_fang', 1, seller.pid);
+    server.clients.delete(seller.pid);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      server.handleMessage(seller, command('market_list', { item: 'wolf_fang', count: 1, price: 100 }));
+      await Promise.resolve();
+    } finally {
+      consoleError.mockRestore();
+    }
+
+    expect(saveEconomyState).not.toHaveBeenCalled();
+  });
+
+  it('persists market cleanup when a listing references missing item content', async () => {
+    const server = new GameServer();
+    const buyer = expectJoined(server.join(fakeWs(), 12, 102, 'Buyer', 'mage', null));
+    standAtMerchant(server, buyer.pid);
+    server.sim.marketListings.push({
+      id: 999,
+      sellerKey: 'Seller',
+      sellerName: 'Seller',
+      itemId: 'missing_item',
+      count: 1,
+      price: 100,
+      expiresAt: server.sim.time + 100,
+      house: false,
+    });
+
+    server.handleMessage(buyer, command('market_buy', { id: 999 }));
+    await vi.waitFor(() => expect(saveEconomyState).toHaveBeenCalledTimes(1));
+
+    const [characters, market] = vi.mocked(saveEconomyState).mock.calls[0];
+    expect(characters).toEqual([]);
+    expect(market?.listings.some((l) => l.id === 999)).toBe(false);
+  });
+
+  it('does not persist rejected market buys or incomplete trades as economy transfers', async () => {
+    const server = new GameServer();
+    const seller = expectJoined(server.join(fakeWs(), 11, 101, 'Seller', 'warrior', null));
+    const buyer = expectJoined(server.join(fakeWs(), 12, 102, 'Buyer', 'mage', null));
+    standAtMerchant(server, seller.pid);
+    standAtMerchant(server, buyer.pid);
+    server.sim.addItem('wolf_fang', 1, seller.pid);
+    server.sim.marketList('wolf_fang', 1, 100, seller.pid);
+    const listing = server.sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    vi.mocked(saveEconomyState).mockClear();
+
+    server.handleMessage(buyer, command('market_buy', { id: listing.id }));
+    server.handleMessage(seller, command('trade_req', { id: buyer.pid }));
+    server.handleMessage(buyer, command('trade_accept'));
+    server.handleMessage(seller, command('trade_confirm'));
+    await Promise.resolve();
+
+    expect(saveEconomyState).not.toHaveBeenCalled();
   });
 });

--- a/tests/interest.test.ts
+++ b/tests/interest.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
+  saveEconomyState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
   insertChatLogs: vi.fn(async () => {}),

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
+  saveEconomyState: vi.fn(async () => {}),
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
   insertChatLogs: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary
- Serializes per-character saves and World Market saves so older async snapshots cannot overwrite newer economy state.
- Persists successful trades and player World Market mutations through one transaction containing all affected character snapshots plus market state when needed.
- Drops stale session commands and cancels trades with missing live peers before mutation so successful grouped economy writes are not partial.

## Diagnosis
Character state and market state were saved by independent async writes. A later autosave or logout save could be overwritten by an older pending write, and trade or market transfers could be durably split if only one owner snapshot reached Postgres before a crash.

## Implementation Notes
- The shared sim now reports narrow economy mutation results for completed trade and market operations.
- The server captures post-mutation snapshots immediately and queues grouped economy transactions behind the affected character and market save queues.
- The database helper updates character JSON and optional market JSON inside one Postgres transaction.
- Invalid market listings that reference missing item content are removed and persisted as market-only cleanup.

## Verification
- `npm test -- tests/game_sessions.test.ts tests/social.test.ts tests/market.test.ts`; 55 tests passed.
- `npm test`; 35 files passed, 407 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.

## Risk
This touches server-authoritative persistence for character JSON and shared market JSON. The sim rules remain unchanged except for return contracts and invalid-listing cleanup reporting; stale sessions are rejected before mutation, and focused tests cover successful, rejected, missing-session, and cleanup paths.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
