### PR TITLE
feat(mobile): Touch Look Speed accessibility setting for the camera joystick

### DIFF
--- a/scripts/mobile_touch_look_speed_shot.mjs
+++ b/scripts/mobile_touch_look_speed_shot.mjs
@@ -1,0 +1,65 @@
+// Mobile screenshot helper for the Touch Look Speed accessibility slider.
+// Usage: node scripts/mobile_touch_look_speed_shot.mjs   (needs `npm run dev` on :5173)
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173/';
+const OUT = process.env.OUT_DIR ?? '/tmp';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+});
+const page = await browser.newPage();
+// Landscape phone with a coarse pointer so body.mobile-touch + isPhoneTouchDevice() activate.
+await page.emulate({
+  viewport: { width: 844, height: 390, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
+  userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148',
+});
+// isPhoneTouchDevice() reads matchMedia(pointer: coarse) — headless Chromium reports
+// fine, so force coarse pointer to mirror a real phone.
+const client = await page.target().createCDPSession();
+await client.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+page.on('console', (m) => { if (m.type() === 'error') console.log('PAGE ERR', m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle2', timeout: 30000 });
+await sleep(500);
+await page.click('#btn-offline');
+await sleep(400);
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await sleep(200);
+await page.type('#char-name', 'Thumbwar');
+await sleep(150);
+await page.click('#btn-start-offline');
+await sleep(6000);
+
+// Open the Esc options menu and jump straight to the Graphics view.
+await page.evaluate(() => {
+  const hud = window.__game.hud;
+  hud.toggleOptionsMenu();
+  hud.optionsView = 'graphics';
+  hud.renderOptions();
+});
+await sleep(400);
+const def = `${OUT}/mobile-touch-look-speed-default.png`;
+await page.screenshot({ path: def });
+console.log('wrote', def);
+
+// Drag the slider to its max (180%) to show the readout updating.
+await page.evaluate(() => {
+  const sliders = [...document.querySelectorAll('#options-menu .set-slider')];
+  const row = sliders.map((s) => s.closest('.set-row')).find((r) => /Touch Look Speed/.test(r?.textContent ?? ''));
+  const slider = row?.querySelector('.set-slider');
+  if (slider) {
+    slider.value = slider.max;
+    slider.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+});
+await sleep(300);
+const max = `${OUT}/mobile-touch-look-speed-max.png`;
+await page.screenshot({ path: max });
+console.log('wrote', max);
+
+await browser.close();

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -72,6 +72,9 @@ export class Input {
   private touchJump = false;
   private touchLookActive = false;
   private touchLookVector = { x: 0, y: 0 };
+  // multiplier on the touch look (camera joystick) rate; setTouchLookSpeed
+  // drives it from the settings menu. Mouselook uses lookSensitivity instead.
+  private touchLookSpeed = 1;
 
   constructor(private canvas: HTMLCanvasElement, private cb: InputCallbacks, private keybinds: Keybinds) {
     window.addEventListener('keydown', (e) => this.onKeyDown(e));
@@ -139,6 +142,10 @@ export class Input {
     this.lookSensitivity = BASE_LOOK_SENS * mult;
   }
 
+  setTouchLookSpeed(mult: number): void {
+    this.touchLookSpeed = mult;
+  }
+
   setTouchMove(move: TouchMoveInput): void {
     const changed = move.forward !== this.touchMove.forward || move.back !== this.touchMove.back
       || move.strafeLeft !== this.touchMove.strafeLeft || move.strafeRight !== this.touchMove.strafeRight;
@@ -185,8 +192,8 @@ export class Input {
 
   updateTouchLook(dt: number): void {
     if (!this.touchLookActive) return;
-    this.camYaw -= this.touchLookVector.x * TOUCH_LOOK_YAW_RATE * dt;
-    this.camPitch = Math.min(1.35, Math.max(-0.4, this.camPitch + this.touchLookVector.y * TOUCH_LOOK_PITCH_RATE * dt));
+    this.camYaw -= this.touchLookVector.x * TOUCH_LOOK_YAW_RATE * this.touchLookSpeed * dt;
+    this.camPitch = Math.min(1.35, Math.max(-0.4, this.camPitch + this.touchLookVector.y * TOUCH_LOOK_PITCH_RATE * this.touchLookSpeed * dt));
   }
 
   isMouselookActive(): boolean {

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -18,6 +18,10 @@ export const SETTING_RANGES = {
   // off by default: always-on click-to-move would disrupt the precise melee
   // positioning the team wanted to preserve, so it's opt-in (#95)
   clickToMove: { min: 0, max: 1, def: 0 },
+  // touch-only: scales the camera (look) joystick turn/pitch rate. The Camera
+  // Speed slider only scales mouselook, so before this phones had no way to
+  // tune look sensitivity; surfaced in Graphics only on phone touch devices.
+  touchLookSpeed: { min: 0.4, max: 1.8, def: 1 },
 } as const;
 
 export const BOOL_SETTINGS = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -472,6 +472,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     const v = settings.set(key as keyof typeof SETTING_RANGES, value as number);
     switch (key) {
       case 'cameraSpeed': input.setCameraSpeed(v); break;
+      case 'touchLookSpeed': input.setTouchLookSpeed(v); break;
       case 'sfxVolume': audio.setVolume(v); break;
       case 'musicVolume': music.setVolume(v); break;
       case 'brightness': renderer.setBrightness(v); break;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -25,6 +25,7 @@ import { iconDataUrl, iconCanvas, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_
 import { svgIcon } from './ui_icons';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES } from '../game/settings';
+import { isPhoneTouchDevice } from '../game/mobile_controls';
 import { chatPlayerContextActions } from './player_context_menu';
 import { TouchPeekGuard, TOOLTIP_PEEK_MS } from './touch_peek';
 import {
@@ -4424,6 +4425,9 @@ export class Hud {
   private renderGraphics(): void {
     const body = this.settingsViewShell('Graphics');
     this.settingSlider(body, 'Camera Speed', 'cameraSpeed');
+    // Camera Speed only scales mouselook; on touch the camera joystick has its
+    // own rate, so phones get a dedicated sensitivity slider here.
+    if (isPhoneTouchDevice()) this.settingSlider(body, 'Touch Look Speed', 'touchLookSpeed');
     this.settingSlider(body, 'Brightness', 'brightness');
     this.settingSlider(body, 'Render Quality', 'renderScale');
     this.settingToggle(body, 'Fullscreen', 'fullscreen');

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -64,6 +64,16 @@ describe('Settings', () => {
     expect(b.get('leftHandedTouch')).toBe(true);
   });
 
+  it('defaults touch look speed to 1x, clamps, and persists', () => {
+    const a = new Settings();
+    expect(a.get('touchLookSpeed')).toBe(SETTING_RANGES.touchLookSpeed.def);
+    expect(a.set('touchLookSpeed', 99)).toBe(SETTING_RANGES.touchLookSpeed.max);
+    expect(a.set('touchLookSpeed', -5)).toBe(SETTING_RANGES.touchLookSpeed.min);
+    a.set('touchLookSpeed', 1.5);
+    const b = new Settings();
+    expect(b.get('touchLookSpeed')).toBe(1.5);
+  });
+
   it('falls back to defaults for missing/corrupt keys', () => {
     localStorage.setItem('woc_settings', JSON.stringify({ cameraSpeed: 0.5 }));
     const s = new Settings();


### PR DESCRIPTION
## What

Adds a touch-only **Touch Look Speed** slider (0.4×–1.8×, default 1.0) to the **Graphics** options so phone players can tune how fast the camera joystick turns/pitches.

## Why

The existing **Camera Speed** slider only scales **mouselook** (`lookSensitivity` = `BASE_LOOK_SENS * mult`). The touch camera joystick instead drives the camera with fixed `TOUCH_LOOK_YAW_RATE`/`TOUCH_LOOK_PITCH_RATE` in `Input.updateTouchLook`, which nothing in settings touched — so on a phone there was **no way to adjust look sensitivity at all**. Players who find the camera too twitchy (or too sluggish) on touch now have a control, matching the joystick/button-size accessibility sliders.

## How

Presentation-only — reuses the settings→subsystem seam, **no sim / IWorld / net / server change**:

- `src/game/settings.ts` — new `touchLookSpeed` in `SETTING_RANGES` (clamp + persistence + reset come free from the generic store).
- `src/game/input.ts` — `touchLookSpeed` field + `setTouchLookSpeed(mult)`, multiplied into both rates in `updateTouchLook`.
- `src/main.ts` — `applySetting` case `'touchLookSpeed': input.setTouchLookSpeed(v)`.
- `src/ui/hud.ts` — slider rendered in `renderGraphics()` **only when `isPhoneTouchDevice()`**, so desktop is unchanged.

## Tests

- `tests/settings.test.ts` — default 1×, clamps to bounds, persists across instances.
- `npx tsc --noEmit` clean; full suite **899 tests pass**.

## Screenshots (landscape phone, 844×390, coarse pointer)

| Default (100%) | Max (180%) |
|---|---|
| ![default](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-touch-look-speed/touch-look-speed-default.png) | ![max](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mobile-touch-look-speed/touch-look-speed-max.png) |

Captured with `scripts/mobile_touch_look_speed_shot.mjs` (puppeteer-core, offline flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)