### PR TITLE
feat(mobile): left-handed touch layout that mirrors the joysticks

### DIFF
--- a/index.html
+++ b/index.html
@@ -2965,6 +2965,28 @@
     overflow: hidden;
     z-index: 25;
   }
+  /* Left-handed mirror: swap the two thumb joysticks (and the bottom HUD that
+     hugs them) so the movement stick sits under the right thumb. Opt-in via the
+     "Left-handed Touch" toggle in Key Bindings; centred combat buttons stay put. */
+  body.mobile-touch.mobile-left-handed .mobile-joystick {
+    left: auto; right: max(18px, env(safe-area-inset-right));
+  }
+  body.mobile-touch.mobile-left-handed #mobile-camera-joystick {
+    right: auto; left: max(18px, env(safe-area-inset-left));
+  }
+  body.mobile-touch.mobile-left-handed #mobile-more {
+    left: auto; right: calc(50% + 190px);
+  }
+  body.mobile-touch.mobile-left-handed #mobile-extra-controls {
+    left: auto; right: calc(50% + 190px);
+  }
+  body.mobile-touch.mobile-left-handed #xpbar,
+  body.mobile-touch.mobile-left-handed #castbar {
+    left: auto; right: calc(max(18px, env(safe-area-inset-right)) + 132px);
+  }
+  body.mobile-touch.mobile-left-handed #meters-window {
+    left: auto; right: calc(max(18px, env(safe-area-inset-right)) + 132px);
+  }
   body.mobile-touch .window { max-width: calc(100vw - 20px); max-height: calc(100vh - 40px); }
   body.mobile-touch #options-menu,
   body.mobile-touch #quest-log-window,

--- a/scripts/mobile_left_handed_shot.mjs
+++ b/scripts/mobile_left_handed_shot.mjs
@@ -1,0 +1,51 @@
+// Screenshot the mobile left-handed touch layout in offline mode: default
+// (move stick left / camera stick right) vs. mirrored (swapped).
+// Needs `npm run dev` on :5173. No server/Postgres required (offline flow).
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.URL || 'http://localhost:5173/';
+const OUT = process.env.OUT || '/tmp/woc-left-handed';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+const cdp = await page.target().createCDPSession();
+await cdp.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+await page.goto(URL, { waitUntil: 'networkidle2' });
+await sleep(800);
+
+// Offline flow: #btn-offline -> pick a class -> name -> start
+await page.evaluate(() => document.getElementById('btn-offline')?.click());
+await sleep(400);
+await page.evaluate(() => document.querySelector('.mini-class[data-class="warrior"]')?.click());
+await sleep(200);
+await page.evaluate(() => {
+  const n = document.getElementById('char-name');
+  if (n) { n.value = 'Southpaw'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await sleep(200);
+await page.evaluate(() => document.getElementById('btn-start-offline')?.click());
+await sleep(3500);
+
+async function shot(name) {
+  await page.screenshot({ path: `${OUT}-${name}.png` });
+  console.log('wrote', `${OUT}-${name}.png`);
+}
+
+// Default: movement joystick on the left, camera joystick on the right.
+await shot('right-handed');
+
+// Toggle left-handed mode -> joysticks mirror (movement now on the right).
+await page.evaluate(() => document.body.classList.add('mobile-left-handed'));
+await sleep(600);
+await shot('left-handed');
+
+await browser.close();

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -22,6 +22,10 @@ export const SETTING_RANGES = {
 
 export const BOOL_SETTINGS = {
   mouseCamera: { def: false },
+  // off by default: mirrors the touch layout so the movement joystick sits on
+  // the right and the camera joystick on the left, for left-thumb-dominant
+  // players. CSS-only swap gated on body.mobile-left-handed; ignored on desktop.
+  leftHandedTouch: { def: false },
 } as const;
 
 export type NumericSettingKey = keyof typeof SETTING_RANGES;

--- a/src/main.ts
+++ b/src/main.ts
@@ -443,6 +443,11 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       input.setMouseCameraEnabled(v);
       return;
     }
+    if (key === 'leftHandedTouch') {
+      const v = settings.set('leftHandedTouch', !!value);
+      document.body.classList.toggle('mobile-left-handed', v);
+      return;
+    }
     const v = settings.set(key as keyof typeof SETTING_RANGES, value as number);
     switch (key) {
       case 'cameraSpeed': input.setCameraSpeed(v); break;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4144,10 +4144,11 @@ export class Hud {
     el.innerHTML = `<div class="panel-title"><span>Key Bindings</span><span class="x-btn" data-close>${svgIcon('close')}</span></div>`;
     this.settingToggleKeybind(el, 'Mouse Camera', 'mouseCamera');
     this.settingToggleKeybind(el, 'Click to Move', 'clickToMove');
+    this.settingToggleKeybind(el, 'Left-handed Touch', 'leftHandedTouch');
     const note = document.createElement('div');
     note.className = 'kb-note';
     note.textContent = this.keybindNote
-      || 'Mouse Camera off: A/D turns, drag to orbit (classic). On: camera-relative WASD, A/D strafes. Click to Move: left-click the ground or an enemy to walk there. Click a key cell to rebind; Esc cancels.';
+      || 'Mouse Camera off: A/D turns, drag to orbit (classic). On: camera-relative WASD, A/D strafes. Click to Move: left-click the ground or an enemy to walk there. Left-handed Touch mirrors the on-screen joysticks for touch devices. Click a key cell to rebind; Esc cancels.';
     el.appendChild(note);
     const rows = document.createElement('div');
     rows.className = 'kb-rows';

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -56,6 +56,14 @@ describe('Settings', () => {
     expect(b.get('mouseCamera')).toBe(true);
   });
 
+  it('defaults left-handed touch off and persists it across instances', () => {
+    const a = new Settings();
+    expect(a.get('leftHandedTouch')).toBe(false);
+    a.set('leftHandedTouch', true);
+    const b = new Settings();
+    expect(b.get('leftHandedTouch')).toBe(true);
+  });
+
   it('falls back to defaults for missing/corrupt keys', () => {
     localStorage.setItem('woc_settings', JSON.stringify({ cameraSpeed: 0.5 }));
     const s = new Settings();


### PR DESCRIPTION
## What

Adds an opt-in **Left-handed Touch** toggle to the Key Bindings panel that mirrors the on-screen touch controls — the movement joystick moves under the **right** thumb and the camera joystick under the **left**, with the bottom HUD that hugs them following along. Centred combat buttons stay put.

| Default (right-handed) | Left-handed (mirrored) |
|---|---|
| ![right](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-left-handed/right-handed.png) | ![left](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-left-handed/left-handed.png) |

Note how the **More** tray, XP/cast bars and meters mirror to the opposite side together with the joysticks.

## Why

The touch layout hard-codes movement on the left and camera on the right. Left-thumb-dominant players have no way to swap them — a standard accessibility option in mobile MMOs/shooters. This is purely a presentation mirror; no movement or camera semantics change, and the `aria-label`/joystick labels ("Move"/"Camera") are preserved so the controls stay self-describing after the swap.

## How

Reuses the existing **settings → subsystem** seam, so there's no new plumbing:

- **`src/game/settings.ts`** — new `leftHandedTouch` bool in `BOOL_SETTINGS` (off by default, persisted to `woc_settings`).
- **`src/main.ts`** — `applySetting` toggles a `body.mobile-left-handed` class (same shape as the `mouseCamera` case); applied on startup with all other saved settings.
- **`index.html`** — pure-CSS mirror gated on `body.mobile-touch.mobile-left-handed`: swaps the two `.mobile-joystick`s and the bottom HUD anchored to them (`#mobile-more`, `#mobile-extra-controls`, `#xpbar`, `#castbar`, `#meters-window`). Desktop is unaffected (rule is `mobile-touch`-scoped).
- **`src/ui/hud.ts`** — surfaced via the existing `settingToggleKeybind` row beside Mouse Camera / Click to Move; note text updated.

No `src/sim/` changes; no DOM/Three imports added to the core. `IWorld` is untouched (this is local input/presentation only).

## Tests

- `tests/settings.test.ts` — new case asserts `leftHandedTouch` defaults off and persists across `Settings` instances.
- `scripts/mobile_left_handed_shot.mjs` — offline screenshot helper (no server/Postgres) that produced the images above.
- `npx tsc --noEmit` clean; `settings` + `mobile_controls` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)