### PR TITLE
feat(mobile): haptic feedback on touch controls with a Haptics toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -2822,6 +2822,8 @@
     z-index: 19;
   }
   body.mobile-touch .mobile-btn:active { transform: translateY(1px); border-color: var(--gold); color: #fff; }
+  body.mobile-touch .mobile-btn.is-on { border-color: var(--gold); color: #fff; }
+  body.mobile-touch .mobile-btn:not(.is-on)#mobile-haptics { opacity: 0.55; }
   body.mobile-touch .mobile-btn .mobile-label { display: block; margin-top: 1px; font-size: 8px; font-family: var(--ui-font); color: #bfb28a; }
   body.mobile-touch #mobile-extra-controls {
     position: fixed;
@@ -4098,6 +4100,7 @@
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
         <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>
         <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map" data-icon="map"><span class="mobile-label">Map</span></button>
+        <button class="mobile-btn" id="mobile-haptics" title="Toggle haptic feedback" aria-label="Toggle haptic feedback" aria-pressed="true" data-icon="vibrate"><span class="mobile-label">Haptics</span></button>
       </div>
     </div>
   </div>

--- a/scripts/mobile_visual.mjs
+++ b/scripts/mobile_visual.mjs
@@ -1,0 +1,82 @@
+// Mobile screenshot tour: boots the game in a phone-sized touch viewport so the
+// on-screen touch controls (body.mobile-touch) activate, then captures the touch
+// HUD, the expanded "More" tray, and the new Haptics toggle in both states.
+// Needs `npm run dev` (:5173). Writes PNGs into tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=900,440', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+// Landscape phone: coarse pointer + small enough to satisfy PHONE_TOUCH_QUERY.
+await page.emulate({
+  name: 'phone-landscape',
+  userAgent: 'Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Mobile Safari/537.36',
+  viewport: { width: 900, height: 420, deviceScaleFactor: 2, isMobile: true, hasTouch: true, isLandscape: true },
+});
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Touchscreen');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2800));
+
+// Dismiss the landscape/fullscreen preflight if it's up.
+await page.evaluate(() => {
+  document.getElementById('mobile-preflight-continue')?.click();
+});
+await new Promise((r) => setTimeout(r, 600));
+
+const touchOn = await page.evaluate(() => document.body.classList.contains('mobile-touch'));
+console.log('mobile-touch active:', touchOn ? 'OK' : 'FAIL');
+await page.screenshot({ path: 'tmp/mobile_01_hud.png' });
+
+// Open the "More" tray to reveal the extra controls incl. Haptics.
+await page.click('#mobile-more');
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({ path: 'tmp/mobile_02_more_tray.png' });
+
+const before = await page.evaluate(() => {
+  const b = document.getElementById('mobile-haptics');
+  return { exists: !!b, pressed: b?.getAttribute('aria-pressed'), label: b?.querySelector('.mobile-label')?.textContent };
+});
+console.log('haptics button (default):', JSON.stringify(before));
+
+// Toggle haptics off — tray stays open, button dims + relabels.
+await page.click('#mobile-haptics');
+await new Promise((r) => setTimeout(r, 300));
+const after = await page.evaluate(() => {
+  const b = document.getElementById('mobile-haptics');
+  return {
+    pressed: b?.getAttribute('aria-pressed'),
+    label: b?.querySelector('.mobile-label')?.textContent,
+    persisted: localStorage.getItem('woc_haptics_on'),
+  };
+});
+console.log('haptics button (after toggle):', JSON.stringify(after));
+await page.screenshot({ path: 'tmp/mobile_03_haptics_off.png' });
+
+const ok = before.exists && before.pressed === 'true' && after.pressed === 'false' && after.persisted === '0';
+console.log('haptics toggle:', ok ? 'OK' : 'FAIL');
+
+if (errors.length) {
+  console.log('\n=== PAGE ERRORS ===');
+  for (const e of errors.slice(0, 20)) console.log(e);
+} else {
+  console.log('no page errors');
+}
+await browser.close();
+process.exit(ok && touchOn ? 0 : 1);

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -4,6 +4,47 @@ export const PHONE_TOUCH_QUERY = '(pointer: coarse) and (max-width: 940px), (poi
 const DEADZONE = 0.22;
 const CAMERA_SENSITIVITY = 0.8;
 
+// Haptic feedback: short Vibration-API buzzes so touch actions feel physical.
+// On by default (own localStorage key, like music's ev_music_on); try/catch +
+// feature-detect guarded so it no-ops on desktop and under Vitest/jsdom.
+export const HAPTICS_STORE_KEY = 'woc_haptics_on';
+export const HAPTIC_TAP = 10;        // a button press
+export const HAPTIC_JOYSTICK = 6;    // grabbing a joystick
+export const HAPTIC_CONFIRM = [12, 40, 12]; // haptics toggled back on
+
+type VibrationNavigator = { vibrate?: (pattern: number | number[]) => boolean };
+
+export function loadHapticsEnabled(storage: Pick<Storage, 'getItem'> | null = safeLocalStorage()): boolean {
+  if (!storage) return true;
+  try {
+    return storage.getItem(HAPTICS_STORE_KEY) !== '0';
+  } catch {
+    return true;
+  }
+}
+
+export function saveHapticsEnabled(on: boolean, storage: Pick<Storage, 'setItem'> | null = safeLocalStorage()): void {
+  try { storage?.setItem(HAPTICS_STORE_KEY, on ? '1' : '0'); } catch { /* storage unavailable */ }
+}
+
+/** Fire a haptic pulse when enabled and the Vibration API exists. Returns whether it fired. */
+export function triggerHaptic(
+  pattern: number | number[],
+  enabled: boolean,
+  nav: VibrationNavigator | null = typeof navigator !== 'undefined' ? navigator : null,
+): boolean {
+  if (!enabled || !nav || typeof nav.vibrate !== 'function') return false;
+  try {
+    return nav.vibrate(pattern);
+  } catch {
+    return false;
+  }
+}
+
+function safeLocalStorage(): Pick<Storage, 'getItem' | 'setItem'> | null {
+  try { return typeof localStorage !== 'undefined' ? localStorage : null; } catch { return null; }
+}
+
 export interface MobileControlCallbacks {
   onAttackNearest(): void;
   onTarget(): void;
@@ -37,6 +78,7 @@ export function mapJoystickVector(x: number, y: number, deadzone = DEADZONE): To
 
 export class MobileControls {
   private active = false;
+  private hapticsOn = loadHapticsEnabled();
   private joyPointer: number | null = null;
   private lookPointer: number | null = null;
   private mq: MediaQueryList | null = null;
@@ -77,6 +119,7 @@ export class MobileControls {
     this.bindButton('mobile-talents', () => this.callbacks.onTalents());
     this.bindButton('mobile-meters', () => this.callbacks.onMeters());
     this.bindButton('mobile-map', () => this.callbacks.onMap());
+    this.bindHapticsToggle('mobile-haptics');
     this.bindButton('mobile-more', () => {
       this.root?.classList.toggle('expanded');
       document.body.classList.toggle('mobile-more-open', this.root?.classList.contains('expanded') ?? false);
@@ -101,12 +144,38 @@ export class MobileControls {
     button?.addEventListener('click', (e) => {
       if (!this.active) return;
       e.preventDefault();
+      triggerHaptic(HAPTIC_TAP, this.hapticsOn);
       cb();
       if (button.closest('#mobile-extra-controls')) {
         this.root?.classList.remove('expanded');
         document.body.classList.remove('mobile-more-open');
       }
     });
+  }
+
+  /** The haptics button is a stateful toggle, so it bypasses bindButton (no tray
+   *  auto-close, no buzz on the press that turns buzzing off) and reflects state
+   *  via aria-pressed + an .is-on class. */
+  private bindHapticsToggle(id: string): void {
+    const button = document.getElementById(id);
+    if (!button) return;
+    this.syncHapticsButton(button);
+    button.addEventListener('click', (e) => {
+      if (!this.active) return;
+      e.preventDefault();
+      this.hapticsOn = !this.hapticsOn;
+      saveHapticsEnabled(this.hapticsOn);
+      this.syncHapticsButton(button);
+      // confirm with a pulse only when enabling, so the player feels what they turned on
+      if (this.hapticsOn) triggerHaptic(HAPTIC_CONFIRM, true);
+    });
+  }
+
+  private syncHapticsButton(button: HTMLElement): void {
+    button.classList.toggle('is-on', this.hapticsOn);
+    button.setAttribute('aria-pressed', this.hapticsOn ? 'true' : 'false');
+    const label = button.querySelector('.mobile-label');
+    if (label) label.textContent = this.hapticsOn ? 'Haptics' : 'Haptics Off';
   }
 
   private toggleChat(): void {
@@ -127,6 +196,7 @@ export class MobileControls {
     if (!this.active || this.joyPointer !== null) return;
     e.preventDefault();
     this.joyPointer = e.pointerId;
+    triggerHaptic(HAPTIC_JOYSTICK, this.hapticsOn);
     try { this.moveJoystick?.setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
     this.onMoveMove(e);
   }
@@ -162,6 +232,7 @@ export class MobileControls {
     e.preventDefault();
     this.lookPointer = e.pointerId;
     this.input.setTouchLook(true);
+    triggerHaptic(HAPTIC_JOYSTICK, this.hapticsOn);
     try { this.cameraJoystick?.setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
     this.onCameraMove(e);
   }

--- a/src/ui/ui_icons.ts
+++ b/src/ui/ui_icons.ts
@@ -20,7 +20,7 @@ export type UiIconName =
   | 'chat' | 'interact'
   // hand-authored geometrics
   | 'close' | 'prev' | 'next' | 'more' | 'meters'
-  | 'whisper' | 'music' | 'talents' | 'skull';
+  | 'whisper' | 'music' | 'talents' | 'skull' | 'vibrate';
 
 // Inner SVG markup per icon (one or more <path>). Default fill rule is nonzero
 // (correct for game-icons.net art incl. overlaps); the two hand-authored cut-out
@@ -52,6 +52,8 @@ const ICONS: Record<UiIconName, string> = {
   music: '<path d="M158 374a54 54 0 1 0 108 0 54 54 0 1 0-108 0M260 128h22v246h-22zM282 122c46 16 70 58 46 98 12-32-6-62-46-74z"/>',
   talents: '<path d="M256 138v104M256 242l-96 86M256 242l96 86" stroke="currentColor" stroke-width="28" fill="none" stroke-linecap="round"/><circle cx="256" cy="116" r="44"/><circle cx="150" cy="352" r="44"/><circle cx="362" cy="352" r="44"/>',
   skull: '<path fill-rule="evenodd" d="M256 64C176 64 112 124 112 198c0 38 16 70 40 92v44a24 24 0 0 0 24 24h160a24 24 0 0 0 24-24v-44c24-22 40-54 40-92 0-74-64-134-144-134zM196 176a36 36 0 0 0 0 72 36 36 0 0 0 0-72zM316 176a36 36 0 0 0 0 72 36 36 0 0 0 0-72zM238 300h36v58h-36z"/>',
+  // phone handset flanked by vibration waves (hand-authored to match the bar glyphs)
+  vibrate: '<path fill-rule="evenodd" d="M196 80h120a24 24 0 0 1 24 24v304a24 24 0 0 1-24 24H196a24 24 0 0 1-24-24V104a24 24 0 0 1 24-24zm4 40v272h112V120H200z"/><path d="M96 176v160h28V176zM388 176v160h28V176zM40 216v80h26v-80zM446 216v80h26v-80z"/>',
 };
 
 export function hasUiIcon(name: string): name is UiIconName {

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { isPhoneTouchDevice, mapJoystickVector, mapLookVector } from '../src/game/mobile_controls';
+import {
+  HAPTICS_STORE_KEY,
+  isPhoneTouchDevice,
+  loadHapticsEnabled,
+  mapJoystickVector,
+  mapLookVector,
+  saveHapticsEnabled,
+  triggerHaptic,
+} from '../src/game/mobile_controls';
 
 describe('mapJoystickVector', () => {
   it('returns neutral inside the deadzone', () => {
@@ -45,5 +53,46 @@ describe('mapLookVector', () => {
     const v = mapLookVector(0.45, -0.25);
     expect(v.x).toBeCloseTo(0.36);
     expect(v.y).toBeCloseTo(-0.2);
+  });
+});
+
+describe('haptics', () => {
+  const makeStore = (initial: Record<string, string> = {}) => {
+    const map = new Map(Object.entries(initial));
+    return {
+      getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+      setItem: (k: string, v: string) => { map.set(k, v); },
+      map,
+    };
+  };
+
+  it('defaults to enabled when nothing is stored or storage is missing', () => {
+    expect(loadHapticsEnabled(makeStore())).toBe(true);
+    expect(loadHapticsEnabled(null)).toBe(true);
+  });
+
+  it('round-trips the stored preference (only "0" disables)', () => {
+    const store = makeStore();
+    saveHapticsEnabled(false, store);
+    expect(store.map.get(HAPTICS_STORE_KEY)).toBe('0');
+    expect(loadHapticsEnabled(store)).toBe(false);
+    saveHapticsEnabled(true, store);
+    expect(store.map.get(HAPTICS_STORE_KEY)).toBe('1');
+    expect(loadHapticsEnabled(store)).toBe(true);
+  });
+
+  it('vibrates only when enabled and the API exists', () => {
+    const calls: Array<number | number[]> = [];
+    const nav = { vibrate: (p: number | number[]) => { calls.push(p); return true; } };
+    expect(triggerHaptic(10, true, nav)).toBe(true);
+    expect(triggerHaptic(10, false, nav)).toBe(false); // disabled
+    expect(triggerHaptic(10, true, {})).toBe(false);    // no Vibration API
+    expect(triggerHaptic(10, true, null)).toBe(false);  // no navigator
+    expect(calls).toEqual([10]);
+  });
+
+  it('swallows Vibration API exceptions', () => {
+    const nav = { vibrate: () => { throw new Error('blocked'); } };
+    expect(triggerHaptic([12, 40, 12], true, nav)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Adds **haptic feedback** to the mobile touch controls. Pressing an on-screen button or grabbing a joystick now fires a short Vibration-API pulse, so touch actions feel physical on phones — the kind of tactile confirmation the keyboard/mouse client gets for free.

A new **Haptics** toggle in the mobile *More* tray lets players turn it off. The choice persists in `localStorage` (`woc_haptics_on`, **on by default**), mirroring how the music toggle uses `ev_music_on`.

## Why

The touch HUD has grown a lot recently (jump, autorun, pinch-zoom, floating joystick, More-tray menus). Buzz-on-tap is a small, classic mobile-game touch that makes those controls noticeably more responsive — and it's fully opt-out for players who dislike vibration or want to save battery.

## How

- **`src/game/mobile_controls.ts`** — pure, testable `triggerHaptic` / `loadHapticsEnabled` / `saveHapticsEnabled` helpers, feature-detected and `try/catch`-guarded so they no-op on desktop and under Vitest/jsdom (consistent with the existing pure `mapJoystickVector`/`mapLookVector` split). Buttons buzz `HAPTIC_TAP` (10ms), joystick grabs buzz `HAPTIC_JOYSTICK` (6ms), and re-enabling confirms with a short `HAPTIC_CONFIRM` pattern.
- The Haptics button is the **first stateful mobile toggle**: it bypasses `bindButton` so the tray stays open, reflects state via `aria-pressed` + an `.is-on` class, and relabels *Haptics* / *Haptics Off*.
- **`src/ui/ui_icons.ts`** — new hand-authored `vibrate` glyph (phone flanked by waves), no asset files.
- **`index.html`** — button markup + dimmed-when-off styling.
- No `IWorld` / sim changes — this is purely a client-side input/UI concern.

## Tests

- `tests/mobile_controls.test.ts` — default-on, persistence round-trip (only `"0"` disables), enabled/feature-detect gating, and exception swallowing.
- Full suite green: **652 passed**. `tsc --noEmit` clean.
- `scripts/mobile_visual.mjs` — new phone-viewport screenshot tour (used for the shots below).

## Screenshots (landscape phone viewport)

**Touch HUD**
![touch HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-haptics/mobile_01_hud.png)

**More tray — Haptics on (lit, bottom-right)**
![more tray](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-haptics/mobile_02_more_tray.png)

**Haptics toggled off (dimmed, relabeled "Haptics Off")**
![haptics off](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-haptics/mobile_03_haptics_off.png)