### PR TITLE
feat: add /target command for a self-only readout of your current target

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,17 @@ export class Sim {
       return null;
     }
 
+    // "/target" (alias "/tar") — self-only readout of your current target.
+    // Reads existing p.targetId state, so it needs no server wiring: it falls
+    // through routeRememberedChat to here and works online for free.
+    if (/^\/(?:target|tar)(?:\s|$)/i.test(raw)) {
+      const tid = r.e.targetId;
+      const t = tid !== null ? this.entities.get(tid) ?? null : null;
+      if (!t) { this.error(r.meta.entityId, 'You have no target.'); return null; }
+      this.error(r.meta.entityId, this.targetReadout(t));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4860,16 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // One-line description of an entity for the self-only "/target" readout:
+  // name, level, what it is (player / pet / mob), and current health. A dead
+  // body reports "dead" instead of a percentage so a lootable corpse reads
+  // sensibly.
+  private targetReadout(t: Entity): string {
+    const kind = t.kind === 'player' ? 'player' : t.ownerId !== null ? 'pet' : 'mob';
+    const health = t.dead ? 'dead' : `${Math.round((t.hp / t.maxHp) * 100)}% HP`;
+    return `Target: ${t.name} (level ${t.level} ${kind}) — ${health}.`;
   }
 }
 

--- a/tests/target_command.test.ts
+++ b/tests/target_command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Entity, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function liveMob(sim: Sim): Entity {
+  const mob = [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null,
+  );
+  if (!mob) throw new Error('test needs a live wild mob');
+  return mob;
+}
+
+function errors(events: SimEvent[]): string[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error').map((e) => e.text);
+}
+
+describe('/target readout command', () => {
+  it('reports no target when nothing is targeted', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.chat('/target', a);
+    const errs = errors(sim.tick());
+    expect(errs.some((t) => /no target/i.test(t))).toBe(true);
+  });
+
+  it('reports a targeted mob with name, level, kind and HP percent', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const mob = liveMob(sim);
+    sim.targetEntity(mob.id, a);
+    sim.chat('/tar', a); // alias
+    const reply = errors(sim.tick()).find((t) => t.includes(mob.name));
+    expect(reply).toBeDefined();
+    expect(reply).toContain(`level ${mob.level}`);
+    expect(reply).toContain('mob');
+    expect(reply).toMatch(/\d+% HP/);
+  });
+
+  it('reports another player target as a player and never reaches other clients', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.targetEntity(b, a);
+    sim.chat('/target', a);
+    const events = sim.tick();
+    const reply = errors(events).find((t) => t.includes('Bet'));
+    expect(reply).toContain('player');
+    // self-only: it is an error event addressed to the asker, not a chat line
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    expect(events.every((e) => e.type !== 'error' || e.pid === a)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds **`/target`** (alias **`/tar`**) to the sim-core chat parser. It prints a one-line, self-only readout of whatever you currently have targeted:

```
Target: Bet (level 5 player) — 100% HP.
Target: Forest Wolf (level 2 mob) — 80% HP.
Target: Snarl (level 3 pet) — 60% HP.
You have no target.
```

A dead body reports `— dead.` instead of a percentage so a lootable corpse reads sensibly.

## Why

A quick way to confirm *what* you're about to attack/heal and its health, without relying on nameplates — handy on mobile/zoomed-out views, and for agent/scripted play that reads chat output.

## How it fits the existing patterns

- Lives in `Sim.chat()` (`src/sim/sim.ts`) next to the other self-only informational replies.
- Reuses the existing self-only `error` event (same channel `/who` uses for its reply) and **returns `null`**, so it is never logged via `routeRememberedChat` nor said out loud.
- Reads only existing `p.targetId` state — no new fields on `PlayerMeta` or `Entity`.
- The server's chat handler (`server/game.ts`) doesn't intercept `/target`, so it falls through `routeRememberedChat` to `sim.chat()` and **works in online play for free** — no net/server/client wiring, mirroring how `/where` and `/played` were added.

## Tests

New `tests/target_command.test.ts` covers: no-target message, a targeted mob (name + level + kind + `% HP`), and a player target (classified as `player`, delivered only to the asker as a self-only `error`, never a `chat` event).

- `npx tsc --noEmit` clean
- `npx vitest run` — 47 files, 535 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)