### PR TITLE
feat: add /buyback command for a self-only vendor buyback readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,13 @@ export class Sim {
       return null;
     }
 
+    // "/buyback" — self-only readout of items sold to a merchant that can
+    // still be repurchased (each at its sell value); never broadcast.
+    if (/^\/(?:buyback|bb|repurchase)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.buybackReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4852,17 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  private buybackReadout(meta: PlayerMeta): string {
+    const slots = meta.vendorBuyback.filter((s) => ITEMS[s.itemId] && s.count > 0);
+    if (slots.length === 0) return 'Your vendor buyback list is empty.';
+    const parts = slots.map((s) => {
+      const def = ITEMS[s.itemId];
+      const qty = s.count > 1 ? ` x${s.count}` : '';
+      return `${def.name}${qty} (${formatMoney(def.sellValue)} each)`;
+    });
+    return `Vendor buyback (${slots.length}): ${parts.join(', ')}. Repurchase at any merchant.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/buyback_command.test.ts
+++ b/tests/buyback_command.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find(
+    (ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error' && ev.pid === pid,
+  );
+  return e?.text;
+}
+
+describe('/buyback command', () => {
+  it('reports an empty buyback list', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/buyback', a);
+    expect(errorText(sim.tick(), a)).toBe('Your vendor buyback list is empty.');
+  });
+
+  it('lists buyback items most-recent first with per-item repurchase price', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    // most-recent-first, as recordVendorBuyback unshifts each sale
+    meta.vendorBuyback = [
+      { itemId: 'wolf_fang', count: 3 },
+      { itemId: 'worn_sword', count: 1 },
+    ];
+    sim.tick();
+
+    sim.chat('/buyback', a);
+    expect(errorText(sim.tick(), a)).toBe(
+      'Vendor buyback (2): Cracked Wolf Fang x3 (4c each), Worn Shortsword (10c each). Repurchase at any merchant.',
+    );
+  });
+
+  it('ignores stale entries with unknown items or zero count', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const meta = sim.players.get(a)!;
+    meta.vendorBuyback = [
+      { itemId: 'no_such_item', count: 2 },
+      { itemId: 'worn_sword', count: 0 },
+      { itemId: 'wolf_fang', count: 1 },
+    ];
+    sim.tick();
+
+    sim.chat('/buyback', a);
+    expect(errorText(sim.tick(), a)).toBe(
+      'Vendor buyback (1): Cracked Wolf Fang (4c each). Repurchase at any merchant.',
+    );
+  });
+
+  it('is reachable via the /bb and /repurchase aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/bb', a);
+    expect(errorText(sim.tick(), a)).toBe('Your vendor buyback list is empty.');
+    sim.chat('/repurchase', a);
+    expect(errorText(sim.tick(), a)).toBe('Your vendor buyback list is empty.');
+  });
+
+  it('does not broadcast a chat message for the readout', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const sent = sim.chat('/buyback', a);
+    expect(sent).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a `/buyback` chat command (aliases `/bb`, `/repurchase`) to the sim-core `Sim.chat()` — a **self-only readout** of the player's vendor buyback list: items sold to a merchant that can still be repurchased.

```
Vendor buyback (2): Cracked Wolf Fang x3 (4c each), Worn Shortsword (10c each). Repurchase at any merchant.
```

Empty list → `Your vendor buyback list is empty.`

## Why

The buyback list (`PlayerMeta.vendorBuyback`) is real, persisted state with full sell/buyback mechanics (`sellItem` → `recordVendorBuyback`, `buyBackItem`), but a player away from a merchant has no way to check what's recoverable or what it'll cost. This is a natural QoL readout that fits the existing self-only command family.

## How

- New private `buybackReadout(meta)` near `error()`. Reads only existing `PlayerMeta.vendorBuyback` + `ITEMS` (name/`sellValue`) — **no new fields**.
- Preserves the list's stored most-recent-first order (it's `unshift`ed on each sale), shows `xN` for stacks, and prints each item's **per-copy** repurchase price via the exported `formatMoney(def.sellValue)` — matching `buyBackItem`, which charges `def.sellValue` per copy.
- Skips stale entries (unknown item id or `count <= 0`), mirroring the HUD buyback filter (`hud.ts:1704`).
- Returns `null`, so it is never broadcast nor persisted, and works online for free (no server-side interceptor needed — `/buyback`/`/bb`/`/repurchase` fall through `routeRememberedChat` to `sim.chat()` untouched).

Distinct from `/bags` (carried items) and `/gold` (purse).

## Tests

`tests/buyback_command.test.ts` — empty list, multi-item ordering + per-item pricing, stale-entry filtering, `/bb` & `/repurchase` aliases, and that the readout emits no chat event and returns `null`.

Full suite: `537 passed`, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)