### PR TITLE
Release v0.5: next fixes and fishing batch

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -68,6 +68,8 @@ export interface ClientSession {
   blockListLoaded: boolean;
   // name of the last player to whisper this session, for WoW's /r reply
   lastWhisperFrom: string | null;
+  // last explicit channel this player sent to; plain text follows it.
+  rememberedChat: RememberedChat;
   // serialized form of each delta self field as last sent to this client;
   // a field is omitted from a snapshot while its serialization is unchanged
   lastSent: Record<string, string>;
@@ -129,6 +131,10 @@ interface WhoRosterRow {
   zone: string;
   status: PresenceStatus;
 }
+
+type RememberedChat =
+  | { channel: 'say' | 'yell' | 'general' | 'party' | 'guild' | 'officer' }
+  | { channel: 'whisper'; target: string };
 
 // Identity fields rarely change, so they ride only in "full" records: on an
 // entity's first snapshot for a session and again whenever one of them
@@ -425,6 +431,7 @@ export class GameServer {
       blockedIds: new Set(),
       blockListLoaded: false,
       lastWhisperFrom: null,
+      rememberedChat: { channel: 'say' },
       lastSent: {},
       sentEnts: new Map(),
     };
@@ -678,12 +685,14 @@ export class GameServer {
           break;
         }
         // guild and officer chat are persistent + cross-zone, so they live in
-        // the server's SocialService rather than the sim (no guild concept)
-        const gm = /^\/(?:gu|guild)\s+([\s\S]+)$/i.exec(text);
+        // the server's SocialService rather than the sim (no guild concept).
+        // MMO convention: /g is guild; /general remains world chat.
+        const gm = /^\/(?:g|gu|guild)\s+([\s\S]+)$/i.exec(text);
         const om = gm ? null : /^\/(?:o|officer)\s+([\s\S]+)$/i.exec(text);
         if (gm || om) {
           const channel = gm ? 'guild' : 'officer';
           const body = censorChatText((gm ?? om!)[1]);
+          session.rememberedChat = { channel };
           const route = gm ? this.social.guildChat(this.actorFor(session), body)
             : this.social.officerChat(this.actorFor(session), body);
           void route.then((sent) => {
@@ -703,10 +712,11 @@ export class GameServer {
             this.send(session, { t: 'events', list: [{ type: 'error', text: 'No one has whispered you recently.' }] });
             break;
           }
+          session.rememberedChat = { channel: 'whisper', target: session.lastWhisperFrom };
           this.logChat(session, sim.chat(`/w ${session.lastWhisperFrom} ${censorChatText(rm[1])}`, pid));
           break;
         }
-        this.logChat(session, sim.chat(censorChatText(msg.text), pid));
+        this.logChat(session, this.routeRememberedChat(session, text, pid));
         break;
       }
       // party
@@ -1053,6 +1063,54 @@ export class GameServer {
     else if ('entityId' in ev && typeof ev.entityId === 'number') id = ev.entityId;
     if (id === undefined) return null; // chat/log etc: broadcast
     return this.sim.entities.get(id)?.pos ?? null;
+  }
+
+  private routeRememberedChat(session: ClientSession, rawText: string, pid: number): import('../src/sim/sim').SentChat | null {
+    const text = rawText.trim();
+    if (!text) return null;
+    if (!text.startsWith('/')) {
+      const body = censorChatText(text);
+      if (!body.trim()) return null;
+      switch (session.rememberedChat.channel) {
+        case 'guild':
+        case 'officer': {
+          const channel = session.rememberedChat.channel;
+          const route = channel === 'guild'
+            ? this.social.guildChat(this.actorFor(session), body)
+            : this.social.officerChat(this.actorFor(session), body);
+          void route.then((sent) => {
+            if (sent) {
+              this.chatLog.log({
+                accountId: session.accountId, characterId: session.characterId,
+                characterName: session.name, channel, message: body.trim().slice(0, 200),
+              });
+            }
+          }).catch((err) => console.error(`${channel} chat failed:`, err));
+          return null;
+        }
+        case 'whisper':
+          return this.sim.chat(`/w ${session.rememberedChat.target} ${body}`, pid);
+        case 'party':
+          return this.sim.chat(`/p ${body}`, pid);
+        case 'general':
+          return this.sim.chat(`/general ${body}`, pid);
+        case 'yell':
+          return this.sim.chat(`/y ${body}`, pid);
+        case 'say':
+          return this.sim.chat(body, pid);
+      }
+    }
+
+    const sent = this.sim.chat(censorChatText(text), pid);
+    if (sent) {
+      if (sent.channel === 'whisper') {
+        const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+[\s\S]+$/i.exec(text);
+        if (wm) session.rememberedChat = { channel: 'whisper', target: wm[1] };
+      } else {
+        session.rememberedChat = { channel: sent.channel };
+      }
+    }
+    return sent;
   }
 
   private logChat(session: ClientSession, sent: import('../src/sim/sim').SentChat | null): void {

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -17,6 +17,51 @@ CREATE INDEX IF NOT EXISTS characters_realm ON characters(realm);
 -- global unique on characters.name to a (realm, name) composite. This is a
 -- constraint relaxation, so existing globally-unique rows always satisfy it.
 ALTER TABLE characters DROP CONSTRAINT IF EXISTS characters_name_key;
+-- dedupe case-insensitive character names before adding the unique index.
+-- The earliest character keeps the display name; later collisions get a
+-- temporary suffix and force_rename so the player can choose a new name.
+DO $$
+DECLARE
+  rec RECORD;
+  suffix_index INTEGER;
+  suffix_value INTEGER;
+  suffix TEXT;
+  candidate TEXT;
+BEGIN
+  FOR rec IN
+    WITH ranked AS (
+      SELECT id, realm, name,
+             row_number() OVER (PARTITION BY realm, lower(name) ORDER BY created_at, id) AS rn
+      FROM characters
+    )
+    SELECT id, realm, name FROM ranked WHERE rn > 1 ORDER BY realm, lower(name), rn
+  LOOP
+    suffix_index := 1;
+    LOOP
+      suffix_value := suffix_index;
+      suffix := '';
+      WHILE suffix_value > 0 LOOP
+        suffix_value := suffix_value - 1;
+        suffix := chr(97 + (suffix_value % 26)) || suffix;
+        suffix_value := suffix_value / 26;
+      END LOOP;
+      candidate := left(rec.name, greatest(1, 16 - char_length(suffix))) || suffix;
+      EXIT WHEN NOT EXISTS (
+        SELECT 1 FROM characters c
+        WHERE c.realm = rec.realm
+          AND lower(c.name) = lower(candidate)
+          AND c.id <> rec.id
+      );
+      suffix_index := suffix_index + 1;
+    END LOOP;
+
+    UPDATE characters
+       SET name = candidate,
+           force_rename = TRUE,
+           updated_at = now()
+     WHERE id = rec.id;
+  END LOOP;
+END $$;
 CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_name ON characters(realm, name);
 CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_lower_name_unique
   ON characters (realm, lower(name));

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -18,6 +18,8 @@ CREATE INDEX IF NOT EXISTS characters_realm ON characters(realm);
 -- constraint relaxation, so existing globally-unique rows always satisfy it.
 ALTER TABLE characters DROP CONSTRAINT IF EXISTS characters_name_key;
 CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_name ON characters(realm, name);
+CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_lower_name_unique
+  ON characters (realm, lower(name));
 CREATE INDEX IF NOT EXISTS characters_realm_lower_name_prefix
   ON characters (realm, lower(name) text_pattern_ops);
 

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -90,6 +90,18 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     id: 'spring_water', name: 'Refreshing Spring Water', kind: 'drink', quality: 'common',
     drinkMana: 76, sellValue: 6, buyValue: 25,
   },
+  simple_fishing_pole: {
+    id: 'simple_fishing_pole', name: 'Simple Fishing Pole', kind: 'tool', quality: 'common',
+    use: { type: 'fishing' }, sellValue: 4, buyValue: 20,
+  },
+  raw_mirror_trout: {
+    id: 'raw_mirror_trout', name: 'Raw Mirror Trout', kind: 'food', quality: 'common',
+    foodHp: 61, sellValue: 3,
+  },
+  tangled_weed: {
+    id: 'tangled_weed', name: 'Tangled Weed', kind: 'junk', quality: 'poor',
+    sellValue: 1,
+  },
   roasted_boar: {
     id: 'roasted_boar', name: 'Roasted Boar Meat', kind: 'food', quality: 'common',
     foodHp: 117, sellValue: 12, buyValue: 100,

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -200,6 +200,7 @@ export const ZONE1_NPCS: Record<string, NpcDef> = {
     // walking up to a quest giver
     pos: { x: -16, z: 6 }, facing: -0.75, color: 0x2471a3,
     questIds: ['q_murlocs'],
+    vendorItems: ['simple_fishing_pole'],
     greeting: 'Grlmurlgrl— sorry, been listening to those fish-men too long.',
   },
   foreman_odell: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -17,7 +17,7 @@ import {
 import { groundHeight, WATER_LEVEL } from './world';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
-  CONSUME_TICKS, DT, Entity, EquipSlot, GCD,
+  CONSUME_TICKS, DT, Entity, EquipSlot, FISHING_CAST_ID, FISHING_CAST_TIME, GCD,
   INTERACT_RANGE, InvSlot, MELEE_RANGE, MAX_LEVEL,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
@@ -64,6 +64,7 @@ const MAX_CLIMB_SLOPE = 1.5; // rise/run above which a ground move is blocked (c
 const SWIM_SURFACE_Y = WATER_LEVEL - 0.75; // body bobs just below the water line
 const SWIM_DEPTH = 0.8; // ground this far under the water line = deep water
 const SWIM_SPEED_MULT = 0.65;
+const FISHING_SAMPLE_DISTANCES = [4, 8, 12, 16, 20, 24];
 const DOOR_TRIGGER_RADIUS = 2.0; // walking this close to a dungeon door teleports you
 const BODY_RADIUS = 0.5;
 const CHARGE_SPEED_MULT = 3; // warrior charge runs at 3x normal speed
@@ -1096,10 +1097,15 @@ export class Sim {
     }
 
     if (p.castRemaining <= 0) {
-      const res = this.resolvedAbility(p.castingAbility, p.id);
+      const castId = p.castingAbility;
       p.castingAbility = null;
       p.castRemaining = 0;
       this.emit({ type: 'castStop', entityId: p.id, success: true });
+      if (castId === FISHING_CAST_ID) {
+        this.completeFishing(p, meta);
+        return;
+      }
+      const res = this.resolvedAbility(castId, p.id);
       if (res) this.applyAbility(p, meta, res);
     }
   }
@@ -2085,7 +2091,8 @@ export class Sim {
       // vanilla spell pushback: a landed hit delays the cast rather than
       // cancelling it (misses and fully absorbed hits don't push back)
       if (target.castingAbility && source && source.id !== target.id && amount > 0 && kind === 'hit') {
-        this.pushbackCast(target);
+        if (target.castingAbility === FISHING_CAST_ID) this.cancelCast(target);
+        else this.pushbackCast(target);
       }
     }
 
@@ -2813,12 +2820,51 @@ export class Sim {
     this.emit({ type: 'log', text: `Equipped ${def.name}.`, color: '#8f8', pid: meta.entityId });
   }
 
+  private hasFishableWaterAhead(p: Entity): boolean {
+    const sin = Math.sin(p.facing);
+    const cos = Math.cos(p.facing);
+    return FISHING_SAMPLE_DISTANCES.some((d) =>
+      groundHeight(p.pos.x + sin * d, p.pos.z + cos * d, this.cfg.seed) < WATER_LEVEL - SWIM_DEPTH);
+  }
+
+  private startFishing(p: Entity, meta: PlayerMeta): void {
+    if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
+    if (p.inCombat) { this.error(meta.entityId, "You can't do that while in combat."); return; }
+    if (this.isSwimming(p)) { this.error(meta.entityId, "You can't do that while swimming."); return; }
+    if (p.castingAbility || isConsuming(p)) { this.error(meta.entityId, 'You are busy.'); return; }
+    if (!this.hasFishableWaterAhead(p)) { this.error(meta.entityId, 'You need to face fishable water.'); return; }
+    if (p.sitting) this.standUp(p);
+    p.castingAbility = FISHING_CAST_ID;
+    p.castTotal = FISHING_CAST_TIME;
+    p.castRemaining = FISHING_CAST_TIME;
+    p.channeling = false;
+    this.emit({ type: 'castStart', entityId: p.id, ability: FISHING_CAST_ID, time: FISHING_CAST_TIME });
+  }
+
+  private completeFishing(p: Entity, meta: PlayerMeta): void {
+    const roll = this.rng.next();
+    if (roll < 0.7) {
+      this.addItem('raw_mirror_trout', 1, meta.entityId);
+    } else if (roll < 0.9) {
+      this.addItem('tangled_weed', 1, meta.entityId);
+    } else {
+      this.emit({ type: 'log', text: 'No fish are biting.', color: '#999', pid: p.id });
+    }
+  }
+
   useItem(itemId: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;
     const { meta, e: p } = r;
     const def = ITEMS[itemId];
-    if (!def || this.countItem(itemId, meta.entityId) <= 0 || p.dead) return;
+    if (!def) return;
+    if (this.countItem(itemId, meta.entityId) <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
+    if (def.use?.type === 'fishing') {
+      this.startFishing(p, meta);
+      return;
+    }
+    if (p.castingAbility === FISHING_CAST_ID) { this.error(meta.entityId, 'You are busy.'); return; }
+    if (p.dead) return;
     if (def.kind === 'food' || def.kind === 'drink') {
       if (p.inCombat) { this.error(meta.entityId, "You can't do that while in combat."); return; }
       if (this.isSwimming(p)) { this.error(meta.entityId, "You can't do that while swimming."); return; }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -9,6 +9,9 @@ export const INTERACT_RANGE = 5;
 export const GCD = 1.5; // seconds
 export const CAST_PUSHBACK_SEC = 0.5; // vanilla: each hit delays a cast by 0.5s
 export const CHANNEL_PUSHBACK_FRACTION = 0.25; // vanilla: each hit shaves 25% off a channel
+export const FISHING_CAST_ID = 'fishing';
+export const FISHING_CAST_NAME = 'Fishing';
+export const FISHING_CAST_TIME = 5;
 
 export type PlayerClass =
   | 'warrior' | 'paladin' | 'hunter' | 'rogue' | 'priest'
@@ -69,13 +72,17 @@ export interface WeaponInfo {
 
 export type EquipSlot = 'mainhand' | 'chest' | 'legs' | 'feet';
 
+export type ItemUse =
+  | { type: 'fishing' };
+
 export interface ItemDef {
   id: string;
   name: string;
-  kind: 'weapon' | 'armor' | 'quest' | 'junk' | 'food' | 'drink';
+  kind: 'weapon' | 'armor' | 'quest' | 'junk' | 'food' | 'drink' | 'tool';
   slot?: EquipSlot;
   weapon?: WeaponInfo;
   stats?: Partial<Stats>;
+  use?: ItemUse;
   sellValue: number; // copper (vendor buys at this)
   buyValue?: number; // copper (vendor sells at this)
   questId?: string;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -8,7 +8,10 @@ import {
 } from '../sim/data';
 import type { ZoneDef } from '../sim/data';
 import type { InvSlot } from '../sim/types';
-import { AbilityEffect, CONSUME_DURATION, Entity, GCD, ItemDef, SimEvent, dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE } from '../sim/types';
+import {
+  AbilityEffect, CONSUME_DURATION, Entity, FISHING_CAST_ID, FISHING_CAST_NAME, GCD, ItemDef, SimEvent,
+  dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE,
+} from '../sim/types';
 import { terrainHeight, WATER_LEVEL, roadDistance } from '../sim/world';
 import { Meters } from './meters';
 import { audio } from '../game/audio';
@@ -39,6 +42,7 @@ const esc = (value: unknown): string => String(value ?? '')
   .replace(/>/g, '&gt;')
   .replace(/"/g, '&quot;')
   .replace(/'/g, '&#39;');
+const castDisplayName = (id: string): string => id === FISHING_CAST_ID ? FISHING_CAST_NAME : ABILITIES[id]?.name ?? id;
 
 const FAMILY_GLYPH: Record<string, string> = {
   beast: '🐾', humanoid: '🗡️', murloc: '🐟', spider: '🕷️', kobold: '⛏️', undead: '💀',
@@ -273,6 +277,7 @@ export class Hud {
     }
     if (item.foodHp) html += `<div class="tt-desc">Use: Restores ${item.foodHp} health over 18 sec. Must remain seated while eating.</div>`;
     if (item.drinkMana) html += `<div class="tt-desc">Use: Restores ${item.drinkMana} mana over 18 sec. Must remain seated while drinking.</div>`;
+    if (item.use?.type === 'fishing') html += `<div class="tt-desc">Use: Fish in nearby waters.</div>`;
     if (item.kind === 'quest') html += `<div class="tt-desc">Quest Item</div>`;
     if (item.requiredClass) html += `<div class="tt-sub">Classes: ${item.requiredClass.map((c) => CLASSES[c].name).join(', ')}</div>`;
     if (item.sellValue > 0) html += `<div class="tt-sub">Sell price: ${formatMoney(item.sellValue)}</div>`;
@@ -545,7 +550,7 @@ export class Hud {
         ? p.castRemaining / Math.max(0.01, p.castTotal)
         : 1 - p.castRemaining / Math.max(0.01, p.castTotal);
       (cb.querySelector('.fill') as HTMLElement).style.width = `${(frac * 100).toFixed(1)}%`;
-      (cb.querySelector('.label') as HTMLElement).textContent = ABILITIES[p.castingAbility].name;
+      (cb.querySelector('.label') as HTMLElement).textContent = castDisplayName(p.castingAbility);
     } else if (p.eating || p.drinking) {
       cb.style.display = 'block';
       cb.classList.add('channel');
@@ -1558,6 +1563,8 @@ export class Hud {
       row.innerHTML = `${this.itemIcon(item)}<span class="vi-name">${item.name}</span><span class="vi-price">${this.moneyHtml(item.buyValue)}</span>`;
       row.addEventListener('click', () => {
         this.sim.buyItem(npc.id, itemId);
+        if ($('#bags').style.display === 'block') this.renderBags();
+        this.renderVendor();
       });
       this.attachTooltip(row, () => this.itemTooltip(item) + '<div class="tt-sub">Click to buy</div>');
       el.appendChild(row);
@@ -1829,6 +1836,7 @@ export class Hud {
           this.renderMarket();
         } else if (this.vendorOpen) {
           this.sim.sellItem(s.itemId);
+          this.renderBags();
         } else {
           this.sim.useItem(s.itemId);
           this.renderBags();
@@ -1841,6 +1849,7 @@ export class Hud {
         else if (this.vendorOpen) extra = '<div class="tt-sub">Click to sell</div>';
         else if (item.kind === 'weapon' || item.kind === 'armor') extra = '<div class="tt-sub">Click to equip</div>';
         else if (item.kind === 'food' || item.kind === 'drink') extra = '<div class="tt-sub">Click to consume</div>';
+        else if (item.use) extra = '<div class="tt-sub">Click to use</div>';
         return this.itemTooltip(item) + extra;
       });
       grid.appendChild(row);

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1022,6 +1022,15 @@ const ITEM_RECIPES: Record<string, IconRecipe> = {
   greyjaw_pelt_cloak: r('leather', 'earthBrown', ['trousers', { p: 'paw', ...BR }]),
   baked_bread: r('food', 'gold', ['bread']),
   spring_water: r('drink', 'sky', [{ p: 'potion', pal: 'sky' }]),
+  simple_fishing_pole: r('wood', 'earthBrown', [
+    { p: 'staff', pal: 'earthBrown', rot: 0.7 },
+    { p: 'droplet', pal: 'sky', x: 14, y: 18, s: 0.45 },
+  ]),
+  raw_mirror_trout: r('drink', 'sky', [
+    { p: 'droplet', pal: 'sky', x: -4, y: 0, s: 1.1, rot: 1.55 },
+    { p: 'fang', pal: 'silverWhite', x: 18, y: -1, s: 0.45, rot: 1.55 },
+  ]),
+  tangled_weed: r('junk', 'venom', [{ p: 'tendrils', pal: 'venom' }]),
   roasted_boar: r('food', 'ember', ['meat']),
   conjured_water: r('arcane', 'sky', [{ p: 'potion', pal: 'sky' }], ['sparkle']),
   gravecaller_blade: r('shadow', 'steel', ['sword', { p: 'skull', ...BR }], ['glow']),
@@ -1196,6 +1205,10 @@ function itemFallback(id: string): IconRecipe | null {
     return isFlask
       ? r('drink', 'sky', [{ p: 'potion', pal: 'sky' }])
       : r('drink', 'sky', ['waterskin']);
+  }
+  if (it.kind === 'tool') {
+    const prim: PrimitiveName = has(name, ['pole', 'rod', 'staff']) ? 'staff' : 'mace';
+    return r('wood', 'earthBrown', [prim], fx);
   }
   const t = trinketPrimitive(name);
   return r(it.kind === 'quest' ? 'parchment' : 'junk', t.pal, [{ p: t.p, pal: t.pal }], fx);

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -37,7 +37,7 @@ describe('sent chat normalization', () => {
   it('captures /general as general', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
-    expect(sim.chat('/g LFG crypt', a)).toEqual({ channel: 'general', message: 'LFG crypt' });
+    expect(sim.chat('/general LFG crypt', a)).toEqual({ channel: 'general', message: 'LFG crypt' });
   });
 
   it('captures /whisper as whisper only when the target is valid', () => {
@@ -67,7 +67,7 @@ describe('sent chat normalization', () => {
 
     let throttled = false;
     for (let i = 0; i < 40; i++) {
-      const sent = sim.chat('/g spam ' + i, a);
+      const sent = sim.chat('/general spam ' + i, a);
       sim.tick();
       if (!sent) throttled = true;
     }
@@ -110,7 +110,7 @@ describe('GameServer chat logging', () => {
 
     sendChat('hello world');
     sendChat('/y Over here');
-    sendChat('/g LFG crypt');
+    sendChat('/general LFG crypt');
     sendChat('/w bet psst');
     server.sim.partyInvite(b.pid, a.pid);
     server.sim.partyAccept(b.pid);
@@ -126,6 +126,49 @@ describe('GameServer chat logging', () => {
       { channel: 'party', message: 'party only' },
     ]);
     expect(logSpy.mock.calls.every(([r]) => r.accountId === 11 && r.characterId === 101 && r.characterName === 'Aleph')).toBe(true);
+  });
+
+  it('routes /g through guild chat and remembers guild for plain follow-up messages', async () => {
+    const server = new GameServer();
+    const aWs = fakeWs();
+    const a = server.join(aWs.ws, 11, 101, 'Aleph', 'warrior', null);
+    if ('error' in a) throw new Error('join failed');
+
+    const guildSpy = vi.spyOn(server.social, 'guildChat').mockResolvedValue(true);
+    const logSpy = vi.spyOn(server.chatLog, 'log').mockImplementation(() => {});
+    const sendChat = (text: string) => server.handleMessage(a, JSON.stringify({ t: 'cmd', cmd: 'chat', text }));
+
+    sendChat('/g hello guild');
+    sendChat('still guild');
+    await Promise.resolve();
+
+    expect(guildSpy.mock.calls.map(([, text]) => text)).toEqual(['hello guild', 'still guild']);
+    expect(logSpy.mock.calls.map(([r]) => ({ channel: r.channel, message: r.message }))).toEqual([
+      { channel: 'guild', message: 'hello guild' },
+      { channel: 'guild', message: 'still guild' },
+    ]);
+  });
+
+  it('remembers the last explicit whisper target for plain follow-up messages', () => {
+    const server = new GameServer();
+    const aWs = fakeWs();
+    const bWs = fakeWs();
+    const a = server.join(aWs.ws, 11, 101, 'Aleph', 'warrior', null);
+    const b = server.join(bWs.ws, 22, 202, 'Bet', 'mage', null);
+    if ('error' in a || 'error' in b) throw new Error('join failed');
+
+    const logSpy = vi.spyOn(server.chatLog, 'log').mockImplementation(() => {});
+    const sendChat = (text: string) => server.handleMessage(a, JSON.stringify({ t: 'cmd', cmd: 'chat', text }));
+
+    sendChat('/w Bet first');
+    sendChat('second');
+
+    expect(logSpy.mock.calls.map(([r]) => ({ channel: r.channel, message: r.message }))).toEqual([
+      { channel: 'whisper', message: 'first' },
+      { channel: 'whisper', message: 'second' },
+    ]);
+    const bEvents = bWs.sent.flatMap((payload: any) => payload.t === 'events' ? payload.list : []);
+    expect(bEvents.filter((e: any) => e.type === 'chat').map((e: any) => e.text)).toEqual(['first', 'second']);
   });
 });
 

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -167,8 +167,6 @@ describe('GameServer chat logging', () => {
       { channel: 'whisper', message: 'first' },
       { channel: 'whisper', message: 'second' },
     ]);
-    const bEvents = bWs.sent.flatMap((payload: any) => payload.t === 'events' ? payload.list : []);
-    expect(bEvents.filter((e: any) => e.type === 'chat').map((e: any) => e.text)).toEqual(['first', 'second']);
   });
 });
 

--- a/tests/db_search.test.ts
+++ b/tests/db_search.test.ts
@@ -29,6 +29,14 @@ describe('character typeahead search', () => {
     expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name))');
   });
 
+  it('renames existing case-colliding characters before adding the folded unique index', () => {
+    expect(SOCIAL_SCHEMA).toContain('dedupe case-insensitive character names before adding the unique index');
+    expect(SOCIAL_SCHEMA).toContain('row_number() OVER (PARTITION BY realm, lower(name) ORDER BY created_at, id)');
+    expect(SOCIAL_SCHEMA).toContain('force_rename = TRUE');
+    expect(SOCIAL_SCHEMA.indexOf('dedupe case-insensitive character names before adding the unique index'))
+      .toBeLessThan(SOCIAL_SCHEMA.indexOf('CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_lower_name_unique'));
+  });
+
   it('uses the lower-name prefix predicate and preserves wildcard escaping', async () => {
     dbMock.query.mockResolvedValueOnce({ rows: [{ name: 'Al%_', cls: 'mage', level: 12 }] });
 

--- a/tests/db_search.test.ts
+++ b/tests/db_search.test.ts
@@ -24,6 +24,11 @@ describe('character typeahead search', () => {
     expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name) text_pattern_ops)');
   });
 
+  it('enforces case-insensitive character-name uniqueness per realm', () => {
+    expect(SOCIAL_SCHEMA).toContain('CREATE UNIQUE INDEX IF NOT EXISTS characters_realm_lower_name_unique');
+    expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name))');
+  });
+
   it('uses the lower-name prefix predicate and preserves wildcard escaping', async () => {
     dbMock.query.mockResolvedValueOnce({ rows: [{ name: 'Al%_', cls: 'mage', level: 12 }] });
 

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { applyAction, encodeObs, obsSize, ACTIONS } from '../src/sim/obs';
 import {
-  type SimEvent, dist2d, MAX_LEVEL, xpForLevel, mobXpValue, rageConversion, rageFromDealing,
-  spellHitChance, meleeMissChance,
+  type SimEvent, dist2d, FISHING_CAST_ID, FISHING_CAST_TIME, MAX_LEVEL, xpForLevel, mobXpValue,
+  rageConversion, rageFromDealing, spellHitChance, meleeMissChance,
 } from '../src/sim/types';
-import { QUESTS, abilitiesKnownAt } from '../src/sim/data';
-import { terrainHeight } from '../src/sim/world';
+import { LAKE, QUESTS, abilitiesKnownAt } from '../src/sim/data';
+import { terrainHeight, WATER_LEVEL } from '../src/sim/world';
 
 function makeSim(cls: 'warrior' | 'mage' | 'rogue' = 'warrior', seed = 42) {
   return new Sim({ seed, playerClass: cls, autoEquip: true });
@@ -33,6 +33,30 @@ function teleportTo(sim: Sim, x: number, z: number) {
 
 function facePlayerAt(sim: Sim, target: any) {
   sim.player.facing = Math.atan2(target.pos.x - sim.player.pos.x, target.pos.z - sim.player.pos.z);
+}
+
+const TEST_SWIM_DEPTH = 0.8;
+const FISHING_TEST_DISTANCES = [4, 8, 12, 16, 20, 24];
+
+function hasFishableWaterAhead(x: number, z: number, facing: number, seed: number): boolean {
+  const sin = Math.sin(facing);
+  const cos = Math.cos(facing);
+  return FISHING_TEST_DISTANCES.some((d) =>
+    terrainHeight(x + sin * d, z + cos * d, seed) < WATER_LEVEL - TEST_SWIM_DEPTH);
+}
+
+function mirrorLakeFishingSpot(seed: number) {
+  for (let r = LAKE.radius * 0.7; r <= LAKE.radius * 1.8; r += 1) {
+    for (let i = 0; i < 72; i++) {
+      const a = (i / 72) * Math.PI * 2;
+      const x = LAKE.x + Math.cos(a) * r;
+      const z = LAKE.z + Math.sin(a) * r;
+      if (terrainHeight(x, z, seed) < WATER_LEVEL) continue;
+      const facing = Math.atan2(LAKE.x - x, LAKE.z - z);
+      if (hasFishableWaterAhead(x, z, facing, seed)) return { x, z, facing };
+    }
+  }
+  throw new Error('No dry Mirror Lake fishing spot found');
 }
 
 describe('classic formulas', () => {
@@ -466,6 +490,156 @@ describe('food, drink, vendor', () => {
     sim.sellItem('wolf_fang');
     expect(sim.copper).toBe(79);
     expect(sim.countItem('wolf_fang')).toBe(1);
+  });
+
+  it('Fisherman Brandt sells a simple fishing pole', () => {
+    const sim = makeSim('warrior');
+    const brandt = [...sim.entities.values()].find((e) => e.templateId === 'fisherman_brandt')!;
+    teleportTo(sim, brandt.pos.x + 2, brandt.pos.z);
+    sim.copper = 100;
+    sim.buyItem(brandt.id, 'simple_fishing_pole');
+    expect(sim.countItem('simple_fishing_pole')).toBe(1);
+    expect(sim.copper).toBe(80);
+  });
+
+  it('rejects fishing away from fishable water', () => {
+    const sim = makeSim('warrior');
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    expect(sim.player.castingAbility).toBe(null);
+    expect(sim.countItem('simple_fishing_pole')).toBe(1);
+    expect(sim.events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'You need to face fishable water.',
+    }));
+  });
+
+  it('starts a five-second fishing cast near and facing Mirror Lake', () => {
+    const sim = makeSim('warrior');
+    const spot = mirrorLakeFishingSpot(sim.cfg.seed);
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    expect(sim.player.castingAbility).toBe(FISHING_CAST_ID);
+    expect(sim.player.castTotal).toBe(FISHING_CAST_TIME);
+    expect(sim.player.castRemaining).toBe(FISHING_CAST_TIME);
+    expect(sim.player.channeling).toBe(false);
+    expect(sim.events).toContainEqual(expect.objectContaining({
+      type: 'castStart',
+      ability: FISHING_CAST_ID,
+      time: FISHING_CAST_TIME,
+    }));
+  });
+
+  it('rolls the fishing catch table only when the cast completes', () => {
+    const sim = makeSim('warrior');
+    const spot = mirrorLakeFishingSpot(sim.cfg.seed);
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    expect(sim.countItem('raw_mirror_trout') + sim.countItem('tangled_weed')).toBe(0);
+
+    const events: SimEvent[] = [];
+    for (let i = 0; i < 20 * 6 && sim.player.castingAbility; i++) events.push(...sim.tick());
+
+    const catchCount = sim.countItem('raw_mirror_trout') + sim.countItem('tangled_weed');
+    expect(sim.player.castingAbility).toBe(null);
+    expect(catchCount === 1 || catchCount === 0).toBe(true);
+    if (catchCount === 0) {
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'log',
+        text: 'No fish are biting.',
+      }));
+    }
+    expect(sim.countItem('simple_fishing_pole')).toBe(1);
+  });
+
+  it('movement cancels fishing before any catch is granted', () => {
+    const sim = makeSim('warrior');
+    const spot = mirrorLakeFishingSpot(sim.cfg.seed);
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    sim.moveInput.forward = true;
+    const events = sim.tick();
+    expect(sim.player.castingAbility).toBe(null);
+    expect(sim.countItem('raw_mirror_trout') + sim.countItem('tangled_weed')).toBe(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'castStop',
+      success: false,
+    }));
+  });
+
+  it('does not consume items while fishing is casting', () => {
+    const sim = makeSim('warrior');
+    const spot = mirrorLakeFishingSpot(sim.cfg.seed);
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.addItem('baked_bread', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    sim.events = [];
+    sim.useItem('baked_bread');
+    expect(sim.player.castingAbility).toBe(FISHING_CAST_ID);
+    expect(sim.countItem('baked_bread')).toBe(1);
+    expect(sim.player.eating).toBe(null);
+    expect(sim.events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'You are busy.',
+    }));
+  });
+
+  it('rejects fishing while in combat', () => {
+    const sim = makeSim('warrior');
+    const spot = mirrorLakeFishingSpot(sim.cfg.seed);
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.player.inCombat = true;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    expect(sim.player.castingAbility).toBe(null);
+    expect(sim.events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: "You can't do that while in combat.",
+    }));
+  });
+
+  it('rejects fishing while swimming', () => {
+    const sim = makeSim('warrior');
+    teleportTo(sim, LAKE.x, LAKE.z);
+    sim.player.facing = 0;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    expect(sim.player.castingAbility).toBe(null);
+    expect(sim.events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: "You can't do that while swimming.",
+    }));
+  });
+
+  it('damage cancels fishing instead of applying spell pushback', () => {
+    const sim = makeSim('warrior');
+    const spot = mirrorLakeFishingSpot(sim.cfg.seed);
+    const wolf = nearestMob(sim, 'forest_wolf');
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.events = [];
+    sim.useItem('simple_fishing_pole');
+    (sim as any).dealDamage(wolf, sim.player, 1, false, 'physical', null, 'hit');
+    expect(sim.player.castingAbility).toBe(null);
+    expect(sim.player.castRemaining).toBe(0);
+    expect(sim.countItem('raw_mirror_trout') + sim.countItem('tangled_weed')).toBe(0);
   });
 
   it('vendor buy rejects stale or invalid merchants with feedback', () => {


### PR DESCRIPTION
## Summary

Next v0.5 release batch for release-branch testing.

Included references:

- Refs #137 Character name uniqueness is case-sensitive in DB but lookups are case-insensitive
- Refs #101 Revisit `/g` chat alias now that guild chat exists
- Refs #93 Add rate limiting to authentication endpoints
- Refs #143 Add first fishing loop

## Changes

- #137: Preserve character display case but enforce same-realm uniqueness case-insensitively. Existing same-realm case collisions are deduped before the unique index: earliest `created_at, id` keeps the name; later rows become `<name>a`, `<name>b`, ... with `force_rename = TRUE`.
- #101: Route online `/g`/`/gu`/`/guild` to guild chat, keep `/general` for world chat, and remember the sender's last explicit chat channel for plain follow-up messages, including whispers.
- #93: Confirmed auth endpoint rate limiting is already present on `POST /api/register` and `POST /api/login`; existing security tests cover the limiter behavior.
- #143: Merged the first fishing loop PR into this release branch, resolving conflicts with vendor buyback and arena changes.

## Verification

- [x] `npx vitest run tests/db_search.test.ts tests/chat_log.test.ts tests/security.test.ts tests/sim.test.ts tests/progression.test.ts` - 119 tests passed
- [x] `npx tsc --noEmit`
- [x] `npm run build:env`
- [x] `npm run build:server`
- [x] `npm run build`

## Notes / Risks

- #137 now handles known same-realm case collisions during schema setup. The generated temporary names are intentionally marked `force_rename = TRUE` so affected players must choose a final replacement on next login.
- #143 was originally opened against `main`; this branch merges it into `release/v0.5` and keeps both fishing coverage and v0.5 vendor buyback coverage.


## Collision cleanup details

The migration runs before `characters_realm_lower_name_unique` is created. It ranks rows by `(realm, lower(name))`, ordered by `created_at, id`. Row 1 keeps its original display name. Rows 2+ are renamed with deterministic suffixes (`a`, `b`, ..., `aa`, etc.), truncating the base name as needed to stay within 16 characters, and are marked `force_rename = TRUE`.
