### PR TITLE
feat: add /r reply-to-last-whisper command in the sim core

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -199,6 +199,9 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // Session-only: name of the last player who whispered us, for "/r" replies.
+  // Never persisted — a fresh login starts with no reply target.
+  lastWhisperFrom?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -3496,8 +3499,19 @@ export class Sim {
       return null;
     }
 
+    // "/r message" — reply to the last player who whispered us. Rewrite it to
+    // the "/w <name> message" form so delivery, the echo, and case-matching
+    // all stay in the single whisper handler below.
+    const rm = /^\/r(?:eply)?\s+([\s\S]+)$/i.exec(raw);
+    let line = raw;
+    if (rm) {
+      const replyTo = r.meta.lastWhisperFrom;
+      if (!replyTo) { this.error(r.meta.entityId, 'You have no one to reply to.'); return null; }
+      line = `/w ${replyTo} ${rm[1]}`;
+    }
+
     // "/w name message" — private whisper to an online player
-    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
+    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
       const targetName = wm[1];
       const msg = wm[2].trim();
@@ -3518,10 +3532,14 @@ export class Sim {
       }
       if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
+      // classic-WoW "/r": the recipient's reply target is whoever last
+      // whispered them, so record it on the target (not the sender).
+      target.lastWhisperFrom = r.meta.name;
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
     }
+
 
     // "/p message" goes to the party channel
     if (/^\/p(arty)?\s/i.test(raw)) {
@@ -3549,7 +3567,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /r /p /g.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -80,6 +80,71 @@ describe('chat channels', () => {
     expect(msgs.some((m) => m.pid === c)).toBe(false);
   });
 
+  it('/r replies to the last player who whispered you', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, b, 0, -900); // reply ignores distance, like whisper
+    sim.tick();
+
+    sim.chat('/w bet psst, secret', a);
+    sim.tick();
+    // Bet replies without naming Aleph
+    sim.chat('/r got it', b);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs).toHaveLength(2);
+    const toTarget = msgs.find((m) => m.pid === a)!;
+    expect(toTarget.channel).toBe('whisper');
+    expect(toTarget.from).toBe('Bet');
+    expect(toTarget.text).toBe('got it');
+    const echo = msgs.find((m) => m.pid === b)!;
+    expect(echo.to).toBe('Aleph');
+  });
+
+  it('/r with no prior whisper errors instead of saying it out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/r hello?', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
+
+  it('/r reply target follows the most recent incoming whisper', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/w aleph first', b); // Bet -> Aleph
+    sim.tick();
+    sim.chat('/w aleph second', c); // Gimel -> Aleph (now the reply target)
+    sim.tick();
+    sim.chat('/r back to you', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.channel === 'whisper' && m.to === undefined)!;
+    expect(toTarget.pid).toBe(c);
+  });
+
+  it('sending a whisper does not change your own /r target', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/w aleph incoming', b); // Bet whispers Aleph -> Aleph's reply target is Bet
+    sim.tick();
+    sim.chat('/w gimel outgoing', a); // Aleph whispers Gimel; reply target stays Bet
+    sim.tick();
+    sim.chat('/r still bet', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.channel === 'whisper' && m.to === undefined)!;
+    expect(toTarget.pid).toBe(b);
+  });
+
   it('whisper to an unknown player errors instead of leaking text', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
## What

Adds the classic WoW **`/r`** (alias `/reply`) command to the deterministic `Sim.chat()` core: reply to the last player who whispered you, without retyping their name.

## Why

The **online server already implements `/r`** (`server/game.ts`, via `session.lastWhisperFrom`), but the deterministic `Sim.chat()` core — which powers **offline play** and all the chat unit tests — did not. This brings `/r` down into the sim for offline parity and test coverage, mirroring how `/who` is handled in the core.

This is purely additive online: the server rewrites `/r` → `/w` *before* calling `sim.chat()`, so the sim never sees `/r` in online play and behavior there is unchanged. The sim now owns canonical `/r` logic for offline use.

## Behavior

- `/r message` / `/reply message` → whispers the last player who **whispered you** (classic-WoW "incoming only" semantics).
- Sending a whisper does **not** change your own reply target — only receiving one does.
- `/r` with no prior incoming whisper errors politely instead of being said out loud.
- Reply target is **session-only** state on `PlayerMeta` (`lastWhisperFrom`), never persisted — a fresh login starts blank.

## Implementation

`/r` is rewritten to the existing `/w <name> message` form *before* the whisper handler runs, so delivery, the sender echo, and case-insensitive name matching all stay in a single code path. No new event type or chat channel.

## Tests

4 new cases in `tests/chat.test.ts`: basic reply + echo, no-target error, reply target follows the most recent incoming whisper, and sending a whisper not changing your own target. Full suite green (533 tests) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)