### PR TITLE
feat: add /bags command for a self-only inventory readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/bags" (aliases /inv, /inventory) — self-only readout of carried items
+    if (/^\/(?:bags|inv|inventory)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.bagsReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4851,27 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of carried items for "/bags": items sorted by quality
+  // (epic first), ties keeping inventory order, with the purse appended via
+  // formatMoney. Reads only PlayerMeta state, so it works online for free.
+  private bagsReadout(meta: PlayerMeta): string {
+    const purse = `Purse: ${formatMoney(meta.copper)}.`;
+    if (meta.inventory.length === 0) return `Your bags are empty. ${purse}`;
+    const rank: Record<string, number> = { epic: 0, rare: 1, uncommon: 2, common: 3, poor: 4 };
+    const sorted = meta.inventory
+      .map((s, i) => ({ s, i }))
+      .sort((a, b) => {
+        const qa = rank[ITEMS[a.s.itemId]?.quality ?? 'common'] ?? 3;
+        const qb = rank[ITEMS[b.s.itemId]?.quality ?? 'common'] ?? 3;
+        return qa - qb || a.i - b.i;
+      });
+    const parts = sorted.map(({ s }) => {
+      const name = ITEMS[s.itemId]?.name ?? s.itemId;
+      return s.count > 1 ? `${name} x${s.count}` : name;
+    });
+    return `Bags (${parts.length}): ${parts.join(', ')}. ${purse}`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/bags_command.test.ts
+++ b/tests/bags_command.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+// The self-only readout reuses the 'error' channel, like /who and the other
+// readout commands; grab the most recent one addressed to the player.
+function lastReadout(sim: Sim, pid: number): string | undefined {
+  const errs = sim.events.filter(
+    (e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error' && e.pid === pid,
+  );
+  return errs.length ? errs[errs.length - 1].text : undefined;
+}
+
+describe('/bags command', () => {
+  it('reports empty bags with the purse', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(pid)!.copper = 0;
+
+    expect(sim.chat('/bags', pid)).toBeNull();
+    expect(lastReadout(sim, pid)).toBe('Your bags are empty. Purse: 0c.');
+  });
+
+  it('lists items sorted by quality with stack counts and the purse', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(pid)!.copper = 12 * 10000 + 4 * 100 + 5; // 12g 4s 5c
+
+    // Added out of quality order to prove the readout sorts them.
+    sim.addItem('wolf_fang', 5, pid); // poor
+    sim.addItem('fen_reaver_glaive', 1, pid); // rare
+    sim.addItem('minor_healing_potion', 3, pid); // common
+    sim.addItem('redbrook_blade', 1, pid); // uncommon
+
+    sim.chat('/bags', pid);
+    expect(lastReadout(sim, pid)).toBe(
+      'Bags (4): Fen Reaver Glaive, Redbrook Militia Blade, ' +
+        'Minor Healing Potion x3, Cracked Wolf Fang x5. Purse: 12g 4s 5c.',
+    );
+  });
+
+  it('works through the /inv and /inventory aliases', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(pid)!.copper = 0;
+
+    expect(sim.chat('/inv', pid)).toBeNull();
+    expect(lastReadout(sim, pid)).toBe('Your bags are empty. Purse: 0c.');
+    expect(sim.chat('/inventory', pid)).toBeNull();
+    expect(lastReadout(sim, pid)).toBe('Your bags are empty. Purse: 0c.');
+  });
+});


### PR DESCRIPTION
## What

Adds `/bags` (aliases `/inv`, `/inventory`) to the sim-core chat handler — a self-only readout of the items you're carrying:

```
Bags (4): Fen Reaver Glaive, Redbrook Militia Blade, Minor Healing Potion x3, Cracked Wolf Fang x5. Purse: 12g 4s 5c.
```

Empty bags report:

```
Your bags are empty. Purse: 0c.
```

Items are sorted by quality (epic → rare → uncommon → common → poor), ties keeping inventory order; stacks of more than one show an `xN` count; the purse is appended via the existing `formatMoney`.

## Why

The recent readout commands (`/gold`, `/stats`, `/buffs`, `/cooldowns`, `/xp`, `/where`, `/target`, `/played`) all surface character state, but there's no quick way to see what's in your bags without opening the UI. `/bags` fills that gap and is handy for agents/headless play.

## How

- New private `bagsReadout(meta)` near `error()`; reads only existing `PlayerMeta.inventory` + `copper` and `ITEMS` for names/quality — no new fields.
- New regex branch in `Sim.chat()` that calls `this.error(pid, ...)` and returns `null`, so nothing is logged or broadcast.
- Works in online play for free: no server-side chat interceptor catches `/bags`, so it falls through to `sim.chat()` like the other readouts.

## Test

`tests/bags_command.test.ts` covers empty bags, quality-sorted listing with stack counts and purse, and the `/inv` / `/inventory` aliases. `npx tsc --noEmit` is clean; existing chat/market suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)