### PR TITLE
feat: desperate mobs self-heal once when first wounded low

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -200,7 +200,7 @@ function blankEntity(id: number): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
     spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -62,6 +62,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     hpBase: 50, hpPerLevel: 20, dmgBase: 10, dmgPerLevel: 2.5, attackSpeed: 2.0,
     armorPerLevel: 14, moveSpeed: 7, aggroRadius: 12,
     loot: [{ copper: 170, chance: 1 }, { itemId: 'linen_scrap', chance: 0.5 }],
+    desperateHeal: { belowHpPct: 0.3, healPct: 0.25 },
     scale: 1.0, color: 0x1f618d,
   },
   drowned_thrall: {

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -18,7 +18,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2725,6 +2725,7 @@ export class Sim {
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;
     mob.enraged = false;
+    mob.healedThisPull = false;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -2889,6 +2890,7 @@ export class Sim {
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;
     mob.enraged = false;
+    mob.healedThisPull = false;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -2918,7 +2920,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -2932,6 +2934,16 @@ export class Sim {
       this.emit({ type: 'aura', targetId: mob.id, name: 'Enrage', gained: true });
       this.emit({ type: 'log', text: `${mob.name} becomes enraged!`, color: '#ff6666', entityId: mob.id });
       this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school: 'fire', fx: 'nova' });
+    }
+    if (tmpl.desperateHeal && !mob.healedThisPull && hpFrac <= tmpl.desperateHeal.belowHpPct) {
+      mob.healedThisPull = true;
+      const heal = Math.min(mob.maxHp - mob.hp, Math.round(mob.maxHp * tmpl.desperateHeal.healPct));
+      if (heal > 0) {
+        mob.hp += heal;
+        this.emit({ type: 'heal', targetId: mob.id, amount: heal });
+        this.emit({ type: 'log', text: `${mob.name} draws on a desperate second wind!`, color: '#66ff99', entityId: mob.id });
+        this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school: 'nature', fx: 'nova' });
+      }
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -163,6 +163,9 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // Mob mechanic: a one-time desperation self-heal the first time hp drops
+  // below the threshold (healPct is a fraction of maxHp). Resets on evade/respawn.
+  desperateHeal?: { belowHpPct: number; healPct: number };
 }
 
 export type AbilityEffect =
@@ -469,6 +472,7 @@ export interface Entity {
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active
+  healedThisPull: boolean; // desperation self-heal already used this pull
   spawnPos: Vec3;
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   evadeStall: number; // seconds an evading mob has failed to get closer to home; snaps it home if it can't path back (e.g. across water)

--- a/tests/mob_desperate_heal.test.ts
+++ b/tests/mob_desperate_heal.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 20061;
+
+// Tidebound Acolyte is the seeded carrier of the desperateHeal mechanic.
+function makeAcolyte(sim: Sim, hpFrac: number) {
+  const mob = createMob(990101, MOBS.tidebound_acolyte, 13, { x: 0, y: 0, z: 0 });
+  mob.hp = Math.round(mob.maxHp * hpFrac);
+  mob.inCombat = true;
+  return mob;
+}
+
+function fire(sim: Sim, mob: ReturnType<typeof makeAcolyte>) {
+  (sim as unknown as { updateBossMechanics(m: typeof mob): void }).updateBossMechanics(mob);
+}
+
+describe('mob desperation self-heal', () => {
+  it('seeds the mechanic on the Tidebound Acolyte', () => {
+    expect(MOBS.tidebound_acolyte.desperateHeal).toEqual({ belowHpPct: 0.3, healPct: 0.25 });
+  });
+
+  it('heals once when hp first drops below the threshold', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const mob = makeAcolyte(sim, 0.25);
+    const before = mob.hp;
+    fire(sim, mob);
+    expect(mob.healedThisPull).toBe(true);
+    expect(mob.hp).toBe(before + Math.round(mob.maxHp * 0.25));
+  });
+
+  it('does not heal again on subsequent ticks in the same pull', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const mob = makeAcolyte(sim, 0.25);
+    fire(sim, mob);
+    const afterFirst = mob.hp;
+    mob.hp = Math.round(mob.maxHp * 0.1); // drop low again
+    fire(sim, mob);
+    expect(mob.hp).toBe(Math.round(mob.maxHp * 0.1));
+    expect(afterFirst).toBeGreaterThan(0);
+  });
+
+  it('does not heal while above the threshold', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const mob = makeAcolyte(sim, 0.5);
+    const before = mob.hp;
+    fire(sim, mob);
+    expect(mob.healedThisPull).toBe(false);
+    expect(mob.hp).toBe(before);
+  });
+
+  it('never overheals past max hp', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const mob = makeAcolyte(sim, 0.29);
+    mob.hp = mob.maxHp - 1; // technically below frac but nearly full
+    // force the threshold by lowering hp under 30%
+    mob.hp = Math.round(mob.maxHp * 0.29);
+    fire(sim, mob);
+    expect(mob.hp).toBeLessThanOrEqual(mob.maxHp);
+  });
+
+  it('re-arms after the mob evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const mob = makeAcolyte(sim, 0.25);
+    fire(sim, mob);
+    expect(mob.healedThisPull).toBe(true);
+    (sim as unknown as { resetEvadingMob(m: typeof mob): void }).resetEvadingMob(mob);
+    expect(mob.healedThisPull).toBe(false);
+    mob.hp = Math.round(mob.maxHp * 0.25);
+    mob.inCombat = true;
+    fire(sim, mob);
+    expect(mob.healedThisPull).toBe(true);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const wolf = createMob(990102, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    wolf.hp = Math.round(wolf.maxHp * 0.1);
+    wolf.inCombat = true;
+    const before = wolf.hp;
+    fire(sim, wolf);
+    expect(wolf.healedThisPull).toBe(false);
+    expect(wolf.hp).toBe(before);
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-WoW **desperation heal** mob-AI mechanic: a mob carrying the new optional `MobTemplate.desperateHeal` field restores a fraction of its max HP the **first** time its health drops below a threshold during a pull, then cannot do it again until it evades and resets. Gives healer-flavored mobs a moment of tactical drama — burst them past the threshold or watch them claw back.

```ts
desperateHeal?: { belowHpPct: number; healPct: number };
```

Seeded on the **Tidebound Acolyte** (the elite humanoid acolyte in The Sunken Bastion) at `belowHpPct: 0.3, healPct: 0.25` — a single 25%-of-max heal when it first drops under 30%.

## How

This follows the exact shape of the existing **enrage** mechanic, so it slots into proven control flow:

- New optional `desperateHeal` on `MobTemplate` (`src/sim/types.ts`) — content-driven and backward compatible (omitted = no heal).
- New `healedThisPull: boolean` once-per-pull flag on `Entity`, initialized in both the sim-core `createMob` (`entity.ts`) and the online client `Entity` stub (`net/online.ts`) so `tsc` stays green.
- Fired from `updateBossMechanics` (already ticked for **every** in-combat mob, not just bosses) using the same `!flag && hpFrac <= threshold` pattern as enrage. Heal is clamped to max HP and emits `heal` + a `log` line + a nature `nova` spellfx for feedback.
- Reset alongside `enraged` in **both** `resetEvadingMob` and the respawn reset, so it re-arms exactly once per fresh pull.

Pure **sim-core**: works offline and online for free — no net/obs/RL/server protocol changes.

## Tests

`tests/mob_desperate_heal.test.ts` — 7 cases: seeds correctly, heals once below threshold, never twice in a pull, ignores above-threshold HP, never overheals, re-arms after evade reset, and leaves mobs without the field untouched.

Full suite: **539 passing** (532 baseline + 7), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

A Tidebound Acolyte, first wounded below 30% HP, draws a one-time *desperate second wind* — the green nature heal flash.

![demo](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-desperate-heal/desperate_heal.gif)

<sub>Recorded in the offline client on this branch via a Puppeteer harness (real combat; player god-moded so the scene survives).</sub>