### PR TITLE
fix: re-validate trade/duel availability when an invite is accepted

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3401,6 +3401,14 @@ export class Sim {
     this.duelInvites.delete(r.meta.entityId);
     const other = this.players.get(invite.fromPid);
     if (!other) return;
+    // Re-validate: the challenger may have multiple pending challenges out, and
+    // either fighter could have entered a duel since. Starting one here would
+    // overwrite a live duel (this.duels is keyed per-pid) and leave the original
+    // opponent fighting a duel nobody else is tracking.
+    if (this.duels.has(invite.fromPid) || this.duels.has(r.meta.entityId)) {
+      this.error(r.meta.entityId, 'A duel is already in progress.');
+      return;
+    }
     const duel: DuelState = { a: invite.fromPid, b: r.meta.entityId, state: 'countdown', timer: DUEL_COUNTDOWN };
     this.duels.set(duel.a, duel);
     this.duels.set(duel.b, duel);
@@ -3809,6 +3817,14 @@ export class Sim {
     if (!invite || invite.expires < this.time) { this.error(r.meta.entityId, 'The trade request has expired.'); return; }
     this.tradeInvites.delete(r.meta.entityId);
     if (!this.players.get(invite.fromPid)) return;
+    // Re-validate availability: an inviter can have several outgoing invites at
+    // once, and either party may have started a trade since the request. Opening
+    // a session here would clobber a live one (this.trades is keyed per-pid) and
+    // strand the other partner in a desynced window.
+    if (this.trades.has(invite.fromPid) || this.trades.has(r.meta.entityId)) {
+      this.error(r.meta.entityId, 'That player is already trading.');
+      return;
+    }
     const session: TradeSession = {
       a: invite.fromPid, b: r.meta.entityId,
       offerA: { items: [], copper: 0 }, offerB: { items: [], copper: 0 },

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -373,3 +373,52 @@ describe('spell visuals', () => {
     expect(fx.some((e) => e.type === 'spellfx' && e.fx === 'projectile' && e.school === 'fire')).toBe(true);
   });
 });
+
+describe('trade and duel invites validate availability at accept time', () => {
+  it('a second invitee cannot hijack the inviter who is already trading', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const a = sim.addPlayer('warrior', 'Anna');
+    const b = sim.addPlayer('mage', 'Bert');
+    const c = sim.addPlayer('warrior', 'Cara');
+
+    // Anna fires off trade requests to both Bert and Cara while still free.
+    sim.tradeRequest(b, a);
+    sim.tradeRequest(c, a);
+
+    // Bert accepts first — Anna and Bert are now trading together.
+    sim.tradeAccept(b);
+    const annaSession = sim.tradeFor(a);
+    const bertSession = sim.tradeFor(b);
+    expect(annaSession).not.toBeNull();
+    expect(annaSession).toBe(bertSession);
+
+    // Cara accepts the stale request. This must NOT silently replace Anna's
+    // live session with Bert (which would desync Bert's trade window).
+    sim.tradeAccept(c);
+
+    expect(sim.tradeFor(c)).toBeNull();
+    // Anna is still trading with the same partner she actually opened with.
+    expect(sim.tradeFor(a)).toBe(bertSession);
+    expect(sim.tradeFor(b)).toBe(bertSession);
+  });
+
+  it('a second challenger acceptance cannot hijack a duelist mid-duel', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const a = sim.addPlayer('warrior', 'Anna');
+    const b = sim.addPlayer('mage', 'Bert');
+    const c = sim.addPlayer('warrior', 'Cara');
+
+    sim.duelRequest(b, a);
+    sim.duelRequest(c, a);
+
+    sim.duelAccept(b);
+    const annaDuel = sim.duelFor(a);
+    expect(annaDuel).not.toBeNull();
+    expect(sim.duelFor(b)).toBe(annaDuel);
+
+    sim.duelAccept(c);
+    expect(sim.duelFor(c)).toBeNull();
+    expect(sim.duelFor(a)).toBe(annaDuel);
+    expect(sim.duelFor(b)).toBe(annaDuel);
+  });
+});


### PR DESCRIPTION
## The bug

Trade and duel invites are stored in maps keyed by the **target** pid, and `hasPendingSocialInvite()` only blocks a new invite when the **target** already has one pending. Nothing stops a single inviter from having several outgoing invites at once.

`this.trades` / `this.duels` are keyed per-pid, with *both* participants' ids pointing at one shared session object. `tradeAccept` / `duelAccept` never re-checked that the inviter was still free, so a second invitee's acceptance silently overwrites the inviter's live session:

```
A invites B and C   ->  B accepts        (A + B trading, both map entries -> session_AB)
                    ->  C accepts:        trades.set(A, session_AC) overwrites trades[A]
                        result:           A -> session_AC, B -> session_AB (orphaned), C -> session_AC
```

Now A's trade/duel UI is bound to the A+C session while B is stranded in a phantom A+B session that A no longer references. For trades this desyncs the two windows (offers/confirms land on different session objects) — an item-integrity hazard. For duels it starts a duel only one side is tracking.

This is distinct from the already-merged trade duplicate-slot fix (#7) and from the party-accept guard (#175, which only checks the *accepter*); here the unguarded side is the *inviter*.

## The fix

Re-validate availability at accept time in both `tradeAccept` and `duelAccept` — if either the inviter or the accepter is already in a trade/duel, reject the late acceptance with a clear message instead of clobbering the existing session.

## Tests

Adds regression tests in `tests/fixes.test.ts` covering both the trade and duel hijack scenarios (A invites B and C; B accepts; C's stale acceptance must not replace A's live session). Both fail before the fix and pass after. Full suite: 391 passing; `tsc --noEmit` clean. (`homepage_foundation.test.ts` fails only because `DATABASE_URL` is unset locally — pre-existing and unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)