### PR TITLE
fix: stop armor from mitigating spell-school AoE damage

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1603,7 +1603,10 @@ export class Sim {
           this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: ability.school, fx: 'nova' });
           for (const m of this.mobsInRadius(p.pos, eff.radius)) {
             let dmg = this.rng.range(eff.min, eff.max);
-            dmg *= 1 - armorReduction(this.effectiveArmor(m), p.level);
+            // Armor only mitigates physical damage, mirroring the single-target
+            // path above — spell-school AoE (Arcane Explosion, Consecration) is
+            // not reduced by the target's armor.
+            if (!isSpell) dmg *= 1 - armorReduction(this.effectiveArmor(m), p.level);
             this.dealDamage(p, m, Math.round(dmg), false, ability.school, ability.name, 'hit', false, threatOpts);
           }
           break;

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -358,6 +358,36 @@ describe('warrior charge', () => {
   });
 });
 
+describe('aoe damage vs armor', () => {
+  // Armor mitigates physical damage only. The single-target path already
+  // gates armor on `!isSpell`; the AoE path must match so spell-school novas
+  // (Arcane Explosion, Consecration) ignore the target's armor like every
+  // other spell in the game.
+  function aoeSetup(ability: string) {
+    const sim = makeSim('mage');
+    (sim as any).grantXp(99999); // level up far past Arcane Explosion (lvl 14)
+    const p = sim.player;
+    const wolf = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'forest_wolf' && !e.dead)!;
+    wolf.maxHp = 100000;
+    wolf.hp = 100000;
+    // huge armor pins armorReduction at its 0.75 cap — a mitigated arcane hit
+    // would land at <=8, well under the unmitigated 26-31 band.
+    wolf.stats.armor = 10_000_000;
+    teleportTo(sim, wolf.pos.x, wolf.pos.z + 1);
+    sim.targetEntity(wolf.id);
+    return { sim, p, wolf, ability };
+  }
+
+  it('arcane explosion ignores the target armor (spell school)', () => {
+    const { sim, wolf } = aoeSetup('arcane_explosion');
+    const before = wolf.hp;
+    sim.castAbility('arcane_explosion');
+    for (let i = 0; i < 3; i++) sim.tick();
+    // full unmitigated arcane damage is 26-31; mitigated would be <=8
+    expect(before - wolf.hp).toBeGreaterThanOrEqual(20);
+  });
+});
+
 describe('spell visuals', () => {
   it('hostile casts emit projectile spellfx events', () => {
     const sim = makeSim('mage');


### PR DESCRIPTION
## Problem

Armor should only mitigate **physical** damage. The single-target damage path enforces this correctly:

```ts
// src/sim/sim.ts — directDamage
const isSpell = ability.school !== 'physical';
...
if (!isSpell) dmg *= 1 - armorReduction(this.effectiveArmor(target), p.level);
```

But the `aoeDamage` effect handler applied `armorReduction` **unconditionally**:

```ts
// src/sim/sim.ts — aoeDamage (before)
dmg *= 1 - armorReduction(this.effectiveArmor(m), p.level);
```

The `aoeDamage` effect is shared by both physical and magic abilities:

| Ability | School | Affected? |
|---|---|---|
| Thunder Clap, Cleave, Swipe | `physical` | correct (armor applies) |
| **Arcane Explosion** | `arcane` | **wrongly mitigated** |
| **Consecration** | `holy` | **wrongly mitigated** |

So mage and paladin AoE spells dealt far less damage than intended against armored targets — inconsistent with how all other spell damage (Fireball, etc.) behaves.

## Fix

Gate the AoE armor reduction on `!isSpell`, mirroring the single-target rule. `isSpell` is already computed once per cast in the enclosing scope.

## Impact / verification

Against a heavily-armored target (armor pinned at the 0.75 `armorReduction` cap), Arcane Explosion went from ~8 damage back to its full 26–31 band. Added a regression test in `tests/fixes.test.ts` that fails before the change (`expected 8 to be greater than or equal to 20`) and passes after. `fixes`, `sim`, `threat`, and `social` suites all green (124 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)