### PR TITLE
fix(mobile): keep the top-right HUD (minimap/buffs/quests) clear of the safe-area notch

### DIFF
--- a/index.html
+++ b/index.html
@@ -2950,9 +2950,9 @@
     transform: scale(0.82);
     transform-origin: left top;
   }
-  body.mobile-touch #buff-bar { right: 10px; top: 140px; max-width: 180px; }
-  body.mobile-touch #minimap-wrap { right: 8px; top: 8px; transform: scale(0.72); transform-origin: right top; }
-  body.mobile-touch #quest-tracker { right: 10px; top: 150px; width: 190px; font-size: 11px; }
+  body.mobile-touch #buff-bar { right: max(10px, env(safe-area-inset-right)); top: max(140px, env(safe-area-inset-top)); max-width: 180px; }
+  body.mobile-touch #minimap-wrap { right: max(8px, env(safe-area-inset-right)); top: max(8px, env(safe-area-inset-top)); transform: scale(0.72); transform-origin: right top; }
+  body.mobile-touch #quest-tracker { right: max(10px, env(safe-area-inset-right)); top: max(150px, env(safe-area-inset-top)); width: 190px; font-size: 11px; }
   body.mobile-touch #meters-window {
     position: fixed;
     left: calc(max(18px, env(safe-area-inset-left)) + 132px);
@@ -3166,8 +3166,8 @@
       top: calc(max(6px, env(safe-area-inset-top)) + 50px);
       transform: scale(0.6);
     }
-    body.mobile-touch #buff-bar { right: 98px; top: 8px; max-width: 160px; transform: scale(0.85); transform-origin: right top; }
-    body.mobile-touch #minimap-wrap { right: 6px; top: 6px; transform: scale(0.46); }
+    body.mobile-touch #buff-bar { right: calc(98px + env(safe-area-inset-right)); top: max(8px, env(safe-area-inset-top)); max-width: 160px; transform: scale(0.85); transform-origin: right top; }
+    body.mobile-touch #minimap-wrap { right: max(6px, env(safe-area-inset-right)); top: max(6px, env(safe-area-inset-top)); transform: scale(0.46); }
     body.mobile-touch #quest-tracker { display: none; }
     body.mobile-touch #meters-window {
       position: fixed;

--- a/scripts/mobile_minimap_safe_area.mjs
+++ b/scripts/mobile_minimap_safe_area.mjs
@@ -1,0 +1,95 @@
+// Visual + geometric check for the mobile top-right HUD cluster (minimap / buff
+// bar / quest tracker) honouring env(safe-area-inset-*) on notched phones.
+//
+// Headless Chromium can't synthesise real safe-area insets, so we simulate a
+// 44px right-edge notch (drawn as a translucent overlay) and compare the
+// minimap's right edge in two states:
+//   BEFORE  — bare `right: 6px` (the pre-fix rule): minimap sits UNDER the notch.
+//   AFTER   — `right: max(6px, <inset>)` (the fixed rule): minimap clears it.
+//
+// Needs `npm run dev` running. Writes before/after PNGs to /tmp.
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.URL || 'http://localhost:5173/';
+const INSET = 44; // simulated right-edge safe-area inset (px), e.g. a landscape notch
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--force-device-scale-factor=1'],
+});
+try {
+  const page = await browser.newPage();
+  // Landscape phone viewport (iPhone-ish 667x375).
+  await page.setViewport({ width: 667, height: 375, isMobile: true, hasTouch: true });
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Enter the offline world: open the panel, pick a class, start.
+  await page.click('#btn-offline').catch(() => {});
+  await sleep(300);
+  await page.type('#char-name', 'Adventurer').catch(() => {});
+  await page.click('#offline-select .mini-class[data-class="warrior"]').catch(() => {});
+  await sleep(150);
+  await page.click('#btn-start-offline').catch(() => {});
+  await sleep(2500);
+  // Dismiss the mobile preflight gate if present.
+  await page.evaluate(() => document.querySelector('#mobile-preflight-continue')?.click());
+  await sleep(600);
+
+  // Headless can't report pointer:coarse, so force the gameplay body classes.
+  await page.evaluate(() => {
+    document.body.classList.add('mobile-touch', 'game-active');
+  });
+  await sleep(400);
+
+  // Draw the simulated notch zone on the right edge.
+  await page.evaluate((inset) => {
+    const n = document.createElement('div');
+    n.id = '__notch';
+    Object.assign(n.style, {
+      position: 'fixed', top: '0', right: '0', width: inset + 'px', height: '100%',
+      background: 'rgba(220,40,40,0.28)', borderLeft: '2px dashed #ff5555',
+      zIndex: '9999', pointerEvents: 'none',
+    });
+    document.body.appendChild(n);
+  }, INSET);
+
+  const mm = '#minimap-wrap';
+  const measure = () => page.$eval(mm, (el) => {
+    const r = el.getBoundingClientRect();
+    return { right: Math.round(r.right), vw: window.innerWidth };
+  });
+
+  // Top-right corner crop so the minimap shift is clearly visible in the PR asset.
+  const corner = { x: 667 - 260, y: 0, width: 260, height: 180 };
+
+  // BEFORE: force the old bare offset (inset ignored).
+  await page.$eval(mm, (el) => { el.style.right = '6px'; });
+  await sleep(150);
+  const before = await measure();
+  await page.screenshot({ path: '/tmp/minimap-before.png' });
+  await page.screenshot({ path: '/tmp/minimap-before-corner.png', clip: corner });
+
+  // AFTER: emulate env(safe-area-inset-right)=INSET honoured by the fixed rule.
+  await page.$eval(mm, (el, inset) => { el.style.right = `max(6px, ${inset}px)`; }, INSET);
+  await sleep(150);
+  const after = await measure();
+  await page.screenshot({ path: '/tmp/minimap-after.png' });
+  await page.screenshot({ path: '/tmp/minimap-after-corner.png', clip: corner });
+
+  const safeEdge = before.vw - INSET; // right edge of the usable (non-notch) area
+  console.log(`viewport width: ${before.vw}px, simulated notch: ${INSET}px (safe right edge at x=${safeEdge})`);
+  console.log(`BEFORE  minimap.right = ${before.right}px  -> ${before.right > safeEdge ? 'CLIPPED under notch ✗' : 'ok'}`);
+  console.log(`AFTER   minimap.right = ${after.right}px  -> ${after.right <= safeEdge ? 'clears notch ✓' : 'still clipped ✗'}`);
+  console.log('screenshots: /tmp/minimap-before.png, /tmp/minimap-after.png');
+
+  if (before.right <= safeEdge || after.right > safeEdge) {
+    console.error('CHECK FAILED: expected before=clipped, after=clear');
+    process.exitCode = 1;
+  }
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## What

On touch phones the **top-left** HUD cluster — player frame, target frame, both joysticks, the meters window — already pins itself with `max(Npx, env(safe-area-inset-*))` so it never slides under a notch, camera cutout or rounded corner. The **top-right** cluster (`#minimap-wrap`, `#buff-bar`, `#quest-tracker`) was the one spot that didn't: it used bare `right: 6–10px; top: 6–150px` and ignored the safe-area insets entirely.

So on notched phones — and especially in the **active landscape layout** (portrait shows the rotate-device overlay, and the camera cutout sits on a short edge in landscape) — the minimap is partly clipped under the notch / rounded corner and is hard to read.

## Fix

Wrap the right/top offsets of the three top-right elements in `max(…, env(safe-area-inset-*))`, in **both** the base `body.mobile-touch` rule and the active landscape `@media (orientation: landscape)` block — mirroring the existing top-left treatment. The buff bar keeps its intentional *left-of-minimap* offset, so its inset is **additive** (`calc(98px + env(safe-area-inset-right))`) rather than a `max()`, ensuring it shifts in lockstep with the minimap instead of colliding with it.

CSS-only — no markup, no JS, no logic change.

## Before / After

Simulated 44px right-edge notch (red dashed zone). Before, the minimap's right edge sits **inside** the unsafe zone; after, it clears it.

| Before (clipped under notch) | After (clears the notch) |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-minimap-safe-area/minimap-before-corner.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-minimap-safe-area/minimap-after-corner.png) |

Full landscape frames:

| Before | After |
|---|---|
| ![before full](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-minimap-safe-area/minimap-before.png) | ![after full](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-minimap-safe-area/minimap-after.png) |

## Verification

Added `scripts/mobile_minimap_safe_area.mjs` (puppeteer-core via `scripts/browser_path.mjs`, needs `npm run dev`). It loads the offline world at a 667×375 landscape viewport, draws a simulated 44px right-edge notch, and asserts the minimap's right edge moves from **inside** the unsafe zone to its safe boundary:

```
viewport width: 667px, simulated notch: 44px (safe right edge at x=623)
BEFORE  minimap.right = 661px  -> CLIPPED under notch ✗
AFTER   minimap.right = 623px  -> clears notch ✓
```

(Headless Chromium can't synthesise real `env(safe-area-inset-*)` values, so the script simulates the inset to demonstrate the geometry; the shipped CSS uses the real `env()` values.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)