### PR TITLE
feat: add /xp command for a self-only leveling progress readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/xp" (aliases /exp, /experience) — self-only readout of leveling
+    // progress. Like /who's reply it returns null so it is never logged or
+    // said, and works online for free (no server interceptor routes it).
+    if (/^\/(?:xp|exp|experience)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.xpReadout(r.meta, r.e.level));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4857,17 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // One-line leveling summary for the /xp readout. At MAX_LEVEL there is no
+  // "next level" so we avoid the percent/remaining math (xpForLevel is 0 there).
+  private xpReadout(meta: PlayerMeta, level: number): string {
+    if (level >= MAX_LEVEL) return `Level ${MAX_LEVEL} — maximum level reached.`;
+    const need = xpForLevel(level);
+    const have = Math.max(0, Math.min(meta.xp, need));
+    const pct = Math.floor((have / need) * 100);
+    const fmt = (n: number) => n.toLocaleString('en-US');
+    return `Level ${level} — ${fmt(have)}/${fmt(need)} XP (${pct}%), ${fmt(need - have)} to go.`;
   }
 }
 

--- a/tests/xp_command.test.ts
+++ b/tests/xp_command.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MAX_LEVEL, SimEvent, xpForLevel } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function chatEvents(events: SimEvent[]): Extract<SimEvent, { type: 'chat' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'chat' }> => e.type === 'chat');
+}
+
+function errorFor(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find((e) => e.type === 'error' && e.pid === pid) as
+    | Extract<SimEvent, { type: 'error' }>
+    | undefined;
+  return e?.text;
+}
+
+describe('/xp command', () => {
+  it('reports level, progress, percent, and remaining XP to the sender only', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const bystander = sim.addPlayer('mage', 'Bet');
+    const meta = sim.players.get(a)!;
+    sim.entities.get(a)!.level = 7;
+    meta.xp = 1240;
+    sim.tick();
+
+    sim.chat('/xp', a);
+    const events = sim.tick();
+    // a readout is private and never logged as chat
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.pid === bystander)).toBe(false);
+
+    const need = xpForLevel(7); // total XP to reach level 8
+    const pct = Math.floor((1240 / need) * 100);
+    const text = errorFor(events, a)!;
+    expect(text).toContain('Level 7');
+    expect(text).toContain('1,240');
+    expect(text).toContain(need.toLocaleString('en-US'));
+    expect(text).toContain(`${pct}%`);
+    expect(text).toContain((need - 1240).toLocaleString('en-US')); // remaining
+  });
+
+  it('aliases /exp and /experience behave the same', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.entities.get(a)!.level = 3;
+    sim.players.get(a)!.xp = 0;
+    sim.tick();
+
+    for (const cmd of ['/exp', '/experience', '/XP']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(errorFor(events, a)).toContain('Level 3');
+    }
+  });
+
+  it('announces the cap at max level instead of dividing by zero', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.entities.get(a)!.level = MAX_LEVEL;
+    sim.players.get(a)!.xp = 0;
+    sim.tick();
+
+    sim.chat('/xp', a);
+    const events = sim.tick();
+    const text = errorFor(events, a)!;
+    expect(text).toContain(`Level ${MAX_LEVEL}`);
+    expect(text).toMatch(/max/i);
+    expect(text).not.toContain('%');
+  });
+});


### PR DESCRIPTION
## What

Adds `/xp` (aliases `/exp`, `/experience`) — a self-only chat readout of your leveling progress.

- Below max level: `Level 7 — 1,240/4,500 XP (27%), 3,260 to go.`
- At max level: `Level 20 — maximum level reached.`

## Why

There's currently no in-game way for a player to see their experience progress. This fills that gap with a small, read-only command that fits the existing pattern.

## How

- One regex branch in `Sim.chat()` (right after the `/who` block) plus a small private `xpReadout(meta, level)` helper next to `error()`.
- Mirrors the established self-only readout idiom: replies via a `pid`-scoped `error` event and returns `null`, so it is never logged or said.
- Reads only existing state (`PlayerMeta.xp`, `Entity.level`, `xpForLevel`/`MAX_LEVEL`) — no new fields.
- Falls through to `sim.chat()` with no server interceptor, so it works online for free (like `/played`/`/where`-style readouts).
- At `MAX_LEVEL` it reports the cap instead of dividing by zero (`xpForLevel` is 0 there).

## Tests

`tests/xp_command.test.ts` covers the mid-level readout (privacy, percent, remaining), the aliases (`/exp`, `/experience`, case-insensitive), and the max-level cap path. Full suite: 535 passed; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)