### PR TITLE
fix: harden release gameplay and server integrity paths

### DIFF
--- a/headless/env_server.ts
+++ b/headless/env_server.ts
@@ -15,6 +15,7 @@ import * as readline from 'node:readline';
 import { Sim, RewardCounters } from '../src/sim/sim';
 import { ACTIONS, NUM_ACTIONS, applyAction, encodeObs, obsSize } from '../src/sim/obs';
 import { MAX_LEVEL } from '../src/sim/types';
+import { MAX_INPUT_LINE_LENGTH, validateAction } from './protocol';
 
 interface EnvConfig {
   frameSkip: number; // sim ticks per env step (20 ticks = 1 second)
@@ -152,6 +153,10 @@ function serve(): void {
   const send = (obj: object) => process.stdout.write(JSON.stringify(obj) + '\n');
 
   rl.on('line', (line: string) => {
+    if (line.length > MAX_INPUT_LINE_LENGTH) {
+      send({ error: 'input line too large' });
+      return;
+    }
     line = line.trim();
     if (!line) return;
     let msg: any;
@@ -170,7 +175,14 @@ function serve(): void {
           send(env.reset(msg.seed ?? 0, msg.player_class ?? 'warrior', msg.config ?? {}));
           break;
         case 'step':
-          send(env.step(msg.action ?? 0));
+          {
+            const action = validateAction(msg.action ?? 0);
+            if (action === null) {
+              send({ error: `invalid action: expected integer 0-${NUM_ACTIONS - 1}` });
+              break;
+            }
+            send(env.step(action));
+          }
           break;
         case 'close':
           send({ ok: true });

--- a/headless/protocol.ts
+++ b/headless/protocol.ts
@@ -1,0 +1,9 @@
+import { NUM_ACTIONS } from '../src/sim/obs';
+
+export const MAX_INPUT_LINE_LENGTH = 1024 * 1024;
+
+export function validateAction(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isInteger(value)) return null;
+  if (value < 0 || value >= NUM_ACTIONS) return null;
+  return value;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2770,17 +2770,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"

--- a/server/db.ts
+++ b/server/db.ts
@@ -274,6 +274,36 @@ export async function createCharacter(accountId: number, name: string, cls: Play
   return res.rows[0];
 }
 
+export async function createCharacterCapped(
+  accountId: number,
+  name: string,
+  cls: PlayerClass,
+  limit = 10,
+): Promise<CharacterRow | null> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const account = await client.query('SELECT id FROM accounts WHERE id = $1 FOR UPDATE', [accountId]);
+    if ((account.rowCount ?? 0) === 0) { await client.query('ROLLBACK'); return null; }
+    const count = await client.query(
+      'SELECT count(*)::int AS n FROM characters WHERE account_id = $1 AND realm = $2',
+      [accountId, REALM],
+    );
+    if (Number(count.rows[0]?.n ?? 0) >= limit) { await client.query('ROLLBACK'); return null; }
+    const res = await client.query(
+      'INSERT INTO characters (account_id, name, class, realm) VALUES ($1, $2, $3, $4) RETURNING id, account_id, name, class, level, state, is_gm, force_rename',
+      [accountId, name, cls, REALM],
+    );
+    await client.query('COMMIT');
+    return res.rows[0];
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
 export async function deleteCharacter(accountId: number, characterId: number): Promise<boolean> {
   const res = await pool.query('DELETE FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3', [characterId, accountId, REALM]);
   return (res.rowCount ?? 0) > 0;

--- a/server/db.ts
+++ b/server/db.ts
@@ -18,7 +18,9 @@ export const DATABASE_URL =
 
 export const pool = new Pool({ connectionString: DATABASE_URL, max: 10 });
 
-const SCHEMA = `
+const REALM_SQL_DEFAULT = REALM.replace(/'/g, "''");
+
+export const SCHEMA = `
 CREATE TABLE IF NOT EXISTS accounts (
   id SERIAL PRIMARY KEY,
   username TEXT UNIQUE NOT NULL,
@@ -38,12 +40,14 @@ CREATE TABLE IF NOT EXISTS characters (
   account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
   name TEXT UNIQUE NOT NULL,
   class TEXT NOT NULL,
+  realm TEXT NOT NULL DEFAULT '${REALM_SQL_DEFAULT}',
   level INT NOT NULL DEFAULT 1,
   state JSONB,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS characters_account ON characters(account_id);
+ALTER TABLE characters ADD COLUMN IF NOT EXISTS realm TEXT NOT NULL DEFAULT '${REALM_SQL_DEFAULT}';
 -- Max-Level XP Overflow leaderboard: indexed lifetime-XP sort key. The first
 -- index serves the realm-scoped in-game panel; the second serves the global
 -- (cross-realm) home-page board.

--- a/server/game.ts
+++ b/server/game.ts
@@ -1196,8 +1196,7 @@ export class GameServer {
     const sent = this.sim.chat(censorChatText(text), pid);
     if (sent) {
       if (sent.channel === 'whisper') {
-        const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+[\s\S]+$/i.exec(text);
-        if (wm) session.rememberedChat = { channel: 'whisper', target: wm[1] };
+        if (sent.target) session.rememberedChat = { channel: 'whisper', target: sent.target };
       } else {
         session.rememberedChat = { channel: sent.channel };
       }

--- a/server/main.ts
+++ b/server/main.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import { WebSocketServer, WebSocket } from 'ws';
 import {
   ensureSchema, pool, createAccount, findAccount, getAccountsCount, touchLogin, saveToken, accountForToken,
-  listCharacters, getCharacter, createCharacter, deleteCharacter, closeOrphanSessions,
+  listCharacters, getCharacter, createCharacterCapped, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
   findCharacterReportTargetByName, topArenaRatings, topLifetimeXp,
 } from './db';
@@ -254,10 +254,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         if (offensiveName(name)) return json(res, 400, { error: 'character name is not allowed' });
         const validClasses = ['warrior', 'paladin', 'hunter', 'rogue', 'priest', 'shaman', 'mage', 'warlock', 'druid'];
         if (!validClasses.includes(body.class)) return json(res, 400, { error: 'invalid class' });
-        const chars = await listCharacters(accountId);
-        if (chars.length >= 10) return json(res, 400, { error: 'character limit reached' });
         try {
-          const c = await createCharacter(accountId, name, body.class);
+          const c = await createCharacterCapped(accountId, name, body.class, 10);
+          if (!c) return json(res, 400, { error: 'character limit reached' });
           return json(res, 200, { id: c.id, name: c.name, class: c.class, level: c.level, forceRename: c.force_rename });
         } catch (err: any) {
           if (isUniqueViolation(err)) return json(res, 409, { error: 'that name is taken' });

--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -219,3 +219,23 @@ export function isBlocked(seed: number, x: number, z: number, r = 0.5): boolean 
   const res = resolvePosition(seed, x, z, r);
   return Math.abs(res.x - x) > 1e-4 || Math.abs(res.z - z) > 1e-4;
 }
+
+export function lineOfSightClear(
+  seed: number,
+  from: { x: number; z: number },
+  to: { x: number; z: number },
+  r = 0.05,
+): boolean {
+  const dx = to.x - from.x;
+  const dz = to.z - from.z;
+  const d = Math.hypot(dx, dz);
+  if (d < 1e-6) return true;
+  const steps = Math.max(2, Math.ceil(d / 0.5));
+  for (let i = 1; i < steps; i++) {
+    const t = i / steps;
+    const x = from.x + dx * t;
+    const z = from.z + dz * t;
+    if (isBlocked(seed, x, z, r)) return false;
+  }
+  return true;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5,7 +5,7 @@ import {
   zoneAt,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
-import { resolvePosition } from './colliders';
+import { lineOfSightClear, resolvePosition } from './colliders';
 import { findPath } from './pathfind';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
 import {
@@ -219,6 +219,7 @@ export interface RewardCounters {
 export interface SentChat {
   channel: 'say' | 'yell' | 'whisper' | 'general' | 'party';
   message: string;
+  target?: string;
 }
 
 // Per-player progression and bags. The entity holds combat state; this holds
@@ -1512,6 +1513,19 @@ export class Sim {
     this.emit({ type: 'castStop', entityId: p.id, success: false });
   }
 
+  private abilityNeedsLineOfSight(ability: AbilityDef): boolean {
+    if (!ability.requiresTarget) return false;
+    return ability.school !== 'physical' || ability.range > MELEE_RANGE;
+  }
+
+  private hasLineOfSight(source: Entity, target: Entity): boolean {
+    return lineOfSightClear(this.cfg.seed, source.pos, target.pos);
+  }
+
+  private lineOfSightBlocked(source: Entity, target: Entity, ability: AbilityDef): boolean {
+    return this.abilityNeedsLineOfSight(ability) && !this.hasLineOfSight(source, target);
+  }
+
   private pushbackCast(p: Entity): void {
     if (p.channeling) {
       p.castRemaining = Math.max(0, p.castRemaining - p.castTotal * CHANNEL_PUSHBACK_FRACTION);
@@ -1583,6 +1597,7 @@ export class Sim {
       target = cur && !cur.dead && this.isFriendlyTo(p, cur) ? cur : p;
       const d = dist2d(p.pos, target.pos);
       if (d > Math.max(ability.range, 5)) { this.error(p.id, 'Out of range.'); return; }
+      if (this.lineOfSightBlocked(p, target, ability)) { this.error(p.id, 'Line of sight.'); return; }
     } else if (ability.requiresTarget) {
       target = p.targetId !== null ? this.entities.get(p.targetId) ?? null : null;
       if (!target || target.dead || !this.isHostileTo(p, target)) { this.error(p.id, 'You have no target.'); return; }
@@ -1590,6 +1605,7 @@ export class Sim {
       const maxRange = ability.range > 0 ? ability.range : MELEE_RANGE;
       if (d > maxRange) { this.error(p.id, 'Out of range.'); return; }
       if (ability.minRange && d < ability.minRange) { this.error(p.id, 'Too close!'); return; }
+      if (this.lineOfSightBlocked(p, target, ability)) { this.error(p.id, 'Line of sight.'); return; }
       const facingDiff = Math.abs(normAngle(angleTo(p.pos, target.pos) - p.facing));
       if (facingDiff > MELEE_ARC) { this.error(p.id, 'You must be facing your target.'); return; }
       // execute-style gate: only usable while the target is nearly dead
@@ -1688,6 +1704,11 @@ export class Sim {
   private applyChannelTick(p: Entity, res: ResolvedAbility): void {
     const target = p.targetId !== null ? this.entities.get(p.targetId) : null;
     if (!target || target.dead) { this.cancelCast(p); return; }
+    if (this.lineOfSightBlocked(p, target, res.def)) {
+      this.error(p.id, 'Line of sight.');
+      this.cancelCast(p);
+      return;
+    }
     this.emit({ type: 'spellfx', sourceId: p.id, targetId: target.id, school: res.def.school, fx: 'projectile' });
     for (const eff of res.effects) {
       if (eff.type === 'directDamage') {
@@ -1766,12 +1787,14 @@ export class Sim {
       const cur = p.targetId !== null ? this.entities.get(p.targetId) ?? null : null;
       target = cur && !cur.dead && this.isFriendlyTo(p, cur) ? cur : p;
       if (dist2d(p.pos, target.pos) > Math.max(ability.range, 5) + 2) { this.error(p.id, 'Out of range.'); return; }
+      if (this.lineOfSightBlocked(p, target, ability)) { this.error(p.id, 'Line of sight.'); return; }
     } else if (ability.requiresTarget) {
       target = p.targetId !== null ? this.entities.get(p.targetId) ?? null : null;
       if (!target || target.dead) { this.error(p.id, 'You have no target.'); return; }
       const d = dist2d(p.pos, target.pos);
       const maxRange = ability.range > 0 ? ability.range : MELEE_RANGE;
       if (d > maxRange + 2) { this.error(p.id, 'Out of range.'); return; }
+      if (this.lineOfSightBlocked(p, target, ability)) { this.error(p.id, 'Line of sight.'); return; }
     }
     if (p.resource < res.cost && !this.formShiftKind(p, ability)) { this.error(p.id, 'Not enough ' + (p.resourceType ?? 'resource') + '!'); return; }
 
@@ -1999,6 +2022,7 @@ export class Sim {
         case 'aoeDamage': {
           this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: ability.school, fx: 'nova' });
           for (const m of this.mobsInRadius(p.pos, eff.radius)) {
+            if (!this.hasLineOfSight(p, m)) continue;
             let dmg = this.rng.range(eff.min, eff.max);
             // Armor only mitigates physical damage, mirroring the single-target
             // path above — spell-school AoE (Arcane Explosion, Consecration) is
@@ -2011,6 +2035,7 @@ export class Sim {
         case 'aoeAttackSpeed': {
           for (const m of this.mobsInRadius(p.pos, eff.radius)) {
             if (m.dead) continue;
+            if (!this.hasLineOfSight(p, m)) continue;
             this.applyAura(m, {
               id: ability.id + '_as', name: ability.name, kind: 'attackspeed',
               remaining: eff.duration, duration: eff.duration, value: eff.mult,
@@ -2022,6 +2047,7 @@ export class Sim {
         case 'aoeRoot': {
           this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: ability.school, fx: 'nova' });
           for (const m of this.hostilesInRadius(p, p.pos, eff.radius)) {
+            if (!this.hasLineOfSight(p, m)) continue;
             const dmg = this.rng.range(eff.min, eff.max);
             this.dealDamage(p, m, Math.round(dmg), false, ability.school, ability.name, 'hit');
             if (!m.dead && this.isHostileTo(p, m)) {
@@ -2332,6 +2358,7 @@ export class Sim {
     // casters (wand-style, no dead zone so they don't run into melee — #94)
     const ranged = CLASSES[meta.cls].ranged;
     if (ranged && d <= ranged.maxRange && d >= (ranged.wand ? 0 : ranged.minRange)) {
+      if (!this.hasLineOfSight(p, t)) return;
       this.rangedSwing(p, t, ranged);
       p.swingTimer = ranged.speed * this.swingIntervalMult(p);
       return;
@@ -3672,16 +3699,17 @@ export class Sim {
     const { meta, e: p } = r;
     const mob = this.entities.get(mobId);
     if (!mob || !mob.lootable || !mob.loot) return;
-    if (mob.tappedById !== null && mob.tappedById !== meta.entityId) {
-      // party members of the tapper share loot rights
-      const tapperParty = this.partyOf(mob.tappedById);
-      if (!tapperParty || !tapperParty.members.includes(meta.entityId)) {
-        this.error(meta.entityId, "You don't have permission to loot that.");
-        return;
-      }
+    const tapperParty = mob.tappedById !== null ? this.partyOf(mob.tappedById) : null;
+    const hasSharedLootRights = mob.tappedById === null
+      || mob.tappedById === meta.entityId
+      || !!tapperParty?.members.includes(meta.entityId);
+    const hasPersonalLoot = mob.loot.items.some((s) => s.personalFor?.includes(meta.entityId));
+    if (!hasSharedLootRights && !hasPersonalLoot) {
+      this.error(meta.entityId, "You don't have permission to loot that.");
+      return;
     }
     if (dist2d(p.pos, mob.pos) > INTERACT_RANGE) { this.error(meta.entityId, 'Too far away.'); return; }
-    if (mob.loot.copper > 0) {
+    if (hasSharedLootRights && mob.loot.copper > 0) {
       meta.copper += mob.loot.copper;
       meta.counters.lootCopper += mob.loot.copper;
       this.emit({ type: 'loot', text: `You loot ${formatMoney(mob.loot.copper)}.`, pid: meta.entityId });
@@ -3694,6 +3722,7 @@ export class Sim {
         s.personalFor = s.personalFor.filter((id) => id !== meta.entityId);
         continue;
       }
+      if (!hasSharedLootRights) continue;
       for (let i = 0; i < s.count; i++) {
         if (!this.rollGroupLoot(s.itemId, mob, meta)) this.addItem(s.itemId, 1, meta.entityId);
       }
@@ -3946,6 +3975,40 @@ export class Sim {
     return true;
   }
 
+  private whisperMessageForName(rest: string, name: string, exactCase: boolean): string | null {
+    const input = exactCase ? rest : rest.toLowerCase();
+    const prefix = exactCase ? name : name.toLowerCase();
+    if (!input.startsWith(prefix)) return null;
+    const next = rest.charAt(name.length);
+    if (!next || !/\s/.test(next)) return null;
+    const message = rest.slice(name.length).trim();
+    return message ? message : null;
+  }
+
+  private resolveWhisperTarget(rest: string): { target: PlayerMeta; message: string } | { error: string } | null {
+    const trimmed = rest.trim();
+    if (!trimmed) return null;
+    const matches: { target: PlayerMeta; message: string; exactCase: boolean }[] = [];
+    for (const target of this.players.values()) {
+      const exactMessage = this.whisperMessageForName(trimmed, target.name, true);
+      if (exactMessage !== null) {
+        matches.push({ target, message: exactMessage, exactCase: true });
+        continue;
+      }
+      const insensitiveMessage = this.whisperMessageForName(trimmed, target.name, false);
+      if (insensitiveMessage !== null) matches.push({ target, message: insensitiveMessage, exactCase: false });
+    }
+    matches.sort((a, b) => b.target.name.length - a.target.name.length);
+    const longestLength = matches[0]?.target.name.length ?? 0;
+    const longest = matches.filter((m) => m.target.name.length === longestLength);
+    const exact = longest.filter((m) => m.exactCase);
+    if (exact.length > 0) return exact[0];
+    if (longest.length === 1) return longest[0];
+    const typedName = trimmed.split(/\s+/, 1)[0] ?? trimmed;
+    if (longest.length > 1) return { error: `Several players match '${typedName}'. Use exact capitalization.` };
+    return { error: `There is no player named '${typedName}' online.` };
+  }
+
   chat(text: string, pid?: number): SentChat | null {
     const r = this.resolve(pid);
     if (!r) return null;
@@ -3962,30 +4025,16 @@ export class Sim {
     }
 
     // "/w name message" — private whisper to an online player
-    const wm = /^\/(?:w|whisper|t|tell)\s+(\S+)\s+([\s\S]+)$/i.exec(raw);
+    const wm = /^\/(?:w|whisper|t|tell)\s+([\s\S]+)$/i.exec(raw);
     if (wm) {
-      const targetName = wm[1];
-      const msg = wm[2].trim();
-      if (!msg) return null;
-      // exact case wins outright; otherwise a case-insensitive match is used
-      // only when unambiguous, so 'Bet' and 'bet' can't silently intercept
-      // each other's whispers
-      let target: PlayerMeta | null = null;
-      const ciMatches: PlayerMeta[] = [];
-      const wanted = targetName.toLowerCase();
-      for (const meta of this.players.values()) {
-        if (meta.name === targetName) { target = meta; break; }
-        if (meta.name.toLowerCase() === wanted) ciMatches.push(meta);
-      }
-      if (!target) {
-        if (ciMatches.length === 1) target = ciMatches[0];
-        else if (ciMatches.length > 1) { this.error(r.meta.entityId, `Several players match '${targetName}'. Use exact capitalization.`); return null; }
-      }
-      if (!target) { this.error(r.meta.entityId, `There is no player named '${targetName}' online.`); return null; }
+      const resolved = this.resolveWhisperTarget(wm[1]);
+      if (!resolved) return null;
+      if ('error' in resolved) { this.error(r.meta.entityId, resolved.error); return null; }
+      const { target, message: msg } = resolved;
       if (target.entityId === r.meta.entityId) { this.error(r.meta.entityId, 'You mutter to yourself. Nobody hears it.'); return null; }
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, text: msg, channel: 'whisper', pid: target.entityId });
       this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
-      return { channel: 'whisper', message: msg };
+      return { channel: 'whisper', message: msg, target: target.name };
     }
 
     // "/p message" goes to the party channel

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -1991,6 +1991,36 @@ export type SupportedLanguage = keyof typeof translations;
 
 let currentLanguage: SupportedLanguage = "en";
 
+function browserStorage(): Storage | null {
+  try {
+    const storage = globalThis.localStorage;
+    return storage && typeof storage === "object" ? storage : null;
+  } catch {
+    return null;
+  }
+}
+
+function getStoredLanguage(): SupportedLanguage | null {
+  const storage = browserStorage();
+  if (!storage || typeof storage.getItem !== "function") return null;
+  try {
+    const saved = storage.getItem("locale") as SupportedLanguage | null;
+    return saved && translations[saved] ? saved : null;
+  } catch {
+    return null;
+  }
+}
+
+function setStoredLanguage(lang: SupportedLanguage): void {
+  const storage = browserStorage();
+  if (!storage || typeof storage.setItem !== "function") return;
+  try {
+    storage.setItem("locale", lang);
+  } catch {
+    // Storage may be disabled or unavailable in test/browser privacy modes.
+  }
+}
+
 // Initialize language from URL query or localStorage if available (browser environments)
 if (typeof window !== "undefined" && window.location) {
   const params = new URLSearchParams(window.location.search);
@@ -1998,16 +2028,10 @@ if (typeof window !== "undefined" && window.location) {
   if (langParam && translations[langParam]) {
     currentLanguage = langParam;
   } else {
-    const saved = localStorage.getItem("locale") as SupportedLanguage | null;
-    if (saved && translations[saved]) {
-      currentLanguage = saved;
-    }
+    currentLanguage = getStoredLanguage() ?? currentLanguage;
   }
-} else if (typeof localStorage !== "undefined") {
-  const saved = localStorage.getItem("locale") as SupportedLanguage | null;
-  if (saved && translations[saved]) {
-    currentLanguage = saved;
-  }
+} else {
+  currentLanguage = getStoredLanguage() ?? currentLanguage;
 }
 
 export function getLanguage(): SupportedLanguage {
@@ -2016,9 +2040,7 @@ export function getLanguage(): SupportedLanguage {
 
 export function setLanguage(lang: SupportedLanguage): void {
   currentLanguage = lang;
-  if (typeof localStorage !== "undefined") {
-    localStorage.setItem("locale", lang);
-  }
+  setStoredLanguage(lang);
 }
 
 export function t(key: Leaves<typeof en>): string {

--- a/tests/character_db.test.ts
+++ b/tests/character_db.test.ts
@@ -2,30 +2,37 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // db.ts builds a pg Pool and requires DATABASE_URL at import time; stub both so
 // the module loads and every query goes through a spy we can assert against.
-const { query } = vi.hoisted(() => ({ query: vi.fn() }));
+const dbMock = vi.hoisted(() => ({ query: vi.fn(), connect: vi.fn() }));
 vi.hoisted(() => {
   process.env.DATABASE_URL = 'postgres://test/test';
 });
 vi.mock('pg', () => ({
   Pool: function Pool() {
-    return { query };
+    return { query: dbMock.query, connect: dbMock.connect };
   },
 }));
 
-import { deleteCharacter } from '../server/db';
+import { createCharacterCapped, deleteCharacter } from '../server/db';
 import { REALM } from '../server/realm';
 
 beforeEach(() => {
-  query.mockReset();
+  dbMock.query.mockReset();
+  dbMock.connect.mockReset();
 });
+
+function clientStub() {
+  const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 0 } as any);
+  const release = vi.fn();
+  return { query, release };
+}
 
 describe('deleteCharacter', () => {
   it('scopes the delete to the current realm so cross-realm characters are safe', async () => {
-    query.mockResolvedValueOnce({ rowCount: 1 } as any);
+    dbMock.query.mockResolvedValueOnce({ rowCount: 1 } as any);
 
     await deleteCharacter(7, 42);
 
-    const [sql, params] = query.mock.calls[0];
+    const [sql, params] = dbMock.query.mock.calls[0];
     expect(sql).toMatch(/realm/i);
     expect(params).toContain(REALM);
     // id + account + realm — the same three predicates getCharacter/renameCharacter use
@@ -33,10 +40,74 @@ describe('deleteCharacter', () => {
   });
 
   it('reports whether a row was actually deleted', async () => {
-    query.mockResolvedValueOnce({ rowCount: 0 } as any);
+    dbMock.query.mockResolvedValueOnce({ rowCount: 0 } as any);
     expect(await deleteCharacter(7, 42)).toBe(false);
 
-    query.mockResolvedValueOnce({ rowCount: 1 } as any);
+    dbMock.query.mockResolvedValueOnce({ rowCount: 1 } as any);
     expect(await deleteCharacter(7, 42)).toBe(true);
+  });
+});
+
+describe('createCharacterCapped', () => {
+  it('locks the account row and checks the realm-scoped character count before inserting', async () => {
+    const client = clientStub();
+    dbMock.connect.mockResolvedValue(client as any);
+    client.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [{ n: 9 }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [{
+        id: 42, account_id: 7, name: 'Captest', class: 'mage', level: 1, state: null, is_gm: false, force_rename: false,
+      }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any); // COMMIT
+
+    const row = await createCharacterCapped(7, 'Captest', 'mage', 10);
+
+    expect(row?.id).toBe(42);
+    expect(client.query.mock.calls[0][0]).toBe('BEGIN');
+    expect(client.query.mock.calls[1][0]).toContain('FOR UPDATE');
+    expect(client.query.mock.calls[1][1]).toEqual([7]);
+    expect(client.query.mock.calls[2][0]).toContain('count(*)::int');
+    expect(client.query.mock.calls[2][1]).toEqual([7, REALM]);
+    expect(client.query.mock.calls[3][0]).toMatch(/INSERT INTO characters/);
+    expect(client.query.mock.calls[4][0]).toBe('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null and skips the insert when the account is already at the realm cap', async () => {
+    const client = clientStub();
+    dbMock.connect.mockResolvedValue(client as any);
+    client.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [{ n: 10 }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any); // ROLLBACK
+
+    await expect(createCharacterCapped(7, 'Overflow', 'warrior', 10)).resolves.toBeNull();
+
+    expect(client.query.mock.calls.map((c) => c[0])).toEqual([
+      'BEGIN',
+      'SELECT id FROM accounts WHERE id = $1 FOR UPDATE',
+      'SELECT count(*)::int AS n FROM characters WHERE account_id = $1 AND realm = $2',
+      'ROLLBACK',
+    ]);
+    expect(client.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back and releases the client when the insert fails', async () => {
+    const client = clientStub();
+    dbMock.connect.mockResolvedValue(client as any);
+    client.query
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ id: 7 }], rowCount: 1 } as any)
+      .mockResolvedValueOnce({ rows: [{ n: 3 }], rowCount: 1 } as any)
+      .mockRejectedValueOnce(new Error('duplicate name'))
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 } as any); // ROLLBACK
+
+    await expect(createCharacterCapped(7, 'Taken', 'rogue', 10)).rejects.toThrow(/duplicate name/);
+
+    expect(client.query.mock.calls.map((c) => c[0])).toContain('ROLLBACK');
+    expect(client.query.mock.calls.map((c) => c[0])).not.toContain('COMMIT');
+    expect(client.release).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -153,6 +153,56 @@ describe('chat channels', () => {
     expect(toTarget!.pid).not.toBe(squatter);
   });
 
+  it('whisper resolves the longest online name so spaced names are not misdelivered', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const short = sim.addPlayer('mage', 'Bob');
+    const spaced = sim.addPlayer('rogue', 'Bob Smith');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+
+    const sent = sim.chat('/w Bob Smith meet at the crypt', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.pid !== a);
+    const echo = msgs.find((m) => m.pid === a);
+
+    expect(sent).toEqual({ channel: 'whisper', message: 'meet at the crypt', target: 'Bob Smith' });
+    expect(toTarget!.pid).toBe(spaced);
+    expect(toTarget!.pid).not.toBe(short);
+    expect(echo!.to).toBe('Bob Smith');
+  });
+
+  it('whisper resolves spaced names case-insensitively only when unambiguous', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const spaced = sim.addPlayer('rogue', 'Bob Smith');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+
+    const sent = sim.chat('/w bob smith lowercase works', a);
+    const msgs = chatEvents(sim.tick());
+
+    expect(sent).toEqual({ channel: 'whisper', message: 'lowercase works', target: 'Bob Smith' });
+    expect(msgs.find((m) => m.pid !== a)!.pid).toBe(spaced);
+  });
+
+  it('a shorter exact-case name does not intercept a longer spaced case-insensitive match', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const short = sim.addPlayer('mage', 'Bob');
+    const spaced = sim.addPlayer('rogue', 'bob smith');
+    teleport(sim, a, 0, -40);
+    sim.tick();
+
+    const sent = sim.chat('/w Bob Smith mixed case target', a);
+    const msgs = chatEvents(sim.tick());
+    const toTarget = msgs.find((m) => m.pid !== a);
+
+    expect(sent).toEqual({ channel: 'whisper', message: 'mixed case target', target: 'bob smith' });
+    expect(toTarget!.pid).toBe(spaced);
+    expect(toTarget!.pid).not.toBe(short);
+  });
+
   it('ambiguous case-insensitive whisper is refused, not misdelivered', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -44,7 +44,7 @@ describe('sent chat normalization', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     sim.addPlayer('mage', 'Bet');
-    expect(sim.chat('/w bet psst', a)).toEqual({ channel: 'whisper', message: 'psst' });
+    expect(sim.chat('/w bet psst', a)).toEqual({ channel: 'whisper', message: 'psst', target: 'Bet' });
     expect(sim.chat('/w nobody psst', a)).toBeNull();
   });
 

--- a/tests/db_search.test.ts
+++ b/tests/db_search.test.ts
@@ -11,7 +11,7 @@ vi.mock('pg', () => ({
   }),
 }));
 
-import { searchCharacters } from '../server/db';
+import { SCHEMA, searchCharacters } from '../server/db';
 import { SOCIAL_SCHEMA } from '../server/social_db';
 
 beforeEach(() => {
@@ -19,6 +19,12 @@ beforeEach(() => {
 });
 
 describe('character typeahead search', () => {
+  it('adds the realm column before indexes that depend on it', () => {
+    expect(SCHEMA).toContain('ALTER TABLE characters ADD COLUMN IF NOT EXISTS realm');
+    expect(SCHEMA.indexOf('ADD COLUMN IF NOT EXISTS realm'))
+      .toBeLessThan(SCHEMA.indexOf('CREATE INDEX IF NOT EXISTS characters_lifetime_xp'));
+  });
+
   it('creates a realm-scoped lower-name prefix index', () => {
     expect(SOCIAL_SCHEMA).toContain('CREATE INDEX IF NOT EXISTS characters_realm_lower_name_prefix');
     expect(SOCIAL_SCHEMA).toContain('ON characters (realm, lower(name) text_pattern_ops)');

--- a/tests/env_protocol.test.ts
+++ b/tests/env_protocol.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { NUM_ACTIONS } from '../src/sim/obs';
+import { MAX_INPUT_LINE_LENGTH, validateAction } from '../headless/protocol';
+
+describe('headless environment protocol validation', () => {
+  it('accepts only integer action ids from the declared action space', () => {
+    expect(validateAction(0)).toBe(0);
+    expect(validateAction(NUM_ACTIONS - 1)).toBe(NUM_ACTIONS - 1);
+    expect(validateAction(-1)).toBeNull();
+    expect(validateAction(NUM_ACTIONS)).toBeNull();
+    expect(validateAction(1.5)).toBeNull();
+    expect(validateAction('1')).toBeNull();
+    expect(validateAction(Number.NaN)).toBeNull();
+  });
+
+  it('keeps the stdin line cap at one mebibyte', () => {
+    expect(MAX_INPUT_LINE_LENGTH).toBe(1024 * 1024);
+  });
+});

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { Entity, dist2d } from '../src/sim/types';
-import { CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, zoneAt, zoneWelcomeText } from '../src/sim/data';
+import { CRYPT_DOOR_POS, DUNGEON_LIST, DUNGEON_X_THRESHOLD, ITEMS, LAKE, MOBS, NPCS, QUESTS, instanceOrigin, zoneAt, zoneWelcomeText } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { groundHeight, WATER_LEVEL } from '../src/sim/world';
-import { isBlocked, resolvePosition } from '../src/sim/colliders';
+import { isBlocked, lineOfSightClear, resolvePosition } from '../src/sim/colliders';
 
 const SEED = 20061;
 
-function makeSim(cls: 'warrior' | 'mage' = 'warrior') {
+function makeSim(cls: 'warrior' | 'mage' | 'hunter' = 'warrior') {
   return new Sim({ seed: SEED, playerClass: cls });
 }
 
@@ -18,6 +18,18 @@ function teleportTo(sim: Sim, x: number, z: number, pid?: number) {
   p.pos.z = z;
   p.pos.y = groundHeight(x, z, sim.cfg.seed);
   p.prevPos = { ...p.pos };
+}
+
+function placeEntity(sim: Sim, e: Entity, x: number, z: number) {
+  e.pos.x = x;
+  e.pos.z = z;
+  e.pos.y = groundHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+  e.spawnPos = { ...e.pos };
+}
+
+function faceTarget(actor: Entity, target: Entity) {
+  actor.facing = Math.atan2(target.pos.x - actor.pos.x, target.pos.z - actor.pos.z);
 }
 
 describe('quest lifecycle', () => {
@@ -486,10 +498,39 @@ describe('boss loot and encounter resets', () => {
     expect(mob.lootable).toBe(true);
     expect(mob.loot?.items).toContainEqual({ itemId: 'boar_hide', count: 1, personalFor: [b] });
 
+    sim.partyLeave(b);
     sim.lootCorpse(mob.id, b);
     expect(sim.countItem('boar_hide', b)).toBe(1);
     expect(mob.loot).toBeNull();
     expect(mob.lootable).toBe(false);
+  });
+
+  it('personal loot remains claimable after party rights are gone without granting shared loot', () => {
+    const sim = makeSim();
+    const a = sim.playerId;
+    const b = sim.addPlayer('mage', 'Bert');
+    const mob = createMob(990103, MOBS.forest_wolf, 2, { x: 20, y: 0, z: 22 });
+    mob.dead = true;
+    mob.lootable = true;
+    mob.tappedById = a;
+    mob.loot = {
+      copper: 88,
+      items: [
+        { itemId: 'boar_hide', count: 1, personalFor: [b] },
+        { itemId: 'wolf_fang', count: 1 },
+      ],
+    };
+    sim.entities.set(mob.id, mob);
+    teleportTo(sim, 20, 20, b);
+
+    const beforeCopper = sim.meta(b)!.copper;
+    sim.lootCorpse(mob.id, b);
+
+    expect(sim.countItem('boar_hide', b)).toBe(1);
+    expect(sim.countItem('wolf_fang', b)).toBe(0);
+    expect(sim.meta(b)!.copper).toBe(beforeCopper);
+    expect(mob.loot?.copper).toBe(88);
+    expect(mob.loot?.items).toContainEqual({ itemId: 'wolf_fang', count: 1 });
   });
 
   it('does not drop a quest-gated item whose quest has no matching collect objective', () => {
@@ -745,5 +786,61 @@ describe('spell visuals', () => {
     for (let i = 0; i < 60; i++) events.push(...sim.tick());
     const fx = events.filter((e) => e.type === 'spellfx');
     expect(fx.some((e) => e.type === 'spellfx' && e.fx === 'projectile' && e.school === 'fire')).toBe(true);
+  });
+
+  it('hostile targeted spells cannot start through dungeon walls', () => {
+    const sim = makeSim('mage');
+    const origin = instanceOrigin(2, 0);
+    const p = sim.player;
+    const mob = createMob(990200, MOBS.sanctum_boneguard, 19, { x: origin.x - 14, y: 0, z: origin.z + 74 });
+    sim.entities.set(mob.id, mob);
+    teleportTo(sim, origin.x - 14, origin.z + 60);
+    faceTarget(p, mob);
+    sim.targetEntity(mob.id);
+
+    expect(lineOfSightClear(sim.cfg.seed, p.pos, mob.pos)).toBe(false);
+    sim.castAbility('fireball');
+    const events = sim.tick();
+
+    expect(p.castingAbility).toBeNull();
+    expect(events.some((e) => e.type === 'castStart' && e.ability === 'fireball')).toBe(false);
+    expect(events.some((e) => e.type === 'error' && /line of sight/i.test(e.text))).toBe(true);
+  });
+
+  it('hostile targeted spells can start through the open dungeon passage', () => {
+    const sim = makeSim('mage');
+    const origin = instanceOrigin(2, 0);
+    const p = sim.player;
+    const mob = createMob(990201, MOBS.sanctum_boneguard, 19, { x: origin.x, y: 0, z: origin.z + 74 });
+    sim.entities.set(mob.id, mob);
+    teleportTo(sim, origin.x, origin.z + 60);
+    faceTarget(p, mob);
+    sim.targetEntity(mob.id);
+
+    expect(lineOfSightClear(sim.cfg.seed, p.pos, mob.pos)).toBe(true);
+    sim.castAbility('fireball');
+    const events = sim.tick();
+
+    expect(p.castingAbility).toBe('fireball');
+    expect(events.some((e) => e.type === 'castStart' && e.ability === 'fireball')).toBe(true);
+  });
+
+  it('ranged auto shot does not fire through dungeon walls', () => {
+    const sim = makeSim('hunter');
+    const origin = instanceOrigin(2, 0);
+    const p = sim.player;
+    const mob = createMob(990202, MOBS.sanctum_boneguard, 19, { x: origin.x - 14, y: 0, z: origin.z + 74 });
+    sim.entities.set(mob.id, mob);
+    teleportTo(sim, origin.x - 14, origin.z + 60);
+    placeEntity(sim, mob, origin.x - 14, origin.z + 74);
+    faceTarget(p, mob);
+    sim.targetEntity(mob.id);
+    sim.startAutoAttack();
+    p.swingTimer = 0;
+
+    const events = sim.tick();
+
+    expect(events.some((e) => e.type === 'spellfx' && e.targetId === mob.id)).toBe(false);
+    expect(events.some((e) => e.type === 'damage' && e.ability === 'Auto Shot')).toBe(false);
   });
 });


### PR DESCRIPTION
Summary
- keep fresh database installs and test imports healthy
- resolve whisper targets by longest matching online player name and preserve the resolved target for replies
- allow entitled personal quest loot after party changes without granting shared corpse money or items
- block targeted spells, ranged auto attacks, and nearby area effects through dungeon collision geometry
- reject invalid headless environment actions and oversized input lines
- enforce the per-realm character cap inside a transaction so concurrent creates cannot exceed it

Validation
- npm test
- npx tsc --noEmit
- npm run build:env
- npm run build:server
- npm run build
- npm audit --audit-level=moderate
- headless environment stdin smoke: reset, invalid action, valid step, close
- fresh Postgres startup smoke: /api/status healthy, characters.realm present, characters_lifetime_xp present
- fresh Postgres API smoke: 12 concurrent character-create requests produced 10 created characters and 2 cap errors