### PR TITLE
feat: add /follow command to auto-trail another player

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -198,7 +198,7 @@ function blankEntity(id: number): Entity {
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
-    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
+    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -16,7 +16,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
-    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
+    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -83,6 +83,8 @@ const BODY_RADIUS = 0.5;
 const CHARGE_SPEED_MULT = 3; // warrior charge runs at 3x normal speed
 const CHARGE_MAX_DURATION = 3; // seconds before a blocked charge gives up
 const CHARGE_ARRIVE_RANGE = MELEE_RANGE - 1; // stop inside melee range
+const FOLLOW_STOP_DIST = 3; // /follow trails this close behind the leader (yards)
+const FOLLOW_MAX_RANGE = 60; // give up follow once the leader is this far away
 const PET_LEASH = 40; // yards from the owner before a pet gives up its target
 const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
@@ -926,8 +928,58 @@ export class Sim {
     return true;
   }
 
+  // /follow: a second forced-movement mode (like charge) that trails another
+  // player. Returns true when it has taken over locomotion for this tick so the
+  // normal input-driven movement below is skipped. Any manual movement, combat,
+  // or the leader slipping out of range ends the follow.
+  stopFollow(p: Entity, msg?: string): void {
+    if (p.followTargetId === null) return;
+    p.followTargetId = null;
+    if (msg) this.error(p.id, msg);
+  }
+
+  private updateFollowMovement(p: Entity, meta: PlayerMeta): boolean {
+    if (p.followTargetId === null) return false;
+    const inp = meta.moveInput;
+    // any manual locomotion (incl. camera turns) breaks follow, classic-style
+    if (inp.forward || inp.back || inp.strafeLeft || inp.strafeRight || inp.jump
+      || inp.turnLeft || inp.turnRight) {
+      this.stopFollow(p, 'You stop following.');
+      return false;
+    }
+    const t = this.entities.get(p.followTargetId);
+    if (!t || t.dead || t.kind !== 'player' || !this.players.has(t.id)) {
+      this.stopFollow(p, 'There is no one to follow.');
+      return false;
+    }
+    if (p.inCombat) { this.stopFollow(p, 'You stop following — you are in combat.'); return false; }
+    const d = dist2d(p.pos, t.pos);
+    if (d > FOLLOW_MAX_RANGE) { this.stopFollow(p, `${t.name} is too far away to follow.`); return false; }
+    // always turn to face the leader, even while held in place
+    p.facing = angleTo(p.pos, t.pos);
+    if (this.isStunned(p) || this.isRooted(p) || d <= FOLLOW_STOP_DIST) return true;
+    let speed = RUN_SPEED * this.moveSpeedMult(p);
+    if (this.isSwimming(p)) speed *= SWIM_SPEED_MULT;
+    const step = Math.min(speed * DT, d - FOLLOW_STOP_DIST);
+    const nx = p.pos.x + Math.sin(p.facing) * step;
+    const nz = p.pos.z + Math.cos(p.facing) * step;
+    const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
+    const h1 = groundHeight(nx, nz, this.cfg.seed);
+    if (h1 < WATER_LEVEL - SWIM_DEPTH) return true; // don't trail into deep water
+    if (h1 > h0 && step > 1e-5 && (h1 - h0) / step > MAX_CLIMB_SLOPE) return true; // wall/cliff
+    const resolved = resolvePosition(this.cfg.seed, nx, nz, BODY_RADIUS);
+    p.pos.x = resolved.x;
+    p.pos.z = resolved.z;
+    p.pos.y = groundHeight(resolved.x, resolved.z, this.cfg.seed);
+    p.vy = 0;
+    p.onGround = true;
+    p.fallStartY = p.pos.y;
+    return true;
+  }
+
   private updatePlayerMovement(p: Entity, meta: PlayerMeta): void {
     if (this.updateChargeMovement(p)) return;
+    if (this.updateFollowMovement(p, meta)) return;
     const inp = meta.moveInput;
     // Convention: facing f points along (sin f, cos f); the camera sits behind
     // the player, so screen-right is the world vector (-cos f, sin f).
@@ -1222,6 +1274,8 @@ export class Sim {
       this.error(p.id, p.resourceType === 'rage' ? 'Not enough rage!' : p.resourceType === 'energy' ? 'Not enough energy!' : 'Not enough mana!');
       return;
     }
+    // casting is deliberate action — drop any active follow so you don't drift
+    this.stopFollow(p);
     if (ability.requiresDodgeProc && this.time > p.overpowerUntil) {
       this.error(p.id, 'Your target must dodge first.');
       return;
@@ -2273,6 +2327,7 @@ export class Sim {
       e.sitting = false;
       e.chargeTargetId = null;
       e.chargePath = [];
+      e.followTargetId = null;
       this.emit({ type: 'playerDeath', pid: e.id });
       for (const m of this.entities.values()) {
         if (m.kind === 'mob' && !m.dead && m.aggroTargetId === e.id && m.aiState !== 'dead') {
@@ -2916,6 +2971,8 @@ export class Sim {
     const r = this.resolve(pid);
     if (!r) return;
     const p = r.e;
+    // switching to a different target ends a follow (re-targeting is manual intent)
+    if (p.followTargetId !== null && id !== p.followTargetId) this.stopFollow(p, 'You stop following.');
     if (id === null) { p.targetId = null; p.autoAttack = false; return; }
     const e = this.entities.get(id);
     if (!e || (e.dead && !e.lootable)) return;
@@ -3496,6 +3553,44 @@ export class Sim {
       return null;
     }
 
+    // "/unfollow" stops an active follow
+    if (/^\/unfollow(?:\s|$)/i.test(raw)) {
+      if (r.e.followTargetId === null) this.error(r.meta.entityId, 'You are not following anyone.');
+      else this.stopFollow(r.e, 'You stop following.');
+      return null;
+    }
+
+    // "/follow [name]" trails another player; with no name it follows the
+    // current target. Movement, combat, casting, re-targeting, or the leader
+    // moving out of range all end it (see updateFollowMovement).
+    const fm = /^\/follow(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (fm) {
+      if (r.e.inCombat) { this.error(r.meta.entityId, "You can't start following while in combat."); return null; }
+      let target: PlayerMeta | null = null;
+      const nameArg = (fm[1] ?? '').trim();
+      if (nameArg) {
+        const wanted = nameArg.toLowerCase();
+        const ci: PlayerMeta[] = [];
+        for (const meta of this.players.values()) {
+          if (meta.name === nameArg) { target = meta; break; }
+          if (meta.name.toLowerCase() === wanted) ci.push(meta);
+        }
+        if (!target) {
+          if (ci.length === 1) target = ci[0];
+          else if (ci.length > 1) { this.error(r.meta.entityId, `Several players match '${nameArg}'. Use exact capitalization.`); return null; }
+        }
+        if (!target) { this.error(r.meta.entityId, `There is no player named '${nameArg}' online.`); return null; }
+      } else {
+        const cur = r.e.targetId !== null ? this.players.get(r.e.targetId) : undefined;
+        if (!cur) { this.error(r.meta.entityId, 'Target a player to follow, or use /follow <name>.'); return null; }
+        target = cur;
+      }
+      if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, "You can't follow yourself."); return null; }
+      r.e.followTargetId = target.entityId;
+      this.error(r.meta.entityId, `Now following ${target.name}.`);
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -3549,7 +3644,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /follow.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -4080,6 +4175,7 @@ export class Sim {
     e.swingTimer = 0;
     e.chargeTargetId = null;
     e.chargePath = [];
+    e.followTargetId = null;
     e.combatTimer = 99;
     e.inCombat = false;
     e.sitting = false;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -450,6 +450,7 @@ export interface Entity {
   chargeTargetId: number | null;
   chargeTimeLeft: number; // seconds; failsafe so a blocked charge can't run forever
   chargePath: Vec3[]; // waypoints consumed front-to-back; last leg homes on the live target
+  followTargetId: number | null; // /follow: auto-walk after another player until interrupted
   savedMana: number; // druid forms: mana put aside while running on rage/energy
   sitting: boolean;
   eating: Consuming | null;

--- a/tests/follow.test.ts
+++ b/tests/follow.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function dist(sim: Sim, a: number, b: number) {
+  const ea = sim.entities.get(a)!;
+  const eb = sim.entities.get(b)!;
+  return Math.hypot(ea.pos.x - eb.pos.x, ea.pos.z - eb.pos.z);
+}
+
+function errors(events: SimEvent[]): string[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error').map((e) => e.text);
+}
+
+describe('/follow', () => {
+  it('walks the follower toward the leader and stops at the trail distance', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 20, -40);
+    sim.tick();
+
+    sim.chat('/follow Bet', a);
+    const msgs = errors(sim.tick());
+    expect(msgs.some((t) => /Now following Bet/.test(t))).toBe(true);
+
+    // run the sim forward; the follower should close the gap and settle near it
+    for (let i = 0; i < 600; i++) sim.tick();
+    const d = dist(sim, a, b);
+    expect(d).toBeLessThanOrEqual(4); // ~FOLLOW_STOP_DIST (3) plus a tick of slop
+    expect(sim.entities.get(a)!.followTargetId).toBe(b);
+  });
+
+  it('keeps trailing when the leader moves away', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 6, -40);
+    sim.tick();
+    sim.chat('/follow Bet', a);
+    for (let i = 0; i < 60; i++) sim.tick();
+
+    // leader strides off; follower should chase and stay close
+    teleport(sim, b, 30, -40);
+    for (let i = 0; i < 600; i++) sim.tick();
+    expect(dist(sim, a, b)).toBeLessThanOrEqual(4);
+  });
+
+  it('breaks follow when the follower issues manual movement', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 10, -40);
+    sim.tick();
+    sim.chat('/follow Bet', a);
+    sim.tick();
+    expect(sim.entities.get(a)!.followTargetId).toBe(b);
+
+    sim.players.get(a)!.moveInput.forward = true;
+    const msgs = errors(sim.tick());
+    expect(sim.entities.get(a)!.followTargetId).toBe(null);
+    expect(msgs.some((t) => /stop following/i.test(t))).toBe(true);
+  });
+
+  it('ends follow when the leader goes out of range', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 5, -40);
+    sim.tick();
+    sim.chat('/follow Bet', a);
+    sim.tick();
+
+    teleport(sim, b, 200, -40); // beyond FOLLOW_MAX_RANGE
+    const msgs = errors(sim.tick());
+    expect(sim.entities.get(a)!.followTargetId).toBe(null);
+    expect(msgs.some((t) => /too far away to follow/i.test(t))).toBe(true);
+  });
+
+  it('rejects following yourself and unknown players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(errors((sim.chat('/follow Aleph', a), sim.tick())).some((t) => /follow yourself/i.test(t))).toBe(true);
+    expect(errors((sim.chat('/follow Nobody', a), sim.tick())).some((t) => /no player named/i.test(t))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a classic MMO **/follow** command so players can auto-walk after another player instead of manually steering the whole way.

- `/follow <name>` — follow the named online player
- `/follow` — follow your current target (if it's a player)
- `/unfollow` — stop following

The follower trails ~3 yards behind the leader and faces them as they move.

## How

Implemented as a second forced-movement mode alongside the existing warrior **charge**: `updatePlayerMovement` calls a new `updateFollowMovement` right after `updateChargeMovement`, and when it takes over it short-circuits the normal input-driven locomotion for that tick. It homes on the live leader using the same `facing = angleTo(...)` + `sin/cos` stepping and the same cliff / deep-water / building-collision guards charge already uses, so it can't be used to climb walls or wade into water you couldn't walk through.

Because both offline and online play run the same deterministic `Sim`, this works in real multiplayer for free — the command flows through `Sim.chat()` exactly like `/w` and `/p`, and the movement runs in the server-side sim tick.

### Follow ends when
- the follower issues any manual movement (incl. camera turns) — classic behavior
- the follower enters combat
- the follower casts a spell or switches target
- the leader dies, logs off, or moves beyond `FOLLOW_MAX_RANGE` (60y)

Follow state is also cleared on death and teleport, mirroring how charge state is reset.

## Tests

New `tests/follow.test.ts` covers: closing the gap and settling at the trail distance, re-chasing when the leader moves off, breaking on manual movement, ending when the leader goes out of range, and rejecting follow-self / unknown-name. Full suite green (534 tests) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)