### PR TITLE
feat: add /targetbuffs command for a self-only readout of your target's auras

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,13 @@ export class Sim {
       return null;
     }
 
+    // "/targetbuffs" (aliases /debuffs, /tb) — self-only readout of the auras
+    // currently on your target, each tagged as a buff or debuff
+    if (/^\/(?:targetbuffs|debuffs|tb)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.targetBuffsReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4847,9 +4854,36 @@ export class Sim {
     return null;
   }
 
+  // Self-only readout of the auras on the player's current target, each tagged
+  // [buff] or [debuff]. Mirrors the self-aura readout but reaches across to the
+  // target's live Entity.auras, so it works for mobs, pets, and other players.
+  private targetBuffsReadout(self: Entity): string {
+    const target = self.targetId !== null ? this.entities.get(self.targetId) : undefined;
+    if (!target || target.hp <= 0) return 'You have no target.';
+    const auras = target.auras;
+    if (auras.length === 0) return `${target.name} has no active effects.`;
+    const parts = auras.map((a) => {
+      const stack = (a.stacks ?? 1) > 1 ? ` x${a.stacks}` : '';
+      const tag = isHarmfulAura(a.kind) ? 'debuff' : 'buff';
+      return `${a.name}${stack} [${tag}] (${Math.ceil(a.remaining)}s)`;
+    });
+    return `Effects on ${target.name} (${auras.length}): ${parts.join(', ')}.`;
+  }
+
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
   }
+}
+
+// The auras a target carries that are working against it. Everything else
+// (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
+// haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
+const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+]);
+
+function isHarmfulAura(kind: AuraKind): boolean {
+  return HARMFUL_AURA_KINDS.has(kind);
 }
 
 export function formatMoney(copper: number): string {

--- a/tests/targetbuffs_command.test.ts
+++ b/tests/targetbuffs_command.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  const e = events.find((ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error');
+  return e?.text;
+}
+
+function aura(partial: Partial<Aura> & Pick<Aura, 'name' | 'kind'>): Aura {
+  return {
+    id: partial.id ?? partial.name.toLowerCase(),
+    name: partial.name,
+    kind: partial.kind,
+    remaining: partial.remaining ?? 10,
+    duration: partial.duration ?? 10,
+    value: partial.value ?? 0,
+    sourceId: partial.sourceId ?? 0,
+    school: partial.school ?? 'physical',
+    stacks: partial.stacks,
+  };
+}
+
+describe('/targetbuffs command', () => {
+  it('reports no target when nothing is targeted', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/targetbuffs', a);
+    expect(errorText(sim.tick())).toBe('You have no target.');
+  });
+
+  it('reports an empty effect list for a clean target', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    sim.targetEntity(b, a);
+    sim.chat('/targetbuffs', a);
+    expect(errorText(sim.tick())).toBe('Bet has no active effects.');
+  });
+
+  it('tags each aura on the target as a buff or debuff with stacks and remaining time', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const target = sim.entities.get(b)!;
+    target.auras = [
+      aura({ name: 'Rend', kind: 'dot', remaining: 3.2 }),
+      aura({ name: 'Sunder Armor', kind: 'sunder', remaining: 11.6, stacks: 3 }),
+      aura({ name: 'Battle Shout', kind: 'buff_ap', remaining: 109.4 }),
+    ];
+    sim.targetEntity(b, a);
+    sim.chat('/targetbuffs', a);
+    expect(errorText(sim.tick())).toBe(
+      'Effects on Bet (3): Rend [debuff] (4s), Sunder Armor x3 [debuff] (12s), Battle Shout [buff] (110s).',
+    );
+  });
+
+  it('responds to the /debuffs and /tb aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/debuffs', a);
+    expect(errorText(sim.tick())).toBe('You have no target.');
+    sim.chat('/tb', a);
+    expect(errorText(sim.tick())).toBe('You have no target.');
+  });
+});


### PR DESCRIPTION
## What

Adds `/targetbuffs` (aliases `/debuffs`, `/tb`) to the sim-core chat handler (`Sim.chat()`): a **self-only** readout of the auras currently on your **target**, each tagged as a `[buff]` or `[debuff]`.

```
Effects on Forest Wolf (3): Rend [debuff] (4s), Sunder Armor x3 [debuff] (12s), Battle Shout [buff] (110s).
```

- No target (or a dead/corpse target) → `You have no target.`
- A target with no auras → `<Name> has no active effects.`
- Stacks shown as `xN`; remaining time is `Math.ceil`'d to whole seconds.

## Why

There's no way to see what's affecting your current target. `/buffs`-style readouts only ever show *your own* effects. Knowing whether your DoT is still ticking, how many Sunder stacks are up, or whether a mob is buffed is core combat information. Tagging each aura helpful-vs-harmful (via the `AuraKind` data that self readouts ignore) makes it readable at a glance.

## How

- New branch in `Sim.chat()` right after the `/who` block; new private `targetBuffsReadout(self)` near `error()`.
- Resolves the target via the existing `Entity.targetId` → `Entity.auras` — **no new state/fields**.
- Harmful kinds (`dot`, `slow`, `stun`, `root`, `incapacitate`, `polymorph`, `sunder`) are classified by a small module-level `isHarmfulAura()` helper; everything else (`buff_*`, `hot`, `absorb`, imbue, stances/forms, stealth, thorns, attackspeed haste) is treated as a buff/neutral.
- Emitted through the private `error()` self-notice event, so it's **unlogged, unsaid, and not broadcast**; returns `null`.
- No server interceptor added — works online for free via `routeRememberedChat`.

Distinct from `/buffs` (self auras): this reads the **target's** auras and tags them helpful vs harmful.

## Tests

`tests/targetbuffs_command.test.ts` — no target, clean target, tagged buff/debuff list with stacks + rounded timers, and the `/debuffs` / `/tb` aliases. Full suite green (536 passing) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)