### PR TITLE
feat(mobile): Touch Controls Opacity accessibility setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -2782,7 +2782,7 @@
   #rotate-device { display: none; }
   body.mobile-touch #game-canvas { touch-action: none; }
   body.mobile-touch #ui { touch-action: none; }
-  body.mobile-touch #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; }
+  body.mobile-touch #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; opacity: var(--touch-opacity, 1); }
   body.mobile-touch .mobile-joystick {
     position: absolute; left: max(18px, env(safe-area-inset-left)); bottom: calc(26px + env(safe-area-inset-bottom));
     width: 122px; height: 122px; border-radius: 50%; pointer-events: auto; touch-action: none;

--- a/scripts/mobile_touch_opacity.mjs
+++ b/scripts/mobile_touch_opacity.mjs
@@ -1,0 +1,53 @@
+// Visual proof for the Touch Controls Opacity accessibility slider.
+// Boots the offline game in a touch-emulated phone viewport and captures the
+// on-screen joysticks + buttons at full, mid, and low opacity. Saves to tmp/.
+//
+// Needs `npm run dev` on :5173. Headless Chromium does not report
+// `pointer: coarse`, so we force `document.body.classList.add('mobile-touch')`
+// to reveal the touch overlay (same trick the mobile e2e scripts use).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=900,440', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 844, height: 390, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Adventurer');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Reveal the touch overlay (headless Chromium reports pointer: fine).
+await page.evaluate(() => document.body.classList.add('mobile-touch'));
+await new Promise((r) => setTimeout(r, 400));
+
+async function shot(opacity, name) {
+  await page.evaluate((o) => {
+    document.documentElement.style.setProperty('--touch-opacity', String(o));
+  }, opacity);
+  await new Promise((r) => setTimeout(r, 250));
+  await page.screenshot({ path: `tmp/${name}` });
+  console.log(`captured ${name} at opacity ${opacity}`);
+}
+
+await shot(1.0, 'touch_opacity_100.png');
+await shot(0.6, 'touch_opacity_60.png');
+await shot(0.3, 'touch_opacity_30.png');
+
+await browser.close();
+if (errors.length) { console.error('Browser errors:\n' + errors.join('\n')); process.exit(1); }
+console.log('done');

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -18,6 +18,9 @@ export const SETTING_RANGES = {
   // off by default: always-on click-to-move would disrupt the precise melee
   // positioning the team wanted to preserve, so it's opt-in (#95)
   clickToMove: { min: 0, max: 1, def: 0 },
+  // 1.0 (fully opaque) by default; touch-only. Lets phone players dim the
+  // on-screen joysticks + buttons so they obscure less of the world.
+  touchOpacity: { min: 0.3, max: 1, def: 1 },
 } as const;
 
 export const BOOL_SETTINGS = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -451,6 +451,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       case 'brightness': renderer.setBrightness(v); break;
       case 'renderScale': renderer.setRenderScale(v); break;
       case 'fullscreen': v >= 0.5 ? requestPreferredFullscreen() : exitBrowserFullscreen(); break;
+      case 'touchOpacity': document.documentElement.style.setProperty('--touch-opacity', String(v)); break;
     }
   }
   // apply persisted settings to the freshly-built subsystems

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -24,6 +24,7 @@ import { iconDataUrl, iconCanvas, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_
 import { svgIcon } from './ui_icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES } from '../game/settings';
+import { isPhoneTouchDevice } from '../game/mobile_controls';
 import { chatPlayerContextActions } from './player_context_menu';
 import {
   talentsFor, computeTalentModifiers, validateAllocation, dormantNodes, pointsSpent,
@@ -4067,6 +4068,8 @@ export class Hud {
     this.settingSlider(body, 'Render Quality', 'renderScale');
     this.settingToggle(body, 'Fullscreen', 'fullscreen');
     this.settingToggle(body, t('game.settings.showOverflowXp'), 'showOverflowXp');
+    // Touch-only: lets phone players dim the on-screen joysticks + buttons.
+    if (isPhoneTouchDevice()) this.settingSlider(body, 'Touch Controls Opacity', 'touchOpacity');
     const note = document.createElement('div');
     note.className = 'set-note';
     note.textContent = 'Lower Camera Speed for a calmer mouselook. Render Quality below 100% boosts FPS on weaker machines. Show Overflow XP keeps the XP bar filling past the level cap.';

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -32,6 +32,14 @@ describe('Settings', () => {
     expect(s.set('fullscreen', -1)).toBe(0);
   });
 
+  it('clamps touch opacity to its 0.3–1.0 bounds and defaults to fully opaque', () => {
+    const s = new Settings();
+    expect(s.get('touchOpacity')).toBe(SETTING_RANGES.touchOpacity.def);
+    expect(s.set('touchOpacity', 5)).toBe(SETTING_RANGES.touchOpacity.max);
+    expect(s.set('touchOpacity', 0)).toBe(SETTING_RANGES.touchOpacity.min);
+    expect(s.set('touchOpacity', 0.6)).toBe(0.6);
+  });
+
   it('ignores non-finite input, keeping a valid value', () => {
     const s = new Settings();
     s.set('brightness', NaN);


### PR DESCRIPTION
## What

Adds a **touch-only "Touch Controls Opacity"** slider (0.3–1.0, default **1.0** = unchanged) to the **Graphics** options panel. Phone players can dim the on-screen joysticks and buttons so more of the world shows through, which helps on small screens where the thumb pads cover a lot of the view.

The action bar keeps its full opacity, so ability icons stay readable — only the joystick/button overlay (`#mobile-controls`) dims.

## Why

A natural companion to the joystick/button **size** sliders: some players don't want the controls *smaller*, they want them *less obtrusive*. Unlike an automatic idle-fade, this is an **explicit, persistent user setting** — predictable and opt-in (default is fully opaque, so nothing changes unless the player moves the slider).

## How

Self-contained in the presentation/settings layer — **no `sim/` or `IWorld` change**, respecting the core isolation invariant:

- `touchOpacity` added to `SETTING_RANGES` (`src/game/settings.ts`) — the generic store gives persistence, clamping and reset for free.
- `applySetting` (`src/main.ts`) writes it to the CSS variable `--touch-opacity` on `<html>`.
- `index.html`: `#mobile-controls` consumes `opacity: var(--touch-opacity, 1)`.
- The slider is rendered in `renderGraphics()` **only when `isPhoneTouchDevice()`**, so desktop users never see it.

## Screenshots

| 100% (default) | 60% | 30% |
|---|---|---|
| ![100%](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-touch-opacity/touch_opacity_100.png) | ![60%](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-touch-opacity/touch_opacity_60.png) | ![30%](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-touch-opacity/touch_opacity_30.png) |

## Testing

- `tests/settings.test.ts` — added clamp/default coverage for `touchOpacity`.
- `npx tsc --noEmit` clean.
- Visual proof via `scripts/mobile_touch_opacity.mjs` (touch-emulated phone viewport; produced the screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)