### PR TITLE
fix: replace dialogue player placeholders

### DIFF
--- a/src/ui/dialogue_text.ts
+++ b/src/ui/dialogue_text.ts
@@ -1,0 +1,8 @@
+import { CLASSES } from '../sim/data';
+import type { PlayerClass } from '../sim/types';
+
+export function formatDialogueText(text: string, playerName: string, playerClass: PlayerClass): string {
+  return text
+    .replace(/\$N/g, playerName)
+    .replace(/\$C/g, CLASSES[playerClass].name.toLowerCase());
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -24,6 +24,7 @@ import {
   clearHotbarSlot, encodeHotbarAction, HOTBAR_ACTION_MIME, HotbarAction, parseHotbarAction, parseHotbarActions,
   placeAbilityOnSlot, placeItemOnSlot, swapHotbarSlots, syncHotbarActions,
 } from './hotbar';
+import { formatDialogueText } from './dialogue_text';
 
 // hooks main wires after Input exists (the options menu drives input, audio,
 // graphics, and logout, all of which live outside the HUD)
@@ -1530,7 +1531,7 @@ export class Hud {
         || (st === 'ready' && QUESTS[q].turnInNpcId === npc.templateId);
     });
     let html = `<div class="panel-title"><span>${npc.name}<span style="color:#998d6a;font-size:11px"> &lt;${def?.title ?? ''}&gt;</span></span><span class="x-btn" data-close>✕</span></div>`;
-    html += `<div class="qd-text">"${(def?.greeting ?? 'Greetings.').replace('$C', CLASSES[this.sim.cfg.playerClass].name.toLowerCase())}"</div>`;
+    html += `<div class="qd-text">"${formatDialogueText(def?.greeting ?? 'Greetings.', this.sim.player.name, this.sim.cfg.playerClass)}"</div>`;
     if (interesting.length > 0) {
       for (const qid of interesting) {
         const st = this.sim.questState(qid);
@@ -1564,7 +1565,7 @@ export class Hud {
     const el = $('#quest-dialog');
     const quest = QUESTS[questId];
     const state = this.sim.questState(questId);
-    const text = (state === 'ready' ? quest.completionText : quest.text).replace(/\$N/g, this.sim.player.name);
+    const text = formatDialogueText(state === 'ready' ? quest.completionText : quest.text, this.sim.player.name, this.sim.cfg.playerClass);
     let html = `<div class="panel-title"><span>${quest.name}${quest.suggestedPlayers ? ` <span style="color:#f96;font-size:11px">(Suggested players: ${quest.suggestedPlayers})</span>` : ''}</span><span class="x-btn" data-close>✕</span></div>`;
     html += `<div class="qd-text">${text}</div>`;
     if (state !== 'ready') {
@@ -2220,7 +2221,7 @@ export class Hud {
       const quest = QUESTS[this.selectedQuestLogId];
       let html = `<div class="qd-sub" style="font-size:15px">${quest.name}${quest.suggestedPlayers ? ` <span style="color:#f96;font-size:11px">(Suggested players: ${quest.suggestedPlayers})</span>` : ''}</div>`;
       html += quest.objectives.map((o, i) => `<div class="qd-obj" style="color:${qp.counts[i] >= o.count ? '#7fdc4f' : '#cfc6a8'}">&bull; ${o.label}: ${qp.counts[i]}/${o.count}</div>`).join('');
-      html += `<div class="qd-text" style="margin-top:8px">${quest.text.replace(/\$N/g, sim.player.name)}</div>`;
+      html += `<div class="qd-text" style="margin-top:8px">${formatDialogueText(quest.text, sim.player.name, sim.cfg.playerClass)}</div>`;
       html += `<div class="qd-sub">Rewards</div><div class="qd-obj">${quest.xpReward} experience &nbsp; ${this.moneyHtml(quest.copperReward)}</div>`;
       const giver = NPCS[quest.turnInNpcId];
       html += `<div class="qd-obj" style="margin-top:6px;color:#998d6a">Return to ${giver?.name ?? '?'}</div>`;

--- a/tests/dialogue_text.test.ts
+++ b/tests/dialogue_text.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { NPCS } from '../src/sim/data';
+import { formatDialogueText } from '../src/ui/dialogue_text';
+
+describe('dialogue text placeholders', () => {
+  it('replaces player names in NPC greetings', () => {
+    const text = formatDialogueText(NPCS.brother_aldric_fen.greeting, 'Mira', 'priest');
+
+    expect(text).toContain('above the water, Mira.');
+    expect(text).toContain('they wade.');
+    expect(text).not.toContain('$N');
+  });
+
+  it('replaces every player and class placeholder', () => {
+    const text = formatDialogueText('$N, stay sharp, $C. $N!', 'Rowan', 'hunter');
+
+    expect(text).toBe('Rowan, stay sharp, hunter. Rowan!');
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes NPC gossip greetings that could show the literal `$N` placeholder instead of the player's name.
- Routes NPC greetings, quest-detail text, and quest-log text through one small dialogue formatter for `$N` and `$C` placeholders.
- Adds focused coverage for the affected Brother Aldric fen greeting and repeated placeholder replacement.

## Diagnosis
Quest detail and quest-log text already replaced `$N`, but the top-level gossip greeting only replaced `$C`. Any NPC greeting authored with `$N` therefore rendered the raw token in the dialogue panel.

## Verification
- `npx vitest run tests/dialogue_text.test.ts`; 1 file passed, 2 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed.
- Full closeout gate passed: `npm test` (47 files, 531 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Browser smoke on local Vite `http://127.0.0.1:5173/`: started offline priest gameplay, opened the affected fen NPC gossip panel, and verified the rendered greeting contained the player name and no literal `$N` placeholder.

## Real behavior proof
- Behavior addressed: a quest NPC greeting could display `$N` instead of the player name.
- Environment tested: local offline browser session with the affected NPC greeting.
- Evidence after fix: the rendered dialogue text showed the selected character name in the greeting and kept the dialogue panel visible.
- Not tested: live multiplayer character session; the change is client-side text rendering shared by offline and online HUD dialogue.

## Risk
Low UI-only risk. The patch changes dialogue text interpolation in the HUD and does not alter quest state, simulation rules, persistence, or server authority.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
