### PR TITLE
feat: add /graveyard command for a self-only resurrection-point readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,15 @@ export class Sim {
       return null;
     }
 
+    // "/graveyard" (aliases /gy, /spirithealer) — self-only readout of where
+    // your spirit will resurrect if you die at your current location. Mirrors
+    // the resurrection target picked in releaseSpirit. Self-only error reply,
+    // returns null so it is neither logged nor spoken; works online for free.
+    if (/^\/(?:graveyard|gy|spirithealer)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.graveyardReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4854,18 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Readout for "/graveyard": names the zone graveyard your spirit returns to
+  // if you die here, and its coordinates. Reads only existing zone/dungeon
+  // lookups (no new fields) and resolves the same target as releaseSpirit —
+  // dying inside a dungeon resurrects you at the graveyard of the zone its door
+  // sits in, dying outdoors at your current zone's graveyard.
+  private graveyardReadout(p: Entity): string {
+    const dungeon = dungeonAt(p.pos.x);
+    const zone = zoneAt(dungeon ? dungeon.doorPos.z : p.pos.z);
+    const gy = zone.graveyard;
+    return `If you fall here, your spirit returns to the ${zone.name} graveyard at (${Math.floor(gy.x)}, ${Math.floor(gy.z)}).`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/graveyard_command.test.ts
+++ b/tests/graveyard_command.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { zoneAt } from '../src/sim/data';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function teleport(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos.x = x; e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function lastError(events: SimEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === 'error') return e.text;
+  }
+  return undefined;
+}
+
+describe('/graveyard command', () => {
+  it('names the current zone graveyard your spirit returns to', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    teleport(sim, a, 0, 0); // overworld, first zone
+    const zone = zoneAt(0);
+    const gy = zone.graveyard;
+    const expected = `If you fall here, your spirit returns to the ${zone.name} graveyard at (${Math.floor(gy.x)}, ${Math.floor(gy.z)}).`;
+
+    sim.chat('/graveyard', a);
+    expect(lastError(sim.tick())).toBe(expected);
+  });
+
+  it('tracks the zone you stand in', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    teleport(sim, a, 0, 600); // deeper zone (Thornpeak range, zMin 540)
+    const zone = zoneAt(600);
+    const gy = zone.graveyard;
+    const expected = `If you fall here, your spirit returns to the ${zone.name} graveyard at (${Math.floor(gy.x)}, ${Math.floor(gy.z)}).`;
+
+    sim.chat('/gy', a);
+    expect(lastError(sim.tick())).toBe(expected);
+  });
+
+  it('is self-only and never logged or spoken', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const result = sim.chat('/spirithealer', a);
+    expect(result).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/graveyard` (aliases `/gy`, `/spirithealer`) to the sim-core `Sim.chat()` — a self-only readout naming the zone graveyard your spirit returns to if you die where you currently stand, plus its coordinates:

`If you fall here, your spirit returns to the Eastbrook Vale graveyard at (120, 40).`

## How

- New private `graveyardReadout(p)` near `error()`; resolves the **same** target as `releaseSpirit` — dying inside a dungeon resurrects you at the graveyard of the zone its door sits in (`dungeonAt(p.pos.x)` → `zone.doorPos.z`), dying outdoors at your current zone's graveyard (`zoneAt(p.pos.z)`).
- Reads only existing `dungeonAt`/`zoneAt` data and `ZoneDef.name`/`graveyard` — no new state.
- Replies via the self-only `error` event and returns `null`, so it is neither written to the chat log nor spoken aloud (same pattern as `/who` / `/where`).
- No server-side interceptor needed — falls through `routeRememberedChat` straight to `sim.chat()`, so it works in online play for free. Branch placed right after the `/who` block.

Distinct from `/where` (your current zone/coords) and `/zones` (the world zone list): this answers "where will I end up if I die here?".

## Test

`tests/graveyard_command.test.ts` covers two zones (coords computed from `zoneAt` rather than hardcoded) and asserts the readout is self-only and never logged/spoken, across all three aliases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)