### PR TITLE
feat: add /pet command for a self-only readout of your active pet

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/pet" (aliases /companion /pets) — self-only readout of your active pet
+    if (/^\/(?:pet|pets|companion)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.petReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4855,18 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout of the player's active pet: name, level, beast family,
+  // and current health. Reads live pet state via petOf() so it stays accurate
+  // regardless of how the pet was acquired (tame, summon).
+  private petReadout(owner: Entity): string {
+    const pet = this.petOf(owner.id);
+    if (!pet) return 'You do not have a pet.';
+    const family = MOBS[pet.templateId]?.family;
+    const kind = family ? ` ${family}` : '';
+    const pct = pet.maxHp > 0 ? Math.round((pet.hp / pet.maxHp) * 100) : 0;
+    return `Your pet: ${pet.name} (level ${pet.level}${kind}) — HP ${pet.hp}/${pet.maxHp} (${pct}%).`;
   }
 }
 

--- a/tests/pet_command.test.ts
+++ b/tests/pet_command.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent, Entity } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'hunter', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  const err = events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+  return err?.text;
+}
+
+// Hand a player a pet by adopting an existing wild mob, mirroring what a
+// completed tame leaves behind (ownerId set, full health, friendly).
+function givePet(sim: Sim, ownerPid: number): Entity {
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) {
+      e.ownerId = ownerPid;
+      e.hostile = false;
+      e.hp = e.maxHp;
+      return e;
+    }
+  }
+  throw new Error('no wild mob available to adopt as a pet');
+}
+
+describe('/pet command', () => {
+  it('reports name, level, family, and health for an active pet', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    const pet = givePet(sim, a);
+    sim.tick();
+
+    sim.chat('/pet', a);
+    const events = sim.tick();
+    // self-only readout: never reaches the chat channel
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    const text = errorText(events)!;
+    expect(text).toContain(`Your pet: ${pet.name}`);
+    expect(text).toContain(`level ${pet.level}`);
+    expect(text).toContain(`HP ${pet.hp}/${pet.maxHp}`);
+    expect(text).toContain('(100%)');
+  });
+
+  it('rounds the health percentage from live pet HP', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    const pet = givePet(sim, a);
+    pet.hp = Math.round(pet.maxHp * 0.5);
+    sim.tick();
+
+    sim.chat('/pet', a);
+    const text = errorText(sim.tick())!;
+    expect(text).toContain('(50%)');
+  });
+
+  it('tells players without a pet that they have none', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    sim.tick();
+
+    sim.chat('/pet', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    expect(errorText(events)).toBe('You do not have a pet.');
+  });
+
+  it('supports the /companion and /pets aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    const pet = givePet(sim, a);
+    sim.tick();
+
+    for (const cmd of ['/companion', '/pets']) {
+      sim.chat(cmd, a);
+      expect(errorText(sim.tick())).toContain(`Your pet: ${pet.name}`);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `/pet` (aliases `/pets`, `/companion`) to the sim-core `Sim.chat()` — a **self-only** readout of the player's active pet:

```
Your pet: Snarler (level 8 beast) — HP 480/600 (80%).
```

Players with no pet get `You do not have a pet.`

## Why

Hunters (and any future summon classes) can tame/control a pet, but there's no way to glance at its status from chat the way `/target`, `/stats`, `/buffs`, etc. let you inspect other live state. `/pet` fills that gap, following the now-established family of self-only info commands.

## How

- New private `petReadout(owner)` near `error()` resolves the pet via the existing `petOf()` helper and reads only live `Entity` state (`name`, `level`, `templateId` → `MOBS[].family`, `hp`/`maxHp`). No new fields on `Entity` or `PlayerMeta`.
- Dispatched before the unknown-command fallthrough; emits the self-only `error` channel and returns `null`, so it's never logged or said.
- No server interceptor needed — it works online for free via `routeRememberedChat`, matching `/played` and `/where`.
- Defensive: falls back to `(level N)` if a pet has no `family`, and guards the `maxHp > 0` division.

## Tests

`tests/pet_command.test.ts` — active-pet readout (name/level/HP), percent rounding, no-pet message, and the `/companion` + `/pets` aliases. Full suite: 536 passing, `tsc --noEmit` clean.