### PR TITLE
fix(mobile): keep the More tray from clipping off narrow landscape phones

### DIFF
--- a/index.html
+++ b/index.html
@@ -2825,7 +2825,10 @@
   body.mobile-touch .mobile-btn .mobile-label { display: block; margin-top: 1px; font-size: 8px; font-family: var(--ui-font); color: #bfb28a; }
   body.mobile-touch #mobile-extra-controls {
     position: fixed;
-    left: calc(50% + 190px);
+    /* Keep the More-aligned position on wide screens, but clamp the left edge so
+       the fixed-width 2-column grid (~214px) can't slide its rightmost button
+       column off short/narrow landscape phones (e.g. 667px wide). */
+    left: min(calc(50% + 190px), calc(100vw - 214px - max(12px, env(safe-area-inset-right, 0px))));
     bottom: calc(66px + env(safe-area-inset-bottom));
     display: none;
     grid-template-columns: repeat(2, 112px);
@@ -3114,7 +3117,9 @@
       bottom: calc(2px + env(safe-area-inset-bottom));
     }
     body.mobile-touch #mobile-extra-controls {
-      left: calc(50% + 176px);
+      /* Clamp the left edge so the 2-column grid (~214px) can't slide its rightmost
+         button column off short/narrow landscape phones (e.g. 667px wide). */
+      left: min(calc(50% + 176px), calc(100vw - 214px - max(12px, env(safe-area-inset-right, 0px))));
       bottom: calc(58px + env(safe-area-inset-bottom));
       grid-template-columns: repeat(2, 104px);
       grid-auto-rows: 38px;
@@ -4088,17 +4093,20 @@
       <button class="mobile-btn" id="mobile-target" title="Target nearest enemy" aria-label="Target nearest enemy" data-icon="target"><span class="mobile-label">Target</span></button>
       <button class="mobile-btn" id="mobile-chat" title="Chat" aria-label="Open chat" data-icon="chat"><span class="mobile-label">Chat</span></button>
       <button class="mobile-btn" id="mobile-more" title="More menus" aria-label="Show more menus" data-icon="more"><span class="mobile-label">More</span></button>
-      <div id="mobile-extra-controls">
-        <button class="mobile-btn" id="mobile-social" title="Social" aria-label="Social" data-icon="social"><span class="mobile-label">Social</span></button>
-        <button class="mobile-btn" id="mobile-arena" title="Arena" aria-label="Arena" data-icon="arena"><span class="mobile-label">Arena</span></button>
-        <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu" data-icon="menu"><span class="mobile-label">Menu</span></button>
-        <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>
-        <button class="mobile-btn" id="mobile-quest" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="mobile-label">Quests</span></button>
-        <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label">Spellbook</span></button>
-        <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
-        <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>
-        <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map" data-icon="map"><span class="mobile-label">Map</span></button>
-      </div>
+    </div>
+    <!-- The More tray lives outside #mobile-combat-controls: that row has a centering
+         transform, which would otherwise become this fixed element's containing block
+         and make its viewport-relative clamp (left: min(...)) resolve incorrectly. -->
+    <div id="mobile-extra-controls">
+      <button class="mobile-btn" id="mobile-social" title="Social" aria-label="Social" data-icon="social"><span class="mobile-label">Social</span></button>
+      <button class="mobile-btn" id="mobile-arena" title="Arena" aria-label="Arena" data-icon="arena"><span class="mobile-label">Arena</span></button>
+      <button class="mobile-btn" id="mobile-menu" title="Game menu" aria-label="Game menu" data-icon="menu"><span class="mobile-label">Menu</span></button>
+      <button class="mobile-btn" id="mobile-interact" title="Interact or loot" aria-label="Interact or loot" data-icon="interact"><span class="mobile-label">Use</span></button>
+      <button class="mobile-btn" id="mobile-quest" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="mobile-label">Quests</span></button>
+      <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label">Spellbook</span></button>
+      <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
+      <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>
+      <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map" data-icon="map"><span class="mobile-label">Map</span></button>
     </div>
   </div>
   <div id="mobile-preflight" role="dialog" aria-modal="true" aria-labelledby="mobile-preflight-title">

--- a/scripts/mobile_tray_horizontal_overflow.mjs
+++ b/scripts/mobile_tray_horizontal_overflow.mjs
@@ -1,0 +1,74 @@
+// E2E Verification Script: checks the mobile "More" tray (#mobile-extra-controls)
+// stays fully on-screen horizontally across landscape phone widths.
+//
+// The tray is a fixed-width 2-column grid anchored near screen-centre
+// (left: calc(50% + 176px)). On a narrow landscape phone that pushes its
+// rightmost button column off the right edge. The fix clamps the left edge so
+// the tray never overflows, while keeping the More-aligned position on wide
+// screens.
+//
+// Usage: `npm run dev` in one shell, then `node scripts/mobile_tray_horizontal_overflow.mjs`.
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+// Common landscape phone widths plus a wide tablet to prove no regression.
+const WIDTHS = [568, 667, 740, 844, 1180];
+const MARGIN = 8; // minimum px the tray's right edge must keep from the viewport edge
+
+async function waitForServer(url, timeoutMs = 15000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch (e) {
+      // ignore connection errors
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Timeout waiting for server at ${url}`);
+}
+
+async function main() {
+  await waitForServer(URL);
+  const browser = await puppeteer.launch({
+    executablePath: BROWSER_PATH,
+    headless: 'new',
+    args: ['--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+    defaultViewport: { width: 844, height: 390 },
+  });
+  const page = await browser.newPage();
+
+  let failures = 0;
+  console.log('  width | tray left → right | viewport | overflow | status');
+  console.log('  ------+-------------------+----------+----------+-------');
+  for (const width of WIDTHS) {
+    await page.setViewport({ width, height: 390 });
+    await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 15000 });
+    // Force the touch layout + open tray (matchMedia can't report coarse pointer headlessly).
+    const m = await page.evaluate(() => {
+      document.body.classList.add('mobile-touch', 'game-active', 'mobile-more-open');
+      const r = document.getElementById('mobile-extra-controls').getBoundingClientRect();
+      return { left: Math.round(r.left), right: Math.round(r.right), vw: window.innerWidth };
+    });
+    const overflow = m.right - m.vw;
+    const ok = overflow <= -MARGIN; // right edge stays at least MARGIN px inside the viewport
+    if (!ok) failures++;
+    console.log(
+      `  ${String(width).padStart(5)} | ${String(m.left).padStart(5)} → ${String(m.right).padStart(5)}     | ${String(m.vw).padStart(6)}   | ${String(overflow).padStart(6)}   | ${ok ? 'OK' : 'OVERFLOW'}`,
+    );
+  }
+
+  await browser.close();
+  if (failures > 0) {
+    console.error(`\nFAIL: ${failures} viewport(s) clip the More tray off the right edge.`);
+    process.exit(1);
+  }
+  console.log('\nPASS: the More tray stays fully on-screen at every tested width.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

The mobile touch **More** tray (`#mobile-extra-controls`) is a fixed-width
2-column grid anchored near screen-centre — `left: calc(50% + 176px)` in the
landscape layout (`+ 190px` in the portrait base rule). On a short/narrow
**landscape** phone `50%` is small, so the ~214px-wide grid runs past the right
edge of the viewport and its **rightmost button column — Use / Spellbook /
Meters / Map — is sliced off and unreachable**.

Measured at **667×375** (a common landscape phone), offline:

| | tray left → right | viewport | overflow |
|---|---|---|---|
| **before** | `510 → 724` | `667` | **+57px off-screen** |
| **after**  | `441 → 655` | `667` | `−12px` (on-screen) |

Merged PR #335 fixed the tray's **vertical** overflow on short phones; this is
the **horizontal** counterpart.

## Fix

Clamp the left edge with `min(...)` so the tray keeps its existing More-aligned
position on wide screens but never pushes its right edge off-screen on narrow
ones:

```css
left: min(calc(50% + 176px), calc(100vw - 214px - max(12px, env(safe-area-inset-right, 0px))));
```

- Applied to **both** breakpoints (landscape `+176px` and the portrait base `+190px`).
- The tray is also moved **out of `#mobile-combat-controls`** — that row carries
  a centering `transform`, which would otherwise become the fixed tray's
  containing block and make the viewport-relative `100vw` clamp resolve against
  the wrong (237px, off-centre) box instead of the viewport. Tray styling is
  fully id-based, so the move is purely structural.
- On wide screens nothing moves: the tray stays aligned under the **More** button.

CSS + markup only; no `sim/`, `IWorld`, `net/`, or behaviour change.

## Verification

New `scripts/mobile_tray_horizontal_overflow.mjs` boots the offline world at
five widths, opens the tray, and asserts its right edge stays on-screen:

```
  width | tray left → right | viewport | overflow | status
    568 |   342 →   556     |    568   |    -12   | OK
    667 |   441 →   655     |    667   |    -12   | OK
    740 |   514 →   728     |    740   |    -12   | OK
    844 |   598 →   812     |    844   |    -32   | OK
   1180 |   766 →   980     |   1180   |   -200   | OK
```

- `tsc --noEmit` clean · full suite green (**648 passed**).

## Screenshots (landscape phone, 667×375, offline)

**Before — rightmost column (Use / Spellbook / Meters / Map) clipped off the right edge**
![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-tray-horizontal-overflow/tray_horizontal_before.png)

**After — the whole tray sits inside the viewport**
![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-tray-horizontal-overflow/tray_horizontal_after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)