### PR TITLE
fix: clear opponent debuffs when a duel ends so DoTs can't kill the loser

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3475,6 +3475,23 @@ export class Sim {
     }
   }
 
+  // Drop every aura on `target` that was applied by `sourceId` (e.g. an
+  // opponent's lingering DoT/CC), emitting the fade events the client expects.
+  private clearAurasFromSource(target: Entity, sourceId: number): void {
+    let statsDirty = false;
+    for (let i = target.auras.length - 1; i >= 0; i--) {
+      const a = target.auras[i];
+      if (a.sourceId !== sourceId) continue;
+      target.auras.splice(i, 1);
+      this.emit({ type: 'aura', targetId: target.id, name: a.name, gained: false });
+      if (a.kind.startsWith('buff') || a.kind.startsWith('form')) statsDirty = true;
+    }
+    if (statsDirty && target.kind === 'player') {
+      const meta = this.players.get(target.id);
+      if (meta) recalcPlayerStats(target, meta.cls, meta.equipment);
+    }
+  }
+
   // winnerPid null = draw/cancelled
   private endDuel(duel: DuelState, winnerPid: number | null): void {
     this.duels.delete(duel.a);
@@ -3489,6 +3506,12 @@ export class Sim {
         e.autoAttack = false;
       }
     }
+    // A duel is non-lethal: damage from the opponent is capped at 1 HP only
+    // while the duel is live (see dealDamage). Strip the debuffs each fighter
+    // applied to the other so a leftover DoT can't tick the loser to a real
+    // death moments after the bout ends.
+    if (ea) this.clearAurasFromSource(ea, duel.b);
+    if (eb) this.clearAurasFromSource(eb, duel.a);
     if (winnerPid !== null && aMeta && bMeta) {
       const winner = winnerPid === duel.a ? aMeta : bMeta;
       const loser = winnerPid === duel.a ? bMeta : aMeta;

--- a/tests/duel.test.ts
+++ b/tests/duel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+import type { Aura } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+  (sim as any).rebucket(e);
+}
+
+// Start an accepted duel between two adjacent players and run the countdown
+// out so the bout is live.
+function startedDuel(): { sim: Sim; a: number; b: number } {
+  const sim = makeWorld();
+  const a = sim.addPlayer('warrior', 'Aleph');
+  const b = sim.addPlayer('mage', 'Bet');
+  teleport(sim, a, 0, -40);
+  teleport(sim, b, 4, -40);
+  sim.duelRequest(b, a);
+  sim.duelAccept(b);
+  // run the 3s countdown (TICK_RATE = 20) to flip the duel to 'active'
+  for (let i = 0; i < 20 * 4; i++) {
+    sim.tick();
+    const d = (sim as any).duels.get(a);
+    if (d && d.state === 'active') break;
+  }
+  return { sim, a, b };
+}
+
+// A bleed/poison style damage-over-time applied by the opponent.
+function opponentDot(sourceId: number): Aura {
+  return {
+    id: 'test_bleed', name: 'Test Bleed', kind: 'dot',
+    remaining: 10, duration: 10, value: 40,
+    tickInterval: 1, tickTimer: 1,
+    sourceId, school: 'physical',
+  } as Aura;
+}
+
+describe('duel: non-lethal cleanup', () => {
+  it('a lingering opponent DoT does not kill the loser after the duel ends', () => {
+    const { sim, a, b } = startedDuel();
+    const ea = sim.entities.get(a)!;
+    const eb = sim.entities.get(b)!;
+    expect((sim as any).duels.get(a)?.state).toBe('active');
+
+    // Aleph puts a strong bleed on Bet, then lands the finishing blow. The
+    // 1-HP duel guard fires, the duel ends, Bet survives at 1 HP.
+    (sim as any).applyAura(eb, opponentDot(ea.id));
+    (sim as any).dealDamage(ea, eb, eb.hp + 1000, false, 'physical', 'Finisher', 'hit');
+
+    expect((sim as any).duels.has(b)).toBe(false); // duel is over
+    expect(eb.dead).toBe(false);
+    expect(eb.hp).toBe(1);
+
+    // Run a few seconds so the leftover bleed ticks several times.
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+
+    // The duel was non-lethal — the opponent's leftover DoT must not have
+    // killed Bet for real after the bout ended.
+    expect(eb.dead).toBe(false);
+    expect(eb.hp).toBeGreaterThanOrEqual(1);
+  });
+
+  it('a lingering DoT does not kill a player who forfeits by running away', () => {
+    const { sim, a, b } = startedDuel();
+    const ea = sim.entities.get(a)!;
+    const eb = sim.entities.get(b)!;
+
+    (sim as any).applyAura(eb, opponentDot(ea.id));
+    eb.hp = 30; // wounded but alive
+
+    // Bet flees past the forfeit distance, ending the duel as a draw.
+    teleport(sim, b, 400, -40);
+    sim.tick();
+    expect((sim as any).duels.has(b)).toBe(false);
+
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    expect(eb.dead).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Duels are supposed to be **non-lethal**. In `dealDamage`, a fighter is capped at 1 HP and the duel is yielded instead of letting them die:

```ts
// duels end at 1 hp — nobody dies
const duel = target.kind === 'player' ? this.duels.get(target.id) : undefined;
if (duel && duel.state === 'active' && source && (source.id === duel.a || source.id === duel.b)) {
  if (target.hp - amount < 1) { amount = Math.max(0, target.hp - 1); target.hp = 1; ... this.endDuel(duel, source.id); return; }
}
```

But that guard only fires **while the duel is still in `this.duels`**. `endDuel` removed the session without clearing the auras the opponent had applied. So a lingering damage-over-time debuff (bleed/poison) keeps ticking, and on its **next tick** — now that the duel is gone — it falls through to the normal lethal path:

```ts
target.hp = Math.max(0, target.hp - amount); // → 0 → real death
```

### Repro
1. Duel goes active. Player A puts a DoT on player B.
2. A lands the finishing blow → 1-HP guard fires, duel ends, B survives at 1 HP.
3. Next tick, B's leftover bleed ticks → B dies **for real**, taking death penalties, right after a "non-lethal" duel.

The same happens when a wounded player **forfeits by running away** (`endDuel(duel, null)`): the opponent's DoT keeps ticking and can kill them after the bout is already over.

## Fix

`endArenaMatch` already wipes auras (`e.auras = []`) for exactly this reason — `endDuel` never got the equivalent cleanup. This PR strips the auras **sourced from the opponent** off both fighters when a duel ends (1-HP defeat, forfeit-by-distance, or expiry), via a small `clearAurasFromSource` helper that also emits the aura-fade events and recalcs stats if a buff was removed.

Scoped to opponent-sourced auras (not a blanket `auras = []`) so a duel ending doesn't strip the player's own self-buffs — unlike arena, duels don't teleport/full-heal you afterward.

## Tests

Added `tests/duel.test.ts` with two cases (both fail before the fix, pass after):
- A lingering opponent DoT does not kill the loser after a 1-HP defeat.
- A lingering DoT does not kill a player who forfeits by running away.

Full suite: 391 passing. (`homepage_foundation.test.ts` fails only because `DATABASE_URL` is unset in the sandbox — pre-existing and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)