### PR TITLE
fix: scale mob armor from level 1 like hp and damage

### DIFF
--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -158,7 +158,9 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   e.hp = e.maxHp;
   const dmg = (template.dmgBase + template.dmgPerLevel * (level - 1)) * dmgMult;
   e.weapon = { min: Math.round(dmg * 0.8), max: Math.round(dmg * 1.25), speed: template.attackSpeed };
-  e.stats.armor = Math.round(template.armorPerLevel * level);
+  // Armor scales from level 1 like hp/dmg above: a template has no armorBase,
+  // so a level-1 mob gets 0 and each level adds armorPerLevel.
+  e.stats.armor = Math.round(template.armorPerLevel * (level - 1));
   e.moveSpeed = template.moveSpeed;
   e.scale = template.scale;
   e.color = template.color;

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -340,6 +340,18 @@ describe('dungeon instance placement and targetability', () => {
   });
 });
 
+describe('mob stat scaling', () => {
+  it('scales armor from level 1 like hp and damage, not one level ahead', () => {
+    const template = MOBS['gray_wolf'] ?? Object.values(MOBS)[0];
+    const lvl1 = createMob(910001, template, 1, { x: 0, y: 0, z: 0 });
+    const lvl10 = createMob(910010, template, 10, { x: 0, y: 0, z: 0 });
+    // A level-1 mob has no level-scaled armor (no armorBase in the template).
+    expect(lvl1.stats.armor).toBe(0);
+    // Each level adds exactly armorPerLevel, matching the (level - 1) convention.
+    expect(lvl10.stats.armor).toBe(Math.round(template.armorPerLevel * 9));
+  });
+});
+
 describe('boss loot and encounter resets', () => {
   it('boss roll groups drop at most one item from each exclusive table', () => {
     const sim = makeSim();


### PR DESCRIPTION
## What

`createMob` in `src/sim/entity.ts` computes mob armor as `armorPerLevel * level`, but mob **hp** and **damage** right above it both scale with `(level - 1)`:

```ts
e.maxHp = Math.round((template.hpBase + template.hpPerLevel * (level - 1)) * hpMult);
const dmg = (template.dmgBase + template.dmgPerLevel * (level - 1)) * dmgMult;
e.stats.armor = Math.round(template.armorPerLevel * level);   // <-- the odd one out
```

The `(level - 1)` convention exists so a level-1 mob equals its template base values. `MobTemplate` has **no `armorBase` field** (unlike players, who carry `baseStats.armor`), so the intended base armor is `0` and the per-level term should scale from level 1.

## Why it's a bug

- Every mob carried **one extra level** of armor.
- Even a **level-1 critter** received a full `armorPerLevel` of mitigation it should not have.
- `e.stats.armor` feeds `armorReduction()` for all physical hits (`src/sim/sim.ts`), so mobs were measurably tankier than designed at every level — a silent, world-wide combat-balance drift.

## Fix

Align armor with the same `(level - 1)` convention used for hp and damage.

## Test

Added a regression test in `tests/fixes.test.ts` (`mob stat scaling`) asserting a level-1 mob has `0` armor and that each level adds exactly `armorPerLevel`. Full suite: 390 tests pass (the unrelated `homepage_foundation` file fails only because it requires `DATABASE_URL` in the environment, independent of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)