### PR TITLE
feat(mobile): nameplates toggle button in touch More tray

### DIFF
--- a/index.html
+++ b/index.html
@@ -2851,6 +2851,12 @@
     font-size: 10px;
     color: #e6d8ae;
   }
+  /* A toggle tray button (e.g. Nameplates) glows gold while its feature is on. */
+  body.mobile-touch #mobile-extra-controls .mobile-btn.active {
+    border-color: var(--gold);
+    box-shadow: 0 0 8px #ffd10066, inset 0 0 6px #ffd10033;
+  }
+  body.mobile-touch #mobile-extra-controls .mobile-btn.active .mobile-label { color: var(--gold); }
   body.mobile-touch #bottom-bar {
     left: 0; right: 0; bottom: calc(62px + env(safe-area-inset-bottom));
     width: 100%;
@@ -4098,6 +4104,7 @@
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
         <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>
         <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map" data-icon="map"><span class="mobile-label">Map</span></button>
+        <button class="mobile-btn active" id="mobile-nameplates" title="Toggle nameplates" aria-label="Toggle nameplates" data-icon="nameplates"><span class="mobile-label">Names</span></button>
       </div>
     </div>
   </div>

--- a/scripts/mobile_nameplates_shot.mjs
+++ b/scripts/mobile_nameplates_shot.mjs
@@ -1,0 +1,69 @@
+// Mobile screenshot for the Nameplates ("Names") touch-tray button.
+// Drives the offline world in a phone-emulated viewport (no server/Postgres),
+// opens the "More" tray, and captures the tray with the new toggle, then the
+// toggled-off state. Requires `npm run dev` on :5173.
+//
+// Usage: node scripts/mobile_nameplates_shot.mjs
+import { mkdirSync } from 'node:fs';
+import puppeteer from '../node_modules/puppeteer-core/lib/puppeteer/puppeteer-core.js';
+
+const URL = 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium',
+  headless: 'new',
+  args: [
+    '--no-sandbox',
+    '--use-gl=angle',
+    '--use-angle=swiftshader',
+    '--enable-unsafe-swiftshader',
+  ],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+  // Satisfy PHONE_TOUCH_QUERY (coarse pointer) so body.mobile-touch turns on.
+  const client = await page.target().createCDPSession();
+  await client.send('Emulation.setEmulatedMedia', {
+    features: [{ name: 'pointer', value: 'coarse' }],
+  });
+
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline → name → pick class → Start.
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Thorgar';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+    const cls = document.querySelector('.mini-class[data-class="warrior"]');
+    if (cls) cls.click();
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+
+  // Let the world spawn + render a few frames.
+  await page.waitForSelector('#mobile-controls', { timeout: 15000 });
+  await new Promise((r) => setTimeout(r, 2500));
+
+  // Open the "More" tray.
+  await page.evaluate(() => document.querySelector('#mobile-more')?.click());
+  await new Promise((r) => setTimeout(r, 400));
+  await page.screenshot({ path: `${OUT}/mobile-nameplates-tray.png` });
+  console.log('saved mobile-nameplates-tray.png');
+
+  // Tap the Names button to toggle nameplates OFF (button loses its gold glow),
+  // which also closes the tray — reopen to show the un-glowed state.
+  await page.evaluate(() => document.querySelector('#mobile-nameplates')?.click());
+  await new Promise((r) => setTimeout(r, 300));
+  await page.evaluate(() => document.querySelector('#mobile-more')?.click());
+  await new Promise((r) => setTimeout(r, 400));
+  await page.screenshot({ path: `${OUT}/mobile-nameplates-off.png` });
+  console.log('saved mobile-nameplates-off.png');
+} finally {
+  await browser.close();
+}

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -17,6 +17,8 @@ export interface MobileControlCallbacks {
   onTalents(): void;
   onMeters(): void;
   onMap(): void;
+  /** Toggle world nameplates; returns the new on/off state to sync the button glow. */
+  onNameplates(): boolean;
 }
 
 export function isPhoneTouchDevice(win: Pick<Window, 'matchMedia'> = window): boolean {
@@ -77,6 +79,11 @@ export class MobileControls {
     this.bindButton('mobile-talents', () => this.callbacks.onTalents());
     this.bindButton('mobile-meters', () => this.callbacks.onMeters());
     this.bindButton('mobile-map', () => this.callbacks.onMap());
+    const nameplatesBtn = document.getElementById('mobile-nameplates');
+    this.bindButton('mobile-nameplates', () => {
+      const on = this.callbacks.onNameplates();
+      nameplatesBtn?.classList.toggle('active', on);
+    });
     this.bindButton('mobile-more', () => {
       this.root?.classList.toggle('expanded');
       document.body.classList.toggle('mobile-more-open', this.root?.classList.contains('expanded') ?? false);

--- a/src/main.ts
+++ b/src/main.ts
@@ -433,6 +433,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     onTalents: () => hud.toggleTalents(),
     onMeters: () => hud.toggleMeters(),
     onMap: () => hud.toggleMap(),
+    onNameplates: () => (renderer.showNameplates = !renderer.showNameplates),
   });
   mobileControls.start();
 

--- a/src/ui/ui_icons.ts
+++ b/src/ui/ui_icons.ts
@@ -20,7 +20,7 @@ export type UiIconName =
   | 'chat' | 'interact'
   // hand-authored geometrics
   | 'close' | 'prev' | 'next' | 'more' | 'meters'
-  | 'whisper' | 'music' | 'talents' | 'skull';
+  | 'whisper' | 'music' | 'talents' | 'skull' | 'nameplates';
 
 // Inner SVG markup per icon (one or more <path>). Default fill rule is nonzero
 // (correct for game-icons.net art incl. overlaps); the two hand-authored cut-out
@@ -48,6 +48,9 @@ const ICONS: Record<UiIconName, string> = {
   next: '<path d="M176 96 376 256 176 416Z"/>',
   more: '<path d="M94 256a34 34 0 1 0 68 0 34 34 0 1 0-68 0M222 256a34 34 0 1 0 68 0 34 34 0 1 0-68 0M350 256a34 34 0 1 0 68 0 34 34 0 1 0-68 0Z"/>',
   meters: '<path d="M84 288h72v152H84zM220 184h72v256h-72zM356 96h72v344h-72z"/>',
+  // hand-authored: a unit nameplate — name bar over a health bar, with a
+  // downward pointer aimed at the unit it floats above.
+  nameplates: '<path d="M88 132h336v68H88zM88 220h336v56H88zM236 296h40l-20 34z"/>',
   whisper: '<path fill-rule="evenodd" d="M48 112h416a16 16 0 0 1 16 16v256a16 16 0 0 1-16 16H48a16 16 0 0 1-16-16V128a16 16 0 0 1 16-16zM72 152 256 292 440 152z"/>',
   music: '<path d="M158 374a54 54 0 1 0 108 0 54 54 0 1 0-108 0M260 128h22v246h-22zM282 122c46 16 70 58 46 98 12-32-6-62-46-74z"/>',
   talents: '<path d="M256 138v104M256 242l-96 86M256 242l96 86" stroke="currentColor" stroke-width="28" fill="none" stroke-linecap="round"/><circle cx="256" cy="116" r="44"/><circle cx="150" cy="352" r="44"/><circle cx="362" cy="352" r="44"/>',


### PR DESCRIPTION
## What

Adds a **Nameplates** toggle ("Names") button to the mobile touch **More** tray.

## Why

World nameplates could only be toggled with the keyboard (`V` → `renderer.showNameplates`), so touch/phone players had no way to hide or re-show mob nameplates. This fills one of the last keyboard-only gaps on mobile, alongside the existing Bags/Character/Leaderboard tray buttons.

## How

Presentation-only — **no `sim/`, `IWorld`, `net/`, or server change** (same last-mile wiring shape as the other tray buttons):

- **index.html** — `#mobile-nameplates` button in `#mobile-extra-controls` (starts `.active` since nameplates default on), plus a `.mobile-btn.active` gold-glow rule so a stateful tray toggle reads its on/off state.
- **ui_icons.ts** — hand-authored `nameplates` glyph (a name bar over a health bar with a downward pointer).
- **mobile_controls.ts** — `onNameplates()` callback that returns the new on/off state; the button's gold glow is synced to it.
- **main.ts** — wires `onNameplates` to the exact same `renderer.showNameplates` flip the keyboard `nameplates` UI action already uses.

The toggle gates only **mob** nameplates (matching `V`); NPC labels are unaffected.

## Screenshots

Landscape phone (844×390), offline world.

| Nameplates ON (Names glows gold, mob plates shown) | Nameplates OFF (no glow, mob plates hidden) |
|---|---|
| ![on](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-nameplates/mobile-nameplates-tray.png) | ![off](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-nameplates/mobile-nameplates-off.png) |

## Testing

- `npx tsc --noEmit` clean.
- `npx vitest run` — 648 tests pass.
- Screenshot repro: `scripts/mobile_nameplates_shot.mjs` (offline flow, no server needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)