### PR TITLE
feat: War Stomp boss mechanic — periodic stun slam

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -200,7 +200,7 @@ function blankEntity(id: number): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
     spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -135,6 +135,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     hpBase: 260, hpPerLevel: 36, dmgBase: 14, dmgPerLevel: 2.9, attackSpeed: 2.8,
     armorPerLevel: 30, moveSpeed: 7, aggroRadius: 15,
     enrage: { belowHpPct: 0.30, dmgMult: 1.5 },
+    stomp: { radius: 10, every: 12, duration: 1.5, min: 20, max: 30, name: 'War Stomp' },
     loot: [
       { copper: 5000, chance: 1 },
       { itemId: 'boneplate_vest', chance: 0.34, rollGroup: 'korgath_guaranteed_uncommon' },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -18,7 +18,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -163,6 +163,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   e.scale = template.scale;
   e.color = template.color;
   e.swingTimer = 0;
+  // Telegraph the first War Stomp: delay it one full interval after engage.
+  if (template.stomp) e.stompTimer = template.stomp.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2685,6 +2685,34 @@ export class Sim {
             }
           }
         }
+        // Boss/miniboss War Stomp: a periodic ground slam that stuns (and
+        // optionally damages) nearby players. Telegraphed via createMob, which
+        // seeds stompTimer to one full interval so the first slam never lands
+        // the instant combat opens.
+        const stomp = MOBS[mob.templateId]?.stomp;
+        if (stomp) {
+          mob.stompTimer -= DT;
+          if (mob.stompTimer <= 0) {
+            mob.stompTimer = stomp.every;
+            const school = stomp.school ?? 'physical';
+            this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+            this.emit({ type: 'log', text: `${mob.name} unleashes ${stomp.name}!`, color: '#ff9933', entityId: mob.id });
+            for (const meta of this.players.values()) {
+              const pe = this.entities.get(meta.entityId);
+              if (!pe || pe.dead || dist2d(pe.pos, mob.pos) > stomp.radius) continue;
+              if (stomp.min !== undefined && stomp.max !== undefined) {
+                const dmg = Math.round(this.rng.range(stomp.min, stomp.max));
+                this.dealDamage(mob, pe, dmg, false, school, stomp.name, 'hit', true);
+              }
+              if (pe.dead) continue; // a fatal slam shouldn't also stun the corpse
+              this.applyAura(pe, {
+                id: 'stomp_stun', name: stomp.name, kind: 'stun',
+                remaining: stomp.duration, duration: stomp.duration, value: 0,
+                sourceId: mob.id, school: school as Aura['school'],
+              });
+            }
+          }
+        }
         break;
       }
       case 'evade': {
@@ -2725,6 +2753,7 @@ export class Sim {
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;
     mob.enraged = false;
+    mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -2889,6 +2918,7 @@ export class Sim {
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;
     mob.enraged = false;
+    mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -163,6 +163,10 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
+  // for `duration`s (and optionally deals min..max damage). Telegraphed: the
+  // first slam only lands one full `every` interval after combat starts.
+  stomp?: { radius: number; every: number; duration: number; min?: number; max?: number; name: string; school?: string };
 }
 
 export type AbilityEffect =
@@ -466,6 +470,7 @@ export interface Entity {
   ownerId: number | null; // controlled pets: owning player's entity id (null = wild)
   petTauntTimer: number; // controlled pet Growl cooldown
   pulseTimer: number; // boss aoe pulse countdown
+  stompTimer: number; // boss War Stomp stun-pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/tests/mob_warstomp.test.ts
+++ b/tests/mob_warstomp.test.ts
@@ -1,0 +1,116 @@
+// "War Stomp" boss mechanic: a mob with a `stomp` template field periodically
+// slams the ground while in melee combat, stunning (and optionally damaging)
+// every player inside its radius. It is telegraphed — the first slam only lands
+// one full interval after the fight begins — and resets on evade/respawn.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+// Spawn a stomping boss locked in melee on the player and return it.
+function engagedStomper(sim: Sim): Entity {
+  const mob = createMob(900100, MOBS.korgath_the_bound, 20, { ...sim.player.pos });
+  mob.spawnPos = { ...sim.player.pos }; // sit on the player: in melee + stomp radius, no leash
+  mob.aiState = 'attack';
+  mob.aggroTargetId = sim.playerId;
+  mob.inCombat = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+const stompAura = (e: Entity) => e.auras.find((a) => a.id === 'stomp_stun');
+
+describe('War Stomp boss mechanic', () => {
+  it('Korgath the Bound carries a War Stomp', () => {
+    expect(MOBS.korgath_the_bound.stomp?.name).toBe('War Stomp');
+  });
+
+  it('is telegraphed: a freshly spawned stomper waits one interval before its first slam', () => {
+    const sim = makeSim();
+    const mob = createMob(900101, MOBS.korgath_the_bound, 20, { x: 0, y: 0, z: 0 });
+    expect(mob.stompTimer).toBe(MOBS.korgath_the_bound.stomp!.every);
+  });
+
+  it('stuns a player in radius when the timer elapses and resets the timer', () => {
+    const sim = makeSim();
+    const mob = engagedStomper(sim);
+    sim.player.maxHp = 5000;
+    sim.player.hp = 5000; // survive the slam so the stun can land
+    mob.stompTimer = 0.001; // due now
+    (sim as any).updateMob(mob);
+
+    const aura = stompAura(sim.player);
+    expect(aura?.kind).toBe('stun');
+    expect(aura?.name).toBe('War Stomp');
+    expect(mob.stompTimer).toBeCloseTo(MOBS.korgath_the_bound.stomp!.every, 5);
+  });
+
+  it('damages the player when the stomp carries a damage range', () => {
+    const sim = makeSim();
+    const mob = engagedStomper(sim);
+    sim.player.maxHp = 5000;
+    sim.player.hp = 5000;
+    mob.stompTimer = 0.001;
+    (sim as any).updateMob(mob);
+
+    expect(sim.player.hp).toBeLessThan(5000);
+  });
+
+  it('stuns only players inside the stomp radius', () => {
+    const sim = makeSim();
+    const mob = engagedStomper(sim); // boss meleeing player one, on top of them
+    sim.player.maxHp = 5000;
+    sim.player.hp = 5000;
+
+    // A second player well outside the slam radius.
+    const farId = sim.addPlayer('mage', 'Faraway');
+    const far = sim.entities.get(farId)!;
+    far.maxHp = 5000;
+    far.hp = 5000;
+    far.pos = { ...mob.pos };
+    far.pos.x += MOBS.korgath_the_bound.stomp!.radius + 5;
+
+    mob.stompTimer = 0.001;
+    (sim as any).updateMob(mob);
+
+    expect(stompAura(sim.player)).toBeDefined();   // in radius → stunned
+    expect(stompAura(far)).toBeUndefined();        // out of radius → spared
+  });
+
+  it('does not slam before the timer elapses', () => {
+    const sim = makeSim();
+    const mob = engagedStomper(sim);
+    mob.stompTimer = 5; // not due yet
+    (sim as any).updateMob(mob);
+
+    expect(stompAura(sim.player)).toBeUndefined();
+    expect(mob.stompTimer).toBeLessThan(5);
+  });
+
+  it('re-arms the telegraph delay when the mob evades home', () => {
+    const sim = makeSim();
+    const mob = engagedStomper(sim);
+    mob.stompTimer = 0;
+    (sim as any).resetEvadingMob(mob);
+    expect(mob.stompTimer).toBe(MOBS.korgath_the_bound.stomp!.every);
+  });
+
+  it('a normal mob without a stomp template never gains a stomp aura', () => {
+    const sim = makeSim();
+    const wolf = createMob(900102, MOBS.forest_wolf, 5, { ...sim.player.pos });
+    wolf.spawnPos = { ...sim.player.pos };
+    wolf.aiState = 'attack';
+    wolf.aggroTargetId = sim.playerId;
+    wolf.inCombat = true;
+    (sim as any).addEntity(wolf);
+    wolf.stompTimer = 0.001;
+    (sim as any).updateMob(wolf);
+
+    expect(stompAura(sim.player)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a fourth data-driven boss mechanic alongside the existing `aoePulse`, `summonAdds`, and `enrage`: an optional `MobTemplate.stomp` field. While a stomping mob is locked in melee, it periodically slams the ground, **stunning** (and optionally damaging) every player inside its radius.

Seeded on **Korgath the Bound**, the level-20 ogre boss of Gravewyrm Sanctum — who previously only had `enrage`. War Stomp: `1.5s` stun, `20–30` damage, `10yd` radius, every `12s`.

## Why

Korgath is the game's only ogre boss yet had no signature ability beyond a damage multiplier. A periodic ground-slam stun is the classic ogre/brute mechanic (vanilla War Stomp) and creates real encounter texture — players have to anticipate the slam rather than stand still and tank.

## Design notes

- **Telegraphed for counterplay.** `createMob` seeds `stompTimer` to one full interval, so the first slam never lands the instant combat opens. The timer re-arms the same way on evade/respawn, mirroring how `firedSummons`/`enraged` reset once per pull.
- **No corpse stuns.** A fatal slam skips the stun once the target is already dead.
- **Pure sim-core.** Players already honor `stun` auras for movement (`sim.ts` movement gate) and casting, so there are **no net/RL/obs/server changes** — it works online for free. The one new `Entity.stompTimer` field is mirrored in the `net/online.ts` client stub.
- Mirrors the `aoePulse` handler structure exactly, placed right after it in the `attack` AI state.

## Tests

`tests/mob_warstomp.test.ts` (8 cases): template wiring, telegraph delay, stun-on-elapse + timer reset, optional damage, radius gating (two players — one in, one out), no premature slam, evade re-arm, and that a normal non-stomp mob never applies the aura. **All 540 tests pass; `tsc --noEmit` clean.**

## Screenshot

Korgath the Bound's *War Stomp* — the red ground telegraph and the resulting stun debuff on the player frame.

![Korgath the Bound's *War Stomp* — the red ground telegraph and the resulting stun debuff on the player frame.](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-warstomp-shot/war_stomp.png)

<sub>Captured in the offline client on this branch via a Puppeteer harness (god-moded player, real combat).</sub>