### PR TITLE
feat: add /attack command for a self-only auto-attack status readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,13 @@ export class Sim {
       return null;
     }
 
+    // "/attack" (aliases /autoattack, /aa) — self-only readout of auto-attack
+    // state: whether it is engaged, what it is striking, and the next swing.
+    if (/^\/(?:attack|autoattack|aa)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.attackReadout(r.e, r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4852,22 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout for /attack: reads only live Entity auto-attack state
+  // (autoAttack/swingTimer/targetId). The displayed swing interval reuses the
+  // exact expression the engine resets the timer with (weapon.speed *
+  // swingIntervalMult), so it reflects any active haste/slow auras.
+  private attackReadout(p: Entity, meta: PlayerMeta): string {
+    if (!p.autoAttack) return 'Auto-attack is off.';
+    const t = p.targetId !== null ? this.entities.get(p.targetId) : null;
+    if (!t || t.dead) return 'Auto-attack is on, but you have no valid target.';
+    // ranged classes (hunter auto shot, caster wands) swing at their ranged
+    // speed; everyone else uses the equipped weapon's speed
+    const base = CLASSES[meta.cls].ranged?.speed ?? p.weapon.speed;
+    const interval = base * this.swingIntervalMult(p);
+    const next = p.swingTimer <= 0 ? 'now' : `in ${p.swingTimer.toFixed(1)}s`;
+    return `Auto-attack is on against ${t.name} — next swing ${next} (${interval.toFixed(1)}s swing).`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/attack_command.test.ts
+++ b/tests/attack_command.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[], pid: number): string | undefined {
+  const e = events.find(
+    (ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error' && ev.pid === pid,
+  );
+  return e?.text;
+}
+
+describe('/attack command', () => {
+  it('reports auto-attack as off for an idle player', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/attack', a);
+    expect(errorText(sim.tick(), a)).toBe('Auto-attack is off.');
+  });
+
+  it('reports the target, next swing, and swing interval when engaged', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const target = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const pa = sim.entities.get(a)!;
+    const tb = sim.entities.get(target)!;
+    pa.autoAttack = true;
+    pa.targetId = tb.id;
+    pa.swingTimer = 1.2;
+    sim.chat('/attack', a);
+    const expected = (pa.weapon.speed).toFixed(1);
+    expect(errorText(sim.tick(), a)).toBe(
+      `Auto-attack is on against Bet — next swing in 1.2s (${expected}s swing).`,
+    );
+  });
+
+  it('says "now" when the swing is ready', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const target = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const pa = sim.entities.get(a)!;
+    pa.autoAttack = true;
+    pa.targetId = target;
+    pa.swingTimer = 0;
+    sim.chat('/aa', a);
+    expect(errorText(sim.tick(), a)).toContain('next swing now');
+  });
+
+  it('reports no valid target when the foe is gone', () => {
+    const sim = makeSim();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const pa = sim.entities.get(a)!;
+    pa.autoAttack = true;
+    pa.targetId = 9999; // unresolvable
+    sim.chat('/autoattack', a);
+    expect(errorText(sim.tick(), a)).toBe('Auto-attack is on, but you have no valid target.');
+  });
+});


### PR DESCRIPTION
## What

Adds `/attack` (aliases `/autoattack`, `/aa`) to the sim-core `chat()` — a self-only readout of your auto-attack state:

- Idle: `Auto-attack is off.`
- Engaged: `Auto-attack is on against Forest Wolf — next swing in 1.2s (2.6s swing).` (`next swing now` when the swing is ready)
- Engaged but the foe is gone/dead: `Auto-attack is on, but you have no valid target.`

## Why

Auto-attack is a core combat loop but its live state (am I swinging? at what? when's the next hit?) was never surfaced in chat. This rounds out the existing family of self-only readouts.

## How

- New private `attackReadout(p, meta)` next to `error()`. Reads only existing live `Entity` fields (`autoAttack`, `targetId`, `swingTimer`, `weapon`).
- The displayed swing interval reuses the engine's own `weapon.speed * swingIntervalMult(p)` expression — the same one that resets the timer at swing time — so it stays truthful under haste/slow auras. Ranged classes (hunter auto-shot, caster wands) report their `ranged.speed`.
- Branch sits right after the `/who` block; returns `null` so it is neither logged nor broadcast. No new fields and no server interceptor, so it works online for free via `routeRememberedChat`.

## Tests

`tests/attack_command.test.ts` covers the off state, the engaged readout (target + countdown + interval), the `now` boundary, and the unresolvable-target guard. Full suite + `tsc --noEmit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)