### PR TITLE
feat(mobile): long-press an action-bar slot to peek its tooltip without casting

### DIFF
--- a/scripts/mobile_tooltip_peek_shot.mjs
+++ b/scripts/mobile_tooltip_peek_shot.mjs
@@ -1,0 +1,77 @@
+// Mobile screenshot: long-press an action-bar slot to PEEK its ability tooltip
+// (without casting). Drives the offline flow on an emulated landscape phone and
+// fires a real CDP touch long-press on a hotbar slot.
+//
+// Prereq: `npm run dev` running on :5173.
+//   node scripts/mobile_tooltip_peek_shot.mjs
+import puppeteer from '../node_modules/puppeteer-core/lib/puppeteer/puppeteer-core.js';
+import { mkdirSync } from 'node:fs';
+
+const URL = 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: '/usr/bin/chromium',
+  headless: 'new',
+  args: [
+    '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+    '--no-sandbox', '--hide-scrollbars',
+  ],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true, deviceScaleFactor: 2 });
+  const client = await page.target().createCDPSession();
+  // Satisfy PHONE_TOUCH_QUERY = '(pointer: coarse) and (max-width: 940px)'.
+  await client.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#btn-offline', { visible: true });
+
+  // Offline flow: pick mode → name → class → enter.
+  await page.evaluate(() => document.getElementById('btn-offline').click());
+  await sleep(250);
+  await page.evaluate(() => {
+    const n = document.getElementById('char-name');
+    n.value = 'Thorgar';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+    document.querySelector('.mini-class[data-class="mage"]').click();
+  });
+  await sleep(150);
+  await page.evaluate(() => document.getElementById('btn-start-offline').click());
+
+  // Let the world boot and the action bar populate.
+  await page.waitForSelector('body.mobile-touch', { timeout: 8000 });
+  await sleep(2500);
+
+  // Pick a populated hotbar slot (skip slot 0 = Attack) and long-press it.
+  const rect = await page.evaluate(() => {
+    const btns = [...document.querySelectorAll('#actionbar .action-btn')];
+    const target = btns.find((b, i) => i >= 1 && !b.classList.contains('empty')) || btns[1];
+    const r = target.getBoundingClientRect();
+    return { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  });
+
+  // Real CDP touch hold > TOOLTIP_PEEK_MS (950ms) so the tooltip appears.
+  await client.send('Input.dispatchTouchEvent', {
+    type: 'touchStart', touchPoints: [{ x: rect.x, y: rect.y }],
+  });
+  await sleep(1200);
+  await page.screenshot({ path: `${OUT}/mobile-tooltip-peek.png` });
+  console.log('captured mobile-tooltip-peek.png (tooltip shown while held)');
+
+  // Release: tooltip dismisses and NO cast fires.
+  await client.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  await sleep(400);
+  const tooltipVisible = await page.evaluate(() => {
+    const t = document.getElementById('tooltip');
+    return t && getComputedStyle(t).display !== 'none';
+  });
+  console.log('tooltip visible after release:', tooltipVisible, '(expected false)');
+} finally {
+  await browser.close();
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -25,6 +25,7 @@ import { svgIcon } from './ui_icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { TouchPeekGuard, TOOLTIP_PEEK_MS } from './touch_peek';
 import {
   talentsFor, computeTalentModifiers, validateAllocation, dormantNodes, pointsSpent,
   exportBuild, importBuild, cloneAllocation, talentPointsAtLevel, FIRST_TALENT_LEVEL,
@@ -115,6 +116,8 @@ export class Hud {
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
   private tooltipEl = $('#tooltip');
+  // Distinguishes a touch long-press "peek" (inspect, no action) from a tap.
+  private peekGuard = new TouchPeekGuard();
   private errorTimer: number | undefined;
   private bannerTimer: number | undefined;
   private minimapCtx: CanvasRenderingContext2D;
@@ -311,6 +314,9 @@ export class Hud {
       touchTimer = undefined;
     };
     const showAt = (x: number, y: number) => {
+      // Touch-only path: showing the tooltip means the held control is being
+      // inspected, so the release click should peek, not fire its action.
+      this.peekGuard.peek();
       this.tooltipEl.innerHTML = html();
       this.tooltipEl.style.display = 'block';
       const tw = this.tooltipEl.offsetWidth, th = this.tooltipEl.offsetHeight;
@@ -332,8 +338,11 @@ export class Hud {
     el.addEventListener('pointerdown', (e) => {
       if (!mobile() || e.pointerType === 'mouse') return;
       clearTouchTimer();
+      // A fresh press: drop any stale peek and dismiss a lingering tooltip.
+      this.peekGuard.press();
+      this.tooltipEl.style.display = 'none';
       const x = e.clientX, y = e.clientY;
-      touchTimer = window.setTimeout(() => showAt(x, y), 950);
+      touchTimer = window.setTimeout(() => showAt(x, y), TOOLTIP_PEEK_MS);
     });
     el.addEventListener('pointerup', clearTouchTimer);
     el.addEventListener('pointercancel', clearTouchTimer);
@@ -553,6 +562,9 @@ export class Hud {
       // slot 0 is Attack for every class (auto-attack toggle — players
       // without right-click need a way in); the kit fills slots 1+
       btn.addEventListener('click', () => {
+        // On touch, the click that ends a long-press peek inspects the slot
+        // (tooltip already shown) instead of casting — release dismisses it.
+        if (this.peekGuard.consume()) { this.hideTooltip(); return; }
         audio.click();
         this.castSlot(slot);
       });

--- a/src/ui/touch_peek.ts
+++ b/src/ui/touch_peek.ts
@@ -1,0 +1,37 @@
+// Touch "peek" guard for long-press tooltips.
+//
+// On a touch device there is no hover, so the HUD shows an element's tooltip
+// after a long press (see `Hud.attachTooltip`). The problem: a synthetic
+// `click` still fires when the finger lifts, so long-pressing an action-bar
+// slot to read its tooltip would ALSO fire the slot's click action (casting the
+// ability). This guard lets the click handler tell "this click is the release
+// of a long-press peek" apart from "this is a real quick tap" and swallow the
+// former, so holding a control inspects it instead of triggering it.
+
+/** Default hold (ms) before a touch press is treated as a tooltip peek. */
+export const TOOLTIP_PEEK_MS = 950;
+
+export class TouchPeekGuard {
+  private peeked = false;
+
+  /** A fresh press began — clear any stale peek from a previous interaction. */
+  press(): void {
+    this.peeked = false;
+  }
+
+  /** The long-press tooltip was shown for the held control. */
+  peek(): void {
+    this.peeked = true;
+  }
+
+  /**
+   * Called from the `click` that follows a release. Returns true when that
+   * click is the tail of a peek and the control's action should be SUPPRESSED.
+   * Consuming resets the guard so the next quick tap activates normally.
+   */
+  consume(): boolean {
+    const wasPeek = this.peeked;
+    this.peeked = false;
+    return wasPeek;
+  }
+}

--- a/tests/touch_peek.test.ts
+++ b/tests/touch_peek.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { TouchPeekGuard, TOOLTIP_PEEK_MS } from '../src/ui/touch_peek';
+
+describe('TouchPeekGuard', () => {
+  it('a quick tap (no peek) activates the control', () => {
+    const g = new TouchPeekGuard();
+    g.press();
+    // no peek() — the long-press timer never fired
+    expect(g.consume()).toBe(false);
+  });
+
+  it('a long-press peek suppresses the release click', () => {
+    const g = new TouchPeekGuard();
+    g.press();
+    g.peek(); // tooltip shown after the hold threshold
+    expect(g.consume()).toBe(true);
+  });
+
+  it('consume resets, so the next tap activates again', () => {
+    const g = new TouchPeekGuard();
+    g.press();
+    g.peek();
+    expect(g.consume()).toBe(true);
+    g.press();
+    expect(g.consume()).toBe(false);
+  });
+
+  it('a fresh press clears a stale peek from a previous control', () => {
+    const g = new TouchPeekGuard();
+    g.press();
+    g.peek(); // peeked an element whose click was never consumed
+    g.press(); // a different control is now pressed
+    expect(g.consume()).toBe(false);
+  });
+
+  it('exposes a sane default hold threshold', () => {
+    expect(TOOLTIP_PEEK_MS).toBeGreaterThan(300);
+    expect(TOOLTIP_PEEK_MS).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
## Problem

On a touch device there is no hover, so the HUD shows an ability/item tooltip after a long press (`Hud.attachTooltip`, ~950 ms). But a synthetic `click` still fires when the finger lifts, so **long-pressing a hotbar slot to read its tooltip also cast the ability** — and the tooltip was never dismissed on touch (there's no `mouseleave`). Inspecting what a slot does on a phone was effectively impossible: every peek triggered a cast and left the tooltip stuck on screen.

## Fix

A tiny `TouchPeekGuard` (`src/ui/touch_peek.ts`) distinguishes a long-press *peek* from a real *tap*:

- a fresh touch press resets the guard (and dismisses any lingering tooltip),
- the long-press tooltip marks a `peek()`,
- the action-bar `click` handler `consume()`s that mark to **suppress the cast and dismiss the tooltip** on release.

A quick tap (the hold timer never fires) casts exactly as before. Resetting on every press keeps a peek on one control from leaking into a tap on another. So: **press-and-hold a slot to inspect it; release to dismiss; it won't cast.**

Presentation-only — no `sim`/`IWorld`/`net`/server changes.

## Screenshot (emulated landscape phone, offline mode)

Holding a hotbar slot shows its tooltip — releasing dismisses it and does **not** cast:

![mobile tooltip peek](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-tooltip-peek/mobile-tooltip-peek.png)

Repro: `scripts/mobile_tooltip_peek_shot.mjs` (drives the offline flow on an 844×390 coarse-pointer viewport and fires a real CDP touch hold).

## Tests

`tests/touch_peek.test.ts` covers the guard (quick tap activates, long-press suppresses, consume resets, cross-control isolation). Full suite: **653 passed**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)