### PR TITLE
[codex] Bundle jgyy QoL and security fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ see each other in town. `Enter` opens chat.
 - **Parties** (up to 5): right-click a player → *Invite to Party*. Party
   frames on the left, members share tap rights, kill quest credit and split
   XP with the real vanilla group bonuses (1.166/1.3/1.43 for 3/4/5). Party
-  chat with `/p message`. Blue member blips on the minimap.
+  chat with `/p message`. Blue member blips on the minimap. Settle loot
+  disputes with `/roll` (also `/roll N` or `/roll M-N`) — a server-rolled
+  number broadcast to the party, or to nearby players when ungrouped.
 - **Trading**: right-click a player → *Trade*. Both sides stage items + money,
   both must accept, and the swap is atomic and server-validated (quest items
   are untradeable). Walking apart cancels.

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ see each other in town. `Enter` opens chat.
   its loot/XP/quest credit — others get "You don't have permission to loot
   that."), mobs retarget the next attacker when their victim dies (no free
   resets), join/leave announcements, `/say`-style chat.
+- **Away status**: `/afk [message]` and `/dnd [message]` mark you as away.
+  Anyone who whispers you gets an automatic reply with your message; `/dnd`
+  also withholds the incoming whisper. Repeat the bare command (or just send
+  any other chat) to clear it. Status is session-only and resets on login.
 
 ## The Hollow Crypt — 5-player elite instance
 

--- a/index.html
+++ b/index.html
@@ -3386,7 +3386,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general, /afk, /dnd)" autocomplete="off" />
   </template>
 
   <main id="start-screen">

--- a/server/db.ts
+++ b/server/db.ts
@@ -408,9 +408,19 @@ export async function closePlaySession(sessionId: number): Promise<void> {
 }
 
 // Sessions left open by a crash have an unknown duration; close them at their
-// start time so they don't inflate playtime stats forever.
+// start time so they don't inflate playtime stats forever. Scope this to the
+// current realm: in the process-per-realm model peers share one database, and
+// an unscoped UPDATE would force-close sessions still live on other realms.
 export async function closeOrphanSessions(): Promise<number> {
-  const res = await pool.query('UPDATE play_sessions SET ended_at = started_at WHERE ended_at IS NULL');
+  const res = await pool.query(
+    `UPDATE play_sessions ps
+        SET ended_at = ps.started_at
+       FROM characters c
+      WHERE ps.character_id = c.id
+        AND c.realm = $1
+        AND ps.ended_at IS NULL`,
+    [REALM],
+  );
   return res.rowCount ?? 0;
 }
 

--- a/server/game.ts
+++ b/server/game.ts
@@ -57,6 +57,7 @@ export interface ClientSession {
   alive: boolean;
   joinedAt: number;
   dbSessionId: number | null; // play_sessions row, set once the insert lands
+  left: boolean; // set in leave(); guards against the open-session insert landing after disconnect
   chatTokens: number;
   chatLastRefill: number;
   chatLastRateError: number;
@@ -429,7 +430,7 @@ export class GameServer {
     }
     const session: ClientSession = {
       ws, accountId, characterId, pid, name,
-      lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
+      lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null, left: false,
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
       blockedIds: new Set(),
@@ -443,7 +444,14 @@ export class GameServer {
     this.sessionsByCharacterId.set(characterId, session);
     this.peakOnline = Math.max(this.peakOnline, this.clients.size);
     openPlaySession(accountId, characterId, name)
-      .then((id) => { session.dbSessionId = id; })
+      .then((id) => {
+        session.dbSessionId = id;
+        // If the player disconnected before this insert landed, leave() saw a
+        // null id and skipped the close. Close it now so the row isn't orphaned.
+        if (session.left) {
+          void closePlaySession(id).catch((err) => console.error('failed to close play session:', err));
+        }
+      })
       .catch((err) => console.error('failed to open play session:', err));
 
     this.send(session, {
@@ -475,6 +483,7 @@ export class GameServer {
 
   async leave(session: ClientSession, reason: string): Promise<void> {
     if (!this.clients.has(session.pid)) return;
+    session.left = true;
     this.clients.delete(session.pid);
     this.sessionsByCharacterId.delete(session.characterId);
     this.social.forget(session.characterId);

--- a/server/game.ts
+++ b/server/game.ts
@@ -671,6 +671,8 @@ export class GameServer {
       case 'target': sim.targetEntity(typeof msg.id === 'number' ? msg.id : null, pid); break;
       case 'tab': sim.tabTarget(pid); break;
       case 'targetNearest': sim.targetNearestEnemy(pid); break;
+      case 'tabFriendly': sim.friendlyTabTarget(pid); break;
+      case 'targetNearestFriendly': sim.targetNearestFriendly(pid); break;
       case 'attack': sim.startAutoAttack(pid); break;
       case 'stopattack': sim.stopAutoAttack(pid); break;
       case 'interact': sim.interact(pid); break;

--- a/server/main.ts
+++ b/server/main.ts
@@ -223,8 +223,17 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const name = normalizeCharName(body.name);
       if (name === null) return json(res, 400, { error: 'invalid character name (2-16 letters)' });
       if (offensiveName(name)) return json(res, 400, { error: 'character name is not allowed' });
+      const characterId = Number(renameMatch[1]);
+      // A rename mutates the DB name and clears force_rename, but a live
+      // ClientSession keeps its own copy of the name (used by reports, chat and
+      // /api/status). Renaming an online character desyncs that copy and — worse
+      // — lets a force-renamed player already in the world clear the moderation
+      // flag without ever leaving. Mirror the DELETE guard and require offline.
+      if ([...game.clients.values()].some((s) => s.characterId === characterId)) {
+        return json(res, 400, { error: 'character is currently online' });
+      }
       try {
-        const c = await renameCharacter(accountId, Number(renameMatch[1]), name);
+        const c = await renameCharacter(accountId, characterId, name);
         if (!c) return json(res, 404, { error: 'character not found' });
         return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
       } catch (err: any) {

--- a/server/main.ts
+++ b/server/main.ts
@@ -10,6 +10,7 @@ import {
 } from './db';
 import { cleanReportReason, createPlayerReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
+import { bufferHandshakeMessages } from './ws_buffer';
 import {
   hashPassword, verifyPassword, newToken, validUsernameShape, offensiveName, validPassword, normalizeCharName,
 } from './auth';
@@ -460,7 +461,12 @@ async function main(): Promise<void> {
 
     ws.once('message', (data) => {
       clearTimeout(authTimer);
-      void authenticateWebSocket(ws, String(data));
+      // Buffer any frames the client sends while the async auth/join handshake
+      // is still in flight, then replay them once authenticateWebSocket has
+      // attached the permanent message handler. Without this the frames are
+      // silently dropped (see ws_buffer.ts).
+      const flush = bufferHandshakeMessages(ws);
+      void authenticateWebSocket(ws, String(data)).finally(flush);
     });
   }
 

--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -117,7 +117,20 @@ export function recordAuthFailure(username: string): void {
   const recent = (authFailures.get(key) ?? []).filter((t) => t > windowStart);
   recent.push(Date.now());
   authFailures.set(key, recent);
-  if (authFailures.size > MAX_TRACKED_IPS) authFailures.clear(); // memory backstop
+  // Memory backstop: evict only accounts whose window has fully expired rather
+  // than clearing everything. A blanket clear() would also wipe the live
+  // lockout counters we are accumulating against accounts under attack — which
+  // is exactly when a credential-stuffing flood inflates this map past the cap,
+  // silently disabling the per-account throttle. Mirrors rateLimited() above.
+  if (authFailures.size > MAX_TRACKED_IPS) {
+    for (const [k, times] of authFailures) {
+      if (k === key) continue;
+      if (times.length === 0 || times[times.length - 1] <= windowStart) {
+        authFailures.delete(k);
+      }
+      if (authFailures.size <= MAX_TRACKED_IPS) break;
+    }
+  }
 }
 
 /** Clear an account's failure history after a successful login. */

--- a/server/social.ts
+++ b/server/social.ts
@@ -226,6 +226,8 @@ export class SocialService {
   async friendRemove(actor: SocialActor, name: string): Promise<void> {
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
     if (!target) { this.err(actor.characterId, `No character named '${name}' on your friends list.`); return; }
+    const friends = await this.db.listFriends(actor.characterId);
+    if (!friends.some((f) => f.id === target.id)) { this.err(actor.characterId, `${target.name} is not on your friends list.`); return; }
     await this.db.removeFriend(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} removed from friends.`);
     this.push(actor.characterId);
@@ -282,6 +284,8 @@ export class SocialService {
   async blockRemove(actor: SocialActor, name: string): Promise<void> {
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
     if (!target) { this.err(actor.characterId, `No character named '${name}' on your ignore list.`); return; }
+    const blocks = await this.db.listBlocks(actor.characterId);
+    if (!blocks.some((b) => b.id === target.id)) { this.err(actor.characterId, `${target.name} is not on your ignore list.`); return; }
     await this.db.removeBlock(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} is no longer ignored.`);
     this.tx.onBlocksChanged(actor.characterId, await this.db.blockedIds(actor.characterId));

--- a/server/ws_buffer.ts
+++ b/server/ws_buffer.ts
@@ -1,0 +1,27 @@
+import type { EventEmitter } from 'node:events';
+
+// A freshly-upgraded websocket authenticates with its first frame, but the
+// permanent message handler is only attached after an async handshake
+// (token + moderation + character lookups, then game.join). The `ws` receiver
+// emits 'message' events and the underlying EventEmitter simply drops any that
+// have no listener, so a client that sends input immediately after its auth
+// frame loses every frame until the handshake resolves.
+//
+// bufferHandshakeMessages captures those in-flight frames and returns a flush
+// callback. Call flush once the real handler is attached to replay the frames
+// in order. Frames that arrive after flush are delivered live by the real
+// handler, so flushing never duplicates them.
+export function bufferHandshakeMessages(ws: EventEmitter): () => void {
+  const pending: unknown[] = [];
+  const capture = (data: unknown) => {
+    pending.push(data);
+  };
+  ws.on('message', capture);
+  let flushed = false;
+  return () => {
+    if (flushed) return;
+    flushed = true;
+    ws.off('message', capture);
+    for (const data of pending) ws.emit('message', data);
+  };
+}

--- a/server/ws_buffer.ts
+++ b/server/ws_buffer.ts
@@ -10,10 +10,14 @@ import type { EventEmitter } from 'node:events';
 // bufferHandshakeMessages captures those in-flight frames and returns a flush
 // callback. Call flush once the real handler is attached to replay the frames
 // in order. Frames that arrive after flush are delivered live by the real
-// handler, so flushing never duplicates them.
-export function bufferHandshakeMessages(ws: EventEmitter): () => void {
+// handler, so flushing never duplicates them. Keep the buffer bounded because
+// these frames arrive before authentication has completed.
+const MAX_HANDSHAKE_FRAMES = 64;
+
+export function bufferHandshakeMessages(ws: EventEmitter, maxFrames = MAX_HANDSHAKE_FRAMES): () => void {
   const pending: unknown[] = [];
   const capture = (data: unknown) => {
+    if (pending.length >= maxFrames) return;
     pending.push(data);
   };
   ws.on('message', capture);

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -15,6 +15,8 @@ const TOUCH_LOOK_PITCH_RATE = 2.2;
 
 export interface InputCallbacks {
   onTab(): void;
+  onTargetFriendly(): void;
+  onCycleFriendly(): void;
   onAbility(slot: number): void;
   onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena'): void;
   onClickPick(x: number, y: number, button: number): void;
@@ -217,6 +219,8 @@ export class Input {
     switch (action) {
       case 'autorun': this.autorun = !this.autorun; return;
       case 'target': this.cb.onTab(); return;
+      case 'targetFriendly': this.cb.onTargetFriendly(); return;
+      case 'targetFriendlyNext': this.cb.onCycleFriendly(); return;
       case 'interact': this.cb.onUiKey('interact'); return;
       case 'bags': this.cb.onUiKey('bags'); return;
       case 'char': this.cb.onUiKey('char'); return;

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -37,6 +37,8 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'autorun', label: 'Toggle Autorun', category: 'Movement', kind: 'edge', defaults: ['KeyR'] },
   // Targeting / interaction
   { id: 'target', label: 'Target Nearest Enemy', category: 'Targeting', kind: 'edge', defaults: ['Tab'] },
+  { id: 'targetFriendly', label: 'Target Nearest Friendly', category: 'Targeting', kind: 'edge', defaults: ['KeyH'] },
+  { id: 'targetFriendlyNext', label: 'Cycle Friendly Target', category: 'Targeting', kind: 'edge', defaults: ['KeyJ'] },
   { id: 'interact', label: 'Interact / Loot', category: 'Targeting', kind: 'edge', defaults: ['KeyF'] },
   // Interface windows
   { id: 'char', label: 'Character', category: 'Interface', kind: 'edge', defaults: ['KeyC'] },

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -113,22 +113,38 @@ export class Keybinds {
     let stored: unknown = null;
     try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
     if (!stored || typeof stored !== 'object') return;
+    const obj = stored as Record<string, unknown>;
     // Apply stored codes over the defaults, but only for known actions and
     // never letting one code land on two actions (first writer keeps it).
+    // Actions absent from the stored blob (e.g. ones added in a later release
+    // than the player's last save) KEEP their defaults rather than loading
+    // unbound — explicit stored bindings still win, so this only fills gaps.
     const claimed = new Set<string>();
     for (const a of BIND_ACTIONS) {
-      const entry = (stored as Record<string, unknown>)[a.id];
+      const entry = obj[a.id];
+      if (!Array.isArray(entry)) continue; // missing action: keep its default
       const slots: (string | null)[] = [null, null];
       for (let i = 0; i < SLOTS_PER_ACTION; i++) {
-        const v = Array.isArray(entry) ? entry[i] : undefined;
+        const v = entry[i];
         if (typeof v === 'string' && !claimed.has(v) && !isReservedCode(v)) {
           slots[i] = v;
           claimed.add(v);
-        } else {
-          slots[i] = null;
         }
       }
       this.map.set(a.id, slots);
+    }
+    // Second pass: for actions that kept their defaults, drop any code an
+    // explicit stored binding already claimed so the same key can't drive two
+    // actions (preserving the WoW-style uniqueness invariant).
+    for (const a of BIND_ACTIONS) {
+      if (Array.isArray(obj[a.id])) continue;
+      const slots = this.map.get(a.id)!;
+      for (let i = 0; i < slots.length; i++) {
+        const c = slots[i];
+        if (c === null) continue;
+        if (claimed.has(c)) slots[i] = null;
+        else claimed.add(c);
+      }
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -355,6 +355,8 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
 
   const input = new Input(canvas, {
     onTab: () => world.tabTarget(),
+    onTargetFriendly: () => world.targetNearestFriendly(),
+    onCycleFriendly: () => world.friendlyTabTarget(),
     // slot 0 (key 1) is Attack for every class — auto-attack without needing
     // right-click; keys and clicks share the Hud's remappable slot layout
     onAbility: (slot) => hud.castSlot(slot),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -591,6 +591,12 @@ export class ClientWorld implements IWorld {
   tabTarget(): void {
     this.cmd({ cmd: 'tab' });
   }
+  targetNearestFriendly(): void {
+    this.cmd({ cmd: 'targetNearestFriendly' });
+  }
+  friendlyTabTarget(): void {
+    this.cmd({ cmd: 'tabFriendly' });
+  }
   startAutoAttack(): void {
     this.cmd({ cmd: 'attack' });
   }

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -198,7 +198,7 @@ function blankEntity(id: number): Entity {
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
-    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
+    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -16,7 +16,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     channeling: false, channelTickTimer: 0, channelTickEvery: 0,
     gcdRemaining: 0, cooldowns: new Map(), queuedOnSwing: null, fiveSecondRule: 99,
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
-    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
+    chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,

--- a/src/sim/obs.ts
+++ b/src/sim/obs.ts
@@ -126,7 +126,10 @@ export function encodeObs(sim: Sim): number[] {
     obs.push(1);
     obs.push(target.hp / Math.max(1, target.maxHp));
     obs.push(clamp((target.level - p.level) / 5, -1, 1));
-    obs.push(clamp(d / 40, 0, 1));
+    // distance shares the d/40 scale used for nearby mobs and the interactable
+    // below; clamp to the same 1.5 ceiling (the 60-unit observation radius) so a
+    // target beyond 40 units stays distinguishable instead of saturating at 1
+    obs.push(clamp(d / 40, 0, 1.5));
     obs.push(Math.sin(rel));
     obs.push(Math.cos(rel));
     obs.push(target.hostile ? 1 : 0);

--- a/src/sim/obs.ts
+++ b/src/sim/obs.ts
@@ -1,4 +1,4 @@
-import { ITEMS, QUESTS, QUEST_ORDER, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } from './data';
+import { CLASSES, ITEMS, QUESTS, QUEST_ORDER, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } from './data';
 import { Sim } from './sim';
 import { Entity, GCD, angleTo, dist2d, normAngle, xpForLevel, MAX_LEVEL } from './types';
 
@@ -6,6 +6,12 @@ import { Entity, GCD, angleTo, dist2d, normAngle, xpForLevel, MAX_LEVEL } from '
 // Discrete action space for RL agents.
 // Movement actions are "held" for the duration of one env step (frame-skip).
 // ---------------------------------------------------------------------------
+
+// Ability slots must cover the largest class kit so the RL agent can observe
+// and cast every ability a player can learn. Derived from CLASSES (not a fixed
+// constant) so adding abilities to any class can never silently leave high
+// learn-order slots unreachable. See abilitiesKnownAt(): one entry per ability.
+const ABILITY_SLOTS = Math.max(...Object.values(CLASSES).map((c) => c.abilities.length));
 
 export const ACTIONS = [
   'noop',          // 0
@@ -18,23 +24,14 @@ export const ACTIONS = [
   'jump',          // 7  (forward+jump)
   'target_nearest',// 8
   'attack',        // 9  start auto-attack on current target
-  'ability_1',     // 10  abilities index the learned list in learn order
-  'ability_2',     // 11
-  'ability_3',     // 12
-  'ability_4',     // 13
-  'ability_5',     // 14
-  'ability_6',     // 15
-  'ability_7',     // 16
-  'ability_8',     // 17
-  'ability_9',     // 18
-  'ability_10',    // 19
-  'interact',      // 20 loot corpse / pick up object / talk to quest npc
-  'stop',          // 21 stop moving + stop attacking
-  'eat_drink',     // 22 consume best food (or water for mana classes) from bags
+  // abilities index the learned list in learn order: ability_1 .. ability_N
+  ...Array.from({ length: ABILITY_SLOTS }, (_, i) => `ability_${i + 1}`),
+  'interact',      // loot corpse / pick up object / talk to quest npc
+  'stop',          // stop moving + stop attacking
+  'eat_drink',     // consume best food (or water for mana classes) from bags
 ] as const;
 
 export const NUM_ACTIONS = ACTIONS.length;
-const ABILITY_SLOTS = 10;
 
 export function applyAction(sim: Sim, action: number): void {
   const inp = sim.moveInput;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3924,6 +3924,14 @@ export class Sim {
       return null;
     }
 
+    // "/cooldowns" (aliases "/cd", "/cds") — self-only readout of the abilities
+    // currently on cooldown, soonest-ready first. The shared GCD lives in a
+    // separate field and is intentionally not listed here.
+    if (/^\/(?:cooldowns?|cds?)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.cooldownsReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5400,6 +5408,24 @@ export class Sim {
   // float, so Math.ceil keeps a still-active 0.3s remainder showing as "(1s)".
   private auraLabel(a: Aura): string {
     return `${a.name} (${Math.ceil(a.remaining)}s)`;
+  }
+
+  // Self-only readout for "/cooldowns": summarise the abilities currently on
+  // cooldown for this entity, soonest-ready first.
+  //
+  // `e.cooldowns` is a Map<abilityId, remainingSeconds> — entries exist ONLY
+  // while an ability is cooling down (updateTimers deletes them at <= 0), so an
+  // empty map means everything is ready. Resolve the display name via
+  // ABILITIES[id]?.name (fall back to the raw id if an ability is ever missing
+  // from the table). `remaining` is a float, so Math.ceil keeps a 0.3s
+  // remainder showing as "(1s)", matching how /buffs renders aura timers.
+  //
+  private cooldownsReadout(e: Entity): string {
+    if (e.cooldowns.size === 0) return 'No abilities are on cooldown.';
+    const parts = [...e.cooldowns]
+      .sort((a, b) => a[1] - b[1])
+      .map(([id, remaining]) => `${ABILITIES[id]?.name ?? id} (${Math.ceil(remaining)}s)`);
+    return `Abilities on cooldown (${parts.length}): ${parts.join(', ')}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3882,6 +3882,17 @@ export class Sim {
       return null;
     }
 
+    // "/target" (alias "/tar") — self-only readout of your current target.
+    // Reads existing p.targetId state, so it needs no server wiring: it falls
+    // through routeRememberedChat to here and works online for free.
+    if (/^\/(?:target|tar)(?:\s|$)/i.test(raw)) {
+      const tid = r.e.targetId;
+      const t = tid !== null ? this.entities.get(tid) ?? null : null;
+      if (!t) { this.error(r.meta.entityId, 'You have no target.'); return null; }
+      this.error(r.meta.entityId, this.targetReadout(t));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5300,6 +5311,16 @@ export class Sim {
       'Whisper a player with /w <name> <message>.',
       '/who lists who is online (online play only).',
     ];
+  }
+
+  // One-line description of an entity for the self-only "/target" readout:
+  // name, level, what it is (player / pet / mob), and current health. A dead
+  // body reports "dead" instead of a percentage so a lootable corpse reads
+  // sensibly.
+  private targetReadout(t: Entity): string {
+    const kind = t.kind === 'player' ? 'player' : t.ownerId !== null ? 'pet' : 'mob';
+    const health = t.dead ? 'dead' : `${Math.round((t.hp / t.maxHp) * 100)}% HP`;
+    return `Target: ${t.name} (level ${t.level} ${kind}) — ${health}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -232,6 +232,9 @@ export interface PlayerMeta {
   questsDone: Set<string>;
   counters: RewardCounters;
   autoEquip: boolean;
+  // sim.time when this character entered the world; powers /played. Session-only
+  // (sim.time resets to 0 each server boot), so it reports time this session.
+  joinedAt: number;
   // Ashen Coliseum standing — persisted in CharacterState
   arenaRating: number;
   arenaWins: number;
@@ -515,6 +518,7 @@ export class Sim {
       questsDone: new Set(),
       counters: freshCounters(),
       autoEquip: opts?.autoEquip ?? false,
+      joinedAt: this.time,
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
@@ -3812,6 +3816,21 @@ export class Sim {
       const replyTo = r.meta.lastWhisperFrom;
       if (!replyTo) { this.error(r.meta.entityId, 'You have no one to reply to.'); return null; }
       line = `/w ${replyTo} ${rm[1]}`;
+    }
+
+    // "/played" — report how long this character has been in the world this
+    // session. Self-only informational line, like /who's reply.
+    if (/^\/played(?:\s|$)/i.test(raw)) {
+      const secs = Math.max(0, Math.floor(this.time - r.meta.joinedAt));
+      const h = Math.floor(secs / 3600);
+      const m = Math.floor((secs % 3600) / 60);
+      const s = secs % 60;
+      const parts: string[] = [];
+      if (h) parts.push(`${h}h`);
+      if (h || m) parts.push(`${m}m`);
+      parts.push(`${s}s`);
+      this.error(r.meta.entityId, `Time played this session: ${parts.join(' ')}.`);
+      return null;
     }
 
     // "/w name message" — private whisper to an online player

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3944,6 +3944,12 @@ export class Sim {
       return null;
     }
 
+    // "/gear" (aliases /equip, /equipment) — self-only readout of equipped items
+    if (/^\/(?:gear|equip|equipment)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.gearReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5477,6 +5483,26 @@ export class Sim {
     }
     if (lines.length === 0) return 'Your quest log is empty.';
     return `Quest log (${lines.length}): ${lines.join(' | ')}.`;
+  }
+
+  // Self-only readout of equipped items, walked in a fixed slot order so the
+  // line is stable and empty slots are visible (the point of a gear check).
+  private gearReadout(meta: PlayerMeta): string {
+    const slots: [EquipSlot, string][] = [
+      ['mainhand', 'Main Hand'],
+      ['chest', 'Chest'],
+      ['legs', 'Legs'],
+      ['feet', 'Feet'],
+    ];
+    let worn = 0;
+    const parts = slots.map(([slot, label]) => {
+      const itemId = meta.equipment[slot];
+      if (!itemId) return `${label}: (empty)`;
+      worn++;
+      return `${label}: ${ITEMS[itemId]?.name ?? itemId}`;
+    });
+    if (worn === 0) return 'You have nothing equipped.';
+    return `Equipped (${worn}/${slots.length}): ${parts.join(', ')}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2,7 +2,7 @@ import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
   ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, questRewardItemId, abilitiesKnownAt, instanceOrigin,
-  zoneAt,
+  zoneAt, ZONES,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
 import { resolvePosition } from './colliders';
@@ -3985,6 +3985,13 @@ export class Sim {
       return null;
     }
 
+    // "/zones" (aliases /zonelist, /worldmap) — self-only readout of every
+    // overworld zone with its level range, tagging the one you're standing in.
+    if (/^\/(?:zones|zonelist|worldmap)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.zonesReadout(r.e.pos.z));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5441,6 +5448,21 @@ export class Sim {
       return `${meta.name} (Lvl ${e.level} ${cls}, ${state})${tag}`;
     });
     return `Party (${party.members.length}/${PARTY_MAX}): ${parts.join(', ')}.`;
+  }
+
+  // Self-only readout for "/zones": lists every overworld zone in travel order
+  // (south -> north) with its level range, tagging the zone the player is in.
+  // `currentZ` is the player's world Z (use zoneAt(currentZ) to find their zone).
+  // ZONES is the ordered ZoneDef[] from ./data; each has .name and
+  // .levelRange = [min, max].
+  private zonesReadout(currentZ: number): string {
+    if (ZONES.length === 0) return 'No zones are defined.';
+    const here = zoneAt(currentZ);
+    const parts = ZONES.map((z) => {
+      const line = `${z.name} (Lvl ${z.levelRange[0]}-${z.levelRange[1]})`;
+      return z.id === here.id ? `${line} [you are here]` : line;
+    });
+    return `Zones (${ZONES.length}): ${parts.join(', ')}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1473,6 +1473,10 @@ export class Sim {
 
   private applyAbility(p: Entity, meta: PlayerMeta, res: ResolvedAbility): void {
     const ability = res.def;
+    // Toggling a buff off (re-casting a form/stance/stealth you already have) is
+    // free and must not re-arm the ability's cooldown — the cooldown only gates
+    // re-entry. See isToggleBuff and the cast-time gate in castAbility.
+    const togglingOff = isToggleBuff(ability) && p.auras.some((a) => a.id === ability.id);
     if (ability.id === 'conjure_water') {
       this.spendResource(p, res.cost);
       // higher ranks conjure better water (falls back if the item isn't defined)
@@ -1498,14 +1502,14 @@ export class Sim {
     // helpful spells never miss
     if (ability.targetType === 'friendly') {
       this.spendResource(p, res.cost);
-      if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+      if (ability.cooldown > 0 && !togglingOff) p.cooldowns.set(ability.id, ability.cooldown);
       this.runEffects(p, meta, target, res);
       return;
     }
 
     if (target && ability.school !== 'physical') {
       this.spendResource(p, res.cost);
-      if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+      if (ability.cooldown > 0 && !togglingOff) p.cooldowns.set(ability.id, ability.cooldown);
       this.emit({ type: 'spellfx', sourceId: p.id, targetId: target.id, school: ability.school, fx: 'projectile' });
       if (!this.rng.chance(spellHitChance(p.level, target.level))) {
         this.emit({ type: 'damage', sourceId: p.id, targetId: target.id, amount: 0, crit: false, school: ability.school, ability: ability.name, kind: 'miss' });
@@ -1517,7 +1521,7 @@ export class Sim {
     }
 
     this.spendAbilityCost(p, res);
-    if (ability.cooldown > 0) p.cooldowns.set(ability.id, ability.cooldown);
+    if (ability.cooldown > 0 && !togglingOff) p.cooldowns.set(ability.id, ability.cooldown);
     this.runEffects(p, meta, target, res);
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3909,6 +3909,14 @@ export class Sim {
       return null;
     }
 
+    // "/stats" (aliases "/st", "/sheet") — self-only character sheet readout.
+    // Reads only live entity state, returns null so it is neither logged nor
+    // spoken, and works online for free (no server interceptor).
+    if (/^\/(?:stats|st|sheet)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.statsReadout(r.meta, r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5313,6 +5321,20 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Builds the self-only "/stats" readout line from live entity state. The
+  // resource clause is dropped for classes whose resourceType is null.
+  private statsReadout(meta: PlayerMeta, e: Entity): string {
+    const className = CLASSES[meta.cls].name;
+    const crit = (e.critChance * 100).toFixed(1);
+    let line = `Level ${e.level} ${className} — HP ${Math.round(e.hp)}/${Math.round(e.maxHp)}`;
+    if (e.resourceType) {
+      const res = e.resourceType.charAt(0).toUpperCase() + e.resourceType.slice(1);
+      line += `, ${res} ${Math.round(e.resource)}/${Math.round(e.maxResource)}`;
+    }
+    line += `. AP ${Math.round(e.attackPower)}, Crit ${crit}%, Armor ${Math.round(e.stats.armor)}.`;
+    return line;
   }
 
   private error(pid: number, text: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2237,7 +2237,7 @@ export class Sim {
     }
 
     // tap rights: the first player (or their pet) to damage a mob owns it
-    if (source && target.kind === 'mob' && target.hostile && target.tappedById === null && amount >= 0) {
+    if (source && target.kind === 'mob' && target.hostile && target.tappedById === null && amount > 0) {
       if (source.kind === 'player') target.tappedById = source.id;
       else if (source.ownerId !== null) target.tappedById = source.ownerId;
     }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3938,6 +3938,12 @@ export class Sim {
       return null;
     }
 
+    // "/quest" (aliases /quests, /ql) — self-only readout of the active quest log
+    if (/^\/(?:quests?|ql)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.questReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5453,6 +5459,24 @@ export class Sim {
       .sort((a, b) => a[1] - b[1])
       .map(([id, remaining]) => `${ABILITIES[id]?.name ?? id} (${Math.ceil(remaining)}s)`);
     return `Abilities on cooldown (${parts.length}): ${parts.join(', ')}.`;
+  }
+
+  // Self-only readout of the active quest log: one entry per tracked quest with
+  // per-objective progress. questLog only ever holds 'active'/'ready' quests
+  // (turn-in deletes the entry), so iterating it gives exactly what to show.
+  private questReadout(meta: PlayerMeta): string {
+    const lines: string[] = [];
+    for (const [qid, qp] of meta.questLog) {
+      const quest = QUESTS[qid];
+      if (!quest) continue;
+      const objs = quest.objectives
+        .map((o, i) => `${o.label} ${Math.min(qp.counts[i] ?? 0, o.count)}/${o.count}`)
+        .join(', ');
+      const tag = qp.state === 'ready' ? ' (ready)' : '';
+      lines.push(`${quest.name}${tag} — ${objs}`);
+    }
+    if (lines.length === 0) return 'Your quest log is empty.';
+    return `Quest log (${lines.length}): ${lines.join(' | ')}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3950,6 +3950,12 @@ export class Sim {
       return null;
     }
 
+    // "/abilities" (aliases /spells, /spellbook) — self-only spellbook readout
+    if (/^\/(?:abilities|spells|spellbook)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.abilitiesReadout(r.meta, r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5503,6 +5509,13 @@ export class Sim {
     });
     if (worn === 0) return 'You have nothing equipped.';
     return `Equipped (${worn}/${slots.length}): ${parts.join(', ')}.`;
+  }
+
+  private abilitiesReadout(meta: PlayerMeta, e: Entity): string {
+    const known = abilitiesKnownAt(meta.cls, e.level);
+    if (known.length === 0) return 'You have not learned any abilities yet.';
+    const list = known.map((k) => `${k.def.name} (Rank ${k.rank})`).join(', ');
+    return `Spellbook (${known.length}): ${list}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -234,6 +234,16 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // Transient presence status. Set by /afk and /dnd, cleared when the player
+  // chats again. Session-only — never persisted, so it resets on login.
+  away: AwayStatus | null;
+}
+
+// Away-from-keyboard / do-not-disturb presence. `afk` still delivers whispers
+// (the sender just gets a heads-up); `dnd` withholds them.
+export interface AwayStatus {
+  mode: 'afk' | 'dnd';
+  message: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -503,6 +513,7 @@ export class Sim {
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
+      away: null,
     };
     this.players.set(player.id, meta);
     if (this.primaryId === -1) this.primaryId = player.id;
@@ -3624,6 +3635,30 @@ export class Sim {
       return null;
     }
 
+    // "/afk [message]" / "/dnd [message]" — set a presence status. Repeating
+    // the same command with no message toggles it off. While away, anyone who
+    // whispers you gets an auto-reply; /dnd also withholds the whisper itself.
+    const awaym = /^\/(afk|dnd)(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (awaym) {
+      const mode = awaym[1].toLowerCase() as AwayStatus['mode'];
+      const custom = awaym[2]?.trim();
+      if (r.meta.away?.mode === mode && !custom) {
+        r.meta.away = null;
+        this.emit({ type: 'log', text: mode === 'afk' ? 'You are no longer Away From Keyboard.' : 'You have left Do Not Disturb mode.', color: '#ffd100', pid: r.meta.entityId });
+      } else {
+        const message = custom || (mode === 'afk' ? 'Away From Keyboard' : 'Do Not Disturb');
+        r.meta.away = { mode, message };
+        this.emit({ type: 'log', text: mode === 'afk' ? `You are now Away From Keyboard: ${message}` : `You are now in Do Not Disturb mode: ${message}`, color: '#ffd100', pid: r.meta.entityId });
+      }
+      return null;
+    }
+
+    // Any other chat means you're back — clear a lingering away status.
+    if (r.meta.away) {
+      r.meta.away = null;
+      this.emit({ type: 'log', text: 'You are no longer marked as away.', color: '#ffd100', pid: r.meta.entityId });
+    }
+
     if (/^\/who(?:\s|$)/i.test(raw)) {
       this.error(r.meta.entityId, 'The /who roster is available in online play.');
       return null;
@@ -3684,6 +3719,16 @@ export class Sim {
       }
       if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
+      if (target.away) {
+        const label = target.away.mode === 'afk' ? 'Away From Keyboard' : 'Do Not Disturb';
+        this.emit({ type: 'log', text: `${target.name} is ${label}: ${target.away.message}`, color: '#ffd100', pid: r.meta.entityId });
+        if (target.away.mode === 'dnd') {
+          // Withhold the whisper, but still echo the sender's own line so they
+          // see what they tried to send.
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
+          return { channel: 'whisper', message: msg };
+        }
+      }
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
@@ -3744,7 +3789,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /roll, /me, or an emote like /wave.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /roll /afk /dnd, /me, or an emote like /wave.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3833,6 +3833,18 @@ export class Sim {
       return null;
     }
 
+    // "/where" (aliases /loc, /zone) — self-only report of the caller's current
+    // zone, its level range, and coordinates. Reuses the self-only error reply
+    // like /who and /played; emits no chat event and is not logged.
+    if (/^\/(?:where|loc|zone)(?:\s|$)/i.test(raw)) {
+      const zone = zoneAt(r.e.pos.z);
+      const [lo, hi] = zone.levelRange;
+      const x = Math.floor(r.e.pos.x);
+      const z = Math.floor(r.e.pos.z);
+      this.error(r.meta.entityId, `You are in ${zone.name} (levels ${lo}–${hi}) at (${x}, ${z}).`);
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3932,6 +3932,12 @@ export class Sim {
       return null;
     }
 
+    // "/bags" (aliases /inv, /inventory) — self-only readout of carried items
+    if (/^\/(?:bags|inv|inventory)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.bagsReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5350,6 +5356,27 @@ export class Sim {
     }
     line += `. AP ${Math.round(e.attackPower)}, Crit ${crit}%, Armor ${Math.round(e.stats.armor)}.`;
     return line;
+  }
+
+  // Self-only readout of carried items for "/bags": items sorted by quality
+  // (epic first), ties keeping inventory order, with the purse appended via
+  // formatMoney. Reads only PlayerMeta state, so it works online for free.
+  private bagsReadout(meta: PlayerMeta): string {
+    const purse = `Purse: ${formatMoney(meta.copper)}.`;
+    if (meta.inventory.length === 0) return `Your bags are empty. ${purse}`;
+    const rank: Record<string, number> = { epic: 0, rare: 1, uncommon: 2, common: 3, poor: 4 };
+    const sorted = meta.inventory
+      .map((s, i) => ({ s, i }))
+      .sort((a, b) => {
+        const qa = rank[ITEMS[a.s.itemId]?.quality ?? 'common'] ?? 3;
+        const qb = rank[ITEMS[b.s.itemId]?.quality ?? 'common'] ?? 3;
+        return qa - qb || a.i - b.i;
+      });
+    const parts = sorted.map(({ s }) => {
+      const name = ITEMS[s.itemId]?.name ?? s.itemId;
+      return s.count > 1 ? `${name} x${s.count}` : name;
+    });
+    return `Bags (${parts.length}): ${parts.join(', ')}. ${purse}`;
   }
 
   private error(pid: number, text: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3971,6 +3971,14 @@ export class Sim {
     this.duelInvites.delete(r.meta.entityId);
     const other = this.players.get(invite.fromPid);
     if (!other) return;
+    // Re-validate: the challenger may have multiple pending challenges out, and
+    // either fighter could have entered a duel since. Starting one here would
+    // overwrite a live duel (this.duels is keyed per-pid) and leave the original
+    // opponent fighting a duel nobody else is tracking.
+    if (this.duels.has(invite.fromPid) || this.duels.has(r.meta.entityId)) {
+      this.error(r.meta.entityId, 'A duel is already in progress.');
+      return;
+    }
     const duel: DuelState = { a: invite.fromPid, b: r.meta.entityId, state: 'countdown', timer: DUEL_COUNTDOWN };
     this.duels.set(duel.a, duel);
     this.duels.set(duel.b, duel);
@@ -4436,6 +4444,14 @@ export class Sim {
     if (!invite || invite.expires < this.time) { this.error(r.meta.entityId, 'The trade request has expired.'); return; }
     this.tradeInvites.delete(r.meta.entityId);
     if (!this.players.get(invite.fromPid)) return;
+    // Re-validate availability: an inviter can have several outgoing invites at
+    // once, and either party may have started a trade since the request. Opening
+    // a session here would clobber a live one (this.trades is keyed per-pid) and
+    // strand the other partner in a desynced window.
+    if (this.trades.has(invite.fromPid) || this.trades.has(r.meta.entityId)) {
+      this.error(r.meta.entityId, 'That player is already trading.');
+      return;
+    }
     const session: TradeSession = {
       a: invite.fromPid, b: r.meta.entityId,
       offerA: { items: [], copper: 0 }, offerB: { items: [], copper: 0 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3893,6 +3893,14 @@ export class Sim {
       return null;
     }
 
+    // "/xp" (aliases /exp, /experience) — self-only readout of leveling
+    // progress. Like /who's reply it returns null so it is never logged or
+    // said, and works online for free (no server interceptor routes it).
+    if (/^\/(?:xp|exp|experience)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.xpReadout(r.meta, r.e.level));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5321,6 +5329,17 @@ export class Sim {
     const kind = t.kind === 'player' ? 'player' : t.ownerId !== null ? 'pet' : 'mob';
     const health = t.dead ? 'dead' : `${Math.round((t.hp / t.maxHp) * 100)}% HP`;
     return `Target: ${t.name} (level ${t.level} ${kind}) — ${health}.`;
+  }
+
+  // One-line leveling summary for the /xp readout. At MAX_LEVEL there is no
+  // "next level" so we avoid the percent/remaining math (xpForLevel is 0 there).
+  private xpReadout(meta: PlayerMeta, level: number): string {
+    if (level >= MAX_LEVEL) return `Level ${MAX_LEVEL} — maximum level reached.`;
+    const need = xpForLevel(level);
+    const have = Math.max(0, Math.min(meta.xp, need));
+    const pct = Math.floor((have / need) * 100);
+    const fmt = (n: number) => n.toLocaleString('en-US');
+    return `Level ${level} — ${fmt(have)}/${fmt(need)} XP (${pct}%), ${fmt(need - have)} to go.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2645,15 +2645,23 @@ export class Sim {
     switch (mob.aiState) {
       case 'idle': {
         const template = MOBS[mob.templateId];
-        const nearest = this.nearestLivingPlayer(mob.pos, 25);
-        if (nearest) {
-          let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - nearest.e.level) * 1.5));
+        // Evaluate every nearby player against ITS OWN effective radius, not
+        // just the single closest one. A stealthed player standing closer
+        // shrinks only its own detectability and must not mask a visible
+        // groupmate who is well inside the normal aggro radius.
+        let detected: Entity | null = null;
+        let detectedD = Infinity;
+        this.playerGrid.forEachInRadius(mob.pos.x, mob.pos.z, 25, (e, d2) => {
+          if (e.dead) return;
+          let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - e.level) * 1.5));
           // stealthed rogues are harder to detect, relative to observer level
-          if (nearest.e.auras.some((a) => a.kind === 'stealth')) radius = stealthDetectionRadius(mob, nearest.e, radius);
-          if (nearest.d < radius) {
-            this.aggroMob(mob, nearest.e, true);
-            break;
-          }
+          if (e.auras.some((a) => a.kind === 'stealth')) radius = stealthDetectionRadius(mob, e, radius);
+          const d = Math.sqrt(d2);
+          if (d < radius && d < detectedD) { detected = e; detectedD = d; }
+        });
+        if (detected) {
+          this.aggroMob(mob, detected, true);
+          break;
         }
         mob.wanderTimer -= DT;
         if (mob.wanderTimer <= 0) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3142,6 +3142,43 @@ export class Sim {
     if (best) p.targetId = (best as Entity).id;
   }
 
+  // Nearby allies a beneficial spell can land on: other players (and friendly
+  // pets) within range, never yourself, never dead/hostile. Mirrors the enemy
+  // targeting helpers so heals/buffs are reachable by keyboard, not just by
+  // clicking party frames or world models (#133).
+  private friendlyCandidates(p: Entity): { e: Entity; d: number }[] {
+    const out: { e: Entity; d: number }[] = [];
+    this.grid.forEachInRadius(p.pos.x, p.pos.z, 40, (e, d2) => {
+      if (e.id === p.id || e.dead || !this.isFriendlyTo(p, e)) return;
+      out.push({ e, d: Math.sqrt(d2) });
+    });
+    return out;
+  }
+
+  targetNearestFriendly(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const p = r.e;
+    let best: Entity | null = null;
+    let bestD = Infinity;
+    for (const c of this.friendlyCandidates(p)) {
+      if (c.d < bestD) { bestD = c.d; best = c.e; }
+    }
+    if (best) p.targetId = best.id;
+  }
+
+  friendlyTabTarget(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const p = r.e;
+    const candidates = this.friendlyCandidates(p);
+    if (candidates.length === 0) return;
+    candidates.sort((a, b) => a.d - b.d);
+    const curIdx = candidates.findIndex((c) => c.e.id === p.targetId);
+    const next = candidates[(curIdx + 1) % candidates.length];
+    p.targetId = next.e.id;
+  }
+
   // -------------------------------------------------------------------------
   // Inventory, items, vendor
   // -------------------------------------------------------------------------

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -118,6 +118,8 @@ const BODY_RADIUS = 0.5;
 const CHARGE_SPEED_MULT = 3; // warrior charge runs at 3x normal speed
 const CHARGE_MAX_DURATION = 3; // seconds before a blocked charge gives up
 const CHARGE_ARRIVE_RANGE = MELEE_RANGE - 1; // stop inside melee range
+const FOLLOW_STOP_DIST = 3; // /follow trails this close behind the leader (yards)
+const FOLLOW_MAX_RANGE = 60; // give up follow once the leader is this far away
 const PET_LEASH = 40; // yards from the owner before a pet gives up its target
 const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
@@ -981,8 +983,58 @@ export class Sim {
     return true;
   }
 
+  // /follow: a second forced-movement mode (like charge) that trails another
+  // player. Returns true when it has taken over locomotion for this tick so the
+  // normal input-driven movement below is skipped. Any manual movement, combat,
+  // or the leader slipping out of range ends the follow.
+  stopFollow(p: Entity, msg?: string): void {
+    if (p.followTargetId === null) return;
+    p.followTargetId = null;
+    if (msg) this.error(p.id, msg);
+  }
+
+  private updateFollowMovement(p: Entity, meta: PlayerMeta): boolean {
+    if (p.followTargetId === null) return false;
+    const inp = meta.moveInput;
+    // any manual locomotion (incl. camera turns) breaks follow, classic-style
+    if (inp.forward || inp.back || inp.strafeLeft || inp.strafeRight || inp.jump
+      || inp.turnLeft || inp.turnRight) {
+      this.stopFollow(p, 'You stop following.');
+      return false;
+    }
+    const t = this.entities.get(p.followTargetId);
+    if (!t || t.dead || t.kind !== 'player' || !this.players.has(t.id)) {
+      this.stopFollow(p, 'There is no one to follow.');
+      return false;
+    }
+    if (p.inCombat) { this.stopFollow(p, 'You stop following — you are in combat.'); return false; }
+    const d = dist2d(p.pos, t.pos);
+    if (d > FOLLOW_MAX_RANGE) { this.stopFollow(p, `${t.name} is too far away to follow.`); return false; }
+    // always turn to face the leader, even while held in place
+    p.facing = angleTo(p.pos, t.pos);
+    if (this.isStunned(p) || this.isRooted(p) || d <= FOLLOW_STOP_DIST) return true;
+    let speed = RUN_SPEED * this.moveSpeedMult(p);
+    if (this.isSwimming(p)) speed *= SWIM_SPEED_MULT;
+    const step = Math.min(speed * DT, d - FOLLOW_STOP_DIST);
+    const nx = p.pos.x + Math.sin(p.facing) * step;
+    const nz = p.pos.z + Math.cos(p.facing) * step;
+    const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
+    const h1 = groundHeight(nx, nz, this.cfg.seed);
+    if (h1 < WATER_LEVEL - SWIM_DEPTH) return true; // don't trail into deep water
+    if (h1 > h0 && step > 1e-5 && (h1 - h0) / step > MAX_CLIMB_SLOPE) return true; // wall/cliff
+    const resolved = resolvePosition(this.cfg.seed, nx, nz, BODY_RADIUS);
+    p.pos.x = resolved.x;
+    p.pos.z = resolved.z;
+    p.pos.y = groundHeight(resolved.x, resolved.z, this.cfg.seed);
+    p.vy = 0;
+    p.onGround = true;
+    p.fallStartY = p.pos.y;
+    return true;
+  }
+
   private updatePlayerMovement(p: Entity, meta: PlayerMeta): void {
     if (this.updateChargeMovement(p)) return;
+    if (this.updateFollowMovement(p, meta)) return;
     const inp = meta.moveInput;
     // Convention: facing f points along (sin f, cos f); the camera sits behind
     // the player, so screen-right is the world vector (-cos f, sin f).
@@ -1277,6 +1329,8 @@ export class Sim {
       this.error(p.id, p.resourceType === 'rage' ? 'Not enough rage!' : p.resourceType === 'energy' ? 'Not enough energy!' : 'Not enough mana!');
       return;
     }
+    // casting is deliberate action — drop any active follow so you don't drift
+    this.stopFollow(p);
     if (ability.requiresDodgeProc && this.time > p.overpowerUntil) {
       this.error(p.id, 'Your target must dodge first.');
       return;
@@ -2335,6 +2389,7 @@ export class Sim {
       e.sitting = false;
       e.chargeTargetId = null;
       e.chargePath = [];
+      e.followTargetId = null;
       this.emit({ type: 'playerDeath', pid: e.id });
       for (const m of this.entities.values()) {
         if (m.kind === 'mob' && !m.dead && m.aggroTargetId === e.id && m.aiState !== 'dead') {
@@ -3042,6 +3097,8 @@ export class Sim {
     const r = this.resolve(pid);
     if (!r) return;
     const p = r.e;
+    // switching to a different target ends a follow (re-targeting is manual intent)
+    if (p.followTargetId !== null && id !== p.followTargetId) this.stopFollow(p, 'You stop following.');
     if (id === null) { p.targetId = null; p.autoAttack = false; return; }
     const e = this.entities.get(id);
     if (!e || (e.dead && !e.lootable)) return;
@@ -3702,6 +3759,44 @@ export class Sim {
           this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: meta.entityId });
         }
       }
+      return null;
+    }
+
+    // "/unfollow" stops an active follow
+    if (/^\/unfollow(?:\s|$)/i.test(raw)) {
+      if (r.e.followTargetId === null) this.error(r.meta.entityId, 'You are not following anyone.');
+      else this.stopFollow(r.e, 'You stop following.');
+      return null;
+    }
+
+    // "/follow [name]" trails another player; with no name it follows the
+    // current target. Movement, combat, casting, re-targeting, or the leader
+    // moving out of range all end it (see updateFollowMovement).
+    const fm = /^\/follow(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (fm) {
+      if (r.e.inCombat) { this.error(r.meta.entityId, "You can't start following while in combat."); return null; }
+      let target: PlayerMeta | null = null;
+      const nameArg = (fm[1] ?? '').trim();
+      if (nameArg) {
+        const wanted = nameArg.toLowerCase();
+        const ci: PlayerMeta[] = [];
+        for (const meta of this.players.values()) {
+          if (meta.name === nameArg) { target = meta; break; }
+          if (meta.name.toLowerCase() === wanted) ci.push(meta);
+        }
+        if (!target) {
+          if (ci.length === 1) target = ci[0];
+          else if (ci.length > 1) { this.error(r.meta.entityId, `Several players match '${nameArg}'. Use exact capitalization.`); return null; }
+        }
+        if (!target) { this.error(r.meta.entityId, `There is no player named '${nameArg}' online.`); return null; }
+      } else {
+        const cur = r.e.targetId !== null ? this.players.get(r.e.targetId) : undefined;
+        if (!cur) { this.error(r.meta.entityId, 'Target a player to follow, or use /follow <name>.'); return null; }
+        target = cur;
+      }
+      if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, "You can't follow yourself."); return null; }
+      r.e.followTargetId = target.entityId;
+      this.error(r.meta.entityId, `Now following ${target.name}.`);
       return null;
     }
 
@@ -4384,6 +4479,7 @@ export class Sim {
     e.swingTimer = 0;
     e.chargeTargetId = null;
     e.chargePath = [];
+    e.followTargetId = null;
     e.combatTimer = 99;
     e.inCombat = false;
     e.sitting = false;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4041,6 +4041,23 @@ export class Sim {
     }
   }
 
+  // Drop every aura on `target` that was applied by `sourceId` (e.g. an
+  // opponent's lingering DoT/CC), emitting the fade events the client expects.
+  private clearAurasFromSource(target: Entity, sourceId: number): void {
+    let statsDirty = false;
+    for (let i = target.auras.length - 1; i >= 0; i--) {
+      const a = target.auras[i];
+      if (a.sourceId !== sourceId) continue;
+      target.auras.splice(i, 1);
+      this.emit({ type: 'aura', targetId: target.id, name: a.name, gained: false });
+      if (a.kind.startsWith('buff') || a.kind.startsWith('form')) statsDirty = true;
+    }
+    if (statsDirty && target.kind === 'player') {
+      const meta = this.players.get(target.id);
+      if (meta) recalcPlayerStats(target, meta.cls, meta.equipment);
+    }
+  }
+
   // winnerPid null = draw/cancelled
   private endDuel(duel: DuelState, winnerPid: number | null): void {
     this.duels.delete(duel.a);
@@ -4056,6 +4073,12 @@ export class Sim {
         e.autoAttack = false;
       }
     }
+    // A duel is non-lethal: damage from the opponent is capped at 1 HP only
+    // while the duel is live (see dealDamage). Strip the debuffs each fighter
+    // applied to the other so a leftover DoT can't tick the loser to a real
+    // death moments after the bout ends.
+    if (ea) this.clearAurasFromSource(ea, duel.b);
+    if (eb) this.clearAurasFromSource(eb, duel.a);
     if (winnerPid !== null && aMeta && bMeta) {
       const winner = winnerPid === duel.a ? aMeta : bMeta;
       const loser = winnerPid === duel.a ? bMeta : aMeta;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -12,7 +12,7 @@ import { Rng } from './rng';
 import { SpatialGrid } from './spatial';
 import {
   HEAL_THREAT_FACTOR, MELEE_SWITCH_MULT, RANGED_SWITCH_MULT,
-  TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatModifier, topThreatValue,
+  TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatEntries, threatModifier, topThreatValue,
 } from './threat';
 import { groundHeight, WATER_LEVEL } from './world';
 import {
@@ -3977,6 +3977,14 @@ export class Sim {
       return null;
     }
 
+    // "/threat" (alias "/aggro") — self-only readout of the threat table on the
+    // player's current target. Reads live state only; returns null so the line
+    // is shown only to the caller and never broadcast or logged.
+    if (/^\/(?:threat|aggro)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.threatReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5579,6 +5587,32 @@ export class Sim {
     return `Session: ${plural(c.kills, 'kill')}, ${plural(c.deaths, 'death')}. ` +
       `Damage dealt ${n(c.damageDealt)}, taken ${n(c.damageTaken)}. ` +
       `XP gained ${n(c.xpGained)}.`;
+  }
+
+  /** Self-only readout of the threat table on the player's current target,
+   *  highest first, as a percentage of the current threat leader. */
+  private threatReadout(self: Entity): string {
+    const t = self.targetId !== null ? this.entities.get(self.targetId) : undefined;
+    if (!t || t.hp <= 0) return 'You have no target.';
+    if (t.kind !== 'mob') return `Threat is only tracked on enemies; ${t.name} is not one.`;
+    const entries = threatEntries(t, 10);
+    if (entries.length === 0) return `Nobody has any threat on ${t.name}.`;
+    const top = entries[0][1] || 1;
+    const parts = entries.map(([id, v], i) => {
+      const pct = Math.round((v / top) * 100);
+      const you = id === self.id ? ' (you)' : '';
+      const lead = i === 0 ? ' [leader]' : '';
+      return `${this.threatName(id)}${you} ${pct}%${lead}`;
+    });
+    return `Threat on ${t.name} (${entries.length}): ${parts.join(', ')}.`;
+  }
+
+  /** Display name for a threat-table source: a player by pid, else the entity
+   *  (pet/mob) name, else a placeholder for sources that have despawned. */
+  private threatName(id: number): string {
+    const meta = this.players.get(id);
+    if (meta) return meta.name;
+    return this.entities.get(id)?.name || 'Unknown';
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -239,6 +239,9 @@ export interface PlayerMeta {
   // Transient presence status. Set by /afk and /dnd, cleared when the player
   // chats again. Session-only — never persisted, so it resets on login.
   away: AwayStatus | null;
+  // Session-only: name of the last player who whispered us, for "/r" replies.
+  // Never persisted — a fresh login starts with no reply target.
+  lastWhisperFrom?: string;
 }
 
 // Away-from-keyboard / do-not-disturb presence. `afk` still delivers whispers
@@ -3800,8 +3803,19 @@ export class Sim {
       return null;
     }
 
+    // "/r message" — reply to the last player who whispered us. Rewrite it to
+    // the "/w <name> message" form so delivery, the echo, and case-matching
+    // all stay in the single whisper handler below.
+    const rm = /^\/r(?:eply)?\s+([\s\S]+)$/i.exec(raw);
+    let line = raw;
+    if (rm) {
+      const replyTo = r.meta.lastWhisperFrom;
+      if (!replyTo) { this.error(r.meta.entityId, 'You have no one to reply to.'); return null; }
+      line = `/w ${replyTo} ${rm[1]}`;
+    }
+
     // "/w name message" — private whisper to an online player
-    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
+    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
       const targetName = wm[1];
       const msg = wm[2].trim();
@@ -3832,10 +3846,14 @@ export class Sim {
           return { channel: 'whisper', message: msg };
         }
       }
+      // classic-WoW "/r": the recipient's reply target is whoever last
+      // whispered them, so record it on the target (not the sender).
+      target.lastWhisperFrom = r.meta.name;
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
     }
+
 
     // "/p message" goes to the party channel
     if (/^\/p(arty)?\s/i.test(raw)) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3969,6 +3969,14 @@ export class Sim {
       return null;
     }
 
+    // "/session" — self-only readout of this session's combat tally. Like the
+    // other readouts it emits a private error line and returns null, so it is
+    // never logged or broadcast and works online without a server interceptor.
+    if (/^\/(?:session|sess|sessionstats)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.sessionReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5558,6 +5566,19 @@ export class Sim {
     const kind = family ? ` ${family}` : '';
     const pct = pet.maxHp > 0 ? Math.round((pet.hp / pet.maxHp) * 100) : 0;
     return `Your pet: ${pet.name} (level ${pet.level}${kind}) — HP ${pet.hp}/${pet.maxHp} (${pct}%).`;
+  }
+
+  // Build the self-only "/session" line from this session's RewardCounters.
+  // Counters are reset each boot (freshCounters), so this is always per-session.
+  // Format kills/deaths first, then a damage clause, then XP — using
+  // toLocaleString('en-US') for thousands separators on the large numbers.
+  private sessionReadout(meta: PlayerMeta): string {
+    const c = meta.counters;
+    const n = (v: number) => v.toLocaleString('en-US');
+    const plural = (v: number, word: string) => `${n(v)} ${word}${v === 1 ? '' : 's'}`;
+    return `Session: ${plural(c.kills, 'kill')}, ${plural(c.deaths, 'death')}. ` +
+      `Damage dealt ${n(c.damageDealt)}, taken ${n(c.damageTaken)}. ` +
+      `XP gained ${n(c.xpGained)}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3760,6 +3760,13 @@ export class Sim {
       this.emit({ type: 'log', text: 'You are no longer marked as away.', color: '#ffd100', pid: r.meta.entityId });
     }
 
+    // "/party" (no message) is a self-only roster readout; "/party <msg>"
+    // and "/p <msg>" stay party chat (the trailing \s in that branch below).
+    if (/^\/(party|group|grp)\s*$/i.test(raw)) {
+      this.error(r.meta.entityId, this.partyReadout(r.meta.entityId));
+      return null;
+    }
+
     if (/^\/who(?:\s|$)/i.test(raw)) {
       this.error(r.meta.entityId, 'The /who roster is available in online play.');
       return null;
@@ -5401,6 +5408,23 @@ export class Sim {
       return s.count > 1 ? `${name} x${s.count}` : name;
     });
     return `Bags (${parts.length}): ${parts.join(', ')}. ${purse}`;
+  }
+
+  // Self-only readout of the player's party: each member in join order with
+  // level, class, and HP% (or (dead)/(offline)), the leader tagged [leader].
+  private partyReadout(pid: number): string {
+    const party = this.partyOf(pid);
+    if (!party) return 'You are not in a party.';
+    const parts = party.members.map((mPid) => {
+      const meta = this.players.get(mPid);
+      const e = this.entities.get(mPid);
+      if (!meta || !e) return meta ? `${meta.name} (offline)` : `Player ${mPid} (offline)`;
+      const cls = CLASSES[meta.cls].name;
+      const state = e.hp <= 0 ? '(dead)' : `${Math.round((e.hp / e.maxHp) * 100)}%`;
+      const tag = mPid === party.leader ? ' [leader]' : '';
+      return `${meta.name} (Lvl ${e.level} ${cls}, ${state})${tag}`;
+    });
+    return `Party (${party.members.length}/${PARTY_MAX}): ${parts.join(', ')}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3901,6 +3901,14 @@ export class Sim {
       return null;
     }
 
+    // "/gold" (aliases /money, /coins) — a self-only readout of your purse.
+    // Reads only meta.copper; like /who's reply it returns null so it is never
+    // logged or broadcast, and with no server interceptor it works online too.
+    if (/^\/(?:gold|money|coins)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.goldReadout(r.meta.copper));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5340,6 +5348,13 @@ export class Sim {
     const pct = Math.floor((have / need) * 100);
     const fmt = (n: number) => n.toLocaleString('en-US');
     return `Level ${level} — ${fmt(have)}/${fmt(need)} XP (${pct}%), ${fmt(need - have)} to go.`;
+  }
+
+  // Render the /gold readout. An empty purse gets flavor text rather than the
+  // bare "You have 0c." that formatMoney would otherwise produce.
+  private goldReadout(copper: number): string {
+    if (copper <= 0) return 'Your purse is empty.';
+    return `You have ${formatMoney(copper)}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3664,6 +3664,14 @@ export class Sim {
       return null;
     }
 
+    // "/help" (or "/?" / "/commands") lists the available chat commands as a
+    // system notice to the asker only. Like /who, it produces no chat message,
+    // so it works identically offline and online without server wiring.
+    if (/^\/(?:help|commands|\?)(?:\s|$)/i.test(raw)) {
+      for (const line of this.helpLines()) this.error(r.meta.entityId, line);
+      return null;
+    }
+
     // "/roll", "/roll N", "/roll M-N" — a classic random roll for loot disputes
     // and social play. Rolled through the deterministic sim RNG so it is
     // server-authoritative (clients can't fake a result) and identical offline.
@@ -3789,7 +3797,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /roll /afk /dnd, /me, or an emote like /wave.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Type /help for a list.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -5100,6 +5108,16 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Lines shown by the "/help" command, one system notice per entry. Keep this
+  // in sync with the commands handled in chat() above.
+  private helpLines(): string[] {
+    return [
+      'Chat channels: /s say, /y yell, /g general, /p party.',
+      'Whisper a player with /w <name> <message>.',
+      '/who lists who is online (online play only).',
+    ];
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3917,6 +3917,13 @@ export class Sim {
       return null;
     }
 
+    // "/buffs" (aliases "/buff", "/auras") — self-only readout of the active
+    // auras on you, newest last, with the remaining time on timed effects.
+    if (/^\/(?:buffs?|auras)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.buffsReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5377,6 +5384,22 @@ export class Sim {
   private goldReadout(copper: number): string {
     if (copper <= 0) return 'Your purse is empty.';
     return `You have ${formatMoney(copper)}.`;
+  }
+
+  // Self-only readout for "/buffs": summarise the auras currently on the
+  // entity. Auras carry no buff/debuff flag, only an AuraKind and a `remaining`
+  // time in seconds; toggles (stances, forms, stealth) use a 3600s sentinel
+  // duration rather than Infinity, so a raw "(3600s)" reads poorly.
+  private buffsReadout(e: Entity): string {
+    if (e.auras.length === 0) return 'You have no active effects.';
+    const parts = e.auras.map((a) => this.auraLabel(a));
+    return `Active effects (${e.auras.length}): ${parts.join(', ')}.`;
+  }
+
+  // Render one aura for the /buffs list, e.g. "Rend (4s)". `remaining` is a
+  // float, so Math.ceil keeps a still-active 0.3s remainder showing as "(1s)".
+  private auraLabel(a: Aura): string {
+    return `${a.name} (${Math.ceil(a.remaining)}s)`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3956,6 +3956,12 @@ export class Sim {
       return null;
     }
 
+    // "/pet" (aliases /companion /pets) — self-only readout of your active pet
+    if (/^\/(?:pet|pets|companion)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.petReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
@@ -5516,6 +5522,18 @@ export class Sim {
     if (known.length === 0) return 'You have not learned any abilities yet.';
     const list = known.map((k) => `${k.def.name} (Rank ${k.rank})`).join(', ');
     return `Spellbook (${known.length}): ${list}.`;
+  }
+
+  // Self-only readout of the player's active pet: name, level, beast family,
+  // and current health. Reads live pet state via petOf() so it stays accurate
+  // regardless of how the pet was acquired (tame, summon).
+  private petReadout(owner: Entity): string {
+    const pet = this.petOf(owner.id);
+    if (!pet) return 'You do not have a pet.';
+    const family = MOBS[pet.templateId]?.family;
+    const kind = family ? ` ${family}` : '';
+    const pct = pet.maxHp > 0 ? Math.round((pet.hp / pet.maxHp) * 100) : 0;
+    return `Your pet: ${pet.name} (level ${pet.level}${kind}) — HP ${pet.hp}/${pet.maxHp} (${pct}%).`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3629,6 +3629,39 @@ export class Sim {
       return null;
     }
 
+    // "/roll", "/roll N", "/roll M-N" — a classic random roll for loot disputes
+    // and social play. Rolled through the deterministic sim RNG so it is
+    // server-authoritative (clients can't fake a result) and identical offline.
+    const rollm = /^\/roll(?:\s+(\d+)(?:\s*-\s*(\d+))?)?\s*$/i.exec(raw);
+    if (rollm) {
+      let lo = 1, hi = 100;
+      if (rollm[1] !== undefined) {
+        const n = parseInt(rollm[1], 10);
+        if (rollm[2] !== undefined) { lo = n; hi = parseInt(rollm[2], 10); }
+        else { hi = n; }
+      }
+      const MAX_ROLL = 1_000_000;
+      if (lo < 1 || hi > MAX_ROLL || lo > hi) {
+        this.error(r.meta.entityId, `Invalid roll range. Use /roll, /roll N, or /roll M-N (1-${MAX_ROLL}).`);
+        return null;
+      }
+      const result = this.rng.int(lo, hi);
+      const text = `${result} (${lo}-${hi})`;
+      const party = this.partyOf(r.meta.entityId);
+      if (party) {
+        for (const mPid of party.members) {
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: mPid });
+        }
+      } else {
+        for (const meta of this.players.values()) {
+          const e = this.entities.get(meta.entityId);
+          if (!e || dist2d(r.e.pos, e.pos) > SAY_RANGE) continue;
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: meta.entityId });
+        }
+      }
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -3711,7 +3744,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g, /me, or an emote like /wave.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /roll, /me, or an emote like /wave.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -450,6 +450,7 @@ export interface Entity {
   chargeTargetId: number | null;
   chargeTimeLeft: number; // seconds; failsafe so a blocked charge can't run forever
   chargePath: Vec3[]; // waypoints consumed front-to-back; last leg homes on the live target
+  followTargetId: number | null; // /follow: auto-walk after another player until interrupted
   savedMana: number; // druid forms: mana put aside while running on rage/energy
   sitting: boolean;
   eating: Consuming | null;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -521,7 +521,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'emote'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'emote' | 'roll'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   // a guild invitation from an online guild officer/leader; resolved by name
   // server-side so it carries no pid

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1047,14 +1047,14 @@ export class Hud {
       const me = r.pid === myPid;
       const cls = CLASSES[r.cls]?.name ?? r.cls;
       return `<div class="ladder-row${me ? ' me' : ''}"><span class="rank">${i + 1}</span>`
-        + `<span class="lr-name" title="${r.name} — ${cls}">${r.name}</span>`
+        + `<span class="lr-name" title="${esc(r.name)} — ${esc(cls)}">${esc(r.name)}</span>`
         + `<span class="lr-rating">${r.rating}</span>`
         + `<span class="lr-wl">${r.wins}-${r.losses}</span></div>`;
     }).join('') || `<div class="ladder-empty">No challengers ranked yet — be the first.</div>`;
 
     let action: string;
     if (inMatch) {
-      action = `<div class="arena-queue-status">⚔ Match in progress vs ${a.match!.oppName}.</div>`;
+      action = `<div class="arena-queue-status">⚔ Match in progress vs ${esc(a.match!.oppName)}.</div>`;
     } else if (a.queued) {
       action = `<button class="btn leave" data-act="leave">Leave Queue</button>`
         + `<div class="arena-queue-status">Searching for an opponent… (${a.queueSize} in queue)</div>`;
@@ -1068,7 +1068,7 @@ export class Hud {
       const me = r.name === this.sim.player.name;
       const cls = CLASSES[r.class as keyof typeof CLASSES]?.name ?? r.class;
       return `<div class="ladder-row${me ? ' me' : ''}"><span class="rank">${i + 1}</span>`
-        + `<span class="lr-name" title="${r.name} — Lv ${r.level} ${cls}">${r.name}</span>`
+        + `<span class="lr-name" title="${esc(r.name)} — Lv ${r.level} ${esc(cls)}">${esc(r.name)}</span>`
         + `<span class="lr-rating">${r.rating}</span>`
         + `<span class="lr-wl">${r.wins}-${r.losses}</span></div>`;
     }).join('');
@@ -1110,7 +1110,7 @@ export class Hud {
     if (sig !== this.lastArenaStatusSig) {
       this.lastArenaStatusSig = sig;
       const cls = CLASSES[m.oppClass]?.name ?? m.oppClass;
-      el.innerHTML = `<div class="as-vs">⚔ VS <span class="opp">${m.oppName}</span> <span style="color:#b6ad8c;font-size:11px">Lv ${m.oppLevel} ${cls}</span></div>`
+      el.innerHTML = `<div class="as-vs">⚔ VS <span class="opp">${esc(m.oppName)}</span> <span style="color:#b6ad8c;font-size:11px">Lv ${m.oppLevel} ${esc(cls)}</span></div>`
         + `<div class="as-timer">${label}</div>`;
       el.style.display = 'block';
     }
@@ -1851,7 +1851,7 @@ export class Hud {
       row.innerHTML =
         `${this.itemIcon(item)}`
         + `<span class="mkt-name"><span class="nm" style="color:${qColor}">${item.name}${l.count > 1 ? ' <span style="color:#ccc">x' + l.count + '</span>' : ''}</span>`
-        + `<span class="seller${l.house ? ' house' : ''}">${l.house ? "Merchant's stock" : l.sellerName}</span></span>`
+        + `<span class="seller${l.house ? ' house' : ''}">${l.house ? "Merchant's stock" : esc(l.sellerName)}</span></span>`
         + `<span class="mkt-price">${this.moneyHtml(l.price)}${each}</span>`;
       const btn = document.createElement('button');
       btn.className = 'mkt-btn' + (l.mine ? ' cancel' : '');
@@ -2942,7 +2942,7 @@ export class Hud {
       return `<div class="trade-item${mine ? ' mine' : ''}" data-item="${mine ? s.itemId : ''}">${this.itemIcon(item)}<span>${item?.name ?? s.itemId}${s.count > 1 ? ' x' + s.count : ''}</span></div>`;
     };
     el.innerHTML = `
-      <div class="panel-title"><span>Trade with ${info.otherName}</span><span class="x-btn" data-close>✕</span></div>
+      <div class="panel-title"><span>Trade with ${esc(info.otherName)}</span><span class="x-btn" data-close>✕</span></div>
       <div class="trade-cols">
         <div class="trade-col ${info.myAccepted ? 'accepted' : ''}">
           <h4>Your offer</h4>
@@ -2950,7 +2950,7 @@ export class Hud {
           <div class="trade-money">Money: <input id="trade-copper" type="number" min="0" value="${this.stagedTrade.copper}" /> copper</div>
         </div>
         <div class="trade-col ${info.theirAccepted ? 'accepted' : ''}">
-          <h4>${info.otherName}'s offer</h4>
+          <h4>${esc(info.otherName)}'s offer</h4>
           <div class="trade-items">${info.theirOffer.items.map((s) => itemRow(s, false)).join('') || '<div style="color:#665c40;font-size:11px;padding:4px">Nothing offered yet</div>'}</div>
           <div class="trade-money">Money: <span class="gold">${formatMoney(info.theirOffer.copper)}</span></div>
         </div>

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1319,6 +1319,7 @@ export class Hud {
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
             case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
             case 'emote': this.chatLogFrom(ev.from, ev.text, '#ff8040', '', ' '); break;
+            case 'roll': this.chatLogFrom(ev.from, ev.text, '#ffd100', '', ' rolls '); break;
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
           if ((ev.channel === 'say' || ev.channel === 'yell' || ev.channel === 'emote') && ev.entityId !== undefined) {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -156,6 +156,8 @@ export interface IWorld {
   castAbilityBySlot(slot: number): void;
   targetEntity(id: number | null): void;
   tabTarget(): void;
+  targetNearestFriendly(): void;
+  friendlyTabTarget(): void;
   startAutoAttack(): void;
   stopAutoAttack(): void;
   interact(): void;

--- a/tests/abilities_command.test.ts
+++ b/tests/abilities_command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { CLASSES, ABILITIES, abilitiesKnownAt } from '../src/sim/content/classes';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorAfter(sim: Sim, text: string, pid: number): string | undefined {
+  sim.chat(text, pid);
+  const events: SimEvent[] = sim.tick();
+  expect(events.filter((e) => e.type === 'chat')).toHaveLength(0);
+  const err = events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+  return err?.text;
+}
+
+describe('/abilities command', () => {
+  it('lists every known ability with its rank, self-only and unsaid', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const text = errorAfter(sim, '/abilities', a)!;
+
+    const known = abilitiesKnownAt('warrior', sim.entities.get(a)!.level);
+    expect(text).toContain(`Spellbook (${known.length}):`);
+    // a level-1 warrior knows Heroic Strike but not yet Charge (learnLevel 4)
+    expect(text).toContain('Heroic Strike (Rank 1)');
+    expect(text).not.toContain('Charge');
+    expect(text.endsWith('.')).toBe(true);
+  });
+
+  it('reflects newly learned abilities and higher ranks at a higher level', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const e = sim.entities.get(a)!;
+    e.level = 20;
+    sim.tick();
+    const text = errorAfter(sim, '/abilities', a)!;
+
+    const known = abilitiesKnownAt('warrior', 20);
+    expect(text).toContain(`Spellbook (${known.length}):`);
+    // Heroic Strike reaches Rank 4 at level 20; Charge is now learned
+    expect(text).toContain('Heroic Strike (Rank 4)');
+    expect(text).toContain('Charge (Rank 1)');
+  });
+
+  it('accepts the /spells and /spellbook aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const first = ABILITIES[CLASSES.mage.abilities[0]].name;
+    expect(errorAfter(sim, '/spells', a)).toContain(first);
+    expect(errorAfter(sim, '/spellbook', a)).toContain('Spellbook');
+  });
+});

--- a/tests/bags_command.test.ts
+++ b/tests/bags_command.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+// The self-only readout reuses the 'error' channel, like /who and the other
+// readout commands; grab the most recent one addressed to the player.
+function lastReadout(sim: Sim, pid: number): string | undefined {
+  const errs = sim.events.filter(
+    (e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error' && e.pid === pid,
+  );
+  return errs.length ? errs[errs.length - 1].text : undefined;
+}
+
+describe('/bags command', () => {
+  it('reports empty bags with the purse', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(pid)!.copper = 0;
+
+    expect(sim.chat('/bags', pid)).toBeNull();
+    expect(lastReadout(sim, pid)).toBe('Your bags are empty. Purse: 0c.');
+  });
+
+  it('lists items sorted by quality with stack counts and the purse', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(pid)!.copper = 12 * 10000 + 4 * 100 + 5; // 12g 4s 5c
+
+    // Added out of quality order to prove the readout sorts them.
+    sim.addItem('wolf_fang', 5, pid); // poor
+    sim.addItem('fen_reaver_glaive', 1, pid); // rare
+    sim.addItem('minor_healing_potion', 3, pid); // common
+    sim.addItem('redbrook_blade', 1, pid); // uncommon
+
+    sim.chat('/bags', pid);
+    expect(lastReadout(sim, pid)).toBe(
+      'Bags (4): Fen Reaver Glaive, Redbrook Militia Blade, ' +
+        'Minor Healing Potion x3, Cracked Wolf Fang x5. Purse: 12g 4s 5c.',
+    );
+  });
+
+  it('works through the /inv and /inventory aliases', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(pid)!.copper = 0;
+
+    expect(sim.chat('/inv', pid)).toBeNull();
+    expect(lastReadout(sim, pid)).toBe('Your bags are empty. Purse: 0c.');
+    expect(sim.chat('/inventory', pid)).toBeNull();
+    expect(lastReadout(sim, pid)).toBe('Your bags are empty. Purse: 0c.');
+  });
+});

--- a/tests/buffs_command.test.ts
+++ b/tests/buffs_command.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errors(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+function timedAura(over: Partial<Aura>): Aura {
+  return {
+    id: 'x', name: 'Effect', kind: 'dot', remaining: 10, duration: 10,
+    value: 0, sourceId: 0, school: 'physical', ...over,
+  };
+}
+
+describe('/buffs command', () => {
+  it('reports no active effects when the aura list is empty', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/buffs', a);
+    const errs = errors(sim.tick());
+    expect(errs.length).toBe(1);
+    expect(errs[0].pid).toBe(a);
+    expect(errs[0].text).toBe('You have no active effects.');
+  });
+
+  it('lists each active aura with its ceil-rounded remaining seconds', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.auras.push(timedAura({ id: 'battle_shout', name: 'Battle Shout', kind: 'buff_ap', remaining: 118 }));
+    e.auras.push(timedAura({ id: 'rend', name: 'Rend', kind: 'dot', remaining: 3.2 }));
+
+    sim.chat('/buffs', a);
+    const errs = errors(sim.tick());
+    expect(errs.length).toBe(1);
+    // 3.2s still ceils to 4s while the effect is live
+    expect(errs[0].text).toBe('Active effects (2): Battle Shout (118s), Rend (4s).');
+  });
+
+  it('accepts the /buff and /auras aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    for (const cmd of ['/buff', '/auras']) {
+      sim.chat(cmd, a);
+      const errs = errors(sim.tick());
+      expect(errs.length).toBe(1);
+      expect(errs[0].text).toBe('You have no active effects.');
+    }
+  });
+
+  it('is self-only: produces no chat event and is not logged', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const result = sim.chat('/buffs', a);
+    expect(result).toBeNull();
+    expect(sim.tick().some((ev) => ev.type === 'chat')).toBe(false);
+  });
+});

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -139,6 +139,42 @@ describe('chat channels', () => {
     }));
   });
 
+  it('/help lists the chat commands as system notices without sending chat', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/help', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    const help = events.filter((e) => e.type === 'error' && e.pid === a) as Extract<SimEvent, { type: 'error' }>[];
+    expect(help.length).toBeGreaterThan(0);
+    const text = help.map((e) => e.text).join('\n');
+    expect(text).toContain('/w <name> <message>');
+    expect(text).toContain('/who');
+  });
+
+  it('/? and /commands are aliases for /help', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const cmd of ['/?', '/commands']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(chatEvents(events)).toHaveLength(0);
+      expect(events.some((e) => e.type === 'error' && e.pid === a)).toBe(true);
+    }
+  });
+
+  it('an unknown slash command points the player at /help', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/bogus stuff', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.pid === a && e.text.includes('/help'))).toBe(true);
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -80,6 +80,71 @@ describe('chat channels', () => {
     expect(msgs.some((m) => m.pid === c)).toBe(false);
   });
 
+  it('/r replies to the last player who whispered you', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, b, 0, -900); // reply ignores distance, like whisper
+    sim.tick();
+
+    sim.chat('/w bet psst, secret', a);
+    sim.tick();
+    // Bet replies without naming Aleph
+    sim.chat('/r got it', b);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs).toHaveLength(2);
+    const toTarget = msgs.find((m) => m.pid === a)!;
+    expect(toTarget.channel).toBe('whisper');
+    expect(toTarget.from).toBe('Bet');
+    expect(toTarget.text).toBe('got it');
+    const echo = msgs.find((m) => m.pid === b)!;
+    expect(echo.to).toBe('Aleph');
+  });
+
+  it('/r with no prior whisper errors instead of saying it out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/r hello?', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
+
+  it('/r reply target follows the most recent incoming whisper', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/w aleph first', b); // Bet -> Aleph
+    sim.tick();
+    sim.chat('/w aleph second', c); // Gimel -> Aleph (now the reply target)
+    sim.tick();
+    sim.chat('/r back to you', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.channel === 'whisper' && m.to === undefined)!;
+    expect(toTarget.pid).toBe(c);
+  });
+
+  it('sending a whisper does not change your own /r target', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/w aleph incoming', b); // Bet whispers Aleph -> Aleph's reply target is Bet
+    sim.tick();
+    sim.chat('/w gimel outgoing', a); // Aleph whispers Gimel; reply target stays Bet
+    sim.tick();
+    sim.chat('/r still bet', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.channel === 'whisper' && m.to === undefined)!;
+    expect(toTarget.pid).toBe(b);
+  });
+
   it('whisper to an unknown player errors instead of leaking text', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -240,6 +240,38 @@ describe('chat channels', () => {
     expect(events.some((e) => e.type === 'error' && e.pid === a && e.text.includes('/help'))).toBe(true);
   });
 
+  it('/played reports zero on a freshly joined character', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/played', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      pid: a,
+      text: 'Time played this session: 0s.',
+    }));
+  });
+
+  it('/played accumulates session time as the sim advances', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    // 20 ticks per sim-second; advance just over a minute of world time
+    for (let i = 0; i < 20 * 65; i++) sim.tick();
+    sim.chat('/played', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    const played = events.find(
+      (e): e is Extract<SimEvent, { type: 'error' }> =>
+        e.type === 'error' && e.text.startsWith('Time played'),
+    );
+    // once past a minute the line switches to "Xm Ys" form
+    expect(played?.text).toMatch(/^Time played this session: 1m \d+s\.$/);
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -3,6 +3,7 @@ import { Sim } from '../src/sim/sim';
 import { ClientWorld } from '../src/net/online';
 import { SimEvent } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
+import { zoneAt } from '../src/sim/data';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -270,6 +271,37 @@ describe('chat channels', () => {
     );
     // once past a minute the line switches to "Xm Ys" form
     expect(played?.text).toMatch(/^Time played this session: 1m \d+s\.$/);
+  });
+
+  it('/where reports the caller\'s zone, level range, and coordinates', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 12, -340);
+    sim.tick();
+    const zone = zoneAt(-340);
+    const [lo, hi] = zone.levelRange;
+    sim.chat('/where', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      pid: a,
+      text: `You are in ${zone.name} (levels ${lo}–${hi}) at (12, -340).`,
+    }));
+  });
+
+  it('/where accepts the /loc and /zone aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    const expected = `You are in ${zoneAt(-40).name}`;
+    for (const cmd of ['/loc', '/zone']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(chatEvents(events)).toHaveLength(0);
+      expect(events.some((e) => e.type === 'error' && e.text.startsWith(expected))).toBe(true);
+    }
   });
 
   it('exact-case whisper wins over a case-variant squatter', () => {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -440,3 +440,69 @@ describe('snapshot interpolation continuity', () => {
     expect(e.prevPos.x).toBeLessThan(e.pos.x);
   });
 });
+
+function logEvents(events: SimEvent[]): Extract<SimEvent, { type: 'log' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'log' }> => e.type === 'log');
+}
+
+describe('/afk and /dnd presence', () => {
+  it('/afk confirms to the setter and auto-replies to whisperers (still delivering)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/afk grabbing lunch', a);
+    const confirm = logEvents(sim.tick());
+    expect(confirm.some((m) => m.pid === a && /Away From Keyboard: grabbing lunch/.test(m.text))).toBe(true);
+
+    sim.chat('/w Aleph you around?', b);
+    const out = sim.tick();
+    // Bet gets an auto-reply line about Aleph being away...
+    expect(logEvents(out).some((m) => m.pid === b && /Aleph is Away From Keyboard: grabbing lunch/.test(m.text))).toBe(true);
+    // ...and the whisper is still delivered to Aleph (afk does not withhold)
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === a && m.text === 'you around?')).toBe(true);
+  });
+
+  it('/dnd withholds the whisper but still echoes the sender and notifies them', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/dnd raiding', a);
+    sim.tick();
+
+    sim.chat('/w Aleph ping', b);
+    const out = sim.tick();
+    expect(logEvents(out).some((m) => m.pid === b && /Aleph is Do Not Disturb: raiding/.test(m.text))).toBe(true);
+    // the recipient copy (no `to`) must not reach Aleph
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === a)).toBe(false);
+    // but the sender still sees their own outgoing line (carries `to`)
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === b && m.to === 'Aleph')).toBe(true);
+  });
+
+  it('repeating the bare command toggles the status off', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/afk', a);
+    sim.tick();
+    sim.chat('/afk', a);
+    const out = logEvents(sim.tick());
+    expect(out.some((m) => m.pid === a && /no longer Away From Keyboard/.test(m.text))).toBe(true);
+  });
+
+  it('sending any other chat clears an away status', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/afk', a);
+    sim.tick();
+    sim.chat('back now', a);
+    const out = logEvents(sim.tick());
+    expect(out.some((m) => m.pid === a && /no longer marked as away/.test(m.text))).toBe(true);
+  });
+});

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -205,6 +205,86 @@ describe('chat channels', () => {
     expect(pids).toContain(b);
     expect(pids).not.toContain(outsider);
   });
+
+  it('/roll broadcasts a deterministic result in the default 1-100 range to nearby players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const near = sim.addPlayer('mage', 'Bet');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, near, 10, -40); // within SAY_RANGE
+    teleport(sim, far, 80, -40);  // beyond SAY_RANGE
+    sim.tick();
+
+    sim.chat('/roll', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs.every((m) => m.channel === 'roll' && m.from === 'Aleph')).toBe(true);
+    // text is "<result> (1-100)" with the result inside the range
+    const m = /^(\d+) \(1-100\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    const result = Number(m[1]);
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(result).toBeLessThanOrEqual(100);
+    const pids = msgs.map((x) => x.pid);
+    expect(pids).toContain(a);    // roller sees their own roll
+    expect(pids).toContain(near);
+    expect(pids).not.toContain(far);
+  });
+
+  it('/roll N rolls within 1-N and /roll M-N within the given bounds', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+
+    sim.chat('/roll 6', a);
+    let msgs = chatEvents(sim.tick());
+    let m = /^(\d+) \(1-6\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(1);
+    expect(Number(m[1])).toBeLessThanOrEqual(6);
+
+    sim.chat('/roll 50-60', a);
+    msgs = chatEvents(sim.tick());
+    m = /^(\d+) \(50-60\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(50);
+    expect(Number(m[1])).toBeLessThanOrEqual(60);
+  });
+
+  it('/roll prefers the party channel when the roller is grouped', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 0, -900);   // out of say range but in the party
+    teleport(sim, outsider, 2, -40);
+    sim.tick();
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    sim.tick();
+
+    sim.chat('/roll', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((x) => x.channel === 'roll')).toBe(true);
+    const pids = msgs.map((x) => x.pid);
+    expect(pids).toContain(a);
+    expect(pids).toContain(b);            // distant party member still sees it
+    expect(pids).not.toContain(outsider); // a nearby non-member does not
+  });
+
+  it('rejects a malformed roll range instead of saying it out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/roll 60-50', a); // min greater than max
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
 });
 
 describe('emotes', () => {

--- a/tests/cooldowns_command.test.ts
+++ b/tests/cooldowns_command.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errors(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+describe('/cooldowns command', () => {
+  it('reports nothing on cooldown when the map is empty', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/cooldowns', a);
+    const errs = errors(sim.tick());
+    expect(errs.length).toBe(1);
+    expect(errs[0].pid).toBe(a);
+    expect(errs[0].text).toBe('No abilities are on cooldown.');
+  });
+
+  it('lists active cooldowns soonest-ready first with ceil-rounded seconds', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    // insert out of order to prove the readout sorts ascending by remaining
+    e.cooldowns.set('execute', 12);
+    e.cooldowns.set('charge', 2.4);
+
+    sim.chat('/cooldowns', a);
+    const errs = errors(sim.tick());
+    expect(errs.length).toBe(1);
+    // 2.4s ceils to 3s while still active; Charge sorts before Execute
+    expect(errs[0].text).toBe('Abilities on cooldown (2): Charge (3s), Execute (12s).');
+  });
+
+  it('accepts the /cd and /cds aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    for (const cmd of ['/cd', '/cds']) {
+      sim.chat(cmd, a);
+      const errs = errors(sim.tick());
+      expect(errs.length).toBe(1);
+      expect(errs[0].text).toBe('No abilities are on cooldown.');
+    }
+  });
+
+  it('is self-only: produces no chat event and is not logged', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const result = sim.chat('/cooldowns', a);
+    expect(result).toBeNull();
+    expect(sim.tick().some((ev) => ev.type === 'chat')).toBe(false);
+  });
+});

--- a/tests/duel.test.ts
+++ b/tests/duel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+import type { Aura } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+  (sim as any).rebucket(e);
+}
+
+// Start an accepted duel between two adjacent players and run the countdown
+// out so the bout is live.
+function startedDuel(): { sim: Sim; a: number; b: number } {
+  const sim = makeWorld();
+  const a = sim.addPlayer('warrior', 'Aleph');
+  const b = sim.addPlayer('mage', 'Bet');
+  teleport(sim, a, 0, -40);
+  teleport(sim, b, 4, -40);
+  sim.duelRequest(b, a);
+  sim.duelAccept(b);
+  // run the 3s countdown (TICK_RATE = 20) to flip the duel to 'active'
+  for (let i = 0; i < 20 * 4; i++) {
+    sim.tick();
+    const d = (sim as any).duels.get(a);
+    if (d && d.state === 'active') break;
+  }
+  return { sim, a, b };
+}
+
+// A bleed/poison style damage-over-time applied by the opponent.
+function opponentDot(sourceId: number): Aura {
+  return {
+    id: 'test_bleed', name: 'Test Bleed', kind: 'dot',
+    remaining: 10, duration: 10, value: 40,
+    tickInterval: 1, tickTimer: 1,
+    sourceId, school: 'physical',
+  } as Aura;
+}
+
+describe('duel: non-lethal cleanup', () => {
+  it('a lingering opponent DoT does not kill the loser after the duel ends', () => {
+    const { sim, a, b } = startedDuel();
+    const ea = sim.entities.get(a)!;
+    const eb = sim.entities.get(b)!;
+    expect((sim as any).duels.get(a)?.state).toBe('active');
+
+    // Aleph puts a strong bleed on Bet, then lands the finishing blow. The
+    // 1-HP duel guard fires, the duel ends, Bet survives at 1 HP.
+    (sim as any).applyAura(eb, opponentDot(ea.id));
+    (sim as any).dealDamage(ea, eb, eb.hp + 1000, false, 'physical', 'Finisher', 'hit');
+
+    expect((sim as any).duels.has(b)).toBe(false); // duel is over
+    expect(eb.dead).toBe(false);
+    expect(eb.hp).toBe(1);
+
+    // Run a few seconds so the leftover bleed ticks several times.
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+
+    // The duel was non-lethal — the opponent's leftover DoT must not have
+    // killed Bet for real after the bout ended.
+    expect(eb.dead).toBe(false);
+    expect(eb.hp).toBeGreaterThanOrEqual(1);
+  });
+
+  it('a lingering DoT does not kill a player who forfeits by running away', () => {
+    const { sim, a, b } = startedDuel();
+    const ea = sim.entities.get(a)!;
+    const eb = sim.entities.get(b)!;
+
+    (sim as any).applyAura(eb, opponentDot(ea.id));
+    eb.hp = 30; // wounded but alive
+
+    // Bet flees past the forfeit distance, ending the duel as a draw.
+    teleport(sim, b, 400, -40);
+    sim.tick();
+    expect((sim as any).duels.has(b)).toBe(false);
+
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    expect(eb.dead).toBe(false);
+  });
+});

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
+import { encodeObs } from '../src/sim/obs';
 import { Entity, dist2d } from '../src/sim/types';
 import { CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
@@ -701,6 +702,31 @@ describe('aoe damage vs armor', () => {
     for (let i = 0; i < 3; i++) sim.tick();
     // full unmitigated arcane damage is 26-31; mitigated would be <=8
     expect(before - wolf.hp).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe('RL observation encoding', () => {
+  // The target block, the nearby-mob block, and the interactable block all
+  // encode entity distance as clamp(d / 40, ...). The target field used to clamp
+  // to [0, 1] while the others use [0, 1.5] (the 60-unit observation radius), so
+  // a target between 40 and 60 units saturated and lost distance granularity.
+  // Index 39 is the target distance: 16 self + 20 abilities + presence/hp/level.
+  const TARGET_DIST_INDEX = 39;
+
+  it('encodes target distance on the same 1.5 scale as nearby mobs', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    teleportTo(sim, 0, -40); // open road
+    const mob = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
+    // park the mob 50 units away (inside the 60-unit obs radius, beyond the
+    // old 40-unit saturation point)
+    mob.pos = { ...sim.groundPos(p.pos.x + 50, p.pos.z) };
+    expect(dist2d(p.pos, mob.pos)).toBeCloseTo(50, 0);
+
+    sim.targetEntity(mob.id);
+    const obs = encodeObs(sim);
+    expect(obs[TARGET_DIST_INDEX]).toBeGreaterThan(1); // would be clamped to 1 before the fix
+    expect(obs[TARGET_DIST_INDEX]).toBeCloseTo(50 / 40, 5);
   });
 });
 

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -730,6 +730,63 @@ describe('RL observation encoding', () => {
   });
 });
 
+describe('pet heel warp', () => {
+  it('keeps the spatial grid exact when a pet warps to its owner', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    // park the owner in open space away from the spawn camp
+    teleportTo(sim, p.pos.x + 400, p.pos.z + 400);
+
+    // adopt a wild beast as a heeling pet and strand it far from the owner
+    const pet = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
+    pet.ownerId = p.id;
+    pet.hostile = false;
+    pet.aggroTargetId = null;
+    pet.inCombat = false;
+    pet.pos = { x: p.pos.x + 200, z: p.pos.z, y: p.pos.y };
+    pet.prevPos = { ...pet.pos };
+    (sim as any).grid.update(pet); // grid now buckets the pet at its far cell
+
+    // 200 yds away with nothing to fight: the pet warps back to heel
+    (sim as any).updatePet(pet);
+    expect(dist2d(pet.pos, p.pos)).toBeLessThan(1);
+
+    // a same-tick radius query at the warp destination must see the pet — it
+    // would miss it if the grid still held the pet in its stale far-away cell
+    const found: number[] = [];
+    (sim as any).grid.forEachInRadius(p.pos.x, p.pos.z, 5, (e: Entity) => found.push(e.id));
+    expect(found).toContain(pet.id);
+  });
+});
+
+describe('mob tap rights', () => {
+  function wolf(sim: Sim): Entity {
+    return [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'forest_wolf')!;
+  }
+
+  it('a hit that deals real damage claims the mob', () => {
+    const sim = makeSim('mage');
+    const m = wolf(sim);
+    expect(m.tappedById).toBeNull();
+    (sim as any).dealDamage(sim.player, m, 7, false, 'fire', 'test', 'hit');
+    expect(m.tappedById).toBe(sim.player.id);
+  });
+
+  it('a fully absorbed (zero-damage) hit does not claim the mob', () => {
+    const sim = makeSim('mage');
+    const m = wolf(sim);
+    // a shield that soaks the whole hit — the mob takes no real damage
+    m.auras.push({
+      id: 'test_absorb', name: 'Test Shield', kind: 'absorb',
+      remaining: 30, duration: 30, value: 1000, sourceId: m.id, school: 'arcane',
+    } as any);
+    const hpBefore = m.hp;
+    (sim as any).dealDamage(sim.player, m, 50, false, 'fire', 'test', 'hit');
+    expect(m.hp).toBe(hpBefore); // nothing got through
+    expect(m.tappedById).toBeNull(); // so nobody owns the tap yet
+  });
+});
+
 describe('spell visuals', () => {
   it('hostile casts emit projectile spellfx events', () => {
     const sim = makeSim('mage');

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -802,3 +802,52 @@ describe('spell visuals', () => {
     expect(fx.some((e) => e.type === 'spellfx' && e.fx === 'projectile' && e.school === 'fire')).toBe(true);
   });
 });
+
+describe('trade and duel invites validate availability at accept time', () => {
+  it('a second invitee cannot hijack the inviter who is already trading', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const a = sim.addPlayer('warrior', 'Anna');
+    const b = sim.addPlayer('mage', 'Bert');
+    const c = sim.addPlayer('warrior', 'Cara');
+
+    // Anna fires off trade requests to both Bert and Cara while still free.
+    sim.tradeRequest(b, a);
+    sim.tradeRequest(c, a);
+
+    // Bert accepts first — Anna and Bert are now trading together.
+    sim.tradeAccept(b);
+    const annaSession = sim.tradeFor(a);
+    const bertSession = sim.tradeFor(b);
+    expect(annaSession).not.toBeNull();
+    expect(annaSession).toBe(bertSession);
+
+    // Cara accepts the stale request. This must NOT silently replace Anna's
+    // live session with Bert (which would desync Bert's trade window).
+    sim.tradeAccept(c);
+
+    expect(sim.tradeFor(c)).toBeNull();
+    // Anna is still trading with the same partner she actually opened with.
+    expect(sim.tradeFor(a)).toBe(bertSession);
+    expect(sim.tradeFor(b)).toBe(bertSession);
+  });
+
+  it('a second challenger acceptance cannot hijack a duelist mid-duel', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const a = sim.addPlayer('warrior', 'Anna');
+    const b = sim.addPlayer('mage', 'Bert');
+    const c = sim.addPlayer('warrior', 'Cara');
+
+    sim.duelRequest(b, a);
+    sim.duelRequest(c, a);
+
+    sim.duelAccept(b);
+    const annaDuel = sim.duelFor(a);
+    expect(annaDuel).not.toBeNull();
+    expect(sim.duelFor(b)).toBe(annaDuel);
+
+    sim.duelAccept(c);
+    expect(sim.duelFor(c)).toBeNull();
+    expect(sim.duelFor(a)).toBe(annaDuel);
+    expect(sim.duelFor(b)).toBe(annaDuel);
+  });
+});

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import { encodeObs } from '../src/sim/obs';
+import { ACTIONS, encodeObs } from '../src/sim/obs';
 import { Entity, dist2d } from '../src/sim/types';
 import { CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
@@ -710,8 +710,9 @@ describe('RL observation encoding', () => {
   // encode entity distance as clamp(d / 40, ...). The target field used to clamp
   // to [0, 1] while the others use [0, 1.5] (the 60-unit observation radius), so
   // a target between 40 and 60 units saturated and lost distance granularity.
-  // Index 39 is the target distance: 16 self + 20 abilities + presence/hp/level.
-  const TARGET_DIST_INDEX = 39;
+  // Target distance index: 16 self + 2 fields per ability slot + presence/hp/level.
+  const ABILITY_SLOTS = ACTIONS.length - 13;
+  const TARGET_DIST_INDEX = 16 + ABILITY_SLOTS * 2 + 3;
 
   it('encodes target distance on the same 1.5 scale as nearby mobs', () => {
     const sim = makeSim();

--- a/tests/follow.test.ts
+++ b/tests/follow.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function dist(sim: Sim, a: number, b: number) {
+  const ea = sim.entities.get(a)!;
+  const eb = sim.entities.get(b)!;
+  return Math.hypot(ea.pos.x - eb.pos.x, ea.pos.z - eb.pos.z);
+}
+
+function errors(events: SimEvent[]): string[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error').map((e) => e.text);
+}
+
+describe('/follow', () => {
+  it('walks the follower toward the leader and stops at the trail distance', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 20, -40);
+    sim.tick();
+
+    sim.chat('/follow Bet', a);
+    const msgs = errors(sim.tick());
+    expect(msgs.some((t) => /Now following Bet/.test(t))).toBe(true);
+
+    // run the sim forward; the follower should close the gap and settle near it
+    for (let i = 0; i < 600; i++) sim.tick();
+    const d = dist(sim, a, b);
+    expect(d).toBeLessThanOrEqual(4); // ~FOLLOW_STOP_DIST (3) plus a tick of slop
+    expect(sim.entities.get(a)!.followTargetId).toBe(b);
+  });
+
+  it('keeps trailing when the leader moves away', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 6, -40);
+    sim.tick();
+    sim.chat('/follow Bet', a);
+    for (let i = 0; i < 60; i++) sim.tick();
+
+    // leader strides off; follower should chase and stay close
+    teleport(sim, b, 30, -40);
+    for (let i = 0; i < 600; i++) sim.tick();
+    expect(dist(sim, a, b)).toBeLessThanOrEqual(4);
+  });
+
+  it('breaks follow when the follower issues manual movement', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 10, -40);
+    sim.tick();
+    sim.chat('/follow Bet', a);
+    sim.tick();
+    expect(sim.entities.get(a)!.followTargetId).toBe(b);
+
+    sim.players.get(a)!.moveInput.forward = true;
+    const msgs = errors(sim.tick());
+    expect(sim.entities.get(a)!.followTargetId).toBe(null);
+    expect(msgs.some((t) => /stop following/i.test(t))).toBe(true);
+  });
+
+  it('ends follow when the leader goes out of range', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 5, -40);
+    sim.tick();
+    sim.chat('/follow Bet', a);
+    sim.tick();
+
+    teleport(sim, b, 200, -40); // beyond FOLLOW_MAX_RANGE
+    const msgs = errors(sim.tick());
+    expect(sim.entities.get(a)!.followTargetId).toBe(null);
+    expect(msgs.some((t) => /too far away to follow/i.test(t))).toBe(true);
+  });
+
+  it('rejects following yourself and unknown players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(errors((sim.chat('/follow Aleph', a), sim.tick())).some((t) => /follow yourself/i.test(t))).toBe(true);
+    expect(errors((sim.chat('/follow Nobody', a), sim.tick())).some((t) => /no player named/i.test(t))).toBe(true);
+  });
+});

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
+const openPlaySession = vi.fn(async () => 1);
+const closePlaySession = vi.fn(async () => {});
+
 vi.mock('../server/db', () => ({
   pool: { query: vi.fn(async () => ({ rows: [] })) },
   saveCharacterState: vi.fn(async () => {}),
-  openPlaySession: vi.fn(async () => 1),
-  closePlaySession: vi.fn(async () => {}),
+  openPlaySession: (...args: unknown[]) => openPlaySession(...(args as [])),
+  closePlaySession: (...args: unknown[]) => closePlaySession(...(args as [])),
   insertChatLogs: vi.fn(async () => {}),
 }));
 
@@ -42,5 +45,31 @@ describe('GameServer sessions', () => {
 
     const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
     expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
+  });
+
+  it('closes the play session even when the open insert lands after the player has left', async () => {
+    openPlaySession.mockReset();
+    closePlaySession.mockReset();
+    closePlaySession.mockResolvedValue(undefined);
+
+    // Defer the openPlaySession insert so the player can disconnect first.
+    let resolveOpen!: (id: number) => void;
+    openPlaySession.mockImplementationOnce(
+      () => new Promise<number>((resolve) => { resolveOpen = resolve; }),
+    );
+
+    const server = new GameServer();
+    const session = expectJoined(server.join(fakeWs(), 21, 201, 'Racer', 'warrior', null));
+    expect(session.dbSessionId).toBeNull();
+
+    // Player disconnects before the insert resolves: leave() sees a null id.
+    await server.leave(session, 'test');
+    expect(closePlaySession).not.toHaveBeenCalled();
+
+    // The insert finally lands; the late callback must close the orphaned row.
+    resolveOpen(99);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(closePlaySession).toHaveBeenCalledWith(99);
   });
 });

--- a/tests/gear_command.test.ts
+++ b/tests/gear_command.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  const e = events.find((ev) => ev.type === 'error');
+  return e && e.type === 'error' ? e.text : undefined;
+}
+
+describe('/gear command', () => {
+  it('lists equipped slots in a fixed order and marks empty ones', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    // A fresh warrior starts with a main hand and a chest piece, no legs/feet.
+    sim.tick();
+    sim.chat('/gear', a);
+    const text = errorText(sim.tick());
+    expect(text).toBeDefined();
+    expect(text).toMatch(/^Equipped \(2\/4\):/);
+    expect(text).toContain('Main Hand:');
+    expect(text).toContain('Chest:');
+    expect(text).toContain('Legs: (empty)');
+    expect(text).toContain('Feet: (empty)');
+    // fixed slot order: main hand before chest before legs before feet
+    expect(text!.indexOf('Main Hand')).toBeLessThan(text!.indexOf('Chest'));
+    expect(text!.indexOf('Chest')).toBeLessThan(text!.indexOf('Legs'));
+    expect(text!.indexOf('Legs')).toBeLessThan(text!.indexOf('Feet'));
+  });
+
+  it('reflects newly equipped gear and resolves item names', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.equipment = { mainhand: 'worn_sword', chest: 'recruit_tunic', legs: 'quilted_trousers', feet: 'oiled_boots' };
+    sim.tick();
+    sim.chat('/gear', a);
+    const text = errorText(sim.tick());
+    expect(text).toMatch(/^Equipped \(4\/4\):/);
+    expect(text).toContain('Worn Shortsword');
+    expect(text).toContain('Quilted Trousers');
+    expect(text).not.toContain('(empty)');
+  });
+
+  it('reports nothing equipped when every slot is empty', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.equipment = {};
+    sim.tick();
+    sim.chat('/gear', a);
+    expect(errorText(sim.tick())).toBe('You have nothing equipped.');
+  });
+
+  it('is reachable via the /equip and /equipment aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const alias of ['/equip', '/equipment']) {
+      sim.chat(alias, a);
+      expect(errorText(sim.tick())).toMatch(/^Equipped /);
+    }
+  });
+
+  it('does not emit a chat event or broadcast to others', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const sent = sim.chat('/gear', a);
+    expect(sent).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});

--- a/tests/gold_command.test.ts
+++ b/tests/gold_command.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { Sim, formatMoney } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTextFor(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find(
+    (ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error' && ev.pid === pid,
+  );
+  return e?.text;
+}
+
+describe('/gold command', () => {
+  it('reports your purse with gold/silver/copper formatting', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 123405; // 12g 34s 5c
+    sim.tick();
+
+    expect(sim.chat('/gold', a)).toBeNull(); // self-only readout, never logged
+    expect(errorTextFor(sim.tick(), a)).toBe(`You have ${formatMoney(123405)}.`);
+  });
+
+  it('shows flavor text for an empty purse instead of "0c"', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 0;
+    sim.tick();
+
+    sim.chat('/gold', a);
+    expect(errorTextFor(sim.tick(), a)).toBe('Your purse is empty.');
+  });
+
+  it('accepts the /money and /coins aliases', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 250;
+    sim.tick();
+
+    for (const cmd of ['/money', '/coins']) {
+      sim.chat(cmd, a);
+      expect(errorTextFor(sim.tick(), a)).toBe(`You have ${formatMoney(250)}.`);
+    }
+  });
+
+  it('is a self-only reply that does not emit a chat event', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.players.get(a)!.copper = 99;
+    sim.tick();
+
+    sim.chat('/gold', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+  });
+});

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -41,6 +41,8 @@ function makeInput() {
   };
   const cb = {
     onTab: vi.fn(),
+    onTargetFriendly: vi.fn(),
+    onCycleFriendly: vi.fn(),
     onAbility: vi.fn(),
     onUiKey: vi.fn(),
     onClickPick: vi.fn(),

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -67,7 +67,9 @@ describe('Keybinds defaults', () => {
     expect(kb.actionForCode('KeyB')).toBe('bags');
     expect(kb.actionForCode('Digit1')).toBe('slot0'); // Attack
     expect(kb.actionForCode('Equal')).toBe('slot11');
-    expect(kb.actionForCode('KeyJ')).toBe(null);
+    expect(kb.actionForCode('KeyH')).toBe('targetFriendly');
+    expect(kb.actionForCode('KeyJ')).toBe('targetFriendlyNext');
+    expect(kb.actionForCode('KeyZ')).toBe(null);
   });
 
   it('exposes primary/secondary codes and labels', () => {

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -147,6 +147,35 @@ describe('persistence', () => {
     expect(b.actionForCode('Space')).toBe(null);
   });
 
+  it('keeps defaults for actions missing from older saved data', () => {
+    // Simulate a save written before some actions existed: it only contains a
+    // couple of bindings. Every other action must keep its default, not load
+    // unbound.
+    localStorage.setItem('woc_keybinds', JSON.stringify({
+      slot0: ['KeyR', null],
+      jump: ['KeyJ', null],
+    }));
+    const kb = new Keybinds();
+    expect(kb.actionForCode('KeyR')).toBe('slot0');
+    expect(kb.actionForCode('KeyJ')).toBe('jump');
+    expect(kb.actionForCode('KeyW')).toBe('forward');
+    expect(kb.actionForCode('Tab')).toBe('target');
+    expect(kb.actionForCode('KeyN')).toBe('meters');
+    expect(kb.actionForCode('Enter')).toBe('chat');
+    expect(kb.actionForCode('Equal')).toBe('slot11');
+  });
+
+  it('drops a retained default that a stored binding already claimed', () => {
+    // A stored binding takes KeyN (the default for the newer "meters" action),
+    // which is absent from the blob. meters must not also keep KeyN.
+    localStorage.setItem('woc_keybinds', JSON.stringify({
+      jump: ['KeyN', null],
+    }));
+    const kb = new Keybinds();
+    expect(kb.actionForCode('KeyN')).toBe('jump');
+    expect(kb.codeAt('meters', 0)).toBe(null);
+  });
+
   it('drops duplicate codes when loading corrupt storage', () => {
     // two actions claim KeyR — the later one must lose it on load
     localStorage.setItem('woc_keybinds', JSON.stringify({

--- a/tests/party_command.test.ts
+++ b/tests/party_command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find((ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error' && ev.pid === pid);
+  return e?.text;
+}
+
+// Form a party with `leader` as leader and the rest as members, in order.
+function formParty(sim: Sim, leader: number, members: number[]) {
+  for (const m of members) {
+    sim.partyInvite(m, leader);
+    sim.partyAccept(m);
+  }
+}
+
+describe('/party readout command', () => {
+  it('lists party members with level, class, and HP%, tagging the leader', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+    formParty(sim, a, [b, c]);
+
+    // Wound Gimel to a known HP% so the readout is deterministic.
+    const ce = sim.entities.get(c)!;
+    ce.hp = Math.round(ce.maxHp * 0.4);
+
+    const sent = sim.chat('/party', a);
+    expect(sent).toBeNull(); // self-only readout is never broadcast
+    const text = errorText(sim.tick(), a);
+    expect(text).toBeDefined();
+    expect(text).toContain('Party (3/5):');
+    expect(text).toContain('Aleph');
+    expect(text).toContain('[leader]');
+    expect(text).toContain('Bet');
+    expect(text).toContain('100%');
+    expect(text).toContain('Gimel');
+    expect(text).toContain('40%');
+  });
+
+  it('reports when you are not in a party', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Solo');
+    sim.tick();
+    sim.chat('/party', a);
+    expect(errorText(sim.tick(), a)).toBe('You are not in a party.');
+  });
+
+  it('shows dead members as (dead)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('priest', 'Bet');
+    sim.tick();
+    formParty(sim, a, [b]);
+    sim.entities.get(b)!.hp = 0;
+
+    sim.chat('/group', a); // alias
+    const text = errorText(sim.tick(), a);
+    expect(text).toContain('Bet');
+    expect(text).toContain('(dead)');
+  });
+});

--- a/tests/pet_command.test.ts
+++ b/tests/pet_command.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent, Entity } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'hunter', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  const err = events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+  return err?.text;
+}
+
+// Hand a player a pet by adopting an existing wild mob, mirroring what a
+// completed tame leaves behind (ownerId set, full health, friendly).
+function givePet(sim: Sim, ownerPid: number): Entity {
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) {
+      e.ownerId = ownerPid;
+      e.hostile = false;
+      e.hp = e.maxHp;
+      return e;
+    }
+  }
+  throw new Error('no wild mob available to adopt as a pet');
+}
+
+describe('/pet command', () => {
+  it('reports name, level, family, and health for an active pet', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    const pet = givePet(sim, a);
+    sim.tick();
+
+    sim.chat('/pet', a);
+    const events = sim.tick();
+    // self-only readout: never reaches the chat channel
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    const text = errorText(events)!;
+    expect(text).toContain(`Your pet: ${pet.name}`);
+    expect(text).toContain(`level ${pet.level}`);
+    expect(text).toContain(`HP ${pet.hp}/${pet.maxHp}`);
+    expect(text).toContain('(100%)');
+  });
+
+  it('rounds the health percentage from live pet HP', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    const pet = givePet(sim, a);
+    pet.hp = Math.round(pet.maxHp * 0.5);
+    sim.tick();
+
+    sim.chat('/pet', a);
+    const text = errorText(sim.tick())!;
+    expect(text).toContain('(50%)');
+  });
+
+  it('tells players without a pet that they have none', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    sim.tick();
+
+    sim.chat('/pet', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    expect(errorText(events)).toBe('You do not have a pet.');
+  });
+
+  it('supports the /companion and /pets aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    const pet = givePet(sim, a);
+    sim.tick();
+
+    for (const cmd of ['/companion', '/pets']) {
+      sim.chat(cmd, a);
+      expect(errorText(sim.tick())).toContain(`Your pet: ${pet.name}`);
+    }
+  });
+});

--- a/tests/quest_command.test.ts
+++ b/tests/quest_command.test.ts
@@ -1,0 +1,69 @@
+// The /quest command (aliases /quests, /ql) is a self-only readout of the
+// active quest log: one entry per tracked quest with per-objective progress.
+// Like the other readout commands it emits a single 'error' event addressed to
+// the caller and returns null, so it never enters the chat log and needs no
+// server interceptor to work online.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { QUESTS } from '../src/sim/data';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTo(events: SimEvent[], pid: number): string[] {
+  return events
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid)
+    .map((e) => e.text);
+}
+
+describe('/quest command', () => {
+  it('reports an empty log when no quests are tracked', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    expect(sim.chat('/quest', a)).toBeNull();
+    expect(errorTo(sim.tick(), a)).toContain('Your quest log is empty.');
+  });
+
+  it('lists each tracked quest with capped per-objective progress', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    // Pick a multi-objective quest if one exists, else the first quest.
+    const quest =
+      Object.values(QUESTS).find((q) => q.objectives.length > 1) ?? Object.values(QUESTS)[0];
+    // Overshoot the first objective to prove the readout caps at the target.
+    const counts = quest.objectives.map((o) => o.count);
+    counts[0] = quest.objectives[0].count + 5;
+    meta.questLog.set(quest.id, { questId: quest.id, counts, state: 'active' });
+    sim.tick();
+
+    expect(sim.chat('/quests', a)).toBeNull();
+    const line = errorTo(sim.tick(), a).find((t) => t.startsWith('Quest log'));
+    expect(line).toBeDefined();
+    expect(line).toContain('Quest log (1):');
+    expect(line).toContain(quest.name);
+    const o0 = quest.objectives[0];
+    expect(line).toContain(`${o0.label} ${o0.count}/${o0.count}`); // capped, not count+5
+  });
+
+  it('tags ready quests and is alias-compatible (/ql)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    const quest = Object.values(QUESTS)[0];
+    meta.questLog.set(quest.id, {
+      questId: quest.id,
+      counts: quest.objectives.map((o) => o.count),
+      state: 'ready',
+    });
+    sim.tick();
+
+    expect(sim.chat('/ql', a)).toBeNull();
+    const line = errorTo(sim.tick(), a).find((t) => t.startsWith('Quest log'));
+    expect(line).toContain(`${quest.name} (ready)`);
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -167,6 +167,23 @@ describe('per-account failed-login throttle (#93)', () => {
     expect(authThrottled('account_a')).toBe(true);
     expect(authThrottled('account_b')).toBe(false);
   });
+
+  it('keeps an account locked out after the memory backstop evicts', () => {
+    // A credential-stuffing flood spreads guesses across thousands of accounts,
+    // pushing the failure map past its backstop threshold. The backstop must
+    // evict expired one-off entries, NOT wipe the live lockout counter for an
+    // account actively under attack — otherwise flooding silently disables the
+    // per-account throttle exactly when it is needed most.
+    const victim = 'lockme_account';
+    for (let i = 0; i < 10; i++) recordAuthFailure(victim);
+    expect(authThrottled(victim)).toBe(true);
+
+    // Churn past MAX_TRACKED_IPS (10_000) distinct accounts to trip the backstop.
+    for (let i = 0; i < 10_050; i++) recordAuthFailure(`throwaway_${i}`);
+
+    // The victim's lockout must survive eviction.
+    expect(authThrottled(victim)).toBe(true);
+  });
 });
 
 describe('malformed websocket frames cannot crash the server', () => {

--- a/tests/session_command.test.ts
+++ b/tests/session_command.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorEvents(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+// Drive a "/session" command for `pid` and return the self-only line it emits.
+function sessionLine(sim: Sim, pid: number): string {
+  sim.chat('/session', pid);
+  const errs = errorEvents(sim.tick());
+  expect(errs).toHaveLength(1);
+  expect(errs[0].pid).toBe(pid);
+  return errs[0].text;
+}
+
+describe('/session command', () => {
+  it('reports a fresh session as all zeros', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(sessionLine(sim, a)).toBe(
+      'Session: 0 kills, 0 deaths. Damage dealt 0, taken 0. XP gained 0.',
+    );
+  });
+
+  it('reflects this session\'s counters with singular/plural and thousands separators', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const c = sim.players.get(a)!.counters;
+    c.kills = 14;
+    c.deaths = 1; // singular
+    c.damageDealt = 8420;
+    c.damageTaken = 3110;
+    c.xpGained = 5300;
+    expect(sessionLine(sim, a)).toBe(
+      'Session: 14 kills, 1 death. Damage dealt 8,420, taken 3,110. XP gained 5,300.',
+    );
+  });
+
+  it('is self-only and never reaches the chat log', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    sim.chat('/session', a);
+    const events = sim.tick();
+    const errs = errorEvents(events);
+    expect(errs).toHaveLength(1);
+    expect(errs[0].pid).toBe(a);
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+  });
+
+  it('accepts the /sess and /sessionstats aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const alias of ['/sess', '/sessionstats']) {
+      sim.chat(alias, a);
+      const errs = errorEvents(sim.tick());
+      expect(errs).toHaveLength(1);
+      expect(errs[0].text).toMatch(/^Session: /);
+    }
+  });
+});

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -457,6 +457,26 @@ describe('rogue', () => {
     expect(sim.player.comboPoints).toBe(0);
   });
 
+  it('toggling stealth off does not re-arm its cooldown', () => {
+    const sim = makeSim('rogue');
+    (sim as any).grantXp(xpForLevel(1) + xpForLevel(2) + 10); // reach level 3, learns stealth (lvl 2)
+    expect(sim.known.map((k) => k.def.id)).toContain('stealth');
+    // Stealth on: arms the 10s re-entry cooldown.
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    expect(sim.player.cooldowns.has('stealth')).toBe(true);
+    // Wait out the cooldown (10s @ 20 ticks/s = 200 ticks).
+    for (let i = 0; i < 220; i++) sim.tick();
+    expect(sim.player.cooldowns.has('stealth')).toBe(false);
+    // Toggling stealth off is free and must not re-arm the cooldown.
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(false);
+    expect(sim.player.cooldowns.has('stealth')).toBe(false);
+    // Therefore the rogue can immediately re-stealth.
+    sim.castAbility('stealth');
+    expect(sim.player.auras.some((a) => a.kind === 'stealth')).toBe(true);
+  });
+
   it('rogue GCD is 1.0s', () => {
     const sim = makeSim('rogue');
     expect(sim.playerGcd).toBe(1.0);

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -1053,3 +1053,76 @@ describe('gm characters', () => {
     expect(sim.player.hp).toBe(before - 5);
   });
 });
+
+describe('friendly targeting (#133)', () => {
+  // Drop an ally `dx` yards east of the caster and return its entity.
+  function addAllyAt(sim: Sim, name: string, dx: number) {
+    const p = sim.player;
+    const pid = sim.addPlayer('priest', name);
+    const e = sim.entities.get(pid)!;
+    e.pos.x = p.pos.x + dx; e.pos.z = p.pos.z;
+    e.pos.y = terrainHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+    e.prevPos = { ...e.pos };
+    return e;
+  }
+
+  it('targetNearestFriendly picks the closest ally and never auto-attacks', () => {
+    const sim = makeSim('warrior');
+    const far = addAllyAt(sim, 'Far', 12);
+    const near = addAllyAt(sim, 'Near', 5);
+    sim.tick(); // rebucket the spatial grid
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBe(near.id);
+    expect(sim.player.targetId).not.toBe(far.id);
+    expect(sim.player.autoAttack).toBe(false);
+  });
+
+  it('targetNearestFriendly never targets yourself', () => {
+    const sim = makeSim('warrior');
+    sim.tick();
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBeNull();
+  });
+
+  it('ignores allies beyond 40 yards and keeps the current target', () => {
+    const sim = makeSim('warrior');
+    addAllyAt(sim, 'WayOut', 60);
+    sim.tick();
+    sim.player.targetId = 1234;
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBe(1234);
+  });
+
+  it('skips dead allies', () => {
+    const sim = makeSim('warrior');
+    const ally = addAllyAt(sim, 'Downed', 5);
+    ally.dead = true; ally.hp = 0;
+    sim.tick();
+    sim.targetNearestFriendly();
+    expect(sim.player.targetId).toBeNull();
+  });
+
+  it('friendlyTabTarget cycles allies by distance and wraps', () => {
+    const sim = makeSim('warrior');
+    const a = addAllyAt(sim, 'A', 5);
+    const b = addAllyAt(sim, 'B', 10);
+    const c = addAllyAt(sim, 'C', 15);
+    sim.tick();
+    sim.friendlyTabTarget();             // none -> nearest
+    expect(sim.player.targetId).toBe(a.id);
+    sim.friendlyTabTarget();
+    expect(sim.player.targetId).toBe(b.id);
+    sim.friendlyTabTarget();
+    expect(sim.player.targetId).toBe(c.id);
+    sim.friendlyTabTarget();             // wraps back to nearest
+    expect(sim.player.targetId).toBe(a.id);
+  });
+
+  it('friendlyTabTarget is a no-op when no ally is nearby', () => {
+    const sim = makeSim('warrior');
+    sim.player.targetId = 77;
+    sim.tick();
+    sim.friendlyTabTarget();
+    expect(sim.player.targetId).toBe(77);
+  });
+});

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -206,6 +206,12 @@ describe('friends', () => {
     expect((await h.svc.snapshot(1)).friends).toHaveLength(0);
   });
 
+  it('does not claim success when removing someone who is not a friend', async () => {
+    await h.svc.friendRemove(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/not on your friends list/i);
+    expect(h.tx.textFor(1).join()).not.toMatch(/removed from friends/i);
+  });
+
   it('notifies watching friends when a character comes online', async () => {
     // 1 has 2 on their friends list; 2 logs in
     await h.svc.friendAdd(h.actor(1), 'Bet');
@@ -240,6 +246,12 @@ describe('ignore / block', () => {
     await h.svc.blockRemove(h.actor(1), 'Bet');
     expect((await h.svc.snapshot(1)).blocks).toHaveLength(0);
     expect(h.tx.blockSets.get(1)).toEqual([]);
+  });
+
+  it('does not claim success when unignoring someone who is not ignored', async () => {
+    await h.svc.blockRemove(h.actor(1), 'Bet');
+    expect(h.tx.errorsFor(1).join()).toMatch(/not on your ignore list/i);
+    expect(h.tx.textFor(1).join()).not.toMatch(/no longer ignored/i);
   });
 
   it('refuses to block yourself', async () => {

--- a/tests/stats_command.test.ts
+++ b/tests/stats_command.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const ev = events.find(
+    (e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid,
+  );
+  return ev?.text;
+}
+
+describe('/stats command', () => {
+  it('reports a self-only character sheet with the rage resource clause', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const sent = sim.chat('/stats', a);
+    expect(sent).toBeNull(); // not logged or spoken
+
+    const events = sim.tick();
+    const text = errorText(events, a)!;
+    expect(text).toMatch(/^Level \d+ Warrior — HP \d+\/\d+, Rage \d+\/\d+\. AP \d+, Crit \d+\.\d%, Armor \d+\.$/);
+    // self-only: no other player receives the readout
+    expect(events.some((e) => e.type === 'error' && e.pid !== a)).toBe(false);
+  });
+
+  it('uses the Energy clause for a rogue', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/stats', a);
+    const text = errorText(sim.tick(), a)!;
+    expect(text).toContain('Rogue');
+    expect(text).toMatch(/Energy \d+\/\d+/);
+  });
+
+  it('uses the Mana clause for a mage and accepts the /st and /sheet aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    for (const cmd of ['/stats', '/st', '/sheet']) {
+      sim.chat(cmd, a);
+      const text = errorText(sim.tick(), a)!;
+      expect(text).toMatch(/Mana \d+\/\d+/);
+    }
+  });
+});

--- a/tests/target_command.test.ts
+++ b/tests/target_command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Entity, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function liveMob(sim: Sim): Entity {
+  const mob = [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null,
+  );
+  if (!mob) throw new Error('test needs a live wild mob');
+  return mob;
+}
+
+function errors(events: SimEvent[]): string[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error').map((e) => e.text);
+}
+
+describe('/target readout command', () => {
+  it('reports no target when nothing is targeted', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.chat('/target', a);
+    const errs = errors(sim.tick());
+    expect(errs.some((t) => /no target/i.test(t))).toBe(true);
+  });
+
+  it('reports a targeted mob with name, level, kind and HP percent', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const mob = liveMob(sim);
+    sim.targetEntity(mob.id, a);
+    sim.chat('/tar', a); // alias
+    const reply = errors(sim.tick()).find((t) => t.includes(mob.name));
+    expect(reply).toBeDefined();
+    expect(reply).toContain(`level ${mob.level}`);
+    expect(reply).toContain('mob');
+    expect(reply).toMatch(/\d+% HP/);
+  });
+
+  it('reports another player target as a player and never reaches other clients', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.targetEntity(b, a);
+    sim.chat('/target', a);
+    const events = sim.tick();
+    const reply = errors(events).find((t) => t.includes('Bet'));
+    expect(reply).toContain('player');
+    // self-only: it is an error event addressed to the asker, not a chat line
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    expect(events.every((e) => e.type !== 'error' || e.pid === a)).toBe(true);
+  });
+});

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -355,6 +355,32 @@ describe('rogue stealth', () => {
     expect(wolf.aiState).not.toBe('idle');
   });
 
+  it('a closer stealthed player does not shield a visible ally from aggro', () => {
+    // Regression: the idle-mob check only evaluated the single NEAREST player.
+    // A stealthed player standing closest shrank the detection radius and, being
+    // nearest, was the only candidate considered — so a visible groupmate well
+    // inside the normal aggro radius was silently ignored.
+    const sim = new Sim({ seed: 42, playerClass: 'rogue', noPlayer: true });
+    const rogue = sim.entities.get(sim.addPlayer('rogue', 'Sneak'))!;
+    const warrior = sim.entities.get(sim.addPlayer('warrior', 'Visible'))!;
+    sim.setPlayerLevel(5, rogue.id);
+    sim.setPlayerLevel(5, warrior.id);
+    const wolf = nearestMob(sim, 'forest_wolf', rogue);
+    wolf.wanderTarget = null;
+    // equal levels: no level-difference radius skew (forest_wolf aggroRadius 10,
+    // shrunk to ~2.5 while stealthed)
+    wolf.level = 5;
+    // rogue is NEAREST (4yd) but stealthed and outside its shrunk radius;
+    // the warrior is visible at 6yd, well inside the wolf's 10yd aggro radius
+    teleport(sim, rogue, wolf.pos.x + 4, wolf.pos.z);
+    teleport(sim, warrior, wolf.pos.x + 6, wolf.pos.z);
+    sim.castAbility('stealth', rogue.id);
+    expect(rogue.auras.some((a) => a.kind === 'stealth')).toBe(true);
+    for (let i = 0; i < 20 && wolf.aiState === 'idle'; i++) sim.tick();
+    expect(wolf.aiState).not.toBe('idle');
+    expect(wolf.aggroTargetId).toBe(warrior.id);
+  });
+
   it('cannot stealth in combat; acting breaks stealth; ambush requires it', () => {
     const sim = makeSim('rogue');
     sim.setPlayerLevel(16);

--- a/tests/threat_command.test.ts
+++ b/tests/threat_command.test.ts
@@ -1,0 +1,70 @@
+// /threat (alias /aggro) is a self-only readout of the threat table on the
+// player's current target — highest first, as a percentage of the threat
+// leader. It reads live state only, emits an `error`-typed line shown only to
+// the caller, and returns null so nothing is broadcast or logged.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function nearestMob(sim: Sim): Entity {
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) return e;
+  }
+  throw new Error('no mob found');
+}
+
+function lastError(sim: Sim, pid: number): string | undefined {
+  const errs = sim.events.filter((e) => e.type === 'error' && (e as any).pid === pid);
+  return errs.length ? (errs[errs.length - 1] as any).text : undefined;
+}
+
+describe('/threat command', () => {
+  it('lists the target threat table highest-first as percentages of the leader', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const mob = nearestMob(sim);
+    mob.threat.clear();
+    mob.threat.set(a, 500); // leader
+    mob.threat.set(b, 250); // half
+    sim.entities.get(a)!.targetId = mob.id;
+
+    expect(sim.chat('/threat', a)).toBeNull();
+    const line = lastError(sim, a);
+    expect(line).toBe(`Threat on ${mob.name} (2): Aleph (you) 100% [leader], Bet 50%.`);
+  });
+
+  it('reports no target when nothing is targeted', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.entities.get(a)!.targetId = null;
+
+    sim.chat('/aggro', a);
+    expect(lastError(sim, a)).toBe('You have no target.');
+  });
+
+  it('reports an empty table when the target has no threat on it', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const mob = nearestMob(sim);
+    mob.threat.clear();
+    sim.entities.get(a)!.targetId = mob.id;
+
+    sim.chat('/threat', a);
+    expect(lastError(sim, a)).toBe(`Nobody has any threat on ${mob.name}.`);
+  });
+
+  it('refuses to read threat off a non-enemy target', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.entities.get(a)!.targetId = b;
+
+    sim.chat('/threat', a);
+    expect(lastError(sim, a)).toBe('Threat is only tracked on enemies; Bet is not one.');
+  });
+});

--- a/tests/ws_buffer.test.ts
+++ b/tests/ws_buffer.test.ts
@@ -57,6 +57,20 @@ describe('bufferHandshakeMessages', () => {
     expect(handled).toEqual(['once']);
   });
 
+  it('bounds pre-auth buffering and drops excess frames', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws, 2);
+    ws.emit('message', 'a');
+    ws.emit('message', 'b');
+    ws.emit('message', 'c');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+
+    expect(handled).toEqual(['a', 'b']);
+  });
+
   it('documents the underlying drop the buffer prevents', () => {
     // Without buffering, a frame emitted before any listener is attached is
     // silently discarded by EventEmitter — exactly the lost-input failure mode.

--- a/tests/ws_buffer.test.ts
+++ b/tests/ws_buffer.test.ts
@@ -1,0 +1,69 @@
+import { EventEmitter } from 'node:events';
+import { describe, expect, it } from 'vitest';
+import { bufferHandshakeMessages } from '../server/ws_buffer';
+
+describe('bufferHandshakeMessages', () => {
+  it('replays frames received during the handshake into the real handler, in order', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+
+    // frames arrive while authentication is still awaiting the database
+    ws.emit('message', 'a');
+    ws.emit('message', 'b');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    expect(handled).toEqual([]); // nothing delivered until the handshake resolves
+
+    flush();
+    expect(handled).toEqual(['a', 'b']);
+  });
+
+  it('delivers post-handshake frames live without duplicating buffered ones', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+    ws.emit('message', 'early');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+    ws.emit('message', 'late');
+
+    expect(handled).toEqual(['early', 'late']);
+  });
+
+  it('is a no-op when no frames arrive during the handshake', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+    ws.emit('message', 'x');
+
+    expect(handled).toEqual(['x']);
+  });
+
+  it('ignores repeated flush calls so frames are never replayed twice', () => {
+    const ws = new EventEmitter();
+    const flush = bufferHandshakeMessages(ws);
+    ws.emit('message', 'once');
+
+    const handled: unknown[] = [];
+    ws.on('message', (d) => handled.push(d));
+    flush();
+    flush();
+
+    expect(handled).toEqual(['once']);
+  });
+
+  it('documents the underlying drop the buffer prevents', () => {
+    // Without buffering, a frame emitted before any listener is attached is
+    // silently discarded by EventEmitter — exactly the lost-input failure mode.
+    const ws = new EventEmitter();
+    const handled: unknown[] = [];
+    ws.emit('message', 'lost');
+    ws.on('message', (d) => handled.push(d));
+    expect(handled).toEqual([]);
+  });
+});

--- a/tests/xp_command.test.ts
+++ b/tests/xp_command.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MAX_LEVEL, SimEvent, xpForLevel } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function chatEvents(events: SimEvent[]): Extract<SimEvent, { type: 'chat' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'chat' }> => e.type === 'chat');
+}
+
+function errorFor(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find((e) => e.type === 'error' && e.pid === pid) as
+    | Extract<SimEvent, { type: 'error' }>
+    | undefined;
+  return e?.text;
+}
+
+describe('/xp command', () => {
+  it('reports level, progress, percent, and remaining XP to the sender only', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const bystander = sim.addPlayer('mage', 'Bet');
+    const meta = sim.players.get(a)!;
+    sim.entities.get(a)!.level = 7;
+    meta.xp = 1240;
+    sim.tick();
+
+    sim.chat('/xp', a);
+    const events = sim.tick();
+    // a readout is private and never logged as chat
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.pid === bystander)).toBe(false);
+
+    const need = xpForLevel(7); // total XP to reach level 8
+    const pct = Math.floor((1240 / need) * 100);
+    const text = errorFor(events, a)!;
+    expect(text).toContain('Level 7');
+    expect(text).toContain('1,240');
+    expect(text).toContain(need.toLocaleString('en-US'));
+    expect(text).toContain(`${pct}%`);
+    expect(text).toContain((need - 1240).toLocaleString('en-US')); // remaining
+  });
+
+  it('aliases /exp and /experience behave the same', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.entities.get(a)!.level = 3;
+    sim.players.get(a)!.xp = 0;
+    sim.tick();
+
+    for (const cmd of ['/exp', '/experience', '/XP']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(errorFor(events, a)).toContain('Level 3');
+    }
+  });
+
+  it('announces the cap at max level instead of dividing by zero', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.entities.get(a)!.level = MAX_LEVEL;
+    sim.players.get(a)!.xp = 0;
+    sim.tick();
+
+    sim.chat('/xp', a);
+    const events = sim.tick();
+    const text = errorFor(events, a)!;
+    expect(text).toContain(`Level ${MAX_LEVEL}`);
+    expect(text).toMatch(/max/i);
+    expect(text).not.toContain('%');
+  });
+});

--- a/tests/zones_command.test.ts
+++ b/tests/zones_command.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { ZONES, zoneAt } from '../src/sim/data';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  return events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')?.text;
+}
+
+describe('/zones command', () => {
+  it('is a self-only readout that is neither said nor logged', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(sim.chat('/zones', a)).toBeNull();
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    const text = errorText(events);
+    expect(text).toBeDefined();
+  });
+
+  it('lists every overworld zone with its level range', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/zones', a);
+    const text = errorText(sim.tick())!;
+    for (const z of ZONES) {
+      expect(text).toContain(z.name);
+      expect(text).toContain(`${z.levelRange[0]}-${z.levelRange[1]}`);
+    }
+  });
+
+  it('tags the zone the player is currently standing in', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    // Stand deep in the last zone, then read.
+    const last = ZONES[ZONES.length - 1];
+    teleport(sim, a, 0, last.zMin + 1);
+    sim.tick();
+    expect(zoneAt(sim.entities.get(a)!.pos.z).name).toBe(last.name);
+    sim.chat('/zones', a);
+    const text = errorText(sim.tick())!;
+    // The current-zone marker sits on the last zone's line, not the first.
+    const here = text.indexOf('here');
+    expect(here).toBeGreaterThan(text.indexOf(ZONES[0].name));
+    expect(here).toBeGreaterThan(text.indexOf(last.name));
+  });
+
+  it('responds the same way to the /zonelist and /worldmap aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const cmd of ['/zonelist', '/worldmap']) {
+      sim.chat(cmd, a);
+      const text = errorText(sim.tick())!;
+      expect(text).toContain(ZONES[0].name);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Bundles the currently mergeable low-hanging PRs from @jgyy into one draft QoL/security integration branch.

Included open PRs: #155, #165, #167, #176, #178, #182, #184, #187, #188, #191, #195, #197, #198, #200, #201, #202, #204, #206, #211, #213, #214, #216, #218, #224, #225, #226, #228, #229, #230, #232, #246, #247, #248, #250, #252, #253, #254, #255, #256, #257, #258, #259, #260, #261, #262, #263, #264.

Highlights:
- Security and integrity fixes: stored XSS escaping for player names, auth-throttle backstop preservation, websocket auth-handshake buffering, play-session cleanup scoping/race closure, social ignore/guild invite checks, and trade/duel revalidation.
- QoL commands: /help, /roll, /afk, /dnd, /follow, /r, /played, /where, /target, /xp, /gold, /stats, /buffs, /cooldowns, /bags, /quest, /gear, /abilities, /pet, /party, /session, /threat, and /zones.
- Targeting/RL/combat fixes: friendly targeting, full RL ability-slot coverage, RL target distance normalization, pet/grid/combat fixes, tap-rights, AoE armor mitigation, duel cleanup, and several gameplay edge cases.

## Security review notes

- Added a follow-up hardening commit to bound websocket handshake buffering to 64 pre-auth frames so the new buffer cannot grow without limit on unauthenticated sockets.
- `npm audit --audit-level=moderate` reports 0 vulnerabilities.
- Reviewed the security-sensitive deltas around `server/main.ts`, `server/ratelimit.ts`, `server/ws_buffer.ts`, `server/db.ts`, `server/social.ts`, `server/game.ts`, and `src/ui/hud.ts`.

## Not included

These @jgyy PRs are still open but conflict with current `main` and should be handled separately with focused review: #139, #159, #164, #169, #179, #180, #199, #209.

## Validation

- `npm test` -> 64 test files passed, 653 tests passed.
- `npm run build` -> passed. Local warnings remain: Node 22.11.0 is below the package-preferred 22.12+, cursor image paths are left for runtime resolution, and the main chunk exceeds the warning threshold.
