### PR TITLE
feat(mobile): pinch-to-zoom for the touch camera

### DIFF
--- a/scripts/mobile_pinch_zoom_shot.mjs
+++ b/scripts/mobile_pinch_zoom_shot.mjs
@@ -1,0 +1,84 @@
+// Mobile screenshot for the two-finger pinch-to-zoom touch camera gesture.
+// Drives the offline world in a phone-emulated viewport (no server/Postgres),
+// then dispatches REAL two-finger touch events on the game canvas via CDP to
+// pinch the camera in and out, capturing each state. Logs input.camDist so the
+// gesture is proven end-to-end (not faked by setting the field directly).
+//
+// Usage: node scripts/mobile_pinch_zoom_shot.mjs   (requires `npm run dev` on :5173)
+import { mkdirSync } from 'node:fs';
+import puppeteer from '../node_modules/puppeteer-core/lib/puppeteer/puppeteer-core.js';
+
+const URL = 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium',
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+  const client = await page.target().createCDPSession();
+  // Satisfy PHONE_TOUCH_QUERY (coarse pointer) so body.mobile-touch turns on.
+  await client.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline → name → pick class → Start.
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Thorgar';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+    document.querySelector('.mini-class[data-class="warrior"]')?.click();
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+  await page.waitForSelector('#mobile-controls', { timeout: 15000 });
+  await sleep(2500);
+
+  const camDist = () => page.evaluate(() => window.__game?.input?.camDist);
+
+  // A two-finger pinch is a series of touchStart → touchMove(s) → touchEnd with
+  // two touch points. Spreading them apart zooms IN; bringing them together
+  // zooms OUT. Centre the gesture on the game view.
+  const cx = 422, cy = 195;
+  const pinch = async (fromGap, toGap, steps = 12) => {
+    const pts = (gap) => [
+      { x: cx - gap / 2, y: cy },
+      { x: cx + gap / 2, y: cy },
+    ];
+    await client.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: pts(fromGap) });
+    for (let i = 1; i <= steps; i++) {
+      const gap = fromGap + (toGap - fromGap) * (i / steps);
+      await client.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: pts(gap) });
+      await sleep(16);
+    }
+    await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  };
+
+  console.log('camDist (default):', await camDist());
+
+  // Zoom OUT: pinch the fingers together (gap shrinks) → camDist grows toward 22.
+  await pinch(280, 60);
+  await sleep(400);
+  console.log('camDist (zoomed out):', await camDist());
+  await page.screenshot({ path: `${OUT}/mobile-pinch-zoomed-out.png` });
+  console.log('saved mobile-pinch-zoomed-out.png');
+
+  // Zoom IN: spread the fingers apart (gap grows) → camDist shrinks toward 3.
+  await pinch(60, 320);
+  await pinch(60, 320);
+  await sleep(400);
+  console.log('camDist (zoomed in):', await camDist());
+  await page.screenshot({ path: `${OUT}/mobile-pinch-zoomed-in.png` });
+  console.log('saved mobile-pinch-zoomed-in.png');
+} finally {
+  await browser.close();
+}

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -81,7 +81,7 @@ export class Input {
     window.addEventListener('mousemove', (e) => this.onMouseMove(e));
     canvas.addEventListener('wheel', (e) => {
       e.preventDefault();
-      this.camDist = Math.min(22, Math.max(3, this.camDist + Math.sign(e.deltaY) * 1.4));
+      this.zoomBy(Math.sign(e.deltaY) * 1.4);
     }, { passive: false });
     canvas.addEventListener('contextmenu', (e) => e.preventDefault());
     canvas.addEventListener('mouseenter', () => { this.hoverActive = true; });
@@ -90,6 +90,11 @@ export class Input {
       this.setHoverCursor('default');
     });
     this.updateCursor();
+  }
+
+  /** Move the camera in/out, clamped to the zoom limits. Shared by wheel + touch pinch. */
+  zoomBy(delta: number): void {
+    this.camDist = Math.min(22, Math.max(3, this.camDist + delta));
   }
 
   /** True while a mouse button is held for camera drag. */

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -3,6 +3,10 @@ import type { Input, TouchMoveInput } from './input';
 export const PHONE_TOUCH_QUERY = '(pointer: coarse) and (max-width: 940px), (pointer: coarse) and (max-height: 760px)';
 const DEADZONE = 0.22;
 const CAMERA_SENSITIVITY = 0.8;
+// Pinch: each pixel the two fingers spread/close maps to this many yards of
+// camera distance. Tuned so a comfortable thumb-to-finger pinch sweeps roughly
+// the full 3..22yd zoom range in one gesture.
+const PINCH_ZOOM_SCALE = 0.04;
 
 export interface MobileControlCallbacks {
   onAttackNearest(): void;
@@ -41,6 +45,11 @@ export class MobileControls {
   private lookPointer: number | null = null;
   private mq: MediaQueryList | null = null;
 
+  // two-finger pinch-to-zoom on the game view (phones have no scroll wheel)
+  private pinchPointers = new Map<number, { x: number; y: number }>();
+  private pinchPrevDist: number | null = null;
+
+  private canvas = document.getElementById('game-canvas') as HTMLElement | null;
   private root = document.getElementById('mobile-controls') as HTMLElement | null;
   private moveJoystick = document.getElementById('mobile-move-joystick') as HTMLElement | null;
   private moveStick = document.getElementById('mobile-move-stick') as HTMLElement | null;
@@ -64,6 +73,11 @@ export class MobileControls {
     this.cameraJoystick.addEventListener('pointermove', (e) => this.onCameraMove(e));
     this.cameraJoystick.addEventListener('pointerup', (e) => this.onCameraEnd(e));
     this.cameraJoystick.addEventListener('pointercancel', (e) => this.onCameraEnd(e));
+
+    this.canvas?.addEventListener('pointerdown', (e) => this.onPinchDown(e));
+    this.canvas?.addEventListener('pointermove', (e) => this.onPinchMove(e));
+    this.canvas?.addEventListener('pointerup', (e) => this.onPinchEnd(e));
+    this.canvas?.addEventListener('pointercancel', (e) => this.onPinchEnd(e));
 
     this.bindButton('mobile-attack-nearest', () => this.callbacks.onAttackNearest());
     this.bindButton('mobile-target', () => this.callbacks.onTarget());
@@ -91,6 +105,7 @@ export class MobileControls {
       document.body.classList.remove('mobile-more-open', 'mobile-chat-open');
       this.releaseMove();
       this.releaseCamera();
+      this.releasePinch();
     } else {
       document.body.classList.remove('mobile-chat-open');
     }
@@ -192,9 +207,50 @@ export class MobileControls {
     this.input.setTouchLookVector({ x: 0, y: 0 });
     if (this.cameraStick) this.cameraStick.style.transform = '';
   }
+
+  private onPinchDown(e: PointerEvent): void {
+    if (!this.active || e.pointerType !== 'touch') return;
+    this.pinchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (this.pinchPointers.size === 2) this.pinchPrevDist = this.currentPinchDist();
+  }
+
+  private onPinchMove(e: PointerEvent): void {
+    if (!this.active || !this.pinchPointers.has(e.pointerId)) return;
+    this.pinchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (this.pinchPointers.size === 2 && this.pinchPrevDist !== null) {
+      e.preventDefault();
+      const cur = this.currentPinchDist();
+      this.input.zoomBy(pinchZoomDelta(this.pinchPrevDist, cur));
+      this.pinchPrevDist = cur;
+    }
+  }
+
+  private onPinchEnd(e: PointerEvent): void {
+    this.pinchPointers.delete(e.pointerId);
+    if (this.pinchPointers.size < 2) this.pinchPrevDist = null;
+  }
+
+  private releasePinch(): void {
+    this.pinchPointers.clear();
+    this.pinchPrevDist = null;
+  }
+
+  private currentPinchDist(): number {
+    const pts = [...this.pinchPointers.values()];
+    return Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+  }
 }
 
 export function mapLookVector(x: number, y: number, deadzone = DEADZONE): { x: number; y: number } {
   if (Math.hypot(x, y) < deadzone) return { x: 0, y: 0 };
   return { x: x * CAMERA_SENSITIVITY, y: y * CAMERA_SENSITIVITY };
+}
+
+/**
+ * Camera-distance delta for a pinch frame, in yards. Fingers spreading apart
+ * (curDist > prevDist) zooms IN, i.e. returns a negative delta to shrink camDist;
+ * pinching together zooms out. Matches the sign convention of the wheel handler.
+ */
+export function pinchZoomDelta(prevDist: number, curDist: number, scale = PINCH_ZOOM_SCALE): number {
+  return (prevDist - curDist) * scale;
 }

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isPhoneTouchDevice, mapJoystickVector, mapLookVector } from '../src/game/mobile_controls';
+import { isPhoneTouchDevice, mapJoystickVector, mapLookVector, pinchZoomDelta } from '../src/game/mobile_controls';
 
 describe('mapJoystickVector', () => {
   it('returns neutral inside the deadzone', () => {
@@ -45,5 +45,24 @@ describe('mapLookVector', () => {
     const v = mapLookVector(0.45, -0.25);
     expect(v.x).toBeCloseTo(0.36);
     expect(v.y).toBeCloseTo(-0.2);
+  });
+});
+
+describe('pinchZoomDelta', () => {
+  it('returns zero when the pinch distance is unchanged', () => {
+    expect(pinchZoomDelta(120, 120)).toBe(0);
+  });
+
+  it('zooms in (negative delta) when the fingers spread apart', () => {
+    expect(pinchZoomDelta(100, 150, 0.04)).toBeCloseTo(-2);
+  });
+
+  it('zooms out (positive delta) when the fingers pinch together', () => {
+    expect(pinchZoomDelta(150, 100, 0.04)).toBeCloseTo(2);
+  });
+
+  it('scales the delta by the magnitude of the spread', () => {
+    expect(pinchZoomDelta(100, 110, 0.04)).toBeCloseTo(-0.4);
+    expect(pinchZoomDelta(100, 200, 0.04)).toBeCloseTo(-4);
   });
 });


### PR DESCRIPTION
## What

Adds a **two-finger pinch gesture** on the game view to zoom the camera in and out on touch devices.

## Why

Camera distance (`camDist`, the 3–22 yd zoom range) was mutated **only** by the canvas `wheel` listener in `input.ts`. Phones have no scroll wheel, so the entire zoom range was unreachable on mobile — players were locked at the default 12 yd. This closes a genuine input gap (not just a menu-reachability one).

## How

- **`src/game/input.ts`** — extracted the wheel clamp into a small `zoomBy(delta)` seam so the wheel handler and the new pinch handler share the single `[3, 22]` clamp.
- **`src/game/mobile_controls.ts`** — track touch pointers on `#game-canvas`; when exactly two are down, feed the frame-to-frame finger-distance change through a new pure `pinchZoomDelta()` helper into `input.zoomBy()`. Spreading the fingers zooms in, pinching together zooms out (matching the wheel sign convention). Pinch state is cleared when touch mode deactivates.
- **Presentation-only**: camera distance is pure client state — no `sim` / `IWorld` / `net` / server changes.

## Testing

- `tests/mobile_controls.test.ts` — new cases cover `pinchZoomDelta` sign + magnitude scaling, beside the existing pure-helper tests.
- Full suite green (`652 passed`), `tsc --noEmit` clean.
- Verified end-to-end with a real CDP two-finger pinch in a phone-emulated viewport (`scripts/mobile_pinch_zoom_shot.mjs`): `camDist` went 12 → 20.8 (pinch together) → 3 (spread apart, clamped at min).

## Screenshots (landscape phone, offline mode)

Zoomed out (pinch together → camDist 20.8):

![zoomed out](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-pinch-zoom/mobile-pinch-zoomed-out.png)

Zoomed in (spread apart → camDist 3):

![zoomed in](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-pinch-zoom/mobile-pinch-zoomed-in.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)