### PR TITLE
feat: add /range command for distance to your current target

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,13 @@ export class Sim {
       return null;
     }
 
+    // "/range" (also /dist, /distance) — self-only readout of how far the
+    // player's current target is, and whether it sits inside melee reach
+    if (/^\/(?:range|dist|distance)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.rangeReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4856,20 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Distance from the player to their current target. Reads only live Entity
+  // state (targetId + positions), so it needs no new fields and works online
+  // for free. The in-melee hint compares the RAW distance to MELEE_RANGE — the
+  // same threshold the swing-resolution code uses — while the displayed yards
+  // are rounded, so the hint stays truthful even when rounding lands on 5yd.
+  private rangeReadout(self: Entity): string {
+    if (self.targetId === null) return 'You have no target.';
+    const t = this.entities.get(self.targetId);
+    if (!t) return 'You have no target.';
+    const d = dist2d(self.pos, t.pos);
+    const reach = d <= MELEE_RANGE ? 'in melee range' : 'out of melee range';
+    return `Your target ${t.name} is ${Math.round(d)}yd away (${reach}).`;
   }
 }
 

--- a/tests/range_command.test.ts
+++ b/tests/range_command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find((ev): ev is Extract<SimEvent, { type: 'error' }> =>
+    ev.type === 'error' && ev.pid === pid);
+  return e?.text;
+}
+
+function findWolf(sim: Sim) {
+  return [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && !e.dead && e.templateId === 'forest_wolf',
+  )!;
+}
+
+describe('/range command', () => {
+  it('reports no target when nothing is targeted', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/range', a);
+    expect(errorText(sim.tick(), a)).toBe('You have no target.');
+  });
+
+  it('reports distance and flags a target inside melee reach', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const player = sim.entities.get(a)!;
+    const wolf = findWolf(sim);
+    player.pos.x = 0; player.pos.z = -200;
+    wolf.pos.x = 3; wolf.pos.z = -200; // 3yd away, within MELEE_RANGE (5)
+    sim.targetEntity(wolf.id, a);
+    sim.tick();
+
+    sim.chat('/range', a);
+    expect(errorText(sim.tick(), a)).toBe(`Your target ${wolf.name} is 3yd away (in melee range).`);
+  });
+
+  it('flags a target beyond melee reach', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const player = sim.entities.get(a)!;
+    const wolf = findWolf(sim);
+    player.pos.x = 0; player.pos.z = -200;
+    wolf.pos.x = 12; wolf.pos.z = -200; // 12yd away, beyond MELEE_RANGE
+    sim.targetEntity(wolf.id, a);
+    sim.tick();
+
+    sim.chat('/range', a);
+    expect(errorText(sim.tick(), a)).toBe(`Your target ${wolf.name} is 12yd away (out of melee range).`);
+  });
+
+  it('supports the /dist and /distance aliases', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/dist', a);
+    expect(errorText(sim.tick(), a)).toBe('You have no target.');
+    sim.chat('/distance', a);
+    expect(errorText(sim.tick(), a)).toBe('You have no target.');
+  });
+});


### PR DESCRIPTION
## What

Adds a self-only chat readout **`/range`** (aliases `/dist`, `/distance`) to the sim core that reports how far the player's current target is, and whether it sits inside melee reach:

```
/range
→ Your target Forest Wolf is 3yd away (in melee range).
→ Your target Forest Wolf is 12yd away (out of melee range).
→ You have no target.
```

## Why

Answers a common combat-awareness question — *am I close enough to swing / do I need to close the gap?* — without forcing the player to eyeball the world. It fills a gap left by the existing readouts: `/target` reports the target's name/level/HP but not distance, and `/nearby` scans every nearby entity rather than focusing on the one you're fighting.

## How

- New private `rangeReadout(self)` next to `error()`. Reads only live `Entity` state (`targetId` + positions) via the existing `dist2d` helper — **no new fields** on `Entity`/`PlayerMeta`.
- The in-melee hint compares the **raw** distance to `MELEE_RANGE` (the same constant the swing-resolution path uses at `sim.ts:2017`), while the displayed yards are rounded — so the hint stays truthful even when rounding lands on 5yd.
- Returns `null` (unlogged, like `/who`) and has **no server interceptor**, so it works in online play for free via `routeRememberedChat`.

## Tests

`tests/range_command.test.ts` — no-target message, in-melee and out-of-melee readouts, and the `/dist` + `/distance` aliases. Full `tsc --noEmit` and the chat suite pass.