### PR TITLE
Release v0.5: arena testing batch

### DIFF
--- a/index.html
+++ b/index.html
@@ -603,7 +603,7 @@
   #arena-status .as-timer { font-size: 11px; color: #d8cba0; margin-top: 1px; }
 
   /* ---------- The World Market (the Merchant's auction house) ---------- */
-  #market-window { left: 50%; top: 12%; transform: translateX(-50%); width: 470px; max-height: 76%; flex-direction: column; }
+  #market-window { left: 50%; top: 12%; transform: translateX(-50%); width: 470px; max-height: 76%; display: none; flex-direction: column; }
   .mkt-tabs { display: flex; gap: 4px; margin: 2px 0 8px; }
   .mkt-tab { flex: 1; text-align: center; font-family: var(--title-font); font-size: 12px; color: #cabb8c;
     padding: 5px 4px; border-radius: 4px 4px 0 0; cursor: pointer; background: #ffffff08; border-bottom: 2px solid transparent; }

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -178,6 +178,11 @@ function copyPos(dst: { x: number; y: number; z: number }, src: { x: number; y: 
   dst.z = src.z;
 }
 
+// A single position update never moves an entity more than a few yards by
+// walking; anything past this is a teleport (arena pit, dungeon portal,
+// graveyard release). Those are snapped, not interpolated — see applyWire.
+const TELEPORT_SNAP_DIST_SQ = 40 * 40;
+
 function blankEntity(id: number): Entity {
   return {
     id, kind: 'mob', templateId: '', name: '', level: 1,
@@ -435,10 +440,25 @@ export class ClientWorld implements IWorld {
         }
       }
       e.netUpdatedAt = now;
-      e.prevPos.x = e.prevPos.x + (e.pos.x - e.prevPos.x) * entAlpha;
-      e.prevPos.y = e.prevPos.y + (e.pos.y - e.prevPos.y) * entAlpha;
-      e.prevPos.z = e.prevPos.z + (e.pos.z - e.prevPos.z) * entAlpha;
-      e.prevFacing = e.prevFacing + wrapAngle(e.facing - e.prevFacing) * entFacingAlpha;
+      // A teleport (arena pit, dungeon portal, graveyard release) jumps an
+      // entity far further than any single walking update could. Interpolating
+      // across that gap streaks it across the map — and when its per-entity
+      // interpolation clock isn't established yet, the renderer falls back to
+      // the global alpha and the entity sticks at its old pose until its next
+      // real update (e.g. taking damage). Snap both poses to the destination so
+      // it appears exactly where the server placed it.
+      const teleDx = w.x - e.pos.x, teleDz = w.z - e.pos.z;
+      if (teleDx * teleDx + teleDz * teleDz > TELEPORT_SNAP_DIST_SQ) {
+        e.prevPos = { x: w.x, y: w.y, z: w.z };
+        e.prevFacing = w.f;
+      } else {
+        e.prevPos = {
+          x: e.prevPos.x + (e.pos.x - e.prevPos.x) * entAlpha,
+          y: e.prevPos.y + (e.pos.y - e.prevPos.y) * entAlpha,
+          z: e.prevPos.z + (e.pos.z - e.prevPos.z) * entAlpha,
+        };
+        e.prevFacing = e.prevFacing + wrapAngle(e.facing - e.prevFacing) * entFacingAlpha;
+      }
       e.pos.x = w.x; e.pos.y = w.y; e.pos.z = w.z;
       e.facing = w.f;
       e.hp = w.hp;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -194,7 +194,7 @@ function blankEntity(id: number): Entity {
     attackPower: 0, rangedPower: 0, critChance: 0.05, dodgeChance: 0.05, moveSpeed: 7, hostile: false,
     targetId: null, autoAttack: false, swingTimer: 0,
     inCombat: false, combatTimer: 99,
-    auras: [], castingAbility: null, castRemaining: 0, castTotal: 0,
+    auras: [], ccDr: new Map(), castingAbility: null, castRemaining: 0, castTotal: 0,
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, savedMana: 0,

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -4,8 +4,9 @@ import type { IWorld } from '../world_api';
 import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import {
   MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
-  instanceOrigin, INSTANCE_SLOT_COUNT, ARENA_SLOT_COUNT, arenaOrigin, isArenaPos,
+  instanceOrigin, INSTANCE_SLOT_COUNT, ARENA_SLOT_COUNT, arenaOrigin, arenaOriginAt, isArenaPos,
 } from '../sim/data';
+import { ARENA_LAYOUT, DUNGEON_WALL_X } from '../sim/dungeon_layout';
 import type { BiomeId } from '../sim/types';
 import { AnimState, CharacterVisual, createCharacterVisual } from './characters';
 import { LocoTrack, newLocoTrack, updateLocomotion } from './locomotion';
@@ -1036,9 +1037,18 @@ export class Renderer {
     const py = p.prevPos.y + (p.pos.y - p.prevPos.y) * alpha;
     const pz = p.prevPos.z + (p.pos.z - p.prevPos.z) * alpha;
     const eyeY = py + 2.0;
-    const cx = px - Math.sin(this.camYaw) * Math.cos(this.camPitch) * this.camDist;
+    let cx = px - Math.sin(this.camYaw) * Math.cos(this.camPitch) * this.camDist;
     const cy = eyeY + Math.sin(this.camPitch) * this.camDist;
-    const cz = pz - Math.cos(this.camYaw) * Math.cos(this.camPitch) * this.camDist;
+    let cz = pz - Math.cos(this.camYaw) * Math.cos(this.camPitch) * this.camDist;
+    // The Ashen Coliseum is a small enclosed pit and the combatants spawn only
+    // ~6yd from the end walls, so the 12yd chase cam would otherwise sit outside
+    // the walls looking in. Keep it inside the room's interior box.
+    if (isArenaPos(p.pos.x)) {
+      const o = arenaOriginAt(p.pos.z);
+      const m = 2; // clearance from the wall faces
+      cx = Math.min(Math.max(cx, o.x - DUNGEON_WALL_X + m), o.x + DUNGEON_WALL_X - m);
+      cz = Math.min(Math.max(cz, o.z + ARENA_LAYOUT.zMin + m), o.z + ARENA_LAYOUT.zMax - m);
+    }
     const groundY = groundHeight(cx, cz, this.sim.cfg.seed) + 0.6;
     this.camera.position.set(cx, Math.max(cy, groundY), cz);
     this.camera.lookAt(px, eyeY, pz);

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -12,7 +12,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     attackPower: 0, rangedPower: 0, critChance: 0.05, dodgeChance: 0.05, moveSpeed: 7, hostile: false,
     targetId: null, autoAttack: false, swingTimer: 0,
     inCombat: false, combatTimer: 99,
-    auras: [], castingAbility: null, castRemaining: 0, castTotal: 0,
+    auras: [], ccDr: new Map(), castingAbility: null, castRemaining: 0, castTotal: 0,
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, savedMana: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3698,7 +3698,7 @@ export class Sim {
         if (match.timer <= 0) {
           match.state = 'active';
           match.timer = 0;
-          for (const e of [ea, eb]) this.resetForArena(e);
+          for (const e of [ea, eb]) this.readyArenaFighter(e, { clearPrep: false });
           for (const mPid of [match.a, match.b]) {
             this.emit({ type: 'log', text: 'Fight!', color: '#ff5a3c', pid: mPid });
             this.emit({ type: 'arenaStart', pid: mPid });
@@ -3788,9 +3788,16 @@ export class Sim {
   // A clean slate so the bout is decided by play, not by what each fighter
   // walked in carrying: full health/resource, cooldowns and combat reset.
   private resetForArena(e: Entity): void {
+    this.readyArenaFighter(e, { clearPrep: true });
+  }
+
+  private readyArenaFighter(e: Entity, opts: { clearPrep: boolean }): void {
+    if (opts.clearPrep) {
+      e.auras = [];
+      e.cooldowns.clear();
+    }
     const meta = this.players.get(e.id);
     if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
-    e.auras = [];
     e.hp = e.maxHp;
     e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
     e.targetId = null;
@@ -3801,7 +3808,6 @@ export class Sim {
     e.channeling = false;
     e.comboPoints = 0;
     e.comboTargetId = null;
-    e.cooldowns.clear();
     e.gcdRemaining = 0;
     e.swingTimer = 0;
     e.chargeTargetId = null;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -41,6 +41,7 @@ const PARTY_XP_RANGE = 80; // yards: members this close share kill xp/credit
 const DUEL_COUNTDOWN = 3;
 // Ashen Coliseum 1v1 arena
 const ARENA_COUNTDOWN = 5; // gates pre-fight: heal up, no swings land yet
+const ARENA_RETURN_DELAY = 5; // aftermath: hold on the sands before going home
 const ARENA_MAX_DURATION = 150; // seconds; a stalling match resolves on hp%
 const ARENA_BASE_RATING = 1500; // every character starts here, unranked
 const ARENA_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
@@ -116,8 +117,8 @@ export interface ArenaMatch {
   a: number; // pid
   b: number; // pid
   slot: number; // arena instance slot
-  state: 'countdown' | 'active';
-  timer: number; // countdown remaining, then elapsed once active
+  state: 'countdown' | 'active' | 'over';
+  timer: number; // countdown remaining, then elapsed once active, then return countdown
   returnA: { x: number; z: number; facing: number };
   returnB: { x: number; z: number; facing: number };
   ratingA: number;
@@ -3674,7 +3675,19 @@ export class Sim {
       seen.add(match);
       const ea = this.entities.get(match.a);
       const eb = this.entities.get(match.b);
-      if (!ea || !eb) { this.endArenaMatch(match, ea ? match.a : eb ? match.b : null, 'forfeit'); continue; }
+      if (!ea || !eb) {
+        // someone logged out: an already-decided bout just sends the survivor
+        // home; an in-progress one is forfeited to the remaining fighter
+        if (match.state === 'over') this.returnFromArena(match);
+        else this.endArenaMatch(match, ea ? match.a : eb ? match.b : null, 'forfeit');
+        continue;
+      }
+      if (match.state === 'over') {
+        // aftermath: both already cleansed and scored — count down, then go home
+        match.timer -= DT;
+        if (match.timer <= 0) this.returnFromArena(match);
+        continue;
+      }
       if (match.state === 'countdown') {
         const before = Math.ceil(match.timer);
         match.timer -= DT;
@@ -3800,11 +3813,11 @@ export class Sim {
     e.drinking = null;
   }
 
-  // winnerPid null = draw; reason is informational (defeat/timeout/forfeit).
+  // Decide a bout: score it (once), then either send a survivor home now (a
+  // forfeit, where the other fighter is gone) or hold both on the sands for a
+  // brief aftermath before returning them. winnerPid null = draw; reason is
+  // informational (defeat/timeout/forfeit).
   private endArenaMatch(match: ArenaMatch, winnerPid: number | null, reason: 'defeat' | 'timeout' | 'forfeit'): void {
-    this.arenaMatches.delete(match.a);
-    this.arenaMatches.delete(match.b);
-    this.arenaBusySlots.delete(match.slot);
     const aMeta = this.players.get(match.a);
     const bMeta = this.players.get(match.b);
     const ea = this.entities.get(match.a);
@@ -3837,25 +3850,36 @@ export class Sim {
       });
     }
 
-    // restore both fighters to where they queued from, healed and out of combat
-    for (const [e, ret] of [[ea, match.returnA], [eb, match.returnB]] as const) {
+    // a forfeit can't have an aftermath (a fighter has gone) — send the
+    // survivor home immediately
+    if (!ea || !eb) { this.returnFromArena(match); return; }
+
+    // decided bout: cleanse both right now so no arena auras/DoTs tick during
+    // the wait, then hold them on the sands for the aftermath countdown
+    this.resetForArena(ea);
+    this.resetForArena(eb);
+    match.state = 'over';
+    match.timer = ARENA_RETURN_DELAY;
+    for (const mPid of [match.a, match.b]) {
+      this.emit({ type: 'log', text: 'The bout is decided. Returning to the world…', color: '#ffa040', pid: mPid });
+    }
+  }
+
+  // Teleport both fighters back to where they queued, fully cleansed (no arena
+  // auras, DoTs, debuffs, cooldowns or combat state follow them out), and
+  // release the instance slot.
+  private returnFromArena(match: ArenaMatch): void {
+    this.arenaMatches.delete(match.a);
+    this.arenaMatches.delete(match.b);
+    this.arenaBusySlots.delete(match.slot);
+    for (const [e, ret] of [[this.entities.get(match.a), match.returnA], [this.entities.get(match.b), match.returnB]] as const) {
       if (!e) continue;
-      const meta = this.players.get(e.id);
+      this.resetForArena(e); // strips every aura/effect/cooldown and heals to full
       e.pos = this.groundPos(ret.x, ret.z);
       e.prevPos = { ...e.pos };
       e.facing = ret.facing;
-      this.rebucket(e);
-      if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);
-      e.auras = [];
       e.dead = false;
-      e.hp = e.maxHp;
-      e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
-      e.targetId = null;
-      e.autoAttack = false;
-      e.castingAbility = null;
-      e.channeling = false;
-      e.combatTimer = 99;
-      e.inCombat = false;
+      this.rebucket(e);
       this.emit({ type: 'respawn', pid: e.id });
     }
   }
@@ -3886,7 +3910,10 @@ export class Sim {
       const oppMeta = this.players.get(oppPid);
       const oppE = this.entities.get(oppPid);
       if (oppMeta && oppE) {
-        matchInfo = { state: match.state, oppName: oppMeta.name, oppClass: oppMeta.cls, oppLevel: oppE.level, oppPid };
+        matchInfo = {
+          state: match.state, oppName: oppMeta.name, oppClass: oppMeta.cls, oppLevel: oppE.level, oppPid,
+          returnIn: match.state === 'over' ? Math.max(0, Math.ceil(match.timer)) : undefined,
+        };
       }
     }
     return {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -17,7 +17,7 @@ import {
 import { groundHeight, WATER_LEVEL } from './world';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
-  CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
+  CONSUME_TICKS, CrowdControlDrCategory, DT, Entity, EquipSlot, GCD,
   INTERACT_RANGE, InvSlot, MELEE_RANGE, MAX_LEVEL,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
@@ -47,6 +47,8 @@ const ARENA_BASE_RATING = 1500; // every character starts here, unranked
 const ARENA_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
 const ARENA_K_FACTOR = 32; // Elo sensitivity per match
 const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
+const PVP_CC_DR_RESET = 18; // seconds before a repeated PvP CC category is fresh again
+const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
 const YELL_RANGE = 100;
 const CHAT_BURST = 8; // messages a player may send back-to-back...
@@ -1603,11 +1605,7 @@ export class Sim {
         }
         case 'root': {
           if (!target || target.dead) break;
-          this.applyAura(target, {
-            id: ability.id + '_root', name: ability.name, kind: 'root',
-            remaining: eff.duration, duration: eff.duration, value: 0,
-            sourceId: p.id, school: ability.school,
-          });
+          this.applyRootAura(p, target, ability.name, ability.id + '_root', eff.duration, ability.school);
           this.enterCombat(p, target);
           break;
         }
@@ -1666,15 +1664,11 @@ export class Sim {
         }
         case 'aoeRoot': {
           this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: ability.school, fx: 'nova' });
-          for (const m of this.mobsInRadius(p.pos, eff.radius)) {
+          for (const m of this.hostilesInRadius(p, p.pos, eff.radius)) {
             const dmg = this.rng.range(eff.min, eff.max);
             this.dealDamage(p, m, Math.round(dmg), false, ability.school, ability.name, 'hit');
-            if (!m.dead) {
-              this.applyAura(m, {
-                id: ability.id + '_root', name: ability.name, kind: 'root',
-                remaining: eff.duration, duration: eff.duration, value: 0,
-                sourceId: p.id, school: ability.school,
-              });
+            if (!m.dead && this.isHostileTo(p, m)) {
+              this.applyRootAura(p, m, ability.name, ability.id + '_root', eff.duration, ability.school);
             }
           }
           break;
@@ -1810,10 +1804,44 @@ export class Sim {
     }
   }
 
+  private applyRootAura(source: Entity, target: Entity, name: string, id: string, duration: number, school: Aura['school']): void {
+    const remaining = this.diminishedCrowdControlDuration(source, target, 'root', duration);
+    if (remaining === null) return;
+    this.applyAura(target, {
+      id, name, kind: 'root',
+      remaining, duration: remaining, value: 0,
+      sourceId: source.id, school,
+    });
+  }
+
+  private diminishedCrowdControlDuration(
+    source: Entity,
+    target: Entity,
+    category: CrowdControlDrCategory,
+    duration: number,
+  ): number | null {
+    if (source.kind !== 'player' || target.kind !== 'player' || !this.isHostileTo(source, target)) {
+      return duration;
+    }
+    const existing = target.ccDr.get(category);
+    const stage = existing && existing.resetAt > this.time ? existing.stage : 0;
+    if (stage >= PVP_CC_DR_MULTIPLIERS.length) return null;
+    target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + PVP_CC_DR_RESET });
+    return duration * PVP_CC_DR_MULTIPLIERS[stage];
+  }
+
   private mobsInRadius(pos: Vec3, radius: number): Entity[] {
     const out: Entity[] = [];
     this.grid.forEachInRadius(pos.x, pos.z, radius, (e) => {
       if (e.kind === 'mob' && !e.dead && e.hostile) out.push(e);
+    });
+    return out;
+  }
+
+  private hostilesInRadius(source: Entity, pos: Vec3, radius: number): Entity[] {
+    const out: Entity[] = [];
+    this.grid.forEachInRadius(pos.x, pos.z, radius, (e) => {
+      if (e.id !== source.id && !e.dead && this.isHostileTo(source, e)) out.push(e);
     });
     return out;
   }
@@ -2174,6 +2202,7 @@ export class Sim {
     e.hp = 0;
     this.clearNonPlayerStatAuras(e);
     e.auras = [];
+    e.ccDr.clear();
     e.castingAbility = null;
     this.emit({ type: 'death', entityId: e.id, killerId: killer?.id ?? -1 });
 
@@ -3251,6 +3280,7 @@ export class Sim {
     this.rebucket(p);
     p.facing = 0;
     p.auras = [];
+    p.ccDr.clear();
     recalcPlayerStats(p, meta.cls, meta.equipment);
     p.hp = p.maxHp;
     p.resource = p.resourceType === 'mana' ? p.maxResource : p.resourceType === 'energy' ? 100 : 0;
@@ -3602,6 +3632,7 @@ export class Sim {
     const eb = this.entities.get(duel.b);
     // stop the combatants from swinging at each other
     for (const e of [ea, eb]) {
+      if (e) e.ccDr.clear();
       if (e && e.targetId !== null && (e.targetId === duel.a || e.targetId === duel.b)) {
         e.autoAttack = false;
       }
@@ -3795,6 +3826,7 @@ export class Sim {
     if (opts.clearPrep) {
       e.auras = [];
       e.cooldowns.clear();
+      e.ccDr.clear();
     }
     const meta = this.players.get(e.id);
     if (meta) recalcPlayerStats(e, meta.cls, meta.equipment);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3850,9 +3850,9 @@ export class Sim {
       });
     }
 
-    // a forfeit can't have an aftermath (a fighter has gone) — send the
-    // survivor home immediately
-    if (!ea || !eb) { this.returnFromArena(match); return; }
+    // a forfeit (rage-quit / disconnect) has no aftermath — send the survivor
+    // home immediately rather than leaving them on empty sands
+    if (reason === 'forfeit' || !ea || !eb) { this.returnFromArena(match); return; }
 
     // decided bout: cleanse both right now so no arena auras/DoTs tick during
     // the wait, then hold them on the sands for the aftermath countdown

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -51,6 +51,13 @@ export interface Aura {
   stacks?: number; // sunder armor: applications stack up to the effect's cap
 }
 
+export type CrowdControlDrCategory = 'root';
+
+export interface CrowdControlDrState {
+  stage: number;
+  resetAt: number;
+}
+
 export interface Stats {
   str: number;
   agi: number;
@@ -400,6 +407,7 @@ export interface Entity {
   inCombat: boolean;
   combatTimer: number; // time since last combat event
   auras: Aura[];
+  ccDr: Map<CrowdControlDrCategory, CrowdControlDrState>;
   castingAbility: string | null;
   castRemaining: number;
   castTotal: number;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -100,6 +100,7 @@ export class Hud {
   private lastPartySig = '';
   private lastArenaSig = '';
   private lastArenaStatusSig = '';
+  private arenaMatchSeen = false; // closes the queue panel once a bout starts
   // World Market (the Merchant's auction house)
   private marketOpen = false;
   private marketTab: 'browse' | 'sell' | 'collect' = 'browse';
@@ -766,6 +767,12 @@ export class Hud {
     this.updatePartyFrames();
     this.updateTradeWindow();
     this.updateArenaStatus();
+    // when a bout begins, get the queue panel out of the way for the fight
+    const inArenaMatch = !!this.sim.arenaInfo?.match;
+    if (inArenaMatch && !this.arenaMatchSeen && $('#arena-window').style.display === 'block') {
+      $('#arena-window').style.display = 'none';
+    }
+    this.arenaMatchSeen = inArenaMatch;
     this.updateMinimap();
     if ($('#map-window').style.display === 'block') this.updateMapWindow();
     if ($('#social-window').classList.contains('open')) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1091,8 +1091,10 @@ export class Hud {
       this.lastArenaStatusSig = '';
       return;
     }
-    const label = m.state === 'countdown' ? 'Steel yourself…' : 'Fight to the yield!';
-    const sig = `${m.oppName}|${m.state}`;
+    const label = m.state === 'countdown' ? 'Steel yourself…'
+      : m.state === 'over' ? `Returning to the world… ${m.returnIn ?? 0}`
+      : 'Fight to the yield!';
+    const sig = `${m.oppName}|${m.state}|${m.state === 'over' ? (m.returnIn ?? 0) : ''}`;
     if (sig !== this.lastArenaStatusSig) {
       this.lastArenaStatusSig = sig;
       const cls = CLASSES[m.oppClass]?.name ?? m.oppClass;

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -98,11 +98,12 @@ export interface ArenaInfo {
   queueSize: number;
   // present only while in a match
   match: {
-    state: 'countdown' | 'active';
+    state: 'countdown' | 'active' | 'over';
     oppName: string;
     oppClass: PlayerClass;
     oppLevel: number;
     oppPid: number;
+    returnIn?: number; // whole seconds left in the post-bout aftermath ('over')
   } | null;
   // live standings of rated players currently online, best first
   ladder: ArenaLadderEntry[];

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -129,6 +129,19 @@ describe('arena: a full bout', () => {
     expect(eb.hp).toBe(eb.maxHp);
   });
 
+  it('keeps buffs cast during the countdown when the fight starts', () => {
+    const { sim, b } = queueDuo();
+    const mage = sim.entities.get(b)!;
+
+    sim.castAbility('frost_armor', b);
+    expect(mage.auras.some((aura) => aura.id === 'frost_armor')).toBe(true);
+
+    startBout(sim);
+
+    expect(sim.arenaMatchFor(b)!.state).toBe('active');
+    expect(mage.auras.some((aura) => aura.id === 'frost_armor')).toBe(true);
+  });
+
   it('ends at 1 health: winner declared and scored at once, then a 5s aftermath returns both', () => {
     const { sim, a, b } = queueDuo();
     startBout(sim);

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { Sim, eloDelta } from '../src/sim/sim';
 import { groundHeight } from '../src/sim/world';
 import { isArenaPos } from '../src/sim/data';
+import type { PlayerClass } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -16,16 +17,29 @@ function teleport(sim: Sim, pid: number, x: number, z: number) {
 }
 
 // Queue two players and advance one tick so matchmaking seats them.
-function queueDuo(): { sim: Sim; a: number; b: number } {
+function queueDuo(aClass: PlayerClass = 'warrior', bClass: PlayerClass = 'mage'): { sim: Sim; a: number; b: number } {
   const sim = makeWorld();
-  const a = sim.addPlayer('warrior', 'Aleph');
-  const b = sim.addPlayer('mage', 'Bet');
+  const a = sim.addPlayer(aClass, 'Aleph');
+  const b = sim.addPlayer(bClass, 'Bet');
   teleport(sim, a, 0, -40);
   teleport(sim, b, 6, -40);
   sim.arenaQueueJoin(a);
   sim.arenaQueueJoin(b);
   sim.tick(); // updateArena() matchmakes the pair
   return { sim, a, b };
+}
+
+function face(sim: Sim, pid: number, targetId: number) {
+  const e = sim.entities.get(pid)!;
+  const t = sim.entities.get(targetId)!;
+  e.facing = Math.atan2(t.pos.x - e.pos.x, t.pos.z - e.pos.z);
+}
+
+function finishCast(sim: Sim, pid: number) {
+  for (let i = 0; i < 20 * 4; i++) {
+    sim.tick();
+    if (!sim.entities.get(pid)!.castingAbility) return;
+  }
 }
 
 // Run the countdown out so the bout goes live.
@@ -246,5 +260,66 @@ describe('arena: forfeit + persistence', () => {
     sim.meta(c)!.arenaRating = 1600;
     const ladder = sim.arenaLadder();
     expect(ladder.map((r) => r.name)).toEqual(['High', 'Mid', 'Low']);
+  });
+});
+
+describe('arena: crowd control diminishing returns', () => {
+  it('shortens repeated roots on the same arena target, then resets', () => {
+    const { sim, a, b } = queueDuo('druid', 'warrior');
+    startBout(sim);
+    const druid = sim.entities.get(a)!;
+    const warrior = sim.entities.get(b)!;
+    (sim as any).rng.chance = () => true;
+    sim.setPlayerLevel(8, a);
+    druid.pos.x = warrior.pos.x;
+    druid.pos.z = warrior.pos.z - 8;
+    druid.targetId = b;
+    face(sim, a, b);
+
+    const castRoot = () => {
+      druid.resource = druid.maxResource;
+      druid.gcdRemaining = 0;
+      sim.castAbility('entangling_roots', a);
+      finishCast(sim, a);
+    };
+
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(12);
+    warrior.auras = [];
+
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(6);
+    warrior.auras = [];
+
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(3);
+    warrior.auras = [];
+
+    castRoot();
+    expect(warrior.auras.some((aura) => aura.kind === 'root')).toBe(false);
+
+    for (let i = 0; i < 20 * 18; i++) sim.tick();
+    castRoot();
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(12);
+  });
+
+  it('lets Frost Nova root arena opponents through the same root category', () => {
+    const { sim, a, b } = queueDuo();
+    startBout(sim);
+    const warrior = sim.entities.get(a)!;
+    const mage = sim.entities.get(b)!;
+    sim.setPlayerLevel(10, b);
+    mage.pos.x = warrior.pos.x;
+    mage.pos.z = warrior.pos.z - 4;
+    mage.facing = 0;
+
+    sim.castAbility('frost_nova', b);
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(8);
+    warrior.auras = [];
+    mage.gcdRemaining = 0;
+    mage.cooldowns.clear();
+
+    sim.castAbility('frost_nova', b);
+    expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(4);
   });
 });

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -129,7 +129,7 @@ describe('arena: a full bout', () => {
     expect(eb.hp).toBe(eb.maxHp);
   });
 
-  it('ends at 1 health: winner declared, ratings move, nobody dies, both returned', () => {
+  it('ends at 1 health: winner declared and scored at once, then a 5s aftermath returns both', () => {
     const { sim, a, b } = queueDuo();
     startBout(sim);
     const ea = sim.entities.get(a)!;
@@ -138,32 +138,34 @@ describe('arena: a full bout', () => {
     const rB0 = sim.meta(b)!.arenaRating;
 
     // Aleph lands a decisive blow
-    let end: any = null;
-    const before = sim.events.length;
     (sim as any).dealDamage(ea, eb, 99999, false, 'physical', null, 'hit');
     const ev = sim.tick();
-    end = ev.find((e) => e.type === 'arenaEnd');
+    const end = ev.find((e) => e.type === 'arenaEnd');
 
-    // match is over and cleaned up
-    expect(sim.arenaMatchFor(a)).toBe(null);
-    expect(sim.arenaMatchFor(b)).toBe(null);
-    // loser yielded at 1 hp — no death
+    // scored immediately: winner declared, zero-sum Elo, loser yields (no death)
+    expect(end).toBeTruthy();
     expect(eb.hp).toBeGreaterThanOrEqual(1);
     expect(eb.dead).toBe(false);
-    // zero-sum Elo: winner up 16, loser down 16
     expect(sim.meta(a)!.arenaRating).toBe(rA0 + 16);
     expect(sim.meta(b)!.arenaRating).toBe(rB0 - 16);
     expect(sim.meta(a)!.arenaWins).toBe(1);
     expect(sim.meta(b)!.arenaLosses).toBe(1);
-    // restored to where they queued (0,-40) and (6,-40), out of the arena band
+    // but they hold on the sands for the aftermath rather than returning at once
+    expect(sim.arenaMatchFor(a)!.state).toBe('over');
+    expect(isArenaPos(ea.pos.x)).toBe(true);
+
+    // run the ~5s aftermath out
+    for (let i = 0; i < 20 * 6 && sim.arenaMatchFor(a); i++) sim.tick();
+
+    // match cleaned up; both restored to where they queued (0,-40)/(6,-40), healed
+    expect(sim.arenaMatchFor(a)).toBe(null);
+    expect(sim.arenaMatchFor(b)).toBe(null);
     expect(isArenaPos(ea.pos.x)).toBe(false);
     expect(isArenaPos(eb.pos.x)).toBe(false);
     expect(Math.hypot(ea.pos.x - 0, ea.pos.z - (-40))).toBeLessThan(3);
     expect(Math.hypot(eb.pos.x - 6, eb.pos.z - (-40))).toBeLessThan(3);
-    // full heal on return
     expect(ea.hp).toBe(ea.maxHp);
     expect(eb.hp).toBe(eb.maxHp);
-    expect(before).toBeGreaterThanOrEqual(0);
   });
 
   it('a slot frees up after the bout so the arena can host again', () => {
@@ -172,7 +174,9 @@ describe('arena: a full bout', () => {
     const ea = sim.entities.get(a)!;
     const eb = sim.entities.get(b)!;
     (sim as any).dealDamage(ea, eb, 99999, false, 'physical', null, 'hit');
-    sim.tick();
+    // run the aftermath out so the slot is released
+    for (let i = 0; i < 20 * 6 && sim.arenaMatchFor(a); i++) sim.tick();
+    expect(sim.arenaMatchFor(a)).toBe(null);
     // requeue both — a fresh match must seat without "all arenas busy"
     sim.arenaQueueJoin(a);
     sim.arenaQueueJoin(b);


### PR DESCRIPTION
## Summary

Arena integration/testing branch for v0.5.

Important context: the core Ashen Coliseum implementation from #117 is already present on `release/v0.5` through the original arena commit. This branch preserves that and layers the remaining arena fixes/polish needed for the v0.5 arena test pass.

Included references:

- #117 Ashen Coliseum 1v1 ranked arena
- #135 Preserve arena countdown buffs
- #138 Diminish repeated arena roots

Cherry-picked from the #117 branch, intentionally excluding the unrelated final Market-removal commit:

- `b830030` snap remote entities on teleport instead of interpolating
- `6456f31` hide World Market window by default
- `650aafb` keep chase camera inside Ashen Coliseum walls
- `a885f18` auto-close arena queue panel when a bout starts
- `ac56119` 5s arena aftermath and cleanse before returning
- `29ab3ba` arena forfeit skips aftermath and test coverage

Also included:

- `deab0ba` #135 preserve arena countdown buffs
- `ac3db06` #138 diminish repeated arena roots

## Verification

Local checks:

- [x] `npx vitest run tests/arena.test.ts` - 15 tests passed
- [x] `npx tsc --noEmit`
- [x] `npm run build:env`
- [x] `npm run build:server`
- [x] `npm run build`

Dev deploy:

- [x] `release/v0.5-arena` deployed to dev at `c31d0ea`
- [x] `https://dev.worldofclaudecraft.com/api/status` healthy
- [x] public client JS asset returns 200

## Manual Test Plan

- [x] Open arena UI from the HUD arena control
- [x] Queue two online characters and confirm they match
- [x] Confirm both teleport into Ashen Coliseum
- [x] Confirm the queue panel auto-closes when countdown starts
- [ ] Confirm countdown prevents damage until active
- [x] Confirm buffs cast during countdown persist into active combat
- [ ] Confirm remote opponent is visually snapped into arena, not stuck outside/interpolating
- [ ] Confirm chase camera stays inside arena walls
- [x] Confirm loser yields with no permanent death
- [x] Confirm 5s aftermath appears, then both return to original world positions
- [x] Confirm forfeit/disconnect skips aftermath and returns survivor cleanly
- [x] Confirm ratings/Elo and online/all-time ladder update
- [x] Confirm repeated roots diminish: full, half, quarter, immune, then reset (automated)
- [x] Confirm normal world state is restored after match: HP/resource, target, combat, auras/cooldowns, position


## Dev Manual Test Results - 2026-06-14

Live tested on dev with Lorak vs ReubMage:

- Arena queue formed a 1v1 match and teleported both characters into Ashen Coliseum.
- Arena queue panel closed when the bout started.
- Frost Armor cast during countdown persisted into active combat.
- Normal victory path awarded Elo/win/loss, showed aftermath, returned both characters to original world positions, and restored HP/resource/combat/target/aura/cooldown state.
- Disconnect/forfeit path skipped aftermath, returned the survivor cleanly, and awarded Elo/win.

Still needs direct manual visual confirmation:

- Countdown damage prevention from a live attempted attack.
- Remote opponent snap visual feel.
- Chase camera bounds inside arena walls.
