### PR TITLE
fix: complete the #218 rate-limit backstop on both maps under in-window floods (#251)

### DIFF
--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -13,6 +13,15 @@ import * as http from 'node:http';
 const WINDOW_MS = 60_000;
 const MAX_TRACKED_IPS = 10_000;
 
+// The strictest (lowest) limit any caller passes to rateLimited(). The `attempts`
+// map is SHARED across routes — game login/register use the default 20, admin
+// login uses 10 (ADMIN_LOGIN_MAX_PER_MINUTE in server/admin.ts). The memory
+// backstop must judge "is this IP currently limited" by the strictest policy, or
+// a flood on a lenient route (limit 20) could evict an IP that is already limited
+// under a stricter route (e.g. 11 admin-login attempts) and reset it mid-window.
+// MUST stay <= the lowest maxPerMinute of any rateLimited() caller.
+const STRICTEST_RATE_LIMIT = 10;
+
 const attempts = new Map<string, number[]>();
 
 function normalizeIp(ip: string): string {
@@ -66,11 +75,25 @@ export function rateLimited(req: http.IncomingMessage, maxPerMinute = 20): boole
   const list = (attempts.get(ip) ?? []).filter((t) => t > windowStart);
   const updated = [...list, now];
   attempts.set(ip, updated);
-  // Memory backstop: when the map grows too large, evict entries whose window
-  // has fully expired rather than clearing everything. A blanket clear() would
-  // also wipe the counter we just recorded, so every IP would perpetually see
-  // a single attempt and rate limiting would silently stop working under load.
+
+  // Memory backstop. A blanket clear() would also wipe the counter we just
+  // recorded, so every IP would perpetually see a single attempt and rate
+  // limiting would silently stop working under load — which is exactly when a
+  // flood of distinct IPs inflates this map past the cap. So bound the map
+  // without clearing it. Mirrors recordAuthFailure() below.
   if (attempts.size > MAX_TRACKED_IPS) {
+    // Never evict an IP that is currently limited, nor the one just recorded. A
+    // burst-then-idle IP ages while a flood of newer one-off IPs arrives, so a
+    // naive least-recently-active eviction would pick it as "oldest" and reset
+    // its live limit before the window expires — the eviction-path version of
+    // the bypass. Judge "currently limited" by the STRICTEST policy sharing this
+    // map (not this call's maxPerMinute): a flood on a lenient route must not
+    // evict an IP that a stricter route has already limited. count >= L+1 means
+    // a call at limit L would return true (rateLimited returns count > L). Shares
+    // atOrOverLimit() with authThrottled() so the predicate can't drift.
+    const isLimited = (times: number[]) => atOrOverLimit(times, windowStart, STRICTEST_RATE_LIMIT + 1);
+
+    // Stage 1 — evict IPs whose window has fully expired (cheap, harmless).
     for (const [key, times] of attempts) {
       if (key === ip) continue;
       if (times.length === 0 || times[times.length - 1] <= windowStart) {
@@ -78,8 +101,39 @@ export function rateLimited(req: http.IncomingMessage, maxPerMinute = 20): boole
       }
       if (attempts.size <= MAX_TRACKED_IPS) break;
     }
+
+    // Stage 2 — a pure flood is all in-window, so stage 1 evicts nothing and
+    // the map would grow unbounded (and every call would re-scan it, O(n^2)).
+    // Fall back to evicting the least-recently-active IP, skipping the current
+    // one and any currently-limited IP. If everything left is current or
+    // limited, accept a soft over-cap rather than reset a live limit.
+    while (attempts.size > MAX_TRACKED_IPS) {
+      let oldestKey: string | undefined;
+      let oldestSeen = Infinity;
+      for (const [key, times] of attempts) {
+        if (key === ip) continue;
+        if (isLimited(times)) continue;
+        const last = times.length === 0 ? 0 : times[times.length - 1];
+        if (last < oldestSeen) {
+          oldestSeen = last;
+          oldestKey = key;
+        }
+      }
+      if (oldestKey === undefined) break;
+      attempts.delete(oldestKey);
+    }
   }
   return updated.length > maxPerMinute;
+}
+
+/** Number of IPs currently tracked. Exposed for the backstop-bound test. */
+export function trackedIpCount(): number {
+  return attempts.size;
+}
+
+/** Reset all tracked IPs. Test-only — keeps the shared map isolated per test. */
+export function resetRateLimits(): void {
+  attempts.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -101,13 +155,28 @@ function authKey(username: string): string {
   return username.trim().toLowerCase();
 }
 
+// Single source of truth for "are there at least `limit` timestamps still inside
+// the window". Both limiters' active-check AND their memory-backstop eviction
+// skip-check route through this, so the "is this key currently limited" question
+// can never drift between the two — a future edit to one can't silently re-open
+// the flood-reset bypass this module exists to prevent. (See isThrottled and the
+// rateLimited skip-check, which pass MAX_AUTH_FAILURES and maxPerMinute+1.)
+function atOrOverLimit(times: number[], windowStart: number, limit: number): boolean {
+  return times.filter((t) => t > windowStart).length >= limit;
+}
+
+// An account is throttled once its in-window failures reach MAX_AUTH_FAILURES.
+function isThrottled(times: number[], windowStart: number): boolean {
+  return atOrOverLimit(times, windowStart, MAX_AUTH_FAILURES);
+}
+
 /** True once an account has hit the failed-attempt ceiling within the window. */
 export function authThrottled(username: string): boolean {
   const key = authKey(username);
   const windowStart = Date.now() - AUTH_FAIL_WINDOW_MS;
   const recent = (authFailures.get(key) ?? []).filter((t) => t > windowStart);
   if (recent.length > 0) authFailures.set(key, recent); else authFailures.delete(key);
-  return recent.length >= MAX_AUTH_FAILURES;
+  return isThrottled(recent, windowStart);
 }
 
 /** Record a failed login for an account (call on bad password / unknown user). */
@@ -117,23 +186,67 @@ export function recordAuthFailure(username: string): void {
   const recent = (authFailures.get(key) ?? []).filter((t) => t > windowStart);
   recent.push(Date.now());
   authFailures.set(key, recent);
-  // Memory backstop: evict only accounts whose window has fully expired rather
-  // than clearing everything. A blanket clear() would also wipe the live
-  // lockout counters we are accumulating against accounts under attack — which
-  // is exactly when a credential-stuffing flood inflates this map past the cap,
+  if (authFailures.size <= MAX_TRACKED_IPS) return;
+
+  // Memory backstop. A blanket clear() would also wipe the live lockout
+  // counters we are accumulating against accounts under attack — which is
+  // exactly when a credential-stuffing flood inflates this map past the cap,
   // silently disabling the per-account throttle. Mirrors rateLimited() above.
-  if (authFailures.size > MAX_TRACKED_IPS) {
+  //
+  // Stage 1 — evict accounts whose window has fully expired (cheap, harmless).
+  for (const [k, times] of authFailures) {
+    if (k === key) continue;
+    if (times.length === 0 || times[times.length - 1] <= windowStart) {
+      authFailures.delete(k);
+    }
+    if (authFailures.size <= MAX_TRACKED_IPS) break;
+  }
+
+  // Stage 2 — a pure flood is all in-window, so stage 1 evicts nothing and the
+  // map would grow unbounded (and every subsequent call would re-scan it,
+  // O(n^2)). Fall back to evicting the least-recently-active account until
+  // back under the cap.
+  //
+  // Critically, NEVER evict a currently-throttled account (isThrottled) or the
+  // account just recorded. On the live login path (server/main.ts) a throttled
+  // account is rejected BEFORE recordAuthFailure runs, so its timestamps go
+  // stale and it would otherwise look "oldest" — letting an attacker reset a
+  // victim's throttle simply by flooding the map with newer one-off failures.
+  // Only non-throttled idle entries (the flood's count-of-1 buckets) are
+  // sacrificed — the cost of a memory bound.
+  while (authFailures.size > MAX_TRACKED_IPS) {
+    let oldestKey: string | undefined;
+    let oldestSeen = Infinity;
     for (const [k, times] of authFailures) {
       if (k === key) continue;
-      if (times.length === 0 || times[times.length - 1] <= windowStart) {
-        authFailures.delete(k);
+      if (isThrottled(times, windowStart)) continue;
+      const last = times.length === 0 ? 0 : times[times.length - 1];
+      if (last < oldestSeen) {
+        oldestSeen = last;
+        oldestKey = k;
       }
-      if (authFailures.size <= MAX_TRACKED_IPS) break;
     }
+    // Nothing evictable means every remaining account is either the current one
+    // or currently throttled. Accept a SOFT cap and stop rather than reset any
+    // throttle. This only happens once an attacker has genuinely locked out
+    // >MAX_TRACKED_IPS distinct accounts (100k+ failed logins); we fail toward
+    // protection (the map grows) instead of toward bypass.
+    if (oldestKey === undefined) break;
+    authFailures.delete(oldestKey);
   }
 }
 
 /** Clear an account's failure history after a successful login. */
 export function clearAuthFailures(username: string): void {
   authFailures.delete(authKey(username));
+}
+
+/** Number of accounts currently tracked. Exposed for the backstop-bound test. */
+export function authFailureCount(): number {
+  return authFailures.size;
+}
+
+/** Reset all tracked failures. Test-only — keeps the shared map isolated per test. */
+export function resetAuthFailures(): void {
+  authFailures.clear();
 }

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -2,11 +2,11 @@ import { EventEmitter } from 'node:events';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
 import { normalizeCharName, offensiveName, offensiveUsername, validCharName, validUsername } from '../server/auth';
-import { rateLimited, requestIp, authThrottled, recordAuthFailure, clearAuthFailures } from '../server/ratelimit';
+import { rateLimited, requestIp, authThrottled, recordAuthFailure, clearAuthFailures, authFailureCount, resetAuthFailures, trackedIpCount, resetRateLimits } from '../server/ratelimit';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
   const req: any = new EventEmitter();
@@ -50,6 +50,10 @@ describe('websocket authentication', () => {
 });
 
 describe('rate-limit client IP selection', () => {
+  // The attempts map is module-level shared state; reset it so the flood tests
+  // below (and any future ordering changes) can't leak entries between cases.
+  beforeEach(() => resetRateLimits());
+
   it('ignores spoofed x-forwarded-for from untrusted direct clients', () => {
     const req = fakeReq({ 'x-forwarded-for': '203.0.113.55' }, '198.51.100.10');
 
@@ -133,9 +137,80 @@ describe('rate-limit client IP selection', () => {
     // The attacker's counter must survive eviction and stay limited.
     expect(rateLimited(fakeReq({ 'x-forwarded-for': attacker }, '172.18.0.1'))).toBe(true);
   });
+
+  it('keeps a burst-then-idle limited IP limited after a flood of newer IPs', () => {
+    // An IP bursts past the limit (so it is rate-limited for the rest of the
+    // 60s window), then goes idle. An attacker floods the map with >10k NEWER
+    // distinct one-off IPs. A naive least-recently-active eviction would pick
+    // the idle-but-still-in-window limited IP as "oldest" and evict it,
+    // resetting its limit before the window expires — the eviction-path version
+    // of the flood-reset bypass. The backstop must skip currently-limited IPs.
+    const victim = '203.0.113.240';
+    let limited = false;
+    for (let i = 0; i < 21; i++) {
+      limited = rateLimited(fakeReq({ 'x-forwarded-for': victim }, '172.18.0.1'));
+    }
+    expect(limited).toBe(true);
+
+    // Flood past MAX_TRACKED_IPS (10_000) with NEWER one-off IPs; victim idle.
+    for (let i = 0; i < 10_050; i++) {
+      const a = (i >> 8) & 0xff;
+      const b = i & 0xff;
+      rateLimited(fakeReq({ 'x-forwarded-for': `100.64.${a}.${b}` }, '172.18.0.1'));
+    }
+
+    // The idle victim must stay limited — its counter must survive eviction.
+    expect(rateLimited(fakeReq({ 'x-forwarded-for': victim }, '172.18.0.1'))).toBe(true);
+  });
+
+  it('does not let a lenient-route flood evict an IP limited by a stricter route', () => {
+    // The attempts map is SHARED across routes with different limits: game
+    // login/register use the default 20, admin login uses 10. An IP that has
+    // tripped the stricter admin limit (11 attempts > 10) is currently limited,
+    // but has only 11 entries. A flood of default-limit (20) requests from newer
+    // IPs must NOT evict that bucket — eviction must judge "limited" by the
+    // strictest policy sharing the map, not the flooding call's lenient limit.
+    const adminLimit = 10;
+    const victim = '203.0.113.230';
+    let adminLimited = false;
+    for (let i = 0; i < 11; i++) {
+      adminLimited = rateLimited(fakeReq({ 'x-forwarded-for': victim }, '172.18.0.1'), adminLimit);
+    }
+    expect(adminLimited).toBe(true);
+
+    // Flood the map via the LENIENT default-limit (20) route with newer IPs.
+    for (let i = 0; i < 10_050; i++) {
+      const a = (i >> 8) & 0xff;
+      const b = i & 0xff;
+      rateLimited(fakeReq({ 'x-forwarded-for': `100.66.${a}.${b}` }, '172.18.0.1'));
+    }
+
+    // The admin-limited victim must still be limited under the admin policy.
+    expect(rateLimited(fakeReq({ 'x-forwarded-for': victim }, '172.18.0.1'), adminLimit)).toBe(true);
+  });
+
+  it('keeps the IP map bounded under a flood of distinct in-window clients', () => {
+    // A pure flood is all in-window, so expired-only eviction would delete
+    // nothing and the map would grow unbounded — and every subsequent call
+    // would re-scan a growing map (O(n^2)). The backstop must fall back to
+    // evicting the least-recently-active IPs so the map stays near the cap.
+    for (let i = 0; i < 12_000; i++) {
+      // Two octets give 256*256 = 65_536 distinct IPs, plenty for 12_000.
+      const a = (i >> 8) & 0xff;
+      const b = i & 0xff;
+      rateLimited(fakeReq({ 'x-forwarded-for': `100.65.${a}.${b}` }, '172.18.0.1'));
+    }
+
+    // MAX_TRACKED_IPS is 10_000; allow a small margin for the just-recorded entry.
+    expect(trackedIpCount()).toBeLessThanOrEqual(10_001);
+  });
 });
 
 describe('per-account failed-login throttle (#93)', () => {
+  // The failure map is module-level shared state; reset it so the flood tests
+  // below (and any future ordering changes) can't leak entries between cases.
+  beforeEach(() => resetAuthFailures());
+
   it('throttles an account after repeated failed logins, regardless of source IP', () => {
     const user = 'victim_account';
     expect(authThrottled(user)).toBe(false);
@@ -183,6 +258,36 @@ describe('per-account failed-login throttle (#93)', () => {
 
     // The victim's lockout must survive eviction.
     expect(authThrottled(victim)).toBe(true);
+  });
+
+  it('keeps a throttled-then-idle victim throttled after a flood of newer accounts', () => {
+    // Models the REAL flow (#251): once an account is throttled, the login
+    // handler rejects it BEFORE recordAuthFailure runs (server/main.ts), so the
+    // victim's timestamps go stale and it is never re-touched. An attacker then
+    // floods the map with >10k NEWER distinct one-off failures. A naive
+    // least-recently-active eviction that ignored throttle state would pick the
+    // idle victim as "oldest" and evict it — resetting its throttle, the exact
+    // bypass the backstop must prevent. The eviction must skip throttled accounts.
+    const victim = 'idle_victim';
+    for (let i = 0; i < 10; i++) recordAuthFailure(victim);
+    expect(authThrottled(victim)).toBe(true);
+
+    // Flood past MAX_TRACKED_IPS (10_000) with newer accounts; victim untouched.
+    for (let i = 0; i < 10_050; i++) recordAuthFailure(`floodacct_${i}`);
+
+    // The idle victim must stay throttled — its counter must survive eviction.
+    expect(authThrottled(victim)).toBe(true);
+  });
+
+  it('keeps the failure map bounded under a flood of distinct in-window accounts', () => {
+    // A pure flood is all in-window (#251), so expired-only eviction would
+    // delete nothing and the map would grow unbounded — and every subsequent
+    // call would re-scan a growing map (O(n^2)). The backstop must fall back to
+    // evicting the least-recently-active accounts so the map stays near the cap.
+    for (let i = 0; i < 12_000; i++) recordAuthFailure(`floodbound_${i}`);
+
+    // MAX_TRACKED_IPS is 10_000; allow a small margin for the just-recorded entry.
+    expect(authFailureCount()).toBeLessThanOrEqual(10_001);
   });
 });
 


### PR DESCRIPTION
Closes #251.

#251 reports that `recordAuthFailure()` uses `authFailures.clear()` as its memory backstop. That literal `clear()` is **already gone** — #218 (landed as `d433d4d`) replaced it with expired-only eviction on both rate-limit maps. But that left the residual #217 originally flagged: under a credential-stuffing / brute-force flood, every entry is freshly timestamped, so the expired-only pass evicts **nothing**. Both the per-account (`authFailures`) and per-IP (`attempts`) maps then grow unbounded past `MAX_TRACKED_IPS` and re-scan on every call — the backstop stops bounding memory under exactly the load it exists for.

## The bug
`recordAuthFailure`/`authFailures` and `rateLimited`/`attempts` both evict only entries whose window has fully expired. Under a sustained in-window flood of distinct keys nothing expires, so the map grows without bound (verified: a 12,000 distinct-in-window flood leaves the map at 12,000, not ≤ 10,001) and every call re-scans the whole map.

## The fix
- **Two-stage eviction on both maps:** stage 1 evicts expired entries (as today); stage 2, if still over `MAX_TRACKED_IPS`, evicts the least-recently-active entry — but **never** the just-recorded key and **never** a currently-rate-limited key, so the backstop can't reset a live lockout.
- **Shared `atOrOverLimit(times, windowStart, limit)` predicate** is the single source of truth for "is this key currently limited?", used by the throttle check and both backstops so the answer can't drift between them.
- The per-IP `attempts` map is shared across routes with different limits (game login 20/min, admin login 10/min); the stage-2 skip-check judges "limited" by the **strictest** policy, so a lenient-route flood can't evict an IP already limited under the stricter route.

## Verification
- New tests in `tests/security.test.ts`, each verified to fail on the exact regression it guards: account- and IP-map bounded-under-flood; account/IP throttled-then-idle survives a flood of newer keys; IP cross-policy (strict-route IP not evicted by a lenient-route flood).
- `npm test` → 653 passed. `npx tsc --noEmit` clean. `npm run build` green.

Design source is the bounded-eviction approach from #217, now applied to complete #218 on **both** maps. A fully complete fix would replace the evict-buckets model with an O(1) "limited-until" marker (so a near-threshold accumulating count can't be reset by a flood) — noted as a follow-up, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
