### PR TITLE
feat: add /form command for a self-only shapeshift form / stance readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,15 @@ export class Sim {
       return null;
     }
 
+    // "/form" — self-only readout of the active shapeshift form or combat
+    // stance. Distinct from /buffs (which lists every aura with its timer):
+    // forms/stances are persistent toggles, so this reports the one active
+    // toggle by name, without a meaningless countdown.
+    if (/^\/(form|stance|shapeshift)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.formReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4854,19 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Reports the active shapeshift form or combat stance. Anchored to the
+  // same toggle set the cast path treats as mutually-exclusive persistent
+  // states (form_bear / form_cat / defensive_stance / stealth); realistically
+  // only one is ever active, so the first match is the answer.
+  private formReadout(e: Entity): string {
+    const form = e.auras.find((a) =>
+      a.kind === 'form_bear' || a.kind === 'form_cat'
+      || a.kind === 'defensive_stance' || a.kind === 'stealth');
+    if (!form) return 'You are not in any form or stance.';
+    if (form.kind === 'stealth') return 'You are stealthed.';
+    return `You are in ${form.name}.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/form_command.test.ts
+++ b/tests/form_command.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { AuraKind, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTexts(events: SimEvent[]): string[] {
+  return events
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')
+    .map((e) => e.text);
+}
+
+// Push a toggle aura directly onto a player; forms/stances use the 3600s
+// toggle sentinel for both remaining and duration.
+function giveForm(sim: Sim, pid: number, kind: AuraKind, name: string) {
+  const e = sim.entities.get(pid)!;
+  e.auras.push({
+    id: name.toLowerCase().replace(/\s+/g, '_'),
+    name,
+    kind,
+    remaining: 3600,
+    duration: 3600,
+    value: 1,
+    sourceId: pid,
+    school: 'physical',
+  });
+}
+
+function lastReply(sim: Sim, cmd: string, pid: number): string {
+  sim.chat(cmd, pid);
+  const texts = errorTexts(sim.tick());
+  return texts[texts.length - 1];
+}
+
+describe('/form command', () => {
+  it('reports no form or stance by default', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(lastReply(sim, '/form', a)).toBe('You are not in any form or stance.');
+  });
+
+  it('names a warrior defensive stance', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    giveForm(sim, a, 'defensive_stance', 'Defensive Stance');
+    expect(lastReply(sim, '/form', a)).toBe('You are in Defensive Stance.');
+  });
+
+  it('names a druid shapeshift form', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('druid', 'Bet');
+    sim.tick();
+    giveForm(sim, a, 'form_bear', 'Bear Form');
+    expect(lastReply(sim, '/form', a)).toBe('You are in Bear Form.');
+  });
+
+  it('uses dedicated phrasing for rogue stealth', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+    giveForm(sim, a, 'stealth', 'Stealth');
+    expect(lastReply(sim, '/form', a)).toBe('You are stealthed.');
+  });
+
+  it('answers to the /stance and /shapeshift aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('druid', 'Dalet');
+    sim.tick();
+    giveForm(sim, a, 'form_cat', 'Cat Form');
+    expect(lastReply(sim, '/stance', a)).toBe('You are in Cat Form.');
+    expect(lastReply(sim, '/shapeshift', a)).toBe('You are in Cat Form.');
+  });
+
+  it('is self-only and never emits a chat event', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const sent = sim.chat('/form', a);
+    expect(sent).toBeNull();
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a `/form` chat command (aliases `/stance`, `/shapeshift`) to the sim-core `Sim.chat()`. It gives a one-line, self-only readout of the player's active shapeshift form or combat stance:

```
You are in Bear Form.
You are in Cat Form.
You are in Defensive Stance.
You are stealthed.
You are not in any form or stance.
```

## Why it's distinct from /buffs

Forms and stances are persistent **toggles** that use the 3600s sentinel duration, so listing them in `/buffs` shows a meaningless countdown. `/form` answers the single question "what stance/form am I in right now?" cleanly, with no timer.

## Design

- Anchored to the exact mutually-exclusive toggle set the cast path already recognizes (`form_bear` / `form_cat` / `defensive_stance` / `stealth`), so it stays correct as new toggle forms are routed through that path. Realistically only one is ever active, so the first match is the answer.
- Reads **only** existing `Entity.auras` — no new fields on Entity or PlayerMeta.
- Self-only via `error()`, returns `null` (so it's unlogged and unsaid).
- No server interceptor needed — works online for free via `routeRememberedChat`. Branch placed right after the `/who` block, before the unknown-command fall-through.

## Tests

`tests/form_command.test.ts` — default (no form), warrior stance, druid bear/cat form, rogue stealth phrasing, `/stance` + `/shapeshift` aliases, and that it emits no chat event and returns null. `npx tsc --noEmit` clean; existing `chat` + `threat` suites still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)