### PR TITLE
fix: harden wow_env.py IPC against hangs and correct stale action-space docs (#150, #151)

### DIFF
--- a/python/test_wow_env.py
+++ b/python/test_wow_env.py
@@ -1,0 +1,184 @@
+"""Unit tests for the WoWClassicEnv stdio IPC and teardown robustness.
+
+These tests do not need the real Node env bundle. They run a tiny fake server
+(plain Python, stdlib only) that speaks the same newline-delimited JSON protocol
+and can be put into pathological modes (crash mid-episode, hang, ignore close).
+The fake is launched through WoWClassicEnv itself by passing
+``node_binary=sys.executable`` and a generated server script as ``server_path``,
+so the real ``_request`` / ``_readline`` / ``close`` code paths are exercised.
+
+Run (after `pip install gymnasium numpy`):
+    python -m unittest python/test_wow_env.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+from wow_env import WoWClassicEnv  # noqa: E402
+
+# A stdlib-only NDJSON server. ``__MODE__`` is substituted per scenario.
+FAKE_SERVER = r'''
+import sys, json, time, os
+
+MODE = "__MODE__"
+OBS = [0.0] * 8
+INFO = {"obs_size": 8, "num_actions": 23, "actions": ["noop", "forward", "attack"], "max_level": 20}
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    cmd = msg.get("cmd")
+    if cmd == "info":
+        send(INFO)
+    elif cmd == "reset":
+        send({"obs": OBS, "info": {}})
+    elif cmd == "step":
+        if MODE == "die_on_step":
+            sys.stderr.write("boom: simulated crash in sim.tick()\n")
+            sys.stderr.flush()
+            os._exit(1)
+        elif MODE == "hang_on_step":
+            time.sleep(30)
+            send({"obs": OBS, "reward": 0.0, "terminated": False, "truncated": False, "info": {}})
+        elif MODE == "slow_step":
+            time.sleep(1.0)  # exceeds the test's short request_timeout, then replies
+            send({"obs": OBS, "reward": 1.0, "terminated": False, "truncated": False, "info": {}})
+        elif MODE == "partial_then_hang":
+            sys.stdout.write('{"obs": [0.0, 0.0')  # partial line, never newline-terminated
+            sys.stdout.flush()
+            time.sleep(30)
+        else:
+            send({"obs": OBS, "reward": 1.0, "terminated": False, "truncated": False, "info": {}})
+    elif cmd == "close":
+        if MODE == "stuck_close":
+            continue  # never acknowledge close; the parent must kill us
+        send({"ok": True})
+        break
+'''
+
+_TMPDIRS: list[str] = []
+
+
+def make_fake_env(mode: str, **kwargs) -> WoWClassicEnv:
+    d = tempfile.mkdtemp(prefix="wow_env_test_")
+    _TMPDIRS.append(d)
+    path = os.path.join(d, "fake_server.py")
+    with open(path, "w") as f:
+        f.write(FAKE_SERVER.replace("__MODE__", mode))
+    return WoWClassicEnv(server_path=path, node_binary=sys.executable, **kwargs)
+
+
+def tearDownModule():
+    for d in _TMPDIRS:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+class HappyPathTest(unittest.TestCase):
+    def test_info_reset_step_and_clean_close(self):
+        env = make_fake_env("normal")
+        try:
+            self.assertEqual(env.observation_space.shape, (8,))
+            self.assertEqual(env.action_space.n, 23)
+            obs, info = env.reset(seed=1)
+            self.assertEqual(obs.shape, (8,))
+            obs, reward, terminated, truncated, info = env.step(0)
+            self.assertEqual(reward, 1.0)
+            self.assertFalse(terminated)
+        finally:
+            env.close()
+        # close() is idempotent and leaves the child dead.
+        env.close()
+        self.assertIsNotNone(env._proc.poll())
+
+
+class DeadChildTest(unittest.TestCase):
+    def test_step_on_crashed_child_raises_and_surfaces_stderr(self):
+        env = make_fake_env("die_on_step", request_timeout=5.0)
+        try:
+            env.reset(seed=1)
+            with self.assertRaises(RuntimeError) as cm:
+                env.step(0)
+            # The child's stderr ("boom") must be surfaced, not swallowed.
+            self.assertIn("boom", str(cm.exception))
+        finally:
+            env.close()
+
+
+class HungChildTest(unittest.TestCase):
+    def test_step_times_out_instead_of_blocking_forever(self):
+        env = make_fake_env("hang_on_step", request_timeout=0.5)
+        try:
+            env.reset(seed=1)
+            t0 = time.monotonic()
+            with self.assertRaises(TimeoutError):
+                env.step(0)
+            self.assertLess(time.monotonic() - t0, 5.0)
+        finally:
+            env.close()
+
+
+class StuckCloseTest(unittest.TestCase):
+    def test_close_kills_a_child_that_ignores_close(self):
+        env = make_fake_env("stuck_close", request_timeout=0.5)
+        env.reset(seed=1)
+        env.step(0)
+        # Must neither raise nor hang even though the child never acks close.
+        env.close()
+        self.assertIsNotNone(env._proc.poll())
+        self.assertTrue(env._proc.stdin.closed)
+        self.assertTrue(env._proc.stdout.closed)
+
+
+class TimeoutDesyncTest(unittest.TestCase):
+    def test_env_is_unusable_after_a_timeout(self):
+        # A slow (not dead) server's late response must never be read as the
+        # answer to a later call. After a timeout the env is marked unusable.
+        env = make_fake_env("slow_step", request_timeout=0.3)
+        try:
+            env.reset(seed=1)
+            with self.assertRaises(TimeoutError):
+                env.step(0)
+            with self.assertRaises(RuntimeError):
+                env.reset(seed=2)
+            with self.assertRaises(RuntimeError):
+                env.step(0)
+        finally:
+            env.close()
+
+
+class PartialLineStallTest(unittest.TestCase):
+    def test_partial_line_then_stall_still_times_out(self):
+        # A child that writes a partial (un-terminated) line and then stalls
+        # must still trip the timeout -- the deadline covers reading a complete
+        # line, not just the first available byte.
+        env = make_fake_env("partial_then_hang", request_timeout=0.5)
+        try:
+            env.reset(seed=1)
+            t0 = time.monotonic()
+            with self.assertRaises(TimeoutError):
+                env.step(0)
+            self.assertLess(time.monotonic() - t0, 5.0)
+        finally:
+            env.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/wow_env.py
+++ b/python/wow_env.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import subprocess
+import tempfile
+import threading
 from typing import Any
 
 import numpy as np
@@ -39,10 +42,13 @@ class WoWClassicEnv(gym.Env):
     """Single-agent World of Claudecraft environment.
 
     Observation: float32 vector (self, abilities, target, nearby mobs,
-    nearest interactable, quest states). Action: Discrete(23) —
-    movement/turn/strafe/jump, targeting, attack, 10 ability slots,
-    interact, stop, eat/drink. Sizes are content-dependent and queried
-    from the env's `info` cmd at startup — never hardcode them.
+    nearest interactable, quest states). Action: Discrete(44) —
+    movement/turn/strafe/jump, targeting, attack, 31 ability slots (one per ability in the largest class kit),
+    interact, stop, eat/drink. The exact observation/action sizes are
+    content-dependent: they are reported by the server in the ``info``
+    payload and read at runtime, so size policy networks from
+    ``env.observation_space`` / ``env.action_space`` rather than from
+    these docstring values.
     """
 
     metadata = {"render_modes": []}
@@ -57,9 +63,18 @@ class WoWClassicEnv(gym.Env):
         rewards: dict[str, float] | None = None,
         server_path: str | None = None,
         node_binary: str = "node",
+        request_timeout: float | None = 30.0,
     ) -> None:
         super().__init__()
         self.player_class = player_class
+        # Per-request read timeout (seconds). Bounds how long the Python side
+        # will wait for the Node subprocess to answer before raising, so a
+        # crashed-mid-write or hung server can't block training forever. Set
+        # to None to wait indefinitely (the old behaviour).
+        self._request_timeout = request_timeout
+        # Set to a reason string once a request times out or the server dies;
+        # the env is then unusable (a late response would desync the protocol).
+        self._broken: str | None = None
         self._config: dict[str, Any] = {
             "frameSkip": frame_skip,
             "maxSteps": max_steps,
@@ -74,14 +89,26 @@ class WoWClassicEnv(gym.Env):
             raise FileNotFoundError(
                 f"env server bundle not found at {server}. Run `npm run build:env` first."
             )
+        # Capture the child's stderr to a temp file rather than discarding it,
+        # so a crash reason can be surfaced when a request fails. A regular
+        # file (not a PIPE) avoids the deadlock where a full, undrained stderr
+        # pipe blocks the child.
+        self._stderr_file = tempfile.TemporaryFile()
         self._proc = subprocess.Popen(
             [node_binary, server],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=self._stderr_file,
             text=True,
             bufsize=1,
         )
+        # A daemon thread drains stdout into a queue so reads can be bounded by
+        # a wall-clock timeout on every platform (select() does not work on
+        # Windows subprocess pipes) and so the deadline covers reading a
+        # COMPLETE line rather than just the first available byte.
+        self._stdout_q: queue.Queue = queue.Queue()
+        self._reader = threading.Thread(target=self._reader_loop, daemon=True)
+        self._reader.start()
         meta = self._request({"cmd": "info"})
         self._obs_size = int(meta["obs_size"])
         self.action_names: list[str] = list(meta["actions"])
@@ -90,14 +117,96 @@ class WoWClassicEnv(gym.Env):
         self._episode_seed = 0
 
     # ------------------------------------------------------------------
+    def _stderr_tail(self, max_lines: int = 20) -> str:
+        """Return a formatted tail of the child's stderr, for error messages."""
+        f = getattr(self, "_stderr_file", None)
+        if f is None:
+            return ""
+        try:
+            f.flush()
+            f.seek(0)
+            data = f.read()
+        except (ValueError, OSError):
+            return ""
+        text = data.decode("utf-8", errors="replace").strip() if isinstance(data, bytes) else str(data).strip()
+        if not text:
+            return ""
+        lines = text.splitlines()
+        tail = "\n".join(lines[-max_lines:])
+        return f"\n--- env server stderr (last {min(len(lines), max_lines)} lines) ---\n{tail}"
+
+    def _kill(self) -> None:
+        """Force-terminate the child and reap it, ignoring teardown errors."""
+        try:
+            self._proc.kill()
+        except Exception:
+            pass
+        try:
+            self._proc.wait(timeout=5)
+        except Exception:
+            pass
+
+    def _reader_loop(self) -> None:
+        """Forward COMPLETE stdout lines to the queue; enqueue None on EOF.
+
+        ``readline()`` only returns once a newline (or EOF) arrives, so a child
+        that writes a partial line and then stalls leaves the queue empty and
+        trips the read timeout instead of hanging the trainer.
+        """
+        out = self._proc.stdout
+        try:
+            assert out is not None
+            while True:
+                line = out.readline()
+                if line == "":
+                    break  # EOF: the child closed stdout
+                self._stdout_q.put(line)
+        except Exception:
+            pass
+        finally:
+            self._stdout_q.put(None)
+
+    def _readline(self) -> str:
+        """Return one response line, bounded by request_timeout (wall clock).
+
+        Raises a clear error (and kills / marks the env unusable) instead of
+        blocking forever when the child has exited or stopped responding.
+        """
+        try:
+            line = self._stdout_q.get(timeout=self._request_timeout)
+        except queue.Empty:
+            # No complete line within the deadline. If the child has exited,
+            # report that; otherwise it is hung -- and a late response would be
+            # misread as the reply to the NEXT request, desyncing the protocol,
+            # so kill the child and mark the env unusable.
+            code = self._proc.poll()
+            if code is not None:
+                self._broken = f"env server exited (code {code}) before responding"
+                raise RuntimeError(f"{self._broken}{self._stderr_tail()}")
+            self._kill()
+            self._broken = (
+                f"env server did not respond within {self._request_timeout}s; subprocess killed"
+            )
+            raise TimeoutError(f"{self._broken}{self._stderr_tail()}")
+        if line is None:
+            code = self._proc.poll()
+            self._broken = f"env server closed the connection (exit code {code})"
+            raise RuntimeError(f"{self._broken}{self._stderr_tail()}")
+        return line
+
     def _request(self, msg: dict[str, Any]) -> dict[str, Any]:
+        if self._broken is not None:
+            raise RuntimeError(f"env is no longer usable ({self._broken}); create a new env")
         assert self._proc.stdin and self._proc.stdout
-        self._proc.stdin.write(json.dumps(msg) + "\n")
-        self._proc.stdin.flush()
-        line = self._proc.stdout.readline()
-        if not line:
-            raise RuntimeError("env server died")
-        out = json.loads(line)
+        try:
+            self._proc.stdin.write(json.dumps(msg) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, ValueError) as e:
+            code = self._proc.poll()
+            raise RuntimeError(
+                f"env server is not accepting input (exit code {code}){self._stderr_tail()}"
+            ) from e
+        out = json.loads(self._readline())
         if "error" in out:
             raise RuntimeError(f"env server error: {out['error']}")
         return out
@@ -126,12 +235,30 @@ class WoWClassicEnv(gym.Env):
         return obs, float(res["reward"]), bool(res["terminated"]), bool(res["truncated"]), res.get("info", {})
 
     def close(self):
-        if self._proc.poll() is None:
+        proc = getattr(self, "_proc", None)
+        if proc is None:
+            return
+        try:
+            if proc.poll() is None:
+                try:
+                    self._request({"cmd": "close"})
+                except Exception:
+                    pass  # graceful close failed; fall through to wait/kill
+                try:
+                    proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._kill()
+        finally:
+            for stream in (proc.stdin, proc.stdout):
+                try:
+                    if stream is not None:
+                        stream.close()
+                except Exception:
+                    pass
             try:
-                self._request({"cmd": "close"})
+                self._stderr_file.close()
             except Exception:
-                self._proc.kill()
-        self._proc.wait(timeout=5)
+                pass
 
 
 def make_env(**kwargs):


### PR DESCRIPTION
## What

Hardens the Python Gym wrapper `python/wow_env.py` so its stdio IPC can't hang or leak resources during training, and corrects a stale action-space docstring.

Closes #150 — blocking IPC with no read timeout, leaked pipes, discarded stderr
Closes #151 — stale action-space docstring

## #150 — IPC robustness

- **Bounded reads (no more infinite hang).** A daemon thread drains the server's stdout into a queue; `_readline` waits on it with a per-request wall-clock timeout (`request_timeout`, default 30s). A crashed-mid-write, hung, or partial-line-then-stalled subprocess now raises a clear error instead of blocking the trainer forever. Using a thread + queue (rather than `select`) keeps this working on Windows — where `select` doesn't support subprocess pipes — and makes the deadline cover reading a *complete* line, not just the first available byte. Pass `request_timeout=None` to restore the old indefinite wait.
- **No protocol desync.** On a timeout the child is killed and the env marked unusable, so a slow server's late response can never be misread as the reply to the next `reset`/`step`.
- **stderr surfaced.** The child's stderr is captured to a temp file (was `DEVNULL`) and its tail is included in the raised error, so failures are diagnosable. A file (not a PIPE) avoids the undrained-stderr-pipe deadlock.
- **Robust teardown.** `close()` closes stdin/stdout in a `finally`, guards `wait()` with a `kill()` fallback, and is safe to call twice — no FD leaks or teardown exceptions under `AsyncVectorEnv`.

## #151 — docstring

Corrected the class docstring to `Discrete(44)` / 31 ability slots; it read a stale `Discrete(23)` / 10. The action count is `10 fixed actions + ABILITY_SLOTS + 3`, where `ABILITY_SLOTS` is the size of the largest class kit (now 31, the druid) per `src/sim/obs.ts` — so the literal had re-staled after the class-kit expansion. Also added a note to size policy networks from `env.observation_space` / `env.action_space` (read from the server's `info` at runtime) rather than the docstring, so it can't silently re-stale when a class kit changes.

## Tests

New `python/test_wow_env.py` (stdlib `unittest`, no new deps) drives the real `_request` / `_readline` / `close` paths against a fake NDJSON server: happy path, crashed child surfaces stderr, hung child times out, partial-line stall times out, post-timeout env is unusable (no desync), and `close()` kills a child that ignores close. Also verified end-to-end against the real Node bundle (`npm run build:env` + reset/step/close).

## Verification

Rebased onto current `main`. Change is Python-only. The local CI gate — `npm test`, `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, `npm run build` — passes, with the single exception of the `i18n_completeness` `wallet.holderTiers.*` locale check, which fails identically on current `main` (the holder-tier strings aren't yet filled for non-Latin locales) and is unrelated to this Python-only change.
