### PR TITLE
fix: keep enemy hp bars on screen

### DIFF
--- a/src/render/nameplate_projection.ts
+++ b/src/render/nameplate_projection.ts
@@ -1,0 +1,10 @@
+import * as THREE from 'three';
+
+export function isProjectedNameplateAnchorVisible(
+  camera: THREE.PerspectiveCamera,
+  worldPos: THREE.Vector3,
+  cameraSpace: THREE.Vector3,
+): boolean {
+  cameraSpace.copy(worldPos).applyMatrix4(camera.matrixWorldInverse);
+  return cameraSpace.z < -camera.near;
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -24,6 +24,7 @@ import { buildClouds, buildSky, SkyView } from './sky';
 import { buildFoliage, FoliageView } from './foliage';
 import { shouldRenderStealthGhost } from './stealth';
 import { raidMarkerDataUrl } from '../ui/icons';
+import { isProjectedNameplateAnchorVisible } from './nameplate_projection';
 
 const NAMEPLATE_RANGE = 55;
 // Entities further than this from the player are hidden entirely: their rigs
@@ -1057,6 +1058,7 @@ export class Renderer {
     const groundY = groundHeight(cx, cz, this.sim.cfg.seed) + 0.6;
     this.camera.position.set(cx, Math.max(cy, groundY), cz);
     this.camera.lookAt(px, eyeY, pz);
+    this.camera.updateMatrixWorld();
   }
 
   private updateNameplates(): void {
@@ -1080,8 +1082,12 @@ export class Renderer {
       }
       this.tmpV.copy(v.group.position);
       this.tmpV.y += v.height * e.scale + 0.5;
+      if (!isProjectedNameplateAnchorVisible(this.camera, this.tmpV, this.tmpV2)) {
+        v.nameplate.style.display = 'none';
+        continue;
+      }
       this.tmpV.project(this.camera);
-      if (this.tmpV.z > 1) { v.nameplate.style.display = 'none'; continue; }
+      if (this.tmpV.z < -1 || this.tmpV.z > 1) { v.nameplate.style.display = 'none'; continue; }
       const sx = (this.tmpV.x * 0.5 + 0.5) * w;
       const sy = (-this.tmpV.y * 0.5 + 0.5) * h;
       v.nameplate.style.display = '';
@@ -1178,8 +1184,12 @@ export class Renderer {
       if (v.group.visible) this.tmpV.copy(v.group.position);
       else this.tmpV.set(e.pos.x, e.pos.y, e.pos.z);
       this.tmpV.y += v.height * e.scale + 1.0;
+      if (!isProjectedNameplateAnchorVisible(this.camera, this.tmpV, this.tmpV2)) {
+        b.el.style.display = 'none';
+        continue;
+      }
       this.tmpV.project(this.camera);
-      if (this.tmpV.z > 1) { b.el.style.display = 'none'; continue; }
+      if (this.tmpV.z < -1 || this.tmpV.z > 1) { b.el.style.display = 'none'; continue; }
       b.el.style.display = '';
       const sx = (this.tmpV.x * 0.5 + 0.5) * w;
       const sy = (-this.tmpV.y * 0.5 + 0.5) * h;

--- a/tests/nameplate_projection.test.ts
+++ b/tests/nameplate_projection.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { isProjectedNameplateAnchorVisible } from '../src/render/nameplate_projection';
+
+describe('nameplate projection', () => {
+  function camera(): THREE.PerspectiveCamera {
+    const cam = new THREE.PerspectiveCamera(60, 16 / 9, 0.1, 1000);
+    cam.position.set(0, 2, 10);
+    cam.lookAt(0, 2, 0);
+    cam.updateMatrixWorld();
+    return cam;
+  }
+
+  it('keeps anchors in front of the camera visible', () => {
+    const cam = camera();
+    const scratch = new THREE.Vector3();
+
+    expect(isProjectedNameplateAnchorVisible(cam, new THREE.Vector3(0, 2, 0), scratch)).toBe(true);
+  });
+
+  it('hides anchors behind the camera before their projected coordinates can leak on-screen', () => {
+    const cam = camera();
+    const scratch = new THREE.Vector3();
+
+    expect(isProjectedNameplateAnchorVisible(cam, new THREE.Vector3(0, 2, 12), scratch)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Keeps enemy nameplate HP bars from disappearing or leaving stale fragments when a mob moves behind the camera or outside the projected view.
- Refreshes the camera matrix before DOM nameplate projection and rejects anchors behind the near plane before applying screen coordinates.
- Adds focused coverage for the projection guard so behind-camera anchors cannot leak into visible nameplate layout.

## Diagnosis
Nameplate and chat-bubble DOM projection used the camera's projected `z > 1` check, but did not reject anchors behind the camera/near plane before deriving screen coordinates. Those anchors can project to extreme or stale screen positions, which can make enemy nameplates appear partially clipped or lose the visible HP bar while the mob is still nearby.

## Verification
- `npx vitest run tests/nameplate_projection.test.ts`; 1 file passed, 2 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- Full closeout gate passed: `npm test` (47 files, 531 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Headless Chromium offline browser smoke at local Vite `/`: entered offline gameplay, positioned a warrior next to wolves, inspected the rendered nameplate DOM, and observed 4 visible wolf nameplates with on-screen HP bars and 0 behind-camera projection leaks.

## Real behavior proof
- Behavior addressed: enemy HP bars could sometimes disappear during normal camera/gameplay movement.
- Environment tested: local offline browser gameplay in headless Chromium.
- Evidence after fix: visible wolf nameplates retained `display:block` HP bars with nonzero on-screen rectangles, while behind-camera projected nameplates were hidden instead of leaking stale coordinates.
- Not tested: live multiplayer session with many remote mobs and players.

## Risk
Low client-rendering risk. The change is limited to DOM projection for nameplates and chat bubbles; simulation, combat, snapshots, targeting, and server authority are unchanged.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
