### PR TITLE
Bundle slash chat commands for v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ see each other in town. `Enter` opens chat.
 - **Parties** (up to 5): right-click a player → *Invite to Party*. Party
   frames on the left, members share tap rights, kill quest credit and split
   XP with the real vanilla group bonuses (1.166/1.3/1.43 for 3/4/5). Party
-  chat with `/p message`. Blue member blips on the minimap.
+  chat with `/p message`. Blue member blips on the minimap. Settle loot
+  disputes with `/roll` (also `/roll N` or `/roll M-N`) — a server-rolled
+  number broadcast to the party, or to nearby players when ungrouped.
 - **Trading**: right-click a player → *Trade*. Both sides stage items + money,
   both must accept, and the swap is atomic and server-validated (quest items
   are untradeable). Walking apart cancels.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ see each other in town. `Enter` opens chat.
   its loot/XP/quest credit — others get "You don't have permission to loot
   that."), mobs retarget the next attacker when their victim dies (no free
   resets), join/leave announcements, `/say`-style chat.
+- **Away status**: `/afk [message]` and `/dnd [message]` mark you as away.
+  Anyone who whispers you gets an automatic reply with your message; `/dnd`
+  also withholds the incoming whisper. Repeat the bare command (or just send
+  any other chat) to clear it. Status is session-only and resets on login.
 
 ## The Hollow Crypt — 5-player elite instance
 

--- a/index.html
+++ b/index.html
@@ -3683,7 +3683,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something... (/w name, /r, /p, /gu, /o, /g, /join world|lfg, /afk, /dnd)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something... (/w name, /r, /p, /gu, /o, /general, /join world|lfg, /afk, /dnd)" autocomplete="off" />
   </template>
 
   <main id="start-screen">

--- a/index.html
+++ b/index.html
@@ -3386,7 +3386,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general, /afk, /dnd)" autocomplete="off" />
   </template>
 
   <main id="start-screen">

--- a/index.html
+++ b/index.html
@@ -3386,7 +3386,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" placeholder="Say something… (/w name whisper, /r reply, /p party, /gu guild, /o officer, /g general)" autocomplete="off" />
+  <input id="chat-input" maxlength="200" placeholder="Say something… (/w whisper, /r reply, /p party, /gu guild, /o officer, /g general, /join world|lfg then /world /lfg)" autocomplete="off" />
   </template>
 
   <main id="start-screen">

--- a/server/game.ts
+++ b/server/game.ts
@@ -133,7 +133,7 @@ interface WhoRosterRow {
 }
 
 type RememberedChat =
-  | { channel: 'say' | 'yell' | 'general' | 'party' | 'guild' | 'officer' }
+  | { channel: 'say' | 'yell' | 'general' | 'party' | 'guild' | 'officer' | 'world' | 'lfg' }
   | { channel: 'whisper'; target: string };
 
 // Identity fields rarely change, so they ride only in "full" records: on an
@@ -1106,6 +1106,10 @@ export class GameServer {
           return this.sim.chat(`/p ${body}`, pid);
         case 'general':
           return this.sim.chat(`/general ${body}`, pid);
+        case 'world':
+          return this.sim.chat(`/world ${body}`, pid);
+        case 'lfg':
+          return this.sim.chat(`/lfg ${body}`, pid);
         case 'yell':
           return this.sim.chat(`/y ${body}`, pid);
         case 'say':

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -222,7 +222,7 @@ export interface SentChat {
 }
 
 // Opt-in global chat channels a player can /join and /leave. `general` is
-// always-on (everyone hears /g), so it is intentionally not joinable here.
+// always-on (everyone hears /general), so it is intentionally not joinable here.
 export const JOINABLE_CHANNELS = ['world', 'lfg'] as const;
 export type JoinableChannel = (typeof JOINABLE_CHANNELS)[number];
 
@@ -5485,7 +5485,7 @@ export class Sim {
   // in sync with the commands handled in chat() above.
   private helpLines(): string[] {
     return [
-      'Chat channels: /s say, /y yell, /g general, /p party, /world, /lfg.',
+      'Chat channels: /s say, /y yell, /general, /p party, /world, /lfg.',
       'Whisper a player with /w <name> <message>, reply with /r.',
       'Other commands: /join <world|lfg>, /roll, /inspect <name>, /afk, /dnd, /who.',
     ];
@@ -5514,7 +5514,7 @@ export class Sim {
       return;
     }
     if (arg === 'general') {
-      this.error(pid, 'The General channel is always on — just use /g.');
+      this.error(pid, 'The General channel is always on - just use /general.');
       return;
     }
     if (!JOINABLE_CHANNELS.includes(arg as JoinableChannel)) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3496,6 +3496,39 @@ export class Sim {
       return null;
     }
 
+    // "/roll", "/roll N", "/roll M-N" — a classic random roll for loot disputes
+    // and social play. Rolled through the deterministic sim RNG so it is
+    // server-authoritative (clients can't fake a result) and identical offline.
+    const rollm = /^\/roll(?:\s+(\d+)(?:\s*-\s*(\d+))?)?\s*$/i.exec(raw);
+    if (rollm) {
+      let lo = 1, hi = 100;
+      if (rollm[1] !== undefined) {
+        const n = parseInt(rollm[1], 10);
+        if (rollm[2] !== undefined) { lo = n; hi = parseInt(rollm[2], 10); }
+        else { hi = n; }
+      }
+      const MAX_ROLL = 1_000_000;
+      if (lo < 1 || hi > MAX_ROLL || lo > hi) {
+        this.error(r.meta.entityId, `Invalid roll range. Use /roll, /roll N, or /roll M-N (1-${MAX_ROLL}).`);
+        return null;
+      }
+      const result = this.rng.int(lo, hi);
+      const text = `${result} (${lo}-${hi})`;
+      const party = this.partyOf(r.meta.entityId);
+      if (party) {
+        for (const mPid of party.members) {
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: mPid });
+        }
+      } else {
+        for (const meta of this.players.values()) {
+          const e = this.entities.get(meta.entityId);
+          if (!e || dist2d(r.e.pos, e.pos) > SAY_RANGE) continue;
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text, channel: 'roll', pid: meta.entityId });
+        }
+      }
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -3549,7 +3582,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /roll.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -199,6 +199,9 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // Session-only: name of the last player who whispered us, for "/r" replies.
+  // Never persisted — a fresh login starts with no reply target.
+  lastWhisperFrom?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -3496,8 +3499,19 @@ export class Sim {
       return null;
     }
 
+    // "/r message" — reply to the last player who whispered us. Rewrite it to
+    // the "/w <name> message" form so delivery, the echo, and case-matching
+    // all stay in the single whisper handler below.
+    const rm = /^\/r(?:eply)?\s+([\s\S]+)$/i.exec(raw);
+    let line = raw;
+    if (rm) {
+      const replyTo = r.meta.lastWhisperFrom;
+      if (!replyTo) { this.error(r.meta.entityId, 'You have no one to reply to.'); return null; }
+      line = `/w ${replyTo} ${rm[1]}`;
+    }
+
     // "/w name message" — private whisper to an online player
-    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
+    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(line);
     if (wm) {
       const targetName = wm[1];
       const msg = wm[2].trim();
@@ -3518,10 +3532,14 @@ export class Sim {
       }
       if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
+      // classic-WoW "/r": the recipient's reply target is whoever last
+      // whispered them, so record it on the target (not the sender).
+      target.lastWhisperFrom = r.meta.name;
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
     }
+
 
     // "/p message" goes to the party channel
     if (/^\/p(arty)?\s/i.test(raw)) {
@@ -3549,7 +3567,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /r /p /g.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -179,9 +179,14 @@ export interface RewardCounters {
 }
 
 export interface SentChat {
-  channel: 'say' | 'yell' | 'whisper' | 'general' | 'party';
+  channel: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'world' | 'lfg';
   message: string;
 }
+
+// Opt-in global chat channels a player can /join and /leave. `general` is
+// always-on (everyone hears /g), so it is intentionally not joinable here.
+export const JOINABLE_CHANNELS = ['world', 'lfg'] as const;
+export type JoinableChannel = (typeof JOINABLE_CHANNELS)[number];
 
 // Per-player progression and bags. The entity holds combat state; this holds
 // everything that belongs to the character sheet.
@@ -339,6 +344,8 @@ export class Sim {
   private nextArenaMatchId = 1;
   // per-player chat token bucket (anti-spam); refilled lazily by sim time
   private chatTokens = new Map<number, { tokens: number; at: number }>();
+  // per-player set of opt-in global channels (world, lfg) joined via /join
+  private channelSubs = new Map<number, Set<JoinableChannel>>();
   // dungeon instances
   instances: InstanceSlot[] = [];
   // the World Market: one shared listing book, per-seller collections keyed by
@@ -548,6 +555,7 @@ export class Sim {
     this.dropEntity(pid);
     this.players.delete(pid);
     this.chatTokens.delete(pid);
+    this.channelSubs.delete(pid);
     if (this.primaryId === pid) this.primaryId = this.players.size > 0 ? [...this.players.keys()][0] : -1;
   }
 
@@ -3596,13 +3604,40 @@ export class Sim {
       return { channel: 'general', message: clean };
     }
 
+    // "/join <channel>" / "/leave <channel>" — opt-in global channels
+    const jm = /^\/(join|leave)\b\s*(\S*)\s*$/i.exec(raw);
+    if (jm) {
+      this.handleChannelMembership(r.meta, jm[1].toLowerCase() as 'join' | 'leave', jm[2].toLowerCase());
+      return null;
+    }
+
+    // "/world message" / "/lfg message" — talk in an opt-in channel; only
+    // players who have /join-ed it hear the message (the sender included)
+    const cm = /^\/(world|lfg)\s+([\s\S]+)$/i.exec(raw);
+    if (cm) {
+      const channel = cm[1].toLowerCase() as JoinableChannel;
+      const clean = cm[2].trim();
+      if (!clean) return null;
+      const mine = this.channelSubs.get(r.meta.entityId);
+      if (!mine || !mine.has(channel)) {
+        this.error(r.meta.entityId, `You are not in the ${channel} channel. Type /join ${channel} first.`);
+        return null;
+      }
+      for (const [subPid, set] of this.channelSubs) {
+        if (set.has(channel) && this.players.has(subPid)) {
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: clean, channel, pid: subPid });
+        }
+      }
+      return { channel, message: clean };
+    }
+
     // bare text and "/s" are local say; "/y" carries further — both are
     // delivered per-player by range and carry the speaker for chat bubbles
     let channel: 'say' | 'yell' = 'say';
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /join /world /lfg.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -4849,6 +4884,42 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // A positive, personal chat-log notice (e.g. confirming a /join). Unlike
+  // error(), this lands in the chat log rather than flashing the error toast.
+  private notice(pid: number, text: string, color = '#ffd100'): void {
+    this.emit({ type: 'log', text, color, pid });
+  }
+
+  // Handles /join and /leave for the opt-in global channels.
+  private handleChannelMembership(meta: PlayerMeta, action: 'join' | 'leave', arg: string): void {
+    const pid = meta.entityId;
+    if (!arg) {
+      this.error(pid, `Usage: /${action} <channel>. Channels: ${JOINABLE_CHANNELS.join(', ')}.`);
+      return;
+    }
+    if (arg === 'general') {
+      this.error(pid, 'The General channel is always on — just use /g.');
+      return;
+    }
+    if (!JOINABLE_CHANNELS.includes(arg as JoinableChannel)) {
+      this.error(pid, `There is no channel named '${arg}'. Channels: ${JOINABLE_CHANNELS.join(', ')}.`);
+      return;
+    }
+    const channel = arg as JoinableChannel;
+    let set = this.channelSubs.get(pid);
+    if (action === 'join') {
+      if (!set) { set = new Set(); this.channelSubs.set(pid, set); }
+      if (set.has(channel)) { this.error(pid, `You are already in the ${channel} channel.`); return; }
+      set.add(channel);
+      this.notice(pid, `Joined the ${channel} channel. Type /${channel} <message> to talk.`);
+    } else {
+      if (!set || !set.has(channel)) { this.error(pid, `You are not in the ${channel} channel.`); return; }
+      set.delete(channel);
+      if (set.size === 0) this.channelSubs.delete(pid);
+      this.notice(pid, `Left the ${channel} channel.`);
+    }
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3549,6 +3549,30 @@ export class Sim {
       return null;
     }
 
+    // "/inspect name" — self-only readout of another online player's level,
+    // class, and health. The first cross-player readout; mirrors WoW's Inspect.
+    const im = /^\/(?:inspect|ins|examine)(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (im) {
+      const targetName = (im[1] ?? '').trim();
+      if (!targetName) { this.error(r.meta.entityId, 'Inspect whom? Usage: /inspect <name>.'); return null; }
+      // resolve by name with the same exact-then-unambiguous-CI rule as /w
+      let target: PlayerMeta | null = null;
+      const ciMatches: PlayerMeta[] = [];
+      const wanted = targetName.toLowerCase();
+      for (const meta of this.players.values()) {
+        if (meta.name === targetName) { target = meta; break; }
+        if (meta.name.toLowerCase() === wanted) ciMatches.push(meta);
+      }
+      if (!target) {
+        if (ciMatches.length === 1) target = ciMatches[0];
+        else if (ciMatches.length > 1) { this.error(r.meta.entityId, `Several players match '${targetName}'. Use exact capitalization.`); return null; }
+      }
+      const te = target ? this.entities.get(target.entityId) : null;
+      if (!target || !te) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
+      this.error(r.meta.entityId, this.inspectReadout(target, te));
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -4849,6 +4873,15 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // One-line readout for /inspect: another player's level, class, and health.
+  private inspectReadout(target: PlayerMeta, e: Entity): string {
+    const cls = CLASSES[target.cls]?.name ?? target.cls;
+    const hp = e.hp <= 0
+      ? 'dead'
+      : `${Math.round(Math.max(0, Math.min(1, e.hp / e.maxHp)) * 100)}%`;
+    return `${target.name}: Level ${e.level} ${cls} — HP ${hp}.`;
   }
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -199,6 +199,16 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // Transient presence status. Set by /afk and /dnd, cleared when the player
+  // chats again. Session-only — never persisted, so it resets on login.
+  away: AwayStatus | null;
+}
+
+// Away-from-keyboard / do-not-disturb presence. `afk` still delivers whispers
+// (the sender just gets a heads-up); `dnd` withholds them.
+export interface AwayStatus {
+  mode: 'afk' | 'dnd';
+  message: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +478,7 @@ export class Sim {
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
+      away: null,
     };
     this.players.set(player.id, meta);
     if (this.primaryId === -1) this.primaryId = player.id;
@@ -3491,6 +3502,30 @@ export class Sim {
       return null;
     }
 
+    // "/afk [message]" / "/dnd [message]" — set a presence status. Repeating
+    // the same command with no message toggles it off. While away, anyone who
+    // whispers you gets an auto-reply; /dnd also withholds the whisper itself.
+    const awaym = /^\/(afk|dnd)(?:\s+([\s\S]+))?$/i.exec(raw);
+    if (awaym) {
+      const mode = awaym[1].toLowerCase() as AwayStatus['mode'];
+      const custom = awaym[2]?.trim();
+      if (r.meta.away?.mode === mode && !custom) {
+        r.meta.away = null;
+        this.emit({ type: 'log', text: mode === 'afk' ? 'You are no longer Away From Keyboard.' : 'You have left Do Not Disturb mode.', color: '#ffd100', pid: r.meta.entityId });
+      } else {
+        const message = custom || (mode === 'afk' ? 'Away From Keyboard' : 'Do Not Disturb');
+        r.meta.away = { mode, message };
+        this.emit({ type: 'log', text: mode === 'afk' ? `You are now Away From Keyboard: ${message}` : `You are now in Do Not Disturb mode: ${message}`, color: '#ffd100', pid: r.meta.entityId });
+      }
+      return null;
+    }
+
+    // Any other chat means you're back — clear a lingering away status.
+    if (r.meta.away) {
+      r.meta.away = null;
+      this.emit({ type: 'log', text: 'You are no longer marked as away.', color: '#ffd100', pid: r.meta.entityId });
+    }
+
     if (/^\/who(?:\s|$)/i.test(raw)) {
       this.error(r.meta.entityId, 'The /who roster is available in online play.');
       return null;
@@ -3518,6 +3553,16 @@ export class Sim {
       }
       if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
+      if (target.away) {
+        const label = target.away.mode === 'afk' ? 'Away From Keyboard' : 'Do Not Disturb';
+        this.emit({ type: 'log', text: `${target.name} is ${label}: ${target.away.message}`, color: '#ffd100', pid: r.meta.entityId });
+        if (target.away.mode === 'dnd') {
+          // Withhold the whisper, but still echo the sender's own line so they
+          // see what they tried to send.
+          this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
+          return { channel: 'whisper', message: msg };
+        }
+      }
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
       return { channel: 'whisper', message: msg };
@@ -3549,7 +3594,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g /afk /dnd.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3496,6 +3496,14 @@ export class Sim {
       return null;
     }
 
+    // "/help" (or "/?" / "/commands") lists the available chat commands as a
+    // system notice to the asker only. Like /who, it produces no chat message,
+    // so it works identically offline and online without server wiring.
+    if (/^\/(?:help|commands|\?)(?:\s|$)/i.test(raw)) {
+      for (const line of this.helpLines()) this.error(r.meta.entityId, line);
+      return null;
+    }
+
     // "/w name message" — private whisper to an online player
     const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
@@ -3549,7 +3557,7 @@ export class Sim {
     let clean = raw;
     if (/^\/y(ell)?\s/i.test(raw)) { channel = 'yell'; clean = raw.replace(/^\/y(ell)?\s+/i, '').trim(); }
     else if (/^\/s(ay)?\s/i.test(raw)) { clean = raw.replace(/^\/s(ay)?\s+/i, '').trim(); }
-    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Try /s /y /w /p /g.`); return null; }
+    else if (raw.startsWith('/')) { this.error(r.meta.entityId, `Unknown command: ${raw.split(' ')[0]}. Type /help for a list.`); return null; }
     if (!clean) return null;
     const range = channel === 'yell' ? YELL_RANGE : SAY_RANGE;
     for (const meta of this.players.values()) {
@@ -4796,6 +4804,16 @@ export class Sim {
 
   private error(pid: number, text: string): void {
     this.emit({ type: 'error', text, pid });
+  }
+
+  // Lines shown by the "/help" command, one system notice per entry. Keep this
+  // in sync with the commands handled in chat() above.
+  private helpLines(): string[] {
+    return [
+      'Chat channels: /s say, /y yell, /g general, /p party.',
+      'Whisper a player with /w <name> <message>.',
+      '/who lists who is online (online play only).',
+    ];
   }
 }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -520,7 +520,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'roll'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   // a guild invitation from an online guild officer/leader; resolved by name
   // server-side so it carries no pid

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -521,7 +521,7 @@ export type SimEvent = { pid?: number } & (
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is
   // a world-wide broadcast
-  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer'; entityId?: number; to?: string }
+  | { type: 'chat'; fromPid: number; from: string; text: string; channel?: 'say' | 'yell' | 'whisper' | 'general' | 'party' | 'guild' | 'officer' | 'world' | 'lfg'; entityId?: number; to?: string }
   | { type: 'partyInvite'; fromPid: number; fromName: string }
   // a guild invitation from an online guild officer/leader; resolved by name
   // server-side so it carries no pid

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1318,6 +1318,7 @@ export class Hud {
             case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
             case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
+            case 'roll': this.chatLogFrom(ev.from, ev.text, '#ffd100', '', ' rolls '); break;
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
           if ((ev.channel === 'say' || ev.channel === 'yell') && ev.entityId !== undefined) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -179,6 +179,7 @@ export class Hud {
     this.showBanner(startZone.name);
     this.log(`Welcome to ${startZone.name}!`, '#ffd100');
     this.logZoneWelcome(startZone);
+    this.log('Tip: type /join world or /join lfg to chat with players across the realm.', '#7fd4ff');
   }
 
   private bindLogTabs(): void {
@@ -1316,6 +1317,8 @@ export class Hud {
               else { this.chatLogFrom(ev.from, ev.text, '#ff80ff', '', ' whispers: '); audio.whisper(); }
               break;
             case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
+            case 'world': this.chatLogFrom(ev.from, ev.text, '#ff9d5c', '[World] ', ': '); break;
+            case 'lfg': this.chatLogFrom(ev.from, ev.text, '#5cd6a0', '[LFG] ', ': '); break;
             case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
             case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -139,6 +139,42 @@ describe('chat channels', () => {
     }));
   });
 
+  it('/help lists the chat commands as system notices without sending chat', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/help', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    const help = events.filter((e) => e.type === 'error' && e.pid === a) as Extract<SimEvent, { type: 'error' }>[];
+    expect(help.length).toBeGreaterThan(0);
+    const text = help.map((e) => e.text).join('\n');
+    expect(text).toContain('/w <name> <message>');
+    expect(text).toContain('/who');
+  });
+
+  it('/? and /commands are aliases for /help', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    for (const cmd of ['/?', '/commands']) {
+      sim.chat(cmd, a);
+      const events = sim.tick();
+      expect(chatEvents(events)).toHaveLength(0);
+      expect(events.some((e) => e.type === 'error' && e.pid === a)).toBe(true);
+    }
+  });
+
+  it('an unknown slash command points the player at /help', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/bogus stuff', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && e.pid === a && e.text.includes('/help'))).toBe(true);
+  });
+
   it('exact-case whisper wins over a case-variant squatter', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -80,6 +80,71 @@ describe('chat channels', () => {
     expect(msgs.some((m) => m.pid === c)).toBe(false);
   });
 
+  it('/r replies to the last player who whispered you', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    teleport(sim, b, 0, -900); // reply ignores distance, like whisper
+    sim.tick();
+
+    sim.chat('/w bet psst, secret', a);
+    sim.tick();
+    // Bet replies without naming Aleph
+    sim.chat('/r got it', b);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs).toHaveLength(2);
+    const toTarget = msgs.find((m) => m.pid === a)!;
+    expect(toTarget.channel).toBe('whisper');
+    expect(toTarget.from).toBe('Bet');
+    expect(toTarget.text).toBe('got it');
+    const echo = msgs.find((m) => m.pid === b)!;
+    expect(echo.to).toBe('Aleph');
+  });
+
+  it('/r with no prior whisper errors instead of saying it out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/r hello?', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
+
+  it('/r reply target follows the most recent incoming whisper', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const c = sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/w aleph first', b); // Bet -> Aleph
+    sim.tick();
+    sim.chat('/w aleph second', c); // Gimel -> Aleph (now the reply target)
+    sim.tick();
+    sim.chat('/r back to you', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.channel === 'whisper' && m.to === undefined)!;
+    expect(toTarget.pid).toBe(c);
+  });
+
+  it('sending a whisper does not change your own /r target', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.addPlayer('rogue', 'Gimel');
+    sim.tick();
+
+    sim.chat('/w aleph incoming', b); // Bet whispers Aleph -> Aleph's reply target is Bet
+    sim.tick();
+    sim.chat('/w gimel outgoing', a); // Aleph whispers Gimel; reply target stays Bet
+    sim.tick();
+    sim.chat('/r still bet', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.channel === 'whisper' && m.to === undefined)!;
+    expect(toTarget.pid).toBe(b);
+  });
+
   it('whisper to an unknown player errors instead of leaking text', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -205,6 +205,86 @@ describe('chat channels', () => {
     expect(pids).toContain(b);
     expect(pids).not.toContain(outsider);
   });
+
+  it('/roll broadcasts a deterministic result in the default 1-100 range to nearby players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const near = sim.addPlayer('mage', 'Bet');
+    const far = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, near, 10, -40); // within SAY_RANGE
+    teleport(sim, far, 80, -40);  // beyond SAY_RANGE
+    sim.tick();
+
+    sim.chat('/roll', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.length).toBeGreaterThan(0);
+    expect(msgs.every((m) => m.channel === 'roll' && m.from === 'Aleph')).toBe(true);
+    // text is "<result> (1-100)" with the result inside the range
+    const m = /^(\d+) \(1-100\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    const result = Number(m[1]);
+    expect(result).toBeGreaterThanOrEqual(1);
+    expect(result).toBeLessThanOrEqual(100);
+    const pids = msgs.map((x) => x.pid);
+    expect(pids).toContain(a);    // roller sees their own roll
+    expect(pids).toContain(near);
+    expect(pids).not.toContain(far);
+  });
+
+  it('/roll N rolls within 1-N and /roll M-N within the given bounds', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+
+    sim.chat('/roll 6', a);
+    let msgs = chatEvents(sim.tick());
+    let m = /^(\d+) \(1-6\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(1);
+    expect(Number(m[1])).toBeLessThanOrEqual(6);
+
+    sim.chat('/roll 50-60', a);
+    msgs = chatEvents(sim.tick());
+    m = /^(\d+) \(50-60\)$/.exec(msgs[0].text)!;
+    expect(m).not.toBeNull();
+    expect(Number(m[1])).toBeGreaterThanOrEqual(50);
+    expect(Number(m[1])).toBeLessThanOrEqual(60);
+  });
+
+  it('/roll prefers the party channel when the roller is grouped', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 0, -900);   // out of say range but in the party
+    teleport(sim, outsider, 2, -40);
+    sim.tick();
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    sim.tick();
+
+    sim.chat('/roll', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((x) => x.channel === 'roll')).toBe(true);
+    const pids = msgs.map((x) => x.pid);
+    expect(pids).toContain(a);
+    expect(pids).toContain(b);            // distant party member still sees it
+    expect(pids).not.toContain(outsider); // a nearby non-member does not
+  });
+
+  it('rejects a malformed roll range instead of saying it out loud', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+    sim.chat('/roll 60-50', a); // min greater than max
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+  });
 });
 
 describe('trade completion event', () => {

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -184,6 +184,112 @@ describe('chat channels', () => {
     expect(delivered).toBeLessThan(20);
   });
 
+  it('a joined player hears /world only from other joined players', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const outsider = sim.addPlayer('rogue', 'Gimel');
+    // distance must not matter for a global channel
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 0, -900);
+    teleport(sim, outsider, 2, -40);
+    sim.tick();
+    sim.chat('/join world', a);
+    sim.chat('/join world', b);
+    sim.tick();
+
+    sim.chat('/world anyone for the crypt?', a);
+    const msgs = chatEvents(sim.tick());
+    expect(msgs.every((m) => m.channel === 'world' && m.text === 'anyone for the crypt?')).toBe(true);
+    const pids = msgs.map((m) => m.pid).sort();
+    expect(pids).toContain(a);          // sender hears their own message
+    expect(pids).toContain(b);          // joined, ignores distance
+    expect(pids).not.toContain(outsider); // never joined → never hears it
+  });
+
+  it('talking in a channel you have not joined errors instead of broadcasting', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/world hello?', a);
+    const events = sim.tick();
+    expect(chatEvents(events)).toHaveLength(0);
+    expect(events.some((e) => e.type === 'error' && /not in the world channel/i.test(e.text))).toBe(true);
+  });
+
+  it('/leave stops further delivery on that channel', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.chat('/join world', a);
+    sim.chat('/join world', b);
+    sim.tick();
+    sim.chat('/leave world', b);
+    sim.tick();
+
+    sim.chat('/world still around?', a);
+    const pids = chatEvents(sim.tick()).map((m) => m.pid);
+    expect(pids).toContain(a);
+    expect(pids).not.toContain(b); // left the channel
+  });
+
+  it('world and lfg are independent channels', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.chat('/join world', a);
+    sim.chat('/join lfg', a);
+    sim.chat('/join lfg', b); // b is only in lfg, not world
+    sim.tick();
+
+    sim.chat('/world world only', a);
+    const worldPids = chatEvents(sim.tick()).map((m) => m.pid);
+    expect(worldPids).toContain(a);
+    expect(worldPids).not.toContain(b);
+
+    sim.chat('/lfg lfg only', a);
+    const lfgMsgs = chatEvents(sim.tick());
+    expect(lfgMsgs.every((m) => m.channel === 'lfg')).toBe(true);
+    const lfgPids = lfgMsgs.map((m) => m.pid);
+    expect(lfgPids).toContain(a);
+    expect(lfgPids).toContain(b);
+  });
+
+  it('/join confirms with a chat-log notice', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/join world', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'log' && e.pid === a && /joined the world channel/i.test(e.text))).toBe(true);
+  });
+
+  it('/join rejects unknown channels and the always-on general channel', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    sim.chat('/join nonsense', a);
+    sim.chat('/join general', a);
+    const events = sim.tick();
+    expect(events.some((e) => e.type === 'error' && /no channel named/i.test(e.text))).toBe(true);
+    expect(events.some((e) => e.type === 'error' && /general channel is always on/i.test(e.text))).toBe(true);
+    expect(chatEvents(events)).toHaveLength(0); // nothing said out loud
+  });
+
+  it('a player who leaves the game is dropped from channel rosters', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.chat('/join world', a);
+    sim.chat('/join world', b);
+    sim.tick();
+    sim.removePlayer(b);
+
+    sim.chat('/world anyone left?', a);
+    const pids = chatEvents(sim.tick()).map((m) => m.pid);
+    expect(pids).toEqual([a]); // only the remaining subscriber
+  });
+
   it('party channel still works and stays private to the party', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -279,3 +279,69 @@ describe('snapshot interpolation continuity', () => {
     expect(e.prevPos.x).toBeLessThan(e.pos.x);
   });
 });
+
+function logEvents(events: SimEvent[]): Extract<SimEvent, { type: 'log' }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: 'log' }> => e.type === 'log');
+}
+
+describe('/afk and /dnd presence', () => {
+  it('/afk confirms to the setter and auto-replies to whisperers (still delivering)', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/afk grabbing lunch', a);
+    const confirm = logEvents(sim.tick());
+    expect(confirm.some((m) => m.pid === a && /Away From Keyboard: grabbing lunch/.test(m.text))).toBe(true);
+
+    sim.chat('/w Aleph you around?', b);
+    const out = sim.tick();
+    // Bet gets an auto-reply line about Aleph being away...
+    expect(logEvents(out).some((m) => m.pid === b && /Aleph is Away From Keyboard: grabbing lunch/.test(m.text))).toBe(true);
+    // ...and the whisper is still delivered to Aleph (afk does not withhold)
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === a && m.text === 'you around?')).toBe(true);
+  });
+
+  it('/dnd withholds the whisper but still echoes the sender and notifies them', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/dnd raiding', a);
+    sim.tick();
+
+    sim.chat('/w Aleph ping', b);
+    const out = sim.tick();
+    expect(logEvents(out).some((m) => m.pid === b && /Aleph is Do Not Disturb: raiding/.test(m.text))).toBe(true);
+    // the recipient copy (no `to`) must not reach Aleph
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === a)).toBe(false);
+    // but the sender still sees their own outgoing line (carries `to`)
+    expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === b && m.to === 'Aleph')).toBe(true);
+  });
+
+  it('repeating the bare command toggles the status off', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/afk', a);
+    sim.tick();
+    sim.chat('/afk', a);
+    const out = logEvents(sim.tick());
+    expect(out.some((m) => m.pid === a && /no longer Away From Keyboard/.test(m.text))).toBe(true);
+  });
+
+  it('sending any other chat clears an away status', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.chat('/afk', a);
+    sim.tick();
+    sim.chat('back now', a);
+    const out = logEvents(sim.tick());
+    expect(out.some((m) => m.pid === a && /no longer marked as away/.test(m.text))).toBe(true);
+  });
+});

--- a/tests/inspect_command.test.ts
+++ b/tests/inspect_command.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+// /inspect replies via the self-only `error` event addressed to the inspector.
+function inspectReply(sim: Sim, pid: number, text: string): string | undefined {
+  sim.chat(text, pid);
+  const errs = sim.events.filter(
+    (e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error' && (e as { pid: number }).pid === pid,
+  );
+  return errs.length ? errs[errs.length - 1].text : undefined;
+}
+
+describe('/inspect command', () => {
+  it('reports another player\'s level, class, and health', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    const e = sim.entities.get(b)!;
+    e.level = 8;
+
+    expect(inspectReply(sim, a, '/inspect Bet')).toBe('Bet: Level 8 Mage — HP 100%.');
+  });
+
+  it('shows a partial-health percentage and "dead" for a corpse', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('rogue', 'Gimel');
+    const e = sim.entities.get(b)!;
+    e.hp = Math.round(e.maxHp * 0.4);
+    expect(inspectReply(sim, a, '/inspect Gimel')).toBe(`Gimel: Level ${e.level} Rogue — HP 40%.`);
+
+    e.hp = 0;
+    expect(inspectReply(sim, a, '/inspect Gimel')).toBe(`Gimel: Level ${e.level} Rogue — HP dead.`);
+  });
+
+  it('matches names case-insensitively when unambiguous', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    expect(inspectReply(sim, a, '/inspect bet')).toMatch(/^Bet: Level \d+ Mage/);
+  });
+
+  it('rejects an ambiguous case-insensitive match', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    sim.addPlayer('rogue', 'bet');
+    expect(inspectReply(sim, a, '/inspect BET')).toBe("Several players match 'BET'. Use exact capitalization.");
+  });
+
+  it('errors when the named player is not online', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    expect(inspectReply(sim, a, '/inspect Nobody')).toBe("There is no player named 'Nobody' online.");
+  });
+
+  it('asks whom to inspect when no name is given', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    expect(inspectReply(sim, a, '/inspect')).toBe('Inspect whom? Usage: /inspect <name>.');
+  });
+
+  it('supports the /ins and /examine aliases', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    sim.addPlayer('mage', 'Bet');
+    expect(inspectReply(sim, a, '/ins Bet')).toMatch(/^Bet: Level \d+ Mage/);
+    expect(inspectReply(sim, a, '/examine Bet')).toMatch(/^Bet: Level \d+ Mage/);
+  });
+});


### PR DESCRIPTION
## Summary

Bundles the approved open slash-command PRs into one integration branch for v0.7. This branch was built with merge commits from each source PR head, so the original commits/authors remain in history.

## Included PRs / Attribution

- Includes #228 by @jgyy — `/help`, `/?`, `/commands`
- Includes #225 by @jgyy — `/roll`, `/roll N`, `/roll M-N`
- Includes #226 by @jgyy — `/afk [message]`, `/dnd [message]`
- Includes #230 by @jgyy — `/r`, `/reply` in the sim core
- Includes #265 by @jgyy — `/inspect`, `/ins`, `/examine`
- Includes #267 by @aqn96 — `/join`, `/leave`, `/world`, `/lfg`

Excluded by request:

- #74 persisted whispers
- issue-only chat requests

## Integration notes

Conflict resolutions kept current v0.7 behavior and combined the command surfaces:

- `/help` remains the canonical unknown-command hint.
- `/roll`, `/inspect`, `/r`, `/afk`, `/dnd`, emotes, and `/join world|lfg` all coexist in `Sim.chat()`.
- `/world` and `/lfg` are parsed before generic emotes so they cannot be swallowed as unknown emote commands.
- `world`/`lfg` chat rendering was added while preserving existing guild/officer/emote/roll rendering.
- Player channel subscriptions are cleaned up on `removePlayer`.

## Verification

- `npx tsc --noEmit`
- `npx vitest run tests/chat.test.ts tests/inspect_command.test.ts` — 2 files / 49 tests passed
- `npx vitest run tests/sim.test.ts` — 62 tests passed
- `npm test -- --testTimeout=15000` — 50 files / 677 tests passed
- `npm run build:env`
- `npm run build:server`
- `npm run build`

Note: local `npm test` with the default 5s per-test timeout repeatedly timed out in the existing RL stress test. The same test passes alone, and the full suite passes with a 15s timeout.
