### PR TITLE
feat: add /overpower command for a self-only warrior proc-window readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/overpower" — self-only readout of the warrior Overpower reactive window
+    if (/^\/(?:overpower|op|overpowered)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.overpowerReadout(r.e, r.meta));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4851,18 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Overpower is a warrior reactive: an enemy dodging the player's attack opens
+  // a 5s window (overpowerUntil = time + 5) in which the ability becomes usable.
+  // It is neither an aura nor a normal cooldown, so no other readout exposes it.
+  private overpowerReadout(e: Entity, meta: PlayerMeta): string {
+    if (meta.cls !== 'warrior') return 'Overpower is a warrior ability; your class cannot use it.';
+    const remaining = Math.ceil(e.overpowerUntil - this.time);
+    if (remaining > 0) {
+      return `Overpower is ready — strike within ${remaining}s (an enemy dodged your attack).`;
+    }
+    return 'Overpower is not available. It opens for 5s after an enemy dodges your attack.';
   }
 
   private error(pid: number, text: string): void {

--- a/tests/overpower_command.test.ts
+++ b/tests/overpower_command.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTexts(events: SimEvent[], pid: number): string[] {
+  return events
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid)
+    .map((e) => e.text);
+}
+
+// /overpower reads only Entity.overpowerUntil + sim.time + the player's class,
+// replies on the self-only error channel, and is never logged to chat.
+describe('/overpower command', () => {
+  it('reports the open reactive window with seconds remaining for a warrior', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(pid)!;
+    e.overpowerUntil = sim.time + 4; // an enemy just dodged the player's attack
+
+    sim.chat('/overpower', pid);
+    expect(errorTexts(sim.tick(), pid)).toContain(
+      'Overpower is ready — strike within 4s (an enemy dodged your attack).',
+    );
+  });
+
+  it('reports the window closed once it has lapsed', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(pid)!;
+    e.overpowerUntil = -1; // default / consumed: no proc active
+
+    sim.chat('/op', pid);
+    expect(errorTexts(sim.tick(), pid)).toContain(
+      'Overpower is not available. It opens for 5s after an enemy dodges your attack.',
+    );
+  });
+
+  it('tells non-warriors the ability is not theirs', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+    const e = sim.entities.get(pid)!;
+    e.overpowerUntil = sim.time + 5; // even with a window set, class gates it out
+
+    sim.chat('/overpowered', pid);
+    expect(errorTexts(sim.tick(), pid)).toContain(
+      'Overpower is a warrior ability; your class cannot use it.',
+    );
+  });
+
+  it('never emits a chat event (self-only, unlogged)', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    expect(sim.chat('/overpower', pid)).toBeNull();
+    const chats = sim.tick().filter((ev) => ev.type === 'chat');
+    expect(chats).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Adds a self-only `/overpower` chat command (aliases `/op`, `/overpowered`) to the sim core `Sim.chat()`, reporting the warrior **Overpower reactive window** — the 5-second opening after an enemy *dodges* your attack during which Overpower becomes usable.

- **Window open:** `Overpower is ready — strike within 4s (an enemy dodged your attack).`
- **Closed:** `Overpower is not available. It opens for 5s after an enemy dodges your attack.`
- **Non-warrior:** `Overpower is a warrior ability; your class cannot use it.`

## Why this is distinct

The proc window lives in `Entity.overpowerUntil` — a bare sim-time deadline set when an attack is dodged (`sim.ts`, `overpowerUntil = time + 5`) and checked by the `requiresDodgeProc` cast gate. It is exposed by **no** existing readout:

- It is **not an aura**, so `/buffs` never shows it.
- It is **not** an entry in the per-ability `Entity.cooldowns` map, so `/cooldowns` never shows it.
- It is its own field, distinct from `potionCooldownUntil`.

So a warrior currently has no way to see whether their Overpower window is live.

## Implementation

- One branch right after the `/who` handler; a new private `overpowerReadout(e, meta)` near `error()`.
- Reads only existing state (`overpowerUntil`, `sim.time`, class) — **no new fields**.
- Replies on the self-only `error` channel, returns `null` (unlogged, never enters chat), and needs no server interceptor, so it works in online play for free — consistent with the other self-readout commands.

## Tests

`tests/overpower_command.test.ts` — open window, lapsed window, non-warrior gating, and the no-chat-event invariant. Full suite green (536 tests), `tsc --noEmit` clean.