### PR TITLE
feat(chat): profanity filter with admin-managed lists and slur enforcement

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -102,9 +102,14 @@ For off-box safety, sync the directory to S3 occasionally:
 - **Username bans**: set `USERNAME_BANLIST_FILE=/opt/eastbrook/username-banlist.txt`
   to load blocked username terms from a private newline- or comma-separated
   file. `USERNAME_BANLIST` can also provide a comma-separated inline list.
-- **Chat censorship**: set `CHAT_CENSOR_FILE=/opt/eastbrook/chat-censor.txt`
-  to mask configured terms from a private newline- or comma-separated file.
-  `CHAT_CENSOR_LIST` can also provide a comma-separated inline list.
+- **Chat filter**: the word lists are now **managed live from the admin
+  dashboard** (Chat Filter tab), stored in the database and seeded with sensible
+  defaults on first boot. Two tiers: *soft* words are masked client-side with
+  `****` (players can toggle the filter off in Options), and *hard* words (slurs)
+  are blocked server-side and escalate from a warning to account-wide timed mutes
+  (durations editable in the same tab). `CHAT_CENSOR_LIST` / `CHAT_CENSOR_FILE`
+  are still read **once**, on the first boot of a fresh database, to seed the soft
+  list — after that they are ignored and the dashboard is authoritative.
 - **Realms (horizontal scaling)**: each server process serves one realm,
   set by `REALM_NAME` (default `Claudemoon`). To add a realm, run another
   process against the **same** `DATABASE_URL` with a different `REALM_NAME`

--- a/admin.html
+++ b/admin.html
@@ -73,6 +73,17 @@
   .admin-page.active { display: block; }
   section { margin-bottom: 18px; }
 
+  /* ---------- chat filter ---------- */
+  .word-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+  .word-chip { display: inline-flex; align-items: center; gap: 6px; padding: 3px 6px 3px 9px; background: #1b1610; border: 1px solid #463a1c; border-radius: 12px; font-size: 13px; }
+  .word-del { background: none; border: none; color: #c98; cursor: pointer; font-size: 15px; line-height: 1; padding: 0 2px; }
+  .word-del:hover { color: #f55; }
+  .word-add { display: flex; gap: 6px; margin-top: 8px; }
+  .word-add input { flex: 1; }
+  .cf-config { display: flex; flex-direction: column; gap: 8px; max-width: 460px; }
+  .cf-config label { display: flex; flex-direction: column; gap: 3px; font-size: 13px; color: #c9b27a; }
+  .chat-mod-status { margin: 6px 0; }
+
   /* ---------- stat cards ---------- */
   #stats { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 10px; }
   .stat { padding: 10px 12px; }
@@ -209,6 +220,7 @@
     <nav id="admin-tabs">
       <button class="admin-tab active" data-admin-page="overview">Overview</button>
       <button class="admin-tab" data-admin-page="moderation">Moderation</button>
+      <button class="admin-tab" data-admin-page="chat-filter">Chat Filter</button>
     </nav>
 
     <main id="page-overview" class="admin-page active">
@@ -242,6 +254,12 @@
         <div class="panel-title">Moderation <span class="hint">highest open report counts first</span></div>
         <div id="moderation"></div>
         <div id="moderation-detail"></div>
+      </section>
+    </main>
+
+    <main id="page-chat-filter" class="admin-page">
+      <section>
+        <div id="chat-filter"></div>
       </section>
     </main>
   </div>

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -10,6 +10,10 @@ import {
 import {
   forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount,
 } from './moderation_db';
+import {
+  addFilterWord, chatModerationForAccount, getFilterConfig, liftChatMute, listFilterWords,
+  removeFilterWord, resetChatStrikes, updateFilterConfig, type WordTier,
+} from './chat_filter_db';
 import type { GameServer } from './game';
 
 // Admin API: everything under /admin/api/*. Auth is a bearer token whose
@@ -41,6 +45,10 @@ export function parsePageParams(params: URLSearchParams): PageParams {
     ? Math.min(MAX_PAGE_LIMIT, Math.max(1, Math.floor(rawLimit)))
     : DEFAULT_PAGE_LIMIT;
   return { page, limit };
+}
+
+function cleanTier(value: unknown): WordTier | null {
+  return value === 'soft' || value === 'hard' ? value : null;
 }
 
 async function adminAccountId(req: http.IncomingMessage): Promise<number | null> {
@@ -131,7 +139,59 @@ export async function handleAdminApi(
       }
     }
 
+    // Chat filter: lift mute / reset strikes for an account.
+    const liftMuteMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/lift-mute$/.exec(path);
+    if (req.method === 'POST' && liftMuteMatch) {
+      const id = Number(liftMuteMatch[1]);
+      const lifted = await liftChatMute(id);
+      if (lifted) game.liftChatMuteLive(id);
+      return lifted ? ok(res, { ok: true }) : fail(res, 404, 'account not found');
+    }
+    const resetStrikesMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)\/reset-strikes$/.exec(path);
+    if (req.method === 'POST' && resetStrikesMatch) {
+      const id = Number(resetStrikesMatch[1]);
+      const reset = await resetChatStrikes(id);
+      if (reset) game.resetChatStrikesLive(id);
+      return reset ? ok(res, { ok: true }) : fail(res, 404, 'account not found');
+    }
+
+    // Chat filter: word list + escalation config management. Every edit reloads
+    // the live filter and pushes the new soft list to connected clients.
+    if (req.method === 'POST' && path === '/admin/api/chat-filter/words') {
+      const body = await readBody(req);
+      const tier = cleanTier(body.tier);
+      if (!tier) return fail(res, 400, 'tier must be "soft" or "hard"');
+      const added = await addFilterWord(body.word, tier);
+      if (!added) return fail(res, 400, 'word is empty after normalization');
+      await game.reloadChatFilter();
+      return ok(res, { ok: true });
+    }
+    const wordDeleteMatch = /^\/admin\/api\/chat-filter\/words\/(\d+)\/delete$/.exec(path);
+    if (req.method === 'POST' && wordDeleteMatch) {
+      const removed = await removeFilterWord(Number(wordDeleteMatch[1]));
+      if (removed) await game.reloadChatFilter();
+      return removed ? ok(res, { ok: true }) : fail(res, 404, 'word not found');
+    }
+    if (req.method === 'POST' && path === '/admin/api/chat-filter/config') {
+      const body = await readBody(req);
+      const config = await updateFilterConfig({
+        warningsBeforeMute: body.warningsBeforeMute,
+        muteLadderSeconds: body.muteLadderSeconds,
+      });
+      await game.reloadChatFilter();
+      return ok(res, config);
+    }
+
     if (req.method !== 'GET') return fail(res, 405, 'method not allowed');
+
+    if (path === '/admin/api/chat-filter') {
+      const [soft, hard, config] = await Promise.all([
+        listFilterWords('soft'),
+        listFilterWords('hard'),
+        getFilterConfig(),
+      ]);
+      return ok(res, { soft, hard, config });
+    }
 
     if (path === '/admin/api/overview') {
       const counts = await overviewCounts();
@@ -160,12 +220,13 @@ export async function handleAdminApi(
     const moderationAccountMatch = /^\/admin\/api\/moderation\/accounts\/(\d+)$/.exec(path);
     if (moderationAccountMatch) {
       const id = Number(moderationAccountMatch[1]);
-      const [detail, reports] = await Promise.all([
+      const [detail, reports, chat] = await Promise.all([
         accountDetail(id),
         moderationReportsForAccount(id),
+        chatModerationForAccount(id),
       ]);
       if (!detail) return fail(res, 404, 'account not found');
-      return ok(res, { account: detail, reports });
+      return ok(res, { account: detail, reports, chat });
     }
     const detailMatch = /^\/admin\/api\/accounts\/(\d+)$/.exec(path);
     if (detailMatch) {

--- a/server/chat_filter.ts
+++ b/server/chat_filter.ts
@@ -1,0 +1,227 @@
+// Pure, host-agnostic chat profanity/slur filtering. No SQL, no DOM — the SQL
+// layer lives in chat_filter_db.ts and the wiring in game.ts. Two tiers:
+//
+//   - "soft" words (everyday swearing): cosmetic only. The server ships the
+//     normalized soft list to each client in `hello`; the client masks matches
+//     locally *iff* the player's profanity filter is on. The server itself
+//     never alters soft words, so toggling the filter off shows raw text.
+//   - "hard" words (slurs): enforced server-side and non-bypassable. A message
+//     containing one is blocked entirely and the sender is warned, then
+//     escalated to timed, account-wide chat mutes (see `escalate`).
+//
+// Matching folds common leet/confusable substitutions so "n1gg3r"-style evasion
+// still resolves to the underlying word.
+
+const CONFUSABLE_CHARS: Record<string, string> = {
+  '0': 'o',
+  '1': 'i',
+  '3': 'e',
+  '4': 'a',
+  '5': 's',
+  '7': 't',
+  '8': 'b',
+  '!': 'i',
+  '|': 'i',
+  '@': 'a',
+  '$': 's',
+  '+': 't',
+};
+
+// Tokens we scan: letters, digits and the leet punctuation that folds into
+// letters. Everything else is a separator.
+const TOKEN_RE = /[A-Za-z0-9_@$!|+]+/g;
+
+/** Fold a token to its comparable core: lowercase, de-leet, strip non-letters. */
+export function normalizeWord(term: string): string {
+  return term
+    .toLowerCase()
+    .replace(/[0134578!|@$+]/g, (ch) => CONFUSABLE_CHARS[ch] ?? ch)
+    .replace(/[^a-z]/g, '');
+}
+
+/** Split a raw blob (newline / comma / space separated) into normalized terms. */
+export function parseWordList(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((t) => normalizeWord(t))
+    .filter((t) => t.length > 0);
+}
+
+// Soft tier: generous substring match (cosmetic, so "shitty" → masked is fine).
+function tokenMatchesSoft(normalizedToken: string, terms: readonly string[]): boolean {
+  return normalizedToken.length > 0 && terms.some((term) => normalizedToken.includes(term));
+}
+
+/**
+ * Mask every token matching a soft term with asterisks. Used client-side for
+ * the display filter and never on the server's broadcast path.
+ */
+export function maskText(text: string, terms: readonly string[]): string {
+  if (terms.length === 0) return text;
+  return text.replace(TOKEN_RE, (tok) =>
+    tokenMatchesSoft(normalizeWord(tok), terms) ? '*'.repeat(tok.length) : tok,
+  );
+}
+
+// Hard tier: strict whole-token equality (plus a stripped trailing plural "s"),
+// NOT substring. Substring matching on a *punitive* list is unacceptable — it
+// would auto-mute "despicable" for containing "spic" or "class" for "ass". The
+// cost of a miss here is small (human reports + admins extend the list); the
+// cost of a false positive is muting an innocent player.
+function tokenMatchesHard(normalizedToken: string, terms: readonly string[]): boolean {
+  if (normalizedToken.length === 0) return false;
+  const singular = normalizedToken.endsWith('s') ? normalizedToken.slice(0, -1) : normalizedToken;
+  return terms.some((term) => normalizedToken === term || singular === term);
+}
+
+/** First hard term a message hits, or null. The match drives enforcement. */
+export function findHardWord(text: string, terms: readonly string[]): string | null {
+  if (terms.length === 0) return null;
+  const tokens = text.match(TOKEN_RE);
+  if (!tokens) return null;
+  for (const tok of tokens) {
+    const normalized = normalizeWord(tok);
+    if (tokenMatchesHard(normalized, terms)) {
+      // Return the configured term that fired, for the incident log.
+      const singular = normalized.endsWith('s') ? normalized.slice(0, -1) : normalized;
+      return terms.find((term) => normalized === term || singular === term) ?? normalized;
+    }
+  }
+  return null;
+}
+
+// -------------------------------------------------------------------------
+// Escalation: warnings, then a ladder of timed account-wide chat mutes.
+// -------------------------------------------------------------------------
+
+export interface EscalationConfig {
+  /** Free passes (warning only) before the first mute. */
+  warningsBeforeMute: number;
+  /** Mute durations in seconds for the 1st, 2nd, … mute. The last entry caps. */
+  muteLadderSeconds: number[];
+}
+
+export const DEFAULT_ESCALATION: EscalationConfig = {
+  warningsBeforeMute: 1,
+  muteLadderSeconds: [10 * 60, 60 * 60, 24 * 60 * 60], // 10m → 1h → 24h
+};
+
+export interface EscalationOutcome {
+  kind: 'warning' | 'mute';
+  /** Mute length in seconds; 0 for a warning. */
+  muteSeconds: number;
+  /** The sender's new strike total after this offense. */
+  strikes: number;
+}
+
+/**
+ * Given the sender's previous strike count, decide what this offense earns.
+ * Strikes are 1-based: the Nth hard-word offense is strike N. The first
+ * `warningsBeforeMute` offenses are warnings; the rest walk the mute ladder,
+ * clamping at its final (longest) entry.
+ */
+export function escalate(previousStrikes: number, cfg: EscalationConfig): EscalationOutcome {
+  const strikes = previousStrikes + 1;
+  const ladder = cfg.muteLadderSeconds;
+  if (strikes <= cfg.warningsBeforeMute || ladder.length === 0) {
+    return { kind: 'warning', muteSeconds: 0, strikes };
+  }
+  const idx = Math.min(strikes - cfg.warningsBeforeMute - 1, ladder.length - 1);
+  return { kind: 'mute', muteSeconds: Math.max(0, Math.floor(ladder[idx])), strikes };
+}
+
+/** Sanitize an escalation config coming from the DB / admin input. */
+export function cleanEscalationConfig(input: {
+  warningsBeforeMute?: unknown;
+  muteLadderSeconds?: unknown;
+}): EscalationConfig {
+  const warnings = Number(input.warningsBeforeMute);
+  const ladderRaw = Array.isArray(input.muteLadderSeconds) ? input.muteLadderSeconds : [];
+  const ladder = ladderRaw
+    .map((n) => Math.floor(Number(n)))
+    .filter((n) => Number.isFinite(n) && n > 0);
+  return {
+    warningsBeforeMute: Number.isFinite(warnings) && warnings >= 0 ? Math.floor(warnings) : DEFAULT_ESCALATION.warningsBeforeMute,
+    muteLadderSeconds: ladder.length > 0 ? ladder : [...DEFAULT_ESCALATION.muteLadderSeconds],
+  };
+}
+
+// -------------------------------------------------------------------------
+// Built-in seed lists ("sensible starting points"). Admins edit the live lists
+// from the dashboard; these only seed an empty table on first boot. Kept short
+// and unambiguous — the hard list especially, since it carries punitive weight.
+// -------------------------------------------------------------------------
+
+export const DEFAULT_SOFT_WORDS: string[] = [
+  'fuck',
+  'shit',
+  'bitch',
+  'bastard',
+  'cunt',
+  'dick',
+  'piss',
+  'asshole',
+  'dumbass',
+  'douche',
+  'wanker',
+  'bollocks',
+  'prick',
+  'slut',
+  'whore',
+];
+
+// Slurs. These have to be stored in their real form to actually match input;
+// whole-token matching (above) keeps them from snagging innocent words.
+export const DEFAULT_HARD_WORDS: string[] = [
+  'nigger',
+  'nigga',
+  'faggot',
+  'chink',
+  'kike',
+  'tranny',
+  'gook',
+  'wetback',
+];
+
+/** A live snapshot of the filter state, loaded from the DB and cached. */
+export interface ChatFilterState {
+  soft: string[];
+  hard: string[];
+  config: EscalationConfig;
+}
+
+/**
+ * Holds the loaded word lists + escalation config and exposes the operations
+ * the server needs. The GameServer owns one instance and refreshes it from the
+ * DB at boot and whenever an admin edits the lists.
+ */
+export class ChatFilter {
+  private state: ChatFilterState = { soft: [], hard: [], config: DEFAULT_ESCALATION };
+
+  load(state: ChatFilterState): void {
+    this.state = {
+      soft: [...state.soft],
+      hard: [...state.hard],
+      config: cleanEscalationConfig(state.config),
+    };
+  }
+
+  /** Normalized soft terms shipped to clients for local masking. */
+  softWords(): string[] {
+    return [...this.state.soft];
+  }
+
+  config(): EscalationConfig {
+    return this.state.config;
+  }
+
+  /** The first hard term `text` hits, or null. */
+  findHardHit(text: string): string | null {
+    return findHardWord(text, this.state.hard);
+  }
+
+  /** Decide the outcome for a sender who has `previousStrikes` prior offenses. */
+  escalate(previousStrikes: number): EscalationOutcome {
+    return escalate(previousStrikes, this.state.config);
+  }
+}

--- a/server/chat_filter_db.ts
+++ b/server/chat_filter_db.ts
@@ -1,0 +1,271 @@
+import { readFileSync } from 'node:fs';
+import type { PoolClient } from 'pg';
+import { pool } from './db';
+import {
+  DEFAULT_HARD_WORDS,
+  DEFAULT_SOFT_WORDS,
+  cleanEscalationConfig,
+  normalizeWord,
+  parseWordList,
+  type ChatFilterState,
+  type EscalationConfig,
+} from './chat_filter';
+
+// SQL for the chat filter: admin-managed word lists, escalation config,
+// per-account mute/strike state, and the hard-word incident log. Logic +
+// matching live in chat_filter.ts; this file is the only place their SQL runs.
+
+export type WordTier = 'soft' | 'hard';
+
+export interface FilterWord {
+  id: number;
+  word: string;
+  tier: WordTier;
+  createdAt: string;
+}
+
+function envSeedSoftWords(): string[] {
+  // One-time migration nicety: fold any legacy CHAT_CENSOR_LIST / CHAT_CENSOR_FILE
+  // operator config into the initial soft seed. After first boot the list is
+  // DB-managed from the admin dashboard and these env vars are ignored.
+  let raw = process.env.CHAT_CENSOR_LIST ?? '';
+  const file = process.env.CHAT_CENSOR_FILE ?? '';
+  if (file) {
+    try {
+      raw += ` ${readFileSync(file, 'utf8')}`;
+    } catch (err) {
+      console.warn(`could not read CHAT_CENSOR_FILE (${file}) for seed:`, err);
+    }
+  }
+  return parseWordList(raw);
+}
+
+async function insertSeedWords(client: PoolClient, words: string[], tier: WordTier): Promise<void> {
+  const unique = Array.from(new Set(words.map((w) => normalizeWord(w)).filter((w) => w.length > 0)));
+  for (const word of unique) {
+    await client.query(
+      `INSERT INTO chat_filter_words (word, tier) VALUES ($1, $2) ON CONFLICT (tier, word) DO NOTHING`,
+      [word, tier],
+    );
+  }
+}
+
+/**
+ * Seed the word lists + config the first time only. Runs inside ensureSchema's
+ * boot transaction (pinned client, under the advisory lock), so it's safe under
+ * concurrent realm boots and only fills a tier when that tier is empty.
+ */
+export async function seedChatFilterDefaults(client: PoolClient): Promise<void> {
+  await client.query(`INSERT INTO chat_filter_config (id) VALUES (1) ON CONFLICT (id) DO NOTHING`);
+  const counts = await client.query(
+    `SELECT tier, count(*)::int AS n FROM chat_filter_words GROUP BY tier`,
+  );
+  const byTier = new Map<string, number>(counts.rows.map((r) => [r.tier, r.n]));
+  if (!byTier.get('soft')) {
+    await insertSeedWords(client, [...DEFAULT_SOFT_WORDS, ...envSeedSoftWords()], 'soft');
+  }
+  if (!byTier.get('hard')) {
+    await insertSeedWords(client, DEFAULT_HARD_WORDS, 'hard');
+  }
+}
+
+/** Load the full live filter state (both word tiers + escalation config). */
+export async function loadChatFilterState(): Promise<ChatFilterState> {
+  const [words, config] = await Promise.all([
+    pool.query(`SELECT word, tier FROM chat_filter_words`),
+    pool.query(`SELECT warnings_before_mute, mute_ladder_seconds FROM chat_filter_config WHERE id = 1`),
+  ]);
+  const soft: string[] = [];
+  const hard: string[] = [];
+  for (const r of words.rows) {
+    (r.tier === 'hard' ? hard : soft).push(r.word);
+  }
+  const cfgRow = config.rows[0];
+  const escalation: EscalationConfig = cleanEscalationConfig({
+    warningsBeforeMute: cfgRow?.warnings_before_mute,
+    muteLadderSeconds: cfgRow?.mute_ladder_seconds,
+  });
+  return { soft, hard, config: escalation };
+}
+
+// ---- Admin: word list CRUD --------------------------------------------------
+
+export async function listFilterWords(tier: WordTier): Promise<FilterWord[]> {
+  const res = await pool.query(
+    `SELECT id, word, tier, created_at FROM chat_filter_words WHERE tier = $1 ORDER BY word`,
+    [tier],
+  );
+  return res.rows.map((r) => ({
+    id: Number(r.id),
+    word: r.word,
+    tier: r.tier,
+    createdAt: new Date(r.created_at).toISOString(),
+  }));
+}
+
+/** Add a normalized word to a tier. Returns false if it normalizes to nothing. */
+export async function addFilterWord(rawWord: unknown, tier: WordTier): Promise<boolean> {
+  const word = normalizeWord(typeof rawWord === 'string' ? rawWord : '');
+  if (!word) return false;
+  await pool.query(
+    `INSERT INTO chat_filter_words (word, tier) VALUES ($1, $2) ON CONFLICT (tier, word) DO NOTHING`,
+    [word, tier],
+  );
+  return true;
+}
+
+export async function removeFilterWord(id: number): Promise<boolean> {
+  const res = await pool.query(`DELETE FROM chat_filter_words WHERE id = $1`, [id]);
+  return (res.rowCount ?? 0) > 0;
+}
+
+// ---- Admin: escalation config ----------------------------------------------
+
+export async function getFilterConfig(): Promise<EscalationConfig> {
+  const res = await pool.query(
+    `SELECT warnings_before_mute, mute_ladder_seconds FROM chat_filter_config WHERE id = 1`,
+  );
+  const row = res.rows[0];
+  return cleanEscalationConfig({
+    warningsBeforeMute: row?.warnings_before_mute,
+    muteLadderSeconds: row?.mute_ladder_seconds,
+  });
+}
+
+export async function updateFilterConfig(input: {
+  warningsBeforeMute?: unknown;
+  muteLadderSeconds?: unknown;
+}): Promise<EscalationConfig> {
+  const clean = cleanEscalationConfig(input);
+  await pool.query(
+    `INSERT INTO chat_filter_config (id, warnings_before_mute, mute_ladder_seconds, updated_at)
+     VALUES (1, $1, $2, now())
+     ON CONFLICT (id) DO UPDATE
+       SET warnings_before_mute = EXCLUDED.warnings_before_mute,
+           mute_ladder_seconds = EXCLUDED.mute_ladder_seconds,
+           updated_at = now()`,
+    [clean.warningsBeforeMute, clean.muteLadderSeconds],
+  );
+  return clean;
+}
+
+// ---- Enforcement: strikes, mutes, incident log ------------------------------
+
+export interface AppliedStrike {
+  strikes: number;
+  chatMutedUntil: string | null;
+}
+
+/**
+ * Atomically record one hard-word offense: bump the strike count and, when
+ * `muteSeconds > 0`, extend the account-wide mute (never shortening an existing
+ * longer mute). Returns the authoritative post-update values for the session.
+ */
+export async function applyChatStrike(accountId: number, muteSeconds: number): Promise<AppliedStrike> {
+  const res = await pool.query(
+    `UPDATE accounts
+     SET chat_strikes = chat_strikes + 1,
+         chat_muted_until = CASE
+           WHEN $2 > 0 THEN GREATEST(COALESCE(chat_muted_until, to_timestamp(0)), now() + ($2 || ' seconds')::interval)
+           ELSE chat_muted_until
+         END
+     WHERE id = $1
+     RETURNING chat_strikes, chat_muted_until`,
+    [accountId, Math.max(0, Math.floor(muteSeconds))],
+  );
+  const row = res.rows[0];
+  return {
+    strikes: Number(row?.chat_strikes ?? 0),
+    chatMutedUntil: row?.chat_muted_until ? new Date(row.chat_muted_until).toISOString() : null,
+  };
+}
+
+export async function recordChatViolation(input: {
+  accountId: number;
+  characterId: number;
+  characterName: string;
+  term: string;
+  channel: string;
+  message: string;
+  action: 'warning' | 'mute';
+  muteSeconds: number;
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO chat_violations
+       (account_id, character_id, character_name, term, channel, message, action, mute_seconds)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+    [
+      input.accountId,
+      input.characterId,
+      input.characterName,
+      input.term.slice(0, 64),
+      input.channel.slice(0, 32),
+      input.message.slice(0, 400),
+      input.action,
+      Math.max(0, Math.floor(input.muteSeconds)),
+    ],
+  );
+}
+
+// ---- Admin: per-account chat moderation view + manual actions ---------------
+
+export interface ChatViolationRow {
+  id: number;
+  characterName: string;
+  term: string;
+  channel: string;
+  message: string;
+  action: string;
+  muteSeconds: number;
+  createdAt: string;
+}
+
+export interface ChatModerationDetail {
+  chatMutedUntil: string | null;
+  chatStrikes: number;
+  violations: ChatViolationRow[];
+}
+
+export async function chatModerationForAccount(accountId: number, limit = 25): Promise<ChatModerationDetail> {
+  const [acct, viol] = await Promise.all([
+    pool.query(`SELECT chat_muted_until, chat_strikes FROM accounts WHERE id = $1`, [accountId]),
+    pool.query(
+      `SELECT id, character_name, term, channel, message, action, mute_seconds, created_at
+       FROM chat_violations WHERE account_id = $1 ORDER BY created_at DESC LIMIT $2`,
+      [accountId, Math.min(100, Math.max(1, limit))],
+    ),
+  ]);
+  const row = acct.rows[0];
+  const mutedUntil = row?.chat_muted_until ? new Date(row.chat_muted_until) : null;
+  return {
+    chatMutedUntil: mutedUntil && mutedUntil.getTime() > Date.now() ? mutedUntil.toISOString() : null,
+    chatStrikes: Number(row?.chat_strikes ?? 0),
+    violations: viol.rows.map((r) => ({
+      id: Number(r.id),
+      characterName: r.character_name,
+      term: r.term,
+      channel: r.channel,
+      message: r.message,
+      action: r.action,
+      muteSeconds: Number(r.mute_seconds),
+      createdAt: new Date(r.created_at).toISOString(),
+    })),
+  };
+}
+
+/** Clear an active mute. Returns the account id touched (for live disconnect/notice). */
+export async function liftChatMute(accountId: number): Promise<boolean> {
+  const res = await pool.query(
+    `UPDATE accounts SET chat_muted_until = NULL WHERE id = $1`,
+    [accountId],
+  );
+  return (res.rowCount ?? 0) > 0;
+}
+
+export async function resetChatStrikes(accountId: number): Promise<boolean> {
+  const res = await pool.query(
+    `UPDATE accounts SET chat_strikes = 0 WHERE id = $1`,
+    [accountId],
+  );
+  return (res.rowCount ?? 0) > 0;
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -3,6 +3,7 @@ import type { CharacterState, MarketSave } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
 import type { ChatLogRow } from './chat_log';
 import { SOCIAL_SCHEMA } from './social_db';
+import { seedChatFilterDefaults } from './chat_filter_db';
 import { REALM } from './realm';
 
 try {
@@ -111,6 +112,41 @@ CREATE TABLE IF NOT EXISTS world_state (
   data JSONB NOT NULL,
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+-- Chat moderation: per-account timed mute + running strike count for the
+-- hard-word (slur) enforcement ladder. A mute blocks chat only, never login.
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS chat_muted_until TIMESTAMPTZ;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS chat_strikes INT NOT NULL DEFAULT 0;
+-- Admin-managed filter word lists. tier 'soft' = cosmetic (masked client-side
+-- when the player's filter is on); tier 'hard' = enforced (blocked + escalated).
+CREATE TABLE IF NOT EXISTS chat_filter_words (
+  id SERIAL PRIMARY KEY,
+  word TEXT NOT NULL,
+  tier TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tier, word)
+);
+-- Single-row escalation config (warnings then a mute ladder, in seconds).
+CREATE TABLE IF NOT EXISTS chat_filter_config (
+  id INT PRIMARY KEY DEFAULT 1,
+  warnings_before_mute INT NOT NULL DEFAULT 1,
+  mute_ladder_seconds INT[] NOT NULL DEFAULT '{600,3600,86400}',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT chat_filter_config_singleton CHECK (id = 1)
+);
+-- Hard-word incident log, surfaced per-account in the moderation dashboard.
+CREATE TABLE IF NOT EXISTS chat_violations (
+  id BIGSERIAL PRIMARY KEY,
+  account_id INT REFERENCES accounts(id) ON DELETE CASCADE,
+  character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  character_name TEXT NOT NULL DEFAULT '',
+  term TEXT NOT NULL DEFAULT '',
+  channel TEXT NOT NULL DEFAULT '',
+  message TEXT NOT NULL DEFAULT '',
+  action TEXT NOT NULL DEFAULT '',
+  mute_seconds INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS chat_violations_account ON chat_violations(account_id, created_at DESC);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -125,6 +161,9 @@ export async function ensureSchema(): Promise<void> {
     await client.query('SELECT pg_advisory_xact_lock($1)', [0x57_4f_43_01]); // "WOC\x01"
     await client.query(SCHEMA);
     await client.query(SOCIAL_SCHEMA);
+    // Seed the chat-filter word lists + config on first boot only (idempotent).
+    // Runs under the same advisory lock so concurrent realm boots don't race.
+    await seedChatFilterDefaults(client);
     await client.query('COMMIT');
   } catch (err) {
     await client.query('ROLLBACK').catch(() => {});
@@ -146,6 +185,11 @@ export interface AccountModerationStatus {
   suspendedUntil: string | null;
   reason: string;
   message: string;
+  // Chat mute is independent of `locked`: a muted account can still log in and
+  // play, it just can't send chat until `chatMutedUntil` passes. Surfaced here
+  // so the WS auth handshake can seed the live session without a second query.
+  chatMutedUntil: string | null;
+  chatStrikes: number;
 }
 
 export async function createAccount(username: string, passwordHash: string): Promise<AccountRow> {
@@ -188,14 +232,19 @@ export async function accountForToken(token: string): Promise<number | null> {
 
 export async function moderationStatusForAccount(accountId: number): Promise<AccountModerationStatus> {
   const res = await pool.query(
-    `SELECT banned_at, suspended_until, moderation_reason
+    `SELECT banned_at, suspended_until, moderation_reason, chat_muted_until, chat_strikes
      FROM accounts WHERE id = $1`,
     [accountId],
   );
   const row = res.rows[0];
   if (!row) {
-    return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '' };
+    return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '', chatMutedUntil: null, chatStrikes: 0 };
   }
+  const mutedUntilDate = row.chat_muted_until ? new Date(row.chat_muted_until) : null;
+  const chatMutedUntil = mutedUntilDate && mutedUntilDate.getTime() > Date.now()
+    ? mutedUntilDate.toISOString()
+    : null;
+  const chatStrikes = Number(row.chat_strikes ?? 0);
   if (row.banned_at) {
     return {
       locked: true,
@@ -203,6 +252,8 @@ export async function moderationStatusForAccount(accountId: number): Promise<Acc
       suspendedUntil: null,
       reason: row.moderation_reason ?? '',
       message: 'This account has been banned.',
+      chatMutedUntil,
+      chatStrikes,
     };
   }
   const suspendedUntil = row.suspended_until ? new Date(row.suspended_until) : null;
@@ -213,9 +264,11 @@ export async function moderationStatusForAccount(accountId: number): Promise<Acc
       suspendedUntil: suspendedUntil.toISOString(),
       reason: row.moderation_reason ?? '',
       message: `This account is suspended until ${suspendedUntil.toUTCString()}.`,
+      chatMutedUntil,
+      chatStrikes,
     };
   }
-  return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '' };
+  return { locked: false, banned: false, suspendedUntil: null, reason: '', message: '', chatMutedUntil, chatStrikes };
 }
 
 export interface CharacterRow {

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'node:fs';
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
@@ -7,6 +6,8 @@ import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { saveCharacterState, openPlaySession, closePlaySession, insertChatLogs, pool, loadMarketState, saveMarketState } from './db';
+import { ChatFilter } from './chat_filter';
+import { loadChatFilterState, applyChatStrike, recordChatViolation } from './chat_filter_db';
 import { ChatLogger } from './chat_log';
 import { SocialService } from './social';
 import type { Presence, PresenceStatus, SocialActor, SocialEvent, SocialTransport } from './social';
@@ -62,6 +63,12 @@ export interface ClientSession {
   chatLastRateError: number;
   chatRateViolations: number;
   chatCooldownUntil: number;
+  // Hard-word enforcement (slurs). chatMutedUntil is epoch seconds (0 = not
+  // muted); chatStrikes is the running offense count driving the mute ladder.
+  // Both are account-scoped: seeded from the DB at join, kept live by the
+  // enforcement gate and admin lift/reset actions.
+  chatMutedUntil: number;
+  chatStrikes: number;
   // character ids this player has ignored; chat from them is dropped before
   // delivery. Loaded from the DB on join, kept in sync by social commands.
   blockedIds: Set<number>;
@@ -233,67 +240,30 @@ function logSocialErr(err: unknown): void {
   console.error('social command failed:', err);
 }
 
-const CONFUSABLE_CHARS: Record<string, string> = {
-  '0': 'o',
-  '1': 'i',
-  '!': 'i',
-  '|': 'i',
-  '3': 'e',
-  '4': 'a',
-  '@': 'a',
-  '5': 's',
-  '$': 's',
-  '7': 't',
-  '+': 't',
-  '8': 'b',
-};
-
-function normalizedCensorTerm(term: string): string {
-  return term
-    .toLowerCase()
-    .replace(/[0134578!|@$+]/g, (ch) => CONFUSABLE_CHARS[ch] ?? ch)
-    .replace(/[^a-z]/g, '');
+// Human-readable mute duration for player-facing notices ("10 minutes").
+function formatDuration(seconds: number): string {
+  const s = Math.max(1, Math.round(seconds));
+  if (s < 60) return `${s} second${s === 1 ? '' : 's'}`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m} minute${m === 1 ? '' : 's'}`;
+  const h = Math.round(m / 60);
+  if (h < 24) return `${h} hour${h === 1 ? '' : 's'}`;
+  const d = Math.round(h / 24);
+  return `${d} day${d === 1 ? '' : 's'}`;
 }
 
-function parseCensorList(raw: string | undefined): string[] {
-  return (raw ?? '')
-    .split(/[\s,]+/)
-    .map((term) => normalizedCensorTerm(term))
-    .filter((term) => term.length > 0);
-}
-
-let censorCacheKey: string | null = null;
-let censorCacheTerms: string[] = [];
-
-function configuredChatCensorTerms(): string[] {
-  const rawList = process.env.CHAT_CENSOR_LIST ?? '';
-  const file = process.env.CHAT_CENSOR_FILE ?? '';
-  const cacheKey = `${rawList}\0${file}`;
-  if (cacheKey === censorCacheKey) return censorCacheTerms;
-
-  const terms = parseCensorList(rawList);
-  if (!file) {
-    censorCacheTerms = terms;
-    censorCacheKey = cacheKey;
-    return censorCacheTerms;
-  }
-  try {
-    censorCacheTerms = terms.concat(parseCensorList(readFileSync(file, 'utf8')));
-  } catch (err) {
-    console.warn(`could not read CHAT_CENSOR_FILE (${file}):`, err);
-    return terms;
-  }
-  censorCacheKey = cacheKey;
-  return censorCacheTerms;
-}
-
-export function censorChatText(text: string): string {
-  const terms = configuredChatCensorTerms();
-  if (terms.length === 0) return text;
-  return text.replace(/[A-Za-z0-9_@$!|+]+/g, (token) => {
-    const normalized = normalizedCensorTerm(token);
-    return terms.some((term) => normalized.includes(term)) ? '*'.repeat(token.length) : token;
-  });
+// Best-effort channel label for the violation log: the hard-word gate runs
+// before the message is routed, so infer the channel from its command prefix
+// (falling back to the player's last-used channel).
+function chatChannelHint(session: ClientSession, text: string): string {
+  if (/^\/(?:g|gu|guild)\s/i.test(text)) return 'guild';
+  if (/^\/(?:o|officer)\s/i.test(text)) return 'officer';
+  if (/^\/(?:w|whisper|t|tell|r|reply)\s/i.test(text)) return 'whisper';
+  if (/^\/(?:y|yell)\s/i.test(text)) return 'yell';
+  if (/^\/(?:p|party)\s/i.test(text)) return 'party';
+  if (/^\/(?:general|world)\s/i.test(text)) return 'general';
+  if (/^\/(?:s|say)\s/i.test(text)) return 'say';
+  return session.rememberedChat.channel;
 }
 
 export class GameServer {
@@ -301,6 +271,9 @@ export class GameServer {
   clients = new Map<number, ClientSession>(); // by pid
   private readonly sessionsByCharacterId = new Map<number, ClientSession>();
   readonly chatLog = new ChatLogger(insertChatLogs);
+  // Admin-managed soft/hard word lists + escalation config. Loaded from the DB
+  // at boot (loadChatFilter) and refreshed whenever an admin edits the lists.
+  readonly chatFilter = new ChatFilter();
   private readonly socialDb = new PgSocialDb(pool);
   readonly social: SocialService;
   private wireCache = new Map<number, EntityWireCache>();
@@ -450,7 +423,7 @@ export class GameServer {
 
   // -------------------------------------------------------------------------
 
-  join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false): ClientSession | { error: string } {
+  join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false, chatMutedUntil: string | null = null, chatStrikes = 0): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
     if (isGm) {
@@ -465,6 +438,8 @@ export class GameServer {
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
+      chatMutedUntil: chatMutedUntil ? new Date(chatMutedUntil).getTime() / 1000 : 0,
+      chatStrikes,
       blockedIds: new Set(),
       blockListLoaded: false,
       lastWhisperFrom: null,
@@ -486,6 +461,12 @@ export class GameServer {
       name,
       cls,
       realm: REALM,
+      // Soft (cosmetic) words the client masks locally when its profanity
+      // filter is on. Hard words are never sent — they're enforced server-side.
+      softWords: this.chatFilter.softWords(),
+      // Epoch ms of an active chat mute, or null. Lets the client show status
+      // at login; sending is still gated server-side regardless.
+      chatMutedUntil: session.chatMutedUntil > 0 ? session.chatMutedUntil * 1000 : null,
     });
     this.broadcastSystem(`${name} has entered World of Claudecraft.`);
     void this.initSocial(session);
@@ -652,6 +633,42 @@ export class GameServer {
   }
 
   // -------------------------------------------------------------------------
+  // Chat filter: load at boot, refresh + push to clients on admin edits, and
+  // sync admin mute/strike actions to any live sessions of the target account.
+  // -------------------------------------------------------------------------
+
+  async loadChatFilter(): Promise<void> {
+    try {
+      this.chatFilter.load(await loadChatFilterState());
+    } catch (err) {
+      console.error('failed to load chat filter:', err);
+    }
+  }
+
+  /** Reload word lists/config from the DB and push the new soft list to clients. */
+  async reloadChatFilter(): Promise<void> {
+    await this.loadChatFilter();
+    const words = this.chatFilter.softWords();
+    for (const session of this.clients.values()) {
+      this.send(session, { t: 'censor', words });
+    }
+  }
+
+  /** Reflect an admin "lift mute" on any live sessions so chat unlocks at once. */
+  liftChatMuteLive(accountId: number): void {
+    for (const session of this.clients.values()) {
+      if (session.accountId === accountId) session.chatMutedUntil = 0;
+    }
+  }
+
+  /** Reflect an admin "reset strikes" on any live sessions. */
+  resetChatStrikesLive(accountId: number): void {
+    for (const session of this.clients.values()) {
+      if (session.accountId === accountId) session.chatStrikes = 0;
+    }
+  }
+
+  // -------------------------------------------------------------------------
   // Input & commands
   // -------------------------------------------------------------------------
 
@@ -726,6 +743,10 @@ export class GameServer {
           this.sendWhoRoster(session);
           break;
         }
+        // Hard-word + mute enforcement gate, applied to every channel before the
+        // message is routed anywhere. Soft (cosmetic) words are NOT touched here
+        // — clients mask those locally when their profanity filter is on.
+        if (this.enforceChatPolicy(session, text)) break;
         // guild and officer chat are persistent + cross-zone, so they live in
         // the server's SocialService rather than the sim (no guild concept).
         // MMO convention: /g is guild; /general remains world chat.
@@ -733,7 +754,7 @@ export class GameServer {
         const om = gm ? null : /^\/(?:o|officer)\s+([\s\S]+)$/i.exec(text);
         if (gm || om) {
           const channel = gm ? 'guild' : 'officer';
-          const body = censorChatText((gm ?? om!)[1]);
+          const body = (gm ?? om!)[1];
           session.rememberedChat = { channel };
           const route = gm ? this.social.guildChat(this.actorFor(session), body)
             : this.social.officerChat(this.actorFor(session), body);
@@ -755,7 +776,7 @@ export class GameServer {
             break;
           }
           session.rememberedChat = { channel: 'whisper', target: session.lastWhisperFrom };
-          this.logChat(session, sim.chat(`/w ${session.lastWhisperFrom} ${censorChatText(rm[1])}`, pid));
+          this.logChat(session, sim.chat(`/w ${session.lastWhisperFrom} ${rm[1]}`, pid));
           break;
         }
         this.logChat(session, this.routeRememberedChat(session, text, pid));
@@ -1161,7 +1182,7 @@ export class GameServer {
     const text = rawText.trim();
     if (!text) return null;
     if (!text.startsWith('/')) {
-      const body = censorChatText(text);
+      const body = text;
       if (!body.trim()) return null;
       switch (session.rememberedChat.channel) {
         case 'guild':
@@ -1193,7 +1214,7 @@ export class GameServer {
       }
     }
 
-    const sent = this.sim.chat(censorChatText(text), pid);
+    const sent = this.sim.chat(text, pid);
     if (sent) {
       if (sent.channel === 'whisper') {
         const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+[\s\S]+$/i.exec(text);
@@ -1214,6 +1235,71 @@ export class GameServer {
       channel: sent.channel,
       message: sent.message,
     });
+  }
+
+  // One-off, player-facing chat notice (reuses the generic error event path the
+  // client already renders for rate-limit / cooldown messages).
+  private sendChatNotice(session: ClientSession, text: string): void {
+    this.send(session, { t: 'events', list: [{ type: 'error', text }] });
+  }
+
+  /**
+   * Enforce the hard-word + mute policy on an outgoing chat message. Returns
+   * true when the message must be dropped (sender is muted, or it contained a
+   * slur). Soft/cosmetic words are deliberately untouched here — those are a
+   * client-side display choice. Applies to every channel because it runs before
+   * the message is routed.
+   */
+  private enforceChatPolicy(session: ClientSession, text: string): boolean {
+    const now = Date.now() / 1000;
+    if (session.chatMutedUntil > now) {
+      this.sendChatNotice(
+        session,
+        `You are muted and can't chat for another ${formatDuration(session.chatMutedUntil - now)}.`,
+      );
+      return true;
+    }
+    const hit = this.chatFilter.findHardHit(text);
+    if (!hit) return false;
+
+    const outcome = this.chatFilter.escalate(session.chatStrikes);
+    const channel = chatChannelHint(session, text);
+    // Optimistically advance the session so a rapid follow-up is already gated;
+    // the DB write below returns the authoritative values and corrects any drift
+    // (e.g. a second character on the same account raising strikes concurrently).
+    session.chatStrikes = outcome.strikes;
+    if (outcome.kind === 'mute') {
+      session.chatMutedUntil = now + outcome.muteSeconds;
+      this.sendChatNotice(
+        session,
+        `That language isn't allowed here. You're muted for ${formatDuration(outcome.muteSeconds)}.`,
+      );
+    } else {
+      this.sendChatNotice(
+        session,
+        `Warning: that language isn't allowed here. Continued use will mute you.`,
+      );
+    }
+
+    void applyChatStrike(session.accountId, outcome.muteSeconds)
+      .then((applied) => {
+        session.chatStrikes = applied.strikes;
+        session.chatMutedUntil = applied.chatMutedUntil
+          ? new Date(applied.chatMutedUntil).getTime() / 1000
+          : session.chatMutedUntil;
+      })
+      .catch((err) => console.error('applyChatStrike failed:', err));
+    void recordChatViolation({
+      accountId: session.accountId,
+      characterId: session.characterId,
+      characterName: session.name,
+      term: hit,
+      channel,
+      message: text,
+      action: outcome.kind,
+      muteSeconds: outcome.muteSeconds,
+    }).catch((err) => console.error('recordChatViolation failed:', err));
+    return true;
   }
 
   private consumeChatToken(session: ClientSession): boolean {

--- a/server/main.ts
+++ b/server/main.ts
@@ -414,6 +414,7 @@ async function main(): Promise<void> {
   const pruned = await pruneChatLogs(CHAT_LOG_RETENTION_DAYS);
   if (pruned > 0) console.log(`pruned ${pruned} chat log row(s) older than ${CHAT_LOG_RETENTION_DAYS} days`);
   await game.loadMarket();
+  await game.loadChatFilter();
   setInterval(() => {
     void pruneChatLogs(CHAT_LOG_RETENTION_DAYS).catch((err) => console.error('chat log prune failed:', err));
   }, 24 * 3600 * 1000).unref();
@@ -492,7 +493,7 @@ async function main(): Promise<void> {
       ws.close();
       return;
     }
-    const result = game.join(ws, accountId, character.id, character.name, character.class, character.state, character.is_gm);
+    const result = game.join(ws, accountId, character.id, character.name, character.class, character.state, character.is_gm, status.chatMutedUntil, status.chatStrikes);
     if ('error' in result) {
       ws.send(JSON.stringify({ t: 'error', error: result.error }));
       ws.close();

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -2,12 +2,12 @@ import { apiGet, apiLogin, apiPost, clearSession, getAdminName, getToken, ApiErr
 import { barChart, chartPanel } from './charts';
 import { escapeHtml, fmtBytes, fmtDuration } from './format';
 import {
-  renderAccountDetail, renderAccountsTable, renderCharactersTable, renderModerationDetail,
-  renderModerationQueue, renderOnlineTable, renderPager,
+  renderAccountDetail, renderAccountsTable, renderCharactersTable, renderChatFilter,
+  renderModerationDetail, renderModerationQueue, renderOnlineTable, renderPager,
 } from './tables';
 import type {
-  AccountDetail, AccountRow, Activity, CharacterRow, LivePlayer, ModerationAccountDetail,
-  ModerationQueueRow, Overview, Paginated,
+  AccountDetail, AccountRow, Activity, CharacterRow, ChatFilterData, LivePlayer,
+  ModerationAccountDetail, ModerationQueueRow, Overview, Paginated,
 } from './types';
 
 const LIVE_REFRESH_MS = 5_000;
@@ -31,7 +31,8 @@ const accountsState: TableState = { page: 1, search: '', sort: 'id', dir: 'desc'
 const charactersState: TableState = { page: 1, search: '', sort: 'level', dir: 'desc' };
 let liveTimer: number | null = null;
 let activityTimer: number | null = null;
-let activePage: 'overview' | 'moderation' = 'overview';
+type AdminPage = 'overview' | 'moderation' | 'chat-filter';
+let activePage: AdminPage = 'overview';
 let pendingModerationAction: { endpoint: string; body: unknown; accountId: number; source: 'account' | 'moderation' } | null = null;
 
 // ---------------------------------------------------------------------------
@@ -74,7 +75,7 @@ async function refreshModeration(): Promise<void> {
   }
 }
 
-function showPage(page: 'overview' | 'moderation'): void {
+function showPage(page: AdminPage): void {
   activePage = page;
   document.querySelectorAll<HTMLButtonElement>('.admin-tab').forEach((tab) => {
     tab.classList.toggle('active', tab.dataset.adminPage === page);
@@ -83,6 +84,16 @@ function showPage(page: 'overview' | 'moderation'): void {
     el.classList.toggle('active', el.id === `page-${page}`);
   });
   if (page === 'moderation') void refreshModeration();
+  if (page === 'chat-filter') void refreshChatFilter();
+}
+
+async function refreshChatFilter(): Promise<void> {
+  try {
+    const data = await apiGet<ChatFilterData>('/admin/api/chat-filter');
+    $('chat-filter').innerHTML = renderChatFilter(data);
+  } catch (err) {
+    if (!handleAuthFailure(err)) $('chat-filter').innerHTML = '<div class="empty">failed to load chat filter</div>';
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -416,8 +427,10 @@ function wireEvents(): void {
   $('admin-tabs').addEventListener('click', (e) => {
     const tab = (e.target as HTMLElement).closest<HTMLButtonElement>('.admin-tab');
     const page = tab?.dataset.adminPage;
-    if (page === 'overview' || page === 'moderation') showPage(page);
+    if (page === 'overview' || page === 'moderation' || page === 'chat-filter') showPage(page);
   });
+
+  wireChatFilterEvents();
 
   let searchTimer: number | null = null;
   $('account-search').addEventListener('input', (e) => {
@@ -457,6 +470,15 @@ function wireEvents(): void {
 
   $('moderation-detail').addEventListener('click', (e) => {
     const target = e.target as HTMLElement;
+    const chatModBtn = target.closest('button[data-lift-mute], button[data-reset-strikes]') as HTMLButtonElement | null;
+    if (chatModBtn) {
+      const accountId = Number((target.closest('.mod-detail')?.querySelector('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
+      const endpoint = chatModBtn.dataset.liftMute !== undefined ? 'lift-mute' : 'reset-strikes';
+      void apiPost(`/admin/api/moderation/accounts/${accountId}/${endpoint}`, {})
+        .then(() => { if (Number.isFinite(accountId)) void openModerationAccount(accountId); })
+        .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : 'action failed'); });
+      return;
+    }
     const ignoreBtn = target.closest('button[data-ignore-report]') as HTMLButtonElement | null;
     if (ignoreBtn) {
       const reportId = Number(ignoreBtn.dataset.ignoreReport);
@@ -481,6 +503,48 @@ function wireEvents(): void {
     charactersState.sort = sort;
     charactersState.page = 1;
     void refreshCharacters();
+  });
+}
+
+function chatFilterError(err: unknown, action: string): void {
+  if (!handleAuthFailure(err)) window.alert(err instanceof Error ? err.message : `${action} failed`);
+}
+
+function wireChatFilterEvents(): void {
+  // Add a word: the per-tier form submits (Enter or the Add button).
+  $('chat-filter').addEventListener('submit', (e) => {
+    const form = (e.target as HTMLElement).closest('form.word-add') as HTMLFormElement | null;
+    if (!form) return;
+    e.preventDefault();
+    const tier = form.dataset.addTier;
+    const input = form.querySelector('input') as HTMLInputElement | null;
+    const word = (input?.value ?? '').trim();
+    if (!word || (tier !== 'soft' && tier !== 'hard')) return;
+    void apiPost('/admin/api/chat-filter/words', { word, tier })
+      .then(() => refreshChatFilter())
+      .catch((err: unknown) => chatFilterError(err, 'add word'));
+  });
+
+  // Remove a word, or save the escalation config.
+  $('chat-filter').addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+    const del = target.closest('button[data-del-word]') as HTMLButtonElement | null;
+    if (del) {
+      void apiPost(`/admin/api/chat-filter/words/${Number(del.dataset.delWord)}/delete`, {})
+        .then(() => refreshChatFilter())
+        .catch((err: unknown) => chatFilterError(err, 'remove word'));
+      return;
+    }
+    if (target.closest('button[data-save-config]')) {
+      const warningsBeforeMute = Number(($('cf-warnings') as HTMLInputElement).value);
+      const muteLadderSeconds = ($('cf-ladder') as HTMLInputElement).value
+        .split(',')
+        .map((s) => Number(s.trim()))
+        .filter((n) => Number.isFinite(n) && n > 0);
+      void apiPost('/admin/api/chat-filter/config', { warningsBeforeMute, muteLadderSeconds })
+        .then(() => refreshChatFilter())
+        .catch((err: unknown) => chatFilterError(err, 'save config'));
+    }
   });
 }
 

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -1,5 +1,8 @@
 import { escapeHtml, fmtCopper, fmtDate, fmtDuration, fmtRelative } from './format';
-import type { AccountDetail, AccountRow, CharacterRow, LivePlayer, ModerationAccountDetail, ModerationQueueRow } from './types';
+import type {
+  AccountDetail, AccountRow, CharacterRow, ChatFilterData, ChatModerationDetail, FilterWord,
+  LivePlayer, ModerationAccountDetail, ModerationQueueRow,
+} from './types';
 
 // Pure HTML-string renderers for the dashboard tables. All dynamic values go
 // through escapeHtml — usernames and character names are player-controlled.
@@ -219,6 +222,7 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
       <span class="hint">account #${d.account.id}</span>
     </div>
     ${renderAccountDetail(d.account)}
+    ${renderChatModeration(d.chat)}
     <div class="mod-account-actions" data-action-account-id="${d.account.id}">
       <input id="mod-reason" placeholder="Moderator note / reason" maxlength="500" />
       ${moderationAccountButtons}
@@ -227,6 +231,72 @@ export function renderModerationDetail(d: ModerationAccountDetail): string {
     <h4>Open reports</h4>
     ${reports || '<div class="empty">no open reports for this account</div>'}
   </div>`;
+}
+
+// Chat-filter state for an account: live mute status, strike count, the
+// warn/mute incident log, and manual lift/reset actions (slurs the player typed).
+function renderChatModeration(chat: ChatModerationDetail): string {
+  const muteStatus = chat.chatMutedUntil
+    ? `<span class="badge bad">muted until ${fmtDate(chat.chatMutedUntil)}</span>`
+    : '<span class="badge">not muted</span>';
+  const incidents = chat.violations.length === 0
+    ? '<div class="empty">no chat filter incidents</div>'
+    : `<table><thead><tr><th>Time</th><th>Channel</th><th>Word</th><th>Action</th><th>Message</th></tr></thead><tbody>${
+        chat.violations.map((v) => `
+          <tr>
+            <td>${fmtDate(v.createdAt)}</td>
+            <td>${escapeHtml(v.channel)}</td>
+            <td>${escapeHtml(v.term)}</td>
+            <td>${escapeHtml(v.action)}${v.muteSeconds > 0 ? ` (${escapeHtml(fmtDuration(v.muteSeconds))})` : ''}</td>
+            <td>${escapeHtml(v.message)}</td>
+          </tr>`).join('')
+      }</tbody></table>`;
+  return `<div class="panel chat-mod">
+    <div class="panel-title">Chat moderation</div>
+    <div class="chat-mod-status">Status: ${muteStatus} &middot; Strikes: <b>${chat.chatStrikes}</b></div>
+    <div class="mod-actions">
+      ${chat.chatMutedUntil ? '<button data-lift-mute="1">Lift mute</button>' : ''}
+      ${chat.chatStrikes > 0 ? '<button data-reset-strikes="1">Reset strikes</button>' : ''}
+    </div>
+    <h4>Recent chat filter incidents</h4>
+    ${incidents}
+  </div>`;
+}
+
+function renderWordChips(words: FilterWord[]): string {
+  if (words.length === 0) return '<div class="empty">no words yet</div>';
+  return `<div class="word-chips">${
+    words.map((w) => `<span class="word-chip">${escapeHtml(w.word)}<button class="word-del" data-del-word="${w.id}" title="Remove">&times;</button></span>`).join('')
+  }</div>`;
+}
+
+export function renderChatFilter(data: ChatFilterData): string {
+  const ladderHuman = data.config.muteLadderSeconds.map((s) => fmtDuration(s)).join(' → ');
+  return `
+    <div class="panel">
+      <div class="panel-title">Escalation</div>
+      <p class="hint">Typing a hard word blocks the message and warns the player, then applies escalating account-wide mutes (survives relog / character swap).</p>
+      <div class="cf-config">
+        <label>Warnings before first mute
+          <input id="cf-warnings" type="number" min="0" max="50" value="${data.config.warningsBeforeMute}" />
+        </label>
+        <label>Mute ladder (seconds, comma-separated)
+          <input id="cf-ladder" type="text" value="${escapeHtml(data.config.muteLadderSeconds.join(', '))}" />
+        </label>
+        <div class="hint">Current ladder: ${escapeHtml(ladderHuman || '—')}</div>
+        <button data-save-config="1">Save escalation settings</button>
+      </div>
+    </div>
+    <div class="panel">
+      <div class="panel-title">Soft words <span class="hint">masked with **** in players' chat; players can toggle the filter off</span></div>
+      <form class="word-add" data-add-tier="soft"><input placeholder="add a soft word" maxlength="64" /><button>Add</button></form>
+      ${renderWordChips(data.soft)}
+    </div>
+    <div class="panel">
+      <div class="panel-title">Hard words <span class="hint">slurs — message blocked + escalating mutes; never shown to anyone, not toggleable</span></div>
+      <form class="word-add" data-add-tier="hard"><input placeholder="add a hard word" maxlength="64" /><button>Add</button></form>
+      ${renderWordChips(data.hard)}
+    </div>`;
 }
 
 function reasonLabel(reason: string): string {

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -143,7 +143,43 @@ export interface ReportDetail {
   }[];
 }
 
+export interface ChatViolationRow {
+  id: number;
+  characterName: string;
+  term: string;
+  channel: string;
+  message: string;
+  action: string;
+  muteSeconds: number;
+  createdAt: string;
+}
+
+export interface ChatModerationDetail {
+  chatMutedUntil: string | null;
+  chatStrikes: number;
+  violations: ChatViolationRow[];
+}
+
 export interface ModerationAccountDetail {
   account: AccountDetail;
   reports: ReportDetail[];
+  chat: ChatModerationDetail;
+}
+
+export interface FilterWord {
+  id: number;
+  word: string;
+  tier: 'soft' | 'hard';
+  createdAt: string;
+}
+
+export interface EscalationConfig {
+  warningsBeforeMute: number;
+  muteLadderSeconds: number[];
+}
+
+export interface ChatFilterData {
+  soft: FilterWord[];
+  hard: FilterWord[];
+  config: EscalationConfig;
 }

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -22,6 +22,10 @@ export const SETTING_RANGES = {
 
 export const BOOL_SETTINGS = {
   mouseCamera: { def: false },
+  // on by default: mask configured swear words in chat with ****. Purely a
+  // local display choice — the server sends raw text and each client decides.
+  // (Slurs are blocked server-side regardless and never reach here.)
+  filterProfanity: { def: true },
 } as const;
 
 export type NumericSettingKey = keyof typeof SETTING_RANGES;

--- a/src/main.ts
+++ b/src/main.ts
@@ -665,6 +665,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     net.setMouselookFacing(netFacing);
     net.pendingFacingDelta = 0; // superseded by the interpolated follow below
     hud.handleEvents(net.drainEvents());
+    if (net.consumeProfanityChanged()) hud.setProfanityWords(net.profanityWords);
     if (net.consumeInventoryChanged()) hud.onInventoryChanged();
     const alpha = net.lastSnapAt > 0
       ? Math.min(1.25, (performance.now() - net.lastSnapAt) / Math.max(20, net.snapInterval))

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -272,6 +272,11 @@ export class ClientWorld implements IWorld {
   // inventory deltas arrive in snapshots, separate from the event frames the
   // HUD redraws on — the frame loop polls this so open panels re-render
   private invChanged = false;
+  // Soft (cosmetic) profanity terms the server sends in `hello` and pushes via
+  // `censor` frames when an admin edits the list. The HUD drains these to mask
+  // chat locally when the player's filter is on. Hard words never arrive here.
+  profanityWords: string[] = [];
+  private profanityDirty = false;
   private pendingQuestCommands = new Map<string, 'accept' | 'turnin'>();
   private mouselookFacing: number | null = null;
   private sendTimer: number | undefined;
@@ -365,7 +370,19 @@ export class ClientWorld implements IWorld {
       this.playerId = msg.pid;
       this.cfg.seed = msg.seed;
       if (typeof msg.realm === 'string') this.realm = msg.realm;
+      if (Array.isArray(msg.softWords)) {
+        this.profanityWords = msg.softWords.filter((w: unknown): w is string => typeof w === 'string');
+        this.profanityDirty = true;
+      }
       this.connected = true;
+      return;
+    }
+    if (msg.t === 'censor') {
+      // live word-list update pushed after an admin edits the filter
+      this.profanityWords = Array.isArray(msg.words)
+        ? msg.words.filter((w: unknown): w is string => typeof w === 'string')
+        : [];
+      this.profanityDirty = true;
       return;
     }
     if (msg.t === 'error') {
@@ -407,6 +424,12 @@ export class ClientWorld implements IWorld {
   consumeSocialChanged(): boolean {
     const v = this.socialDirty;
     this.socialDirty = false;
+    return v;
+  }
+
+  consumeProfanityChanged(): boolean {
+    const v = this.profanityDirty;
+    this.profanityDirty = false;
     return v;
   }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -25,6 +25,7 @@ import { svgIcon } from './ui_icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
+import { maskProfanity } from './profanity';
 import {
   talentsFor, computeTalentModifiers, validateAllocation, dormantNodes, pointsSpent,
   exportBuild, importBuild, cloneAllocation, talentPointsAtLevel, FIRST_TALENT_LEVEL,
@@ -107,6 +108,9 @@ export class Hud {
   private dragAction: { action: Exclude<HotbarAction, null>; sourceIndex: number | null } | null = null;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
+  // Soft swear terms from the server (online only), masked in chat when the
+  // player's "Filter Profanity" setting is on. Fed by main.ts from ClientWorld.
+  private profanityWords: string[] = [];
   private optionsView: 'main' | 'keybinds' | 'graphics' | 'audio' = 'main';
   private capturingKey: { action: string; index: number } | null = null; // binding awaiting a key
   private keybindNote = '';
@@ -1587,7 +1591,8 @@ export class Hud {
             default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
           if ((ev.channel === 'say' || ev.channel === 'yell' || ev.channel === 'emote') && ev.entityId !== undefined) {
-            const bubble = ev.channel === 'emote' ? `${ev.from} ${ev.text}` : ev.text;
+            const masked = this.maskChat(ev.text);
+            const bubble = ev.channel === 'emote' ? `${ev.from} ${masked}` : masked;
             this.renderer.showChatBubble(ev.entityId, bubble, ev.channel === 'yell');
           }
           break;
@@ -1727,10 +1732,24 @@ export class Hud {
       ev.preventDefault();
       this.openChatPlayerContextMenu(name, ev.clientX, ev.clientY);
     });
-    div.append(sender, document.createTextNode(`${separator}${text}`));
+    div.append(sender, document.createTextNode(`${separator}${this.maskChat(text)}`));
     this.chatLogEl.appendChild(div);
     while (this.chatLogEl.children.length > 200) this.chatLogEl.removeChild(this.chatLogEl.firstChild!);
     if (wasNearBottom) this.chatLogEl.scrollTop = this.chatLogEl.scrollHeight;
+  }
+
+  /** Replace the server-supplied soft word list (online play only). */
+  setProfanityWords(words: string[]): void {
+    this.profanityWords = words;
+  }
+
+  // Mask a chat body with **** when the player's profanity filter is on. The
+  // filter defaults on; turning it off in Options shows the raw text the server
+  // sent. Slurs are blocked server-side and never reach this path.
+  private maskChat(text: string): string {
+    if (this.profanityWords.length === 0) return text;
+    if (!(this.optionsHooks?.settings.get('filterProfanity') ?? true)) return text;
+    return maskProfanity(text, this.profanityWords);
   }
 
   private combatLog(text: string, color = '#ccc'): void {
@@ -4144,10 +4163,11 @@ export class Hud {
     el.innerHTML = `<div class="panel-title"><span>Key Bindings</span><span class="x-btn" data-close>${svgIcon('close')}</span></div>`;
     this.settingToggleKeybind(el, 'Mouse Camera', 'mouseCamera');
     this.settingToggleKeybind(el, 'Click to Move', 'clickToMove');
+    this.settingToggleKeybind(el, 'Filter Profanity', 'filterProfanity');
     const note = document.createElement('div');
     note.className = 'kb-note';
     note.textContent = this.keybindNote
-      || 'Mouse Camera off: A/D turns, drag to orbit (classic). On: camera-relative WASD, A/D strafes. Click to Move: left-click the ground or an enemy to walk there. Click a key cell to rebind; Esc cancels.';
+      || 'Mouse Camera off: A/D turns, drag to orbit (classic). On: camera-relative WASD, A/D strafes. Click to Move: left-click the ground or an enemy to walk there. Filter Profanity masks swear words in chat with ****. Click a key cell to rebind; Esc cancels.';
     el.appendChild(note);
     const rows = document.createElement('div');
     rows.className = 'kb-rows';

--- a/src/ui/profanity.ts
+++ b/src/ui/profanity.ts
@@ -1,0 +1,45 @@
+// Client-side cosmetic profanity masking for the chat log. The server ships the
+// soft word list (in `hello` / `censor` frames) but never alters the text, so
+// each client masks locally according to the player's "Filter Profanity"
+// setting. This is display-only — slurs are blocked server-side and never get
+// here, and a player who turns the filter off simply sees the raw text.
+//
+// The normalization MUST stay in lockstep with server/chat_filter.ts so the
+// terms the server sends mask the same tokens the server intended. It's a tiny,
+// stable function; the layering rules (ui/ can't import server/) make a small
+// duplicate cleaner than a shared cross-boundary module.
+
+const CONFUSABLE_CHARS: Record<string, string> = {
+  '0': 'o',
+  '1': 'i',
+  '3': 'e',
+  '4': 'a',
+  '5': 's',
+  '7': 't',
+  '8': 'b',
+  '!': 'i',
+  '|': 'i',
+  '@': 'a',
+  '$': 's',
+  '+': 't',
+};
+
+const TOKEN_RE = /[A-Za-z0-9_@$!|+]+/g;
+
+function normalizeWord(term: string): string {
+  return term
+    .toLowerCase()
+    .replace(/[0134578!|@$+]/g, (ch) => CONFUSABLE_CHARS[ch] ?? ch)
+    .replace(/[^a-z]/g, '');
+}
+
+/** Replace every token containing a soft term with asterisks of equal length. */
+export function maskProfanity(text: string, terms: readonly string[]): string {
+  if (terms.length === 0) return text;
+  return text.replace(TOKEN_RE, (tok) => {
+    const normalized = normalizeWord(tok);
+    return normalized.length > 0 && terms.some((term) => normalized.includes(term))
+      ? '*'.repeat(tok.length)
+      : tok;
+  });
+}

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -31,11 +31,25 @@ vi.mock('../server/moderation_db', () => ({
   ignoreReport: vi.fn(),
   moderateAccount: vi.fn(),
 }));
+vi.mock('../server/chat_filter_db', () => ({
+  addFilterWord: vi.fn(),
+  chatModerationForAccount: vi.fn(),
+  getFilterConfig: vi.fn(),
+  liftChatMute: vi.fn(),
+  listFilterWords: vi.fn(),
+  removeFilterWord: vi.fn(),
+  resetChatStrikes: vi.fn(),
+  updateFilterConfig: vi.fn(),
+}));
 
 import { handleAdminApi, parsePageParams } from '../server/admin';
 import { accountForToken, isAdminAccount, findAccount } from '../server/db';
 import { overviewCounts, listAccounts, accountDetail, escapeLike } from '../server/admin_db';
 import { forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount } from '../server/moderation_db';
+import {
+  addFilterWord, chatModerationForAccount, getFilterConfig, liftChatMute, listFilterWords,
+  removeFilterWord, resetChatStrikes, updateFilterConfig,
+} from '../server/chat_filter_db';
 
 const VALID_TOKEN = 'a'.repeat(64);
 
@@ -72,10 +86,16 @@ const fakeGame: any = {
   liveSessions: () => [],
   liveAccountIds: () => new Set([9]),
   disconnectAccount: vi.fn(),
+  reloadChatFilter: vi.fn(async () => {}),
+  liftChatMuteLive: vi.fn(),
+  resetChatStrikesLive: vi.fn(),
 };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default so the moderation-detail route (which now also loads chat state)
+  // resolves; individual chat-filter tests override as needed.
+  vi.mocked(chatModerationForAccount).mockResolvedValue({ chatMutedUntil: null, chatStrikes: 0, violations: [] });
 });
 
 describe('admin api auth', () => {
@@ -308,6 +328,148 @@ describe('admin api auth', () => {
     expect(res.statusCode).toBe(200);
     expect(forceCharacterRename).toHaveBeenCalledWith({ characterId: 42, adminAccountId: 7, reason: 'bad name' });
     expect(fakeGame.disconnectAccount).toHaveBeenCalledWith(9, 'A moderator requires one of your characters to be renamed.');
+  });
+});
+
+describe('admin api chat filter', () => {
+  beforeEach(() => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+  });
+
+  it('serves both word tiers and the escalation config', async () => {
+    vi.mocked(listFilterWords).mockImplementation(async (tier) => (
+      tier === 'hard'
+        ? [{ id: 2, word: 'slur', tier: 'hard', createdAt: '' }]
+        : [{ id: 1, word: 'darn', tier: 'soft', createdAt: '' }]
+    ));
+    vi.mocked(getFilterConfig).mockResolvedValue({ warningsBeforeMute: 1, muteLadderSeconds: [600] });
+    const res = fakeRes();
+
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/chat-filter' }), res, fakeGame);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.soft[0].word).toBe('darn');
+    expect(res.body.data.hard[0].word).toBe('slur');
+    expect(res.body.data.config.muteLadderSeconds).toEqual([600]);
+  });
+
+  it('adds a word and reloads the live filter', async () => {
+    vi.mocked(addFilterWord).mockResolvedValue(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/chat-filter/words', body: { word: 'Heck', tier: 'soft' } }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(addFilterWord).toHaveBeenCalledWith('Heck', 'soft');
+    expect(fakeGame.reloadChatFilter).toHaveBeenCalled();
+  });
+
+  it('rejects an invalid tier', async () => {
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/chat-filter/words', body: { word: 'x', tier: 'medium' } }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(addFilterWord).not.toHaveBeenCalled();
+  });
+
+  it('rejects a word that normalizes to nothing', async () => {
+    vi.mocked(addFilterWord).mockResolvedValue(false);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/chat-filter/words', body: { word: '!!!', tier: 'hard' } }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(fakeGame.reloadChatFilter).not.toHaveBeenCalled();
+  });
+
+  it('deletes a word by id', async () => {
+    vi.mocked(removeFilterWord).mockResolvedValue(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/chat-filter/words/5/delete' }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(removeFilterWord).toHaveBeenCalledWith(5);
+    expect(fakeGame.reloadChatFilter).toHaveBeenCalled();
+  });
+
+  it('updates the escalation config', async () => {
+    vi.mocked(updateFilterConfig).mockResolvedValue({ warningsBeforeMute: 2, muteLadderSeconds: [60, 120] });
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({
+        method: 'POST', token: VALID_TOKEN, url: '/admin/api/chat-filter/config',
+        body: { warningsBeforeMute: 2, muteLadderSeconds: [60, 120] },
+      }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(updateFilterConfig).toHaveBeenCalledWith({ warningsBeforeMute: 2, muteLadderSeconds: [60, 120] });
+    expect(fakeGame.reloadChatFilter).toHaveBeenCalled();
+  });
+
+  it('lifts a mute and syncs the live session', async () => {
+    vi.mocked(liftChatMute).mockResolvedValue(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/lift-mute' }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(liftChatMute).toHaveBeenCalledWith(9);
+    expect(fakeGame.liftChatMuteLive).toHaveBeenCalledWith(9);
+  });
+
+  it('resets strikes and syncs the live session', async () => {
+    vi.mocked(resetChatStrikes).mockResolvedValue(true);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9/reset-strikes' }),
+      res, fakeGame,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(resetChatStrikes).toHaveBeenCalledWith(9);
+    expect(fakeGame.resetChatStrikesLive).toHaveBeenCalledWith(9);
+  });
+
+  it('includes chat moderation state in the moderation account detail', async () => {
+    vi.mocked(accountDetail).mockResolvedValue({
+      id: 9, username: 'badactor', createdAt: '', lastLogin: null, isAdmin: false,
+      bannedAt: null, suspendedUntil: null, moderationReason: '',
+      playtimeSeconds: 0, characters: [], recentSessions: [],
+    });
+    vi.mocked(moderationReportsForAccount).mockResolvedValue([]);
+    vi.mocked(chatModerationForAccount).mockResolvedValue({
+      chatMutedUntil: null, chatStrikes: 3,
+      violations: [{ id: 1, characterName: 'badactor', term: 'slur', channel: 'say', message: 'a slur', action: 'mute', muteSeconds: 600, createdAt: '' }],
+    });
+    const res = fakeRes();
+
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/moderation/accounts/9' }), res, fakeGame);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.data.chat.chatStrikes).toBe(3);
+    expect(res.body.data.chat.violations).toHaveLength(1);
   });
 });
 

--- a/tests/chat_filter.test.ts
+++ b/tests/chat_filter.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  cleanEscalationConfig,
+  DEFAULT_ESCALATION,
+  escalate,
+  findHardWord,
+  maskText,
+  normalizeWord,
+  parseWordList,
+} from '../server/chat_filter';
+
+describe('normalizeWord', () => {
+  it('lowercases, de-leets confusables, and strips non-letters', () => {
+    expect(normalizeWord('N1GG3R')).toBe('nigger');
+    expect(normalizeWord('f.u_c-k')).toBe('fuck');
+    expect(normalizeWord('@$$')).toBe('ass');
+    expect(normalizeWord('123')).toBe('ie'); // 1->i, 2 dropped, 3->e
+  });
+});
+
+describe('parseWordList', () => {
+  it('splits on whitespace/commas and normalizes each term', () => {
+    expect(parseWordList('Fuck, sh1t\n bitch')).toEqual(['fuck', 'shit', 'bitch']);
+    expect(parseWordList('   ')).toEqual([]);
+  });
+});
+
+describe('maskText (soft, cosmetic)', () => {
+  it('masks tokens containing a soft term, preserving length', () => {
+    expect(maskText('oh shit really', ['shit'])).toBe('oh **** really');
+    expect(maskText('that is shitty', ['shit'])).toBe('that is ******'); // substring match
+  });
+
+  it('catches leet-spelled evasions', () => {
+    expect(maskText('sh1t', ['shit'])).toBe('****');
+  });
+
+  it('returns the text unchanged when no terms are configured', () => {
+    expect(maskText('anything goes', [])).toBe('anything goes');
+  });
+});
+
+describe('findHardWord (hard, punitive)', () => {
+  it('matches whole tokens, including leet and plurals', () => {
+    expect(findHardWord('you are a nigger', ['nigger'])).toBe('nigger');
+    expect(findHardWord('n1gger', ['nigger'])).toBe('nigger');
+    expect(findHardWord('two niggers here', ['nigger'])).toBe('nigger'); // plural strip
+    expect(findHardWord('NIGGER', ['nigger'])).toBe('nigger'); // case-insensitive
+  });
+
+  it('does NOT substring-match innocent words (no false mutes)', () => {
+    // The classic Scunthorpe trap: substring matching would wrongly fire here.
+    expect(findHardWord('that is despicable', ['spic'])).toBeNull();
+    expect(findHardWord('what a classy pass', ['ass'])).toBeNull();
+    expect(findHardWord('assassin guild', ['ass'])).toBeNull();
+  });
+
+  it('returns null with no terms or no hit', () => {
+    expect(findHardWord('anything', [])).toBeNull();
+    expect(findHardWord('perfectly fine message', ['nigger'])).toBeNull();
+  });
+});
+
+describe('escalate', () => {
+  const cfg = { warningsBeforeMute: 1, muteLadderSeconds: [600, 3600, 86400] };
+
+  it('warns for the first offense, then walks the mute ladder, capping at the last', () => {
+    expect(escalate(0, cfg)).toEqual({ kind: 'warning', muteSeconds: 0, strikes: 1 });
+    expect(escalate(1, cfg)).toEqual({ kind: 'mute', muteSeconds: 600, strikes: 2 });
+    expect(escalate(2, cfg)).toEqual({ kind: 'mute', muteSeconds: 3600, strikes: 3 });
+    expect(escalate(3, cfg)).toEqual({ kind: 'mute', muteSeconds: 86400, strikes: 4 });
+    expect(escalate(9, cfg)).toEqual({ kind: 'mute', muteSeconds: 86400, strikes: 10 }); // clamps
+  });
+
+  it('mutes immediately when warningsBeforeMute is 0', () => {
+    expect(escalate(0, { warningsBeforeMute: 0, muteLadderSeconds: [600] })).toEqual({
+      kind: 'mute', muteSeconds: 600, strikes: 1,
+    });
+  });
+
+  it('never mutes when the ladder is empty', () => {
+    expect(escalate(5, { warningsBeforeMute: 1, muteLadderSeconds: [] })).toEqual({
+      kind: 'warning', muteSeconds: 0, strikes: 6,
+    });
+  });
+});
+
+describe('cleanEscalationConfig', () => {
+  it('falls back to defaults on garbage input', () => {
+    expect(cleanEscalationConfig({})).toEqual(DEFAULT_ESCALATION);
+    expect(cleanEscalationConfig({ warningsBeforeMute: -3, muteLadderSeconds: 'nope' })).toEqual(DEFAULT_ESCALATION);
+  });
+
+  it('keeps valid values and drops non-positive ladder entries', () => {
+    expect(cleanEscalationConfig({ warningsBeforeMute: 2, muteLadderSeconds: [60, -1, 0, 120] })).toEqual({
+      warningsBeforeMute: 2,
+      muteLadderSeconds: [60, 120],
+    });
+  });
+});

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -1,6 +1,3 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock the db layer so no Postgres is needed; snapshot logic is under test.
@@ -12,7 +9,7 @@ vi.mock('../server/db', () => ({
   insertChatLogs: vi.fn(async () => {}),
 }));
 
-import { censorChatText, GameServer, ClientSession } from '../server/game';
+import { GameServer, ClientSession } from '../server/game';
 import { saveCharacterState } from '../server/db';
 import { ClientWorld } from '../src/net/online';
 import type { PlayerClass } from '../src/sim/types';
@@ -80,27 +77,6 @@ function bareClient(pid: number): ClientWorld {
   c.eventQueue = [];
   c.mouselookFacing = null;
   return c;
-}
-
-function withChatCensorConfig(list: string | undefined, file: string | undefined, test: () => void): void {
-  const prev = process.env.CHAT_CENSOR_LIST;
-  const prevFile = process.env.CHAT_CENSOR_FILE;
-  if (list === undefined) delete process.env.CHAT_CENSOR_LIST;
-  else process.env.CHAT_CENSOR_LIST = list;
-  if (file === undefined) delete process.env.CHAT_CENSOR_FILE;
-  else process.env.CHAT_CENSOR_FILE = file;
-  try {
-    test();
-  } finally {
-    if (prev === undefined) delete process.env.CHAT_CENSOR_LIST;
-    else process.env.CHAT_CENSOR_LIST = prev;
-    if (prevFile === undefined) delete process.env.CHAT_CENSOR_FILE;
-    else process.env.CHAT_CENSOR_FILE = prevFile;
-  }
-}
-
-function withChatCensorList(list: string | undefined, test: () => void): void {
-  withChatCensorConfig(list, undefined, test);
 }
 
 describe('delta snapshots', () => {
@@ -300,67 +276,58 @@ describe('chat moderation', () => {
     }));
   });
 
-  it('censors configured terrible words while still sending chat', () => {
-    withChatCensorList('blockedterm', () => {
-      expect(censorChatText('hello blockedterm and bl0ckedt3rm')).toBe('hello *********** and ***********');
+  it('blocks hard-word (slur) messages and escalates warning -> mute', () => {
+    const server = new GameServer();
+    server.chatFilter.load({ soft: [], hard: ['slurword'], config: { warningsBeforeMute: 1, muteLadderSeconds: [600] } });
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
 
-      const server = new GameServer();
-      const fc = fakeWs();
-      const session = joinServer(server, fc, 1, 'Testa');
-      fc.sent.length = 0;
-      server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'hello blockedterm' }));
-      (server as any).routeEvents(server.sim.tick());
+    // First offense: blocked entirely + warning; it never becomes a chat event.
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'you are a slurword' }));
+    (server as any).routeEvents(server.sim.tick());
+    let events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events.some((ev) => ev.type === 'chat')).toBe(false);
+    expect(events).toContainEqual(expect.objectContaining({ type: 'error', text: expect.stringContaining('Warning') }));
 
-      const events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
-      expect(events).toContainEqual(expect.objectContaining({
-        type: 'chat',
-        text: 'hello ***********',
-      }));
-    });
+    // Second offense: escalates to a timed mute.
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'slurword strikes again' }));
+    events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events).toContainEqual(expect.objectContaining({ type: 'error', text: expect.stringContaining('muted') }));
+
+    // Now muted: even a clean message is dropped until the mute expires.
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'hello everyone' }));
+    (server as any).routeEvents(server.sim.tick());
+    events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events.some((ev) => ev.type === 'chat')).toBe(false);
+    expect(events).toContainEqual(expect.objectContaining({ type: 'error', text: expect.stringContaining('muted') }));
   });
 
-  it('caches file-backed censor terms until censor env changes', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'claudecraft-censor-'));
-    const firstFile = join(dir, 'first.txt');
-    const secondFile = join(dir, 'second.txt');
-    writeFileSync(firstFile, 'fileterm\n');
-    writeFileSync(secondFile, 'otherterm\n');
-
-    try {
-      withChatCensorConfig(undefined, firstFile, () => {
-        expect(censorChatText('fileterm again')).toBe('******** again');
-        writeFileSync(firstFile, 'changedterm\n');
-        expect(censorChatText('fileterm changedterm')).toBe('******** changedterm');
-
-        process.env.CHAT_CENSOR_FILE = secondFile;
-        expect(censorChatText('fileterm otherterm')).toBe('fileterm *********');
-
-        delete process.env.CHAT_CENSOR_FILE;
-        expect(censorChatText('otherterm')).toBe('otherterm');
-      });
-    } finally {
-      rmSync(dir, { force: true, recursive: true });
-    }
+  it('leaves soft (cosmetic) words untouched server-side — clients mask them', () => {
+    const server = new GameServer();
+    server.chatFilter.load({ soft: ['darn'], hard: [], config: { warningsBeforeMute: 1, muteLadderSeconds: [600] } });
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
+    fc.sent.length = 0;
+    server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'chat', text: 'oh darn it' }));
+    (server as any).routeEvents(server.sim.tick());
+    const events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events).toContainEqual(expect.objectContaining({ type: 'chat', text: 'oh darn it' }));
   });
 
-  it('retries file-backed censor terms after a failed read', () => {
-    const dir = mkdtempSync(join(tmpdir(), 'claudecraft-censor-missing-'));
-    const missingFile = join(dir, 'missing.txt');
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-    try {
-      withChatCensorConfig(undefined, missingFile, () => {
-        expect(censorChatText('laterterm')).toBe('laterterm');
-        expect(warn).toHaveBeenCalledOnce();
-
-        writeFileSync(missingFile, 'laterterm\n');
-        expect(censorChatText('laterterm')).toBe('*********');
-      });
-    } finally {
-      warn.mockRestore();
-      rmSync(dir, { force: true, recursive: true });
-    }
+  it('ships the soft word list to clients in the hello payload', () => {
+    const server = new GameServer();
+    server.chatFilter.load({ soft: ['darn', 'heck'], hard: ['slurword'], config: { warningsBeforeMute: 1, muteLadderSeconds: [600] } });
+    const fc = fakeWs();
+    joinServer(server, fc, 1, 'Testa');
+    const hello = fc.sent.find((msg) => msg.t === 'hello');
+    expect(hello.softWords).toEqual(['darn', 'heck']);
+    // Hard words are enforcement-only and must never be shipped to the client.
+    expect(JSON.stringify(hello)).not.toContain('slurword');
   });
+
 });
 
 describe('autosaves', () => {


### PR DESCRIPTION
## What

A two-tier chat moderation system.

**Soft tier (everyday swearing) — cosmetic, per-player, on by default**
- Masked client-side with `****`; toggle in **Esc → Key Bindings → Filter Profanity**.
- The server ships the soft word list in the `hello` frame and pushes live updates when an admin edits it, but **never alters the text** — turning the filter off shows raw text.
- Applied to **both** the chat log panel and the floating chat bubble above the player's head.

**Hard tier (slurs) — server-side, non-bypassable**
- The message is **blocked entirely**, then the sender is **warned**, then escalated to **account-wide, all-channel timed mutes** (10m → 1h → 24h, admin-tunable) that survive relog and character swap.
- Matching is **whole-token** (with leet folding + plural strip), not substring, so it can't false-mute innocent words like *despicable* or *classy*.

**Admin dashboard**
- New **Chat Filter** tab: edit both word lists live + tune the warnings count and mute ladder.
- **Moderation** view gains mute status, strike count, an incident log, and **Lift mute** / **Reset strikes** controls.

## How it's wired
- Word lists + escalation config are **DB-backed** (`chat_filter_words`, `chat_filter_config`, `chat_violations`; `accounts.chat_muted_until` / `chat_strikes`), seeded with sensible defaults on first boot. Legacy `CHAT_CENSOR_LIST` / `CHAT_CENSOR_FILE` fold into the soft seed once, then are ignored (the dashboard is authoritative — see `DEPLOY.md`).
- Pure matching/escalation logic lives in `server/chat_filter.ts` (unit-tested); SQL is isolated in `server/chat_filter_db.ts`, per the repo's "SQL only in `*_db.ts`" rule.
- The old server-side `censorChatText` (env-driven, applied to everyone) is removed in favor of the per-player client-side soft filter + the new hard-word gate.

## Testing
- `tests/chat_filter.test.ts` — masking, hard-hit (incl. false-positive avoidance, leet, plurals), and the escalation ladder.
- `tests/snapshots.test.ts` — enforcement integration (warn → mute → muted-blocks-clean-message), soft passthrough, and the `hello` soft-list payload.
- `tests/admin.test.ts` — chat-filter endpoint routing, tier validation, lift-mute / reset-strikes, and chat state in the moderation detail.
- Full CI gate green locally: **670 tests**, `tsc --noEmit`, `build:env`, `build:server`, `build`.

## Decisions worth a reviewer's eye
- **Per-player client-side soft filter** means raw profanity crosses the wire (a determined user can un-filter their own view). That's intentional for a cosmetic filter; the hard tier never reaches the client.
- The default **hard-word seed list is committed** (`DEFAULT_HARD_WORDS` in `chat_filter.ts`) so enforcement works out of the box — admins can edit the live list anytime.
- The settings toggle uses a plain-string label (matching the existing `Mouse Camera` / `Click to Move` toggles) rather than threading new i18n keys through every locale; mute notices are server-side English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
