### PR TITLE
feat: add campfire burn hazards

### DIFF
--- a/src/game/audio.ts
+++ b/src/game/audio.ts
@@ -86,6 +86,12 @@ export class GameAudio {
     this.tone(160, 0.35, 0.2, 'sawtooth', 0, 60);
   }
 
+  burnReaction(): void {
+    this.tone(520, 0.1, 0.16, 'sawtooth', 0, 360);
+    this.tone(360, 0.18, 0.12, 'triangle', 0.06, 210);
+    this.noise(0.16, 1200, 0.08, 0.75, 'bandpass');
+  }
+
   frost(): void {
     this.noise(0.35, 4500, 0.18, 0.7, 'highpass');
     this.tone(1300, 0.3, 0.12, 'sine', 0, 700);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,7 +1,7 @@
 import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
-  ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, REWARD_ARCHETYPE, abilitiesKnownAt, instanceOrigin,
+  ITEMS, MOBS, NPCS, PLAYER_START, PROPS, QUESTS, REWARD_ARCHETYPE, abilitiesKnownAt, instanceOrigin,
   zoneAt,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
@@ -74,6 +74,10 @@ const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_GROWL_INTERVAL = 8; // controlled pets can tank by forcing attention
+const FIRE_HAZARD_RADIUS = 1.75;
+const FIRE_HAZARD_TICKS = 40; // every 2 seconds
+const FIRE_HAZARD_HP_FRACTION = 0.04;
+const FIRE_HAZARD_MIN_DAMAGE = 2;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
   'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
 ]);
@@ -711,6 +715,7 @@ export class Sim {
         this.updateCasting(p, meta);
         this.updatePlayerAutoAttack(p, meta);
         this.updateRegen(p, meta);
+        this.updateFireHazards(p);
       }
       this.updateTimers(p);
       this.updateAuras(p);
@@ -1008,6 +1013,25 @@ export class Sim {
       }
       c.remaining -= 2;
       if (c.remaining <= 0) p[slot] = null;
+    }
+  }
+
+  private updateFireHazards(p: Entity): void {
+    if (this.tickCount % FIRE_HAZARD_TICKS !== 0) return;
+    const r2 = FIRE_HAZARD_RADIUS * FIRE_HAZARD_RADIUS;
+    for (const [x, z] of PROPS.campfires) {
+      const dx = p.pos.x - x;
+      const dz = p.pos.z - z;
+      if (dx * dx + dz * dz > r2) continue;
+      const hpBefore = p.hp;
+      const dmg = Math.max(FIRE_HAZARD_MIN_DAMAGE, Math.round(p.maxHp * FIRE_HAZARD_HP_FRACTION));
+      this.dealDamage(null, p, dmg, false, 'fire', 'Fire', 'hit', true);
+      if (p.hp < hpBefore) {
+        p.combatTimer = 0;
+        this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: 'fire', fx: 'tick' });
+        this.emit({ type: 'burnReaction', targetId: p.id, pid: p.id });
+      }
+      break;
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -507,6 +507,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'heal2'; sourceId: number; targetId: number; amount: number; crit: boolean; ability: string }
   // visual-only cue for the renderer: spell projectiles, dot ticks, aoe novas
   | { type: 'spellfx'; sourceId: number; targetId: number; school: string; fx: 'projectile' | 'tick' | 'nova' }
+  | { type: 'burnReaction'; targetId: number }
   // entityId (when set) anchors the log to that entity so the server only
   // delivers it to nearby players; anchorless logs broadcast server-wide
   | { type: 'log'; text: string; color?: string; entityId?: number }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1118,8 +1118,13 @@ export class Hud {
             else audio.meleeHit(ev.crit);
           } else if (isPlayerTarget) {
             this.fct(tgt, `-${ev.amount}`, '#ff5544', ev.crit);
-            this.combatLog(`${src?.name ?? 'Something'} hits you for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, '#ff8877');
-            audio.hitTaken();
+            if (ev.sourceId === -1 && ev.school === 'fire' && ev.ability === 'Fire') {
+              this.combatLog(`Fire burns you for ${ev.amount}.`, '#ff8877');
+              audio.fire();
+            } else {
+              this.combatLog(`${src?.name ?? 'Something'} hits you for ${ev.amount}${ev.crit ? ' (Critical)' : ''}.`, '#ff8877');
+              audio.hitTaken();
+            }
           }
           break;
         }
@@ -1275,6 +1280,14 @@ export class Hud {
             this.showBanner(`Defeated by ${ev.oppName}.  Rating ${ev.ratingAfter} (${sign}${delta})`);
             this.combatLog(`${ev.oppName} bested you in the Ashen Coliseum. Rating ${ev.ratingAfter} (${sign}${delta}).`, '#ff7a6a');
             audio.death();
+          }
+          break;
+        }
+        case 'burnReaction': {
+          const tgt = sim.entities.get(ev.targetId);
+          if (tgt && ev.targetId === sim.playerId) {
+            this.fct(tgt, 'Ah!', '#ffb45e', false);
+            audio.burnReaction();
           }
           break;
         }

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -5,7 +5,7 @@ import {
   type SimEvent, dist2d, MAX_LEVEL, xpForLevel, mobXpValue, rageConversion, rageFromDealing,
   spellHitChance, meleeMissChance,
 } from '../src/sim/types';
-import { QUESTS, abilitiesKnownAt } from '../src/sim/data';
+import { PROPS, QUESTS, abilitiesKnownAt } from '../src/sim/data';
 import { terrainHeight } from '../src/sim/world';
 
 function makeSim(cls: 'warrior' | 'mage' | 'rogue' = 'warrior', seed = 42) {
@@ -122,6 +122,47 @@ describe('world generation', () => {
     expect(terrainHeight(10, 10, 42)).toBe(terrainHeight(10, 10, 42));
     expect(Math.abs(terrainHeight(0, 0, 42) - terrainHeight(8, 8, 42))).toBeLessThan(1.5);
     expect(terrainHeight(-85, 80, 42)).toBeLessThan(-4.5);
+  });
+});
+
+describe('environment hazards', () => {
+  it('slowly burns players standing too close to campfires', () => {
+    const sim = makeSim();
+    const [x, z] = PROPS.campfires[0];
+    teleportTo(sim, x + 1.45, z);
+    const hpBefore = sim.player.hp;
+    const events: SimEvent[] = [];
+
+    for (let i = 0; i < 80; i++) events.push(...sim.tick());
+
+    const fireDamage = events.filter((ev): ev is Extract<SimEvent, { type: 'damage' }> =>
+      ev.type === 'damage' && ev.sourceId === -1 && ev.targetId === sim.player.id && ev.school === 'fire');
+    const damageTaken = fireDamage.reduce((sum, ev) => sum + ev.amount, 0);
+    expect(fireDamage).toHaveLength(2);
+    expect(sim.player.hp).toBe(hpBefore - damageTaken);
+    expect(fireDamage).toContainEqual(expect.objectContaining({
+      type: 'damage',
+      sourceId: -1,
+      targetId: sim.player.id,
+      school: 'fire',
+      ability: 'Fire',
+      kind: 'hit',
+    }));
+    expect(events).toContainEqual({ type: 'spellfx', sourceId: sim.player.id, targetId: sim.player.id, school: 'fire', fx: 'tick' });
+    expect(events).toContainEqual({ type: 'burnReaction', targetId: sim.player.id, pid: sim.player.id });
+  });
+
+  it('does not burn players at a safe distance from campfires', () => {
+    const sim = makeSim();
+    const [x, z] = PROPS.campfires[0];
+    teleportTo(sim, x + 2.5, z);
+    const hpBefore = sim.player.hp;
+    const events: SimEvent[] = [];
+
+    for (let i = 0; i < 80; i++) events.push(...sim.tick());
+
+    expect(sim.player.hp).toBe(hpBefore);
+    expect(events.some((ev) => ev.type === 'burnReaction')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds sim-owned fire hazard pulses for players standing too close to world campfires.
- Applies slow fire damage every two seconds, delays normal health regen after a burn pulse, and keeps the rule shared for offline and online play.
- Emits a world-visible fire tick VFX event plus a personal burn reaction that shows `Ah!` floating text and plays a procedural reaction sound.

## Implementation Notes
- The hazard uses the existing merged campfire prop list, so authored campfires across zones become the source of truth for the burn radius.
- Environmental fire damage uses the existing `dealDamage` path with no attacker, preserving GM invulnerability, death handling, consumption interruption, and damage event delivery.
- The fire tick VFX is world-visible to nearby clients; only the burn reaction cue is personal to the burned player.

## Verification
- `npx vitest run tests/sim.test.ts -t "environment hazards"`; 2 tests passed.
- `npx vitest run tests/sim.test.ts`; 44 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- Full final branch gate: `npm test` (35 files, 399 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build` passed.
- Headless Chromium offline browser smoke at local Vite `/`: started an offline warrior, moved the player to the first campfire hazard edge, drove the burn pulse in-browser, and observed HP 90 -> 86, one fire damage event, one fire tick VFX event, one burn reaction event, floating `-4` and `Ah!` text, and combat log text `Fire burns you for 4.`.

## Risk
Low gameplay risk. The change is limited to authored campfire prop positions and existing player damage/event paths. The main tuning choices are the 1.75 yard hazard radius and 4% max-health damage pulse every two seconds.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
