### PR TITLE
feat: add /combo command for a self-only combo-points readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/combo" — self-only readout of combo points built on the current target
+    if (/^\/(?:combo|cp|combopoints)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.comboReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4851,13 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  private comboReadout(e: Entity): string {
+    if (e.comboPoints <= 0) return 'You have no combo points built up.';
+    const target = e.comboTargetId !== null ? this.entities.get(e.comboTargetId) : undefined;
+    const on = target ? ` on ${target.name}` : '';
+    return `Combo points: ${e.comboPoints}/5${on}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/combo_command.test.ts
+++ b/tests/combo_command.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'rogue', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const err = events.filter(
+    (e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid,
+  );
+  return err.length ? err[err.length - 1].text : undefined;
+}
+
+describe('/combo command', () => {
+  it('reports combo points and the target they are built on', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('rogue', 'Aleph');
+    const foe = sim.addPlayer('warrior', 'Bet');
+    sim.tick();
+
+    const e = sim.entities.get(pid)!;
+    e.comboPoints = 3;
+    e.comboTargetId = foe;
+
+    sim.chat('/combo', pid);
+    expect(errorText(sim.tick(), pid)).toBe('Combo points: 3/5 on Bet.');
+  });
+
+  it('omits the target when it can no longer be resolved', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('rogue', 'Aleph');
+    sim.tick();
+
+    const e = sim.entities.get(pid)!;
+    e.comboPoints = 5;
+    e.comboTargetId = 999999; // no such entity
+
+    sim.chat('/combo', pid);
+    expect(errorText(sim.tick(), pid)).toBe('Combo points: 5/5.');
+  });
+
+  it('reports an empty pool when no combo points are built up', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('rogue', 'Aleph');
+    sim.tick();
+
+    sim.chat('/cp', pid);
+    expect(errorText(sim.tick(), pid)).toBe('You have no combo points built up.');
+  });
+
+  it('is reachable via the /combopoints alias and stays self-only and unlogged', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('rogue', 'Aleph');
+    sim.tick();
+
+    const sent = sim.chat('/combopoints', pid);
+    expect(sent).toBeNull();
+    expect(errorText(sim.tick(), pid)).toBe('You have no combo points built up.');
+  });
+});


### PR DESCRIPTION
## What

Adds `/combo` (aliases `/cp`, `/combopoints`) to the sim-core `chat()` — a self-only readout of the combo points built on your current combo target, in the same family as the existing readout commands (`/target`, `/cooldowns`, `/buffs`, …):

- Built up: `Combo points: 3/5 on Forest Wolf.`
- Points linger but the target can no longer be resolved: `Combo points: 3/5.`
- None: `You have no combo points built up.`

## How

- New branch right after the `/who` block in `chat()`, matching `/^\/(?:combo|cp|combopoints)(?:\s|$)/i`.
- New private `comboReadout(e)` near `error()`, reading only the live `Entity.comboPoints` / `comboTargetId` fields (max 5, set by `addComboPoints`). No new state on Entity or PlayerMeta.
- Resolves the target name via `this.entities.get(comboTargetId)?.name`; drops the `on X` clause if it no longer resolves.
- Returns `null` so the command is unlogged and self-only, and works in online play for free (no server interceptor — falls through `routeRememberedChat` like the other readouts).

Combo points are inherently target-bound (they reset on target switch, `sim.ts`), which is why the readout names the target. Works for any class — non-rogues simply always see "no combo points," which is honest.

## Tests

`tests/combo_command.test.ts` covers: points + target name, lingering points with an unresolvable target, the empty pool, and the `/combopoints` alias being self-only (`chat()` returns `null`). Full suite: 536 passing, clean `tsc --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)