### PR TITLE
fix(mobile): keep the community/social rail clear of the right safe-area notch

### DIFF
--- a/index.html
+++ b/index.html
@@ -2907,7 +2907,7 @@
   body.mobile-touch .action-btn:first-child { display: none; }
   body.mobile-touch .action-btn.empty { display: none; }
   body.mobile-touch #community-hud {
-    right: 8px;
+    right: max(8px, env(safe-area-inset-right));
     top: 130px;
     bottom: auto;
     width: 70px;
@@ -3145,7 +3145,7 @@
       min-width: 100px;
       height: 5px;
     }
-    body.mobile-touch #community-hud { top: 108px; right: 8px; width: 62px; padding: 4px; gap: 4px; }
+    body.mobile-touch #community-hud { top: 108px; right: max(8px, env(safe-area-inset-right)); width: 62px; padding: 4px; gap: 4px; }
     body.mobile-touch .community-link { height: 40px; }
     body.mobile-touch .community-link svg { width: 20px; height: 20px; }
     body.mobile-touch #chatlog-wrap { left: 10px; bottom: calc(112px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }

--- a/scripts/mobile_community_hud_safe_area.mjs
+++ b/scripts/mobile_community_hud_safe_area.mjs
@@ -1,0 +1,120 @@
+// Verifies the mobile community/social rail (#community-hud) clears the
+// right-edge safe-area notch in landscape, and captures before/after PNGs.
+//
+// Needs `npm run dev` running on :5173. Usage:
+//   node scripts/mobile_community_hud_safe_area.mjs
+//
+// Landscape phones with a notch report env(safe-area-inset-right) > 0. We try
+// the real CDP Emulation.setSafeAreaInsetsOverride so env() resolves to a true
+// inset; if this Chromium build lacks it we paint a visible notch band and pin
+// the rail with the equivalent px so the screenshot still shows the behaviour.
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.URL || 'http://localhost:5173/';
+const OUT = 'screenshots';
+const INSET = 44; // px — representative right notch (e.g. iPhone landscape)
+fs.mkdirSync(OUT, { recursive: true });
+
+const showHud = () => {
+  document.body.classList.add('mobile-touch', 'game-active');
+  const rd = document.getElementById('rotate-device');
+  if (rd) rd.style.display = 'none';
+};
+
+async function tryRealInset(page) {
+  try {
+    const client = await page.target().createCDPSession();
+    await client.send('Emulation.setSafeAreaInsetsOverride', {
+      insets: { top: 0, left: 0, bottom: 0, right: INSET },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function shoot(page, name, { simulate, rule }) {
+  await page.evaluate(showHud);
+  await page.evaluate(
+    ({ simulate, rule, INSET }) => {
+      document.getElementById('__notch')?.remove();
+      document.getElementById('__sim')?.remove();
+      // Always paint the unsafe band so the notch is visible in the shot.
+      const band = document.createElement('div');
+      band.id = '__notch';
+      band.style.cssText =
+        `position:fixed;top:0;right:0;bottom:0;width:${INSET}px;z-index:9999;` +
+        'pointer-events:none;background:repeating-linear-gradient(' +
+        '45deg,#e0303066,#e0303066 8px,#90101066 8px,#90101066 16px);';
+      document.body.appendChild(band);
+      if (simulate) {
+        const s = document.createElement('style');
+        s.id = '__sim';
+        s.textContent = rule;
+        document.head.appendChild(s);
+      }
+    },
+    { simulate, rule, INSET },
+  );
+  await new Promise((r) => setTimeout(r, 300));
+  await page.screenshot({ path: `${OUT}/${name}.png` });
+  console.log(`wrote ${OUT}/${name}.png`);
+}
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--hide-scrollbars'],
+});
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 740, height: 360, deviceScaleFactor: 2, isMobile: true });
+  await page.goto(URL, { waitUntil: 'networkidle2', timeout: 60000 });
+
+  // Enter the offline world so the in-game HUD (incl. #community-hud) renders.
+  const click = async (sel) => {
+    try {
+      await page.waitForSelector(sel, { timeout: 8000, visible: true });
+      await page.click(sel);
+      await new Promise((r) => setTimeout(r, 600));
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  await click('div[role=button][aria-label*=Offline]');
+  // Offline character creation: name + class + Enter World.
+  try {
+    await page.waitForSelector('#char-name', { timeout: 8000, visible: true });
+    await page.type('#char-name', 'Notchy');
+    await new Promise((r) => setTimeout(r, 200));
+  } catch {}
+  await click('#offline-select .mini-class[data-class=warrior]');
+  await click('#btn-start-offline');
+  await new Promise((r) => setTimeout(r, 1200));
+  await click('#mobile-preflight-continue');
+  await new Promise((r) => setTimeout(r, 2500));
+
+  const real = await tryRealInset(page);
+  console.log(real ? 'using real CDP safe-area inset' : 'CDP inset unavailable — simulating');
+
+  // BEFORE: emulate the pre-fix rule (bare right:8px) under the notch.
+  await shoot(page, 'community-hud-before', {
+    simulate: true,
+    rule:
+      'body.mobile-touch #community-hud{right:8px !important}' +
+      '@media (orientation:landscape){body.mobile-touch #community-hud{right:8px !important}}',
+  });
+  // AFTER: the shipped rule. With a real inset env() already clears the band;
+  // when simulating, pin to the inset to mirror what env() would resolve to.
+  await shoot(page, 'community-hud-after', {
+    simulate: !real,
+    rule:
+      `body.mobile-touch #community-hud{right:max(8px, ${INSET}px) !important}` +
+      `@media (orientation:landscape){body.mobile-touch #community-hud{right:max(8px, ${INSET}px) !important}}`,
+  });
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
## Problem

On mobile the `#community-hud` rail (Discord / GitHub / **Donate** links) is repositioned to the top-right edge. It's pinned with a bare `right: 8px` in **both** the base touch rules (~index.html:2909) **and** the active `@media (orientation: landscape)` block (~index.html:3148).

On landscape phones with a notch or rounded corner, `env(safe-area-inset-right)` is non-zero, so the rail clips under the unsafe area — the Donate pill and link icons slide partly off-screen / under the notch.

> Note: this repo forces landscape on mobile (a `#rotate-device` overlay covers portrait), so the landscape rule is the one that actually renders — editing only the base rule has no visible effect.

## Fix

Clamp to `right: max(8px, env(safe-area-inset-right))` in both rules. Spacing is unchanged on non-notched screens; on notched devices the rail never sits closer to the edge than the inset.

This is the same idiom and the same top-right family as the merged minimap/buffs/quests safe-area handling — the community rail was the one right-edge element still uncovered. CSS-only.

## Before / After

Landscape phone with a simulated 44px right notch (red striped band = unsafe area), rendered with the real Chromium CDP `Emulation.setSafeAreaInsetsOverride` so `env()` resolves truthfully.

| Before (rail clips under notch) | After (rail clears the inset) |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-community-hud-safe-area/before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/mobile-community-hud-safe-area/after.png) |

## Testing

- `npx vitest run tests/client_shell.test.ts` — passes.
- Repro/verify script added: `scripts/mobile_community_hud_safe_area.mjs` (puppeteer-core via `scripts/browser_path.mjs`, needs `npm run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)