### PR TITLE
fix(mobile): cap More-tray height so it can't overflow off short landscape phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -2913,6 +2913,14 @@
     gap: 7px;
     pointer-events: auto;
     z-index: 70;
+    /* The tray grows upward from a fixed bottom. As it has gained buttons it can
+       now run off the TOP of a short landscape phone, leaving the upper rows
+       unreachable — so cap it to the space above the bottom controls and let the
+       overflow scroll. 100dvh accounts for mobile browser chrome (unlike 100vh). */
+    max-height: calc(100dvh - 84px - env(safe-area-inset-bottom));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
   body.mobile-touch.mobile-more-open #mobile-extra-controls { display: grid; }
   body.mobile-touch #mobile-extra-controls .mobile-btn {
@@ -3234,6 +3242,7 @@
       grid-template-columns: repeat(2, 104px);
       grid-auto-rows: 38px;
       gap: 6px;
+      max-height: calc(100dvh - 74px - env(safe-area-inset-bottom));
     }
     body.mobile-touch #mobile-extra-controls .mobile-btn {
       width: 104px;

--- a/scripts/mobile_tray_overflow.mjs
+++ b/scripts/mobile_tray_overflow.mjs
@@ -1,0 +1,60 @@
+// Reproduces + verifies the mobile More-tray overflow on short landscape phones.
+// The tray is a fixed 2-col grid anchored to the bottom that grows upward with
+// no max-height/scroll, so once it holds enough buttons the top rows render
+// above the viewport (negative top) and become unreachable.
+//
+// Usage: node scripts/mobile_tray_overflow.mjs           (default 740x360)
+//        VP=812x375 node scripts/mobile_tray_overflow.mjs
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as CHROME } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const [W, H] = (process.env.VP ?? '740x360').split('x').map(Number);
+const TAG = process.env.TAG ?? 'before';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME, headless: 'new',
+  args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.emulate({
+  viewport: { width: W, height: H, deviceScaleFactor: 2, isMobile: true, hasTouch: true },
+  userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148',
+});
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(250);
+await page.type('#char-name', 'Mobile');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await sleep(2500);
+await page.click('#mobile-more');
+await sleep(400);
+
+const report = await page.evaluate((vh) => {
+  const tray = document.getElementById('mobile-extra-controls');
+  const btns = [...document.querySelectorAll('#mobile-extra-controls .mobile-btn')];
+  const cs = getComputedStyle(tray);
+  const clipped = btns
+    .map((b) => ({ id: b.id, top: Math.round(b.getBoundingClientRect().top) }))
+    .filter((b) => b.top < 0 || b.top > vh);
+  return {
+    count: btns.length,
+    trayTop: Math.round(tray.getBoundingClientRect().top),
+    trayBottom: Math.round(tray.getBoundingClientRect().bottom),
+    overflowY: cs.overflowY,
+    maxHeight: cs.maxHeight,
+    clipped,
+  };
+}, H);
+
+await page.screenshot({ path: `tmp/tray_overflow_${TAG}.png` });
+console.log(`viewport ${W}x${H} — ${report.count} buttons, tray top=${report.trayTop} bottom=${report.trayBottom}, overflowY=${report.overflowY}, maxHeight=${report.maxHeight}`);
+console.log('off-screen (unreachable) buttons:', JSON.stringify(report.clipped));
+await browser.close();
+const bug = report.clipped.length > 0;
+console.log(bug ? `RESULT: BUG — ${report.clipped.length} buttons off-screen` : 'RESULT: OK — all buttons on-screen');
+process.exit(0);


### PR DESCRIPTION
## What

The mobile touch **More** tray (`#mobile-extra-controls`) is a `position: fixed`
2-column grid anchored to the **bottom** that grows **upward**, with **no
`max-height` and no overflow handling**. As the tray has accumulated buttons
(Bags/Character, Nameplates, Leaderboard, Music, …) it now reaches ~8 rows, and
on a short landscape phone the upper rows render **above the top of the
viewport** — with no way to scroll to them, so those actions are **completely
unreachable**.

Measured at **740×360** (a common landscape phone) on `release/v0.7`: the tray's
top edge sits at **`top: -46px`** and the **Social / Arena / Menu / Use** buttons
are off-screen.

## Fix

Cap the tray to the height available above the bottom controls and let the
overflow scroll, keeping the bottom pinned:

```css
max-height: calc(100dvh - 84px - env(safe-area-inset-bottom));
overflow-y: auto;
overscroll-behavior: contain;
-webkit-overflow-scrolling: touch;
```

- Uses **`100dvh`** (dynamic viewport height) so the cap respects mobile browser
  chrome — `100vh` would over-estimate and re-introduce the clipping.
- `overscroll-behavior: contain` stops the scroll from chaining to the world view.
- Applied to **both** size breakpoints (the `58px`-bottom compact one too).
- On tall screens nothing changes — the tray fits, so no scrollbar appears.

CSS-only; no `sim/`, `IWorld`, `net/`, or behavior change.

## Verification

New `scripts/mobile_tray_overflow.mjs` boots the offline world at a short
landscape viewport, opens the tray, and reports each button's on-screen position:

| | tray top | overflow-y | off-screen buttons |
|---|---|---|---|
| **before** | `-46px` | `visible` | 4 (Social, Arena, Menu, Use) |
| **after** | `+14px` | `auto` | **0** |

- `tsc --noEmit` clean · full suite green (**896 passed**).

## Screenshots (landscape phone, 740×360, offline)

**Before — top rows clipped above the viewport (Social/Arena/Menu/Use unreachable)**
![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-tray-overflow/tray_overflow_before.png)

**After — tray capped + scrollable, all buttons reachable**
![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-tray-overflow/tray_overflow_after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
