### PR TITLE
feat: add /arena command for a self-only Ashen Coliseum standing readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/arena" (aliases "/pvp", "/rating") — self-only Ashen Coliseum standing
+    if (/^\/(?:arena|pvp|rating)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.arenaReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4851,17 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of a character's Ashen Coliseum standing. Reads only the
+  // persisted PlayerMeta arena fields (no new state). Draws count as neither a
+  // win nor a loss (see resolveArena), so "matches played" is wins + losses.
+  private arenaReadout(meta: PlayerMeta): string {
+    const { arenaRating: rating, arenaWins: wins, arenaLosses: losses } = meta;
+    const played = wins + losses;
+    if (played <= 0) return `Arena: Rating ${rating} — no matches played yet.`;
+    const pct = Math.round((wins / played) * 100);
+    return `Arena: Rating ${rating} — ${wins} wins, ${losses} losses (${pct}% win rate).`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/arena_command.test.ts
+++ b/tests/arena_command.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const ev = events.filter(
+    (e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid,
+  );
+  return ev.length ? ev[ev.length - 1].text : undefined;
+}
+
+describe('/arena command', () => {
+  it('reports rating with a win/loss record and win rate', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.arenaRating = 1530;
+    meta.arenaWins = 12;
+    meta.arenaLosses = 8;
+    sim.tick();
+
+    sim.chat('/arena', a);
+    expect(errorText(sim.tick(), a)).toBe(
+      'Arena: Rating 1530 — 12 wins, 8 losses (60% win rate).',
+    );
+  });
+
+  it('reports an unranked character with no matches played', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph'); // defaults: 1500 / 0 / 0
+    sim.tick();
+
+    sim.chat('/arena', a);
+    expect(errorText(sim.tick(), a)).toBe('Arena: Rating 1500 — no matches played yet.');
+  });
+
+  it('does not divide by zero when all games were draws (no wins or losses)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.arenaRating = 1490;
+    meta.arenaWins = 0;
+    meta.arenaLosses = 0;
+    sim.tick();
+
+    sim.chat('/arena', a);
+    expect(errorText(sim.tick(), a)).toBe('Arena: Rating 1490 — no matches played yet.');
+  });
+
+  it('rounds the win rate and works through the /pvp and /rating aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.arenaRating = 1602;
+    meta.arenaWins = 1;
+    meta.arenaLosses = 2; // 33.33% -> 33%
+    sim.tick();
+
+    sim.chat('/pvp', a);
+    expect(errorText(sim.tick(), a)).toBe(
+      'Arena: Rating 1602 — 1 wins, 2 losses (33% win rate).',
+    );
+
+    sim.chat('/rating', a);
+    expect(errorText(sim.tick(), a)).toBe(
+      'Arena: Rating 1602 — 1 wins, 2 losses (33% win rate).',
+    );
+  });
+
+  it('does not emit a chat event (self-only, unlogged)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const result = sim.chat('/arena', a);
+    expect(result).toBeNull();
+    const chats = sim.tick().filter((e) => e.type === 'chat');
+    expect(chats).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Adds `/arena` (aliases `/pvp`, `/rating`) to the sim-core `Sim.chat()` — a self-only readout of your persisted Ashen Coliseum PvP standing:

- With matches: `Arena: Rating 1530 — 12 wins, 8 losses (60% win rate).`
- Unranked (0 matches): `Arena: Rating 1500 — no matches played yet.`

## Why

`arenaRating` / `arenaWins` / `arenaLosses` already live on `PlayerMeta`, persist to `CharacterState`, and drive matchmaking (`sim.ts:4052`) and the leaderboard (`sim.ts:4224`) — but there was no in-game way to read your own standing. This fills that gap, matching the existing family of self-only readout commands.

## How

- New private `arenaReadout(meta)` beside `error()` reads only the existing arena fields — **no new state**.
- Win-rate divides by `wins + losses`; since draws count as neither a win nor a loss (`resolveArena`, `sim.ts:4160`), the unranked/all-draw case is guarded to avoid `NaN%`.
- Emits via `this.error(pid, …)` and `return null`, so it is unlogged and unspoken. No server interceptor matches it, so it works in online play for free through `routeRememberedChat`.

## Tests

`tests/arena_command.test.ts` — record + win-rate, unranked, all-draws div-by-zero guard, `/pvp` & `/rating` aliases with rounding, and the no-chat-event (self-only) guarantee. `npm test` and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)