### PR TITLE
feat: target-nearest and cycle-friendly targeting (#133)

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -658,6 +658,8 @@ export class GameServer {
       case 'target': sim.targetEntity(typeof msg.id === 'number' ? msg.id : null, pid); break;
       case 'tab': sim.tabTarget(pid); break;
       case 'targetNearest': sim.targetNearestEnemy(pid); break;
+      case 'tabFriendly': sim.friendlyTabTarget(pid); break;
+      case 'targetNearestFriendly': sim.targetNearestFriendly(pid); break;
       case 'attack': sim.startAutoAttack(pid); break;
       case 'stopattack': sim.stopAutoAttack(pid); break;
       case 'interact': sim.interact(pid); break;

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -15,6 +15,8 @@ const TOUCH_LOOK_PITCH_RATE = 2.2;
 
 export interface InputCallbacks {
   onTab(): void;
+  onTargetFriendly(): void;
+  onCycleFriendly(): void;
   onAbility(slot: number): void;
   onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena'): void;
   onClickPick(x: number, y: number, button: number): void;
@@ -217,6 +219,8 @@ export class Input {
     switch (action) {
       case 'autorun': this.autorun = !this.autorun; return;
       case 'target': this.cb.onTab(); return;
+      case 'targetFriendly': this.cb.onTargetFriendly(); return;
+      case 'targetFriendlyNext': this.cb.onCycleFriendly(); return;
       case 'interact': this.cb.onUiKey('interact'); return;
       case 'bags': this.cb.onUiKey('bags'); return;
       case 'char': this.cb.onUiKey('char'); return;

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -37,6 +37,8 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'autorun', label: 'Toggle Autorun', category: 'Movement', kind: 'edge', defaults: ['KeyR'] },
   // Targeting / interaction
   { id: 'target', label: 'Target Nearest Enemy', category: 'Targeting', kind: 'edge', defaults: ['Tab'] },
+  { id: 'targetFriendly', label: 'Target Nearest Friendly', category: 'Targeting', kind: 'edge', defaults: ['KeyH'] },
+  { id: 'targetFriendlyNext', label: 'Cycle Friendly Target', category: 'Targeting', kind: 'edge', defaults: ['KeyJ'] },
   { id: 'interact', label: 'Interact / Loot', category: 'Targeting', kind: 'edge', defaults: ['KeyF'] },
   // Interface windows
   { id: 'char', label: 'Character', category: 'Interface', kind: 'edge', defaults: ['KeyC'] },

--- a/src/main.ts
+++ b/src/main.ts
@@ -355,6 +355,8 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
 
   const input = new Input(canvas, {
     onTab: () => world.tabTarget(),
+    onTargetFriendly: () => world.targetNearestFriendly(),
+    onCycleFriendly: () => world.friendlyTabTarget(),
     // slot 0 (key 1) is Attack for every class — auto-attack without needing
     // right-click; keys and clicks share the Hud's remappable slot layout
     onAbility: (slot) => hud.castSlot(slot),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -591,6 +591,12 @@ export class ClientWorld implements IWorld {
   tabTarget(): void {
     this.cmd({ cmd: 'tab' });
   }
+  targetNearestFriendly(): void {
+    this.cmd({ cmd: 'targetNearestFriendly' });
+  }
+  friendlyTabTarget(): void {
+    this.cmd({ cmd: 'tabFriendly' });
+  }
   startAutoAttack(): void {
     this.cmd({ cmd: 'attack' });
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3005,6 +3005,43 @@ export class Sim {
     if (best) p.targetId = (best as Entity).id;
   }
 
+  // Nearby allies a beneficial spell can land on: other players (and friendly
+  // pets) within range, never yourself, never dead/hostile. Mirrors the enemy
+  // targeting helpers so heals/buffs are reachable by keyboard, not just by
+  // clicking party frames or world models (#133).
+  private friendlyCandidates(p: Entity): { e: Entity; d: number }[] {
+    const out: { e: Entity; d: number }[] = [];
+    this.grid.forEachInRadius(p.pos.x, p.pos.z, 40, (e, d2) => {
+      if (e.id === p.id || e.dead || !this.isFriendlyTo(p, e)) return;
+      out.push({ e, d: Math.sqrt(d2) });
+    });
+    return out;
+  }
+
+  targetNearestFriendly(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const p = r.e;
+    let best: Entity | null = null;
+    let bestD = Infinity;
+    for (const c of this.friendlyCandidates(p)) {
+      if (c.d < bestD) { bestD = c.d; best = c.e; }
+    }
+    if (best) p.targetId = best.id;
+  }
+
+  friendlyTabTarget(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const p = r.e;
+    const candidates = this.friendlyCandidates(p);
+    if (candidates.length === 0) return;
+    candidates.sort((a, b) => a.d - b.d);
+    const curIdx = candidates.findIndex((c) => c.e.id === p.targetId);
+    const next = candidates[(curIdx + 1) % candidates.length];
+    p.targetId = next.e.id;
+  }
+
   // -------------------------------------------------------------------------
   // Inventory, items, vendor
   // -------------------------------------------------------------------------

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -156,6 +156,8 @@ export interface IWorld {
   castAbilityBySlot(slot: number): void;
   targetEntity(id: number | null): void;
   tabTarget(): void;
+  targetNearestFriendly(): void;
+  friendlyTabTarget(): void;
   startAutoAttack(): void;
   stopAutoAttack(): void;
   interact(): void;

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -41,6 +41,8 @@ function makeInput() {
   };
   const cb = {
     onTab: vi.fn(),
+    onTargetFriendly: vi.fn(),
+    onCycleFriendly: vi.fn(),
     onAbility: vi.fn(),
     onUiKey: vi.fn(),
     onClickPick: vi.fn(),

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -67,7 +67,9 @@ describe('Keybinds defaults', () => {
     expect(kb.actionForCode('KeyB')).toBe('bags');
     expect(kb.actionForCode('Digit1')).toBe('slot0'); // Attack
     expect(kb.actionForCode('Equal')).toBe('slot11');
-    expect(kb.actionForCode('KeyJ')).toBe(null);
+    expect(kb.actionForCode('KeyH')).toBe('targetFriendly');
+    expect(kb.actionForCode('KeyJ')).toBe('targetFriendlyNext');
+    expect(kb.actionForCode('KeyZ')).toBe(null);
   });
 
   it('exposes primary/secondary codes and labels', () => {

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -1003,3 +1003,76 @@ describe('gm characters', () => {
     expect(sim.player.hp).toBe(before - 5);
   });
 });
+
+describe('friendly targeting (#133)', () => {
+  // Drop an ally `dx` yards east of the caster and return its entity.
+  function addAllyAt(sim: Sim, name: string, dx: number) {
+    const p = sim.player;
+    const pid = sim.addPlayer('priest', name);
+    const e = sim.entities.get(pid)!;
+    e.pos.x = p.pos.x + dx; e.pos.z = p.pos.z;
+    e.pos.y = terrainHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+    e.prevPos = { ...e.pos };
+    return e;
+  }
+
+  it('targetNearestFriendly picks the closest ally and never auto-attacks', () => {
+    const sim = makeSim('warrior');
+    const far = addAllyAt(sim, 'Far', 12);
+    const near = addAllyAt(sim, 'Near', 5);
+    sim.tick(); // rebucket the spatial grid
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBe(near.id);
+    expect(sim.player.targetId).not.toBe(far.id);
+    expect(sim.player.autoAttack).toBe(false);
+  });
+
+  it('targetNearestFriendly never targets yourself', () => {
+    const sim = makeSim('warrior');
+    sim.tick();
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBeNull();
+  });
+
+  it('ignores allies beyond 40 yards and keeps the current target', () => {
+    const sim = makeSim('warrior');
+    addAllyAt(sim, 'WayOut', 60);
+    sim.tick();
+    sim.player.targetId = 1234;
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBe(1234);
+  });
+
+  it('skips dead allies', () => {
+    const sim = makeSim('warrior');
+    const ally = addAllyAt(sim, 'Downed', 5);
+    ally.dead = true; ally.hp = 0;
+    sim.tick();
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBeNull();
+  });
+
+  it('friendlyTabTarget cycles allies by distance and wraps', () => {
+    const sim = makeSim('warrior');
+    const a = addAllyAt(sim, 'A', 5);
+    const b = addAllyAt(sim, 'B', 10);
+    const c = addAllyAt(sim, 'C', 15);
+    sim.tick();
+    sim.friendlyTabTarget();             // none -> nearest
+    expect(sim.player.targetId).toBe(a.id);
+    sim.friendlyTabTarget();
+    expect(sim.player.targetId).toBe(b.id);
+    sim.friendlyTabTarget();
+    expect(sim.player.targetId).toBe(c.id);
+    sim.friendlyTabTarget();             // wraps back to nearest
+    expect(sim.player.targetId).toBe(a.id);
+  });
+
+  it('friendlyTabTarget is a no-op when no ally is nearby', () => {
+    const sim = makeSim('warrior');
+    sim.player.targetId = 77;
+    sim.tick();
+    sim.friendlyTabTarget();
+    expect(sim.player.targetId).toBe(77);
+  });
+});


### PR DESCRIPTION
## What & why

Closes the keyboard/agent half of #133. Healing and buffing friendlies **already works** today — you can target an ally by clicking their model or party frame, and the cast path (`castAbility` / `applyAbility`) resolves `targetType: 'friendly'` to your current friendly target, falling back to yourself, then applies the heal/buff. 16 abilities already declare `targetType: 'friendly'`.

The remaining gap was **reachability without the mouse**: both the Tab and "Target" keybinds route to `tabTarget()`, and `targetNearestEnemy()` filters `e.hostile`, so there was no keyboard (or RL-agent) way to select an ally.

## Change

Two sim-core helpers mirroring `targetNearestEnemy` / `tabTarget`, sharing one `friendlyCandidates()` filter so they can't drift:

- **`targetNearestFriendly()`** — nearest entity within 40yd where `isFriendlyTo()` holds (other players + friendly pets), excluding self/dead/hostile; never auto-attacks.
- **`friendlyTabTarget()`** — cycles that same set by distance, wrapping.

Wired through the whole stack so it works offline **and** online:

- `IWorld` interface (`src/world_api.ts`)
- Online command passthrough (`tabFriendly` / `targetNearestFriendly`) + matching server dispatch in `server/game.ts`
- Two new rebindable **Targeting** actions — defaults **H** (Target Nearest Friendly) and **J** (Cycle Friendly Target); both keys were previously unbound. They appear in the existing key-bindings menu automatically.
- Input dispatcher callbacks (`onTargetFriendly` / `onCycleFriendly`)

## Deliberately out of scope

- **RL action space (`obs.ts`)** left untouched: adding an action would resize the `Discrete(n)` space and break the `wow_env.py` contract (cf. #150/#151).
- **Mobile controls** unchanged — can follow up if desired.

## Tests

`tests/sim.test.ts` — nearest picks closest ally, self excluded, >40yd ignored (keeps current target), dead excluded, cycle wraps in distance order, empty-case no-op. Updated `keybinds.test.ts` for the new default binds. Full suite: **538 passed**, `tsc --noEmit` clean.