### PR TITLE
feat: add /queued command for a self-only on-swing ability readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,11 @@ export class Sim {
       return null;
     }
 
+    if (/^\/(queued|onswing|swingqueue)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.queuedReadout(r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4854,25 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Self-only readout of the ability armed to fire on the next melee swing
+  // (Heroic Strike / Raptor Strike / Maul). Distinct from /casting (active
+  // cast bar) and /cooldowns (recharge timers): an on-swing ability is neither
+  // casting nor on cooldown, just waiting for the swing — and it silently
+  // fizzles if the resource can't be paid when the swing lands (see swing
+  // resolution), so the readout flags that case up front.
+  private queuedReadout(e: Entity): string {
+    if (!e.queuedOnSwing) return 'You have no ability queued for your next swing.';
+    const queued = this.resolvedAbility(e.queuedOnSwing, e.id);
+    const name = queued?.def.name ?? e.queuedOnSwing;
+    if (!queued) return `${name} is queued for your next melee swing.`;
+    const res = e.resourceType ?? 'resource';
+    const have = Math.floor(e.resource);
+    if (e.resource >= queued.cost) {
+      return `${name} is queued for your next melee swing (costs ${queued.cost} ${res}; you have ${have}).`;
+    }
+    return `${name} is queued for your next melee swing, but you cannot afford it (costs ${queued.cost} ${res}; you have ${have}) — it will fizzle.`;
   }
 }
 

--- a/tests/queued_command.test.ts
+++ b/tests/queued_command.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function errorEvents(events: SimEvent[]): Extract<SimEvent, { type: 'error' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+}
+
+// The readout replies via the self-only `error` event; events surface on the
+// tick following the chat() call, like the other chat fixtures.
+function queuedReply(sim: Sim, pid: number): string {
+  sim.chat('/queued', pid);
+  const errs = errorEvents(sim.tick()).filter((e) => e.pid === pid);
+  return errs[errs.length - 1]?.text ?? '';
+}
+
+describe('/queued command', () => {
+  it('reports nothing queued for a fresh warrior', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    expect(queuedReply(sim, a)).toBe('You have no ability queued for your next swing.');
+  });
+
+  it('reports the queued ability with its cost and current resource', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.queuedOnSwing = 'heroic_strike';
+    e.resource = 50; // ample rage
+    const reply = queuedReply(sim, a);
+    expect(reply).toMatch(/^Heroic Strike is queued for your next melee swing \(costs \d+ rage; you have 50\)\.$/);
+    expect(reply).not.toContain('fizzle');
+  });
+
+  it('warns that an unaffordable queued ability will fizzle', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const e = sim.entities.get(a)!;
+    e.queuedOnSwing = 'heroic_strike';
+    e.resource = 0; // cannot pay the cost
+    const reply = queuedReply(sim, a);
+    expect(reply).toContain('but you cannot afford it');
+    expect(reply).toContain('it will fizzle');
+  });
+
+  it('is reachable through every alias', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const cmd of ['/queued', '/onswing', '/swingqueue']) {
+      sim.chat(cmd, a);
+      const errs = errorEvents(sim.tick()).filter((ev) => ev.pid === a);
+      expect(errs[errs.length - 1]?.text).toBe('You have no ability queued for your next swing.');
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a `/queued` chat command (aliases `/onswing`, `/swingqueue`) to the sim-core `Sim.chat()` handler. It gives a self-only readout of the ability armed to fire on the player's **next melee swing** — Heroic Strike (warrior), Raptor Strike (hunter), or Maul (druid bear).

```
/queued
> Heroic Strike is queued for your next melee swing (costs 15 rage; you have 50).

/queued                       # when you can't pay the cost
> Heroic Strike is queued for your next melee swing, but you cannot afford it (costs 15 rage; you have 0) — it will fizzle.

/queued                       # nothing armed
> You have no ability queued for your next swing.
```

## Why

The on-swing queue (`Entity.queuedOnSwing`) is otherwise invisible in chat, and it behaves unlike anything `/casting` or `/cooldowns` would show: an armed on-swing ability is neither casting nor on cooldown, just waiting for the swing. Crucially, it **silently fizzles** if the resource can't be paid when the swing lands (the queue is cleared with no effect in the swing-resolution path). This readout surfaces that gap up front — affordable queues show cost vs. current resource; unaffordable ones warn that the ability will fizzle.

## How it fits the existing pattern

- Reply goes through the private `error()` event (self-only), and the branch `return`s `null` so it is never logged or broadcast.
- No server interceptor — the command falls through `routeRememberedChat` untouched, so it works in online play for free.
- Reads only existing `Entity` state (`queuedOnSwing`, `resource`, `resourceType`) — **no new fields**.
- Branch placed right after the `/who` block, ahead of the unknown-command fall-through.

## Tests

`tests/queued_command.test.ts` — nothing-queued, affordable readout (cost + resource), unaffordable fizzle warning, and alias coverage. Full `tsc --noEmit` and the existing chat suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)