### PR TITLE
feat: add eastbrook guard assistance

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -194,7 +194,7 @@ function blankEntity(id: number): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
+    aiState: 'idle', tappedById: null, guardDamageTaken: 0, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
     spawnPos: { x: 0, y: 0, z: 0 }, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -364,6 +364,7 @@ const FAMILY_KEYS: Record<string, string> = {
 
 const NPC_KEYS: Record<string, string> = {
   marshal_redbrook: 'npc_knight',
+  eastbrook_guard: 'npc_knight',
   warden_fenwick: 'npc_knight',
   captain_thessaly: 'npc_knight',
   loremaster_caddis: 'npc_mage',

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -160,6 +160,13 @@ export const ZONE1_NPCS: Record<string, NpcDef> = {
     questIds: ['q_wolves', 'q_greyjaw', 'q_bandits', 'q_ringleader'],
     greeting: 'Keep your blade close, $C. The Vale is not what it was.',
   },
+  eastbrook_guard: {
+    id: 'eastbrook_guard', name: 'Guard Mira', title: 'Eastbrook Guard',
+    pos: { x: 13, z: 5 }, facing: -Math.PI / 2, color: 0x8e9aaf,
+    questIds: [],
+    guard: { assistRadius: 12, leashRadius: 12, attackSpeed: 1.8 },
+    greeting: 'Run to the square if the Vale turns on you. I will hold the line.',
+  },
   trader_wilkes: {
     id: 'trader_wilkes', name: 'Trader Wilkes', title: 'Provisioner',
     pos: { x: -7, z: 3 }, facing: Math.PI / 2, color: 0x1e8449,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -18,7 +18,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
+    aiState: 'idle', tappedById: null, guardDamageTaken: 0, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
     spawnPos: { ...pos }, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -74,6 +74,7 @@ const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_GROWL_INTERVAL = 8; // controlled pets can tank by forcing attention
+const GUARD_REWARD_DENY_FRACTION = 0.5;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
   'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
 ]);
@@ -338,6 +339,7 @@ export class Sim {
     for (const npcDef of Object.values(NPCS)) {
       const safe = this.findSafePos(npcDef.pos.x, npcDef.pos.z, WATER_LEVEL + 0.6);
       const npc = createNpc(this.nextId++, npcDef, this.groundPos(safe.x, safe.z));
+      if (npcDef.guard) this.configureGuardStats(npc, npcDef.guard.attackSpeed);
       this.addEntity(npc);
       if (npcDef.market) this.merchantId = npc.id; // the World Market is anchored here
     }
@@ -722,6 +724,7 @@ export class Sim {
         this.updateAuras(e);
       } else if (e.kind === 'npc') {
         this.cleanseFriendlyNpcAuras(e);
+        this.updateGuardNpc(e);
       } else if (e.kind === 'object') {
         if (!e.lootable) {
           e.respawnTimer -= DT;
@@ -2033,6 +2036,7 @@ export class Sim {
       }
     }
 
+    const hpDamage = Math.min(target.hp, amount);
     target.hp = Math.max(0, target.hp - amount);
     this.emit({ type: 'damage', sourceId: source?.id ?? -1, targetId: target.id, amount, crit, school, ability, kind });
 
@@ -2056,9 +2060,13 @@ export class Sim {
     // classic threat: damage (and the ability's flat bonus) lands on the mob's
     // hate table, scaled by the attacker's stance/form modifiers
     if (source && source.id !== target.id && target.kind === 'mob' && target.hostile
-      && (source.kind === 'player' || source.ownerId !== null)) {
+      && (source.kind === 'player' || source.ownerId !== null || this.isGuardNpc(source))) {
       const threat = (amount * (threatOpts?.mult ?? 1) + (threatOpts?.flat ?? 0)) * threatModifier(source, school);
       addThreat(target, source.id, threat);
+    }
+
+    if (source && source.id !== target.id && this.isGuardNpc(source) && target.kind === 'mob' && target.hostile) {
+      target.guardDamageTaken += hpDamage;
     }
 
     // tap rights: the first player (or their pet) to damage a mob owns it
@@ -2100,7 +2108,7 @@ export class Sim {
     a.inCombat = true;
     b.inCombat = true;
     // players and their pets pull wild mobs; pets never run wild-mob AI
-    const aAttacker = a.kind === 'player' || (a.kind === 'mob' && a.ownerId !== null);
+    const aAttacker = a.kind === 'player' || (a.kind === 'mob' && a.ownerId !== null) || this.isGuardNpc(a);
     if (b.kind === 'mob' && b.ownerId === null && !b.dead && aAttacker && b.aiState !== 'evade') {
       if (b.aiState === 'idle') this.aggroMob(b, a, true);
       else if (b.aggroTargetId === null) b.aggroTargetId = a.id;
@@ -2179,19 +2187,22 @@ export class Sim {
         if (eligible.length === 0) eligible.push(meta);
         const bonus = GROUP_XP_BONUS[Math.min(eligible.length, GROUP_XP_BONUS.length) - 1];
 
-        meta.counters.kills++;
+        const rewardScale = this.guardRewardScale(e);
         if (creditEntity.targetId === e.id) creditEntity.autoAttack = false;
         if (creditEntity.comboTargetId === e.id) {
           creditEntity.comboPoints = 0;
           creditEntity.comboTargetId = null;
           this.emit({ type: 'comboPoint', points: 0, pid: creditEntity.id });
         }
+        if (rewardScale <= 0) return;
+
+        meta.counters.kills++;
         for (const member of eligible) {
           const mE = this.entities.get(member.entityId);
           if (!mE) continue;
-          const xpGain = Math.round((mobXpValue(e.level, mE.level) * eliteMult * bonus) / eligible.length);
+          const xpGain = Math.round((mobXpValue(e.level, mE.level) * eliteMult * bonus * rewardScale) / eligible.length);
           if (xpGain > 0 && mE.level < MAX_LEVEL) this.grantXp(xpGain, member);
-          this.onMobKilledForQuests(e, member);
+          if (e.guardDamageTaken <= 0) this.onMobKilledForQuests(e, member);
         }
         this.rollLoot(e, meta);
       }
@@ -2218,6 +2229,7 @@ export class Sim {
   }
 
   private rollLoot(mob: Entity, meta: PlayerMeta): void {
+    if (this.guardRewardScale(mob) <= 0) return;
     const template = MOBS[mob.templateId];
     if (!template) return;
     let copper = 0;
@@ -2243,6 +2255,7 @@ export class Sim {
         continue;
       }
       if (entry.questId) {
+        if (mob.guardDamageTaken > 0) continue;
         const qp = meta.questLog.get(entry.questId);
         if (!qp || qp.state !== 'active') continue;
         const quest = QUESTS[entry.questId];
@@ -2262,6 +2275,116 @@ export class Sim {
   // -------------------------------------------------------------------------
   // Mob AI
   // -------------------------------------------------------------------------
+
+  private isGuardNpc(e: Entity | null): e is Entity {
+    return !!e && e.kind === 'npc' && NPCS[e.templateId]?.guard !== undefined;
+  }
+
+  private configureGuardStats(guard: Entity, attackSpeed: number): void {
+    const zone = zoneAt(guard.pos.z);
+    const regionLevel = zone.levelRange[1];
+    const damage = 8 + regionLevel * 3;
+    guard.level = regionLevel + 3;
+    guard.maxHp = 500 + regionLevel * 120;
+    guard.hp = guard.maxHp;
+    guard.stats.armor = regionLevel * 35;
+    guard.weapon = {
+      min: Math.round(damage * 0.85),
+      max: Math.round(damage * 1.15),
+      speed: attackSpeed,
+    };
+    guard.moveSpeed = Math.max(8, RUN_SPEED);
+  }
+
+  private guardRewardScale(mob: Entity): number {
+    if (mob.kind !== 'mob' || mob.maxHp <= 0 || mob.guardDamageTaken <= 0) return 1;
+    const fraction = mob.guardDamageTaken / mob.maxHp;
+    return fraction > GUARD_REWARD_DENY_FRACTION ? 0 : Math.max(0, 1 - fraction);
+  }
+
+  private updateGuardNpc(guard: Entity): void {
+    const def = NPCS[guard.templateId]?.guard;
+    if (!def || guard.dead) return;
+
+    guard.combatTimer += DT;
+    let target = guard.aggroTargetId !== null ? this.entities.get(guard.aggroTargetId) ?? null : null;
+    if (!target || target.dead || target.kind !== 'mob' || !target.hostile
+      || dist2d(target.pos, guard.spawnPos) > def.leashRadius || !this.isInsideGuardHub(guard, target.pos)) {
+      target = this.findGuardAssistTarget(guard, def.assistRadius);
+      guard.aggroTargetId = target?.id ?? null;
+      if (target) {
+        addThreat(target, guard.id, topThreatValue(target) + 25);
+        target.aggroTargetId = guard.id;
+        target.aiState = 'chase';
+        target.inCombat = true;
+        guard.aiState = 'chase';
+        guard.inCombat = true;
+      }
+    }
+
+    if (!target) {
+      if (dist2d(guard.pos, guard.spawnPos) > 0.5) this.moveToward(guard, guard.spawnPos, guard.moveSpeed);
+      else {
+        guard.aiState = 'idle';
+        guard.inCombat = false;
+        guard.facing = NPCS[guard.templateId]?.facing ?? guard.facing;
+      }
+      return;
+    }
+
+    const d = dist2d(guard.pos, target.pos);
+    if (d > def.leashRadius || dist2d(guard.pos, guard.spawnPos) > def.leashRadius || !this.isInsideGuardHub(guard, target.pos)) {
+      guard.aggroTargetId = null;
+      guard.aiState = 'idle';
+      return;
+    }
+    if (d > MELEE_RANGE * 0.8) {
+      guard.aiState = 'chase';
+      if (!this.isRooted(guard)) this.moveToward(guard, target.pos, guard.moveSpeed * this.moveSpeedMult(guard));
+      return;
+    }
+
+    guard.aiState = 'attack';
+    guard.facing = angleTo(guard.pos, target.pos);
+    guard.swingTimer -= DT;
+    if (guard.swingTimer <= 0) {
+      this.guardSwing(guard, target);
+      guard.swingTimer = def.attackSpeed * this.swingIntervalMult(guard);
+    }
+  }
+
+  private findGuardAssistTarget(guard: Entity, radius: number): Entity | null {
+    let best: Entity | null = null;
+    let bestD2 = radius * radius;
+    this.grid.forEachInRadius(guard.pos.x, guard.pos.z, radius, (m, d2) => {
+      if (m.kind !== 'mob' || m.dead || !m.hostile || m.ownerId !== null) return;
+      if (m.aiState !== 'chase' && m.aiState !== 'attack') return;
+      if (!this.isInsideGuardHub(guard, m.pos)) return;
+      const target = m.aggroTargetId !== null ? this.entities.get(m.aggroTargetId) : null;
+      if (!target || target.kind !== 'player' || target.dead) return;
+      if (d2 < bestD2) { best = m; bestD2 = d2; }
+    });
+    return best;
+  }
+
+  private isInsideGuardHub(guard: Entity, pos: Vec3): boolean {
+    const hub = zoneAt(guard.spawnPos.z).hub;
+    return dist2d(pos, { x: hub.x, y: 0, z: hub.z }) <= hub.radius;
+  }
+
+  private guardSwing(guard: Entity, target: Entity): void {
+    const missChance = meleeMissChance(guard.level, target.level);
+    const roll = this.rng.next();
+    if (roll < missChance) {
+      this.emit({ type: 'damage', sourceId: guard.id, targetId: target.id, amount: 0, crit: false, school: 'physical', ability: null, kind: 'miss' });
+      return;
+    }
+    let dmg = this.rng.range(guard.weapon.min, guard.weapon.max);
+    const crit = this.rng.chance(0.05);
+    if (crit) dmg *= 2;
+    dmg *= 1 - armorReduction(this.effectiveArmor(target), guard.level);
+    this.dealDamage(guard, target, Math.max(1, Math.round(dmg)), crit, 'physical', null, 'hit');
+  }
 
   // When a mob's target dies/leaves it swings to its next-highest-threat
   // attacker; with an empty hate table it falls back to the nearest living
@@ -2437,8 +2560,10 @@ export class Sim {
           this.retargetMob(mob);
           break;
         }
+        const guardTarget = this.isGuardNpc(target) ? target : null;
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
-        if (dist2d(mob.pos, mob.spawnPos) > leash) {
+        if ((guardTarget && !this.isInsideGuardHub(guardTarget, mob.pos))
+          || (!guardTarget && dist2d(mob.pos, mob.spawnPos) > leash)) {
           mob.aiState = 'evade';
           mob.aggroTargetId = null;
           clearThreat(mob);
@@ -2492,6 +2617,7 @@ export class Sim {
           mob.auras = [];
           mob.inCombat = false;
           mob.tappedById = null;
+          mob.guardDamageTaken = 0;
           clearThreat(mob);
           this.despawnSummonedAdds(mob);
           mob.firedSummons = 0;
@@ -2620,6 +2746,7 @@ export class Sim {
     mob.lootable = false;
     mob.loot = null;
     mob.tappedById = null;
+    mob.guardDamageTaken = 0;
     mob.ownerId = null; // a dead pet returns to the wild at its old camp
     mob.hostile = true; // ...and is wild again: a tamed beast must not respawn neutral
     mob.pos = { ...mob.spawnPos };

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -226,6 +226,7 @@ export interface NpcDef {
   // The Merchant: talking to this NPC opens the player-driven World Market
   // (auction house) instead of a fixed vendor stock.
   market?: boolean;
+  guard?: { assistRadius: number; leashRadius: number; attackSpeed: number };
   greeting: string;
 }
 
@@ -424,6 +425,7 @@ export interface Entity {
   // mob AI
   aiState: AiState;
   tappedById: number | null; // first player to damage this mob owns loot/xp/quest credit
+  guardDamageTaken: number; // town-guard damage used to scale or deny mob rewards
   /** Classic-style hate table: attacker entity id (player or pet) -> threat.
    *  Wiped on evade/respawn/death; drives target selection with the 110%
    *  melee / 130% ranged pull-over rules. */

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -3,7 +3,7 @@ import { Sim } from '../src/sim/sim';
 import { applyAction, encodeObs, obsSize, ACTIONS } from '../src/sim/obs';
 import {
   type SimEvent, dist2d, MAX_LEVEL, xpForLevel, mobXpValue, rageConversion, rageFromDealing,
-  spellHitChance, meleeMissChance,
+  spellHitChance, meleeMissChance, type Entity,
 } from '../src/sim/types';
 import { QUESTS, abilitiesKnownAt } from '../src/sim/data';
 import { terrainHeight } from '../src/sim/world';
@@ -22,6 +22,12 @@ function nearestMob(sim: Sim, templateId?: string) {
     if (d < bestD) { bestD = d; best = e; }
   }
   return best;
+}
+
+function npcByTemplate(sim: Sim, templateId: string): Entity {
+  const npc = [...sim.entities.values()].find((e) => e.kind === 'npc' && e.templateId === templateId);
+  expect(npc).toBeTruthy();
+  return npc!;
 }
 
 function teleportTo(sim: Sim, x: number, z: number) {
@@ -118,6 +124,14 @@ describe('world generation', () => {
     expect(objects.length).toBeGreaterThanOrEqual(6);
   });
 
+  it('places an armed Eastbrook guard with the town NPCs', () => {
+    const sim = makeSim('warrior');
+    const guard = npcByTemplate(sim, 'eastbrook_guard');
+    expect(guard.name).toBe('Guard Mira');
+    expect(dist2d(guard.pos, { x: 0, y: 0, z: 0 })).toBeLessThan(26);
+    expect(guard.weapon.min).toBeGreaterThan(1);
+  });
+
   it('terrain is deterministic, town is flat, lake is below water level', () => {
     expect(terrainHeight(10, 10, 42)).toBe(terrainHeight(10, 10, 42));
     expect(Math.abs(terrainHeight(0, 0, 42) - terrainHeight(8, 8, 42))).toBeLessThan(1.5);
@@ -176,6 +190,99 @@ describe('combat', () => {
     expect(wolf.lootable).toBe(true);
     sim.lootCorpse(wolf.id);
     expect(sim.copper).toBeGreaterThan(0);
+  });
+
+  it('Eastbrook guard assists when a hostile mob chases a player into town', () => {
+    const sim = makeSim('warrior');
+    const guard = npcByTemplate(sim, 'eastbrook_guard');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    wolf.maxHp = 500;
+    wolf.hp = 500;
+    teleportTo(sim, guard.pos.x + 10, guard.pos.z);
+    wolf.pos = { x: guard.pos.x + 7, y: guard.pos.y, z: guard.pos.z };
+    wolf.prevPos = { ...wolf.pos };
+    (sim as any).rebucket(wolf);
+    wolf.aiState = 'chase';
+    wolf.aggroTargetId = sim.playerId;
+    wolf.inCombat = true;
+    wolf.threat.set(sim.playerId, 25);
+
+    for (let i = 0; i < 20 * 5 && wolf.aggroTargetId !== guard.id; i++) sim.tick();
+
+    expect(guard.aggroTargetId).toBe(wolf.id);
+    expect(wolf.aggroTargetId).toBe(guard.id);
+    expect(wolf.threat.get(guard.id)).toBeGreaterThan(wolf.threat.get(sim.playerId) ?? 0);
+  });
+
+  it('Eastbrook guard does not extend aggro outside the town boundary', () => {
+    const sim = makeSim('warrior');
+    const guard = npcByTemplate(sim, 'eastbrook_guard');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    teleportTo(sim, 30, 0);
+    wolf.pos = { x: 30, y: sim.player.pos.y, z: 0 };
+    wolf.prevPos = { ...wolf.pos };
+    (sim as any).rebucket(wolf);
+    wolf.aiState = 'chase';
+    wolf.aggroTargetId = sim.playerId;
+    wolf.inCombat = true;
+    wolf.threat.set(sim.playerId, 25);
+
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+
+    expect(guard.aggroTargetId).not.toBe(wolf.id);
+    expect(wolf.threat.has(guard.id)).toBe(false);
+  });
+
+  it('scales mob xp when the Eastbrook guard damages less than half the mob', () => {
+    const sim = makeSim('warrior');
+    const guard = npcByTemplate(sim, 'eastbrook_guard');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    teleportTo(sim, 4, 6);
+    sim.acceptQuest('q_wolves');
+    wolf.level = 1;
+    wolf.maxHp = 100;
+    wolf.hp = 100;
+
+    (sim as any).dealDamage(sim.player, wolf, 60, false, 'physical', null, 'hit', true);
+    (sim as any).dealDamage(guard, wolf, 40, false, 'physical', null, 'hit', true);
+
+    expect(wolf.dead).toBe(true);
+    expect(sim.counters.xpGained).toBe(Math.round(mobXpValue(1, 1) * 0.6));
+    expect(sim.meta(sim.playerId)!.questLog.get('q_wolves')!.counts[0]).toBe(0);
+    expect(wolf.lootable).toBe(true);
+  });
+
+  it('blocks quest item drops from guard-assisted kills', () => {
+    const sim = makeSim('warrior');
+    const meta = sim.meta(sim.playerId)!;
+    const greyjaw = nearestMob(sim, 'old_greyjaw');
+    meta.questLog.set('q_greyjaw', { questId: 'q_greyjaw', counts: [0], state: 'active' });
+    greyjaw.guardDamageTaken = 1;
+
+    (sim as any).rollLoot(greyjaw, meta);
+
+    expect((greyjaw.loot?.items ?? []).some((s: { itemId: string }) => s.itemId === 'greyjaw_fang')).toBe(false);
+  });
+
+  it('denies xp, loot, kills, and quest credit when the Eastbrook guard does most of the damage', () => {
+    const sim = makeSim('warrior');
+    const guard = npcByTemplate(sim, 'eastbrook_guard');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    teleportTo(sim, 4, 6);
+    sim.acceptQuest('q_wolves');
+    wolf.level = 1;
+    wolf.maxHp = 100;
+    wolf.hp = 100;
+
+    (sim as any).dealDamage(sim.player, wolf, 40, false, 'physical', null, 'hit', true);
+    (sim as any).dealDamage(guard, wolf, 60, false, 'physical', null, 'hit', true);
+
+    expect(wolf.dead).toBe(true);
+    expect(sim.counters.xpGained).toBe(0);
+    expect(sim.counters.kills).toBe(0);
+    expect(sim.meta(sim.playerId)!.questLog.get('q_wolves')!.counts[0]).toBe(0);
+    expect(wolf.lootable).toBe(false);
+    expect(wolf.loot).toBeNull();
   });
 
   it('warrior generates rage from combat (vanilla formula scale)', () => {


### PR DESCRIPTION
## Summary
- Adds Guard Mira to Eastbrook as a friendly armed guard who intercepts hostile mobs that chase players into the town hub.
- Keeps the assist radius small and hub-bound so the guard does not extend aggro beyond Eastbrook.
- Tracks guard damage on mobs for anti-abuse rewards: any guard damage blocks kill quest credit and quest-tagged loot, XP scales down while guard damage is at or below 50%, and XP/loot are denied when guard damage exceeds 50%.

## Implementation Notes
- Guard level, health, armor, and weapon damage derive from the zone level range, so the guard role can scale with its region instead of hard-coded Eastbrook damage numbers.
- The shared sim owns guard AI, threat, reward scaling, loot suppression, and quest-credit rules, preserving offline and online parity.
- Guard-intercepted mobs can stay engaged inside the hub instead of immediately evading from their original spawn leash, but they reset if the fight leaves the town boundary.

## Verification
- `npx vitest run tests/sim.test.ts`; 48 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- `npm test`; 35 files passed, 403 tests passed during closeout.
- Targeted headless browser smoke on local Vite at `http://127.0.0.1:5173/`: teleported a chased wolf into Eastbrook near Guard Mira and verified the guard targeted the wolf, the wolf targeted the guard, and guard threat exceeded player threat. Screenshot saved at `tmp/eastbrook_guard_smoke.png`.

## Real behavior proof
- Behavior addressed: beginner-zone players can run into Eastbrook with mobs chasing them and get town-guard assistance without turning the guard into an XP, loot, or quest-credit farming tool.
- Environment tested: local offline sim tests and a local browser session.
- Evidence after fix: guard assistance stays inside the Eastbrook hub, guard damage records on the mob, low guard contribution scales XP while blocking quest credit, high guard contribution denies XP/loot/kills, and quest-tagged loot is suppressed on any guard-assisted kill.
- Not tested: live multiplayer session with multiple players training mobs into town.

## Risk
Gameplay-balance risk is moderate because this changes starter-zone combat and rewards. The guard only assists hostile mobs already chasing a living player inside the town hub, uses a small assist/leash radius, keeps rewards server/sim-authoritative, and blocks quest progress on any guard-damaged kill.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
