### PR TITLE
fix: make evading mobs immune to damage while they reset

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1984,6 +1984,11 @@ export class Sim {
   private dealDamage(source: Entity | null, target: Entity, amount: number, crit: boolean, school: string, ability: string | null, kind: 'hit' | 'miss' | 'dodge', noRage = false, threatOpts?: { flat?: number; mult?: number }): void {
     if (target.dead) return;
     if (target.gm) return; // GM characters are invulnerable — every damage path funnels here
+    // A mob that broke leash (or a pet freed to the wild) is in 'evade': it has
+    // dropped its hate table and walks home without fighting back, healing to
+    // full only on arrival. Classic mechanics make it immune while it retreats,
+    // so it can't be chipped down — or killed outright — for a risk-free kill.
+    if (target.kind === 'mob' && target.aiState === 'evade') return;
     amount = Math.max(0, amount);
 
     // Defensive Stance, classic: deal 10% less, take 10% less (and +30% threat below)

--- a/tests/evade_immunity.test.ts
+++ b/tests/evade_immunity.test.ts
@@ -1,0 +1,71 @@
+// A wild mob retreating home after a leash break (aiState 'evade') has dropped
+// its hate table and will not fight back. It must be immune to damage while it
+// resets, otherwise a player can chip it down — or kill it outright — for a
+// risk-free kill, which also breaks the classic reset contract.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d } from '../src/sim/types';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+function nearestMob(sim: Sim): Entity {
+  let best: Entity | null = null;
+  let bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.ownerId !== null) continue;
+    const d = dist2d(sim.player.pos, e.pos);
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  return best!;
+}
+
+function hit(sim: Sim, source: Entity, target: Entity, amount: number) {
+  (sim as any).dealDamage(source, target, amount, false, 'physical', null, 'hit', true);
+}
+
+describe('evading mobs are immune while resetting', () => {
+  it('takes no damage and gains no threat from a hit while evading', () => {
+    const sim = makeSim();
+    const wolf = nearestMob(sim);
+    wolf.maxHp = 5000;
+    wolf.hp = 5000;
+    wolf.aiState = 'evade';
+    wolf.threat.clear();
+
+    hit(sim, sim.player, wolf, 1000);
+
+    expect(wolf.hp).toBe(5000);
+    expect(wolf.threat.size).toBe(0);
+    expect(wolf.dead).toBe(false);
+  });
+
+  it('cannot be killed while evading', () => {
+    const sim = makeSim();
+    const wolf = nearestMob(sim);
+    wolf.maxHp = 50;
+    wolf.hp = 50;
+    wolf.aiState = 'evade';
+
+    hit(sim, sim.player, wolf, 99999);
+
+    expect(wolf.dead).toBe(false);
+    expect(wolf.hp).toBe(50);
+  });
+
+  it('still takes damage normally once it is fighting again', () => {
+    const sim = makeSim();
+    const wolf = nearestMob(sim);
+    wolf.maxHp = 5000;
+    wolf.hp = 5000;
+    wolf.aiState = 'attack';
+    wolf.threat.clear();
+
+    hit(sim, sim.player, wolf, 100);
+
+    expect(wolf.hp).toBe(4900);
+    expect(wolf.threat.get(sim.playerId)).toBeCloseTo(100, 5);
+  });
+});


### PR DESCRIPTION
## Problem

When a wild mob is pulled past its leash it switches to the `evade` state (`src/sim/sim.ts`): it **drops its hate table**, walks home at `EVADE_SPEED_MULT`, and only heals to full **on arrival**. `enterCombat` explicitly refuses to re-aggro a mob in `evade`, so it will not fight back during the retreat.

However, `dealDamage` only guarded `dead` and `gm` targets — there was **no guard for `evade`**:

```ts
private dealDamage(...) {
  if (target.dead) return;
  if (target.gm) return;
  // <-- nothing stopped damage to an evading mob
```

So a player could:
- keep landing hits on a retreating mob (re-seeding its threat table with damage it never reacts to), and
- **kill it outright** before it reached home — a completely risk-free kill, since the mob never retaliates.

This also breaks the classic reset contract, where an evading mob is immune until it fully resets.

## Fix

Add an early return in `dealDamage` for mobs in the `evade` state:

```ts
if (target.kind === 'mob' && target.aiState === 'evade') return;
```

This covers both leash-broken wild mobs and pets freed to the wild (`releasePetToWild` clears `ownerId` and sets `aiState = 'evade'`). Direct hits and lingering DoT ticks now no-op until the mob resets and can be pulled again.

## Tests

Adds `tests/evade_immunity.test.ts`:
- no damage and no threat gained from a hit while evading
- cannot be killed while evading
- normal damage + threat resume once the mob is fighting again

Verified the new test **fails without** the one-line fix (2/3 cases) and **passes with** it. Full suite: 392 tests pass; `tsc --noEmit` clean. (The unrelated `homepage_foundation` file only fails when `DATABASE_URL` is unset in the environment — pre-existing, passes with it set.)

This is independent of #153 (leash anchoring / social-pull tuning), which does not address damage immunity during `evade`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)