### PR TITLE
Add countdown timer to the cast bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,6 +324,8 @@
   #castbar.channel .fill { background: linear-gradient(#8ad4ff, #1a74c9 60%, #125a9a); }
   #castbar .label { position: absolute; inset: 0; text-align: center; font-size: 12px; line-height: 21px;
     color: #fff; text-shadow: 1px 1px 2px #000; font-family: var(--title-font); }
+  #castbar .timer { position: absolute; top: 0; right: 6px; line-height: 21px; font-size: 11px;
+    color: #fff; text-shadow: 1px 1px 2px #000; font-family: var(--title-font); font-variant-numeric: tabular-nums; }
 
   /* ---------- bottom cluster ---------- */
   #bottom-bar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 6px; text-align: center; }
@@ -3278,7 +3280,7 @@
     <div id="prompt-stack"></div>
     <div id="trade-window" class="window panel"></div>
 
-    <div id="castbar"><div class="fill"></div><div class="label"></div></div>
+    <div id="castbar"><div class="fill"></div><div class="label"></div><div class="timer"></div></div>
 
     <div id="minimap-wrap">
       <div id="zone-label">Eastbrook Vale</div>

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -648,6 +648,7 @@ export class Hud {
         : 1 - p.castRemaining / Math.max(0.01, p.castTotal);
       (cb.querySelector('.fill') as HTMLElement).style.width = `${(frac * 100).toFixed(1)}%`;
       (cb.querySelector('.label') as HTMLElement).textContent = castDisplayName(p.castingAbility);
+      (cb.querySelector('.timer') as HTMLElement).textContent = `${Math.max(0, p.castRemaining).toFixed(1)}`;
     } else if (p.eating || p.drinking) {
       cb.style.display = 'block';
       cb.classList.add('channel');
@@ -657,11 +658,13 @@ export class Hud {
       (cb.querySelector('.fill') as HTMLElement).style.width = `${((c.remaining / CONSUME_DURATION) * 100).toFixed(1)}%`;
       (cb.querySelector('.label') as HTMLElement).textContent =
         p.eating && p.drinking ? 'Eating & Drinking…' : p.eating ? 'Eating…' : 'Drinking…';
+      (cb.querySelector('.timer') as HTMLElement).textContent = `${Math.max(0, c.remaining).toFixed(1)}`;
     } else {
       cb.style.display = 'none';
       cb.classList.remove('channel');
       (cb.querySelector('.fill') as HTMLElement).style.width = '0%';
       (cb.querySelector('.label') as HTMLElement).textContent = '';
+      (cb.querySelector('.timer') as HTMLElement).textContent = '';
     }
 
     // action bar


### PR DESCRIPTION
## What

Adds a right-aligned remaining-time readout to the cast bar so players can see how long is left on a cast, channel, or eat/drink.

- New `.timer` element in `#castbar`, styled right-aligned with `tabular-nums` so the digits don't jitter as they count down.
- HUD updates the timer each frame from `castRemaining` (casts/channels) or the consumable's `remaining` (eating/drinking), formatted to one decimal, and clears it when the bar hides.

## Screenshot

Cast bar with the centered ability label and the right-aligned countdown:

```
┌──────────────────────────────────────────────┐
│ ████████        Frostbolt                 1.5 │
└──────────────────────────────────────────────┘
```

## Testing

- `npx tsc --noEmit` — clean.
- Verified live in the offline client (headless Chromium): the timer renders, counts down (2.0 → 1.5 over ~0.5s) and matches `castRemaining`. Confirmed visually via screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)