### PR TITLE
fix: reject friending a player you are already ignoring

### DIFF
--- a/server/social.ts
+++ b/server/social.ts
@@ -204,6 +204,14 @@ export class SocialService {
     const target = await this.resolveTarget(actor, name);
     if (!target) return;
     if (target.id === actor.characterId) { this.err(actor.characterId, 'You cannot befriend yourself.'); return; }
+    // friends and ignore are mutually exclusive — blockAdd drops an ignored
+    // player from your friends, so friendAdd must refuse the reverse, or a
+    // player could end up both ignored and friended at once.
+    const blocks = await this.db.listBlocks(actor.characterId);
+    if (blocks.some((b) => b.id === target.id)) {
+      this.err(actor.characterId, `You are ignoring ${target.name}. Remove them from your ignore list first.`);
+      return;
+    }
     const friends = await this.db.listFriends(actor.characterId);
     if (friends.some((f) => f.id === target.id)) { this.err(actor.characterId, `${target.name} is already your friend.`); return; }
     if (friends.length >= FRIEND_LIMIT) { this.err(actor.characterId, 'Your friends list is full.'); return; }

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -243,6 +243,16 @@ describe('ignore / block', () => {
     await h.svc.blockAdd(h.actor(1), 'Aleph');
     expect(h.tx.errorsFor(1).join()).toMatch(/yourself/i);
   });
+
+  it('refuses to friend a player you are ignoring', async () => {
+    await h.svc.blockAdd(h.actor(1), 'Bet');
+    h.tx.clear();
+    await h.svc.friendAdd(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/ignoring/i);
+    const snap = await h.svc.snapshot(1);
+    expect(snap.friends).toHaveLength(0);
+    expect(snap.blocks.map((b) => b.name)).toEqual(['Bet']);
+  });
 });
 
 describe('guilds', () => {


### PR DESCRIPTION
## Summary
Friends and ignore are meant to be mutually exclusive. `SocialService.blockAdd` enforces this in one direction — it drops the target from your friends list when you ignore them (server/social.ts, *"ignoring someone also drops them from your friends list"*). But `friendAdd` never enforced the reverse.

## The bug
1. Ignore a player → they're removed from friends (correct).
2. `friendAdd` the same player → it never checks the ignore list, so the add succeeds.
3. The character is now **simultaneously ignored and friended**: their chat/whispers stay filtered (still on the ignore list) while they also generate friend come-online/go-offline notices and occupy a friends-list slot.

This is an invariant that was guarded at only one of its two mutation sites.

## Fix
In `friendAdd`, check the actor's ignore list and refuse the add, mirroring WoW's behavior ("You are ignoring X. Remove them from your ignore list first."). Minimal, low-risk, and symmetric with the existing `blockAdd` behavior.

## Test
Added `refuses to friend a player you are already ignoring` to `tests/social_system.test.ts`: after ignoring a player, `friendAdd` errors with an "ignoring" message and the friends list stays empty while the ignore entry remains.

## Verification
- `npx vitest run tests/social_system.test.ts` → 31 passed
- `npx vitest run` → 390 tests passed (the one failing file, `homepage_foundation.test.ts`, fails only because `DATABASE_URL` is unset in the sandbox — unrelated to this change, which touches only `server/social.ts` and its test)
- `npx tsc --noEmit` → passed
- `npm run build:server` → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)