### PR TITLE
feat: add /nearby command for a distance-sorted scan of nearby entities

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -54,6 +54,8 @@ const PVP_CC_DR_RESET = 18; // seconds before a repeated PvP CC category is fres
 const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
 const YELL_RANGE = 100;
+const NEARBY_RANGE = 40; // /nearby scan radius — wider than say, tighter than yell
+const NEARBY_MAX = 10; // cap the /nearby list so a crowded camp can't spam chat
 const CHAT_BURST = 8; // messages a player may send back-to-back...
 const CHAT_REFILL = 2; // ...then this many more per second (caps spam amplifiers)
 const DUEL_FORFEIT_DISTANCE = 60;
@@ -3549,6 +3551,14 @@ export class Sim {
       return null;
     }
 
+    // "/nearby" (aliases "/near", "/around") — self-only readout of players,
+    // pets, mobs, and NPCs within scan range, nearest first. Self-targeted
+    // error reply, matches no server interceptor, so it works online for free.
+    if (/^\/(?:nearby|near|around)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.nearbyReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4859,34 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // One scannable entry per nearby entity: name, what it is, and how far.
+  // Pets are mobs with a non-null ownerId; players have no level prefix.
+  private nearbyLabel(e: Entity, d: number): string {
+    const yd = `${Math.round(d)}yd`;
+    if (e.kind === 'player') return `${e.name} (player, ${yd})`;
+    const kind = e.kind === 'mob' && e.ownerId !== null ? 'pet' : e.kind;
+    return `${e.name} (Lvl ${e.level} ${kind}, ${yd})`;
+  }
+
+  // Self-only readout of living entities within NEARBY_RANGE of `self`,
+  // nearest first. Reads only live Entity state (pos/kind/level/hp), so it
+  // never desyncs and adds no persisted fields.
+  private nearbyReadout(self: Entity): string {
+    const found: { e: Entity; d: number }[] = [];
+    for (const e of this.entities.values()) {
+      if (e.id === self.id || e.kind === 'object' || e.hp <= 0) continue;
+      const d = dist2d(self.pos, e.pos);
+      if (d <= NEARBY_RANGE) found.push({ e, d });
+    }
+    if (found.length === 0) return 'Nothing is nearby.';
+    found.sort((a, b) => a.d - b.d);
+    const shown = found.slice(0, NEARBY_MAX);
+    const labels = shown.map(({ e, d }) => this.nearbyLabel(e, d));
+    const more = found.length - shown.length;
+    if (more > 0) labels.push(`(+${more} more)`);
+    return `Nearby (${found.length}): ${labels.join(', ')}.`;
   }
 }
 

--- a/tests/nearby_command.test.ts
+++ b/tests/nearby_command.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+import { SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, id: number, x: number, z: number) {
+  const e = sim.entities.get(id)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+// Drop a mob directly into the world at a fixed spot near the origin.
+function spawnMob(sim: Sim, id: number, template: string, level: number, x: number, z: number) {
+  const mob = createMob(id, MOBS[template], level, sim.groundPos(x, z));
+  sim.entities.set(id, mob);
+  return mob;
+}
+
+function errors(events: SimEvent[]): string[] {
+  return events.filter((e) => e.type === 'error').map((e) => (e as { text: string }).text);
+}
+
+function readout(sim: Sim, pid: number, cmd = '/nearby'): string {
+  sim.tick();
+  sim.chat(cmd, pid);
+  const lines = errors(sim.tick());
+  return lines[lines.length - 1] ?? '';
+}
+
+// A spot far from town hubs and camps, so only entities placed by the test
+// fall within NEARBY_RANGE (the overworld seeds ambient NPCs/mobs near hubs).
+const HX = -200, HZ = 0;
+
+describe('/nearby command', () => {
+  it('lists players and mobs within range, nearest first', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const bet = sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, HX, HZ);
+    teleport(sim, bet, HX + 20, HZ);          // 20yd, within range
+    spawnMob(sim, 900001, 'forest_wolf', 5, HX + 5, HZ); // 5yd
+
+    const line = readout(sim, a);
+    expect(line.startsWith('Nearby (2): ')).toBe(true);
+    // closest entry (the 5yd mob) comes before Bet (20yd)
+    expect(line.indexOf('5yd')).toBeLessThan(line.indexOf('Bet (player, 20yd)'));
+    expect(line).toContain('Bet (player, 20yd)');
+    expect(line.endsWith('.')).toBe(true);
+  });
+
+  it('excludes the caller, the dead, and out-of-range entities', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, HX, HZ);
+    teleport(sim, far, HX, HZ + 300);                   // far beyond NEARBY_RANGE
+    const corpse = spawnMob(sim, 900002, 'forest_wolf', 5, HX + 5, HZ);
+    corpse.hp = 0;                                       // dead → excluded
+
+    expect(readout(sim, a)).toBe('Nothing is nearby.');
+  });
+
+  it('aliases /near and /around behave the same', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, HX, HZ);
+    spawnMob(sim, 900003, 'forest_wolf', 5, HX + 5, HZ);
+
+    expect(readout(sim, a, '/near')).toBe(readout(sim, a, '/around'));
+    expect(readout(sim, a, '/near').startsWith('Nearby (1): ')).toBe(true);
+  });
+
+  it('caps the list and reports the overflow honestly', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, HX, HZ);
+    for (let i = 0; i < 13; i++) spawnMob(sim, 901000 + i, 'forest_wolf', 5, HX + (i - 6), HZ + 2);
+
+    const line = readout(sim, a);
+    expect(line.startsWith('Nearby (13): ')).toBe(true); // true total, not the cap
+    expect(line).toContain('(+3 more)');                 // 13 - 10 shown
+  });
+
+  it('produces a self-only error reply with no chat broadcast', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    teleport(sim, a, HX, HZ);
+    sim.tick();
+    sim.chat('/nearby', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    const errs = events.filter((e) => e.type === 'error') as { pid: number }[];
+    expect(errs.every((e) => e.pid === a)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds `/nearby` (aliases `/near`, `/around`) to the sim-core `Sim.chat()` — a self-only readout of living players, pets, mobs, and NPCs within a **40yd scan radius**, nearest first:

```
Nearby (3): Forest Wolf (Lvl 5 mob, 5yd), Bet (player, 20yd), Innkeeper (Lvl 1 npc, 31yd).
```

- Empty surroundings → `Nothing is nearby.`
- Players show no level prefix; pets are detected as mobs with a non-null `ownerId`.
- The list caps at **10** entries, but the header always shows the **true total** and appends `(+N more)` — so a crowded camp never reads as if only 10 things exist.

## Why

Every existing readout (`/where`, `/stats`, `/target`, …) is self-only and answers "what is *my* state?". `/nearby` is the first **spatial, cross-entity** scan — "what and who is *around* me?" — which is genuinely useful for situational awareness without a minimap. It's distinct from `/where` (own zone + coords only).

## How

- New `nearbyReadout(self)` + `nearbyLabel(e, d)` private helpers beside `error()`.
- Reads **only** live `Entity` state (`pos`/`kind`/`level`/`hp`) — no new persisted fields on `PlayerMeta` or `Entity`, so it can't desync or bloat saves.
- Excludes the caller, the dead (`hp <= 0`), and `kind === 'object'` ground props/loot.
- Emits a self-targeted `error` event (not a chat event) and matches **no** server-side interceptor, so it works in online play for free via `routeRememberedChat`.

## Tests

`tests/nearby_command.test.ts` — ordering by distance, exclusion of self/dead/out-of-range, alias parity, honest overflow reporting, and self-only delivery (no chat broadcast).

`npx tsc --noEmit` clean; full suite **537 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)