### PR TITLE
fix(mobile): keep the touch chat box clear of the left safe-area notch

### DIFF
--- a/index.html
+++ b/index.html
@@ -2923,11 +2923,11 @@
     width: 22px;
     height: 22px;
   }
-  body.mobile-touch #chatlog-wrap { left: 10px; bottom: calc(160px + env(safe-area-inset-bottom)); width: min(340px, calc(100vw - 20px)); display: none; z-index: 24; }
+  body.mobile-touch #chatlog-wrap { left: max(10px, env(safe-area-inset-left)); bottom: calc(160px + env(safe-area-inset-bottom)); width: min(340px, calc(100vw - 20px)); display: none; z-index: 24; }
   body.mobile-touch.mobile-chat-open #chatlog-wrap { display: block; }
   body.mobile-touch #chatlog-frame { height: 126px; }
   body.mobile-touch #chatlog-tabs { transform: scale(0.92); transform-origin: left bottom; }
-  body.mobile-touch #chat-input { left: 10px; bottom: calc(296px + env(safe-area-inset-bottom)); width: min(360px, calc(100vw - 20px)); }
+  body.mobile-touch #chat-input { left: max(10px, env(safe-area-inset-left)); bottom: calc(296px + env(safe-area-inset-bottom)); width: min(360px, calc(100vw - 20px)); }
   body.mobile-touch #player-frame {
     position: fixed;
     left: max(8px, env(safe-area-inset-left));
@@ -3148,9 +3148,9 @@
     body.mobile-touch #community-hud { top: 108px; right: 8px; width: 62px; padding: 4px; gap: 4px; }
     body.mobile-touch .community-link { height: 40px; }
     body.mobile-touch .community-link svg { width: 20px; height: 20px; }
-    body.mobile-touch #chatlog-wrap { left: 10px; bottom: calc(112px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }
+    body.mobile-touch #chatlog-wrap { left: max(10px, env(safe-area-inset-left)); bottom: calc(112px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }
     body.mobile-touch #chatlog-frame { height: 92px; }
-    body.mobile-touch #chat-input { left: 10px; bottom: calc(213px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }
+    body.mobile-touch #chat-input { left: max(10px, env(safe-area-inset-left)); bottom: calc(213px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }
     body.mobile-touch #player-frame {
       left: max(6px, env(safe-area-inset-left));
       top: max(6px, env(safe-area-inset-top));

--- a/scripts/mobile_chat_safe_area.mjs
+++ b/scripts/mobile_chat_safe_area.mjs
@@ -1,0 +1,91 @@
+// Visual check for fix(mobile): keep the touch chat box clear of the
+// landscape safe-area (notch) on the left edge.
+//
+// Headless Chromium always resolves env(safe-area-inset-left) to 0 (no real
+// notch), so we can't observe the patched CSS directly. Instead we emulate a
+// notched landscape phone, draw the unsafe inset region, and render the chat
+// box at the value each CSS *computes* for that inset:
+//   before (old code):  left: 10px                     -> sits under the notch
+//   after  (this fix):  left: max(10px, <inset>)        -> clears the notch
+//
+// Usage: node scripts/mobile_chat_safe_area.mjs   (needs `npm run dev`)
+import { BROWSER_PATH } from './browser_path.mjs';
+import puppeteer from 'puppeteer-core';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5174/';
+const INSET = 44; // typical iPhone landscape safe-area-inset-left in CSS px
+const OUT = process.env.OUT_DIR ?? '/tmp/woc-shots';
+import fs from 'node:fs';
+fs.mkdirSync(OUT, { recursive: true });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function enterGame(page) {
+  await page.goto(URL, { waitUntil: 'networkidle2', timeout: 60000 });
+  // Play Offline -> start -> dismiss mobile preflight.
+  const clickIf = (sel) => page.evaluate((s) => {
+    const el = document.querySelector(s);
+    if (el) { el.click(); return true; }
+    return false;
+  }, sel);
+  await clickIf('#btn-offline');         // Play Offline mode card
+  await sleep(600);
+  await page.evaluate(() => {             // name the character + pick first class
+    const n = document.getElementById('char-name');
+    if (n) { n.value = 'Tester'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+    document.querySelector('.class-card,[data-class]')?.click();
+  });
+  await sleep(300);
+  await clickIf('#btn-start-offline');    // Enter World
+  await sleep(2000);
+  await clickIf('#mobile-preflight-continue');
+  await sleep(1000);
+  // Force the touch UI + open the chat overlay (headless can't report coarse pointer).
+  await page.evaluate(() => {
+    document.body.classList.add('mobile-touch', 'game-active', 'mobile-chat-open');
+  });
+  await sleep(400);
+}
+
+async function shoot(page, label, leftExpr) {
+  await page.evaluate((leftExpr, inset) => {
+    document.getElementById('woc-notch')?.remove();
+    document.getElementById('woc-chatfix')?.remove();
+    // Draw the unsafe inset (notch) region.
+    const notch = document.createElement('div');
+    notch.id = 'woc-notch';
+    notch.style.cssText =
+      `position:fixed;left:0;top:0;bottom:0;width:${inset}px;z-index:9999;` +
+      'background:repeating-linear-gradient(45deg,#e0303055,#e0303055 8px,#e0303022 8px,#e0303022 16px);' +
+      'border-right:2px solid #ff5555;pointer-events:none;';
+    document.body.appendChild(notch);
+    // Apply the computed chat left for this state.
+    const st = document.createElement('style');
+    st.id = 'woc-chatfix';
+    st.textContent =
+      `body.mobile-touch #chatlog-wrap{left:${leftExpr} !important;display:block !important;}` +
+      `body.mobile-touch #chat-input{left:${leftExpr} !important;}`;
+    document.head.appendChild(st);
+  }, leftExpr, INSET);
+  await sleep(500);
+  const path = `${OUT}/chat-safe-area-${label}.png`;
+  await page.screenshot({ path });
+  console.log('wrote', path);
+}
+
+async function main() {
+  const browser = await puppeteer.launch({
+    executablePath: BROWSER_PATH,
+    headless: 'new',
+    args: ['--no-sandbox', '--use-gl=swiftshader', '--enable-webgl', '--ignore-gpu-blocklist'],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: 812, height: 375, deviceScaleFactor: 2, isMobile: true, hasTouch: true });
+  await enterGame(page);
+  await shoot(page, 'before', '10px');
+  await shoot(page, 'after', `max(10px, ${INSET}px)`);
+  await browser.close();
+  console.log('done');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Problem

In the mobile touch layout, every **left-anchored** HUD element already offsets itself by the left safe-area inset so it clears a notch / rounded corner / camera cutout:

- `#player-frame` → `left: max(8px, env(safe-area-inset-left))`
- `#target-frame` → `left: max(8px, env(safe-area-inset-left))`
- `#xpbar`, `#castbar`, `#meters-window` → `left: calc(max(18px, env(safe-area-inset-left)) + …)`

The **chat log** (`#chatlog-wrap`) and **chat input** (`#chat-input`) were the lone exceptions — they hardcode `left: 10px` in *both* the portrait and the landscape rules. On a notched phone held in landscape (where `env(safe-area-inset-left)` is ~44px) the chat box and its "Chat / Combat Log" tabs get tucked under the notch / rounded corner.

This is the left-side counterpart of the right-side HUD safe-area handling — chat was simply missed.

## Fix

Make chat follow the convention the file already establishes:

```css
#chatlog-wrap, #chat-input { left: max(10px, env(safe-area-inset-left)); }
```

…in both the portrait and landscape media queries. **CSS only** — no markup, behavior, or sim changes.

## Before / After

Emulated landscape phone (812×375) with the left safe-area inset region drawn in red. The chat tabs / frame move out from under the notch; the player frame (already inset-aware) is unchanged.

| Before (`left: 10px` — under the notch) | After (`left: max(10px, inset)` — clear) |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-chat-safe-area/before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-chat-safe-area/after.png) |

Headless Chromium resolves `env(safe-area-inset-*)` to 0, so the included `scripts/mobile_chat_safe_area.mjs` renders the chat box at the value each rule *computes* for a 44px inset (old `10px` vs new `max(10px, 44px)`) to make the difference visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)