### PR TITLE
fix: apply ghost wolf movement speed as a form

### DIFF
--- a/docs/design/spell-ranks.md
+++ b/docs/design/spell-ranks.md
@@ -257,7 +257,7 @@
 | Ability | Learn | Cost | Cast/CD | Effects |
 |---|---|---|---|---|
 | `frost_shock` | 14 | 50 | inst, 6cd, 20yd | directDamage 36–42 + slow 0.5/8s |
-| `ghost_wolf` | 16 | 35 | 2.0s cast | selfBuff buff_speed 1.4, 10min |
+| `ghost_wolf` | 16 | 35 | 2.0s cast | selfBuff form_ghost_wolf 1.4, 10min |
 | `stormstrike` | 20 | 40 | inst, 12cd | weaponStrike +26 |
 
 **Sanity** — L14: LB R3 avg 48 → 292/48 ≈ 6.1 casts ✓ (the brief's own anchor). L20: LB R4 avg 80 → 5 casts, or shock-weave melee w/ Rockbiter R3 ✓.

--- a/src/render/characters/index.ts
+++ b/src/render/characters/index.ts
@@ -10,7 +10,9 @@ export { CharacterVisual } from './visual';
 export type { AnimState } from './visual';
 export { CharacterPreview } from './preview';
 
-/** Build the visual for an entity (or an explicit form key: polymorph/bear). */
-export function createCharacterVisual(e: Entity, formKey?: 'form_sheep' | 'form_bear'): CharacterVisual {
+type FormVisualKey = 'form_sheep' | 'form_bear' | 'form_ghost_wolf';
+
+/** Build the visual for an entity (or an explicit form key). */
+export function createCharacterVisual(e: Entity, formKey?: FormVisualKey): CharacterVisual {
   return new CharacterVisual(formKey ?? visualKeyFor(e), e.color);
 }

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -189,6 +189,10 @@ export const VISUALS: Record<string, VisualDef> = {
     url: `${CREATURES}/yetialt.glb`, height: 1.9,
     clips: BIPED14, tint: 0x5a4030, tintStrength: 0.55,
   },
+  form_ghost_wolf: {
+    url: `${CREATURES}/wolf.glb`, height: 1.6,
+    clips: animal(['Attack']), tint: 0x9fb8c8, tintStrength: 0.6,
+  },
 
   // -- mob families --------------------------------------------------------
   mob_wolf: {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -69,6 +69,7 @@ interface EntityView {
   visual: CharacterVisual | null;
   sheepVisual: CharacterVisual | null; // polymorph form, built lazily
   bearVisual: CharacterVisual | null; // druid bear form, built lazily
+  ghostWolfVisual: CharacterVisual | null; // shaman Ghost Wolf form, built lazily
   /** unscaled height — nameplate/vfx anchor reads height * e.scale */
   height: number;
   /** what removeView pulls back out of clickTargets */
@@ -329,7 +330,7 @@ export class Renderer {
       const v = this.views.get(id);
       if (!v) return null;
       const e = this.sim.entities.get(id);
-      const h = v.height * (e?.scale ?? 1) * frac;
+      const h = this.activeHeight(v) * (e?.scale ?? 1) * frac;
       return new THREE.Vector3(v.group.position.x, v.group.position.y + h, v.group.position.z);
     });
     this.vfx.setViewportScale(this.webgl.domElement.clientHeight * this.webgl.getPixelRatio(), 60);
@@ -583,7 +584,7 @@ export class Renderer {
     const objectCasters: THREE.Object3D[] = [];
     if (!visual) collectCasters(group, objectCasters);
     this.views.set(e.id, {
-      group, visual, sheepVisual: null, bearVisual: null, height, clickTarget,
+      group, visual, sheepVisual: null, bearVisual: null, ghostWolfVisual: null, height, clickTarget,
       nameplate: np, nameEl, hpBar, hpFill, markerEl: marker, raidMarkEl: raidMark, sparkle, objectMesh, portal,
       objectCasters, shadowOn: true, isFar: false,
       lastX: e.pos.x, lastZ: e.pos.z,
@@ -595,7 +596,12 @@ export class Renderer {
   private activeVisual(v: EntityView): CharacterVisual | null {
     if (v.sheepVisual?.root.visible) return v.sheepVisual;
     if (v.bearVisual?.root.visible) return v.bearVisual;
+    if (v.ghostWolfVisual?.root.visible) return v.ghostWolfVisual;
     return v.visual;
+  }
+
+  private activeHeight(v: EntityView): number {
+    return this.activeVisual(v)?.height ?? v.height;
   }
 
   triggerAttack(entityId: number): void {
@@ -736,6 +742,7 @@ export class Renderer {
       v.visual.dispose();
       v.sheepVisual?.dispose();
       v.bearVisual?.dispose();
+      v.ghostWolfVisual?.dispose();
     } else {
       // Object views (door arch, loot crates) own their geometries; their
       // materials are shared caches (door stone / crate planks / sparkle) and
@@ -777,10 +784,11 @@ export class Renderer {
     for (const e of sim.entities.values()) {
       const v = this.views.get(e.id);
       if (!v) continue;
-      // form swaps (polymorph sheep, druid bear) — computed up front because
+      // form swaps (polymorph sheep, druid bear, Ghost Wolf) — computed up front because
       // the shadow gates below must not run the base rig's proxy under a form
       const polyed = e.auras.some((a) => a.kind === 'polymorph');
       const bear = !polyed && e.auras.some((a) => a.kind === 'form_bear');
+      const ghostWolf = !polyed && !bear && e.auras.some((a) => a.kind === 'form_ghost_wolf');
       const stealthed = e.auras.some((a) => a.kind === 'stealth');
       // distance cull: far rigs are invisible specks but cost real draw calls
       const cdx = e.pos.x - p.pos.x, cdz = e.pos.z - p.pos.z;
@@ -799,12 +807,13 @@ export class Renderer {
           v.isFar = d2 > ENTITY_LOD_RANGE_SQ;
           // past the articulated gate the static-pose proxy carries the
           // shadow; an active form's own rig keeps casting instead
-          v.visual.setProxyShadow(!wantShadow && inProxyBand && !polyed && !bear);
-          // sheep/bear keep articulated shadows through the whole proxy band —
+          v.visual.setProxyShadow(!wantShadow && inProxyBand && !polyed && !bear && !ghostWolf);
+          // form rigs keep articulated shadows through the whole proxy band —
           // a frozen humanoid proxy silhouette would be wrong under a form
           const wantFormShadow = wantShadow || inProxyBand;
           v.sheepVisual?.setShadow(wantFormShadow);
           v.bearVisual?.setShadow(wantFormShadow);
+          v.ghostWolfVisual?.setShadow(wantFormShadow);
         } else if (wantShadow !== v.shadowOn) {
           v.shadowOn = wantShadow;
           for (const caster of v.objectCasters) (caster as THREE.Mesh).castShadow = wantShadow;
@@ -849,7 +858,7 @@ export class Renderer {
         && groundHeight(e.pos.x, e.pos.z, this.sim.cfg.seed) < WATER_LEVEL - 0.8
         && e.pos.y <= WATER_LEVEL - 0.5;
 
-      // lazy form visuals, swapped by visibility like the old sheep/bear rigs
+      // lazy form visuals, swapped by visibility so inactive rigs stay mounted
       if (polyed && !v.sheepVisual) {
         v.sheepVisual = createCharacterVisual(e, 'form_sheep');
         v.sheepVisual.root.scale.multiplyScalar(e.scale);
@@ -860,10 +869,17 @@ export class Renderer {
         v.bearVisual.root.scale.multiplyScalar(e.scale);
         v.group.add(v.bearVisual.root);
       }
+      if (ghostWolf && !v.ghostWolfVisual) {
+        v.ghostWolfVisual = createCharacterVisual(e, 'form_ghost_wolf');
+        v.ghostWolfVisual.root.scale.multiplyScalar(e.scale);
+        v.group.add(v.ghostWolfVisual.root);
+      }
       if (v.sheepVisual) v.sheepVisual.root.visible = polyed;
       if (v.bearVisual) v.bearVisual.root.visible = bear;
+      if (v.ghostWolfVisual) v.ghostWolfVisual.root.visible = ghostWolf;
       const active = polyed && v.sheepVisual ? v.sheepVisual
-        : bear && v.bearVisual ? v.bearVisual : v.visual;
+        : bear && v.bearVisual ? v.bearVisual
+          : ghostWolf && v.ghostWolfVisual ? v.ghostWolfVisual : v.visual;
       const ghost = shouldRenderStealthGhost(this.sim.playerId, e);
       active.setGhost(ghost);
       v.visual.root.visible = active === v.visual;
@@ -1079,7 +1095,7 @@ export class Renderer {
         continue;
       }
       this.tmpV.copy(v.group.position);
-      this.tmpV.y += v.height * e.scale + 0.5;
+      this.tmpV.y += this.activeHeight(v) * e.scale + 0.5;
       this.tmpV.project(this.camera);
       if (this.tmpV.z > 1) { v.nameplate.style.display = 'none'; continue; }
       const sx = (this.tmpV.x * 0.5 + 0.5) * w;
@@ -1177,7 +1193,7 @@ export class Renderer {
       // fall back to the live entity position when the rig isn't being drawn
       if (v.group.visible) this.tmpV.copy(v.group.position);
       else this.tmpV.set(e.pos.x, e.pos.y, e.pos.z);
-      this.tmpV.y += v.height * e.scale + 1.0;
+      this.tmpV.y += this.activeHeight(v) * e.scale + 1.0;
       this.tmpV.project(this.camera);
       if (this.tmpV.z > 1) { b.el.style.display = 'none'; continue; }
       b.el.style.display = '';
@@ -1232,7 +1248,7 @@ export class Renderer {
       const e = this.sim.entities.get(id);
       if (!e || (e.dead && !e.lootable)) continue;
       this.tmpV.copy(v.group.position);
-      this.tmpV.y += v.height * e.scale * 0.5;
+      this.tmpV.y += this.activeHeight(v) * e.scale * 0.5;
       this.tmpV.project(this.camera);
       if (this.tmpV.z > 1) continue;
       const sx = (this.tmpV.x * 0.5 + 0.5) * this.viewport.width;

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -1017,9 +1017,9 @@ export const ABILITIES: Record<string, AbilityDef> = {
     id: 'ghost_wolf', name: 'Ghost Wolf', class: 'shaman', learnLevel: 16,
     cost: 35, castTime: 2.0, cooldown: 0, range: 0, school: 'nature',
     requiresTarget: false,
-    effects: [{ type: 'selfBuff', kind: 'buff_speed', value: 1.4, duration: 600 }],
+    effects: [{ type: 'selfBuff', kind: 'form_ghost_wolf', value: 1.4, duration: 600 }],
     icon: 'GW', iconColor: '#aab7b8',
-    description: 'Turns you into a Ghost Wolf, increasing movement speed by 40% for 10 min.',
+    description: 'Turns you into a Ghost Wolf, increasing movement speed by 40% for 10 min. Cast again to return to caster form.',
   },
   stormstrike: {
     id: 'stormstrike', name: 'Stormstrike', class: 'shaman', learnLevel: 20,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -296,7 +296,8 @@ function isFormToggle(ability: AbilityDef): boolean {
 // cancelling is never gated by cost or cooldown (the cooldown gates re-entry).
 function isToggleBuff(ability: AbilityDef): boolean {
   return ability.effects.some((e) => e.type === 'selfBuff'
-    && (e.kind === 'form_bear' || e.kind === 'form_cat' || e.kind === 'defensive_stance' || e.kind === 'stealth'));
+    && (e.kind === 'form_bear' || e.kind === 'form_cat' || e.kind === 'form_ghost_wolf'
+      || e.kind === 'defensive_stance' || e.kind === 'stealth'));
 }
 
 export class Sim {
@@ -817,6 +818,7 @@ export class Sim {
     for (const a of e.auras) {
       if (a.kind === 'slow' || a.kind === 'stealth') slow = Math.min(slow, a.value);
       if (a.kind === 'buff_speed') speed = Math.max(speed, a.value);
+      if (a.kind === 'form_ghost_wolf') speed = Math.max(speed, a.value);
     }
     return slow * speed;
   }
@@ -1188,6 +1190,16 @@ export class Sim {
     this.emit({ type: 'castStop', entityId: p.id, success: false });
   }
 
+  private removeToggleAura(p: Entity, meta: PlayerMeta, ability: AbilityDef): void {
+    const existing = p.auras.findIndex((a) => a.id === ability.id);
+    if (existing < 0) return;
+    p.auras.splice(existing, 1);
+    if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+    if (!ability.offGcd) p.gcdRemaining = Math.max(p.gcdRemaining, this.playerGcdFor(meta.cls));
+    this.emit({ type: 'aura', targetId: p.id, name: ability.name, gained: false });
+    recalcPlayerStats(p, meta.cls, meta.equipment);
+  }
+
   private pushbackCast(p: Entity): void {
     if (p.channeling) {
       p.castRemaining = Math.max(0, p.castRemaining - p.castTotal * CHANNEL_PUSHBACK_FRACTION);
@@ -1230,9 +1242,10 @@ export class Sim {
       this.error(p.id, 'That ability requires combo points.');
       return;
     }
-    // druid forms gate their kit both ways: form abilities need the form, and
-    // everything else (the caster kit) is locked while shapeshifted
+    // Forms gate their kit: druid form abilities need their form, while caster
+    // abilities are locked while in druid forms or Ghost Wolf.
     const form = p.auras.find((a) => a.kind === 'form_bear' || a.kind === 'form_cat');
+    const ghostWolfForm = p.auras.find((a) => a.kind === 'form_ghost_wolf');
     if (ability.requiresForm) {
       const need = ability.requiresForm === 'bear' ? 'form_bear' : 'form_cat';
       if (!form || form.kind !== need) {
@@ -1242,6 +1255,9 @@ export class Sim {
     } else if (form && !isFormToggle(ability)) {
       this.error(p.id, "You can't do that while shapeshifted.");
       return;
+    } else if (ghostWolfForm && !togglingOff) {
+      this.error(p.id, "You can't do that while shapeshifted.");
+      return;
     }
     if (ability.requiresStealth && !p.auras.some((a) => a.kind === 'stealth')) {
       this.error(p.id, 'You must be stealthed.');
@@ -1249,6 +1265,11 @@ export class Sim {
     }
     if (ability.requiresOutOfCombat && p.inCombat) {
       this.error(p.id, "You can't do that while in combat.");
+      return;
+    }
+    if (togglingOff) {
+      if (p.sitting) this.standUp(p);
+      this.removeToggleAura(p, meta, ability);
       return;
     }
 
@@ -1706,7 +1727,7 @@ export class Sim {
         case 'selfBuff': {
           // forms, stances and stealth are toggles: casting again cancels
           const isToggle = eff.kind === 'form_bear' || eff.kind === 'form_cat'
-            || eff.kind === 'defensive_stance' || eff.kind === 'stealth';
+            || eff.kind === 'form_ghost_wolf' || eff.kind === 'defensive_stance' || eff.kind === 'stealth';
           if (isToggle) {
             const existing = p.auras.findIndex((a) => a.id === ability.id);
             if (existing >= 0) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -35,7 +35,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder';
+  | 'form_cat' | 'form_ghost_wolf' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder';
 
 export interface Aura {
   id: string; // ability id that applied it

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1080,6 +1080,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_buff_allstats: r('arcane', 'arcanePink', ['gem']),
   aura_thorns: r('nature', 'leafGreen', ['leaf', { p: 'claw_slash', ...BR }]),
   aura_form_bear: r('earth', 'earthBrown', ['paw']),
+  aura_form_ghost_wolf: r('frost', 'ice', ['paw'], ['motion']),
 };
 
 // ---------------------------------------------------------------------------

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -8,7 +8,7 @@ import {
 import { LAKE, QUESTS, abilitiesKnownAt } from '../src/sim/data';
 import { terrainHeight, WATER_LEVEL } from '../src/sim/world';
 
-function makeSim(cls: 'warrior' | 'mage' | 'rogue' = 'warrior', seed = 42) {
+function makeSim(cls: 'warrior' | 'mage' | 'rogue' | 'shaman' = 'warrior', seed = 42) {
   return new Sim({ seed, playerClass: cls, autoEquip: true });
 }
 
@@ -178,6 +178,44 @@ describe('movement directions', () => {
     const x1 = sim.player.pos.x;
     for (let i = 0; i < 20; i++) sim.tick();
     expect(sim.player.pos.x).toBeGreaterThan(x1);
+  });
+
+  it('ghost wolf increases forward movement speed', () => {
+    const normal = makeSim('shaman');
+    const wolf = makeSim('shaman');
+
+    for (const sim of [normal, wolf]) {
+      teleportTo(sim, 0, -40);
+      sim.player.facing = 0;
+    }
+
+    wolf.setPlayerLevel(16);
+    wolf.castAbility('ghost_wolf');
+    for (let i = 0; i < 20 * 2; i++) wolf.tick();
+    expect(wolf.player.auras.some((a) => a.id === 'ghost_wolf' && a.kind === 'form_ghost_wolf')).toBe(true);
+
+    wolf.events.length = 0;
+    wolf.castAbility('lightning_bolt');
+    expect(wolf.player.castingAbility).toBeNull();
+    expect(wolf.events.some((e) => e.type === 'error' && /shapeshifted/.test(e.text))).toBe(true);
+
+    normal.moveInput.forward = true;
+    wolf.moveInput.forward = true;
+    for (let i = 0; i < 20; i++) {
+      normal.tick();
+      wolf.tick();
+    }
+
+    expect(dist2d(wolf.player.pos, { x: 0, y: 0, z: -40 }))
+      .toBeGreaterThan(dist2d(normal.player.pos, { x: 0, y: 0, z: -40 }) * 1.3);
+
+    wolf.moveInput.forward = false;
+    for (let i = 0; i < 20; i++) wolf.tick();
+    wolf.player.sitting = true;
+    wolf.castAbility('ghost_wolf');
+    expect(wolf.player.auras.some((a) => a.kind === 'form_ghost_wolf')).toBe(false);
+    expect(wolf.player.sitting).toBe(false);
+    expect(wolf.player.gcdRemaining).toBeGreaterThan(0);
   });
 });
 

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -72,6 +72,7 @@ describe('threat from damage', () => {
     for (let i = 0; i < 30; i++) sim.tick();
     sim.castAbility('defensive_stance');
     expect(sim.player.auras.some((a) => a.kind === 'defensive_stance')).toBe(false);
+    expect(sim.player.cooldowns.get('defensive_stance')).toBeGreaterThan(0);
   });
 
   it('bear form multiplies threat by 1.3', () => {


### PR DESCRIPTION
## Summary
- Fixes a gameplay report that Ghost Wolf did not appear to increase movement speed.
- Adds `form_ghost_wolf` as an explicit sim aura so movement speed, form toggling, cooldown/GCD handling, and caster-kit lockout all follow the form path instead of a generic speed buff.
- Renders Ghost Wolf with the wolf rig, uses the active form height for UI/VFX anchors, and updates the aura icon and spell-rank docs.

## Diagnosis
Ghost Wolf reused the generic `buff_speed` aura. That made the spell look like a normal self buff instead of a form, so form-specific behavior such as shape toggling, spell lockout, rendered form swapping, and active-form UI anchoring did not apply consistently.

## Implementation Notes
- `form_ghost_wolf` participates in the shared movement multiplier calculation and the existing toggle-aura path.
- Recasting Ghost Wolf removes the form, stands the player up first, and preserves the form-style cooldown/GCD behavior.
- Normal Shaman caster abilities are blocked while Ghost Wolf is active, matching the existing shapeshift lockout model.

## Documentation
- `docs/design/spell-ranks.md`: updates the Ghost Wolf row to document `form_ghost_wolf 1.4` instead of the old generic speed buff.

## Verification
- `npx vitest run tests/sim.test.ts -t "ghost wolf increases forward movement speed"`; 1 passed, 60 skipped.
- `npx vitest run tests/threat.test.ts -t "defensive stance"`; focused defensive stance coverage passed.
- `npx tsc --noEmit`; passed.
- `npm test`; 46 files passed, 530 tests passed.
- `npm run build:env`; passed.
- `npm run build:server`; passed.
- `npm run build`; passed.
- Browser smoke at `http://127.0.0.1:5173/?gfx=low` with an offline Shaman: confirmed `form_ghost_wolf`, aura value `1.4`, wolf visual mounted and visible, base visual hidden, active height `1.6`, and 9.8 yards of forward movement in one second.

## Real behavior proof
- Behavior addressed: Ghost Wolf should noticeably increase forward movement speed.
- Environment tested: local offline browser session using the shared sim and renderer.
- Evidence after fix: Ghost Wolf traveled 9.8 yards in one second and rendered as the wolf form while the base player visual was hidden.

## Risk
Low gameplay risk. The change is scoped to Ghost Wolf plus the existing generic toggle cancellation helper used by form-like toggles, with regression coverage for Ghost Wolf movement, caster lockout, sitting cancel, and defensive stance cooldown behavior.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
