### PR TITLE
[codex] Auto-report suspicious registrations and add chat mute

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -8,7 +8,7 @@ import {
   listAccounts, listCharacters, accountDetail,
 } from './admin_db';
 import {
-  forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount,
+  forceCharacterRename, ignoreReport, moderateAccount, muteAccountChat, moderationQueue, moderationReportsForAccount,
 } from './moderation_db';
 import type { GameServer } from './game';
 
@@ -107,6 +107,26 @@ export async function handleAdminApi(
         return ok(res, { ok: true });
       } catch (err) {
         return fail(res, 400, err instanceof Error ? err.message : 'moderation action failed');
+      }
+    }
+    const chatMuteMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/chat-mute$/.exec(path);
+    if (req.method === 'POST' && chatMuteMatch) {
+      const targetAccountId = Number(chatMuteMatch[1]);
+      if (await isAdminAccount(targetAccountId)) {
+        return fail(res, 400, 'admin accounts cannot be chat muted');
+      }
+      const body = await readBody(req);
+      try {
+        await muteAccountChat({
+          accountId: targetAccountId,
+          adminAccountId: accountId,
+          reason: body.reason,
+          expiresAt: body.expiresAt,
+        });
+        game.muteAccountChat(targetAccountId, String(body.expiresAt ?? ''), String(body.reason ?? ''));
+        return ok(res, { ok: true });
+      } catch (err) {
+        return fail(res, 400, err instanceof Error ? err.message : 'chat mute failed');
       }
     }
     const ignoreMatch = /^\/admin\/api\/moderation\/reports\/(\d+)\/ignore$/.exec(path);

--- a/server/admin_db.ts
+++ b/server/admin_db.ts
@@ -234,6 +234,8 @@ export interface AccountDetail {
   bannedAt: string | null;
   suspendedUntil: string | null;
   moderationReason: string;
+  chatMutedUntil: string | null;
+  chatMuteReason: string;
   playtimeSeconds: number;
   characters: {
     id: number;
@@ -260,6 +262,8 @@ export async function accountDetail(accountId: number): Promise<AccountDetail | 
     pool.query(
       `SELECT id, username, created_at, last_login, is_admin, banned_at, suspended_until,
               COALESCE(moderation_reason, '') AS moderation_reason,
+              chat_muted_until,
+              COALESCE(chat_mute_reason, '') AS chat_mute_reason,
               COALESCE((SELECT sum(EXTRACT(EPOCH FROM (COALESCE(s.ended_at, now()) - s.started_at)))
                         FROM play_sessions s WHERE s.account_id = accounts.id), 0)::bigint AS playtime_seconds
        FROM accounts WHERE id = $1`,
@@ -291,6 +295,8 @@ export async function accountDetail(accountId: number): Promise<AccountDetail | 
     bannedAt: a.banned_at,
     suspendedUntil: a.suspended_until,
     moderationReason: a.moderation_reason,
+    chatMutedUntil: a.chat_muted_until,
+    chatMuteReason: a.chat_mute_reason,
     playtimeSeconds: Number(a.playtime_seconds),
     characters: characters.rows.map((c) => ({
       id: c.id,

--- a/server/db.ts
+++ b/server/db.ts
@@ -55,6 +55,8 @@ ALTER TABLE accounts ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT 
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS suspended_until TIMESTAMPTZ;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS banned_at TIMESTAMPTZ;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS moderation_reason TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS chat_muted_until TIMESTAMPTZ;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS chat_mute_reason TEXT;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS created_ip TEXT;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS created_user_agent TEXT;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_ip TEXT;
@@ -157,6 +159,11 @@ export interface AccountModerationStatus {
   message: string;
 }
 
+export interface AccountChatMuteStatus {
+  mutedUntil: string | null;
+  reason: string;
+}
+
 export interface RequestMetadata {
   ip?: string | null;
   userAgent?: string | null;
@@ -242,6 +249,21 @@ export async function moderationStatusForAccount(accountId: number): Promise<Acc
     };
   }
   return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '' };
+}
+
+export async function chatMuteStatusForAccount(accountId: number): Promise<AccountChatMuteStatus> {
+  const res = await pool.query(
+    `SELECT chat_muted_until, chat_mute_reason
+     FROM accounts WHERE id = $1`,
+    [accountId],
+  );
+  const row = res.rows[0];
+  const mutedUntil = row?.chat_muted_until ? new Date(row.chat_muted_until) : null;
+  if (!mutedUntil || mutedUntil.getTime() <= Date.now()) return { mutedUntil: null, reason: '' };
+  return {
+    mutedUntil: mutedUntil.toISOString(),
+    reason: row.chat_mute_reason ?? '',
+  };
 }
 
 export interface CharacterRow {

--- a/server/db.ts
+++ b/server/db.ts
@@ -59,6 +59,9 @@ ALTER TABLE accounts ADD COLUMN IF NOT EXISTS created_ip TEXT;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS created_user_agent TEXT;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_ip TEXT;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_user_agent TEXT;
+CREATE INDEX IF NOT EXISTS accounts_created_at ON accounts(created_at DESC);
+CREATE INDEX IF NOT EXISTS accounts_created_ip_created ON accounts(created_ip, created_at DESC);
+CREATE INDEX IF NOT EXISTS accounts_created_user_agent_created ON accounts(created_user_agent, created_at DESC);
 ALTER TABLE characters ADD COLUMN IF NOT EXISTS is_gm BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE characters ADD COLUMN IF NOT EXISTS force_rename BOOLEAN NOT NULL DEFAULT FALSE;
 CREATE TABLE IF NOT EXISTS play_sessions (

--- a/server/db.ts
+++ b/server/db.ts
@@ -55,6 +55,10 @@ ALTER TABLE accounts ADD COLUMN IF NOT EXISTS is_admin BOOLEAN NOT NULL DEFAULT 
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS suspended_until TIMESTAMPTZ;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS banned_at TIMESTAMPTZ;
 ALTER TABLE accounts ADD COLUMN IF NOT EXISTS moderation_reason TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS created_ip TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS created_user_agent TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_ip TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS last_login_user_agent TEXT;
 ALTER TABLE characters ADD COLUMN IF NOT EXISTS is_gm BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE characters ADD COLUMN IF NOT EXISTS force_rename BOOLEAN NOT NULL DEFAULT FALSE;
 CREATE TABLE IF NOT EXISTS play_sessions (
@@ -65,6 +69,8 @@ CREATE TABLE IF NOT EXISTS play_sessions (
   started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   ended_at TIMESTAMPTZ
 );
+ALTER TABLE play_sessions ADD COLUMN IF NOT EXISTS ip_address TEXT;
+ALTER TABLE play_sessions ADD COLUMN IF NOT EXISTS user_agent TEXT;
 CREATE INDEX IF NOT EXISTS play_sessions_account ON play_sessions(account_id);
 CREATE INDEX IF NOT EXISTS play_sessions_started ON play_sessions(started_at);
 CREATE TABLE IF NOT EXISTS chat_logs (
@@ -148,10 +154,22 @@ export interface AccountModerationStatus {
   message: string;
 }
 
-export async function createAccount(username: string, passwordHash: string): Promise<AccountRow> {
+export interface RequestMetadata {
+  ip?: string | null;
+  userAgent?: string | null;
+}
+
+function cleanMetadataText(value: string | null | undefined, max: number): string | null {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return text ? text.slice(0, max) : null;
+}
+
+export async function createAccount(username: string, passwordHash: string, meta: RequestMetadata = {}): Promise<AccountRow> {
   const res = await pool.query(
-    'INSERT INTO accounts (username, password_hash) VALUES ($1, $2) RETURNING id, username, password_hash',
-    [username, passwordHash],
+    `INSERT INTO accounts (username, password_hash, created_ip, created_user_agent)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, username, password_hash`,
+    [username, passwordHash, cleanMetadataText(meta.ip, 128), cleanMetadataText(meta.userAgent, 512)],
   );
   return res.rows[0];
 }
@@ -167,8 +185,13 @@ export async function getAccountsCount(): Promise<number> {
 }
 
 
-export async function touchLogin(accountId: number): Promise<void> {
-  await pool.query('UPDATE accounts SET last_login = now() WHERE id = $1', [accountId]);
+export async function touchLogin(accountId: number, meta: RequestMetadata = {}): Promise<void> {
+  await pool.query(
+    `UPDATE accounts
+     SET last_login = now(), last_login_ip = $2, last_login_user_agent = $3
+     WHERE id = $1`,
+    [accountId, cleanMetadataText(meta.ip, 128), cleanMetadataText(meta.userAgent, 512)],
+  );
 }
 
 export async function saveToken(token: string, accountId: number, ttlHours = 24 * 7): Promise<void> {
@@ -452,10 +475,13 @@ export async function openPlaySession(
   accountId: number,
   characterId: number,
   characterName: string,
+  meta: RequestMetadata = {},
 ): Promise<number> {
   const res = await pool.query(
-    'INSERT INTO play_sessions (account_id, character_id, character_name) VALUES ($1, $2, $3) RETURNING id',
-    [accountId, characterId, characterName],
+    `INSERT INTO play_sessions (account_id, character_id, character_name, ip_address, user_agent)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id`,
+    [accountId, characterId, characterName, cleanMetadataText(meta.ip, 128), cleanMetadataText(meta.userAgent, 512)],
   );
   return res.rows[0].id;
 }

--- a/server/game.ts
+++ b/server/game.ts
@@ -7,7 +7,7 @@ import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
-import type { RequestMetadata } from './db';
+import type { AccountChatMuteStatus, RequestMetadata } from './db';
 import { ChatLogger } from './chat_log';
 import { SocialService } from './social';
 import type { Presence, PresenceStatus, SocialActor, SocialEvent, SocialTransport } from './social';
@@ -63,6 +63,8 @@ export interface ClientSession {
   chatLastRateError: number;
   chatRateViolations: number;
   chatCooldownUntil: number;
+  chatMutedUntil: number | null;
+  chatMuteReason: string;
   // character ids this player has ignored; chat from them is dropped before
   // delivery. Loaded from the DB on join, kept in sync by social commands.
   blockedIds: Set<number>;
@@ -459,7 +461,7 @@ export class GameServer {
     cls: import('../src/sim/types').PlayerClass,
     state: import('../src/sim/sim').CharacterState | null,
     isGm = false,
-    meta: RequestMetadata = {},
+    meta: RequestMetadata & Partial<AccountChatMuteStatus> = {},
   ): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
@@ -475,6 +477,8 @@ export class GameServer {
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
+      chatMutedUntil: meta.mutedUntil ? new Date(meta.mutedUntil).getTime() : null,
+      chatMuteReason: meta.reason ?? '',
       blockedIds: new Set(),
       blockListLoaded: false,
       lastWhisperFrom: null,
@@ -661,6 +665,17 @@ export class GameServer {
     }
   }
 
+  muteAccountChat(accountId: number, mutedUntil: string, reason: string): void {
+    const until = new Date(mutedUntil);
+    if (!Number.isFinite(until.getTime())) return;
+    for (const session of this.clients.values()) {
+      if (session.accountId !== accountId) continue;
+      session.chatMutedUntil = until.getTime();
+      session.chatMuteReason = reason.trim();
+      this.send(session, { t: 'events', list: [{ type: 'error', text: this.chatMuteMessage(session) }] });
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Input & commands
   // -------------------------------------------------------------------------
@@ -730,6 +745,7 @@ export class GameServer {
       case 'release': sim.releaseSpirit(pid); break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;
+        if (this.isChatMuted(session)) break;
         if (!this.consumeChatToken(session)) break;
         const text = msg.text.trim();
         if (/^\/who(?:\s|$)/i.test(text)) {
@@ -1262,6 +1278,24 @@ export class GameServer {
       this.send(session, { t: 'events', list: [{ type: 'error', text: 'You are sending messages too quickly. Slow down.' }] });
     }
     return false;
+  }
+
+  private isChatMuted(session: ClientSession): boolean {
+    if (session.chatMutedUntil === null) return false;
+    if (session.chatMutedUntil <= Date.now()) {
+      session.chatMutedUntil = null;
+      session.chatMuteReason = '';
+      return false;
+    }
+    this.send(session, { t: 'events', list: [{ type: 'error', text: this.chatMuteMessage(session) }] });
+    return true;
+  }
+
+  private chatMuteMessage(session: ClientSession): string {
+    const remainingMs = Math.max(0, (session.chatMutedUntil ?? Date.now()) - Date.now());
+    const minutes = Math.max(1, Math.ceil(remainingMs / 60_000));
+    const reason = session.chatMuteReason ? ` Reason: ${session.chatMuteReason}` : '';
+    return `You are muted from chat for ${minutes} more minute${minutes === 1 ? '' : 's'}.${reason}`;
   }
 
   private sendWhoRoster(session: ClientSession): void {

--- a/server/game.ts
+++ b/server/game.ts
@@ -7,6 +7,7 @@ import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
+import type { RequestMetadata } from './db';
 import { ChatLogger } from './chat_log';
 import { SocialService } from './social';
 import type { Presence, PresenceStatus, SocialActor, SocialEvent, SocialTransport } from './social';
@@ -450,7 +451,16 @@ export class GameServer {
 
   // -------------------------------------------------------------------------
 
-  join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false): ClientSession | { error: string } {
+  join(
+    ws: WebSocket,
+    accountId: number,
+    characterId: number,
+    name: string,
+    cls: import('../src/sim/types').PlayerClass,
+    state: import('../src/sim/sim').CharacterState | null,
+    isGm = false,
+    meta: RequestMetadata = {},
+  ): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
     if (isGm) {
@@ -475,7 +485,7 @@ export class GameServer {
     this.clients.set(pid, session);
     this.sessionsByCharacterId.set(characterId, session);
     this.peakOnline = Math.max(this.peakOnline, this.clients.size);
-    openPlaySession(accountId, characterId, name)
+    openPlaySession(accountId, characterId, name, meta)
       .then((id) => { session.dbSessionId = id; })
       .catch((err) => console.error('failed to open play session:', err));
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -6,7 +6,7 @@ import {
   ensureSchema, pool, createAccount, findAccount, getAccountsCount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
-  findCharacterReportTargetByName, topArenaRatings, topLifetimeXp,
+  findCharacterReportTargetByName, topArenaRatings, topLifetimeXp, chatMuteStatusForAccount,
 } from './db';
 import { virtualLevel } from '../src/sim/types';
 import type { LeaderboardEntry } from '../src/world_api';
@@ -504,6 +504,7 @@ async function main(): Promise<void> {
       ws.close();
       return;
     }
+    const chatMute = await chatMuteStatusForAccount(accountId);
     const result = game.join(
       ws,
       accountId,
@@ -512,7 +513,7 @@ async function main(): Promise<void> {
       character.class,
       character.state,
       character.is_gm,
-      requestMetadata(req),
+      { ...requestMetadata(req), ...chatMute },
     );
     if ('error' in result) {
       ws.send(JSON.stringify({ t: 'error', error: result.error }));

--- a/server/main.ts
+++ b/server/main.ts
@@ -10,13 +10,13 @@ import {
 } from './db';
 import { virtualLevel } from '../src/sim/types';
 import type { LeaderboardEntry } from '../src/world_api';
-import { cleanReportReason, createPlayerReport } from './moderation_db';
+import { cleanReportReason, createPlayerReport, createSuspiciousRegistrationReport } from './moderation_db';
 import { resolveReportTarget } from './report_target';
 import {
   hashPassword, verifyPassword, newToken, validUsernameShape, offensiveName, validPassword, normalizeCharName,
 } from './auth';
 import { json, readBody, isUniqueViolation } from './http_util';
-import { rateLimited, authThrottled, recordAuthFailure, clearAuthFailures } from './ratelimit';
+import { requestIp, rateLimited, authThrottled, recordAuthFailure, clearAuthFailures } from './ratelimit';
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
@@ -94,6 +94,13 @@ async function bearerActiveAccount(req: http.IncomingMessage, res: http.ServerRe
     return null;
   }
   return accountId;
+}
+
+function requestMetadata(req: http.IncomingMessage): { ip: string; userAgent: string } {
+  return {
+    ip: requestIp(req),
+    userAgent: String(req.headers['user-agent'] ?? ''),
+  };
 }
 
 const MIME: Record<string, string> = {
@@ -200,7 +207,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (existing) return json(res, 409, { error: 'username already taken' });
       let account;
       try {
-        account = await createAccount(body.username, await hashPassword(body.password));
+        account = await createAccount(body.username, await hashPassword(body.password), requestMetadata(req));
       } catch (err: any) {
         // a concurrent registration can win the insert after our findAccount
         // check; the username UNIQUE index is the real guard. Surface it as a
@@ -210,6 +217,11 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       }
       const token = newToken();
       await saveToken(token, account.id);
+      void createSuspiciousRegistrationReport({
+        accountId: account.id,
+        username: account.username,
+        ...requestMetadata(req),
+      }).catch((err) => console.error('suspicious registration report failed:', err));
       return json(res, 200, { token, username: account.username });
     }
     if (req.method === 'POST' && url === '/api/login') {
@@ -228,7 +240,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const status = await moderationStatusForAccount(account.id);
       if (status.locked) return json(res, 403, { error: status.message });
       clearAuthFailures(username); // correct password: forgive earlier typos
-      await touchLogin(account.id);
+      await touchLogin(account.id, requestMetadata(req));
       const token = newToken();
       await saveToken(token, account.id);
       return json(res, 200, { token, username: account.username });
@@ -448,11 +460,11 @@ async function main(): Promise<void> {
       return;
     }
     wss.handleUpgrade(req, socket, head, (ws) => {
-      void onConnection(ws);
+      void onConnection(ws, req);
     });
   });
 
-  async function authenticateWebSocket(ws: WebSocket, raw: string): Promise<void> {
+  async function authenticateWebSocket(ws: WebSocket, raw: string, req: http.IncomingMessage): Promise<void> {
     let msg: any;
     try {
       msg = JSON.parse(raw);
@@ -492,7 +504,16 @@ async function main(): Promise<void> {
       ws.close();
       return;
     }
-    const result = game.join(ws, accountId, character.id, character.name, character.class, character.state, character.is_gm);
+    const result = game.join(
+      ws,
+      accountId,
+      character.id,
+      character.name,
+      character.class,
+      character.state,
+      character.is_gm,
+      requestMetadata(req),
+    );
     if ('error' in result) {
       ws.send(JSON.stringify({ t: 'error', error: result.error }));
       ws.close();
@@ -512,7 +533,7 @@ async function main(): Promise<void> {
     });
   }
 
-  async function onConnection(ws: WebSocket): Promise<void> {
+  async function onConnection(ws: WebSocket, req: http.IncomingMessage): Promise<void> {
     const authTimer = setTimeout(() => {
       ws.send(JSON.stringify({ t: 'error', error: 'authentication timed out' }));
       ws.close();
@@ -529,7 +550,7 @@ async function main(): Promise<void> {
 
     ws.once('message', (data) => {
       clearTimeout(authTimer);
-      void authenticateWebSocket(ws, String(data));
+      void authenticateWebSocket(ws, String(data), req);
     });
   }
 

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -362,6 +362,41 @@ export async function moderateAccount(input: {
   }
 }
 
+export async function muteAccountChat(input: {
+  accountId: number;
+  adminAccountId: number;
+  reason: unknown;
+  expiresAt: unknown;
+}): Promise<void> {
+  const reason = cleanText(input.reason, ACTION_REASON_MAX);
+  if (!reason) throw new Error('moderation reason is required');
+  const expiresAt = new Date(String(input.expiresAt ?? ''));
+  if (!Number.isFinite(expiresAt.getTime()) || expiresAt.getTime() <= Date.now()) {
+    throw new Error('chat mute expiry must be in the future');
+  }
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(
+      `UPDATE accounts
+       SET chat_muted_until = $2, chat_mute_reason = $3
+       WHERE id = $1`,
+      [input.accountId, expiresAt, reason],
+    );
+    await client.query(
+      `INSERT INTO account_moderation_actions (account_id, admin_account_id, action, reason, expires_at)
+       VALUES ($1, $2, $3, $4, $5)`,
+      [input.accountId, input.adminAccountId, 'chat_mute', reason, expiresAt],
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 export async function forceCharacterRename(input: {
   characterId: number;
   adminAccountId: number;

--- a/server/moderation_db.ts
+++ b/server/moderation_db.ts
@@ -7,6 +7,12 @@ export type ModerationAction = 'ignore' | 'suspend' | 'ban' | 'unban';
 const REPORT_DETAILS_MAX = 1000;
 const ACTION_REASON_MAX = 500;
 const DUPLICATE_REPORT_WINDOW_HOURS = 12;
+const REGISTRATION_BURST_WINDOW_MINUTES = 10;
+const REGISTRATION_PREFIX_THRESHOLD = 25;
+const REGISTRATION_IP_THRESHOLD = 8;
+const REGISTRATION_SUBNET_THRESHOLD = 20;
+const REGISTRATION_USER_AGENT_THRESHOLD = 60;
+const SYSTEM_REPORT_PREFIX = 'Automated registration pattern:';
 
 export function cleanReportReason(value: unknown): ReportReason | null {
   return typeof value === 'string' && REPORT_REASONS.includes(value as ReportReason)
@@ -65,6 +71,101 @@ export async function createPlayerReport(input: {
     ],
   );
   return { id: Number(res.rows[0].id) };
+}
+
+function numericPrefix(username: string): string | null {
+  const m = /^([a-z][a-z_]*?)[0-9]{2,}$/i.exec(username.trim());
+  return m ? m[1].toLowerCase() : null;
+}
+
+function ipv4Subnet24(ip: string | null | undefined): string | null {
+  const text = String(ip ?? '').trim();
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.\d{1,3}$/.exec(text);
+  if (!m) return null;
+  const octets = m.slice(1).map(Number);
+  if (octets.some((n) => n < 0 || n > 255)) return null;
+  return `${octets[0]}.${octets[1]}.${octets[2]}.`;
+}
+
+async function countRecentRegistrations(whereSql: string, params: unknown[]): Promise<number> {
+  const res = await pool.query(
+    `SELECT count(*)::int AS n
+     FROM accounts
+     WHERE created_at > now() - ($1 || ' minutes')::interval
+       AND banned_at IS NULL
+       AND ${whereSql}`,
+    [String(REGISTRATION_BURST_WINDOW_MINUTES), ...params],
+  );
+  return Number(res.rows[0]?.n ?? 0);
+}
+
+export async function createSuspiciousRegistrationReport(input: {
+  accountId: number;
+  username: string;
+  ip?: string | null;
+  userAgent?: string | null;
+}): Promise<{ created: boolean; signals: string[] }> {
+  const signals: string[] = [];
+  const prefix = numericPrefix(input.username);
+  const ip = cleanText(input.ip, 128);
+  const userAgent = cleanText(input.userAgent, 512);
+  const subnet24 = ipv4Subnet24(ip);
+
+  const prefixCount = prefix
+    ? await countRecentRegistrations(
+        `lower(username) LIKE $2 || '%' AND lower(username) ~ ('^' || $2 || '[0-9]+$')`,
+        [prefix],
+      )
+    : 0;
+  if (prefix && prefixCount >= REGISTRATION_PREFIX_THRESHOLD) {
+    signals.push(`${prefixCount} accounts with username prefix "${prefix}" in ${REGISTRATION_BURST_WINDOW_MINUTES} minutes`);
+  }
+
+  const ipCount = ip ? await countRecentRegistrations('created_ip = $2', [ip]) : 0;
+  if (ip && ipCount >= REGISTRATION_IP_THRESHOLD) {
+    signals.push(`${ipCount} accounts from IP ${ip} in ${REGISTRATION_BURST_WINDOW_MINUTES} minutes`);
+  }
+
+  const subnetCount = subnet24 ? await countRecentRegistrations('created_ip LIKE $2', [`${subnet24}%`]) : 0;
+  if (subnet24 && subnetCount >= REGISTRATION_SUBNET_THRESHOLD) {
+    signals.push(`${subnetCount} accounts from subnet ${subnet24}0/24 in ${REGISTRATION_BURST_WINDOW_MINUTES} minutes`);
+  }
+
+  const userAgentCount = userAgent ? await countRecentRegistrations('created_user_agent = $2', [userAgent]) : 0;
+  if (userAgent && userAgentCount >= REGISTRATION_USER_AGENT_THRESHOLD) {
+    signals.push(`${userAgentCount} accounts with the same user agent in ${REGISTRATION_BURST_WINDOW_MINUTES} minutes`);
+  }
+
+  if (signals.length === 0) return { created: false, signals };
+
+  const duplicate = await pool.query(
+    `SELECT id FROM player_reports
+     WHERE reporter_account_id IS NULL
+       AND reported_account_id = $1
+       AND status = 'open'
+       AND details LIKE $2
+     LIMIT 1`,
+    [input.accountId, `${SYSTEM_REPORT_PREFIX}%`],
+  );
+  if (duplicate.rows[0]) return { created: false, signals };
+
+  const details = cleanText([
+    `${SYSTEM_REPORT_PREFIX} ${signals.join('; ')}.`,
+    `Username: ${input.username}`,
+    ip ? `IP: ${ip}` : '',
+    subnet24 ? `Subnet: ${subnet24}0/24` : '',
+    userAgent ? `User-Agent: ${userAgent}` : '',
+  ].filter(Boolean).join('\n'), REPORT_DETAILS_MAX);
+
+  await pool.query(
+    `INSERT INTO player_reports (
+       reporter_account_id, reporter_character_id, reporter_character_name,
+       reported_account_id, reported_character_id, reported_character_name,
+       reason, details
+     ) VALUES (NULL, NULL, '', $1, NULL, '', $2, $3)`,
+    [input.accountId, 'spam', details],
+  );
+  return { created: true, signals };
 }
 
 export interface ModerationQueueRow {

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -354,6 +354,53 @@ function handleModerationActionClick(e: Event, source: 'account' | 'moderation')
     });
     return true;
   }
+  const chatMuteBtn = target.closest('button[data-chat-mute-hours]') as HTMLButtonElement | null;
+  if (chatMuteBtn) {
+    if (!requireNote()) return true;
+    const hours = Number(chatMuteBtn.dataset.chatMuteHours);
+    const expiresAt = new Date(Date.now() + hours * 3600 * 1000).toISOString();
+    showModerationConfirm({
+      title: 'Confirm chat mute',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Mute chat and send warning' },
+        { label: 'Length', value: `${hours} hour${hours === 1 ? '' : 's'}` },
+        { label: 'Until', value: new Date(expiresAt).toLocaleString() },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/chat-mute`,
+      body: { reason: note, expiresAt },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
+  const customChatMute = target.closest('button[data-chat-mute-custom]') as HTMLButtonElement | null;
+  if (customChatMute) {
+    if (!requireNote()) return true;
+    const raw = moderationCustomExpiryInput(target)?.value ?? '';
+    const expiry = raw ? new Date(raw) : null;
+    if (!expiry || !Number.isFinite(expiry.getTime())) {
+      window.alert('Choose a custom chat mute expiry.');
+      return true;
+    }
+    showModerationConfirm({
+      title: 'Confirm custom chat mute',
+      rows: [
+        { label: 'Account', value: `#${accountId}` },
+        { label: 'Action', value: 'Mute chat and send warning' },
+        { label: 'Until', value: expiry.toLocaleString() },
+        { label: 'Reason', value: note },
+      ],
+      endpoint: `/admin/api/moderation/accounts/${accountId}/chat-mute`,
+      body: { reason: note, expiresAt: expiry.toISOString() },
+      accountId,
+      source,
+      confirmEl,
+    });
+    return true;
+  }
   const banBtn = target.closest('button[data-ban-account]') as HTMLButtonElement | null;
   if (banBtn) {
     if (!requireNote()) return true;

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -58,9 +58,10 @@ function accountStatusBadge(a: { bannedAt: string | null; suspendedUntil: string
 
 function accountStatusDetail(d: AccountDetail): string {
   const activeSuspension = d.suspendedUntil !== null && new Date(d.suspendedUntil).getTime() > Date.now();
+  const activeChatMute = d.chatMutedUntil !== null && new Date(d.chatMutedUntil).getTime() > Date.now();
   if (d.bannedAt) return `<span class="badge bad">banned</span> <span class="hint">since ${fmtDate(d.bannedAt)}</span>`;
   if (activeSuspension) return `<span class="badge warn">suspended until ${fmtDate(d.suspendedUntil)}</span>`;
-  return '<span class="badge">active</span>';
+  return `<span class="badge">active</span>${activeChatMute ? ` <span class="badge warn">chat muted until ${fmtDate(d.chatMutedUntil)}</span>` : ''}`;
 }
 
 export function renderAccountDetail(d: AccountDetail, includeAdminControls = false): string {
@@ -100,10 +101,13 @@ export function renderAccountDetail(d: AccountDetail, includeAdminControls = fal
       <button data-suspend-hours="720">Suspend 30d</button>
       <input class="account-custom-expiry" type="datetime-local" />
       <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-chat-mute-hours="1">Mute Chat 1h</button>
+      <button data-chat-mute-custom="1">Mute Chat Custom</button>
       <button data-ban-account="1" class="danger">Ban</button>`;
   const adminControls = canModerateAccount ? `
     <div class="account-admin-controls mod-account-actions" data-action-account-id="${d.id}">
       <div class="account-status"><b>Status:</b> ${accountStatus}${d.moderationReason ? ` <span class="hint">reason: ${escapeHtml(d.moderationReason)}</span>` : ''}</div>
+      ${d.chatMutedUntil && new Date(d.chatMutedUntil).getTime() > Date.now() && d.chatMuteReason ? `<div class="account-status"><b>Chat mute:</b> <span class="hint">reason: ${escapeHtml(d.chatMuteReason)}</span></div>` : ''}
       <input class="account-mod-reason" placeholder="Moderator note / reason" maxlength="500" />
       ${accountActionButtons}
     </div>
@@ -212,6 +216,8 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
       <button data-suspend-hours="720">Suspend 30d</button>
       <input id="mod-custom-expiry" type="datetime-local" />
       <button data-suspend-custom="1">Suspend Custom</button>
+      <button data-chat-mute-hours="1">Mute Chat 1h</button>
+      <button data-chat-mute-custom="1">Mute Chat Custom</button>
       <button data-ban-account="1">Ban</button>`;
   return `<div class="mod-detail">
     <div class="panel-title">

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -87,6 +87,8 @@ export interface AccountDetail {
   bannedAt: string | null;
   suspendedUntil: string | null;
   moderationReason: string;
+  chatMutedUntil: string | null;
+  chatMuteReason: string;
   playtimeSeconds: number;
   characters: {
     id: number;

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -30,12 +30,13 @@ vi.mock('../server/moderation_db', () => ({
   moderationReportsForAccount: vi.fn(),
   ignoreReport: vi.fn(),
   moderateAccount: vi.fn(),
+  muteAccountChat: vi.fn(),
 }));
 
 import { handleAdminApi, parsePageParams } from '../server/admin';
 import { accountForToken, isAdminAccount, findAccount } from '../server/db';
 import { overviewCounts, listAccounts, accountDetail, escapeLike } from '../server/admin_db';
-import { forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount } from '../server/moderation_db';
+import { forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount, muteAccountChat } from '../server/moderation_db';
 
 const VALID_TOKEN = 'a'.repeat(64);
 
@@ -72,6 +73,7 @@ const fakeGame: any = {
   liveSessions: () => [],
   liveAccountIds: () => new Set([9]),
   disconnectAccount: vi.fn(),
+  muteAccountChat: vi.fn(),
 };
 
 beforeEach(() => {
@@ -257,6 +259,25 @@ describe('admin api auth', () => {
     expect(res.statusCode).toBe(200);
     expect(moderateAccount).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, action: 'ban', reason: 'severe abuse', expiresAt: undefined });
     expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'This account has been banned.');
+  });
+
+  it('mutes account chat and sends a live warning without disconnecting', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    vi.mocked(muteAccountChat).mockResolvedValue();
+    const res = fakeRes();
+    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/chat-mute', body: { reason: 'keep chat civil', expiresAt } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(muteAccountChat).toHaveBeenCalledWith({ accountId: 9, adminAccountId: 7, reason: 'keep chat civil', expiresAt });
+    expect(fakeGame.muteAccountChat).toHaveBeenCalledWith(9, expiresAt, 'keep chat civil');
+    expect(fakeGame.disconnectAccount).not.toHaveBeenCalled();
   });
 
   it('unbans without disconnecting the account', async () => {

--- a/tests/character_db.test.ts
+++ b/tests/character_db.test.ts
@@ -12,7 +12,7 @@ vi.mock('pg', () => ({
   },
 }));
 
-import { deleteCharacter } from '../server/db';
+import { createAccount, deleteCharacter, openPlaySession, touchLogin } from '../server/db';
 import { REALM } from '../server/realm';
 
 beforeEach(() => {
@@ -38,5 +38,40 @@ describe('deleteCharacter', () => {
 
     query.mockResolvedValueOnce({ rowCount: 1 } as any);
     expect(await deleteCharacter(7, 42)).toBe(true);
+  });
+});
+
+describe('account and session request metadata', () => {
+  it('stores account creation IP and user agent when registering', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 7, username: 'alice', password_hash: 'hash' }] } as any);
+
+    await createAccount('alice', 'hash', { ip: '203.0.113.4', userAgent: 'Mozilla/5.0' });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/created_ip/);
+    expect(sql).toMatch(/created_user_agent/);
+    expect(params).toEqual(['alice', 'hash', '203.0.113.4', 'Mozilla/5.0']);
+  });
+
+  it('updates last login IP and user agent when logging in', async () => {
+    query.mockResolvedValueOnce({ rows: [] } as any);
+
+    await touchLogin(7, { ip: '203.0.113.5', userAgent: 'Mozilla/5.0' });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/last_login_ip/);
+    expect(sql).toMatch(/last_login_user_agent/);
+    expect(params).toEqual([7, '203.0.113.5', 'Mozilla/5.0']);
+  });
+
+  it('stores play session IP and user agent when entering the world', async () => {
+    query.mockResolvedValueOnce({ rows: [{ id: 99 }] } as any);
+
+    await openPlaySession(7, 42, 'Alice', { ip: '203.0.113.6', userAgent: 'Mozilla/5.0' });
+
+    const [sql, params] = query.mock.calls[0];
+    expect(sql).toMatch(/ip_address/);
+    expect(sql).toMatch(/user_agent/);
+    expect(params).toEqual([7, 42, 'Alice', '203.0.113.6', 'Mozilla/5.0']);
   });
 });

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -168,6 +168,26 @@ describe('GameServer chat logging', () => {
       { channel: 'whisper', message: 'second' },
     ]);
   });
+
+  it('blocks chat from muted accounts and shows the mute warning', () => {
+    const server = new GameServer();
+    const aWs = fakeWs();
+    const a = server.join(aWs.ws, 11, 101, 'Aleph', 'warrior', null, false, {
+      chatMutedUntil: new Date(Date.now() + 3600_000).toISOString(),
+      chatMuteReason: 'keep chat civil',
+    } as any);
+    if ('error' in a) throw new Error('join failed');
+
+    const logSpy = vi.spyOn(server.chatLog, 'log').mockImplementation(() => {});
+
+    server.handleMessage(a, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'hello world' }));
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(aWs.sent.some((msg: any) =>
+      msg.t === 'events' &&
+      msg.list?.some((ev: any) => ev.type === 'error' && /muted from chat/i.test(ev.text) && /keep chat civil/i.test(ev.text)),
+    )).toBe(true);
+  });
 });
 
 describe('ChatLogger', () => {

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -173,8 +173,8 @@ describe('GameServer chat logging', () => {
     const server = new GameServer();
     const aWs = fakeWs();
     const a = server.join(aWs.ws, 11, 101, 'Aleph', 'warrior', null, false, {
-      chatMutedUntil: new Date(Date.now() + 3600_000).toISOString(),
-      chatMuteReason: 'keep chat civil',
+      mutedUntil: new Date(Date.now() + 3600_000).toISOString(),
+      reason: 'keep chat civil',
     } as any);
     if ('error' in a) throw new Error('join failed');
 

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -7,7 +7,7 @@ vi.mock('../server/db', () => ({
 import { pool } from '../server/db';
 import {
   cleanReportReason, cleanText, createPlayerReport, createSuspiciousRegistrationReport, forceCharacterRename, moderateAccount,
-  moderationQueue, moderationReportsForAccount,
+  muteAccountChat, moderationQueue, moderationReportsForAccount,
 } from '../server/moderation_db';
 
 const query = vi.mocked(pool.query);
@@ -165,6 +165,38 @@ describe('moderation report helpers', () => {
       expiresAt: '2020-01-01T00:00:00Z',
     })).rejects.toThrow(/future/);
     expect(query).not.toHaveBeenCalled();
+  });
+
+  it('requires a future chat mute expiry', async () => {
+    await expect(muteAccountChat({
+      accountId: 2,
+      adminAccountId: 1,
+      reason: 'cool down',
+      expiresAt: '2020-01-01T00:00:00Z',
+    })).rejects.toThrow(/future/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('mutes account chat and writes an audit action in one transaction', async () => {
+    const client = clientStub();
+    connect.mockResolvedValue(client as any);
+    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
+
+    await muteAccountChat({
+      accountId: 2,
+      adminAccountId: 1,
+      reason: 'tone it down',
+      expiresAt,
+    });
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(client.query.mock.calls[0][0]).toBe('BEGIN');
+    expect(client.query.mock.calls[1][0]).toMatch(/chat_muted_until/);
+    expect(client.query.mock.calls[1][1]).toEqual([2, new Date(expiresAt), 'tone it down']);
+    expect(client.query.mock.calls[2][0]).toMatch(/account_moderation_actions/);
+    expect(client.query.mock.calls[2][1]).toEqual([2, 1, 'chat_mute', 'tone it down', new Date(expiresAt)]);
+    expect(client.query.mock.calls[3][0]).toBe('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 
   it('requires a moderation reason for suspend and ban actions', async () => {

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -102,7 +102,7 @@ describe('moderation report helpers', () => {
     });
 
     expect(result).toEqual({ created: false, signals: [] });
-    expect(query).toHaveBeenCalledTimes(4);
+    expect(query).toHaveBeenCalledTimes(3);
   });
 
   it('sorts moderation queue by open report count, recency, then online status', async () => {

--- a/tests/moderation_db.test.ts
+++ b/tests/moderation_db.test.ts
@@ -6,7 +6,7 @@ vi.mock('../server/db', () => ({
 
 import { pool } from '../server/db';
 import {
-  cleanReportReason, cleanText, createPlayerReport, forceCharacterRename, moderateAccount,
+  cleanReportReason, cleanText, createPlayerReport, createSuspiciousRegistrationReport, forceCharacterRename, moderateAccount,
   moderationQueue, moderationReportsForAccount,
 } from '../server/moderation_db';
 
@@ -58,6 +58,51 @@ describe('moderation report helpers', () => {
       reason: 'harassment',
       details: 'duplicate',
     })).rejects.toThrow(/already reported/);
+  });
+
+  it('creates a system moderation report for suspicious sequential registration bursts', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ n: 31 }] } as any) // same numeric prefix
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any) // same IP
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any) // same /24
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any) // same UA
+      .mockResolvedValueOnce({ rows: [] } as any) // duplicate report check
+      .mockResolvedValueOnce({ rows: [{ id: 123 }] } as any); // insert
+
+    const result = await createSuspiciousRegistrationReport({
+      accountId: 42,
+      username: 'aintgrave1031',
+      ip: '203.0.113.44',
+      userAgent: 'Mozilla/5.0',
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.signals).toContain('31 accounts with username prefix "aintgrave" in 10 minutes');
+    expect(query.mock.calls[4][0]).toMatch(/FROM player_reports/);
+    expect(query.mock.calls[5][0]).toMatch(/INSERT INTO player_reports/);
+    expect(query.mock.calls[5][1]).toEqual([
+      42,
+      'spam',
+      expect.stringContaining('Automated registration pattern'),
+    ]);
+  });
+
+  it('does not create a system moderation report without a suspicious registration signal', async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any)
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any)
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any)
+      .mockResolvedValueOnce({ rows: [{ n: 1 }] } as any);
+
+    const result = await createSuspiciousRegistrationReport({
+      accountId: 42,
+      username: 'reuben',
+      ip: '203.0.113.44',
+      userAgent: 'Mozilla/5.0',
+    });
+
+    expect(result).toEqual({ created: false, signals: [] });
+    expect(query).toHaveBeenCalledTimes(4);
   });
 
   it('sorts moderation queue by open report count, recency, then online status', async () => {


### PR DESCRIPTION
## Summary

Adds the first anti-abuse observability and lightweight moderation pass without blocking legitimate signups.

- Persist request metadata on accounts and play sessions:
  - `accounts.created_ip`
  - `accounts.created_user_agent`
  - `accounts.last_login_ip`
  - `accounts.last_login_user_agent`
  - `play_sessions.ip_address`
  - `play_sessions.user_agent`
- Thread Cloudflare/nginx-aware request IPs from HTTP registration/login and WebSocket world entry.
- Detect suspicious registration bursts after successful account creation.
- Auto-create system moderation reports for accounts matching abuse signals so they appear in the existing admin moderation dashboard.
- Add indexes for registration metadata checks so bot floods do not force full-table scans.
- Add timed chat mute moderation from the admin panel.

## Detection Signals

A new account can be auto-reported when recent registrations cross one of these thresholds:

- sequential username prefix burst, e.g. `aintgrave1001`
- repeated registrations from the same IP
- repeated registrations from the same IPv4 `/24`
- repeated registrations from the same exact user agent

This does not block registration, challenge users, or auto-ban accounts. It only creates admin-reviewable reports.

## Chat Mute Moderation

Admins can now mute an account's chat for one hour or until a custom expiry from the moderation panel. Muted users stay online, receive a warning message, and cannot send chat until the mute expires. The action writes an audit row with `chat_mute` and keeps suspension/ban as the heavier tools for more severe abuse.

## Validation

- `npm test`
- `npm run build`

Both pass locally.
