### PR TITLE
fix: make character name uniqueness case-insensitive (#137)

### DIFF
--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -17,7 +17,23 @@ CREATE INDEX IF NOT EXISTS characters_realm ON characters(realm);
 -- global unique on characters.name to a (realm, name) composite. This is a
 -- constraint relaxation, so existing globally-unique rows always satisfy it.
 ALTER TABLE characters DROP CONSTRAINT IF EXISTS characters_name_key;
-CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_name ON characters(realm, name);
+-- Uniqueness must be CASE-INSENSITIVE to match every name lookup, which folds
+-- with lower() (findCharacterByName, report-target resolution, /who search).
+-- A verbatim (realm, name) unique index let 'Bob' and 'bob' coexist, making
+-- those lookups ambiguous/non-deterministic. Fold the unique index too so the
+-- DB rejects case-collisions (creation relies on the 23505 -> 409 path).
+-- Dedupe any pre-existing case-collisions first (keep the lowest id, suffix the
+-- rest) so the unique index can be built on legacy data.
+UPDATE characters c SET name = c.name || '_' || c.id
+WHERE EXISTS (
+  SELECT 1 FROM characters o
+  WHERE o.realm = c.realm AND lower(o.name) = lower(c.name) AND o.id < c.id
+);
+DROP INDEX IF EXISTS characters_realm_name;
+CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_lower_name
+  ON characters(realm, lower(name));
+-- Kept for prefix typeahead (LIKE 'abc%'); the unique btree above can't serve
+-- text_pattern_ops range scans, so this is not redundant with it.
 CREATE INDEX IF NOT EXISTS characters_realm_lower_name_prefix
   ON characters (realm, lower(name) text_pattern_ops);
 

--- a/tests/db_search.test.ts
+++ b/tests/db_search.test.ts
@@ -24,6 +24,17 @@ describe('character typeahead search', () => {
     expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name) text_pattern_ops)');
   });
 
+  it('enforces case-insensitive name uniqueness to match folded lookups', () => {
+    // The unique index must fold case so the DB rejects 'Bob' vs 'bob'; a
+    // verbatim (realm, name) unique index would let case-collisions coexist and
+    // make report-target / social name resolution ambiguous.
+    expect(SOCIAL_SCHEMA).toContain('CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_lower_name');
+    expect(SOCIAL_SCHEMA).toContain('ON characters(realm, lower(name))');
+    // the old case-sensitive unique index must be dropped, not left behind
+    expect(SOCIAL_SCHEMA).toContain('DROP INDEX IF EXISTS characters_realm_name');
+    expect(SOCIAL_SCHEMA).not.toContain('CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_name ');
+  });
+
   it('uses the lower-name prefix predicate and preserves wildcard escaping', async () => {
     dbMock.query.mockResolvedValueOnce({ rows: [{ name: 'Al%_', cls: 'mage', level: 12 }] });
 


### PR DESCRIPTION
Fixes #137.

## Problem

Character-name uniqueness is enforced **case-sensitively** by a verbatim `(realm, name)` unique index (`server/social_db.ts`), but every name *lookup* folds case with `lower()`:

- `findCharacterByName` — exact case, else case-insensitive `LIMIT 2` (`social_db.ts`)
- report-target resolution — `lower(name) = lower($2) LIMIT 1` (`server/db.ts`)
- `/who` typeahead — `lower(name) LIKE lower($2)` (`server/db.ts`)

So `Bob` and `bob` can both be created in one realm. Then:

1. **Moderation can action the wrong account** — `lower(name) = … LIMIT 1` returns an arbitrary colliding row.
2. **Social actions silently fail** — `resolveName` returns `null` on an ambiguous case-insensitive match, so the colliding name can't be friended/ignored/invited except by exact case.
3. The documented *"names are unique per realm"* invariant is broken.

Creation never catches the dupe because the verbatim index doesn't raise `23505` for a case-only difference, so the existing `409 "that name is taken"` path never fires.

## Fix

Fold the unique index to `(realm, lower(name))`. Now the DB rejects case-collisions on insert — `createCharacter` already maps `23505` → `409`, so creation is corrected for free, and both lookups become unambiguous (at most one row per folded name).

- Pre-existing case-collisions are deduped before the index is built (keep the lowest `id`, suffix the rest with `_<id>`) so it can apply to legacy data.
- The `text_pattern_ops` prefix index is **kept** — a plain unique btree on `lower(name)` can't serve `LIKE 'abc%'` typeahead range scans, so it is not redundant.

## Testing

- Added a schema assertion in `tests/db_search.test.ts` (case-insensitive unique index present, old case-sensitive unique index dropped).
- `vitest` db_search / character_db / social / social_system / report_target suites pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)