### PR TITLE
feat: add /abilities command for a self-only spellbook readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/(?:abilities|spells|spellbook)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.abilitiesReadout(r.meta, r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4854,13 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  private abilitiesReadout(meta: PlayerMeta, e: Entity): string {
+    const known = abilitiesKnownAt(meta.cls, e.level);
+    if (known.length === 0) return 'You have not learned any abilities yet.';
+    const list = known.map((k) => `${k.def.name} (Rank ${k.rank})`).join(', ');
+    return `Spellbook (${known.length}): ${list}.`;
   }
 }
 

--- a/tests/abilities_command.test.ts
+++ b/tests/abilities_command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { CLASSES, ABILITIES, abilitiesKnownAt } from '../src/sim/content/classes';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorAfter(sim: Sim, text: string, pid: number): string | undefined {
+  sim.chat(text, pid);
+  const events: SimEvent[] = sim.tick();
+  expect(events.filter((e) => e.type === 'chat')).toHaveLength(0);
+  const err = events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+  return err?.text;
+}
+
+describe('/abilities command', () => {
+  it('lists every known ability with its rank, self-only and unsaid', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const text = errorAfter(sim, '/abilities', a)!;
+
+    const known = abilitiesKnownAt('warrior', sim.entities.get(a)!.level);
+    expect(text).toContain(`Spellbook (${known.length}):`);
+    // a level-1 warrior knows Heroic Strike but not yet Charge (learnLevel 4)
+    expect(text).toContain('Heroic Strike (Rank 1)');
+    expect(text).not.toContain('Charge');
+    expect(text.endsWith('.')).toBe(true);
+  });
+
+  it('reflects newly learned abilities and higher ranks at a higher level', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const e = sim.entities.get(a)!;
+    e.level = 20;
+    sim.tick();
+    const text = errorAfter(sim, '/abilities', a)!;
+
+    const known = abilitiesKnownAt('warrior', 20);
+    expect(text).toContain(`Spellbook (${known.length}):`);
+    // Heroic Strike reaches Rank 4 at level 20; Charge is now learned
+    expect(text).toContain('Heroic Strike (Rank 4)');
+    expect(text).toContain('Charge (Rank 1)');
+  });
+
+  it('accepts the /spells and /spellbook aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const first = ABILITIES[CLASSES.mage.abilities[0]].name;
+    expect(errorAfter(sim, '/spells', a)).toContain(first);
+    expect(errorAfter(sim, '/spellbook', a)).toContain('Spellbook');
+  });
+});


### PR DESCRIPTION
## What

Adds `/abilities` (aliases `/spells`, `/spellbook`) to the sim-core `chat()` handler — a self-only readout of every ability the character has learned, in learn order, each with its current rank:

```
Spellbook (5): Heroic Strike (Rank 1), Battle Shout (Rank 1), Charge (Rank 1), Rend (Rank 1), Thunder Clap (Rank 1).
```

## Why

There's no in-game way to glance at your full known kit from chat. `/cooldowns` shows only what's currently cooling down, and `/stats` shows computed stats — neither lists the spellbook. This fills that gap.

## How

- New private `abilitiesReadout(meta, e)` helper next to `error()`, plus one early-return block in `chat()` before the unknown-command fallback.
- Computes from `abilitiesKnownAt(cls, level)` — the same source of truth the spellbook UI uses — so the list and ranks always match what the player can actually cast.
- Follows the existing self-readout convention exactly: emits a single `error`-channel line, returns `null` (never logged or said), reads no new state fields, and works in online play for free (no server interceptor needed — it falls through `routeRememberedChat` to `sim.chat()`).

## Testing

- New `tests/abilities_command.test.ts`: verifies the level-gated list at level 1 vs 20 (newly learned abilities + higher ranks appear), the rank suffix, self-only/unsaid behavior, and the `/spells` + `/spellbook` aliases.
- Full suite green: 535 passed, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)