### PR TITLE
feat: add /gear command for a self-only readout of equipped items

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/gear" (aliases /equip, /equipment) — self-only readout of equipped items
+    if (/^\/(?:gear|equip|equipment)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.gearReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4855,26 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout of equipped items, walked in a fixed slot order so the
+  // line is stable and empty slots are visible (the point of a gear check).
+  private gearReadout(meta: PlayerMeta): string {
+    const slots: [EquipSlot, string][] = [
+      ['mainhand', 'Main Hand'],
+      ['chest', 'Chest'],
+      ['legs', 'Legs'],
+      ['feet', 'Feet'],
+    ];
+    let worn = 0;
+    const parts = slots.map(([slot, label]) => {
+      const itemId = meta.equipment[slot];
+      if (!itemId) return `${label}: (empty)`;
+      worn++;
+      return `${label}: ${ITEMS[itemId]?.name ?? itemId}`;
+    });
+    if (worn === 0) return 'You have nothing equipped.';
+    return `Equipped (${worn}/${slots.length}): ${parts.join(', ')}.`;
   }
 }
 

--- a/tests/gear_command.test.ts
+++ b/tests/gear_command.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  const e = events.find((ev) => ev.type === 'error');
+  return e && e.type === 'error' ? e.text : undefined;
+}
+
+describe('/gear command', () => {
+  it('lists equipped slots in a fixed order and marks empty ones', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    // A fresh warrior starts with a main hand and a chest piece, no legs/feet.
+    sim.tick();
+    sim.chat('/gear', a);
+    const text = errorText(sim.tick());
+    expect(text).toBeDefined();
+    expect(text).toMatch(/^Equipped \(2\/4\):/);
+    expect(text).toContain('Main Hand:');
+    expect(text).toContain('Chest:');
+    expect(text).toContain('Legs: (empty)');
+    expect(text).toContain('Feet: (empty)');
+    // fixed slot order: main hand before chest before legs before feet
+    expect(text!.indexOf('Main Hand')).toBeLessThan(text!.indexOf('Chest'));
+    expect(text!.indexOf('Chest')).toBeLessThan(text!.indexOf('Legs'));
+    expect(text!.indexOf('Legs')).toBeLessThan(text!.indexOf('Feet'));
+  });
+
+  it('reflects newly equipped gear and resolves item names', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.equipment = { mainhand: 'worn_sword', chest: 'recruit_tunic', legs: 'quilted_trousers', feet: 'oiled_boots' };
+    sim.tick();
+    sim.chat('/gear', a);
+    const text = errorText(sim.tick());
+    expect(text).toMatch(/^Equipped \(4\/4\):/);
+    expect(text).toContain('Worn Shortsword');
+    expect(text).toContain('Quilted Trousers');
+    expect(text).not.toContain('(empty)');
+  });
+
+  it('reports nothing equipped when every slot is empty', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.equipment = {};
+    sim.tick();
+    sim.chat('/gear', a);
+    expect(errorText(sim.tick())).toBe('You have nothing equipped.');
+  });
+
+  it('is reachable via the /equip and /equipment aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const alias of ['/equip', '/equipment']) {
+      sim.chat(alias, a);
+      expect(errorText(sim.tick())).toMatch(/^Equipped /);
+    }
+  });
+
+  it('does not emit a chat event or broadcast to others', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const sent = sim.chat('/gear', a);
+    expect(sent).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/gear` (aliases `/equip`, `/equipment`) to the sim-core `chat()` — a **self-only** readout of the items you currently have equipped, walked in a fixed slot order so the line is stable and gaps are visible (the point of a gear check):

```
Equipped (2/4): Main Hand: Worn Shortsword, Chest: Recruit's Tunic, Legs: (empty), Feet: (empty).
```

- Fully equipped → `Equipped (4/4): ...`
- Nothing equipped → `You have nothing equipped.`

## How

- New private `gearReadout(meta)` next to `error()`; iterates the four `EquipSlot`s (`mainhand`, `chest`, `legs`, `feet`) in fixed order, resolving names via `ITEMS[id]?.name ?? id`.
- Reads only existing state (`PlayerMeta.equipment` + `ITEMS`) — no new fields on `PlayerMeta` or `Entity`.
- Uses the self-only `error` event, returns `null` (so it is neither logged to chat nor spoken), and matches **no** server-side interceptor, so it works in online play for free via `routeRememberedChat` — same approach as the other self-only readout commands.

## Why it's distinct

This lists what is **worn**, per slot — different from an inventory readout (carried items) or a character sheet (computed stats like AP/crit/armor).

## Tests

`tests/gear_command.test.ts` — fixed slot order + empty markers, resolving newly-equipped item names, the nothing-equipped case, both aliases, and that no `chat` event is emitted / `chat()` returns `null`.

Full suite: 537 passing; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)