### PR TITLE
feat: add /played command for session time played

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -195,6 +195,9 @@ export interface PlayerMeta {
   questsDone: Set<string>;
   counters: RewardCounters;
   autoEquip: boolean;
+  // sim.time when this character entered the world; powers /played. Session-only
+  // (sim.time resets to 0 each server boot), so it reports time this session.
+  joinedAt: number;
   // Ashen Coliseum standing — persisted in CharacterState
   arenaRating: number;
   arenaWins: number;
@@ -465,6 +468,7 @@ export class Sim {
       questsDone: new Set(),
       counters: freshCounters(),
       autoEquip: opts?.autoEquip ?? false,
+      joinedAt: this.time,
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
@@ -3493,6 +3497,21 @@ export class Sim {
 
     if (/^\/who(?:\s|$)/i.test(raw)) {
       this.error(r.meta.entityId, 'The /who roster is available in online play.');
+      return null;
+    }
+
+    // "/played" — report how long this character has been in the world this
+    // session. Self-only informational line, like /who's reply.
+    if (/^\/played(?:\s|$)/i.test(raw)) {
+      const secs = Math.max(0, Math.floor(this.time - r.meta.joinedAt));
+      const h = Math.floor(secs / 3600);
+      const m = Math.floor((secs % 3600) / 60);
+      const s = secs % 60;
+      const parts: string[] = [];
+      if (h) parts.push(`${h}h`);
+      if (h || m) parts.push(`${m}m`);
+      parts.push(`${s}s`);
+      this.error(r.meta.entityId, `Time played this session: ${parts.join(' ')}.`);
       return null;
     }
 

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -139,6 +139,38 @@ describe('chat channels', () => {
     }));
   });
 
+  it('/played reports zero on a freshly joined character', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/played', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      pid: a,
+      text: 'Time played this session: 0s.',
+    }));
+  });
+
+  it('/played accumulates session time as the sim advances', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    // 20 ticks per sim-second; advance just over a minute of world time
+    for (let i = 0; i < 20 * 65; i++) sim.tick();
+    sim.chat('/played', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    const played = events.find(
+      (e): e is Extract<SimEvent, { type: 'error' }> =>
+        e.type === 'error' && e.text.startsWith('Time played'),
+    );
+    // once past a minute the line switches to "Xm Ys" form
+    expect(played?.text).toMatch(/^Time played this session: 1m \d+s\.$/);
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
## What

Adds the classic `/played` chat command. It reports how long the character has been in the world **this session**, formatted with the smallest sensible units:

- `Time played this session: 0s.`
- `Time played this session: 1m 4s.`
- `Time played this session: 2h 13m 7s.`

## Why

`/played` is a staple MMO command and a natural companion to the existing chat verbs (`/s /y /w /p /g`) and `/who`. It's a small, self-contained QoL addition with no gameplay-balance impact.

## How

- New `joinedAt` field on `PlayerMeta`, set to `sim.time` in `addPlayer`. Because `sim.time` resets to 0 each server boot, this measures the current session rather than lifetime — no persistence needed.
- Handled entirely in `Sim.chat()`, so it works offline and online (online routes through `routeRememberedChat` → `sim.chat`). No new event type, channel, or client rendering: the reply reuses the existing self-only `error` event, exactly like `/who`'s reply.

## Tests

Two new cases in `tests/chat.test.ts`:
- a freshly joined character reports `0s`
- session time accumulates as the sim advances (reports `1m …` after a minute)

Full suite: 531 passing, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)