### PR TITLE
fix: apply the ignore list to guild and officer chat

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -348,6 +348,10 @@ export class GameServer {
         const s = this.sessionByCharacterId(id);
         if (s) s.blockedIds = new Set(ids);
       },
+      isIgnoring: (recipientId, senderCharacterId) => {
+        const s = this.sessionByCharacterId(recipientId);
+        return s ? s.blockedIds.has(senderCharacterId) : false;
+      },
     };
   }
 

--- a/server/social.ts
+++ b/server/social.ts
@@ -103,6 +103,9 @@ export interface SocialTransport {
   pushSnapshot(characterId: number): void;
   // a character's block set changed; refresh the in-memory chat filter
   onBlocksChanged(characterId: number, blockedIds: number[]): void;
+  // true if `recipientId` has `senderCharacterId` on their ignore list, so
+  // guild/officer chat can honour the same filter say/whisper already apply
+  isIgnoring(recipientId: number, senderCharacterId: number): boolean;
 }
 
 export type SocialEvent =
@@ -426,7 +429,15 @@ export class SocialService {
     if (!text) return false;
     const membership = await this.db.guildMembership(actor.characterId);
     if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return false; }
-    await this.broadcastGuild(membership.guildId, [{ type: 'chat', from: actor.name, text, channel: 'guild' }]);
+    const event: SocialEvent = { type: 'chat', from: actor.name, text, channel: 'guild' };
+    const members = await this.db.guildMembers(membership.guildId);
+    for (const m of members) {
+      if (!this.tx.isOnline(m.id)) continue;
+      // a player who ignores the speaker does not see their guild chat (the
+      // speaker always sees their own line); mirrors say/whisper filtering
+      if (m.id !== actor.characterId && this.tx.isIgnoring(m.id, actor.characterId)) continue;
+      this.tx.deliver(m.id, [event]);
+    }
     return true;
   }
 
@@ -440,6 +451,8 @@ export class SocialService {
     const members = await this.db.guildMembers(membership.guildId);
     for (const m of members) {
       if ((m.rank === 'officer' || m.rank === 'leader') && this.tx.isOnline(m.id)) {
+        // honour the recipient's ignore list, just like guild/say/whisper
+        if (m.id !== actor.characterId && this.tx.isIgnoring(m.id, actor.characterId)) continue;
         this.tx.deliver(m.id, [{ type: 'chat', from: actor.name, text, channel: 'officer' }]);
       }
     }

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -14,7 +14,7 @@ import { resolveRealm } from '../server/realm';
 class FakeDb implements SocialDb {
   private chars = new Map<number, CharInfo>();
   private friends = new Map<number, Set<number>>();
-  private blocks = new Map<number, Set<number>>();
+  blocks = new Map<number, Set<number>>();
   private guilds = new Map<number, string>();
   private members = new Map<number, { guildId: number; rank: GuildRank }>();
   private nextGuildId = 1;
@@ -104,6 +104,9 @@ class FakeTransport implements SocialTransport {
   }
   pushSnapshot(id: number): void { this.snapshotCount.set(id, (this.snapshotCount.get(id) ?? 0) + 1); }
   onBlocksChanged(id: number, ids: number[]): void { this.blockSets.set(id, ids); }
+  isIgnoring(recipientId: number, senderCharacterId: number): boolean {
+    return !!this.db.blocks.get(recipientId)?.has(senderCharacterId);
+  }
 
   eventsFor(id: number): SocialEvent[] { return this.delivered.get(id) ?? []; }
   errorsFor(id: number): string[] { return this.eventsFor(id).filter((e) => e.type === 'error').map((e: any) => e.text); }
@@ -335,6 +338,37 @@ describe('guilds', () => {
     expect(h.tx.eventsFor(1).some((e) => e.type === 'chat' && e.channel === 'guild' && e.text === 'hello guild')).toBe(true);
     expect(h.tx.eventsFor(2).some((e) => e.type === 'chat' && e.text === 'hello guild')).toBe(true);
     expect(h.tx.eventsFor(3)).toHaveLength(0); // Gimel is not in the guild
+  });
+
+  it('suppresses guild chat from a player the recipient ignores', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    await h.svc.guildInvite(h.actor(1), 'Gimel');
+    await h.svc.guildAccept(h.actor(3));
+    // Bet ignores Aleph
+    await h.svc.blockAdd(h.actor(2), 'Aleph');
+    h.tx.clear();
+    const ok = await h.svc.guildChat(h.actor(1), 'hello guild');
+    expect(ok).toBe(true);
+    // Aleph still sees their own line; an uninvolved member (Gimel) sees it
+    expect(h.tx.eventsFor(1).some((e) => e.type === 'chat' && e.text === 'hello guild')).toBe(true);
+    expect(h.tx.eventsFor(3).some((e) => e.type === 'chat' && e.text === 'hello guild')).toBe(true);
+    // Bet, who ignores Aleph, receives nothing
+    expect(h.tx.eventsFor(2)).toHaveLength(0);
+  });
+
+  it('suppresses officer chat from an officer the recipient ignores', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+    await h.svc.guildSetRank(h.actor(1), 'Bet', 'officer');
+    // Bet ignores the Guild Master Aleph
+    await h.svc.blockAdd(h.actor(2), 'Aleph');
+    h.tx.clear();
+    expect(await h.svc.officerChat(h.actor(1), 'officers only')).toBe(true);
+    expect(h.tx.eventsFor(1).some((e) => e.type === 'chat' && e.channel === 'officer')).toBe(true);
+    expect(h.tx.eventsFor(2)).toHaveLength(0);
   });
 
   it('blocks guild chat from a non-member', async () => {


### PR DESCRIPTION
## Problem

The ignore list (`/ignore`) is enforced for **say** and **whisper** in `GameServer.routeEvents` (`server/game.ts:980`), which drops any `chat` event whose sender is in the recipient's in-memory `blockedIds` set before it reaches their client.

**Guild chat** and **officer chat** take a different delivery path — `SocialService.guildChat` / `officerChat` call `SocialTransport.deliver` directly (`server/social.ts`), which writes straight to the recipient's socket and never consults `blockedIds`. As a result, ignoring a guildmate still let their guild/officer chat through.

In WoW, `/ignore` suppresses a player's guild chat as well, so this is both a behavioral mismatch and a real harassment vector (an ignored player can keep messaging via the guild channel).

This is distinct from the existing friend/ignore PRs (#184 friending an ignored player, #165 membership confirmation) — none of those touch chat delivery.

## Fix

- Add `isIgnoring(recipientId, senderCharacterId)` to the `SocialTransport` interface, implemented in `game.ts` against the same in-memory `blockedIds` set — no extra DB query on the chat path.
- `guildChat` now delivers per online member and skips anyone who ignores the speaker; `officerChat` gets the same guard. The speaker always sees their own line (you can't ignore yourself).

## Tests

Added two cases to `tests/social_system.test.ts`:
- guild chat is suppressed for a member who ignores the speaker while other members and the speaker still receive it;
- officer chat is suppressed for an officer who ignores the speaker.

Full suite: `391 passed`. (The unrelated `homepage_foundation.test.ts` failure is a pre-existing `DATABASE_URL` env issue, reproduced on a clean tree.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)