### PR TITLE
Fix: releasing right mouse button stops movement

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -71,7 +71,7 @@ export class Input {
     window.addEventListener('pointerup', (e) => this.onMouseUp(e));
     window.addEventListener('pointercancel', (e) => this.onMouseUp(e));
     document.addEventListener('pointerlockchange', () => {
-      if (!document.pointerLockElement) this.releaseCapture('pointerlock');
+      if (!document.pointerLockElement) this.releasePointerDrag();
     });
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) this.releaseCapture('hidden');
@@ -177,6 +177,14 @@ export class Input {
 
   private releaseCapture(_reason: string): void {
     this.keys.clear();
+    this.releasePointerDrag();
+  }
+
+  // Drop the mouse-drag/steer state without touching held keyboard keys. Used
+  // when pointer lock ends — releasing RMB exits the lock, but the window still
+  // has focus and will deliver keyups normally, so clearing `keys` here would
+  // wrongly stop a player who is still holding a movement key (e.g. W).
+  private releasePointerDrag(): void {
     this.leftDown = false;
     this.rightDown = false;
     this.downButton = -1;

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -70,4 +70,26 @@ describe('Input pointer lock', () => {
 
     expect(canvas.requestPointerLock).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps held movement keys when releasing RMB exits pointer lock', () => {
+    const { canvas, canvasListeners, windowListeners, documentListeners, input } = makeInput();
+
+    // Player is running forward...
+    windowListeners.get('keydown')!({ code: 'KeyW', repeat: false });
+    expect(input.readMoveInput().forward).toBe(true);
+
+    // ...while right-mouse steering, which becomes a drag and grabs pointer lock.
+    canvasListeners.get('mousedown')!({ button: 2 });
+    windowListeners.get('mousemove')!({ movementX: 10, movementY: 0 });
+    (document as any).pointerLockElement = canvas;
+
+    // Releasing RMB exits pointer lock; the browser then fires pointerlockchange.
+    windowListeners.get('mouseup')!({ button: 2 });
+    expect((document as any).exitPointerLock).toHaveBeenCalled();
+    (document as any).pointerLockElement = null;
+    documentListeners.get('pointerlockchange')!({});
+
+    // The keyboard key is still physically held, so forward movement must persist.
+    expect(input.readMoveInput().forward).toBe(true);
+  });
 });


### PR DESCRIPTION
## Bug

When moving with a held key (e.g. W) **and** right-mouse steering, releasing the right mouse button stopped the player dead.

## Cause

Right-mouse steering grabs pointer lock once the drag passes the threshold. Releasing RMB calls `exitPointerLock()`, and the `pointerlockchange` handler ran `releaseCapture()` — which clears **all** held keyboard keys. So the still-held movement key was wiped and movement stopped.

## Fix

Split the cleanup:
- **Pointer-lock loss** now calls a new `releasePointerDrag()` that resets only the mouse-drag/steer state and leaves held keys intact — the window still has focus and will deliver the real keyup when the key is actually released.
- **`blur` / `visibilitychange`** keep clearing keys via `releaseCapture()`, since those events genuinely lose keyups (and would otherwise leave movement stuck).

In the non-mouse-camera path, pointer lock only ends once both mouse buttons are up, so "both-buttons-run-forward" is unaffected.

## Testing

- New regression test in `tests/input.test.ts` replays keydown-W → RMB drag → pointer lock → RMB release → `pointerlockchange`, asserting `forward` stays `true`. Confirmed it fails before the fix and passes after.
- `npx tsc --noEmit` clean; full suite **533/533 passing**.

Verified at the input-logic level (where the bug lives); not driven through real pointer lock in a live browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)