### PR TITLE
feat: add /roll command for random rolls and loot disputes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ see each other in town. `Enter` opens chat.
 - **Parties** (up to 5): right-click a player → *Invite to Party*. Party
   frames on the left, members share tap rights, kill quest credit and split
   XP with the real vanilla group bonuses (1.166/1.3/1.43 for 3/4/5). Party
-  chat with `/p message`. Blue member blips on the minimap.
+  chat with `/p message`. Blue member blips on the minimap. Settle loot
+  disputes with `/roll` (also `/roll N` or `/roll M-N`) — a server-rolled
+  number broadcast to the party, or to nearby players when ungrouped.
 - **Trading**: right-click a player → *Trade*. Both sides stage items + money,
   both must accept, and the swap is atomic and server-validated (quest items
   are untradeable). Walking apart cancels.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3496,6 +3496,39 @@ export class Sim {
       return null;
     }
 
+    // "/roll", "/roll N", "/roll M-N" — a classic random roll for loot disputes
+    // and social play. Rolled through the deterministic sim RNG so it is
+    // server-authoritative (clients can't fake a result) and identical offline.
+    const rollm = /^\/roll(?:\s+(\d+)(?:\s*-\s*(\d+))?)?\s*$/i.exec(raw);
+    if (rollm) {
+      let lo = 1, hi = 100;
+      if (rollm[1] !== undefined) {
+        const n = parseInt(rollm[1], 10);
+        if (rollm[2] !== undefined) { lo = n; hi = parseInt(rollm[2], 10); }
+        else { hi = n; }
+      }
+      const MAX_ROLL = 1_000_000;
+      if (lo < 1 || hi > MAX_ROLL || lo > hi) {
+        this.error(r.meta.entityId, `Invalid roll range. Use /roll, /roll N, or /roll M-N (1-${MAX_ROLL}).`);
+        return null;
+      }
+      const result = this.rng.int(lo, hi);
+      const text = `${result} (${lo}-${hi})`;
+      const party = this.partyOf(r.meta.entityId);
+      if (party) {
+        for (const mPid of party.members) {
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: mPid });
+        }
+      } else {
+        for (const meta of this.players.values()) {
+          const e = this.entities.get(meta.entityId);
+          if (!e || dist2d(r.e.pos, e.pos) > SAY_RANGE) continue;
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: meta.entityId });
+        }
+      }
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -3549,7 +3582,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /roll.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -520,7 +520,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'roll'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   // a guild invitation from an online guild officer/leader; resolved by name
   // server-side so it carries no pid

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1318,6 +1318,7 @@ export class Hud {
             case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
             case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
+            case 'roll': this.chatLogFrom(ev.from, ev.text, '#ffd100', '', ' rolls '); break;
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
           if ((ev.channel === 'say' || ev.channel === 'yell') && ev.entityId !== undefined) {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -205,6 +205,86 @@ describe('chat channels', () => {
     expect(pids).toContain(b);
     expect(pids).not.toContain(outsider);
   });
+
+  it('/roll broadcasts a deterministic result in the default 1-100 range to nearby players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const near = sim.addPlayer('mage', 'Bet');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, near, 10, -40); // within SAY_RANGE
+    teleport(sim, far, 80, -40);  // beyond SAY_RANGE
+    sim.tick();
+
+    sim.chat('/roll', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs.every((m) => m.channel === 'roll' && m.from === 'Aleph')).toBe(true);
+    // text is "<result> (1-100)" with the result inside the range
+    const m = /^(\d+) \(1-100\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    const result = Number(m[1]);
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(result).toBeLessThanOrEqual(100);
+    const pids = msgs.map((x) => x.pid);
+    expect(pids).toContain(a);    // roller sees their own roll
+    expect(pids).toContain(near);
+    expect(pids).not.toContain(far);
+  });
+
+  it('/roll N rolls within 1-N and /roll M-N within the given bounds', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+
+    sim.chat('/roll 6', a);
+    let msgs = chatEvents(sim.tick());
+    let m = /^(\d+) \(1-6\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(1);
+    expect(Number(m[1])).toBeLessThanOrEqual(6);
+
+    sim.chat('/roll 50-60', a);
+    msgs = chatEvents(sim.tick());
+    m = /^(\d+) \(50-60\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(50);
+    expect(Number(m[1])).toBeLessThanOrEqual(60);
+  });
+
+  it('/roll prefers the party channel when the roller is grouped', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 0, -900);   // out of say range but in the party
+    teleport(sim, outsider, 2, -40);
+    sim.tick();
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    sim.tick();
+
+    sim.chat('/roll', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((x) => x.channel === 'roll')).toBe(true);
+    const pids = msgs.map((x) => x.pid);
+    expect(pids).toContain(a);
+    expect(pids).toContain(b);            // distant party member still sees it
+    expect(pids).not.toContain(outsider); // a nearby non-member does not
+  });
+
+  it('rejects a malformed roll range instead of saying it out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/roll 60-50', a); // min greater than max
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
 });
 
 describe('trade completion event', () => {


### PR DESCRIPTION
## What

Adds the classic WoW **`/roll`** social command — the standard way to settle loot disputes and add some flavor to group play.

- `/roll` → random number in **1–100**
- `/roll N` → random number in **1–N**
- `/roll M-N` → random number in **M–N**

Output renders as a distinct gold system line, e.g. `Aleph rolls 47 (1-100)`.

## Why it's safe & consistent

- **Server-authoritative & cheat-proof:** the result is generated inside `Sim.chat()` using the deterministic sim RNG (`this.rng`), so a client can never fabricate a roll.
- **Identical offline/online:** because it lives in the shared sim core, offline browser play and the authoritative server behave the same for free.
- **Reuses existing plumbing:** broadcasts to the roller's **party** when grouped, otherwise to **nearby players in say range** — mirroring `/p` and `/say` routing. Goes through the existing chat token throttle, so it can't be used to spam.
- Malformed ranges (e.g. `/roll 60-50`, out-of-bounds) are rejected with an error instead of being said out loud.

## Changes

- `src/sim/sim.ts` — parse, validate, roll, and broadcast in `Sim.chat()`; advertise `/roll` in the unknown-command hint
- `src/sim/types.ts` — add `'roll'` chat channel to the event union
- `src/ui/hud.ts` — render the roll line in gold
- `tests/chat.test.ts` — cover default / `N` / `M-N` ranges, party-vs-local routing, and malformed-range rejection
- `README.md` — document the command

## Testing

`npm test` → **533 passing** (4 new), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)