### PR TITLE
fix: make unreachable mobs evade immediately

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2472,8 +2472,19 @@ export class Sim {
       mob.inCombat = true;
       return;
     }
-    mob.aggroTargetId = null;
+    this.beginMobEvade(mob);
+  }
+
+  private beginMobEvade(mob: Entity): void {
     mob.aiState = 'evade';
+    mob.aggroTargetId = null;
+    mob.hp = mob.maxHp;
+    mob.auras = [];
+    mob.inCombat = false;
+    mob.tappedById = null;
+    mob.enraged = false;
+    clearThreat(mob);
+    mob.leashAnchor = null;
   }
 
   /** Highest-threat living attacker on the table; prunes stale entries. */
@@ -2640,10 +2651,7 @@ export class Sim {
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
         const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
         if (dist2d(mob.pos, leashAnchor) > leash) {
-          mob.aiState = 'evade';
-          mob.aggroTargetId = null;
-          clearThreat(mob);
-          mob.leashAnchor = null;
+          this.beginMobEvade(mob);
           break;
         }
         const d = dist2d(mob.pos, target.pos);
@@ -2652,8 +2660,17 @@ export class Sim {
           mob.swingTimer = Math.min(mob.swingTimer, 0.4);
           break;
         }
-        if (!this.isRooted(mob)) this.moveToward(mob, target.pos, mob.moveSpeed * this.moveSpeedMult(mob));
-        else mob.facing = angleTo(mob.pos, target.pos);
+        if (!this.isRooted(mob)) {
+          this.moveToward(mob, target.pos, mob.moveSpeed * this.moveSpeedMult(mob));
+          const afterD = dist2d(mob.pos, target.pos);
+          if (afterD < d - 1e-3) {
+            break;
+          } else {
+            this.beginMobEvade(mob);
+          }
+        } else {
+          mob.facing = angleTo(mob.pos, target.pos);
+        }
         break;
       }
       case 'attack': {
@@ -2721,6 +2738,7 @@ export class Sim {
     mob.tappedById = null;
     mob.leashAnchor = null;
     mob.evadeStall = 0;
+    mob.aggroTargetId = null;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -20,6 +20,10 @@ function teleportTo(sim: Sim, x: number, z: number, pid?: number) {
   p.prevPos = { ...p.pos };
 }
 
+function hit(sim: Sim, source: Entity, target: Entity, amount: number) {
+  (sim as any).dealDamage(source, target, amount, false, 'physical', null, 'hit', true);
+}
+
 describe('quest lifecycle', () => {
   it('stops showing the Redbrook starter hint after the first quest is accepted', () => {
     const sim = makeSim();
@@ -157,6 +161,61 @@ describe('swimming', () => {
     wolf.spawnPos = { ...wolf.pos };
     for (let i = 0; i < 100; i++) sim.tick();
     expect(groundHeight(wolf.pos.x, wolf.pos.z, SEED)).toBeGreaterThan(WATER_LEVEL - 0.8);
+  });
+
+  it('landlocked mobs evade as soon as a deep-water target cannot be reached', () => {
+    const sim = makeSim();
+    const wolf = [...sim.entities.values()].find((e) => e.templateId === 'forest_wolf')!;
+    const p = sim.player;
+    teleportTo(sim, LAKE.x, LAKE.z);
+
+    let shore: { x: number; z: number } | null = null;
+    for (let r = 5; r < 80; r += 0.25) {
+      const x = LAKE.x + r;
+      const z = LAKE.z;
+      if (
+        groundHeight(x, z, SEED) > WATER_LEVEL - 0.8 &&
+        groundHeight(x - 0.5, z, SEED) < WATER_LEVEL - 0.8
+      ) {
+        shore = { x, z };
+        break;
+      }
+    }
+    expect(shore).not.toBeNull();
+
+    wolf.pos = { ...sim.groundPos(shore!.x, shore!.z) };
+    wolf.prevPos = { ...wolf.pos };
+    wolf.spawnPos = { ...sim.groundPos(shore!.x + 10, shore!.z) };
+    wolf.hp = Math.max(1, wolf.maxHp - 10);
+    wolf.aiState = 'chase';
+    wolf.aggroTargetId = p.id;
+    wolf.inCombat = true;
+    wolf.leashAnchor = { ...wolf.pos };
+    wolf.threat.set(p.id, 50);
+
+    sim.tick();
+    expect(wolf.aiState).toBe('evade');
+    expect(wolf.hp).toBe(wolf.maxHp);
+    hit(sim, p, wolf, 99999);
+    expect(wolf.dead).toBe(false);
+    expect(wolf.hp).toBe(wolf.maxHp);
+
+    let resetPos: Entity['pos'] | null = null;
+    for (let i = 0; i < 200; i++) {
+      sim.tick();
+      const state: string = wolf.aiState;
+      if (state === 'idle') {
+        resetPos = { ...wolf.pos };
+        break;
+      }
+    }
+
+    expect(wolf.aiState).toBe('idle');
+    expect(wolf.aggroTargetId).toBeNull();
+    expect(wolf.threat.size).toBe(0);
+    expect(wolf.hp).toBe(wolf.maxHp);
+    expect(resetPos).not.toBeNull();
+    expect(dist2d(resetPos!, wolf.spawnPos)).toBeLessThan(0.5);
   });
 
   it('rare swimmers can chase into deep water', () => {


### PR DESCRIPTION
## Summary
- Landlocked mobs now enter evade immediately when terrain or deep water prevents them from closing on their target.
- The evade transition heals the mob, clears tap/threat/combat state, and keeps the existing reset immunity while it returns home.
- Adds regression coverage for the shoreline exploit where a player standing in deep water could damage a non-swimming mob that could not fight back.

## Diagnosis
Non-swimming mobs already refused to walk into deep water, but the chase state did not treat a blocked step as a failed combat engagement. A mob could therefore stand at the shoreline with threat on a swimming player, stay hittable, and never swing back.

## Implementation Notes
- The rule lives in the shared sim mob AI, so offline and server-authoritative behavior stay aligned.
- The new transition reuses the existing `evade` reset path and immunity instead of adding a second reset mode.
- Normal rooted mobs are not forced to evade by this path; the trigger is specifically a failed movement step while trying to chase.

## Verification
- `npx vitest run tests/fixes.test.ts -t "deep-water target"`; 1 test passed.
- `npx vitest run tests/fixes.test.ts tests/evade_immunity.test.ts tests/sim.test.ts tests/threat.test.ts`; 4 files passed, 134 tests passed.
- `npx tsc --noEmit`; passed.
- `npm run build`; passed, with existing cursor-resolution and chunk-size warnings.
- Full local gate passed: `npm test` (46 files, 533 tests), `npx tsc --noEmit`, `npm run build:env`, `npm run build:server`, and `npm run build`.
- Local Chromium smoke at `http://127.0.0.1:5173/?gfx=low`: started offline warrior gameplay, placed the player in deep water and a forest wolf at a dry shoreline step, and verified the wolf entered `evade` on the next sim tick, healed to full, cleared threat, and ignored a forced damage hit while evading.

## Real behavior proof
- Behavior addressed: non-swimming enemies could be damaged safely from deep water while unable to retaliate.
- Environment tested: deterministic sim tests plus a local offline browser session running the shared sim.
- Evidence after fix: the reproduced shoreline wolf reset immediately instead of remaining hittable in chase, then returned home through the existing evade path.
- Not tested: live multiplayer encounter with a naturally pulled outdoor boss.

## Risk
Moderate gameplay-balance reach because this changes how wild mobs respond to blocked chase movement. The behavior is limited to failed movement progress while chasing, keeps rooted combat unchanged, and reuses the established evade reset contract that already clears threat and denies damage while the mob returns home.

## Notes
- Reviewed locally by Codex with `gpt-5.5` and high reasoning.
