### PR TITLE
fix: suppress ranged auto-attack crit vs higher-level targets like melee

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2055,7 +2055,9 @@ export class Sim {
       return;
     }
     let dmg = this.rng.range(ranged.min, ranged.max) + (attacker.rangedPower / 14) * ranged.speed;
-    const crit = this.rng.chance(attacker.critChance);
+    // ranged white hits suffer the same higher-level crit suppression as melee
+    const critChance = Math.max(0.005, attacker.critChance - Math.max(0, target.level - attacker.level) * 0.002);
+    const crit = this.rng.chance(critChance);
     if (crit) dmg *= 2;
     // wand bolts are magic — armor doesn't apply; physical auto shot is mitigated
     if (!ranged.wand) dmg *= 1 - armorReduction(this.effectiveArmor(target), attacker.level);

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { Entity, dist2d } from '../src/sim/types';
-import { CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
+import { CLASSES, CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { groundHeight, WATER_LEVEL } from '../src/sim/world';
 import { isBlocked, resolvePosition } from '../src/sim/colliders';
@@ -614,6 +614,42 @@ describe('warrior charge', () => {
     wolf.dead = true;
     sim.tick();
     expect(p.chargeTargetId).toBe(null);
+  });
+});
+
+describe('ranged auto-attack crit suppression', () => {
+  // The crit chance a swing rolls against is the second rng.chance() call in
+  // both meleeSwing and rangedSwing (the first is the miss roll). Capture the
+  // args and return false so no miss/crit branches fire and perturb state.
+  function critChanceRolled(sim: Sim, swing: () => void): number {
+    const calls: number[] = [];
+    (sim as any).rng.chance = (p: number) => { calls.push(p); return false; };
+    swing();
+    return calls[1];
+  }
+
+  function setup(level: number, targetLevel: number) {
+    const sim = new Sim({ seed: SEED, playerClass: 'hunter' });
+    const hunter = sim.player;
+    if (level > 1) sim.setPlayerLevel(level);
+    hunter.critChance = 0.5;
+    const wolf = [...sim.entities.values()].find((e) => e.kind === 'mob')!;
+    wolf.level = targetLevel;
+    const ranged = CLASSES.hunter.ranged!;
+    return { sim, hunter, wolf, ranged };
+  }
+
+  it('suppresses crit against a higher-level target, matching melee', () => {
+    const { sim, hunter, wolf, ranged } = setup(10, 13); // +3 levels
+    const rolled = critChanceRolled(sim, () => (sim as any).rangedSwing(hunter, wolf, ranged));
+    // 0.5 base - 3 * 0.002 suppression = 0.494 (was a flat 0.5 before the fix)
+    expect(rolled).toBeCloseTo(0.5 - 3 * 0.002, 5);
+  });
+
+  it('does not suppress crit against an equal-or-lower-level target', () => {
+    const { sim, hunter, wolf, ranged } = setup(10, 8); // lower level
+    const rolled = critChanceRolled(sim, () => (sim as any).rangedSwing(hunter, wolf, ranged));
+    expect(rolled).toBeCloseTo(0.5, 5);
   });
 });
 


### PR DESCRIPTION
## Problem

In `Sim`, the two **white auto-attack** paths handle higher-level crit suppression inconsistently.

`meleeSwing` (`src/sim/sim.ts`) reduces crit chance against higher-level targets and floors it:

```ts
const critChance = Math.max(0.005, attacker.critChance - Math.max(0, target.level - attacker.level) * 0.002);
const crit = this.rng.chance(critChance);
```

But the sibling `rangedSwing` (Hunter Auto Shot) rolled against the **raw** crit chance with no suppression:

```ts
const crit = this.rng.chance(attacker.critChance);
```

Both are "white" auto-attacks and share the same hit table in classic WoW, so they should treat the higher-level crit penalty identically.

## Impact

A hunter shooting a higher-level target (e.g. a `+2`/`+3` elite, which occurs naturally given the level-appropriate and elite mobs in the world) crits at its full base rate, while a warrior meleeing the same target has its crit chance suppressed. Same situation, inconsistent outcome — ranged auto-attack damage is systematically overtuned against higher-level enemies relative to melee.

## Fix

Apply the exact suppression expression `meleeSwing` already uses to `rangedSwing` (same `0.002`/level coefficient and `0.005` floor). One-line behavioral change, consistent with the neighbouring melee path.

## Tests

Added `ranged auto-attack crit suppression` in `tests/fixes.test.ts`:
- the crit chance a ranged swing rolls against is suppressed vs a higher-level target (fails on the pre-fix code, passes after)
- it stays at full value vs an equal/lower-level target

Verified: the new higher-level test **fails on `main`** and passes with this change. Full suite: 391 passed; `tsc --noEmit` clean. (The only failing file, `homepage_foundation.test.ts`, requires `DATABASE_URL` and fails independently of this change on `main`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)