### PR TITLE
fix: scope orphan play-session cleanup to the current realm

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -407,9 +407,19 @@ export async function closePlaySession(sessionId: number): Promise<void> {
 }
 
 // Sessions left open by a crash have an unknown duration; close them at their
-// start time so they don't inflate playtime stats forever.
+// start time so they don't inflate playtime stats forever. Scope this to the
+// current realm: in the process-per-realm model peers share one database, and
+// an unscoped UPDATE would force-close sessions still live on other realms.
 export async function closeOrphanSessions(): Promise<number> {
-  const res = await pool.query('UPDATE play_sessions SET ended_at = started_at WHERE ended_at IS NULL');
+  const res = await pool.query(
+    `UPDATE play_sessions ps
+        SET ended_at = ps.started_at
+       FROM characters c
+      WHERE ps.character_id = c.id
+        AND c.realm = $1
+        AND ps.ended_at IS NULL`,
+    [REALM],
+  );
   return res.rowCount ?? 0;
 }
 


### PR DESCRIPTION
## Problem

`closeOrphanSessions()` runs at every server boot (`server/main.ts:334`) and executed an **unscoped** update:

```sql
UPDATE play_sessions SET ended_at = started_at WHERE ended_at IS NULL
```

The intent (per the comment at `db.ts:409-410`) is only to close sessions a **crashed copy of this process** left dangling, so they don't inflate playtime stats forever.

But this game runs a **process-per-realm model where every realm process shares one database** (`db.ts:225-227`, `db.ts:110-114`, `realm.ts`), and `play_sessions` has **no realm column** (`db.ts:53-60`). So the query closes *every* open session in the whole database — not just this process's orphans.

## Impact

Restarting or redeploying **any one realm** force-closes the **live** sessions of every player currently online on **every other realm**, stamping `ended_at = started_at` (zero duration).

Because `closePlaySession` only updates rows where `ended_at IS NULL` (`db.ts:405-406`), the affected player's real logout later becomes a no-op — the bogus zero-length record is **permanent**. This silently undercounts playtime / sessions / DAU in every admin-dashboard aggregate over `play_sessions` (`admin_db.ts`). The more realms and the more frequent the deploys, the worse the corruption.

## Fix

Scope the cleanup to this process's realm by joining through `characters`, which carries the `realm` column and is already the ownership boundary for all character reads/writes:

```sql
UPDATE play_sessions ps
   SET ended_at = ps.started_at
  FROM characters c
 WHERE ps.character_id = c.id
   AND c.realm = $1
   AND ps.ended_at IS NULL
```

This still clears this realm's own crash-orphaned sessions while leaving peer realms' live sessions untouched.

### Note / residual gap
Sessions whose `character_id` went `NULL` via `ON DELETE SET NULL` can't be realm-attributed and are no longer touched by the cleanup; these are rare. A fuller fix would add a `realm` column to `play_sessions`, but the join keeps the change minimal and resolves the actual corruption for the normal case.

## Testing
- `npx tsc --noEmit` passes.
- `npm run build:server` bundles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)