### PR TITLE
fix: reject party invites accepted while already in a party

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3310,6 +3310,11 @@ export class Sim {
     const invite = this.partyInvites.get(r.meta.entityId);
     if (!invite || invite.expires < this.time) { this.error(r.meta.entityId, 'The invitation has expired.'); return; }
     this.partyInvites.delete(r.meta.entityId);
+    // A player can hold a stale incoming invite while having since joined or
+    // formed a party of their own (inviting others never consumes one's own
+    // pending invite). Accepting now would add them to a second party's member
+    // list, corrupting the "at most one party" invariant.
+    if (this.partyOf(r.meta.entityId)) { this.error(r.meta.entityId, 'You are already in a party.'); return; }
     const leaderMeta = this.players.get(invite.fromPid);
     if (!leaderMeta) return;
     let party = this.partyOf(invite.fromPid);

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -253,6 +253,30 @@ describe('parties', () => {
     expect(sim.partyOf(a)).toBe(null);
   });
 
+  it('refuses to accept an invite while already in a party', () => {
+    // A player can become a party leader (by inviting someone who accepts)
+    // while still holding an unconsumed incoming invite — inviting someone
+    // never consumes the inviter's own pending invite. Accepting that stale
+    // invite must NOT leave the player a member of two parties at once.
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    const d = sim.addPlayer('mage', 'Dalet');
+    // C invites A while A is solo (stored, unaccepted).
+    sim.partyInvite(a, c);
+    // A forms a party of its own by inviting D, who accepts. A is now leader.
+    sim.partyInvite(d, a);
+    sim.partyAccept(d);
+    expect(sim.partyOf(a)?.leader).toBe(a);
+    const ownParty = sim.partyOf(a)!.id;
+    // A now accepts C's stale invite — this must be rejected.
+    sim.partyAccept(a);
+    // A stays in its own party only; no second membership is created.
+    expect(sim.partyOf(a)?.id).toBe(ownParty);
+    expect(sim.partyOf(c)?.members.includes(a) ?? false).toBe(false);
+    expect(sim.partyOf(a)?.members).toEqual([a, d]);
+  });
+
   it('partyInfo reports per-member combat state for the UI badges', () => {
     const { sim, a, b } = makeDuo();
     // out of combat by default


### PR DESCRIPTION
## Problem

The invariant *"a player belongs to at most one party"* is enforced at **invite** time — `partyInvite` rejects a target who is already in a party — but **not** at **accept** time.

Because party invites are keyed by **invitee**, inviting other players never consumes your *own* incoming invite. This makes the following sequence reachable:

1. **C** invites **A** while A is solo → invite stored for A.
2. **A** invites **D**; D accepts → A is now the **leader** of its own party `[A, D]`. A's incoming invite from C is still pending.
3. **A** accepts C's stale invite.

At step 3, `partyAccept` adds A to C's party member list and repoints `partyByPid[A]` to C's party, while A remains in its original party's `members` array. A is now double-membered: party broadcasts, loot/threat crediting (`partyOf`), and disband-at-1 logic all desync.

## Fix

`partyAccept` now checks whether the accepting player is already in a party and rejects with *"You are already in a party."* — mirroring the guard `partyInvite` already applies to invite targets.

```ts
if (this.partyOf(r.meta.entityId)) { this.error(r.meta.entityId, 'You are already in a party.'); return; }
```

## Test

Added a regression test in `tests/social.test.ts` reproducing the exact 3-step path. It fails before the fix (player ends up in two parties) and passes after. Full social/sim/threat/interactions suites remain green (132 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)