### PR TITLE
feat: add /potion command for a self-only combat-potion cooldown readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/(?:potion|potioncd|pot)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.potionReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4854,16 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout of the shared combat-potion cooldown (#103). Distinct from
+  // /cooldowns, which reads the per-ability Entity.cooldowns map and never shows
+  // this separate 60s potion timer. potionCooldownUntil is an absolute sim-time
+  // deadline, so the remaining time is computed against this.time.
+  private potionReadout(e: Entity): string {
+    const remaining = e.potionCooldownUntil - this.time;
+    if (remaining <= 0) return 'Combat potion is ready to use.';
+    return `Combat potion on cooldown — ready in ${Math.ceil(remaining)}s.`;
   }
 }
 

--- a/tests/potion_command.test.ts
+++ b/tests/potion_command.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  return events.find((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')?.text;
+}
+
+describe('/potion command', () => {
+  it('reports the combat potion as ready when off cooldown', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.potionCooldownUntil = -1;
+
+    sim.chat('/potion', a);
+    expect(errorText(sim.tick())).toBe('Combat potion is ready to use.');
+  });
+
+  it('reports remaining cooldown, ceiled, when on cooldown', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    // potionCooldownUntil is an absolute sim-time deadline measured against sim.time.
+    e.potionCooldownUntil = sim.time + 22.4;
+
+    sim.chat('/pot', a);
+    expect(errorText(sim.tick())).toBe('Combat potion on cooldown — ready in 23s.');
+  });
+
+  it('responds to the /potioncd alias', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.entities.get(a)!.potionCooldownUntil = -1;
+
+    sim.chat('/potioncd', a);
+    expect(errorText(sim.tick())).toBe('Combat potion is ready to use.');
+  });
+});


### PR DESCRIPTION
## What

Adds a self-only `/potion` chat command (aliases `/potioncd`, `/pot`) to the sim core that reports the shared combat-potion cooldown introduced in #103:

- Ready: `Combat potion is ready to use.`
- On cooldown: `Combat potion on cooldown — ready in 23s.`

## Why

`/cooldowns`-style readouts cover per-ability cooldowns (`Entity.cooldowns`), but the combat potion runs on a **separate shared 60s timer** (`Entity.potionCooldownUntil`) that nothing in chat currently surfaces. When you try to quaff a potion too soon you get `That potion is not ready yet.` with no way to check how long is left — this fills that gap.

## How

- New private `potionReadout(e)` near `error()`. `potionCooldownUntil` is an absolute sim-time deadline (`this.time + 60`), so remaining time is `Math.ceil(potionCooldownUntil - this.time)`, clamped to "ready" once passed.
- Branch placed right after the `/who` block; returns `null` so it is unlogged and unsaid (self-only `error()` reply, same as other readouts).
- Reads only existing `Entity.potionCooldownUntil` + `this.time` — no new fields.
- No server interceptor needed: bare `/potion` falls through `routeRememberedChat` to `sim.chat()` untouched, so it works in online play for free.

## Tests

`tests/potion_command.test.ts` — ready state, ceiled remaining-time on cooldown, and the `/potioncd` alias. `npx vitest run tests/potion_command.test.ts` and `npx tsc --noEmit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)