### PR TITLE
fix: only drop quest-gated loot when the quest actually collects that item

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2359,7 +2359,11 @@ export class Sim {
     if (!qp || qp.state !== 'active') return false;
     const quest = QUESTS[entry.questId];
     const objIdx = quest.objectives.findIndex((o) => o.type === 'collect' && o.itemId === entry.itemId);
-    return objIdx < 0 || this.countItem(entry.itemId, meta.entityId) < quest.objectives[objIdx].count;
+    // A quest-gated drop is only "needed" while the player has an actual collect
+    // objective for this item that is still short of its required count. If the
+    // quest has no matching collect objective, the player never needs the item,
+    // so it must not drop (fail closed rather than dropping unconditionally).
+    return objIdx >= 0 && this.countItem(entry.itemId, meta.entityId) < quest.objectives[objIdx].count;
   }
 
   private rollLoot(mob: Entity, meta: PlayerMeta, eligible: PlayerMeta[] = [meta]): void {

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -483,6 +483,25 @@ describe('boss loot and encounter resets', () => {
     expect(mob.lootable).toBe(false);
   });
 
+  it('does not drop a quest-gated item whose quest has no matching collect objective', () => {
+    const sim = makeSim();
+    const a = sim.playerId;
+    // q_boars only collects boar_hide; it has no collect objective for greyjaw_fang.
+    sim.meta(a)!.questLog.set('q_boars', { questId: 'q_boars', counts: [0], state: 'active' });
+    const mob = createMob(990102, MOBS.wild_boar, 3, { x: 20, y: 0, z: 22 });
+    // Inject a (mis)configured drop gated on q_boars but for an item the quest
+    // does not collect. It must never drop, even at chance 1.
+    const bogus = { itemId: 'greyjaw_fang', chance: 1, questId: 'q_boars' };
+    MOBS.wild_boar.loot.push(bogus as any);
+    try {
+      (sim as any).rollLoot(mob, sim.meta(a)!, [sim.meta(a)!]);
+    } finally {
+      MOBS.wild_boar.loot.pop();
+    }
+    const dropped = (mob.loot?.items ?? []).some((slot) => slot.itemId === 'greyjaw_fang');
+    expect(dropped).toBe(false);
+  });
+
   it('boss adds despawn on encounter reset instead of stacking across pulls', () => {
     const sim = makeSim();
     const p = sim.player;


### PR DESCRIPTION
## Problem

`Sim.needsQuestDrop()` decides whether a quest-gated loot entry should drop for a player:

```ts
const objIdx = quest.objectives.findIndex((o) => o.type === 'collect' && o.itemId === entry.itemId);
return objIdx < 0 || this.countItem(entry.itemId, meta.entityId) < quest.objectives[objIdx].count;
```

The `objIdx < 0 || …` short-circuits to **true** when the gating quest has *no* matching `collect` objective for the item. The guard is meant to fail *closed* (don't drop something the player doesn't need) but instead fails *open*: such an item drops unconditionally for everyone who has that quest active.

No shipped content triggers this today (every current quest-gated drop has a matching collect objective), but it's a latent trap: any new quest-gated loot entry whose quest collects a *different* item — or is a kill quest with no collect objective at all — would immediately leak an unconditional personal drop. Given how frequently new zones/quests/loot are added, that's an easy mistake to hit.

## Fix

Make the guard fail closed — a quest drop is only "needed" when the player has an actual `collect` objective for the item that is still short of its required count:

```ts
return objIdx >= 0 && this.countItem(entry.itemId, meta.entityId) < quest.objectives[objIdx].count;
```

## Test

Added a regression test in `tests/fixes.test.ts` that gates a drop on a quest with no matching collect objective and asserts it never drops (chance forced to 1). The test fails on the old code and passes with the fix.

- `npx tsc --noEmit` clean
- full suite: 530 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)