### PR TITLE
feat: Mortal Strike mobs leave a healing-reduction wound on hit

### DIFF
--- a/src/sim/content/dungeons.ts
+++ b/src/sim/content/dungeons.ts
@@ -56,6 +56,7 @@ export const DUNGEON_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 18, moveSpeed: 6.5, aggroRadius: 12,
     loot: [{ copper: 150, chance: 1 }, { itemId: 'bone_fragments', chance: 0.7 }],
     scale: 1.1, color: 0x7fa8a0,
+    mortalStrike: { chance: 0.3, healReduction: 0.5, duration: 6, name: 'Mortal Strike' },
   },
   tidebound_acolyte: {
     id: 'tidebound_acolyte', name: 'Tidebound Acolyte', minLevel: 12, maxLevel: 13, family: 'humanoid', elite: true,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1394,7 +1394,7 @@ export class Sim {
       const c = p[slot];
       if (!c) continue;
       if (c.hpPer2s > 0 && p.hp < p.maxHp) {
-        const heal = Math.min(c.hpPer2s, p.maxHp - p.hp);
+        const heal = Math.min(Math.round(c.hpPer2s * this.healingTakenMult(p)), p.maxHp - p.hp);
         p.hp += heal;
         this.emit({ type: 'heal', targetId: p.id, amount: heal });
       }
@@ -1441,7 +1441,7 @@ export class Sim {
             this.dealDamage(this.entities.get(a.sourceId) ?? null, e, a.value, false, a.school, a.name, 'hit', true);
             if (e.dead) return;
           } else if (a.kind === 'hot') {
-            const healed = Math.min(a.value, e.maxHp - e.hp);
+            const healed = Math.min(Math.round(a.value * this.healingTakenMult(e)), e.maxHp - e.hp);
             if (healed > 0) {
               e.hp += healed;
               this.emit({ type: 'heal2', sourceId: a.sourceId, targetId: e.id, amount: healed, crit: false, ability: a.name });
@@ -1714,10 +1714,21 @@ export class Sim {
     return 0.05 + p.stats.int * 0.0008;
   }
 
+  // Combined incoming-healing multiplier from Mortal Wound debuffs (classic
+  // Mortal Strike): each reduces healing the target receives; multiple stack
+  // multiplicatively. 1 = unaffected, 0 = fully suppressed.
+  private healingTakenMult(target: Entity): number {
+    let mult = 1;
+    for (const a of target.auras) {
+      if (a.kind === 'mortal_wound') mult *= 1 - a.value;
+    }
+    return mult < 0 ? 0 : mult;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
-    let healed = Math.round(amount * (crit ? 1.5 : 1));
+    let healed = Math.round(amount * (crit ? 1.5 : 1) * this.healingTakenMult(target));
     healed = Math.min(healed, target.maxHp - target.hp);
     target.hp += healed;
     this.emit({ type: 'heal2', sourceId: source.id, targetId: target.id, amount: healed, crit, ability });
@@ -3145,6 +3156,21 @@ export class Sim {
         }
       }
     }
+    // Mortal Strike: a landed hit can leave a healing-reduction debuff. Guarded on
+    // `hostile` so a friendly pet (mobSwing's other caller) never debuffs the party.
+    const ms = MOBS[mob.templateId]?.mortalStrike;
+    if (ms && mob.hostile && !target.dead && this.rng.chance(ms.chance)) {
+      this.applyAura(target, {
+        id: `mortal_wound_${mob.templateId}`,
+        name: ms.name,
+        kind: 'mortal_wound',
+        remaining: ms.duration,
+        duration: ms.duration,
+        value: ms.healReduction,
+        sourceId: mob.id,
+        school: (ms.school as Aura['school']) ?? 'physical',
+      });
+    }
   }
 
   // Pet brain: assist the owner (attack whatever they fight or whatever
@@ -3554,7 +3580,7 @@ export class Sim {
       this.removeItem(itemId, 1, meta.entityId);
       p.potionCooldownUntil = this.time + POTION_COOLDOWN;
       if (restoresHp) {
-        const heal = Math.min(def.potionHp!, p.maxHp - p.hp);
+        const heal = Math.min(Math.round(def.potionHp! * this.healingTakenMult(p)), p.maxHp - p.hp);
         p.hp += heal;
         this.emit({ type: 'heal', targetId: p.id, amount: heal });
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -35,7 +35,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -163,6 +163,9 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // Melee mechanic: a landed swing has `chance` to inflict a Mortal Wound debuff
+  // that reduces all healing the victim receives by `healReduction` for `duration`.
+  mortalStrike?: { chance: number; healReduction: number; duration: number; name: string; school?: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_mortal_strike.test.ts
+++ b/tests/mob_mortal_strike.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura, Entity } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+function woundAura(value: number, remaining = 6): Aura {
+  return {
+    id: 'mortal_wound_test', name: 'Mortal Strike', kind: 'mortal_wound',
+    remaining, duration: 6, value, sourceId: -1, school: 'physical',
+  };
+}
+
+// A heal-over-time aura primed to tick on the next updateAuras call. The HoT path
+// has no crit roll, so it isolates the healing-reduction math deterministically.
+function primedHot(value: number): Aura {
+  return {
+    id: 'hot_test', name: 'Renew', kind: 'hot', remaining: 10, duration: 10,
+    value, tickInterval: 1, tickTimer: 0.01, sourceId: -1, school: 'holy',
+  };
+}
+
+describe('Mortal Strike healing-reduction debuff', () => {
+  it('reduces incoming healing by the debuff fraction', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+
+    p.hp = 1000;
+    p.auras.push(primedHot(100));
+    (sim as any).updateAuras(p);
+    const baseline = p.hp - 1000;
+    expect(baseline).toBe(100);
+
+    const p2 = sim.entities.get(sim.playerId)!;
+    p2.auras.length = 0;
+    p2.hp = 1000;
+    p2.auras.push(woundAura(0.5));
+    p2.auras.push(primedHot(100));
+    (sim as any).updateAuras(p2);
+    const reduced = p2.hp - 1000;
+    expect(reduced).toBe(50);
+  });
+
+  it('fully suppresses healing at 100% reduction and never goes negative', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+    p.hp = 1000;
+    p.auras.push(woundAura(1));
+    p.auras.push(primedHot(200));
+    (sim as any).updateAuras(p);
+    expect(p.hp).toBe(1000);
+  });
+
+  it('stacks multiplicatively across multiple Mortal Wound auras', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.auras.push({ ...woundAura(0.5), id: 'a', sourceId: 1 });
+    p.auras.push({ ...woundAura(0.5), id: 'b', sourceId: 2 });
+    expect((sim as any).healingTakenMult(p)).toBeCloseTo(0.25, 6);
+  });
+
+  it('does not affect healing once the debuff expires via updateAuras', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+    p.auras.push(woundAura(0.5, 0.05)); // one tick of life
+    (sim as any).updateAuras(p); // remaining -> 0 -> spliced
+    expect(p.auras.some((a) => a.kind === 'mortal_wound')).toBe(false);
+    p.hp = 1000;
+    p.auras.push(primedHot(100));
+    (sim as any).updateAuras(p);
+    expect(p.hp - 1000).toBe(100);
+  });
+
+  it('a landed bastion_revenant swing can inflict the Mortal Wound', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.bastion_revenant;
+    const saved = tmpl.mortalStrike!.chance;
+    tmpl.mortalStrike!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900500, tmpl, 13, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'mortal_wound');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'mortal_wound')!;
+      expect(a.name).toBe('Mortal Strike');
+      expect(a.value).toBe(0.5);
+    } finally {
+      tmpl.mortalStrike!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts Mortal Wound', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.bastion_revenant;
+    const saved = tmpl.mortalStrike!.chance;
+    tmpl.mortalStrike!.chance = 1;
+    try {
+      const pet = createMob(900501, tmpl, 13, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'mortal_wound')).toBe(false);
+    } finally {
+      tmpl.mortalStrike!.chance = saved;
+    }
+  });
+
+  it('a mob without mortalStrike applies no debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900502, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'mortal_wound')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-WoW **Mortal Strike** mechanic: a landed mob melee swing can inflict a **Mortal Wound** debuff that reduces *all* healing the victim receives for its duration.

This is the first mob mechanic to hook the **heal** path rather than the damage path — it pressures healers the way Mortal Strike does in vanilla, rather than just hitting harder.

## How

- New optional `MobTemplate.mortalStrike` field (`chance` / `healReduction` / `duration` / `name` / optional `school`), applied right after a landed hit in `mobSwing`. Guarded on `mob.hostile && !target.dead` so a friendly **pet** (the other `mobSwing` caller) never debuffs the party — same guard rationale as cleave/venom.
- Rides the existing **aura system** via a new `mortal_wound` `AuraKind`. No new `Entity` field → no `net/online.ts` `blankEntity` change, and `updateAuras` already ticks/expires it. `applyAura` refreshes (not stacks) a re-applied wound from the same source.
- A small `healingTakenMult(target)` helper folds every active Mortal Wound (multiplicative, clamped `>= 0`) into **every** incoming-heal site: `applyHeal` (spells), HoT ticks, potions, and food/drink.
- Seeded on `bastion_revenant` (Sunken Bastion elite, previously mechanic-less) at **30% chance / 50% reduction / 6s**.

Pure `src/sim/` core change — works online for free, no net/RL/obs/server changes. Backward-compatible: omitting `mortalStrike` is a no-op.

## Test

`tests/mob_mortal_strike.test.ts` (7 cases): reduction fraction, full suppression / no-negative, multiplicative stacking, expiry restores healing, a landed `bastion_revenant` swing applies the wound, friendly pet never applies it, and a mob without the field applies nothing.

`npx tsc --noEmit` clean; full suite **655 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot

A Bastion Revenant lands its *Mortal Strike*, leaving the healing-reduction wound on the player frame.

![A Bastion Revenant lands its *Mortal Strike*, leaving the healing-reduction wound on the player frame.](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-mortal-strike/mortal_strike.png)

<sub>Captured in the offline client on this branch via a Puppeteer harness (god-moded player, real combat).</sub>