### PR TITLE
feat: add browser performance doctor

### DIFF
--- a/src/game/perf.ts
+++ b/src/game/perf.ts
@@ -1,5 +1,6 @@
 import type { Renderer } from '../render/renderer';
 import { assetTimingSnapshot, type AssetTimingSnapshot } from '../render/assets/stats';
+import { analyzePerfSuggestions, type PerfSuggestion } from './perf_doctor';
 
 export interface PerfSnapshot {
   seconds: number;
@@ -87,6 +88,11 @@ function pushSample(values: number[], sample: number): void {
 export class PerfMonitor {
   readonly enabled: boolean;
   private overlay: HTMLDivElement | null = null;
+  private doctor: HTMLDivElement | null = null;
+  private doctorList: HTMLDivElement | null = null;
+  private doctorDismissed = false;
+  private lastDoctorAt = 0;
+  private lastDoctorIds = '';
   private startedAt = performance.now();
   private lastOverlayAt = 0;
   private frames = 0;
@@ -115,8 +121,8 @@ export class PerfMonitor {
     this.enabled = params.has('perf') || localStorage.getItem('woc_perf') === '1';
     if (this.enabled) {
       this.mountOverlay();
-      this.observeLongTasks();
     }
+    this.observeLongTasks();
   }
 
   setRenderer(renderer: Renderer): void {
@@ -128,7 +134,6 @@ export class PerfMonitor {
   }
 
   frame(dt: number, now = performance.now()): void {
-    if (!this.enabled) return;
     this.frames++;
     const ms = Math.min(250, Math.max(0, dt * 1000));
     pushSample(this.frameMs, ms);
@@ -220,11 +225,11 @@ export class PerfMonitor {
   }
 
   tick(now = performance.now()): void {
-    if (!this.enabled) return;
     if (now - this.lastOverlayAt < 1000) return;
     this.lastOverlayAt = now;
     this.lastSnapshot = this.snapshot(now);
-    this.renderOverlay(this.lastSnapshot);
+    if (this.enabled) this.renderOverlay(this.lastSnapshot);
+    this.renderDoctor(this.lastSnapshot, now);
   }
 
   snapshot(now = performance.now()): PerfSnapshot {
@@ -344,6 +349,93 @@ export class PerfMonitor {
     this.overlay.textContent = 'perf: collecting...';
     this.overlay.addEventListener('click', () => this.copyReport());
     document.body.appendChild(this.overlay);
+  }
+
+  private mountDoctor(): void {
+    this.doctor = document.createElement('div');
+    this.doctor.style.cssText = [
+      'position:fixed',
+      'right:14px',
+      'bottom:14px',
+      'z-index:2147483600',
+      'width:min(360px,calc(100vw - 28px))',
+      'font:13px/1.35 system-ui,-apple-system,Segoe UI,sans-serif',
+      'color:#e5edf8',
+      'background:rgba(8,13,22,0.94)',
+      'border:1px solid rgba(250,204,21,0.42)',
+      'border-radius:8px',
+      'box-shadow:0 12px 36px rgba(0,0,0,0.45)',
+      'padding:11px',
+      'pointer-events:auto',
+    ].join(';');
+    const head = document.createElement('div');
+    head.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:7px';
+    const title = document.createElement('div');
+    title.textContent = 'Performance suggestions';
+    title.style.cssText = 'font-weight:700;color:#fde68a;letter-spacing:0';
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.textContent = 'x';
+    close.setAttribute('aria-label', 'Dismiss performance suggestions');
+    close.style.cssText = [
+      'width:28px',
+      'height:28px',
+      'border:1px solid rgba(255,255,255,0.18)',
+      'border-radius:6px',
+      'background:rgba(255,255,255,0.08)',
+      'color:#e5edf8',
+      'font:20px/1 system-ui,sans-serif',
+      'cursor:pointer',
+    ].join(';');
+    close.addEventListener('click', () => {
+      this.doctorDismissed = true;
+      this.doctor?.remove();
+      this.doctor = null;
+      this.doctorList = null;
+    });
+    head.append(title, close);
+    this.doctorList = document.createElement('div');
+    this.doctor.append(head, this.doctorList);
+    document.body.appendChild(this.doctor);
+  }
+
+  private renderDoctor(s: PerfSnapshot, now: number): void {
+    if (this.doctorDismissed || now - this.startedAt < 12_000 || now - this.lastDoctorAt < 5_000) return;
+    this.lastDoctorAt = now;
+    const suggestions = analyzePerfSuggestions(s, location.search);
+    if (!suggestions.length) {
+      this.doctor?.remove();
+      this.doctor = null;
+      this.doctorList = null;
+      this.lastDoctorIds = '';
+      return;
+    }
+    const ids = suggestions.map((x) => x.id).join('|');
+    if (ids === this.lastDoctorIds && this.doctor) return;
+    this.lastDoctorIds = ids;
+    if (!this.doctor) this.mountDoctor();
+    if (!this.doctorList) return;
+    this.doctorList.replaceChildren(...suggestions.map((suggestion) => this.doctorItem(suggestion)));
+  }
+
+  private doctorItem(suggestion: PerfSuggestion): HTMLElement {
+    const item = document.createElement('div');
+    item.style.cssText = 'padding:8px 0;border-top:1px solid rgba(255,255,255,0.08)';
+    const title = document.createElement('div');
+    title.textContent = suggestion.title;
+    title.style.cssText = `font-weight:700;color:${suggestion.severity === 'critical' ? '#fecaca' : '#dbeafe'};margin-bottom:3px`;
+    const body = document.createElement('div');
+    body.textContent = suggestion.body;
+    body.style.cssText = 'color:#b8c4d6';
+    item.append(title, body);
+    if (suggestion.action) {
+      const action = document.createElement('a');
+      action.textContent = suggestion.action.label;
+      action.href = suggestion.action.href;
+      action.style.cssText = 'display:inline-block;margin-top:7px;color:#93c5fd;text-decoration:underline;font-weight:700';
+      item.append(action);
+    }
+    return item;
   }
 
   private renderOverlay(s: PerfSnapshot): void {

--- a/src/game/perf_doctor.ts
+++ b/src/game/perf_doctor.ts
@@ -1,0 +1,135 @@
+export type PerfSuggestionSeverity = 'info' | 'warning' | 'critical';
+
+export interface PerfSuggestion {
+  id: string;
+  severity: PerfSuggestionSeverity;
+  title: string;
+  body: string;
+  action?: { label: string; href: string };
+}
+
+interface PerfDoctorSnapshot {
+  frameMs: { p95: number; long50: number };
+  windows: { last10s: { frames: number; fps: number; frameMs: { p95: number; long50: number } } };
+  renderer: {
+    tier: string;
+    pixelRatio: number;
+    glRenderer: string;
+    contextLost: number;
+    contextRestored: number;
+  } | null;
+  browser: {
+    longTasks: { count: number; p95: number; max: number };
+    memory: { usedMB: number; limitMB: number } | null;
+  };
+  device: {
+    dpr: number;
+    deviceMemory: number | null;
+    hardwareConcurrency: number;
+    maxTouchPoints: number;
+  };
+}
+
+function hasForcedHighGraphics(search: string): boolean {
+  const params = new URLSearchParams(search);
+  const gfx = params.get('gfx');
+  return gfx === 'high' || gfx === 'ultra';
+}
+
+function lowGraphicsHref(search: string): string {
+  const params = new URLSearchParams(search);
+  params.set('gfx', 'low');
+  const qs = params.toString();
+  const path = typeof location !== 'undefined' ? location.pathname : '/';
+  const hash = typeof location !== 'undefined' ? location.hash : '';
+  return `${path}${qs ? `?${qs}` : ''}${hash}`;
+}
+
+function isSoftwareRenderer(glRenderer: string): boolean {
+  return /swiftshader|llvmpipe|software/i.test(glRenderer);
+}
+
+function isBadFrameWindow(s: PerfDoctorSnapshot): boolean {
+  const w = s.windows.last10s;
+  return w.frames !== 0 && (w.fps < 45 || w.frameMs.p95 >= 28 || w.frameMs.long50 >= 3);
+}
+
+export function analyzePerfSuggestions(
+  s: PerfDoctorSnapshot,
+  search = typeof location !== 'undefined' ? location.search : '',
+): PerfSuggestion[] {
+  const out: PerfSuggestion[] = [];
+  const badFrames = isBadFrameWindow(s);
+  const renderer = s.renderer;
+
+  if (renderer && isSoftwareRenderer(renderer.glRenderer)) {
+    out.push({
+      id: 'hardware-acceleration',
+      severity: 'critical',
+      title: 'Browser is using software rendering',
+      body: 'The game is not using the real GPU. Enable hardware acceleration in your browser settings, then fully restart the browser.',
+    });
+  }
+
+  if (badFrames && renderer && s.device.dpr >= 2 && renderer.pixelRatio >= 1.7) {
+    out.push({
+      id: 'high-dpi',
+      severity: 'warning',
+      title: 'High-DPI rendering is expensive here',
+      body: 'This screen is rendering a lot of pixels. Lower graphics quality if movement or camera turns feel choppy.',
+      action: { label: 'Use Low graphics', href: lowGraphicsHref(search) },
+    });
+  }
+
+  if (badFrames && hasForcedHighGraphics(search)) {
+    out.push({
+      id: 'forced-high-graphics',
+      severity: 'warning',
+      title: 'Forced high graphics is hurting performance',
+      body: 'This session is overriding automatic graphics detection. Switch back to Auto or Low for smoother laptop play.',
+      action: { label: 'Use Low graphics', href: lowGraphicsHref(search) },
+    });
+  }
+
+  if (badFrames && s.device.deviceMemory !== null && s.device.deviceMemory <= 4) {
+    out.push({
+      id: 'low-memory',
+      severity: 'warning',
+      title: 'Low memory device detected',
+      body: 'Close extra tabs and apps before playing. Browser games share memory with the operating system and extensions.',
+      action: { label: 'Use Low graphics', href: lowGraphicsHref(search) },
+    });
+  }
+
+  const longTasks = s.browser.longTasks;
+  if (badFrames && longTasks.count >= 3 && (longTasks.p95 >= 80 || longTasks.max >= 150)) {
+    out.push({
+      id: 'browser-stalls',
+      severity: 'warning',
+      title: 'Browser or extension stalls detected',
+      body: 'Something outside the game is blocking the browser main thread. Try disabling extensions or ad blockers for this site.',
+    });
+  }
+
+  const memory = s.browser.memory;
+  if (badFrames && memory && memory.limitMB > 0 && memory.usedMB / memory.limitMB >= 0.75) {
+    out.push({
+      id: 'heap-pressure',
+      severity: 'warning',
+      title: 'Browser memory pressure detected',
+      body: 'Reloading the game or closing other tabs may reduce stutters during long sessions.',
+    });
+  }
+
+  if (renderer && (renderer.contextLost > 0 || renderer.contextRestored > 0)) {
+    out.push({
+      id: 'context-loss',
+      severity: 'critical',
+      title: 'Graphics context reset detected',
+      body: 'The browser reset the game graphics context. Lower graphics quality and update your browser or GPU drivers if this repeats.',
+      action: { label: 'Use Low graphics', href: lowGraphicsHref(search) },
+    });
+  }
+
+  return out.slice(0, 3);
+}

--- a/tests/perf_doctor.test.ts
+++ b/tests/perf_doctor.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { analyzePerfSuggestions } from '../src/game/perf_doctor';
+
+const base = {
+  frameMs: { p95: 16, long50: 0 },
+  windows: { last10s: { frames: 600, fps: 60, frameMs: { p95: 16, long50: 0 } } },
+  renderer: {
+    tier: 'high',
+    pixelRatio: 1.5,
+    glRenderer: 'ANGLE (Apple, Apple M2, OpenGL)',
+    contextLost: 0,
+    contextRestored: 0,
+  },
+  browser: {
+    longTasks: { count: 0, p95: 0, max: 0 },
+    memory: null,
+  },
+  device: {
+    dpr: 1.5,
+    deviceMemory: 8,
+    hardwareConcurrency: 8,
+    maxTouchPoints: 0,
+  },
+};
+
+describe('analyzePerfSuggestions', () => {
+  it('stays quiet for a healthy session', () => {
+    expect(analyzePerfSuggestions(base)).toEqual([]);
+  });
+
+  it('flags software rendering as a hardware acceleration problem', () => {
+    const suggestions = analyzePerfSuggestions({
+      ...base,
+      renderer: { ...base.renderer, glRenderer: 'Google SwiftShader' },
+    });
+
+    expect(suggestions.map((s) => s.id)).toContain('hardware-acceleration');
+  });
+
+  it('suggests low graphics for high-DPI sessions with bad frame windows', () => {
+    const suggestions = analyzePerfSuggestions({
+      ...base,
+      windows: { last10s: { frames: 300, fps: 30, frameMs: { p95: 40, long50: 4 } } },
+      renderer: { ...base.renderer, pixelRatio: 2 },
+      device: { ...base.device, dpr: 2 },
+    }, '?foo=bar');
+
+    const highDpi = suggestions.find((s) => s.id === 'high-dpi');
+    expect(highDpi?.action?.href).toContain('gfx=low');
+  });
+
+  it('does not blame extensions unless frame performance is also bad', () => {
+    const healthyWithLongTasks = analyzePerfSuggestions({
+      ...base,
+      browser: { ...base.browser, longTasks: { count: 4, p95: 120, max: 180 } },
+    });
+    expect(healthyWithLongTasks.map((s) => s.id)).not.toContain('browser-stalls');
+
+    const badWithLongTasks = analyzePerfSuggestions({
+      ...base,
+      windows: { last10s: { frames: 300, fps: 30, frameMs: { p95: 42, long50: 5 } } },
+      browser: { ...base.browser, longTasks: { count: 4, p95: 120, max: 180 } },
+    });
+    expect(badWithLongTasks.map((s) => s.id)).toContain('browser-stalls');
+  });
+
+  it('warns when high graphics is forced during bad performance', () => {
+    const suggestions = analyzePerfSuggestions({
+      ...base,
+      windows: { last10s: { frames: 280, fps: 28, frameMs: { p95: 45, long50: 8 } } },
+    }, '?gfx=ultra');
+
+    expect(suggestions.map((s) => s.id)).toContain('forced-high-graphics');
+  });
+});
+


### PR DESCRIPTION
## Summary\n\nAdds a lightweight in-game Performance Doctor that detects common browser/device causes of poor gameplay and suggests practical fixes to players.\n\n## What changed\n\n- Keeps the existing `?perf` debug overlay opt-in, but now collects cheap frame-window and browser long-task signals during normal play.\n- Adds `analyzePerfSuggestions()`, a testable rule engine for player-facing performance advice.\n- Shows a small dismissible "Performance suggestions" panel only after the game has evidence of a useful recommendation.\n- Adds direct "Use Low graphics" links where lowering graphics is the right fix.\n\n## What it can explain to players\n\n- **Hardware acceleration / software rendering:** if WebGL reports SwiftShader, llvmpipe, or software rendering, the player is probably not using their real GPU. The game suggests enabling browser hardware acceleration and restarting the browser.\n- **High-DPI laptop screens:** if frame times are poor and the browser is rendering at a high pixel ratio, the game suggests Low graphics because retina/high-DPI screens multiply pixel cost.\n- **Forced high graphics:** if the URL forces `?gfx=high` or `?gfx=ultra` while performance is bad, the game suggests returning to Low/Auto.\n- **Low memory:** if the browser exposes `navigator.deviceMemory <= 4` and frames are bad, the game suggests closing tabs/apps or using Low graphics.\n- **Extensions/ad blockers:** the game does not claim to identify a specific extension. It only suggests extensions/ad blockers when browser long-task stalls coincide with bad frame performance.\n- **Memory pressure/context loss:** the game suggests reload/low graphics/browser or driver updates when the browser exposes heap pressure or WebGL context resets.\n\n## Validation\n\n- `npx tsc --noEmit`\n- `npx vitest run tests/perf_doctor.test.ts tests/gfx.test.ts` (2 files, 8 tests)\n- `npm test` (97 files, 903 tests)\n- `npm run build` (passed; existing cursor URL and large bundle warnings only)\n- `npm run asset:budget`\n