### PR TITLE
fix: shorten mogger quest respawn

### DIFF
--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -125,7 +125,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
   },
   mogger: {
     id: 'mogger', name: 'Mogger', minLevel: 6, maxLevel: 6, family: 'humanoid', rare: true,
-    elite: true, canSwim: true, ccImmune: true, respawnMult: 24,
+    elite: true, canSwim: true, ccImmune: true, respawnMult: 4,
     hpBase: 300, hpPerLevel: 58, dmgBase: 12, dmgPerLevel: 3.5, attackSpeed: 2.2,
     armorPerLevel: 34, moveSpeed: 7.4, aggroRadius: 14,
     aoePulse: { min: 14, max: 20, radius: 8, every: 10, name: 'Ground Pound', school: 'physical' },

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -195,7 +195,7 @@ describe('rare spawn rules', () => {
       elite: true,
       canSwim: true,
       ccImmune: true,
-      respawnMult: 24,
+      respawnMult: 4,
     });
   });
 
@@ -231,6 +231,15 @@ describe('rare spawn rules', () => {
     const rare = createMob(990003, MOBS.elder_bristleback, 5, { x: 0, y: 0, z: 0 });
     (sim as any).handleDeath(rare, null);
     expect(rare.respawnTimer).toBe(864);
+  });
+
+  it('Mogger respawns on a quest-boss timer instead of a long rare-spawn timer', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', respawnSeconds: 2 });
+    const mogger = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'mogger')!;
+
+    (sim as any).handleDeath(mogger, null);
+
+    expect(mogger.respawnTimer).toBe(8);
   });
 
   it('outdoor rare spawns have 3-player mechanics and no-loot summoned helpers', () => {


### PR DESCRIPTION
## Summary
- Shortens Mogger's custom rare respawn multiplier from 24x to 4x, changing the default respawn from about ten minutes to about 100 seconds.
- Keeps Mogger's rare elite mechanics, summoned adds, enrage, and loot identity unchanged.
- Adds focused coverage for both the authored multiplier and the death-time respawn timer.

## Diagnosis
Mogger is an early group quest objective, but his special rare multiplier made players wait far longer than a normal quest boss after another group killed him. The generic respawn system was working; the content override made the dead camp look permanent during ordinary questing.

## Verification
- `npx vitest run tests/fixes.test.ts -t "rare spawn rules"`; 5 tests passed.
- `npx vitest run tests/fixes.test.ts`; 34 tests passed.
- `npx tsc --noEmit`; passed.
- Browser smoke at local Vite `http://localhost:5173/`: started offline warrior gameplay, inspected the browser-loaded sim, killed the Mogger entity, and verified `respawnTimer: 100`.
- Full closeout gate: `npm test` passed with 46 files and 530 tests, followed by `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.

## Real behavior proof
- Behavior addressed: an early quest boss could appear permanently dead after another kill.
- Environment tested: local deterministic sim tests and local offline browser gameplay.
- Evidence after fix: Mogger's death timer is 100 seconds on the default 25-second base respawn, while longer rare-spawn timers for the other outdoor rares stay covered separately.
- Not tested: live multiplayer server with multiple questing groups waiting at Mogger's camp.

## Risk
Low content-tuning risk. The change is scoped to Mogger's respawn multiplier; combat mechanics, quest credit, loot rolls, server authority, and generic respawn behavior are unchanged. The main gameplay effect is higher availability for a required group quest boss and slightly more frequent access to his existing loot table.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
