### PR TITLE
feat: add /afk and /dnd away status with whisper auto-replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ see each other in town. `Enter` opens chat.
   its loot/XP/quest credit — others get "You don't have permission to loot
   that."), mobs retarget the next attacker when their victim dies (no free
   resets), join/leave announcements, `/say`-style chat.
+- **Away status**: `/afk [message]` and `/dnd [message]` mark you as away.
+  Anyone who whispers you gets an automatic reply with your message; `/dnd`
+  also withholds the incoming whisper. Repeat the bare command (or just send
+  any other chat) to clear it. Status is session-only and resets on login.
 
 ## The Hollow Crypt — 5-player elite instance
 

--- a/index.html
+++ b/index.html
@@ -3386,7 +3386,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general, /afk, /dnd)" autocomplete="off" />
   </template>
 
   <main id="start-screen">

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -199,6 +199,16 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // Transient presence status. Set by /afk and /dnd, cleared when the player
+  // chats again. Session-only — never persisted, so it resets on login.
+  away: AwayStatus | null;
+}
+
+// Away-from-keyboard / do-not-disturb presence. `afk` still delivers whispers
+// (the sender just gets a heads-up); `dnd` withholds them.
+export interface AwayStatus {
+  mode: 'afk' | 'dnd';
+  message: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +478,7 @@ export class Sim {
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
+      away: null,
     };
     this.players.set(player.id, meta);
     if (this.primaryId === -1) this.primaryId = player.id;
@@ -3491,6 +3502,30 @@ export class Sim {
       return null;
     }
 
+    // "/afk [message]" / "/dnd [message]" — set a presence status. Repeating
+    // the same command with no message toggles it off. While away, anyone who
+    // whispers you gets an auto-reply; /dnd also withholds the whisper itself.
+    const awaym = /^\/(afk|dnd)(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (awaym) {
+      const mode = awaym[1].toLowerCase() as AwayStatus['mode'];
+      const custom = awaym[2]?.trim();
+      if (r.meta.away?.mode === mode && !custom) {
+        r.meta.away = null;
+        this.emit({ type: 'log', text: mode === 'afk' ? 'You are no longer Away From Keyboard.' : 'You have left Do Not Disturb mode.', color: '#ffd100', pid: r.meta.entityId });
+      } else {
+        const message = custom || (mode === 'afk' ? 'Away From Keyboard' : 'Do Not Disturb');
+        r.meta.away = { mode, message };
+        this.emit({ type: 'log', text: mode === 'afk' ? `You are now Away From Keyboard: ${message}` : `You are now in Do Not Disturb mode: ${message}`, color: '#ffd100', pid: r.meta.entityId });
+      }
+      return null;
+    }
+
+    // Any other chat means you're back — clear a lingering away status.
+    if (r.meta.away) {
+      r.meta.away = null;
+      this.emit({ type: 'log', text: 'You are no longer marked as away.', color: '#ffd100', pid: r.meta.entityId });
+    }
+
     if (/^\/who(?:\s|$)/i.test(raw)) {
       this.error(r.meta.entityId, 'The /who roster is available in online play.');
       return null;
@@ -3518,6 +3553,16 @@ export class Sim {
       }
       if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
+      if (target.away) {
+        const label = target.away.mode === 'afk' ? 'Away From Keyboard' : 'Do Not Disturb';
+        this.emit({ type: 'log', text: `${target.name} is ${label}: ${target.away.message}`, color: '#ffd100', pid: r.meta.entityId });
+        if (target.away.mode === 'dnd') {
+          // Withhold the whisper, but still echo the sender's own line so they
+          // see what they tried to send.
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
+          return { channel: 'whisper', message: msg };
+        }
+      }
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
@@ -3549,7 +3594,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /afk /dnd.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -279,3 +279,69 @@ describe('snapshot interpolation continuity', () => {
     expect(e.prevPos.x).toBeLessThan(e.pos.x);
   });
 });
+
+function logEvents(events: SimEvent[]): Extract<SimEvent, { type: 'log' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'log' }> => e.type === 'log');
+}
+
+describe('/afk and /dnd presence', () => {
+  it('/afk confirms to the setter and auto-replies to whisperers (still delivering)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/afk grabbing lunch', a);
+    const confirm = logEvents(sim.tick());
+    expect(confirm.some((m) => m.pid === a && /Away From Keyboard: grabbing lunch/.test(m.text))).toBe(true);
+
+    sim.chat('/w Aleph you around?', b);
+    const out = sim.tick();
+    // Bet gets an auto-reply line about Aleph being away...
+    expect(logEvents(out).some((m) => m.pid === b && /Aleph is Away From Keyboard: grabbing lunch/.test(m.text))).toBe(true);
+    // ...and the whisper is still delivered to Aleph (afk does not withhold)
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === a && m.text === 'you around?')).toBe(true);
+  });
+
+  it('/dnd withholds the whisper but still echoes the sender and notifies them', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/dnd raiding', a);
+    sim.tick();
+
+    sim.chat('/w Aleph ping', b);
+    const out = sim.tick();
+    expect(logEvents(out).some((m) => m.pid === b && /Aleph is Do Not Disturb: raiding/.test(m.text))).toBe(true);
+    // the recipient copy (no `to`) must not reach Aleph
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === a)).toBe(false);
+    // but the sender still sees their own outgoing line (carries `to`)
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === b && m.to === 'Aleph')).toBe(true);
+  });
+
+  it('repeating the bare command toggles the status off', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/afk', a);
+    sim.tick();
+    sim.chat('/afk', a);
+    const out = logEvents(sim.tick());
+    expect(out.some((m) => m.pid === a && /no longer Away From Keyboard/.test(m.text))).toBe(true);
+  });
+
+  it('sending any other chat clears an away status', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/afk', a);
+    sim.tick();
+    sim.chat('back now', a);
+    const out = logEvents(sim.tick());
+    expect(out.some((m) => m.pid === a && /no longer marked as away/.test(m.text))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds the classic WoW presence commands **`/afk [message]`** and **`/dnd [message]`**.

- While you're away, anyone who whispers you gets an automatic reply carrying your message (e.g. *"Aleph is Away From Keyboard: grabbing lunch"*).
- **`/afk`** still delivers the whisper — it's just a heads-up.
- **`/dnd`** withholds the whisper entirely; the sender still sees their own outgoing line plus the auto-reply.
- Repeating the bare command toggles the status off; sending any other chat clears it ("you're back").
- With no message, sensible defaults are used (`Away From Keyboard` / `Do Not Disturb`).

## Why

`/afk` and `/dnd` are staple social-MMO commands and a natural companion to the existing whisper/`/r` reply system. They give players a polite way to signal availability without going offline.

## How

- Status lives on `PlayerMeta` as transient **session-only** state — never persisted, so it resets on login. No `CharacterState`/DB changes.
- All logic sits in `Sim.chat()`, the deterministic core, so it works identically in **offline play** and **online** (both `/w` and `/r` reply route through `Sim.chat`).
- Self-confirmations and sender auto-replies use the existing gold `log` system line.

## Tests

`tests/chat.test.ts` covers:
- `/afk` confirms to the setter, auto-replies to whisperers, and still delivers the whisper.
- `/dnd` withholds the whisper to the target but still echoes the sender and notifies them.
- Repeating the bare command toggles the status off.
- Sending any other chat clears an away status.

Full suite green (533 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)