### PR TITLE
feat: add /completed command for a self-only finished-quest log

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,15 @@ export class Sim {
       return null;
     }
 
+    // "/completed" (aliases /questsdone, /qdone) — self-only readout of the
+    // quests you have turned in, in completion order. Self-only error reply,
+    // returns null so it is neither logged nor spoken; works online for free
+    // (no server interceptor).
+    if (/^\/(?:completed|questsdone|qdone)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.completedReadout(r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4854,16 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Readout for "/completed": the quests you have turned in, in completion
+  // order (questsDone is a Set whose insertion order is preserved on save/load).
+  // Reads only PlayerMeta.questsDone + the QUESTS registry for names (no new
+  // fields); distinct from /quest, which lists the active log.
+  private completedReadout(meta: PlayerMeta): string {
+    const names = [...meta.questsDone].map((id) => QUESTS[id]?.name ?? id);
+    if (names.length === 0) return 'You have not completed any quests yet.';
+    return `Completed quests (${names.length}): ${names.join(', ')}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/completed_command.test.ts
+++ b/tests/completed_command.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { QUESTS } from '../src/sim/data';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function lastError(events: SimEvent[]): string | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i];
+    if (e.type === 'error') return e.text;
+  }
+  return undefined;
+}
+
+describe('/completed command', () => {
+  it('reports an empty completion log for a fresh character', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/completed', a);
+    expect(lastError(sim.tick())).toBe('You have not completed any quests yet.');
+  });
+
+  it('lists turned-in quests in completion order with their names', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const ids = Object.keys(QUESTS).slice(0, 2);
+    const meta = [...sim.players.values()].find((m) => m.entityId === a)!;
+    for (const id of ids) meta.questsDone.add(id);
+
+    const expected = `Completed quests (${ids.length}): ${ids.map((id) => QUESTS[id].name).join(', ')}.`;
+    sim.chat('/questsdone', a);
+    expect(lastError(sim.tick())).toBe(expected);
+  });
+
+  it('is self-only and never logged or spoken', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const result = sim.chat('/qdone', a);
+    expect(result).toBeNull();
+    expect(sim.tick().some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds `/completed` (aliases `/questsdone`, `/qdone`) to the sim-core `Sim.chat()` — a self-only readout of the quests you have **turned in**, in completion order:

`Completed quests (3): Wolves at the Door, Webwood Menace, Webwood Silk.`

None yet → `You have not completed any quests yet.`

## How

- New private `completedReadout(meta)` near `error()`; reads only `PlayerMeta.questsDone` (a `Set<string>` whose insertion order — i.e. completion order — is preserved across save/load, since deserialize re-adds from the saved array) and resolves names via the `QUESTS` registry (`QUESTS[id]?.name ?? id`). No new state.
- Replies via the self-only `error` event and returns `null`, so it is neither written to the chat log nor spoken aloud (same pattern as `/quest`).
- No server-side interceptor needed — falls through `routeRememberedChat` straight to `sim.chat()`, so it works in online play for free. Branch placed right after the `/who` block.

Distinct from `/quest` (the **active** quest log): a player's finished quests were previously not visible anywhere — useful for completionists and for knowing which prerequisite chains you've cleared.

## Test

`tests/completed_command.test.ts` covers the empty state, a populated list (ids/names pulled from `QUESTS` rather than hardcoded), all three aliases, and that the readout is self-only and never logged/spoken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)