### PR TITLE
fix: chasing mobs slide around camp props instead of pinning on them

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -33,6 +33,10 @@ const EVADE_SPEED_MULT = 1.6;
 // immune while resetting, a permanent stall = a permanently unkillable mob. If it
 // can't get closer to home for this long, it starts phasing through the blocker.
 const EVADE_STALL_TIMEOUT = 3;
+// Heading offsets (radians) a mob tries when its straight path is blocked, so it
+// can slide around a prop instead of pinning on it. Desired heading (0) first;
+// only evaluated past the first entry when that straight step is obstructed.
+const MOVE_SLIDE_FAN = [0, 0.5, -0.5, 1.0, -1.0, 1.6, -1.6];
 const BACKPEDAL_MULT = 0.65;
 const GRAVITY = 16;
 const JUMP_VELOCITY = 6;
@@ -2827,27 +2831,43 @@ export class Sim {
   private moveToward(e: Entity, dest: Vec3, speed: number, ignoreObstacles = false): boolean {
     const d = dist2d(e.pos, dest);
     if (d < 0.3) return true;
-    e.facing = angleTo(e.pos, dest);
+    const desired = angleTo(e.pos, dest);
+    e.facing = desired;
     const step = Math.min(speed * DT, d);
-    const nx = e.pos.x + Math.sin(e.facing) * step;
-    const nz = e.pos.z + Math.cos(e.facing) * step;
     const canSwim = this.mobCanSwim(MOBS[e.templateId]);
+
     if (ignoreObstacles) {
+      const nx = e.pos.x + Math.sin(desired) * step;
+      const nz = e.pos.z + Math.cos(desired) * step;
       e.pos.x = nx;
       e.pos.z = nz;
       const g = groundHeight(nx, nz, this.cfg.seed);
       e.pos.y = Math.max(g, SWIM_SURFACE_Y); // ride the surface while phasing, don't sink under terrain/water
       return d - step < 0.3;
     }
-    const ground = groundHeight(nx, nz, this.cfg.seed);
-    // landlocked creatures stop at the waterline instead of walking under it
-    if (!canSwim && ground < WATER_LEVEL - SWIM_DEPTH) return false;
-    const resolved = resolvePosition(this.cfg.seed, nx, nz, BODY_RADIUS);
-    e.pos.x = resolved.x;
-    e.pos.z = resolved.z;
-    const g = groundHeight(e.pos.x, e.pos.z, this.cfg.seed);
+
+    // Mobs have no nav mesh. Try the straight path first; only if a prop or the
+    // waterline eats it do we fan the heading out and take the best slide AROUND
+    // the obstacle. That lets a mob round the camp props to reach its target
+    // instead of pinning on them. Open-ground movers take the first branch and
+    // do a single collision check, exactly as before — no added cost.
+    let bestX = e.pos.x, bestZ = e.pos.z, bestProgress = 1e-3;
+    for (const off of MOVE_SLIDE_FAN) {
+      const a = desired + off;
+      const nx = e.pos.x + Math.sin(a) * step;
+      const nz = e.pos.z + Math.cos(a) * step;
+      // landlocked creatures stop at the waterline instead of walking under it
+      if (!canSwim && groundHeight(nx, nz, this.cfg.seed) < WATER_LEVEL - SWIM_DEPTH) continue;
+      const r = resolvePosition(this.cfg.seed, nx, nz, BODY_RADIUS);
+      const progress = d - Math.hypot(r.x - dest.x, r.z - dest.z);
+      if (progress > bestProgress) { bestProgress = progress; bestX = r.x; bestZ = r.z; }
+      if (off === 0 && progress >= step - 1e-3) break; // straight path is clear
+    }
+    e.pos.x = bestX;
+    e.pos.z = bestZ;
+    const g = groundHeight(bestX, bestZ, this.cfg.seed);
     e.pos.y = canSwim && g < WATER_LEVEL - SWIM_DEPTH ? SWIM_SURFACE_Y : g;
-    return d - step < 0.3;
+    return dist2d(e.pos, dest) < 0.3;
   }
 
   // Would a normal (collision- and water-aware) step toward `dest` be blocked —

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -276,6 +276,34 @@ describe('combat', () => {
     expect(wolf.leashAnchor).not.toBeNull();
   });
 
+  it('chasing mobs slide around a camp prop to reach the player instead of pinning on it', () => {
+    // Gravecaller Summoners pinned on their own camp tent while chasing: moveToward
+    // pushed straight into the collider with no way around it, so the mob froze a few
+    // yards short of the player. collide-and-slide must let it round the prop.
+    const sim = makeSim('warrior', 20061);
+    const tent = { x: -3, z: 505, y: 0 }; // tent collider radius ~1.95
+    const mob = [...sim.entities.values()]
+      .filter((e: any) => e.kind === 'mob' && e.templateId === 'gravecaller_summoner')
+      .sort((a: any, b: any) => dist2d(a.spawnPos, tent) - dist2d(b.spawnPos, tent))[0] as any;
+
+    mob.maxHp = 100000; mob.hp = 100000;
+    mob.pos = { x: tent.x, z: tent.z + 5, y: 0 }; mob.prevPos = { ...mob.pos };
+    mob.spawnPos = { ...mob.pos };
+    teleportTo(sim, tent.x, tent.z - 5); // player on the far side, tent dead between them (10yd)
+    mob.aiState = 'chase';
+    mob.aggroTargetId = sim.playerId;
+    mob.inCombat = true;
+    mob.leashAnchor = { ...mob.pos };
+    mob.threat.set(sim.playerId, 1e6);
+
+    let minDist = Infinity;
+    for (let i = 0; i < 60; i++) { // 3s — reaches melee well before any disengage
+      sim.tick();
+      minDist = Math.min(minDist, dist2d(mob.pos, sim.player.pos));
+    }
+    expect(minDist).toBeLessThanOrEqual(5); // got into melee range — routed around the tent
+  });
+
   it('social pulls only very close same-template mobs', () => {
     const sim = makeSim('warrior');
     const wolf = nearestMob(sim, 'forest_wolf');


### PR DESCRIPTION
Follow-up to #237 (the evade/unkillable fix). With summoners no longer frozen in `evade`, players reported the remaining symptom: mobs "pathfind to a place where it looks like they're stuck" while aiming at the player.

## Cause

Same no-pathfinding root cause as #237, but in the **`chase`** state (which #237 deliberately didn't touch). `moveToward` walks a straight line at the target and `resolvePosition` only pushes a body **radially out** of a collider — never around it. So a mob chasing a player with a camp prop (tent/crate/campfire) between them pins on the prop's edge a few yards short of the player.

Repro (Gravecaller Summoner, player on the far side of the camp tent), before this change:
- t0–t10: walks to the tent edge and **pins** at `(-3, 507.4)`
- t10–t45: frozen ~7.4 yd from the player (in `chase`, so not immune, but never reaches melee)
- t50: gives up and resets — the "looks stuck" the players saw

## Fix — collide-and-slide

In `moveToward`: try the straight step first; **only if a prop or the waterline eats it**, fan the heading out (`MOVE_SLIDE_FAN`) and take the best slide *around* the obstacle. After the change, the same summoner rounds the tent and reaches melee (`attack` state) in ~1.3 s.

Benefits both states: chase reaches the target, and evade now walks around props too (the #237 phasing watchdog stays as the backstop for truly trapped geometry / water with no land route).

## Overhead

Unchanged on the common path. An open-ground mover takes the desired heading, makes full progress, and **stops after a single collision check**, exactly as before — the fan only runs for a mob whose straight path is actually blocked.

## Tests

- New: a chasing summoner routes around its camp tent and reaches melee range of a player on the far side.
- Full suite **533/533**, typecheck clean. (Snapshot/kiting/leash/threat tests unaffected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)