### PR TITLE
feat: add /dungeons command for a self-only group-instance listing

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,15 @@ export class Sim {
       return null;
     }
 
+    // "/dungeons" (aliases /dungeon, /instances) — self-only readout of every
+    // group instance, the overworld zone its door sits in, and its suggested
+    // party size. Self-only error reply, returns null so it is neither logged
+    // nor spoken; works online for free (no server interceptor).
+    if (/^\/(?:dungeons|dungeon|instances)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.dungeonsReadout());
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4854,15 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Readout for "/dungeons": lists every group instance in entrance order with
+  // the overworld zone its door sits in and its suggested party size. Reads
+  // only the static DUNGEON_LIST (already entrance-sorted by index) and the
+  // door zone via zoneAt — no new fields.
+  private dungeonsReadout(): string {
+    const parts = DUNGEON_LIST.map((d) => `${d.name} (${zoneAt(d.doorPos.z).name}, ${d.suggestedPlayers} players)`);
+    return `Dungeons (${parts.length}): ${parts.join(', ')}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/dungeons_command.test.ts
+++ b/tests/dungeons_command.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { DUNGEON_LIST, zoneAt } from '../src/sim/data';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function lastError(events: SimEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === 'error') return e.text;
+  }
+  return undefined;
+}
+
+describe('/dungeons command', () => {
+  it('lists every dungeon with its door zone and suggested party size', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    const parts = DUNGEON_LIST.map(
+      (d) => `${d.name} (${zoneAt(d.doorPos.z).name}, ${d.suggestedPlayers} players)`,
+    );
+    const expected = `Dungeons (${parts.length}): ${parts.join(', ')}.`;
+
+    sim.chat('/dungeons', a);
+    expect(lastError(sim.tick())).toBe(expected);
+  });
+
+  it('responds to the /dungeon and /instances aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/dungeon', a);
+    const first = lastError(sim.tick());
+    sim.chat('/instances', a);
+    const second = lastError(sim.tick());
+
+    expect(first).toMatch(/^Dungeons \(/);
+    expect(second).toBe(first);
+  });
+
+  it('is self-only and never logged or spoken', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const result = sim.chat('/dungeons', a);
+    expect(result).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/dungeons` (aliases `/dungeon`, `/instances`) to the sim-core `Sim.chat()` — a self-only readout of every group instance, the overworld zone its door sits in, and its suggested party size:

`Dungeons (3): The Hollow Crypt (Eastbrook Vale, 5 players), The Sunken Bastion (Mirefen Marsh, 5 players), Gravewyrm Sanctum (Thornpeak Heights, 5 players).`

## How

- New private `dungeonsReadout()` near `error()`; iterates the static `DUNGEON_LIST` (already entrance-sorted by `index`) and resolves each door's overworld zone via `zoneAt(d.doorPos.z)`. Reads only `DungeonDef.name`/`doorPos`/`suggestedPlayers` and `ZoneDef.name` — no new state.
- Replies via the self-only `error` event and returns `null`, so it is neither written to the chat log nor spoken aloud (same pattern as `/who` / `/zones`).
- No server-side interceptor needed — falls through `routeRememberedChat` straight to `sim.chat()`, so it works in online play for free. Branch placed right after the `/who` block.

Distinct from `/zones` (the overworld zone list): this lists the group instances and where to find their entrances.

## Test

`tests/dungeons_command.test.ts` asserts the full listing (computed from `DUNGEON_LIST`/`zoneAt` rather than hardcoded), all three aliases, and that the readout is self-only and never logged/spoken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)