### PR TITLE
fix: clear stale online movement input

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
-import { DT, Entity, SimEvent, dist2d } from '../src/sim/types';
+import { DT, Entity, SimEvent, dist2d, emptyMoveInput } from '../src/sim/types';
 import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
@@ -45,6 +45,10 @@ const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
 const WHO_RESULT_LIMIT = 50;
+// Clients stream movement intent every 50ms. If that stream goes silent while
+// the last packet held a key down, stop applying it instead of turning/running
+// forever. 750ms leaves room for normal jitter and short browser stalls.
+const STALE_INPUT_SECONDS = 0.75;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
 
@@ -73,6 +77,8 @@ export interface ClientSession {
   rememberedChat: RememberedChat;
   // last client input sequence processed; echoed in snapshots for latency telemetry
   lastInputSeq: number;
+  // sim time of the last movement input frame, used to clear stale held input
+  lastInputAt: number;
   // serialized form of each delta self field as last sent to this client;
   // a field is omitted from a snapshot while its serialization is unchanged
   lastSent: Record<string, string>;
@@ -430,6 +436,7 @@ export class GameServer {
       if (dt > 0.5) dt = 0.5;
       acc += dt;
       while (acc >= DT) {
+        this.clearStaleInputs();
         const events = this.sim.tick();
         this.routeEvents(events);
         acc -= DT;
@@ -457,6 +464,19 @@ export class GameServer {
 
   // -------------------------------------------------------------------------
 
+  private clearStaleInputs(): void {
+    for (const session of this.clients.values()) {
+      if (this.sim.time - session.lastInputAt <= STALE_INPUT_SECONDS) continue;
+      const meta = this.sim.meta(session.pid);
+      if (!meta) continue;
+      const mi = meta.moveInput;
+      if (!(mi.forward || mi.back || mi.turnLeft || mi.turnRight || mi.strafeLeft || mi.strafeRight || mi.jump)) continue;
+      Object.assign(meta.moveInput, emptyMoveInput());
+    }
+  }
+
+  // -------------------------------------------------------------------------
+
   join(ws: WebSocket, accountId: number, characterId: number, name: string, cls: import('../src/sim/types').PlayerClass, state: import('../src/sim/sim').CharacterState | null, isGm = false): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
@@ -477,6 +497,7 @@ export class GameServer {
       lastWhisperFrom: null,
       rememberedChat: { channel: 'say' },
       lastInputSeq: 0,
+      lastInputAt: this.sim.time,
       lastSent: {},
       sentEnts: new Map(),
     };
@@ -691,6 +712,7 @@ export class GameServer {
       if (!meta || !e) return;
       const { moveInput, facing } = parseMoveInputFrame(msg);
       Object.assign(meta.moveInput, moveInput);
+      session.lastInputAt = sim.time;
       if (typeof msg.seq === 'number' && Number.isFinite(msg.seq) && msg.seq > 0) {
         session.lastInputSeq = Math.max(session.lastInputSeq, Math.floor(msg.seq));
       }

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -15,7 +15,7 @@ vi.mock('../server/db', () => ({
 import { censorChatText, GameServer, ClientSession } from '../server/game';
 import { saveCharacterState } from '../server/db';
 import { ClientWorld } from '../src/net/online';
-import type { PlayerClass } from '../src/sim/types';
+import { DT, type PlayerClass } from '../src/sim/types';
 
 const DELTA_KEYS = ['inv', 'buyback', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
 
@@ -294,6 +294,30 @@ describe('delta snapshots', () => {
     expect(snapOld.self).not.toHaveProperty('inv');
     // both players spawn together, so each sees the other in ents
     expect(snapNew.ents.some((e: any) => e.id === session.pid)).toBe(true);
+  });
+});
+
+describe('online movement input lifetime', () => {
+  it('clears stale held movement when the websocket input stream goes quiet', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Spinner');
+
+    server.handleMessage(session, JSON.stringify({
+      t: 'input',
+      seq: 1,
+      mi: { f: 0, b: 0, tl: 1, tr: 0, sl: 0, sr: 0, j: 0 },
+    }));
+    const meta = server.sim.meta(session.pid)!;
+    expect(meta.moveInput.turnLeft).toBe(true);
+
+    for (let i = 0; i < Math.floor(0.5 / DT); i++) server.sim.tick();
+    (server as any).clearStaleInputs();
+    expect(meta.moveInput.turnLeft).toBe(true);
+
+    for (let i = 0; i < Math.ceil(0.35 / DT); i++) server.sim.tick();
+    (server as any).clearStaleInputs();
+    expect(meta.moveInput.turnLeft).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary\n\nAdds a conservative server-side stale input backstop for online movement.\n\nThe client normally streams movement input every 50ms. If that stream goes silent while the last packet held movement/turning, the server now clears the stored movement input after 750ms instead of applying it forever.\n\n## Why\n\nA stuck-spin report can happen if the server receives a held input like `turnLeft=true` but never receives the matching neutral/release input. WebSockets are ordered while healthy, but browser focus/pointer-lock issues, stalls, or stale connection edge cases can still leave the server with a held input as the last known state.\n\nThis changes the failure mode from "spin/run forever" to "movement stops after a short input-stream silence". Holding a key normally should keep working because the client keeps sending input frames far more frequently than the timeout.\n\n## Implementation\n\n- Tracks `lastInputAt` per online session using sim time.\n- Updates `lastInputAt` whenever an input frame arrives.\n- Before each server sim tick, clears movement input for sessions whose input stream has been silent for more than `0.75s`.\n- Only clears when there is actually held movement input.\n\n## Validation\n\n- `npx tsc --noEmit`\n- `npx vitest run tests/snapshots.test.ts tests/move_input.test.ts` (2 files, 33 tests)\n- `npm test` (96 files, 899 tests)\n- `npm run build` (passed; existing cursor URL and large bundle warnings only)\n- `npm run asset:budget`\n