### PR TITLE
feat: add /savedmana command for a self-only parked-mana readout

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,12 @@ export class Sim {
       return null;
     }
 
+    // "/savedmana" — how much mana is parked while shapeshifted out of a form
+    if (/^\/(?:savedmana|parkedmana|sm)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.savedManaReadout(r.meta, r.e));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4845,6 +4851,24 @@ export class Sim {
       if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
     }
     return null;
+  }
+
+  // Druid forms park the mana bar in savedMana and run on rage/energy instead
+  // (entity.ts:126-130). That parked pool has no in-game UI — the bar shows the
+  // form's resource — so this readout is the only way to see what returns on
+  // shift-out. Gates on the class's natural resource so non-casters get a clean
+  // "never applies" rather than a misleading zero.
+  private savedManaReadout(meta: PlayerMeta, e: Entity): string {
+    if (CLASSES[meta.cls].resourceType !== 'mana') {
+      return 'Only mana-using classes park mana; your class never does.';
+    }
+    if (e.resourceType === 'mana') {
+      return 'Your mana is not parked — you are not shapeshifted.';
+    }
+    if (e.savedMana <= 0) {
+      return 'You have no mana parked while shifted.';
+    }
+    return `You have ${Math.round(e.savedMana)} mana parked while shifted; it returns when you leave your form.`;
   }
 
   private error(pid: number, text: string): void {

--- a/tests/savedmana_command.test.ts
+++ b/tests/savedmana_command.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function chatEvents(events: SimEvent[]): Extract<SimEvent, { type: 'chat' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'chat' }> => e.type === 'chat');
+}
+
+function errorText(sim: Sim, cmd: string, pid: number): string | undefined {
+  sim.chat(cmd, pid);
+  const events = sim.tick();
+  // a readout is self-only and must never leak as chat
+  expect(chatEvents(events)).toHaveLength(0);
+  const err = events.find((e) => e.type === 'error');
+  return err && err.type === 'error' ? err.text : undefined;
+}
+
+describe('/savedmana command', () => {
+  it('reports mana parked while a druid is shapeshifted', () => {
+    const sim = makeWorld();
+    const d = sim.addPlayer('druid', 'Ash');
+    sim.tick();
+    const e = sim.entities.get(d)!;
+    // simulate bear form: the mana bar is swapped for rage and the mana pool
+    // is parked aside (entity.ts:126-130)
+    e.resourceType = 'rage';
+    e.savedMana = 340;
+    sim.tick();
+    expect(errorText(sim, '/savedmana', d)).toBe(
+      'You have 340 mana parked while shifted; it returns when you leave your form.',
+    );
+  });
+
+  it('aliases /parkedmana and /sm work too', () => {
+    const sim = makeWorld();
+    const d = sim.addPlayer('druid', 'Ash');
+    sim.tick();
+    const e = sim.entities.get(d)!;
+    e.resourceType = 'energy';
+    e.savedMana = 12;
+    sim.tick();
+    const expected = 'You have 12 mana parked while shifted; it returns when you leave your form.';
+    expect(errorText(sim, '/parkedmana', d)).toBe(expected);
+    expect(errorText(sim, '/sm', d)).toBe(expected);
+  });
+
+  it('explains a druid that is not shapeshifted has no parked mana', () => {
+    const sim = makeWorld();
+    const d = sim.addPlayer('druid', 'Ash');
+    sim.tick();
+    expect(errorText(sim, '/savedmana', d)).toBe(
+      'Your mana is not parked — you are not shapeshifted.',
+    );
+  });
+
+  it('reports nothing parked when shifted with an empty saved pool', () => {
+    const sim = makeWorld();
+    const d = sim.addPlayer('druid', 'Ash');
+    sim.tick();
+    const e = sim.entities.get(d)!;
+    e.resourceType = 'rage';
+    e.savedMana = 0;
+    sim.tick();
+    expect(errorText(sim, '/savedmana', d)).toBe('You have no mana parked while shifted.');
+  });
+
+  it('tells non-mana classes the mechanic never applies', () => {
+    const sim = makeWorld();
+    const w = sim.addPlayer('warrior', 'Bron');
+    sim.tick();
+    expect(errorText(sim, '/savedmana', w)).toBe(
+      'Only mana-using classes park mana; your class never does.',
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds `/savedmana` (aliases `/parkedmana`, `/sm`) — a self-only chat readout of the mana a druid has **parked while shapeshifted**.

When a druid enters bear/cat form the resource bar is swapped to rage/energy and the mana pool is set aside in `Entity.savedMana`, then restored via `Math.min(savedMana, maxResource)` on shift-out (`src/sim/entity.ts:126-130`). That parked pool has **no in-game UI** — the bar shows the form's resource — so until now there was no way to see what mana you'll get back.

## Behaviour

- Shifted with parked mana → `You have 340 mana parked while shifted; it returns when you leave your form.`
- Druid not shifted → `Your mana is not parked — you are not shapeshifted.`
- Shifted with an empty pool → `You have no mana parked while shifted.`
- Non-mana class → `Only mana-using classes park mana; your class never does.`

Gating on the class's *natural* resource (`CLASSES[meta.cls].resourceType`) cleanly distinguishes "druid in form" from a warrior that simply never had mana.

## Implementation

Mirrors the existing self-only readout pattern: a chat branch placed right after the `/who` block that emits a self-only `error` event and returns `null`, so it is neither logged as chat nor broadcast. No server interceptor is needed — it works online for free via `routeRememberedChat`. No new `Entity`/`PlayerMeta` fields; reads only existing live state.

## Tests

`tests/savedmana_command.test.ts` — 5 cases covering parked readout, aliases, not-shifted, empty pool, and non-mana class. Full suite green (537 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)