### PR TITLE
feat(mobile): add on-screen Jump button to touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2805,7 +2805,7 @@
   }
   body.mobile-touch #mobile-combat-controls {
     position: absolute; left: 50%; bottom: calc(4px + env(safe-area-inset-bottom)); transform: translateX(-50%);
-    display: grid; grid-template-columns: 124px 58px 58px; gap: 8px; pointer-events: auto; align-items: end;
+    display: grid; grid-template-columns: 124px 58px 58px 58px; gap: 8px; pointer-events: auto; align-items: end;
   }
   body.mobile-touch .mobile-btn {
     width: 58px; height: 54px; border: 2px solid #4a3d1d; border-radius: 8px;
@@ -3105,7 +3105,7 @@
     }
     body.mobile-touch .mobile-joy-label { bottom: -15px; font-size: 8px; color: #d7c987aa; }
     body.mobile-touch #mobile-combat-controls {
-      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px 54px 54px; gap: 7px;
+      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px 54px 54px 54px; gap: 7px;
     }
     body.mobile-touch .mobile-btn { width: 54px; height: 48px; font-size: 20px; background: radial-gradient(circle at 35% 30%, #2d3048bf, #11121ec2 72%); }
     body.mobile-touch #mobile-attack-nearest { width: 115px; }
@@ -4085,6 +4085,7 @@
     </div>
     <div id="mobile-combat-controls">
       <button class="mobile-btn" id="mobile-attack-nearest" title="Attack nearest enemy" aria-label="Attack nearest enemy" data-icon="attack"><span class="mobile-label">Attack</span></button>
+      <button class="mobile-btn" id="mobile-jump" title="Jump" aria-label="Jump" data-icon="jump"><span class="mobile-label">Jump</span></button>
       <button class="mobile-btn" id="mobile-target" title="Target nearest enemy" aria-label="Target nearest enemy" data-icon="target"><span class="mobile-label">Target</span></button>
       <button class="mobile-btn" id="mobile-chat" title="Chat" aria-label="Open chat" data-icon="chat"><span class="mobile-label">Chat</span></button>
       <button class="mobile-btn" id="mobile-more" title="More menus" aria-label="Show more menus" data-icon="more"><span class="mobile-label">More</span></button>

--- a/scripts/mobile_jump_shot.mjs
+++ b/scripts/mobile_jump_shot.mjs
@@ -1,0 +1,59 @@
+// Captures a mobile (landscape phone) screenshot of the offline game world to
+// showcase the new mobile Jump button. Needs `npm run dev` running on :5173.
+// Run: node scripts/mobile_jump_shot.mjs
+import puppeteer from '../node_modules/puppeteer-core/lib/puppeteer/puppeteer-core.js';
+
+const URL = process.env.WOC_URL || 'http://localhost:5173/';
+const OUT = process.env.OUT || 'mobile-jump.png';
+
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium',
+  headless: 'new',
+  args: [
+    '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+    '--no-sandbox', '--disable-dev-shm-usage',
+  ],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true, deviceScaleFactor: 2 });
+  const client = await page.target().createCDPSession();
+  await client.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline -> pick a class -> Start.
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.getElementById('btn-offline').click());
+  await page.waitForSelector('.mini-class[data-class="warrior"]', { timeout: 10000 });
+  await page.evaluate(() => document.querySelector('.mini-class[data-class="warrior"]').click());
+  await page.evaluate(() => {
+    const name = document.getElementById('char-name');
+    name.value = 'Thunderpaw';
+    name.dispatchEvent(new Event('input', { bubbles: true }));
+    document.getElementById('btn-start-offline').click();
+  });
+
+  // Let the world, renderer and mobile controls settle.
+  await page.waitForSelector('body.mobile-touch #mobile-jump', { timeout: 15000 });
+  await new Promise((r) => setTimeout(r, 4000));
+
+  await page.screenshot({ path: OUT });
+  console.log('wrote', OUT);
+
+  if (process.env.CLIP_OUT) {
+    const box = await page.evaluate(() => {
+      const r = document.getElementById('mobile-combat-controls').getBoundingClientRect();
+      return { x: r.x, y: r.y, w: r.width, h: r.height };
+    });
+    const pad = 16;
+    await page.screenshot({
+      path: process.env.CLIP_OUT,
+      clip: { x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad), width: box.w + pad * 2, height: box.h + pad * 2 },
+    });
+    console.log('wrote', process.env.CLIP_OUT);
+  }
+} finally {
+  await browser.close();
+}

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -61,6 +61,7 @@ export class Input {
   // was BASE_LOOK_SENS — setCameraSpeed scales it from the settings menu
   private lookSensitivity = BASE_LOOK_SENS;
   private touchMove: TouchMoveInput = { forward: false, back: false, strafeLeft: false, strafeRight: false };
+  private touchJump = false;
   private touchLookActive = false;
   private touchLookVector = { x: 0, y: 0 };
 
@@ -131,6 +132,13 @@ export class Input {
 
   clearTouchMove(): void {
     this.touchMove = { forward: false, back: false, strafeLeft: false, strafeRight: false };
+  }
+
+  // A touch jump is momentary: the on-screen button arms this flag and the next
+  // readMoveInput() poll consumes it, yielding a single frame of jump=true (the
+  // sim only launches when grounded, so one frame is enough — same as a Space tap).
+  triggerTouchJump(): void {
+    this.touchJump = true;
   }
 
   setTouchLook(active: boolean): void {
@@ -296,7 +304,8 @@ export class Input {
     const bothButtons = this.leftDown && this.rightDown;
     const forward = held('forward') || bothButtons || this.autorun || this.touchMove.forward;
     const back = held('back') || this.touchMove.back;
-    const jump = held('jump');
+    const jump = held('jump') || this.touchJump;
+    this.touchJump = false;
 
     if (this.mouseCameraEnabled) {
       return {

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -6,6 +6,7 @@ const CAMERA_SENSITIVITY = 0.8;
 
 export interface MobileControlCallbacks {
   onAttackNearest(): void;
+  onJump(): void;
   onTarget(): void;
   onInteract(): void;
   onChat(): void;
@@ -66,6 +67,7 @@ export class MobileControls {
     this.cameraJoystick.addEventListener('pointercancel', (e) => this.onCameraEnd(e));
 
     this.bindButton('mobile-attack-nearest', () => this.callbacks.onAttackNearest());
+    this.bindButton('mobile-jump', () => this.callbacks.onJump());
     this.bindButton('mobile-target', () => this.callbacks.onTarget());
     this.bindButton('mobile-interact', () => this.callbacks.onInteract());
     this.bindButton('mobile-chat', () => this.toggleChat());

--- a/src/main.ts
+++ b/src/main.ts
@@ -420,6 +420,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
 
   const mobileControls = new MobileControls(input, {
     onAttackNearest: () => attackNearest(),
+    onJump: () => input.triggerTouchJump(),
     onTarget: () => world.tabTarget(),
     onInteract: () => interactKey(),
     onChat: () => openChat(),

--- a/src/ui/ui_icons.ts
+++ b/src/ui/ui_icons.ts
@@ -20,7 +20,7 @@ export type UiIconName =
   | 'chat' | 'interact'
   // hand-authored geometrics
   | 'close' | 'prev' | 'next' | 'more' | 'meters'
-  | 'whisper' | 'music' | 'talents' | 'skull';
+  | 'whisper' | 'music' | 'talents' | 'skull' | 'jump';
 
 // Inner SVG markup per icon (one or more <path>). Default fill rule is nonzero
 // (correct for game-icons.net art incl. overlaps); the two hand-authored cut-out
@@ -52,6 +52,7 @@ const ICONS: Record<UiIconName, string> = {
   music: '<path d="M158 374a54 54 0 1 0 108 0 54 54 0 1 0-108 0M260 128h22v246h-22zM282 122c46 16 70 58 46 98 12-32-6-62-46-74z"/>',
   talents: '<path d="M256 138v104M256 242l-96 86M256 242l96 86" stroke="currentColor" stroke-width="28" fill="none" stroke-linecap="round"/><circle cx="256" cy="116" r="44"/><circle cx="150" cy="352" r="44"/><circle cx="362" cy="352" r="44"/>',
   skull: '<path fill-rule="evenodd" d="M256 64C176 64 112 124 112 198c0 38 16 70 40 92v44a24 24 0 0 0 24 24h160a24 24 0 0 0 24-24v-44c24-22 40-54 40-92 0-74-64-134-144-134zM196 176a36 36 0 0 0 0 72 36 36 0 0 0 0-72zM316 176a36 36 0 0 0 0 72 36 36 0 0 0 0-72zM238 300h36v58h-36z"/>',
+  jump: '<path d="M256 56 400 216 320 216 320 344 192 344 192 216 112 216Z"/><rect x="144" y="408" width="224" height="40" rx="14"/>',
 };
 
 export function hasUiIcon(name: string): name is UiIconName {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -105,3 +105,18 @@ describe('Input movement is not cancelled by a camera drag', () => {
     expect(input.readMoveInput().forward).toBe(false);
   });
 });
+
+describe('touch jump', () => {
+  it('jump is off until the touch button arms it', () => {
+    const { input } = makeInput();
+    expect(input.readMoveInput().jump).toBe(false);
+  });
+
+  it('triggerTouchJump yields exactly one frame of jump', () => {
+    const { input } = makeInput();
+    input.triggerTouchJump();
+    expect(input.readMoveInput().jump).toBe(true);
+    // momentary: a single poll consumes it so it cannot stick on like a held key
+    expect(input.readMoveInput().jump).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

Mobile / touch players have no way to **jump**. Jump is a `held` movement action read **only from the keyboard** (Space) in `Input.readMoveInput()`:

```ts
const jump = held('jump');
```

The touch path (`setTouchMove` ← `mapJoystickVector`) only ever produces directional intent (forward/back/strafe), so the existing jump/fall physics are completely unreachable on phones.

## Fix

Add a dedicated **Jump** button to the mobile combat-control row.

- **`src/game/input.ts`** — new momentary `triggerTouchJump()`. It arms a one-shot flag that the next `readMoveInput()` poll consumes, yielding exactly **one frame** of `jump:true`. The sim only launches when grounded, so a single frame behaves just like a Space tap and the jump can't "stick on" like a held key.
- **`src/game/mobile_controls.ts`** — new `onJump` callback bound to `#mobile-jump` (mobile controls stay world-agnostic, only firing injected callbacks).
- **`src/main.ts`** — wires `onJump` → `input.triggerTouchJump()`, preserving the `game/` → `IWorld` boundary.
- **`index.html`** — Jump button placed between Attack and Target; combat grid widened to 4 columns in both the base rule and the small-screen media query.
- **`src/ui/ui_icons.ts`** — hand-authored `jump` glyph (up-arrow over a ground line) matching the existing geometric icon set.

## Screenshots

Landscape phone (offline mode):

![Game world with mobile controls](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-jump/mobile-jump.png)

Control bar close-up — new **Jump** button between Attack and Target:

![Mobile control bar](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-jump/mobile-jump-bar.png)

## Tests

- `tests/input.test.ts` — covers the momentary one-frame jump consumption.
- Full suite green: **650 tests pass**, `tsc --noEmit` clean.

A reusable screenshot harness (`scripts/mobile_jump_shot.mjs`, consistent with the other `scripts/*.mjs` browser drivers) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)