### PR TITLE
fix: cache banlist read instead of readFileSync on every name validation (#148)

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -69,16 +69,29 @@ function parseBanlist(raw: string | undefined): string[] {
     .filter((term) => term.length > 0);
 }
 
+let banlistCacheKey: string | null = null;
+let banlistCacheTerms: string[] = [];
+
 function bannedUsernameTerms(): string[] {
-  const terms = BUILT_IN_BANNED_NAME_TERMS.concat(parseBanlist(process.env.USERNAME_BANLIST));
-  const file = process.env.USERNAME_BANLIST_FILE;
-  if (!file) return terms;
+  const rawList = process.env.USERNAME_BANLIST ?? '';
+  const file = process.env.USERNAME_BANLIST_FILE ?? '';
+  const cacheKey = `${rawList}\0${file}`;
+  if (cacheKey === banlistCacheKey) return banlistCacheTerms;
+
+  const terms = BUILT_IN_BANNED_NAME_TERMS.concat(parseBanlist(rawList));
+  if (!file) {
+    banlistCacheTerms = terms;
+    banlistCacheKey = cacheKey;
+    return banlistCacheTerms;
+  }
   try {
-    return terms.concat(parseBanlist(readFileSync(file, 'utf8')));
+    banlistCacheTerms = terms.concat(parseBanlist(readFileSync(file, 'utf8')));
   } catch (err) {
     console.warn(`could not read USERNAME_BANLIST_FILE (${file}):`, err);
     return terms;
   }
+  banlistCacheKey = cacheKey;
+  return banlistCacheTerms;
 }
 
 export function offensiveUsername(u: unknown): boolean {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'node:events';
-import { rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
 import { normalizeCharName, offensiveName, offensiveUsername, validCharName, validUsername } from '../server/auth';
@@ -298,6 +298,51 @@ describe('username censorship', () => {
       });
     } finally {
       rmSync(file, { force: true });
+    }
+  });
+
+  it('caches file-backed banned terms until banlist env changes', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'woc-banlist-'));
+    const firstFile = join(dir, 'first.txt');
+    const secondFile = join(dir, 'second.txt');
+    writeFileSync(firstFile, 'fileterm\n');
+    writeFileSync(secondFile, 'otherterm\n');
+
+    try {
+      withUsernameBanlist({ file: firstFile }, () => {
+        expect(offensiveName('fileterm')).toBe(true);
+        writeFileSync(firstFile, 'changedterm\n');
+        expect(offensiveName('fileterm')).toBe(true);
+        expect(offensiveName('changedterm')).toBe(false);
+
+        process.env.USERNAME_BANLIST_FILE = secondFile;
+        expect(offensiveName('fileterm')).toBe(false);
+        expect(offensiveName('otherterm')).toBe(true);
+
+        delete process.env.USERNAME_BANLIST_FILE;
+        expect(offensiveName('otherterm')).toBe(false);
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it('retries file-backed banned terms after a failed read', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'woc-banlist-missing-'));
+    const missingFile = join(dir, 'missing.txt');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    try {
+      withUsernameBanlist({ file: missingFile }, () => {
+        expect(offensiveName('laterterm')).toBe(false);
+        expect(warn).toHaveBeenCalledOnce();
+
+        writeFileSync(missingFile, 'laterterm\n');
+        expect(offensiveName('laterterm')).toBe(true);
+      });
+    } finally {
+      warn.mockRestore();
+      rmSync(dir, { force: true, recursive: true });
     }
   });
 });


### PR DESCRIPTION
## Summary
`offensiveName()` → `bannedUsernameTerms()` did a synchronous `readFileSync` of `USERNAME_BANLIST_FILE` on every username/character-name validation (registration, character create, rename), blocking the event loop on a hot path. This memoizes the banned-terms list, reading the file once per distinct env configuration instead of on every call.

## Implementation
- Adds a module-level cache to `bannedUsernameTerms()` keyed on `${USERNAME_BANLIST}\0${USERNAME_BANLIST_FILE}`, mirroring the existing chat-censor terms cache at `server/game.ts:261-283`.
- On a cache-key match, returns cached terms with no disk read.
- A read error returns the uncached fallback without poisoning the cache, so a transient failure is retried on the next call (same behavior as the chat-censor cache).

## Behavior
No functional change beyond caching. When the banlist env vars change, the cache key changes and the list is recomputed. Like the chat-censor cache, this keys on env-var values, not file mtime — editing the file in place without changing an env var won't hot-reload until restart (matches the established pattern; gate hot-reload behind an explicit signal/TTL if ever desired).

## Tests
Adds two tests mirroring the chat-censor cache's coverage: cache-until-env-change, and retry-after-failed-read.

## Verification
- `npm test` — 531 passed (46 files)
- `npx tsc --noEmit` — clean
- `npm run build:env`, `npm run build:server`, `npm run build` — all pass

## Relationship to #66
Open PR #66 refactors `bannedUsernameTerms`/`offensiveName` for character-name moderation but does not address the per-call `readFileSync` (its default path still calls the uncached function), so this is complementary. If #66 lands first, this rebases cleanly into the renamed helper.

Closes #148