### PR TITLE
feat: add /falling command for a self-only vertical/fall-state readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/(?:falling|jump|airborne)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.fallingReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4850,23 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of vertical/fall state — surfaces the otherwise-invisible
+  // jump physics (sim.ts updatePlayerMovement). Reads only live Entity fields and
+  // the same groundHeight()/FALL_SAFE_DISTANCE the landing-damage model uses, so
+  // the "this will hurt" preview matches what an actual landing would deal.
+  private fallingReadout(e: Entity): string {
+    const ground = groundHeight(e.pos.x, e.pos.z, this.cfg.seed);
+    if (e.onGround) return 'You are on solid ground.';
+    const height = Math.max(0, Math.round(e.pos.y - ground));
+    if (e.vy > 0) return `You are airborne and rising — ${height}yd above the ground.`;
+    const drop = e.fallStartY - ground;
+    const danger =
+      drop > FALL_SAFE_DISTANCE
+        ? ' Brace for impact — this fall is going to hurt.'
+        : ' It should be a safe landing.';
+    return `You are falling — ${height}yd above the ground.${danger}`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/falling_command.test.ts
+++ b/tests/falling_command.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorTextFor(sim: Sim, pid: number): string | undefined {
+  const ev = sim
+    .tick()
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error' && e.pid === pid);
+  return ev.length ? ev[ev.length - 1].text : undefined;
+}
+
+describe('/falling command', () => {
+  it('reports solid ground when not airborne', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.onGround = true;
+
+    sim.chat('/falling', a);
+    expect(errorTextFor(sim, a)).toBe('You are on solid ground.');
+  });
+
+  it('reports rising while ascending (vy > 0)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    const ground = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+    e.onGround = false;
+    e.vy = 5;
+    e.pos.y = ground + 4;
+    e.fallStartY = e.pos.y;
+
+    sim.chat('/jump', a);
+    expect(errorTextFor(sim, a)).toBe('You are airborne and rising — 4yd above the ground.');
+  });
+
+  it('warns of a dangerous fall when the peak drop exceeds the safe distance', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    const ground = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+    e.onGround = false;
+    e.vy = -8;
+    e.pos.y = ground + 9;
+    e.fallStartY = ground + 20; // 20yd drop > 12yd safe distance
+
+    sim.chat('/airborne', a);
+    expect(errorTextFor(sim, a)).toBe(
+      'You are falling — 9yd above the ground. Brace for impact — this fall is going to hurt.',
+    );
+  });
+
+  it('reports a safe landing for a short fall', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    const ground = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+    e.onGround = false;
+    e.vy = -3;
+    e.pos.y = ground + 2;
+    e.fallStartY = ground + 5; // 5yd drop <= 12yd safe distance
+
+    sim.chat('/falling', a);
+    expect(errorTextFor(sim, a)).toBe(
+      'You are falling — 2yd above the ground. It should be a safe landing.',
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds `/falling` (aliases `/jump`, `/airborne`) to the sim-core chat handler in `Sim.chat()` — the first command to surface the otherwise player-invisible **jump/fall physics**.

Output:
- On ground → `You are on solid ground.`
- Airborne, rising (`vy > 0`) → `You are airborne and rising — 4yd above the ground.`
- Airborne, falling → `You are falling — 9yd above the ground.` plus a danger preview:
  - peak drop > `FALL_SAFE_DISTANCE` (12yd) → ` Brace for impact — this fall is going to hurt.`
  - otherwise → ` It should be a safe landing.`

## Why it's safe / consistent

- **No new fields.** Reads only live `Entity` state (`onGround`, `vy`, `fallStartY`, `pos.y`) plus the already-imported `groundHeight()`.
- The danger preview uses the **same `groundHeight()` + `FALL_SAFE_DISTANCE` (12yd)** that the landing-damage model in `updatePlayerMovement` uses, so the warning matches what an actual landing would deal (`maxHp * (drop - 12) * 0.07`).
- Self-only `error` event — unlogged, unsaid, returns `null` so nothing is broadcast. No server interceptor needed, so it works in online play for free (falls through `routeRememberedChat` to `sim.chat()`).
- Branch placed right after the `/who` block, before the unknown-command fall-through.

## Tests

`tests/falling_command.test.ts` — covers on-ground, rising, dangerous fall, and safe fall. Full suite green (`npx vitest run`: 536 passed), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)