### PR TITLE
feat(mobile): promote Interact/"Use" to the primary touch row

### DIFF
--- a/index.html
+++ b/index.html
@@ -2805,7 +2805,7 @@
   }
   body.mobile-touch #mobile-combat-controls {
     position: absolute; left: 50%; bottom: calc(4px + env(safe-area-inset-bottom)); transform: translateX(-50%);
-    display: grid; grid-template-columns: 124px 58px 58px; gap: 8px; pointer-events: auto; align-items: end;
+    display: grid; grid-template-columns: 124px 58px 58px 58px; gap: 8px; pointer-events: auto; align-items: end;
   }
   body.mobile-touch .mobile-btn {
     width: 58px; height: 54px; border: 2px solid #4a3d1d; border-radius: 8px;
@@ -3105,7 +3105,7 @@
     }
     body.mobile-touch .mobile-joy-label { bottom: -15px; font-size: 8px; color: #d7c987aa; }
     body.mobile-touch #mobile-combat-controls {
-      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px 54px 54px; gap: 7px;
+      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px 54px 54px 54px; gap: 7px;
     }
     body.mobile-touch .mobile-btn { width: 54px; height: 48px; font-size: 20px; background: radial-gradient(circle at 35% 30%, #2d3048bf, #11121ec2 72%); }
     body.mobile-touch #mobile-attack-nearest { width: 115px; }
@@ -4086,13 +4086,13 @@
     <div id="mobile-combat-controls">
       <button class="mobile-btn" id="mobile-attack-nearest" title="Attack nearest enemy" aria-label="Attack nearest enemy" data-icon="attack"><span class="mobile-label">Attack</span></button>
       <button class="mobile-btn" id="mobile-target" title="Target nearest enemy" aria-label="Target nearest enemy" data-icon="target"><span class="mobile-label">Target</span></button>
+      <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>
       <button class="mobile-btn" id="mobile-chat" title="Chat" aria-label="Open chat" data-icon="chat"><span class="mobile-label">Chat</span></button>
       <button class="mobile-btn" id="mobile-more" title="More menus" aria-label="Show more menus" data-icon="more"><span class="mobile-label">More</span></button>
       <div id="mobile-extra-controls">
         <button class="mobile-btn" id="mobile-social" title="Social" aria-label="Social" data-icon="social"><span class="mobile-label">Social</span></button>
         <button class="mobile-btn" id="mobile-arena" title="Arena" aria-label="Arena" data-icon="arena"><span class="mobile-label">Arena</span></button>
         <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu" data-icon="menu"><span class="mobile-label">Menu</span></button>
-        <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>
         <button class="mobile-btn" id="mobile-quest" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="mobile-label">Quests</span></button>
         <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label">Spellbook</span></button>
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>


### PR DESCRIPTION
## What

Move the **Interact / \"Use\"** touch button out of the collapsed *More* tray and into the primary on-screen control row, between **Target** and **Chat**.

## Why

Interact is one of the most frequently used actions on touch: it loots kills, talks to NPCs, opens chests, and enters dungeon portals. Living in the *More* tray meant every loot or interaction cost **two taps** (open tray → tap Use, and the tray then auto-closes again). Promoting it makes the single most repetitive mobile action **one tap**, matching how Attack/Target already work.

## How

- Move the existing `#mobile-interact` button into `#mobile-combat-controls`.
- Widen the primary grid from 3 → 4 columns in both the base and the narrow-screen landscape media-query rule.
- **No JS change.** `MobileControls.bindButton()` already wires the button by id, and the tray auto-collapse logic only targets buttons inside `#mobile-extra-controls`, so it correctly stops applying once the button moves to the primary row.

## Screenshots (landscape phone, offline world)

Primary row — now **Attack · Target · Use · Chat**, all one tap:

![primary row](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-interact/mobile-primary-row.png)

In context:

![mobile full](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mobile-interact/mobile-full.png)

## Testing

- `npx vitest run tests/mobile_controls.test.ts` — green (pure helpers unaffected).
- `npx tsc --noEmit` — clean.
- Verified live in the offline browser world at a landscape-phone viewport: the 4-button row lays out correctly and the *More* tray still opens with the remaining menu buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)