### PR TITLE
feat(mobile): add Character and Bags buttons to the touch More tray (#323)

### DIFF
--- a/index.html
+++ b/index.html
@@ -4093,6 +4093,8 @@
         <button class="mobile-btn" id="mobile-arena" title="Arena" aria-label="Arena" data-icon="arena"><span class="mobile-label">Arena</span></button>
         <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu" data-icon="menu"><span class="mobile-label">Menu</span></button>
         <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>
+        <button class="mobile-btn" id="mobile-character" title="Character" aria-label="Character" data-icon="character"><span class="mobile-label">Character</span></button>
+        <button class="mobile-btn" id="mobile-bags" title="Bags" aria-label="Bags" data-icon="bags"><span class="mobile-label">Bags</span></button>
         <button class="mobile-btn" id="mobile-quest" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="mobile-label">Quests</span></button>
         <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label">Spellbook</span></button>
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -10,6 +10,8 @@ export interface MobileControlCallbacks {
   onInteract(): void;
   onChat(): void;
   onMenu(): void;
+  onCharacter(): void;
+  onBags(): void;
   onSocial(): void;
   onArena(): void;
   onQuestLog(): void;
@@ -70,6 +72,8 @@ export class MobileControls {
     this.bindButton('mobile-interact', () => this.callbacks.onInteract());
     this.bindButton('mobile-chat', () => this.toggleChat());
     this.bindButton('mobile-menu', () => this.callbacks.onMenu());
+    this.bindButton('mobile-character', () => this.callbacks.onCharacter());
+    this.bindButton('mobile-bags', () => this.callbacks.onBags());
     this.bindButton('mobile-social', () => this.callbacks.onSocial());
     this.bindButton('mobile-arena', () => this.callbacks.onArena());
     this.bindButton('mobile-quest', () => this.callbacks.onQuestLog());

--- a/src/main.ts
+++ b/src/main.ts
@@ -426,6 +426,8 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     onMenu: () => {
       if (!hud.closeAll()) hud.toggleOptionsMenu();
     },
+    onCharacter: () => hud.toggleChar(),
+    onBags: () => hud.toggleBags(),
     onSocial: () => hud.toggleSocial(),
     onArena: () => hud.toggleArena(),
     onQuestLog: () => hud.toggleQuestLog(),


### PR DESCRIPTION
## Summary

Touch/mobile players had **no on-screen way to open their Character sheet or Bags** — both windows are fully implemented but bound to keyboard-only keys, and a phone has no keyboard:

- **Character** — `KeyC` → `hud.toggleChar()`
- **Bags** — `KeyB` → `hud.toggleBags()`

The mobile **More** tray (`#mobile-extra-controls`) already surfaces Social, Arena, Menu, Use, Quests, Spellbook, Talents, Meters and Map — but not these two core windows. This continues the mobile-parity work for the touch controls.

## Change

Add two buttons to the More tray, wired through the established four-layer pattern:

1. **Markup** — `#mobile-character` / `#mobile-bags` buttons in `index.html` (the `character` and `bags` glyphs already exist in `ICON_PATHS`, so no icon work needed).
2. **Callbacks** — `onCharacter`/`onBags` on `MobileControlCallbacks` + `bindButton` in `src/game/mobile_controls.ts`.
3. **Handlers** — wired in `src/main.ts`, reusing the **same** `hud.toggleChar()`/`hud.toggleBags()` the desktop keybinds call, so mobile and desktop stay behaviorally identical.

**Presentation-only:** no `sim/`, `IWorld`, or `net/` changes. +8 lines across 3 files.

## Screenshots (offline world, phone landscape viewport)

More tray with the new **Character** and **Bags** buttons:

![More tray](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-tray/shots/01_more_tray.png)

Tapping **Character** opens the paperdoll:

![Character window](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-tray/shots/02_character.png)

Tapping **Bags** opens the inventory:

![Bags window](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-tray/shots/03_bags.png)

## Testing

- `npx tsc --noEmit` — clean.
- `npx vitest run tests/mobile_controls.test.ts` — 6/6 pass.
- Manually verified in a 896×414 touch viewport: tray expands, both buttons appear, each opens its window and auto-collapses the tray (existing tray behavior).

Closes #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)