### PR TITLE
fix: stop auth-throttle backstop from wiping live lockout counters

### DIFF
--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -117,7 +117,20 @@ export function recordAuthFailure(username: string): void {
   const recent = (authFailures.get(key) ?? []).filter((t) => t > windowStart);
   recent.push(Date.now());
   authFailures.set(key, recent);
-  if (authFailures.size > MAX_TRACKED_IPS) authFailures.clear(); // memory backstop
+  // Memory backstop: evict only accounts whose window has fully expired rather
+  // than clearing everything. A blanket clear() would also wipe the live
+  // lockout counters we are accumulating against accounts under attack — which
+  // is exactly when a credential-stuffing flood inflates this map past the cap,
+  // silently disabling the per-account throttle. Mirrors rateLimited() above.
+  if (authFailures.size > MAX_TRACKED_IPS) {
+    for (const [k, times] of authFailures) {
+      if (k === key) continue;
+      if (times.length === 0 || times[times.length - 1] <= windowStart) {
+        authFailures.delete(k);
+      }
+      if (authFailures.size <= MAX_TRACKED_IPS) break;
+    }
+  }
 }
 
 /** Clear an account's failure history after a successful login. */

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -167,6 +167,23 @@ describe('per-account failed-login throttle (#93)', () => {
     expect(authThrottled('account_a')).toBe(true);
     expect(authThrottled('account_b')).toBe(false);
   });
+
+  it('keeps an account locked out after the memory backstop evicts', () => {
+    // A credential-stuffing flood spreads guesses across thousands of accounts,
+    // pushing the failure map past its backstop threshold. The backstop must
+    // evict expired one-off entries, NOT wipe the live lockout counter for an
+    // account actively under attack — otherwise flooding silently disables the
+    // per-account throttle exactly when it is needed most.
+    const victim = 'lockme_account';
+    for (let i = 0; i < 10; i++) recordAuthFailure(victim);
+    expect(authThrottled(victim)).toBe(true);
+
+    // Churn past MAX_TRACKED_IPS (10_000) distinct accounts to trip the backstop.
+    for (let i = 0; i < 10_050; i++) recordAuthFailure(`throwaway_${i}`);
+
+    // The victim's lockout must survive eviction.
+    expect(authThrottled(victim)).toBe(true);
+  });
 });
 
 describe('malformed websocket frames cannot crash the server', () => {


### PR DESCRIPTION
## Summary

The per-account failed-login throttle (#93) is silently disabled under exactly the load it's meant to defend against.

In `server/ratelimit.ts`, `recordAuthFailure()` used a blanket `authFailures.clear()` as its memory backstop:

```ts
if (authFailures.size > MAX_TRACKED_IPS) authFailures.clear(); // memory backstop
```

When the tracked-account map exceeds `MAX_TRACKED_IPS` (10k), this wipes **every** account's in-progress failed-login counter at once. A credential-stuffing botnet spreads guesses across thousands of accounts, which inflates this map past the cap on its own — so the backstop fires precisely when the brute-force throttle matters most, handing every attacked account a brand-new allowance.

This is the **same anti-pattern PR #164 fixed** in the per-IP `rateLimited()` backstop (and which its own comment explicitly warns against) — `recordAuthFailure()` was simply left behind.

## Fix

Evict only accounts whose window has fully expired instead of clearing the whole map, mirroring the eviction loop already used in `rateLimited()`. Live lockout counters survive.

## Testing

- Added a regression test in `tests/security.test.ts` that locks an account out, churns past the cap with 10k+ throwaway accounts, and asserts the victim stays throttled. **Fails before, passes after.**
- Full suite green: **530 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)