### PR TITLE
fix: keep a pet's owner in combat while the pet is fighting

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -760,9 +760,18 @@ export class Sim {
     // with, instead of one full scan per player
     this.engagedPids.clear();
     for (const e of this.entities.values()) {
-      if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId !== null) {
+      if (e.kind !== 'mob' || e.dead) continue;
+      // a wild mob actively engaged keeps its target in combat — and if that
+      // target is someone's pet, the pet's owner stays in combat too, so a
+      // hunter/warlock can't regen, eat/drink, or use out-of-combat abilities
+      // while their pet tanks
+      if (e.ownerId === null && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId !== null) {
         this.engagedPids.add(e.aggroTargetId);
+        const tgt = this.entities.get(e.aggroTargetId);
+        if (tgt && tgt.ownerId !== null) this.engagedPids.add(tgt.ownerId);
       }
+      // a player's pet that is engaging an enemy keeps its owner in combat
+      if (e.ownerId !== null && e.aggroTargetId !== null) this.engagedPids.add(e.ownerId);
     }
     for (const meta of this.players.values()) {
       const p = this.entities.get(meta.entityId);

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -467,6 +467,32 @@ describe('hunter pets', () => {
     expect(boar.tappedById).toBe(sim.playerId);
   });
 
+  it('keeps the owner in combat while their pet tanks a mob', () => {
+    // Regression: inCombat was recomputed only from a mob's *direct* target,
+    // so when a mob attacked the pet (mob.aggroTargetId === pet.id) the owner
+    // was never marked engaged. Once the owner's combatTimer passed 5s with no
+    // personal damage, they dropped out of combat mid-fight and could regen
+    // health, eat/drink, and use out-of-combat-only abilities while the pet
+    // kept fighting.
+    const { sim, wolf: pet } = tamedSetup();
+    const boar = nearestMob(sim, 'wild_boar');
+    beefUp(boar);
+    teleport(sim, sim.player, boar.pos.x + 4, boar.pos.z);
+    teleport(sim, pet, boar.pos.x + 5, boar.pos.z);
+    hit(sim, sim.player, boar, 5); // boar comes for the hunter; pet assists
+
+    // let the boar transfer onto the tanking pet
+    for (let i = 0; i < 20 * 20 && boar.aggroTargetId !== pet.id; i++) sim.tick();
+    expect(boar.aggroTargetId).toBe(pet.id);
+
+    // owner stops dealing damage; age their personal combat timer past 5s
+    sim.player.combatTimer = 99;
+    sim.tick();
+
+    expect(pet.inCombat).toBe(true);
+    expect(sim.player.inCombat).toBe(true);
+  });
+
   it('dismiss releases the pet back to the wild', () => {
     const { sim, wolf } = tamedSetup();
     const priestId = sim.addPlayer('priest', 'Priest');


### PR DESCRIPTION
## Problem

The per-tick combat-state recompute in `src/sim/sim.ts` builds `engagedPids` from each mob's **direct** `aggroTargetId` only:

```ts
if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId !== null) {
  this.engagedPids.add(e.aggroTargetId);
}
```

A player's pet is a separate `mob` entity with `ownerId` set. When a mob attacks the pet, `mob.aggroTargetId === pet.id`, so the **owner** is never added to `engagedPids`. The owner's `inCombat` then falls back to `combatTimer < 5`, and `combatTimer` is reset to 0 only when the owner *personally* deals or takes damage (`enterCombat`).

## Impact

If the owner stops dealing/taking damage for 5s while the pet keeps fighting — e.g. a warlock sending the voidwalker to tank, or a hunter pausing between shots — `inCombat` flips to `false` mid-fight. That incorrectly enables, while the pet is still tanking:

- out-of-combat health regeneration (`updateRegen`),
- eating/drinking (`requiresOutOfCombat` gate), and
- out-of-combat-only abilities.

## Fix

When collecting engaged players, also mark the **owner** of a targeted pet, and keep an owner in combat whenever their pet is actively engaging an enemy.

## Tests

Added a regression test under `hunter pets` that sends a boar onto a tanking pet, ages the owner's `combatTimer` past 5s, and asserts the owner stays `inCombat`. It fails on `main` and passes with this change. Full suite: **530 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)