### PR TITLE
fix: stop a second guild invite from clobbering a pending one

### DIFF
--- a/server/social.ts
+++ b/server/social.ts
@@ -292,6 +292,10 @@ export class SocialService {
     if (target.id === actor.characterId) { this.err(actor.characterId, 'You are already in the guild.'); return; }
     if (!this.tx.isOnline(target.id)) { this.err(actor.characterId, `${target.name} must be online to be invited.`); return; }
     if (await this.db.guildMembership(target.id)) { this.err(actor.characterId, `${target.name} is already in a guild.`); return; }
+    const existing = this.pendingGuildInvites.get(target.id);
+    if (existing && existing.expiresAt >= this.now()) {
+      this.err(actor.characterId, `${target.name} already has a pending guild invitation.`); return;
+    }
     const members = await this.db.guildMembers(membership.guildId);
     if (members.length >= GUILD_MEMBER_LIMIT) { this.err(actor.characterId, 'Your guild is full.'); return; }
     this.pendingGuildInvites.set(target.id, {

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -325,6 +325,30 @@ describe('guilds', () => {
     expect((await h.svc.snapshot(2)).guild).toBeNull();
   });
 
+  it('rejects inviting someone who already has a pending guild invite', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildCreate(h.actor(3), 'Raiders');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    h.tx.clear();
+    // a second guild tries to invite Bet while the first invite is still live
+    await h.svc.guildInvite(h.actor(3), 'Bet');
+    expect(h.tx.errorsFor(3).join()).toMatch(/already has a pending guild invitation/i);
+    // the original invite is untouched, so Bet still joins the first guild
+    await h.svc.guildAccept(h.actor(2));
+    expect((await h.svc.snapshot(2)).guild?.name).toBe('Knights');
+  });
+
+  it('allows a fresh invite once the previous one has expired', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Knights');
+    await h.svc.guildCreate(h.actor(3), 'Raiders');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    h.advance(61_000); // first invite lapses
+    h.tx.clear();
+    await h.svc.guildInvite(h.actor(3), 'Bet');
+    expect(h.tx.errorsFor(3)).toHaveLength(0);
+    expect(h.tx.eventsFor(2).some((e) => e.type === 'guildInvite')).toBe(true);
+  });
+
   it('routes guild chat only to guild members', async () => {
     await h.svc.guildCreate(h.actor(1), 'Knights');
     await h.svc.guildInvite(h.actor(1), 'Bet');


### PR DESCRIPTION
## Problem

`SocialService.guildInvite()` unconditionally calls `pendingGuildInvites.set(target.id, …)`, with no check for an invite already in flight. So if two guilds invite the same online player in quick succession, the second invite **silently overwrites** the first:

- The first guild's invite is destroyed — the player can no longer accept it.
- Neither the first inviter nor the player gets any indication this happened.
- The player can only ever act on the most recently received invite.

## Why this is a bug (not intended behaviour)

The sim-side invite system (party / trade / duel) already guards against exactly this. `Sim.partyInvite()` rejects when the target already holds a live invite:

```ts
if (this.hasPendingSocialInvite(targetPid)) {
  this.error(r.meta.entityId, `${target.name} already has a pending invitation.`); return;
}
```

The DB-backed guild invite path simply never got the equivalent guard. This change brings guild invites in line with the established, already-tested behaviour.

## Fix

Reject a guild invite when the target already has a **live** (non-expired) pending guild invite, while still allowing a fresh invite once the previous one has lapsed (mirroring `hasActiveInvite`'s expiry semantics):

```ts
const existing = this.pendingGuildInvites.get(target.id);
if (existing && existing.expiresAt >= this.now()) {
  this.err(actor.characterId, `${target.name} already has a pending guild invitation.`); return;
}
```

## Tests

Added two cases to `tests/social_system.test.ts`:
- a second guild inviting an already-invited player is rejected, and the original invite still resolves correctly;
- a fresh invite is allowed once the previous invite has expired.

All 32 tests in the suite pass; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)