### PR TITLE
feat: add /manaregen command for a self-only five-second-rule readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/manaregen" (aliases /regen, /5sr) — self-only readout of the classic
+    // five-second-rule mana state. Reads only existing Entity fields; returns
+    // null so it is never broadcast, mirroring the other self-readouts.
+    if (/^\/(?:manaregen|regen|5sr)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.manaRegenReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4853,23 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of the five-second-rule mana state (#103 out-of-combat
+  // regen). `fiveSecondRule` is the seconds elapsed since the player last spent
+  // mana on an ability (reset to 0 at sim.ts cast path, bumped by DT each tick);
+  // out-of-combat mana regen only ticks once it reaches FSR_THRESHOLD. Only
+  // mana users have meaningful state here — rage/energy classes never spend mana.
+  private manaRegenReadout(e: Entity): string {
+    const FSR_THRESHOLD = 5; // matches the `fiveSecondRule >= 5` gate in updateRegen
+    if (e.resourceType !== 'mana') {
+      return 'Mana regeneration does not apply to your class.';
+    }
+    if (e.fiveSecondRule >= FSR_THRESHOLD) {
+      return 'Your mana is regenerating (out of combat for 5s+).';
+    }
+    const resumesIn = Math.ceil(FSR_THRESHOLD - e.fiveSecondRule);
+    return `Mana regen is paused — resumes in ${resumesIn}s (you spent mana recently).`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/manaregen_command.test.ts
+++ b/tests/manaregen_command.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorText(events: SimEvent[]): string | undefined {
+  const e = events.find((ev): ev is Extract<SimEvent, { type: 'error' }> => ev.type === 'error');
+  return e?.text;
+}
+
+describe('/manaregen command', () => {
+  it('reports regen active once past the five-second rule', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.fiveSecondRule = 6;
+    sim.chat('/manaregen', a);
+    expect(errorText(sim.tick())).toBe('Your mana is regenerating (out of combat for 5s+).');
+  });
+
+  it('reports the resume countdown when regen is paused', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.fiveSecondRule = 2.4; // 5 - 2.4 = 2.6 -> ceil 3
+    sim.chat('/5sr', a);
+    expect(errorText(sim.tick())).toBe('Mana regen is paused — resumes in 3s (you spent mana recently).');
+  });
+
+  it('tells non-mana classes the mechanic does not apply', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph'); // rage user
+    sim.tick();
+    sim.chat('/regen', a);
+    expect(errorText(sim.tick())).toBe('Mana regeneration does not apply to your class.');
+  });
+});


### PR DESCRIPTION
## What

Adds a self-only chat readout command **`/manaregen`** (aliases `/regen`, `/5sr`) to the sim-core `Sim.chat()` handler. It exposes the classic **five-second rule** mana state — a mechanic that drives out-of-combat mana regen (#103) but is currently invisible to players.

Three states:
- **Regen active** (`fiveSecondRule >= 5`): `Your mana is regenerating (out of combat for 5s+).`
- **Regen paused** (`fiveSecondRule < 5`): `Mana regen is paused — resumes in Ns (you spent mana recently).`
- **Non-mana class** (rage/energy): `Mana regeneration does not apply to your class.`

## How

- New branch right after the `/who` block in `chat()`, dispatching to a private `manaRegenReadout(e)` helper near `error()`.
- Reads only existing `Entity.fiveSecondRule` and `Entity.resourceType` — **no new fields**.
- The displayed threshold/countdown mirror the engine's own `fiveSecondRule >= 5` gate in `updateRegen` (`src/sim/sim.ts`), so the readout always matches actual regen behavior. Fractional remainder is `Math.ceil`'d.
- Returns `null`, so it is never logged or broadcast (self-only, like the other readout commands).
- No server-side interceptor needed — it falls through to `sim.chat()` and so works in online play for free.

Distinct from `/stats` (shows the resource *value*) and `/consumable` (drink-based regen).

## Test

`tests/manaregen_command.test.ts` covers all three states. Full suite + `tsc --noEmit` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)