### PR TITLE
feat: add /gold command for a self-only purse readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/gold" (aliases /money, /coins) — a self-only readout of your purse.
+    // Reads only meta.copper; like /who's reply it returns null so it is never
+    // logged or broadcast, and with no server interceptor it works online too.
+    if (/^\/(?:gold|money|coins)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.goldReadout(r.meta.copper));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4857,13 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Render the /gold readout. An empty purse gets flavor text rather than the
+  // bare "You have 0c." that formatMoney would otherwise produce.
+  private goldReadout(copper: number): string {
+    if (copper <= 0) return 'Your purse is empty.';
+    return `You have ${formatMoney(copper)}.`;
   }
 }
 

--- a/tests/gold_command.test.ts
+++ b/tests/gold_command.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { Sim, formatMoney } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTextFor(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find(
+    (ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error' && ev.pid === pid,
+  );
+  return e?.text;
+}
+
+describe('/gold command', () => {
+  it('reports your purse with gold/silver/copper formatting', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 123405; // 12g 34s 5c
+    sim.tick();
+
+    expect(sim.chat('/gold', a)).toBeNull(); // self-only readout, never logged
+    expect(errorTextFor(sim.tick(), a)).toBe(`You have ${formatMoney(123405)}.`);
+  });
+
+  it('shows flavor text for an empty purse instead of "0c"', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 0;
+    sim.tick();
+
+    sim.chat('/gold', a);
+    expect(errorTextFor(sim.tick(), a)).toBe('Your purse is empty.');
+  });
+
+  it('accepts the /money and /coins aliases', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 250;
+    sim.tick();
+
+    for (const cmd of ['/money', '/coins']) {
+      sim.chat(cmd, a);
+      expect(errorTextFor(sim.tick(), a)).toBe(`You have ${formatMoney(250)}.`);
+    }
+  });
+
+  it('is a self-only reply that does not emit a chat event', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 99;
+    sim.tick();
+
+    sim.chat('/gold', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/gold` (aliases `/money`, `/coins`) to the sim-core `chat()` — a self-only readout of your current currency:

```
/gold  ->  You have 12g 34s 5c.
/gold  ->  Your purse is empty.   (when copper is 0)
```

## Why

This continues the established family of self-only readout commands. There's no in-game way to check your exact balance from chat, and the currency state (`PlayerMeta.copper`) and a WoW-style formatter (`formatMoney`) already exist — so this is a small, natural addition.

## How

- Reads only the existing `PlayerMeta.copper` — no new `PlayerMeta`/`Entity` fields.
- Formats via the existing exported `formatMoney()` (`Ng Ns Nc`).
- Empty purse (`copper <= 0`) gets flavor text rather than a bare `0c`, via a small private `goldReadout()` helper next to `error()`.
- Emits a self-only `error` event and returns `null`, so it is never logged or broadcast (same shape as the existing `/who` reply).
- No server-side interceptor in `server/game.ts` matches these tokens, so it falls through to `sim.chat()` and works in online play for free via `routeRememberedChat`.

## Tests

`tests/gold_command.test.ts` covers the formatted readout, the empty-purse flavor text, the `/money` + `/coins` aliases, and that no `chat` event is emitted. `npx tsc --noEmit` is clean and the existing chat suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)