### PR TITLE
feat(mobile): floating move joystick that springs to the thumb

### DIFF
--- a/index.html
+++ b/index.html
@@ -2792,6 +2792,22 @@
   body.mobile-touch .mobile-joystick::before {
     content: ''; position: absolute; inset: 28px; border-radius: 50%; border: 1px solid #ffffff18;
   }
+  /* Floating move joystick: a lower-left capture zone lets the thumb land
+     anywhere; the joystick rests dimmed at home until touched, then springs to
+     the touch point with a gold "engaged" glow. */
+  body.mobile-touch #mobile-move-zone {
+    position: absolute; left: 0; bottom: 0; width: 44%; height: 58%;
+    pointer-events: auto; touch-action: none; z-index: 1;
+  }
+  body.mobile-touch.mobile-chat-open #mobile-move-zone { pointer-events: none; }
+  body.mobile-touch #mobile-move-joystick { opacity: .5; transition: opacity .12s linear; }
+  body.mobile-touch #mobile-move-joystick.floating {
+    opacity: 1; bottom: auto; left: 0; transition: none;
+  }
+  body.mobile-touch #mobile-move-joystick.active {
+    border-color: var(--gold);
+    box-shadow: 0 3px 18px #0008, inset 0 1px 0 #ffffff12, inset 0 0 26px #0008, 0 0 16px 3px #e3c66a55;
+  }
   body.mobile-touch #mobile-camera-joystick {
     left: auto; right: max(18px, env(safe-area-inset-right));
   }
@@ -4075,6 +4091,7 @@
   </main>
 
   <div id="mobile-controls" aria-label="Mobile controls">
+    <div id="mobile-move-zone" aria-hidden="true"></div>
     <div id="mobile-move-joystick" class="mobile-joystick" aria-label="Move">
       <div id="mobile-move-stick" class="mobile-stick"></div>
       <div class="mobile-joy-label">Move</div>

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -23,6 +23,21 @@ export function isPhoneTouchDevice(win: Pick<Window, 'matchMedia'> = window): bo
   return win.matchMedia(PHONE_TOUCH_QUERY).matches;
 }
 
+export interface OriginBounds { left: number; top: number; right: number; bottom: number; }
+
+/**
+ * Clamp a floating joystick's spawn centre so the whole circle (given `radius`)
+ * stays inside `bounds`. If the zone is narrower/shorter than the joystick on an
+ * axis, the centre falls back to the midpoint of that axis.
+ */
+export function clampJoystickOrigin(px: number, py: number, radius: number, bounds: OriginBounds): { x: number; y: number } {
+  const clamp = (v: number, lo: number, hi: number) => (hi < lo ? (lo + hi) / 2 : Math.min(hi, Math.max(lo, v)));
+  return {
+    x: clamp(px, bounds.left + radius, bounds.right - radius),
+    y: clamp(py, bounds.top + radius, bounds.bottom - radius),
+  };
+}
+
 export function mapJoystickVector(x: number, y: number, deadzone = DEADZONE): TouchMoveInput {
   const mag = Math.hypot(x, y);
   if (mag < deadzone) return { forward: false, back: false, strafeLeft: false, strafeRight: false };
@@ -41,7 +56,12 @@ export class MobileControls {
   private lookPointer: number | null = null;
   private mq: MediaQueryList | null = null;
 
+  private moveOriginX = 0;
+  private moveOriginY = 0;
+  private moveRadius = 1;
+
   private root = document.getElementById('mobile-controls') as HTMLElement | null;
+  private moveZone = document.getElementById('mobile-move-zone') as HTMLElement | null;
   private moveJoystick = document.getElementById('mobile-move-joystick') as HTMLElement | null;
   private moveStick = document.getElementById('mobile-move-stick') as HTMLElement | null;
   private cameraJoystick = document.getElementById('mobile-camera-joystick') as HTMLElement | null;
@@ -55,10 +75,15 @@ export class MobileControls {
     this.setActive(this.mq.matches);
     this.mq.addEventListener?.('change', (e) => this.setActive(e.matches));
 
-    this.moveJoystick.addEventListener('pointerdown', (e) => this.onMoveDown(e));
-    this.moveJoystick.addEventListener('pointermove', (e) => this.onMoveMove(e));
-    this.moveJoystick.addEventListener('pointerup', (e) => this.onMoveEnd(e));
-    this.moveJoystick.addEventListener('pointercancel', (e) => this.onMoveEnd(e));
+    // The move joystick floats: the pointer lifecycle lives on the lower-left
+    // capture zone (so a thumb can land anywhere), while the joystick element is
+    // just the visual that JS repositions under the touch. Fall back to the
+    // joystick element itself if the zone is absent (e.g. an older shell).
+    const moveSurface = this.moveZone ?? this.moveJoystick;
+    moveSurface.addEventListener('pointerdown', (e) => this.onMoveDown(e));
+    moveSurface.addEventListener('pointermove', (e) => this.onMoveMove(e));
+    moveSurface.addEventListener('pointerup', (e) => this.onMoveEnd(e));
+    moveSurface.addEventListener('pointercancel', (e) => this.onMoveEnd(e));
 
     this.cameraJoystick.addEventListener('pointerdown', (e) => this.onCameraDown(e));
     this.cameraJoystick.addEventListener('pointermove', (e) => this.onCameraMove(e));
@@ -124,20 +149,30 @@ export class MobileControls {
   }
 
   private onMoveDown(e: PointerEvent): void {
-    if (!this.active || this.joyPointer !== null) return;
+    if (!this.active || this.joyPointer !== null || !this.moveJoystick) return;
     e.preventDefault();
     this.joyPointer = e.pointerId;
-    try { this.moveJoystick?.setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
+    // Spawn the joystick base under the thumb, clamped so the circle stays
+    // on-screen, then pin the stick offset to that floating centre.
+    const radius = Math.max(1, this.moveJoystick.offsetWidth / 2 || 61);
+    const zone = (this.moveZone ?? this.moveJoystick).getBoundingClientRect();
+    const origin = clampJoystickOrigin(e.clientX, e.clientY, radius, zone);
+    this.moveOriginX = origin.x;
+    this.moveOriginY = origin.y;
+    this.moveRadius = radius;
+    this.moveJoystick.style.left = `${(origin.x - radius).toFixed(1)}px`;
+    this.moveJoystick.style.top = `${(origin.y - radius).toFixed(1)}px`;
+    this.moveJoystick.classList.add('floating', 'active');
+    try { (this.moveZone ?? this.moveJoystick).setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
     this.onMoveMove(e);
   }
 
   private onMoveMove(e: PointerEvent): void {
-    if (!this.active || e.pointerId !== this.joyPointer || !this.moveJoystick || !this.moveStick) return;
+    if (!this.active || e.pointerId !== this.joyPointer || !this.moveStick) return;
     e.preventDefault();
-    const r = this.moveJoystick.getBoundingClientRect();
-    const radius = Math.max(1, r.width / 2);
-    const rawX = (e.clientX - (r.left + radius)) / radius;
-    const rawY = (e.clientY - (r.top + radius)) / radius;
+    const radius = this.moveRadius;
+    const rawX = (e.clientX - this.moveOriginX) / radius;
+    const rawY = (e.clientY - this.moveOriginY) / radius;
     const mag = Math.max(1, Math.hypot(rawX, rawY));
     const x = rawX / mag;
     const y = rawY / mag;
@@ -155,6 +190,11 @@ export class MobileControls {
     this.joyPointer = null;
     this.input.clearTouchMove();
     if (this.moveStick) this.moveStick.style.transform = '';
+    if (this.moveJoystick) {
+      this.moveJoystick.classList.remove('floating', 'active');
+      this.moveJoystick.style.left = '';
+      this.moveJoystick.style.top = '';
+    }
   }
 
   private onCameraDown(e: PointerEvent): void {

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isPhoneTouchDevice, mapJoystickVector, mapLookVector } from '../src/game/mobile_controls';
+import { clampJoystickOrigin, isPhoneTouchDevice, mapJoystickVector, mapLookVector } from '../src/game/mobile_controls';
 
 describe('mapJoystickVector', () => {
   it('returns neutral inside the deadzone', () => {
@@ -45,5 +45,27 @@ describe('mapLookVector', () => {
     const v = mapLookVector(0.45, -0.25);
     expect(v.x).toBeCloseTo(0.36);
     expect(v.y).toBeCloseTo(-0.2);
+  });
+});
+
+describe('clampJoystickOrigin', () => {
+  const bounds = { left: 0, top: 0, right: 400, bottom: 600 };
+  const radius = 61;
+
+  it('keeps an interior touch exactly where the thumb landed', () => {
+    expect(clampJoystickOrigin(200, 300, radius, bounds)).toEqual({ x: 200, y: 300 });
+  });
+
+  it('pushes a corner touch inward so the whole circle stays on-screen', () => {
+    expect(clampJoystickOrigin(5, 595, radius, bounds)).toEqual({ x: radius, y: bounds.bottom - radius });
+  });
+
+  it('clamps against the far edges too', () => {
+    expect(clampJoystickOrigin(900, -50, radius, bounds)).toEqual({ x: bounds.right - radius, y: radius });
+  });
+
+  it('falls back to the axis midpoint when the zone is smaller than the joystick', () => {
+    const tight = { left: 0, top: 0, right: 80, bottom: 600 };
+    expect(clampJoystickOrigin(10, 300, radius, tight)).toEqual({ x: 40, y: 300 });
   });
 });


### PR DESCRIPTION
## Summary
On touch devices the **move** joystick was a fixed circle pinned to the bottom-left corner, so players had to look down and reach for an exact spot to start running. This makes it **float**: a lower-left capture zone lets the thumb land *anywhere*, and the joystick base springs to wherever you touch (clamped so the circle always stays on-screen), glows gold while engaged, then fades back to its dimmed home position on release. This is the standard mobile-MMO/twin-stick control feel.

The **camera** joystick is intentionally left fixed on the right — only movement benefits from thumb-anywhere placement.

## Screenshots (landscape phone, 844×390)
| Resting — dimmed at home | Engaged — sprung to the thumb, gold glow, stick deflected |
|---|---|
| ![resting](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/floating-joystick-shots/mobile-joystick-resting.png) | ![engaged](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/floating-joystick-shots/mobile-joystick-engaged.png) |

## What changed
- **`index.html`** — added a transparent `#mobile-move-zone` over the lower-left, plus CSS for the dimmed resting state, the gold `.active` "engaged" glow, and the `.floating` repositioning. The zone yields pointer events while chat is open so it never blocks the chat panel.
- **`src/game/mobile_controls.ts`** — the move pointer lifecycle now lives on the capture zone (falling back to the joystick element on an older shell). On `pointerdown` the joystick base is positioned under the touch via the new pure `clampJoystickOrigin` helper, and the stick offset is computed against that floating origin instead of the element's static `getBoundingClientRect`. Floating/active classes and inline position are cleared on release/cancel.
- **`tests/mobile_controls.test.ts`** — unit tests for `clampJoystickOrigin` (interior touch unchanged, corner/edge clamping, and midpoint fallback when the zone is smaller than the joystick), alongside the existing `mapJoystickVector`/`mapLookVector` cases.

Movement semantics are unchanged: the joystick still feeds the same digital WASD `mapJoystickVector` intent into `input.setTouchMove`, so the sim and server authority paths are untouched. Desktop input is unaffected.

## Verification
- `npx vitest run tests/mobile_controls.test.ts` — 10 passed.
- `npm test` — 49 files, 652 tests passed.
- `npx tsc --noEmit` — clean.
- `npm run build` — succeeds.
- Manual: drove a landscape-phone-emulated Chromium into an offline session; confirmed the joystick spawns under the touch point with the gold glow and deflected stick, and that the floating/active classes + inline position reset on release (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)