### PR TITLE
feat: add /cooldowns command for a self-only readout of active cooldowns

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/cooldowns" (aliases "/cd", "/cds") — self-only readout of the abilities
+    // currently on cooldown, soonest-ready first. The shared GCD lives in a
+    // separate field and is intentionally not listed here.
+    if (/^\/(?:cooldowns?|cds?)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.cooldownsReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4857,24 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout for "/cooldowns": summarise the abilities currently on
+  // cooldown for this entity, soonest-ready first.
+  //
+  // `e.cooldowns` is a Map<abilityId, remainingSeconds> — entries exist ONLY
+  // while an ability is cooling down (updateTimers deletes them at <= 0), so an
+  // empty map means everything is ready. Resolve the display name via
+  // ABILITIES[id]?.name (fall back to the raw id if an ability is ever missing
+  // from the table). `remaining` is a float, so Math.ceil keeps a 0.3s
+  // remainder showing as "(1s)", matching how /buffs renders aura timers.
+  //
+  private cooldownsReadout(e: Entity): string {
+    if (e.cooldowns.size === 0) return 'No abilities are on cooldown.';
+    const parts = [...e.cooldowns]
+      .sort((a, b) => a[1] - b[1])
+      .map(([id, remaining]) => `${ABILITIES[id]?.name ?? id} (${Math.ceil(remaining)}s)`);
+    return `Abilities on cooldown (${parts.length}): ${parts.join(', ')}.`;
   }
 }
 

--- a/tests/cooldowns_command.test.ts
+++ b/tests/cooldowns_command.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errors(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+describe('/cooldowns command', () => {
+  it('reports nothing on cooldown when the map is empty', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/cooldowns', a);
+    const errs = errors(sim.tick());
+    expect(errs.length).toBe(1);
+    expect(errs[0].pid).toBe(a);
+    expect(errs[0].text).toBe('No abilities are on cooldown.');
+  });
+
+  it('lists active cooldowns soonest-ready first with ceil-rounded seconds', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    // insert out of order to prove the readout sorts ascending by remaining
+    e.cooldowns.set('execute', 12);
+    e.cooldowns.set('charge', 2.4);
+
+    sim.chat('/cooldowns', a);
+    const errs = errors(sim.tick());
+    expect(errs.length).toBe(1);
+    // 2.4s ceils to 3s while still active; Charge sorts before Execute
+    expect(errs[0].text).toBe('Abilities on cooldown (2): Charge (3s), Execute (12s).');
+  });
+
+  it('accepts the /cd and /cds aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    for (const cmd of ['/cd', '/cds']) {
+      sim.chat(cmd, a);
+      const errs = errors(sim.tick());
+      expect(errs.length).toBe(1);
+      expect(errs[0].text).toBe('No abilities are on cooldown.');
+    }
+  });
+
+  it('is self-only: produces no chat event and is not logged', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const result = sim.chat('/cooldowns', a);
+    expect(result).toBeNull();
+    expect(sim.tick().some((ev) => ev.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/cooldowns` (aliases `/cd`, `/cds`) to the sim-core `chat()` — a self-only readout of the abilities currently on cooldown, **soonest-ready first**:

```
Abilities on cooldown (2): Charge (3s), Execute (12s).
```

or `No abilities are on cooldown.` when nothing is cooling down.

## Why

Players have no in-game way to check what's still on cooldown without watching the action bar. This mirrors the existing self-only readout commands (`/played`, `/where`) and gives a quick textual status check, especially handy mid-fight.

## How

- Reads only the live `Entity.cooldowns` map (`Map<abilityId, remainingSeconds>`) — no new `Entity`/`PlayerMeta` fields.
- Resolves display names via the existing `ABILITIES` table (`ABILITIES[id]?.name ?? id` as a defensive fallback).
- `Math.ceil` on the remaining float so a 0.3s remainder still shows as `(1s)`, matching how `/buffs` renders timers.
- The shared GCD lives in the separate `gcdRemaining` field and is intentionally **not** listed.
- Returns `null` so the command is unlogged/unsaid, and it works online for free with no server interceptor (matches no game.ts chat interceptor and falls through to `sim.chat()`).

## Tests

`tests/cooldowns_command.test.ts` covers the empty case, sorted multi-entry output with ceil rounding, both aliases, and self-only behavior (no chat event, `chat()` returns null). Full suite: 536 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)