### PR TITLE
feat(mobile): add Emotes button to the touch More tray

### DIFF
--- a/index.html
+++ b/index.html
@@ -4220,6 +4220,7 @@
       <button class="mobile-btn" id="mobile-more" title="More menus" aria-label="Show more menus" data-icon="more"><span class="mobile-label">More</span></button>
       <div id="mobile-extra-controls">
         <button class="mobile-btn" id="mobile-social" title="Social" aria-label="Social" data-icon="social"><span class="mobile-label">Social</span></button>
+        <button class="mobile-btn" id="mobile-emote" title="Emotes" aria-label="Emotes" data-icon="emote"><span class="mobile-label">Emotes</span></button>
         <button class="mobile-btn" id="mobile-arena" title="Arena" aria-label="Arena" data-icon="arena"><span class="mobile-label">Arena</span></button>
         <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu" data-icon="menu"><span class="mobile-label">Menu</span></button>
         <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>

--- a/scripts/mobile_emote_shot.mjs
+++ b/scripts/mobile_emote_shot.mjs
@@ -1,0 +1,58 @@
+// Mobile screenshots for the touch "More" tray Emotes button.
+// Runs the offline flow (no server/Postgres) on a landscape-phone viewport.
+// Needs `npm run dev` running. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const CLASS = process.env.GAME_CLASS ?? 'warrior';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 844, height: 390, isMobile: true, hasTouch: true });
+// Satisfy PHONE_TOUCH_QUERY: (pointer: coarse) ...
+const cdp = await page.target().createCDPSession();
+await cdp.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+// Menu buttons fail puppeteer's clickable-point check on mobile menus → click in-page.
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await tap('#btn-offline');
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Thorgar'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap(`#offline-select .mini-class[data-class="${CLASS}"]`);
+await tap('#btn-start-offline');
+await wait(3000);
+
+// Don't get eaten while posing for the camera.
+await page.evaluate(() => { const p = window.__game.sim.player; p.maxHp = 99999; p.hp = 99999; });
+
+// 1) Open the "More" tray — shows the new Emotes button.
+await tap('#mobile-more');
+await wait(400);
+await page.screenshot({ path: 'tmp/mobile_more_tray.png' });
+
+// 2) Tap Emotes — opens the radial emote wheel (pinned so a tap selects a slice).
+await tap('#mobile-emote');
+await wait(500);
+await page.screenshot({ path: 'tmp/mobile_emote_wheel.png' });
+
+if (errors.length) console.log('PAGE ERRORS:\n' + errors.join('\n'));
+console.log('wrote tmp/mobile_more_tray.png, tmp/mobile_emote_wheel.png');
+await browser.close();

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -58,6 +58,7 @@ export interface MobileControlCallbacks {
   onChat(): void;
   onMenu(): void;
   onSocial(): void;
+  onEmotes(): void;
   onArena(): void;
   onQuestLog(): void;
   onCharacter(): void;
@@ -196,6 +197,7 @@ export class MobileControls {
     this.bindButton('mobile-chat', () => this.toggleChat());
     this.bindButton('mobile-menu', () => this.callbacks.onMenu());
     this.bindButton('mobile-social', () => this.callbacks.onSocial());
+    this.bindButton('mobile-emote', () => this.callbacks.onEmotes());
     this.bindButton('mobile-arena', () => this.callbacks.onArena());
     this.bindButton('mobile-quest', () => this.callbacks.onQuestLog());
     this.bindButton('mobile-char', () => this.callbacks.onCharacter());

--- a/src/main.ts
+++ b/src/main.ts
@@ -437,6 +437,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       if (!hud.closeAll()) hud.toggleOptionsMenu();
     },
     onSocial: () => hud.toggleSocial(),
+    onEmotes: () => hud.toggleEmoteWheel(),
     onArena: () => hud.toggleArena(),
     onQuestLog: () => hud.toggleQuestLog(),
     onCharacter: () => hud.toggleChar(),

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -233,7 +233,7 @@ export class Hud {
     window.addEventListener('pointerdown', (ev) => {
       if (!this.emoteWheelOpen || !this.emoteWheelPinned) return;
       const target = ev.target as Node | null;
-      if (target && (this.emoteWheelEl?.contains(target) || document.getElementById('mm-emote')?.contains(target))) return;
+      if (target && (this.emoteWheelEl?.contains(target) || document.getElementById('mm-emote')?.contains(target) || document.getElementById('mobile-emote')?.contains(target))) return;
       this.hideEmoteWheel();
     });
     $('#release-btn').addEventListener('click', () => { this.sim.releaseSpirit(); });
@@ -299,11 +299,7 @@ export class Hud {
     const emoteBtn = $('#mm-emote');
     emoteBtn.addEventListener('click', (ev) => {
       ev.preventDefault();
-      if (this.emoteWheelOpen && this.emoteWheelPinned) {
-        this.hideEmoteWheel();
-        return;
-      }
-      this.showEmoteWheel(true);
+      this.toggleEmoteWheel();
     });
     const musicBtn = $('#mm-music');
     const styleMusicBtn = () => {
@@ -424,6 +420,17 @@ export class Hud {
 
   private emoteWheelDisplayLabel(id: OverheadEmoteId): string {
     return `${this.emoteLabel(id)} (${this.emoteWheelKeyLabel()})`;
+  }
+
+  /** Tap-to-toggle the pinned emote wheel — used by the menu-bar and on-screen
+   *  touch Emote buttons (touch has no key to hold, so the wheel stays pinned
+   *  until a slice or the outside is tapped). */
+  toggleEmoteWheel(): void {
+    if (this.emoteWheelOpen && this.emoteWheelPinned) {
+      this.hideEmoteWheel();
+      return;
+    }
+    this.showEmoteWheel(true);
   }
 
   setEmoteWheelOpen(open: boolean): void {

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -220,6 +220,7 @@ function installMobileControlDom(): {
   moveZone: FakeElement;
   moveJoystick: FakeElement;
   cameraJoystick: FakeElement;
+  emoteButton: FakeElement;
   windowTarget: EventTarget;
 } {
   const elements = new Map<string, FakeElement>([
@@ -229,6 +230,7 @@ function installMobileControlDom(): {
     ['mobile-move-stick', new FakeElement()],
     ['mobile-camera-joystick', new FakeElement()],
     ['mobile-camera-stick', new FakeElement()],
+    ['mobile-emote', new FakeElement()],
   ]);
   const body = new FakeElement();
   const documentTarget = new EventTarget();
@@ -251,6 +253,7 @@ function installMobileControlDom(): {
     moveZone: elements.get('mobile-move-zone')!,
     moveJoystick: elements.get('mobile-move-joystick')!,
     cameraJoystick: elements.get('mobile-camera-joystick')!,
+    emoteButton: elements.get('mobile-emote')!,
     windowTarget,
   };
 }
@@ -276,6 +279,7 @@ function mobileCallbacks() {
     onChat: noop,
     onMenu: noop,
     onSocial: noop,
+    onEmotes: noop,
     onArena: noop,
     onQuestLog: noop,
     onCharacter: noop,
@@ -338,5 +342,23 @@ describe('MobileControls pointer lifecycle', () => {
 
     expect(touchLookActive).toBe(false);
     expect(lastLook).toEqual({ x: 0, y: 0 });
+  });
+
+  it('fires the emote callback when the on-screen Emotes button is tapped', () => {
+    const { emoteButton } = installMobileControlDom();
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: () => {},
+      setTouchLookVector: () => {},
+    } as unknown as Input;
+
+    let emotes = 0;
+    const callbacks = { ...mobileCallbacks(), onEmotes: () => { emotes += 1; } };
+    new MobileControls(input, callbacks).start();
+
+    emoteButton.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
+
+    expect(emotes).toBe(1);
   });
 });


### PR DESCRIPTION
## What & why

The emote wheel was only reachable two ways — the `emoteWheel` keybind and the `#mm-emote` menu-bar micro-button — **neither of which exists on phones**. Touch players had no way to emote. This adds an **Emotes** button to the on-screen *More* tray that opens the wheel in its existing *pinned* (tap-to-select) mode, the same flow the menu-bar button already uses.

## Changes

- **index.html** — new `#mobile-emote` button in `#mobile-extra-controls`, reusing the existing `emote` icon.
- **src/ui/hud.ts** — extract a public `toggleEmoteWheel()` (now shared by `#mm-emote` and the mobile button) and add `#mobile-emote` to the outside-tap dismissal exclusion so re-tapping the button toggles the wheel cleanly.
- **src/game/mobile_controls.ts** / **src/main.ts** — wire a new `onEmotes` callback → `hud.toggleEmoteWheel()`.
- **tests/mobile_controls.test.ts** — assert the button fires its callback (21 pass).
- **scripts/mobile_emote_shot.mjs** — screenshot helper for the tray + wheel.

No `IWorld` change: emotes already play through the existing `sim.playEmote()`, so this is purely a presentation-layer addition.

## Screenshots

More tray with the new **Emotes** button:

![More tray](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-emote/mobile_more_tray.png)

Tapping it opens the radial emote wheel (pinned, so a tap selects a slice):

![Emote wheel](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-emote/mobile_emote_wheel.png)

## Verification

- `npx tsc --noEmit`
- `npx vitest run tests/mobile_controls.test.ts tests/keybinds.test.ts` (36 tests)
- `npm run build`
- `GAME_URL=http://localhost:5173 node scripts/mobile_emote_shot.mjs` (offline; the only page errors were the expected local `/api/project-stats` 404s without a backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)