### PR TITLE
fix: throttle-safe bounded eviction for the authFailures backstop (#147)

### DIFF
--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -101,13 +101,21 @@ function authKey(username: string): string {
   return username.trim().toLowerCase();
 }
 
+// Single source of truth for "is this account at/over the failure ceiling right
+// now". Both authThrottled() and the memory backstop's eviction skip-check call
+// this, so the two can never drift apart — if they did, the backstop could evict
+// a still-throttled account and silently re-open the flood-reset bypass (#147).
+function isThrottled(times: number[], windowStart: number): boolean {
+  return times.filter((t) => t > windowStart).length >= MAX_AUTH_FAILURES;
+}
+
 /** True once an account has hit the failed-attempt ceiling within the window. */
 export function authThrottled(username: string): boolean {
   const key = authKey(username);
   const windowStart = Date.now() - AUTH_FAIL_WINDOW_MS;
   const recent = (authFailures.get(key) ?? []).filter((t) => t > windowStart);
   if (recent.length > 0) authFailures.set(key, recent); else authFailures.delete(key);
-  return recent.length >= MAX_AUTH_FAILURES;
+  return isThrottled(recent, windowStart);
 }
 
 /** Record a failed login for an account (call on bad password / unknown user). */
@@ -117,7 +125,61 @@ export function recordAuthFailure(username: string): void {
   const recent = (authFailures.get(key) ?? []).filter((t) => t > windowStart);
   recent.push(Date.now());
   authFailures.set(key, recent);
-  if (authFailures.size > MAX_TRACKED_IPS) authFailures.clear(); // memory backstop
+  // Memory backstop: keep the map bounded without a blanket clear(), which would
+  // also wipe the counter we just recorded — letting an attacker bypass the
+  // throttle by flooding the map with failures against many distinct usernames
+  // to force the overflow. First evict accounts whose window has fully expired.
+  if (authFailures.size > MAX_TRACKED_IPS) {
+    for (const [k, times] of authFailures) {
+      if (k === key) continue;
+      if (times.length === 0 || times[times.length - 1] <= windowStart) {
+        authFailures.delete(k);
+      }
+      if (authFailures.size <= MAX_TRACKED_IPS) break;
+    }
+    // A pure flood is all in-window, so nothing above is expired and the map
+    // would grow unbounded (and each call would re-scan it). Fall back to
+    // evicting the least-recently-active account until back under the cap.
+    //
+    // Critically, NEVER evict a currently-throttled account (isThrottled) or the
+    // account just recorded. In the real flow (server/main.ts) a throttled
+    // account is rejected BEFORE recordAuthFailure runs, so its timestamps go
+    // stale and it would otherwise look "oldest" — letting an attacker reset a
+    // victim's throttle simply by flooding the map with newer one-off failures.
+    // Only non-throttled idle entries (the flood's count-of-1 buckets) are
+    // sacrificed — the cost of a memory bound.
+    while (authFailures.size > MAX_TRACKED_IPS) {
+      let oldestKey: string | undefined;
+      let oldestSeen = Infinity;
+      for (const [k, times] of authFailures) {
+        if (k === key) continue;
+        // Currently throttled? Same predicate authThrottled uses; never evict it.
+        if (isThrottled(times, windowStart)) continue;
+        const last = times.length === 0 ? 0 : times[times.length - 1];
+        if (last < oldestSeen) {
+          oldestSeen = last;
+          oldestKey = k;
+        }
+      }
+      // Nothing evictable means every remaining account is either the current
+      // one or currently throttled. Accept a SOFT cap and stop rather than
+      // reset any throttle. This only happens once an attacker has genuinely
+      // locked out >MAX_TRACKED_IPS distinct accounts (100k+ failed logins);
+      // we fail toward protection (map grows) instead of toward bypass.
+      if (oldestKey === undefined) break;
+      authFailures.delete(oldestKey);
+    }
+  }
+}
+
+/** Number of accounts currently tracked. Exposed for the backstop-bound test. */
+export function authFailureCount(): number {
+  return authFailures.size;
+}
+
+/** Reset all tracked failures. Test-only — keeps the shared map isolated per test. */
+export function resetAuthFailures(): void {
+  authFailures.clear();
 }
 
 /** Clear an account's failure history after a successful login. */

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -2,11 +2,11 @@ import { EventEmitter } from 'node:events';
 import { rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
 import { normalizeCharName, offensiveName, offensiveUsername, validCharName, validUsername } from '../server/auth';
-import { rateLimited, requestIp, authThrottled, recordAuthFailure, clearAuthFailures } from '../server/ratelimit';
+import { rateLimited, requestIp, authThrottled, recordAuthFailure, clearAuthFailures, authFailureCount, resetAuthFailures } from '../server/ratelimit';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
   const req: any = new EventEmitter();
@@ -136,6 +136,10 @@ describe('rate-limit client IP selection', () => {
 });
 
 describe('per-account failed-login throttle (#93)', () => {
+  // The failure map is module-level shared state; reset it so the flood tests
+  // below (and any future order changes) can't leak entries between cases.
+  beforeEach(() => resetAuthFailures());
+
   it('throttles an account after repeated failed logins, regardless of source IP', () => {
     const user = 'victim_account';
     expect(authThrottled(user)).toBe(false);
@@ -166,6 +170,36 @@ describe('per-account failed-login throttle (#93)', () => {
     for (let i = 0; i < 10; i++) recordAuthFailure('account_a');
     expect(authThrottled('account_a')).toBe(true);
     expect(authThrottled('account_b')).toBe(false);
+  });
+
+  it('keeps a throttled-then-idle victim throttled after the backstop trips', () => {
+    // Models the REAL flow: once an account is throttled, handleApi rejects it
+    // BEFORE recordAuthFailure runs (server/main.ts), so the victim's timestamps
+    // go stale and it is never re-touched. An attacker then floods the map with
+    // >10k NEWER distinct one-off failures. A least-recently-active eviction that
+    // ignored throttle state would pick the idle victim as "oldest" and evict it,
+    // resetting its throttle — the exact #147 bypass through a new door. The
+    // backstop must refuse to evict currently-throttled accounts.
+    const victim = 'idle_victim';
+    for (let i = 0; i < 10; i++) recordAuthFailure(victim);
+    expect(authThrottled(victim)).toBe(true);
+
+    // Flood past MAX_TRACKED_IPS (10_000) with newer accounts; victim untouched.
+    for (let i = 0; i < 10_050; i++) recordAuthFailure(`floodacct_${i}`);
+
+    // The idle victim must stay throttled — its counter must survive eviction.
+    expect(authThrottled(victim)).toBe(true);
+  });
+
+  it('keeps the failure map bounded under a flood of distinct in-window accounts', () => {
+    // A pure flood is all in-window, so expired-only eviction would delete
+    // nothing and the map would grow unbounded (and every subsequent call would
+    // re-scan a growing map → O(n^2)). The backstop must fall back to evicting
+    // the least-recently-active accounts so the map stays bounded near the cap.
+    for (let i = 0; i < 12_000; i++) recordAuthFailure(`floodbound_${i}`);
+
+    // MAX_TRACKED_IPS is 10_000; allow a small margin for the just-recorded entry.
+    expect(authFailureCount()).toBeLessThanOrEqual(10_001);
   });
 });
 


### PR DESCRIPTION
## The bug (#147)

The per-account failed-login throttle's memory backstop wipes **every** account's failure history when the tracking map overflows:

```ts
// recordAuthFailure(), server/ratelimit.ts
if (authFailures.size > MAX_TRACKED_IPS) authFailures.clear(); // memory backstop
```

This is the same class of issue #147 reports for the per-IP `attempts` map, on the second map. It's **trivially attacker-triggerable**: fail logins against >10k distinct usernames to force `authFailures.size > MAX_TRACKED_IPS`, the `clear()` fires, and every throttled account — including the attacker's actual target — is reset to zero. The brute-force protection collapses exactly when it's under attack.

## The fix: throttle-safe bounded eviction

Replace the blanket `clear()` with two-stage eviction in `recordAuthFailure`:

1. **Expired pass** — evict accounts whose window has fully expired (cheap; mirrors the eviction the per-IP `attempts` backstop already does in `main`).
2. **Least-recently-active fallback** — a pure flood is all *in-window*, so stage 1 finds nothing to evict and the map would otherwise grow unbounded (and every subsequent call would re-scan it). When still over the cap, evict the least-recently-active account — but **never one that is currently throttled, and never the account just recorded**.

The "currently throttled?" test is a single shared helper (`isThrottled`) called by **both** `authThrottled()` and the eviction skip-check, so the two cannot drift apart — a future edit to one can't silently re-open the bypass.

**Why stage 2 must skip throttled accounts:** in the real flow (`server/main.ts`) a throttled account is rejected *before* `recordAuthFailure` runs, so its timestamps go stale and a naive least-recently-active eviction would pick the idle victim as "oldest" and evict it — reopening the #147 bypass through the eviction path (flood newer one-off failures, victim's throttle resets). This was caught in review and is covered by a dedicated regression test.

## Known residual / open design questions

This is a strong improvement over the blanket `clear()` — it closes the cheap, full-bypass reset — but two hard cases remain that I'd value the maintainer's call on:

1. **Near-threshold accounts are still evictable under an expensive flood.** An account mid-accumulation (1–9 in-window failures, not yet at the ceiling) is *not* skipped, so a flood can still evict it and reset its accumulating count. The cost to the attacker is high — a fresh >10k-distinct-username flood per reset (~1,111 flood requests per single real guess they want to preserve) — but it's not zero. This is an **inherent tension** in the evict-buckets model: a count-1 flood entry is indistinguishable from a victim's legitimate first failure, so it can't be fully closed here. The complete fix is a different throttle data model — e.g. collapsing throttled accounts to an O(1) "throttled-until" marker, or tracking throttle state separately from the eviction population. That's a maintainer-level design decision; happy to pursue it here or as a follow-up — guidance welcome.

2. **The per-IP `attempts` map shares the same expired-only backstop limitation** (it would likewise grow unbounded under an all-in-window IP flood). Left out of scope to keep this change focused on the #147 `authFailures` regression — flagging as a follow-up.

**Soft-cap edge (handled):** if every over-cap account is itself currently throttled, the map is allowed to grow past the cap rather than reset any throttle. That requires an attacker to genuinely lock out >`MAX_TRACKED_IPS` distinct accounts (100k+ failed logins) and resets *none* of them — it fails toward protection, not bypass.

## Verification

Extends the `#93` throttle suite (with a `beforeEach` reset of the shared map for isolation):

- **a throttled-then-idle victim stays throttled** after a >10k newer-account flood — fails on naive LRA eviction and on any drift of the shared `isThrottled` skip-check;
- **the failure map stays bounded** near the cap under a >10k distinct-account flood — fails on stage-1-only (expired-only) eviction.

Both were verified to fail on their respective buggy versions and pass here. Full gate green: `npm ci && npm test` (531 passing) `&& npx tsc --noEmit && npm run build:env && npm run build:server && npm run build`.

Opening as a **draft** for design feedback on the residual above before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
