### PR TITLE
feat: add /combat command for a self-only combat-status readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,15 @@ export class Sim {
       return null;
     }
 
+    // "/combat" (aliases /cb, /incombat) — self-only readout of whether you are
+    // in combat and, when only the linger timer is keeping you there, how long
+    // until you drop out. Self-only error reply, returns null so it is neither
+    // logged nor spoken; works online for free (no server interceptor).
+    if (/^\/(?:combat|cb|incombat)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.combatReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4854,22 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Readout for "/combat": reads only the live Entity.inCombat / combatTimer
+  // (no new fields). combatTimer is "time since last combat event"; a player
+  // lingers in combat until it reaches COMBAT_LINGER (the literal 5s drop-out
+  // window applied in updatePlayers, sim.ts where inCombat is recomputed). If
+  // inCombat is still set past that window, an enemy is actively engaged, so no
+  // countdown can be promised.
+  private combatReadout(e: Entity): string {
+    if (!e.inCombat) return 'You are not in combat.';
+    const COMBAT_LINGER = 5;
+    const remaining = COMBAT_LINGER - e.combatTimer;
+    if (remaining > 0) {
+      return `You are in combat — leaving in ${Math.ceil(remaining)}s if no further action.`;
+    }
+    return 'You are in combat (enemies still engaged).';
   }
 
   private error(pid: number, text: string): void {

--- a/tests/combat_command.test.ts
+++ b/tests/combat_command.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function lastError(events: SimEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === 'error') return e.text;
+  }
+  return undefined;
+}
+
+describe('/combat command', () => {
+  it('reports when you are not in combat', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.entities.get(a)!.inCombat = false;
+
+    sim.chat('/combat', a);
+    expect(lastError(sim.tick())).toBe('You are not in combat.');
+  });
+
+  it('reports the linger countdown while only the combat timer keeps you engaged', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.inCombat = true;
+    e.combatTimer = 2; // 5s linger window - 2s elapsed -> 3s remaining
+
+    sim.chat('/cb', a);
+    expect(lastError(sim.tick())).toBe('You are in combat — leaving in 3s if no further action.');
+  });
+
+  it('reports active engagement when in combat past the linger window', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.inCombat = true;
+    e.combatTimer = 99; // engaged: timer well past the drop-out window
+
+    sim.chat('/incombat', a);
+    expect(lastError(sim.tick())).toBe('You are in combat (enemies still engaged).');
+  });
+});


### PR DESCRIPTION
## What

Adds `/combat` (aliases `/cb`, `/incombat`) to the sim-core `Sim.chat()` — a self-only readout of your current combat status:

- **Not in combat:** `You are not in combat.`
- **Lingering** (only the drop-out timer keeps you engaged): `You are in combat — leaving in 3s if no further action.`
- **Actively engaged** (still in combat past the 5s linger window): `You are in combat (enemies still engaged).`

## How

- New private `combatReadout(e)` near `error()`; reads only the existing `Entity.inCombat` / `combatTimer` fields — no new state. `combatTimer` is "time since last combat event"; while it is below the 5s linger window the readout shows the rounded-up countdown, otherwise it reports active engagement.
- Replies via the self-only `error` event and returns `null`, so the readout is neither written to the chat log nor spoken aloud (same pattern as `/who`).
- No server-side interceptor needed — the command falls through `routeRememberedChat` straight to `sim.chat()`, so it works in online play for free.
- Branch placed right after the `/who` block, before the unknown-command fall-through.

## Test

`tests/combat_command.test.ts` covers all three states (out of combat, linger countdown, active engagement) across the three aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)