### PR TITLE
Add friend invite links

### DIFF
--- a/index.html
+++ b/index.html
@@ -558,6 +558,10 @@
   .soc-empty { color: #887c5c; font-size: 12px; padding: 10px 6px; text-align: center; }
   .soc-guild-head { font-family: var(--title-font); color: var(--gold); font-size: 15px; padding: 2px 4px 6px; }
   .soc-guild-head .gm { color: #998d6a; font-size: 11px; }
+  .soc-invite { margin: 6px 0 8px; padding: 7px; border: 1px solid #4a3d1d; background: #08070bcc; display: grid; grid-template-columns: 1fr auto; gap: 8px; align-items: center; border-radius: 5px; }
+  .soc-invite-actions { display: flex; gap: 6px; }
+  .soc-invite .btn { margin: 0; padding: 4px 8px; font-size: 11px; }
+  .soc-invite-link { grid-column: 1 / -1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #ffd9a0; font-size: 11px; user-select: text; }
 
   /* map */
   #map-window { left: 50%; top: 50%; transform: translate(-50%, -50%); padding: 14px; }
@@ -687,6 +691,10 @@
   #banner { position: absolute; left: 50%; top: 28%; transform: translateX(-50%); color: var(--gold);
     font-size: 38px; font-weight: bold; text-shadow: 0 0 18px #00000088, 2px 2px 6px #000; opacity: 0;
     transition: opacity 1.2s; pointer-events: none; font-family: var(--title-font); letter-spacing: 1px; white-space: nowrap; }
+  .invite-banner { position: fixed; left: 50%; top: 12px; transform: translateX(-50%); z-index: 140; display: flex; align-items: center; gap: 10px; max-width: min(560px, calc(100vw - 24px)); padding: 8px 10px; color: #f6ead0; font-size: 13px; }
+  .invite-banner.err { border-color: #a94332; color: #ffb3a6; }
+  .invite-banner[hidden] { display: none; }
+  .invite-banner .btn { margin: 0; padding: 3px 8px; font-size: 11px; }
 
   /* ---------- death overlay ---------- */
   #death-overlay { position: absolute; inset: 0; background: radial-gradient(ellipse at center, #40000077 0%, #300000bb 100%);

--- a/server/db.ts
+++ b/server/db.ts
@@ -104,6 +104,25 @@ CREATE TABLE IF NOT EXISTS world_state (
   data JSONB NOT NULL,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+CREATE TABLE IF NOT EXISTS friend_invites (
+  token TEXT PRIMARY KEY,
+  inviter_account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  inviter_character_id INT NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+  realm TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  accepted_account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  accepted_character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  accepted_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  CHECK (accepted_account_id IS NULL OR accepted_account_id <> inviter_account_id)
+);
+CREATE INDEX IF NOT EXISTS friend_invites_inviter_active
+  ON friend_invites(inviter_character_id, expires_at DESC)
+  WHERE accepted_account_id IS NULL;
+CREATE INDEX IF NOT EXISTS friend_invites_accepted_account
+  ON friend_invites(accepted_account_id)
+  WHERE accepted_account_id IS NOT NULL;
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -169,6 +188,190 @@ export async function saveToken(token: string, accountId: number, ttlHours = 24 
     `INSERT INTO auth_tokens (token, account_id, expires_at) VALUES ($1, $2, now() + ($3 || ' hours')::interval)`,
     [token, accountId, String(ttlHours)],
   );
+}
+
+// ---------------------------------------------------------------------------
+// Friend invite links: opaque share tokens that help a new/returning player
+// land on the inviter's realm, then unlock cosmetic social credit once their
+// character actually enters online play.
+// ---------------------------------------------------------------------------
+
+export interface FriendInviteView {
+  token: string;
+  inviterAccountId: number;
+  inviterCharacterId: number;
+  inviterName: string;
+  realm: string;
+  expiresAt: string;
+  acceptedAccountId: number | null;
+  acceptedCharacterId: number | null;
+  acceptedCharacterName: string | null;
+  completedAt: string | null;
+}
+
+export interface FriendInviteStats {
+  sentCompleted: number;
+  acceptedCompleted: number;
+  titleUnlocked: boolean;
+}
+
+function inviteFromRow(row: any): FriendInviteView {
+  return {
+    token: row.token,
+    inviterAccountId: Number(row.inviter_account_id),
+    inviterCharacterId: Number(row.inviter_character_id),
+    inviterName: row.inviter_name,
+    realm: row.realm,
+    expiresAt: new Date(row.expires_at).toISOString(),
+    acceptedAccountId: row.accepted_account_id === null ? null : Number(row.accepted_account_id),
+    acceptedCharacterId: row.accepted_character_id === null ? null : Number(row.accepted_character_id),
+    acceptedCharacterName: row.accepted_character_name ?? null,
+    completedAt: row.completed_at ? new Date(row.completed_at).toISOString() : null,
+  };
+}
+
+export async function createFriendInvite(
+  token: string,
+  inviterAccountId: number,
+  inviterCharacterId: number,
+  ttlDays = 14,
+): Promise<FriendInviteView> {
+  const existing = await pool.query(
+    `SELECT fi.*, c.name AS inviter_name, ac.name AS accepted_character_name
+       FROM friend_invites fi
+       JOIN characters c ON c.id = fi.inviter_character_id
+       LEFT JOIN characters ac ON ac.id = fi.accepted_character_id
+      WHERE fi.inviter_account_id = $1
+        AND fi.inviter_character_id = $2
+        AND fi.realm = $3
+        AND fi.accepted_account_id IS NULL
+        AND fi.expires_at > now()
+      ORDER BY fi.created_at DESC
+      LIMIT 1`,
+    [inviterAccountId, inviterCharacterId, REALM],
+  );
+  if (existing.rows[0]) return inviteFromRow(existing.rows[0]);
+
+  const res = await pool.query(
+    `INSERT INTO friend_invites (token, inviter_account_id, inviter_character_id, realm, expires_at)
+     VALUES ($1, $2, $3, $4, now() + ($5 || ' days')::interval)
+     RETURNING *,
+       (SELECT name FROM characters WHERE id = $3) AS inviter_name,
+       NULL::text AS accepted_character_name`,
+    [token, inviterAccountId, inviterCharacterId, REALM, String(ttlDays)],
+  );
+  return inviteFromRow(res.rows[0]);
+}
+
+export async function getFriendInvite(token: string): Promise<FriendInviteView | null> {
+  const res = await pool.query(
+    `SELECT fi.*, c.name AS inviter_name, ac.name AS accepted_character_name
+       FROM friend_invites fi
+       JOIN characters c ON c.id = fi.inviter_character_id
+       LEFT JOIN characters ac ON ac.id = fi.accepted_character_id
+      WHERE fi.token = $1`,
+    [token],
+  );
+  return res.rows[0] ? inviteFromRow(res.rows[0]) : null;
+}
+
+export type AcceptFriendInviteResult =
+  | { ok: true; invite: FriendInviteView; completedNow: boolean }
+  | { ok: false; status: 400 | 404 | 409 | 410; error: string };
+
+export async function acceptFriendInvite(
+  token: string,
+  accountId: number,
+  characterId?: number,
+): Promise<AcceptFriendInviteResult> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const found = await client.query(
+      `SELECT fi.*, c.name AS inviter_name, ac.name AS accepted_character_name
+         FROM friend_invites fi
+         JOIN characters c ON c.id = fi.inviter_character_id
+         LEFT JOIN characters ac ON ac.id = fi.accepted_character_id
+        WHERE fi.token = $1
+        FOR UPDATE OF fi`,
+      [token],
+    );
+    const row = found.rows[0];
+    if (!row) {
+      await client.query('ROLLBACK');
+      return { ok: false, status: 404, error: 'invite not found' };
+    }
+    if (new Date(row.expires_at).getTime() <= Date.now()) {
+      await client.query('ROLLBACK');
+      return { ok: false, status: 410, error: 'invite expired' };
+    }
+    if (Number(row.inviter_account_id) === accountId) {
+      await client.query('ROLLBACK');
+      return { ok: false, status: 400, error: 'you cannot use your own invite' };
+    }
+    if (row.accepted_account_id !== null && Number(row.accepted_account_id) !== accountId) {
+      await client.query('ROLLBACK');
+      return { ok: false, status: 409, error: 'invite already used' };
+    }
+
+    let completedNow = false;
+    let acceptedCharacterId: number | null = row.accepted_character_id === null ? null : Number(row.accepted_character_id);
+    if (characterId !== undefined) {
+      const char = await client.query(
+        'SELECT id, name, realm FROM characters WHERE id = $1 AND account_id = $2',
+        [characterId, accountId],
+      );
+      const c = char.rows[0];
+      if (!c) {
+        await client.query('ROLLBACK');
+        return { ok: false, status: 404, error: 'character not found' };
+      }
+      if (c.realm !== row.realm) {
+        await client.query('ROLLBACK');
+        return { ok: false, status: 400, error: 'wrong realm for this invite' };
+      }
+      acceptedCharacterId = Number(c.id);
+      completedNow = row.completed_at === null;
+    }
+
+    const updated = await client.query(
+      `UPDATE friend_invites
+          SET accepted_account_id = COALESCE(accepted_account_id, $2),
+              accepted_at = COALESCE(accepted_at, now()),
+              accepted_character_id = COALESCE(accepted_character_id, $3),
+              completed_at = CASE WHEN $3::int IS NOT NULL THEN COALESCE(completed_at, now()) ELSE completed_at END
+        WHERE token = $1
+        RETURNING *,
+          (SELECT name FROM characters WHERE id = friend_invites.inviter_character_id) AS inviter_name,
+          (SELECT name FROM characters WHERE id = friend_invites.accepted_character_id) AS accepted_character_name`,
+      [token, accountId, acceptedCharacterId],
+    );
+    await client.query('COMMIT');
+    return { ok: true, invite: inviteFromRow(updated.rows[0]), completedNow };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function friendInviteStats(accountId: number): Promise<FriendInviteStats> {
+  const res = await pool.query(
+    `SELECT
+       count(*) FILTER (WHERE inviter_account_id = $1 AND completed_at IS NOT NULL)::int AS sent_completed,
+       count(*) FILTER (WHERE accepted_account_id = $1 AND completed_at IS NOT NULL)::int AS accepted_completed
+     FROM friend_invites
+     WHERE inviter_account_id = $1 OR accepted_account_id = $1`,
+    [accountId],
+  );
+  const sentCompleted = Number(res.rows[0]?.sent_completed ?? 0);
+  const acceptedCompleted = Number(res.rows[0]?.accepted_completed ?? 0);
+  return {
+    sentCompleted,
+    acceptedCompleted,
+    titleUnlocked: sentCompleted + acceptedCompleted > 0,
+  };
 }
 
 export async function accountForToken(token: string): Promise<number | null> {

--- a/server/main.ts
+++ b/server/main.ts
@@ -6,7 +6,8 @@ import {
   ensureSchema, pool, createAccount, findAccount, getAccountsCount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
-  findCharacterReportTargetByName, topArenaRatings,
+  findCharacterReportTargetByName, topArenaRatings, createFriendInvite, getFriendInvite,
+  acceptFriendInvite, friendInviteStats,
 } from './db';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
@@ -29,6 +30,24 @@ const game = new GameServer();
 
 function normalizeDeleteConfirmation(name: unknown): string {
   return typeof name === 'string' ? name.trim().toLowerCase() : '';
+}
+
+function publicOrigin(req: http.IncomingMessage): string {
+  const proto = typeof req.headers['x-forwarded-proto'] === 'string'
+    ? req.headers['x-forwarded-proto'].split(',')[0].trim()
+    : 'http';
+  const host = typeof req.headers['x-forwarded-host'] === 'string'
+    ? req.headers['x-forwarded-host'].split(',')[0].trim()
+    : String(req.headers.host ?? `localhost:${PORT}`);
+  return `${proto}://${host}`;
+}
+
+function inviteUrl(req: http.IncomingMessage, token: string): string {
+  return `${publicOrigin(req)}/?invite=${encodeURIComponent(token)}`;
+}
+
+function validInviteToken(token: string): boolean {
+  return /^[a-f0-9]{64}$/.test(token);
 }
 
 async function bearerAccount(req: http.IncomingMessage): Promise<number | null> {
@@ -255,6 +274,65 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const q = new URL(req.url ?? '/', 'http://localhost').searchParams.get('q') ?? '';
       const results = q.trim().length >= 1 ? await searchCharacters(q, 8) : [];
       return json(res, 200, { results });
+    }
+    if (req.method === 'GET' && url === '/api/invites/me') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      return json(res, 200, { stats: await friendInviteStats(accountId) });
+    }
+    if (req.method === 'POST' && url === '/api/invites') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      const body = await readBody(req);
+      const characterId = Number(body.characterId);
+      if (!Number.isFinite(characterId)) return json(res, 400, { error: 'character required' });
+      const character = await getCharacter(accountId, characterId);
+      if (!character) return json(res, 404, { error: 'character not found' });
+      const invite = await createFriendInvite(newToken(), accountId, character.id);
+      return json(res, 200, {
+        token: invite.token,
+        url: inviteUrl(req, invite.token),
+        expiresAt: invite.expiresAt,
+        inviterName: invite.inviterName,
+        realm: invite.realm,
+        stats: await friendInviteStats(accountId),
+      });
+    }
+    const invitePreviewMatch = /^\/api\/invites\/([a-f0-9]{64})$/.exec(url);
+    if (req.method === 'GET' && invitePreviewMatch) {
+      const token = invitePreviewMatch[1];
+      const invite = await getFriendInvite(token);
+      if (!invite) return json(res, 404, { error: 'invite not found' });
+      const expired = new Date(invite.expiresAt).getTime() <= Date.now();
+      return json(res, 200, {
+        token,
+        inviterName: invite.inviterName,
+        realm: invite.realm,
+        expired,
+        accepted: invite.acceptedAccountId !== null,
+      });
+    }
+    const inviteAcceptMatch = /^\/api\/invites\/([a-f0-9]{64})\/accept$/.exec(url);
+    if (req.method === 'POST' && inviteAcceptMatch) {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      const token = inviteAcceptMatch[1];
+      if (!validInviteToken(token)) return json(res, 400, { error: 'invalid invite' });
+      const body = await readBody(req);
+      const rawCharacterId = body.characterId === undefined ? undefined : Number(body.characterId);
+      if (rawCharacterId !== undefined && !Number.isFinite(rawCharacterId)) {
+        return json(res, 400, { error: 'invalid character' });
+      }
+      const result = await acceptFriendInvite(token, accountId, rawCharacterId);
+      if (!result.ok) return json(res, result.status, { error: result.error });
+      return json(res, 200, {
+        inviterName: result.invite.inviterName,
+        realm: result.invite.realm,
+        completed: result.invite.completedAt !== null,
+        completedNow: result.completedNow,
+        acceptedCharacterName: result.invite.acceptedCharacterName,
+        stats: await friendInviteStats(accountId),
+      });
     }
     if (req.method === 'POST' && url === '/api/reports') {
       const accountId = await bearerActiveAccount(req, res);

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ import { Hud } from './ui/hud';
 import { audio } from './game/audio';
 import { music } from './game/music';
 import { handlePickedEntity } from './game/interactions';
-import { Api, ClientWorld, CharacterSummary } from './net/online';
+import { Api, ClientWorld, CharacterSummary, InviteAcceptResult, InvitePreview } from './net/online';
 import type { IWorld } from './world_api';
 import { assetsReady } from './render/assets/preload';
 import { CharacterPreview } from './render/characters';
@@ -425,6 +425,21 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       submit: (targetPid, reason, details) => api.reportPlayer(online.characterId, targetPid, reason, details),
       submitByName: (targetName, reason, details) => api.reportPlayerByName(online.characterId, targetName, reason, details),
     });
+    hud.attachInvites({
+      create: () => api.createInvite(online.characterId),
+      stats: () => api.inviteStats(),
+    });
+    if (pendingInviteCompletion) {
+      const accepted = pendingInviteCompletion;
+      pendingInviteCompletion = null;
+      const inviter = [...world.entities.values()].find((e) => e.kind === 'player' && e.name === accepted.inviterName && e.id !== world.playerId);
+      if (inviter) {
+        world.partyInvite(inviter.id);
+        hud.showError(`Invite complete. Party invite sent to ${accepted.inviterName}.`);
+      } else {
+        hud.showError(`Invite complete. ${accepted.inviterName} is not nearby.`);
+      }
+    }
   }
 
   function interactKey(): void {
@@ -587,10 +602,116 @@ async function startOffline(playerClass: PlayerClass, name: string): Promise<voi
 // ---------------------------------------------------------------------------
 
 const api = new Api();
+const INVITE_TOKEN_KEY = 'woc_pending_invite';
+let pendingInviteToken: string | null = null;
+let pendingInvitePreview: InvitePreview | null = null;
+let pendingInviteCompletion: InviteAcceptResult | null = null;
 
 let activeTransitionTimeout: number | null = null;
 let activeTransitionCleanup: (() => void) | null = null;
 let characterPreview: CharacterPreview | null = null;
+
+function validPendingInviteToken(token: string | null): token is string {
+  return typeof token === 'string' && /^[a-f0-9]{64}$/.test(token);
+}
+
+function capturePendingInviteToken(): void {
+  const params = new URLSearchParams(location.search);
+  const fromUrl = params.get('invite');
+  if (validPendingInviteToken(fromUrl)) {
+    pendingInviteToken = fromUrl;
+    localStorage.setItem(INVITE_TOKEN_KEY, fromUrl);
+    params.delete('invite');
+    const qs = params.toString();
+    history.replaceState(null, '', `${location.pathname}${qs ? `?${qs}` : ''}${location.hash}`);
+    return;
+  }
+  const stored = localStorage.getItem(INVITE_TOKEN_KEY);
+  pendingInviteToken = validPendingInviteToken(stored) ? stored : null;
+}
+
+function clearPendingInvite(): void {
+  pendingInviteToken = null;
+  pendingInvitePreview = null;
+  localStorage.removeItem(INVITE_TOKEN_KEY);
+  renderInviteBanner();
+}
+
+function inviteBannerEl(): HTMLElement {
+  let el = document.getElementById('invite-banner') as HTMLElement | null;
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'invite-banner';
+    el.className = 'panel invite-banner';
+    el.setAttribute('hidden', '');
+    document.body.appendChild(el);
+  }
+  return el;
+}
+
+function renderInviteBanner(message?: string, error = false): void {
+  const el = inviteBannerEl();
+  if (!pendingInviteToken && !message) {
+    el.setAttribute('hidden', '');
+    el.innerHTML = '';
+    return;
+  }
+  const preview = pendingInvitePreview;
+  const text = message ?? (preview
+    ? `${preview.inviterName} invited you to ${preview.realm}.`
+    : 'Friend invite ready.');
+  el.className = `panel invite-banner${error ? ' err' : ''}`;
+  el.innerHTML = `<span>${text}</span><button class="btn btn-small" type="button">Dismiss</button>`;
+  el.removeAttribute('hidden');
+  el.querySelector('button')?.addEventListener('click', () => clearPendingInvite());
+}
+
+async function loadPendingInvitePreview(): Promise<void> {
+  if (!pendingInviteToken) return;
+  renderInviteBanner();
+  try {
+    const preview = await api.invitePreview(pendingInviteToken);
+    if (preview.expired) {
+      clearPendingInvite();
+      renderInviteBanner('That friend invite has expired.', true);
+      return;
+    }
+    pendingInvitePreview = preview;
+    renderInviteBanner();
+  } catch {
+    clearPendingInvite();
+    renderInviteBanner('That friend invite is not valid.', true);
+  }
+}
+
+async function acceptPendingInvite(characterId?: number): Promise<InviteAcceptResult | null> {
+  if (!pendingInviteToken) return null;
+  try {
+    const result = await api.acceptInvite(pendingInviteToken, characterId);
+    pendingInvitePreview = {
+      token: pendingInviteToken,
+      inviterName: result.inviterName,
+      realm: result.realm,
+      expired: false,
+      accepted: true,
+    };
+    if (characterId !== undefined && result.completed) {
+      pendingInviteCompletion = result;
+      clearPendingInvite();
+    } else {
+      renderInviteBanner(`${result.inviterName}'s invite is linked. Create or enter a character on ${result.realm}.`);
+    }
+    return result;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Could not accept invite.';
+    if (characterId === undefined) {
+      clearPendingInvite();
+      renderInviteBanner(msg, true);
+    }
+    else $('#charselect-error').textContent = msg;
+    return null;
+  }
+}
 
 function updatePreviewContainer(panelId: string): void {
   if (!characterPreview) return;
@@ -847,6 +968,9 @@ function realmPopulation(online: boolean, players: number): { label: string; cls
 async function enterRealmFlow(): Promise<void> {
   const dir = await api.realms();
   $('#realm-list-user').textContent = api.username ? `${api.username}` : '';
+  await acceptPendingInvite();
+  const invited = pendingInvitePreview?.realm ? dir.realms.find((r) => r.name === pendingInvitePreview?.realm) : null;
+  if (invited) { selectRealm(invited); return; }
   const remembered = localStorage.getItem(LAST_REALM_KEY);
   const auto = dir.realms.find((r) => r.name === remembered);
   if (auto) { selectRealm(auto); return; }
@@ -1055,6 +1179,7 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     audio.init();
     music.init();
     enterLoadingState('Connecting to realm…');
+    await acceptPendingInvite(c.id);
   } finally {
     if (!hasBegunWorldEntry && button) {
       button.disabled = false;
@@ -1465,6 +1590,8 @@ async function loadProjectStats(): Promise<void> {
 }
 
 function wireStartScreens(): void {
+  capturePendingInviteToken();
+  void loadPendingInvitePreview();
   // Initial page translation and stats load
   translatePage();
   void loadProjectStats();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -44,6 +44,38 @@ export interface RealmDirectory {
   characters: Record<string, number>; // realm name -> how many characters you have
 }
 
+export interface InvitePreview {
+  token: string;
+  inviterName: string;
+  realm: string;
+  expired: boolean;
+  accepted: boolean;
+}
+
+export interface InviteStats {
+  sentCompleted: number;
+  acceptedCompleted: number;
+  titleUnlocked: boolean;
+}
+
+export interface CreatedInvite {
+  token: string;
+  url: string;
+  expiresAt: string;
+  inviterName: string;
+  realm: string;
+  stats: InviteStats;
+}
+
+export interface InviteAcceptResult {
+  inviterName: string;
+  realm: string;
+  completed: boolean;
+  completedNow: boolean;
+  acceptedCharacterName: string | null;
+  stats: InviteStats;
+}
+
 export class Api {
   token: string | null = null;
   username: string | null = null;
@@ -158,6 +190,23 @@ export class Api {
 
   async projectStats(): Promise<{ accounts_created: number; players_online: number; realm: string }> {
     return this.get('/api/project-stats');
+  }
+
+  async createInvite(characterId: number): Promise<CreatedInvite> {
+    return this.post('/api/invites', { characterId });
+  }
+
+  async inviteStats(): Promise<InviteStats> {
+    const data = await this.get('/api/invites/me');
+    return data.stats ?? { sentCompleted: 0, acceptedCompleted: 0, titleUnlocked: false };
+  }
+
+  async invitePreview(token: string): Promise<InvitePreview> {
+    return this.get(`/api/invites/${encodeURIComponent(token)}`);
+  }
+
+  async acceptInvite(token: string, characterId?: number): Promise<InviteAcceptResult> {
+    return this.post(`/api/invites/${encodeURIComponent(token)}/accept`, characterId === undefined ? {} : { characterId });
   }
 }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -32,6 +32,17 @@ export interface ReportHooks {
   submitByName?(targetName: string, reason: string, details: string): Promise<void>;
 }
 
+export interface InviteStatsView {
+  sentCompleted: number;
+  acceptedCompleted: number;
+  titleUnlocked: boolean;
+}
+
+export interface InviteHooks {
+  create(): Promise<{ url: string; expiresAt: string; stats: InviteStatsView }>;
+  stats(): Promise<InviteStatsView>;
+}
+
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
 const esc = (value: unknown): string => String(value ?? '')
   .replace(/&/g, '&amp;')
@@ -69,6 +80,7 @@ export class Hud {
   private dragFromSlot: number | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
+  private inviteHooks: InviteHooks | null = null;
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
   private capturingKey: { action: string; index: number } | null = null; // binding awaiting a key
   private keybindNote = '';
@@ -113,6 +125,9 @@ export class Hud {
   private lastSocialStruct = '';
   private lastSocialContent = '';
   private socialNotice: { text: string; error: boolean } | null = null;
+  private inviteStats: InviteStatsView | null = null;
+  private inviteLink: string | null = null;
+  private inviteBusy = false;
   private socialSuggestTimer: number | undefined;
   // current typeahead state: which input, its results, and the keyboard-
   // highlighted row (-1 = none), so Enter/Arrow keys can pick a suggestion
@@ -2250,6 +2265,7 @@ export class Hud {
     this.socialNotice = null;
     this.lastSocialStruct = this.socialStructSig();
     this.lastSocialContent = JSON.stringify(this.sim.socialInfo);
+    if (this.inviteHooks) void this.refreshInviteStats();
     this.renderSocial();
   }
 
@@ -2360,7 +2376,7 @@ export class Hud {
   // The add/action row changes with the tab (and guild membership). Inputs
   // tagged data-suggest get the username typeahead.
   private socialFooter(): string {
-    if (this.socialTab === 'friends') return this.addRow('friend', 'friend-add', 'Search to add a friend…', 'Add', 16, true);
+    if (this.socialTab === 'friends') return this.inviteHtml() + this.addRow('friend', 'friend-add', 'Search to add a friend…', 'Add', 16, true);
     if (this.socialTab === 'ignore') return this.addRow('ignore', 'block-add', 'Search to ignore…', 'Ignore', 16, true);
     const guild = this.sim.socialInfo?.guild ?? null;
     if (!guild) return this.addRow('gname', 'guild-create', 'Name your new guild', 'Found', 24, false);
@@ -2381,6 +2397,22 @@ export class Hud {
       + `<button class="btn" data-act="${act}">${label}</button></div>`;
   }
 
+  private inviteHtml(): string {
+    if (!this.inviteHooks) return '';
+    const stats = this.inviteStats;
+    const count = (stats?.sentCompleted ?? 0) + (stats?.acceptedCompleted ?? 0);
+    const state = stats?.titleUnlocked
+      ? `Friend Founder unlocked · ${count} completed`
+      : 'Bring a friend into your realm';
+    const link = this.inviteLink ? `<div class="soc-invite-link">${esc(this.inviteLink)}</div>` : '';
+    return `<div class="soc-invite">`
+      + `<div><b>Invite Friend</b><br><span class="soc-meta">${state}</span></div>`
+      + `<div class="soc-invite-actions">`
+      + `<button class="btn" data-act="create-invite" ${this.inviteBusy ? 'disabled' : ''}>${this.inviteLink ? 'Copy Link' : 'Create Link'}</button>`
+      + `<button class="btn" data-act="open-discord">Discord</button>`
+      + `</div>${link}</div>`;
+  }
+
   // Wire the parts that survive a content refresh: close, tabs, footer + search.
   private wireSocialChrome(el: HTMLElement): void {
     el.querySelector('[data-close]')?.addEventListener('click', () => this.toggleSocial());
@@ -2398,8 +2430,11 @@ export class Hud {
       else if (act === 'guild-create') { const n = field('gname'); if (n) { this.sim.guildCreate(n); this.clearSocialInput('gname'); } }
       else if (act === 'guild-leave') this.sim.guildLeave();
       else if (act === 'guild-disband') this.showPrompt('Disband your guild? This cannot be undone.', 'Disband', () => this.sim.guildDisband(), () => { /* keep */ });
+      else if (act === 'create-invite') void this.createInviteLink();
+      else if (act === 'open-discord') window.open('https://discord.gg/GjhnUsBtw', '_blank', 'noopener,noreferrer');
     };
     el.querySelectorAll('.soc-add .btn').forEach((b) => b.addEventListener('click', () => submit((b as HTMLElement).dataset.act)));
+    el.querySelectorAll('.soc-invite .btn').forEach((b) => b.addEventListener('click', () => submit((b as HTMLElement).dataset.act)));
     // Enter-to-submit only for plain inputs (the guild name). Search inputs get
     // richer keyboard handling — arrows + Enter to pick a suggestion — below.
     el.querySelectorAll('.soc-add input:not([data-suggest])').forEach((inp) => inp.addEventListener('keydown', (e) => {
@@ -2407,6 +2442,34 @@ export class Hud {
       submit((inp.parentElement?.querySelector('.btn') as HTMLElement | null)?.dataset.act);
     }));
     this.wireSuggest(el);
+  }
+
+  private async refreshInviteStats(): Promise<void> {
+    if (!this.inviteHooks || this.sim.socialInfo === null) return;
+    try {
+      this.inviteStats = await this.inviteHooks.stats();
+      if ($('#social-window').classList.contains('open') && this.socialTab === 'friends') this.renderSocial();
+    } catch {
+      // Cosmetic invite status should never break the Social panel.
+    }
+  }
+
+  private async createInviteLink(): Promise<void> {
+    if (!this.inviteHooks || this.inviteBusy) return;
+    this.inviteBusy = true;
+    this.renderSocial();
+    try {
+      const invite = await this.inviteHooks.create();
+      this.inviteStats = invite.stats;
+      this.inviteLink = invite.url;
+      if (navigator.clipboard?.writeText) await navigator.clipboard.writeText(invite.url);
+      this.setSocialNotice('Invite link copied. Send it to a friend or post it in Discord.', false);
+    } catch (err) {
+      this.setSocialNotice(err instanceof Error ? err.message : 'Could not create invite link.', true);
+    } finally {
+      this.inviteBusy = false;
+      this.renderSocial();
+    }
   }
 
   // Wire per-row actions (re-run on every list refresh).
@@ -2674,6 +2737,10 @@ export class Hud {
 
   attachReporting(hooks: ReportHooks): void {
     this.reportHooks = hooks;
+  }
+
+  attachInvites(hooks: InviteHooks): void {
+    this.inviteHooks = hooks;
   }
 
   get optionsOpen(): boolean {

--- a/tests/friend_invites.test.ts
+++ b/tests/friend_invites.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMock = vi.hoisted(() => {
+  process.env.DATABASE_URL = 'postgres://test/test';
+  const poolQuery = vi.fn();
+  const clientQuery = vi.fn();
+  const client = { query: clientQuery, release: vi.fn() };
+  return { poolQuery, clientQuery, client, connect: vi.fn(() => client) };
+});
+
+vi.mock('pg', () => ({
+  Pool: vi.fn(function Pool() {
+    return { query: dbMock.poolQuery, connect: dbMock.connect };
+  }),
+}));
+
+import { acceptFriendInvite, createFriendInvite, friendInviteStats } from '../server/db';
+import { REALM } from '../server/realm';
+
+const inviteRow = {
+  token: 'a'.repeat(64),
+  inviter_account_id: 1,
+  inviter_character_id: 10,
+  inviter_name: 'Aldren',
+  realm: REALM,
+  expires_at: new Date(Date.now() + 86_400_000),
+  accepted_account_id: null,
+  accepted_character_id: null,
+  accepted_character_name: null,
+  completed_at: null,
+};
+
+beforeEach(() => {
+  dbMock.poolQuery.mockReset();
+  dbMock.clientQuery.mockReset();
+  dbMock.client.release.mockReset();
+  dbMock.connect.mockClear();
+});
+
+describe('friend invite db helpers', () => {
+  it('reuses an active unaccepted invite for the same character', async () => {
+    dbMock.poolQuery.mockResolvedValueOnce({ rows: [inviteRow] });
+
+    const invite = await createFriendInvite('b'.repeat(64), 1, 10);
+
+    expect(invite.token).toBe(inviteRow.token);
+    expect(invite.inviterName).toBe('Aldren');
+    expect(dbMock.poolQuery).toHaveBeenCalledTimes(1);
+    expect(dbMock.poolQuery.mock.calls[0][1]).toEqual([1, 10, REALM]);
+  });
+
+  it('creates a new invite when no active invite exists', async () => {
+    dbMock.poolQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ ...inviteRow, token: 'b'.repeat(64) }] });
+
+    const invite = await createFriendInvite('b'.repeat(64), 1, 10);
+
+    expect(invite.token).toBe('b'.repeat(64));
+    expect(dbMock.poolQuery.mock.calls[1][1]).toEqual(['b'.repeat(64), 1, 10, REALM, '14']);
+  });
+
+  it('rejects using your own invite', async () => {
+    dbMock.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [inviteRow] })
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const result = await acceptFriendInvite(inviteRow.token, 1);
+
+    expect(result).toEqual({ ok: false, status: 400, error: 'you cannot use your own invite' });
+    expect(dbMock.client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('completes an accepted invite once an invited character enters the realm', async () => {
+    dbMock.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ ...inviteRow, accepted_account_id: 2 }] })
+      .mockResolvedValueOnce({ rows: [{ id: 20, name: 'Bera', realm: REALM }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          ...inviteRow,
+          accepted_account_id: 2,
+          accepted_character_id: 20,
+          accepted_character_name: 'Bera',
+          completed_at: new Date(),
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const result = await acceptFriendInvite(inviteRow.token, 2, 20);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.completedNow).toBe(true);
+      expect(result.invite.acceptedCharacterName).toBe('Bera');
+    }
+  });
+
+  it('reports cosmetic invite milestone status', async () => {
+    dbMock.poolQuery.mockResolvedValueOnce({ rows: [{ sent_completed: 1, accepted_completed: 0 }] });
+
+    await expect(friendInviteStats(1)).resolves.toEqual({
+      sentCompleted: 1,
+      acceptedCompleted: 0,
+      titleUnlocked: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds persistent friend invite links with public preview, authenticated acceptance, and completion when the invited character enters online play.
- Adds an Invite Friend block in the Social/Friends tab with copyable links and Discord handoff.
- Carries invite tokens through login/register/realm select/character select and auto-selects the inviter's realm.
- Adds cosmetic-only Friend Founder status based on completed invite milestones.

## Verification
- DATABASE_URL=postgres://test/test npm test -- --run
- npm run build
- npm run build:server

## Notes
- Implemented in an isolated worktree so the existing wiki branch/uncommitted changes were not touched.
- Invite rewards are cosmetic only: no XP, gold, gear, stats, market currency, or combat power.