### PR TITLE
feat: add /quest command for a self-only active quest log readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3596,6 +3596,12 @@ export class Sim {
       return { channel: 'general', message: clean };
     }
 
+    // "/quest" (aliases /quests, /ql) — self-only readout of the active quest log
+    if (/^\/(?:quests?|ql)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.questReadout(r.meta));
+      return null;
+    }
+
     // bare text and "/s" are local say; "/y" carries further — both are
     // delivered per-player by range and carry the speaker for chat bubbles
     let channel: 'say' | 'yell' = 'say';
@@ -4849,6 +4855,24 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout of the active quest log: one entry per tracked quest with
+  // per-objective progress. questLog only ever holds 'active'/'ready' quests
+  // (turn-in deletes the entry), so iterating it gives exactly what to show.
+  private questReadout(meta: PlayerMeta): string {
+    const lines: string[] = [];
+    for (const [qid, qp] of meta.questLog) {
+      const quest = QUESTS[qid];
+      if (!quest) continue;
+      const objs = quest.objectives
+        .map((o, i) => `${o.label} ${Math.min(qp.counts[i] ?? 0, o.count)}/${o.count}`)
+        .join(', ');
+      const tag = qp.state === 'ready' ? ' (ready)' : '';
+      lines.push(`${quest.name}${tag} — ${objs}`);
+    }
+    if (lines.length === 0) return 'Your quest log is empty.';
+    return `Quest log (${lines.length}): ${lines.join(' | ')}.`;
   }
 }
 

--- a/tests/quest_command.test.ts
+++ b/tests/quest_command.test.ts
@@ -1,0 +1,69 @@
+// The /quest command (aliases /quests, /ql) is a self-only readout of the
+// active quest log: one entry per tracked quest with per-objective progress.
+// Like the other readout commands it emits a single 'error' event addressed to
+// the caller and returns null, so it never enters the chat log and needs no
+// server interceptor to work online.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { QUESTS } from '../src/sim/data';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTo(events: SimEvent[], pid: number): string[] {
+  return events
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid)
+    .map((e) => e.text);
+}
+
+describe('/quest command', () => {
+  it('reports an empty log when no quests are tracked', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    expect(sim.chat('/quest', a)).toBeNull();
+    expect(errorTo(sim.tick(), a)).toContain('Your quest log is empty.');
+  });
+
+  it('lists each tracked quest with capped per-objective progress', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    // Pick a multi-objective quest if one exists, else the first quest.
+    const quest =
+      Object.values(QUESTS).find((q) => q.objectives.length > 1) ?? Object.values(QUESTS)[0];
+    // Overshoot the first objective to prove the readout caps at the target.
+    const counts = quest.objectives.map((o) => o.count);
+    counts[0] = quest.objectives[0].count + 5;
+    meta.questLog.set(quest.id, { questId: quest.id, counts, state: 'active' });
+    sim.tick();
+
+    expect(sim.chat('/quests', a)).toBeNull();
+    const line = errorTo(sim.tick(), a).find((t) => t.startsWith('Quest log'));
+    expect(line).toBeDefined();
+    expect(line).toContain('Quest log (1):');
+    expect(line).toContain(quest.name);
+    const o0 = quest.objectives[0];
+    expect(line).toContain(`${o0.label} ${o0.count}/${o0.count}`); // capped, not count+5
+  });
+
+  it('tags ready quests and is alias-compatible (/ql)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    const quest = Object.values(QUESTS)[0];
+    meta.questLog.set(quest.id, {
+      questId: quest.id,
+      counts: quest.objectives.map((o) => o.count),
+      state: 'ready',
+    });
+    sim.tick();
+
+    expect(sim.chat('/ql', a)).toBeNull();
+    const line = errorTo(sim.tick(), a).find((t) => t.startsWith('Quest log'));
+    expect(line).toContain(`${quest.name} (ready)`);
+  });
+});


### PR DESCRIPTION
## What

Adds `/quest` (aliases `/quests`, `/ql`) to the deterministic sim core (`Sim.chat()`): a self-only readout of the player's **active quest log**, one entry per tracked quest with per-objective progress.

Example:

```
Quest log (2): Wolves at the Door — Forest Wolf slain 5/8 | Webwood Menace (ready) — Webwood Lurker slain 6/6, Webwood Silk Gland 4/4.
```

- Quests that are ready to turn in are tagged `(ready)`.
- Empty log replies `Your quest log is empty.`

## Why

You can see quest progress in toasts/objectives as it happens, but there's no on-demand way to ask "what am I working on and how far along am I?" from chat — a staple `/quest`-style readout. It complements the other lightweight self-readout commands.

## How

- Reads only existing state: `PlayerMeta.questLog` (which only ever holds `active`/`ready` entries — turn-in deletes the entry) plus the `QUESTS` registry. No new fields.
- Objective counts are capped at their target with `Math.min`, mirroring `obs.ts`, since kill/collect counters can transiently overshoot.
- Emits a single self-addressed `error` event and returns `null`, so it never enters the chat log and works online for free — no server interceptor needed; it falls through to `sim.chat()` unchanged.

## Tests

`tests/quest_command.test.ts` — empty log, multi-objective progress with overshoot capping, and `(ready)` tagging via the `/ql` alias. Full suite + `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)