### PR TITLE
feat: add /where command for current zone, level range, and coordinates

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,18 @@ export class Sim {
       return null;
     }
 
+    // "/where" (aliases /loc, /zone) — self-only report of the caller's current
+    // zone, its level range, and coordinates. Reuses the self-only error reply
+    // like /who and /played; emits no chat event and is not logged.
+    if (/^\/(?:where|loc|zone)(?:\s|$)/i.test(raw)) {
+      const zone = zoneAt(r.e.pos.z);
+      const [lo, hi] = zone.levelRange;
+      const x = Math.floor(r.e.pos.x);
+      const z = Math.floor(r.e.pos.z);
+      this.error(r.meta.entityId, `You are in ${zone.name} (levels ${lo}–${hi}) at (${x}, ${z}).`);
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -3,6 +3,7 @@ import { Sim } from '../src/sim/sim';
 import { ClientWorld } from '../src/net/online';
 import { SimEvent } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
+import { zoneAt } from '../src/sim/data';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -137,6 +138,37 @@ describe('chat channels', () => {
       type: 'error',
       text: 'The /who roster is available in online play.',
     }));
+  });
+
+  it('/where reports the caller\'s zone, level range, and coordinates', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 12, -340);
+    sim.tick();
+    const zone = zoneAt(-340);
+    const [lo, hi] = zone.levelRange;
+    sim.chat('/where', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      pid: a,
+      text: `You are in ${zone.name} (levels ${lo}–${hi}) at (12, -340).`,
+    }));
+  });
+
+  it('/where accepts the /loc and /zone aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    const expected = `You are in ${zoneAt(-40).name}`;
+    for (const cmd of ['/loc', '/zone']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(chatEvents(events)).toHaveLength(0);
+      expect(events.some((e) => e.type === 'error' && e.text.startsWith(expected))).toBe(true);
+    }
   });
 
   it('exact-case whisper wins over a case-variant squatter', () => {


### PR DESCRIPTION
## What

Adds `/where` (aliases `/loc`, `/zone`) to the sim-core `chat()` — a self-only reply telling a player their current zone, its level range, and their coordinates:

```
You are in Eastbrook (levels 1–10) at (12, -340).
```

## Why

The world is a strip of named zones (`ZONES` in `src/sim/data.ts`), and the sim already resolves them by coordinate via `zoneAt(z)` — but nothing exposed this to players. "What zone am I in / is this area my level?" is a basic MMO question with no answer in-game today. No `/where`-style command exists in the sim core, the server, or any open PR.

## How

- Single branch in `Sim.chat()` (`src/sim/sim.ts`), placed beside the `/who` self-reply. Matches `/^\/(?:where|loc|zone)(?:\s|$)/i`.
- Reuses the existing self-only `error` event (the "reply to sender, no broadcast" pattern shared with `/who` and `/played`) and returns `null`, so the message is never logged as chat.
- Sim-core only, so **both offline and online** get it for free: online routes `/where` through `sim.chat()` untouched (it matches no server-side interceptor), exactly like `/played`.
- `zoneAt` was already imported; no new dependencies.

## Tests

Two new cases in `tests/chat.test.ts` (expected values computed from `zoneAt` rather than hardcoded): asserts the zone/level/coords reply fires on the caller's pid with no broadcast `chat` event, and that the `/loc` and `/zone` aliases work. Full suite green (534 passed), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)