### PR TITLE
feat: venomous mobs inflict an on-hit poison DoT

### DIFF
--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -92,6 +92,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     id: 'webwood_spider', name: 'Webwood Lurker', minLevel: 2, maxLevel: 4, family: 'spider',
     hpBase: 30, hpPerLevel: 15, dmgBase: 4, dmgPerLevel: 1.7, attackSpeed: 1.8,
     armorPerLevel: 8, moveSpeed: 8, aggroRadius: 10,
+    venom: { chance: 0.35, perTick: 2, interval: 2, duration: 10, name: 'Spider Venom', school: 'nature' },
     loot: [
       { copper: 14, chance: 1 },
       { itemId: 'webwood_silk', chance: 0.55, questId: 'q_spiders' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3137,6 +3137,18 @@ export class Sim {
     if (mob.enraged && enrage) dmg *= enrage.dmgMult;
     dmg *= 1 - armorReduction(this.effectiveArmor(target), mob.level);
     this.dealDamage(mob, target, Math.max(1, Math.round(dmg)), crit, 'physical', null, 'hit');
+    // venom: a landed swing may inflict a refreshing poison DoT (hostile mobs only,
+    // never a friendly pet — mobSwing is also the pet attack path).
+    const venom = MOBS[mob.templateId]?.venom;
+    if (venom && mob.hostile && !target.dead && this.rng.chance(venom.chance)) {
+      this.applyAura(target, {
+        id: 'venom_' + mob.templateId, name: venom.name, kind: 'dot',
+        remaining: venom.duration, duration: venom.duration,
+        value: Math.max(1, Math.round(venom.perTick)),
+        tickInterval: venom.interval, tickTimer: venom.interval,
+        sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
+      });
+    }
     // thorns / lightning shield on the defender
     if (!mob.dead) {
       for (const a of target.auras) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -163,6 +163,9 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
+  // damage-over-time poison on the struck target (spiders, serpents, scorpions).
+  venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_venom.test.ts
+++ b/tests/mob_venom.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn a venomous spider adjacent to the player and hand it back.
+function spawnSpider(sim: Sim, id = 970001, level = 4) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.webwood_spider, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the venom aura (the chance is 1 in these tests).
+function swingUntilVenom(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'venom_webwood_spider')) return true;
+  }
+  return false;
+}
+
+describe('mob venom (on-hit poison DoT)', () => {
+  it('the Webwood Lurker carries venom data tuned to a nature DoT', () => {
+    const v = MOBS.webwood_spider.venom!;
+    expect(v).toBeDefined();
+    expect(v.school).toBe('nature');
+    expect(v.chance).toBeGreaterThan(0);
+    expect(v.perTick).toBeGreaterThan(0);
+    expect(v.interval).toBeGreaterThan(0);
+    expect(v.duration).toBeGreaterThan(v.interval);
+  });
+
+  it('a landed venomous swing inflicts a poison DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSpider(sim);
+    const orig = MOBS.webwood_spider.venom!.chance;
+    MOBS.webwood_spider.venom!.chance = 1;
+    try {
+      expect(swingUntilVenom(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.webwood_spider.venom!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'venom_webwood_spider')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('nature');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.webwood_spider.venom!.duration);
+  });
+
+  it('the poison DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSpider(sim);
+    const orig = MOBS.webwood_spider.venom!.chance;
+    MOBS.webwood_spider.venom!.chance = 1;
+    try {
+      expect(swingUntilVenom(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.webwood_spider.venom!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 3; i++) sim.tick(); // 3s — at least one tick interval
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-venomous mob (forest wolf) applies no poison aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(970050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated bites from the same spider', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSpider(sim);
+    const orig = MOBS.webwood_spider.venom!.chance;
+    MOBS.webwood_spider.venom!.chance = 1;
+    try {
+      swingUntilVenom(sim, mob, player);
+      swingUntilVenom(sim, mob, player);
+      swingUntilVenom(sim, mob, player);
+    } finally {
+      MOBS.webwood_spider.venom!.chance = orig;
+    }
+    const venomAuras = player.auras.filter((a) => a.id === 'venom_webwood_spider');
+    expect(venomAuras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-WoW **venom-on-hit** mechanic: spiders, serpents and other venomous creatures have a chance, on each landed melee swing, to inflict a stacking-refresh **poison damage-over-time** debuff on the player they strike.

This is the next data-driven `MobTemplate` mechanic in the same family as `aoePulse` / `summonAdds` / `enrage` — declarative content, generic engine handler.

## How

- **`src/sim/types.ts`** — new optional `MobTemplate.venom?: { chance, perTick, interval, duration, name, school? }` (after `enrage`).
- **`src/sim/sim.ts`** — in `mobSwing`, after a landed hit, roll `venom.chance` and apply a `kind:'dot'` aura (id `venom_<templateId>`). Guarded on `mob.hostile` so a friendly **pet** (the other `mobSwing` caller) never poisons the party.
- **`src/sim/content/zone1.ts`** — seed the **Webwood Lurker** (`webwood_spider`, family `spider`) with `Spider Venom`: 35% chance, 2 dmg / 2s for 10s, nature school.

### Why it's free online
The DoT rides the existing `Aura` system — `updateAuras` already ticks `kind:'dot'` auras and `net/online.ts` already mirrors auras over the wire. **No new `Entity` field**, and no `net` / RL / `obs` / server changes. `applyAura` replaces an existing aura with the same `id`+`sourceId`, so repeated bites from one spider **refresh** rather than stack infinitely.

## Tests

`tests/mob_venom.test.ts` — 5 cases: venom data tuning, aura applied on a landed swing, DoT actually ticks HP down over time, a non-venomous mob (forest wolf) applies nothing, and repeated bites refresh (single aura). Full suite: **653 passed**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot

A Webwood spider's bite applies the *Spider Venom* poison DoT (green debuff on the player frame).

![A Webwood spider's bite applies the *Spider Venom* poison DoT (green debuff on the player frame).](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-venom-shot/spider_venom.png)

<sub>Captured in the offline client on this branch via a Puppeteer harness (god-moded player, real combat).</sub>