### PR TITLE
fix: close play session when open insert lands after a fast disconnect

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -54,6 +54,7 @@ export interface ClientSession {
   alive: boolean;
   joinedAt: number;
   dbSessionId: number | null; // play_sessions row, set once the insert lands
+  left: boolean; // set in leave(); guards against the open-session insert landing after disconnect
   chatTokens: number;
   chatLastRefill: number;
   chatLastRateError: number;
@@ -406,7 +407,7 @@ export class GameServer {
     }
     const session: ClientSession = {
       ws, accountId, characterId, pid, name,
-      lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
+      lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null, left: false,
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
       blockedIds: new Set(),
@@ -418,7 +419,14 @@ export class GameServer {
     this.sessionsByCharacterId.set(characterId, session);
     this.peakOnline = Math.max(this.peakOnline, this.clients.size);
     openPlaySession(accountId, characterId, name)
-      .then((id) => { session.dbSessionId = id; })
+      .then((id) => {
+        session.dbSessionId = id;
+        // If the player disconnected before this insert landed, leave() saw a
+        // null id and skipped the close. Close it now so the row isn't orphaned.
+        if (session.left) {
+          void closePlaySession(id).catch((err) => console.error('failed to close play session:', err));
+        }
+      })
       .catch((err) => console.error('failed to open play session:', err));
 
     this.send(session, {
@@ -449,6 +457,7 @@ export class GameServer {
 
   async leave(session: ClientSession, reason: string): Promise<void> {
     if (!this.clients.has(session.pid)) return;
+    session.left = true;
     this.clients.delete(session.pid);
     this.sessionsByCharacterId.delete(session.characterId);
     this.social.forget(session.characterId);

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const openPlaySession = vi.fn(async () => 1);
+const closePlaySession = vi.fn(async () => {});
+
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
-  openPlaySession: vi.fn(async () => 1),
-  closePlaySession: vi.fn(async () => {}),
+  openPlaySession: (...args: unknown[]) => openPlaySession(...(args as [])),
+  closePlaySession: (...args: unknown[]) => closePlaySession(...(args as [])),
   insertChatLogs: vi.fn(async () => {}),
 }));
 
@@ -42,5 +45,31 @@ describe('GameServer sessions', () => {
 
     const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
     expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
+  });
+
+  it('closes the play session even when the open insert lands after the player has left', async () => {
+    openPlaySession.mockReset();
+    closePlaySession.mockReset();
+    closePlaySession.mockResolvedValue(undefined);
+
+    // Defer the openPlaySession insert so the player can disconnect first.
+    let resolveOpen!: (id: number) => void;
+    openPlaySession.mockImplementationOnce(
+      () => new Promise<number>((resolve) => { resolveOpen = resolve; }),
+    );
+
+    const server = new GameServer();
+    const session = expectJoined(server.join(fakeWs(), 21, 201, 'Racer', 'warrior', null));
+    expect(session.dbSessionId).toBeNull();
+
+    // Player disconnects before the insert resolves: leave() sees a null id.
+    await server.leave(session, 'test');
+    expect(closePlaySession).not.toHaveBeenCalled();
+
+    // The insert finally lands; the late callback must close the orphaned row.
+    resolveOpen(99);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(closePlaySession).toHaveBeenCalledWith(99);
   });
 });


### PR DESCRIPTION
## Problem

`GameServer.join()` starts the `play_sessions` row asynchronously and fire-and-forgets it:

```ts
openPlaySession(accountId, characterId, name)
  .then((id) => { session.dbSessionId = id; })
  .catch(...);
```

`session.dbSessionId` is only set **after** the insert resolves. If a player disconnects in that window (slow DB, immediate reconnect/flap, a client that drops right after `hello`), `leave()` runs while `dbSessionId` is still `null`:

```ts
if (session.dbSessionId !== null) {
  void closePlaySession(session.dbSessionId)...
}
```

…so `closePlaySession()` is never called. The row is left open (`ended_at = NULL`) until the next server restart's `closeOrphanSessions()` sweep — meaning any live session-duration analytics are skewed by phantom "still online" sessions, and the leak persists for the whole uptime.

## Fix

Track a `left` flag on the session. When the deferred `openPlaySession` insert resolves *after* the player has already left, close the row immediately:

```ts
.then((id) => {
  session.dbSessionId = id;
  if (session.left) {
    void closePlaySession(id).catch(...);
  }
})
```

This keeps `join()` synchronous (no signature change rippling to callers, no DB latency on the hot join path) and is self-healing for the race.

## Test

Added a regression test in `tests/game_sessions.test.ts` that defers the `openPlaySession` insert, leaves before it resolves, then resolves it — asserting `closePlaySession` is ultimately called with the late row id.

Full suite passes (390 tests); `tsc --noEmit` clean. (The `homepage_foundation` test failure is pre-existing and unrelated — it requires `DATABASE_URL` at import time.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)