### PR TITLE
Release v0.5: merge moderate gameplay and QoL batch

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -95,6 +95,16 @@
   tr.detail-row > td { background: #0d0d14; padding: 12px 16px; white-space: normal; }
   .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
   .detail-grid h4 { font-family: var(--title-font); color: var(--gold-dim); margin-bottom: 6px; font-size: 13px; }
+  .detail-row button {
+    padding: 4px 8px;
+    background: #1a1410;
+    color: #c9b27a;
+    border: 1px solid #463a1c;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+  }
+  .detail-row button:hover { color: #fff; border-color: var(--gold-dim); }
   @media (max-width: 800px) { .detail-grid { grid-template-columns: 1fr; } }
 
   /* ---------- controls ---------- */
@@ -124,6 +134,24 @@
   }
   .mod-actions button:hover, .mod-account-actions button:hover { color: #fff; border-color: var(--gold-dim); }
   .mod-account-actions input { padding: 6px 8px; background: #11111a; border: 1px solid var(--border); border-radius: 4px; color: var(--text); }
+  .account-admin-controls {
+    align-items: stretch;
+    padding: 10px;
+    background: #090910;
+    border: 1px solid #2a2414;
+    border-radius: 4px;
+  }
+  .account-status {
+    flex: 1 0 100%;
+    color: #c9b27a;
+    font-size: 12px;
+  }
+  .account-status .hint {
+    color: var(--text-dim);
+    margin-left: 8px;
+  }
+  .account-mod-reason { min-width: 300px; flex: 1 1 300px; }
+  .account-custom-expiry { width: 190px; }
   #mod-reason { min-width: 300px; flex: 1 1 300px; }
   #mod-custom-expiry { width: 190px; }
   .mod-confirm { display: none; margin: 10px 0; padding: 10px; border: 1px solid #8a6f2d; border-radius: 4px; background: #171207; }
@@ -133,8 +161,30 @@
   .mod-confirm dt { color: var(--text-dim); }
   .mod-confirm dd { color: var(--text); }
   .mod-confirm .confirm-actions { display: flex; gap: 8px; margin-top: 10px; }
-  .mod-confirm button { padding: 5px 10px; background: #1a1410; color: #c9b27a; border: 1px solid #463a1c; border-radius: 3px; cursor: pointer; }
-  .mod-confirm .danger { border-color: #b34a3a; color: #ff7a5e; }
+  .mod-confirm button {
+    min-width: 78px;
+    padding: 6px 12px;
+    background: linear-gradient(#2a2112, #15100b);
+    color: #e8d8a8;
+    border: 1px solid #6f5a2a;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 12px;
+    line-height: 1.1;
+  }
+  .mod-confirm button:hover { color: #fff; border-color: var(--gold-dim); }
+  .mod-confirm button:focus-visible {
+    outline: 2px solid var(--gold);
+    outline-offset: 2px;
+  }
+  .mod-confirm button[data-confirm-moderation] {
+    color: var(--gold);
+    border-color: var(--gold-dim);
+  }
+  .mod-confirm .danger {
+    border-color: #b34a3a;
+    color: #ff7a5e;
+  }
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -471,6 +471,7 @@
   #spellbook { left: 50%; top: 16%; transform: translateX(-50%); width: 430px; max-height: 64%; overflow-y: auto; }
   .spell-row { display: flex; gap: 10px; padding: 6px; border-radius: 4px; align-items: center; }
   .spell-row:hover { background: #ffffff0e; }
+  .spell-row[draggable="true"] { cursor: grab; }
   .spell-row .spell-name { font-size: 13px; color: #fff; font-family: var(--title-font); }
   .spell-row .spell-sub { font-size: 11px; color: #998d6a; }
   .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;

--- a/index.html
+++ b/index.html
@@ -491,6 +491,8 @@
   .vendor-item:hover { background: #ffffff10; }
   .vendor-item .vi-name { font-size: 12px; flex: 1; }
   .vendor-item .vi-price { font-size: 11px; color: #ddd; }
+  .vendor-section-title { margin-top: 8px; padding-top: 7px; border-top: 1px solid #463a1c; color: var(--gold); font-family: var(--title-font); font-size: 12px; }
+  .vendor-empty { padding: 5px; font-size: 11px; color: #887c5c; }
   .vendor-hint { font-size: 11px; color: #c8b888; margin-top: 8px; border-top: 1px solid #463a1c; padding-top: 6px; }
 
   /* bags */

--- a/index.html
+++ b/index.html
@@ -320,6 +320,8 @@
   .action-btn:active { transform: translateY(1px); }
   .action-btn.empty { background: #0d0d13; cursor: default; box-shadow: inset 0 0 10px #000; }
   .action-btn .keybind { position: absolute; top: 1px; right: 3px; font-size: 9px; color: #ddd; font-family: var(--ui-font); }
+  .action-btn .item-count { position: absolute; right: 3px; bottom: 1px; min-width: 10px; text-align: right;
+    font-size: 10px; color: #fff; font-family: var(--ui-font); font-weight: bold; text-shadow: 1px 1px 2px #000; }
   .action-btn .cdtext { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
     font-size: 17px; color: var(--gold); text-shadow: 1px 1px 2px #000; }
   .action-btn .cd-overlay { position: absolute; left: 0; right: 0; bottom: 0; background: #000d; height: 0%; border-radius: 0 0 4px 4px; }

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -84,10 +84,13 @@ export async function handleAdminApi(
     const accountId = await adminAccountId(req);
     if (accountId === null) return fail(res, 401, 'admin authentication required');
 
-    const actionMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/(suspend|ban)$/.exec(path);
+    const actionMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/(suspend|ban|unban)$/.exec(path);
     if (req.method === 'POST' && actionMatch) {
       const targetAccountId = Number(actionMatch[1]);
-      const action = actionMatch[2] as 'suspend' | 'ban';
+      const action = actionMatch[2] as 'suspend' | 'ban' | 'unban';
+      if (action !== 'unban' && await isAdminAccount(targetAccountId)) {
+        return fail(res, 400, 'admin accounts cannot be suspended or banned');
+      }
       const body = await readBody(req);
       try {
         await moderateAccount({
@@ -97,8 +100,10 @@ export async function handleAdminApi(
           reason: body.reason,
           expiresAt: body.expiresAt,
         });
-        const statusText = action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
-        game.disconnectAccount(targetAccountId, statusText);
+        if (action !== 'unban') {
+          const statusText = action === 'ban' ? 'This account has been banned.' : 'This account is suspended.';
+          game.disconnectAccount(targetAccountId, statusText);
+        }
         return ok(res, { ok: true });
       } catch (err) {
         return fail(res, 400, err instanceof Error ? err.message : 'moderation action failed');

--- a/server/admin_db.ts
+++ b/server/admin_db.ts
@@ -107,6 +107,8 @@ export interface AdminAccountRow {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
   characterCount: number;
   maxLevel: number;
   playtimeSeconds: number;
@@ -125,6 +127,7 @@ export async function listAccounts(search: string, page: number, limit: number):
   const [rows, total] = await Promise.all([
     pool.query(
       `SELECT a.id, a.username, a.created_at, a.last_login, a.is_admin,
+              a.banned_at, a.suspended_until,
               count(c.id)::int AS character_count,
               COALESCE(max(c.level), 0)::int AS max_level,
               COALESCE((SELECT sum(EXTRACT(EPOCH FROM (COALESCE(s.ended_at, now()) - s.started_at)))
@@ -146,6 +149,8 @@ export async function listAccounts(search: string, page: number, limit: number):
       createdAt: r.created_at,
       lastLogin: r.last_login,
       isAdmin: r.is_admin,
+      bannedAt: r.banned_at,
+      suspendedUntil: r.suspended_until,
       characterCount: r.character_count,
       maxLevel: r.max_level,
       playtimeSeconds: Number(r.playtime_seconds),
@@ -226,6 +231,9 @@ export interface AccountDetail {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
+  moderationReason: string;
   playtimeSeconds: number;
   characters: {
     id: number;
@@ -250,7 +258,8 @@ export interface AccountDetail {
 export async function accountDetail(accountId: number): Promise<AccountDetail | null> {
   const [account, characters, sessions] = await Promise.all([
     pool.query(
-      `SELECT id, username, created_at, last_login, is_admin,
+      `SELECT id, username, created_at, last_login, is_admin, banned_at, suspended_until,
+              COALESCE(moderation_reason, '') AS moderation_reason,
               COALESCE((SELECT sum(EXTRACT(EPOCH FROM (COALESCE(s.ended_at, now()) - s.started_at)))
                         FROM play_sessions s WHERE s.account_id = accounts.id), 0)::bigint AS playtime_seconds
        FROM accounts WHERE id = $1`,
@@ -279,6 +288,9 @@ export async function accountDetail(accountId: number): Promise<AccountDetail | 
     createdAt: a.created_at,
     lastLogin: a.last_login,
     isAdmin: a.is_admin,
+    bannedAt: a.banned_at,
+    suspendedUntil: a.suspended_until,
+    moderationReason: a.moderation_reason,
     playtimeSeconds: Number(a.playtime_seconds),
     characters: characters.rows.map((c) => ({
       id: c.id,

--- a/server/game.ts
+++ b/server/game.ts
@@ -36,6 +36,7 @@ const QUARTER_RATE_DIVISOR = 4;
 const WIRE_CACHE_SWEEP_TICKS = 1200;
 const EVENT_RADIUS = 90;
 const AUTOSAVE_SECONDS = 30;
+const SAVE_CONCURRENCY = 4;
 const CHAT_RATE_BURST = 5;
 const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
@@ -285,6 +286,7 @@ export class GameServer {
   private lastWireSweepTick = 0;
   private interval: NodeJS.Timeout | null = null;
   private saveTimer = 0;
+  private saveAllInFlight: Promise<void> | null = null;
   private readonly startedAt = Date.now();
   private peakOnline = 0;
   private tickMsAvg = 0;
@@ -473,9 +475,31 @@ export class GameServer {
   }
 
   async saveAll(reason: string): Promise<void> {
-    for (const session of this.clients.values()) {
-      await this.saveCharacter(session).catch((err) => console.error(`${reason} failed for ${session.name}:`, err));
+    while (this.saveAllInFlight) {
+      const inFlight = this.saveAllInFlight;
+      if (reason !== 'shutdown') return;
+      await inFlight;
     }
+    const run = this.saveAllSnapshot(reason);
+    this.saveAllInFlight = run;
+    try {
+      await run;
+    } finally {
+      if (this.saveAllInFlight === run) this.saveAllInFlight = null;
+    }
+  }
+
+  private async saveAllSnapshot(reason: string): Promise<void> {
+    const sessions = [...this.clients.values()];
+    let next = 0;
+    const worker = async () => {
+      for (;;) {
+        const session = sessions[next++];
+        if (!session) return;
+        await this.saveCharacter(session).catch((err) => console.error(`${reason} failed for ${session.name}:`, err));
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(SAVE_CONCURRENCY, sessions.length) }, worker));
   }
 
   // The World Market is shared global state, persisted as a single JSONB blob.

--- a/server/game.ts
+++ b/server/game.ts
@@ -41,6 +41,7 @@ const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
+const WHO_RESULT_LIMIT = 50;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
 
@@ -62,6 +63,7 @@ export interface ClientSession {
   // character ids this player has ignored; chat from them is dropped before
   // delivery. Loaded from the DB on join, kept in sync by social commands.
   blockedIds: Set<number>;
+  blockListLoaded: boolean;
   // name of the last player to whisper this session, for WoW's /r reply
   lastWhisperFrom: string | null;
   // serialized form of each delta self field as last sent to this client;
@@ -116,6 +118,14 @@ interface WireAura {
   kind: string;
   rem: number;
   dur: number;
+}
+
+interface WhoRosterRow {
+  name: string;
+  cls: string;
+  level: number;
+  zone: string;
+  status: PresenceStatus;
 }
 
 // Identity fields rarely change, so they ride only in "full" records: on an
@@ -410,6 +420,7 @@ export class GameServer {
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
       blockedIds: new Set(),
+      blockListLoaded: false,
       lastWhisperFrom: null,
       lastSent: {},
       sentEnts: new Map(),
@@ -439,6 +450,7 @@ export class GameServer {
   private async initSocial(session: ClientSession): Promise<void> {
     try {
       session.blockedIds = new Set(await this.socialDb.blockedIds(session.characterId));
+      session.blockListLoaded = true;
     } catch (err) {
       console.error('failed to load block list:', err);
     }
@@ -637,6 +649,10 @@ export class GameServer {
         if (typeof msg.text !== 'string') break;
         if (!this.consumeChatToken(session)) break;
         const text = msg.text.trim();
+        if (/^\/who(?:\s|$)/i.test(text)) {
+          this.sendWhoRoster(session);
+          break;
+        }
         // guild and officer chat are persistent + cross-zone, so they live in
         // the server's SocialService rather than the sim (no guild concept)
         const gm = /^\/(?:gu|guild)\s+([\s\S]+)$/i.exec(text);
@@ -1061,6 +1077,60 @@ export class GameServer {
       this.send(session, { t: 'events', list: [{ type: 'error', text: 'You are sending messages too quickly. Slow down.' }] });
     }
     return false;
+  }
+
+  private sendWhoRoster(session: ClientSession): void {
+    if (!session.blockListLoaded) {
+      this.send(session, { t: 'events', list: [{ type: 'error', text: 'Your ignore list is still loading. Try /who again in a moment.' }] });
+      return;
+    }
+    const rows = this.whoRosterFor(session);
+    const total = rows.length;
+    const list: { type: 'log'; text: string; color: string }[] = [{
+      type: 'log',
+      text: `Who: ${total} ${total === 1 ? 'player' : 'players'} online on ${REALM}.`,
+      color: '#7fd4ff',
+    }];
+    for (const row of rows.slice(0, WHO_RESULT_LIMIT)) {
+      const status = row.status === 'online' ? '' : ` (${row.status})`;
+      list.push({
+        type: 'log',
+        text: `${row.name} - level ${row.level} ${row.cls} - ${row.zone}${status}`,
+        color: '#c9b27a',
+      });
+    }
+    if (total > WHO_RESULT_LIMIT) {
+      list.push({
+        type: 'log',
+        text: `...and ${total - WHO_RESULT_LIMIT} more.`,
+        color: '#998d6a',
+      });
+    }
+    this.send(session, { t: 'events', list });
+  }
+
+  private whoRosterFor(viewer: ClientSession): WhoRosterRow[] {
+    const rows: WhoRosterRow[] = [];
+    for (const session of this.clients.values()) {
+      if (!this.canShowInWho(viewer, session)) continue;
+      const e = this.sim.entities.get(session.pid);
+      const meta = this.sim.meta(session.pid);
+      if (!e || !meta) continue;
+      rows.push({
+        name: session.name,
+        cls: meta.cls,
+        level: e.level,
+        ...this.presenceOf(session),
+      });
+    }
+    return rows.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private canShowInWho(viewer: ClientSession, candidate: ClientSession): boolean {
+    if (!candidate.blockListLoaded) return false;
+    if (viewer.blockedIds.has(candidate.characterId)) return false;
+    if (candidate.characterId !== viewer.characterId && candidate.blockedIds.has(viewer.characterId)) return false;
+    return true;
   }
 
   private broadcastSystem(text: string): void {

--- a/server/game.ts
+++ b/server/game.ts
@@ -632,6 +632,7 @@ export class GameServer {
       case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
       case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
       case 'sell': if (typeof msg.item === 'string') sim.sellItem(msg.item, pid); break;
+      case 'buyback': if (typeof msg.item === 'string') sim.buyBackItem(msg.item, pid); break;
       case 'release': sim.releaseSpirit(pid); break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;
@@ -912,6 +913,7 @@ export class GameServer {
       }
     };
     maybe('inv', meta.inventory);
+    maybe('buyback', meta.vendorBuyback);
     maybe('equip', meta.equipment);
     maybe('qlog', [...meta.questLog.values()]);
     maybe('qdone', [...meta.questsDone]);

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -2,7 +2,7 @@ import { pool } from './db';
 
 export const REPORT_REASONS = ['harassment', 'spam', 'cheating', 'offensive_name_or_chat', 'other'] as const;
 export type ReportReason = typeof REPORT_REASONS[number];
-export type ModerationAction = 'ignore' | 'suspend' | 'ban';
+export type ModerationAction = 'ignore' | 'suspend' | 'ban' | 'unban';
 
 const REPORT_DETAILS_MAX = 1000;
 const ACTION_REASON_MAX = 500;
@@ -194,7 +194,7 @@ export async function ignoreReport(reportId: number, adminAccountId: number, not
 export async function moderateAccount(input: {
   accountId: number;
   adminAccountId: number;
-  action: 'suspend' | 'ban';
+  action: 'suspend' | 'ban' | 'unban';
   reason: unknown;
   expiresAt?: unknown;
 }): Promise<void> {
@@ -218,6 +218,13 @@ export async function moderateAccount(input: {
       await client.query(
         `UPDATE accounts
          SET banned_at = now(), suspended_until = NULL, moderation_reason = $2
+         WHERE id = $1`,
+        [input.accountId, reason],
+      );
+    } else if (input.action === 'unban') {
+      await client.query(
+        `UPDATE accounts
+         SET banned_at = NULL, suspended_until = NULL, moderation_reason = $2
          WHERE id = $1`,
         [input.accountId, reason],
       );

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -32,7 +32,7 @@ const charactersState: TableState = { page: 1, search: '', sort: 'level', dir: '
 let liveTimer: number | null = null;
 let activityTimer: number | null = null;
 let activePage: 'overview' | 'moderation' = 'overview';
-let pendingModerationAction: { endpoint: string; body: unknown; accountId: number } | null = null;
+let pendingModerationAction: { endpoint: string; body: unknown; accountId: number; source: 'account' | 'moderation' } | null = null;
 
 // ---------------------------------------------------------------------------
 // Auth flow
@@ -180,10 +180,22 @@ async function toggleAccountDetail(row: HTMLTableRowElement, accountId: number):
     const detail = await apiGet<AccountDetail>(`/admin/api/accounts/${accountId}`);
     const detailRow = document.createElement('tr');
     detailRow.className = 'detail-row';
-    detailRow.innerHTML = `<td colspan="7">${renderAccountDetail(detail)}</td>`;
+    detailRow.innerHTML = `<td colspan="7">${renderAccountDetail(detail, true)}</td>`;
     row.after(detailRow);
   } catch (err) {
     if (!handleAuthFailure(err)) console.error('account detail failed:', err);
+  }
+}
+
+async function refreshOpenAccountDetail(accountId: number): Promise<void> {
+  const row = document.querySelector<HTMLTableRowElement>(`#accounts tr.clickable[data-account-id="${CSS.escape(String(accountId))}"]`);
+  const detailRow = row?.nextElementSibling;
+  if (!row || !detailRow?.classList.contains('detail-row')) return;
+  try {
+    const detail = await apiGet<AccountDetail>(`/admin/api/accounts/${accountId}`);
+    detailRow.innerHTML = `<td colspan="7">${renderAccountDetail(detail, true)}</td>`;
+  } catch (err) {
+    if (!handleAuthFailure(err)) console.error('account detail refresh failed:', err);
   }
 }
 
@@ -203,11 +215,13 @@ function showModerationConfirm(opts: {
   endpoint: string;
   body: unknown;
   accountId: number;
+  source: 'account' | 'moderation';
+  confirmEl: HTMLElement;
   danger?: boolean;
 }): void {
-  pendingModerationAction = { endpoint: opts.endpoint, body: opts.body, accountId: opts.accountId };
-  const el = $('mod-confirm');
-  el.className = 'mod-confirm show';
+  pendingModerationAction = { endpoint: opts.endpoint, body: opts.body, accountId: opts.accountId, source: opts.source };
+  const el = opts.confirmEl;
+  el.className = `mod-confirm show${el.classList.contains('account-mod-confirm') ? ' account-mod-confirm' : ''}`;
   el.innerHTML = `
     <h4>${escapeHtml(opts.title)}</h4>
     <dl>${opts.rows.map((r) => `<dt>${escapeHtml(r.label)}</dt><dd>${escapeHtml(r.value)}</dd>`).join('')}</dl>
@@ -216,6 +230,168 @@ function showModerationConfirm(opts: {
       <button data-cancel-moderation>Cancel</button>
     </div>`;
   el.scrollIntoView({ block: 'nearest' });
+}
+
+function moderationReasonInput(target: HTMLElement): HTMLInputElement | null {
+  const detailRow = target.closest('.detail-row');
+  return (detailRow?.querySelector('.account-mod-reason') as HTMLInputElement | null) ??
+    ($('mod-reason') as HTMLInputElement | null);
+}
+
+function moderationCustomExpiryInput(target: HTMLElement): HTMLInputElement | null {
+  const detailRow = target.closest('.detail-row');
+  return (detailRow?.querySelector('.account-custom-expiry') as HTMLInputElement | null) ??
+    ($('mod-custom-expiry') as HTMLInputElement | null);
+}
+
+function moderationConfirmEl(target: HTMLElement): HTMLElement {
+  const detailRow = target.closest('.detail-row');
+  return (detailRow?.querySelector('.account-mod-confirm') as HTMLElement | null) ?? $('mod-confirm');
+}
+
+async function finishModerationAction(): Promise<void> {
+  const pending = pendingModerationAction;
+  if (!pending) return;
+  await apiPost(pending.endpoint, pending.body);
+  pendingModerationAction = null;
+  void refreshAccounts();
+  void refreshModeration();
+  if (pending.source === 'account' && Number.isFinite(pending.accountId)) {
+    await refreshOpenAccountDetail(pending.accountId);
+  } else {
+    await openModerationAccount(pending.accountId);
+  }
+}
+
+function handleModerationActionClick(e: Event, source: 'account' | 'moderation'): boolean {
+  const target = e.target as HTMLElement;
+  const confirmEl = moderationConfirmEl(target);
+  if (target.closest('[data-cancel-moderation]')) {
+    pendingModerationAction = null;
+    confirmEl.className = `mod-confirm${confirmEl.classList.contains('account-mod-confirm') ? ' account-mod-confirm' : ''}`;
+    confirmEl.innerHTML = '';
+    return true;
+  }
+  if (target.closest('[data-confirm-moderation]')) {
+    void finishModerationAction()
+      .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'moderation action failed'); });
+    return true;
+  }
+  const actionWrap = target.closest('[data-action-account-id]') as HTMLElement | null;
+  const detailWrap = target.closest('.mod-detail') as HTMLElement | null;
+  const accountId = Number((actionWrap ?? detailWrap?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
+  const note = (moderationReasonInput(target)?.value ?? '').trim();
+  const requireNote = (): boolean => {
+    if (note) return true;
+    window.alert('Enter a moderator note / reason first.');
+    return false;
+  };
+  const forceRenameBtn = target.closest('button[data-force-rename-character]') as HTMLButtonElement | null;
+  if (forceRenameBtn) {
+    if (!requireNote()) return true;
+    const characterId = Number(forceRenameBtn.dataset.forceRenameCharacter);
+    const characterName = forceRenameBtn.dataset.characterName ?? `#${characterId}`;
+    showModerationConfirm({
+      title: 'Confirm forced name change',
+      rows: [
+        { label: 'Character', value: characterName },
+        { label: 'Action', value: 'Require player to choose a new character name before entering the world.' },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/characters/${characterId}/force-rename`,
+      body: { reason: note },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  if (!actionWrap) return false;
+  const suspendBtn = target.closest('button[data-suspend-hours]') as HTMLButtonElement | null;
+  if (suspendBtn) {
+    if (!requireNote()) return true;
+    const hours = Number(suspendBtn.dataset.suspendHours);
+    const expiresAt = new Date(Date.now() + hours * 3600 * 1000).toISOString();
+    showModerationConfirm({
+      title: 'Confirm suspension',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Temporary account lockout' },
+        { label: 'Length', value: `${hours} hour${hours === 1 ? '' : 's'}` },
+        { label: 'Until', value: new Date(expiresAt).toLocaleString() },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
+      body: { reason: note, expiresAt },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  const customSuspend = target.closest('button[data-suspend-custom]') as HTMLButtonElement | null;
+  if (customSuspend) {
+    if (!requireNote()) return true;
+    const raw = moderationCustomExpiryInput(target)?.value ?? '';
+    const expiry = raw ? new Date(raw) : null;
+    if (!expiry || !Number.isFinite(expiry.getTime())) {
+      window.alert('Choose a custom suspension expiry.');
+      return true;
+    }
+    showModerationConfirm({
+      title: 'Confirm custom suspension',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Temporary account lockout' },
+        { label: 'Until', value: expiry.toLocaleString() },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
+      body: { reason: note, expiresAt: expiry.toISOString() },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  const banBtn = target.closest('button[data-ban-account]') as HTMLButtonElement | null;
+  if (banBtn) {
+    if (!requireNote()) return true;
+    showModerationConfirm({
+      title: 'Confirm ban',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Permanent account lockout' },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/ban`,
+      body: { reason: note },
+      accountId,
+      source,
+      confirmEl,
+      danger: true,
+    });
+    return true;
+  }
+  const unbanBtn = target.closest('button[data-unban-account]') as HTMLButtonElement | null;
+  if (unbanBtn) {
+    if (!requireNote()) return true;
+    showModerationConfirm({
+      title: 'Confirm unban',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Restore account login access' },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/unban`,
+      body: { reason: note },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -262,7 +438,13 @@ function wireEvents(): void {
   });
 
   $('accounts').addEventListener('click', (e) => {
-    const row = (e.target as HTMLElement).closest('tr.clickable') as HTMLTableRowElement | null;
+    const target = e.target as HTMLElement;
+    const isAccountModClick = target.closest('.account-admin-controls, .account-mod-confirm, button[data-force-rename-character]');
+    if (isAccountModClick && handleModerationActionClick(e, 'account')) {
+      e.stopPropagation();
+      return;
+    }
+    const row = target.closest('tr.clickable') as HTMLTableRowElement | null;
     const accountId = Number(row?.dataset.accountId);
     if (row && Number.isFinite(accountId)) void toggleAccountDetail(row, accountId);
   });
@@ -275,24 +457,6 @@ function wireEvents(): void {
 
   $('moderation-detail').addEventListener('click', (e) => {
     const target = e.target as HTMLElement;
-    if (target.closest('[data-cancel-moderation]')) {
-      pendingModerationAction = null;
-      $('mod-confirm').className = 'mod-confirm';
-      $('mod-confirm').innerHTML = '';
-      return;
-    }
-    if (target.closest('[data-confirm-moderation]')) {
-      const pending = pendingModerationAction;
-      if (!pending) return;
-      void apiPost(pending.endpoint, pending.body)
-        .then(() => {
-          pendingModerationAction = null;
-          void refreshModeration();
-          void openModerationAccount(pending.accountId);
-        })
-        .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'moderation action failed'); });
-      return;
-    }
     const ignoreBtn = target.closest('button[data-ignore-report]') as HTMLButtonElement | null;
     if (ignoreBtn) {
       const reportId = Number(ignoreBtn.dataset.ignoreReport);
@@ -306,93 +470,7 @@ function wireEvents(): void {
         .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'ignore failed'); });
       return;
     }
-    const actionWrap = target.closest('[data-action-account-id]') as HTMLElement | null;
-    const detailWrap = target.closest('.mod-detail') as HTMLElement | null;
-    const accountId = Number((actionWrap ?? detailWrap?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
-    const note = (($('mod-reason') as HTMLInputElement | null)?.value ?? '').trim();
-    const requireNote = (): boolean => {
-      if (note) return true;
-      window.alert('Enter a moderator note / reason first.');
-      return false;
-    };
-    const forceRenameBtn = target.closest('button[data-force-rename-character]') as HTMLButtonElement | null;
-    if (forceRenameBtn) {
-      if (!requireNote()) return;
-      const characterId = Number(forceRenameBtn.dataset.forceRenameCharacter);
-      const characterName = forceRenameBtn.dataset.characterName ?? `#${characterId}`;
-      showModerationConfirm({
-        title: 'Confirm forced name change',
-        rows: [
-          { label: 'Character', value: characterName },
-          { label: 'Action', value: 'Require player to choose a new character name before entering the world.' },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/characters/${characterId}/force-rename`,
-        body: { reason: note },
-        accountId,
-      });
-      return;
-    }
-    if (!actionWrap) return;
-    const suspendBtn = target.closest('button[data-suspend-hours]') as HTMLButtonElement | null;
-    if (suspendBtn) {
-      if (!requireNote()) return;
-      const hours = Number(suspendBtn.dataset.suspendHours);
-      const expiresAt = new Date(Date.now() + hours * 3600 * 1000).toISOString();
-      showModerationConfirm({
-        title: 'Confirm suspension',
-        rows: [
-          { label: 'Account', value: `#${accountId}` },
-          { label: 'Action', value: 'Temporary account lockout' },
-          { label: 'Length', value: `${hours} hour${hours === 1 ? '' : 's'}` },
-          { label: 'Until', value: new Date(expiresAt).toLocaleString() },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
-        body: { reason: note, expiresAt },
-        accountId,
-      });
-      return;
-    }
-    const customSuspend = target.closest('button[data-suspend-custom]') as HTMLButtonElement | null;
-    if (customSuspend) {
-      if (!requireNote()) return;
-      const raw = ($('mod-custom-expiry') as HTMLInputElement).value;
-      const expiry = raw ? new Date(raw) : null;
-      if (!expiry || !Number.isFinite(expiry.getTime())) {
-        window.alert('Choose a custom suspension expiry.');
-        return;
-      }
-      showModerationConfirm({
-        title: 'Confirm custom suspension',
-        rows: [
-          { label: 'Account', value: `#${accountId}` },
-          { label: 'Action', value: 'Temporary account lockout' },
-          { label: 'Until', value: expiry.toLocaleString() },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/accounts/${accountId}/suspend`,
-        body: { reason: note, expiresAt: expiry.toISOString() },
-        accountId,
-      });
-      return;
-    }
-    const banBtn = target.closest('button[data-ban-account]') as HTMLButtonElement | null;
-    if (banBtn) {
-      if (!requireNote()) return;
-      showModerationConfirm({
-        title: 'Confirm ban',
-        rows: [
-          { label: 'Account', value: `#${accountId}` },
-          { label: 'Action', value: 'Permanent account lockout' },
-          { label: 'Reason', value: note },
-        ],
-        endpoint: `/admin/api/moderation/accounts/${accountId}/ban`,
-        body: { reason: note },
-        accountId,
-        danger: true,
-      });
-    }
+    handleModerationActionClick(e, 'moderation');
   });
 
   $('characters').addEventListener('click', (e) => {

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -33,7 +33,7 @@ export function renderAccountsTable(rows: AccountRow[]): string {
   const body = rows.map((a) => `
     <tr class="clickable" data-account-id="${a.id}">
       <td class="num">${a.id}</td>
-      <td>${escapeHtml(a.username)}${a.isAdmin ? ' <span class="badge">admin</span>' : ''}</td>
+      <td>${escapeHtml(a.username)}${a.isAdmin ? ' <span class="badge">admin</span>' : ''} ${accountStatusBadge(a)}</td>
       <td class="num">${a.characterCount}</td>
       <td class="num">${a.maxLevel}</td>
       <td class="num">${fmtDuration(a.playtimeSeconds)}</td>
@@ -49,10 +49,25 @@ export function renderAccountsTable(rows: AccountRow[]): string {
   </table>`;
 }
 
-export function renderAccountDetail(d: AccountDetail): string {
+function accountStatusBadge(a: { bannedAt: string | null; suspendedUntil: string | null }): string {
+  if (a.bannedAt) return '<span class="badge bad">banned</span>';
+  const suspendedUntil = a.suspendedUntil ? new Date(a.suspendedUntil) : null;
+  if (suspendedUntil && suspendedUntil.getTime() > Date.now()) return '<span class="badge warn">suspended</span>';
+  return '';
+}
+
+function accountStatusDetail(d: AccountDetail): string {
+  const activeSuspension = d.suspendedUntil !== null && new Date(d.suspendedUntil).getTime() > Date.now();
+  if (d.bannedAt) return `<span class="badge bad">banned</span> <span class="hint">since ${fmtDate(d.bannedAt)}</span>`;
+  if (activeSuspension) return `<span class="badge warn">suspended until ${fmtDate(d.suspendedUntil)}</span>`;
+  return '<span class="badge">active</span>';
+}
+
+export function renderAccountDetail(d: AccountDetail, includeAdminControls = false): string {
+  const canModerateAccount = includeAdminControls && !d.isAdmin;
   const chars = d.characters.length === 0
     ? '<div class="empty">no characters</div>'
-    : `<table><thead><tr><th>Name</th><th>Class</th><th class="num">Lvl</th><th class="num">XP</th><th class="num">Money</th><th class="num">Pos</th><th>Last played</th></tr></thead><tbody>${
+    : `<table><thead><tr><th>Name</th><th>Class</th><th class="num">Lvl</th><th class="num">XP</th><th class="num">Money</th><th class="num">Pos</th><th>Last played</th>${canModerateAccount ? '<th>Actions</th>' : ''}</tr></thead><tbody>${
         d.characters.map((c) => `
           <tr>
             <td>${escapeHtml(c.name)}</td>
@@ -62,6 +77,7 @@ export function renderAccountDetail(d: AccountDetail): string {
             <td class="num">${fmtCopper(c.copper)}</td>
             <td class="num">${c.pos ? `${Math.round(c.pos.x)}, ${Math.round(c.pos.z)}` : '—'}</td>
             <td>${fmtRelative(c.updatedAt)}</td>
+            ${canModerateAccount ? `<td><button data-force-rename-character="${c.id}" data-character-name="${escapeHtml(c.name)}">Force Name Change</button></td>` : ''}
           </tr>`).join('')
       }</tbody></table>`;
   const sessions = d.recentSessions.length === 0
@@ -74,10 +90,31 @@ export function renderAccountDetail(d: AccountDetail): string {
             <td class="num">${s.endedAt ? fmtDuration(s.seconds) : 'online now'}</td>
           </tr>`).join('')
       }</tbody></table>`;
-  return `<div class="detail-grid">
+  const accountStatus = accountStatusDetail(d);
+  const accountActionButtons = d.bannedAt ? `
+      <button data-unban-account="1">Unban</button>` : `
+      <button data-suspend-hours="1">Suspend 1h</button>
+      <button data-suspend-hours="24">Suspend 24h</button>
+      <button data-suspend-hours="72">Suspend 3d</button>
+      <button data-suspend-hours="168">Suspend 7d</button>
+      <button data-suspend-hours="720">Suspend 30d</button>
+      <input class="account-custom-expiry" type="datetime-local" />
+      <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-ban-account="1" class="danger">Ban</button>`;
+  const adminControls = canModerateAccount ? `
+    <div class="account-admin-controls mod-account-actions" data-action-account-id="${d.id}">
+      <div class="account-status"><b>Status:</b> ${accountStatus}${d.moderationReason ? ` <span class="hint">reason: ${escapeHtml(d.moderationReason)}</span>` : ''}</div>
+      <input class="account-mod-reason" placeholder="Moderator note / reason" maxlength="500" />
+      ${accountActionButtons}
+    </div>
+    <div class="mod-confirm account-mod-confirm"></div>` : includeAdminControls ? `
+    <div class="account-admin-controls">
+      <div class="account-status"><b>Status:</b> <span class="badge">admin</span> ${accountStatus}</div>
+    </div>` : '';
+  return `<div class="account-detail" data-action-account-id="${d.id}">${adminControls}<div class="detail-grid">
     <div><h4>Characters</h4>${chars}</div>
     <div><h4>Recent sessions — total playtime ${fmtDuration(d.playtimeSeconds)}</h4>${sessions}</div>
-  </div>`;
+  </div></div>`;
 }
 
 export function renderCharactersTable(rows: CharacterRow[], sort: string, dir: string): string {
@@ -166,6 +203,16 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
       ${chat}
     </div>`;
   }).join('');
+  const moderationAccountButtons = d.account.bannedAt ? `
+      <button data-unban-account="1">Unban</button>` : `
+      <button data-suspend-hours="1">Suspend 1h</button>
+      <button data-suspend-hours="24">Suspend 24h</button>
+      <button data-suspend-hours="72">Suspend 3d</button>
+      <button data-suspend-hours="168">Suspend 7d</button>
+      <button data-suspend-hours="720">Suspend 30d</button>
+      <input id="mod-custom-expiry" type="datetime-local" />
+      <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-ban-account="1">Ban</button>`;
   return `<div class="mod-detail">
     <div class="panel-title">
       <span>${escapeHtml(d.account.username)}</span>
@@ -174,14 +221,7 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
     ${renderAccountDetail(d.account)}
     <div class="mod-account-actions" data-action-account-id="${d.account.id}">
       <input id="mod-reason" placeholder="Moderator note / reason" maxlength="500" />
-      <button data-suspend-hours="1">Suspend 1h</button>
-      <button data-suspend-hours="24">Suspend 24h</button>
-      <button data-suspend-hours="72">Suspend 3d</button>
-      <button data-suspend-hours="168">Suspend 7d</button>
-      <button data-suspend-hours="720">Suspend 30d</button>
-      <input id="mod-custom-expiry" type="datetime-local" />
-      <button data-suspend-custom="1">Suspend Custom</button>
-      <button data-ban-account="1">Ban</button>
+      ${moderationAccountButtons}
     </div>
     <div id="mod-confirm" class="mod-confirm"></div>
     <h4>Open reports</h4>

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -51,6 +51,8 @@ export interface AccountRow {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
   characterCount: number;
   maxLevel: number;
   playtimeSeconds: number;
@@ -82,6 +84,9 @@ export interface AccountDetail {
   createdAt: string;
   lastLogin: string | null;
   isAdmin: boolean;
+  bannedAt: string | null;
+  suspendedUntil: string | null;
+  moderationReason: string;
   playtimeSeconds: number;
   characters: {
     id: number;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -209,6 +209,7 @@ export class ClientWorld implements IWorld {
   playerId = -1;
   moveInput: MoveInput = emptyMoveInput();
   inventory: InvSlot[] = [];
+  vendorBuyback: InvSlot[] = [];
   equipment: Partial<Record<EquipSlot, string>> = {};
   copper = 0;
   xp = 0;
@@ -496,6 +497,7 @@ export class ClientWorld implements IWorld {
       this.xp = s.xp ?? 0;
       this.copper = s.copper ?? 0;
       if (s.inv !== undefined) { this.inventory = s.inv; this.invChanged = true; }
+      if (s.buyback !== undefined) { this.vendorBuyback = s.buyback; this.invChanged = true; }
       if (s.equip !== undefined) this.equipment = s.equip;
       if (s.qlog !== undefined) this.questLog = new Map((s.qlog as QuestProgress[]).map((q) => [q.questId, q]));
       if (s.qdone !== undefined) this.questsDone = new Set(s.qdone);
@@ -600,6 +602,9 @@ export class ClientWorld implements IWorld {
   }
   sellItem(itemId: string): void {
     this.cmd({ cmd: 'sell', item: itemId });
+  }
+  buyBackItem(itemId: string): void {
+    this.cmd({ cmd: 'buyback', item: itemId });
   }
   releaseSpirit(): void {
     this.cmd({ cmd: 'release' });

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -197,7 +197,7 @@ function blankEntity(id: number): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { x: 0, y: 0, z: 0 }, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { ...pos }, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1984,6 +1984,11 @@ export class Sim {
   private dealDamage(source: Entity | null, target: Entity, amount: number, crit: boolean, school: string, ability: string | null, kind: 'hit' | 'miss' | 'dodge', noRage = false, threatOpts?: { flat?: number; mult?: number }): void {
     if (target.dead) return;
     if (target.gm) return; // GM characters are invulnerable — every damage path funnels here
+    // A mob that broke leash (or a pet freed to the wild) is in 'evade': it has
+    // dropped its hate table and walks home without fighting back, healing to
+    // full only on arrival. Classic mechanics make it immune while it retreats,
+    // so it can't be chipped down — or killed outright — for a risk-free kill.
+    if (target.kind === 'mob' && target.aiState === 'evade') return;
     amount = Math.max(0, amount);
 
     // Defensive Stance, classic: deal 10% less, take 10% less (and +30% threat below)

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -26,6 +26,8 @@ import {
 
 const LEASH_DISTANCE = 45;
 const DUNGEON_LEASH_DISTANCE = 70;
+const SOCIAL_PULL_RADIUS = 5;
+const MURLOC_SOCIAL_PULL_RADIUS = 8;
 const CORPSE_DURATION = 60;
 const EVADE_SPEED_MULT = 1.6;
 const BACKPEDAL_MULT = 0.65;
@@ -1753,6 +1755,8 @@ export class Sim {
     if (existing >= 0) target.auras.splice(existing, 1);
     target.auras.push(aura);
     this.emit({ type: 'aura', targetId: target.id, name: aura.name, gained: true });
+    const source = this.entities.get(aura.sourceId);
+    this.refreshMobLeashFromAction(source ?? null, target);
     if (target.kind === 'player') {
       const meta = this.players.get(target.id);
       if (meta) recalcPlayerStats(target, meta.cls, meta.equipment);
@@ -2052,6 +2056,7 @@ export class Sim {
     }
 
     if (source && source.id !== target.id) this.enterCombat(source, target);
+    this.refreshMobLeashFromAction(source, target);
 
     // classic threat: damage (and the ability's flat bonus) lands on the mob's
     // hate table, scaled by the attacker's stance/form modifiers
@@ -2263,9 +2268,15 @@ export class Sim {
   // Mob AI
   // -------------------------------------------------------------------------
 
+  private refreshMobLeashFromAction(source: Entity | null, target: Entity): void {
+    if (!source || source.id === target.id || target.kind !== 'mob' || target.ownerId !== null || target.dead) return;
+    if (source.kind !== 'player' && source.ownerId === null) return;
+    target.leashAnchor = { ...target.pos };
+  }
+
   // When a mob's target dies/leaves it swings to its next-highest-threat
-  // attacker; with an empty hate table it falls back to the nearest living
-  // player, and failing that it goes home.
+  // attacker. With no living threat left, it evades home instead of grabbing a
+  // nearby bystander who never acted on the mob.
   private retargetMob(mob: Entity): void {
     const next = this.highestThreatTarget(mob);
     if (next) {
@@ -2274,16 +2285,8 @@ export class Sim {
       mob.inCombat = true;
       return;
     }
-    const near = this.nearestLivingPlayer(mob.pos, 35);
-    if (near) {
-      addThreat(mob, near.e.id, 1);
-      mob.aggroTargetId = near.e.id;
-      mob.aiState = 'chase';
-      mob.inCombat = true;
-    } else {
-      mob.aggroTargetId = null;
-      mob.aiState = 'evade';
-    }
+    mob.aggroTargetId = null;
+    mob.aiState = 'evade';
   }
 
   /** Highest-threat living attacker on the table; prunes stale entries. */
@@ -2336,15 +2339,17 @@ export class Sim {
     mob.aiState = 'chase';
     mob.aggroTargetId = target.id;
     mob.inCombat = true;
+    mob.leashAnchor = { ...mob.pos };
     addThreat(mob, target.id, 1); // seed the hate table so taunts/heals have a baseline
     if (social) {
-      const pullRadius = MOBS[mob.templateId]?.family === 'murloc' ? 18 : 12;
+      const pullRadius = MOBS[mob.templateId]?.family === 'murloc' ? MURLOC_SOCIAL_PULL_RADIUS : SOCIAL_PULL_RADIUS;
       this.grid.forEachInRadius(mob.pos.x, mob.pos.z, pullRadius, (m, d2) => {
         if (m.kind === 'mob' && m.id !== mob.id && !m.dead && m.hostile && m.aiState === 'idle' && m.ownerId === null
           && m.templateId === mob.templateId && d2 < pullRadius * pullRadius) {
           m.aiState = 'chase';
           m.aggroTargetId = target.id;
           m.inCombat = true;
+          m.leashAnchor = { ...m.pos };
           addThreat(m, target.id, 1);
         }
       });
@@ -2438,10 +2443,12 @@ export class Sim {
           break;
         }
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
-        if (dist2d(mob.pos, mob.spawnPos) > leash) {
+        const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
+        if (dist2d(mob.pos, leashAnchor) > leash) {
           mob.aiState = 'evade';
           mob.aggroTargetId = null;
           clearThreat(mob);
+          mob.leashAnchor = null;
           break;
         }
         const d = dist2d(mob.pos, target.pos);
@@ -2492,6 +2499,7 @@ export class Sim {
           mob.auras = [];
           mob.inCombat = false;
           mob.tappedById = null;
+          mob.leashAnchor = null;
           clearThreat(mob);
           this.despawnSummonedAdds(mob);
           mob.firedSummons = 0;
@@ -2631,6 +2639,7 @@ export class Sim {
     mob.aiState = 'idle';
     mob.aggroTargetId = null;
     mob.inCombat = false;
+    mob.leashAnchor = null;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3179,6 +3179,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/who(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, 'The /who roster is available in online play.');
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3310,6 +3310,11 @@ export class Sim {
     const invite = this.partyInvites.get(r.meta.entityId);
     if (!invite || invite.expires < this.time) { this.error(r.meta.entityId, 'The invitation has expired.'); return; }
     this.partyInvites.delete(r.meta.entityId);
+    // A player can hold a stale incoming invite while having since joined or
+    // formed a party of their own (inviting others never consumes one's own
+    // pending invite). Accepting now would add them to a second party's member
+    // list, corrupting the "at most one party" invariant.
+    if (this.partyOf(r.meta.entityId)) { this.error(r.meta.entityId, 'You are already in a party.'); return; }
     const leaderMeta = this.players.get(invite.fromPid);
     if (!leaderMeta) return;
     let party = this.partyOf(invite.fromPid);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -789,10 +789,42 @@ export class Sim {
   private effectiveArmor(e: Entity): number {
     let armor = e.stats.armor;
     for (const a of e.auras) {
+      if (e.kind !== 'player' && a.kind === 'buff_armor') armor += a.value;
       if (a.kind === 'sunder') armor -= a.value * (a.stacks ?? 1);
     }
     return Math.max(0, armor);
   }
+
+  private effectiveAttackPower(e: Entity): number {
+    let attackPower = e.attackPower;
+    if (e.kind !== 'player') {
+      for (const a of e.auras) {
+        if (a.kind === 'buff_ap') attackPower += a.value;
+      }
+    }
+    return attackPower;
+  }
+
+  private nonPlayerAuraHp(aura: Aura): number {
+    if (aura.kind === 'buff_sta') return aura.value * 10;
+    if (aura.kind === 'buff_allstats') return aura.value * 10;
+    return 0;
+  }
+
+  private applyNonPlayerStatAura(target: Entity, aura: Aura, direction: 1 | -1): void {
+    if (target.kind === 'player') return;
+    const hpDelta = this.nonPlayerAuraHp(aura) * direction;
+    if (hpDelta === 0) return;
+    const hpFrac = target.maxHp > 0 ? target.hp / target.maxHp : 1;
+    target.maxHp = Math.max(1, target.maxHp + hpDelta);
+    target.hp = target.dead ? 0 : Math.max(1, Math.min(target.maxHp, Math.round(target.maxHp * hpFrac)));
+  }
+
+  private clearNonPlayerStatAuras(target: Entity): void {
+    if (target.kind === 'player') return;
+    for (const aura of target.auras) this.applyNonPlayerStatAura(target, aura, -1);
+  }
+
   // swing interval multiplier: >1 = slower (thunder clap), haste divides
   private swingIntervalMult(e: Entity): number {
     let m = 1;
@@ -1061,6 +1093,7 @@ export class Sim {
       }
       if (a.remaining <= 0) {
         e.auras.splice(i, 1);
+        this.applyNonPlayerStatAura(e, a, -1);
         this.emit({ type: 'aura', targetId: e.id, name: a.name, gained: false });
         if (a.kind.startsWith('buff') || a.kind.startsWith('form')) statsDirty = true;
       }
@@ -1439,7 +1472,7 @@ export class Sim {
         }
         case 'finisherDamage': {
           if (!target || spentCombo <= 0) break;
-          let dmg = eff.base + eff.perCombo * spentCombo + this.rng.range(0, eff.variance) + (p.attackPower / 14);
+          let dmg = eff.base + eff.perCombo * spentCombo + this.rng.range(0, eff.variance) + (this.effectiveAttackPower(p) / 14);
           const crit = this.rng.chance(p.critChance);
           if (crit) dmg *= 2;
           dmg *= 1 - armorReduction(this.effectiveArmor(target), p.level);
@@ -1750,8 +1783,12 @@ export class Sim {
   private applyAura(target: Entity, aura: Aura): void {
     if (target.kind === 'npc' && isRejectedFriendlyNpcAura(aura)) return;
     const existing = target.auras.findIndex((a) => a.id === aura.id && a.sourceId === aura.sourceId);
-    if (existing >= 0) target.auras.splice(existing, 1);
+    if (existing >= 0) {
+      this.applyNonPlayerStatAura(target, target.auras[existing], -1);
+      target.auras.splice(existing, 1);
+    }
     target.auras.push(aura);
+    this.applyNonPlayerStatAura(target, aura, 1);
     this.emit({ type: 'aura', targetId: target.id, name: aura.name, gained: true });
     if (target.kind === 'player') {
       const meta = this.players.get(target.id);
@@ -1843,6 +1880,8 @@ export class Sim {
   /** Dismissal, owner logout, or pet respawn: the beast goes back to the wild
    *  and walks home. Mobs that were fighting it forget it. */
   private releasePetToWild(pet: Entity): void {
+    this.clearNonPlayerStatAuras(pet);
+    pet.auras = [];
     pet.ownerId = null;
     pet.petTauntTimer = 0;
     pet.hostile = true;
@@ -1959,7 +1998,7 @@ export class Sim {
     // weapon imbues (seals, rockbiter) add flat damage to every swing
     let imbueBonus = 0;
     for (const a of attacker.auras) if (a.kind === 'imbue') imbueBonus += a.value;
-    let dmg = (this.rng.range(attacker.weapon.min, attacker.weapon.max) + (attacker.attackPower / 14) * attacker.weapon.speed) * mult + bonus + imbueBonus;
+    let dmg = (this.rng.range(attacker.weapon.min, attacker.weapon.max) + (this.effectiveAttackPower(attacker) / 14) * attacker.weapon.speed) * mult + bonus + imbueBonus;
     const critChance = Math.max(0.005, attacker.critChance - Math.max(0, target.level - attacker.level) * 0.002);
     const crit = this.rng.chance(critChance);
     if (crit) dmg *= 2;
@@ -2113,6 +2152,7 @@ export class Sim {
   private handleDeath(e: Entity, killer: Entity | null): void {
     e.dead = true;
     e.hp = 0;
+    this.clearNonPlayerStatAuras(e);
     e.auras = [];
     e.castingAbility = null;
     this.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
@@ -2515,7 +2555,7 @@ export class Sim {
       this.emit({ type: 'damage', sourceId: mob.id, targetId: target.id, amount: 0, crit: false, school: 'physical', ability: null, kind: 'dodge' });
       return;
     }
-    let dmg = this.rng.range(mob.weapon.min, mob.weapon.max);
+    let dmg = this.rng.range(mob.weapon.min, mob.weapon.max) + (this.effectiveAttackPower(mob) / 14) * mob.weapon.speed;
     const crit = this.rng.chance(0.05);
     if (crit) dmg *= 2;
     const enrage = MOBS[mob.templateId]?.enrage;
@@ -2616,6 +2656,7 @@ export class Sim {
   }
 
   private respawnMob(mob: Entity): void {
+    this.clearNonPlayerStatAuras(mob);
     mob.dead = false;
     mob.lootable = false;
     mob.loot = null;
@@ -3260,8 +3301,12 @@ export class Sim {
   }
 
   private isFriendlyTo(caster: Entity, target: Entity): boolean {
-    if (target.kind !== 'player') return false;
-    return !this.isHostileTo(caster, target);
+    if (target.kind === 'player') return !this.isHostileTo(caster, target);
+    if (target.kind === 'mob' && target.ownerId !== null) {
+      const owner = this.entities.get(target.ownerId);
+      return !!owner && owner.kind === 'player' && !this.isHostileTo(caster, owner);
+    }
+    return false;
   }
 
   // -------------------------------------------------------------------------

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -58,6 +58,7 @@ const MARKET_MAX_PRICE = 5_000_000; // 500g ceiling — guards against overflow 
 const MARKET_CUT = 0.05; // the Merchant's cut on a completed sale (a gold sink)
 const MARKET_LISTING_DURATION = 48 * 3600; // sim-seconds an unsold listing lingers before returning
 const MARKET_WIRE_LIMIT = 120; // most listings shipped to one client at a time
+const VENDOR_BUYBACK_LIMIT = 12;
 const INSTANCE_EMPTY_TIMEOUT = 300; // seconds before an empty instance resets
 const HUNTER_RANGED_DEADZONE = 8;
 const MAX_CLIMB_SLOPE = 1.5; // rise/run above which a ground move is blocked (cliffs, world rim)
@@ -172,6 +173,7 @@ export interface PlayerMeta {
   name: string;
   moveInput: MoveInput;
   inventory: InvSlot[];
+  vendorBuyback: InvSlot[];
   copper: number;
   equipment: PlayerEquipment;
   xp: number;
@@ -234,6 +236,7 @@ export interface CharacterState {
   facing: number;
   equipment: PlayerEquipment;
   inventory: InvSlot[];
+  vendorBuyback?: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
   questsDone: string[];
   arenaRating?: number;
@@ -436,6 +439,7 @@ export class Sim {
       name,
       moveInput: emptyMoveInput(),
       inventory: [],
+      vendorBuyback: [],
       copper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
       xp: 0,
@@ -460,6 +464,7 @@ export class Sim {
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
       meta.inventory = s.inventory.map((i) => ({ ...i }));
+      meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
       for (const q of s.questLog) {
         if (q.state !== 'done') meta.questLog.set(q.questId, { questId: q.questId, counts: [...q.counts], state: q.state });
       }
@@ -538,6 +543,7 @@ export class Sim {
       facing: e.facing,
       equipment: { ...meta.equipment },
       inventory: meta.inventory.map((i) => ({ ...i })),
+      vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
       questLog: [...meta.questLog.values()].map((q) => ({ questId: q.questId, counts: [...q.counts], state: q.state })),
       questsDone: [...meta.questsDone],
       arenaRating: meta.arenaRating,
@@ -565,6 +571,9 @@ export class Sim {
   }
   get inventory(): InvSlot[] {
     return this.primary.inventory;
+  }
+  get vendorBuyback(): InvSlot[] {
+    return this.primary.vendorBuyback;
   }
   get equipment(): PlayerEquipment {
     return this.primary.equipment;
@@ -2858,6 +2867,23 @@ export class Sim {
     this.emit({ type: 'vendor', action: 'buy', itemId, pid: meta.entityId });
   }
 
+  private vendorInRange(p: Entity): boolean {
+    return [...this.entities.values()].some((e) =>
+      e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
+  }
+
+  private recordVendorBuyback(meta: PlayerMeta, itemId: string, count: number): void {
+    const existingIndex = meta.vendorBuyback.findIndex((s) => s.itemId === itemId);
+    if (existingIndex >= 0) {
+      const [existing] = meta.vendorBuyback.splice(existingIndex, 1);
+      existing.count += count;
+      meta.vendorBuyback.unshift(existing);
+    } else {
+      meta.vendorBuyback.unshift({ itemId, count });
+    }
+    while (meta.vendorBuyback.length > VENDOR_BUYBACK_LIMIT) meta.vendorBuyback.pop();
+  }
+
   sellItem(itemId: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
@@ -2865,15 +2891,32 @@ export class Sim {
     const def = ITEMS[itemId];
     if (!def || this.countItem(itemId, meta.entityId) <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
     if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
-    // mirror buyItem's gate: selling requires a vendor in interact range
-    const nearVendor = [...this.entities.values()].some((e) =>
-      e.kind === 'npc' && e.vendorItems.length > 0 && dist2d(p.pos, e.pos) <= INTERACT_RANGE + 2);
-    if (!nearVendor) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
+    if (!this.vendorInRange(p)) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
     if (def.kind === 'quest') { this.error(meta.entityId, 'You cannot sell quest items.'); return; }
     this.removeItem(itemId, 1, meta.entityId);
+    this.recordVendorBuyback(meta, itemId, 1);
     meta.copper += def.sellValue;
     this.emit({ type: 'vendor', action: 'sell', itemId, pid: meta.entityId });
     this.emit({ type: 'loot', text: `Sold ${def.name} for ${formatMoney(def.sellValue)}.`, pid: meta.entityId });
+  }
+
+  buyBackItem(itemId: string, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta, e: p } = r;
+    const def = ITEMS[itemId];
+    const slot = meta.vendorBuyback.find((s) => s.itemId === itemId);
+    if (!def || !slot || slot.count <= 0) { this.error(meta.entityId, 'That item is not available for buyback.'); return; }
+    if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
+    if (!this.vendorInRange(p)) { this.error(meta.entityId, 'There is no merchant nearby.'); return; }
+    if (meta.copper < def.sellValue) { this.error(meta.entityId, 'Not enough money.'); return; }
+    meta.copper -= def.sellValue;
+    slot.count -= 1;
+    if (slot.count <= 0) meta.vendorBuyback = meta.vendorBuyback.filter((s) => s !== slot);
+    this.addItemSilent(itemId, 1, meta);
+    this.onInventoryChangedForQuests(meta);
+    this.emit({ type: 'vendor', action: 'buyback', itemId, pid: meta.entityId });
+    this.emit({ type: 'loot', text: `Bought back ${def.name} for ${formatMoney(def.sellValue)}.`, pid: meta.entityId });
   }
 
   private addItemSilent(itemId: string, count: number, meta: PlayerMeta): void {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -437,6 +437,7 @@ export interface Entity {
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active
   spawnPos: Vec3;
+  leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   wanderTarget: Vec3 | null;
   wanderTimer: number;
   aggroTargetId: number | null;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -481,7 +481,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'comboPoint'; points: number }
   | { type: 'playerDeath' }
   | { type: 'respawn' }
-  | { type: 'vendor'; action: 'buy' | 'sell'; itemId: string }
+  | { type: 'vendor'; action: 'buy' | 'sell' | 'buyback'; itemId: string }
   // say/yell are delivered only to players in range and carry the speaker's
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,0 +1,16 @@
+export function placeAbilityOnSlot(
+  slotMap: readonly (string | null)[],
+  abilityId: string,
+  targetIndex: number,
+): (string | null)[] {
+  const next = slotMap.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  const sourceIndex = next.indexOf(abilityId);
+  if (sourceIndex === targetIndex) return next;
+  if (sourceIndex !== -1) {
+    [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+    return next;
+  }
+  next[targetIndex] = abilityId;
+  return next;
+}

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -14,3 +14,27 @@ export function placeAbilityOnSlot(
   next[targetIndex] = abilityId;
   return next;
 }
+
+export function clearHotbarSlot(
+  slotMap: readonly (string | null)[],
+  targetIndex: number,
+): (string | null)[] {
+  if (targetIndex < 0 || targetIndex >= slotMap.length) return [...slotMap];
+  return slotMap.map((slot, index) => index === targetIndex ? null : slot);
+}
+
+export function syncHotbarSlotMap(
+  slotMap: readonly (string | null)[],
+  knownAbilityIds: readonly string[],
+  autoPlaceAbilityIds: ReadonlySet<string>,
+): (string | null)[] {
+  const known = new Set(knownAbilityIds);
+  const next = slotMap.map((id) => id !== null && !known.has(id) ? null : id);
+  for (const id of knownAbilityIds) {
+    if (next.includes(id) || !autoPlaceAbilityIds.has(id)) continue;
+    const empty = next.indexOf(null);
+    if (empty === -1) break;
+    next[empty] = id;
+  }
+  return next;
+}

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -1,16 +1,105 @@
+export type HotbarAction =
+  | { type: 'ability'; id: string }
+  | { type: 'item'; id: string }
+  | null;
+
+export const HOTBAR_ACTION_MIME = 'application/x-woc-hotbar-action';
+
+export function encodeHotbarAction(action: Exclude<HotbarAction, null>): string {
+  return JSON.stringify(action);
+}
+
+export function parseHotbarAction(
+  value: unknown,
+  abilityExists: (id: string) => boolean,
+  itemExists: (id: string) => boolean,
+): Exclude<HotbarAction, null> | null {
+  if (!value || typeof value !== 'object') return null;
+  const action = value as { type?: unknown; id?: unknown };
+  if (typeof action.id !== 'string') return null;
+  if (action.type === 'ability' && abilityExists(action.id)) return { type: 'ability', id: action.id };
+  if (action.type === 'item' && itemExists(action.id)) return { type: 'item', id: action.id };
+  return null;
+}
+
+export function parseHotbarActions(
+  value: unknown,
+  slots: number,
+  abilityExists: (id: string) => boolean,
+  itemExists: (id: string) => boolean,
+): HotbarAction[] {
+  const seenAbilities = new Set<string>();
+  return Array.from({ length: slots }, (_, i) => {
+    const raw = Array.isArray(value) ? value[i] : null;
+    const action = typeof raw === 'string'
+      ? (abilityExists(raw) ? { type: 'ability' as const, id: raw } : null)
+      : parseHotbarAction(raw, abilityExists, itemExists);
+    if (action?.type === 'ability') {
+      if (seenAbilities.has(action.id)) return null;
+      seenAbilities.add(action.id);
+    }
+    return action;
+  });
+}
+
 export function placeAbilityOnSlot(
-  slotMap: readonly (string | null)[],
+  actions: readonly HotbarAction[],
   abilityId: string,
   targetIndex: number,
-): (string | null)[] {
-  const next = slotMap.slice();
+): HotbarAction[] {
+  const next = actions.slice();
   if (targetIndex < 0 || targetIndex >= next.length) return next;
-  const sourceIndex = next.indexOf(abilityId);
+  const sourceIndex = next.findIndex((action) => action?.type === 'ability' && action.id === abilityId);
   if (sourceIndex === targetIndex) return next;
   if (sourceIndex !== -1) {
     [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
     return next;
   }
-  next[targetIndex] = abilityId;
+  next[targetIndex] = { type: 'ability', id: abilityId };
   return next;
+}
+
+export function placeItemOnSlot(
+  actions: readonly HotbarAction[],
+  itemId: string,
+  targetIndex: number,
+): HotbarAction[] {
+  const next = actions.slice();
+  if (targetIndex < 0 || targetIndex >= next.length) return next;
+  next[targetIndex] = { type: 'item', id: itemId };
+  return next;
+}
+
+export function swapHotbarSlots(
+  actions: readonly HotbarAction[],
+  sourceIndex: number,
+  targetIndex: number,
+): HotbarAction[] {
+  const next = actions.slice();
+  if (
+    sourceIndex < 0 || sourceIndex >= next.length ||
+    targetIndex < 0 || targetIndex >= next.length ||
+    sourceIndex === targetIndex
+  ) return next;
+  [next[sourceIndex], next[targetIndex]] = [next[targetIndex], next[sourceIndex]];
+  return next;
+}
+
+export function syncHotbarActions(
+  actions: readonly HotbarAction[],
+  knownAbilityIds: readonly string[],
+): { actions: HotbarAction[]; changed: boolean } {
+  const known = new Set(knownAbilityIds);
+  const next = actions.map((action) => (
+    action?.type === 'ability' && !known.has(action.id) ? null : action
+  ));
+  let changed = next.some((action, i) => action !== actions[i]);
+  for (const id of knownAbilityIds) {
+    if (next.some((action) => action?.type === 'ability' && action.id === id)) continue;
+    const empty = next.indexOf(null);
+    if (empty === -1) continue;
+    next[empty] = { type: 'ability', id };
+    changed = true;
+  }
+  return { actions: next, changed };
 }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,7 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
-import { placeAbilityOnSlot } from './hotbar';
+import { clearHotbarSlot, placeAbilityOnSlot, syncHotbarSlotMap } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -67,6 +67,8 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
+  private loadedSlotMapFromStorage = false;
+  private knownAbilityIdsAtLastSlotSync: Set<string> | null = null;
   private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
@@ -347,6 +349,7 @@ export class Hud {
   private loadSlotMap(): void {
     let arr: unknown = null;
     try { arr = JSON.parse(localStorage.getItem(this.slotMapKey()) ?? 'null'); } catch { /* corrupt */ }
+    this.loadedSlotMapFromStorage = Array.isArray(arr);
     const seen = new Set<string>();
     this.slotMap = Array.from({ length: Hud.BAR_ABILITY_SLOTS }, (_, i) => {
       const v = Array.isArray(arr) ? arr[i] : null;
@@ -363,18 +366,23 @@ export class Hud {
   // Drop unlearned ids; place newly learned abilities in the first empty
   // slot. With empty storage this reproduces the default class-order layout.
   private syncSlotMap(): void {
-    const ids = new Set(this.sim.known.map((k) => k.def.id));
-    let dirty = false;
-    for (let i = 0; i < this.slotMap.length; i++) {
-      const id = this.slotMap[i];
-      if (id !== null && !ids.has(id)) { this.slotMap[i] = null; dirty = true; }
+    const knownAbilityIds = this.sim.known.map((k) => k.def.id);
+    const autoPlaceAbilityIds = new Set<string>();
+    if (this.knownAbilityIdsAtLastSlotSync === null) {
+      if (!this.loadedSlotMapFromStorage) {
+        for (const id of knownAbilityIds) autoPlaceAbilityIds.add(id);
+      }
+    } else {
+      for (const id of knownAbilityIds) {
+        if (!this.knownAbilityIdsAtLastSlotSync.has(id)) autoPlaceAbilityIds.add(id);
+      }
     }
-    for (const k of this.sim.known) {
-      if (this.slotMap.includes(k.def.id)) continue;
-      const empty = this.slotMap.indexOf(null);
-      if (empty !== -1) { this.slotMap[empty] = k.def.id; dirty = true; }
+    const next = syncHotbarSlotMap(this.slotMap, knownAbilityIds, autoPlaceAbilityIds);
+    if (next.some((id, i) => id !== this.slotMap[i])) {
+      this.slotMap = next;
+      this.saveSlotMap();
     }
-    if (dirty) this.saveSlotMap();
+    this.knownAbilityIdsAtLastSlotSync = new Set(knownAbilityIds);
   }
 
   abilityForSlot(barSlot: number): ResolvedAbility | null { // barSlot 1..11
@@ -422,12 +430,32 @@ export class Hud {
           return '<div class="tt-title">Attack</div><div class="tt-sub">Toggle auto-attack on your target.<br>Right-clicking an enemy also attacks.</div>';
         }
         const known = this.abilityForSlot(slot);
-        return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
+        return known
+          ? this.abilityTooltip(known) + '<div class="tt-sub">Shift-right-click or Shift-Delete to clear</div>'
+          : '<div class="tt-sub">Empty slot<br>Shift-right-click or Shift-Delete to clear</div>';
       });
       if (slot >= 1) {
         // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
+        const clearSlot = () => {
+          this.slotMap = clearHotbarSlot(this.slotMap, slot - 1);
+          this.saveSlotMap();
+          btn.classList.add('empty');
+          btn.classList.remove('drop-target', 'oor', 'queued', 'unusable');
+          this.hideTooltip();
+        };
+        btn.addEventListener('contextmenu', (e) => {
+          if (!e.shiftKey) return;
+          e.preventDefault();
+          clearSlot();
+        });
+        btn.addEventListener('keydown', (e) => {
+          if (!e.shiftKey || (e.key !== 'Delete' && e.key !== 'Backspace')) return;
+          e.preventDefault();
+          e.stopPropagation();
+          clearSlot();
+        });
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
@@ -588,6 +616,7 @@ export class Hud {
       const known = this.abilityForSlot(i);
       if (!known) {
         ab.btn.classList.add('empty');
+        ab.btn.classList.remove('oor', 'queued', 'unusable');
         if (ab.lastIcon !== '') {
           ab.lastIcon = '';
           ab.label.style.backgroundImage = '';

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,6 +17,7 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { placeAbilityOnSlot } from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -66,7 +67,7 @@ export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragFromSlot: number | null = null;
+  private dragAbilityId: string | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -424,19 +425,19 @@ export class Hud {
         return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to swap the two keybinds;
+        // drag an ability onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
           const known = this.abilityForSlot(slot);
           if (!known) { e.preventDefault(); return; }
-          this.dragFromSlot = slot;
+          this.dragAbilityId = known.def.id;
           e.dataTransfer!.setData('text/plain', known.def.id);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragFromSlot === null || this.dragFromSlot === slot) return;
+          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
           e.preventDefault(); // required to permit the drop
           e.dataTransfer!.dropEffect = 'move';
           btn.classList.add('drop-target');
@@ -445,21 +446,24 @@ export class Hud {
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const from = this.dragFromSlot;
-          this.dragFromSlot = null;
-          if (from === null || from === slot) return;
-          const a = from - 1, b = slot - 1;
-          [this.slotMap[a], this.slotMap[b]] = [this.slotMap[b], this.slotMap[a]]; // swap; empty target = move
+          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
+          this.dragAbilityId = null;
+          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
+          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragFromSlot = null;
-          bar.querySelectorAll('.drop-target').forEach((el) => el.classList.remove('drop-target'));
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
       this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
+  }
+
+  private clearActionDropTargets(): void {
+    document.querySelectorAll('#actionbar .drop-target').forEach((el) => el.classList.remove('drop-target'));
   }
 
   // Repaint the keycap on every action button from the current bindings.
@@ -1927,8 +1931,20 @@ export class Hud {
       row.innerHTML = `<div class="spell-icon" style="background-image:url(${iconDataUrl('ability', abilityId)});${locked ? 'filter:grayscale(1) brightness(0.5)' : ''}"></div>
         <div><div class="spell-name" style="${locked ? 'color:#777' : ''}">${def.name}${known && known.rank > 1 ? ` <span style="color:#998d6a;font-size:11px">Rank ${known.rank}</span>` : ''}</div>
         <div class="spell-sub">${locked ? `Trainable at level ${def.learnLevel}` : describeCost(known!, sim)}</div></div>`;
-      if (known) this.attachTooltip(row, () => this.abilityTooltip(known));
-      else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
+      if (known) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          this.dragAbilityId = known.def.id;
+          e.dataTransfer!.setData('text/plain', known.def.id);
+          e.dataTransfer!.effectAllowed = 'move';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAbilityId = null;
+          this.clearActionDropTargets();
+        });
+        this.attachTooltip(row, () => this.abilityTooltip(known));
+      } else this.attachTooltip(row, () => `<div class="tt-title" style="color:#999">${def.name}</div><div class="tt-sub">You will learn this at level ${def.learnLevel}.</div>`);
       el.appendChild(row);
     }
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1149,7 +1149,7 @@ export class Hud {
         case 'comboPoint': break;
         case 'loot': {
           this.log(ev.text, '#7fdc4f');
-          if (ev.text.includes('loot') || ev.text.includes('Sold')) audio.coin();
+          if (ev.text.includes('loot') || ev.text.includes('Sold') || ev.text.includes('Bought back')) audio.coin();
           else audio.lootItem();
           if ($('#bags').style.display === 'block') this.renderBags();
           break;
@@ -1562,6 +1562,28 @@ export class Hud {
       this.attachTooltip(row, () => this.itemTooltip(item) + '<div class="tt-sub">Click to buy</div>');
       el.appendChild(row);
     }
+    const buybackTitle = document.createElement('div');
+    buybackTitle.className = 'vendor-section-title';
+    buybackTitle.textContent = 'Buyback';
+    el.appendChild(buybackTitle);
+    const buyback = this.sim.vendorBuyback.filter((s) => ITEMS[s.itemId] && s.count > 0);
+    if (buyback.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'vendor-empty';
+      empty.textContent = 'No items';
+      el.appendChild(empty);
+    }
+    for (const s of buyback) {
+      const item = ITEMS[s.itemId]!;
+      const row = document.createElement('div');
+      row.className = 'vendor-item';
+      row.innerHTML = `${this.itemIcon(item)}<span class="vi-name">${item.name}${s.count > 1 ? ` x${s.count}` : ''}</span><span class="vi-price">${this.moneyHtml(item.sellValue)}</span>`;
+      row.addEventListener('click', () => {
+        this.sim.buyBackItem(s.itemId);
+      });
+      this.attachTooltip(row, () => this.itemTooltip(item) + '<div class="tt-sub">Click to buy back</div>');
+      el.appendChild(row);
+    }
     const hint = document.createElement('div');
     hint.className = 'vendor-hint';
     hint.textContent = 'Click an item in your bags to sell it while this window is open.';
@@ -1802,6 +1824,7 @@ export class Hud {
   // carry inventory separately from the event frames that normally redraw).
   onInventoryChanged(): void {
     if ($('#bags').style.display === 'block') this.renderBags();
+    if (this.openVendorNpcId !== null) this.renderVendor();
   }
 
   renderBags(): void {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -17,7 +17,10 @@ import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
-import { placeAbilityOnSlot } from './hotbar';
+import {
+  encodeHotbarAction, HOTBAR_ACTION_MIME, HotbarAction, parseHotbarAction, parseHotbarActions,
+  placeAbilityOnSlot, placeItemOnSlot, swapHotbarSlots, syncHotbarActions,
+} from './hotbar';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -65,9 +68,9 @@ const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
 
 export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
-  private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
-  private slotMap: (string | null)[] = []; // index = barSlot-1, value = ability id
-  private dragAbilityId: string | null = null;
+  private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; countEl: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
+  private hotbarActions: HotbarAction[] = []; // index = barSlot-1
+  private dragAction: { action: Exclude<HotbarAction, null>; sourceIndex: number | null } | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
@@ -337,49 +340,59 @@ export class Hud {
   // Action bar
   // -------------------------------------------------------------------------
 
-  // The hotbar layout is a client-side remap over the learned abilities,
-  // keyed by ability id (known is class-ordered and shifts on level-up, so
-  // indices would not survive). Persisted per class+character.
+  // The hotbar layout is a client-side remap over learned abilities and item
+  // shortcuts. Abilities are keyed by id (known is class-ordered and shifts on
+  // level-up, so indices would not survive). Persisted per class+character.
   private slotMapKey(): string {
     return `woc_hotbar_${this.sim.cfg.playerClass}_${this.sim.player.name}`;
+  }
+
+  private isHotbarItemId(itemId: string): boolean {
+    const item = ITEMS[itemId];
+    return item?.kind === 'food' || item?.kind === 'drink';
   }
 
   private loadSlotMap(): void {
     let arr: unknown = null;
     try { arr = JSON.parse(localStorage.getItem(this.slotMapKey()) ?? 'null'); } catch { /* corrupt */ }
-    const seen = new Set<string>();
-    this.slotMap = Array.from({ length: Hud.BAR_ABILITY_SLOTS }, (_, i) => {
-      const v = Array.isArray(arr) ? arr[i] : null;
-      if (typeof v !== 'string' || !ABILITIES[v] || seen.has(v)) return null;
-      seen.add(v);
-      return v;
-    });
+    this.hotbarActions = parseHotbarActions(
+      arr,
+      Hud.BAR_ABILITY_SLOTS,
+      (id) => !!ABILITIES[id],
+      (id) => this.isHotbarItemId(id),
+    );
   }
 
   private saveSlotMap(): void {
-    try { localStorage.setItem(this.slotMapKey(), JSON.stringify(this.slotMap)); } catch { /* storage unavailable */ }
+    try { localStorage.setItem(this.slotMapKey(), JSON.stringify(this.hotbarActions)); } catch { /* storage unavailable */ }
   }
 
-  // Drop unlearned ids; place newly learned abilities in the first empty
-  // slot. With empty storage this reproduces the default class-order layout.
+  // Drop unlearned ability ids; place newly learned abilities in the first
+  // empty slot. Item shortcuts stay assigned even when their count reaches 0.
   private syncSlotMap(): void {
-    const ids = new Set(this.sim.known.map((k) => k.def.id));
-    let dirty = false;
-    for (let i = 0; i < this.slotMap.length; i++) {
-      const id = this.slotMap[i];
-      if (id !== null && !ids.has(id)) { this.slotMap[i] = null; dirty = true; }
-    }
-    for (const k of this.sim.known) {
-      if (this.slotMap.includes(k.def.id)) continue;
-      const empty = this.slotMap.indexOf(null);
-      if (empty !== -1) { this.slotMap[empty] = k.def.id; dirty = true; }
-    }
-    if (dirty) this.saveSlotMap();
+    const synced = syncHotbarActions(this.hotbarActions, this.sim.known.map((k) => k.def.id));
+    this.hotbarActions = synced.actions;
+    if (synced.changed) this.saveSlotMap();
+  }
+
+  private actionForSlot(barSlot: number): HotbarAction { // barSlot 1..11
+    return this.hotbarActions[barSlot - 1] ?? null;
   }
 
   abilityForSlot(barSlot: number): ResolvedAbility | null { // barSlot 1..11
-    const id = this.slotMap[barSlot - 1];
-    return id ? this.sim.known.find((k) => k.def.id === id) ?? null : null;
+    const action = this.actionForSlot(barSlot);
+    return action?.type === 'ability'
+      ? this.sim.known.find((k) => k.def.id === action.id) ?? null
+      : null;
+  }
+
+  private itemForSlot(barSlot: number): ItemDef | null {
+    const action = this.actionForSlot(barSlot);
+    return action?.type === 'item' ? ITEMS[action.id] ?? null : null;
+  }
+
+  private inventoryCount(itemId: string): number {
+    return this.sim.inventory.reduce((total, slot) => total + (slot.itemId === itemId ? slot.count : 0), 0);
   }
 
   // Shared entry point for hotbar clicks and the 1..0-= keybinds.
@@ -389,10 +402,31 @@ export class Hud {
       else this.sim.startAutoAttack();
       return;
     }
-    const known = this.abilityForSlot(barSlot);
-    // cast by ability id: the server validates against its own known list,
-    // so the client-side slot remap never desyncs slot semantics
-    if (known) this.sim.castAbility(known.def.id);
+    const action = this.actionForSlot(barSlot);
+    if (action?.type === 'ability') {
+      // cast by ability id: the server validates against its own known list,
+      // so the client-side slot remap never desyncs slot semantics
+      if (this.abilityForSlot(barSlot)) this.sim.castAbility(action.id);
+    } else if (action?.type === 'item' && this.isHotbarItemId(action.id)) {
+      if (this.tradeOpen) return;
+      this.sim.useItem(action.id);
+      if ($('#bags').style.display === 'block') this.renderBags();
+    }
+  }
+
+  private writeDraggedAction(dt: DataTransfer | null, action: Exclude<HotbarAction, null>): void {
+    if (!dt) return;
+    dt.setData(HOTBAR_ACTION_MIME, encodeHotbarAction(action));
+    dt.setData('text/plain', action.id);
+  }
+
+  private readDraggedAction(dt: DataTransfer | null): Exclude<HotbarAction, null> | null {
+    if (!dt) return null;
+    const raw = dt.getData(HOTBAR_ACTION_MIME);
+    if (!raw) return null;
+    let parsed: unknown = null;
+    try { parsed = JSON.parse(raw); } catch { return null; }
+    return parseHotbarAction(parsed, (id) => this.sim.known.some((k) => k.def.id === id), (id) => this.isHotbarItemId(id));
   }
 
   private buildActionBar(): void {
@@ -402,6 +436,8 @@ export class Hud {
       btn.className = 'action-btn empty';
       const label = document.createElement('span');
       label.className = 'icon-label';
+      const countEl = document.createElement('span');
+      countEl.className = 'item-count';
       const kb = document.createElement('span');
       kb.className = 'keybind';
       kb.textContent = this.keybinds.primaryLabel(`slot${i}`); // rebindable; refreshKeybindLabels keeps it current
@@ -409,7 +445,7 @@ export class Hud {
       cdOverlay.className = 'cd-overlay';
       const cdText = document.createElement('div');
       cdText.className = 'cdtext';
-      btn.append(label, kb, cdOverlay, cdText);
+      btn.append(label, countEl, kb, cdOverlay, cdText);
       const slot = i;
       // slot 0 is Attack for every class (auto-attack toggle — players
       // without right-click need a way in); the kit fills slots 1+
@@ -422,43 +458,57 @@ export class Hud {
           return '<div class="tt-title">Attack</div><div class="tt-sub">Toggle auto-attack on your target.<br>Right-clicking an enemy also attacks.</div>';
         }
         const known = this.abilityForSlot(slot);
-        return known ? this.abilityTooltip(known) : '<div class="tt-sub">Empty slot</div>';
+        if (known) return this.abilityTooltip(known);
+        const item = this.itemForSlot(slot);
+        if (item) {
+          const count = this.inventoryCount(item.id);
+          return this.itemTooltip(item) + (count > 0 ? `<div class="tt-sub">In bags: ${count}</div>` : '<div class="tt-sub">None in bags</div>');
+        }
+        return '<div class="tt-sub">Empty slot</div>';
       });
       if (slot >= 1) {
-        // drag an ability onto another slot to place or swap it;
+        // drag an action onto another slot to place or swap it;
         // slot 0 (Attack) stays fixed
         btn.draggable = true;
         btn.addEventListener('dragstart', (e) => {
-          const known = this.abilityForSlot(slot);
-          if (!known) { e.preventDefault(); return; }
-          this.dragAbilityId = known.def.id;
-          e.dataTransfer!.setData('text/plain', known.def.id);
+          const action = this.actionForSlot(slot);
+          if (!action) { e.preventDefault(); return; }
+          this.dragAction = { action, sourceIndex: slot - 1 };
+          this.writeDraggedAction(e.dataTransfer, action);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         btn.addEventListener('dragover', (e) => {
-          if (this.dragAbilityId === null || this.slotMap[slot - 1] === this.dragAbilityId) return;
+          const dragged = this.dragAction?.action ?? this.readDraggedAction(e.dataTransfer);
+          if (!dragged) return;
+          if (this.dragAction?.sourceIndex === slot - 1) return;
           e.preventDefault(); // required to permit the drop
-          e.dataTransfer!.dropEffect = 'move';
+          e.dataTransfer!.dropEffect = this.dragAction?.sourceIndex === null && dragged.type === 'item' ? 'copy' : 'move';
           btn.classList.add('drop-target');
         });
         btn.addEventListener('dragleave', () => btn.classList.remove('drop-target'));
         btn.addEventListener('drop', (e) => {
           e.preventDefault();
           btn.classList.remove('drop-target');
-          const abilityId = this.dragAbilityId ?? e.dataTransfer?.getData('text/plain') ?? '';
-          this.dragAbilityId = null;
-          if (!this.sim.known.some((k) => k.def.id === abilityId)) return;
-          this.slotMap = placeAbilityOnSlot(this.slotMap, abilityId, slot - 1);
+          const dragged = this.dragAction ?? { action: this.readDraggedAction(e.dataTransfer), sourceIndex: null };
+          this.dragAction = null;
+          const action = dragged.action;
+          if (!action) return;
+          if (dragged.sourceIndex !== null) this.hotbarActions = swapHotbarSlots(this.hotbarActions, dragged.sourceIndex, slot - 1);
+          else if (action.type === 'ability' && this.sim.known.some((k) => k.def.id === action.id)) {
+            this.hotbarActions = placeAbilityOnSlot(this.hotbarActions, action.id, slot - 1);
+          } else if (action.type === 'item' && this.isHotbarItemId(action.id)) {
+            this.hotbarActions = placeItemOnSlot(this.hotbarActions, action.id, slot - 1);
+          }
           this.saveSlotMap();
         });
         btn.addEventListener('dragend', () => {
-          this.dragAbilityId = null;
+          this.dragAction = null;
           this.clearActionDropTargets();
         });
       }
       bar.appendChild(btn);
-      this.abilityButtons.push({ btn, label, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
+      this.abilityButtons.push({ btn, label, countEl, keybindEl: kb, cdOverlay, cdText, lastIcon: '' });
     }
   }
 
@@ -569,7 +619,7 @@ export class Hud {
     // action bar
     const tgtDist = target && !target.dead ? dist2d(p.pos, target.pos) : null;
     const actionbar = $('#actionbar');
-    actionbar.classList.toggle('many-spells', this.slotMap.filter((id) => id !== null).length > 10);
+    actionbar.classList.toggle('many-spells', this.hotbarActions.filter((action) => action !== null).length > 10);
     for (let i = 0; i < this.abilityButtons.length; i++) {
       const ab = this.abilityButtons[i];
       if (i === 0) {
@@ -579,37 +629,58 @@ export class Hud {
           ab.lastIcon = '__attack';
           ab.label.style.backgroundImage = `url(${iconDataUrl('ability', 'attack')})`;
         }
+        ab.countEl.textContent = '';
         ab.cdOverlay.style.height = '0%';
         ab.cdText.textContent = '';
         ab.btn.classList.toggle('queued', !!p.autoAttack);
         ab.btn.classList.toggle('oor', tgtDist !== null && tgtDist > MELEE_RANGE);
         continue;
       }
+      const action = this.actionForSlot(i);
       const known = this.abilityForSlot(i);
-      if (!known) {
+      const item = this.itemForSlot(i);
+      if (!known && !item) {
         ab.btn.classList.add('empty');
+        ab.btn.classList.remove('unusable', 'oor', 'queued');
         if (ab.lastIcon !== '') {
           ab.lastIcon = '';
           ab.label.style.backgroundImage = '';
         }
+        ab.countEl.textContent = '';
         ab.cdOverlay.style.height = '0%';
         ab.cdText.textContent = '';
         continue;
       }
-      const a = known.def;
       ab.btn.classList.remove('empty');
+      if (item && action?.type === 'item') {
+        const iconKey = `item:${item.id}`;
+        if (ab.lastIcon !== iconKey) {
+          ab.lastIcon = iconKey;
+          ab.label.style.backgroundImage = `url(${iconDataUrl('item', item.id)})`;
+        }
+        const count = this.inventoryCount(item.id);
+        ab.countEl.textContent = String(count);
+        ab.cdOverlay.style.height = '0%';
+        ab.cdText.textContent = '';
+        ab.btn.classList.toggle('unusable', count <= 0 || p.dead);
+        ab.btn.classList.remove('oor', 'queued');
+        continue;
+      }
+      const a = known!.def;
       // set the painted icon once per slot change, not every frame
-      if (ab.lastIcon !== a.id) {
-        ab.lastIcon = a.id;
+      const iconKey = `ability:${a.id}`;
+      if (ab.lastIcon !== iconKey) {
+        ab.lastIcon = iconKey;
         ab.label.style.backgroundImage = `url(${iconDataUrl('ability', a.id)})`;
       }
+      ab.countEl.textContent = '';
       const cd = p.cooldowns.get(a.id) ?? 0;
       const gcdActive = !a.offGcd && p.gcdRemaining > 0;
       const shown = Math.max(cd, gcdActive ? p.gcdRemaining : 0);
       const denom = cd > 0 ? a.cooldown : GCD;
       ab.cdOverlay.style.height = shown > 0 ? `${Math.min(100, (shown / Math.max(0.01, denom)) * 100)}%` : '0%';
       ab.cdText.textContent = cd > 1 ? Math.ceil(cd).toString() : '';
-      ab.btn.classList.toggle('unusable', p.resource < known.cost);
+      ab.btn.classList.toggle('unusable', p.resource < known!.cost);
       const oor = a.requiresTarget && tgtDist !== null && tgtDist > (a.range > 0 ? a.range : MELEE_RANGE);
       ab.btn.classList.toggle('oor', !!oor);
       ab.btn.classList.toggle('queued', p.queuedOnSwing === a.id);
@@ -1838,6 +1909,20 @@ export class Hud {
           this.renderBags();
         }
       });
+      if (!this.tradeOpen && !this.vendorOpen && this.isHotbarItemId(s.itemId)) {
+        row.draggable = true;
+        row.addEventListener('dragstart', (e) => {
+          const action = { type: 'item' as const, id: s.itemId };
+          this.dragAction = { action, sourceIndex: null };
+          this.writeDraggedAction(e.dataTransfer, action);
+          e.dataTransfer!.effectAllowed = 'copy';
+          this.hideTooltip();
+        });
+        row.addEventListener('dragend', () => {
+          this.dragAction = null;
+          this.clearActionDropTargets();
+        });
+      }
       this.attachTooltip(row, () => {
         let extra = '';
         if (this.tradeOpen) extra = '<div class="tt-sub">Click to offer in trade</div>';
@@ -1934,13 +2019,14 @@ export class Hud {
       if (known) {
         row.draggable = true;
         row.addEventListener('dragstart', (e) => {
-          this.dragAbilityId = known.def.id;
-          e.dataTransfer!.setData('text/plain', known.def.id);
+          const action = { type: 'ability' as const, id: known.def.id };
+          this.dragAction = { action, sourceIndex: null };
+          this.writeDraggedAction(e.dataTransfer, action);
           e.dataTransfer!.effectAllowed = 'move';
           this.hideTooltip();
         });
         row.addEventListener('dragend', () => {
-          this.dragAbilityId = null;
+          this.dragAction = null;
           this.clearActionDropTargets();
         });
         this.attachTooltip(row, () => this.abilityTooltip(known));
@@ -2618,6 +2704,7 @@ export class Hud {
         this.tradeWasOpen = false;
         this.stagedTrade = { items: [], copper: 0 };
         this.lastTradeSig = '';
+        if ($('#bags').style.display === 'block') this.renderBags();
       }
       return;
     }
@@ -2860,7 +2947,7 @@ export class Hud {
     this.settingsViewFooter();
   }
 
-  // Display name for an action row. Action-bar slots show the ability that
+  // Display name for an action row. Action-bar slots show the shortcut that
   // currently occupies them (slot 0 is always Attack); everything else uses
   // its registry label.
   private actionDisplayName(actionId: string, fallback: string): string {
@@ -2868,7 +2955,9 @@ export class Hud {
     const slot = Number(actionId.slice(4));
     if (slot === 0) return 'Attack';
     const known = this.abilityForSlot(slot);
-    return known ? known.def.name : fallback;
+    if (known) return known.def.name;
+    const item = this.itemForSlot(slot);
+    return item ? item.name : fallback;
   }
 
   private renderKeybinds(): void {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -143,6 +143,7 @@ export interface IWorld {
   player: Entity;
   moveInput: MoveInput;
   inventory: InvSlot[];
+  vendorBuyback: InvSlot[];
   equipment: Partial<Record<EquipSlot, string>>;
   copper: number;
   xp: number;
@@ -166,6 +167,7 @@ export interface IWorld {
   useItem(itemId: string): void;
   buyItem(npcId: number, itemId: string): void;
   sellItem(itemId: string): void;
+  buyBackItem(itemId: string): void;
   releaseSpirit(): void;
   chat(text: string): void;
   // social systems

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -196,6 +196,7 @@ describe('admin api auth', () => {
     vi.mocked(isAdminAccount).mockResolvedValue(true);
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9, username: 'badactor', createdAt: '', lastLogin: null, isAdmin: false,
+      bannedAt: null, suspendedUntil: null, moderationReason: '',
       playtimeSeconds: 0, characters: [], recentSessions: [],
     });
     vi.mocked(moderationReportsForAccount).mockResolvedValue([]);
@@ -225,7 +226,7 @@ describe('admin api auth', () => {
 
   it('suspends and disconnects an account', async () => {
     vi.mocked(accountForToken).mockResolvedValue(7);
-    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
     const expiresAt = new Date(Date.now() + 3600_000).toISOString();
@@ -243,7 +244,7 @@ describe('admin api auth', () => {
 
   it('bans and disconnects an account', async () => {
     vi.mocked(accountForToken).mockResolvedValue(7);
-    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
     vi.mocked(moderateAccount).mockResolvedValue();
     const res = fakeRes();
 
@@ -256,6 +257,40 @@ describe('admin api auth', () => {
     expect(res.statusCode).toBe(200);
     expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'ban', reason: 'severe abuse', expiresAt: undefined });
     expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account has been banned.');
+  });
+
+  it('unbans without disconnecting the account', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(moderateAccount).mockResolvedValue();
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/unban', body: { reason: 'appeal accepted' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'unban', reason: 'appeal accepted', expiresAt: undefined });
+    expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
+  });
+
+  it('rejects suspending or banning admin accounts', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/ban', body: { reason: 'bad admin' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.error).toMatch(/admin accounts cannot/);
+    expect(moderateAccount).not.toHaveBeenCalled();
+    expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
   });
 
   it('forces a character rename and disconnects that account', async () => {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -126,6 +126,19 @@ describe('chat channels', () => {
     expect(events.some((e) => e.type === 'error' && e.text.includes('/dance'))).toBe(true);
   });
 
+  it('/who explains that the roster is online-only in offline sim play', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/who', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'The /who roster is available in online play.',
+    }));
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/evade_immunity.test.ts
+++ b/tests/evade_immunity.test.ts
@@ -1,0 +1,71 @@
+// A wild mob retreating home after a leash break (aiState 'evade') has dropped
+// its hate table and will not fight back. It must be immune to damage while it
+// resets, otherwise a player can chip it down — or kill it outright — for a
+// risk-free kill, which also breaks the classic reset contract.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d } from '../src/sim/types';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+function nearestMob(sim: Sim): Entity {
+  let best: Entity | null = null;
+  let bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.ownerId !== null) continue;
+    const d = dist2d(sim.player.pos, e.pos);
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  return best!;
+}
+
+function hit(sim: Sim, source: Entity, target: Entity, amount: number) {
+  (sim as any).dealDamage(source, target, amount, false, 'physical', null, 'hit', true);
+}
+
+describe('evading mobs are immune while resetting', () => {
+  it('takes no damage and gains no threat from a hit while evading', () => {
+    const sim = makeSim();
+    const wolf = nearestMob(sim);
+    wolf.maxHp = 5000;
+    wolf.hp = 5000;
+    wolf.aiState = 'evade';
+    wolf.threat.clear();
+
+    hit(sim, sim.player, wolf, 1000);
+
+    expect(wolf.hp).toBe(5000);
+    expect(wolf.threat.size).toBe(0);
+    expect(wolf.dead).toBe(false);
+  });
+
+  it('cannot be killed while evading', () => {
+    const sim = makeSim();
+    const wolf = nearestMob(sim);
+    wolf.maxHp = 50;
+    wolf.hp = 50;
+    wolf.aiState = 'evade';
+
+    hit(sim, sim.player, wolf, 99999);
+
+    expect(wolf.dead).toBe(false);
+    expect(wolf.hp).toBe(50);
+  });
+
+  it('still takes damage normally once it is fighting again', () => {
+    const sim = makeSim();
+    const wolf = nearestMob(sim);
+    wolf.maxHp = 5000;
+    wolf.hp = 5000;
+    wolf.aiState = 'attack';
+    wolf.threat.clear();
+
+    hit(sim, sim.player, wolf, 100);
+
+    expect(wolf.hp).toBe(4900);
+    expect(wolf.threat.get(sim.playerId)).toBeCloseTo(100, 5);
+  });
+});

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { placeAbilityOnSlot } from '../src/ui/hotbar';
+
+describe('hotbar ability placement', () => {
+  it('places a spellbook ability onto the target action slot', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'polymorph', 1);
+
+    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
+    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+  });
+
+  it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
+    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+
+    const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
+
+    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { placeAbilityOnSlot } from '../src/ui/hotbar';
+import { clearHotbarSlot, placeAbilityOnSlot, syncHotbarSlotMap } from '../src/ui/hotbar';
 
 describe('hotbar ability placement', () => {
   it('places a spellbook ability onto the target action slot', () => {
@@ -17,5 +17,58 @@ describe('hotbar ability placement', () => {
     const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
 
     expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+});
+
+describe('hotbar slot clearing', () => {
+  it('clears an occupied slot', () => {
+    const slotMap = ['fireball', 'frostbolt', null];
+
+    expect(clearHotbarSlot(slotMap, 1)).toEqual(['fireball', null, null]);
+  });
+
+  it('leaves an empty slot stable', () => {
+    const slotMap = ['fireball', null, 'blink'];
+
+    expect(clearHotbarSlot(slotMap, 1)).toEqual(['fireball', null, 'blink']);
+  });
+
+  it('does not mutate the input array', () => {
+    const slotMap = ['fireball', 'frostbolt', null];
+
+    clearHotbarSlot(slotMap, 1);
+
+    expect(slotMap).toEqual(['fireball', 'frostbolt', null]);
+  });
+
+  it('ignores out-of-range slots', () => {
+    const slotMap = ['fireball', 'frostbolt', null];
+
+    expect(clearHotbarSlot(slotMap, -1)).toEqual(slotMap);
+    expect(clearHotbarSlot(slotMap, 3)).toEqual(slotMap);
+  });
+});
+
+describe('hotbar slot sync', () => {
+  it('preserves a missing already-known ability as a cleared slot', () => {
+    const slots = ['fireball', null, 'blink'];
+
+    expect(syncHotbarSlotMap(slots, ['fireball', 'frostbolt', 'blink'], new Set())).toEqual(slots);
+  });
+
+  it('places a newly learned ability into the first empty slot', () => {
+    const slots = ['fireball', null, 'blink'];
+
+    expect(syncHotbarSlotMap(slots, ['fireball', 'frostbolt', 'blink'], new Set(['frostbolt']))).toEqual([
+      'fireball',
+      'frostbolt',
+      'blink',
+    ]);
+  });
+
+  it('drops abilities that are no longer known', () => {
+    const slots = ['fireball', 'frostbolt', 'blink'];
+
+    expect(syncHotbarSlotMap(slots, ['fireball', 'blink'], new Set())).toEqual(['fireball', null, 'blink']);
   });
 });

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { CLASSES } from '../src/sim/content/classes';
 import { placeAbilityOnSlot } from '../src/ui/hotbar';
 
 describe('hotbar ability placement', () => {
@@ -17,5 +18,26 @@ describe('hotbar ability placement', () => {
     const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
 
     expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+  });
+
+  it('places the mage overflow spell onto a full non-Attack action bar', () => {
+    const barSlots = 11;
+    const mageAbilities = CLASSES.mage.abilities;
+    const slots = mageAbilities.slice(0, barSlots);
+    const targetIndex = 4;
+    const displacedAbility = slots[targetIndex];
+
+    expect(slots).toHaveLength(barSlots);
+    expect(mageAbilities[barSlots]).toBe('ice_barrier');
+    expect(slots).not.toContain('ice_barrier');
+
+    const next = placeAbilityOnSlot(slots, 'ice_barrier', targetIndex);
+    const occupied = next.filter((id) => id !== null);
+
+    expect(next[targetIndex]).toBe('ice_barrier');
+    expect(next).not.toContain(displacedAbility);
+    expect(occupied).toHaveLength(barSlots);
+    expect(new Set(occupied).size).toBe(occupied.length);
+    expect(slots).toEqual(mageAbilities.slice(0, barSlots));
   });
 });

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,21 +1,119 @@
 import { describe, expect, it } from 'vitest';
-import { placeAbilityOnSlot } from '../src/ui/hotbar';
+import {
+  parseHotbarActions, placeAbilityOnSlot, placeItemOnSlot, syncHotbarActions,
+} from '../src/ui/hotbar';
 
-describe('hotbar ability placement', () => {
+const abilityIds = new Set(['fireball', 'frost_armor', 'arcane_intellect', 'polymorph', 'shared_id']);
+const itemIds = new Set(['baked_bread', 'spring_water', 'shared_id']);
+const abilityExists = (id: string) => abilityIds.has(id);
+const itemExists = (id: string) => itemIds.has(id);
+
+describe('hotbar action parsing', () => {
+  it('migrates legacy ability strings and drops duplicate abilities', () => {
+    const actions = parseHotbarActions(
+      ['fireball', 'frost_armor', 'fireball', 'baked_bread'],
+      5,
+      abilityExists,
+      itemExists,
+    );
+
+    expect(actions).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'frost_armor' },
+      null,
+      null,
+      null,
+    ]);
+  });
+
+  it('keeps item and ability actions distinct even when ids overlap', () => {
+    const actions = parseHotbarActions(
+      [{ type: 'ability', id: 'shared_id' }, { type: 'item', id: 'shared_id' }],
+      2,
+      abilityExists,
+      itemExists,
+    );
+
+    expect(actions).toEqual([
+      { type: 'ability', id: 'shared_id' },
+      { type: 'item', id: 'shared_id' },
+    ]);
+  });
+});
+
+describe('hotbar action placement', () => {
   it('places a spellbook ability onto the target action slot', () => {
-    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+    const slots = [
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'ability' as const, id: 'frost_armor' },
+      { type: 'ability' as const, id: 'arcane_intellect' },
+      null,
+    ];
 
     const next = placeAbilityOnSlot(slots, 'polymorph', 1);
 
-    expect(next).toEqual(['fireball', 'polymorph', 'arcane_intellect', null]);
-    expect(slots).toEqual(['fireball', 'frost_armor', 'arcane_intellect', null]);
+    expect(next).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'polymorph' },
+      { type: 'ability', id: 'arcane_intellect' },
+      null,
+    ]);
+    expect(slots).toEqual([
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'frost_armor' },
+      { type: 'ability', id: 'arcane_intellect' },
+      null,
+    ]);
   });
 
   it('swaps instead of duplicating when the spellbook ability is already on the bar', () => {
-    const slots = ['fireball', 'frost_armor', 'arcane_intellect', null];
+    const slots = [
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'ability' as const, id: 'frost_armor' },
+      { type: 'ability' as const, id: 'arcane_intellect' },
+      null,
+    ];
 
     const next = placeAbilityOnSlot(slots, 'arcane_intellect', 0);
 
-    expect(next).toEqual(['arcane_intellect', 'frost_armor', 'fireball', null]);
+    expect(next).toEqual([
+      { type: 'ability', id: 'arcane_intellect' },
+      { type: 'ability', id: 'frost_armor' },
+      { type: 'ability', id: 'fireball' },
+      null,
+    ]);
+  });
+
+  it('places a food item on an occupied action slot without removing other item shortcuts', () => {
+    const slots = [
+      { type: 'item' as const, id: 'baked_bread' },
+      { type: 'ability' as const, id: 'fireball' },
+      null,
+    ];
+
+    const next = placeItemOnSlot(slots, 'baked_bread', 1);
+
+    expect(next).toEqual([
+      { type: 'item', id: 'baked_bread' },
+      { type: 'item', id: 'baked_bread' },
+      null,
+    ]);
+  });
+
+  it('keeps item shortcuts when learned abilities resync', () => {
+    const slots = [
+      { type: 'item' as const, id: 'spring_water' },
+      { type: 'ability' as const, id: 'fireball' },
+      null,
+    ];
+
+    const synced = syncHotbarActions(slots, ['fireball', 'polymorph']);
+
+    expect(synced.actions).toEqual([
+      { type: 'item', id: 'spring_water' },
+      { type: 'ability', id: 'fireball' },
+      { type: 'ability', id: 'polymorph' },
+    ]);
+    expect(synced.changed).toBe(true);
   });
 });

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -132,6 +132,27 @@ describe('moderation report helpers', () => {
     expect(query).not.toHaveBeenCalled();
   });
 
+  it('unbans accounts and writes an audit action in one transaction', async () => {
+    const client = clientStub();
+    connect.mockResolvedValue(client as any);
+
+    await moderateAccount({
+      accountId: 2,
+      adminAccountId: 1,
+      action: 'unban',
+      reason: 'appeal accepted',
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(client.query.mock.calls[0][0]).toBe('BEGIN');
+    expect(client.query.mock.calls[1][0]).toMatch(/SET banned_at = NULL, suspended_until = NULL/);
+    expect(client.query.mock.calls[1][1]).toEqual([2, 'appeal accepted']);
+    expect(client.query.mock.calls[2][0]).toMatch(/account_moderation_actions/);
+    expect(client.query.mock.calls[2][1]).toEqual([2, 1, 'unban', 'appeal accepted', null]);
+    expect(client.query.mock.calls[4][0]).toBe('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
   it('marks a character for forced rename and action-resolves its reports', async () => {
     query.mockResolvedValueOnce({ rows: [{ account_id: 2 }] } as any);
     const client = clientStub();

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -233,6 +233,56 @@ describe('combat', () => {
     expect(wolf.hp).toBe(wolf.maxHp);
   });
 
+  it('hostile actions refresh the mob leash anchor for kiting', () => {
+    const sim = makeSim('warrior');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    wolf.maxHp = 5000;
+    wolf.hp = 5000;
+    wolf.pos.x = wolf.spawnPos.x + 50;
+    wolf.pos.z = wolf.spawnPos.z;
+    wolf.pos.y = terrainHeight(wolf.pos.x, wolf.pos.z, sim.cfg.seed);
+    wolf.prevPos = { ...wolf.pos };
+    teleportTo(sim, wolf.pos.x + 2, wolf.pos.z);
+
+    (sim as any).dealDamage(sim.player, wolf, 1, false, 'physical', 'Test', 'hit', true);
+    sim.tick();
+
+    expect(dist2d(wolf.pos, wolf.spawnPos)).toBeGreaterThan(45);
+    expect(wolf.aiState).not.toBe('evade');
+    expect(wolf.leashAnchor).not.toBeNull();
+  });
+
+  it('social pulls only very close same-template mobs', () => {
+    const sim = makeSim('warrior');
+    const wolf = nearestMob(sim, 'forest_wolf');
+    const otherWolf = [...sim.entities.values()].find((e: any) => e.kind === 'mob' && e.id !== wolf.id && e.templateId === 'forest_wolf') as any;
+    wolf.pos = { ...wolf.spawnPos };
+    otherWolf.pos = { x: wolf.pos.x + 6, y: wolf.pos.y, z: wolf.pos.z };
+    otherWolf.prevPos = { ...otherWolf.pos };
+    (sim as any).rebucket(wolf);
+    (sim as any).rebucket(otherWolf);
+    teleportTo(sim, wolf.pos.x + 2, wolf.pos.z);
+
+    (sim as any).aggroMob(wolf, sim.player, true);
+
+    expect(otherWolf.aiState).toBe('idle');
+
+    const murloc = nearestMob(sim, 'mudfin_murloc');
+    const otherMurloc = [...sim.entities.values()].find((e: any) => e.kind === 'mob' && e.id !== murloc.id && e.templateId === 'mudfin_murloc') as any;
+    murloc.aiState = 'idle';
+    otherMurloc.aiState = 'idle';
+    murloc.pos = { ...murloc.spawnPos };
+    otherMurloc.pos = { x: murloc.pos.x + 9, y: murloc.pos.y, z: murloc.pos.z };
+    otherMurloc.prevPos = { ...otherMurloc.pos };
+    (sim as any).rebucket(murloc);
+    (sim as any).rebucket(otherMurloc);
+    teleportTo(sim, murloc.pos.x + 2, murloc.pos.z);
+
+    (sim as any).aggroMob(murloc, sim.player, true);
+
+    expect(otherMurloc.aiState).toBe('idle');
+  });
+
   it('dead mobs respawn', () => {
     const sim = new Sim({ seed: 42, playerClass: 'warrior', respawnSeconds: 2 });
     const wolf = nearestMob(sim, 'forest_wolf');

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -468,6 +468,78 @@ describe('food, drink, vendor', () => {
     expect(sim.countItem('wolf_fang')).toBe(1);
   });
 
+  it('vendor buyback restores recently sold gear for the sale price', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('apprentice_staff', 1);
+
+    sim.sellItem('apprentice_staff');
+
+    expect(sim.countItem('apprentice_staff')).toBe(0);
+    expect(sim.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    expect(sim.copper).toBe(120);
+
+    sim.buyBackItem('apprentice_staff');
+
+    expect(sim.countItem('apprentice_staff')).toBe(1);
+    expect(sim.vendorBuyback).toEqual([]);
+    expect(sim.copper).toBe(0);
+  });
+
+  it('vendor buyback round-trips through saved character state', () => {
+    const sim = makeSim('warrior');
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('apprentice_staff', 1);
+    sim.sellItem('apprentice_staff');
+
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+
+    const sim2 = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false });
+    const pid2 = sim2.addPlayer('warrior', 'Saved', { state });
+    const wilkes2 = [...sim2.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim2, wilkes2.pos.x + 2, wilkes2.pos.z);
+
+    expect(sim2.meta(pid2)!.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    sim2.buyBackItem('apprentice_staff', pid2);
+    expect(sim2.countItem('apprentice_staff', pid2)).toBe(1);
+    expect(sim2.meta(pid2)!.vendorBuyback).toEqual([]);
+  });
+
+  it('vendor buyback requires money and keeps only recent sold item groups', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: false });
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    teleportTo(sim, wilkes.pos.x + 2, wilkes.pos.z);
+    sim.addItem('wolf_fang', 2);
+    sim.sellItem('wolf_fang');
+    sim.sellItem('wolf_fang');
+    expect(sim.vendorBuyback).toEqual([{ itemId: 'wolf_fang', count: 2 }]);
+    sim.copper = 0;
+
+    sim.buyBackItem('wolf_fang');
+
+    expect(sim.countItem('wolf_fang')).toBe(0);
+    expect(sim.vendorBuyback).toEqual([{ itemId: 'wolf_fang', count: 2 }]);
+    expect(sim.events).toContainEqual({ type: 'error', text: 'Not enough money.', pid: sim.player.id });
+
+    const itemIds = [
+      'bandit_bandana', 'tough_jerky', 'mudfin_scale', 'tallow_candle',
+      'spider_leg', 'bone_fragments', 'linen_scrap', 'baked_bread',
+      'spring_water', 'roasted_boar', 'worn_sword', 'hickory_shortstaff',
+      'apprentice_staff',
+    ];
+    for (const itemId of itemIds) {
+      sim.addItem(itemId, 1);
+      sim.sellItem(itemId);
+    }
+
+    expect(sim.vendorBuyback).toHaveLength(12);
+    expect(sim.vendorBuyback[0]).toEqual({ itemId: 'apprentice_staff', count: 1 });
+    expect(sim.vendorBuyback.some((s) => s.itemId === 'wolf_fang')).toBe(false);
+  });
+
   it('vendor buy rejects stale or invalid merchants with feedback', () => {
     const sim = makeSim('warrior');
     const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -13,6 +13,7 @@ vi.mock('../server/db', () => ({
 }));
 
 import { censorChatText, GameServer, ClientSession } from '../server/game';
+import { saveCharacterState } from '../server/db';
 import { ClientWorld } from '../src/net/online';
 
 const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
@@ -273,6 +274,68 @@ describe('chat moderation', () => {
       warn.mockRestore();
       rmSync(dir, { force: true, recursive: true });
     }
+  });
+});
+
+describe('autosaves', () => {
+  beforeEach(() => {
+    vi.mocked(saveCharacterState).mockReset();
+    vi.mocked(saveCharacterState).mockResolvedValue(undefined);
+  });
+
+  it('skips overlapping saveAll runs while saving each current session once', async () => {
+    const server = new GameServer();
+    joinServer(server, fakeWs(), 1, 'Testa');
+    joinServer(server, fakeWs(), 2, 'Testb');
+    joinServer(server, fakeWs(), 3, 'Testc');
+
+    let resolveFirstSave!: () => void;
+    const firstSave = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    vi.mocked(saveCharacterState).mockImplementationOnce(() => firstSave);
+
+    const firstRun = server.saveAll('test');
+    await vi.waitFor(() => {
+      expect(saveCharacterState).toHaveBeenCalledTimes(3);
+    });
+
+    await server.saveAll('test');
+    expect(saveCharacterState).toHaveBeenCalledTimes(3);
+
+    resolveFirstSave();
+    await firstRun;
+
+    const savedCharacterIds = vi.mocked(saveCharacterState).mock.calls.map((call) => call[0]);
+    expect(savedCharacterIds.sort((a, b) => a - b)).toEqual([1, 2, 3]);
+  });
+
+  it('waits for an active autosave before running the shutdown save pass', async () => {
+    const server = new GameServer();
+    joinServer(server, fakeWs(), 1, 'Testa');
+    joinServer(server, fakeWs(), 2, 'Testb');
+
+    let resolveFirstSave!: () => void;
+    const firstSave = new Promise<void>((resolve) => {
+      resolveFirstSave = resolve;
+    });
+    vi.mocked(saveCharacterState).mockImplementationOnce(() => firstSave);
+
+    const autosave = server.saveAll('autosave');
+    await vi.waitFor(() => {
+      expect(saveCharacterState).toHaveBeenCalledTimes(2);
+    });
+
+    const shutdown = server.saveAll('shutdown');
+    await Promise.resolve();
+    expect(saveCharacterState).toHaveBeenCalledTimes(2);
+
+    resolveFirstSave();
+    await autosave;
+    await shutdown;
+
+    const savedCharacterIds = vi.mocked(saveCharacterState).mock.calls.map((call) => call[0]);
+    expect(savedCharacterIds.sort((a, b) => a - b)).toEqual([1, 1, 2, 2]);
   });
 });
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -14,6 +14,7 @@ vi.mock('../server/db', () => ({
 
 import { censorChatText, GameServer, ClientSession } from '../server/game';
 import { ClientWorld } from '../src/net/online';
+import type { PlayerClass } from '../src/sim/types';
 
 const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
 
@@ -34,10 +35,18 @@ function lastSnap(sent: any[]): any {
   return null;
 }
 
-function joinServer(server: GameServer, fc: FakeClient, characterId: number, name: string): ClientSession {
-  const session = server.join(fc.ws, characterId, characterId, name, 'warrior', null);
+function joinServer(server: GameServer, fc: FakeClient, characterId: number, name: string, cls: PlayerClass = 'warrior'): ClientSession {
+  const session = server.join(fc.ws, characterId, characterId, name, cls, null);
   if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
   return session;
+}
+
+function eventTexts(sent: any[]): string[] {
+  return sent
+    .flatMap((msg) => msg.t === 'events' ? msg.list : [])
+    .filter((ev) => ev.type === 'log' || ev.type === 'error')
+    .map((ev) => ev.text);
 }
 
 function broadcast(server: GameServer): void {
@@ -273,6 +282,75 @@ describe('chat moderation', () => {
       warn.mockRestore();
       rmSync(dir, { force: true, recursive: true });
     }
+  });
+});
+
+describe('/who command', () => {
+  it('lists online players with class, level, realm, and zone metadata', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph', 'warrior');
+    const fc2 = fakeWs();
+    const other = joinServer(server, fc2, 2, 'Bet', 'mage');
+    server.sim.setPlayerLevel(7, other.pid);
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    const text = eventTexts(fc.sent).join('\n');
+    expect(text).toContain('Who: 2 players online on Claudemoon.');
+    expect(text).toContain('Aleph - level 1 warrior - Eastbrook Vale');
+    expect(text).toContain('Bet - level 7 mage - Eastbrook Vale');
+  });
+
+  it('hides ignored players and players who ignored the requester', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph');
+    const fcIgnored = fakeWs();
+    const ignored = joinServer(server, fcIgnored, 2, 'Bet');
+    const fcBlocking = fakeWs();
+    const blocking = joinServer(server, fcBlocking, 3, 'Gimel');
+    self.blockedIds = new Set([ignored.characterId]);
+    blocking.blockedIds = new Set([self.characterId]);
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    const text = eventTexts(fc.sent).join('\n');
+    expect(text).toContain('Who: 1 player online on Claudemoon.');
+    expect(text).toContain('Aleph - level 1 warrior - Eastbrook Vale');
+    expect(text).not.toContain('Bet');
+    expect(text).not.toContain('Gimel');
+  });
+
+  it('waits for the requester ignore list before showing online players', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph');
+    joinServer(server, fakeWs(), 2, 'Bet');
+    self.blockListLoaded = false;
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    expect(eventTexts(fc.sent)).toContain('Your ignore list is still loading. Try /who again in a moment.');
+  });
+
+  it('omits players whose own ignore list is still loading', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const self = joinServer(server, fc, 1, 'Aleph');
+    const pending = joinServer(server, fakeWs(), 2, 'Bet');
+    pending.blockListLoaded = false;
+    fc.sent.length = 0;
+
+    server.handleMessage(self, JSON.stringify({ t: 'cmd', cmd: 'chat', text: '/who' }));
+
+    const text = eventTexts(fc.sent).join('\n');
+    expect(text).toContain('Who: 1 player online on Claudemoon.');
+    expect(text).toContain('Aleph - level 1 warrior - Eastbrook Vale');
+    expect(text).not.toContain('Bet');
   });
 });
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -15,7 +15,7 @@ vi.mock('../server/db', () => ({
 import { censorChatText, GameServer, ClientSession } from '../server/game';
 import { ClientWorld } from '../src/net/online';
 
-const DELTA_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
+const DELTA_KEYS = ['inv', 'buyback', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
 
 interface FakeClient {
   sent: any[];
@@ -52,6 +52,7 @@ function bareClient(pid: number): ClientWorld {
   c.playerId = pid;
   c.moveInput = {};
   c.inventory = [];
+  c.vendorBuyback = [];
   c.equipment = {};
   c.copper = 0;
   c.xp = 0;
@@ -141,6 +142,33 @@ describe('delta snapshots', () => {
     expect(snap.self.inv.some((s: any) => s.itemId === 'baked_bread')).toBe(true);
     expect(snap.self).not.toHaveProperty('qlog');
     expect(snap.self).not.toHaveProperty('stats');
+  });
+
+  it('mirrors vendor buyback deltas to the client', () => {
+    const wilkes = [...server.sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    const player = server.sim.entities.get(session.pid)!;
+    player.pos.x = wilkes.pos.x + 2;
+    player.pos.z = wilkes.pos.z;
+    player.prevPos = { ...player.pos };
+    server.sim.addItem('apprentice_staff', 1, session.pid);
+    broadcast(server);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.vendorBuyback).toEqual([]);
+    expect(client.consumeInventoryChanged()).toBe(true);
+
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'sell', item: 'apprentice_staff' }));
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self).toHaveProperty('buyback');
+    expect(snap.self.buyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+
+    const buybackOnly = { ...snap, self: { ...snap.self } };
+    delete buybackOnly.self.inv;
+    (client as any).applySnapshot(buybackOnly);
+    expect(client.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    expect(client.consumeInventoryChanged()).toBe(true);
   });
 
   it('quest commands force a quest-state resync even when rejected', () => {

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -71,6 +71,28 @@ describe('nine classes', () => {
     expect(p.hp).toBe(hpBefore); // fully soaked
   });
 
+  it('friendly target spells can affect selected players', () => {
+    const sim = makeWorld();
+    const priestId = sim.addPlayer('priest', 'Healer');
+    const priest = sim.entities.get(priestId)!;
+    const allyId = sim.addPlayer('warrior', 'Ally');
+    const ally = sim.entities.get(allyId)!;
+    teleport(sim, priestId, ally.pos.x + 5, ally.pos.z);
+    sim.setPlayerLevel(6, priestId);
+    priest.resource = priest.maxResource;
+    ally.hp = 20;
+
+    sim.targetEntity(ally.id, priestId);
+    sim.castAbility('lesser_heal', priestId);
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    expect(ally.hp).toBeGreaterThan(20);
+
+    for (let i = 0; i < 25; i++) sim.tick();
+    sim.castAbility('power_word_shield', priestId);
+    sim.tick();
+    expect(ally.auras.some((a) => a.kind === 'absorb')).toBe(true);
+  });
+
   it('renew ticks healing over time', () => {
     const sim = new Sim({ seed: 42, playerClass: 'priest' });
     sim.setPlayerLevel(8);

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -253,6 +253,30 @@ describe('parties', () => {
     expect(sim.partyOf(a)).toBe(null);
   });
 
+  it('refuses to accept an invite while already in a party', () => {
+    // A player can become a party leader (by inviting someone who accepts)
+    // while still holding an unconsumed incoming invite — inviting someone
+    // never consumes the inviter's own pending invite. Accepting that stale
+    // invite must NOT leave the player a member of two parties at once.
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    const d = sim.addPlayer('mage', 'Dalet');
+    // C invites A while A is solo (stored, unaccepted).
+    sim.partyInvite(a, c);
+    // A forms a party of its own by inviting D, who accepts. A is now leader.
+    sim.partyInvite(d, a);
+    sim.partyAccept(d);
+    expect(sim.partyOf(a)?.leader).toBe(a);
+    const ownParty = sim.partyOf(a)!.id;
+    // A now accepts C's stale invite — this must be rejected.
+    sim.partyAccept(a);
+    // A stays in its own party only; no second membership is created.
+    expect(sim.partyOf(a)?.id).toBe(ownParty);
+    expect(sim.partyOf(c)?.members.includes(a) ?? false).toBe(false);
+    expect(sim.partyOf(a)?.members).toEqual([a, d]);
+  });
+
   it('partyInfo reports per-member combat state for the UI badges', () => {
     const { sim, a, b } = makeDuo();
     // out of combat by default

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -387,6 +387,55 @@ describe('hunter pets', () => {
     expect(sim.petOf(sim.playerId)).toBe(wolf);
   });
 
+  it('friendly target spells can affect controlled pets', () => {
+    const { sim, wolf: pet } = tamedSetup();
+    const druidId = sim.addPlayer('druid', 'Druid');
+    const druid = sim.entities.get(druidId)!;
+    teleport(sim, druid, pet.pos.x + 5, pet.pos.z);
+    druid.resource = druid.maxResource;
+    const armorBefore = (sim as any).effectiveArmor(pet);
+
+    sim.targetEntity(pet.id, druidId);
+    sim.castAbility('mark_of_the_wild', druidId);
+    expect(pet.auras.some((a) => a.id === 'mark_of_the_wild')).toBe(true);
+    expect((sim as any).effectiveArmor(pet)).toBeGreaterThan(armorBefore);
+
+    const priestId = sim.addPlayer('priest', 'Priest');
+    const priest = sim.entities.get(priestId)!;
+    teleport(sim, priest, pet.pos.x + 6, pet.pos.z);
+    priest.resource = priest.maxResource;
+    const maxHpBefore = pet.maxHp;
+    sim.targetEntity(pet.id, priestId);
+    sim.castAbility('power_word_fortitude', priestId);
+    expect(pet.maxHp).toBeGreaterThan(maxHpBefore);
+
+    const paladinId = sim.addPlayer('paladin', 'Paladin');
+    const paladin = sim.entities.get(paladinId)!;
+    sim.setPlayerLevel(4, paladinId);
+    teleport(sim, paladin, pet.pos.x + 7, pet.pos.z);
+    paladin.resource = paladin.maxResource;
+    const attackPowerBefore = (sim as any).effectiveAttackPower(pet);
+    sim.targetEntity(pet.id, paladinId);
+    sim.castAbility('blessing_of_might', paladinId);
+    expect((sim as any).effectiveAttackPower(pet)).toBeGreaterThan(attackPowerBefore);
+
+    pet.hp = pet.maxHp - 40;
+    const damagedHp = pet.hp;
+    for (let i = 0; i < 20 * 2; i++) sim.tick();
+    sim.castAbility('healing_touch', druidId);
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+
+    expect(pet.hp).toBeGreaterThan(damagedHp);
+
+    (sim as any).dealDamage(null, pet, pet.hp, false, 'physical', 'test', 'hit');
+    expect(pet.dead).toBe(true);
+    expect(pet.auras).toHaveLength(0);
+    expect(pet.maxHp).toBe(maxHpBefore);
+    (sim as any).respawnMob(pet);
+    expect(pet.auras).toHaveLength(0);
+    expect(pet.maxHp).toBe(maxHpBefore);
+  });
+
   it('the pet assists against attackers, growls, and builds its own threat', () => {
     const { sim, wolf: pet } = tamedSetup();
     const boar = nearestMob(sim, 'wild_boar');
@@ -408,10 +457,21 @@ describe('hunter pets', () => {
 
   it('dismiss releases the pet back to the wild', () => {
     const { sim, wolf } = tamedSetup();
+    const priestId = sim.addPlayer('priest', 'Priest');
+    const priest = sim.entities.get(priestId)!;
+    teleport(sim, priest, wolf.pos.x + 5, wolf.pos.z);
+    priest.resource = priest.maxResource;
+    const maxHpBefore = wolf.maxHp;
+    sim.targetEntity(wolf.id, priestId);
+    sim.castAbility('power_word_fortitude', priestId);
+    expect(wolf.maxHp).toBeGreaterThan(maxHpBefore);
+
     for (let i = 0; i < 25; i++) sim.tick();
     sim.castAbility('dismiss_pet');
     expect(wolf.ownerId).toBe(null);
     expect(wolf.hostile).toBe(true);
+    expect(wolf.auras).toHaveLength(0);
+    expect(wolf.maxHp).toBe(maxHpBefore);
     expect(sim.petOf(sim.playerId)).toBe(null);
   });
 

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -232,6 +232,18 @@ describe('classic pull-over rules (110% melee / 130% ranged)', () => {
     // the dead player dropped off the table entirely
     expect(wolf.threat.has(a.id)).toBe(false);
   });
+
+  it('when the target dies the mob evades instead of attacking a bystander with no threat', () => {
+    const { sim, a, b, wolf } = aggroSetup();
+    teleport(sim, b, wolf.pos.x + 2, wolf.pos.z + 2);
+
+    (sim as any).dealDamage(wolf, a, 99999, false, 'physical', null, 'hit', true);
+
+    expect(a.dead).toBe(true);
+    expect(wolf.threat.has(b.id)).toBe(false);
+    expect(wolf.aggroTargetId).not.toBe(b.id);
+    expect(wolf.aiState).toBe('evade');
+  });
 });
 
 describe('taunt and growl', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
-  base: './',
+  base: '/',
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

Merge the tested `release/v0.5-moderate` integration branch into `release/v0.5`.

This batch includes the moderate gameplay/QoL/admin set we validated on dev:

- #175 Party invite accept double-membership guard
- #173 Evading mobs are immune to damage while resetting
- #84 Bound and dedupe autosaves
- #123 Allow dragging spellbook abilities to hotbar
- #124 Full actionbar spell replacement coverage
- #127 Allow clearing actionbar slots
- #129 Food/drink actionbar shortcuts
- #141 Support friendly spell targets, tracked by #133
- #144 Add `/who` command, tracked by #106
- #153 Tune mob reset and social pull behavior
- #156 Add vendor item buyback
- #154 Add admin account moderation controls

Also included from integration testing:

- `8b83dca` fix: initialize online leash anchor field
- `30d4c7b` fix: serve built assets from root

## Verification

Automated checks on `release/v0.5-moderate`:

- [x] `npm test` - 40 files / 453 tests
- [x] `npx tsc --noEmit`
- [x] `npm run build:env`
- [x] `npm run build:server`
- [x] `npm run build`

Dev smoke/manual checks:

- [x] Dev deploy completed for `release/v0.5-moderate`; `/api/status` healthy
- [x] Public client loads and login/character select/enter world works
- [x] Vendor sell/buyback works
- [x] Food/drink hotbar shortcuts can be added, used, cleared, and survive reload behavior
- [x] `/who` works
- [x] Stale party invite accept does not create double membership
- [x] Friendly party healing works: Lorak healed ReubLock from damaged HP to full with `Healing Wave`
- [x] Admin dashboard loads, admin account protection is visible, and moderation controls are present for non-admin accounts

## Follow-up Risk

- Manual leash/evade feel should still get a final pass after `release/v0.5` deploy.
- Admin destructive actions were not clicked against a throwaway account during this pass.