### PR TITLE
feat(loot): add fair split and random party loot strategies

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -24,8 +24,9 @@ import { groundHeight, WATER_LEVEL } from './world';
 import type { LeaderboardEntry } from '../world_api';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
+  DEFAULT_PARTY_LOOT_STRATEGIES,
   CONSUME_TICKS, CrowdControlDrCategory, DT, Entity, EquipSlot, FISHING_CAST_ID, FISHING_CAST_TIME, GCD,
-  INTERACT_RANGE, InvSlot, LootEntry, LootSlot, MELEE_RANGE, MAX_LEVEL, MobFamily, MobTemplate,
+  CurrencyLootStrategy, INTERACT_RANGE, InvSlot, ItemLootStrategy, LootEntry, LootSlot, LootStrategies, MELEE_RANGE, MAX_LEVEL, MobFamily, MobTemplate,
   MoveInput, OverheadEmoteId, PetMode, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
   rageFromDealing, rageFromTaking, spellHitChance, xpForLevel,
@@ -197,6 +198,7 @@ export interface Party {
   id: number;
   leader: number; // pid
   members: number[]; // pids
+  lootStrategies: LootStrategies;
 }
 
 export interface TradeSession {
@@ -1342,9 +1344,30 @@ export class Sim {
   private isControlAura(kind: AuraKind): boolean {
     return kind === 'stun' || kind === 'root' || kind === 'incapacitate' || kind === 'polymorph';
   }
-  private itemRequiresGroupRoll(itemId: string): boolean {
+  private partyLootStrategiesForMob(mob: Entity): LootStrategies | null {
+    if (mob.tappedById === null) return null;
+    return this.partyOf(mob.tappedById)?.lootStrategies ?? null;
+  }
+  private partyLootCandidatesForMob(mob: Entity): PlayerMeta[] {
+    if (mob.tappedById === null) return [];
+    const party = this.partyOf(mob.tappedById);
+    if (!party || party.members.length <= 1) return [];
+    const candidates: PlayerMeta[] = [];
+    for (const pid of party.members) {
+      const candidate = this.players.get(pid);
+      const e = this.entities.get(pid);
+      if (candidate && e && !e.dead && dist2d(e.pos, mob.pos) <= PARTY_XP_RANGE) candidates.push(candidate);
+    }
+    return candidates;
+  }
+  private effectiveCurrencyLootStrategy(mob: Entity): CurrencyLootStrategy {
+    return this.partyLootStrategiesForMob(mob)?.currency ?? 'looter-takes-all';
+  }
+  private effectiveItemLootStrategy(itemId: string, mob: Entity): ItemLootStrategy {
     const q = ITEMS[itemId]?.quality ?? 'common';
-    return q === 'uncommon' || q === 'rare' || q === 'epic';
+    const strategies = this.partyLootStrategiesForMob(mob);
+    if (!strategies) return 'looter-takes-all';
+    return q === 'poor' || q === 'common' ? strategies.commonItems : strategies.premiumItems;
   }
   private moveSpeedMult(e: Entity): number {
     let slow = 1, speed = 1;
@@ -3643,16 +3666,46 @@ export class Sim {
     }
   }
 
-  private rollGroupLoot(itemId: string, mob: Entity, looter: PlayerMeta): boolean {
-    if (!this.itemRequiresGroupRoll(itemId) || mob.tappedById === null) return false;
-    const party = this.partyOf(mob.tappedById);
-    if (!party || party.members.length <= 1) return false;
-    const candidates: PlayerMeta[] = [];
-    for (const pid of party.members) {
-      const candidate = this.players.get(pid);
-      const e = this.entities.get(pid);
-      if (candidate && e && !e.dead && dist2d(e.pos, mob.pos) <= PARTY_XP_RANGE) candidates.push(candidate);
+  private grantLootCopper(meta: PlayerMeta, amount: number): void {
+    meta.copper += amount;
+    meta.counters.lootCopper += amount;
+    this.emit({ type: 'loot', text: `You loot ${formatMoney(amount)}.`, pid: meta.entityId });
+  }
+
+  private awardAllCopperToLooter(looter: PlayerMeta, copper: number): void {
+    this.grantLootCopper(looter, copper);
+  }
+
+  private tryAwardCopperByFairSplit(mob: Entity, copper: number): boolean {
+    if (this.effectiveCurrencyLootStrategy(mob) !== 'fair-split') return false;
+    const candidates = this.partyLootCandidatesForMob(mob);
+    if (candidates.length <= 1) return false;
+    const base = Math.floor(copper / candidates.length);
+    const remainder = copper % candidates.length;
+    const shares = new Map<PlayerMeta, number>(candidates.map((candidate) => [candidate, base]));
+    const order = [...candidates];
+    for (let i = 0; i < remainder; i++) {
+      const idx = this.rng.int(i, order.length - 1);
+      [order[i], order[idx]] = [order[idx], order[i]];
+      shares.set(order[i], (shares.get(order[i]) ?? 0) + 1);
     }
+    for (const candidate of candidates) {
+      const amount = shares.get(candidate) ?? 0;
+      if (amount > 0) this.grantLootCopper(candidate, amount);
+    }
+    return true;
+  }
+
+  private distributeLootCopper(mob: Entity, looter: PlayerMeta): void {
+    if (!mob.loot || mob.loot.copper <= 0) return;
+    const copper = mob.loot.copper;
+    if (!this.tryAwardCopperByFairSplit(mob, copper)) this.awardAllCopperToLooter(looter, copper);
+    mob.loot.copper = 0;
+  }
+
+  private tryAwardItemByRandomRoll(itemId: string, mob: Entity): boolean {
+    if (this.effectiveItemLootStrategy(itemId, mob) !== 'random') return false;
+    const candidates = this.partyLootCandidatesForMob(mob);
     if (candidates.length <= 1) return false;
     let winner = candidates[0];
     let bestRoll = -1;
@@ -3669,6 +3722,10 @@ export class Sim {
     }
     this.addItem(itemId, 1, winner.entityId);
     return true;
+  }
+
+  private awardSharedLootItem(itemId: string, mob: Entity, looter: PlayerMeta): void {
+    if (!this.tryAwardItemByRandomRoll(itemId, mob)) this.addItem(itemId, 1, looter.entityId);
   }
 
   private lootSlotVisibleTo(slot: LootSlot, pid: number): boolean {
@@ -5094,12 +5151,7 @@ export class Sim {
       return;
     }
     if (dist2d(p.pos, mob.pos) > INTERACT_RANGE) { this.error(meta.entityId, 'Too far away.'); return; }
-    if (hasSharedLootRights && mob.loot.copper > 0) {
-      meta.copper += mob.loot.copper;
-      meta.counters.lootCopper += mob.loot.copper;
-      this.emit({ type: 'loot', text: `You loot ${formatMoney(mob.loot.copper)}.`, pid: meta.entityId });
-      mob.loot.copper = 0;
-    }
+    if (hasSharedLootRights) this.distributeLootCopper(mob, meta);
     for (const s of [...mob.loot.items]) {
       if (!this.lootSlotVisibleTo(s, meta.entityId)) continue;
       if (s.personalFor) {
@@ -5109,7 +5161,7 @@ export class Sim {
       }
       if (!hasSharedLootRights) continue;
       for (let i = 0; i < s.count; i++) {
-        if (!this.rollGroupLoot(s.itemId, mob, meta)) this.addItem(s.itemId, 1, meta.entityId);
+        this.awardSharedLootItem(s.itemId, mob, meta);
       }
       s.count = 0;
     }
@@ -5933,7 +5985,12 @@ export class Sim {
     if (!leaderMeta) return;
     let party = this.partyOf(invite.fromPid);
     if (!party) {
-      party = { id: this.nextPartyId++, leader: invite.fromPid, members: [invite.fromPid] };
+      party = {
+        id: this.nextPartyId++,
+        leader: invite.fromPid,
+        members: [invite.fromPid],
+        lootStrategies: { ...DEFAULT_PARTY_LOOT_STRATEGIES },
+      };
       this.parties.set(party.id, party);
       this.partyByPid.set(invite.fromPid, party.id);
     }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -142,6 +142,21 @@ export interface CorpseLoot {
   items: LootSlot[];
 }
 
+export type CurrencyLootStrategy = 'looter-takes-all' | 'fair-split';
+export type ItemLootStrategy = 'looter-takes-all' | 'random';
+
+export interface LootStrategies {
+  currency: CurrencyLootStrategy;
+  commonItems: ItemLootStrategy;
+  premiumItems: ItemLootStrategy;
+}
+
+export const DEFAULT_PARTY_LOOT_STRATEGIES: LootStrategies = {
+  currency: 'fair-split',
+  commonItems: 'random',
+  premiumItems: 'random',
+};
+
 export interface LootEntry {
   itemId?: string;
   copper?: number;

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -483,6 +483,71 @@ describe('boss loot and encounter resets', () => {
     }
   });
 
+  it('fair-splits corpse copper among nearby living party members', () => {
+    const sim = makeSim();
+    const a = sim.playerId;
+    const b = sim.addPlayer('mage', 'Bert');
+    const c = sim.addPlayer('rogue', 'Cyra');
+    const d = sim.addPlayer('priest', 'Dara');
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    sim.partyInvite(c, a);
+    sim.partyAccept(c);
+    sim.partyInvite(d, a);
+    sim.partyAccept(d);
+    teleportTo(sim, 20, 20, a);
+    teleportTo(sim, 21, 20, b);
+    teleportTo(sim, 20, 21, c);
+    teleportTo(sim, 160, 160, d);
+    sim.entities.get(c)!.dead = true;
+    const mob = createMob(990099, MOBS.forest_wolf, 2, { x: 20, y: 0, z: 22 });
+    mob.dead = true;
+    mob.lootable = true;
+    mob.tappedById = a;
+    mob.loot = { copper: 11, items: [] };
+    sim.entities.set(mob.id, mob);
+
+    sim.lootCorpse(mob.id, b);
+
+    const gains = [a, b, c, d].map((pid) => sim.meta(pid)!.copper);
+    expect(gains[0] + gains[1]).toBe(11);
+    expect(Math.abs(gains[0] - gains[1])).toBeLessThanOrEqual(1);
+    expect(gains[2]).toBe(0);
+    expect(gains[3]).toBe(0);
+    expect(mob.loot).toBeNull();
+  });
+
+  it('poor and common corpse drops are randomly awarded among nearby party members', () => {
+    const sim = makeSim();
+    const a = sim.playerId;
+    const b = sim.addPlayer('mage', 'Bert');
+    sim.partyInvite(b, a);
+    sim.partyAccept(b);
+    teleportTo(sim, 20, 20, a);
+    teleportTo(sim, 21, 20, b);
+    const mob = createMob(990098, MOBS.forest_wolf, 2, { x: 20, y: 0, z: 22 });
+    mob.dead = true;
+    mob.lootable = true;
+    mob.tappedById = a;
+    mob.loot = { copper: 0, items: [{ itemId: 'wolf_fang', count: 1 }, { itemId: 'raw_mirror_trout', count: 1 }] };
+    sim.entities.set(mob.id, mob);
+
+    sim.events.length = 0;
+    sim.lootCorpse(mob.id, a);
+
+    const poorTotal =
+      sim.countItem('wolf_fang', a) +
+      sim.countItem('wolf_fang', b);
+    const commonTotal =
+      sim.countItem('raw_mirror_trout', a) +
+      sim.countItem('raw_mirror_trout', b);
+    expect(poorTotal).toBe(1);
+    expect(commonTotal).toBe(1);
+    expect(sim.events.some((e) => e.type === 'loot' && e.text.includes('wins Cracked Wolf Fang'))).toBe(true);
+    expect(sim.events.some((e) => e.type === 'loot' && e.text.includes('wins Raw Mirror Trout'))).toBe(true);
+    expect(mob.loot).toBeNull();
+  });
+
   it('uncommon and better corpse drops are rolled among nearby party members', () => {
     const sim = makeSim();
     const a = sim.playerId;

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -355,7 +355,7 @@ describe('parties', () => {
     expect(metaB.questLog.get('q_wolves')!.counts[0]).toBe(1);
   });
 
-  it('party members may loot each other\'s tapped kills', () => {
+  it('party members may loot each other\'s tapped kills and split copper', () => {
     const { sim, a, b } = makeDuo();
     const wolf = nearestMob(sim, 'forest_wolf');
     wolf.hp = 1;
@@ -366,9 +366,14 @@ describe('parties', () => {
     sim.startAutoAttack(a);
     for (let i = 0; i < 20 * 20 && !wolf.dead; i++) { face(sim, a, wolf.id); sim.tick(); }
     expect(wolf.lootable).toBe(true);
-    const copperBefore = sim.meta(b)!.copper;
+    const copper = wolf.loot!.copper;
+    const aBefore = sim.meta(a)!.copper;
+    const bBefore = sim.meta(b)!.copper;
     sim.lootCorpse(wolf.id, b);
-    expect(sim.meta(b)!.copper).toBeGreaterThan(copperBefore);
+    const aGain = sim.meta(a)!.copper - aBefore;
+    const bGain = sim.meta(b)!.copper - bBefore;
+    expect(aGain + bGain).toBe(copper);
+    expect(Math.abs(aGain - bGain)).toBeLessThanOrEqual(1);
   });
 
   it('non-party members cannot loot tapped kills', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

- Adds explicit party loot strategies for currency and shared item drops.
- Changes party defaults so currency is fairly split between nearby eligible members, while shared poor/common/uncommon+ items are awarded by random roll.
- Keeps quest drops personal via the existing `personalFor` flow, preserving per-player quest item collection.

Partially addresses #317 by improving the default party loot behavior. Configurable party loot settings remain future work.


## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
- `npm test -- tests/social.test.ts tests/fixes.test.ts`


- Manual steps:

1. Connect 2 players
2. Create a party
3. Kill multiple monsters
4. Check than the copper is distributed 
5. Check that the common items are distributed randomly

## Screenshots / recordings

<img width="2024" height="1321" alt="Screenshot from 2026-06-17 23-37-21" src="https://github.com/user-attachments/assets/af48b67a-a4e4-4f66-9a31-a13172bc05e0" />

<img width="2024" height="1321" alt="Screenshot from 2026-06-17 23-37-13" src="https://github.com/user-attachments/assets/ff4be168-4f18-40bb-a4d4-4167169c37b7" />


---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.**  (base branch is broken)
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop**
- [ ] **Tested on mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
