### PR TITLE
feat: corrosive mobs shred armor on hit (Acid Spit)

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -72,6 +72,8 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'mudfin_scale', chance: 0.4 },
     ],
     scale: 0.85, color: 0x45b39d,
+    // Acid Spit: a snapper's bite corrodes armor, stacking so a swarm shreds you fast.
+    corrode: { chance: 0.35, armor: 20, maxStacks: 5, duration: 15, name: 'Acid Spit', school: 'nature' },
   },
   mirejaw_the_ravenous: {
     id: 'mirejaw_the_ravenous', name: 'Mirejaw the Ravenous', minLevel: 10, maxLevel: 10, family: 'murloc', rare: true,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -24,7 +24,7 @@ import type { LeaderboardEntry } from '../world_api';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
   CONSUME_TICKS, CrowdControlDrCategory, DT, Entity, EquipSlot, FISHING_CAST_ID, FISHING_CAST_TIME, GCD,
-  INTERACT_RANGE, InvSlot, LootEntry, LootSlot, MELEE_RANGE, MAX_LEVEL, MobFamily,
+  INTERACT_RANGE, InvSlot, LootEntry, LootSlot, MELEE_RANGE, MAX_LEVEL, MobFamily, MobTemplate,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
   rageFromDealing, rageFromTaking, spellHitChance, xpForLevel,
@@ -3137,6 +3137,12 @@ export class Sim {
     if (mob.enraged && enrage) dmg *= enrage.dmgMult;
     dmg *= 1 - armorReduction(this.effectiveArmor(target), mob.level);
     this.dealDamage(mob, target, Math.max(1, Math.round(dmg)), crit, 'physical', null, 'hit');
+    // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
+    // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
+    const corrode = MOBS[mob.templateId]?.corrode;
+    if (corrode && mob.hostile && !target.dead && this.rng.chance(corrode.chance)) {
+      this.applyCorrosion(mob, target, corrode);
+    }
     // thorns / lightning shield on the defender
     if (!mob.dead) {
       for (const a of target.auras) {
@@ -3144,6 +3150,28 @@ export class Sim {
           this.dealDamage(target, mob, a.value, false, a.school, a.name, 'hit', true);
         }
       }
+    }
+  }
+
+  // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.
+  // Mirrors the warrior Sunder Armor stacking: one shared `sunder` slot found by
+  // kind, bumped up to `maxStacks`, with its timer fully refreshed each application.
+  // effectiveArmor() already subtracts value*stacks, so the victim takes more
+  // physical damage from every attacker until it expires.
+  private applyCorrosion(mob: Entity, target: Entity, corrode: NonNullable<MobTemplate['corrode']>): void {
+    const existing = target.auras.find((a) => a.kind === 'sunder');
+    if (existing) {
+      existing.stacks = Math.min(corrode.maxStacks, (existing.stacks ?? 1) + 1);
+      existing.value = corrode.armor;
+      existing.remaining = existing.duration;
+      this.emit({ type: 'aura', targetId: target.id, name: corrode.name, gained: true });
+    } else {
+      this.applyAura(target, {
+        id: `corrode_${mob.templateId}`, name: corrode.name, kind: 'sunder',
+        remaining: corrode.duration, duration: corrode.duration,
+        value: corrode.armor, stacks: 1,
+        sourceId: mob.id, school: corrode.school ?? 'nature',
+      });
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -163,6 +163,11 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // Combat mechanic: a landed melee hit has `chance` to corrode the victim's
+  // armor — a stacking `sunder` debuff (up to `maxStacks`) so the victim takes
+  // more physical damage from everyone until it expires. Rides the existing
+  // sunder aura; no new aura kind.
+  corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
 }
 
 export type AbilityEffect =

--- a/tests/mob_corrode.test.ts
+++ b/tests/mob_corrode.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 42;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+
+// Spawn a Deepfen Snapper next to the player, force its Acid Spit to always land,
+// and swing until a hit connects (a swing can miss/dodge).
+const setup = () => {
+  const sim = makeSim();
+  const player = sim.player;
+  const mob = createMob(990500, MOBS.deepfen_murloc, 9, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return { sim, player, mob };
+};
+
+const swingUntilHit = (sim: Sim, mob: any, target: any, max = 200) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a bite never kills (death would clear auras)
+    const before = target.auras.length + (target.auras.find((a: any) => a.kind === 'sunder')?.stacks ?? 0);
+    (sim as any).mobSwing(mob, target);
+    const after = target.auras.length + (target.auras.find((a: any) => a.kind === 'sunder')?.stacks ?? 0);
+    if (after > before) return true;
+  }
+  return false;
+};
+
+describe('mob corrosive armor shred (Acid Spit)', () => {
+  it('Deepfen Snapper template carries the corrode mechanic', () => {
+    expect(MOBS.deepfen_murloc.corrode).toBeDefined();
+    expect(MOBS.deepfen_murloc.corrode!.name).toBe('Acid Spit');
+  });
+
+  it('a landed hit applies a sunder aura with the template values', () => {
+    const { sim, player, mob } = setup();
+    const corrode = MOBS.deepfen_murloc.corrode!;
+    const old = corrode.chance;
+    corrode.chance = 1;
+    try {
+      expect(swingUntilHit(sim, mob, player)).toBe(true);
+    } finally {
+      corrode.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'sunder');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Acid Spit');
+    expect(aura!.value).toBe(corrode.armor);
+    expect(aura!.stacks).toBe(1);
+    expect(aura!.sourceId).toBe(mob.id);
+  });
+
+  it('repeated hits stack the debuff up to maxStacks and no further', () => {
+    const { sim, player, mob } = setup();
+    const corrode = MOBS.deepfen_murloc.corrode!;
+    const old = corrode.chance;
+    corrode.chance = 1;
+    try {
+      for (let i = 0; i < corrode.maxStacks + 5; i++) swingUntilHit(sim, mob, player);
+    } finally {
+      corrode.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'sunder');
+    expect(aura!.stacks).toBe(corrode.maxStacks);
+  });
+
+  it('corrosion lowers the victim effective armor (so they take more damage)', () => {
+    const { sim, player, mob } = setup();
+    const corrode = MOBS.deepfen_murloc.corrode!;
+    const baseArmor = (sim as any).effectiveArmor(player);
+    const old = corrode.chance;
+    corrode.chance = 1;
+    try {
+      swingUntilHit(sim, mob, player);
+    } finally {
+      corrode.chance = old;
+    }
+    const shredded = (sim as any).effectiveArmor(player);
+    expect(shredded).toBe(Math.max(0, baseArmor - corrode.armor));
+  });
+
+  it('a friendly pet never corrodes its target (hostile guard)', () => {
+    const { sim, player, mob } = setup();
+    mob.hostile = false; // emulate a tamed pet swinging
+    const corrode = MOBS.deepfen_murloc.corrode!;
+    const old = corrode.chance;
+    corrode.chance = 1;
+    try {
+      for (let i = 0; i < 50; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      corrode.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'sunder')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new data-driven mob combat mechanic: an optional `MobTemplate.corrode` gives a mob's **landed** melee hit a chance to corrode the victim's armor — a stacking `sunder` debuff (up to `maxStacks`) whose timer fully refreshes on each application. The victim then takes more **physical damage from everyone** until it expires, so a swarm shreds you fast — the classic murloc *Acid Spit*.

Seeded on the **Deepfen Snapper** (`deepfen_murloc`, a Mirefen Marsh murloc that swarms from far out in packs) at `{ chance: 0.35, armor: 20, maxStacks: 5, duration: 15 }`.

## Why it's clean / purely additive

It rides systems that already exist, so there is no surface-area beyond the sim core:

- **Reuses the existing `sunder` aura kind.** `effectiveArmor()` already subtracts `value * stacks` for player targets, so there is **no new aura kind** and **no damage-path change**.
- **No new `Entity` field**, so **no `net/online.ts` client-stub change**, and no RL/obs or server change. Works online for free.
- **Stacking mirrors the warrior Sunder Armor exactly** — one shared `sunder` slot found by kind, bumped to the cap, timer refreshed.
- **Guarded on `mob.hostile`** so a friendly hunter pet (the other `mobSwing` caller) never debuffs an ally — same rationale as other on-hit mob mechanics.

## Changes
- `src/sim/types.ts` — optional `corrode` field on `MobTemplate`.
- `src/sim/sim.ts` — roll + `applyCorrosion()` helper in `mobSwing` on a landed hit.
- `src/sim/content/zone2.ts` — seed the Deepfen Snapper.
- `tests/mob_corrode.test.ts` — 5 cases (template carries it, single-hit application, stack-to-cap, effective-armor drop, pet hostile-guard).

## Verification
- `tests/mob_corrode.test.ts`: 5 pass.
- Full suite: **653 pass**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshot

A swarm of Deepfen Snappers stacks the *Acid Spit* armor-shred debuff on the player (visible on the player frame).

![A swarm of Deepfen Snappers stacks the *Acid Spit* armor-shred debuff on the player (visible on the player frame).](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-acid-spit/acid_spit.png)

<sub>Captured in the offline client on this branch via a Puppeteer harness (god-moded player, real combat).</sub>