### PR TITLE
fix(mobile): hide touch controls before world entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -2776,13 +2776,13 @@
     text-shadow: 0 0 8px var(--class-color);
   }
 
-  /* ---------- mobile touch controls (runtime-gated with body.mobile-touch) ---------- */
+  /* ---------- mobile touch controls (runtime-gated with body.mobile-touch + game-active) ---------- */
   #mobile-controls { display: none; }
   #mobile-preflight { display: none; }
   #rotate-device { display: none; }
   body.mobile-touch #game-canvas { touch-action: none; }
   body.mobile-touch #ui { touch-action: none; }
-  body.mobile-touch #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; }
+  body.mobile-touch.game-active #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; }
   body.mobile-touch .mobile-joystick {
     position: absolute; left: max(18px, env(safe-area-inset-left)); bottom: calc(26px + env(safe-area-inset-bottom));
     width: 122px; height: 122px; border-radius: 50%; pointer-events: auto; touch-action: none;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -37,6 +37,11 @@ describe('client HTML shell', () => {
     expect(html).toContain('aria-label="Quest Log"');
   });
 
+  it('only displays mobile touch controls after the game is active', () => {
+    expect(html).toContain('body.mobile-touch.game-active #mobile-controls');
+    expect(html).not.toContain('body.mobile-touch #mobile-controls { position: absolute; inset: 0; display: block;');
+  });
+
   it('caps mobile quest and NPC panels instead of stretching them edge to edge', () => {
     expect(html).toContain('body.mobile-touch #quest-log-window,\n  body.mobile-touch #vendor-window,\n  body.mobile-touch #quest-dialog');
     expect(html).toContain('width: clamp(320px, 76vw, 680px);');


### PR DESCRIPTION
## What

The mobile touch controls are enabled as soon as the browser matches the phone-touch media query. That adds `body.mobile-touch` on the home/menu screens, and the old CSS displayed `#mobile-controls` for that class alone.

On mobile, the result is that the move/camera joystick overlay can briefly paint over the home screen or menu during vertical scrolling before the player has entered the world.

## Fix

Gate the joystick/control overlay on both mobile touch **and** active gameplay:

```css
body.mobile-touch.game-active #mobile-controls { ... display: block; ... }
```

The broader `mobile-touch` class still drives the mobile home/auth layout. Only the in-world touch-control overlay waits for `game-active`, which is set when gameplay starts.

## Verification

- Reproduced on `main` with Chrome mobile/touch emulation: `#mobile-controls` computed to `display: block` on the home screen before world entry.
- Verified after the fix that `#mobile-controls` stays `display: none` through repeated mobile home/menu scroll samples.
- Verified offline gameplay still shows the controls after `body.game-active` is set.
- `npx vitest run tests/client_shell.test.ts tests/mobile_controls.test.ts`
- `npx tsc --noEmit`

## Scope

CSS + regression test only. No server, database, sim, networking, or gameplay behavior changes.
