### PR TITLE
feat(mobile): on-screen autorun toggle for touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2822,6 +2822,16 @@
     z-index: 19;
   }
   body.mobile-touch .mobile-btn:active { transform: translateY(1px); border-color: var(--gold); color: #fff; }
+  body.mobile-touch #mobile-autorun {
+    position: absolute; pointer-events: auto;
+    left: max(150px, calc(env(safe-area-inset-left) + 132px));
+    bottom: calc(40px + env(safe-area-inset-bottom));
+  }
+  body.mobile-touch #mobile-autorun.active {
+    border-color: var(--gold); color: #fff;
+    background: radial-gradient(circle at 35% 30%, #5a4a1ed8, #2a230fd8 72%);
+    box-shadow: inset 0 1px 0 #ffffff20, 0 0 12px #e3c46a80;
+  }
   body.mobile-touch .mobile-btn .mobile-label { display: block; margin-top: 1px; font-size: 8px; font-family: var(--ui-font); color: #bfb28a; }
   body.mobile-touch #mobile-extra-controls {
     position: fixed;
@@ -4083,6 +4093,7 @@
       <div id="mobile-camera-stick" class="mobile-stick"></div>
       <div class="mobile-joy-label">Camera</div>
     </div>
+    <button class="mobile-btn" id="mobile-autorun" title="Toggle autorun" aria-label="Toggle autorun" data-icon="autorun"><span class="mobile-label">Autorun</span></button>
     <div id="mobile-combat-controls">
       <button class="mobile-btn" id="mobile-attack-nearest" title="Attack nearest enemy" aria-label="Attack nearest enemy" data-icon="attack"><span class="mobile-label">Attack</span></button>
       <button class="mobile-btn" id="mobile-target" title="Target nearest enemy" aria-label="Target nearest enemy" data-icon="target"><span class="mobile-label">Target</span></button>

--- a/scripts/mobile_autorun_shot.mjs
+++ b/scripts/mobile_autorun_shot.mjs
@@ -1,0 +1,49 @@
+// Screenshot the mobile autorun toggle button in offline mode.
+// Needs `npm run dev` on :5173. No server/Postgres required (offline flow).
+import puppeteer from '../node_modules/puppeteer-core/lib/puppeteer/puppeteer-core.js';
+
+const URL = process.env.URL || 'http://localhost:5173/';
+const OUT = process.env.OUT || '/tmp/woc-autorun';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium',
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+const cdp = await page.target().createCDPSession();
+await cdp.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+await page.goto(URL, { waitUntil: 'networkidle2' });
+await sleep(800);
+
+// Offline flow: #btn-offline -> pick a class -> name -> start
+await page.evaluate(() => document.getElementById('btn-offline')?.click());
+await sleep(400);
+await page.evaluate(() => document.querySelector('.mini-class[data-class="warrior"]')?.click());
+await sleep(200);
+await page.evaluate(() => {
+  const n = document.getElementById('char-name');
+  if (n) { n.value = 'Trailblazer'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await sleep(200);
+await page.evaluate(() => document.getElementById('btn-start-offline')?.click());
+await sleep(3500);
+
+async function shot(name) {
+  await page.screenshot({ path: `${OUT}-${name}.png` });
+  console.log('wrote', `${OUT}-${name}.png`);
+}
+
+// Autorun OFF (default)
+await shot('off');
+
+// Tap autorun -> ON (gold glow + character starts running)
+await page.evaluate(() => document.getElementById('mobile-autorun')?.click());
+await sleep(1500);
+await shot('on');
+
+await browser.close();

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -133,6 +133,13 @@ export class Input {
     this.touchMove = { forward: false, back: false, strafeLeft: false, strafeRight: false };
   }
 
+  // Touch-reachable autorun toggle (the keyboard path is the 'autorun' edge action).
+  // Returns the new state so the on-screen button can reflect it.
+  toggleAutorun(): boolean {
+    this.autorun = !this.autorun;
+    return this.autorun;
+  }
+
   setTouchLook(active: boolean): void {
     this.touchLookActive = active;
   }

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -8,6 +8,7 @@ export interface MobileControlCallbacks {
   onAttackNearest(): void;
   onTarget(): void;
   onInteract(): void;
+  onAutorun(): boolean;
   onChat(): void;
   onMenu(): void;
   onSocial(): void;
@@ -46,6 +47,7 @@ export class MobileControls {
   private moveStick = document.getElementById('mobile-move-stick') as HTMLElement | null;
   private cameraJoystick = document.getElementById('mobile-camera-joystick') as HTMLElement | null;
   private cameraStick = document.getElementById('mobile-camera-stick') as HTMLElement | null;
+  private autorunButton = document.getElementById('mobile-autorun') as HTMLElement | null;
 
   constructor(private input: Input, private callbacks: MobileControlCallbacks) {}
 
@@ -64,6 +66,13 @@ export class MobileControls {
     this.cameraJoystick.addEventListener('pointermove', (e) => this.onCameraMove(e));
     this.cameraJoystick.addEventListener('pointerup', (e) => this.onCameraEnd(e));
     this.cameraJoystick.addEventListener('pointercancel', (e) => this.onCameraEnd(e));
+
+    this.autorunButton?.addEventListener('click', (e) => {
+      if (!this.active) return;
+      e.preventDefault();
+      const on = this.callbacks.onAutorun();
+      this.autorunButton?.classList.toggle('active', on);
+    });
 
     this.bindButton('mobile-attack-nearest', () => this.callbacks.onAttackNearest());
     this.bindButton('mobile-target', () => this.callbacks.onTarget());
@@ -88,6 +97,7 @@ export class MobileControls {
     document.body.classList.toggle('mobile-touch', active);
     if (!active) {
       this.root?.classList.remove('expanded');
+      this.autorunButton?.classList.remove('active');
       document.body.classList.remove('mobile-more-open', 'mobile-chat-open');
       this.releaseMove();
       this.releaseCamera();
@@ -142,7 +152,10 @@ export class MobileControls {
     const x = rawX / mag;
     const y = rawY / mag;
     this.moveStick.style.transform = `translate(${(x * radius * 0.46).toFixed(1)}px, ${(y * radius * 0.46).toFixed(1)}px)`;
-    this.input.setTouchMove(mapJoystickVector(x, y));
+    const move = mapJoystickVector(x, y);
+    this.input.setTouchMove(move);
+    // setTouchMove cancels autorun on forward/back input — keep the button glow honest.
+    if (move.forward || move.back) this.autorunButton?.classList.remove('active');
   }
 
   private onMoveEnd(e: PointerEvent): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -422,6 +422,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     onAttackNearest: () => attackNearest(),
     onTarget: () => world.tabTarget(),
     onInteract: () => interactKey(),
+    onAutorun: () => input.toggleAutorun(),
     onChat: () => openChat(),
     onMenu: () => {
       if (!hud.closeAll()) hud.toggleOptionsMenu();

--- a/src/ui/ui_icons.ts
+++ b/src/ui/ui_icons.ts
@@ -20,7 +20,7 @@ export type UiIconName =
   | 'chat' | 'interact'
   // hand-authored geometrics
   | 'close' | 'prev' | 'next' | 'more' | 'meters'
-  | 'whisper' | 'music' | 'talents' | 'skull';
+  | 'whisper' | 'music' | 'talents' | 'skull' | 'autorun';
 
 // Inner SVG markup per icon (one or more <path>). Default fill rule is nonzero
 // (correct for game-icons.net art incl. overlaps); the two hand-authored cut-out
@@ -52,6 +52,8 @@ const ICONS: Record<UiIconName, string> = {
   music: '<path d="M158 374a54 54 0 1 0 108 0 54 54 0 1 0-108 0M260 128h22v246h-22zM282 122c46 16 70 58 46 98 12-32-6-62-46-74z"/>',
   talents: '<path d="M256 138v104M256 242l-96 86M256 242l96 86" stroke="currentColor" stroke-width="28" fill="none" stroke-linecap="round"/><circle cx="256" cy="116" r="44"/><circle cx="150" cy="352" r="44"/><circle cx="362" cy="352" r="44"/>',
   skull: '<path fill-rule="evenodd" d="M256 64C176 64 112 124 112 198c0 38 16 70 40 92v44a24 24 0 0 0 24 24h160a24 24 0 0 0 24-24v-44c24-22 40-54 40-92 0-74-64-134-144-134zM196 176a36 36 0 0 0 0 72 36 36 0 0 0 0-72zM316 176a36 36 0 0 0 0 72 36 36 0 0 0 0-72zM238 300h36v58h-36z"/>',
+  // two stacked forward chevrons — continuous run
+  autorun: '<path d="M136 264 256 152 376 264M136 392 256 280 376 392" stroke="currentColor" stroke-width="34" fill="none" stroke-linecap="round" stroke-linejoin="round"/>',
 };
 
 export function hasUiIcon(name: string): name is UiIconName {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -53,6 +53,33 @@ beforeEach(() => {
   installStorage();
 });
 
+describe('Input autorun', () => {
+  it('toggleAutorun flips state and feeds forward into readMoveInput', () => {
+    const { input } = makeInput();
+    expect(input.autorun).toBe(false);
+    expect(input.toggleAutorun()).toBe(true);
+    expect(input.autorun).toBe(true);
+    expect(input.readMoveInput().forward).toBe(true);
+    expect(input.toggleAutorun()).toBe(false);
+    expect(input.readMoveInput().forward).toBe(false);
+  });
+
+  it('a forward touch-move cancels autorun (classic tap-to-stop)', () => {
+    const { input } = makeInput();
+    input.toggleAutorun();
+    input.setTouchMove({ forward: true, back: false, strafeLeft: false, strafeRight: false });
+    expect(input.autorun).toBe(false);
+  });
+
+  it('a strafe-only touch-move keeps autorun engaged', () => {
+    const { input } = makeInput();
+    input.toggleAutorun();
+    input.setTouchMove({ forward: false, back: false, strafeLeft: true, strafeRight: false });
+    expect(input.autorun).toBe(true);
+    expect(input.readMoveInput().forward).toBe(true);
+  });
+});
+
 describe('Input pointer lock', () => {
   it('does not request pointer lock for a plain right click', () => {
     const { canvas, canvasListeners } = makeInput();


### PR DESCRIPTION
## What

Adds an on-screen **autorun toggle** to the mobile touch controls, sitting just above the move joystick (left-thumb reach).

| Autorun off (default) | Autorun on (gold glow, character running) |
|---|---|
| ![off](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-autorun/autorun-off.png) | ![on](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-autorun/autorun-on.png) |

## Why

Autorun already exists in the engine — `Input.autorun` and the `autorun` edge action — but it was **only reachable from the keyboard**. On a phone the only way to travel was to hold the move joystick down the entire journey, which is the classic mobile-MMO fatigue complaint. This exposes the existing capability to touch players; no new movement semantics are introduced.

## How

Wires the existing autorun flag through the input→UI stack (same shape as the other mobile buttons):

- **`src/game/input.ts`** — new `toggleAutorun()` that flips `this.autorun` and returns the new state.
- **`src/game/mobile_controls.ts`** — `onAutorun` callback + `#mobile-autorun` binding; reflects the returned state with a gold `.active` glow.
- **`src/main.ts`** — `onAutorun: () => input.toggleAutorun()`.
- **`index.html`** — `#mobile-autorun` button + positioned / active-glow CSS.
- **`src/ui/ui_icons.ts`** — hand-authored `autorun` double-chevron glyph.

### State stays honest
`Input.setTouchMove()` already cancels autorun on forward/back input (classic "tap a direction to stop"). The button clears its glow in that same path, so it never shows "on" while the engine has dropped autorun. **Strafe-only** joystick input keeps autorun engaged, matching the engine exactly.

## Tests

`tests/input.test.ts` — `toggleAutorun()` flips state and feeds `forward` into `readMoveInput()`; a forward touch-move cancels autorun; a strafe-only touch-move keeps it. Full suite green (651 passing), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)