### PR TITLE
fix: stop dropping client input sent during the websocket auth handshake

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -10,6 +10,7 @@ import {
 } from './db';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
+import { bufferHandshakeMessages } from './ws_buffer';
 import {
   hashPassword, verifyPassword, newToken, validUsernameShape, offensiveName, validPassword, normalizeCharName,
 } from './auth';
@@ -443,7 +444,12 @@ async function main(): Promise<void> {
 
     ws.once('message', (data) => {
       clearTimeout(authTimer);
-      void authenticateWebSocket(ws, String(data));
+      // Buffer any frames the client sends while the async auth/join handshake
+      // is still in flight, then replay them once authenticateWebSocket has
+      // attached the permanent message handler. Without this the frames are
+      // silently dropped (see ws_buffer.ts).
+      const flush = bufferHandshakeMessages(ws);
+      void authenticateWebSocket(ws, String(data)).finally(flush);
     });
   }
 

--- a/server/ws_buffer.ts
+++ b/server/ws_buffer.ts
@@ -1,0 +1,27 @@
+import type { EventEmitter } from 'node:events';
+
+// A freshly-upgraded websocket authenticates with its first frame, but the
+// permanent message handler is only attached after an async handshake
+// (token + moderation + character lookups, then game.join). The `ws` receiver
+// emits 'message' events and the underlying EventEmitter simply drops any that
+// have no listener, so a client that sends input immediately after its auth
+// frame loses every frame until the handshake resolves.
+//
+// bufferHandshakeMessages captures those in-flight frames and returns a flush
+// callback. Call flush once the real handler is attached to replay the frames
+// in order. Frames that arrive after flush are delivered live by the real
+// handler, so flushing never duplicates them.
+export function bufferHandshakeMessages(ws: EventEmitter): () => void {
+  const pending: unknown[] = [];
+  const capture = (data: unknown) => {
+    pending.push(data);
+  };
+  ws.on('message', capture);
+  let flushed = false;
+  return () => {
+    if (flushed) return;
+    flushed = true;
+    ws.off('message', capture);
+    for (const data of pending) ws.emit('message', data);
+  };
+}

--- a/tests/ws_buffer.test.ts
+++ b/tests/ws_buffer.test.ts
@@ -1,0 +1,69 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import { bufferHandshakeMessages } from '../server/ws_buffer';
+
+describe('bufferHandshakeMessages', () => {
+  it('replays frames received during the handshake into the real handler, in order', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+
+    // frames arrive while authentication is still awaiting the database
+    ws.emit('message', 'a');
+    ws.emit('message', 'b');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    expect(handled).toEqual([]); // nothing delivered until the handshake resolves
+
+    flush();
+    expect(handled).toEqual(['a', 'b']);
+  });
+
+  it('delivers post-handshake frames live without duplicating buffered ones', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+    ws.emit('message', 'early');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+    ws.emit('message', 'late');
+
+    expect(handled).toEqual(['early', 'late']);
+  });
+
+  it('is a no-op when no frames arrive during the handshake', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+    ws.emit('message', 'x');
+
+    expect(handled).toEqual(['x']);
+  });
+
+  it('ignores repeated flush calls so frames are never replayed twice', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+    ws.emit('message', 'once');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+    flush();
+
+    expect(handled).toEqual(['once']);
+  });
+
+  it('documents the underlying drop the buffer prevents', () => {
+    // Without buffering, a frame emitted before any listener is attached is
+    // silently discarded by EventEmitter — exactly the lost-input failure mode.
+    const ws = new EventEmitter();
+    const handled: unknown[] = [];
+    ws.emit('message', 'lost');
+    ws.on('message', (d) => handled.push(d));
+    expect(handled).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

A freshly-upgraded websocket authenticates with its first frame, consumed by `ws.once('message', …)` in `onConnection`. The **permanent** message handler is only attached later, inside `authenticateWebSocket`, *after* a chain of `await`s — `accountForToken`, `moderationStatusForAccount`, `getCharacter`, then `game.join`.

Node's `EventEmitter` (which `ws.WebSocket` extends) **silently discards** `'message'` events that have no listener. So during that async window the socket has *no* `'message'` listener, and any frame the client sends — movement, a cast, a chat line — is dropped, not queued. Clients that wait for the first snapshot before sending are fine, but fast/headless/agent clients that send input immediately after the auth frame lose those frames.

## Fix

`server/ws_buffer.ts` adds `bufferHandshakeMessages(ws)`, which attaches a temporary capture listener and returns a `flush` callback. `onConnection` buffers frames received during the handshake and replays them in order via `.finally(flush)` once `authenticateWebSocket` has attached the real handler.

Ordering note: `ws` delivers frames on I/O macrotasks, while `.finally` runs on a microtask immediately after `authenticateWebSocket` returns. No new frame can interleave between the real handler attaching and the flush, so replayed frames are never delivered twice. On auth failure the socket is already closed and there is no game handler, so the flush is a harmless no-op.

## Tests

`tests/ws_buffer.test.ts` covers: in-order replay of handshake frames, no duplication of buffered-then-live frames, the empty-handshake no-op, idempotent flush, and a guard documenting the underlying EventEmitter drop.

- `npx tsc --noEmit` clean
- Full suite: 394 pass (the one failing file, `homepage_foundation.test.ts`, fails on `main` too — it requires `DATABASE_URL`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)