### PR TITLE
feat(ui): add first-run camera mode picker for new accounts

### DIFF
--- a/index.html
+++ b/index.html
@@ -713,6 +713,103 @@
   #confirm-dialog .cd-actions { display: flex; justify-content: flex-end; gap: 8px; }
   #confirm-dialog .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }
 
+  /* first-run camera mode picker */
+  #camera-mode-prompt { z-index: 310; }
+  #camera-mode-prompt .camera-mode-panel {
+    width: min(440px, calc(100vw - 32px));
+    padding: 18px;
+    border-radius: 8px;
+  }
+  #camera-mode-prompt .camera-mode-panel h2 {
+    margin: 0 0 8px;
+    font-family: var(--title-font);
+    font-size: 20px;
+    color: var(--gold);
+  }
+  #camera-mode-prompt .camera-mode-intro {
+    margin: 0 0 14px;
+    font-size: 12.5px;
+    line-height: 1.55;
+    color: #e8e0c8;
+  }
+  #camera-mode-prompt .camera-mode-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 14px;
+  }
+  #camera-mode-prompt .camera-mode-opt {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: 100%;
+    padding: 12px 36px 12px 12px;
+    text-align: left;
+    border: 1px solid #5a4a22;
+    border-radius: 6px;
+    background: #1a140a;
+    color: #e8e0c8;
+    cursor: pointer;
+    transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+  }
+  #camera-mode-prompt .camera-mode-opt:hover,
+  #camera-mode-prompt .camera-mode-opt:focus-visible {
+    border-color: #8a6a26;
+    background: #221a0d;
+    outline: none;
+  }
+  #camera-mode-prompt .camera-mode-opt.sel {
+    border-color: var(--gold);
+    background: #2c2410;
+    box-shadow: inset 0 0 0 1px #ffd10033;
+  }
+  #camera-mode-prompt .camera-mode-opt.sel::after {
+    content: "✓";
+    position: absolute;
+    right: 12px;
+    top: 12px;
+    width: 18px;
+    height: 18px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #120d04;
+    background: #ffd100;
+    border-radius: 50%;
+    font: 700 11px/1 var(--body-font);
+  }
+  #camera-mode-prompt .camera-mode-opt b {
+    font-size: 13px;
+    color: #fff;
+  }
+  #camera-mode-prompt .camera-mode-opt span {
+    font-size: 11.5px;
+    line-height: 1.45;
+    color: #c8b888;
+  }
+  #camera-mode-prompt .camera-mode-badge {
+    align-self: flex-start;
+    margin-bottom: 2px;
+    padding: 2px 7px;
+    border-radius: 999px;
+    background: linear-gradient(#8a6a26, #5a4413 55%, #473409);
+    color: #ffe6a8;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+  }
+  #camera-mode-prompt .camera-mode-actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+  #camera-mode-prompt .camera-mode-actions .btn {
+    min-width: 120px;
+    background: linear-gradient(#8a6a26, #5a4413 55%, #473409);
+    color: #ffe6a8;
+  }
+
   /* vendor */
   #vendor-window { width: 400px; }
   .vendor-item { display: flex; gap: 8px; align-items: center; padding: 5px; border-radius: 4px; cursor: pointer; }

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -31,6 +31,16 @@ export type GameSettings = { [K in NumericSettingKey]: number } & { [K in BoolSe
 interface Range { min: number; max: number; def: number }
 
 const STORE_KEY = 'woc_settings';
+const CAMERA_PROMPT_KEY = 'woc_camera_prompt_seen';
+
+/** Whether the first-run camera mode picker has been dismissed on this browser. */
+export function hasSeenCameraPrompt(): boolean {
+  try { return localStorage.getItem(CAMERA_PROMPT_KEY) === '1'; } catch { return true; }
+}
+
+export function markCameraPromptSeen(): void {
+  try { localStorage.setItem(CAMERA_PROMPT_KEY, '1'); } catch { /* storage unavailable */ }
+}
 const NUMERIC_KEYS = Object.keys(SETTING_RANGES) as NumericSettingKey[];
 const BOOL_KEYS = Object.keys(BOOL_SETTINGS) as BoolSettingKey[];
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { Sim } from './sim/sim';
 import { Renderer } from './render/renderer';
 import { Input } from './game/input';
 import { Keybinds } from './game/keybinds';
-import { Settings, GameSettings, SETTING_RANGES } from './game/settings';
+import { Settings, GameSettings, SETTING_RANGES, hasSeenCameraPrompt, markCameraPromptSeen } from './game/settings';
 import { MobileControls, PHONE_TOUCH_QUERY, isPhoneTouchDevice } from './game/mobile_controls';
 import { Hud } from './ui/hud';
 import { audio } from './game/audio';
@@ -26,6 +26,7 @@ const WORLD_SEED = 20061; // fixed: World of Claudecraft is a persistent place
 
 const $ = <T extends HTMLElement = HTMLElement>(sel: string): T => document.querySelector(sel) as T;
 let pendingDeleteCharacter: CharacterSummary | null = null;
+let pendingCameraPrompt = false;
 
 declare const __APP_VERSION__: string;
 declare const __APP_BUILD_ID__: string;
@@ -465,6 +466,16 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     settings,
     onSettingChange: (key, value) => applySetting(key, value),
   });
+  if (!isPhoneTouchDevice() && (pendingCameraPrompt || !hasSeenCameraPrompt())) {
+    hud.showCameraModePrompt((mouseCamera) => {
+      applySetting('mouseCamera', mouseCamera);
+      markCameraPromptSeen();
+      pendingCameraPrompt = false;
+    });
+  } else if (pendingCameraPrompt || !hasSeenCameraPrompt()) {
+    markCameraPromptSeen();
+    pendingCameraPrompt = false;
+  }
   if (online) {
     hud.attachReporting({
       submit: (targetPid, reason, details) => api.reportPlayer(online.characterId, targetPid, reason, details),
@@ -1822,7 +1833,10 @@ function wireStartScreens(): void {
     loginError('');
     try {
       if (mode === 'login') await api.login(username, password);
-      else await api.register(username, password);
+      else {
+        await api.register(username, password);
+        pendingCameraPrompt = true;
+      }
       $('#charselect-user').textContent = api.username ?? '';
       await enterRealmFlow();
     } catch (err: any) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -3927,7 +3927,58 @@ export class Hud {
 
   // True while a menu that should pause character movement is up.
   isModalOpen(): boolean {
-    return this.optionsOpen;
+    return this.optionsOpen || !!document.getElementById('camera-mode-prompt');
+  }
+
+  /** First-run picker for Classic vs Mouse Camera. Mouse Camera is pre-selected. */
+  showCameraModePrompt(onChoose: (mouseCamera: boolean) => void): void {
+    document.getElementById('camera-mode-prompt')?.remove();
+    let mouseCamera = true;
+    const backdrop = document.createElement('div');
+    backdrop.id = 'camera-mode-prompt';
+    backdrop.className = 'modal-backdrop';
+    backdrop.setAttribute('role', 'dialog');
+    backdrop.setAttribute('aria-modal', 'true');
+    backdrop.setAttribute('aria-labelledby', 'camera-mode-title');
+    const panel = document.createElement('div');
+    panel.className = 'confirm-modal panel auth-panel-premium camera-mode-panel';
+    panel.innerHTML = `<h2 id="camera-mode-title">${esc(t('game.cameraPrompt.title'))}</h2>`
+      + `<p class="camera-mode-intro">${esc(t('game.cameraPrompt.body'))}</p>`
+      + `<div class="camera-mode-options">`
+      + `<button type="button" class="camera-mode-opt" data-mode="classic">`
+      + `<b>${esc(t('game.cameraPrompt.classicTitle'))}</b>`
+      + `<span>${esc(t('game.cameraPrompt.classicDesc'))}<br>${esc(t('game.cameraPrompt.classicDescDrag'))}</span>`
+      + `</button>`
+      + `<button type="button" class="camera-mode-opt sel" data-mode="mouse">`
+      + `<span class="camera-mode-badge">${esc(t('game.cameraPrompt.recommended'))}</span>`
+      + `<b>${esc(t('game.cameraPrompt.mouseTitle'))}</b>`
+      + `<span>${esc(t('game.cameraPrompt.mouseDesc'))}</span>`
+      + `</button>`
+      + `</div>`
+      + `<div class="camera-mode-actions"><button type="button" class="btn" data-continue>${esc(t('game.cameraPrompt.continue'))}</button></div>`;
+    backdrop.appendChild(panel);
+    document.body.appendChild(backdrop);
+    const opts = panel.querySelectorAll<HTMLButtonElement>('.camera-mode-opt');
+    const sync = () => {
+      opts.forEach((btn) => btn.classList.toggle('sel', btn.dataset.mode === (mouseCamera ? 'mouse' : 'classic')));
+    };
+    opts.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        audio.click();
+        mouseCamera = btn.dataset.mode === 'mouse';
+        sync();
+      });
+    });
+    const close = (choice: boolean) => {
+      backdrop.remove();
+      music.resumeFromMenu();
+      onChoose(choice);
+    };
+    panel.querySelector('[data-continue]')!.addEventListener('click', () => {
+      audio.click();
+      close(mouseCamera);
+    });
+    music.pauseForMenu();
   }
 
   toggleOptionsMenu(): void {
@@ -4260,6 +4311,8 @@ export class Hud {
     if (this.marketOpen) { this.closeMarket(); closed = true; }
     const confirmEl = document.getElementById('confirm-dialog');
     if (confirmEl) { confirmEl.remove(); closed = true; }
+    const cameraPrompt = document.getElementById('camera-mode-prompt');
+    if (cameraPrompt) { cameraPrompt.remove(); closed = true; }
     for (const id of Hud.MODAL_IDS) {
       const el = $(id);
       if (el.style.display === 'block') {

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -72,6 +72,17 @@ export const gameStrings = {
   settings: {
     showOverflowXp: "Show Overflow XP",
   },
+  cameraPrompt: {
+    title: "Choose Your Camera",
+    body: "Pick how you want to move and look around. You can change this anytime in Esc → Key Bindings.",
+    classicTitle: "Classic Camera",
+    classicDesc: "A/D turns your character.",
+    classicDescDrag: "Drag with the mouse to orbit the camera.",
+    mouseTitle: "Mouse Camera",
+    mouseDesc: "Camera-relative movement: WASD moves where you look. A/D strafes. Hold right-click to look around.",
+    recommended: "Recommended",
+    continue: "Continue",
+  },
   // Talents & Specializations — UI chrome only (node/spec names are content,
   // rendered directly like ability names). Registered here so the panel routes
   // through t() per the i18n constraint.

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { Settings, SETTING_RANGES } from '../src/game/settings';
+import { Settings, SETTING_RANGES, hasSeenCameraPrompt, markCameraPromptSeen } from '../src/game/settings';
 
 function installStorage(): void {
   const map = new Map<string, string>();
@@ -82,5 +82,13 @@ describe('Settings', () => {
     const snap = s.all();
     snap.cameraSpeed = 99;
     expect(s.get('cameraSpeed')).not.toBe(99);
+  });
+});
+
+describe('camera prompt flag', () => {
+  it('starts unseen and persists once marked', () => {
+    expect(hasSeenCameraPrompt()).toBe(false);
+    markCameraPromptSeen();
+    expect(hasSeenCameraPrompt()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a first-run modal when entering the world after account creation (or on first play in a browser) so players can choose Classic or Mouse Camera.
- Mouse Camera is pre-selected and marked as recommended; the choice is persisted via the existing `mouseCamera` setting and can be changed later in Esc → Key Bindings.
- Skips the prompt on phone touch devices (joystick controls) and records dismissal in localStorage so it only appears once per browser.

## Test plan
- [ ] Clear `woc_camera_prompt_seen` from localStorage (or use a fresh profile)
- [ ] Create a new account, make a character, enter world — confirm the camera picker appears
- [ ] Verify Mouse Camera is selected by default; click Continue and confirm camera-relative movement works
- [ ] Select Classic Camera instead, continue, and confirm A/D turns + drag-to-orbit behavior
- [ ] Re-enter world on the same browser — confirm the picker does not reappear
- [ ] `npx vitest run tests/settings.test.ts`