### PR TITLE
feat: enraged mobs frenzy faster, not just harder

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -134,7 +134,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     id: 'korgath_the_bound', name: 'Korgath the Bound', minLevel: 20, maxLevel: 20, family: 'ogre', elite: true,
     hpBase: 260, hpPerLevel: 36, dmgBase: 14, dmgPerLevel: 2.9, attackSpeed: 2.8,
     armorPerLevel: 30, moveSpeed: 7, aggroRadius: 15,
-    enrage: { belowHpPct: 0.30, dmgMult: 1.5 },
+    enrage: { belowHpPct: 0.30, dmgMult: 1.5, hasteMult: 1.3 },
     loot: [
       { copper: 5000, chance: 1 },
       { itemId: 'boneplate_vest', chance: 0.34, rollGroup: 'korgath_guaranteed_uncommon' },
@@ -178,7 +178,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     hpBase: 420, hpPerLevel: 48, dmgBase: 15, dmgPerLevel: 3.0, attackSpeed: 2.6,
     armorPerLevel: 34, moveSpeed: 7, aggroRadius: 18,
     aoePulse: { min: 30, max: 42, radius: 14, every: 8, name: 'Necrotic Shockwave' },
-    enrage: { belowHpPct: 0.30, dmgMult: 1.5 },
+    enrage: { belowHpPct: 0.30, dmgMult: 1.5, hasteMult: 1.3 },
     loot: [
       { copper: 50000, chance: 1 },
       { itemId: 'boneplate_vest', chance: 0.34, rollGroup: 'korzul_guaranteed_uncommon' },

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -77,7 +77,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     hpBase: 260, hpPerLevel: 52, dmgBase: 11, dmgPerLevel: 3.3, attackSpeed: 2.4,
     armorPerLevel: 30, moveSpeed: 7.2, aggroRadius: 12,
     aoePulse: { min: 12, max: 18, radius: 8, every: 9, name: 'Bristleback Stomp', school: 'physical' },
-    enrage: { belowHpPct: 0.35, dmgMult: 1.4 },
+    enrage: { belowHpPct: 0.35, dmgMult: 1.4, hasteMult: 1.3 },
     loot: [
       { copper: 120, chance: 1 },
       { itemId: 'tough_jerky', chance: 1 },
@@ -130,7 +130,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 34, moveSpeed: 7.4, aggroRadius: 14,
     aoePulse: { min: 14, max: 20, radius: 8, every: 10, name: 'Ground Pound', school: 'physical' },
     summonAdds: { mobId: 'mogger_lackey', count: 2, atHpPct: [0.70] },
-    enrage: { belowHpPct: 0.30, dmgMult: 1.6 },
+    enrage: { belowHpPct: 0.30, dmgMult: 1.6, hasteMult: 1.3 },
     loot: [
       { copper: 180, chance: 1 },
       { itemId: 'linen_scrap', chance: 1 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -72,7 +72,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 38, moveSpeed: 7, aggroRadius: 12,
     aoePulse: { min: 28, max: 38, radius: 8, every: 10, name: 'Powder Keg', school: 'fire' },
     summonAdds: { mobId: 'ironvein_sapper', count: 2, atHpPct: [0.50] },
-    enrage: { belowHpPct: 0.30, dmgMult: 1.45 },
+    enrage: { belowHpPct: 0.30, dmgMult: 1.45, hasteMult: 1.3 },
     loot: [
       { copper: 420, chance: 1 },
       { itemId: 'glowing_wax', chance: 1 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -873,6 +873,12 @@ export class Sim {
       if (a.kind === 'attackspeed') m *= a.value;
       if (a.kind === 'buff_haste') m /= a.value;
     }
+    // Enrage frenzy: an enraged mob swings faster (mirrors the inline dmgMult
+    // applied in mobSwing). Composes with any slow/haste auras above.
+    if (e.enraged) {
+      const h = MOBS[e.templateId]?.enrage?.hasteMult;
+      if (h && h > 0) m /= h;
+    }
     return m;
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -161,8 +161,9 @@ export interface MobTemplate {
   aoePulse?: { min: number; max: number; radius: number; every: number; name: string; school?: string; fx?: 'nova' | 'projectile' };
   // Boss mechanic: spawn adds when hp first drops below each threshold (descending fractions).
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
-  // Boss mechanic: damage multiplier once hp drops below the threshold.
-  enrage?: { belowHpPct: number; dmgMult: number };
+  // Boss mechanic: damage multiplier (and optional swing-speed haste) once hp
+  // drops below the threshold. hasteMult > 1 makes the enraged mob swing faster.
+  enrage?: { belowHpPct: number; dmgMult: number; hasteMult?: number };
 }
 
 export type AbilityEffect =

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -259,7 +259,7 @@ describe('rare spawn rules', () => {
     }
 
     expect(MOBS.mogger.summonAdds).toEqual({ mobId: 'mogger_lackey', count: 2, atHpPct: [0.70] });
-    expect(MOBS.mogger.enrage).toEqual({ belowHpPct: 0.30, dmgMult: 1.6 });
+    expect(MOBS.mogger.enrage).toEqual({ belowHpPct: 0.30, dmgMult: 1.6, hasteMult: 1.3 });
   });
 });
 

--- a/tests/mob_enrage.test.ts
+++ b/tests/mob_enrage.test.ts
@@ -1,0 +1,81 @@
+// Enrage frenzy: an enraged mob with a template hasteMult swings faster, not
+// just harder. The damage half (dmgMult) was already applied inline in
+// mobSwing; this covers the swing-speed half folded into swingIntervalMult.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d } from '../src/sim/types';
+import type { Entity } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+
+function makeSim(seed = 42) {
+  return new Sim({ seed, playerClass: 'warrior', autoEquip: true });
+}
+
+function anyMob(sim: Sim): Entity {
+  let best: Entity | null = null;
+  let bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.ownerId !== null) continue;
+    const d = dist2d(sim.player.pos, e.pos);
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  return best!;
+}
+
+function swingMult(sim: Sim, e: Entity): number {
+  return (sim as any).swingIntervalMult(e);
+}
+
+describe('enrage frenzy (swing-speed haste)', () => {
+  it('an enraged mob with hasteMult swings faster than normal', () => {
+    const sim = makeSim();
+    const mob = anyMob(sim);
+    mob.templateId = 'elder_bristleback'; // enrage: { ..., hasteMult: 1.3 }
+    const haste = MOBS['elder_bristleback'].enrage!.hasteMult!;
+    expect(haste).toBeGreaterThan(1);
+
+    mob.enraged = false;
+    expect(swingMult(sim, mob)).toBeCloseTo(1, 6);
+
+    mob.enraged = true;
+    expect(swingMult(sim, mob)).toBeCloseTo(1 / haste, 6);
+    expect(swingMult(sim, mob)).toBeLessThan(1); // faster swings
+  });
+
+  it('does nothing when the mob is not enraged', () => {
+    const sim = makeSim();
+    const mob = anyMob(sim);
+    mob.templateId = 'elder_bristleback';
+    mob.enraged = false;
+    expect(swingMult(sim, mob)).toBeCloseTo(1, 6);
+  });
+
+  it('is a no-op for an enraged mob whose template has no hasteMult', () => {
+    const sim = makeSim();
+    const mob = anyMob(sim);
+    // forest_wolf has no enrage block at all -> no haste even if flagged
+    mob.templateId = 'forest_wolf';
+    expect(MOBS['forest_wolf'].enrage).toBeUndefined();
+    mob.enraged = true;
+    expect(swingMult(sim, mob)).toBeCloseTo(1, 6);
+  });
+
+  it('composes multiplicatively with a slow aura', () => {
+    const sim = makeSim();
+    const mob = anyMob(sim);
+    mob.templateId = 'elder_bristleback';
+    const haste = MOBS['elder_bristleback'].enrage!.hasteMult!;
+    mob.enraged = true;
+    // attackspeed aura: value > 1 slows (multiplies the interval)
+    mob.auras.push({ kind: 'attackspeed', value: 2, name: 'Thunder Clap', remaining: 10, stacks: 1, sourceId: null } as any);
+    expect(swingMult(sim, mob)).toBeCloseTo(2 / haste, 6);
+  });
+
+  it('every enrage template defines a frenzy hasteMult', () => {
+    const enraged = Object.values(MOBS).filter((m) => m.enrage);
+    expect(enraged.length).toBeGreaterThan(0);
+    for (const m of enraged) {
+      expect(m.enrage!.hasteMult, `${m.id} should frenzy`).toBeGreaterThan(1);
+    }
+  });
+});


### PR DESCRIPTION
## What

Enrage currently only multiplies a mob's **damage** (`dmgMult`) once its HP drops below the threshold — an enraged mob hits harder but swings at exactly the same pace. This adds the missing **frenzy** half: an optional `hasteMult` on the enrage template that also speeds up the enraged mob's swings, matching the classic-WoW enrage/frenzy where wounded brutes both hit harder *and* faster.

## How

- `MobTemplate.enrage` gains an optional `hasteMult?: number` (`> 1` = faster swings).
- The haste is folded into `swingIntervalMult()` — the single chokepoint the engine already uses for haste/slow auras — so it composes correctly with any existing slow (e.g. Thunder Clap) or haste on the mob, exactly like the inline `dmgMult` is applied in `mobSwing`.
- All five content mobs that already enrage (Elder Bristleback, Mogger, the Ironvein rare, Korgath the Bound, Korzul the Gravewyrm) now frenzy at **1.3× swing speed**.
- `hasteMult` is optional and omitting it means no speed change, so the field is fully backward compatible.

## Scope / safety

Pure sim-core change. Works online for free — the `enraged` flag is already mirrored in the client entity stub and swing timing is server-authoritative. No net/obs/RL/server changes.

## Tests

`tests/mob_enrage.test.ts` covers: faster swing when enraged with `hasteMult`, no-op when not enraged, no-op for an enraged mob whose template has no `hasteMult`, multiplicative composition with a slow aura, and that every enrage template defines a frenzy value. Full suite: 537 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)