### PR TITLE
fix: rebucket pet in the spatial grid when it warps to its owner

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2577,6 +2577,10 @@ export class Sim {
     if (d > PET_TELEPORT_DISTANCE) {
       pet.pos = { ...owner.pos };
       pet.prevPos = { ...pet.pos };
+      // a warp is a teleport: keep the spatial grid exact this tick instead of
+      // waiting for the end-of-tick refresh, so same-tick aggro/AoE queries
+      // don't miss the pet at its old cell (matches every other teleport site)
+      this.rebucket(pet);
     } else if (d > PET_FOLLOW_DISTANCE && !this.isRooted(pet)) {
       this.moveToward(pet, owner.pos, Math.max(pet.moveSpeed, RUN_SPEED * 1.1) * this.moveSpeedMult(pet));
     }

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -358,6 +358,35 @@ describe('warrior charge', () => {
   });
 });
 
+describe('pet heel warp', () => {
+  it('keeps the spatial grid exact when a pet warps to its owner', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    // park the owner in open space away from the spawn camp
+    teleportTo(sim, p.pos.x + 400, p.pos.z + 400);
+
+    // adopt a wild beast as a heeling pet and strand it far from the owner
+    const pet = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
+    pet.ownerId = p.id;
+    pet.hostile = false;
+    pet.aggroTargetId = null;
+    pet.inCombat = false;
+    pet.pos = { x: p.pos.x + 200, z: p.pos.z, y: p.pos.y };
+    pet.prevPos = { ...pet.pos };
+    (sim as any).grid.update(pet); // grid now buckets the pet at its far cell
+
+    // 200 yds away with nothing to fight: the pet warps back to heel
+    (sim as any).updatePet(pet);
+    expect(dist2d(pet.pos, p.pos)).toBeLessThan(1);
+
+    // a same-tick radius query at the warp destination must see the pet — it
+    // would miss it if the grid still held the pet in its stale far-away cell
+    const found: number[] = [];
+    (sim as any).grid.forEachInRadius(p.pos.x, p.pos.z, 5, (e: Entity) => found.push(e.id));
+    expect(found).toContain(pet.id);
+  });
+});
+
 describe('spell visuals', () => {
   it('hostile casts emit projectile spellfx events', () => {
     const sim = makeSim('mage');


### PR DESCRIPTION
## Problem

When a pet heels and its owner is farther than `PET_TELEPORT_DISTANCE` (60 yds), `updatePet` snaps the pet to the owner's position but never updates the spatial grid:

```ts
// src/sim/sim.ts
if (d > PET_TELEPORT_DISTANCE) {
  pet.pos = { ...owner.pos };
  pet.prevPos = { ...pet.pos };
}
```

`SpatialGrid` only re-buckets *gradually-moving* entities once per tick via `refresh()` at the end of `step()`. For the rest of the tick the warped pet remains in its old, far-away cell. This contradicts the grid's own documented invariant:

> Cells are re-bucketed once per tick (gradual movement) and **kept exact on spawn/despawn/teleport**, so queries always see the same roster as the entities map.

Every other teleport site already honors this — death respawn, arena placement/return, dungeon enter/leave, and mob respawn all call `this.rebucket(e)` immediately after moving the entity. The pet warp was the lone exception.

## Impact

Same-tick spatial queries (`grid.forEachInRadius` — mob aggro pulls, AoE spell target gathering, interaction scans) scan the cell window around the *query* point. Because a warp moves the pet several cells, those queries miss the just-warped pet at its new location (or find it at its stale one) until the next tick's `refresh()` heals it.

## Fix

Add the missing `this.rebucket(pet)` call, matching every other teleport site.

## Test

Adds a regression test in `tests/fixes.test.ts`: strand a heeling pet 200 yds from its owner, run the pet brain, and assert a radius query at the warp destination finds the pet. The test fails without the fix and passes with it.

- `npx tsc --noEmit` — clean
- `npx vitest run` — 390 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)