### PR TITLE
fix: unblock fresh installs and test imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,17 +2770,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/server/db.ts
+++ b/server/db.ts
@@ -18,7 +18,9 @@ export const DATABASE_URL =
 
 export const pool = new Pool({ connectionString: DATABASE_URL, max: 10 });
 
-const SCHEMA = `
+const REALM_SQL_DEFAULT = REALM.replace(/'/g, "''");
+
+export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS accounts (
   id SERIAL PRIMARY KEY,
   username TEXT UNIQUE NOT NULL,
@@ -38,12 +40,14 @@ CREATE TABLE IF NOT EXISTS characters (
   account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
   name TEXT UNIQUE NOT NULL,
   class TEXT NOT NULL,
+  realm TEXT NOT NULL DEFAULT '${REALM_SQL_DEFAULT}',
   level INT NOT NULL DEFAULT 1,
   state JSONB,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS characters_account ON characters(account_id);
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS realm TEXT NOT NULL DEFAULT '${REALM_SQL_DEFAULT}';
 -- Max-Level XP Overflow leaderboard: indexed lifetime-XP sort key. The first
 -- index serves the realm-scoped in-game panel; the second serves the global
 -- (cross-realm) home-page board.

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -1991,6 +1991,36 @@ export type SupportedLanguage = keyof typeof translations;
 
 let currentLanguage: SupportedLanguage = "en";
 
+function browserStorage(): Storage | null {
+  try {
+    const storage = globalThis.localStorage;
+    return storage && typeof storage === "object" ? storage : null;
+  } catch {
+    return null;
+  }
+}
+
+function getStoredLanguage(): SupportedLanguage | null {
+  const storage = browserStorage();
+  if (!storage || typeof storage.getItem !== "function") return null;
+  try {
+    const saved = storage.getItem("locale") as SupportedLanguage | null;
+    return saved && translations[saved] ? saved : null;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredLanguage(lang: SupportedLanguage): void {
+  const storage = browserStorage();
+  if (!storage || typeof storage.setItem !== "function") return;
+  try {
+    storage.setItem("locale", lang);
+  } catch {
+    // Storage may be disabled or unavailable in test/browser privacy modes.
+  }
+}
+
 // Initialize language from URL query or localStorage if available (browser environments)
 if (typeof window !== "undefined" && window.location) {
   const params = new URLSearchParams(window.location.search);
@@ -1998,16 +2028,10 @@ if (typeof window !== "undefined" && window.location) {
   if (langParam && translations[langParam]) {
     currentLanguage = langParam;
   } else {
-    const saved = localStorage.getItem("locale") as SupportedLanguage | null;
-    if (saved && translations[saved]) {
-      currentLanguage = saved;
-    }
+    currentLanguage = getStoredLanguage() ?? currentLanguage;
   }
-} else if (typeof localStorage !== "undefined") {
-  const saved = localStorage.getItem("locale") as SupportedLanguage | null;
-  if (saved && translations[saved]) {
-    currentLanguage = saved;
-  }
+} else {
+  currentLanguage = getStoredLanguage() ?? currentLanguage;
 }
 
 export function getLanguage(): SupportedLanguage {
@@ -2016,9 +2040,7 @@ export function getLanguage(): SupportedLanguage {
 
 export function setLanguage(lang: SupportedLanguage): void {
   currentLanguage = lang;
-  if (typeof localStorage !== "undefined") {
-    localStorage.setItem("locale", lang);
-  }
+  setStoredLanguage(lang);
 }
 
 export function t(key: Leaves<typeof en>): string {

--- a/tests/db_search.test.ts
+++ b/tests/db_search.test.ts
@@ -11,7 +11,7 @@ vi.mock('pg', () => ({
   }),
 }));
 
-import { searchCharacters } from '../server/db';
+import { SCHEMA, searchCharacters } from '../server/db';
 import { SOCIAL_SCHEMA } from '../server/social_db';
 
 beforeEach(() => {
@@ -19,6 +19,12 @@ beforeEach(() => {
 });
 
 describe('character typeahead search', () => {
+  it('adds the realm column before indexes that depend on it', () => {
+    expect(SCHEMA).toContain('ALTER TABLE characters ADD COLUMN IF NOT EXISTS realm');
+    expect(SCHEMA.indexOf('ADD COLUMN IF NOT EXISTS realm'))
+      .toBeLessThan(SCHEMA.indexOf('CREATE INDEX IF NOT EXISTS characters_lifetime_xp'));
+  });
+
   it('creates a realm-scoped lower-name prefix index', () => {
     expect(SOCIAL_SCHEMA).toContain('CREATE INDEX IF NOT EXISTS characters_realm_lower_name_prefix');
     expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name) text_pattern_ops)');


### PR DESCRIPTION
## Summary

- Add `characters.realm` during core schema setup before creating lifetime-XP indexes that depend on it.
- Guard i18n `localStorage` reads and writes so imports and language changes do not crash when storage is unavailable or partially implemented.
- Bump the transitive `form-data` lockfile entry from `4.0.5` to `4.0.6` to clear the current high-severity audit advisory.

## Root cause

Fresh databases failed during schema setup because the lifetime-XP index referenced `characters.realm` before that column was created. The i18n module also assumed that any defined `localStorage` object had working `getItem` and `setItem` methods.

## Validation

- `npx vitest run tests/db_search.test.ts tests/homepage_foundation.test.ts tests/xp.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npm audit --audit-level=moderate`
- `npm run build:env`
- `npm run build:server`
- `npm run build`
- Fresh Postgres startup smoke: initialized an empty temporary Postgres cluster, booted the built server against it, confirmed `/api/status` returned healthy, and verified both the `characters.realm` column and `characters_lifetime_xp` index exist.
