### PR TITLE
fix: require real damage to claim mob tap rights

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2062,7 +2062,7 @@ export class Sim {
     }
 
     // tap rights: the first player (or their pet) to damage a mob owns it
-    if (source && target.kind === 'mob' && target.hostile && target.tappedById === null && amount >= 0) {
+    if (source && target.kind === 'mob' && target.hostile && target.tappedById === null && amount > 0) {
       if (source.kind === 'player') target.tappedById = source.id;
       else if (source.ownerId !== null) target.tappedById = source.ownerId;
     }

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -358,6 +358,34 @@ describe('warrior charge', () => {
   });
 });
 
+describe('mob tap rights', () => {
+  function wolf(sim: Sim): Entity {
+    return [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'forest_wolf')!;
+  }
+
+  it('a hit that deals real damage claims the mob', () => {
+    const sim = makeSim('mage');
+    const m = wolf(sim);
+    expect(m.tappedById).toBeNull();
+    (sim as any).dealDamage(sim.player, m, 7, false, 'fire', 'test', 'hit');
+    expect(m.tappedById).toBe(sim.player.id);
+  });
+
+  it('a fully absorbed (zero-damage) hit does not claim the mob', () => {
+    const sim = makeSim('mage');
+    const m = wolf(sim);
+    // a shield that soaks the whole hit — the mob takes no real damage
+    m.auras.push({
+      id: 'test_absorb', name: 'Test Shield', kind: 'absorb',
+      remaining: 30, duration: 30, value: 1000, sourceId: m.id, school: 'arcane',
+    } as any);
+    const hpBefore = m.hp;
+    (sim as any).dealDamage(sim.player, m, 50, false, 'fire', 'test', 'hit');
+    expect(m.hp).toBe(hpBefore); // nothing got through
+    expect(m.tappedById).toBeNull(); // so nobody owns the tap yet
+  });
+});
+
 describe('spell visuals', () => {
   it('hostile casts emit projectile spellfx events', () => {
     const sim = makeSim('mage');


### PR DESCRIPTION
## Problem

In `Sim.dealDamage` (`src/sim/sim.ts`), the tap-rights assignment is gated on `amount >= 0`:

```ts
// tap rights: the first player (or their pet) to damage a mob owns it
if (source && target.kind === 'mob' && target.hostile && target.tappedById === null && amount >= 0) {
```

Every other amount-gated branch in the same function uses `amount > 0` (the stealth break and the `breaksOnDamage` aura cleanup). Since `amount` is clamped to `>= 0` and then reduced by absorb shields earlier in the function, a **fully-absorbed hit reaches this check as `0` and still tags the mob**.

### Impact

Tap rights decide kill credit and loot ownership (consumed at kill time via `tappedById` → `rollLoot`). With `>= 0`, a player can claim an untapped mob with a hit that deals **no real damage** (e.g. fully soaked by an absorb shield), then another player who does all the actual work loses the loot/credit. It's also internally inconsistent with the neighbouring guards.

## Fix

Tighten the guard to `amount > 0`, so only a hit that lands real damage establishes the tap — matching the surrounding logic. Pure-debuff / zero-damage paths never flow through `dealDamage` with `amount > 0` anyway, so legitimate tagging is unaffected.

## Tests

Added regression coverage in `tests/fixes.test.ts` (`mob tap rights`):
- a hit dealing real damage claims the mob ✅
- a fully-absorbed, zero-damage hit does **not** claim the mob ✅

The new absorb test fails on `main` and passes with this change. Full suite: 391 passed (the only failing file is the pre-existing `homepage_foundation` suite, which requires `DATABASE_URL` and is unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)