### PR TITLE
Add optional OSRS-style mouse camera movement mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,6 +653,22 @@
     background: linear-gradient(#2c2c3a, #15151f); color: #ffd9a0; border-color: #4a3d1d; }
   .kb-key.capturing { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd100aa; }
   .kb-note { font-size: 11px; color: #b9ac82; margin: 2px 0 6px; min-height: 14px; line-height: 1.4; }
+  .kb-toggle-row { margin-bottom: 6px; background: #ffffff0a; border-radius: 4px; }
+  .kb-toggle-row .kb-toggle {
+    grid-column: 2;
+    width: 78px;
+    min-width: 78px;
+    max-width: 78px;
+    margin: 0;
+    padding: 3px 6px;
+    text-align: center;
+    font-size: 12px;
+    font-family: var(--ui-font);
+    line-height: 1.2;
+    justify-self: start;
+    box-sizing: border-box;
+  }
+  .kb-toggle.off { filter: grayscale(0.6) brightness(0.8); color: #b9ac82; }
   .set-rows { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
   .set-row { display: grid; grid-template-columns: 120px 1fr 48px; align-items: center; gap: 10px; padding: 3px 6px; }
   .set-name { font-size: 12.5px; color: #e8e0c8; }

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -1,13 +1,11 @@
-// WoW-style input: WASD + A/D keyboard turn, Q/E strafe, space jump,
-// left-drag orbits the camera, right-drag mouselooks (turns the character),
-// both buttons run forward, wheel zooms, Tab targets, action-bar keys cast
-// (player-rebindable, see Keybinds), C/P/L/M/B windows, V nameplates,
-// F interacts, R autorun.
+// Default (Mouse Camera off): WoW-style — WASD + A/D keyboard turn, Q/E strafe,
+// left-drag orbits, right-drag mouselooks, both buttons run forward.
+// Optional Mouse Camera (on): OSRS-style — WASD is camera-relative, A/D strafe,
+// mouse drag rotates the orbit (no pointer lock), no keyboard turn.
+// Shared: space jump, wheel zoom, Tab target, rebindable action bar, R autorun.
 
 import { Keybinds, actionKind } from './keybinds';
 
-// the camera sensitivity that used to be hard-coded in onMouseMove; the
-// settings slider scales this (cameraSpeed 1.0 reproduces the old feel)
 const BASE_LOOK_SENS = 0.0045;
 const TOUCH_LOOK_YAW_RATE = 3.2;
 const TOUCH_LOOK_PITCH_RATE = 2.2;
@@ -17,6 +15,8 @@ export interface InputCallbacks {
   onAbility(slot: number): void;
   onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena'): void;
   onClickPick(x: number, y: number, button: number): void;
+  /** When false, edge actions (spells, UI keys) are ignored. */
+  canUseGameKeys?: () => boolean;
 }
 
 export interface TouchMoveInput {
@@ -34,16 +34,11 @@ export class Input {
   camPitch = 0.32;
   camDist = 12;
   autorun = false;
-  // while true, readMoveInput reports neutral — set when a modal (the options
-  // menu) is open so held WASD doesn't drive the character behind it
   suspendMovement = false;
+  private mouseCameraEnabled = false;
   private dragDistance = 0;
   private downButton = -1;
-  // one-shot key capture for the rebind UI: the next keydown is delivered here
-  // (Escape cancels with null) instead of being dispatched as an action
   private captureCb: ((code: string | null) => void) | null = null;
-  // mouse-look sensitivity, in radians per pixel of drag; the old fixed value
-  // was BASE_LOOK_SENS — setCameraSpeed scales it from the settings menu
   private lookSensitivity = BASE_LOOK_SENS;
   private touchMove: TouchMoveInput = { forward: false, back: false, strafeLeft: false, strafeRight: false };
   private touchLookActive = false;
@@ -52,7 +47,15 @@ export class Input {
   constructor(private canvas: HTMLCanvasElement, private cb: InputCallbacks, private keybinds: Keybinds) {
     window.addEventListener('keydown', (e) => this.onKeyDown(e));
     window.addEventListener('keyup', (e) => { this.keys.delete(e.code); });
-    window.addEventListener('blur', () => { this.keys.clear(); this.leftDown = false; this.rightDown = false; });
+    window.addEventListener('blur', () => this.releaseCapture('blur'));
+    window.addEventListener('pointerup', (e) => this.onMouseUp(e));
+    window.addEventListener('pointercancel', (e) => this.onMouseUp(e));
+    document.addEventListener('pointerlockchange', () => {
+      if (!document.pointerLockElement) this.releaseCapture('pointerlock');
+    });
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) this.releaseCapture('hidden');
+    });
     canvas.addEventListener('mousedown', (e) => this.onMouseDown(e));
     window.addEventListener('mouseup', (e) => this.onMouseUp(e));
     window.addEventListener('mousemove', (e) => this.onMouseMove(e));
@@ -63,12 +66,26 @@ export class Input {
     canvas.addEventListener('contextmenu', (e) => e.preventDefault());
   }
 
-  /** Capture the next keypress (for the rebind UI) instead of acting on it. */
+  isDragging(): boolean {
+    return this.leftDown || this.rightDown;
+  }
+
+  isMouseCameraMode(): boolean {
+    return this.mouseCameraEnabled;
+  }
+
+  setMouseCameraEnabled(on: boolean): void {
+    this.mouseCameraEnabled = on;
+    if (on && document.pointerLockElement === this.canvas) {
+      document.exitPointerLock?.();
+    }
+    this.updateDragCursor();
+  }
+
   captureNextKey(cb: (code: string | null) => void): void {
     this.captureCb = cb;
   }
 
-  /** Scale mouse-look sensitivity. 1.0 = the original fixed speed. */
   setCameraSpeed(mult: number): void {
     this.lookSensitivity = BASE_LOOK_SENS * mult;
   }
@@ -102,12 +119,28 @@ export class Input {
   }
 
   isMouselookActive(): boolean {
+    if (this.mouseCameraEnabled) return this.touchLookActive;
     return this.rightDown || this.touchLookActive;
+  }
+
+  private releaseCapture(_reason: string): void {
+    this.keys.clear();
+    this.leftDown = false;
+    this.rightDown = false;
+    this.downButton = -1;
+    this.updateDragCursor();
+  }
+
+  private updateDragCursor(): void {
+    if (this.mouseCameraEnabled && this.isDragging()) {
+      this.canvas.style.cursor = 'grabbing';
+    } else {
+      this.canvas.style.cursor = '';
+    }
   }
 
   private onKeyDown(e: KeyboardEvent): void {
     if (e.repeat) return;
-    // rebind capture intercepts everything (incl. action/UI keys); Escape cancels
     if (this.captureCb) {
       e.preventDefault();
       const cb = this.captureCb;
@@ -117,13 +150,12 @@ export class Input {
     }
     const tag = (document.activeElement?.tagName ?? '').toLowerCase();
     if (tag === 'input' || tag === 'textarea') return;
-    // Escape always opens/closes the game menu — never rebindable
+    if (this.cb.canUseGameKeys && !this.cb.canUseGameKeys()) return;
     if (e.code === 'Escape') { this.cb.onUiKey('escape'); return; }
-    if (e.code === 'Tab') e.preventDefault(); // keep Tab from moving DOM focus in-game
+    if (e.code === 'Tab') e.preventDefault();
     const action = this.keybinds.actionForCode(e.code);
     if (action === null) return;
     if (actionKind(action) === 'held') {
-      // movement: just record the key; readMoveInput polls it each frame
       this.keys.add(e.code);
       if (action === 'forward' || action === 'back') this.autorun = false;
       return;
@@ -131,8 +163,6 @@ export class Input {
     this.dispatchEdge(action);
   }
 
-  // Fire a one-shot (edge) action by id. Action-bar slots route to onAbility;
-  // the rest map to the targeting/interface callbacks; autorun is internal.
   private dispatchEdge(action: string): void {
     if (action.startsWith('slot')) { this.cb.onAbility(Number(action.slice(4))); return; }
     switch (action) {
@@ -157,25 +187,32 @@ export class Input {
     if (e.button === 2) this.rightDown = true;
     this.downButton = e.button;
     this.dragDistance = 0;
-    this.canvas.requestPointerLock?.();
+    if (!this.mouseCameraEnabled) {
+      this.canvas.requestPointerLock?.();
+    } else {
+      this.updateDragCursor();
+    }
   }
 
   private onMouseUp(e: MouseEvent): void {
     const wasDrag = this.dragDistance > 5;
     if (e.button === 0) this.leftDown = false;
     if (e.button === 2) this.rightDown = false;
-    if (!this.leftDown && !this.rightDown && document.pointerLockElement) {
+    if (!this.mouseCameraEnabled && !this.leftDown && !this.rightDown && document.pointerLockElement) {
       document.exitPointerLock();
     }
-    if (!wasDrag && e.button === this.downButton && (e.target === this.canvas || document.pointerLockElement === this.canvas)) {
+    const onCanvas = e.target === this.canvas || document.pointerLockElement === this.canvas;
+    if (!wasDrag && e.button === this.downButton && onCanvas) {
       this.cb.onClickPick(e.clientX, e.clientY, e.button);
     }
     this.downButton = -1;
+    this.updateDragCursor();
   }
 
   private onMouseMove(e: MouseEvent): void {
     if (!this.leftDown && !this.rightDown) return;
     const mx = e.movementX ?? 0, my = e.movementY ?? 0;
+    if (mx === 0 && my === 0) return;
     this.dragDistance += Math.abs(mx) + Math.abs(my);
     this.camYaw -= mx * this.lookSensitivity;
     this.camPitch = Math.min(1.35, Math.max(-0.4, this.camPitch + my * this.lookSensitivity));
@@ -191,17 +228,29 @@ export class Input {
     const k = this.keys;
     const held = (id: string) => this.keybinds.codesForAction(id).some((c) => k.has(c));
     const bothButtons = this.leftDown && this.rightDown;
-    const mouselook = this.isMouselookActive();
-    // A/D (turn) double as strafe while mouselooking, matching WoW; Q/E always strafe
-    const aHeld = held('turnLeft');
-    const dHeld = held('turnRight');
     const forward = held('forward') || bothButtons || this.autorun || this.touchMove.forward;
     const back = held('back') || this.touchMove.back;
-    const strafeLeft = held('strafeLeft') || (mouselook && aHeld) || this.touchMove.strafeLeft;
-    const strafeRight = held('strafeRight') || (mouselook && dHeld) || this.touchMove.strafeRight;
-    const turnLeft = !mouselook && aHeld;
-    const turnRight = !mouselook && dHeld;
     const jump = held('jump');
-    return { forward, back, turnLeft, turnRight, strafeLeft, strafeRight, jump };
+
+    if (this.mouseCameraEnabled) {
+      return {
+        forward, back, jump,
+        turnLeft: false,
+        turnRight: false,
+        strafeLeft: held('strafeLeft') || held('turnLeft') || this.touchMove.strafeLeft,
+        strafeRight: held('strafeRight') || held('turnRight') || this.touchMove.strafeRight,
+      };
+    }
+
+    const mouselook = this.isMouselookActive();
+    const aHeld = held('turnLeft');
+    const dHeld = held('turnRight');
+    return {
+      forward, back, jump,
+      strafeLeft: held('strafeLeft') || (mouselook && aHeld) || this.touchMove.strafeLeft,
+      strafeRight: held('strafeRight') || (mouselook && dHeld) || this.touchMove.strafeRight,
+      turnLeft: !mouselook && aHeld,
+      turnRight: !mouselook && dHeld,
+    };
   }
 }

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -2,33 +2,30 @@
 // Esc options menu. Pure + persisted to localStorage; main.ts applies each
 // value to the live subsystem (Input / GameAudio / MusicDirector / Renderer).
 
-export interface GameSettings {
-  cameraSpeed: number;  // mouse-look sensitivity multiplier (1 = the old fixed speed)
-  sfxVolume: number;    // 0..1
-  musicVolume: number;  // 0..1
-  brightness: number;   // tone-mapping exposure multiplier
-  renderScale: number;  // resolution multiplier on top of the device pixel ratio
-  fullscreen: number;   // 0/1 browser fullscreen preference
-}
-
-interface Range { min: number; max: number; def: number }
-
-// Camera default is 0.7: the old fixed speed (1.0) was near the top of the
-// reasonable range and drew complaints, so out of the box it's calmer while
-// the slider still reaches 1.25 for players who liked it fast.
-export const SETTING_RANGES: Record<keyof GameSettings, Range> = {
+export const SETTING_RANGES = {
   cameraSpeed: { min: 0.25, max: 1.25, def: 0.7 },
   sfxVolume: { min: 0, max: 1, def: 0.8 },
   musicVolume: { min: 0, max: 1, def: 0.8 },
   brightness: { min: 0.6, max: 1.5, def: 1 },
   renderScale: { min: 0.5, max: 1, def: 1 },
   fullscreen: { min: 0, max: 1, def: 1 },
-};
+} as const;
+
+export const BOOL_SETTINGS = {
+  mouseCamera: { def: false },
+} as const;
+
+export type NumericSettingKey = keyof typeof SETTING_RANGES;
+export type BoolSettingKey = keyof typeof BOOL_SETTINGS;
+export type GameSettings = { [K in NumericSettingKey]: number } & { [K in BoolSettingKey]: boolean };
+
+interface Range { min: number; max: number; def: number }
 
 const STORE_KEY = 'woc_settings';
-const KEYS = Object.keys(SETTING_RANGES) as (keyof GameSettings)[];
+const NUMERIC_KEYS = Object.keys(SETTING_RANGES) as NumericSettingKey[];
+const BOOL_KEYS = Object.keys(BOOL_SETTINGS) as BoolSettingKey[];
 
-function clampSetting(key: keyof GameSettings, v: number): number {
+function clampNumeric(key: NumericSettingKey, v: number): number {
   const r = SETTING_RANGES[key];
   if (!Number.isFinite(v)) return r.def;
   return Math.min(r.max, Math.max(r.min, v));
@@ -44,10 +41,15 @@ export class Settings {
   private load(): GameSettings {
     let stored: unknown = null;
     try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
+    const raw = stored && typeof stored === 'object' ? stored as Record<string, unknown> : {};
     const out = {} as GameSettings;
-    for (const key of KEYS) {
-      const raw = stored && typeof stored === 'object' ? (stored as Record<string, unknown>)[key] : undefined;
-      out[key] = typeof raw === 'number' ? clampSetting(key, raw) : SETTING_RANGES[key].def;
+    for (const key of NUMERIC_KEYS) {
+      const v = raw[key];
+      out[key] = typeof v === 'number' ? clampNumeric(key, v) : SETTING_RANGES[key].def;
+    }
+    for (const key of BOOL_KEYS) {
+      const v = raw[key];
+      out[key] = typeof v === 'boolean' ? v : BOOL_SETTINGS[key].def;
     }
     return out;
   }
@@ -65,15 +67,26 @@ export class Settings {
   }
 
   /** Clamp + store a value; returns the value actually applied. */
-  set<K extends keyof GameSettings>(key: K, value: number): number {
-    const v = clampSetting(key, value);
-    this.values[key] = v;
+  set<K extends NumericSettingKey>(key: K, value: number): number;
+  set<K extends BoolSettingKey>(key: K, value: boolean): boolean;
+  set<K extends keyof GameSettings>(key: K, value: GameSettings[K]): GameSettings[K] {
+    if ((BOOL_KEYS as readonly string[]).includes(key)) {
+      const v = !!value;
+      (this.values as Record<string, unknown>)[key] = v;
+      this.save();
+      return v as GameSettings[K];
+    }
+    const v = clampNumeric(key as NumericSettingKey, value as number);
+    (this.values as Record<string, unknown>)[key] = v;
     this.save();
-    return v;
+    return v as GameSettings[K];
   }
 
   reset(): void {
-    for (const key of KEYS) this.values[key] = SETTING_RANGES[key].def;
+    for (const key of NUMERIC_KEYS) this.values[key] = SETTING_RANGES[key].def;
+    for (const key of BOOL_KEYS) this.values[key] = BOOL_SETTINGS[key].def;
     this.save();
   }
 }
+
+export type { Range };

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { Sim } from './sim/sim';
 import { Renderer } from './render/renderer';
 import { Input } from './game/input';
 import { Keybinds } from './game/keybinds';
-import { Settings, GameSettings } from './game/settings';
+import { Settings, GameSettings, SETTING_RANGES } from './game/settings';
 import { MobileControls, PHONE_TOUCH_QUERY, isPhoneTouchDevice } from './game/mobile_controls';
 import { Hud } from './ui/hud';
 import { audio } from './game/audio';
@@ -377,6 +377,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       }
     },
     onClickPick: (x, y, button) => handlePick(x, y, button),
+    canUseGameKeys: () => !hud.isModalOpen() && chatInput.style.display !== 'block',
   }, keybinds);
   input.camYaw = world.player.facing;
 
@@ -397,8 +398,13 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   mobileControls.start();
 
   // apply a setting to its live subsystem (also used to apply all on startup)
-  function applySetting(key: keyof GameSettings, value: number): void {
-    const v = settings.set(key, value);
+  function applySetting(key: keyof GameSettings, value: number | boolean): void {
+    if (key === 'mouseCamera') {
+      const v = settings.set('mouseCamera', !!value);
+      input.setMouseCameraEnabled(v);
+      return;
+    }
+    const v = settings.set(key as keyof typeof SETTING_RANGES, value as number);
     switch (key) {
       case 'cameraSpeed': input.setCameraSpeed(v); break;
       case 'sfxVolume': audio.setVolume(v); break;
@@ -491,6 +497,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   }
 
   function updateCamera(frameDt: number, interpFacing: number): void {
+    if (input.isMouseCameraMode()) return;
     if (!input.isMouselookActive()) {
       // follow turns 1:1 (keeps any manual orbit offset constant)
       if (lastInterpFacing !== null) input.camYaw += wrapAngle(interpFacing - lastInterpFacing);
@@ -504,6 +511,19 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     lastInterpFacing = interpFacing; // track through mouselook too — no snap on release
   }
 
+  function applyCameraFacing(): boolean {
+    if (!input.isMouseCameraMode()) return false;
+    const mi = input.readMoveInput();
+    return !!(mi.forward || mi.back || mi.strafeLeft || mi.strafeRight) && !world.player.dead;
+  }
+
+  function renderFacingOverride(): number | null {
+    if (input.isMouseCameraMode()) {
+      return applyCameraFacing() ? input.camYaw : null;
+    }
+    return input.isMouselookActive() && !world.player.dead ? input.camYaw : null;
+  }
+
   function frame(now: number): void {
     requestAnimationFrame(frame);
     let frameDt = (now - last) / 1000;
@@ -515,14 +535,15 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     input.suspendMovement = hud.isModalOpen();
     input.updateTouchLook(frameDt);
 
-    const mouselook = input.isMouselookActive() && !world.player.dead;
+    const renderFacing = renderFacingOverride();
+    const faceFromCamera = renderFacing !== null;
 
     if (offlineSim) {
       acc += frameDt;
       while (acc >= DT) {
         const mi = input.readMoveInput();
         Object.assign(offlineSim.moveInput, mi);
-        if (mouselook) offlineSim.player.facing = input.camYaw;
+        if (faceFromCamera) offlineSim.player.facing = input.camYaw;
         const events = offlineSim.tick();
         hud.handleEvents(events);
         acc -= DT;
@@ -532,7 +553,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       renderer.camYaw = input.camYaw;
       renderer.camPitch = input.camPitch;
       renderer.camDist = input.camDist;
-      renderer.sync(acc / DT, frameDt, mouselook ? input.camYaw : null);
+      renderer.sync(acc / DT, frameDt, renderFacing);
       hud.update();
       return;
     }
@@ -540,7 +561,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     // online: inputs stream on a timer inside ClientWorld; here we mirror state
     const net = online!;
     Object.assign(net.moveInput, input.readMoveInput());
-    net.setMouselookFacing(mouselook ? input.camYaw : null);
+    net.setMouselookFacing(renderFacing);
     net.pendingFacingDelta = 0; // superseded by the interpolated follow below
     hud.handleEvents(net.drainEvents());
     if (net.consumeInventoryChanged()) hud.onInventoryChanged();
@@ -553,7 +574,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     renderer.camYaw = input.camYaw;
     renderer.camPitch = input.camPitch;
     renderer.camDist = input.camDist;
-    renderer.sync(alpha, frameDt, mouselook ? input.camYaw : null);
+    renderer.sync(alpha, frameDt, renderFacing);
     hud.update();
   }
   requestAnimationFrame(frame);

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -15,7 +15,7 @@ import { audio } from '../game/audio';
 import { music } from '../game/music';
 import { iconDataUrl, QUALITY_COLOR } from './icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
-import { Settings, GameSettings, SETTING_RANGES } from '../game/settings';
+import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
@@ -24,7 +24,7 @@ export interface OptionsHooks {
   logout(): void;
   captureKey(cb: (code: string | null) => void): void;
   settings: Settings;
-  onSettingChange(key: keyof GameSettings, value: number): void;
+  onSettingChange(key: keyof GameSettings, value: GameSettings[keyof GameSettings]): void;
 }
 
 export interface ReportHooks {
@@ -2727,7 +2727,7 @@ export class Hud {
   }
 
   // A labelled slider bound to a numeric setting; live-applies via the hook.
-  private settingSlider(parent: HTMLElement, label: string, key: keyof GameSettings): void {
+  private settingSlider(parent: HTMLElement, label: string, key: NumericSettingKey): void {
     const hooks = this.optionsHooks;
     if (!hooks) return;
     const r = SETTING_RANGES[key];
@@ -2755,7 +2755,7 @@ export class Hud {
     parent.appendChild(row);
   }
 
-  private settingToggle(parent: HTMLElement, label: string, key: keyof GameSettings): void {
+  private settingToggle(parent: HTMLElement, label: string, key: 'fullscreen'): void {
     const hooks = this.optionsHooks;
     if (!hooks) return;
     const row = document.createElement('div');
@@ -2855,12 +2855,42 @@ export class Hud {
     return known ? known.def.name : fallback;
   }
 
+  private settingBoolToggleKeybind(parent: HTMLElement, label: string, key: BoolSettingKey): void {
+    const hooks = this.optionsHooks;
+    if (!hooks) return;
+    const row = document.createElement('div');
+    row.className = 'kb-row kb-toggle-row';
+    const name = document.createElement('span');
+    name.className = 'kb-name';
+    name.textContent = label;
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.className = 'btn kb-key kb-toggle';
+    const sync = () => {
+      const on = hooks.settings.get(key);
+      toggle.textContent = on ? 'On' : 'Off';
+      toggle.classList.toggle('off', !on);
+      toggle.setAttribute('aria-pressed', on ? 'true' : 'false');
+    };
+    sync();
+    toggle.addEventListener('click', () => {
+      audio.click();
+      const next = !hooks.settings.get(key);
+      hooks.onSettingChange(key, hooks.settings.set(key, next));
+      sync();
+    });
+    row.append(name, toggle);
+    parent.appendChild(row);
+  }
+
   private renderKeybinds(): void {
     const el = $('#options-menu');
     el.innerHTML = `<div class="panel-title"><span>Key Bindings</span><span class="x-btn" data-close>✕</span></div>`;
+    this.settingBoolToggleKeybind(el, 'Mouse Camera', 'mouseCamera');
     const note = document.createElement('div');
     note.className = 'kb-note';
-    note.textContent = this.keybindNote || 'Click a key cell, then press a key to bind it. Esc cancels. Each action has a primary and an alternate key.';
+    note.textContent = this.keybindNote
+      || 'Mouse Camera off: A/D turns, drag to orbit (classic). On: camera-relative WASD, A/D strafes. Click a key cell to rebind; Esc cancels.';
     el.appendChild(note);
     const rows = document.createElement('div');
     rows.className = 'kb-rows';

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -21,6 +21,7 @@ describe('Settings', () => {
     expect(s.get('sfxVolume')).toBe(SETTING_RANGES.sfxVolume.def);
     expect(s.get('renderScale')).toBe(1);
     expect(s.get('fullscreen')).toBe(1);
+    expect(s.get('mouseCamera')).toBe(false);
   });
 
   it('clamps out-of-range values to the slider bounds', () => {
@@ -48,6 +49,13 @@ describe('Settings', () => {
     expect(b.get('fullscreen')).toBe(0);
   });
 
+  it('persists boolean settings across instances', () => {
+    const a = new Settings();
+    a.set('mouseCamera', true);
+    const b = new Settings();
+    expect(b.get('mouseCamera')).toBe(true);
+  });
+
   it('falls back to defaults for missing/corrupt keys', () => {
     localStorage.setItem('woc_settings', JSON.stringify({ cameraSpeed: 0.5 }));
     const s = new Settings();
@@ -61,10 +69,12 @@ describe('Settings', () => {
     s.set('cameraSpeed', 1.2);
     s.set('renderScale', 0.5);
     s.set('fullscreen', 0);
+    s.set('mouseCamera', true);
     s.reset();
     expect(s.get('cameraSpeed')).toBe(SETTING_RANGES.cameraSpeed.def);
     expect(s.get('renderScale')).toBe(SETTING_RANGES.renderScale.def);
     expect(s.get('fullscreen')).toBe(SETTING_RANGES.fullscreen.def);
+    expect(s.get('mouseCamera')).toBe(false);
   });
 
   it('all() returns an independent snapshot', () => {


### PR DESCRIPTION
## Summary
- Adds a **Mouse Camera** toggle in Key Bindings (default **Off**)
- **Off (classic):** A/D turns, pointer-lock drag to orbit, right-drag mouselook — unchanged WoW-style controls
- **On (OSRS):** camera-relative WASD, A/D strafe, drag-to-orbit without pointer lock
- Toggle UI aligned with key-bind rows (78px On/Off button)
- Independent of the cursors PR (#207); both can merge in either order

## Test plan
- [ ] Default off — keyboard turn + mouse drag orbit work
- [ ] Toggle on — WASD moves relative to camera, A/D strafe only
- [ ] Setting persists across reload; reset restores default off
- [ ] Touch controls still work on mobile
- [ ] \
pm test -- tests/settings.test.ts\ passes