### PR TITLE
feat(mobile): Bags & Character buttons in touch More tray

### DIFF
--- a/index.html
+++ b/index.html
@@ -4094,6 +4094,8 @@
         <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu" data-icon="menu"><span class="mobile-label">Menu</span></button>
         <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>
         <button class="mobile-btn" id="mobile-quest" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="mobile-label">Quests</span></button>
+        <button class="mobile-btn" id="mobile-char" title="Character" aria-label="Character" data-icon="character"><span class="mobile-label">Character</span></button>
+        <button class="mobile-btn" id="mobile-bags" title="Bags" aria-label="Bags" data-icon="bags"><span class="mobile-label">Bags</span></button>
         <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label">Spellbook</span></button>
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
         <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>

--- a/scripts/mobile_bags_char_shot.mjs
+++ b/scripts/mobile_bags_char_shot.mjs
@@ -1,0 +1,67 @@
+// Mobile screenshots for the touch "More" tray Bags + Character buttons.
+// Runs the offline flow (no server/Postgres) on a landscape-phone viewport.
+// Needs `npm run dev` running. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const CLASS = process.env.GAME_CLASS ?? 'warrior';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+// Satisfy PHONE_TOUCH_QUERY: (pointer: coarse) ...
+const cdp = await page.target().createCDPSession();
+await cdp.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+// Menu buttons fail puppeteer's clickable-point check on mobile menus → click in-page.
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await tap('#btn-offline');
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Thorgar'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap(`#offline-select .mini-class[data-class="${CLASS}"]`);
+await tap('#btn-start-offline');
+await wait(3000);
+
+// Don't get eaten while posing for the camera.
+await page.evaluate(() => { const p = window.__game.sim.player; p.maxHp = 99999; p.hp = 99999; });
+
+// 1) Open the "More" tray — shows the new Character + Bags buttons.
+await tap('#mobile-more');
+await wait(400);
+await page.screenshot({ path: 'tmp/mobile_more_tray.png' });
+
+// 2) Tap Character — opens the character sheet.
+await tap('#mobile-char');
+await wait(500);
+await page.screenshot({ path: 'tmp/mobile_character.png' });
+await page.evaluate(() => window.__game.hud.closeAll?.());
+await wait(200);
+
+// 3) Reopen tray, tap Bags — opens the inventory.
+await tap('#mobile-more');
+await wait(300);
+await tap('#mobile-bags');
+await wait(500);
+await page.screenshot({ path: 'tmp/mobile_bags.png' });
+
+if (errors.length) console.log('PAGE ERRORS:\n' + errors.join('\n'));
+console.log('wrote tmp/mobile_more_tray.png, tmp/mobile_character.png, tmp/mobile_bags.png');
+await browser.close();

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -13,6 +13,8 @@ export interface MobileControlCallbacks {
   onSocial(): void;
   onArena(): void;
   onQuestLog(): void;
+  onCharacter(): void;
+  onBags(): void;
   onSpellbook(): void;
   onTalents(): void;
   onMeters(): void;
@@ -73,6 +75,8 @@ export class MobileControls {
     this.bindButton('mobile-social', () => this.callbacks.onSocial());
     this.bindButton('mobile-arena', () => this.callbacks.onArena());
     this.bindButton('mobile-quest', () => this.callbacks.onQuestLog());
+    this.bindButton('mobile-char', () => this.callbacks.onCharacter());
+    this.bindButton('mobile-bags', () => this.callbacks.onBags());
     this.bindButton('mobile-spellbook', () => this.callbacks.onSpellbook());
     this.bindButton('mobile-talents', () => this.callbacks.onTalents());
     this.bindButton('mobile-meters', () => this.callbacks.onMeters());

--- a/src/main.ts
+++ b/src/main.ts
@@ -429,6 +429,8 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     onSocial: () => hud.toggleSocial(),
     onArena: () => hud.toggleArena(),
     onQuestLog: () => hud.toggleQuestLog(),
+    onCharacter: () => hud.toggleChar(),
+    onBags: () => hud.toggleBags(),
     onSpellbook: () => hud.toggleSpellbook(),
     onTalents: () => hud.toggleTalents(),
     onMeters: () => hud.toggleMeters(),


### PR DESCRIPTION
## What

The mobile touch **More** tray already exposes Social, Arena, Quests, Spellbook, Talents, Meters and Map — but not the two most-used core windows: the **inventory (Bags**, keyboard `B`) and the **character sheet** (keyboard `C`). On a phone these were simply unreachable, so touch players could not check their stats/equipment or open their bags.

This adds **Character** and **Bags** buttons to the touch More tray, grouped with the other character/progression windows.

## How

Pure presentation glue — no sim, `IWorld`, or net changes:

- **`index.html`** — add `#mobile-char` and `#mobile-bags` buttons to `#mobile-extra-controls`, reusing the existing `character` / `bags` inline-SVG icons (hydrated by `hydrateIcons()`).
- **`src/game/mobile_controls.ts`** — add `onCharacter()` / `onBags()` to `MobileControlCallbacks` + two `bindButton` calls.
- **`src/main.ts`** — wire them to the existing `hud.toggleChar()` / `hud.toggleBags()` (the same handlers the keyboard `C` / `B` binds already use).

## Screenshots (landscape phone, 844×390, offline)

More tray with the new **Character** and **Bags** buttons:

![More tray](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-bags-char/mobile_more_tray.png)

Tapping **Character** opens the character sheet:

![Character sheet](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-bags-char/mobile_character.png)

Tapping **Bags** opens the inventory:

![Bags](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-bags-char/mobile_bags.png)

## Testing

- `tsc --noEmit` clean.
- Full Vitest suite green (648 tests).
- Manually verified end-to-end on an emulated landscape phone via `scripts/mobile_bags_char_shot.mjs` (offline flow, included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)