### PR TITLE
fix(mobile): polish More tray and touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -2876,7 +2876,7 @@
   }
   body.mobile-touch #mobile-combat-controls {
     position: absolute; left: 50%; bottom: calc(4px + env(safe-area-inset-bottom)); transform: translateX(-50%);
-    display: grid; grid-template-columns: 124px 58px 58px 58px; gap: 8px; pointer-events: auto; align-items: end;
+    display: grid; grid-template-columns: 124px repeat(4, 58px); gap: 8px; pointer-events: auto; align-items: end;
   }
   body.mobile-touch .mobile-btn {
     width: 58px; height: 54px; border: 2px solid #4a3d1d; border-radius: 8px;
@@ -2887,31 +2887,31 @@
   body.mobile-touch .mobile-btn .ui-icon { width: 22px; height: 22px; }
   body.mobile-touch #mobile-attack-nearest { width: 124px; color: #ffdf9c; border-color: #8b4e2c; }
   body.mobile-touch #mobile-more {
-    position: fixed;
-    left: calc(50% + 190px);
-    bottom: calc(4px + env(safe-area-inset-bottom));
+    position: static;
     z-index: 19;
   }
   body.mobile-touch .mobile-btn:active { transform: translateY(1px); border-color: var(--gold); color: #fff; }
   body.mobile-touch #mobile-autorun {
-    position: absolute; pointer-events: auto;
-    left: max(150px, calc(env(safe-area-inset-left) + 132px));
-    bottom: calc(40px + env(safe-area-inset-bottom));
+    position: fixed; pointer-events: auto;
+    left: max(calc(18px + env(safe-area-inset-left)), calc(50% - 208px));
+    bottom: calc(72px + env(safe-area-inset-bottom));
+    z-index: 19;
   }
   body.mobile-touch #mobile-autorun.active {
     border-color: var(--gold); color: #fff;
     background: radial-gradient(circle at 35% 30%, #5a4a1ed8, #2a230fd8 72%);
     box-shadow: inset 0 1px 0 #ffffff20, 0 0 12px #e3c46a80;
   }
+  body.mobile-touch.mobile-window-open #mobile-autorun { display: none; }
   body.mobile-touch .mobile-btn.is-on { border-color: var(--gold); color: #fff; }
   body.mobile-touch .mobile-btn:not(.is-on)#mobile-haptics { opacity: 0.55; }
   body.mobile-touch .mobile-btn .mobile-label { display: block; margin-top: 1px; font-size: 8px; font-family: var(--ui-font); color: #bfb28a; }
   body.mobile-touch #mobile-extra-controls {
     position: fixed;
-    left: calc(50% + 190px);
+    left: min(calc(50% + 136px), calc(100vw - 222px - max(12px, env(safe-area-inset-right, 0px))));
     bottom: calc(66px + env(safe-area-inset-bottom));
     display: none;
-    grid-template-columns: repeat(2, 112px);
+    grid-template-columns: repeat(2, 104px);
     grid-auto-rows: 42px;
     gap: 7px;
     pointer-events: auto;
@@ -2927,9 +2927,10 @@
   }
   body.mobile-touch.mobile-more-open #mobile-extra-controls { display: grid; }
   body.mobile-touch #mobile-extra-controls .mobile-btn {
-    width: 112px;
+    width: 104px;
     height: 42px;
     display: flex;
+    flex-direction: row;
     align-items: center;
     justify-content: flex-start;
     gap: 8px;
@@ -2941,6 +2942,9 @@
     margin: 0;
     font-size: 10px;
     color: #e6d8ae;
+  }
+  body.mobile-touch #mobile-extra-controls .mobile-btn .ui-icon {
+    flex: 0 0 22px;
   }
   /* A toggle tray button (e.g. Nameplates) glows gold while its feature is on. */
   body.mobile-touch #mobile-extra-controls .mobile-btn.active {
@@ -2956,7 +2960,7 @@
     transform: translate(-50%, -50%) rotate(-45deg); pointer-events: none;
   }
   body.mobile-touch #bottom-bar {
-    left: 0; right: 0; bottom: calc(62px + env(safe-area-inset-bottom));
+    left: 0; right: 0; bottom: calc(72px + env(safe-area-inset-bottom));
     width: 100%;
     transform: none;
     z-index: 18;
@@ -3023,9 +3027,22 @@
     height: 46px;
     padding: 0;
   }
+  body.mobile-touch .community-link.donate {
+    width: auto;
+    min-width: 58px;
+    height: 36px;
+    padding: 0 7px;
+    gap: 4px;
+    font-size: 10px;
+    letter-spacing: 0.15px;
+  }
   body.mobile-touch .community-link svg {
     width: 22px;
     height: 22px;
+  }
+  body.mobile-touch .community-link.donate svg {
+    width: 16px;
+    height: 16px;
   }
   body.mobile-touch #chatlog-wrap { left: 10px; bottom: calc(160px + env(safe-area-inset-bottom)); width: min(340px, calc(100vw - 20px)); display: none; z-index: 24; }
   body.mobile-touch.mobile-chat-open #chatlog-wrap { display: block; }
@@ -3079,10 +3096,11 @@
     right: auto; left: max(18px, env(safe-area-inset-left));
   }
   body.mobile-touch.mobile-left-handed #mobile-more {
-    left: auto; right: calc(50% + 190px);
+    left: auto; right: auto;
   }
   body.mobile-touch.mobile-left-handed #mobile-extra-controls {
-    left: auto; right: calc(50% + 190px);
+    left: auto;
+    right: min(calc(50% + 136px), calc(100vw - 222px - max(12px, env(safe-area-inset-right, 0px))));
   }
   body.mobile-touch.mobile-left-handed #xpbar,
   body.mobile-touch.mobile-left-handed #castbar {
@@ -3231,30 +3249,34 @@
     }
     body.mobile-touch .mobile-joy-label { bottom: -15px; font-size: 8px; color: #d7c987aa; }
     body.mobile-touch #mobile-combat-controls {
-      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px 54px 54px 54px; gap: 7px;
+      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px repeat(4, 54px); gap: 7px;
     }
     body.mobile-touch .mobile-btn { width: 54px; height: 48px; font-size: 20px; background: radial-gradient(circle at 35% 30%, #2d3048bf, #11121ec2 72%); }
     body.mobile-touch #mobile-attack-nearest { width: 115px; }
-    body.mobile-touch #mobile-more {
-      left: calc(50% + 176px);
-      bottom: calc(2px + env(safe-area-inset-bottom));
-    }
     body.mobile-touch #mobile-extra-controls {
-      left: calc(50% + 176px);
+      left: min(calc(50% + 126px), calc(100vw - 208px - max(12px, env(safe-area-inset-right, 0px))));
       bottom: calc(58px + env(safe-area-inset-bottom));
-      grid-template-columns: repeat(2, 104px);
+      grid-template-columns: repeat(2, 98px);
       grid-auto-rows: 38px;
       gap: 6px;
       max-height: calc(100dvh - 74px - env(safe-area-inset-bottom));
     }
+    body.mobile-touch.mobile-left-handed #mobile-extra-controls {
+      left: auto;
+      right: min(calc(50% + 126px), calc(100vw - 208px - max(12px, env(safe-area-inset-right, 0px))));
+    }
     body.mobile-touch #mobile-extra-controls .mobile-btn {
-      width: 104px;
+      width: 98px;
       height: 38px;
       font-size: 16px;
       padding: 0 9px;
     }
     body.mobile-touch #mobile-extra-controls .mobile-label { font-size: 9px; }
-    body.mobile-touch #bottom-bar { bottom: calc(50px + env(safe-area-inset-bottom)); }
+    body.mobile-touch #bottom-bar { bottom: calc(58px + env(safe-area-inset-bottom)); }
+    body.mobile-touch #mobile-autorun {
+      left: max(calc(20px + env(safe-area-inset-left)), calc(50% - 194px));
+      bottom: calc(58px + env(safe-area-inset-bottom));
+    }
     body.mobile-touch #actionbar { grid-template-columns: repeat(5, 38px); grid-auto-rows: 38px; gap: 4px; padding: 4px; width: max-content; background: linear-gradient(170deg, #15151fa8, #08080db8); }
     body.mobile-touch #actionbar.many-spells { grid-template-columns: repeat(6, 38px); }
     body.mobile-touch .action-btn { width: 38px; height: 38px; }
@@ -3657,6 +3679,23 @@
       height: 36px;
       padding: 0;
       justify-content: center;
+    }
+    .donate-cta {
+      gap: 5px;
+      padding: 7px 12px;
+      font-size: 11px;
+      letter-spacing: 0.25px;
+    }
+    .donate-cta svg {
+      width: 14px;
+      height: 14px;
+    }
+    .community-link.donate {
+      height: 34px;
+      padding: 0 9px;
+      gap: 5px;
+      font-size: 10px;
+      letter-spacing: 0.15px;
     }
     .social-link span { display: none; }
     .social-link svg { width: 18px; height: 18px; }

--- a/index.html
+++ b/index.html
@@ -3110,6 +3110,9 @@
     left: auto; right: calc(max(18px, env(safe-area-inset-right)) + 132px);
   }
   body.mobile-touch .window { max-width: calc(100vw - 20px); max-height: calc(100vh - 40px); }
+  body.mobile-touch.mobile-window-open #ui {
+    z-index: 90;
+  }
   body.mobile-touch #options-menu,
   body.mobile-touch #quest-log-window,
   body.mobile-touch #spellbook,
@@ -3136,6 +3139,17 @@
     width: min(560px, calc(100vw - 170px));
     max-height: calc(100vh - 92px);
     transform: translateX(-50%);
+  }
+  body.mobile-touch #talents-window {
+    position: fixed;
+    left: 50%;
+    right: auto;
+    top: 50%;
+    width: min(600px, calc(100vw - 20px));
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 24px);
+    transform: translate(-50%, -50%);
+    z-index: 95 !important;
   }
   body.mobile-touch #social-window {
     left: 50%;
@@ -4270,7 +4284,6 @@
         <button class="mobile-btn" id="mobile-bags" title="Bags" aria-label="Bags" data-icon="bags"><span class="mobile-label">Bags</span></button>
         <button class="mobile-btn" id="mobile-spellbook" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label">Spellbook</span></button>
         <button class="mobile-btn" id="mobile-talents" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label">Talents</span></button>
-        <button class="mobile-btn" id="mobile-meters" title="Meters" aria-label="Meters" data-icon="meters"><span class="mobile-label">Meters</span></button>
         <button class="mobile-btn" id="mobile-map" title="Map" aria-label="Map" data-icon="map"><span class="mobile-label">Map</span></button>
         <button class="mobile-btn" id="mobile-leaderboard" title="Leaderboard" aria-label="Leaderboard" data-icon="leaderboard"><span class="mobile-label">Ranks</span></button>
         <button class="mobile-btn active" id="mobile-nameplates" title="Toggle nameplates" aria-label="Toggle nameplates" data-icon="nameplates"><span class="mobile-label">Names</span></button>

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -64,7 +64,6 @@ export interface MobileControlCallbacks {
   onBags(): void;
   onSpellbook(): void;
   onTalents(): void;
-  onMeters(): void;
   onMap(): void;
   onLeaderboard(): void;
   /** Toggle world nameplates; returns the new on/off state to sync the button glow. */
@@ -202,7 +201,6 @@ export class MobileControls {
     this.bindButton('mobile-bags', () => this.callbacks.onBags());
     this.bindButton('mobile-spellbook', () => this.callbacks.onSpellbook());
     this.bindButton('mobile-talents', () => this.callbacks.onTalents());
-    this.bindButton('mobile-meters', () => this.callbacks.onMeters());
     this.bindButton('mobile-map', () => this.callbacks.onMap());
     this.bindButton('mobile-leaderboard', () => this.callbacks.onLeaderboard());
     const nameplatesBtn = document.getElementById('mobile-nameplates');

--- a/src/main.ts
+++ b/src/main.ts
@@ -443,7 +443,6 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     onBags: () => hud.toggleBags(),
     onSpellbook: () => hud.toggleSpellbook(),
     onTalents: () => hud.toggleTalents(),
-    onMeters: () => hud.toggleMeters(),
     onMap: () => hud.toggleMap(),
     onLeaderboard: () => hud.toggleLeaderboard(),
     onNameplates: () => (renderer.showNameplates = !renderer.showNameplates),

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -390,6 +390,7 @@ export class Hud {
     });
     document.querySelectorAll<HTMLElement>('.window.panel').forEach(observeWindow);
     this.windowObserver.observe(document.body, { childList: true, subtree: true });
+    this.syncAnyWindowOpenState();
 
     document.addEventListener('pointerdown', (ev) => {
       const target = ev.target as HTMLElement | null;
@@ -439,12 +440,21 @@ export class Hud {
   private syncWindowOpenState(el: HTMLElement): void {
     if (!this.isWindowVisible(el)) {
       delete el.dataset.windowOpen;
+      this.syncAnyWindowOpenState();
       return;
     }
-    if (el.dataset.windowOpen === '1') return;
-    el.dataset.windowOpen = '1';
-    this.placeNewWindow(el);
-    this.bringWindowToFront(el);
+    if (el.dataset.windowOpen !== '1') {
+      el.dataset.windowOpen = '1';
+      this.placeNewWindow(el);
+      this.bringWindowToFront(el);
+    }
+    this.syncAnyWindowOpenState();
+  }
+
+  private syncAnyWindowOpenState(): void {
+    const anyOpen = [...document.querySelectorAll<HTMLElement>('.window.panel')]
+      .some((win) => this.isWindowVisible(win));
+    document.body.classList.toggle('mobile-window-open', anyOpen);
   }
 
   private placeNewWindow(el: HTMLElement): void {
@@ -518,6 +528,7 @@ export class Hud {
       case 'emote-editor': this.closeEmoteEditor(); break;
       default: el.style.display = 'none'; this.hideTooltip(); break;
     }
+    this.syncAnyWindowOpenState();
   }
 
   private bindLogTabs(): void {

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -37,6 +37,30 @@ describe('client HTML shell', () => {
     expect(html).toContain('aria-label="Quest Log"');
   });
 
+  it('lays out mobile More tray buttons horizontally', () => {
+    expect(html).toContain('body.mobile-touch #mobile-extra-controls .mobile-btn');
+    expect(html).toContain('flex-direction: row;');
+    expect(html).toContain('body.mobile-touch #mobile-extra-controls .mobile-btn .ui-icon');
+  });
+
+  it('keeps the mobile More button in the combat row', () => {
+    expect(html).toContain('grid-template-columns: 124px repeat(4, 58px);');
+    expect(html).toContain('grid-template-columns: 115px repeat(4, 54px);');
+    expect(html).toContain('body.mobile-touch #mobile-more {\n    position: static;');
+  });
+
+  it('places mobile Autorun beside the spell bar', () => {
+    expect(html).toContain('body.mobile-touch #mobile-autorun {\n    position: fixed;');
+    expect(html).toContain('left: max(calc(18px + env(safe-area-inset-left)), calc(50% - 208px));');
+    expect(html).toContain('bottom: calc(72px + env(safe-area-inset-bottom));');
+    expect(html).toContain('body.mobile-touch.mobile-window-open #mobile-autorun { display: none; }');
+  });
+
+  it('keeps the expanded mobile More tray inside the viewport', () => {
+    expect(html).toContain('calc(100vw - 222px - max(12px, env(safe-area-inset-right, 0px)))');
+    expect(html).toContain('calc(100vw - 208px - max(12px, env(safe-area-inset-right, 0px)))');
+  });
+
   it('caps mobile quest and NPC panels instead of stretching them edge to edge', () => {
     expect(html).toContain('body.mobile-touch #quest-log-window,\n  body.mobile-touch #vendor-window,\n  body.mobile-touch #quest-dialog');
     expect(html).toContain('width: clamp(320px, 76vw, 680px);');

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -43,6 +43,11 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch #mobile-extra-controls .mobile-btn .ui-icon');
   });
 
+  it('omits Meters from the mobile More tray while keeping the desktop window', () => {
+    expect(html).toContain('id="meters-window"');
+    expect(html).not.toContain('id="mobile-meters"');
+  });
+
   it('keeps the mobile More button in the combat row', () => {
     expect(html).toContain('grid-template-columns: 124px repeat(4, 58px);');
     expect(html).toContain('grid-template-columns: 115px repeat(4, 54px);');
@@ -66,5 +71,13 @@ describe('client HTML shell', () => {
     expect(html).toContain('width: clamp(320px, 76vw, 680px);');
     expect(html).toContain('max-width: calc(100vw - 20px);');
     expect(html).toContain('transform: translateX(-50%);');
+  });
+
+  it('centers mobile Talents above touch controls', () => {
+    expect(html).toContain('body.mobile-touch.mobile-window-open #ui {\n    z-index: 90;');
+    expect(html).toContain('body.mobile-touch #talents-window {\n    position: fixed;');
+    expect(html).toContain('top: 50%;');
+    expect(html).toContain('transform: translate(-50%, -50%);');
+    expect(html).toContain('z-index: 95 !important;');
   });
 });

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -282,7 +282,6 @@ function mobileCallbacks() {
     onBags: noop,
     onSpellbook: noop,
     onTalents: noop,
-    onMeters: noop,
     onMap: noop,
     onLeaderboard: noop,
     onNameplates: () => false,


### PR DESCRIPTION
## What

This polishes the mobile touch interface for the v0.7 More-tray flow:

- The expanded **More** tray buttons inherited the global mobile button column layout, so icon + label could stack vertically and overflow.
- The **More** button was fixed off to the right instead of sitting with the other bottom-row controls, which could place it over the camera joystick.
- **Attack** and **Autorun** could collide in the lower-left mobile controls.
- **Autorun** could cover windows opened from the More tray.
- The mobile donate affordances were cramped and oversized.

## Fix

- Make More-tray buttons explicitly horizontal (`flex-direction: row`) with fixed icon sizing.
- Put **More** into the mobile combat-control grid as the fifth button beside Chat.
- Move **Autorun** to the left of the spell/action bar, with a small gap above the lower combat controls.
- Narrow the More tray columns and clamp its right edge inside the viewport, including short landscape and left-handed layouts.
- Track whether any managed HUD window is open with `body.mobile-window-open`; hide Autorun while More-opened windows/modals are visible.
- Tighten mobile donate CTA/community donate padding and type size.

No `sim/`, `IWorld`, `net/`, server, or gameplay rule changes.

## Verification

- `npx vitest run tests/client_shell.test.ts tests/mobile_controls.test.ts`
- `npx tsc --noEmit`
- Chrome mobile/touch emulation verified:
  - More-tray item flex direction is `row`.
  - Attack does not overlap Autorun.
  - More does not overlap the camera joystick.
  - Autorun sits left of the action bar and does not overlap the action bar, movement joystick, or Attack.
  - Action bar/Autorun row has an 8px gap above the lower combat row.
  - More tray stays inside the viewport after narrowing.
  - Autorun hides while a managed HUD window is open and returns after close.
  - Mobile donate uses smaller text and restored horizontal padding.
