### PR TITLE
fix: sync online food consumption

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -155,6 +155,7 @@ function dynamicFields(e: Entity): Record<string, unknown> {
     hp: e.hp, mhp: e.maxHp,
   };
   if (e.dead) out.dead = 1;
+  if (e.inCombat) out.cbt = 1;
   if (e.lootable) out.loot = 1;
   if (e.hostile) out.h = 1;
   if (e.castingAbility) {
@@ -666,8 +667,18 @@ export class GameServer {
       case 'accept': if (typeof msg.quest === 'string') { sim.acceptQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'turnin': if (typeof msg.quest === 'string') { sim.turnInQuest(msg.quest, pid); this.resyncQuests(session); } break;
       case 'abandon': if (typeof msg.quest === 'string') { sim.abandonQuest(msg.quest, pid); this.resyncQuests(session); } break;
-      case 'equip': if (typeof msg.item === 'string') sim.equipItem(msg.item, pid); break;
-      case 'use': if (typeof msg.item === 'string') sim.useItem(msg.item, pid); break;
+      case 'equip':
+        if (typeof msg.item === 'string') {
+          sim.equipItem(msg.item, pid);
+          this.resyncItems(session);
+        }
+        break;
+      case 'use':
+        if (typeof msg.item === 'string') {
+          sim.useItem(msg.item, pid);
+          this.resyncItems(session);
+        }
+        break;
       case 'buy': if (typeof msg.npc === 'number' && typeof msg.item === 'string') sim.buyItem(msg.npc, msg.item, pid); break;
       case 'sell':
         if (typeof msg.item === 'string') {
@@ -1239,6 +1250,16 @@ export class GameServer {
   private resyncQuests(session: ClientSession): void {
     delete session.lastSent.qlog;
     delete session.lastSent.qdone;
+  }
+
+  // Item commands can consume stacks, equip gear, or start cooldowns. Re-echo
+  // the affected self fields so optimistic clients always reconcile.
+  private resyncItems(session: ClientSession): void {
+    delete session.lastSent.inv;
+    delete session.lastSent.equip;
+    delete session.lastSent.cds;
+    delete session.lastSent.stats;
+    delete session.lastSent.weapon;
   }
 
   private send(session: ClientSession, obj: unknown): void {

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1,9 +1,9 @@
 // Online play: REST auth client + WebSocket world mirror.
 
-import { NPCS, abilitiesKnownAt } from '../sim/data';
+import { ITEMS, NPCS, abilitiesKnownAt } from '../sim/data';
 import { computeQuestState, ResolvedAbility } from '../sim/sim';
 import {
-  Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
+  CONSUME_DURATION, CONSUME_TICKS, Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
 import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
@@ -325,9 +325,10 @@ export class ClientWorld implements IWorld {
     return this.connected && this.ws.readyState === WebSocket.OPEN;
   }
 
-  private cmd(payload: Record<string, unknown>): void {
-    if (!this.canSendCommand()) return;
+  private cmd(payload: Record<string, unknown>): boolean {
+    if (!this.canSendCommand()) return false;
     this.ws.send(JSON.stringify({ t: 'cmd', ...payload }));
+    return true;
   }
 
   private onMessage(raw: string): void {
@@ -465,6 +466,7 @@ export class ClientWorld implements IWorld {
       e.hp = w.hp;
       e.maxHp = w.mhp;
       e.dead = !!w.dead;
+      e.inCombat = !!w.cbt;
       e.lootable = !!w.loot;
       e.hostile = !!w.h;
       e.castingAbility = w.cast ?? null;
@@ -570,6 +572,33 @@ export class ClientWorld implements IWorld {
     return v;
   }
 
+  private predictConsumeItem(itemId: string): void {
+    const item = ITEMS[itemId];
+    if (!item || (item.kind !== 'food' && item.kind !== 'drink')) return;
+    const p = this.entities.get(this.playerId);
+    if (!p || p.dead || p.inCombat) return;
+    const idx = this.inventory.findIndex((slot) => slot.itemId === itemId && slot.count > 0);
+    if (idx < 0) return;
+
+    const nextInventory = this.inventory.map((slot) => ({ ...slot }));
+    const slot = nextInventory[idx];
+    slot.count -= 1;
+    if (slot.count <= 0) nextInventory.splice(idx, 1);
+    this.inventory = nextInventory;
+    this.invChanged = true;
+
+    p.sitting = true;
+    const consume = {
+      itemId,
+      kind: item.kind,
+      hpPer2s: item.foodHp ? Math.round(item.foodHp / CONSUME_TICKS) : 0,
+      manaPer2s: item.drinkMana ? Math.round(item.drinkMana / CONSUME_TICKS) : 0,
+      remaining: CONSUME_DURATION,
+    };
+    if (item.kind === 'food') p.eating = consume;
+    else p.drinking = consume;
+  }
+
   castAbility(abilityId: string): void {
     this.cmd({ cmd: 'cast', ability: abilityId });
   }
@@ -623,7 +652,8 @@ export class ClientWorld implements IWorld {
     this.cmd({ cmd: 'equip', item: itemId });
   }
   useItem(itemId: string): void {
-    this.cmd({ cmd: 'use', item: itemId });
+    if (!this.cmd({ cmd: 'use', item: itemId })) return;
+    this.predictConsumeItem(itemId);
   }
   buyItem(npcId: number, itemId: string): void {
     this.cmd({ cmd: 'buy', npc: npcId, item: itemId });

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -763,8 +763,7 @@ export class Hud {
     }
 
     // soundtrack: pick the zone theme and layer in combat percussion.
-    // Combat = a mob is on us, or we traded blows in the last few seconds
-    // (the wire protocol doesn't ship the inCombat flag).
+    // Combat = a mob is on us, or we traded blows in the last few seconds.
     let aggroed = false;
     for (const e of sim.entities.values()) {
       if (e.kind === 'mob' && !e.dead && e.aggroTargetId === sim.playerId) { aggroed = true; break; }

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -172,6 +172,50 @@ describe('delta snapshots', () => {
     expect(snap.self).not.toHaveProperty('stats');
   });
 
+  it('use command consumes food and mirrors eating state online', () => {
+    server.sim.addItem('baked_bread', 1, session.pid);
+    const player = server.sim.entities.get(session.pid)!;
+    player.hp = 20;
+    player.inCombat = false;
+    player.combatTimer = 99;
+    broadcast(server);
+
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(lastSnap(fc.sent));
+    expect(client.inventory).toEqual([{ itemId: 'baked_bread', count: 1 }]);
+
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'use', item: 'baked_bread' }));
+    broadcast(server);
+
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.eat).toEqual({ remaining: 18 });
+    expect(snap.self.inv).toEqual([]);
+    (client as any).applySnapshot(snap);
+    expect(client.inventory).toEqual([]);
+    expect(client.player.eating).not.toBeNull();
+  });
+
+  it('resends inventory after rejected food use commands', () => {
+    server.sim.addItem('baked_bread', 1, session.pid);
+    const player = server.sim.entities.get(session.pid)!;
+    player.hp = 20;
+    player.inCombat = true;
+    broadcast(server);
+    fc.sent.length = 0;
+
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'use', item: 'baked_bread' }));
+    broadcast(server);
+
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.cbt).toBe(1);
+    expect(snap.self.eat).toBeNull();
+    expect(snap.self.inv).toEqual([{ itemId: 'baked_bread', count: 1 }]);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(snap);
+    expect(client.player.inCombat).toBe(true);
+  });
+
   it('mirrors vendor buyback deltas to the client', () => {
     const wilkes = [...server.sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
     const player = server.sim.entities.get(session.pid)!;


### PR DESCRIPTION
## Summary
- Makes online food and drink use update the client mirror immediately after a bag click or action-bar hotkey sends the command.
- Forces item-related snapshot fields to re-sync after server equip/use commands so accepted and rejected item uses reconcile back to the authoritative state.
- Mirrors the player's combat flag in the normal entity wire so the client avoids predicting food or drink consumption when combat already makes it invalid.

## Diagnosis
The shared sim already consumed food correctly, but online bag clicks and item hotkeys were fire-and-forget client commands. Until the next authoritative snapshot carried the item/eating state, the UI could look unchanged. Rejected item uses had the opposite problem: a client that predicted consumption still needed the next snapshot to carry unchanged inventory so it could recover.

## Implementation Notes
- `ClientWorld.useItem()` predicts only food/drink consumption after the command is actually sendable and the local mirror has the item.
- `GameServer` invalidates item-related delta fields after equip/use commands, covering inventory, equipment, cooldowns, stats, and weapon changes.
- The compact `cbt` wire flag keeps `ClientWorld.player.inCombat` current without changing server authority or sim rules.

## Verification
- `npx vitest run tests/snapshots.test.ts`; 1 file passed, 23 tests passed.
- `npx vitest run tests/bandwidth.test.ts tests/interest.test.ts`; 2 files passed, 24 tests passed.
- `npx vitest run tests/social.test.ts -t "partyInfo reports per-member combat state"`; 1 test passed.
- `npx tsc --noEmit`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- Full closeout gate passed: `npm test` (46 files, 531 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Browser smoke on local Vite at `http://127.0.0.1:5173/?gfx=low`: started an offline warrior, added Freshly Baked Bread, opened Bags and clicked the bread row, then placed bread on the action bar and pressed `Digit2`; both paths removed the bread from inventory and put the player into sitting/eating state.

## Real behavior proof
- Behavior addressed: clicking food in bags or hotkeying food could appear not to consume it.
- Environment tested: local deterministic online snapshot tests and local offline browser gameplay for the visible bag/hotkey paths.
- Evidence after fix: accepted online food use mirrors empty inventory plus eating state, rejected online food use re-sends unchanged inventory, and the browser-visible bag and hotkey paths both start eating immediately.
- Not tested: live multiplayer session with a persisted character.

## Risk
Low client/server sync risk. The authoritative sim remains unchanged; the client only predicts food/drink after a command is sendable and reconciles from the next server snapshot. The extra combat wire flag is compact and covered by bandwidth/interest-adjacent tests.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
