### PR TITLE
feat: add /help chat command listing available commands

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3496,6 +3496,14 @@ export class Sim {
       return null;
     }
 
+    // "/help" (or "/?" / "/commands") lists the available chat commands as a
+    // system notice to the asker only. Like /who, it produces no chat message,
+    // so it works identically offline and online without server wiring.
+    if (/^\/(?:help|commands|\?)(?:\s|$)/i.test(raw)) {
+      for (const line of this.helpLines()) this.error(r.meta.entityId, line);
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -3549,7 +3557,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Type /help for a list.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -4796,6 +4804,16 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Lines shown by the "/help" command, one system notice per entry. Keep this
+  // in sync with the commands handled in chat() above.
+  private helpLines(): string[] {
+    return [
+      'Chat channels: /s say, /y yell, /g general, /p party.',
+      'Whisper a player with /w <name> <message>.',
+      '/who lists who is online (online play only).',
+    ];
   }
 }
 

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -139,6 +139,42 @@ describe('chat channels', () => {
     }));
   });
 
+  it('/help lists the chat commands as system notices without sending chat', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/help', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    const help = events.filter((e) => e.type === 'error' && e.pid === a) as Extract<SimEvent, { type: 'error' }>[];
+    expect(help.length).toBeGreaterThan(0);
+    const text = help.map((e) => e.text).join('\n');
+    expect(text).toContain('/w <name> <message>');
+    expect(text).toContain('/who');
+  });
+
+  it('/? and /commands are aliases for /help', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const cmd of ['/?', '/commands']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(chatEvents(events)).toHaveLength(0);
+      expect(events.some((e) => e.type === 'error' && e.pid === a)).toBe(true);
+    }
+  });
+
+  it('an unknown slash command points the player at /help', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/bogus stuff', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.pid === a && e.text.includes('/help'))).toBe(true);
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
## What

Adds a `/help` chat command (with aliases `/?` and `/commands`) that lists the available chat commands.

## Why

There was no proactive way to discover chat commands — they were only surfaced reactively in the `Unknown command: ... Try /s /y /w /p /g.` error when a player mistyped one. New players had no way to ask "what can I type?". `/help` closes that gap.

## How

- Handled in `Sim.chat()`, right next to `/who`. It emits a short **single-summary** set of system notices (`{ type: 'error', ... }`) to the asker only and produces **no chat message**, so it behaves identically offline and online with zero server wiring — same pattern as the existing offline `/who` notice.
- The unknown-command hint now points at `/help` instead of repeating a hard-coded command list, so the two can't drift.
- Help text covers the channels (`/s /y /g /p`), whisper syntax (`/w <name> <message>`), and `/who`.

## Tests

Added cases to `tests/chat.test.ts`:
- `/help` emits the command notices and sends no chat event
- `/?` and `/commands` work as aliases
- an unknown slash command now points the player at `/help`

Full suite green: `532 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)