### PR TITLE
feat: add /speed command for a self-only movement-speed readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/(?:speed|movespeed|ms)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.speedReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4850,19 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of current movement speed as a percent of normal run
+  // speed. Effective speed is RUN_SPEED * moveSpeedMult(p), where the
+  // multiplier folds slow/stealth auras against speed buffs; a root pins the
+  // player regardless of the multiplier, so it is reported first.
+  private speedReadout(e: Entity): string {
+    if (this.isRooted(e)) return 'You are rooted in place and cannot move.';
+    const mult = this.moveSpeedMult(e);
+    const pct = Math.round(mult * 100);
+    if (pct > 100) return `Movement speed: ${pct}% of normal (hastened).`;
+    if (pct < 100) return `Movement speed: ${pct}% of normal (slowed).`;
+    return 'Movement speed: 100% of normal.';
   }
 
   private error(pid: number, text: string): void {

--- a/tests/speed_command.test.ts
+++ b/tests/speed_command.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function aura(kind: Aura['kind'], value: number): Aura {
+  return {
+    id: `${kind}_test`,
+    name: kind,
+    kind,
+    remaining: 10,
+    duration: 10,
+    value,
+    sourceId: 0,
+    school: 'physical',
+  };
+}
+
+function speedText(sim: Sim, pid: number): string | undefined {
+  sim.chat('/speed', pid);
+  const events: SimEvent[] = sim.tick();
+  const err = events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+  return err?.text;
+}
+
+describe('/speed command', () => {
+  it('reports 100% of normal when unaffected', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(speedText(sim, a)).toBe('Movement speed: 100% of normal.');
+  });
+
+  it('reports a slowed percent under a slow aura', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.entities.get(a)!.auras.push(aura('slow', 0.6));
+    expect(speedText(sim, a)).toBe('Movement speed: 60% of normal (slowed).');
+  });
+
+  it('reports a hastened percent under a speed buff', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.entities.get(a)!.auras.push(aura('buff_speed', 1.4));
+    expect(speedText(sim, a)).toBe('Movement speed: 140% of normal (hastened).');
+  });
+
+  it('reports rooted state regardless of speed modifiers', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.auras.push(aura('buff_speed', 1.4));
+    e.auras.push(aura('root', 1));
+    expect(speedText(sim, a)).toBe('You are rooted in place and cannot move.');
+  });
+
+  it('aliases /movespeed and /ms behave the same', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(speedText(sim, a)).toBe('Movement speed: 100% of normal.');
+    sim.chat('/movespeed', a);
+    expect(sim.tick().some((e) => e.type === 'error' && e.text === 'Movement speed: 100% of normal.')).toBe(true);
+    sim.chat('/ms', a);
+    expect(sim.tick().some((e) => e.type === 'error' && e.text === 'Movement speed: 100% of normal.')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a `/speed` chat command (aliases `/movespeed`, `/ms`) to the sim core that reports the player's current movement speed as a percent of normal run speed.

Examples:
- `Movement speed: 100% of normal.`
- `Movement speed: 60% of normal (slowed).` — under a slow/stealth aura
- `Movement speed: 140% of normal (hastened).` — under a speed buff
- `You are rooted in place and cannot move.` — when rooted/stunned

## How

The readout derives entirely from existing live state:
- `moveSpeedMult(e)` — the same multiplier the movement integrator uses at `sim.ts:960` (`RUN_SPEED * moveSpeedMult(p)`), which folds slow/stealth auras (`Math.min`) against speed buffs (`Math.max`).
- `isRooted(e)` — reported first, since a root pins the player regardless of the multiplier.

No new `Entity`/`PlayerMeta` fields. The branch sits right after the `/who` block in `Sim.chat()`, emits a self-only `error` event, and returns `null` (so it is not logged or broadcast), mirroring the existing `/who` reply. There is no server-side interceptor for it, so it works in online play for free via `routeRememberedChat`.

Distinct from `/stats` (no movement speed) and from any targeting readout — this is about the player's own locomotion state.

## Test

`tests/speed_command.test.ts` covers the normal, slowed, hastened, and rooted cases plus both aliases. Full suite green (`npm test`: 537 passed) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)