### PR TITLE
feat(guild): add confirmation dialog when leaving guild

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -3640,7 +3640,7 @@ export class Hud {
       else if (act === 'block-add') void this.socialResolveAndAct('ignore', field('ignore'));
       else if (act === 'guild-invite') void this.socialResolveAndAct('ginvite', field('ginvite'));
       else if (act === 'guild-create') { const n = field('gname'); if (n) { this.sim.guildCreate(n); this.clearSocialInput('gname'); } }
-      else if (act === 'guild-leave') this.sim.guildLeave();
+      else if (act === 'guild-leave') this.showPrompt('Are you sure you want to leave your guild?', 'Leave Guild', () => this.sim.guildLeave(), () => {});
       else if (act === 'guild-disband') this.showPrompt('Disband your guild? This cannot be undone.', 'Disband', () => this.sim.guildDisband(), () => { /* keep */ });
     };
     el.querySelectorAll('.soc-add .btn').forEach((b) => b.addEventListener('click', () => submit((b as HTMLElement).dataset.act)));


### PR DESCRIPTION
## Summary
- Add a confirmation prompt before leaving a guild from the Social > Guild panel.
- Prevent players from accidentally leaving their guild with a single misclick.

## Test Plan
- Verified that clicking `Leave Guild` opens a confirmation prompt.
- Verified that the guild leave command is only sent after confirming.

<img width="944" height="907" alt="Screenshot from 2026-06-15 23-22-01" src="https://github.com/user-attachments/assets/972c15ac-bf70-4b3d-a34e-bf5ecbc3a9bc" />
