### PR TITLE
fix: reset stalled evading mobs

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -202,7 +202,7 @@ function blankEntity(id: number): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, wanderTarget: null, wanderTimer: 0, evadeTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { ...pos }, leashAnchor: null, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, wanderTarget: null, wanderTimer: 0, evadeTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -28,6 +28,7 @@ const LEASH_DISTANCE = 45;
 const DUNGEON_LEASH_DISTANCE = 70;
 const CORPSE_DURATION = 60;
 const EVADE_SPEED_MULT = 1.6;
+const EVADE_RESET_TIMEOUT = 12;
 const BACKPEDAL_MULT = 0.65;
 const GRAVITY = 16;
 const JUMP_VELOCITY = 6;
@@ -1961,7 +1962,8 @@ export class Sim {
     pet.hostile = true;
     pet.aggroTargetId = null;
     pet.inCombat = false;
-    pet.aiState = pet.dead ? 'dead' : 'evade';
+    if (pet.dead) pet.aiState = 'dead';
+    else this.startEvade(pet);
     clearThreat(pet);
     for (const m of this.entities.values()) {
       if (m.kind !== 'mob' || m.id === pet.id) continue;
@@ -2467,8 +2469,30 @@ export class Sim {
       mob.inCombat = true;
       return;
     }
+    this.startEvade(mob);
+  }
+
+  private startEvade(mob: Entity): void {
     mob.aggroTargetId = null;
     mob.aiState = 'evade';
+    mob.evadeTimer = 0;
+  }
+
+  private finishEvade(mob: Entity): void {
+    mob.pos = { ...mob.spawnPos };
+    mob.prevPos = { ...mob.spawnPos };
+    mob.aiState = 'idle';
+    mob.hp = mob.maxHp;
+    mob.auras = [];
+    mob.inCombat = false;
+    mob.tappedById = null;
+    mob.leashAnchor = null;
+    clearThreat(mob);
+    this.despawnSummonedAdds(mob);
+    mob.firedSummons = 0;
+    mob.enraged = false;
+    mob.evadeTimer = 0;
+    mob.wanderTimer = this.rng.range(2, 8);
   }
 
   /** Highest-threat living attacker on the table; prunes stale entries. */
@@ -2575,6 +2599,7 @@ export class Sim {
     if (!mob.hostile) mob.hostile = true;
 
     if (mob.inCombat) this.updateBossMechanics(mob);
+    if (mob.aiState === 'evade') mob.evadeTimer += DT;
 
     if (this.isStunned(mob)) {
       if (mob.auras.some((a) => a.kind === 'polymorph')) {
@@ -2635,8 +2660,7 @@ export class Sim {
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
         const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
         if (dist2d(mob.pos, leashAnchor) > leash) {
-          mob.aiState = 'evade';
-          mob.aggroTargetId = null;
+          this.startEvade(mob);
           clearThreat(mob);
           mob.leashAnchor = null;
           break;
@@ -2684,19 +2708,7 @@ export class Sim {
       }
       case 'evade': {
         const arrived = this.moveToward(mob, mob.spawnPos, mob.moveSpeed * EVADE_SPEED_MULT);
-        if (arrived) {
-          mob.aiState = 'idle';
-          mob.hp = mob.maxHp;
-          mob.auras = [];
-          mob.inCombat = false;
-          mob.tappedById = null;
-          mob.leashAnchor = null;
-          clearThreat(mob);
-          this.despawnSummonedAdds(mob);
-          mob.firedSummons = 0;
-          mob.enraged = false;
-          mob.wanderTimer = this.rng.range(2, 8);
-        }
+        if (arrived || mob.evadeTimer >= EVADE_RESET_TIMEOUT) this.finishEvade(mob);
         break;
       }
     }
@@ -2832,6 +2844,7 @@ export class Sim {
     mob.aggroTargetId = null;
     mob.inCombat = false;
     mob.leashAnchor = null;
+    mob.evadeTimer = 0;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -473,6 +473,7 @@ export interface Entity {
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   wanderTarget: Vec3 | null;
   wanderTimer: number;
+  evadeTimer: number;
   aggroTargetId: number | null;
   /** GM character: invulnerable (dealDamage no-ops). Server-set from the
    *  characters.is_gm column; never user-settable. */

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -509,6 +509,33 @@ describe('boss loot and encounter resets', () => {
     expect(thralls()).toBe(0);
   });
 
+  it('resets evading Gravecaller Summoners that stall against camp props', () => {
+    const sim = makeSim();
+    const summoner = [...sim.entities.values()]
+      .find((e) => e.kind === 'mob' && e.templateId === 'gravecaller_summoner')!;
+
+    summoner.pos = sim.groundPos(summoner.spawnPos.x, summoner.spawnPos.z - 9);
+    summoner.prevPos = { ...summoner.pos };
+    summoner.aiState = 'evade';
+    summoner.aggroTargetId = null;
+    summoner.inCombat = true;
+    summoner.evadeTimer = 0;
+
+    for (let i = 0; i < 20 * 14; i++) sim.tick();
+
+    expect(summoner.aiState).toBe('idle');
+    expect(dist2d(summoner.pos, summoner.spawnPos)).toBeLessThan(0.1);
+
+    const hp = summoner.hp;
+    teleportTo(sim, summoner.pos.x - 1.5, summoner.pos.z);
+    sim.player.facing = Math.atan2(summoner.pos.x - sim.player.pos.x, summoner.pos.z - sim.player.pos.z);
+    sim.targetEntity(summoner.id);
+    sim.startAutoAttack();
+    for (let i = 0; i < 20 * 4 && summoner.hp === hp; i++) sim.tick();
+
+    expect(summoner.hp).toBeLessThan(hp);
+  });
+
   it('leaveDungeon outdoors is a no-op (no crypt-door fallback teleport)', () => {
     const sim = makeSim();
     const p = sim.player;

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -64,6 +64,7 @@ function stubEntity(partial: Partial<Entity> & Pick<Entity, 'id' | 'kind'>): Ent
     firedSummons: 0,
     summonedIds: [],
     enraged: false,
+    evadeTimer: 0,
     dead: false,
     lootable: false,
     respawnAt: 0,


### PR DESCRIPTION
## Summary
- Resets mobs that remain in evade too long back to their spawn point, so a stalled return path cannot leave them alive, hostile-looking, and damage-immune.
- Tracks the reset window with explicit evade state instead of reusing combat timing.
- Adds regression coverage for the Gravecaller Summoner camp case and keeps the client mirror/test entity stubs aligned with the new field.

## Diagnosis
Evading mobs ignore damage while they return home, which is the intended reset contract. A Gravecaller Summoner could evade from the south side of its camp and get caught on the central tent/campfire collision before reaching its spawn. Because it never completed the evade transition, it stayed in the damage-immune reset state and could not be attacked normally.

## Implementation Notes
- `Entity.evadeTimer` is reset when a mob enters or finishes evade, and increments only while `aiState === "evade"`.
- Normal evades still walk home; the timeout only finishes the reset if movement fails to complete it within the return window.
- The existing evade damage immunity is preserved while the reset is in progress.

## Verification
- `npx vitest run tests/fixes.test.ts -t "resets evading Gravecaller Summoners"`; failed before the fix with the Summoner still in `evade`, passed after the fix.
- `npx vitest run tests/fixes.test.ts tests/evade_immunity.test.ts tests/interactions.test.ts`; 3 files passed, 41 tests passed.
- `npx tsc --noEmit`; passed.
- Full closeout gate passed: `npm test` (46 files, 530 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Headless Chromium smoke on local Vite `http://127.0.0.1:5173/?gfx=low`: started offline warrior gameplay, forced a Gravecaller Summoner into the reproduced stalled evade position, waited through the reset window, and verified it returned to idle at spawn and was pickable by the renderer.

## Real behavior proof
- Behavior addressed: Gravecaller Summoners could become stuck in a reset state where players could not attack them.
- Environment tested: deterministic sim tests and local offline browser gameplay.
- Evidence after fix: the reproduced Summoner leaves `evade`, returns to its spawn, and the sim regression proves it can take player auto-attack damage again.
- Not tested: live multiplayer session with naturally occurring camp leash resets.

## Risk
Low gameplay risk. The change is limited to wild mob evade recovery; it does not remove evade immunity, alter combat math, change loot/quest credit, or affect persistence. The main behavior change is that a mob whose return path stalls finishes its existing reset instead of staying permanently damage-immune.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
