### PR TITLE
fix: stop toggling a buff off from re-arming its cooldown

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1352,6 +1352,10 @@ export class Sim {
 
   private applyAbility(p: Entity, meta: PlayerMeta, res: ResolvedAbility): void {
     const ability = res.def;
+    // Toggling a buff off (re-casting a form/stance/stealth you already have) is
+    // free and must not re-arm the ability's cooldown — the cooldown only gates
+    // re-entry. See isToggleBuff and the cast-time gate in castAbility.
+    const togglingOff = isToggleBuff(ability) && p.auras.some((a) => a.id === ability.id);
     if (ability.id === 'conjure_water') {
       this.spendResource(p, res.cost);
       // higher ranks conjure better water (falls back if the item isn't defined)
@@ -1377,14 +1381,14 @@ export class Sim {
     // helpful spells never miss
     if (ability.targetType === 'friendly') {
       this.spendResource(p, res.cost);
-      if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+      if (ability.cooldown > 0 && !togglingOff) p.cooldowns.set(ability.id, ability.cooldown);
       this.runEffects(p, meta, target, res);
       return;
     }
 
     if (target && ability.school !== 'physical') {
       this.spendResource(p, res.cost);
-      if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+      if (ability.cooldown > 0 && !togglingOff) p.cooldowns.set(ability.id, ability.cooldown);
       this.emit({ type: 'spellfx', sourceId: p.id, targetId: target.id, school: ability.school, fx: 'projectile' });
       if (!this.rng.chance(spellHitChance(p.level, target.level))) {
         this.emit({ type: 'damage', sourceId: p.id, targetId: target.id, amount: 0, crit: false, school: ability.school, ability: ability.name, kind: 'miss' });
@@ -1396,7 +1400,7 @@ export class Sim {
     }
 
     this.spendAbilityCost(p, res);
-    if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+    if (ability.cooldown > 0 && !togglingOff) p.cooldowns.set(ability.id, ability.cooldown);
     this.runEffects(p, meta, target, res);
   }
 

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -383,6 +383,26 @@ describe('rogue', () => {
     expect(sim.player.comboPoints).toBe(0);
   });
 
+  it('toggling stealth off does not re-arm its cooldown', () => {
+    const sim = makeSim('rogue');
+    (sim as any).grantXp(xpForLevel(1) + xpForLevel(2) + 10); // reach level 3, learns stealth (lvl 2)
+    expect(sim.known.map((k) => k.def.id)).toContain('stealth');
+    // Stealth on: arms the 10s re-entry cooldown.
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    expect(sim.player.cooldowns.has('stealth')).toBe(true);
+    // Wait out the cooldown (10s @ 20 ticks/s = 200 ticks).
+    for (let i = 0; i < 220; i++) sim.tick();
+    expect(sim.player.cooldowns.has('stealth')).toBe(false);
+    // Toggling stealth off is free and must not re-arm the cooldown.
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(false);
+    expect(sim.player.cooldowns.has('stealth')).toBe(false);
+    // Therefore the rogue can immediately re-stealth.
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+  });
+
   it('rogue GCD is 1.0s', () => {
     const sim = makeSim('rogue');
     expect(sim.playerGcd).toBe(1.0);


### PR DESCRIPTION
## Problem

Forms, stances and stealth are *toggles*: re-casting cancels the aura. The code documents the contract right above `isToggleBuff` (src/sim/sim.ts):

> Forms, stances and stealth are toggles: re-casting cancels the aura, and cancelling is never gated by cost or cooldown (the cooldown gates re-entry).

`castAbility` honors this for the cooldown *check* (`togglingOff` at the gate), but `applyAbility` set the cooldown **unconditionally** on all three resolution paths. So *cancelling* a toggle re-armed its cooldown:

- **Stealth** (`cooldown: 10`): a rogue who stealths, waits out the 10s, then manually steps out of Stealth is put back on a fresh 10s cooldown and cannot immediately re-stealth — despite choosing to drop it.
- **Defensive Stance** (`cooldown: 1`): leaving the stance re-arms its 1s cooldown, briefly blocking re-entry.

Bear/Cat Form have `cooldown: 0`, so they were already unaffected.

## Fix

Compute `togglingOff` in `applyAbility` (mirroring the existing computation in `castAbility`) and skip the cooldown set when toggling off. Three one-line guards; no behavior change for non-toggle abilities.

## Test

Adds a regression test (`tests/sim.test.ts`) that stealths, waits out the cooldown, toggles off, and asserts the cooldown is **not** re-armed (so the rogue can immediately re-stealth). Verified the test fails on `main` and passes with the fix. Full suite: 390 tests pass; `tsc --noEmit` clean. (The unrelated `homepage_foundation` suite requires `DATABASE_URL` and is skipped without Postgres.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)