### PR TITLE
feat: add /session command for a self-only session-stats readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/session" — self-only readout of this session's combat tally. Like the
+    // other readouts it emits a private error line and returns null, so it is
+    // never logged or broadcast and works online without a server interceptor.
+    if (/^\/(?:session|sess|sessionstats)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.sessionReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4857,19 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Build the self-only "/session" line from this session's RewardCounters.
+  // Counters are reset each boot (freshCounters), so this is always per-session.
+  // Format kills/deaths first, then a damage clause, then XP — using
+  // toLocaleString('en-US') for thousands separators on the large numbers.
+  private sessionReadout(meta: PlayerMeta): string {
+    const c = meta.counters;
+    const n = (v: number) => v.toLocaleString('en-US');
+    const plural = (v: number, word: string) => `${n(v)} ${word}${v === 1 ? '' : 's'}`;
+    return `Session: ${plural(c.kills, 'kill')}, ${plural(c.deaths, 'death')}. ` +
+      `Damage dealt ${n(c.damageDealt)}, taken ${n(c.damageTaken)}. ` +
+      `XP gained ${n(c.xpGained)}.`;
   }
 }
 

--- a/tests/session_command.test.ts
+++ b/tests/session_command.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorEvents(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+// Drive a "/session" command for `pid` and return the self-only line it emits.
+function sessionLine(sim: Sim, pid: number): string {
+  sim.chat('/session', pid);
+  const errs = errorEvents(sim.tick());
+  expect(errs).toHaveLength(1);
+  expect(errs[0].pid).toBe(pid);
+  return errs[0].text;
+}
+
+describe('/session command', () => {
+  it('reports a fresh session as all zeros', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(sessionLine(sim, a)).toBe(
+      'Session: 0 kills, 0 deaths. Damage dealt 0, taken 0. XP gained 0.',
+    );
+  });
+
+  it('reflects this session\'s counters with singular/plural and thousands separators', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const c = sim.players.get(a)!.counters;
+    c.kills = 14;
+    c.deaths = 1; // singular
+    c.damageDealt = 8420;
+    c.damageTaken = 3110;
+    c.xpGained = 5300;
+    expect(sessionLine(sim, a)).toBe(
+      'Session: 14 kills, 1 death. Damage dealt 8,420, taken 3,110. XP gained 5,300.',
+    );
+  });
+
+  it('is self-only and never reaches the chat log', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    sim.chat('/session', a);
+    const events = sim.tick();
+    const errs = errorEvents(events);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].pid).toBe(a);
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+  });
+
+  it('accepts the /sess and /sessionstats aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const alias of ['/sess', '/sessionstats']) {
+      sim.chat(alias, a);
+      const errs = errorEvents(sim.tick());
+      expect(errs).toHaveLength(1);
+      expect(errs[0].text).toMatch(/^Session: /);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a `/session` chat command (aliases `/sess`, `/sessionstats`) that gives the player a self-only readout of this session's combat tally:

```
Session: 14 kills, 1 death. Damage dealt 8,420, taken 3,110. XP gained 5,300.
```

## Why

The sim already tracks rich per-session stats in `RewardCounters` (kills, deaths, damage dealt/taken, XP gained), but nothing ever surfaces them to the player. This exposes data the engine already maintains — no new state, no new fields.

## How

- New `/session` branch in `Sim.chat()` and a private `sessionReadout(meta)` helper next to `error()`, mirroring the existing readout convention.
- Emits a private `error`-type line and returns `null`, so it is never logged or broadcast, and works in online play for free (no server-side interceptor needed).
- Counters are reset each boot (`freshCounters`), so the line is always scoped to the current session.
- Singular/plural handling on kills/deaths; `toLocaleString('en-US')` thousands separators on the large numbers (consistent with other readouts).

## Tests

`tests/session_command.test.ts` — fresh-session zero state, populated counters with singular/plural + separators, self-only (no chat event leaks), and the `/sess` / `/sessionstats` aliases. Full suite: 536 passing, clean `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)