### PR TITLE
feat: add starter-zone elite boss "Diremaw the Blighted" (#112)

### DIFF
--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -81,6 +81,15 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     id: 'greyjaw_pelt_cloak', name: "Greyjaw's Pelt Leggings", kind: 'armor', slot: 'legs', quality: 'uncommon',
     stats: { armor: 35, sta: 1, agi: 1 }, sellValue: 110,
   },
+  // --- Diremaw (starter elite boss, #112) drops; usable by any class ---
+  diremaw_hide: {
+    id: 'diremaw_hide', name: "Diremaw's Tainted Hide", kind: 'armor', slot: 'chest', quality: 'uncommon',
+    stats: { armor: 78, sta: 3 }, sellValue: 160,
+  },
+  blightfang_cleaver: {
+    id: 'blightfang_cleaver', name: 'Blightfang Cleaver', kind: 'weapon', slot: 'mainhand', quality: 'rare',
+    weapon: { min: 8, max: 14, speed: 2.5 }, stats: { str: 3, sta: 2 }, sellValue: 600,
+  },
   // --- food & drink (vendor) ---
   baked_bread: {
     id: 'baked_bread', name: 'Freshly Baked Bread', kind: 'food', quality: 'common',

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -23,6 +23,7 @@ export const ZONE1_ZONE: ZoneDef = {
   pois: [
     { x: 0, z: -3, label: 'Eastbrook' },
     { x: -2, z: 70, label: 'Wolf Run' },
+    { x: 35, z: 120, label: 'Blighted Hollow' },
     { x: 65, z: 0, label: 'Boar Meadow' },
     { x: -88, z: 82, label: 'Mirror Lake' },
     { x: -60, z: 4, label: 'Webwood' },
@@ -138,6 +139,32 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'quilted_trousers', chance: 0.5 },
     ],
     scale: 1.25, color: 0x6c3483,
+  },
+  // #112 — the starter zone's notorious elite (a Hogger homage). Calls its pack
+  // for aid at half health, then enrages near death. Tuned as a 2-3 player pull.
+  diremaw: {
+    id: 'diremaw', name: 'Diremaw the Blighted', minLevel: 8, maxLevel: 8, family: 'beast',
+    elite: true, boss: true, rare: true,
+    hpBase: 70, hpPerLevel: 20, dmgBase: 7, dmgPerLevel: 2.2, attackSpeed: 2.2,
+    armorPerLevel: 22, moveSpeed: 8, aggroRadius: 14,
+    summonAdds: { mobId: 'blighted_packling', count: 2, atHpPct: [0.5] },
+    enrage: { belowHpPct: 0.3, dmgMult: 1.4 },
+    loot: [
+      { copper: 320, chance: 1 },
+      { itemId: 'wolf_fang', chance: 1 },
+      { itemId: 'diremaw_hide', chance: 0.6 },
+      { itemId: 'blightfang_cleaver', chance: 0.35 },
+    ],
+    scale: 1.45, color: 0x4a5a3a,
+  },
+  // Diremaw's summoned pack — level-appropriate so the add phase is a real
+  // threat. Adds never drop loot.
+  blighted_packling: {
+    id: 'blighted_packling', name: 'Blighted Packling', minLevel: 7, maxLevel: 7, family: 'beast',
+    hpBase: 42, hpPerLevel: 14, dmgBase: 5, dmgPerLevel: 1.8, attackSpeed: 2.0,
+    armorPerLevel: 14, moveSpeed: 8.5, aggroRadius: 10,
+    loot: [],
+    scale: 0.95, color: 0x5a6a4a,
   },
 };
 
@@ -401,6 +428,8 @@ export const ZONE1_CAMPS: CampDef[] = [
   { mobId: 'forest_wolf', center: { x: -15, z: 55 }, radius: 22, count: 7 },
   { mobId: 'forest_wolf', center: { x: 20, z: 70 }, radius: 20, count: 6 },
   { mobId: 'old_greyjaw', center: { x: 0, z: 95 }, radius: 8, count: 1 },
+  // Elite boss: Blighted Hollow, deep in the north woods past the wolf runs
+  { mobId: 'diremaw', center: { x: 35, z: 120 }, radius: 2, count: 1 },
   // Boars: east meadow
   { mobId: 'wild_boar', center: { x: 55, z: 12 }, radius: 22, count: 6 },
   { mobId: 'wild_boar', center: { x: 80, z: -15 }, radius: 18, count: 5 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2364,6 +2364,14 @@ export class Sim {
     if (mob.dead) {
       mob.corpseTimer -= DT;
       mob.respawnTimer -= DT;
+      // summoned boss adds are temporary: remove them when their corpse fades
+      // instead of respawning like a normal overworld mob (else a killed add
+      // wave would return ~respawnSeconds later even though its threshold fired
+      // only once).
+      if (mob.summoned) {
+        if (mob.corpseTimer <= 0) this.dropEntity(mob.id);
+        return;
+      }
       // dungeon mobs stay dead until the instance resets
       const isInstanceMob = mob.spawnPos.x > DUNGEON_X_THRESHOLD;
       if (!isInstanceMob && mob.respawnTimer <= 0 && (mob.corpseTimer <= 0 || !mob.lootable)) {
@@ -2644,7 +2652,9 @@ export class Sim {
 
   // Encounter reset: remove the adds a boss summoned this pull so retries
   // start clean (firedSummons re-fires a fresh wave per pull). Player
-  // target/combo refs are cleared first, like freeInstance does.
+  // target/combo refs are cleared first, like freeInstance does. Called on
+  // evade and respawn — NOT on boss death: a slain boss's adds intentionally
+  // keep fighting and drop when killed (or are swept here on the next respawn).
   private despawnSummonedAdds(boss: Entity): void {
     if (boss.summonedIds.length === 0) return;
     for (const id of boss.summonedIds) {
@@ -2699,6 +2709,7 @@ export class Sim {
       const level = this.rng.int(template.minLevel, template.maxLevel);
       const add = createMob(this.nextId++, template, level, pos);
       add.spawnPos = { ...boss.spawnPos }; // leashes with the boss; stays dead in instances
+      add.summoned = true; // temporary — never respawns once killed (see updateMob)
       add.tappedById = boss.tappedById;
       this.addEntity(add);
       boss.summonedIds.push(add.id);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -435,6 +435,7 @@ export interface Entity {
   pulseTimer: number; // boss aoe pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
+  summoned?: boolean; // a temporary boss add — never respawns; removed when its corpse fades
   enraged: boolean; // enrage mechanic active
   spawnPos: Vec3;
   wanderTarget: Vec3 | null;

--- a/tests/diremaw.test.ts
+++ b/tests/diremaw.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS, ITEMS } from '../src/sim/data';
+import type { Entity } from '../src/sim/types';
+
+// #112 — a level-8 elite boss in the starter zone (Hogger homage): it calls its
+// pack for aid at half health and enrages near death.
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function findBoss(sim: Sim): Entity {
+  const boss = [...sim.entities.values()].find((e) => e.templateId === 'diremaw');
+  if (!boss) throw new Error('Diremaw is not spawned in the overworld');
+  return boss;
+}
+
+function livePacklings(sim: Sim): number {
+  return [...sim.entities.values()].filter((e) => e.templateId === 'blighted_packling' && !e.dead).length;
+}
+
+describe('Diremaw the Blighted (#112 starter elite boss)', () => {
+  it('spawns as a level-8 elite/boss with its encounter mechanics', () => {
+    const sim = makeWorld();
+    const boss = findBoss(sim);
+    const t = MOBS['diremaw'];
+    expect(boss.level).toBe(8);
+    expect(t.elite).toBe(true);
+    expect(t.boss).toBe(true);
+    expect(t.summonAdds?.mobId).toBe('blighted_packling');
+    expect(t.enrage?.belowHpPct).toBe(0.3);
+    // elite scaling is 2.3x of (hpBase + hpPerLevel*(level-1))
+    expect(boss.maxHp).toBe(Math.round((t.hpBase + t.hpPerLevel * 7) * 2.3));
+  });
+
+  it('calls its pack for aid at half health', () => {
+    const sim = makeWorld();
+    const boss = findBoss(sim);
+    expect(livePacklings(sim)).toBe(0);
+    boss.inCombat = true;
+    boss.hp = Math.floor(boss.maxHp * 0.5);
+    sim.tick();
+    expect(boss.firedSummons).toBeGreaterThan(0);
+    expect(livePacklings(sim)).toBe(MOBS['diremaw'].summonAdds!.count);
+  });
+
+  it('enrages below 30% health', () => {
+    const sim = makeWorld();
+    const boss = findBoss(sim);
+    expect(boss.enraged).toBe(false);
+    boss.inCombat = true;
+    boss.hp = Math.floor(boss.maxHp * 0.25);
+    sim.tick();
+    expect(boss.enraged).toBe(true);
+  });
+
+  it('summons a level-appropriate pack (a real threat, not trivial low-level adds)', () => {
+    const add = MOBS['blighted_packling'];
+    expect(add).toBeTruthy();
+    expect(add.minLevel).toBeGreaterThanOrEqual(6);
+  });
+
+  it('does not respawn killed summoned adds (overworld add cleanup)', () => {
+    const sim = makeWorld();
+    const boss = findBoss(sim);
+    boss.inCombat = true;
+    boss.hp = Math.floor(boss.maxHp * 0.5);
+    sim.tick(); // summons the pack
+    const adds = [...sim.entities.values()].filter((e) => e.templateId === 'blighted_packling');
+    expect(adds.length).toBe(2);
+    expect(adds.every((a) => a.summoned)).toBe(true);
+    // kill the pack and expire their corpses
+    for (const a of adds) { a.dead = true; a.aiState = 'dead'; a.corpseTimer = 0; a.respawnTimer = 0; }
+    for (let i = 0; i < 5; i++) sim.tick();
+    // they are removed, NOT respawned like a normal overworld mob
+    expect(livePacklings(sim)).toBe(0);
+    expect([...sim.entities.values()].filter((e) => e.templateId === 'blighted_packling').length).toBe(0);
+  });
+
+  it('drops coin plus an uncommon and a rare reward that exist in the item table', () => {
+    const loot = MOBS['diremaw'].loot;
+    expect(loot.some((l) => (l.copper ?? 0) > 0)).toBe(true);
+    const itemIds = loot.map((l) => l.itemId).filter(Boolean) as string[];
+    expect(itemIds).toContain('diremaw_hide');
+    expect(itemIds).toContain('blightfang_cleaver');
+    expect(ITEMS['diremaw_hide']?.quality).toBe('uncommon');
+    expect(ITEMS['blightfang_cleaver']?.quality).toBe('rare');
+  });
+});


### PR DESCRIPTION
Closes #112.

Adds **Diremaw the Blighted**, a level-8 elite boss in Eastbrook Vale — a homage to the classic "notorious early-zone elite" (Hogger), tuned as a 2-3 player social challenge.

## The encounter
- Lives at a new **Blighted Hollow** POI in the north woods, past the wolf runs (fixed spawn, `radius:2 count:1`, mapped so placement is clear).
- **Calls its pack for aid at 50% HP** — summons 2 level-7 Blighted Packlings (a real threat, not trivial low-level adds).
- **Enrages below 30% HP** (×1.4 damage).
- `elite` (≈483 HP) + `boss` + `rare` (4× respawn timer, for the named-world-boss feel).
- **Rewards:** coin + a green chest (*Diremaw's Tainted Hide*) and a blue weapon (*Blightfang Cleaver*), tuned just under the Hollow Crypt (L10) blues; usable by any class.

## Implementation
Mechanics are **data-driven** — `summonAdds` + `enrage` on the `MobTemplate` are read generically by the sim (`updateBossMechanics`/`mobSwing`), so the boss itself is pure content (`zone1.ts` templates + camp + POI, `items.ts` rewards).

**One small engine addition** was needed: this is the first *overworld* `summonAdds` user. Overworld mobs respawn (dungeon adds despawn with their instance), so without a guard a killed add wave would respawn ~`respawnSeconds` later even though its threshold fired once. Added an optional `Entity.summoned` flag (set in `spawnBossAdds`) — a dead summoned add now drops when its corpse fades instead of respawning. Dungeon adds are unaffected (they were already exempt via the instance check; the evade-despawn reset path is untouched).

## Files
- `src/sim/content/zone1.ts` — `diremaw` + `blighted_packling` templates, the camp, the POI.
- `src/sim/content/items.ts` — `diremaw_hide`, `blightfang_cleaver`.
- `src/sim/sim.ts` + `src/sim/types.ts` — the `summoned`-add cleanup.
- `tests/diremaw.test.ts` — new.

## Verification
- **`npm test`** — full suite green; 6 new tests: spawns as a level-8 elite with correct 2.3× HP scaling, calls its pack at 50% HP, enrages below 30%, the pack is level-appropriate, killed adds **do not respawn**, and the rewards resolve in the item table.
- `tsc --noEmit` clean; `npm run build`, `build:server`, `build:env` all pass.
- Reviewed by **Codex (GPT-5.5)** — caught the overworld-add respawn issue (fixed above) — and a second **independent review** confirmed the fix correct (map-mutation-safe, no dungeon-add regression, no stale-id leak) with no remaining P1s.

## Notes
- **Adds intentionally outlive a slain boss** — they keep fighting after Diremaw dies and drop when killed (or are swept on the boss's next respawn); documented at `despawnSummonedAdds`. Yanking actively-fighting adds the instant the boss died felt worse.
- A reviewer suggested an extra dungeon-add death regression test; the existing Vael/Velkhar instance tests already pass (the real regression guard), so I left it out as disproportionate scaffolding for a verified-safe path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
