### PR TITLE
fix: normalize RL target distance on the same scale as nearby mobs

### DIFF
--- a/src/sim/obs.ts
+++ b/src/sim/obs.ts
@@ -126,7 +126,10 @@ export function encodeObs(sim: Sim): number[] {
     obs.push(1);
     obs.push(target.hp / Math.max(1, target.maxHp));
     obs.push(clamp((target.level - p.level) / 5, -1, 1));
-    obs.push(clamp(d / 40, 0, 1));
+    // distance shares the d/40 scale used for nearby mobs and the interactable
+    // below; clamp to the same 1.5 ceiling (the 60-unit observation radius) so a
+    // target beyond 40 units stays distinguishable instead of saturating at 1
+    obs.push(clamp(d / 40, 0, 1.5));
     obs.push(Math.sin(rel));
     obs.push(Math.cos(rel));
     obs.push(target.hostile ? 1 : 0);

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
+import { encodeObs } from '../src/sim/obs';
 import { Entity, dist2d } from '../src/sim/types';
 import { CRYPT_DOOR_POS, DUNGEON_X_THRESHOLD, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
@@ -355,6 +356,31 @@ describe('warrior charge', () => {
     wolf.dead = true;
     sim.tick();
     expect(p.chargeTargetId).toBe(null);
+  });
+});
+
+describe('RL observation encoding', () => {
+  // The target block, the nearby-mob block, and the interactable block all
+  // encode entity distance as clamp(d / 40, ...). The target field used to clamp
+  // to [0, 1] while the others use [0, 1.5] (the 60-unit observation radius), so
+  // a target between 40 and 60 units saturated and lost distance granularity.
+  // Index 39 is the target distance: 16 self + 20 abilities + presence/hp/level.
+  const TARGET_DIST_INDEX = 39;
+
+  it('encodes target distance on the same 1.5 scale as nearby mobs', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    teleportTo(sim, 0, -40); // open road
+    const mob = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
+    // park the mob 50 units away (inside the 60-unit obs radius, beyond the
+    // old 40-unit saturation point)
+    mob.pos = { ...sim.groundPos(p.pos.x + 50, p.pos.z) };
+    expect(dist2d(p.pos, mob.pos)).toBeCloseTo(50, 0);
+
+    sim.targetEntity(mob.id);
+    const obs = encodeObs(sim);
+    expect(obs[TARGET_DIST_INDEX]).toBeGreaterThan(1); // would be clamped to 1 before the fix
+    expect(obs[TARGET_DIST_INDEX]).toBeCloseTo(50 / 40, 5);
   });
 });
 


### PR DESCRIPTION
## Problem

In the RL observation encoder (`src/sim/obs.ts`), the **target** block encodes distance as:

```ts
obs.push(clamp(d / 40, 0, 1));   // target distance
```

but the **nearby-mob** block and the **nearest-interactable** block encode the *same* `d / 40` distance with a different ceiling:

```ts
obs.push(clamp(d / 40, 0, 1.5)); // mob distance      (line 154)
obs.push(1, clamp(best.d / 40, 0, 1.5), ...); // interactable (line 178)
```

Mobs and interactables are gathered within a **60-unit** observation radius (`d < 60`), and `60 / 40 = 1.5` — so `1.5` is the deliberate ceiling that keeps distance granular across the whole radius. The target field's `1.0` ceiling is the outlier: any target between **40 and 60 units** away saturates to `1`, so the policy network sees it as "as close as 40 units," even though a mob sitting at the exact same spot is encoded as `1.25`.

## Impact

The agent loses distance information for distant targets, and the *same physical quantity* (distance to an entity) is encoded on two different scales within one observation vector — an inconsistency that can only confuse a learned policy. Targets can legitimately sit in the 40–60 unit band (you can target a mob across the obs radius, or target then back away), so this is hit in normal play.

## Fix

One-line change: clamp the target distance to the same `1.5` ceiling as its siblings.

```ts
obs.push(clamp(d / 40, 0, 1.5));
```

## Tests

Adds a regression test (`tests/fixes.test.ts` → "RL observation encoding") that parks a mob 50 units from the player, targets it, and asserts the encoded target distance is `50 / 40` (≈1.25, i.e. `> 1`) rather than saturating at `1`. Verified the test **fails on the pre-fix code** and passes after.

Full suite: 390 pass; `tsc --noEmit` clean. (The unrelated pre-existing `homepage_foundation.test.ts` `DATABASE_URL` failure exists on `main` independently of this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)