### PR TITLE
feat: melee mobs cleave nearby players on each swing

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -85,6 +85,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
       { itemId: 'eelscale_leggings', chance: 0.10, rollGroup: 'olen_bonus' },
     ], // his greaves are Maren's quest reward, not a drop
     scale: 1.2, color: 0x95a5a6,
+    cleave: { radius: 8, mult: 0.6, name: 'Cleave' },
   },
   vael_the_mistcaller: {
     id: 'vael_the_mistcaller', name: 'Vael the Mistcaller', minLevel: 13, maxLevel: 13, family: 'humanoid',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3135,8 +3135,23 @@ export class Sim {
     if (crit) dmg *= 2;
     const enrage = MOBS[mob.templateId]?.enrage;
     if (mob.enraged && enrage) dmg *= enrage.dmgMult;
+    const rawDmg = dmg; // pre-armor, post-crit/enrage — basis for cleave splash
     dmg *= 1 - armorReduction(this.effectiveArmor(target), mob.level);
     this.dealDamage(mob, target, Math.max(1, Math.round(dmg)), crit, 'physical', null, 'hit');
+    // Cleave: the swing splashes onto other players standing near the primary
+    // target, each taking the hit reduced by their own armor. Hostile mobs only,
+    // so a friendly pet swinging through mobSwing never cleaves its owner's party.
+    const cleave = MOBS[mob.templateId]?.cleave;
+    if (cleave && mob.hostile && !mob.dead) {
+      for (const meta of this.players.values()) {
+        const pe = this.entities.get(meta.entityId);
+        if (!pe || pe.dead || pe.id === target.id) continue;
+        if (dist2d(pe.pos, target.pos) > cleave.radius) continue;
+        let sd = rawDmg * cleave.mult;
+        sd *= 1 - armorReduction(this.effectiveArmor(pe), mob.level);
+        this.dealDamage(mob, pe, Math.max(1, Math.round(sd)), crit, 'physical', cleave.name ?? 'Cleave', 'hit', true);
+      }
+    }
     // thorns / lightning shield on the defender
     if (!mob.dead) {
       for (const a of target.auras) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -163,6 +163,9 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // Melee mechanic: each landed swing also splashes onto other players near the
+  // primary target for `mult` of the (pre-armor) hit. Classic-WoW Cleave.
+  cleave?: { radius: number; mult: number; name?: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_cleave.test.ts
+++ b/tests/mob_cleave.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+import type { Entity, SimEvent } from '../src/sim/types';
+
+// Spawn a fresh Knight-Commander Olen (the seeded cleaver) at the origin and
+// register it with the sim. Returns the live entity.
+function spawnOlen(sim: Sim): Entity {
+  const mob = createMob((sim as any).nextId++, MOBS['knight_commander_olen'], 13, { x: 0, y: 0, z: 0 });
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Place a player's entity at a position (pos.y matched to the mob's so dist2d is
+// the planar distance) and give it enough HP to survive a cleave splash.
+function placePlayer(sim: Sim, pid: number, x: number, z: number): Entity {
+  const e = sim.entities.get(pid)!;
+  e.pos = { x, y: 0, z };
+  e.prevPos = { ...e.pos };
+  e.maxHp = 5000;
+  e.hp = 5000;
+  return e;
+}
+
+describe('mob cleave', () => {
+  it('Knight-Commander Olen is seeded with the Cleave mechanic', () => {
+    expect(MOBS['knight_commander_olen'].cleave).toEqual({ radius: 8, mult: 0.6, name: 'Cleave' });
+  });
+
+  it('a landed swing splashes onto a second player near the primary target', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const main = sim.addPlayer('warrior', 'Tank');
+    const near = sim.addPlayer('warrior', 'Cleaved');
+    const olen = spawnOlen(sim);
+    const mainE = placePlayer(sim, main, 1, 0); // primary target, in melee
+    const nearE = placePlayer(sim, near, 1, 4); // 4yd from primary, within radius 8
+
+    const events: SimEvent[] = [];
+    const origEmit = (sim as any).emit.bind(sim);
+    (sim as any).emit = (ev: SimEvent) => { events.push(ev); return origEmit(ev); };
+
+    // Force a guaranteed hit rather than relying on the swing RNG.
+    for (let i = 0; i < 50; i++) {
+      events.length = 0;
+      (sim as any).mobSwing(olen, mainE);
+      const dmg = events.filter((e) => e.type === 'damage') as any[];
+      const splash = dmg.find((e) => e.targetId === nearE.id && e.amount > 0);
+      if (splash) {
+        expect(splash.ability).toBe('Cleave');
+        return; // a hit landed and cleaved — done
+      }
+    }
+    throw new Error('expected a cleave splash within 50 swings');
+  });
+
+  it('does not splash onto a player outside the cleave radius', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const main = sim.addPlayer('warrior', 'Tank');
+    const far = sim.addPlayer('warrior', 'Safe');
+    const olen = spawnOlen(sim);
+    const mainE = placePlayer(sim, main, 1, 0);
+    const farE = placePlayer(sim, far, 1, 40); // well beyond radius 8
+
+    const events: SimEvent[] = [];
+    const origEmit = (sim as any).emit.bind(sim);
+    (sim as any).emit = (ev: SimEvent) => { events.push(ev); return origEmit(ev); };
+
+    for (let i = 0; i < 50; i++) (sim as any).mobSwing(olen, mainE);
+    const splash = (events.filter((e) => e.type === 'damage') as any[]).find((e) => e.targetId === farE.id && e.amount > 0);
+    expect(splash).toBeUndefined();
+  });
+
+  it('a non-cleaving mob does not splash', () => {
+    const sim = new Sim({ seed: 1, playerClass: 'warrior', noPlayer: true });
+    const main = sim.addPlayer('warrior', 'Tank');
+    const near = sim.addPlayer('warrior', 'Bystander');
+    // A plain wolf has no cleave field.
+    const wolf = createMob((sim as any).nextId++, MOBS['forest_wolf'], 5, { x: 0, y: 0, z: 0 });
+    wolf.hostile = true; wolf.hp = wolf.maxHp;
+    (sim as any).addEntity(wolf);
+    const mainE = placePlayer(sim, main, 1, 0);
+    const nearE = placePlayer(sim, near, 1, 2);
+
+    const events: SimEvent[] = [];
+    const origEmit = (sim as any).emit.bind(sim);
+    (sim as any).emit = (ev: SimEvent) => { events.push(ev); return origEmit(ev); };
+
+    for (let i = 0; i < 50; i++) (sim as any).mobSwing(wolf, mainE);
+    const splash = (events.filter((e) => e.type === 'damage') as any[]).find((e) => e.targetId === nearE.id && e.amount > 0);
+    expect(splash).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-WoW **Cleave** melee mechanic for mobs, in the existing data-driven boss-mechanic style (alongside `aoePulse` / `summonAdds` / `enrage`).

A mob template can declare:

```ts
cleave?: { radius: number; mult: number; name?: string }
```

On each **landed** melee swing, the mob's hit also splashes onto every *other* player within `radius` of the primary target, for `mult` of the pre-armor damage — each splashed player taking it reduced by their *own* armor. This makes stacking melee on a cleaver punishing, the way it is in vanilla.

## How

- **`src/sim/types.ts`** — new optional `cleave` field on `MobTemplate`.
- **`src/sim/sim.ts`** (`mobSwing`) — capture the pre-armor `rawDmg`, then after the primary `dealDamage` splash to nearby players. Branch off the *pre-armor* value so each splashed player's own armor applies. Guarded on `mob.hostile` so a friendly pet swinging through the shared `mobSwing` path never cleaves its owner's party.
- **`src/sim/content/dungeons.ts`** — seed it on **Knight-Commander Olen** (the elite undead miniboss in The Sunken Bastion, previously mechanic-less) at `{ radius: 8, mult: 0.6 }`.

Misses and dodges don't cleave (the splash is after the hit-table resolution). Cleave splash events carry `ability: 'Cleave'` so the combat log / FCT label it.

## Scope / invariants

- **Pure sim-core.** No new `Entity` state (reads only the template + live positions), so there's nothing to mirror in `net/online.ts` — works online for free, identical offline/server/headless.
- No `obs.ts`/RL action-space changes (no `Discrete(n)` resize).
- Balance numbers live on the content template, not inline.

## Tests

`tests/mob_cleave.test.ts` — 4 cases: Olen is seeded; a swing splashes onto a second player in-radius (labelled `Cleave`); no splash outside the radius; a non-cleaving mob (`forest_wolf`) never splashes. Full suite: **652 passing**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Demo

Knight-Commander Olen swings at the tank; each swing cleaves onto the second player standing within 8yd (splash damage numbers over the ally).

![demo](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-cleave-shot/cleave.gif)

<sub>Recorded in the offline client on this branch via a Puppeteer harness (real combat; player god-moded so the scene survives).</sub>