### PR TITLE
feat: add /stats command for a self-only character sheet readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3596,6 +3596,14 @@ export class Sim {
       return { channel: 'general', message: clean };
     }
 
+    // "/stats" (aliases "/st", "/sheet") — self-only character sheet readout.
+    // Reads only live entity state, returns null so it is neither logged nor
+    // spoken, and works online for free (no server interceptor).
+    if (/^\/(?:stats|st|sheet)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.statsReadout(r.meta, r.e));
+      return null;
+    }
+
     // bare text and "/s" are local say; "/y" carries further — both are
     // delivered per-player by range and carry the speaker for chat bubbles
     let channel: 'say' | 'yell' = 'say';
@@ -4845,6 +4853,20 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Builds the self-only "/stats" readout line from live entity state. The
+  // resource clause is dropped for classes whose resourceType is null.
+  private statsReadout(meta: PlayerMeta, e: Entity): string {
+    const className = CLASSES[meta.cls].name;
+    const crit = (e.critChance * 100).toFixed(1);
+    let line = `Level ${e.level} ${className} — HP ${Math.round(e.hp)}/${Math.round(e.maxHp)}`;
+    if (e.resourceType) {
+      const res = e.resourceType.charAt(0).toUpperCase() + e.resourceType.slice(1);
+      line += `, ${res} ${Math.round(e.resource)}/${Math.round(e.maxResource)}`;
+    }
+    line += `. AP ${Math.round(e.attackPower)}, Crit ${crit}%, Armor ${Math.round(e.stats.armor)}.`;
+    return line;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/stats_command.test.ts
+++ b/tests/stats_command.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const ev = events.find(
+    (e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid,
+  );
+  return ev?.text;
+}
+
+describe('/stats command', () => {
+  it('reports a self-only character sheet with the rage resource clause', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const sent = sim.chat('/stats', a);
+    expect(sent).toBeNull(); // not logged or spoken
+
+    const events = sim.tick();
+    const text = errorText(events, a)!;
+    expect(text).toMatch(/^Level \d+ Warrior — HP \d+\/\d+, Rage \d+\/\d+\. AP \d+, Crit \d+\.\d%, Armor \d+\.$/);
+    // self-only: no other player receives the readout
+    expect(events.some((e) => e.type === 'error' && e.pid !== a)).toBe(false);
+  });
+
+  it('uses the Energy clause for a rogue', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/stats', a);
+    const text = errorText(sim.tick(), a)!;
+    expect(text).toContain('Rogue');
+    expect(text).toMatch(/Energy \d+\/\d+/);
+  });
+
+  it('uses the Mana clause for a mage and accepts the /st and /sheet aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    for (const cmd of ['/stats', '/st', '/sheet']) {
+      sim.chat(cmd, a);
+      const text = errorText(sim.tick(), a)!;
+      expect(text).toMatch(/Mana \d+\/\d+/);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `/stats` (aliases `/st`, `/sheet`) to the sim-core `chat()` — a self-only readout of the player's character sheet:

```
Level 7 Warrior — HP 420/420, Rage 35/100. AP 156, Crit 12.4%, Armor 890.
```

It reports level, class, HP, resource (with the resource clause dropped for any class whose `resourceType` is `null`), attack power, crit chance, and armor.

## Why

A lightweight quality-of-life lookup so players can check their combat stats without opening the character panel — handy in chat, and consistent with the other self-readout chat commands.

## How

Follows the established readout pattern:

- Reads only live `Entity` state plus `CLASSES[meta.cls].name` — **no new `PlayerMeta`/`Entity` fields**, so it is fully save-compatible.
- Replies via the self-only `error` event (same channel `/who` uses), so the line is neither logged to chat history nor spoken to nearby players.
- Returns `null`, and matches no server-side chat interceptor, so it works in online play for free via `routeRememberedChat`.

## Tests

`tests/stats_command.test.ts` (vitest) covers the rage/energy/mana resource clauses, the `/st` and `/sheet` aliases, and asserts the readout is self-only and unlogged. Full suite and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)