### PR TITLE
[RFC] Implemented HUD chat filter tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,13 +422,21 @@
   /* width shrinks on narrower screens so the chat never overlaps the centred
      bottom bar (≈612px wide); caps at 370px when there's room. */
   #chatlog-wrap { position: absolute; left: 12px; bottom: 8px; width: min(370px, calc(50vw - 330px)); }
-  #chatlog-tabs { display: flex; gap: 2px; margin-left: 6px; margin-bottom: -1px; position: relative; z-index: 2; }
-  .chat-tab { height: 22px; padding: 0 12px; border: 1px solid #3a321d; border-bottom: none;
+  #chatlog-tabs { display: flex; gap: 2px; margin-left: 6px; margin-bottom: -1px; max-width: 100%; overflow-x: auto; position: relative; scrollbar-width: none; z-index: 2; }
+  #chatlog-tabs::-webkit-scrollbar { display: none; }
+  .chat-tab { flex: 0 0 auto; height: 22px; padding: 0 8px; border: 1px solid #3a321d; border-bottom: none;
     border-radius: 6px 6px 0 0; background: linear-gradient(#1c1824, #0d0b13); color: #95886a;
     cursor: pointer; font-family: var(--title-font); font-size: 12px; text-shadow: 1px 1px 1px #000; }
   .chat-tab.active { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#2a2436, #161220); }
-  #chatlog-frame { height: 184px; padding: 0; overflow: hidden; border-radius: 0 6px 6px 6px; }
-  .chat-pane { display: none; height: 100%; overflow-y: auto; overflow-x: hidden; padding: 7px 10px;
+  #chatlog-frame { display: flex; flex-direction: column; height: 184px; padding: 0; overflow: hidden; border-radius: 0 6px 6px 6px; }
+  #chat-filter-row { display: flex; flex: 0 0 auto; gap: 3px; overflow-x: auto; padding: 5px 7px 4px; scrollbar-width: none; }
+  #chat-filter-row::-webkit-scrollbar { display: none; }
+  #chat-filter-row.hidden { display: none; }
+  .chat-filter-toggle { flex: 0 0 auto; height: 19px; padding: 0 7px; border: 1px solid #3a321d; border-radius: 4px;
+    background: linear-gradient(#16131e, #0b0a10); color: #8f8468; cursor: pointer; font-family: var(--title-font);
+    font-size: 10px; text-shadow: 1px 1px 1px #000; }
+  .chat-filter-toggle.active { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#272030, #121019); }
+  .chat-pane { display: none; flex: 1 1 auto; height: auto; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: 7px 10px;
     font-size: 11px; line-height: 1.45; }
   .chat-pane.active { display: block; }
   .chat-pane div { text-shadow: 1px 1px 1px #000; overflow-wrap: break-word; user-select: text; }
@@ -2927,6 +2935,7 @@
   body.mobile-touch.mobile-chat-open #chatlog-wrap { display: block; }
   body.mobile-touch #chatlog-frame { height: 126px; }
   body.mobile-touch #chatlog-tabs { transform: scale(0.92); transform-origin: left bottom; }
+  body.mobile-touch .chat-filter-toggle { height: 18px; padding: 0 5px; font-size: 9px; }
   body.mobile-touch #chat-input { left: 10px; bottom: calc(296px + env(safe-area-inset-bottom)); width: min(360px, calc(100vw - 20px)); }
   body.mobile-touch #player-frame {
     position: fixed;
@@ -3627,10 +3636,15 @@
 
     <div id="chatlog-wrap">
       <div id="chatlog-tabs">
-        <button class="chat-tab active" data-log-tab="chat">Chat</button>
+        <button class="chat-tab active" data-log-tab="all">All</button>
+        <button class="chat-tab" data-log-tab="local">Local</button>
+        <button class="chat-tab" data-log-tab="global">Global</button>
+        <button class="chat-tab" data-log-tab="whisper">Whispers</button>
+        <button class="chat-tab" data-log-tab="system">System</button>
         <button class="chat-tab" data-log-tab="combat">Combat Log</button>
       </div>
       <div id="chatlog-frame" class="panel">
+        <div id="chat-filter-row" aria-label="All chat filters"></div>
         <div id="chatlog" class="chat-pane active"></div>
         <div id="combatlog" class="chat-pane"></div>
       </div>

--- a/server/game.ts
+++ b/server/game.ts
@@ -487,7 +487,7 @@ export class GameServer {
       cls,
       realm: REALM,
     });
-    this.broadcastSystem(`${name} has entered World of Claudecraft.`);
+    this.broadcastSystem(`${name} has entered World of Claudecraft.`, 'presence');
     void this.initSocial(session);
     return session;
   }
@@ -519,7 +519,7 @@ export class GameServer {
     }
     await this.saveCharacter(session).catch((err) => console.error('save on leave failed:', err));
     this.sim.removePlayer(session.pid);
-    this.broadcastSystem(`${session.name} has left the world. (${reason})`);
+    this.broadcastSystem(`${session.name} has left the world. (${reason})`, 'presence');
   }
 
   async saveCharacter(session: ClientSession): Promise<void> {
@@ -1308,9 +1308,9 @@ export class GameServer {
     return true;
   }
 
-  private broadcastSystem(text: string): void {
+  private broadcastSystem(text: string, category: 'system' | 'presence' = 'system'): void {
     for (const session of this.clients.values()) {
-      this.send(session, { t: 'events', list: [{ type: 'log', text, color: '#ffd100' }] });
+      this.send(session, { t: 'events', list: [{ type: 'log', text, color: '#ffd100', category }] });
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -546,7 +546,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'spellfx'; sourceId: number; targetId: number; school: string; fx: 'projectile' | 'tick' | 'nova' }
   // entityId (when set) anchors the log to that entity so the server only
   // delivers it to nearby players; anchorless logs broadcast server-wide
-  | { type: 'log'; text: string; color?: string; entityId?: number }
+  | { type: 'log'; text: string; color?: string; entityId?: number; category?: 'system' | 'presence' }
 );
 
 export interface MoveInput {

--- a/src/ui/chat_filters.ts
+++ b/src/ui/chat_filters.ts
@@ -1,0 +1,68 @@
+import type { SimEvent } from '../sim/types';
+
+export type ChatChannel = NonNullable<Extract<SimEvent, { type: 'chat' }>['channel']>;
+export type ChatCategory = 'local' | 'global' | 'whisper' | 'social' | 'system' | 'presence';
+export type ChatView = 'all' | 'local' | 'global' | 'whisper' | 'system';
+export type ChatCategoryFilters = Record<ChatCategory, boolean>;
+
+export const CHAT_FILTER_CATEGORIES: ChatCategory[] = ['local', 'global', 'whisper', 'social', 'system', 'presence'];
+export const CHAT_CATEGORY_LABELS: Record<ChatCategory, string> = {
+  local: 'Local',
+  global: 'Global',
+  whisper: 'Whispers',
+  social: 'Social',
+  system: 'System',
+  presence: 'Presence',
+};
+export const DEFAULT_CHAT_CATEGORY_FILTERS: ChatCategoryFilters = {
+  local: true,
+  global: true,
+  whisper: true,
+  social: true,
+  system: true,
+  presence: true,
+};
+
+const CHAT_VIEWS: ChatView[] = ['all', 'local', 'global', 'whisper', 'system'];
+
+export function chatCategoryForChannel(channel: ChatChannel): ChatCategory {
+  switch (channel) {
+    case 'general': return 'global';
+    case 'whisper': return 'whisper';
+    case 'party':
+    case 'guild':
+    case 'officer':
+      return 'social';
+    case 'say':
+    case 'yell':
+    case 'emote':
+    default:
+      return 'local';
+  }
+}
+
+export function chatCategoryForLog(category: Extract<SimEvent, { type: 'log' }>['category'] | undefined): ChatCategory {
+  return category === 'presence' ? 'presence' : 'system';
+}
+
+export function normalizeChatView(value: unknown): ChatView {
+  return typeof value === 'string' && (CHAT_VIEWS as string[]).includes(value) ? value as ChatView : 'all';
+}
+
+export function normalizeChatCategoryFilters(value: unknown): ChatCategoryFilters {
+  const filters: ChatCategoryFilters = { ...DEFAULT_CHAT_CATEGORY_FILTERS };
+  if (!value || typeof value !== 'object') return filters;
+  const raw = value as Partial<Record<ChatCategory, unknown>>;
+  for (const category of CHAT_FILTER_CATEGORIES) {
+    if (typeof raw[category] === 'boolean') filters[category] = raw[category];
+  }
+  return filters;
+}
+
+export function isChatEntryVisible(category: ChatCategory, view: ChatView, filters: ChatCategoryFilters): boolean {
+  switch (view) {
+    case 'all': return filters[category];
+    case 'system': return category === 'system' || category === 'presence';
+    default: return category === view;
+  }
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -26,6 +26,11 @@ import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } fro
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES } from '../game/settings';
 import { chatPlayerContextActions } from './player_context_menu';
 import {
+  CHAT_CATEGORY_LABELS, CHAT_FILTER_CATEGORIES, DEFAULT_CHAT_CATEGORY_FILTERS,
+  chatCategoryForChannel, chatCategoryForLog, isChatEntryVisible, normalizeChatCategoryFilters, normalizeChatView,
+  type ChatCategory, type ChatCategoryFilters, type ChatView,
+} from './chat_filters';
+import {
   talentsFor, computeTalentModifiers, validateAllocation, dormantNodes, pointsSpent,
   exportBuild, importBuild, cloneAllocation, talentPointsAtLevel, FIRST_TALENT_LEVEL,
   type TalentAllocation, type TalentNode, type SpecDef, type Role, type TalentEffect,
@@ -91,6 +96,12 @@ const PARTY_RANGE_YD = 100;
 // yards past a zone boundary before the crossing banner/welcome commits
 const ZONE_BANNER_DEADBAND = 5;
 const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
+const CHAT_FILTER_STATE_KEY = 'woc_chat_filter_state';
+
+type ChatLogTab = ChatView | 'combat';
+type ChatEntry =
+  | { kind: 'text'; category: ChatCategory; text: string; color: string }
+  | { kind: 'player'; category: ChatCategory; name: string; text: string; color: string; prefix: string; separator: string };
 
 // world map: terrain is pre-rendered for the whole zone at this resolution
 // (cached per zone) and a sub-rect is blitted for the current zoom.
@@ -112,6 +123,7 @@ export class Hud {
   private keybindNote = '';
   private chatLogEl = $('#chatlog');
   private combatLogEl = $('#combatlog');
+  private chatFilterRowEl = $('#chat-filter-row');
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
   private tooltipEl = $('#tooltip');
@@ -150,6 +162,9 @@ export class Hud {
   private mapView: { spanX: number; spanZ: number; minX: number; maxX: number; minZ: number; maxZ: number } | null = null;
   private mapDecorations: Decoration[] | null = null; // cached trees/rocks (whole world)
   private ignoredChatNames = new Set<string>();
+  private chatEntries: ChatEntry[] = [];
+  private activeLogTab: ChatLogTab = 'all';
+  private chatCategoryFilters: ChatCategoryFilters = { ...DEFAULT_CHAT_CATEGORY_FILTERS };
   private socialTab: 'friends' | 'guild' | 'ignore' = 'friends';
   // split signatures: structural changes (tab, guild membership) rebuild the
   // whole panel; content-only changes (a friend's presence) refresh just the
@@ -169,8 +184,10 @@ export class Hud {
 
   constructor(private sim: IWorld, private renderer: Renderer, private keybinds: Keybinds) {
     this.ignoredChatNames = this.loadIgnoredChatNames();
+    this.loadChatFilterState();
     this.meters = new Meters(sim);
     this.bindLogTabs();
+    this.bindChatFilterToggles();
     this.loadSlotMap();
     this.buildActionBar();
     this.refreshKeybindLabels();
@@ -266,11 +283,50 @@ export class Hud {
     const tabs = document.querySelectorAll<HTMLButtonElement>('.chat-tab');
     tabs.forEach((tab) => {
       tab.addEventListener('click', () => {
-        const which = tab.dataset.logTab;
-        tabs.forEach((t) => t.classList.toggle('active', t === tab));
-        $('#chatlog').classList.toggle('active', which === 'chat');
-        $('#combatlog').classList.toggle('active', which === 'combat');
+        const which = this.normalizeLogTab(tab.dataset.logTab);
+        this.activeLogTab = which;
+        this.saveChatFilterState();
+        this.updateLogTabControls();
+        this.renderChatLog();
       });
+    });
+    this.updateLogTabControls();
+  }
+
+  private bindChatFilterToggles(): void {
+    this.chatFilterRowEl.innerHTML = '';
+    for (const category of CHAT_FILTER_CATEGORIES) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'chat-filter-toggle';
+      btn.dataset.chatFilter = category;
+      btn.textContent = CHAT_CATEGORY_LABELS[category];
+      btn.addEventListener('click', () => {
+        this.chatCategoryFilters[category] = !this.chatCategoryFilters[category];
+        this.saveChatFilterState();
+        this.updateLogTabControls();
+        this.renderChatLog();
+      });
+      this.chatFilterRowEl.appendChild(btn);
+    }
+    this.updateLogTabControls();
+  }
+
+  private normalizeLogTab(value: unknown): ChatLogTab {
+    return value === 'combat' ? 'combat' : normalizeChatView(value);
+  }
+
+  private updateLogTabControls(): void {
+    document.querySelectorAll<HTMLButtonElement>('.chat-tab').forEach((tab) => {
+      tab.classList.toggle('active', this.normalizeLogTab(tab.dataset.logTab) === this.activeLogTab);
+    });
+    this.chatLogEl.classList.toggle('active', this.activeLogTab !== 'combat');
+    this.combatLogEl.classList.toggle('active', this.activeLogTab === 'combat');
+    this.chatFilterRowEl.classList.toggle('hidden', this.activeLogTab !== 'all');
+    this.chatFilterRowEl.querySelectorAll<HTMLButtonElement>('.chat-filter-toggle').forEach((btn) => {
+      const category = btn.dataset.chatFilter as ChatCategory | undefined;
+      btn.classList.toggle('active', !!category && this.chatCategoryFilters[category]);
+      btn.setAttribute('aria-pressed', String(!!category && this.chatCategoryFilters[category]));
     });
   }
 
@@ -1573,22 +1629,24 @@ export class Hud {
           break;
         case 'chat': {
           if (this.isChatIgnored(ev.from)) break;
-          switch (ev.channel) {
-            case 'party': this.chatLogFrom(ev.from, ev.text, '#7fd4ff', '[Party] ', ': '); break;
-            case 'yell': this.chatLogFrom(ev.from, ev.text, '#ff5040', '', ' yells: '); break;
+          const channel = ev.channel ?? 'say';
+          const category = chatCategoryForChannel(channel);
+          switch (channel) {
+            case 'party': this.chatLogFrom(category, ev.from, ev.text, '#7fd4ff', '[Party] ', ': '); break;
+            case 'yell': this.chatLogFrom(category, ev.from, ev.text, '#ff5040', '', ' yells: '); break;
             case 'whisper':
-              if (ev.to) this.chatLogFrom(ev.to, ev.text, '#ff80ff', 'To ', ': ');
-              else { this.chatLogFrom(ev.from, ev.text, '#ff80ff', '', ' whispers: '); audio.whisper(); }
+              if (ev.to) this.chatLogFrom(category, ev.to, ev.text, '#ff80ff', 'To ', ': ');
+              else { this.chatLogFrom(category, ev.from, ev.text, '#ff80ff', '', ' whispers: '); audio.whisper(); }
               break;
-            case 'general': this.chatLogFrom(ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
-            case 'guild': this.chatLogFrom(ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
-            case 'officer': this.chatLogFrom(ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
-            case 'emote': this.chatLogFrom(ev.from, ev.text, '#ff8040', '', ' '); break;
-            default: this.chatLogFrom(ev.from, ev.text, '#f0ead8', '', ' says: '); break;
+            case 'general': this.chatLogFrom(category, ev.from, ev.text, '#ffc864', '[General] ', ': '); break;
+            case 'guild': this.chatLogFrom(category, ev.from, ev.text, '#40d264', '[Guild] ', ': '); break;
+            case 'officer': this.chatLogFrom(category, ev.from, ev.text, '#4ce0c0', '[Officer] ', ': '); break;
+            case 'emote': this.chatLogFrom(category, ev.from, ev.text, '#ff8040', '', ' '); break;
+            default: this.chatLogFrom(category, ev.from, ev.text, '#f0ead8', '', ' says: '); break;
           }
-          if ((ev.channel === 'say' || ev.channel === 'yell' || ev.channel === 'emote') && ev.entityId !== undefined) {
-            const bubble = ev.channel === 'emote' ? `${ev.from} ${ev.text}` : ev.text;
-            this.renderer.showChatBubble(ev.entityId, bubble, ev.channel === 'yell');
+          if ((channel === 'say' || channel === 'yell' || channel === 'emote') && ev.entityId !== undefined) {
+            const bubble = channel === 'emote' ? `${ev.from} ${ev.text}` : ev.text;
+            this.renderer.showChatBubble(ev.entityId, bubble, channel === 'yell');
           }
           break;
         }
@@ -1676,7 +1734,7 @@ export class Hud {
           }
           break;
         }
-        case 'log': this.log(ev.text, ev.color ?? '#ccc'); break;
+        case 'log': this.log(ev.text, ev.color ?? '#ccc', chatCategoryForLog(ev.category)); break;
         case 'playerDeath': {
           this.log('You have died.', '#ff4444');
           audio.death();
@@ -1705,8 +1763,8 @@ export class Hud {
     }
   }
 
-  log(text: string, color = '#ccc'): void {
-    this.appendLog(this.chatLogEl, text, color);
+  log(text: string, color = '#ccc', category: ChatCategory = 'system'): void {
+    this.addChatEntry({ kind: 'text', category, text, color });
   }
 
   private logZoneWelcome(zone: ZoneDef): void {
@@ -1714,23 +1772,45 @@ export class Hud {
     if (text) this.log(text, '#ffd100');
   }
 
-  private chatLogFrom(name: string, text: string, color: string, prefix: string, separator: string): void {
+  private chatLogFrom(category: ChatCategory, name: string, text: string, color: string, prefix: string, separator: string): void {
+    this.addChatEntry({ kind: 'player', category, name, text, color, prefix, separator });
+  }
+
+  private addChatEntry(entry: ChatEntry): void {
+    this.chatEntries.push(entry);
+    while (this.chatEntries.length > 200) this.chatEntries.shift();
+    this.renderChatLog();
+  }
+
+  private renderChatLog(): void {
     const wasNearBottom = this.chatLogEl.scrollHeight - this.chatLogEl.scrollTop - this.chatLogEl.clientHeight < 24;
+    const view = this.activeLogTab === 'combat' ? 'all' : this.activeLogTab;
+    this.chatLogEl.replaceChildren();
+    for (const entry of this.chatEntries) {
+      if (!isChatEntryVisible(entry.category, view, this.chatCategoryFilters)) continue;
+      this.chatLogEl.appendChild(this.renderChatEntry(entry));
+    }
+    if (wasNearBottom) this.chatLogEl.scrollTop = this.chatLogEl.scrollHeight;
+  }
+
+  private renderChatEntry(entry: ChatEntry): HTMLDivElement {
     const div = document.createElement('div');
-    div.style.color = color;
-    if (prefix) div.append(document.createTextNode(prefix));
+    div.style.color = entry.color;
+    if (entry.kind === 'text') {
+      div.textContent = entry.text;
+      return div;
+    }
+    if (entry.prefix) div.append(document.createTextNode(entry.prefix));
     const sender = document.createElement('span');
     sender.className = 'chat-player-name';
-    sender.textContent = name;
-    sender.title = `Right-click ${name}`;
+    sender.textContent = entry.name;
+    sender.title = `Right-click ${entry.name}`;
     sender.addEventListener('contextmenu', (ev) => {
       ev.preventDefault();
-      this.openChatPlayerContextMenu(name, ev.clientX, ev.clientY);
+      this.openChatPlayerContextMenu(entry.name, ev.clientX, ev.clientY);
     });
-    div.append(sender, document.createTextNode(`${separator}${text}`));
-    this.chatLogEl.appendChild(div);
-    while (this.chatLogEl.children.length > 200) this.chatLogEl.removeChild(this.chatLogEl.firstChild!);
-    if (wasNearBottom) this.chatLogEl.scrollTop = this.chatLogEl.scrollHeight;
+    div.append(sender, document.createTextNode(`${entry.separator}${entry.text}`));
+    return div;
   }
 
   private combatLog(text: string, color = '#ccc'): void {
@@ -3455,6 +3535,27 @@ export class Hud {
     } catch {
       return new Set();
     }
+  }
+
+  private loadChatFilterState(): void {
+    try {
+      const raw = localStorage.getItem(CHAT_FILTER_STATE_KEY);
+      const parsed = raw ? JSON.parse(raw) : null;
+      this.chatCategoryFilters = normalizeChatCategoryFilters(parsed?.filters);
+      this.activeLogTab = this.normalizeLogTab(parsed?.activeLogTab);
+    } catch {
+      this.chatCategoryFilters = { ...DEFAULT_CHAT_CATEGORY_FILTERS };
+      this.activeLogTab = 'all';
+    }
+  }
+
+  private saveChatFilterState(): void {
+    try {
+      localStorage.setItem(CHAT_FILTER_STATE_KEY, JSON.stringify({
+        activeLogTab: this.activeLogTab,
+        filters: this.chatCategoryFilters,
+      }));
+    } catch { /* storage unavailable */ }
   }
 
   private saveIgnoredChatNames(): void {

--- a/tests/chat_filters.test.ts
+++ b/tests/chat_filters.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CHAT_CATEGORY_FILTERS,
+  chatCategoryForChannel,
+  chatCategoryForLog,
+  isChatEntryVisible,
+  normalizeChatCategoryFilters,
+  normalizeChatView,
+} from '../src/ui/chat_filters';
+
+describe('chat filters', () => {
+  it('classifies chat channels into filter categories', () => {
+    expect(chatCategoryForChannel('say')).toBe('local');
+    expect(chatCategoryForChannel('yell')).toBe('local');
+    expect(chatCategoryForChannel('emote')).toBe('local');
+    expect(chatCategoryForChannel('general')).toBe('global');
+    expect(chatCategoryForChannel('whisper')).toBe('whisper');
+    expect(chatCategoryForChannel('party')).toBe('social');
+    expect(chatCategoryForChannel('guild')).toBe('social');
+    expect(chatCategoryForChannel('officer')).toBe('social');
+  });
+
+  it('uses explicit log metadata for presence messages', () => {
+    expect(chatCategoryForLog('presence')).toBe('presence');
+    expect(chatCategoryForLog('system')).toBe('system');
+    expect(chatCategoryForLog(undefined)).toBe('system');
+  });
+
+  it('normalizes stored views and filter toggles defensively', () => {
+    expect(normalizeChatView('whisper')).toBe('whisper');
+    expect(normalizeChatView('combat')).toBe('all');
+    expect(normalizeChatView(null)).toBe('all');
+
+    expect(normalizeChatCategoryFilters({ local: false, presence: false, global: 'nope' })).toEqual({
+      ...DEFAULT_CHAT_CATEGORY_FILTERS,
+      local: false,
+      presence: false,
+    });
+    expect(normalizeChatCategoryFilters('corrupt')).toEqual(DEFAULT_CHAT_CATEGORY_FILTERS);
+  });
+
+  it('applies all-tab toggles while fixed tabs show their category groups', () => {
+    const filters = { ...DEFAULT_CHAT_CATEGORY_FILTERS, presence: false, social: false };
+
+    expect(isChatEntryVisible('presence', 'all', filters)).toBe(false);
+    expect(isChatEntryVisible('social', 'all', filters)).toBe(false);
+    expect(isChatEntryVisible('local', 'local', filters)).toBe(true);
+    expect(isChatEntryVisible('global', 'local', filters)).toBe(false);
+    expect(isChatEntryVisible('presence', 'system', filters)).toBe(true);
+    expect(isChatEntryVisible('system', 'system', filters)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Status

Draft / RFC. This is a proposal for review and QA, not a request to merge as-is.

## Summary

Adds client-side HUD chat filtering with tabs for All, Local, Global, Whispers, System, and Combat Log. The All view includes category toggles, including presence messages.

## Implementation Notes

- Filtering changes local HUD rendering only.
- Message delivery, moderation, persistence, chat logging, and server routing are unchanged.
- Join/leave presence messages use explicit log metadata instead of client-side text matching.
- The HUD retains structured chat entries so tab switches and filter toggles re-render consistently.
- Sender right-click context menus and local chat bubbles are preserved.

## Validation

- `npx vitest run tests/chat_filters.test.ts` passed.
- `npm test` passed: 50 files, 652 tests.
- `npm run build` passed.
- Local Vite smoke check confirmed the updated page serves on `127.0.0.1:5173`.

## QA Needed

- Visual QA at desktop and mobile widths.
- Logged-in online QA with two players.
- Incoming and outgoing whispers.
- Party, guild, and officer channels.
- Join/leave presence messages and the Presence toggle.
- Confirm Combat Log remains unaffected.