### PR TITLE
feat: add player emote system (/wave, /dance, /me)

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -49,6 +49,36 @@ const PVP_CC_DR_RESET = 18; // seconds before a repeated PvP CC category is fres
 const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
 const YELL_RANGE = 100;
+
+// Predefined social emotes. Each entry maps a command (and its aliases) to the
+// third-person action text shown to everyone in /say range. `solo` is used with
+// no target; `target` (when present) is used when the emote names another
+// player and contains a `%t` placeholder for that player's name. The actor's
+// own name is rendered separately by the client, so these strings start at the
+// verb (e.g. "Aleph" + " waves.").
+interface EmoteDef { solo: string; target?: string }
+const EMOTES: Record<string, EmoteDef> = {
+  wave: { solo: 'waves.', target: 'waves at %t.' },
+  bow: { solo: 'bows.', target: 'bows before %t.' },
+  cheer: { solo: 'cheers!', target: 'cheers at %t!' },
+  dance: { solo: 'bursts into dance.', target: 'dances with %t.' },
+  laugh: { solo: 'laughs.', target: 'laughs at %t.' },
+  cry: { solo: 'cries.', target: "cries on %t's shoulder." },
+  salute: { solo: 'salutes.', target: 'salutes %t.' },
+  thank: { solo: 'thanks everyone.', target: 'thanks %t.' },
+  clap: { solo: 'applauds. Bravo!', target: 'applauds %t. Bravo!' },
+  greet: { solo: 'greets everyone with a hearty hello.', target: 'greets %t with a hearty hello.' },
+  roar: { solo: 'lets out a mighty roar.', target: 'roars at %t.' },
+  sigh: { solo: 'sighs.', target: 'sighs at %t.' },
+  kneel: { solo: 'kneels down.', target: 'kneels before %t.' },
+  point: { solo: 'points.', target: 'points at %t.' },
+  flex: { solo: 'flexes.', target: 'flexes at %t.' },
+  cower: { solo: 'cowers in fear.', target: 'cowers in fear at the sight of %t.' },
+};
+// Command aliases → canonical emote key above.
+const EMOTE_ALIASES: Record<string, string> = {
+  hi: 'greet', hello: 'greet', thanks: 'thank', applaud: 'clap',
+};
 const CHAT_BURST = 8; // messages a player may send back-to-back...
 const CHAT_REFILL = 2; // ...then this many more per second (caps spam amplifiers)
 const DUEL_FORFEIT_DISTANCE = 60;
@@ -3543,13 +3573,42 @@ export class Sim {
       return { channel: 'general', message: clean };
     }
 
+    // "/me <action>" — freeform third-person action text, e.g.
+    // "/me ponders the void" → "Aleph ponders the void". Emotes never become
+    // the player's sticky chat channel, so this returns null on success.
+    const meMatch = /^\/(?:me|emote|e)\s+([\s\S]+)$/i.exec(raw);
+    if (meMatch) {
+      const action = meMatch[1].trim();
+      if (action) this.broadcastEmote(r.meta, r.e, action);
+      return null;
+    }
+
+    // "/wave", "/dance [name]" — predefined social emotes. An optional name
+    // targets an online player (in range or not); unknown names fall back to
+    // the untargeted form, matching WoW.
+    const emMatch = /^\/([a-z]+)(?:\s+(\S+))?\s*$/i.exec(raw);
+    if (emMatch) {
+      const key = EMOTE_ALIASES[emMatch[1].toLowerCase()] ?? emMatch[1].toLowerCase();
+      const def = EMOTES[key];
+      if (def) {
+        const targetName = emMatch[2];
+        let text = def.solo;
+        if (targetName && def.target) {
+          const t = this.findPlayerByName(targetName);
+          if (t) text = def.target.replace('%t', t.name === r.meta.name ? 'themselves' : t.name);
+        }
+        this.broadcastEmote(r.meta, r.e, text);
+        return null;
+      }
+    }
+
     // bare text and "/s" are local say; "/y" carries further — both are
     // delivered per-player by range and carry the speaker for chat bubbles
     let channel: 'say' | 'yell' = 'say';
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g, /me, or an emote like /wave.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -3558,6 +3617,31 @@ export class Sim {
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: clean, channel, entityId: r.e.id, pid: meta.entityId });
     }
     return { channel, message: clean };
+  }
+
+  // Resolve a player by name the same way whispers do: an exact-case match
+  // wins outright, otherwise a case-insensitive match is used only when it is
+  // unambiguous.
+  private findPlayerByName(name: string): PlayerMeta | null {
+    const wanted = name.toLowerCase();
+    const ci: PlayerMeta[] = [];
+    for (const meta of this.players.values()) {
+      if (meta.name === name) return meta;
+      if (meta.name.toLowerCase() === wanted) ci.push(meta);
+    }
+    return ci.length === 1 ? ci[0] : null;
+  }
+
+  // Send a third-person emote to every player within /say range (including the
+  // actor). `from` carries the actor's name so the client can render it as a
+  // clickable name; `text` is the action predicate (e.g. "waves at Bet.").
+  private broadcastEmote(actor: PlayerMeta, actorEntity: Entity, text: string): void {
+    const body = text.slice(0, 200);
+    for (const meta of this.players.values()) {
+      const e = this.entities.get(meta.entityId);
+      if (!e || dist2d(actorEntity.pos, e.pos) > SAY_RANGE) continue;
+      this.emit({ type: 'chat', fromPid: actor.entityId, from: actor.name, text: body, channel: 'emote', entityId: actorEntity.id, pid: meta.entityId });
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -520,7 +520,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'emote'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   // a guild invitation from an online guild officer/leader; resolved by name
   // server-side so it carries no pid

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1318,10 +1318,12 @@ export class Hud {
             case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
             case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
+            case 'emote': this.chatLogFrom(ev.from, ev.text, '#ff8040', '', ' '); break;
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
-          if ((ev.channel === 'say' || ev.channel === 'yell') && ev.entityId !== undefined) {
-            this.renderer.showChatBubble(ev.entityId, ev.text, ev.channel === 'yell');
+          if ((ev.channel === 'say' || ev.channel === 'yell' || ev.channel === 'emote') && ev.entityId !== undefined) {
+            const bubble = ev.channel === 'emote' ? `${ev.from} ${ev.text}` : ev.text;
+            this.renderer.showChatBubble(ev.entityId, bubble, ev.channel === 'yell');
           }
           break;
         }

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -120,10 +120,10 @@ describe('chat channels', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     sim.tick();
-    sim.chat('/dance', a);
+    sim.chat('/wiggle', a);
     const events = sim.tick();
     expect(chatEvents(events)).toHaveLength(0);
-    expect(events.some((e) => e.type === 'error' && e.text.includes('/dance'))).toBe(true);
+    expect(events.some((e) => e.type === 'error' && e.text.includes('/wiggle'))).toBe(true);
   });
 
   it('/who explains that the roster is online-only in offline sim play', () => {
@@ -204,6 +204,87 @@ describe('chat channels', () => {
     expect(pids).toContain(a);
     expect(pids).toContain(b);
     expect(pids).not.toContain(outsider);
+  });
+});
+
+describe('emotes', () => {
+  it('a predefined emote reaches everyone in say range with third-person text', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const near = sim.addPlayer('mage', 'Bet');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, near, 10, -40); // within say range
+    teleport(sim, far, 60, -40);  // beyond say range
+    sim.tick();
+
+    sim.chat('/wave', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((m) => m.channel === 'emote' && m.from === 'Aleph' && m.text === 'waves.')).toBe(true);
+    const pids = msgs.map((m) => m.pid).sort();
+    expect(pids).toContain(a);    // the actor sees their own emote
+    expect(pids).toContain(near);
+    expect(pids).not.toContain(far);
+  });
+
+  it('a targeted emote names an online player', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 10, -40);
+    sim.tick();
+
+    sim.chat('/bow Bet', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs[0].channel).toBe('emote');
+    expect(msgs[0].text).toBe('bows before Bet.');
+  });
+
+  it('a targeted emote falls back to the solo form for an unknown name', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/cheer Nobody', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs[0].text).toBe('cheers!');
+  });
+
+  it('emote aliases resolve to the canonical emote', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/hi', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs[0].text).toBe('greets everyone with a hearty hello.');
+  });
+
+  it('/me broadcasts freeform action text', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/me ponders the void', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs[0].channel).toBe('emote');
+    expect(msgs[0].from).toBe('Aleph');
+    expect(msgs[0].text).toBe('ponders the void');
+  });
+
+  it('an empty /me does nothing', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/me   ', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    // a bare "/me" with no body is an unknown command
+    sim.chat('/me', a);
+    const events2 = sim.tick();
+    expect(events2.some((e) => e.type === 'error')).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What

Adds a classic WoW-style **emote system** — a staple social feature that was entirely absent from the game.

- **Predefined emotes:** `/wave`, `/bow`, `/cheer`, `/dance`, `/laugh`, `/cry`, `/salute`, `/thank`, `/clap`, `/greet`, `/roar`, `/sigh`, `/kneel`, `/point`, `/flex`, `/cower` (plus aliases `/hi`, `/hello`, `/thanks`, `/applaud`).
- **Targeted emotes:** an optional name targets an online player — `/bow Bet` → *"Aleph bows before Bet."* Unknown names fall back to the solo form, matching WoW.
- **Freeform emotes:** `/me ponders the void` → *"Aleph ponders the void."*

## How

Emotes are parsed in the authoritative `sim.chat()`, so they automatically reuse the existing infrastructure:

- **Range-based broadcast** to everyone within `SAY_RANGE` (including the actor), via the same per-player event emission as `/say`.
- **Anti-spam rate limiting** (`chatAllowed`) already applies.
- A new `'emote'` chat channel renders in orange (`#ff8040`) in the chat log and shows a floating chat bubble above the actor.
- Emotes are **one-shot** and intentionally return `null` so they never become the player's sticky `rememberedChat` channel (an emote shouldn't hijack your active chat channel).

No new assets or animation clips are required — this is the text/social layer, which can later be enriched with animations by hooking the same `emote` events on the client.

## Tests

Added an `emotes` describe block in `tests/chat.test.ts` covering range delivery, targeted vs. solo fallback, aliases, `/me`, and empty-body handling. The previous test that assumed `/dance` was an unknown command was updated to use `/wiggle`.

- `npx tsc --noEmit` — clean
- `npx vitest run` — **535 passed**