### PR TITLE
feat: add /threat command for a self-only target threat-table readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -12,7 +12,7 @@ import { Rng } from './rng';
 import { SpatialGrid } from './spatial';
 import {
   HEAL_THREAT_FACTOR, MELEE_SWITCH_MULT, RANGED_SWITCH_MULT,
-  TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatModifier, topThreatValue,
+  TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatEntries, threatModifier, topThreatValue,
 } from './threat';
 import { groundHeight, WATER_LEVEL } from './world';
 import {
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/threat" (alias "/aggro") — self-only readout of the threat table on the
+    // player's current target. Reads live state only; returns null so the line
+    // is shown only to the caller and never broadcast or logged.
+    if (/^\/(?:threat|aggro)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.threatReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4857,32 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  /** Self-only readout of the threat table on the player's current target,
+   *  highest first, as a percentage of the current threat leader. */
+  private threatReadout(self: Entity): string {
+    const t = self.targetId !== null ? this.entities.get(self.targetId) : undefined;
+    if (!t || t.hp <= 0) return 'You have no target.';
+    if (t.kind !== 'mob') return `Threat is only tracked on enemies; ${t.name} is not one.`;
+    const entries = threatEntries(t, 10);
+    if (entries.length === 0) return `Nobody has any threat on ${t.name}.`;
+    const top = entries[0][1] || 1;
+    const parts = entries.map(([id, v], i) => {
+      const pct = Math.round((v / top) * 100);
+      const you = id === self.id ? ' (you)' : '';
+      const lead = i === 0 ? ' [leader]' : '';
+      return `${this.threatName(id)}${you} ${pct}%${lead}`;
+    });
+    return `Threat on ${t.name} (${entries.length}): ${parts.join(', ')}.`;
+  }
+
+  /** Display name for a threat-table source: a player by pid, else the entity
+   *  (pet/mob) name, else a placeholder for sources that have despawned. */
+  private threatName(id: number): string {
+    const meta = this.players.get(id);
+    if (meta) return meta.name;
+    return this.entities.get(id)?.name || 'Unknown';
   }
 }
 

--- a/tests/threat_command.test.ts
+++ b/tests/threat_command.test.ts
@@ -1,0 +1,70 @@
+// /threat (alias /aggro) is a self-only readout of the threat table on the
+// player's current target — highest first, as a percentage of the threat
+// leader. It reads live state only, emits an `error`-typed line shown only to
+// the caller, and returns null so nothing is broadcast or logged.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function nearestMob(sim: Sim): Entity {
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) return e;
+  }
+  throw new Error('no mob found');
+}
+
+function lastError(sim: Sim, pid: number): string | undefined {
+  const errs = sim.events.filter((e) => e.type === 'error' && (e as any).pid === pid);
+  return errs.length ? (errs[errs.length - 1] as any).text : undefined;
+}
+
+describe('/threat command', () => {
+  it('lists the target threat table highest-first as percentages of the leader', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const mob = nearestMob(sim);
+    mob.threat.clear();
+    mob.threat.set(a, 500); // leader
+    mob.threat.set(b, 250); // half
+    sim.entities.get(a)!.targetId = mob.id;
+
+    expect(sim.chat('/threat', a)).toBeNull();
+    const line = lastError(sim, a);
+    expect(line).toBe(`Threat on ${mob.name} (2): Aleph (you) 100% [leader], Bet 50%.`);
+  });
+
+  it('reports no target when nothing is targeted', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.entities.get(a)!.targetId = null;
+
+    sim.chat('/aggro', a);
+    expect(lastError(sim, a)).toBe('You have no target.');
+  });
+
+  it('reports an empty table when the target has no threat on it', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const mob = nearestMob(sim);
+    mob.threat.clear();
+    sim.entities.get(a)!.targetId = mob.id;
+
+    sim.chat('/threat', a);
+    expect(lastError(sim, a)).toBe(`Nobody has any threat on ${mob.name}.`);
+  });
+
+  it('refuses to read threat off a non-enemy target', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.entities.get(a)!.targetId = b;
+
+    sim.chat('/threat', a);
+    expect(lastError(sim, a)).toBe('Threat is only tracked on enemies; Bet is not one.');
+  });
+});


### PR DESCRIPTION
## What

Adds `/threat` (alias `/aggro`) to the sim-core `Sim.chat()` — a self-only readout of the threat table on your **current target**, highest first, as a percentage of the current threat leader:

```
Threat on Forest Wolf (2): Aleph (you) 100% [leader], Bet 50%.
```

## Why

Players see floating threat meters during combat, but there's no way to *query* the live hate table on a mob. Tanks have no quick check on whether they hold aggro, and DPS have no way to see how close they are to pulling. The data already exists (`threatEntries` in `src/sim/threat.ts`) — this just surfaces it on demand.

## Edge cases

- No target → `You have no target.`
- Target isn't an enemy (another player/pet) → `Threat is only tracked on enemies; <name> is not one.`
- Empty table → `Nobody has any threat on <name>.`

## How

- New private `threatReadout(self)` + `threatName(id)` near `error()`. Reads only `Entity.targetId` and `threatEntries(mob, 10)`; resolves source names via `this.players` (player pids) falling back to entity names (pets/mobs).
- Adds no new `Entity`/`PlayerMeta` fields.
- Emits the self-only `error` event and returns `null`, so the line is shown only to the caller and is never broadcast or logged — matching the existing `/who` reply convention.
- No server interceptor needed: it falls through to `sim.chat()` and works in online play for free via `routeRememberedChat`.

## Tests

`tests/threat_command.test.ts` covers the populated table (percentages + leader/you tags), no-target, empty-table, and non-enemy-target cases. Full suite green (`npm test`), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)