### PR TITLE
fix: escape key should close the game menu

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -205,8 +205,8 @@ export class Input {
     }
     const tag = (document.activeElement?.tagName ?? '').toLowerCase();
     if (tag === 'input' || tag === 'textarea') return;
-    if (this.cb.canUseGameKeys && !this.cb.canUseGameKeys()) return;
     if (e.code === 'Escape') { this.cb.onUiKey('escape'); return; }
+    if (this.cb.canUseGameKeys && !this.cb.canUseGameKeys()) return;
     if (e.code === 'Tab') e.preventDefault();
     const action = this.keybinds.actionForCode(e.code);
     if (action === null) return;

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -72,6 +72,19 @@ describe('Input pointer lock', () => {
   });
 });
 
+describe('Input Escape handling', () => {
+  it('dispatches Escape even when modal UI blocks game keys', () => {
+    const { cb, windowListeners } = makeInput();
+    (cb as any).canUseGameKeys = vi.fn(() => false);
+
+    windowListeners.get('keydown')!({ code: 'Escape', repeat: false });
+    windowListeners.get('keydown')!({ code: 'KeyB', repeat: false });
+
+    expect(cb.onUiKey).toHaveBeenCalledTimes(1);
+    expect(cb.onUiKey).toHaveBeenCalledWith('escape');
+  });
+});
+
 describe('Input movement is not cancelled by a camera drag', () => {
   // Discord regression: walking with W (or any held key) then right/left-drag to
   // look around and releasing the button stopped movement, because exiting


### PR DESCRIPTION
## Summary
- Fixes a regression where pressing `Escape` opened the Game menu but could not close it.
- Adds a regression test covering `Escape` dispatch when `canUseGameKeys()` is false.

## Test plan
- `npm test`
- Tested on local server
