### PR TITLE
fix: stop wasting a mana potion used at full mana

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3080,7 +3080,7 @@ export class Sim {
         this.error(meta.entityId, 'That potion is not ready yet.');
         return;
       }
-      const restoresMana = (def.potionMana ?? 0) > 0 && p.resourceType === 'mana';
+      const restoresMana = (def.potionMana ?? 0) > 0 && p.resourceType === 'mana' && p.resource < p.maxResource;
       const restoresHp = (def.potionHp ?? 0) > 0 && p.hp < p.maxHp;
       if (!restoresHp && !restoresMana) {
         this.error(meta.entityId, p.hp >= p.maxHp && (def.potionMana ?? 0) === 0 ? 'You are already at full health.' : 'Nothing to restore.');

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -531,6 +531,19 @@ describe('food, drink, vendor', () => {
     expect(sim.countItem('minor_mana_potion')).toBe(1); // not consumed
   });
 
+  it('a mana potion is not wasted (consumed + put on cooldown) at full mana', () => {
+    const sim = makeSim('mage');
+    sim.addItem('minor_mana_potion', 1);
+    sim.player.resource = sim.player.maxResource; // already topped off
+
+    sim.useItem('minor_mana_potion');
+    // nothing to restore: the potion stays in the bag and the shared
+    // cooldown is never armed (mirrors the at-full-health guard for HP potions)
+    expect(sim.player.resource).toBe(sim.player.maxResource);
+    expect(sim.countItem('minor_mana_potion')).toBe(1);
+    expect(sim.player.potionCooldownUntil).toBeLessThanOrEqual(sim.time);
+  });
+
   it('out-of-combat mana regen is brisk and scales past the old spi/4+2 rate (#103)', () => {
     const sim = makeSim('mage');
     sim.setPlayerLevel(10);


### PR DESCRIPTION
## Problem

The combat-potion path in `useItem` (`src/sim/sim.ts`) guards the **HP** side against waste but not the **mana** side:

```ts
const restoresMana = (def.potionMana ?? 0) > 0 && p.resourceType === 'mana';
const restoresHp   = (def.potionHp ?? 0) > 0 && p.hp < p.maxHp;
if (!restoresHp && !restoresMana) { /* "Nothing to restore." */ return; }
```

`restoresHp` correctly requires `p.hp < p.maxHp`, but `restoresMana` never checks whether the player is actually missing mana. So a mana-class player **at full mana** who quaffs a mana potion sails past the "Nothing to restore" guard: the potion is consumed and the shared 60s cooldown is armed for **zero benefit** (`Math.min(maxResource, resource + potionMana)` is a no-op when already full). The same waste happens for a combined HP+mana potion used at full HP and full mana.

This is the mana-side mirror of the existing at-full-health protection — the HP side already prevents it, the mana side was simply missing the condition.

## Fix

Require `p.resource < p.maxResource` for `restoresMana`, matching the HP guard. A full-mana quaff is now rejected with "Nothing to restore." and the item + cooldown are preserved.

## Test

Adds a regression test (`tests/sim.test.ts`): a mage at full mana that uses `minor_mana_potion` keeps the potion and never arms the cooldown. Verified the test fails on the pre-fix code and passes with the fix. Full suite: 530 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)