### PR TITLE
fix: cover full class kit in RL action/observation space

### DIFF
--- a/src/sim/obs.ts
+++ b/src/sim/obs.ts
@@ -1,4 +1,4 @@
-import { ITEMS, QUESTS, QUEST_ORDER, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } from './data';
+import { CLASSES, ITEMS, QUESTS, QUEST_ORDER, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } from './data';
 import { Sim } from './sim';
 import { Entity, GCD, angleTo, dist2d, normAngle, xpForLevel, MAX_LEVEL } from './types';
 
@@ -6,6 +6,12 @@ import { Entity, GCD, angleTo, dist2d, normAngle, xpForLevel, MAX_LEVEL } from '
 // Discrete action space for RL agents.
 // Movement actions are "held" for the duration of one env step (frame-skip).
 // ---------------------------------------------------------------------------
+
+// Ability slots must cover the largest class kit so the RL agent can observe
+// and cast every ability a player can learn. Derived from CLASSES (not a fixed
+// constant) so adding abilities to any class can never silently leave high
+// learn-order slots unreachable. See abilitiesKnownAt(): one entry per ability.
+const ABILITY_SLOTS = Math.max(...Object.values(CLASSES).map((c) => c.abilities.length));
 
 export const ACTIONS = [
   'noop',          // 0
@@ -18,23 +24,14 @@ export const ACTIONS = [
   'jump',          // 7  (forward+jump)
   'target_nearest',// 8
   'attack',        // 9  start auto-attack on current target
-  'ability_1',     // 10  abilities index the learned list in learn order
-  'ability_2',     // 11
-  'ability_3',     // 12
-  'ability_4',     // 13
-  'ability_5',     // 14
-  'ability_6',     // 15
-  'ability_7',     // 16
-  'ability_8',     // 17
-  'ability_9',     // 18
-  'ability_10',    // 19
-  'interact',      // 20 loot corpse / pick up object / talk to quest npc
-  'stop',          // 21 stop moving + stop attacking
-  'eat_drink',     // 22 consume best food (or water for mana classes) from bags
+  // abilities index the learned list in learn order: ability_1 .. ability_N
+  ...Array.from({ length: ABILITY_SLOTS }, (_, i) => `ability_${i + 1}`),
+  'interact',      // loot corpse / pick up object / talk to quest npc
+  'stop',          // stop moving + stop attacking
+  'eat_drink',     // consume best food (or water for mana classes) from bags
 ] as const;
 
 export const NUM_ACTIONS = ACTIONS.length;
-const ABILITY_SLOTS = 10;
 
 export function applyAction(sim: Sim, action: number): void {
   const inp = sim.moveInput;


### PR DESCRIPTION
## Problem

The RL action and observation space hard-caps abilities at **10 slots** (`ABILITY_SLOTS = 10`, actions `ability_1`…`ability_10` in `src/sim/obs.ts`), but several classes learn **more than 10** abilities.

`abilitiesKnownAt()` (`src/sim/content/classes.ts:1324`) returns one entry per distinct ability id, in learn order, so at higher levels `sim.known` has up to 17 entries:

| class | abilities |
|-------|-----------|
| warrior | 14 |
| mage / paladin / hunter | 12 |
| druid | **17** |

Abilities at learn-order index ≥ 10 are therefore **both**:
- **unobservable** — `encodeObs` only loops `for (i = 0; i < ABILITY_SLOTS=10; i++)` over `sim.known[i]`, so their readiness/cooldown signal is never in the obs; and
- **uncastable** — there is no `ability_11`+ action, and `applyAction` only maps `ability_1..10` to `castAbilityBySlot(0..9)`.

This silently hides core kit from the agent — warrior **Taunt / Defensive Stance / Sunder Armor**, and the **entire druid cat/bear form kit** (Cat Form, Claw, Ferocious Bite, Bear Maul, Swipe, Growl, Starfire). The policy can never learn correct high-level rotations or tanking, and it degrades every episode past those unlock levels with **no error raised**.

## Fix

Derive `ABILITY_SLOTS` from the largest class kit instead of hardcoding `10`, and generate the `ability_*` actions from that count:

```ts
const ABILITY_SLOTS = Math.max(...Object.values(CLASSES).map((c) => c.abilities.length));
```

So adding abilities to any class can never again leave high learn-order slots unreachable.

`castAbilityBySlot` already indexes `meta.known[slot]` for any slot, so no dispatch change is needed. Nothing downstream hardcodes the sizes — `headless/env_server.ts`, `python/wow_env.py` and `tests/sim.test.ts` all query `obsSize()` / `NUM_ACTIONS` dynamically.

**Effect:** `obsSize` 206 → 220, `NUM_ACTIONS` 23 → 30.

## Testing

- `npx tsc --noEmit` — clean
- `npx vitest run tests/sim.test.ts` — 42/42 pass (obs length asserted against `obsSize()` dynamically)
- Full suite: 389 tests pass (the one failing file, `homepage_foundation.test.ts`, fails on a pre-existing `DATABASE_URL` requirement, unaffected by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)