### PR TITLE
feat: cowardly mobs flee at low HP and call for help

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -202,7 +202,7 @@ function blankEntity(id: number): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
-    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -34,6 +34,17 @@ const EVADE_SPEED_MULT = 1.6;
 // can't get closer to home for this long, it starts phasing through the blocker.
 const EVADE_STALL_TIMEOUT = 3;
 const BACKPEDAL_MULT = 0.65;
+// Low-HP flee ("fear"): a cowardly mob at or below this HP fraction panics, turns
+// and runs from its attacker for FLEE_DURATION seconds at FLEE_SPEED_MULT speed,
+// calling same-family allies within FLEE_HELP_RADIUS to assist. It flees only once
+// per pull, then recovers its nerve and re-engages if it survived.
+const FLEE_HP_THRESHOLD = 0.2;
+const FLEE_DURATION = 5;
+const FLEE_SPEED_MULT = 1.4;
+const FLEE_HELP_RADIUS = 8;
+// Only sentient, cowardly families flee; beasts/undead/elementals/dragonkin fight
+// to the death. Elites, rares, and bosses never flee regardless of family.
+const FLEEING_FAMILIES: ReadonlySet<MobFamily> = new Set(['humanoid', 'kobold', 'murloc', 'troll']);
 const GRAVITY = 16;
 const JUMP_VELOCITY = 6;
 const MELEE_ARC = 2.2; // radians half-arc within which melee swings connect
@@ -765,7 +776,7 @@ export class Sim {
     // with, instead of one full scan per player
     this.engagedPids.clear();
     for (const e of this.entities.values()) {
-      if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack') && e.aggroTargetId !== null) {
+      if (e.kind === 'mob' && !e.dead && (e.aiState === 'chase' || e.aiState === 'attack' || e.aiState === 'flee') && e.aggroTargetId !== null) {
         this.engagedPids.add(e.aggroTargetId);
       }
     }
@@ -1900,6 +1911,7 @@ export class Sim {
     mob.forcedTargetTimer = TAUNT_FORCE_SECONDS;
     if (mob.aiState === 'idle') this.aggroMob(mob, p, false);
     else if (mob.aiState === 'chase' || mob.aiState === 'attack') mob.aggroTargetId = p.id;
+    else if (mob.aiState === 'flee') { mob.aggroTargetId = p.id; mob.aiState = 'attack'; mob.fleeTimer = 0; }
     this.enterCombat(p, mob);
   }
 
@@ -2522,7 +2534,7 @@ export class Sim {
   }
 
   private aggroMob(mob: Entity, target: Entity, social: boolean): void {
-    if (mob.dead || mob.aiState === 'evade' || mob.aiState === 'chase' || mob.aiState === 'attack') return;
+    if (mob.dead || mob.aiState === 'evade' || mob.aiState === 'chase' || mob.aiState === 'attack' || mob.aiState === 'flee') return;
     mob.aiState = 'chase';
     mob.aggroTargetId = target.id;
     mob.inCombat = true;
@@ -2637,6 +2649,7 @@ export class Sim {
           this.retargetMob(mob);
           break;
         }
+        if (this.maybeFlee(mob, target)) break;
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
         const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
         if (dist2d(mob.pos, leashAnchor) > leash) {
@@ -2660,6 +2673,7 @@ export class Sim {
         this.updateMobTarget(mob);
         const target = mob.aggroTargetId !== null ? this.entities.get(mob.aggroTargetId) : null;
         if (!target || target.dead) { this.retargetMob(mob); break; }
+        if (this.maybeFlee(mob, target)) break;
         const d = dist2d(mob.pos, target.pos);
         if (d > MELEE_RANGE) { mob.aiState = 'chase'; break; }
         mob.facing = angleTo(mob.pos, target.pos);
@@ -2684,6 +2698,36 @@ export class Sim {
               }
             }
           }
+        }
+        break;
+      }
+      case 'flee': {
+        const target = mob.aggroTargetId !== null ? this.entities.get(mob.aggroTargetId) : null;
+        if (!target || target.dead) { this.retargetMob(mob); break; }
+        // Outran the leash while panicking: drop the pull and reset home.
+        const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
+        const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
+        if (dist2d(mob.pos, leashAnchor) > leash) {
+          mob.aiState = 'evade';
+          mob.aggroTargetId = null;
+          clearThreat(mob);
+          mob.leashAnchor = null;
+          break;
+        }
+        mob.fleeTimer -= DT;
+        if (mob.fleeTimer <= 0) {
+          // Recover nerve and turn to fight again; hasFled keeps it from re-fleeing.
+          mob.aiState = 'attack';
+          mob.swingTimer = Math.min(mob.swingTimer, 0.4);
+          break;
+        }
+        // Run directly away from the attacker. A root pins it in place (it just
+        // cowers facing away); a stun is already handled by the early return above.
+        const away = angleTo(target.pos, mob.pos);
+        mob.facing = away;
+        if (!this.isRooted(mob)) {
+          const fleePos = this.groundPos(mob.pos.x + Math.sin(away) * 10, mob.pos.z + Math.cos(away) * 10);
+          this.moveToward(mob, fleePos, mob.moveSpeed * FLEE_SPEED_MULT * this.moveSpeedMult(mob));
         }
         break;
       }
@@ -2721,11 +2765,51 @@ export class Sim {
     mob.tappedById = null;
     mob.leashAnchor = null;
     mob.evadeStall = 0;
+    mob.fleeTimer = 0;
+    mob.hasFled = false;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;
     mob.enraged = false;
     mob.wanderTimer = this.rng.range(2, 8);
+  }
+
+  // Cowardly mobs panic once per pull at low HP: turn and run from the attacker
+  // for a few seconds, rallying nearby same-family allies. Returns true if the mob
+  // entered (or is already in) the flee state so the caller can stop its turn.
+  private canFlee(mob: Entity): boolean {
+    if (mob.hasFled || mob.enraged) return false;
+    const tmpl = MOBS[mob.templateId];
+    if (!tmpl || tmpl.boss || tmpl.elite || tmpl.rare) return false;
+    return FLEEING_FAMILIES.has(tmpl.family);
+  }
+
+  private maybeFlee(mob: Entity, target: Entity): boolean {
+    if (mob.maxHp <= 0 || mob.hp / mob.maxHp > FLEE_HP_THRESHOLD) return false;
+    if (!this.canFlee(mob)) return false;
+    mob.aiState = 'flee';
+    mob.hasFled = true;
+    mob.fleeTimer = FLEE_DURATION;
+    this.emit({ type: 'log', text: `${mob.name} attempts to flee!`, color: '#ffd966', entityId: mob.id });
+    this.callForHelp(mob, target);
+    return true;
+  }
+
+  // A fleeing mob shouts for aid: nearby idle same-family mobs join the fight,
+  // mirroring the social-pull seeding in aggroMob.
+  private callForHelp(mob: Entity, target: Entity): void {
+    const family = MOBS[mob.templateId]?.family;
+    if (!family) return;
+    this.grid.forEachInRadius(mob.pos.x, mob.pos.z, FLEE_HELP_RADIUS, (m, d2) => {
+      if (m.kind === 'mob' && m.id !== mob.id && !m.dead && m.hostile && m.aiState === 'idle' && m.ownerId === null
+        && MOBS[m.templateId]?.family === family && d2 < FLEE_HELP_RADIUS * FLEE_HELP_RADIUS) {
+        m.aiState = 'chase';
+        m.aggroTargetId = target.id;
+        m.inCombat = true;
+        m.leashAnchor = { ...m.pos };
+        addThreat(m, target.id, 1);
+      }
+    });
   }
 
   private mobSwing(mob: Entity, target: Entity): void {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -29,7 +29,7 @@ export interface Vec3 {
 
 export type EntityKind = 'player' | 'mob' | 'npc' | 'object';
 
-export type AiState = 'idle' | 'chase' | 'attack' | 'evade' | 'dead';
+export type AiState = 'idle' | 'chase' | 'attack' | 'flee' | 'evade' | 'dead';
 
 export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
@@ -472,6 +472,8 @@ export interface Entity {
   spawnPos: Vec3;
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   evadeStall: number; // seconds an evading mob has failed to get closer to home; snaps it home if it can't path back (e.g. across water)
+  fleeTimer: number; // seconds left in a low-HP panic flee; counts down in the 'flee' state
+  hasFled: boolean; // a cowardly mob flees only once per pull; cleared when it resets at spawn
   wanderTarget: Vec3 | null;
   wanderTimer: number;
   aggroTargetId: number | null;

--- a/tests/mob_flee.test.ts
+++ b/tests/mob_flee.test.ts
@@ -1,0 +1,146 @@
+// Cowardly mobs (sentient families: humanoid/kobold/murloc/troll) panic at low HP
+// instead of fighting to the death: they turn and run from their attacker for a few
+// seconds, rallying nearby same-family allies, then recover their nerve. They flee
+// only ONCE per pull, and elites/bosses/beasts never flee.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d } from '../src/sim/types';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+function wildMobs(sim: Sim): Entity[] {
+  return [...sim.entities.values()].filter((e) => e.kind === 'mob' && !e.dead && e.ownerId === null);
+}
+
+// Put a wild mob into an active fight with the player at low HP, as a chosen family.
+function engageLowHp(sim: Sim, mob: Entity, templateId: string, hpFrac: number) {
+  mob.templateId = templateId;
+  mob.hostile = true;
+  mob.maxHp = 1000;
+  mob.hp = Math.round(mob.maxHp * hpFrac);
+  mob.auras = [];
+  mob.enraged = false;
+  mob.hasFled = false;
+  mob.fleeTimer = 0;
+  mob.pos = { x: sim.player.pos.x + 3, z: sim.player.pos.z, y: sim.player.pos.y };
+  mob.prevPos = { ...mob.pos };
+  mob.spawnPos = { ...mob.pos };
+  mob.leashAnchor = { ...mob.pos };
+  mob.aiState = 'attack';
+  mob.aggroTargetId = sim.playerId;
+  mob.inCombat = true;
+}
+
+describe('cowardly mobs flee at low HP', () => {
+  it('a low-HP humanoid panics and enters the flee state', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.15);
+
+    sim.tick();
+
+    expect(sim.entities.get(mob.id)!.aiState).toBe('flee');
+    expect(mob.hasFled).toBe(true);
+  });
+
+  it('a healthy humanoid stands and fights (no flee above the threshold)', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.5);
+
+    sim.tick();
+
+    expect(sim.entities.get(mob.id)!.aiState).toBe('attack');
+  });
+
+  it('runs AWAY from its attacker while fleeing', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+
+    const before = dist2d(mob.pos, sim.player.pos);
+    for (let i = 0; i < 10; i++) sim.tick();
+
+    expect(mob.aiState === 'flee' || mob.hasFled).toBe(true);
+    expect(dist2d(mob.pos, sim.player.pos)).toBeGreaterThan(before);
+  });
+
+  it('calls a nearby same-family ally into the fight when it flees', () => {
+    const sim = makeSim();
+    const mobs = wildMobs(sim);
+    const fleer = mobs[0];
+    const ally = mobs.find((m) => m.id !== fleer.id)!;
+    engageLowHp(sim, fleer, 'gravecaller_cultist', 0.12);
+    // an idle same-family ally standing right next to the fleer
+    ally.templateId = 'gravecaller_cultist';
+    ally.hostile = true;
+    ally.dead = false;
+    ally.aiState = 'idle';
+    ally.aggroTargetId = null;
+    ally.pos = { x: fleer.pos.x + 2, z: fleer.pos.z, y: fleer.pos.y };
+    ally.prevPos = { ...ally.pos };
+
+    sim.tick();
+
+    expect(sim.entities.get(ally.id)!.aggroTargetId).toBe(sim.playerId);
+    expect(sim.entities.get(ally.id)!.aiState).toBe('chase');
+  });
+
+  it('recovers its nerve after the flee window and re-engages', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+    // keep the player on top of the mob so it never outruns the leash
+    sim.tick();
+    expect(mob.aiState).toBe('flee');
+
+    for (let i = 0; i < 200; i++) {
+      sim.player.pos = { ...mob.pos }; // shadow it so it stays leashed
+      sim.tick();
+      if (mob.aiState === 'attack') break;
+    }
+    expect(mob.aiState).toBe('attack');
+  });
+
+  it('flees only once per pull', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+    sim.tick();
+    expect(mob.aiState).toBe('flee');
+
+    // force it back to fighting, then drop it low again — it must NOT flee a 2nd time
+    mob.aiState = 'attack';
+    mob.fleeTimer = 0;
+    mob.hp = Math.round(mob.maxHp * 0.05);
+    sim.player.pos = { ...mob.pos };
+    sim.tick();
+
+    expect(mob.aiState).not.toBe('flee');
+  });
+});
+
+describe('brave mobs never flee', () => {
+  it('a low-HP beast fights to the death', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'forest_wolf', 0.05);
+
+    sim.tick();
+
+    expect(sim.entities.get(mob.id)!.aiState).not.toBe('flee');
+  });
+
+  it('an elite humanoid does not flee', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'tidebound_acolyte', 0.05); // humanoid, elite
+
+    sim.tick();
+
+    expect(sim.entities.get(mob.id)!.aiState).not.toBe('flee');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a classic-WoW **flee-at-low-HP ("fear")** behaviour to the wild-mob AI — the first new mob AI state since `evade`. A *sentient, cowardly* mob that first drops to **≤20% HP** in a fight panics instead of fighting to the death: it turns and **runs directly away** from its attacker, **calls nearby same-family allies** into the fight, then **recovers its nerve** and re-engages if it survived.

This is a non-command gameplay feature (no new slash command) — it deepens combat by making low-level pulls feel alive: wounded humanoids run for help, occasionally chaining a second mob if you don't finish them fast.

## Behaviour

- **Who flees:** only `humanoid`, `kobold`, `murloc`, `troll` families, and never `elite`/`rare`/`boss` mobs. Beasts, undead, elementals and dragonkin fight to the death.
- **Trigger:** first time HP ≤ 20% while in `chase`/`attack`. Enraged mobs (an elite/boss mechanic) never flee — the two are mutually exclusive.
- **Flee:** runs away from the attacker at `1.4x` move speed for `5s`; emits a `"<name> attempts to flee!"` combat-log line.
- **Call for help:** idle same-family mobs within `8yd` are pulled onto the target, reusing the existing social-pull seeding from `aggroMob`.
- **Once per pull:** `hasFled` prevents infinite kiting; the mob recovers and re-engages after the flee window. Reset to `false` when the mob resets at spawn.
- **Edge cases handled:** outrunning the leash while fleeing → `evade` home; target dies → retarget/evade; **taunt breaks flee** (yanks the mob back to `attack`); fleeing mobs still keep players flagged in-combat; roots pin a fleeing mob in place (it cowers facing away); stuns already short-circuit `updateMob`.

## Implementation

- `types.ts`: add `'flee'` to `AiState`; add `fleeTimer` / `hasFled` to `Entity`.
- `sim.ts`: `FLEE_*` constants + `FLEEING_FAMILIES`; `maybeFlee` / `canFlee` / `callForHelp` helpers; new `case 'flee'` in `updateMob`; trigger guard atop the `chase`/`attack` cases; flee fields reset in `resetEvadingMob`; taunt + combat-engaged + aggro-guard sites updated for the new state.
- `entity.ts`, `net/online.ts`: initialise the two new `Entity` fields.

No new network fields, no RL obs/action-space changes, no server interceptor — purely sim-core AI, so it works identically offline and online.

## Tests

`tests/mob_flee.test.ts` — 8 cases: panics below threshold; stands and fights above it; runs away from the attacker; calls a same-family ally; recovers and re-engages after the window; flees only once per pull; beasts don't flee; elites don't flee.

- `npx vitest run` → **47 files, 540 tests passed**
- `npm run build` → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

A Vale Bandit drops below 20% HP, panics, and turns to flee (yellow "attempts to flee!" combat-log callout).

![demo](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-flee/flee.gif)

<sub>Recorded in the offline client on this branch via a Puppeteer harness (real combat; player god-moded so the scene survives).</sub>