### PR TITLE
fix: keep default keybinds for actions added after a player's last save

### DIFF
--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -113,22 +113,38 @@ export class Keybinds {
     let stored: unknown = null;
     try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
     if (!stored || typeof stored !== 'object') return;
+    const obj = stored as Record<string, unknown>;
     // Apply stored codes over the defaults, but only for known actions and
     // never letting one code land on two actions (first writer keeps it).
+    // Actions absent from the stored blob (e.g. ones added in a later release
+    // than the player's last save) KEEP their defaults rather than loading
+    // unbound — explicit stored bindings still win, so this only fills gaps.
     const claimed = new Set<string>();
     for (const a of BIND_ACTIONS) {
-      const entry = (stored as Record<string, unknown>)[a.id];
+      const entry = obj[a.id];
+      if (!Array.isArray(entry)) continue; // missing action: keep its default
       const slots: (string | null)[] = [null, null];
       for (let i = 0; i < SLOTS_PER_ACTION; i++) {
-        const v = Array.isArray(entry) ? entry[i] : undefined;
+        const v = entry[i];
         if (typeof v === 'string' && !claimed.has(v) && !isReservedCode(v)) {
           slots[i] = v;
           claimed.add(v);
-        } else {
-          slots[i] = null;
         }
       }
       this.map.set(a.id, slots);
+    }
+    // Second pass: for actions that kept their defaults, drop any code an
+    // explicit stored binding already claimed so the same key can't drive two
+    // actions (preserving the WoW-style uniqueness invariant).
+    for (const a of BIND_ACTIONS) {
+      if (Array.isArray(obj[a.id])) continue;
+      const slots = this.map.get(a.id)!;
+      for (let i = 0; i < slots.length; i++) {
+        const c = slots[i];
+        if (c === null) continue;
+        if (claimed.has(c)) slots[i] = null;
+        else claimed.add(c);
+      }
     }
   }
 

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -147,6 +147,35 @@ describe('persistence', () => {
     expect(b.actionForCode('Space')).toBe(null);
   });
 
+  it('keeps defaults for actions missing from older saved data', () => {
+    // Simulate a save written before some actions existed: it only contains a
+    // couple of bindings. Every other action must keep its default, not load
+    // unbound.
+    localStorage.setItem('woc_keybinds', JSON.stringify({
+      slot0: ['KeyR', null],
+      jump: ['KeyJ', null],
+    }));
+    const kb = new Keybinds();
+    expect(kb.actionForCode('KeyR')).toBe('slot0');
+    expect(kb.actionForCode('KeyJ')).toBe('jump');
+    expect(kb.actionForCode('KeyW')).toBe('forward');
+    expect(kb.actionForCode('Tab')).toBe('target');
+    expect(kb.actionForCode('KeyN')).toBe('meters');
+    expect(kb.actionForCode('Enter')).toBe('chat');
+    expect(kb.actionForCode('Equal')).toBe('slot11');
+  });
+
+  it('drops a retained default that a stored binding already claimed', () => {
+    // A stored binding takes KeyN (the default for the newer "meters" action),
+    // which is absent from the blob. meters must not also keep KeyN.
+    localStorage.setItem('woc_keybinds', JSON.stringify({
+      jump: ['KeyN', null],
+    }));
+    const kb = new Keybinds();
+    expect(kb.actionForCode('KeyN')).toBe('jump');
+    expect(kb.codeAt('meters', 0)).toBe(null);
+  });
+
   it('drops duplicate codes when loading corrupt storage', () => {
     // two actions claim KeyR — the later one must lose it on load
     localStorage.setItem('woc_keybinds', JSON.stringify({


### PR DESCRIPTION
## Problem

`Keybinds.load()` (`src/game/keybinds.ts`) seeds defaults, then **unconditionally** overwrites every action with slots derived from the stored `localStorage` blob:

```ts
for (const a of BIND_ACTIONS) {
  const entry = (stored as Record<string, unknown>)[a.id]; // undefined for new actions
  const slots = [null, null];
  for (let i = 0; i < SLOTS_PER_ACTION; i++) {
    const v = Array.isArray(entry) ? entry[i] : undefined;
    ...else slots[i] = null;
  }
  this.map.set(a.id, slots); // always overwrites, even when entry was missing
}
```

A saved blob only contains the actions that existed when it was last written. Any action introduced in a **later release** — e.g. `meters` (N), `social` (O), `arena` (G), `chat` (Enter) — is absent from older saves, so `entry` is `undefined`, every slot resolves to `null`, and the action loads **completely unbound**.

### Impact

Every returning player with pre-existing keybinds loses all newly-added keybinds on upgrade. The new interface keys do nothing (the default never takes effect) until the player manually opens the rebind menu and reassigns them — reads as "this feature is broken." This recurs every time a bindable action is added.

## Fix

Actions missing from the stored blob now **keep their defaults**. Explicit stored bindings still win, and a second pass drops any retained default whose code a stored binding already claimed — preserving the existing "one code can't drive two actions" invariant.

## Tests

Added two regression tests to `tests/keybinds.test.ts`:
- older saved data (only a couple of bindings) keeps defaults for all absent actions, including newer ones (`meters`, `chat`, etc.)
- a stored binding that claims a newer action's default code wins; the newer action does not also keep that code

Full suite: `17 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)