### PR TITLE
feat: add /party command for a self-only party roster readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3544,6 +3544,13 @@ export class Sim {
       return null;
     }
 
+    // "/party" (no message) is a self-only roster readout; "/party <msg>"
+    // and "/p <msg>" stay party chat (the trailing \s in that branch below).
+    if (/^\/(party|group|grp)\s*$/i.test(raw)) {
+      this.error(r.meta.entityId, this.partyReadout(r.meta.entityId));
+      return null;
+    }
+
     if (/^\/who(?:\s|$)/i.test(raw)) {
       this.error(r.meta.entityId, 'The /who roster is available in online play.');
       return null;
@@ -4845,6 +4852,23 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of the player's party: each member in join order with
+  // level, class, and HP% (or (dead)/(offline)), the leader tagged [leader].
+  private partyReadout(pid: number): string {
+    const party = this.partyOf(pid);
+    if (!party) return 'You are not in a party.';
+    const parts = party.members.map((mPid) => {
+      const meta = this.players.get(mPid);
+      const e = this.entities.get(mPid);
+      if (!meta || !e) return meta ? `${meta.name} (offline)` : `Player ${mPid} (offline)`;
+      const cls = CLASSES[meta.cls].name;
+      const state = e.hp <= 0 ? '(dead)' : `${Math.round((e.hp / e.maxHp) * 100)}%`;
+      const tag = mPid === party.leader ? ' [leader]' : '';
+      return `${meta.name} (Lvl ${e.level} ${cls}, ${state})${tag}`;
+    });
+    return `Party (${party.members.length}/${PARTY_MAX}): ${parts.join(', ')}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/party_command.test.ts
+++ b/tests/party_command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find((ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error' && ev.pid === pid);
+  return e?.text;
+}
+
+// Form a party with `leader` as leader and the rest as members, in order.
+function formParty(sim: Sim, leader: number, members: number[]) {
+  for (const m of members) {
+    sim.partyInvite(m, leader);
+    sim.partyAccept(m);
+  }
+}
+
+describe('/party readout command', () => {
+  it('lists party members with level, class, and HP%, tagging the leader', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+    formParty(sim, a, [b, c]);
+
+    // Wound Gimel to a known HP% so the readout is deterministic.
+    const ce = sim.entities.get(c)!;
+    ce.hp = Math.round(ce.maxHp * 0.4);
+
+    const sent = sim.chat('/party', a);
+    expect(sent).toBeNull(); // self-only readout is never broadcast
+    const text = errorText(sim.tick(), a);
+    expect(text).toBeDefined();
+    expect(text).toContain('Party (3/5):');
+    expect(text).toContain('Aleph');
+    expect(text).toContain('[leader]');
+    expect(text).toContain('Bet');
+    expect(text).toContain('100%');
+    expect(text).toContain('Gimel');
+    expect(text).toContain('40%');
+  });
+
+  it('reports when you are not in a party', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Solo');
+    sim.tick();
+    sim.chat('/party', a);
+    expect(errorText(sim.tick(), a)).toBe('You are not in a party.');
+  });
+
+  it('shows dead members as (dead)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('priest', 'Bet');
+    sim.tick();
+    formParty(sim, a, [b]);
+    sim.entities.get(b)!.hp = 0;
+
+    sim.chat('/group', a); // alias
+    const text = errorText(sim.tick(), a);
+    expect(text).toContain('Bet');
+    expect(text).toContain('(dead)');
+  });
+});


### PR DESCRIPTION
## What

Adds `/party` (aliases `/group`, `/grp`) to the sim-core `Sim.chat()`: a **self-only readout** of your current party. Each member is listed in join order with level, class, and HP%, the leader tagged `[leader]`:

```
Party (3/5): Aleph (Lvl 12 Warrior, 100%) [leader], Bet (Lvl 11 Mage, 100%), Gimel (Lvl 10 Rogue, 40%).
```

Dead members show `(dead)`; a member whose entity can't be resolved shows `(offline)`. Not in a party shows `You are not in a party.`

## How

- New private `partyReadout(pid)` near `error()`; resolves the party via the existing `partyOf(pid)` and reads only live `Party.members` / `Entity` (`level`, `hp`/`maxHp`) / `PlayerMeta` (`name`, `cls`) — **no new fields**.
- Emits a self-only `error` event and returns `null`, so it's never logged or broadcast (matches the `/who` reply pattern).
- Works in online play for free: bare `/party` isn't intercepted server-side and falls through `routeRememberedChat` to `sim.chat`.
- The party-chat branch is untouched — it requires a trailing space (`/p <msg>`, `/party <msg>`), so bare `/party` is a free token.

## Testing

`tests/party_command.test.ts` covers the populated roster (level/class/HP%/`[leader]`), the not-in-a-party message, dead members, and the `/group` alias. Full suite green (535 tests) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)