### PR TITLE
feat: pack mobs frenzy when a packmate is slain

### DIFF
--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -48,6 +48,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'wolf_fang', chance: 0.45 },
     ],
     scale: 0.9, color: 0x7f8c8d,
+    packFrenzy: { radius: 12, hasteMult: 1.3, duration: 8 },
   },
   old_greyjaw: {
     id: 'old_greyjaw', name: 'Old Greyjaw', minLevel: 4, maxLevel: 4, family: 'beast', rare: true,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -116,6 +116,7 @@ const DEFAULT_SOCIAL_PULL_RADIUS = 5;
 const SOCIAL_PULL_RADIUS: Partial<Record<MobFamily, number>> = {
   murloc: 8,
 };
+const PACK_FRENZY_AURA_ID = 'pack_frenzy'; // attack-speed buff granted to surviving packmates
 const SWIM_SURFACE_Y = WATER_LEVEL - 0.75; // body bobs just below the water line
 const SWIM_DEPTH = 0.8; // ground this far under the water line = deep water
 const SWIM_SPEED_MULT = 0.65;
@@ -2621,6 +2622,7 @@ export class Sim {
         this.emit({ type: 'log', text: `${e.name} dies.`, color: '#f66', pid: e.ownerId });
         return; // pets drop no loot and grant no credit; they respawn wild
       }
+      this.frenzyPackmates(e); // wild packmates fly into a frenzy when one falls
 
       // credit goes to the tapping player (fall back to the killer)
       const creditId = e.tappedById ?? (killer?.kind === 'player' ? killer.id : null);
@@ -3305,6 +3307,40 @@ export class Sim {
       this.dropEntity(id);
     }
     boss.summonedIds = [];
+  }
+
+  // Classic beast "Frenzy": when a mob carrying the packFrenzy trait dies, the
+  // surviving same-family hostile mobs nearby briefly attack faster. Modelled as
+  // a refreshable buff_haste aura, so it rides the normal aura tick (expires on
+  // its own) and the existing snapshot wire — no new Entity field is needed.
+  private frenzyPackmates(dead: Entity): void {
+    const fr = MOBS[dead.templateId]?.packFrenzy;
+    if (!fr) return;
+    const r2 = fr.radius * fr.radius;
+    this.grid.forEachInRadius(dead.pos.x, dead.pos.z, fr.radius, (m, d2) => {
+      if (m.id === dead.id || m.kind !== 'mob' || m.dead || m.aiState === 'dead') return;
+      if (!m.hostile || m.ownerId !== null || d2 > r2) return;
+      // packmates = same creature type (a wolf pack), matching the social-aggro convention
+      if (m.templateId !== dead.templateId) return;
+      const existing = m.auras.find((a) => a.id === PACK_FRENZY_AURA_ID);
+      if (existing) {
+        existing.remaining = fr.duration; // refresh on each further loss; don't stack
+        return;
+      }
+      m.auras.push({
+        id: PACK_FRENZY_AURA_ID,
+        name: 'Pack Frenzy',
+        kind: 'buff_haste',
+        remaining: fr.duration,
+        duration: fr.duration,
+        value: fr.hasteMult,
+        sourceId: m.id,
+        school: 'physical',
+      });
+      this.emit({ type: 'aura', targetId: m.id, name: 'Pack Frenzy', gained: true });
+      this.emit({ type: 'log', text: `${m.name} flies into a frenzy!`, color: '#ff8c00', entityId: m.id });
+      this.emit({ type: 'spellfx', sourceId: m.id, targetId: m.id, school: 'physical', fx: 'nova' });
+    });
   }
 
   // Boss threshold mechanics: add waves (summonAdds) and enrage. Checked

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -163,6 +163,10 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // Classic beast "Frenzy": when a mob with this trait dies, nearby living
+  // same-family hostile mobs briefly attack faster (hasteMult, e.g. 1.3 = +30%
+  // swing speed) for `duration` seconds. Applied as a buff_haste aura.
+  packFrenzy?: { radius: number; hasteMult: number; duration: number };
 }
 
 export type AbilityEffect =

--- a/tests/mob_pack_frenzy.test.ts
+++ b/tests/mob_pack_frenzy.test.ts
@@ -1,0 +1,121 @@
+// Classic beast "Frenzy": when a wild mob carrying the packFrenzy trait dies,
+// nearby living same-family hostile packmates fly into a brief attack-speed
+// frenzy. Forest Wolves (a pack mob) carry the trait; killing one should hasten
+// the survivors next to it, but not distant ones, other families, or pets.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import type { Entity } from '../src/sim/types';
+
+const makeSim = () => new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+
+function wolves(sim: Sim): Entity[] {
+  return [...sim.entities.values()].filter(
+    (e) => e.kind === 'mob' && e.templateId === 'forest_wolf' && e.ownerId === null,
+  );
+}
+
+// Lethally strike a target so handleDeath (and frenzyPackmates) runs.
+function kill(sim: Sim, victim: Entity) {
+  victim.aiState = 'idle';
+  victim.auras = [];
+  (sim as any).dealDamage(sim.player, victim, victim.hp + 1000, false, 'physical', null, 'hit', true);
+}
+
+function frenzy(e: Entity) {
+  return e.auras.find((a) => a.id === 'pack_frenzy');
+}
+
+describe('pack frenzy on packmate death', () => {
+  it('forest_wolf carries the packFrenzy trait', () => {
+    expect(MOBS.forest_wolf.packFrenzy).toEqual({ radius: 12, hasteMult: 1.3, duration: 8 });
+  });
+
+  it('a nearby wolf frenzies when a packmate dies', () => {
+    const sim = makeSim();
+    const [victim, survivor] = wolves(sim);
+    survivor.pos = { x: victim.pos.x + 4, z: victim.pos.z, y: victim.pos.y };
+    survivor.auras = [];
+    sim.tick(); // re-bucket the spatial grid so the radius query sees the survivor
+
+    kill(sim, victim);
+
+    const aura = frenzy(survivor);
+    expect(aura).toBeTruthy();
+    expect(aura!.kind).toBe('buff_haste');
+    expect(aura!.value).toBe(1.3);
+    expect(aura!.remaining).toBe(8);
+  });
+
+  it('the frenzy actually shortens the swing interval', () => {
+    const sim = makeSim();
+    const [victim, survivor] = wolves(sim);
+    survivor.pos = { x: victim.pos.x + 4, z: victim.pos.z, y: victim.pos.y };
+    sim.tick();
+    const before = (sim as any).swingIntervalMult(survivor);
+
+    kill(sim, victim);
+
+    const after = (sim as any).swingIntervalMult(survivor);
+    expect(after).toBeCloseTo(before / 1.3, 5);
+  });
+
+  it('does not frenzy a wolf outside the trait radius', () => {
+    const sim = makeSim();
+    const [victim, survivor] = wolves(sim);
+    survivor.pos = { x: victim.pos.x + 50, z: victim.pos.z, y: victim.pos.y }; // > 12yd away
+    survivor.auras = [];
+    sim.tick();
+
+    kill(sim, victim);
+
+    expect(frenzy(survivor)).toBeUndefined();
+  });
+
+  it('refreshes rather than stacks on a second loss', () => {
+    const sim = makeSim();
+    const ws = wolves(sim);
+    const survivor = ws[0];
+    const a = ws[1];
+    const b = ws[2];
+    for (const v of [a, b]) v.pos = { x: survivor.pos.x + 3, z: survivor.pos.z, y: survivor.pos.y };
+    survivor.auras = [];
+    sim.tick();
+
+    kill(sim, a);
+    survivor.auras.find((au) => au.id === 'pack_frenzy')!.remaining = 2; // let it tick down
+    kill(sim, b);
+
+    const matches = survivor.auras.filter((au) => au.id === 'pack_frenzy');
+    expect(matches.length).toBe(1); // one aura, refreshed
+    expect(matches[0].remaining).toBe(8);
+  });
+
+  it('does not frenzy a different creature type', () => {
+    const sim = makeSim();
+    const [victim] = wolves(sim);
+    const boar = [...sim.entities.values()].find(
+      (e) => e.kind === 'mob' && e.templateId === 'wild_boar' && e.ownerId === null,
+    )!;
+    boar.pos = { x: victim.pos.x + 4, z: victim.pos.z, y: victim.pos.y };
+    boar.auras = [];
+    sim.tick();
+
+    kill(sim, victim);
+
+    expect(frenzy(boar)).toBeUndefined();
+  });
+
+  it('a dying pet does not frenzy wild mobs', () => {
+    const sim = makeSim();
+    const [victim, survivor] = wolves(sim);
+    survivor.pos = { x: victim.pos.x + 4, z: victim.pos.z, y: victim.pos.y };
+    survivor.auras = [];
+    victim.ownerId = sim.playerId; // make the victim a pet
+    sim.tick();
+
+    kill(sim, victim);
+
+    expect(frenzy(survivor)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

A classic-WoW beast **Frenzy** mob mechanic. When a wild mob carrying the new optional `MobTemplate.packFrenzy` trait dies, its nearby living same-type hostile **packmates fly into a brief attack-speed frenzy** — killing one wolf in a pack now makes the rest hit faster, so pulls have a bit of escalating bite.

This extends the existing family of data-driven mob mechanics (`aoePulse`, `summonAdds`, `enrage`). Unlike those, which trigger on the mob's *own* HP/state, this is the first **reactive social trigger** — it fires from the death-handling path of a *different* mob.

## How

- **`MobTemplate.packFrenzy = { radius, hasteMult, duration }`** (`src/sim/types.ts`).
- **`frenzyPackmates()`** runs from `handleDeath`, placed *after* the pet early-return so only wild deaths trigger it. It scans the spatial grid for living, hostile, same-`templateId` mobs within `radius` (same "packmate = same creature type" rule the social-aggro pull already uses) and grants each a refreshable `buff_haste` aura.
- The buff folds into the existing **`swingIntervalMult`** chokepoint (`m /= value`), so the swing loop is untouched. It's modelled as an **aura**, so it rides the normal aura tick (self-expiring, refreshes rather than stacks on a second loss) and the existing snapshot wire — **no new `Entity` field, no `net`/RL/obs/server change**. Pure sim-core, so it works online for free.
- Seeded on **`forest_wolf`** (the canonical pack mob — spawns in groups of 6-7) at `{ radius: 12, hasteMult: 1.3, duration: 8 }`. Backward-compatible: omitting the field = no behaviour change.

## Tests

`tests/mob_pack_frenzy.test.ts` (7 cases): trait shape, nearby packmate frenzies, swing interval actually shortens, out-of-range wolf unaffected, refresh-not-stack on a second death, a different creature type is unaffected, and a dying pet doesn't frenzy wild mobs. Full suite: **655 passing**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot

A wolf flies into a *Pack Frenzy* when a packmate is slain (buff on the target frame; orange combat-log callout).

![A wolf flies into a *Pack Frenzy* when a packmate is slain (buff on the target frame; orange combat-log callout).](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-pack-frenzy/pack_frenzy.png)

<sub>Captured in the offline client on this branch via a Puppeteer harness (god-moded player, real combat).</sub>