### PR TITLE
fix(security): harden market, dungeons, arena, and commands

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -1,6 +1,6 @@
 import * as http from 'node:http';
 import { json, readBody } from './http_util';
-import { rateLimited } from './ratelimit';
+import { authThrottled, clearAuthFailures, rateLimited, recordAuthFailure } from './ratelimit';
 import { findAccount, touchLogin, saveToken, accountForToken, isAdminAccount } from './db';
 import { verifyPassword, newToken } from './auth';
 import {
@@ -56,10 +56,19 @@ async function handleLogin(req: http.IncomingMessage, res: http.ServerResponse):
     return fail(res, 429, 'too many attempts — wait a minute and try again');
   }
   const body = await readBody(req);
-  const account = typeof body.username === 'string' ? await findAccount(body.username) : null;
+  const username = typeof body.username === 'string' ? body.username : '';
+  // Mirror the public login throttle on the admin login surface too. The
+  // per-IP bucket above stops one noisy source, but distributed credential
+  // stuffing against a single admin username must share one server-side bucket.
+  if (username && authThrottled(username)) {
+    return fail(res, 429, 'too many failed attempts — wait a few minutes and try again');
+  }
+  const account = username ? await findAccount(username) : null;
   if (!account || !(await verifyPassword(String(body.password ?? ''), account.password_hash))) {
+    if (username) recordAuthFailure(username);
     return fail(res, 401, 'invalid username or password');
   }
+  clearAuthFailures(username); // correct password: forgive earlier typos, even for non-admins
   if (!(await isAdminAccount(account.id))) {
     return fail(res, 403, 'this account does not have admin access');
   }

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs';
 import type { WebSocket } from 'ws';
-import { Sim } from '../src/sim/sim';
+import { Sim, marketSellerKeyForCharacterId } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
-import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
+import { DT, Entity, SimEvent, dist2d, normAngle } from '../src/sim/types';
 import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
@@ -43,9 +43,23 @@ const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
+const CMD_RATE_BURST = 30;
+const CMD_RATE_REFILL_PER_SECOND = 15;
+const CMD_RATE_ERROR_COOLDOWN_SECONDS = 2;
+const MAX_SERVER_FACING_STEP = Math.PI / 2; // per input frame; blocks instant 180 snaps without fighting mouse turn
 const WHO_RESULT_LIMIT = 50;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
+
+function currentDungeonLockoutPeriod(now = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+function clampFacingStep(current: number, requested: number): number {
+  const delta = normAngle(requested - current);
+  const step = Math.max(-MAX_SERVER_FACING_STEP, Math.min(MAX_SERVER_FACING_STEP, delta));
+  return normAngle(current + step);
+}
 
 export interface ClientSession {
   ws: WebSocket;
@@ -62,6 +76,9 @@ export interface ClientSession {
   chatLastRateError: number;
   chatRateViolations: number;
   chatCooldownUntil: number;
+  cmdTokens: number;
+  cmdLastRefill: number;
+  cmdLastRateError: number;
   // character ids this player has ignored; chat from them is dropped before
   // delivery. Loaded from the DB on join, kept in sync by social commands.
   blockedIds: Set<number>;
@@ -312,9 +329,15 @@ export class GameServer {
   private readonly startedAt = Date.now();
   private peakOnline = 0;
   private tickMsAvg = 0;
+  private dungeonLockoutPeriod = currentDungeonLockoutPeriod();
 
   constructor() {
-    this.sim = new Sim({ seed: WORLD_SEED, playerClass: 'warrior', noPlayer: true });
+    this.sim = new Sim({
+      seed: WORLD_SEED,
+      playerClass: 'warrior',
+      noPlayer: true,
+      dungeonLockoutPeriod: this.dungeonLockoutPeriod,
+    });
     this.social = new SocialService(this.socialDb, this.socialTransport());
   }
 
@@ -423,6 +446,7 @@ export class GameServer {
       if (dt > 0.5) dt = 0.5;
       acc += dt;
       while (acc >= DT) {
+        this.refreshDungeonLockoutPeriod();
         const events = this.sim.tick();
         this.routeEvents(events);
         acc -= DT;
@@ -448,11 +472,21 @@ export class GameServer {
     if (this.interval) clearInterval(this.interval);
   }
 
+  private refreshDungeonLockoutPeriod(now = new Date()): void {
+    const period = currentDungeonLockoutPeriod(now);
+    if (period === this.dungeonLockoutPeriod) return;
+    this.dungeonLockoutPeriod = period;
+    this.sim.setDungeonLockoutPeriod(period);
+  }
+
   // -------------------------------------------------------------------------
 
   join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
-    const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
+    const pid = this.sim.addPlayer(cls, name, {
+      state: state ?? undefined,
+      characterKey: marketSellerKeyForCharacterId(characterId),
+    });
     if (isGm) {
       // GM characters: invulnerable, and always at the level cap (the row is
       // created without state, so the first join levels them up)
@@ -465,6 +499,7 @@ export class GameServer {
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null,
       chatTokens: CHAT_RATE_BURST, chatLastRefill: Date.now() / 1000, chatLastRateError: 0,
       chatRateViolations: 0, chatCooldownUntil: 0,
+      cmdTokens: CMD_RATE_BURST, cmdLastRefill: Date.now() / 1000, cmdLastRateError: 0,
       blockedIds: new Set(),
       blockListLoaded: false,
       lastWhisperFrom: null,
@@ -684,11 +719,12 @@ export class GameServer {
       const { moveInput, facing } = parseMoveInputFrame(msg);
       Object.assign(meta.moveInput, moveInput);
       if (facing !== null && !e.dead) {
-        e.facing = facing;
+        e.facing = clampFacingStep(e.facing, facing);
       }
       return;
     }
     if (msg.t !== 'cmd') return;
+    if (!this.consumeCommandToken(session)) return;
     switch (msg.cmd) {
       case 'castSlot': sim.castAbilityBySlot(msg.slot | 0, pid); break;
       case 'cast': if (typeof msg.ability === 'string') sim.castAbility(msg.ability, pid); break;
@@ -1214,6 +1250,22 @@ export class GameServer {
       channel: sent.channel,
       message: sent.message,
     });
+  }
+
+  private consumeCommandToken(session: ClientSession): boolean {
+    const now = Date.now() / 1000;
+    const elapsed = Math.max(0, now - session.cmdLastRefill);
+    session.cmdTokens = Math.min(CMD_RATE_BURST, session.cmdTokens + elapsed * CMD_RATE_REFILL_PER_SECOND);
+    session.cmdLastRefill = now;
+    if (session.cmdTokens >= 1) {
+      session.cmdTokens -= 1;
+      return true;
+    }
+    if (now - session.cmdLastRateError >= CMD_RATE_ERROR_COOLDOWN_SECONDS) {
+      session.cmdLastRateError = now;
+      this.send(session, { t: 'events', list: [{ type: 'error', text: 'You are issuing commands too quickly. Slow down.' }] });
+    }
+    return false;
   }
 
   private consumeChatToken(session: ClientSession): boolean {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -57,6 +57,7 @@ const ARENA_BASE_RATING = 1500; // every character starts here, unranked
 const ARENA_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
 const ARENA_K_FACTOR = 32; // Elo sensitivity per match
 const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
+const ARENA_REMATCH_COOLDOWN = 10 * 60; // anti win-trade: same pair waits before rematching
 const PVP_CC_DR_RESET = 18; // seconds before a repeated PvP CC category is fresh again
 const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
@@ -103,6 +104,7 @@ const MARKET_MAX_PRICE = 5_000_000; // 500g ceiling — guards against overflow 
 const MARKET_CUT = 0.05; // the Merchant's cut on a completed sale (a gold sink)
 const MARKET_LISTING_DURATION = 48 * 3600; // sim-seconds an unsold listing lingers before returning
 const MARKET_WIRE_LIMIT = 120; // most listings shipped to one client at a time
+const MARKET_CHARACTER_KEY_PREFIX = 'char:'; // online stable seller identity prefix
 const VENDOR_BUYBACK_LIMIT = 12;
 const INSTANCE_EMPTY_TIMEOUT = 300; // seconds before an empty instance resets
 const MAX_CLIMB_SLOPE = 1.5; // rise/run above which a ground move is blocked (cliffs, world rim)
@@ -184,6 +186,10 @@ export function eloDelta(winnerRating: number, loserRating: number, score = 1): 
   return Math.round(ARENA_K_FACTOR * (score - expected));
 }
 
+export function marketSellerKeyForCharacterId(characterId: number): string {
+  return `${MARKET_CHARACTER_KEY_PREFIX}${Math.max(0, Math.floor(characterId))}`;
+}
+
 export interface InstanceSlot {
   dungeonId: string;
   slot: number;
@@ -227,6 +233,9 @@ export interface PlayerMeta {
   entityId: number;
   cls: PlayerClass;
   name: string;
+  // Stable online seller identity (`char:<characters.id>`). Offline/legacy
+  // players omit it and fall back to character name.
+  characterKey?: string;
   moveInput: MoveInput;
   inventory: InvSlot[];
   vendorBuyback: InvSlot[];
@@ -249,6 +258,9 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // dungeonId -> lockout period id in which the character already received the
+  // instance boss reward. Persisted in CharacterState.
+  dungeonBossLockouts: Record<string, string>;
   // Talents & Specializations. `talents` is the active allocation; `talentMods`
   // is its precomputed flat struct — resolved only on allocation/respec/loadout
   // change (recomputeTalents), never walked on the combat or stat hot path.
@@ -262,13 +274,14 @@ export interface PlayerMeta {
 // The World Market — a single shared, server-authoritative auction house run
 // by the Merchant NPC. Listings live in the sim (so offline play has a market
 // too and the rules are testable); the server persists them to Postgres.
-// Sellers are keyed by character name, which is globally unique, so proceeds
-// and returns reach the right player even while they are offline.
+// Online sellers are keyed by stable character id (`char:<id>`), with legacy
+// name keys still recognized for pre-migration listings. This prevents
+// delete/recreate-with-same-name attacks from collecting someone else's sales.
 // ---------------------------------------------------------------------------
 
 export interface MarketListing {
   id: number;
-  sellerKey: string; // stable seller identity (character name); '' for house stock
+  sellerKey: string; // stable seller identity (`char:<id>` online; legacy name offline); '' for house stock
   sellerName: string; // display name
   itemId: string;
   count: number;
@@ -278,7 +291,7 @@ export interface MarketListing {
 }
 
 // Gold + items awaiting pickup at the Merchant (sale proceeds, expired
-// listings), keyed by seller name so an offline seller can collect later.
+// listings), keyed by stable seller key so an offline seller can collect later.
 export interface MarketCollection {
   copper: number;
   items: InvSlot[];
@@ -317,6 +330,7 @@ export interface CharacterState {
   arenaRating?: number;
   arenaWins?: number;
   arenaLosses?: number;
+  dungeonBossLockouts?: Record<string, string>;
   // Talents & Specializations (JSONB; no schema migration). All optional so
   // characters saved before talents existed load cleanly (default: no points spent).
   talents?: TalentAllocation;
@@ -399,12 +413,14 @@ export class Sim {
   arenaMatches = new Map<number, ArenaMatch>(); // pid -> shared match (both pids)
   private arenaBusySlots = new Set<number>();
   private nextArenaMatchId = 1;
+  private arenaRecentOpponents = new Map<string, Map<string, number>>(); // stable arena key -> opp key -> expiresAt sim.time
   // per-player chat token bucket (anti-spam); refilled lazily by sim time
   private chatTokens = new Map<number, { tokens: number; at: number }>();
   // dungeon instances
   instances: InstanceSlot[] = [];
+  private dungeonBossLootAccess = new Map<number, Set<number>>(); // boss corpse id -> pids allowed to loot this kill
   // the World Market: one shared listing book, per-seller collections keyed by
-  // character name, and the Merchant entity these are anchored to
+  // stable seller key, and the Merchant entity these are anchored to
   marketListings: MarketListing[] = [];
   private marketCollections = new Map<string, MarketCollection>();
   private nextListingId = 1;
@@ -417,6 +433,7 @@ export class Sim {
       respawnSeconds: cfg.respawnSeconds ?? 25,
       autoEquip: cfg.autoEquip ?? false,
       playerName: cfg.playerName ?? 'Adventurer',
+      dungeonLockoutPeriod: cfg.dungeonLockoutPeriod ?? '',
     };
     this.rng = new Rng(cfg.seed);
 
@@ -474,6 +491,10 @@ export class Sim {
     }
   }
 
+  setDungeonLockoutPeriod(period: string): void {
+    this.cfg.dungeonLockoutPeriod = String(period || '');
+  }
+
   // -------------------------------------------------------------------------
   // Entity roster: every add/remove/teleport goes through these so the
   // spatial indexes always match the entities map
@@ -487,6 +508,7 @@ export class Sim {
 
   private dropEntity(id: number): void {
     this.clearEntityMarker(id); // a despawned entity keeps no raid marker
+    this.dungeonBossLootAccess.delete(id);
     const e = this.entities.get(id);
     if (!e) return;
     this.grid.remove(e);
@@ -503,7 +525,7 @@ export class Sim {
   // Players: join / leave / persistence
   // -------------------------------------------------------------------------
 
-  addPlayer(cls: PlayerClass, name: string, opts?: { autoEquip?: boolean; state?: CharacterState }): number {
+  addPlayer(cls: PlayerClass, name: string, opts?: { autoEquip?: boolean; state?: CharacterState; characterKey?: string }): number {
     // Characters saved inside a dungeon instance rejoin at its entrance —
     // their old instance is gone (or belongs to someone else) by now.
     let savedPos = opts?.state?.pos ?? null;
@@ -521,6 +543,7 @@ export class Sim {
       entityId: player.id,
       cls,
       name,
+      characterKey: opts?.characterKey ? String(opts.characterKey) : undefined,
       moveInput: emptyMoveInput(),
       inventory: [],
       vendorBuyback: [],
@@ -538,6 +561,7 @@ export class Sim {
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
+      dungeonBossLockouts: { ...(opts?.state?.dungeonBossLockouts ?? {}) },
       talents: emptyAllocation(),
       talentMods: emptyModifiers(),
       loadouts: [],
@@ -603,6 +627,7 @@ export class Sim {
     this.arenaDequeue(pid);
     const match = this.arenaMatches.get(pid);
     if (match) this.endArenaMatch(match, match.a === pid ? match.b : match.a, 'forfeit');
+    this.forgetTransientArenaRecentOpponent(pid);
     this.partyInvites.delete(pid);
     this.tradeInvites.delete(pid);
     this.duelInvites.delete(pid);
@@ -655,6 +680,7 @@ export class Sim {
       arenaRating: meta.arenaRating,
       arenaWins: meta.arenaWins,
       arenaLosses: meta.arenaLosses,
+      dungeonBossLockouts: { ...meta.dungeonBossLockouts },
       talents: cloneAllocation(meta.talents),
       loadouts: meta.loadouts.map((l) => ({ name: l.name, alloc: cloneAllocation(l.alloc), bar: [...l.bar] })),
       activeLoadout: meta.activeLoadout,
@@ -2659,7 +2685,27 @@ export class Sim {
           if (xpGain > 0) this.grantXp(xpGain, member);
           this.onMobKilledForQuests(e, member);
         }
-        this.rollLoot(e, meta, eligible);
+        const dungeon = this.dungeonForBossMob(e);
+        if (dungeon && this.cfg.dungeonLockoutPeriod) {
+          const unlocked = eligible.filter((member) => !this.hasDungeonBossLockout(member, dungeon.id));
+          if (unlocked.length === 0) {
+            for (const member of eligible) {
+              this.emit({ type: 'log', text: `${dungeon.name}'s boss reward is already locked for this reset.`, color: '#caa472', pid: member.entityId });
+            }
+            return;
+          }
+          this.dungeonBossLootAccess.set(e.id, new Set(unlocked.map((member) => member.entityId)));
+          for (const member of unlocked) this.markDungeonBossLockout(member, dungeon.id);
+          for (const member of eligible) {
+            if (!unlocked.includes(member)) {
+              this.emit({ type: 'log', text: `${dungeon.name}'s boss reward is already locked for this reset.`, color: '#caa472', pid: member.entityId });
+            }
+          }
+          this.rollLoot(e, meta, unlocked);
+          if (!e.lootable || !e.loot) this.dungeonBossLootAccess.delete(e.id);
+        } else {
+          this.rollLoot(e, meta, eligible);
+        }
       }
     }
   }
@@ -2757,6 +2803,22 @@ export class Sim {
     return objIdx >= 0 && this.countItem(entry.itemId, meta.entityId) < quest.objectives[objIdx].count;
   }
 
+  private dungeonForBossMob(mob: Entity): DungeonDef | null {
+    const template = MOBS[mob.templateId];
+    if (!template?.boss) return null;
+    return dungeonAt(mob.spawnPos.x);
+  }
+
+  private hasDungeonBossLockout(meta: PlayerMeta, dungeonId: string): boolean {
+    const period = this.cfg.dungeonLockoutPeriod;
+    return !!period && meta.dungeonBossLockouts[dungeonId] === period;
+  }
+
+  private markDungeonBossLockout(meta: PlayerMeta, dungeonId: string): void {
+    const period = this.cfg.dungeonLockoutPeriod;
+    if (period) meta.dungeonBossLockouts[dungeonId] = period;
+  }
+
   private rollLoot(mob: Entity, meta: PlayerMeta, eligible: PlayerMeta[] = [meta]): void {
     const template = MOBS[mob.templateId];
     if (!template) return;
@@ -2838,6 +2900,7 @@ export class Sim {
       mob.loot = null;
       mob.lootable = false;
       mob.corpseTimer = Math.min(mob.corpseTimer, 4);
+      this.dungeonBossLootAccess.delete(mob.id);
     }
   }
 
@@ -3262,6 +3325,7 @@ export class Sim {
 
   private respawnMob(mob: Entity): void {
     this.clearNonPlayerStatAuras(mob);
+    this.dungeonBossLootAccess.delete(mob.id);
     mob.dead = false;
     mob.lootable = false;
     mob.loot = null;
@@ -3681,6 +3745,11 @@ export class Sim {
       }
     }
     if (dist2d(p.pos, mob.pos) > INTERACT_RANGE) { this.error(meta.entityId, 'Too far away.'); return; }
+    const bossAccess = this.dungeonBossLootAccess.get(mob.id);
+    if (bossAccess && !bossAccess.has(meta.entityId)) {
+      this.error(meta.entityId, 'You are locked to this boss reward for the current reset.');
+      return;
+    }
     if (mob.loot.copper > 0) {
       meta.copper += mob.loot.copper;
       meta.counters.lootCopper += mob.loot.copper;
@@ -4503,10 +4572,54 @@ export class Sim {
     }
   }
 
+  private arenaIdentityKey(pid: number): string {
+    const meta = this.players.get(pid);
+    return meta?.characterKey ? `character:${meta.characterKey}` : `pid:${pid}`;
+  }
+
+  private arenaRecentlyMatched(aPid: number, bPid: number): boolean {
+    const aKey = this.arenaIdentityKey(aPid);
+    const bKey = this.arenaIdentityKey(bPid);
+    return (this.arenaRecentOpponents.get(aKey)?.get(bKey) ?? 0) > this.time;
+  }
+
+  private noteArenaOpponents(aPid: number, bPid: number): void {
+    const aKey = this.arenaIdentityKey(aPid);
+    const bKey = this.arenaIdentityKey(bPid);
+    const until = this.time + ARENA_REMATCH_COOLDOWN;
+    let aRecent = this.arenaRecentOpponents.get(aKey);
+    if (!aRecent) { aRecent = new Map(); this.arenaRecentOpponents.set(aKey, aRecent); }
+    let bRecent = this.arenaRecentOpponents.get(bKey);
+    if (!bRecent) { bRecent = new Map(); this.arenaRecentOpponents.set(bKey, bRecent); }
+    aRecent.set(bKey, until);
+    bRecent.set(aKey, until);
+  }
+
+  private pruneArenaRecentOpponents(): void {
+    for (const [key, recent] of this.arenaRecentOpponents.entries()) {
+      for (const [oppKey, until] of recent.entries()) {
+        if (until <= this.time) recent.delete(oppKey);
+      }
+      if (recent.size === 0) this.arenaRecentOpponents.delete(key);
+    }
+  }
+
+  private forgetTransientArenaRecentOpponent(pid: number): void {
+    const key = this.arenaIdentityKey(pid);
+    // Online characters keep a stable characterKey, so their short rematch
+    // cooldown should survive reconnects. Offline/test-only pid identities can
+    // be forgotten immediately to avoid stale pid-key buildup.
+    if (!key.startsWith('pid:')) return;
+    this.arenaRecentOpponents.delete(key);
+    for (const recent of this.arenaRecentOpponents.values()) recent.delete(key);
+  }
+
   // Pair the longest-waiting contender with the nearest-rated opponent still in
   // line, one bout per free slot. Skips (and drops) anyone who went offline or
-  // died while waiting.
+  // died while waiting, and skips immediate same-pair rematches to make
+  // low-population win-trading slower and more visible.
   private matchmakeArena(): void {
+    this.pruneArenaRecentOpponents();
     let guard = ARENA_SLOT_COUNT + 1;
     while (guard-- > 0) {
       this.arenaQueue = this.arenaQueue.filter((id) => {
@@ -4514,13 +4627,18 @@ export class Sim {
         return !!e && !e.dead && !this.arenaMatches.has(id);
       });
       if (this.arenaQueue.length < 2 || this.freeArenaSlot() === null) return;
-      const aPid = this.arenaQueue[0];
-      const aRating = this.players.get(aPid)?.arenaRating ?? ARENA_BASE_RATING;
-      let bPid = -1, bestGap = Infinity;
-      for (let i = 1; i < this.arenaQueue.length; i++) {
-        const id = this.arenaQueue[i];
-        const gap = Math.abs((this.players.get(id)?.arenaRating ?? ARENA_BASE_RATING) - aRating);
-        if (gap < bestGap) { bestGap = gap; bPid = id; }
+      let aPid = -1, bPid = -1;
+      for (let aIdx = 0; aIdx < this.arenaQueue.length - 1; aIdx++) {
+        const candidateA = this.arenaQueue[aIdx];
+        const aRating = this.players.get(candidateA)?.arenaRating ?? ARENA_BASE_RATING;
+        let bestPid = -1, bestGap = Infinity;
+        for (let bIdx = aIdx + 1; bIdx < this.arenaQueue.length; bIdx++) {
+          const id = this.arenaQueue[bIdx];
+          if (this.arenaRecentlyMatched(candidateA, id)) continue;
+          const gap = Math.abs((this.players.get(id)?.arenaRating ?? ARENA_BASE_RATING) - aRating);
+          if (gap < bestGap) { bestGap = gap; bestPid = id; }
+        }
+        if (bestPid >= 0) { aPid = candidateA; bPid = bestPid; break; }
       }
       if (bPid < 0) return;
       this.arenaDequeue(aPid);
@@ -4550,6 +4668,7 @@ export class Sim {
     };
     this.arenaMatches.set(aPid, match);
     this.arenaMatches.set(bPid, match);
+    this.noteArenaOpponents(aPid, bPid);
     const origin = arenaOrigin(slot);
     this.placeInArena(ea, origin, ARENA_SPAWN_A);
     this.placeInArena(eb, origin, ARENA_SPAWN_B);
@@ -4891,9 +5010,28 @@ export class Sim {
     return !!m && dist2d(e.pos, m.pos) <= MARKET_RANGE;
   }
 
-  private metaByName(name: string): PlayerMeta | null {
-    if (!name) return null;
-    for (const m of this.players.values()) if (m.name === name) return m;
+  private primaryMarketSellerKey(meta: PlayerMeta): string {
+    return meta.characterKey ?? meta.name;
+  }
+
+  private marketSellerKeys(meta: PlayerMeta): string[] {
+    const keys = [this.primaryMarketSellerKey(meta)];
+    // Pre-hardening persisted market rows used the display name as the key.
+    // Keep those collectable/cancellable by the same live character after the
+    // server starts writing stable character ids.
+    if (meta.name && !keys.includes(meta.name)) keys.push(meta.name);
+    return keys;
+  }
+
+  private marketListingOwnedBy(listing: MarketListing, meta: PlayerMeta): boolean {
+    return !listing.house && this.marketSellerKeys(meta).includes(listing.sellerKey);
+  }
+
+  private metaByMarketKey(key: string): PlayerMeta | null {
+    if (!key) return null;
+    for (const m of this.players.values()) {
+      if (this.marketSellerKeys(m).includes(key)) return m;
+    }
     return null;
   }
 
@@ -4939,11 +5077,11 @@ export class Sim {
     const ask = Math.floor(price);
     if (!Number.isFinite(ask) || ask < MARKET_MIN_PRICE) { this.error(meta.entityId, 'Name a price of at least 1 copper.'); return; }
     if (ask > MARKET_MAX_PRICE) { this.error(meta.entityId, 'That price is beyond what the Merchant will broker.'); return; }
-    const mine = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
+    const mine = this.marketListings.reduce((n, l) => n + (this.marketListingOwnedBy(l, meta) ? 1 : 0), 0);
     if (mine >= MARKET_MAX_LISTINGS) { this.error(meta.entityId, `You may keep at most ${MARKET_MAX_LISTINGS} goods on the market at once.`); return; }
     this.removeItem(itemId, want, meta.entityId); // escrow
     this.marketListings.push({
-      id: this.nextListingId++, sellerKey: meta.name, sellerName: meta.name,
+      id: this.nextListingId++, sellerKey: this.primaryMarketSellerKey(meta), sellerName: meta.name,
       itemId, count: want, price: ask, expiresAt: this.time + MARKET_LISTING_DURATION, house: false,
     });
     this.emit({ type: 'loot', text: `Listed ${def.name}${want > 1 ? ' x' + want : ''} on the World Market for ${formatMoney(ask)}.`, pid: meta.entityId });
@@ -4962,7 +5100,7 @@ export class Sim {
     const listing = this.marketListings[idx];
     const def = ITEMS[listing.itemId];
     if (!def) { this.marketListings.splice(idx, 1); return; }
-    if (!listing.house && listing.sellerKey === meta.name) {
+    if (this.marketListingOwnedBy(listing, meta)) {
       this.error(meta.entityId, 'That is your own listing — cancel it to reclaim it.');
       return;
     }
@@ -4973,7 +5111,7 @@ export class Sim {
       const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
       this.collectionFor(listing.sellerKey).copper += proceeds;
       this.marketListings.splice(idx, 1);
-      const sellerMeta = this.metaByName(listing.sellerKey);
+      const sellerMeta = this.metaByMarketKey(listing.sellerKey);
       if (sellerMeta) {
         this.emit({ type: 'loot', text: `${meta.name} bought your ${def.name} for ${formatMoney(listing.price)} — collect ${formatMoney(proceeds)} from the Merchant.`, pid: sellerMeta.entityId });
       }
@@ -4990,7 +5128,7 @@ export class Sim {
     const idx = this.marketListings.findIndex((l) => l.id === listingId);
     if (idx < 0) return;
     const listing = this.marketListings[idx];
-    if (listing.house || listing.sellerKey !== meta.name) { this.error(meta.entityId, 'That is not your listing.'); return; }
+    if (!this.marketListingOwnedBy(listing, meta)) { this.error(meta.entityId, 'That is not your listing.'); return; }
     this.marketListings.splice(idx, 1);
     this.addItem(listing.itemId, listing.count, meta.entityId);
     const def = ITEMS[listing.itemId];
@@ -5004,14 +5142,22 @@ export class Sim {
     if (!r) return;
     const { meta, e: p } = r;
     if (!this.nearMerchant(p)) { this.error(meta.entityId, 'You are too far from the Merchant.'); return; }
-    const col = this.marketCollections.get(meta.name);
-    if (!col || (col.copper <= 0 && col.items.length === 0)) { this.error(meta.entityId, 'You have nothing to collect.'); return; }
-    if (col.copper > 0) {
-      meta.copper += col.copper;
-      this.emit({ type: 'loot', text: `You collect ${formatMoney(col.copper)} from the Merchant.`, pid: meta.entityId });
+    const keys = this.marketSellerKeys(meta);
+    let copper = 0;
+    const items: InvSlot[] = [];
+    for (const key of keys) {
+      const col = this.marketCollections.get(key);
+      if (!col) continue;
+      copper += Math.max(0, col.copper);
+      items.push(...col.items.map((s) => ({ ...s })));
     }
-    for (const s of col.items) this.addItem(s.itemId, s.count, meta.entityId);
-    this.marketCollections.delete(meta.name);
+    if (copper <= 0 && items.length === 0) { this.error(meta.entityId, 'You have nothing to collect.'); return; }
+    if (copper > 0) {
+      meta.copper += copper;
+      this.emit({ type: 'loot', text: `You collect ${formatMoney(copper)} from the Merchant.`, pid: meta.entityId });
+    }
+    for (const s of items) this.addItem(s.itemId, s.count, meta.entityId);
+    for (const key of keys) this.marketCollections.delete(key);
   }
 
   // Once a second: return expired player listings to their seller's collection.
@@ -5022,7 +5168,7 @@ export class Sim {
       if (l.house || this.time < l.expiresAt) continue;
       this.marketListings.splice(i, 1);
       this.collectionFor(l.sellerKey).items.push({ itemId: l.itemId, count: l.count });
-      const sellerMeta = this.metaByName(l.sellerKey);
+      const sellerMeta = this.metaByMarketKey(l.sellerKey);
       if (sellerMeta) {
         const def = ITEMS[l.itemId];
         this.emit({ type: 'log', text: `Your market listing of ${def?.name ?? l.itemId} expired and waits at the Merchant.`, color: '#caa472', pid: sellerMeta.entityId });
@@ -5044,14 +5190,22 @@ export class Sim {
     });
     const listings = sorted.slice(0, MARKET_WIRE_LIMIT).map((l) => ({
       id: l.id, sellerName: l.sellerName, itemId: l.itemId, count: l.count,
-      price: l.price, mine: !l.house && l.sellerKey === meta.name, house: l.house,
+      price: l.price, mine: this.marketListingOwnedBy(l, meta), house: l.house,
     }));
-    const col = this.marketCollections.get(meta.name);
-    const myListingCount = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
+    const keys = this.marketSellerKeys(meta);
+    let collectionCopper = 0;
+    const collectionItems: InvSlot[] = [];
+    for (const key of keys) {
+      const col = this.marketCollections.get(key);
+      if (!col) continue;
+      collectionCopper += Math.max(0, col.copper);
+      collectionItems.push(...col.items.map((s) => ({ ...s })));
+    }
+    const myListingCount = this.marketListings.reduce((n, l) => n + (this.marketListingOwnedBy(l, meta) ? 1 : 0), 0);
     return {
       listings,
-      collectionCopper: col?.copper ?? 0,
-      collectionItems: col ? col.items.map((s) => ({ ...s })) : [],
+      collectionCopper,
+      collectionItems,
       cutPct: Math.round(MARKET_CUT * 100),
       maxListings: MARKET_MAX_LISTINGS,
       myListingCount,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -565,6 +565,9 @@ export interface SimConfig {
   respawnSeconds?: number; // mob respawn time (default 25)
   autoEquip?: boolean; // auto-equip better gear on loot (headless convenience)
   playerName?: string;
+  // Empty/offline default disables real-time reward lockouts. Online servers pass
+  // a deterministic period id (for example an ISO UTC date) at boot.
+  dungeonLockoutPeriod?: string;
   noPlayer?: boolean; // multiplayer server: start with an empty world and addPlayer() later
 }
 

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
+import { hashPassword } from '../server/auth';
+import { authThrottled, clearAuthFailures, recordAuthFailure } from '../server/ratelimit';
 
 // Mock the db layers so no Postgres is needed; the router logic is under test.
 vi.mock('../server/db', () => ({
@@ -39,12 +41,12 @@ import { forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, m
 
 const VALID_TOKEN = 'a'.repeat(64);
 
-function fakeReq(opts: { method?: string; url?: string; token?: string; body?: unknown } = {}) {
+function fakeReq(opts: { method?: string; url?: string; token?: string; body?: unknown; remoteAddress?: string } = {}) {
   const req: any = new EventEmitter();
   req.method = opts.method ?? 'GET';
   req.url = opts.url ?? '/admin/api/overview';
   req.headers = opts.token ? { authorization: `Bearer ${opts.token}` } : {};
-  req.socket = { remoteAddress: `10.0.0.${Math.floor(Math.random() * 250) + 1}` };
+  req.socket = { remoteAddress: opts.remoteAddress ?? `10.0.0.${Math.floor(Math.random() * 250) + 1}` };
   if (opts.method === 'POST') {
     setImmediate(() => {
       if (opts.body !== undefined) req.emit('data', JSON.stringify(opts.body));
@@ -76,6 +78,8 @@ const fakeGame: any = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearAuthFailures('adminbrute');
+  clearAuthFailures('nonadmin');
 });
 
 describe('admin api auth', () => {
@@ -118,19 +122,69 @@ describe('admin api auth', () => {
   });
 
   it('rejects admin login for a non-admin account even with the right password', async () => {
-    // scrypt hash of "hunter22" is irrelevant — verifyPassword fails on a junk
-    // hash, so this asserts the credential failure path returns 401.
-    vi.mocked(findAccount).mockResolvedValue({ id: 3, username: 'bob', password_hash: 'junk' });
+    vi.mocked(findAccount).mockResolvedValue({ id: 3, username: 'nonadmin', password_hash: await hashPassword('hunter22') });
+    vi.mocked(isAdminAccount).mockResolvedValue(false);
     const res = fakeRes();
 
     await handleAdminApi(
-      fakeReq({ method: 'POST', url: '/admin/api/login', body: { username: 'bob', password: 'hunter22' } }),
+      fakeReq({ method: 'POST', url: '/admin/api/login', body: { username: 'nonadmin', password: 'hunter22' } }),
       res,
       fakeGame,
     );
 
-    expect(res.statusCode).toBe(401);
-    expect(res.body.error).toMatch(/invalid username or password/);
+    expect(res.statusCode).toBe(403);
+    expect(res.body.error).toMatch(/admin access/);
+  });
+
+  it('throttles distributed failed admin-login attempts by username', async () => {
+    vi.mocked(findAccount).mockResolvedValue(null);
+
+    for (let i = 0; i < 10; i++) {
+      const res = fakeRes();
+      await handleAdminApi(
+        fakeReq({
+          method: 'POST',
+          url: '/admin/api/login',
+          remoteAddress: `10.41.0.${i + 1}`,
+          body: { username: 'adminbrute', password: `wrong-${i}` },
+        }),
+        res,
+        fakeGame,
+      );
+      expect(res.statusCode).toBe(401);
+    }
+
+    const blocked = fakeRes();
+    await handleAdminApi(
+      fakeReq({
+        method: 'POST',
+        url: '/admin/api/login',
+        remoteAddress: '10.41.0.250',
+        body: { username: 'adminbrute', password: 'still-wrong' },
+      }),
+      blocked,
+      fakeGame,
+    );
+
+    expect(blocked.statusCode).toBe(429);
+    expect(blocked.body.error).toMatch(/too many failed attempts/);
+  });
+
+  it('clears admin-login failure history after a correct password before denying non-admins', async () => {
+    for (let i = 0; i < 9; i++) recordAuthFailure('nonadmin');
+    vi.mocked(findAccount).mockResolvedValue({ id: 3, username: 'nonadmin', password_hash: await hashPassword('hunter22') });
+    vi.mocked(isAdminAccount).mockResolvedValue(false);
+    const res = fakeRes();
+
+    await handleAdminApi(
+      fakeReq({ method: 'POST', url: '/admin/api/login', body: { username: 'nonadmin', password: 'hunter22' } }),
+      res,
+      fakeGame,
+    );
+
+    expect(res.statusCode).toBe(403);
+    recordAuthFailure('nonadmin');
+    expect(authThrottled('nonadmin')).toBe(false);
   });
 
   it('rejects non-GET methods on data endpoints', async () => {

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -204,11 +204,62 @@ describe('arena: a full bout', () => {
     // run the aftermath out so the slot is released
     for (let i = 0; i < 20 * 6 && sim.arenaMatchFor(a); i++) sim.tick();
     expect(sim.arenaMatchFor(a)).toBe(null);
-    // requeue both — a fresh match must seat without "all arenas busy"
+    // A third contender can still be seated immediately: the free-slot check
+    // must not be confused by the new rematch cooldown for Aleph/Bet.
+    const c = sim.addPlayer('rogue', 'Gimel');
+    teleport(sim, c, 12, -40);
+    sim.arenaQueueJoin(a);
+    sim.arenaQueueJoin(b);
+    sim.arenaQueueJoin(c);
+    sim.tick();
+    expect(sim.arenaMatchFor(a)).toBeTruthy();
+    const rematch = sim.arenaMatchFor(a)!;
+    expect([rematch.a, rematch.b].sort()).toEqual([a, c].sort());
+    expect(sim.arenaMatchFor(b)).toBe(null);
+    expect(sim.arenaInfoFor(b)!.queued).toBe(true);
+  });
+
+  it('does not immediately rematch the same pair after a bout', () => {
+    const { sim, a, b } = queueDuo();
+    startBout(sim);
+    (sim as any).dealDamage(sim.entities.get(a)!, sim.entities.get(b)!, 99999, false, 'physical', null, 'hit');
+    for (let i = 0; i < 20 * 6 && sim.arenaMatchFor(a); i++) sim.tick();
+
     sim.arenaQueueJoin(a);
     sim.arenaQueueJoin(b);
     sim.tick();
-    expect(sim.arenaMatchFor(a)).toBeTruthy();
+
+    expect(sim.arenaMatchFor(a)).toBe(null);
+    expect(sim.arenaMatchFor(b)).toBe(null);
+    expect(sim.arenaInfoFor(a)!.queued).toBe(true);
+    expect(sim.arenaInfoFor(b)!.queued).toBe(true);
+  });
+
+  it('keeps same-character rematch cooldowns across reconnects', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph', { characterKey: 'char:1' });
+    const b = sim.addPlayer('mage', 'Bet', { characterKey: 'char:2' });
+    teleport(sim, a, 0, -40);
+    teleport(sim, b, 6, -40);
+    sim.arenaQueueJoin(a);
+    sim.arenaQueueJoin(b);
+    sim.tick();
+    startBout(sim);
+    (sim as any).dealDamage(sim.entities.get(a)!, sim.entities.get(b)!, 99999, false, 'physical', null, 'hit');
+    for (let i = 0; i < 20 * 6 && sim.arenaMatchFor(a); i++) sim.tick();
+    sim.removePlayer(a);
+    sim.removePlayer(b);
+
+    const a2 = sim.addPlayer('warrior', 'Aleph', { characterKey: 'char:1' });
+    const b2 = sim.addPlayer('mage', 'Bet', { characterKey: 'char:2' });
+    teleport(sim, a2, 0, -40);
+    teleport(sim, b2, 6, -40);
+    sim.arenaQueueJoin(a2);
+    sim.arenaQueueJoin(b2);
+    sim.tick();
+
+    expect(sim.arenaMatchFor(a2)).toBe(null);
+    expect(sim.arenaMatchFor(b2)).toBe(null);
   });
 });
 

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+const normalizedHtml = html.replace(/\r\n/g, '\n');
 
 function splitGameUiTemplate(): { templateHtml: string; liveHtml: string } {
   const marker = '<template id="game-ui-template">';
@@ -38,7 +39,7 @@ describe('client HTML shell', () => {
   });
 
   it('caps mobile quest and NPC panels instead of stretching them edge to edge', () => {
-    expect(html).toContain('body.mobile-touch #quest-log-window,\n  body.mobile-touch #vendor-window,\n  body.mobile-touch #quest-dialog');
+    expect(normalizedHtml).toContain('body.mobile-touch #quest-log-window,\n  body.mobile-touch #vendor-window,\n  body.mobile-touch #quest-dialog');
     expect(html).toContain('width: clamp(320px, 76vw, 680px);');
     expect(html).toContain('max-width: calc(100vw - 20px);');
     expect(html).toContain('transform: translateX(-50%);');

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -350,6 +350,14 @@ describe('dungeon instance placement and targetability', () => {
 });
 
 describe('boss loot and encounter resets', () => {
+  function killMorthen(sim: Sim, pid = sim.playerId): Entity {
+    sim.enterDungeon('hollow_crypt', pid);
+    const boss = [...sim.entities.values()].find((e) => e.templateId === 'morthen' && e.spawnPos.x > DUNGEON_X_THRESHOLD && !e.dead);
+    if (!boss) throw new Error('Morthen was not spawned in the instance');
+    (sim as any).dealDamage(sim.entities.get(pid)!, boss, 999999, false, 'physical', null, 'hit');
+    return boss;
+  }
+
   it('boss roll groups drop at most one item from each exclusive table', () => {
     const sim = makeSim();
     const meta = sim.meta(sim.playerId)!;
@@ -387,6 +395,49 @@ describe('boss loot and encounter resets', () => {
       }
       if (exactlyOne) expect([...seen].sort()).toEqual([...groupItems].sort()); // all three reachable
     }
+  });
+
+  it('persists dungeon boss reward lockouts in character state', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', dungeonLockoutPeriod: 'day1' });
+    sim.meta(sim.playerId)!.dungeonBossLockouts.hollow_crypt = 'day1';
+
+    const state = sim.serializeCharacter(sim.playerId)!;
+    const sim2 = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true, dungeonLockoutPeriod: 'day1' });
+    const reloaded = sim2.addPlayer('warrior', 'Reloaded', { state });
+
+    expect(sim2.meta(reloaded)!.dungeonBossLockouts.hollow_crypt).toBe('day1');
+  });
+
+  it('locks dungeon boss loot after the first reward in the same reset period', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', dungeonLockoutPeriod: 'day1' });
+    const firstBoss = killMorthen(sim);
+
+    expect(sim.meta(sim.playerId)!.dungeonBossLockouts.hollow_crypt).toBe('day1');
+    expect(firstBoss.lootable).toBe(true);
+    expect((firstBoss.loot?.items.length ?? 0) + (firstBoss.loot?.copper ?? 0)).toBeGreaterThan(0);
+
+    const lockedState = sim.serializeCharacter(sim.playerId)!;
+    const sim2 = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true, dungeonLockoutPeriod: 'day1' });
+    const reloaded = sim2.addPlayer('warrior', 'Reloaded', { state: lockedState });
+    const secondBoss = killMorthen(sim2, reloaded);
+
+    expect(secondBoss.lootable).toBe(false);
+    expect(secondBoss.loot).toBeNull();
+    expect(sim2.events.some((e) => e.type === 'log' && e.text.includes('already locked'))).toBe(true);
+  });
+
+  it('allows dungeon boss rewards again in a new reset period', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', dungeonLockoutPeriod: 'day1' });
+    killMorthen(sim);
+    const lockedState = sim.serializeCharacter(sim.playerId)!;
+
+    const sim2 = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true, dungeonLockoutPeriod: 'day2' });
+    const reloaded = sim2.addPlayer('warrior', 'Reloaded', { state: lockedState });
+    const boss = killMorthen(sim2, reloaded);
+
+    expect(sim2.meta(reloaded)!.dungeonBossLockouts.hollow_crypt).toBe('day2');
+    expect(boss.lootable).toBe(true);
+    expect((boss.loot?.items.length ?? 0) + (boss.loot?.copper ?? 0)).toBeGreaterThan(0);
   });
 
   it('dungeon bosses always drop gear but cap bonus quality drops', () => {

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -224,6 +224,62 @@ describe('the World Market — the Merchant', () => {
     expect(sim.marketListings.filter((l) => l.sellerKey === 'Seller').length).toBe(12);
   });
 
+  it('uses stable character keys for online listings', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller', { characterKey: 'char:1' });
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 1, seller);
+
+    sim.marketList('wolf_fang', 1, 100, seller);
+
+    const listing = sim.marketListings.find((l) => !l.house && l.itemId === 'wolf_fang')!;
+    expect(listing).toMatchObject({ sellerKey: 'char:1', sellerName: 'Seller' });
+    expect(sim.marketInfoFor(seller)!.myListingCount).toBe(1);
+  });
+
+  it('does not let a deleted/recreated same-name character collect stable-key sale proceeds', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller', { characterKey: 'char:1' });
+    const buyer = sim.addPlayer('mage', 'Buyer', { characterKey: 'char:99' });
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.players.get(buyer)!.copper = 500;
+    sim.marketList('wolf_fang', 1, 100, seller);
+    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'char:1')!.id, buyer);
+    sim.removePlayer(seller);
+
+    const impostor = sim.addPlayer('rogue', 'Seller', { characterKey: 'char:2' });
+    standAtMerchant(sim, impostor);
+    sim.events.length = 0;
+    sim.marketCollect(impostor);
+
+    expect(copperOf(sim, impostor)).toBe(0);
+    expect(errorsSince(sim).join(' ')).toMatch(/nothing to collect/i);
+
+    const realSeller = sim.addPlayer('warrior', 'SellerRenamed', { characterKey: 'char:1' });
+    standAtMerchant(sim, realSeller);
+    sim.marketCollect(realSeller);
+    expect(copperOf(sim, realSeller)).toBe(95);
+  });
+
+  it('keeps legacy name-keyed collections collectable after the stable-key migration', () => {
+    const sim = makeWorld();
+    sim.loadMarket({
+      listings: [],
+      collections: [{ key: 'Seller', copper: 123, items: [{ itemId: 'wolf_fang', count: 1 }] }],
+      nextListingId: 1,
+    });
+    const seller = sim.addPlayer('warrior', 'Seller', { characterKey: 'char:1' });
+    standAtMerchant(sim, seller);
+
+    sim.marketCollect(seller);
+
+    expect(copperOf(sim, seller)).toBe(123);
+    expect(sim.countItem('wolf_fang', seller)).toBe(1);
+    expect(sim.marketInfoFor(seller)!.collectionCopper).toBe(0);
+  });
+
   it('survives a save/load round-trip (persistence)', () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -261,6 +261,39 @@ describe('delta snapshots', () => {
   });
 });
 
+describe('server input hardening', () => {
+  it('rate-limits non-chat command bursts per connected client', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
+    fc.sent.length = 0;
+
+    for (let i = 0; i < 31; i++) {
+      server.handleMessage(session, JSON.stringify({ t: 'cmd', cmd: 'tab' }));
+    }
+
+    const events = fc.sent.flatMap((msg) => msg.t === 'events' ? msg.list : []);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'error',
+      text: 'You are issuing commands too quickly. Slow down.',
+    }));
+  });
+
+  it('clamps client-requested facing so an input frame cannot snap 180 degrees', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Testa');
+    const player = server.sim.entities.get(session.pid)!;
+    player.facing = 0;
+
+    server.handleMessage(session, JSON.stringify({ t: 'input', mi: {}, facing: Math.PI }));
+    expect(player.facing).toBeCloseTo(Math.PI / 2);
+
+    server.handleMessage(session, JSON.stringify({ t: 'input', mi: {}, facing: Math.PI }));
+    expect(player.facing).toBeCloseTo(Math.PI);
+  });
+});
+
 describe('chat moderation', () => {
   it('rate-limits chat bursts per connected client before cooldown', () => {
     const server = new GameServer();


### PR DESCRIPTION
## Summary
- Harden market seller ownership by using stable character-backed seller keys while preserving legacy name-key collection for migration.
- Add dungeon boss loot lockouts keyed by reset period so repeated instance resets cannot farm boss reward loot.
- Add arena recent-opponent rematch cooldowns, command burst rate limiting, and server-side facing-step clamping.
- Add per-username failed-attempt throttling to the admin login surface so distributed credential stuffing shares the same server-side bucket as public login.
- Add/adjust Vitest coverage for market ownership, dungeon lockouts, arena rematches, command throttling, facing clamp, admin-login throttling, and Windows newline HTML baseline handling.

## Verification
- `npx vitest run tests/admin.test.ts tests/security.test.ts` — 2 files passed, 56 tests passed.
- `npm test` — 49 files passed, 660 tests passed.
- `npx tsc --noEmit` — passed.
- `npm run build:server` — passed.
- `npm run build:env` — passed.
- `npm run build` — passed; only pre-existing cursor asset/chunk-size warnings observed.
- `npm audit --omit=dev --audit-level=moderate --json` — production vulnerabilities total 0.
- `git diff --check origin/release/v0.6...HEAD` — passed.

## Deployment note
This branch is based on `release/v0.6` because production documentation/handoff indicates that ref is the deployed production baseline. Direct push to `levy-street/world-of-claudecraft` is not available for the current GitHub account (`shupivot` has READ permission only), so this PR is opened from the fork for owner review/merge or deployment by an account with production access.