### PR TITLE
feat: add /inspect command for a cross-player level/class/health readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,30 @@ export class Sim {
       return null;
     }
 
+    // "/inspect name" — self-only readout of another online player's level,
+    // class, and health. The first cross-player readout; mirrors WoW's Inspect.
+    const im = /^\/(?:inspect|ins|examine)(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (im) {
+      const targetName = (im[1] ?? '').trim();
+      if (!targetName) { this.error(r.meta.entityId, 'Inspect whom? Usage: /inspect <name>.'); return null; }
+      // resolve by name with the same exact-then-unambiguous-CI rule as /w
+      let target: PlayerMeta | null = null;
+      const ciMatches: PlayerMeta[] = [];
+      const wanted = targetName.toLowerCase();
+      for (const meta of this.players.values()) {
+        if (meta.name === targetName) { target = meta; break; }
+        if (meta.name.toLowerCase() === wanted) ciMatches.push(meta);
+      }
+      if (!target) {
+        if (ciMatches.length === 1) target = ciMatches[0];
+        else if (ciMatches.length > 1) { this.error(r.meta.entityId, `Several players match '${targetName}'. Use exact capitalization.`); return null; }
+      }
+      const te = target ? this.entities.get(target.entityId) : null;
+      if (!target || !te) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
+      this.error(r.meta.entityId, this.inspectReadout(target, te));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4873,15 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // One-line readout for /inspect: another player's level, class, and health.
+  private inspectReadout(target: PlayerMeta, e: Entity): string {
+    const cls = CLASSES[target.cls]?.name ?? target.cls;
+    const hp = e.hp <= 0
+      ? 'dead'
+      : `${Math.round(Math.max(0, Math.min(1, e.hp / e.maxHp)) * 100)}%`;
+    return `${target.name}: Level ${e.level} ${cls} — HP ${hp}.`;
   }
 }
 

--- a/tests/inspect_command.test.ts
+++ b/tests/inspect_command.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+// /inspect replies via the self-only `error` event addressed to the inspector.
+function inspectReply(sim: Sim, pid: number, text: string): string | undefined {
+  sim.chat(text, pid);
+  const errs = sim.events.filter(
+    (e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error' && (e as { pid: number }).pid === pid,
+  );
+  return errs.length ? errs[errs.length - 1].text : undefined;
+}
+
+describe('/inspect command', () => {
+  it('reports another player\'s level, class, and health', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const e = sim.entities.get(b)!;
+    e.level = 8;
+
+    expect(inspectReply(sim, a, '/inspect Bet')).toBe('Bet: Level 8 Mage — HP 100%.');
+  });
+
+  it('shows a partial-health percentage and "dead" for a corpse', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('rogue', 'Gimel');
+    const e = sim.entities.get(b)!;
+    e.hp = Math.round(e.maxHp * 0.4);
+    expect(inspectReply(sim, a, '/inspect Gimel')).toBe(`Gimel: Level ${e.level} Rogue — HP 40%.`);
+
+    e.hp = 0;
+    expect(inspectReply(sim, a, '/inspect Gimel')).toBe(`Gimel: Level ${e.level} Rogue — HP dead.`);
+  });
+
+  it('matches names case-insensitively when unambiguous', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    expect(inspectReply(sim, a, '/inspect bet')).toMatch(/^Bet: Level \d+ Mage/);
+  });
+
+  it('rejects an ambiguous case-insensitive match', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    sim.addPlayer('rogue', 'bet');
+    expect(inspectReply(sim, a, '/inspect BET')).toBe("Several players match 'BET'. Use exact capitalization.");
+  });
+
+  it('errors when the named player is not online', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    expect(inspectReply(sim, a, '/inspect Nobody')).toBe("There is no player named 'Nobody' online.");
+  });
+
+  it('asks whom to inspect when no name is given', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    expect(inspectReply(sim, a, '/inspect')).toBe('Inspect whom? Usage: /inspect <name>.');
+  });
+
+  it('supports the /ins and /examine aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    expect(inspectReply(sim, a, '/ins Bet')).toMatch(/^Bet: Level \d+ Mage/);
+    expect(inspectReply(sim, a, '/examine Bet')).toMatch(/^Bet: Level \d+ Mage/);
+  });
+});


### PR DESCRIPTION
## What

Adds `/inspect <name>` (aliases `/ins`, `/examine`) to the sim-core `Sim.chat()`. Unlike the recent self-only readout commands, this is the **first cross-player readout** — it inspects another online player, mirroring WoW's right-click Inspect.

Replies self-only via the `error` event:

```
Aleph: Level 12 Warrior — HP 100%.
```

## Behavior

- No name → `Inspect whom? Usage: /inspect <name>.`
- Unknown name → `There is no player named 'X' online.`
- Ambiguous case-insensitive match → `Several players match 'X'. Use exact capitalization.`
- Dead target → `... — HP dead.`

Name resolution reuses the `/w` whisper handler's exact-then-unambiguous case-insensitive rule, so matching semantics are consistent across commands.

## Implementation notes

- One new block in `Sim.chat()` (before the whisper handler) plus a private `inspectReadout(target, e)` helper near `error()`.
- Reads only `PlayerMeta.name`/`cls` and `Entity.level`/`hp`/`maxHp` plus `CLASSES[cls].name` — **no new fields**.
- Returns `null` so it is unlogged, and needs **no server interceptor** (works online for free via `routeRememberedChat`, like the other readouts).

## Tests

`tests/inspect_command.test.ts` — 7 cases (readout, partial/dead HP, CI match, ambiguity, unknown name, missing arg, aliases). Full type-check and chat suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)