### PR TITLE
fix: reject renaming a character while it is online

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -215,8 +215,17 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const name = normalizeCharName(body.name);
       if (name === null) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
       if (offensiveName(name)) return json(res, 400, { error: 'character name is not allowed' });
+      const characterId = Number(renameMatch[1]);
+      // A rename mutates the DB name and clears force_rename, but a live
+      // ClientSession keeps its own copy of the name (used by reports, chat and
+      // /api/status). Renaming an online character desyncs that copy and — worse
+      // — lets a force-renamed player already in the world clear the moderation
+      // flag without ever leaving. Mirror the DELETE guard and require offline.
+      if ([...game.clients.values()].some((s) => s.characterId === characterId)) {
+        return json(res, 400, { error: 'character is currently online' });
+      }
       try {
-        const c = await renameCharacter(accountId, Number(renameMatch[1]), name);
+        const c = await renameCharacter(accountId, characterId, name);
         if (!c) return json(res, 404, { error: 'character not found' });
         return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
       } catch (err: any) {


### PR DESCRIPTION
## Problem

The `DELETE /api/characters/:id` handler refuses to act on a character that is currently online:

```ts
if ([...game.clients.values()].some((s) => s.characterId === characterId)) {
  return json(res, 400, { error: 'character is currently online' });
}
```

The `POST /api/characters/:id/rename` handler had **no equivalent guard**. `renameCharacter()` updates the DB `name` and clears `force_rename`, but a live `ClientSession` keeps its own copy of the name (used by player reports, chat, and `/api/status`).

So renaming an online character:

- **Desyncs identity** — the live session still announces the old name while the DB/leaderboard show the new one, breaking report-by-name and `/api/status` lookups for that player.
- **Bypasses moderation** — `force_rename` is meant to block world entry until a flagged player renames. A force-renamed player who is *already in the world* (the flag only gates new joins) can call the rename API, which sets `force_rename = FALSE`, clearing the moderation flag without ever disconnecting.

## Fix

Mirror the existing delete-handler guard: return `400 "character is currently online"` when a live session is bound to the character id, before mutating the DB.

## Testing

- `npx tsc --noEmit` clean, `npm run build:server` succeeds.
- Full suite: **389 tests pass** (the one unrelated `homepage_foundation` failure is purely a missing `DATABASE_URL` env var and passes once it is set — independent of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)