### PR TITLE
feat: add /join world and /join lfg global chat channels

### DIFF
--- a/index.html
+++ b/index.html
@@ -3386,7 +3386,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/w whisper, /r reply, /p party, /gu guild, /o officer, /g general, /join world|lfg then /world /lfg)" autocomplete="off" />
   </template>
 
   <main id="start-screen">

--- a/server/game.ts
+++ b/server/game.ts
@@ -133,7 +133,7 @@ interface WhoRosterRow {
 }
 
 type RememberedChat =
-  | { channel: 'say' | 'yell' | 'general' | 'party' | 'guild' | 'officer' }
+  | { channel: 'say' | 'yell' | 'general' | 'party' | 'guild' | 'officer' | 'world' | 'lfg' }
   | { channel: 'whisper'; target: string };
 
 // Identity fields rarely change, so they ride only in "full" records: on an
@@ -1106,6 +1106,10 @@ export class GameServer {
           return this.sim.chat(`/p ${body}`, pid);
         case 'general':
           return this.sim.chat(`/general ${body}`, pid);
+        case 'world':
+          return this.sim.chat(`/world ${body}`, pid);
+        case 'lfg':
+          return this.sim.chat(`/lfg ${body}`, pid);
         case 'yell':
           return this.sim.chat(`/y ${body}`, pid);
         case 'say':

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -179,9 +179,14 @@ export interface RewardCounters {
 }
 
 export interface SentChat {
-  channel: 'say' | 'yell' | 'whisper' | 'general' | 'party';
+  channel: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'world' | 'lfg';
   message: string;
 }
+
+// Opt-in global chat channels a player can /join and /leave. `general` is
+// always-on (everyone hears /g), so it is intentionally not joinable here.
+export const JOINABLE_CHANNELS = ['world', 'lfg'] as const;
+export type JoinableChannel = (typeof JOINABLE_CHANNELS)[number];
 
 // Per-player progression and bags. The entity holds combat state; this holds
 // everything that belongs to the character sheet.
@@ -339,6 +344,8 @@ export class Sim {
   private nextArenaMatchId = 1;
   // per-player chat token bucket (anti-spam); refilled lazily by sim time
   private chatTokens = new Map<number, { tokens: number; at: number }>();
+  // per-player set of opt-in global channels (world, lfg) joined via /join
+  private channelSubs = new Map<number, Set<JoinableChannel>>();
   // dungeon instances
   instances: InstanceSlot[] = [];
   // the World Market: one shared listing book, per-seller collections keyed by
@@ -548,6 +555,7 @@ export class Sim {
     this.dropEntity(pid);
     this.players.delete(pid);
     this.chatTokens.delete(pid);
+    this.channelSubs.delete(pid);
     if (this.primaryId === pid) this.primaryId = this.players.size > 0 ? [...this.players.keys()][0] : -1;
   }
 
@@ -3596,13 +3604,40 @@ export class Sim {
       return { channel: 'general', message: clean };
     }
 
+    // "/join <channel>" / "/leave <channel>" — opt-in global channels
+    const jm = /^\/(join|leave)\b\s*(\S*)\s*$/i.exec(raw);
+    if (jm) {
+      this.handleChannelMembership(r.meta, jm[1].toLowerCase() as 'join' | 'leave', jm[2].toLowerCase());
+      return null;
+    }
+
+    // "/world message" / "/lfg message" — talk in an opt-in channel; only
+    // players who have /join-ed it hear the message (the sender included)
+    const cm = /^\/(world|lfg)\s+([\s\S]+)$/i.exec(raw);
+    if (cm) {
+      const channel = cm[1].toLowerCase() as JoinableChannel;
+      const clean = cm[2].trim();
+      if (!clean) return null;
+      const mine = this.channelSubs.get(r.meta.entityId);
+      if (!mine || !mine.has(channel)) {
+        this.error(r.meta.entityId, `You are not in the ${channel} channel. Type /join ${channel} first.`);
+        return null;
+      }
+      for (const [subPid, set] of this.channelSubs) {
+        if (set.has(channel) && this.players.has(subPid)) {
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: clean, channel, pid: subPid });
+        }
+      }
+      return { channel, message: clean };
+    }
+
     // bare text and "/s" are local say; "/y" carries further — both are
     // delivered per-player by range and carry the speaker for chat bubbles
     let channel: 'say' | 'yell' = 'say';
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /join /world /lfg.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -4849,6 +4884,42 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // A positive, personal chat-log notice (e.g. confirming a /join). Unlike
+  // error(), this lands in the chat log rather than flashing the error toast.
+  private notice(pid: number, text: string, color = '#ffd100'): void {
+    this.emit({ type: 'log', text, color, pid });
+  }
+
+  // Handles /join and /leave for the opt-in global channels.
+  private handleChannelMembership(meta: PlayerMeta, action: 'join' | 'leave', arg: string): void {
+    const pid = meta.entityId;
+    if (!arg) {
+      this.error(pid, `Usage: /${action} <channel>. Channels: ${JOINABLE_CHANNELS.join(', ')}.`);
+      return;
+    }
+    if (arg === 'general') {
+      this.error(pid, 'The General channel is always on — just use /g.');
+      return;
+    }
+    if (!JOINABLE_CHANNELS.includes(arg as JoinableChannel)) {
+      this.error(pid, `There is no channel named '${arg}'. Channels: ${JOINABLE_CHANNELS.join(', ')}.`);
+      return;
+    }
+    const channel = arg as JoinableChannel;
+    let set = this.channelSubs.get(pid);
+    if (action === 'join') {
+      if (!set) { set = new Set(); this.channelSubs.set(pid, set); }
+      if (set.has(channel)) { this.error(pid, `You are already in the ${channel} channel.`); return; }
+      set.add(channel);
+      this.notice(pid, `Joined the ${channel} channel. Type /${channel} <message> to talk.`);
+    } else {
+      if (!set || !set.has(channel)) { this.error(pid, `You are not in the ${channel} channel.`); return; }
+      set.delete(channel);
+      if (set.size === 0) this.channelSubs.delete(pid);
+      this.notice(pid, `Left the ${channel} channel.`);
+    }
   }
 }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -521,7 +521,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'world' | 'lfg'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   // a guild invitation from an online guild officer/leader; resolved by name
   // server-side so it carries no pid

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -179,6 +179,7 @@ export class Hud {
     this.showBanner(startZone.name);
     this.log(`Welcome to ${startZone.name}!`, '#ffd100');
     this.logZoneWelcome(startZone);
+    this.log('Tip: type /join world or /join lfg to chat with players across the realm.', '#7fd4ff');
   }
 
   private bindLogTabs(): void {
@@ -1316,6 +1317,8 @@ export class Hud {
               else { this.chatLogFrom(ev.from, ev.text, '#ff80ff', '', ' whispers: '); audio.whisper(); }
               break;
             case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
+            case 'world': this.chatLogFrom(ev.from, ev.text, '#ff9d5c', '[World] ', ': '); break;
+            case 'lfg': this.chatLogFrom(ev.from, ev.text, '#5cd6a0', '[LFG] ', ': '); break;
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
             case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -184,6 +184,112 @@ describe('chat channels', () => {
     expect(delivered).toBeLessThan(20);
   });
 
+  it('a joined player hears /world only from other joined players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    // distance must not matter for a global channel
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 0, -900);
+    teleport(sim, outsider, 2, -40);
+    sim.tick();
+    sim.chat('/join world', a);
+    sim.chat('/join world', b);
+    sim.tick();
+
+    sim.chat('/world anyone for the crypt?', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((m) => m.channel === 'world' && m.text === 'anyone for the crypt?')).toBe(true);
+    const pids = msgs.map((m) => m.pid).sort();
+    expect(pids).toContain(a);          // sender hears their own message
+    expect(pids).toContain(b);          // joined, ignores distance
+    expect(pids).not.toContain(outsider); // never joined → never hears it
+  });
+
+  it('talking in a channel you have not joined errors instead of broadcasting', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/world hello?', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && /not in the world channel/i.test(e.text))).toBe(true);
+  });
+
+  it('/leave stops further delivery on that channel', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.chat('/join world', a);
+    sim.chat('/join world', b);
+    sim.tick();
+    sim.chat('/leave world', b);
+    sim.tick();
+
+    sim.chat('/world still around?', a);
+    const pids = chatEvents(sim.tick()).map((m) => m.pid);
+    expect(pids).toContain(a);
+    expect(pids).not.toContain(b); // left the channel
+  });
+
+  it('world and lfg are independent channels', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.chat('/join world', a);
+    sim.chat('/join lfg', a);
+    sim.chat('/join lfg', b); // b is only in lfg, not world
+    sim.tick();
+
+    sim.chat('/world world only', a);
+    const worldPids = chatEvents(sim.tick()).map((m) => m.pid);
+    expect(worldPids).toContain(a);
+    expect(worldPids).not.toContain(b);
+
+    sim.chat('/lfg lfg only', a);
+    const lfgMsgs = chatEvents(sim.tick());
+    expect(lfgMsgs.every((m) => m.channel === 'lfg')).toBe(true);
+    const lfgPids = lfgMsgs.map((m) => m.pid);
+    expect(lfgPids).toContain(a);
+    expect(lfgPids).toContain(b);
+  });
+
+  it('/join confirms with a chat-log notice', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/join world', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'log' && e.pid === a && /joined the world channel/i.test(e.text))).toBe(true);
+  });
+
+  it('/join rejects unknown channels and the always-on general channel', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/join nonsense', a);
+    sim.chat('/join general', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'error' && /no channel named/i.test(e.text))).toBe(true);
+    expect(events.some((e) => e.type === 'error' && /general channel is always on/i.test(e.text))).toBe(true);
+    expect(chatEvents(events)).toHaveLength(0); // nothing said out loud
+  });
+
+  it('a player who leaves the game is dropped from channel rosters', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.chat('/join world', a);
+    sim.chat('/join world', b);
+    sim.tick();
+    sim.removePlayer(b);
+
+    sim.chat('/world anyone left?', a);
+    const pids = chatEvents(sim.tick()).map((m) => m.pid);
+    expect(pids).toEqual([a]); // only the remaining subscriber
+  });
+
   it('party channel still works and stays private to the party', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
## Summary

Adds opt-in **global chat channels** that players join with `/join` and talk in with `/world` / `/lfg`, sitting alongside the existing always-on `/g` General channel. There's currently no world/LFG channel and no way for players to manage which channels they're in — this fills that gap with a small, server-authoritative addition that reuses the existing chat plumbing (no new tabs, no new network message types).

- `/join <world|lfg>` and `/leave <world|lfg>` manage per-player channel membership. Joining confirms with a chat-log notice; `/join general` (always-on) and unknown channels are rejected with a helpful message.
- `/world <msg>` / `/lfg <msg>` deliver only to players who have joined that channel (the sender included), regardless of distance, and the two channels are independent of each other.
- Channel membership is cleared when a player leaves the game (`removePlayer`).
- Sticky-channel routing remembers `world`/`lfg`, so a bare follow-up message stays in the active channel (matching the existing behavior for the other channels).
- The client renders `[World]` / `[LFG]` lines in distinct colors, and a startup tip points new players at `/join world` and `/join lfg`. The input placeholder lists the new commands.

Membership lives in the sim (like party membership), so messages route through the existing per-pid event delivery — which means the ignore list applies to these channels for free.

## Test plan / Verification

- `npx vitest run` — 46 files / 539 tests passing, including 7 new cases in `tests/chat.test.ts` covering: joined-only delivery, talking before joining, `/leave`, world/lfg independence, the join notice, rejection of unknown/general channels, and roster cleanup on leave.
- `npx tsc --noEmit` — clean
- `npm run build:env`, `npm run build:server`, `npm run build` — all succeed (client emits the usual chunk-size advisory only)

## Notes

Offered for the **v0.6** release (#249) as a QoL/social addition — it complements the live World Map's "find your friends" theme by giving players realm-wide channels to coordinate in. Deliberately avoids the per-channel-tabs approach of the rejected #234 (no HTML/tab restructuring); world/LFG lines render inline like General/Guild/Officer.