### PR TITLE
fix: allow discarding quest items

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -668,6 +668,11 @@ export class GameServer {
       case 'abandon': if (typeof msg.quest === 'string') { sim.abandonQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'equip': if (typeof msg.item === 'string') sim.equipItem(msg.item, pid); break;
       case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
+      case 'discard':
+        if (typeof msg.item === 'string') {
+          sim.discardItem(msg.item, typeof msg.count === 'number' ? msg.count : undefined, pid);
+        }
+        break;
       case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
       case 'sell':
         if (typeof msg.item === 'string') {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -625,6 +625,9 @@ export class ClientWorld implements IWorld {
   useItem(itemId: string): void {
     this.cmd({ cmd: 'use', item: itemId });
   }
+  discardItem(itemId: string, count?: number): void {
+    this.cmd({ cmd: 'discard', item: itemId, count });
+  }
   buyItem(npcId: number, itemId: string): void {
     this.cmd({ cmd: 'buy', npc: npcId, item: itemId });
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2994,6 +2994,24 @@ export class Sim {
     this.onInventoryChangedForQuests(meta);
   }
 
+  discardItem(itemId: string, count = 1, pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const { meta } = r;
+    const def = ITEMS[itemId];
+    const available = this.countItem(itemId, meta.entityId);
+    if (!def || available <= 0) { this.error(meta.entityId, "You don't have that item."); return; }
+    const discardCount = Number.isFinite(count) ? Math.min(Math.floor(count), available) : 0;
+    if (discardCount <= 0) return;
+    this.removeItem(itemId, discardCount, meta.entityId);
+    this.emit({
+      type: 'log',
+      text: `Discarded ${def.name}${discardCount > 1 ? ' x' + discardCount : ''}.`,
+      color: '#999',
+      pid: meta.entityId,
+    });
+  }
+
   equipItem(itemId: string, pid?: number): void {
     const r = this.resolve(pid);
     if (!r) return;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1988,6 +1988,8 @@ export class Hud {
           this.renderMarket();
         } else if (this.vendorOpen) {
           this.sellBagItem(s, ev);
+        } else if (item.kind === 'quest') {
+          this.showDiscardItemPrompt(s.itemId, Math.max(1, Math.floor(s.count)));
         } else {
           this.sim.useItem(s.itemId);
           this.renderBags();
@@ -2016,7 +2018,8 @@ export class Hud {
         let extra = '';
         if (this.tradeOpen) extra = '<div class="tt-sub">Click to offer in trade</div>';
         else if (this.marketOpen && this.marketTab === 'sell') extra = item.kind === 'quest' ? '<div class="tt-sub">Cannot be sold on the market</div>' : '<div class="tt-sub">Click to put on the market</div>';
-        else if (this.vendorOpen) extra = '<div class="tt-sub">Click to sell</div>';
+        else if (this.vendorOpen) extra = item.kind === 'quest' ? '<div class="tt-sub">Cannot be sold to merchants</div>' : '<div class="tt-sub">Click to sell</div>';
+        else if (item.kind === 'quest') extra = '<div class="tt-sub">Click to destroy</div>';
         else if (item.kind === 'weapon' || item.kind === 'armor') extra = '<div class="tt-sub">Click to equip</div>';
         else if (item.kind === 'food' || item.kind === 'drink') extra = '<div class="tt-sub">Click to consume</div>';
         else if (item.kind === 'potion') extra = '<div class="tt-sub">Click to use — instant, usable in combat</div>';
@@ -2042,6 +2045,51 @@ export class Hud {
     } else {
       this.sim.sellItem(slot.itemId);
     }
+  }
+
+  private showDiscardItemPrompt(itemId: string, maxCount: number): void {
+    document.querySelectorAll('.discard-item-prompt').forEach((el) => el.remove());
+    const item = ITEMS[itemId];
+    const stack = $('#prompt-stack');
+    const prompt = document.createElement('div');
+    prompt.className = 'prompt panel discard-item-prompt';
+    prompt.innerHTML = `<div class="prompt-text">Destroy ${esc(item?.name ?? itemId)}</div>`;
+    let input: HTMLInputElement | null = null;
+    if (maxCount > 1) {
+      input = document.createElement('input');
+      input.className = 'prompt-number';
+      input.type = 'number';
+      input.min = '1';
+      input.max = String(maxCount);
+      input.step = '1';
+      input.value = '1';
+      prompt.appendChild(input);
+    }
+    const confirm = document.createElement('button');
+    confirm.className = 'btn';
+    confirm.textContent = 'Destroy';
+    const cancel = document.createElement('button');
+    cancel.className = 'btn';
+    cancel.textContent = 'Cancel';
+    const close = () => prompt.remove();
+    const submit = () => {
+      const count = input ? Math.max(1, Math.min(maxCount, Math.floor(Number(input.value) || 0))) : 1;
+      this.sim.discardItem(itemId, count);
+      close();
+      this.hideTooltip();
+      this.renderBags();
+    };
+    confirm.addEventListener('click', submit);
+    cancel.addEventListener('click', close);
+    if (input) {
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') submit();
+        else if (e.key === 'Escape') close();
+      });
+    }
+    prompt.append(confirm, cancel);
+    stack.appendChild(prompt);
+    if (input) window.setTimeout(() => { input.focus(); input.select(); }, 0);
   }
 
   private showSellQuantityPrompt(itemId: string, maxCount: number): void {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -166,6 +166,7 @@ export interface IWorld {
   abandonQuest(questId: string): void;
   equipItem(itemId: string): void;
   useItem(itemId: string): void;
+  discardItem(itemId: string, count?: number): void;
   buyItem(npcId: number, itemId: string): void;
   sellItem(itemId: string, count?: number): void;
   buyBackItem(itemId: string): void;

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -838,6 +838,23 @@ describe('food, drink, vendor', () => {
     expect(sim.copper).toBe(0);
     expect(sim.countItem('wolf_fang')).toBe(2);
   });
+
+  it('discarding quest items removes them without vendor payout or buyback', () => {
+    const sim = makeSim('warrior');
+    const meta = sim.meta(sim.playerId)!;
+    meta.questLog.set('q_widows', { questId: 'q_widows', counts: [10, 0], state: 'active' });
+    sim.addItem('widow_venom_sac', 6);
+    expect(meta.questLog.get('q_widows')).toMatchObject({ counts: [10, 6], state: 'ready' });
+    sim.events = [];
+
+    sim.discardItem('widow_venom_sac', 2);
+
+    expect(sim.countItem('widow_venom_sac')).toBe(4);
+    expect(sim.copper).toBe(0);
+    expect(sim.vendorBuyback).toEqual([]);
+    expect(meta.questLog.get('q_widows')).toMatchObject({ counts: [10, 4], state: 'active' });
+    expect(sim.events).toContainEqual({ type: 'log', text: 'Discarded Widow Venom Sac x2.', color: '#999', pid: sim.player.id });
+  });
 });
 
 describe('leveling', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -160,6 +160,23 @@ describe('delta snapshots', () => {
     expect(server.sim.countItem('wolf_fang', session.pid)).toBe(0);
   });
 
+  it('discard command mirrors inventory and quest progress changes', () => {
+    const meta = server.sim.meta(session.pid)!;
+    meta.questLog.set('q_widows', { questId: 'q_widows', counts: [10, 0], state: 'active' });
+    server.sim.addItem('widow_venom_sac', 6, session.pid);
+    broadcast(server);
+    fc.sent.length = 0;
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'discard', item: 'widow_venom_sac', count: 2 }));
+    broadcast(server);
+
+    expect(server.sim.countItem('widow_venom_sac', session.pid)).toBe(4);
+    expect(meta.questLog.get('q_widows')).toMatchObject({ counts: [10, 4], state: 'active' });
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.inv).toEqual([{ itemId: 'widow_venom_sac', count: 4 }]);
+    expect(snap.self.qlog).toEqual([{ questId: 'q_widows', counts: [10, 4], state: 'active' }]);
+  });
+
   it('resends a heavy field once it changes', () => {
     broadcast(server);
     fc.sent.length = 0;


### PR DESCRIPTION
## Summary
- Adds an authoritative discard path for inventory items so leftover quest items can be destroyed from bags instead of being stuck forever.
- Keeps quest items blocked from vendor, trade, and market economy paths while giving players a confirmation prompt for destructive removal.
- Updates online command forwarding and server snapshot coverage so offline and multiplayer inventory/quest progress stay aligned.

## Diagnosis
Quest items such as Widow Venom Sac cannot be sold, traded, or listed on the market by design, but the shared world API had no discard command. If a quest item remained after the player no longer needed it, the client had no server-authoritative way to remove it from inventory.

## Implementation Notes
- `Sim.discardItem()` removes bounded stack quantities without copper payout or vendor buyback entries.
- Inventory removal still flows through the existing quest-progress recalculation, so destroying collect items can move an active quest back from ready to active.
- The online client sends a `discard` command and the server applies it through the shared sim path.
- Bags show a destroy confirmation for quest items outside vendor, trade, and market flows.

## Verification
- `npx vitest run tests/sim.test.ts tests/snapshots.test.ts -t "discard"`; 2 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- Full closeout gate: `npm test` passed with 46 files and 531 tests, followed by typecheck and env/server/client builds.
- Browser smoke on local Vite: started an offline warrior, added 3 Widow Venom Sac quest items, opened Bags, destroyed 2 through the confirmation prompt, and verified 1 remained while `q_widows` collect progress updated to 1/6.

## Real behavior proof
- Behavior addressed: a player can end up with an unneeded quest item that cannot be sold.
- Environment tested: local offline browser session plus deterministic sim and server snapshot tests.
- Evidence after fix: destroying a stacked quest item updates the live bag, removes only the requested quantity, gives no vendor payout or buyback row, and updates collect-quest progress through the shared sim.
- Not tested: live multiplayer session with a persisted character carrying old quest-item leftovers.

## Risk
Low inventory risk. The discard command is explicit, bounded by the player's current inventory count, uses the existing inventory removal helper, and does not bypass the current restrictions on quest-item selling, trading, or market listing. The main user-visible risk is accidental destruction, mitigated by the confirmation prompt.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
