### PR TITLE
feat: add /zones command for a self-only world zone listing

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2,7 +2,7 @@ import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
   ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, questRewardItemId, abilitiesKnownAt, instanceOrigin,
-  zoneAt,
+  zoneAt, ZONES,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
 import { resolvePosition } from './colliders';
@@ -3549,6 +3549,13 @@ export class Sim {
       return null;
     }
 
+    // "/zones" (aliases /zonelist, /worldmap) — self-only readout of every
+    // overworld zone with its level range, tagging the one you're standing in.
+    if (/^\/(?:zones|zonelist|worldmap)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.zonesReadout(r.e.pos.z));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4852,21 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout for "/zones": lists every overworld zone in travel order
+  // (south -> north) with its level range, tagging the zone the player is in.
+  // `currentZ` is the player's world Z (use zoneAt(currentZ) to find their zone).
+  // ZONES is the ordered ZoneDef[] from ./data; each has .name and
+  // .levelRange = [min, max].
+  private zonesReadout(currentZ: number): string {
+    if (ZONES.length === 0) return 'No zones are defined.';
+    const here = zoneAt(currentZ);
+    const parts = ZONES.map((z) => {
+      const line = `${z.name} (Lvl ${z.levelRange[0]}-${z.levelRange[1]})`;
+      return z.id === here.id ? `${line} [you are here]` : line;
+    });
+    return `Zones (${ZONES.length}): ${parts.join(', ')}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/zones_command.test.ts
+++ b/tests/zones_command.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { ZONES, zoneAt } from '../src/sim/data';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  return events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')?.text;
+}
+
+describe('/zones command', () => {
+  it('is a self-only readout that is neither said nor logged', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(sim.chat('/zones', a)).toBeNull();
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    const text = errorText(events);
+    expect(text).toBeDefined();
+  });
+
+  it('lists every overworld zone with its level range', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/zones', a);
+    const text = errorText(sim.tick())!;
+    for (const z of ZONES) {
+      expect(text).toContain(z.name);
+      expect(text).toContain(`${z.levelRange[0]}-${z.levelRange[1]}`);
+    }
+  });
+
+  it('tags the zone the player is currently standing in', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    // Stand deep in the last zone, then read.
+    const last = ZONES[ZONES.length - 1];
+    teleport(sim, a, 0, last.zMin + 1);
+    sim.tick();
+    expect(zoneAt(sim.entities.get(a)!.pos.z).name).toBe(last.name);
+    sim.chat('/zones', a);
+    const text = errorText(sim.tick())!;
+    // The current-zone marker sits on the last zone's line, not the first.
+    const here = text.indexOf('here');
+    expect(here).toBeGreaterThan(text.indexOf(ZONES[0].name));
+    expect(here).toBeGreaterThan(text.indexOf(last.name));
+  });
+
+  it('responds the same way to the /zonelist and /worldmap aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const cmd of ['/zonelist', '/worldmap']) {
+      sim.chat(cmd, a);
+      const text = errorText(sim.tick())!;
+      expect(text).toContain(ZONES[0].name);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds `/zones` (aliases `/zonelist`, `/worldmap`) to the sim-core `Sim.chat()` — a self-only readout of every overworld zone, in south→north travel order, with each zone's level range, tagging the zone you're currently standing in:

```
Zones (3): Eastbrook Vale (Lvl 1-7) [you are here], Mirefen Marsh (Lvl 6-13), Thornpeak Heights (Lvl 13-20).
```

## Why

It's a lightweight navigation/planning aid — "where should I level next?" — and complements `/where` (which reports only the *current* zone). Players can see the whole world's level bands at a glance without leaving chat.

## How

- New private `zonesReadout(currentZ)` near `error()`; iterates the static `ZONES` array (`src/sim/data.ts`) and marks the current zone via `zoneAt(currentZ)`.
- Reads **only** existing static zone data — no new `Entity`/`PlayerMeta` fields.
- Returns `null` so the readout is never said or logged (self-only `error` emit), and there's **no server interceptor**, so it works online for free via `routeRememberedChat`. Matches the established readout-command convention.

## Tests

`tests/zones_command.test.ts` — covers: self-only (not said/logged), every zone + level range present, current-zone tagging follows the player, and the `/zonelist` + `/worldmap` aliases. Full chat suite still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)