### PR TITLE
feat(mobile): fade idle touch joysticks so they obscure less of the world

### DIFF
--- a/index.html
+++ b/index.html
@@ -2788,6 +2788,11 @@
     width: 122px; height: 122px; border-radius: 50%; pointer-events: auto; touch-action: none;
     border: 2px solid #b7a35a80; background: radial-gradient(circle at 50% 50%, #1b1b2960 0%, #0b0b1280 62%, #0505089a 100%);
     box-shadow: 0 3px 18px #0008, inset 0 1px 0 #ffffff12, inset 0 0 26px #0008;
+    opacity: 0.4; transition: opacity .18s ease;
+  }
+  body.mobile-touch .mobile-joystick.touching { opacity: 1; }
+  @media (prefers-reduced-motion: reduce) {
+    body.mobile-touch .mobile-joystick { transition: none; }
   }
   body.mobile-touch .mobile-joystick::before {
     content: ''; position: absolute; inset: 28px; border-radius: 50%; border: 1px solid #ffffff18;

--- a/scripts/mobile_fade_shot.mjs
+++ b/scripts/mobile_fade_shot.mjs
@@ -1,0 +1,49 @@
+// Ad-hoc mobile screenshot helper for the offline world.
+// Usage: node scripts/mobile_shot.mjs   (needs `npm run dev` running on :5173)
+import puppeteer from 'puppeteer-core';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173/';
+const CHROME = process.env.CHROME_PATH ?? '/usr/bin/google-chrome-stable';
+const OUT = process.env.OUT_DIR ?? '/tmp';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+});
+const page = await browser.newPage();
+// iPhone-ish portrait with a coarse pointer so body.mobile-touch activates.
+await page.emulate({
+  viewport: { width: 844, height: 390, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
+  userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148',
+});
+page.on('console', (m) => { if (m.type() === 'error') console.log('PAGE ERR', m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle2', timeout: 30000 });
+await sleep(500);
+await page.click('#btn-offline');
+await sleep(400);
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await sleep(200);
+await page.type('#char-name', 'Thumbwar');
+await sleep(150);
+await page.click('#btn-start-offline');
+// Let the world load and settle.
+await sleep(6000);
+
+const idlePath = `${OUT}/mobile-idle-fade.png`;
+await page.screenshot({ path: idlePath });
+console.log('wrote', idlePath);
+
+// Now simulate a finger resting on the move joystick -> .touching (full opacity).
+await page.evaluate(() => {
+  document.getElementById('mobile-move-joystick')?.classList.add('touching');
+  document.getElementById('mobile-camera-joystick')?.classList.add('touching');
+});
+await sleep(400);
+const activePath = `${OUT}/mobile-active-joystick.png`;
+await page.screenshot({ path: activePath });
+console.log('wrote', activePath);
+
+await browser.close();

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -127,6 +127,7 @@ export class MobileControls {
     if (!this.active || this.joyPointer !== null) return;
     e.preventDefault();
     this.joyPointer = e.pointerId;
+    this.moveJoystick?.classList.add('touching');
     try { this.moveJoystick?.setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
     this.onMoveMove(e);
   }
@@ -153,6 +154,7 @@ export class MobileControls {
 
   private releaseMove(): void {
     this.joyPointer = null;
+    this.moveJoystick?.classList.remove('touching');
     this.input.clearTouchMove();
     if (this.moveStick) this.moveStick.style.transform = '';
   }
@@ -161,6 +163,7 @@ export class MobileControls {
     if (!this.active || this.lookPointer !== null) return;
     e.preventDefault();
     this.lookPointer = e.pointerId;
+    this.cameraJoystick?.classList.add('touching');
     this.input.setTouchLook(true);
     try { this.cameraJoystick?.setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
     this.onCameraMove(e);
@@ -188,6 +191,7 @@ export class MobileControls {
 
   private releaseCamera(): void {
     this.lookPointer = null;
+    this.cameraJoystick?.classList.remove('touching');
     this.input.setTouchLook(false);
     this.input.setTouchLookVector({ x: 0, y: 0 });
     if (this.cameraStick) this.cameraStick.style.transform = '';


### PR DESCRIPTION
## Problem

On a phone the two **122px** touch joysticks sit at full opacity in the bottom corners **permanently**. In landscape on a small display that covers a meaningful slice of the playfield — and unlike the action buttons, the joysticks are big circles you're looking *past*, not *at*, most of the time.

## Fix

Fade each joystick down to **~40% opacity when idle**, and back to full the instant a finger rests on it.

- **`index.html`** — `.mobile-joystick` now defaults to `opacity: .4` with a `.18s` ease; a new `.touching` class restores `opacity: 1`. Wrapped the transition in a `prefers-reduced-motion: reduce` guard so it snaps instantly for users who ask for less motion.
- **`src/game/mobile_controls.ts`** — toggle `.touching` on the move / camera joystick inside the **existing** pointer-down and release handlers (`onMoveDown`/`releaseMove`, `onCameraDown`/`releaseCamera`). Pure presentation — no new sim or `IWorld` coupling, and it's cleared automatically on deactivate since `setActive(false)` already calls both release paths.

Scope is deliberately limited to the joysticks; the combat button row stays fully opaque so actions remain glanceable.

## Screenshots

Landscape phone (offline mode) — joysticks dimmed while idle:

![Mobile world, idle joysticks](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-idle-fade/mobile-idle-fade.png)

Close-up comparison — idle (~40%, grass shows through) vs. touching (100%):

![Idle vs touching joystick](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-idle-fade/joystick-fade-compare.png)

## Tests

- `tsc --noEmit` clean; full suite green (**648 tests**).
- `MobileControls` needs a DOM, which the node-only Vitest setup intentionally doesn't provide (only the pure helpers — `mapJoystickVector` etc. — are unit-tested), so this follows the existing convention and adds no jsdom dependency.

A reusable landscape-phone screenshot harness (`scripts/mobile_fade_shot.mjs`, consistent with the other `scripts/*.mjs` browser drivers) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)