### PR TITLE
feat: trivial low-level mobs go passive and stop auto-aggroing

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -26,6 +26,10 @@ import {
 
 const LEASH_DISTANCE = 45;
 const DUNGEON_LEASH_DISTANCE = 70;
+// Classic "trivial con": a wild mob this many levels below the player goes
+// passive and will not auto-aggro from proximity (it still fights back if
+// attacked). Elites, rares, and bosses are never trivial.
+const TRIVIAL_LEVEL_GAP = 10;
 const CORPSE_DURATION = 60;
 const EVADE_SPEED_MULT = 1.6;
 // An evading mob walks a straight line home (no pathfinding) and stalls if deep
@@ -2553,6 +2557,14 @@ export class Sim {
     return best ? { e: best, d: Math.sqrt(bestD2) } : null;
   }
 
+  // Classic "trivial con": a wild mob far below the player's level stops
+  // auto-aggroing from proximity. Elites, rares, and bosses are never trivial.
+  private isTrivialTo(mob: Entity, player: Entity): boolean {
+    const template = MOBS[mob.templateId];
+    if (template.elite || template.rare || template.boss) return false;
+    return player.level - mob.level >= TRIVIAL_LEVEL_GAP;
+  }
+
   private updateMob(mob: Entity): void {
     if (mob.dead) {
       mob.corpseTimer -= DT;
@@ -2600,7 +2612,7 @@ export class Sim {
       case 'idle': {
         const template = MOBS[mob.templateId];
         const nearest = this.nearestLivingPlayer(mob.pos, 25);
-        if (nearest) {
+        if (nearest && !this.isTrivialTo(mob, nearest.e)) {
           let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - nearest.e.level) * 1.5));
           // stealthed rogues are harder to detect, relative to observer level
           if (nearest.e.auras.some((a) => a.kind === 'stealth')) radius = stealthDetectionRadius(mob, nearest.e, radius);

--- a/tests/trivial_mob_passive.test.ts
+++ b/tests/trivial_mob_passive.test.ts
@@ -1,0 +1,88 @@
+// Classic-WoW "trivial con" rule: a wild mob far below the player's level goes
+// passive — it will not auto-aggro from proximity while idle. It still fights
+// back if attacked (that path is the damage/threat handler, not the idle gate),
+// and elites/rares/bosses are never trivial, so they always remain dangerous.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d } from '../src/sim/types';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+function nearestMob(sim: Sim): Entity {
+  let best: Entity | null = null;
+  let bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.ownerId !== null) continue;
+    const d = dist2d(sim.player.pos, e.pos);
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  return best!;
+}
+
+// Park an idle mob right on top of the player so proximity aggro would fire.
+function placeIdleOnPlayer(sim: Sim, mob: Entity) {
+  mob.aiState = 'idle';
+  mob.aggroTargetId = null;
+  mob.threat.clear();
+  mob.pos = { ...sim.player.pos };
+}
+
+describe('trivial mobs go passive', () => {
+  it('a mob 10+ levels below the player does not aggro from proximity', () => {
+    const sim = makeSim();
+    const mob = nearestMob(sim);
+    mob.level = 2;
+    sim.player.level = 12;
+    placeIdleOnPlayer(sim, mob);
+
+    sim.tick();
+
+    expect(mob.aiState).toBe('idle');
+    expect(mob.aggroTargetId).toBeNull();
+  });
+
+  it('a mob just under the gap (9 levels below) still aggros', () => {
+    const sim = makeSim();
+    const mob = nearestMob(sim);
+    mob.level = 3;
+    sim.player.level = 12;
+    placeIdleOnPlayer(sim, mob);
+
+    sim.tick();
+
+    expect(mob.aiState).not.toBe('idle');
+    expect(mob.aggroTargetId).toBe(sim.playerId);
+  });
+
+  it('an elite/rare mob is never trivial and aggros even far below level', () => {
+    const sim = makeSim();
+    const mob = nearestMob(sim);
+    mob.templateId = 'elder_bristleback'; // elite + rare template
+    mob.level = 2;
+    sim.player.level = 30;
+    placeIdleOnPlayer(sim, mob);
+
+    sim.tick();
+
+    expect(mob.aiState).not.toBe('idle');
+    expect(mob.aggroTargetId).toBe(sim.playerId);
+  });
+
+  it('a trivial mob still retaliates when attacked', () => {
+    const sim = makeSim();
+    const mob = nearestMob(sim);
+    mob.level = 2;
+    mob.maxHp = 5000;
+    mob.hp = 5000;
+    sim.player.level = 12;
+    placeIdleOnPlayer(sim, mob);
+
+    (sim as any).dealDamage(sim.player, mob, 100, false, 'physical', null, 'hit', true);
+
+    expect(mob.threat.get(sim.playerId)).toBeGreaterThan(0);
+    expect(mob.aiState).not.toBe('idle');
+  });
+});


### PR DESCRIPTION
## What

Adds the classic-WoW **"trivial con"** rule to mob AI: a wild mob far below the player's level goes **passive** and no longer auto-aggros from proximity. It still fights back if attacked.

## Why

The idle aggro formula already shrinks a mob's detection radius as the player out-levels it:

```ts
let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - nearest.e.level) * 1.5));
```

…but the `Math.max(4, …)` floor meant even a vastly lower-level mob still aggroed the instant you brushed past it. This completes the mechanic that formula already gestures at — matching classic WoW, where mobs roughly 10+ levels below you ("gray con") simply ignore you.

## Behaviour

- A wild mob `TRIVIAL_LEVEL_GAP` (**10**) or more levels below the player no longer auto-aggros from proximity while idle.
- It **still retaliates** when attacked — the new guard lives only in the idle proximity check, so the damage/threat path (`aggroMob`) is untouched.
- **Elites, rares, and bosses are never trivial** and always remain dangerous, regardless of level gap.

## Implementation

- New module const `TRIVIAL_LEVEL_GAP = 10`.
- New private helper `isTrivialTo(mob, player)` reading the mob's live level + template `elite`/`rare`/`boss` flags.
- One guard added to the `idle` aggro check in `updateMob`.

Sim-core only — no net/obs/RL/server changes — so it works online for free via the deterministic core, the same low-risk pattern as recent AI work.

## Tests

`tests/trivial_mob_passive.test.ts` — 4 cases (trivial mob stays idle; mob one level under the gap still aggros; elite/rare always aggros; trivial mob still retaliates when hit). Full suite: **536 passing**.

## Demo

A level-15 player stands among level-1 Forest Wolves: being 10+ levels above them, they con trivial and never auto-aggro (they still fight back if struck).

![demo](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-trivial-passive/trivial_passive.gif)

<sub>Recorded in the offline client on this branch via a Puppeteer harness (real combat; player god-moded so the scene survives).</sub>