### PR TITLE
feat: add /consider command for a self-only target difficulty check

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,15 @@ export class Sim {
       return null;
     }
 
+    // "/consider" (aliases /con, /difficulty) — self-only readout sizing up your
+    // current target's level relative to yours, with a difficulty verdict. Self-
+    // only error reply, returns null so it is neither logged nor spoken; works
+    // online for free (no server interceptor).
+    if (/^\/(?:consider|con|difficulty)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.considerReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4854,26 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Readout for "/consider": sizes up the current target's level versus yours.
+  // The verdict bands track the real combat model — meleeMissChance (types.ts)
+  // applies a sharp miss penalty once the target is 3+ levels above you (its
+  // `diff > 2` cliff), and dodge/crit also scale with the level gap — so a
+  // target 3+ levels up is flagged as a steep step beyond a merely tough one.
+  // Reads only the live target Entity.level versus your own (no new fields).
+  private considerReadout(self: Entity): string {
+    const t = self.targetId !== null ? this.entities.get(self.targetId) : undefined;
+    if (!t) return 'You have no target to consider.';
+    const diff = t.level - self.level;
+    let verdict: string;
+    if (diff >= 5) verdict = 'an overwhelming fight';
+    else if (diff >= 3) verdict = 'a daunting fight';
+    else if (diff >= 1) verdict = 'a tough fight';
+    else if (diff === 0) verdict = 'an even fight';
+    else if (diff >= -2) verdict = 'a manageable fight';
+    else verdict = 'an easy fight';
+    return `${t.name} is level ${t.level} — ${verdict} for you (level ${self.level}).`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/consider_command.test.ts
+++ b/tests/consider_command.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function lastError(events: SimEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === 'error') return e.text;
+  }
+  return undefined;
+}
+
+// Sets up two players, targets `target` from `self`, and forces both levels.
+function setup(selfLevel: number, targetLevel: number) {
+  const sim = makeWorld();
+  const self = sim.addPlayer('warrior', 'Aleph');
+  const target = sim.addPlayer('mage', 'Bet');
+  sim.tick();
+  sim.entities.get(self)!.level = selfLevel;
+  sim.entities.get(target)!.level = targetLevel;
+  sim.targetEntity(target, self);
+  return { sim, self, target };
+}
+
+function verdict(sim: Sim, self: number): string | undefined {
+  sim.chat('/consider', self);
+  return lastError(sim.tick());
+}
+
+describe('/consider command', () => {
+  it('reports no target when nothing is selected', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/consider', a);
+    expect(lastError(sim.tick())).toBe('You have no target to consider.');
+  });
+
+  it('calls an equal-level target an even fight', () => {
+    const { sim, self } = setup(10, 10);
+    expect(verdict(sim, self)).toBe('Bet is level 10 — an even fight for you (level 10).');
+  });
+
+  it('flags a target 3+ levels up as daunting (the miss-penalty cliff)', () => {
+    const { sim, self } = setup(10, 13);
+    expect(verdict(sim, self)).toBe('Bet is level 13 — a daunting fight for you (level 10).');
+  });
+
+  it('flags a far-higher target as overwhelming', () => {
+    const { sim, self } = setup(10, 16);
+    expect(verdict(sim, self)).toBe('Bet is level 16 — an overwhelming fight for you (level 10).');
+  });
+
+  it('calls a much lower target an easy fight via the /con alias', () => {
+    const { sim, self } = setup(10, 6);
+    sim.chat('/con', self);
+    expect(lastError(sim.tick())).toBe('Bet is level 6 — an easy fight for you (level 10).');
+  });
+
+  it('is self-only and never logged or spoken', () => {
+    const { sim, self } = setup(10, 10);
+    const result = sim.chat('/difficulty', self);
+    expect(result).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/consider` (aliases `/con`, `/difficulty`) to the sim-core `Sim.chat()` — the classic "size up your target" check. It compares your current target's level to yours and gives a difficulty verdict:

`Bet is level 13 — a daunting fight for you (level 10).`

No target → `You have no target to consider.`

## How

- New private `considerReadout(self)` near `error()`; reads only the live target `Entity.level` (via `self.targetId`) versus your own — no new state.
- The verdict bands are **anchored to the real combat model** rather than invented: `meleeMissChance` (types.ts) applies a sharp miss penalty once the target is 3+ levels above you (its `diff > 2` cliff), and dodge/crit also scale with the level gap — so a target 3+ levels up is flagged "daunting" (a steeper step) versus a merely "tough" 1–2 levels up. Bands: ≥5 overwhelming, 3–4 daunting, 1–2 tough, 0 even, −1/−2 manageable, ≤−3 easy.
- Replies via the self-only `error` event and returns `null`, so it is neither written to the chat log nor spoken aloud (same pattern as `/target`).
- No server-side interceptor needed — falls through `routeRememberedChat` straight to `sim.chat()`, so it works in online play for free. Branch placed right after the `/who` block.

Distinct from `/target` (name/kind/HP) and `/range` (distance): this answers "how dangerous is this fight?".

## Test

`tests/consider_command.test.ts` covers no-target, even/daunting/overwhelming/easy bands (including the 3-level cliff), all three aliases, and that the readout is self-only and never logged/spoken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)