### PR TITLE
fix: block ranged attacks through dungeon walls

### DIFF
--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -181,6 +181,74 @@ function resolveAgainst(list: Collider[], x: number, z: number, r: number): { x:
   return { x: px, z: pz };
 }
 
+function segmentIntersectsCircle(
+  ax: number, az: number, bx: number, bz: number,
+  c: CircleCollider,
+): boolean {
+  const dx = bx - ax, dz = bz - az;
+  const len2 = dx * dx + dz * dz;
+  if (len2 < 1e-8) {
+    const px = ax - c.x, pz = az - c.z;
+    return px * px + pz * pz < c.r * c.r;
+  }
+  const t = Math.max(0, Math.min(1, ((c.x - ax) * dx + (c.z - az) * dz) / len2));
+  const px = ax + dx * t - c.x, pz = az + dz * t - c.z;
+  return px * px + pz * pz < c.r * c.r;
+}
+
+function segmentIntersectsAabb(
+  ax: number, az: number, bx: number, bz: number,
+  hw: number, hd: number,
+): boolean {
+  let tMin = 0, tMax = 1;
+  const dx = bx - ax, dz = bz - az;
+  for (const [p, d, min, max] of [
+    [ax, dx, -hw, hw],
+    [az, dz, -hd, hd],
+  ] as const) {
+    if (Math.abs(d) < 1e-8) {
+      if (p <= min || p >= max) return false;
+      continue;
+    }
+    const inv = 1 / d;
+    let t1 = (min - p) * inv;
+    let t2 = (max - p) * inv;
+    if (t1 > t2) [t1, t2] = [t2, t1];
+    tMin = Math.max(tMin, t1);
+    tMax = Math.min(tMax, t2);
+    if (tMin >= tMax) return false;
+  }
+  return true;
+}
+
+function segmentIntersectsObb(
+  ax: number, az: number, bx: number, bz: number,
+  c: ObbCollider,
+): boolean {
+  const a = rotY(ax - c.x, az - c.z, -c.rot);
+  const b = rotY(bx - c.x, bz - c.z, -c.rot);
+  return segmentIntersectsAabb(a.x, a.z, b.x, b.z, c.hw, c.hd);
+}
+
+function segmentIntersectsCollider(
+  ax: number, az: number, bx: number, bz: number,
+  c: Collider,
+): boolean {
+  return c.type === 'circle'
+    ? segmentIntersectsCircle(ax, az, bx, bz, c)
+    : segmentIntersectsObb(ax, az, bx, bz, c);
+}
+
+function anySegmentHit(
+  colliders: Iterable<Collider>,
+  ax: number, az: number, bx: number, bz: number,
+): boolean {
+  for (const c of colliders) {
+    if (segmentIntersectsCollider(ax, az, bx, bz, c)) return true;
+  }
+  return false;
+}
+
 function instanceLocal(x: number, z: number): { ox: number; oz: number; interior: string } {
   const dungeon = dungeonAt(x);
   const index = dungeon?.index ?? 0;
@@ -218,4 +286,35 @@ export function resolvePosition(seed: number, x: number, z: number, r = 0.5): { 
 export function isBlocked(seed: number, x: number, z: number, r = 0.5): boolean {
   const res = resolvePosition(seed, x, z, r);
   return Math.abs(res.x - x) > 1e-4 || Math.abs(res.z - z) > 1e-4;
+}
+
+export function hasLineOfSight(seed: number, ax: number, az: number, bx: number, bz: number): boolean {
+  if (isArenaPos(ax) || isArenaPos(bx)) {
+    if (!isArenaPos(ax) || !isArenaPos(bx)) return false;
+    const oa = arenaOriginAt(az), ob = arenaOriginAt(bz);
+    if (oa.slot !== ob.slot) return false;
+    return !anySegmentHit(ARENA_COLLIDERS, ax - oa.x, az - oa.z, bx - oa.x, bz - oa.z);
+  }
+  if (ax > DUNGEON_X_THRESHOLD || bx > DUNGEON_X_THRESHOLD) {
+    if (ax <= DUNGEON_X_THRESHOLD || bx <= DUNGEON_X_THRESHOLD) return false;
+    const da = dungeonAt(ax), db = dungeonAt(bx);
+    if (!da || !db || da.id !== db.id) return false;
+    const a = instanceLocal(ax, az), b = instanceLocal(bx, bz);
+    if (a.ox !== b.ox || a.oz !== b.oz) return false;
+    const colliders = INTERIOR_COLLIDERS[a.interior] ?? CRYPT_COLLIDERS;
+    return !anySegmentHit(colliders, ax - a.ox, az - a.oz, bx - a.ox, bz - a.oz);
+  }
+  const minX = Math.min(ax, bx), maxX = Math.max(ax, bx);
+  const minZ = Math.min(az, bz), maxZ = Math.max(az, bz);
+  const x0 = Math.floor(minX / GRID_CELL), x1 = Math.floor(maxX / GRID_CELL);
+  const z0 = Math.floor(minZ / GRID_CELL), z1 = Math.floor(maxZ / GRID_CELL);
+  const candidates = new Set<Collider>();
+  const grid = gridFor(seed);
+  for (let gx = x0; gx <= x1; gx++) {
+    for (let gz = z0; gz <= z1; gz++) {
+      const list = grid.cells.get(gx + ',' + gz);
+      if (list) for (const c of list) candidates.add(c);
+    }
+  }
+  return !anySegmentHit(candidates, ax, az, bx, bz);
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5,7 +5,7 @@ import {
   zoneAt,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
-import { resolvePosition } from './colliders';
+import { hasLineOfSight, resolvePosition } from './colliders';
 import { findPath } from './pathfind';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
 import { Rng } from './rng';
@@ -1271,6 +1271,7 @@ export class Sim {
       const maxRange = ability.range > 0 ? ability.range : MELEE_RANGE;
       if (d > maxRange) { this.error(p.id, 'Out of range.'); return; }
       if (ability.minRange && d < ability.minRange) { this.error(p.id, 'Too close!'); return; }
+      if (this.requiresHostileLineOfSight(ability) && !this.canSeeTarget(p, target, true)) return;
       const facingDiff = Math.abs(normAngle(angleTo(p.pos, target.pos) - p.facing));
       if (facingDiff > MELEE_ARC) { this.error(p.id, 'You must be facing your target.'); return; }
       // execute-style gate: only usable while the target is nearly dead
@@ -1369,6 +1370,7 @@ export class Sim {
   private applyChannelTick(p: Entity, res: ResolvedAbility): void {
     const target = p.targetId !== null ? this.entities.get(p.targetId) : null;
     if (!target || target.dead) { this.cancelCast(p); return; }
+    if (this.requiresHostileLineOfSight(res.def) && !this.canSeeTarget(p, target, false)) { this.cancelCast(p); return; }
     this.emit({ type: 'spellfx', sourceId: p.id, targetId: target.id, school: res.def.school, fx: 'projectile' });
     for (const eff of res.effects) {
       if (eff.type === 'directDamage') {
@@ -1453,6 +1455,7 @@ export class Sim {
       const d = dist2d(p.pos, target.pos);
       const maxRange = ability.range > 0 ? ability.range : MELEE_RANGE;
       if (d > maxRange + 2) { this.error(p.id, 'Out of range.'); return; }
+      if (this.requiresHostileLineOfSight(ability) && !this.canSeeTarget(p, target, true)) return;
     }
     if (p.resource < res.cost && !this.formShiftKind(p, ability)) { this.error(p.id, 'Not enough ' + (p.resourceType ?? 'resource') + '!'); return; }
 
@@ -2010,6 +2013,7 @@ export class Sim {
     // casters (wand-style, no dead zone so they don't run into melee — #94)
     const ranged = CLASSES[meta.cls].ranged;
     if (ranged && d <= ranged.maxRange && d >= (ranged.wand ? 0 : ranged.minRange)) {
+      if (!this.canSeeTarget(p, t, false)) return;
       this.rangedSwing(p, t, ranged);
       p.swingTimer = ranged.speed * this.swingIntervalMult(p);
       return;
@@ -2060,6 +2064,16 @@ export class Sim {
     // wand bolts are magic — armor doesn't apply; physical auto shot is mitigated
     if (!ranged.wand) dmg *= 1 - armorReduction(this.effectiveArmor(target), attacker.level);
     this.dealDamage(attacker, target, Math.max(1, Math.round(dmg)), crit, school, label, 'hit');
+  }
+
+  private requiresHostileLineOfSight(ability: AbilityDef): boolean {
+    return ability.requiresTarget && ability.targetType !== 'friendly' && ability.range > MELEE_RANGE;
+  }
+
+  private canSeeTarget(source: Entity, target: Entity, emitError: boolean): boolean {
+    if (hasLineOfSight(this.cfg.seed, source.pos.x, source.pos.z, target.pos.x, target.pos.z)) return true;
+    if (emitError) this.error(source.id, 'Target not in line of sight.');
+    return false;
   }
 
   // Returns true if the swing connected.

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import { Entity, dist2d } from '../src/sim/types';
+import { Entity, PlayerClass, dist2d } from '../src/sim/types';
 import { CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { groundHeight, WATER_LEVEL } from '../src/sim/world';
@@ -8,7 +8,7 @@ import { isBlocked, resolvePosition } from '../src/sim/colliders';
 
 const SEED = 20061;
 
-function makeSim(cls: 'warrior' | 'mage' = 'warrior') {
+function makeSim(cls: PlayerClass = 'warrior') {
   return new Sim({ seed: SEED, playerClass: cls });
 }
 
@@ -18,6 +18,13 @@ function teleportTo(sim: Sim, x: number, z: number, pid?: number) {
   p.pos.z = z;
   p.pos.y = groundHeight(x, z, sim.cfg.seed);
   p.prevPos = { ...p.pos };
+}
+
+function placeEntity(sim: Sim, e: Entity, x: number, z: number) {
+  e.pos.x = x;
+  e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
 }
 
 describe('quest lifecycle', () => {
@@ -337,6 +344,67 @@ describe('dungeon instance placement and targetability', () => {
         expect(isBlocked(SEED, mob.pos.x, mob.pos.z, 0.5), `${dungeon.id} ${mob.name} spawned in geometry`).toBe(false);
       }
     }
+  });
+
+  it('blocks hostile ranged casts through Gravewyrm Sanctum chamber walls', () => {
+    const sim = makeSim('mage');
+    sim.setPlayerLevel(20);
+    sim.enterDungeon('gravewyrm_sanctum');
+    const p = sim.player;
+    const origin = { x: p.pos.x, z: p.pos.z - 4 };
+    const target = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'sanctum_boneguard')!;
+    teleportTo(sim, origin.x - 10, origin.z + 60);
+    placeEntity(sim, target, origin.x - 10, origin.z + 75);
+    p.facing = 0;
+    p.resource = p.maxResource;
+    sim.targetEntity(target.id);
+
+    sim.castAbility('fireball');
+
+    expect(p.castingAbility).toBeNull();
+    expect(sim.events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'Target not in line of sight.',
+    }));
+  });
+
+  it('allows hostile ranged casts through the Gravewyrm Sanctum center passage', () => {
+    const sim = makeSim('mage');
+    sim.setPlayerLevel(20);
+    sim.enterDungeon('gravewyrm_sanctum');
+    const p = sim.player;
+    const origin = { x: p.pos.x, z: p.pos.z - 4 };
+    const target = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'sanctum_boneguard')!;
+    teleportTo(sim, origin.x, origin.z + 60);
+    placeEntity(sim, target, origin.x, origin.z + 75);
+    p.facing = 0;
+    p.resource = p.maxResource;
+    sim.targetEntity(target.id);
+
+    sim.castAbility('fireball');
+
+    expect(p.castingAbility).toBe('fireball');
+  });
+
+  it('blocks Auto Shot through Gravewyrm Sanctum chamber walls', () => {
+    const sim = makeSim('hunter');
+    sim.setPlayerLevel(20);
+    sim.enterDungeon('gravewyrm_sanctum');
+    const p = sim.player;
+    const origin = { x: p.pos.x, z: p.pos.z - 4 };
+    const target = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'sanctum_boneguard')!;
+    teleportTo(sim, origin.x - 10, origin.z + 60);
+    placeEntity(sim, target, origin.x - 10, origin.z + 75);
+    p.facing = 0;
+    p.swingTimer = 0;
+    sim.targetEntity(target.id);
+    sim.startAutoAttack();
+    sim.events.length = 0;
+
+    const events = sim.tick();
+
+    expect(target.hp).toBe(target.maxHp);
+    expect(events.some((e) => e.type === 'spellfx' && e.fx === 'projectile')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixes #240 by making hostile ranged combat respect static line of sight through the same dungeon, arena, and outdoor collider data that already blocks movement.
- Blocks ranged spells, channel ticks, wand shots, and Auto Shot when dungeon walls or other static geometry stand between source and target.
- Adds Gravewyrm Sanctum regression coverage for chamber-divider wall stubs, including a center-passage control case so the intended opening remains usable.

## Diagnosis
Movement resolution used shared static colliders for dungeon walls, but hostile ranged combat only checked target validity, range, facing, and class-specific minimum range. In Gravewyrm Sanctum, chamber divider walls therefore stopped players from walking through while still allowing attacks to land on enemies in the next chamber.

## Implementation Notes
- `src/sim/colliders.ts` now exposes a deterministic 2D line-of-sight query over the existing collider sets.
- `src/sim/sim.ts` applies that query to hostile targeted ranged abilities, hostile channel ticks, wand attacks, and Auto Shot while leaving melee and friendly spells outside the new wall check.

## Verification
- `npx vitest run tests/fixes.test.ts -t "Gravewyrm Sanctum"`; 3 tests passed.
- `npx vitest run tests/fixes.test.ts`; 36 tests passed.
- `npx tsc --noEmit`; passed.
- Full closeout gate passed: `npm test` (46 files, 535 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Targeted local Chromium smoke at `http://127.0.0.1:5173/?gfx=low`: started an offline mage, entered Gravewyrm Sanctum, positioned the mage and a hostile mob across a chamber-divider wall, and confirmed Fireball was rejected with `Target not in line of sight.` while the target stayed at full health.

## Real behavior proof
- Behavior addressed: ranged attacks could damage enemies through dungeon walls.
- Environment tested: local deterministic sim tests plus local offline browser gameplay.
- Evidence after fix: the Sanctum divider blocks through-wall Fireball and Auto Shot, while the center passage still permits ranged casting.
- Not tested: live multiplayer dungeon run with multiple clients.

## Risk
Moderate gameplay reach because this changes combat validation for hostile ranged attacks. The check is static-geometry-only, reuses the same collision layout movement already trusts, keeps friendly spells and melee behavior unchanged, and is covered by dungeon-specific regression tests.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
