### PR TITLE
feat: add /casting command for a self-only cast-bar readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,13 @@ export class Sim {
       return null;
     }
 
+    // "/casting" (aliases /cast, /castbar) — self-only readout of the player's
+    // current cast or channel progress
+    if (/^\/(?:casting|cast|castbar)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.castingReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4856,22 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Reads the live cast-bar state (no stored fields): castingAbility holds an
+  // ability id or the FISHING_CAST_ID sentinel, channeling distinguishes a
+  // channel from a normal cast. Times are fractional seconds, so toFixed(1)
+  // stays truthful rather than rounding a 2.5s cast to "3s".
+  private castingReadout(e: Entity): string {
+    if (!e.castingAbility) return 'You are not casting anything.';
+    const remaining = e.castRemaining.toFixed(1);
+    const total = e.castTotal.toFixed(1);
+    if (e.castingAbility === FISHING_CAST_ID) {
+      return `You are fishing — ${remaining}s of ${total}s remaining.`;
+    }
+    const name = ABILITIES[e.castingAbility]?.name ?? e.castingAbility;
+    const verb = e.channeling ? 'Channeling' : 'Casting';
+    return `${verb} ${name} — ${remaining}s of ${total}s remaining.`;
   }
 }
 

--- a/tests/casting_command.test.ts
+++ b/tests/casting_command.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { FISHING_CAST_ID } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'mage', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  return events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')?.text;
+}
+
+function casting(sim: Sim, pid: number): string | undefined {
+  sim.chat('/casting', pid);
+  return errorText(sim.tick());
+}
+
+describe('/casting command', () => {
+  it('reports nothing when the player is idle', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    expect(casting(sim, a)).toBe('You are not casting anything.');
+  });
+
+  it('reports a normal cast with the ability name and fractional times', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.castingAbility = 'fireball';
+    e.castTotal = 2.5;
+    e.castRemaining = 1.8;
+    e.channeling = false;
+    expect(casting(sim, a)).toBe('Casting Fireball — 1.8s of 2.5s remaining.');
+  });
+
+  it('uses "Channeling" for a channelled spell', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.castingAbility = 'arcane_missiles';
+    e.castTotal = 6.0;
+    e.castRemaining = 4.2;
+    e.channeling = true;
+    expect(casting(sim, a)).toBe('Channeling Arcane Missiles — 4.2s of 6.0s remaining.');
+  });
+
+  it('special-cases the fishing sentinel', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.castingAbility = FISHING_CAST_ID;
+    e.castTotal = 5.0;
+    e.castRemaining = 3.1;
+    e.channeling = false;
+    expect(casting(sim, a)).toBe('You are fishing — 3.1s of 5.0s remaining.');
+  });
+
+  it('responds to the /cast and /castbar aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    sim.chat('/cast', a);
+    expect(errorText(sim.tick())).toBe('You are not casting anything.');
+    sim.chat('/castbar', a);
+    expect(errorText(sim.tick())).toBe('You are not casting anything.');
+  });
+});


### PR DESCRIPTION
## What

Adds `/casting` (aliases `/cast`, `/castbar`) to the sim-core `chat()` — a self-only readout of the player's current cast or channel progress.

```
Casting Fireball — 1.8s of 2.5s remaining.
Channeling Arcane Missiles — 4.2s of 6.0s remaining.
You are fishing — 3.1s of 5.0s remaining.
You are not casting anything.
```

## Why

Cast-bar progress was previously not exposed to chat. This complements the existing readouts and is distinct from cooldown/ability listings — it answers "what am I casting right now and how long is left?".

## How

- New branch in `chat()` placed right after the `/who` block; calls `this.error()` and returns `null`, so it is not logged as chat and works in online play for free (no server interceptor needed).
- New private `castingReadout(e)` next to `error()` reads only the live `Entity` cast-bar fields (`castingAbility`, `castRemaining`, `castTotal`, `channeling`) — **no new state**.
- The `FISHING_CAST_ID` sentinel (not present in `ABILITIES`) is special-cased to a fishing message; `channeling` selects the "Channeling" verb.
- Times use `toFixed(1)` so a 2.5s cast isn't rounded to "3s".

## Test

`tests/casting_command.test.ts` — idle, normal cast, channel, fishing sentinel, and `/cast`/`/castbar` aliases. Full `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)