### PR TITLE
fix: reject non-finite count in market_list (#146)

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -708,7 +708,7 @@ export class GameServer {
       case 'arena_leave': sim.arenaQueueLeave(pid); break;
       // World Market (the Merchant's auction house)
       case 'market_list':
-        if (typeof msg.item === 'string' && typeof msg.count === 'number' && typeof msg.price === 'number') {
+        if (typeof msg.item === 'string' && Number.isFinite(msg.count) && Number.isFinite(msg.price)) {
           sim.marketList(msg.item, msg.count, msg.price, pid);
         }
         break;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3997,6 +3997,7 @@ export class Sim {
     const def = ITEMS[itemId];
     if (!def) return;
     if (def.kind === 'quest') { this.error(meta.entityId, 'The Merchant will not broker quest items.'); return; }
+    if (!Number.isFinite(count)) { this.error(meta.entityId, 'Name how many you wish to sell.'); return; }
     const want = Math.max(1, Math.floor(count));
     if (this.countItem(itemId, meta.entityId) < want) { this.error(meta.entityId, 'You do not have that many to sell.'); return; }
     const ask = Math.floor(price);

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -183,6 +183,23 @@ describe('the World Market — the Merchant', () => {
     expect(sim.marketInfoFor(seller)).toBeNull(); // not streamed when far
   });
 
+  it('rejects a non-finite count without escrowing goods or listing them', () => {
+    for (const badCount of [NaN, Infinity, -Infinity]) {
+      const sim = makeWorld();
+      const seller = sim.addPlayer('warrior', 'Seller');
+      standAtMerchant(sim, seller);
+      sim.addItem('wolf_fang', 3, seller);
+      sim.events.length = 0;
+
+      sim.marketList('wolf_fang', badCount, 100, seller);
+
+      // an error is surfaced, nothing is escrowed, and no listing is created
+      expect(errorsSince(sim).length).toBeGreaterThan(0);
+      expect(sim.countItem('wolf_fang', seller)).toBe(3); // nothing removed
+      expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+    }
+  });
+
   it('will not broker quest items', () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');


### PR DESCRIPTION
## What & why

`market_list` trusted a client-supplied `count` that was only checked with `typeof msg.count === 'number'` — which passes for `NaN` and `Infinity`. The telling asymmetry: `price` was already guarded with `Number.isFinite(ask)`, but `count` was not.

## The bug (#146)

In `Sim.marketList`, `Math.floor(NaN) === NaN`, so `want = Math.max(1, NaN) = NaN`. The "you do not have that many to sell" guard is then `this.countItem(...) < want` → `x < NaN`, which is **always false**, so the check is bypassed. A listing with `count: NaN` is pushed onto the board and `removeItem` escrows `NaN`, corrupting both the market listings and inventory accounting. Any player near the Merchant could trigger it with `{cmd:'market_list', item:'<owned item>', count: NaN, price: 1}`. High severity.

## The fix

Mirror the existing price guard for count, with defense in depth:

- **`server/game.ts` dispatcher** — replace `typeof msg.count === 'number'` with `Number.isFinite(msg.count)` (and the same for `price`, for consistency), so a non-finite count never reaches the sim.
- **`src/sim/sim.ts` `marketList`** — add `if (!Number.isFinite(count)) { this.error(...); return; }` at the top, *before* `Math.floor`, so the sim is safe even when called directly (RL env, tests, future callers), not just through the dispatcher.

Minimal and surgical — no behavior change for finite counts.

## Test plan

- New case in `tests/market.test.ts` drives `marketList` with `NaN`, `Infinity`, and `-Infinity` on an owned item and asserts: an error is surfaced, no goods are escrowed (count unchanged), and no listing is created. Confirmed **RED** before the fix, **GREEN** after.
- Full verify gate: `npx tsc --noEmit` clean · `npm test` → **390 passed** (the one failing suite, `homepage_foundation`, is a pre-existing `DATABASE_URL`-required env failure, reproduced on unmodified `main` — not a regression) · `npm run build` OK · `npm run build:server` OK.

## Review

Ran a Codex (GPT-5.5) adversarial code review against the diff — it came back clean with no findings, confirming the non-finite rejection happens before escrow and the dispatcher guards don't alter valid-input behavior.

Closes #146