### PR TITLE
feat: add /pettaunt command for a self-only pet Growl cooldown readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,14 @@ export class Sim {
       return null;
     }
 
+    // "/pettaunt" (aliases /pettaunt /growl) — self-only readout of the
+    // controlled pet's Growl (taunt) cooldown, the otherwise-invisible
+    // petTauntTimer that drives the pet's forced-aggro pulses
+    if (/^\/(?:pettaunt|petgrowl|growl)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.petTauntReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4853,20 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Self-only readout of the controlled pet's Growl (taunt) cooldown. Reads
+  // only the live pet Entity's petTauntTimer (the same field updatePet counts
+  // down at sim.ts ~2770 and resets to PET_GROWL_INTERVAL after each growl), so
+  // it stays truthful without any new state. Distinct from /pet (vitals) and
+  // /cooldowns (the player's own ability map, which never holds this timer).
+  private petTauntReadout(owner: Entity): string {
+    const pet = this.petOf(owner.id);
+    if (!pet) return 'You do not have a pet.';
+    if (pet.petTauntTimer <= 0) {
+      return `Your pet's Growl is ready — it will taunt its target on the next melee swing.`;
+    }
+    return `Your pet's Growl is on cooldown — ready in ${Math.ceil(pet.petTauntTimer)}s.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/pettaunt_command.test.ts
+++ b/tests/pettaunt_command.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent, Entity } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'hunter', noPlayer: true });
+}
+
+function errorTexts(events: SimEvent[]): string[] {
+  return events
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')
+    .map((e) => e.text);
+}
+
+// Adopt a living wild mob as the player's pet: petOf() only requires a
+// non-dead mob whose ownerId is the owner pid.
+function givePet(sim: Sim, ownerPid: number): Entity {
+  const mob = [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && !e.dead && e.ownerId === null,
+  )!;
+  mob.ownerId = ownerPid;
+  mob.hostile = false;
+  mob.hp = mob.maxHp;
+  return mob;
+}
+
+describe('/pettaunt command', () => {
+  it('reports no pet when the player has none', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    sim.tick();
+    sim.chat('/pettaunt', a);
+    expect(errorTexts(sim.tick())).toContain('You do not have a pet.');
+  });
+
+  it('reports Growl ready when the taunt timer is spent', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    sim.tick();
+    const pet = givePet(sim, a);
+    pet.petTauntTimer = 0;
+    sim.chat('/growl', a);
+    expect(errorTexts(sim.tick())).toContain(
+      `Your pet's Growl is ready — it will taunt its target on the next melee swing.`,
+    );
+  });
+
+  it('reports remaining cooldown rounded up while Growl recharges', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('hunter', 'Aleph');
+    sim.tick();
+    const pet = givePet(sim, a);
+    pet.petTauntTimer = 4.2;
+    sim.chat('/petgrowl', a);
+    expect(errorTexts(sim.tick())).toContain(
+      `Your pet's Growl is on cooldown — ready in 5s.`,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds `/pettaunt` (aliases `/growl`, `/petgrowl`) — a self-only chat readout of the controlled pet's **Growl** (taunt) cooldown.

```
Your pet's Growl is ready — it will taunt its target on the next melee swing.
Your pet's Growl is on cooldown — ready in 5s.
You do not have a pet.
```

## Why

`Entity.petTauntTimer` drives a pet's forced-aggro pulses — a pet auto-casts Growl whenever it's in melee and the timer is spent, then resets to `PET_GROWL_INTERVAL` (8s) (`sim.ts` `updatePet`). It's the field that lets a pet tank, yet it's completely invisible in-game. Hunters (and anyone with a pet) currently have no way to see when their pet will next pull threat.

It's distinct from existing/proposed readouts:
- `/pet` reports pet **vitals** (name/level/HP), not its taunt timing.
- `/cooldowns` reads the **player's** ability map, which never holds this pet-only timer.

## Implementation

- New branch in the sim-core `Sim.chat()` right after the `/who` block, plus a private `petTauntReadout(owner)` near `error()`.
- Resolves the pet via the existing `petOf()` helper and reads only the live `Entity.petTauntTimer` — **no new fields**.
- Returns `null` (unlogged via the self-only `error` event, like other readouts), and needs **no server interceptor**, so it works online for free through `routeRememberedChat`.
- Cooldown shown with `Math.ceil` so a partial second still reads as "ready in Ns".

## Tests

`tests/pettaunt_command.test.ts` covers all three states (no pet, ready, recharging). Full suite green (535 tests) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)