### PR TITLE
feat(mobile): Leaderboard (Ranks) button in touch More tray

### DIFF
--- a/index.html
+++ b/index.html
@@ -4098,6 +4098,7 @@
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
         <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>
         <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map" data-icon="map"><span class="mobile-label">Map</span></button>
+        <button class="mobile-btn" id="mobile-leaderboard" title="Leaderboard" aria-label="Leaderboard" data-icon="leaderboard"><span class="mobile-label">Ranks</span></button>
       </div>
     </div>
   </div>

--- a/scripts/mobile_leaderboard_shot.mjs
+++ b/scripts/mobile_leaderboard_shot.mjs
@@ -1,0 +1,58 @@
+// Mobile screenshots for the touch "More" tray Leaderboard (Ranks) button.
+// Runs the offline flow (no server/Postgres) on a landscape-phone viewport.
+// Needs `npm run dev` running. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const CLASS = process.env.GAME_CLASS ?? 'warrior';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+// Satisfy PHONE_TOUCH_QUERY: (pointer: coarse) ...
+const cdp = await page.target().createCDPSession();
+await cdp.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+// Menu buttons fail puppeteer's clickable-point check on mobile menus → click in-page.
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await tap('#btn-offline');
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Thorgar'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap(`#offline-select .mini-class[data-class="${CLASS}"]`);
+await tap('#btn-start-offline');
+await wait(3000);
+
+// Don't get eaten while posing for the camera.
+await page.evaluate(() => { const p = window.__game.sim.player; p.maxHp = 99999; p.hp = 99999; });
+
+// 1) Open the "More" tray — shows the new Ranks (Leaderboard) button.
+await tap('#mobile-more');
+await wait(400);
+await page.screenshot({ path: 'tmp/mobile_more_tray.png' });
+
+// 2) Tap Ranks — opens the leaderboard window.
+await tap('#mobile-leaderboard');
+await wait(500);
+await page.screenshot({ path: 'tmp/mobile_leaderboard.png' });
+
+if (errors.length) console.log('PAGE ERRORS:\n' + errors.join('\n'));
+console.log('wrote tmp/mobile_more_tray.png, tmp/mobile_leaderboard.png');
+await browser.close();

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -17,6 +17,7 @@ export interface MobileControlCallbacks {
   onTalents(): void;
   onMeters(): void;
   onMap(): void;
+  onLeaderboard(): void;
 }
 
 export function isPhoneTouchDevice(win: Pick<Window, 'matchMedia'> = window): boolean {
@@ -77,6 +78,7 @@ export class MobileControls {
     this.bindButton('mobile-talents', () => this.callbacks.onTalents());
     this.bindButton('mobile-meters', () => this.callbacks.onMeters());
     this.bindButton('mobile-map', () => this.callbacks.onMap());
+    this.bindButton('mobile-leaderboard', () => this.callbacks.onLeaderboard());
     this.bindButton('mobile-more', () => {
       this.root?.classList.toggle('expanded');
       document.body.classList.toggle('mobile-more-open', this.root?.classList.contains('expanded') ?? false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,6 +433,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     onTalents: () => hud.toggleTalents(),
     onMeters: () => hud.toggleMeters(),
     onMap: () => hud.toggleMap(),
+    onLeaderboard: () => hud.toggleLeaderboard(),
   });
   mobileControls.start();
 


### PR DESCRIPTION
## What

Adds a **Leaderboard** button (labelled *Ranks*) to the mobile touch **More** tray, so phone players can open the global lifetime-XP rankings.

## Why

The leaderboard window is already fully built — there's a `KeyK` keybind, `hud.toggleLeaderboard()`, and even a `leaderboard` glyph in `ICON_PATHS` — but it was **only reachable from the keyboard**. Touch devices had no way to open it. This mirrors the existing Map / Meters / Quests tray entries.

## Changes

- `index.html` — `#mobile-leaderboard` button in `#mobile-extra-controls`, after Map (icon hydrated from the existing `leaderboard` glyph).
- `src/game/mobile_controls.ts` — `onLeaderboard()` added to `MobileControlCallbacks` + one `bindButton` call.
- `src/main.ts` — wires `onLeaderboard: () => hud.toggleLeaderboard()` (the same handler the keyboard `leaderboard` action already calls).
- `scripts/mobile_leaderboard_shot.mjs` — offline-mode screenshot script.

No `sim/`, `IWorld`, `net/`, or server changes — purely the input/presentation glue layer, so determinism and the authoritative server are untouched.

## Verification

- `tsc --noEmit` clean.
- `npx vitest run tests/mobile_controls.test.ts` — 6 passing (helpers; tray buttons mirror the untested onMap/onMeters wiring).

## Screenshots (landscape phone, offline mode)

More tray with the new **Ranks** button:

![More tray](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-leaderboard/mobile_more_tray.png)

Tapping it opens the leaderboard window:

![Leaderboard window](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-leaderboard/mobile_leaderboard.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)