### PR TITLE
feat: add /consumable command for a self-only food/drink regen readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/consumable" — self-only readout of active food/drink regen
+    if (/^\/(consumable|consumables|eat|drink)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.consumableReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4855,25 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout of what the player is currently eating/drinking. Food and
+  // drink occupy separate slots and tick concurrently, each on its own remaining
+  // timer, so both are reported with their own restore rate and time left.
+  private consumableReadout(e: Entity): string {
+    const parts: string[] = [];
+    for (const c of [e.eating, e.drinking]) {
+      if (!c) continue;
+      const name = ITEMS[c.itemId]?.name ?? c.itemId;
+      const restores: string[] = [];
+      if (c.hpPer2s > 0) restores.push(`+${c.hpPer2s} HP/2s`);
+      if (c.manaPer2s > 0) restores.push(`+${c.manaPer2s} mana/2s`);
+      restores.push(`${Math.ceil(c.remaining)}s left`);
+      const verb = c.kind === 'food' ? 'eating' : 'drinking';
+      parts.push(`${verb} ${name} (${restores.join(', ')})`);
+    }
+    if (parts.length === 0) return 'You are not eating or drinking.';
+    return `You are ${parts.join(' and ')}.`;
   }
 }
 

--- a/tests/consumable_command.test.ts
+++ b/tests/consumable_command.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'mage', noPlayer: true });
+}
+
+function errors(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+// The readout emits a self-targeted error event, collected on the next tick.
+function readout(sim: Sim, cmd: string, pid: number): string {
+  sim.chat(cmd, pid);
+  const errs = errors(sim.tick());
+  expect(errs.length).toBe(1);
+  expect(errs[0].pid).toBe(pid);
+  return errs[0].text;
+}
+
+describe('/consumable command', () => {
+  it('reports nothing when not eating or drinking', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    expect(readout(sim, '/consumable', a)).toBe('You are not eating or drinking.');
+  });
+
+  it('reports food and drink running concurrently with their own timers', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.eating = { itemId: 'baked_bread', kind: 'food', hpPer2s: 7, manaPer2s: 0, remaining: 12 };
+    e.drinking = { itemId: 'spring_water', kind: 'drink', hpPer2s: 0, manaPer2s: 8, remaining: 9 };
+    expect(readout(sim, '/consumable', a)).toBe(
+      'You are eating Freshly Baked Bread (+7 HP/2s, 12s left) and drinking Refreshing Spring Water (+8 mana/2s, 9s left).',
+    );
+  });
+
+  it('reports drink alone when only drinking', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.drinking = { itemId: 'spring_water', kind: 'drink', hpPer2s: 0, manaPer2s: 8, remaining: 5 };
+    expect(readout(sim, '/consumable', a)).toBe(
+      'You are drinking Refreshing Spring Water (+8 mana/2s, 5s left).',
+    );
+  });
+
+  it('rounds the remaining time up so a partial second still shows', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.eating = { itemId: 'baked_bread', kind: 'food', hpPer2s: 7, manaPer2s: 0, remaining: 0.3 };
+    expect(readout(sim, '/consumable', a)).toBe('You are eating Freshly Baked Bread (+7 HP/2s, 1s left).');
+  });
+
+  it('responds to the /eat and /drink aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    expect(readout(sim, '/eat', a)).toBe('You are not eating or drinking.');
+    expect(readout(sim, '/drink', a)).toBe('You are not eating or drinking.');
+  });
+});


### PR DESCRIPTION
## What

Adds a `/consumable` chat command (aliases `/consumables`, `/eat`, `/drink`) — a self-only readout of what the player is currently eating and drinking.

Food and drink occupy separate slots and tick concurrently (`src/sim/sim.ts:3120`), each on its own remaining timer, so both are reported independently with their restore rate and time left:

```
/consumable
→ You are eating Freshly Baked Bread (+7 HP/2s, 12s left) and drinking Refreshing Spring Water (+8 mana/2s, 9s left).
```

When only one slot is active it reports just that one; idle players get `You are not eating or drinking.`

## How

- New private `consumableReadout(e)` near `error()`, reading only existing `Entity.eating`/`Entity.drinking` (`Consuming` structs: `itemId`, `kind`, `hpPer2s`, `manaPer2s`, `remaining`) plus `ITEMS` for names — **no new fields**.
- New branch placed right after the `/who` block, before the unknown-command fall-through, using `(?:\s|$)` so the bare command matches.
- Returns `null`, so it is never logged as chat and emits only a self-targeted `error` event. Works in online play for free — no server interceptor needed (`routeRememberedChat` passes it straight through to `sim.chat()`).
- `Math.ceil` on remaining time so a partial final second still shows.

Distinct from `/combat` (combat status) and `/casting` (cast bar) — this exposes the out-of-combat regen state that was previously invisible to the player.

## Tests

`tests/consumable_command.test.ts` — idle, food+drink concurrent, drink-only, sub-second rounding, and `/eat`/`/drink` aliases (5 tests, all passing). Full chat suite and `tsc --noEmit` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)