### PR TITLE
feat(wiki): MediaWiki fandom community site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,24 @@ DATABASE_URL=postgres://eastbrook:change-me@127.0.0.1:5433/eastbrook
 # absolute /opt/eastbrook path in production.
 EASTBROOK_MEDIA_DIR=./media-cache
 
+# The player wiki is MediaWiki, reverse-proxied by the game server at /wiki —
+# so it's reached on the game's own origin, e.g. http://localhost:8787/wiki/.
+MEDIAWIKI_DB_NAME=mediawiki
+MEDIAWIKI_DB_USER=mediawiki
+MEDIAWIKI_DB_PASSWORD=mediawiki-change-me
+MEDIAWIKI_ADMIN_USER=WikiAdmin
+MEDIAWIKI_ADMIN_PASS=change-me-admin-password
+# Public origin the wiki is served on. Leave unset to auto-detect it from the
+# request (works on the game's origin and the Vite dev server). Set it to your
+# real domain in production, e.g. https://play.example.com.
+#MEDIAWIKI_SERVER=
+# Optional production secrets. Set long random values before exposing publicly.
+#MEDIAWIKI_SECRET_KEY=
+#MEDIAWIKI_UPGRADE_KEY=
+# Where the game server proxies /wiki to (the MediaWiki backend). In Docker
+# Compose this is the service address; defaults to the local container.
+WIKI_UPSTREAM=http://127.0.0.1:8080
+
 # Realm (world/shard) this process serves (default "Claudemoon"). Characters,
 # friends, guilds, and presence are all scoped to it. To run multiple isolated
 # realms, start one process per realm — same DATABASE_URL, a different

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ media-cache/
 
 # test artifacts & screenshots
 tmp/
+.codex-research/
 
 # python
 __pycache__/

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -7,7 +7,7 @@
 > `ansible-playbook playbooks/setup_server.yml -e target_host=idyllic-games-prod`
 > pulls and redeploys. The guide below is the generic, standalone path.
 
-One EC2 instance runs everything: the game server, Postgres, and Caddy
+One EC2 instance runs everything: the game server, Postgres, MediaWiki, and Caddy
 (TLS reverse proxy). Sized for a small population — a `t4g.small`
 (~$14/month all-in) is comfortable for a handful of concurrent players.
 
@@ -63,6 +63,11 @@ echo 'play.example.com {
 }' | sudo tee /etc/caddy/Caddyfile
 sudo systemctl reload caddy
 ```
+
+The game server reverse-proxies `/wiki` to MediaWiki itself, so Caddy just
+points everything at the game (`8787`) — the wiki shares the game's domain at
+`play.example.com/wiki`. Set `MEDIAWIKI_SERVER=https://play.example.com` so the
+wiki builds correct absolute links.
 
 Caddy fetches and renews the Let's Encrypt certificate automatically;
 WebSockets are proxied with no extra config, and the client auto-selects

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Open http://localhost:5173 → **Play Online** → create an account → create 
 character → Enter World. Open a second browser/tab and log in again — you'll
 see each other in town. `Enter` opens chat.
 
+The player wiki is a real MediaWiki service, reverse-proxied by the game server
+so it lives on the same origin: open http://localhost:8787/wiki/ when running
+Docker Compose. Its seed pages are generated from the current game content and
+community research with `npm run wiki:seed`.
+
 - **Accounts**: scrypt-hashed passwords, 7-day bearer tokens (`auth_tokens`).
 - **Characters**: up to 10 per account; level/gear/bags/quests/position/money
   persist as JSONB in Postgres — saved every 30 s, on logout, and on server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,14 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      mediawiki:
+        condition: service_started
     environment:
       DATABASE_URL: postgres://eastbrook:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env. See .env.example.}@postgres:5432/eastbrook
       PORT: "8787"
+      # The game reverse-proxies /wiki to the MediaWiki container, so the wiki
+      # is served on the game's own origin (no separate port).
+      WIKI_UPSTREAM: http://mediawiki:80
       USERNAME_BANLIST: ${USERNAME_BANLIST:-}
       USERNAME_BANLIST_FILE: ${USERNAME_BANLIST_FILE:-}
       CHAT_CENSOR_LIST: ${CHAT_CENSOR_LIST:-}
@@ -40,5 +45,53 @@ services:
     volumes:
       - ${EASTBROOK_MEDIA_DIR:-./media-cache}:/app/dist/media
 
+  mediawiki-db:
+    image: mariadb:11
+    container_name: eastbrook-wiki-db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${MEDIAWIKI_DB_NAME:-mediawiki}
+      MYSQL_USER: ${MEDIAWIKI_DB_USER:-mediawiki}
+      MYSQL_PASSWORD: ${MEDIAWIKI_DB_PASSWORD:-mediawiki-change-me}
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+    volumes:
+      - eastbrook_wikidb:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mariadb-admin ping -h 127.0.0.1 -u${MEDIAWIKI_DB_USER:-mediawiki} -p${MEDIAWIKI_DB_PASSWORD:-mediawiki-change-me} --silent"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  mediawiki:
+    build:
+      context: .
+      dockerfile: mediawiki/Dockerfile
+    container_name: eastbrook-wiki
+    restart: unless-stopped
+    depends_on:
+      mediawiki-db:
+        condition: service_healthy
+    environment:
+      MEDIAWIKI_DB_HOST: mediawiki-db
+      MEDIAWIKI_DB_NAME: ${MEDIAWIKI_DB_NAME:-mediawiki}
+      MEDIAWIKI_DB_USER: ${MEDIAWIKI_DB_USER:-mediawiki}
+      MEDIAWIKI_DB_PASSWORD: ${MEDIAWIKI_DB_PASSWORD:-mediawiki-change-me}
+      MEDIAWIKI_ADMIN_USER: ${MEDIAWIKI_ADMIN_USER:-WikiAdmin}
+      MEDIAWIKI_ADMIN_PASS: ${MEDIAWIKI_ADMIN_PASS:-change-me-admin-password}
+      MEDIAWIKI_SECRET_KEY: ${MEDIAWIKI_SECRET_KEY:-local-dev-change-me-world-of-claudecraft}
+      MEDIAWIKI_UPGRADE_KEY: ${MEDIAWIKI_UPGRADE_KEY:-local-dev-upgrade-key}
+      # Optional override of the wiki's public origin. Left unset so MediaWiki
+      # auto-detects it from the request (works whether reached via the game's
+      # origin or the Vite dev server); set it to your domain in production.
+      MEDIAWIKI_SERVER: ${MEDIAWIKI_SERVER:-}
+    # Exposed on loopback for direct debugging; normal access is via the game
+    # at <game-origin>/wiki. Safe to remove this mapping in production.
+    ports:
+      - "127.0.0.1:8080:80"
+    volumes:
+      - eastbrook_wiki_images:/var/www/html/images
+
 volumes:
   eastbrook_pgdata:
+  eastbrook_wikidb:
+  eastbrook_wiki_images:

--- a/index.html
+++ b/index.html
@@ -1365,6 +1365,35 @@
     margin-top: var(--spacing-xs);
   }
 
+  .wiki-cta-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-sm);
+    padding: 10px 22px;
+    background: linear-gradient(180deg, var(--color-primary), var(--color-primary-dim));
+    border: 1px solid var(--color-primary);
+    border-radius: var(--radius-sm);
+    color: #1c1206;
+    font-family: var(--font-heading);
+    font-size: 13px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    text-decoration: none;
+    text-shadow: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.3);
+    transition: transform 0.12s ease, box-shadow 0.12s ease, filter 0.12s ease;
+  }
+
+  .wiki-cta-btn:hover {
+    filter: brightness(1.08);
+    transform: translateY(-1px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  }
+
+  .wiki-cta-btn:active { transform: translateY(0); }
+  .wiki-cta-btn .wiki-cta-arrow { font-size: 15px; line-height: 1; }
+
   /* Home-page global leaderboard (Max-Level XP Overflow) */
   .hs-panel {
     display: flex;
@@ -3948,7 +3977,7 @@
             </div>
             <h2 class="skeleton-title" data-i18n="wiki.title">Game Wiki & Guide</h2>
             <p class="skeleton-desc" data-i18n="wiki.desc">Discover the secrets of the realm, class guides, and strategies.</p>
-            <div class="coming-soon-badge" data-i18n="comingSoon.placeholder">Coming Soon...</div>
+            <a class="wiki-cta-btn" href="/wiki/" target="_blank" rel="noopener"><span data-i18n="wiki.cta">Open the Wiki</span><span class="wiki-cta-arrow" aria-hidden="true">↗</span></a>
           </div>
           
           <div class="wiki-controls-guide">

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -1,0 +1,15 @@
+FROM mediawiki:1.43
+
+COPY mediawiki/apache-wiki.conf /etc/apache2/conf-enabled/wiki-path.conf
+COPY mediawiki/entrypoint.sh /usr/local/bin/woc-mediawiki-entrypoint
+COPY mediawiki/LocalSettings.php /opt/woc/LocalSettings.php
+COPY mediawiki/seed/pages.xml /opt/woc/seed/pages.xml
+COPY mediawiki/theme/Common.css /var/www/html/resources/assets/woc-mediawiki.css
+COPY public/loading-screen.jpg /var/www/html/resources/assets/woc-loading-screen.jpg
+COPY public/woc_logo_square.webp /var/www/html/resources/assets/woc-logo-square.webp
+COPY public/worldofclaudecraft-logo.png /var/www/html/resources/assets/worldofclaudecraft-logo.png
+
+RUN chmod +x /usr/local/bin/woc-mediawiki-entrypoint
+
+ENTRYPOINT ["woc-mediawiki-entrypoint"]
+CMD ["apache2-foreground"]

--- a/mediawiki/LocalSettings.php
+++ b/mediawiki/LocalSettings.php
@@ -1,0 +1,78 @@
+<?php
+if ( !defined( 'MEDIAWIKI' ) ) {
+	exit;
+}
+
+$wgSitename = 'World of Claudecraft Wiki';
+$wgMetaNamespace = 'World_of_Claudecraft';
+$wgScriptPath = '/wiki';
+// Origin the wiki is browsed on. An explicit MEDIAWIKI_SERVER wins (set it in
+// production for safety); otherwise derive it from the reverse proxy's
+// forwarded headers — the game server sets these — falling back to the request
+// Host so direct access and the Vite dev origin both work without config.
+$mwServer = getenv( 'MEDIAWIKI_SERVER' );
+if ( !$mwServer ) {
+	$mwProto = $_SERVER['HTTP_X_FORWARDED_PROTO']
+		?? ( ( ( $_SERVER['HTTPS'] ?? '' ) === 'on' ) ? 'https' : 'http' );
+	$mwHost = $_SERVER['HTTP_X_FORWARDED_HOST']
+		?? ( $_SERVER['HTTP_HOST'] ?? 'localhost:8080' );
+	$mwServer = $mwProto . '://' . $mwHost;
+}
+$wgServer = $mwServer;
+$wgArticlePath = "$wgScriptPath/index.php/$1";
+$wgUsePathInfo = true;
+$wgResourceBasePath = $wgScriptPath;
+
+$wgLogos = [
+	'1x' => "$wgScriptPath/resources/assets/woc-logo-square.webp",
+	'icon' => "$wgScriptPath/resources/assets/woc-logo-square.webp",
+];
+
+$wgEnableEmail = false;
+$wgEnableUserEmail = false;
+
+$wgDBtype = 'mysql';
+$wgDBserver = getenv( 'MEDIAWIKI_DB_HOST' ) ?: 'mediawiki-db';
+$wgDBname = getenv( 'MEDIAWIKI_DB_NAME' ) ?: 'mediawiki';
+$wgDBuser = getenv( 'MEDIAWIKI_DB_USER' ) ?: 'mediawiki';
+$wgDBpassword = getenv( 'MEDIAWIKI_DB_PASSWORD' ) ?: 'mediawiki';
+$wgDBprefix = '';
+$wgDBTableOptions = 'ENGINE=InnoDB, DEFAULT CHARSET=binary';
+
+$wgMainCacheType = CACHE_ACCEL;
+$wgMemCachedServers = [];
+
+$wgSecretKey = getenv( 'MEDIAWIKI_SECRET_KEY' ) ?: 'local-dev-change-me-world-of-claudecraft';
+$wgAuthenticationTokenVersion = '1';
+$wgUpgradeKey = getenv( 'MEDIAWIKI_UPGRADE_KEY' ) ?: 'local-dev-upgrade-key';
+
+$wgLanguageCode = 'en';
+$wgLocaltimezone = 'UTC';
+$wgEmergencyContact = 'admin@localhost';
+$wgPasswordSender = 'admin@localhost';
+
+$wgEnableUploads = true;
+$wgUseImageMagick = false;
+$wgImageMagickConvertCommand = '/usr/bin/convert';
+
+$wgDefaultSkin = 'vector-2022';
+$wgVectorDefaultSkinVersion = '2';
+
+$wgGroupPermissions['*']['edit'] = false;
+$wgGroupPermissions['*']['createaccount'] = false;
+$wgGroupPermissions['user']['edit'] = true;
+
+$wgDefaultUserOptions['usebetatoolbar'] = 1;
+$wgDefaultUserOptions['usenewrc'] = 1;
+$wgDefaultUserOptions['vector-theme'] = 'os';
+$wgDefaultUserOptions['vector-toc-pinned'] = 1;
+$wgDefaultUserOptions['vector-page-tools-pinned'] = 1;
+
+$wgAllowSiteCSSOnRestrictedPages = true;
+$wgRawHtml = false;
+
+wfLoadSkin( 'Vector' );
+
+$wgHooks['BeforePageDisplay'][] = static function ( OutputPage $out, Skin $skin ): void {
+	$out->addStyle( '/wiki/resources/assets/woc-mediawiki.css' );
+};

--- a/mediawiki/apache-wiki.conf
+++ b/mediawiki/apache-wiki.conf
@@ -1,0 +1,7 @@
+Alias /wiki /var/www/html
+
+<Directory /var/www/html>
+    Options FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>

--- a/mediawiki/entrypoint.sh
+++ b/mediawiki/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /var/www/html
+
+: "${MEDIAWIKI_DB_HOST:=mediawiki-db}"
+: "${MEDIAWIKI_DB_NAME:=mediawiki}"
+: "${MEDIAWIKI_DB_USER:=mediawiki}"
+: "${MEDIAWIKI_DB_PASSWORD:=mediawiki}"
+: "${MEDIAWIKI_ADMIN_USER:=WikiAdmin}"
+: "${MEDIAWIKI_ADMIN_PASS:=change-me-admin-password}"
+# NB: do NOT default MEDIAWIKI_SERVER here — that would export it to Apache and
+# defeat the request-based $wgServer auto-detection in LocalSettings.php. It is
+# only needed at install time below, where a local default is applied inline.
+
+echo "Waiting for MediaWiki database at ${MEDIAWIKI_DB_HOST}..."
+until php -r '$m = @mysqli_connect(getenv("MEDIAWIKI_DB_HOST"), getenv("MEDIAWIKI_DB_USER"), getenv("MEDIAWIKI_DB_PASSWORD")); exit($m ? 0 : 1);'; do
+  sleep 2
+done
+
+has_tables="$(php -r '$m = mysqli_connect(getenv("MEDIAWIKI_DB_HOST"), getenv("MEDIAWIKI_DB_USER"), getenv("MEDIAWIKI_DB_PASSWORD"), getenv("MEDIAWIKI_DB_NAME")); $r = $m ? mysqli_query($m, "SHOW TABLES LIKE '\''page'\''") : false; echo ($r && mysqli_num_rows($r) > 0) ? "yes" : "no";')"
+
+if [ "${has_tables}" != "yes" ]; then
+  echo "Installing MediaWiki schema..."
+  rm -f LocalSettings.php
+  php maintenance/install.php \
+    --dbtype mysql \
+    --dbserver "${MEDIAWIKI_DB_HOST}" \
+    --dbname "${MEDIAWIKI_DB_NAME}" \
+    --dbuser "${MEDIAWIKI_DB_USER}" \
+    --dbpass "${MEDIAWIKI_DB_PASSWORD}" \
+    --server "${MEDIAWIKI_SERVER:-http://localhost:8080}" \
+    --scriptpath /wiki \
+    --pass "${MEDIAWIKI_ADMIN_PASS}" \
+    "World of Claudecraft Wiki" \
+    "${MEDIAWIKI_ADMIN_USER}"
+fi
+
+cp /opt/woc/LocalSettings.php LocalSettings.php
+php maintenance/update.php --quick
+
+seed_hash="$(sha256sum /opt/woc/seed/pages.xml | awk '{print $1}')"
+seed_marker=/var/www/html/images/.woc-seed-hash
+current_hash=""
+if [ -f "${seed_marker}" ]; then
+  current_hash="$(cat "${seed_marker}")"
+fi
+
+if [ "${seed_hash}" != "${current_hash}" ]; then
+  echo "Importing World of Claudecraft wiki seed pages..."
+  printf '%s\n' 'Main Page' | php maintenance/deleteBatch.php --u "${MEDIAWIKI_ADMIN_USER}" --r 'Replace stock install page with World of Claudecraft seed' || true
+  php maintenance/importDump.php --no-updates < /opt/woc/seed/pages.xml
+  php maintenance/rebuildrecentchanges.php
+  php maintenance/runJobs.php
+  echo "${seed_hash}" > "${seed_marker}"
+fi
+
+exec docker-php-entrypoint "$@"

--- a/mediawiki/seed/pages.xml
+++ b/mediawiki/seed/pages.xml
@@ -1,0 +1,24618 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" version="0.11" xml:lang="en">
+  <siteinfo>
+    <sitename>World of Claudecraft Wiki</sitename>
+    <dbname>mediawiki</dbname>
+    <base>http://localhost:8080/wiki/index.php/Main_Page</base>
+    <generator>MediaWiki seed</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="0" case="first-letter" />
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+    </namespaces>
+  </siteinfo>
+
+  <page>
+    <title>MediaWiki:Common.css</title>
+    <ns>8</ns>
+    <id>1</id>
+    <revision>
+      <id>1</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="10448">/* =========================================================================
+   World of Claudecraft Wiki — &quot;Aged Grimoire&quot; theme for Vector 2022.
+   Warm parchment reading surface, deep oak chrome, gold + wax-seal-red
+   accents, elegant serif display headings.
+   ========================================================================= */
+
+:root {
+  --woc-ink: #2a1c10;          /* primary text on parchment */
+  --woc-ink-soft: #5a4427;     /* secondary text */
+  --woc-parchment: #f3e8cc;    /* reading surface */
+  --woc-parchment-2: #ece0bf;  /* alt surface (zebra, facts) */
+  --woc-oak: #241710;          /* dark chrome base */
+  --woc-oak-2: #160e09;        /* darker chrome */
+  --woc-gold: #e7b54a;         /* primary accent */
+  --woc-gold-soft: #f0d28a;    /* accent text on dark */
+  --woc-seal: #8a1f1c;         /* wax-seal red */
+  --woc-rule: rgba(106, 74, 33, 0.30);
+  --woc-rule-strong: #9d7c43;
+  --woc-link: #1c5a7a;         /* lapis on parchment */
+  --woc-link-visited: #6a417e; /* aged plum */
+  --woc-display: &apos;Iowan Old Style&apos;, &apos;Palatino Linotype&apos;, Palatino, &apos;Book Antiqua&apos;, Georgia, serif;
+}
+
+/* ---- Page backdrop: photo pushed back behind a dark &quot;table&quot; overlay ---- */
+html {
+  background: #0d0906;
+}
+
+body {
+  background:
+    radial-gradient(ellipse at 50% -10%, rgba(231, 181, 74, 0.10), rgba(13, 9, 6, 0) 55%),
+    linear-gradient(rgba(15, 10, 7, 0.80), rgba(11, 7, 5, 0.93)),
+    url(&apos;/wiki/resources/assets/woc-loading-screen.jpg&apos;) center top / cover fixed,
+    var(--woc-oak-2);
+  color: var(--woc-ink);
+}
+
+.mw-page-container,
+.vector-header-container,
+.vector-sticky-header,
+.mw-footer-container {
+  background: transparent;
+}
+
+/* ---- Top header bar ---- */
+/* warm the stark white masthead so it reads as part of the parchment page */
+.vector-header.mw-header {
+  background: linear-gradient(180deg, #f7efd9, #ece0bd);
+  border-bottom: 1px solid rgba(157, 124, 67, 0.6);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+}
+
+.mw-logo-wordmark,
+.mw-logo-tagline {
+  color: #b9831f;
+  font-family: var(--woc-display);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-shadow: 0 1px 0 rgba(255, 252, 240, 0.6);
+}
+
+/* keep the header search field crisp on the warm bar */
+.vector-header .cdx-text-input__input,
+.vector-header .cdx-search-input input {
+  background: #fffaf0;
+  border-color: rgba(157, 124, 67, 0.5);
+}
+
+/* ---- Reading surface ---- */
+.mw-body,
+.vector-page-titlebar,
+.vector-page-toolbar {
+  background: var(--woc-parchment);
+  color: var(--woc-ink);
+  border-color: var(--woc-rule-strong);
+}
+
+.mw-body {
+  background:
+    radial-gradient(120% 90% at 100% 0, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 60%),
+    var(--woc-parchment);
+  border: 1px solid var(--woc-rule-strong);
+  border-radius: 4px;
+  box-shadow:
+    0 1px 0 rgba(255, 246, 222, 0.5) inset,
+    0 22px 50px rgba(0, 0, 0, 0.42);
+}
+
+.vector-body {
+  color: var(--woc-ink);
+}
+
+/* ---- Side columns: dark oak panels ---- */
+/* NB: don&apos;t give .vector-settings panel chrome — an empty collapsed copy of
+   it lives in the right column and would render as a stray dark nub. */
+.vector-main-menu,
+.vector-toc,
+.vector-page-tools,
+.vector-appearance {
+  background: linear-gradient(180deg, rgba(45, 30, 19, 0.97), rgba(22, 14, 9, 0.98));
+  color: var(--woc-parchment);
+  border: 1px solid rgba(231, 181, 74, 0.28);
+  border-radius: 4px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.34);
+  padding: 6px 10px 10px;
+}
+
+/* readable text + controls inside the dark side panels (incl. Appearance) */
+.vector-main-menu,
+.vector-main-menu *,
+.vector-toc,
+.vector-toc *,
+.vector-page-tools,
+.vector-page-tools *,
+.vector-appearance,
+.vector-appearance *,
+.vector-settings,
+.vector-settings * {
+  color: var(--woc-parchment);
+}
+
+.vector-main-menu a,
+.vector-toc a,
+.vector-page-tools a,
+.vector-appearance a {
+  color: var(--woc-gold-soft);
+}
+
+.vector-main-menu a:hover,
+.vector-toc a:hover,
+.vector-page-tools a:hover {
+  color: #fff;
+}
+
+.vector-toc .vector-toc-list-item-active &gt; a,
+.vector-toc-list-item-active .vector-toc-text {
+  color: #fff;
+  font-weight: 600;
+}
+
+/* section / landmark labels */
+.mw-logo-wordmark,
+.mw-logo-tagline,
+.vector-main-menu-landmark,
+.vector-toc-landmark,
+.vector-page-tools-landmark,
+.vector-pinnable-header-label,
+.vector-pinnable-header h2,
+.vector-pinnable-header h3 {
+  color: var(--woc-gold);
+}
+
+/* keep the Appearance widget&apos;s labels legible */
+.vector-settings .cdx-field__label,
+.vector-settings .cdx-label,
+.vector-settings legend,
+.vector-appearance legend,
+.vector-pinnable-header-label {
+  color: var(--woc-gold-soft) !important;
+}
+
+/* tone down the white pin / collapse toggle buttons that sit on the oak panels */
+.vector-main-menu .vector-pinnable-header-toggle-button,
+.vector-toc .vector-pinnable-header-toggle-button,
+.vector-page-tools .vector-pinnable-header-toggle-button,
+.vector-appearance .vector-pinnable-header-toggle-button,
+.vector-pinnable-header-toggle-button {
+  background: rgba(231, 181, 74, 0.12);
+  color: var(--woc-gold-soft);
+  border-radius: 4px;
+}
+
+.vector-pinnable-header-toggle-button:hover {
+  background: rgba(231, 181, 74, 0.24);
+}
+
+/* the header divider under &quot;Contents&quot;/&quot;Appearance&quot; defaults to light grey,
+   which paints a harsh line across the dark oak panels — soften to gold */
+.vector-pinnable-header {
+  border-bottom: 1px solid rgba(231, 181, 74, 0.22) !important;
+}
+
+/* ---- Typography ---- */
+.mw-first-heading,
+.mw-parser-output h1,
+.mw-parser-output h2,
+.mw-parser-output h3,
+.mw-parser-output h4 {
+  font-family: var(--woc-display);
+  color: #281607;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+}
+
+.mw-first-heading {
+  font-size: 2.45rem;
+  line-height: 1.12;
+  border-bottom: 2px solid var(--woc-gold);
+  padding-bottom: 0.25em;
+}
+
+.mw-parser-output h2 {
+  font-size: 1.6rem;
+  border-bottom: 1px solid var(--woc-rule);
+  padding-bottom: 0.22em;
+  margin-top: 1.4em;
+}
+
+.mw-parser-output h3 {
+  font-size: 1.22rem;
+  color: var(--woc-seal);
+  border: 0;
+}
+
+.mw-parser-output p,
+.mw-parser-output li {
+  line-height: 1.65;
+}
+
+/* ---- Links ---- */
+.mw-parser-output a,
+.mw-body-content a:not(.external):not(.image) {
+  color: var(--woc-link);
+  text-decoration-color: rgba(28, 90, 122, 0.4);
+  text-underline-offset: 2px;
+}
+
+.mw-parser-output a:visited {
+  color: var(--woc-link-visited);
+}
+
+.mw-parser-output a:hover {
+  color: #0f3e57;
+}
+
+.mw-parser-output a.new {
+  color: var(--woc-seal);
+}
+
+/* ---- Hero ---- */
+.woc-main,
+.woc-hero,
+.woc-card,
+.wikitable,
+.article-facts {
+  border-color: var(--woc-rule) !important;
+}
+
+.woc-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 264px;
+  gap: 22px;
+  padding: 26px 28px;
+  margin-bottom: 22px;
+  align-items: center;
+  background:
+    radial-gradient(140% 120% at 0 0, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0) 55%),
+    linear-gradient(180deg, #f6edd4, #ecddb7);
+  border: 1px solid var(--woc-rule-strong);
+  border-radius: 6px;
+  box-shadow:
+    0 1px 0 rgba(255, 250, 232, 0.7) inset,
+    0 16px 34px rgba(0, 0, 0, 0.22);
+}
+
+.woc-hero h1 {
+  margin: 0.08em 0 0.28em;
+  font-family: var(--woc-display);
+  font-size: 3rem;
+  line-height: 1.04;
+  color: #271404;
+  border: 0;
+}
+
+.woc-kicker {
+  margin: 0 0 6px;
+  color: var(--woc-seal);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.woc-hero p {
+  color: #43321b;
+  font-size: 1.02rem;
+}
+
+.woc-card {
+  display: grid;
+  place-items: center;
+  padding: 14px;
+  background: radial-gradient(120% 120% at 50% 0, #34221580, transparent 70%), linear-gradient(180deg, #2c1c13, #160d08);
+  border: 1px solid rgba(231, 181, 74, 0.42);
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3) inset, 0 12px 26px rgba(0, 0, 0, 0.4);
+}
+
+.woc-crest {
+  display: grid;
+  place-items: end center;
+  width: min(220px, 100%);
+  aspect-ratio: 1;
+  padding: 14px;
+  background:
+    linear-gradient(rgba(24, 15, 10, 0), rgba(24, 15, 10, 0.85)),
+    url(&apos;/wiki/resources/assets/worldofclaudecraft-logo.png&apos;) center / contain no-repeat;
+  color: var(--woc-gold-soft);
+  font-family: var(--woc-display);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+
+/* ---- Tables ---- */
+.wikitable,
+.article-facts {
+  background: var(--woc-parchment) !important;
+  border: 1px solid var(--woc-rule-strong) !important;
+  border-collapse: collapse;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.14);
+}
+
+.wikitable &gt; * &gt; tr &gt; th,
+.wikitable &gt; * &gt; tr &gt; td,
+.article-facts &gt; * &gt; tr &gt; th,
+.article-facts &gt; * &gt; tr &gt; td {
+  border: 1px solid var(--woc-rule) !important;
+  padding: 8px 12px;
+}
+
+/* column + top headers — light text on oak, now actually visible */
+.wikitable &gt; * &gt; tr &gt; th,
+.article-facts &gt; * &gt; tr &gt; th {
+  color: #fdeec8 !important;
+  background: linear-gradient(180deg, #4a3017, #2f1d0e) !important;
+  font-family: var(--woc-display);
+  font-weight: 600;
+  text-align: left;
+}
+
+/* row-header (key/value fact tables) gets a narrower, distinct tone */
+.article-facts &gt; * &gt; tr &gt; th {
+  background: linear-gradient(180deg, #402a14, #281a0c) !important;
+  white-space: nowrap;
+  width: 1%;
+}
+
+.wikitable &gt; * &gt; tr:nth-child(even) &gt; td,
+.article-facts &gt; * &gt; tr:nth-child(even) &gt; td {
+  background: var(--woc-parchment-2);
+}
+
+/* ---- Categories / footer of article ---- */
+.catlinks {
+  background: rgba(64, 42, 20, 0.10);
+  border: 1px solid var(--woc-rule);
+  border-radius: 4px;
+  padding: 8px 12px;
+  color: var(--woc-ink-soft);
+}
+
+/* ---- Code / quotes ---- */
+.mw-parser-output pre,
+.mw-parser-output code,
+.mw-parser-output tt {
+  background: #efe2c0;
+  border: 1px solid var(--woc-rule);
+  border-radius: 4px;
+  color: #3a2710;
+}
+
+.mw-parser-output blockquote {
+  border-left: 3px solid var(--woc-gold);
+  background: rgba(231, 181, 74, 0.08);
+  padding: 0.5em 1em;
+  border-radius: 0 4px 4px 0;
+}
+
+/* ---- Site footer ---- */
+.mw-footer,
+.mw-footer li,
+.mw-footer-info,
+.mw-footer-places {
+  color: rgba(243, 232, 204, 0.72);
+}
+
+.mw-footer a {
+  color: var(--woc-gold-soft);
+}
+
+.mw-footer {
+  border-top: 1px solid rgba(231, 181, 74, 0.18);
+  margin-top: 8px;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 720px) {
+  .woc-hero {
+    grid-template-columns: 1fr;
+    padding: 20px;
+    text-align: center;
+  }
+
+  .woc-hero h1 {
+    font-size: 2.1rem;
+  }
+
+  .woc-card {
+    max-width: 230px;
+    margin: 0 auto;
+  }
+
+  .mw-first-heading {
+    font-size: 1.9rem;
+  }
+}
+
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Main Page</title>
+    <ns>0</ns>
+    <id>2</id>
+    <revision>
+      <id>2</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1103">&lt;div class=&quot;woc-main&quot;&gt;
+&lt;div class=&quot;woc-hero&quot;&gt;
+&lt;div&gt;
+&lt;p class=&quot;woc-kicker&quot;&gt;Community player encyclopedia&lt;/p&gt;
+&lt;h1&gt;World of Claudecraft Wiki&lt;/h1&gt;
+World of Claudecraft is a browser-playable, WoW-Classic-flavored micro-MMO with online persistence, offline play, deterministic simulation logic, and a launch-week community that quickly turned jokes, dungeon clears, level races, bug reports, and feature requests into game history.
+
+&apos;&apos;&apos;Start here:&apos;&apos;&apos; [[Quick Start]] · [[All Pages]] · [[Zones]] · [[Classes]] · [[Gameplay Systems]] · [[Community Lore]] · [[Development Timeline]]
+&lt;/div&gt;
+&lt;div class=&quot;woc-card&quot;&gt;&lt;div class=&quot;woc-crest&quot;&gt;World of Claudecraft&lt;/div&gt;&lt;/div&gt;
+&lt;/div&gt;
+&lt;/div&gt;
+== Featured portals ==
+* [[Zones]] — Eastbrook Vale, Mirefen Marsh, Thornpeak Heights.
+* [[Classes]] — all nine playable class kits.
+* [[Quests]] — the full source-defined quest chain.
+* [[Dungeons]] — Hollow Crypt, Sunken Bastion, and Gravewyrm Sanctum.
+* [[Community Lore]] — launch-week player culture from Discord, Reddit, and X.
+* [[Development Timeline]] — issue, PR, and release themes.
+[[Category:Wiki]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Quick Start</title>
+    <ns>0</ns>
+    <id>3</id>
+    <revision>
+      <id>3</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="844">== First hour route ==
+* Create an online character for persistence, or use offline play for a quick solo test.
+* Speak to [[Marshal Redbrook (NPC)|Marshal Redbrook]] for [[Wolves at the Door]].
+* Collect nearby Eastbrook quests before leaving town so wolf, boar, spider, lake, mine, bandit, and chapel objectives overlap.
+* Sell poor-quality junk, buy food and water, and keep your action bar filled.
+* Follow [[Brother Aldric (NPC)|Brother Aldric]] into the Gravecaller story once the Fallen Chapel quests open.
+
+== Controls ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! WASD
+| Move and turn
+|-
+! Q / E
+| Strafe
+|-
+! Space
+| Jump
+|-
+! Tab
+| Target nearest enemy
+|-
+! F
+| Interact, loot, talk
+|-
+! 1-0, -, =
+| Action bar
+|-
+! C / P / L / M / B / G
+| Character, spellbook, quest log, map, bags, arena
+|-
+! Enter
+| Open chat
+|}
+[[Category:Guides]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Gravecaller Saga</title>
+    <ns>0</ns>
+    <id>4</id>
+    <revision>
+      <id>4</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="415">== Overview ==
+The main story follows Brother Aldric from restless bones outside Eastbrook to Korzul the Gravewyrm beneath Thornpeak.
+
+== Acts ==
+* [[Eastbrook Vale]] — Morthen the Gravecaller and [[The Hollow Crypt]].
+* [[Mirefen Marsh]] — Vael the Mistcaller and [[The Sunken Bastion]].
+* [[Thornpeak Heights]] — Wyrmcult zealots, Highwatch, and [[Gravewyrm Sanctum]].
+[[Category:Lore]]
+[[Category:Quests]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Community Lore</title>
+    <ns>0</ns>
+    <id>5</id>
+    <revision>
+      <id>5</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1376">== Launch-week myths ==
+* Players raced toward level 20 within the first weekend, and Discord mentions multiple level-20 characters plus jokes about level-cap roles.
+* A community prediction around Bucky becoming world-first level 20 turned the level race into channel folklore.
+* An early dungeon-clear clip by profitwizard and friends circulated through Discord and X.
+* The first-guild debate included Cool People Guild and a WOC Pumpfun guild.
+* Players joked about a future &quot;Wrath of the Claude King&quot; expansion before the first weekend was over.
+
+== Community requests ==
+* Fishing, professions, and skilling loops.
+* Player-facing leaderboards for level, class, arena Elo, boss kills, and guilds.
+* Discord Rich Presence, public guild discovery, target markers, mobile improvements, mana pacing, and anti-bot handling.
+* Arena rewards, arena accept/decline prompts, and countdown buff preservation.
+
+== Outside reception ==
+Recent Reddit threads framed World of Claudecraft as a viral open-source, Fable 5-built MMORPG with thousands of early players and hundreds of GitHub stars. The same discussions mixed excitement, skepticism about generated code quality, nostalgia for Fable, questions about the TypeScript/Three.js stack, and stories of players unexpectedly sticking around to grind.
+[[Category:Community]]
+[[Category:Discord]]
+[[Category:Reddit]]
+[[Category:X]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Development Timeline</title>
+    <ns>0</ns>
+    <id>6</id>
+    <revision>
+      <id>6</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="896">== Release themes ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! v0.3 baseline
+| Persistent multiplayer, account flow, classes, quests, dungeons, social systems, and classic MMO presentation.
+|-
+! v0.4 hardening
+| Moderation, reports, homepage polish, mobile controls, OpenGraph, bug fixes, and database correctness work.
+|-
+! v0.5 focus
+| Ashen Coliseum ranked arena, first fishing loop, security fixes, guild/social polish, QoL, and release testing.
+|}
+
+== Known active topics ==
+* Arena polish, Elo, leaderboards, and rewards.
+* Fishing and broader professions.
+* Guild discovery, /who, friend/guild status clarity, and chat alias behavior.
+* Security and correctness work around market inputs, rate limits, guild transactions, character names, report handling, and moderation.
+* Headless environment and agent support for Codex/Claude-driven players.
+[[Category:Development]]
+[[Category:GitHub]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sources Used</title>
+    <ns>0</ns>
+    <id>7</id>
+    <revision>
+      <id>7</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1024">== Local sources ==
+* Repository README, design docs, screenshots, source code, tests, sim content, class definitions, dungeon data, and server routes.
+* GitHub CLI exports of 45 issues and 141 pull requests.
+* Discord export of 3,205 messages from the World of Claudecraft community general channel.
+
+== External sources ==
+* [https://github.com/levy-street/world-of-claudecraft GitHub repository]
+* [https://www.reddit.com/r/artificial/comments/1u4h7k1/world_of_claudecraft_the_first_opensource_mmorpg/ r/artificial launch thread]
+* [https://www.reddit.com/r/ClaudeAI/comments/1u3m6a8/i_vibe_coded_the_first_mmorpg_with_fable_5/ r/ClaudeAI Fable 5 thread]
+* [https://www.reddit.com/r/vibecoding/comments/1u47wo5/world_of_claudecraft_first_mmorpg_vibecoded_with/ r/vibecoding launch thread]
+* [https://www.reddit.com/r/AI_Agents/comments/1u4hstu/agents_have_entered_the_world_of_claudecraft_open/ r/AI_Agents thread]
+* [https://x.com/i/communities/2030944892999135272 World Of Claudecraft X community]
+[[Category:Sources]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gameplay Systems</title>
+    <ns>0</ns>
+    <id>8</id>
+    <revision>
+      <id>8</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1103">== Systems index ==
+* [[Combat]] — Vanilla-style combat math, resources, GCD, threat, leashing, death, food, drink, and recovery.
+* [[Parties]] — Five-player grouping, shared tap rights, shared kill credit, XP bonuses, party chat, and shared instances.
+* [[Guilds]] — Guild creation, ranks, roster management, invites, guild chat, and public-discovery roadmap requests.
+* [[Trading]] — Nearby players stage items and copper; both sides accept; walking apart cancels.
+* [[World Market]] — The Merchant runs player listings, purchases, cancellations, and collections.
+* [[Duels]] — Friendly PvP challenges end at 1 HP.
+* [[Ashen Coliseum]] — Ranked 1v1 arena with matchmaking, private arena instances, Elo, ladder, and leaderboard.
+* [[Fishing]] — First professions slice: pole purchase, water checks, casting, and starter catch results.
+* [[Mobile Play]] — Touch controls, joystick fixes, quest-log access, fullscreen polish, and launch-week mobile testing.
+* [[Agents and Bots]] — Headless training environment, Codex/Claude agent culture, and anti-bot roadmap.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Combat</title>
+    <ns>0</ns>
+    <id>9</id>
+    <revision>
+      <id>9</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="131">== Overview ==
+Vanilla-style combat math, resources, GCD, threat, leashing, death, food, drink, and recovery.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Parties</title>
+    <ns>0</ns>
+    <id>10</id>
+    <revision>
+      <id>10</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="143">== Overview ==
+Five-player grouping, shared tap rights, shared kill credit, XP bonuses, party chat, and shared instances.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Guilds</title>
+    <ns>0</ns>
+    <id>11</id>
+    <revision>
+      <id>11</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="138">== Overview ==
+Guild creation, ranks, roster management, invites, guild chat, and public-discovery roadmap requests.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Trading</title>
+    <ns>0</ns>
+    <id>12</id>
+    <revision>
+      <id>12</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="117">== Overview ==
+Nearby players stage items and copper; both sides accept; walking apart cancels.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>World Market</title>
+    <ns>0</ns>
+    <id>13</id>
+    <revision>
+      <id>13</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="114">== Overview ==
+The Merchant runs player listings, purchases, cancellations, and collections.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Duels</title>
+    <ns>0</ns>
+    <id>14</id>
+    <revision>
+      <id>14</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="73">== Overview ==
+Friendly PvP challenges end at 1 HP.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ashen Coliseum</title>
+    <ns>0</ns>
+    <id>15</id>
+    <revision>
+      <id>15</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="126">== Overview ==
+Ranked 1v1 arena with matchmaking, private arena instances, Elo, ladder, and leaderboard.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fishing</title>
+    <ns>0</ns>
+    <id>16</id>
+    <revision>
+      <id>16</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="126">== Overview ==
+First professions slice: pole purchase, water checks, casting, and starter catch results.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mobile Play</title>
+    <ns>0</ns>
+    <id>17</id>
+    <revision>
+      <id>17</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="137">== Overview ==
+Touch controls, joystick fixes, quest-log access, fullscreen polish, and launch-week mobile testing.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Agents and Bots</title>
+    <ns>0</ns>
+    <id>18</id>
+    <revision>
+      <id>18</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="117">== Overview ==
+Headless training environment, Codex/Claude agent culture, and anti-bot roadmap.
+[[Category:Systems]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Zones</title>
+    <ns>0</ns>
+    <id>19</id>
+    <revision>
+      <id>19</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="101">== Articles ==
+* [[Eastbrook Vale]]
+* [[Mirefen Marsh]]
+* [[Thornpeak Heights]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Classes</title>
+    <ns>0</ns>
+    <id>20</id>
+    <revision>
+      <id>20</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="152">== Articles ==
+* [[Druid]]
+* [[Hunter]]
+* [[Mage]]
+* [[Paladin]]
+* [[Priest]]
+* [[Rogue]]
+* [[Shaman]]
+* [[Warlock]]
+* [[Warrior]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Dungeons</title>
+    <ns>0</ns>
+    <id>21</id>
+    <revision>
+      <id>21</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="108">== Articles ==
+* [[Gravewyrm Sanctum]]
+* [[The Hollow Crypt]]
+* [[The Sunken Bastion]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>NPCs</title>
+    <ns>0</ns>
+    <id>22</id>
+    <revision>
+      <id>22</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="563">== Articles ==
+* [[Apothecary Lin (NPC)]]
+* [[Armorer Hode (NPC)]]
+* [[Brother Aldric (NPC)]]
+* [[Brother Aldric (NPC) (2)]]
+* [[Brother Aldric (NPC) (3)]]
+* [[Captain Thessaly (NPC)]]
+* [[Fisherman Brandt (NPC)]]
+* [[Foreman Odell (NPC)]]
+* [[Herbalist Yara (NPC)]]
+* [[Loremaster Caddis (NPC)]]
+* [[Marshal Redbrook (NPC)]]
+* [[Provisioner Hale (NPC)]]
+* [[Quartermaster Bree (NPC)]]
+* [[Scout Maren (NPC)]]
+* [[Scout Maren (NPC) (2)]]
+* [[Smith Haldren (NPC)]]
+* [[The Merchant (NPC)]]
+* [[Trader Wilkes (NPC)]]
+* [[Warden Fenwick (NPC)]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Quests</title>
+    <ns>0</ns>
+    <id>23</id>
+    <revision>
+      <id>23</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1645">== Articles ==
+* [[Back to the Shallows]]
+* [[Bandits of the Vale]]
+* [[Bones of the Vanguard]]
+* [[Break the War-Camp]]
+* [[Breaking the Seal]]
+* [[Bristleback Hides]]
+* [[Censers from the Deep]]
+* [[Chants on the Wind]]
+* [[Cores of the Storm]]
+* [[Deeprock Trouble]]
+* [[Fetish and Bone]]
+* [[Idols of the Deep]]
+* [[Into the Hollow]]
+* [[Korzul the Gravewyrm]]
+* [[Mogger Must Fall]]
+* [[Mogger&apos;s Trail]]
+* [[Mounds of the Mirefen]]
+* [[Muster at Fenbridge]]
+* [[No Rest in the Reeds]]
+* [[Ogres at the Foothills]]
+* [[Orders from Below]]
+* [[Pelts for the Causeway]]
+* [[Rats in the Mine]]
+* [[Robes in the Reeds]]
+* [[Sigils of the Wyrm]]
+* [[Silence the Call]]
+* [[Silk and Venom]]
+* [[Stalkers on the Ridge]]
+* [[Stolen Supplies]]
+* [[Stopping the Summoning]]
+* [[Strange Wax]]
+* [[Teeth of the Fen]]
+* [[The Binding Rite]]
+* [[The Bound Guardian]]
+* [[The Broodmother]]
+* [[The Captain&apos;s Bounty]]
+* [[The Deacon of the Mire]]
+* [[The Deepfen Stirs]]
+* [[The Drowned Dead]]
+* [[The Glutton]]
+* [[The Grand Necromancer]]
+* [[The Gravecaller&apos;s Trail]]
+* [[The Knight-Commander&apos;s Shame]]
+* [[The Lost Caravan]]
+* [[The Mistcaller]]
+* [[The Mountain Wakes]]
+* [[The Names of the Dead]]
+* [[The Old Wolf]]
+* [[The Phylactery Ring]]
+* [[The Restless Dead]]
+* [[The Revenant Fields]]
+* [[The Ringleader]]
+* [[The Sanctum Gate]]
+* [[The Sexton&apos;s Bell]]
+* [[The Shardlord]]
+* [[The Sunken Bastion (2)]]
+* [[The Voice Below]]
+* [[The Watch on the Peaks]]
+* [[Totems of War]]
+* [[Trouble at the Lake]]
+* [[Warlord Drogmar]]
+* [[Webwood Menace]]
+* [[Whispers Below]]
+* [[Winter Is Coming to Highwatch]]
+* [[Wolves at the Door]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mobs</title>
+    <ns>0</ns>
+    <id>24</id>
+    <revision>
+      <id>24</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1697">== Articles ==
+* [[Bastion Revenant (Mob)]]
+* [[Bonechill Widow (Mob)]]
+* [[Boneclad Revenant (Mob)]]
+* [[Crypt Shambler (Mob)]]
+* [[Deacon Voss (Mob)]]
+* [[Deepfen Snapper (Mob)]]
+* [[Deeprock Tunneler (Mob)]]
+* [[Drowned Dead (Mob)]]
+* [[Drowned Thrall (Mob)]]
+* [[Elder Bristleback (Mob)]]
+* [[Forest Wolf (Mob)]]
+* [[Gorrak the Ruthless (Mob)]]
+* [[Grand Necromancer Velkhar (Mob)]]
+* [[Gravecaller Cultist (Mob)]]
+* [[Gravecaller Summoner (Mob)]]
+* [[Grubjaw the Glutton (Mob)]]
+* [[Hollow Acolyte (Mob)]]
+* [[Ironvein Foreman (Mob)]]
+* [[Ironvein Sapper (Mob)]]
+* [[Knight-Commander Olen (Mob)]]
+* [[Korgath the Bound (Mob)]]
+* [[Korzul the Gravewyrm (Mob)]]
+* [[Marrowlord Varkas (Mob)]]
+* [[Mire Prowler (Mob)]]
+* [[Mirefen Troll (Mob)]]
+* [[Mirefen Widow (Mob)]]
+* [[Mirejaw Frenzy (Mob)]]
+* [[Mirejaw the Ravenous (Mob)]]
+* [[Mogger (Mob)]]
+* [[Mogger Lackey (Mob)]]
+* [[Morthen the Gravecaller (Mob)]]
+* [[Mudfin Skulker (Mob)]]
+* [[Nhalia Mourner (Mob)]]
+* [[Old Greyjaw (Mob)]]
+* [[Raised Bonewalker (Mob)]]
+* [[Restless Bones (Mob)]]
+* [[Ridge Stalker (Mob)]]
+* [[Sableweb Hatchling (Mob)]]
+* [[Sableweb Matriarch (Mob)]]
+* [[Sanctum Boneguard (Mob)]]
+* [[Sanctum Drakonid (Mob)]]
+* [[Sexton Marrow (Mob)]]
+* [[Shardlord Kazzix (Mob)]]
+* [[Sister Nhalia (Mob)]]
+* [[Stormcrag Elemental (Mob)]]
+* [[The Broodmother (Mob)]]
+* [[Thornpeak Crusher (Mob)]]
+* [[Thornpeak Ogre (Mob)]]
+* [[Tidebound Acolyte (Mob)]]
+* [[Tunnel Rat Digger (Mob)]]
+* [[Vael the Mistcaller (Mob)]]
+* [[Vale Bandit (Mob)]]
+* [[Varkas Boneguard (Mob)]]
+* [[Warlord Drogmar (Mob)]]
+* [[Webwood Lurker (Mob)]]
+* [[Wild Boar (Mob)]]
+* [[Wyrmcult Necromancer (Mob)]]
+* [[Wyrmcult Zealot (Mob)]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Items</title>
+    <ns>0</ns>
+    <id>25</id>
+    <revision>
+      <id>25</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="4725">== Articles ==
+* [[Apprentice&apos;s Robe]]
+* [[Bastion Ward Stone]]
+* [[Blessed Embers]]
+* [[Blessed Tallow]]
+* [[Bogiron Hauberk]]
+* [[Bogiron Mace]]
+* [[Bogiron Nugget]]
+* [[Bone Fragments]]
+* [[Boneguard Breastplate]]
+* [[Boneplate Vest]]
+* [[Bristleback Maul]]
+* [[Bristly Boar Hide]]
+* [[Bronzework Mace]]
+* [[Broodmother&apos;s Silk Robe]]
+* [[Chipped Tusk]]
+* [[Conjured Mineral Water]]
+* [[Conjured Sparkling Water]]
+* [[Conjured Spring Water]]
+* [[Cracked Fetish]]
+* [[Cracked Wolf Fang]]
+* [[Cracked Wyrm Scale]]
+* [[Craghorn Staff]]
+* [[Cragwalker Boots]]
+* [[Cryptbone Greaves]]
+* [[Cryptstalker Jerkin]]
+* [[Cultist Flayer]]
+* [[Deacon&apos;s Cleaver]]
+* [[Deathlord Legguards]]
+* [[Deathlord Sabatons]]
+* [[Deathlord Warplate]]
+* [[Deepfen Pearl]]
+* [[Drogmar&apos;s Skullcleaver]]
+* [[Drogmar&apos;s Warboots]]
+* [[Drowned Prayer Leggings]]
+* [[Drowned Prayer Sandals]]
+* [[Drownedguard Breastplate]]
+* [[Eastbrook Arming Sword]]
+* [[Eastbrook Chainmail Vest]]
+* [[Eastbrook Wool Trousers]]
+* [[Eelscale Leggings]]
+* [[Eelscale Treads]]
+* [[Eelskin Tunic]]
+* [[Emberwood Staff]]
+* [[Fang of Korzul]]
+* [[Fen Reaver Glaive]]
+* [[Fenbridge Muster Order]]
+* [[Fenbridge Rye Loaf]]
+* [[Fenmist Robe]]
+* [[Fenreed Staff]]
+* [[Fenwalker Boots]]
+* [[Footpad&apos;s Jerkin]]
+* [[Frayed Prayer Beads]]
+* [[Freshly Baked Bread]]
+* [[Ghostly Essence]]
+* [[Glacier Melt]]
+* [[Glowing Wax]]
+* [[Gnarled Staff]]
+* [[Gorrak&apos;s Cruel Chopper]]
+* [[Gravecaller Cipher]]
+* [[Gravecaller&apos;s Broadblade]]
+* [[Gravecaller&apos;s Sigil]]
+* [[Gravepath Treads]]
+* [[Gravewalker Softboots]]
+* [[Gravewoven Raiment]]
+* [[Gravewyrm Sabatons]]
+* [[Gravewyrm Scale Hauberk]]
+* [[Gravewyrm Sigil]]
+* [[Gravewyrm Stalker&apos;s Treads]]
+* [[Greyjaw Hide Boots]]
+* [[Greyjaw&apos;s Pelt Leggings]]
+* [[Grubjaw&apos;s Tusk]]
+* [[Gutripper Shiv]]
+* [[Hickory Shortstaff]]
+* [[Highwatch Breastplate]]
+* [[Highwatch Summons]]
+* [[Highwatch Trail Hardtack]]
+* [[Highwatch Warblade]]
+* [[Hobnailed Boots]]
+* [[Hollowbone Hauberk]]
+* [[Hollowbound Legguards]]
+* [[Icevein Dirk]]
+* [[Inert Storm Shard]]
+* [[Ironvein Lantern Staff]]
+* [[Ironvein Pickblade]]
+* [[Kazzix&apos;s Heartshard]]
+* [[Keen Dirk]]
+* [[Knight-Commander&apos;s Greaves]]
+* [[Korgath&apos;s Chainwraps]]
+* [[Linen Scrap]]
+* [[Lost Caravan Goods]]
+* [[Marrowlord Boneboots]]
+* [[Marrowtread Boots]]
+* [[Marsh Mint Tea]]
+* [[Marshcloth Robe]]
+* [[Marshstrider Boots]]
+* [[Meltwater Flask]]
+* [[Militia Chainvest]]
+* [[Minor Healing Potion]]
+* [[Minor Mana Potion]]
+* [[Mire Prowler Pelt]]
+* [[Mirefen Skinner]]
+* [[Mirefen Troll Fetish]]
+* [[Mirejaw Biteblade]]
+* [[Mirejaw Oracle Staff]]
+* [[Mirejaw Scale Vest]]
+* [[Mistbinder Kris]]
+* [[Mistcaller&apos;s Edge]]
+* [[Mogger&apos;s Copper Cudgel]]
+* [[Mogger&apos;s Shiv]]
+* [[Mogger&apos;s Stomper Boots]]
+* [[Morthen&apos;s Grimoire]]
+* [[Necromancer&apos;s Legwraps]]
+* [[Necromancer&apos;s Soulsteps]]
+* [[Necromancer&apos;s Starshroud]]
+* [[Nhalia&apos;s Dirgeblade]]
+* [[Nhalia&apos;s Funeral Wraps]]
+* [[Nightwalk Jerkin]]
+* [[Ogre Bonecharm Staff]]
+* [[Ogre Toe Ring]]
+* [[Ogre War Totem]]
+* [[Oiled Leather Boots]]
+* [[Old Greyjaw&apos;s Fang]]
+* [[Peakwool Robe]]
+* [[Quilted Trousers]]
+* [[Raw Mirror Trout]]
+* [[Recruit&apos;s Tunic]]
+* [[Red Bandana]]
+* [[Redbrook Militia Blade]]
+* [[Reedwoven Jerkin]]
+* [[Reedwoven Trousers]]
+* [[Refreshing Spring Water]]
+* [[Revenant Silk Robe]]
+* [[Ridge Stalker Pelt]]
+* [[Ridgestalker Treads]]
+* [[Riptide Dirk]]
+* [[Ritual Phylactery]]
+* [[Roast Mountain Goat]]
+* [[Roasted Boar Meat]]
+* [[Rusted Censer]]
+* [[Rusty Dagger]]
+* [[Rusty Hatchet]]
+* [[Sableweb Slippers]]
+* [[Sanctum Key Shard]]
+* [[Sexton&apos;s Slippers]]
+* [[Shadowmeld Tunic]]
+* [[Shadowstitch Jerkin]]
+* [[Silvermist Cordial]]
+* [[Simple Fishing Pole]]
+* [[Slimy Murloc Scale]]
+* [[Smoked Mirefen Eel]]
+* [[Soggy Moccasin]]
+* [[Staff of Drowned Prayers]]
+* [[Staff of Velkhar]]
+* [[Staff of the Gravewyrm]]
+* [[Staff of the Hollow]]
+* [[Stalkerhide Jerkin]]
+* [[Stolen Supply Crate]]
+* [[Storm Core]]
+* [[Stormshard Leggings]]
+* [[Tallow Candle]]
+* [[Tangled Weed]]
+* [[Tanned Leather Jerkin]]
+* [[Tideguard Greaves]]
+* [[Tideguard Sabatons]]
+* [[Tidescale Vest]]
+* [[Tough Jerky]]
+* [[Training Mace]]
+* [[Trollhide Leggings]]
+* [[Twitching Spider Leg]]
+* [[Vael&apos;s Mist-Staff]]
+* [[Vale Apprentice Staff]]
+* [[Vale Carving Knife]]
+* [[Valeborn Spellblade]]
+* [[Valespun Robe]]
+* [[Valewoven Robe]]
+* [[Voss&apos;s Sanctified Mace]]
+* [[Waterlogged Idol]]
+* [[Weathered Ledger Page]]
+* [[Webwood Silk Gland]]
+* [[Widow Venom Sac]]
+* [[Widowfang Dirk]]
+* [[Windguard Leggings]]
+* [[Worn Shortsword]]
+* [[Wyrmcult Grand Robe]]
+* [[Wyrmcult Orders]]
+* [[Wyrmcult Soulsteps]]
+* [[Wyrmfang Greatblade]]
+* [[Wyrmscale Jerkin]]
+* [[Wyrmshadow Harness]]
+* [[Wyrmshadow Legguards]]
+* [[Wyrmshadow Treads]]
+* [[Zealotsbane Blade]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Abilities</title>
+    <ns>0</ns>
+    <id>26</id>
+    <revision>
+      <id>26</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="3146">== Articles ==
+* [[Adrenaline Rush (Ability)]]
+* [[Aimed Shot (Ability)]]
+* [[Ambush (Ability)]]
+* [[Arcane Explosion (Ability)]]
+* [[Arcane Intellect (Ability)]]
+* [[Arcane Missiles (Ability)]]
+* [[Arcane Shot (Ability)]]
+* [[Aspect of the Cheetah (Ability)]]
+* [[Aspect of the Hawk (Ability)]]
+* [[Backstab (Ability)]]
+* [[Barkskin (Ability)]]
+* [[Battle Shout (Ability)]]
+* [[Bear Form (Ability)]]
+* [[Berserker Rage (Ability)]]
+* [[Blessing of Might (Ability)]]
+* [[Bloodrage (Ability)]]
+* [[Bloodthirst (Ability)]]
+* [[Cat Form (Ability)]]
+* [[Charge (Ability)]]
+* [[Claw (Ability)]]
+* [[Cleave (Ability)]]
+* [[Concussive Shot (Ability)]]
+* [[Conjure Water (Ability)]]
+* [[Consecration (Ability)]]
+* [[Corruption (Ability)]]
+* [[Curse of Agony (Ability)]]
+* [[Defensive Stance (Ability)]]
+* [[Demon Skin (Ability)]]
+* [[Devotion Aura (Ability)]]
+* [[Dismiss Pet (Ability)]]
+* [[Divine Protection (Ability)]]
+* [[Drain Life (Ability)]]
+* [[Earth Shock (Ability)]]
+* [[Entangling Roots (Ability)]]
+* [[Evasion (Ability)]]
+* [[Eviscerate (Ability)]]
+* [[Execute (Ability)]]
+* [[Exorcism (Ability)]]
+* [[Fear (Ability)]]
+* [[Ferocious Bite (Ability)]]
+* [[Fire Blast (Ability)]]
+* [[Fireball (Ability)]]
+* [[Flame Shock (Ability)]]
+* [[Flash Heal (Ability)]]
+* [[Flash of Light (Ability)]]
+* [[Frost Armor (Ability)]]
+* [[Frost Nova (Ability)]]
+* [[Frost Shock (Ability)]]
+* [[Frostbolt (Ability)]]
+* [[Ghost Wolf (Ability)]]
+* [[Gouge (Ability)]]
+* [[Growl (Ability)]]
+* [[Hammer of Justice (Ability)]]
+* [[Hamstring (Ability)]]
+* [[Heal (Ability)]]
+* [[Healing Touch (Ability)]]
+* [[Healing Wave (Ability)]]
+* [[Heroic Strike (Ability)]]
+* [[Holy Light (Ability)]]
+* [[Ice Barrier (Ability)]]
+* [[Immolate (Ability)]]
+* [[Judgement (Ability)]]
+* [[Kidney Shot (Ability)]]
+* [[Lay on Hands (Ability)]]
+* [[Lesser Heal (Ability)]]
+* [[Life Tap (Ability)]]
+* [[Lightning Bolt (Ability)]]
+* [[Lightning Shield (Ability)]]
+* [[Mark of the Wild (Ability)]]
+* [[Maul (Ability)]]
+* [[Mind Blast (Ability)]]
+* [[Mind Flay (Ability)]]
+* [[Mongoose Bite (Ability)]]
+* [[Moonfire (Ability)]]
+* [[Mortal Strike (Ability)]]
+* [[Overpower (Ability)]]
+* [[Polymorph (Ability)]]
+* [[Power Word: Fortitude (Ability)]]
+* [[Power Word: Shield (Ability)]]
+* [[Rapid Fire (Ability)]]
+* [[Raptor Strike (Ability)]]
+* [[Regrowth (Ability)]]
+* [[Rejuvenation (Ability)]]
+* [[Rend (Ability)]]
+* [[Renew (Ability)]]
+* [[Righteous Fury (Ability)]]
+* [[Rockbiter Weapon (Ability)]]
+* [[Scorch (Ability)]]
+* [[Seal of Righteousness (Ability)]]
+* [[Searing Pain (Ability)]]
+* [[Serpent Sting (Ability)]]
+* [[Shadow Bolt (Ability)]]
+* [[Shadow Word: Pain (Ability)]]
+* [[Shadowburn (Ability)]]
+* [[Shield Slam (Ability)]]
+* [[Sinister Strike (Ability)]]
+* [[Slam (Ability)]]
+* [[Slice and Dice (Ability)]]
+* [[Smite (Ability)]]
+* [[Sprint (Ability)]]
+* [[Starfire (Ability)]]
+* [[Stealth (Ability)]]
+* [[Stormstrike (Ability)]]
+* [[Sunder Armor (Ability)]]
+* [[Swipe (Ability)]]
+* [[Tame Beast (Ability)]]
+* [[Taunt (Ability)]]
+* [[Thorns (Ability)]]
+* [[Thunder Clap (Ability)]]
+* [[Whirlwind (Ability)]]
+* [[Wing Clip (Ability)]]
+* [[Wrath (Ability)]]
+[[Category:Portals]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eastbrook Vale</title>
+    <ns>0</ns>
+    <id>27</id>
+    <revision>
+      <id>27</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="902">== Overview ==
+Find Marshal Redbrook in town — he has work for you.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Level range
+| 1-7
+|-
+! Hub
+| Eastbrook
+|-
+! Biome
+| vale
+|-
+! Graveyard
+| -12, -14
+|}
+
+== Points of interest ==
+* Eastbrook
+* Wolf Run
+* Boar Meadow
+* Mirror Lake
+* Webwood
+* Copper Dig
+* Bandit Camp
+* Fallen Chapel
+
+== NPCs ==
+* [[The Merchant (NPC)]]
+* [[Marshal Redbrook (NPC)]]
+* [[Trader Wilkes (NPC)]]
+* [[Apothecary Lin (NPC)]]
+* [[Brother Aldric (NPC)]]
+* [[Smith Haldren (NPC)]]
+* [[Fisherman Brandt (NPC)]]
+* [[Foreman Odell (NPC)]]
+
+== Quest chain ==
+* [[Wolves at the Door]]
+* [[The Old Wolf]]
+* [[Bristleback Hides]]
+* [[Webwood Menace]]
+* [[Trouble at the Lake]]
+* [[Rats in the Mine]]
+* [[The Restless Dead]]
+* [[Stolen Supplies]]
+* [[Whispers Below]]
+* [[The Names of the Dead]]
+* [[Bandits of the Vale]]
+* [[The Ringleader]]
+[[Category:Zones]]
+[[Category:vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirefen Marsh</title>
+    <ns>0</ns>
+    <id>28</id>
+    <revision>
+      <id>28</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="869">== Overview ==
+Report to Warden Fenwick at the Fenbridge gate.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Level range
+| 6-13
+|-
+! Hub
+| Fenbridge
+|-
+! Biome
+| marsh
+|-
+! Graveyard
+| -18, 286
+|}
+
+== Points of interest ==
+* Fenbridge
+* Prowler Reeds
+* Deepfen Shallows
+* Widow Thicket
+* Drowned Chapel
+* Troll Mounds
+* Gravecaller Encampment
+* The Sunken Bastion
+
+== NPCs ==
+* [[Warden Fenwick (NPC)]]
+* [[Brother Aldric (NPC) (2)]]
+* [[Provisioner Hale (NPC)]]
+* [[Herbalist Yara (NPC)]]
+* [[Scout Maren (NPC)]]
+
+== Quest chain ==
+* [[Silence the Call]]
+* [[The Binding Rite]]
+* [[Into the Hollow]]
+* [[The Sexton&apos;s Bell]]
+* [[The Gravecaller&apos;s Trail]]
+* [[Mogger&apos;s Trail]]
+* [[Mogger Must Fall]]
+* [[Muster at Fenbridge]]
+* [[Teeth of the Fen]]
+* [[Pelts for the Causeway]]
+* [[The Lost Caravan]]
+* [[The Deepfen Stirs]]
+[[Category:Zones]]
+[[Category:marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Thornpeak Heights</title>
+    <ns>0</ns>
+    <id>29</id>
+    <revision>
+      <id>29</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1672">== Overview ==
+Captain Thessaly holds the wall at Highwatch — barely.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Level range
+| 13-20
+|-
+! Hub
+| Highwatch
+|-
+! Biome
+| peaks
+|-
+! Graveyard
+| 15, 645
+|}
+
+== Points of interest ==
+* Highwatch
+* Stalker Ridge
+* Deeprock Burrows
+* Ogre Foothills
+* Drogmar&apos;s War-Camp
+* Stormcrag
+* Wyrmcult Tents
+* Revenant Fields
+* Gravewyrm Sanctum
+
+== NPCs ==
+* [[Captain Thessaly (NPC)]]
+* [[Brother Aldric (NPC) (3)]]
+* [[Scout Maren (NPC) (2)]]
+* [[Quartermaster Bree (NPC)]]
+* [[Armorer Hode (NPC)]]
+* [[Loremaster Caddis (NPC)]]
+
+== Quest chain ==
+* [[Idols of the Deep]]
+* [[Back to the Shallows]]
+* [[Silk and Venom]]
+* [[The Broodmother]]
+* [[The Drowned Dead]]
+* [[Censers from the Deep]]
+* [[No Rest in the Reeds]]
+* [[Mounds of the Mirefen]]
+* [[Fetish and Bone]]
+* [[The Glutton]]
+* [[Robes in the Reeds]]
+* [[Stopping the Summoning]]
+* [[The Deacon of the Mire]]
+* [[The Sunken Bastion (2)]]
+* [[The Knight-Commander&apos;s Shame]]
+* [[The Mistcaller]]
+* [[The Watch on the Peaks]]
+* [[Stalkers on the Ridge]]
+* [[Winter Is Coming to Highwatch]]
+* [[Deeprock Trouble]]
+* [[Strange Wax]]
+* [[Ogres at the Foothills]]
+* [[Totems of War]]
+* [[The Captain&apos;s Bounty]]
+* [[Break the War-Camp]]
+* [[Warlord Drogmar]]
+* [[The Mountain Wakes]]
+* [[Cores of the Storm]]
+* [[The Shardlord]]
+* [[Chants on the Wind]]
+* [[Orders from Below]]
+* [[The Phylactery Ring]]
+* [[The Revenant Fields]]
+* [[Bones of the Vanguard]]
+* [[Sigils of the Wyrm]]
+* [[Breaking the Seal]]
+* [[The Voice Below]]
+* [[The Sanctum Gate]]
+* [[The Bound Guardian]]
+* [[The Grand Necromancer]]
+* [[Korzul the Gravewyrm]]
+[[Category:Zones]]
+[[Category:peaks]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Warrior</title>
+    <ns>0</ns>
+    <id>30</id>
+    <revision>
+      <id>30</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="741">== Overview ==
+Warrior starts with Worn Shortsword and uses rage.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 23
+|-
+! AGI
+| 20
+|-
+! STA
+| 22
+|-
+! INT
+| 10
+|-
+! SPI
+| 11
+|-
+! ARMOR
+| 50
+|}
+
+== Abilities ==
+* [[Heroic Strike (Ability)|Heroic Strike]]
+* [[Battle Shout (Ability)|Battle Shout]]
+* [[Charge (Ability)|Charge]]
+* [[Rend (Ability)|Rend]]
+* [[Thunder Clap (Ability)|Thunder Clap]]
+* [[Hamstring (Ability)|Hamstring]]
+* [[Bloodrage (Ability)|Bloodrage]]
+* [[Overpower (Ability)|Overpower]]
+* [[Execute (Ability)|Execute]]
+* [[Slam (Ability)|Slam]]
+* [[Cleave (Ability)|Cleave]]
+* [[Defensive Stance (Ability)|Defensive Stance]]
+* [[Sunder Armor (Ability)|Sunder Armor]]
+* [[Taunt (Ability)|Taunt]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mage</title>
+    <ns>0</ns>
+    <id>31</id>
+    <revision>
+      <id>31</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="720">== Overview ==
+Mage starts with Gnarled Staff and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 10
+|-
+! AGI
+| 12
+|-
+! STA
+| 14
+|-
+! INT
+| 24
+|-
+! SPI
+| 22
+|-
+! ARMOR
+| 25
+|}
+
+== Abilities ==
+* [[Fireball (Ability)|Fireball]]
+* [[Frost Armor (Ability)|Frost Armor]]
+* [[Arcane Intellect (Ability)|Arcane Intellect]]
+* [[Frostbolt (Ability)|Frostbolt]]
+* [[Conjure Water (Ability)|Conjure Water]]
+* [[Fire Blast (Ability)|Fire Blast]]
+* [[Arcane Missiles (Ability)|Arcane Missiles]]
+* [[Polymorph (Ability)|Polymorph]]
+* [[Frost Nova (Ability)|Frost Nova]]
+* [[Arcane Explosion (Ability)|Arcane Explosion]]
+* [[Scorch (Ability)|Scorch]]
+* [[Ice Barrier (Ability)|Ice Barrier]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rogue</title>
+    <ns>0</ns>
+    <id>32</id>
+    <revision>
+      <id>32</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="644">== Overview ==
+Rogue starts with Rusty Dagger and uses energy.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 17
+|-
+! AGI
+| 25
+|-
+! STA
+| 17
+|-
+! INT
+| 11
+|-
+! SPI
+| 12
+|-
+! ARMOR
+| 40
+|}
+
+== Abilities ==
+* [[Sinister Strike (Ability)|Sinister Strike]]
+* [[Eviscerate (Ability)|Eviscerate]]
+* [[Backstab (Ability)|Backstab]]
+* [[Gouge (Ability)|Gouge]]
+* [[Evasion (Ability)|Evasion]]
+* [[Slice and Dice (Ability)|Slice and Dice]]
+* [[Sprint (Ability)|Sprint]]
+* [[Kidney Shot (Ability)|Kidney Shot]]
+* [[Ambush (Ability)|Ambush]]
+* [[Adrenaline Rush (Ability)|Adrenaline Rush]]
+* [[Stealth (Ability)|Stealth]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Paladin</title>
+    <ns>0</ns>
+    <id>33</id>
+    <revision>
+      <id>33</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="783">== Overview ==
+Paladin starts with Training Mace and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 22
+|-
+! AGI
+| 17
+|-
+! STA
+| 22
+|-
+! INT
+| 13
+|-
+! SPI
+| 14
+|-
+! ARMOR
+| 45
+|}
+
+== Abilities ==
+* [[Seal of Righteousness (Ability)|Seal of Righteousness]]
+* [[Holy Light (Ability)|Holy Light]]
+* [[Devotion Aura (Ability)|Devotion Aura]]
+* [[Judgement (Ability)|Judgement]]
+* [[Blessing of Might (Ability)|Blessing of Might]]
+* [[Divine Protection (Ability)|Divine Protection]]
+* [[Hammer of Justice (Ability)|Hammer of Justice]]
+* [[Lay on Hands (Ability)|Lay on Hands]]
+* [[Flash of Light (Ability)|Flash of Light]]
+* [[Exorcism (Ability)|Exorcism]]
+* [[Consecration (Ability)|Consecration]]
+* [[Righteous Fury (Ability)|Righteous Fury]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hunter</title>
+    <ns>0</ns>
+    <id>34</id>
+    <revision>
+      <id>34</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="762">== Overview ==
+Hunter starts with Rusty Hatchet and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 14
+|-
+! AGI
+| 25
+|-
+! STA
+| 19
+|-
+! INT
+| 13
+|-
+! SPI
+| 14
+|-
+! ARMOR
+| 45
+|}
+
+== Abilities ==
+* [[Raptor Strike (Ability)|Raptor Strike]]
+* [[Aspect of the Hawk (Ability)|Aspect of the Hawk]]
+* [[Serpent Sting (Ability)|Serpent Sting]]
+* [[Arcane Shot (Ability)|Arcane Shot]]
+* [[Concussive Shot (Ability)|Concussive Shot]]
+* [[Mongoose Bite (Ability)|Mongoose Bite]]
+* [[Wing Clip (Ability)|Wing Clip]]
+* [[Aspect of the Cheetah (Ability)|Aspect of the Cheetah]]
+* [[Aimed Shot (Ability)|Aimed Shot]]
+* [[Rapid Fire (Ability)|Rapid Fire]]
+* [[Tame Beast (Ability)|Tame Beast]]
+* [[Dismiss Pet (Ability)|Dismiss Pet]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Priest</title>
+    <ns>0</ns>
+    <id>35</id>
+    <revision>
+      <id>35</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="638">== Overview ==
+Priest starts with Gnarled Staff and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 10
+|-
+! AGI
+| 11
+|-
+! STA
+| 13
+|-
+! INT
+| 22
+|-
+! SPI
+| 24
+|-
+! ARMOR
+| 20
+|}
+
+== Abilities ==
+* [[Smite (Ability)|Smite]]
+* [[Lesser Heal (Ability)|Lesser Heal]]
+* [[Power Word: Fortitude (Ability)|Power Word: Fortitude]]
+* [[Shadow Word: Pain (Ability)|Shadow Word: Pain]]
+* [[Power Word: Shield (Ability)|Power Word: Shield]]
+* [[Renew (Ability)|Renew]]
+* [[Mind Blast (Ability)|Mind Blast]]
+* [[Heal (Ability)|Heal]]
+* [[Mind Flay (Ability)|Mind Flay]]
+* [[Flash Heal (Ability)|Flash Heal]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shaman</title>
+    <ns>0</ns>
+    <id>36</id>
+    <revision>
+      <id>36</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="624">== Overview ==
+Shaman starts with Training Mace and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 18
+|-
+! AGI
+| 16
+|-
+! STA
+| 20
+|-
+! INT
+| 18
+|-
+! SPI
+| 18
+|-
+! ARMOR
+| 40
+|}
+
+== Abilities ==
+* [[Lightning Bolt (Ability)|Lightning Bolt]]
+* [[Rockbiter Weapon (Ability)|Rockbiter Weapon]]
+* [[Healing Wave (Ability)|Healing Wave]]
+* [[Earth Shock (Ability)|Earth Shock]]
+* [[Lightning Shield (Ability)|Lightning Shield]]
+* [[Flame Shock (Ability)|Flame Shock]]
+* [[Frost Shock (Ability)|Frost Shock]]
+* [[Ghost Wolf (Ability)|Ghost Wolf]]
+* [[Stormstrike (Ability)|Stormstrike]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Warlock</title>
+    <ns>0</ns>
+    <id>37</id>
+    <revision>
+      <id>37</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="613">== Overview ==
+Warlock starts with Gnarled Staff and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 11
+|-
+! AGI
+| 12
+|-
+! STA
+| 15
+|-
+! INT
+| 21
+|-
+! SPI
+| 21
+|-
+! ARMOR
+| 22
+|}
+
+== Abilities ==
+* [[Shadow Bolt (Ability)|Shadow Bolt]]
+* [[Demon Skin (Ability)|Demon Skin]]
+* [[Immolate (Ability)|Immolate]]
+* [[Corruption (Ability)|Corruption]]
+* [[Life Tap (Ability)|Life Tap]]
+* [[Curse of Agony (Ability)|Curse of Agony]]
+* [[Drain Life (Ability)|Drain Life]]
+* [[Fear (Ability)|Fear]]
+* [[Searing Pain (Ability)|Searing Pain]]
+* [[Shadowburn (Ability)|Shadowburn]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Druid</title>
+    <ns>0</ns>
+    <id>38</id>
+    <revision>
+      <id>38</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="841">== Overview ==
+Druid starts with Gnarled Staff and uses mana.
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 15
+|-
+! AGI
+| 15
+|-
+! STA
+| 17
+|-
+! INT
+| 19
+|-
+! SPI
+| 20
+|-
+! ARMOR
+| 30
+|}
+
+== Abilities ==
+* [[Wrath (Ability)|Wrath]]
+* [[Healing Touch (Ability)|Healing Touch]]
+* [[Mark of the Wild (Ability)|Mark of the Wild]]
+* [[Moonfire (Ability)|Moonfire]]
+* [[Rejuvenation (Ability)|Rejuvenation]]
+* [[Thorns (Ability)|Thorns]]
+* [[Entangling Roots (Ability)|Entangling Roots]]
+* [[Bear Form (Ability)|Bear Form]]
+* [[Regrowth (Ability)|Regrowth]]
+* [[Barkskin (Ability)|Barkskin]]
+* [[Starfire (Ability)|Starfire]]
+* [[Maul (Ability)|Maul]]
+* [[Growl (Ability)|Growl]]
+* [[Cat Form (Ability)|Cat Form]]
+* [[Claw (Ability)|Claw]]
+* [[Ferocious Bite (Ability)|Ferocious Bite]]
+* [[Swipe (Ability)|Swipe]]
+[[Category:Classes]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Hollow Crypt</title>
+    <ns>0</ns>
+    <id>39</id>
+    <revision>
+      <id>39</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1018">== Overview ==
+The Hollow Crypt is a private party instance with 13 source-defined spawns.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Interior
+| crypt
+|-
+! Spawn count
+| 13
+|-
+! Door position
+| 80, 90
+|}
+
+== Bosses ==
+* [[Morthen the Gravecaller (Mob)|Morthen the Gravecaller]]
+
+== Spawn list ==
+* [[Crypt Shambler (Mob)|Crypt Shambler]] at -3, 18
+* [[Crypt Shambler (Mob)|Crypt Shambler]] at 3, 19
+* [[Crypt Shambler (Mob)|Crypt Shambler]] at -9, 38
+* [[Hollow Acolyte (Mob)|Hollow Acolyte]] at -5, 39
+* [[Crypt Shambler (Mob)|Crypt Shambler]] at 9, 54
+* [[Hollow Acolyte (Mob)|Hollow Acolyte]] at 5, 55
+* [[Bonechill Widow (Mob)|Bonechill Widow]] at -5, 68
+* [[Bonechill Widow (Mob)|Bonechill Widow]] at -1, 70
+* [[Sexton Marrow (Mob)|Sexton Marrow]] at -4, 82
+* [[Hollow Acolyte (Mob)|Hollow Acolyte]] at 1, 83
+* [[Morthen the Gravecaller (Mob)|Morthen the Gravecaller]] at 0, 98
+* [[Crypt Shambler (Mob)|Crypt Shambler]] at -4, 96
+* [[Crypt Shambler (Mob)|Crypt Shambler]] at 4, 96
+[[Category:Dungeons]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Sunken Bastion</title>
+    <ns>0</ns>
+    <id>40</id>
+    <revision>
+      <id>40</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1069">== Overview ==
+The Sunken Bastion is a private party instance with 13 source-defined spawns.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Interior
+| crypt
+|-
+! Spawn count
+| 13
+|-
+! Door position
+| 45, 515
+|}
+
+== Bosses ==
+* [[Vael the Mistcaller (Mob)|Vael the Mistcaller]]
+
+== Spawn list ==
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at -3, 18
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at 3, 19
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at -9, 38
+* [[Tidebound Acolyte (Mob)|Tidebound Acolyte]] at -5, 39
+* [[Tidebound Acolyte (Mob)|Tidebound Acolyte]] at 9, 54
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at 5, 55
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at -5, 68
+* [[Tidebound Acolyte (Mob)|Tidebound Acolyte]] at -1, 70
+* [[Knight-Commander Olen (Mob)|Knight-Commander Olen]] at -4, 82
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at 1, 83
+* [[Vael the Mistcaller (Mob)|Vael the Mistcaller]] at 0, 98
+* [[Tidebound Acolyte (Mob)|Tidebound Acolyte]] at -4, 96
+* [[Bastion Revenant (Mob)|Bastion Revenant]] at 4, 96
+[[Category:Dungeons]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewyrm Sanctum</title>
+    <ns>0</ns>
+    <id>41</id>
+    <revision>
+      <id>41</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="1547">== Overview ==
+Gravewyrm Sanctum is a private party instance with 21 source-defined spawns.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Interior
+| sanctum
+|-
+! Spawn count
+| 21
+|-
+! Door position
+| 0, 880
+|}
+
+== Bosses ==
+* [[Korzul the Gravewyrm (Mob)|Korzul the Gravewyrm]]
+
+== Spawn list ==
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at -3, 16
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at 3, 17
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at -8, 30
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at -4, 31
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at 7, 44
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at 3, 45
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at -6, 58
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at -2, 59
+* [[Korgath the Bound (Mob)|Korgath the Bound]] at 0, 72
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at -7, 86
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at -3, 87
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at 6, 100
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at 2, 101
+* [[Grand Necromancer Velkhar (Mob)|Grand Necromancer Velkhar]] at 0, 114
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at -4, 112
+* [[Sanctum Boneguard (Mob)|Sanctum Boneguard]] at 4, 112
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at -5, 130
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at -1, 132
+* [[Korzul the Gravewyrm (Mob)|Korzul the Gravewyrm]] at 0, 146
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at -5, 144
+* [[Sanctum Drakonid (Mob)|Sanctum Drakonid]] at 5, 144
+[[Category:Dungeons]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Merchant (NPC)</title>
+    <ns>0</ns>
+    <id>42</id>
+    <revision>
+      <id>42</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="320">== Greeting ==
+Welcome to the World Market, $C. Buy from every adventurer in the realm — or set out your own wares and let coin find you.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Keeper of the World Market
+|-
+! Position
+| 0, 9.5
+|-
+! Quest count
+| 0
+|-
+! Vendor
+| World Market
+|}
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marshal Redbrook (NPC)</title>
+    <ns>0</ns>
+    <id>43</id>
+    <revision>
+      <id>43</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="374">== Greeting ==
+Keep your blade close, $C. The Vale is not what it was.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Town Marshal
+|-
+! Position
+| 4, 6
+|-
+! Quest count
+| 6
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Wolves at the Door]]
+* [[The Old Wolf]]
+* [[Bandits of the Vale]]
+* [[The Ringleader]]
+* [[Mogger&apos;s Trail]]
+* [[Mogger Must Fall]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Trader Wilkes (NPC)</title>
+    <ns>0</ns>
+    <id>44</id>
+    <revision>
+      <id>44</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="458">== Greeting ==
+Fresh bread, clean water, fair prices. What can I get you?
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Provisioner
+|-
+! Position
+| -7, 3
+|-
+! Quest count
+| 2
+|-
+! Vendor
+| Yes
+|}
+
+== Quests ==
+* [[Bristleback Hides]]
+* [[Stolen Supplies]]
+
+== Vendor stock ==
+* [[Freshly Baked Bread]]
+* [[Refreshing Spring Water]]
+* [[Roasted Boar Meat]]
+* [[Tough Jerky]]
+* [[Minor Healing Potion]]
+* [[Minor Mana Potion]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Apothecary Lin (NPC)</title>
+    <ns>0</ns>
+    <id>45</id>
+    <revision>
+      <id>45</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="256">== Greeting ==
+Careful where you step in the eastern woods, friend.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Herbalist
+|-
+! Position
+| 11, -3
+|-
+! Quest count
+| 1
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Webwood Menace]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Brother Aldric (NPC)</title>
+    <ns>0</ns>
+    <id>46</id>
+    <revision>
+      <id>46</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="475">== Greeting ==
+The Light keep you. Even the dead find no rest here of late.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Priest of the Vale
+|-
+! Position
+| -14, -10
+|-
+! Quest count
+| 9
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[The Restless Dead]]
+* [[Whispers Below]]
+* [[The Names of the Dead]]
+* [[Silence the Call]]
+* [[The Binding Rite]]
+* [[The Sexton&apos;s Bell]]
+* [[Into the Hollow]]
+* [[The Gravecaller&apos;s Trail]]
+* [[Muster at Fenbridge]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Smith Haldren (NPC)</title>
+    <ns>0</ns>
+    <id>47</id>
+    <revision>
+      <id>47</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="512">== Greeting ==
+Mind the sparks, $C. Good steel is the difference between a scar and a grave.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Armorer &amp; Weaponsmith
+|-
+! Position
+| 7, 16.5
+|-
+! Quest count
+| 0
+|-
+! Vendor
+| Yes
+|}
+
+== Vendor stock ==
+* [[Eastbrook Arming Sword]]
+* [[Bronzework Mace]]
+* [[Vale Carving Knife]]
+* [[Hickory Shortstaff]]
+* [[Eastbrook Chainmail Vest]]
+* [[Valespun Robe]]
+* [[Tanned Leather Jerkin]]
+* [[Hobnailed Boots]]
+* [[Eastbrook Wool Trousers]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fisherman Brandt (NPC)</title>
+    <ns>0</ns>
+    <id>48</id>
+    <revision>
+      <id>48</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="318">== Greeting ==
+Grlmurlgrl— sorry, been listening to those fish-men too long.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Old Salt
+|-
+! Position
+| -16, 6
+|-
+! Quest count
+| 1
+|-
+! Vendor
+| Yes
+|}
+
+== Quests ==
+* [[Trouble at the Lake]]
+
+== Vendor stock ==
+* [[Simple Fishing Pole]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Foreman Odell (NPC)</title>
+    <ns>0</ns>
+    <id>49</id>
+    <revision>
+      <id>49</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="263">== Greeting ==
+Whole dig&apos;s crawling with those candle-headed vermin!
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Mine Foreman
+|-
+! Position
+| -4, -14
+|-
+! Quest count
+| 1
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Rats in the Mine]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Warden Fenwick (NPC)</title>
+    <ns>0</ns>
+    <id>50</id>
+    <revision>
+      <id>50</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="422">== Greeting ==
+Hold at the gate, $C. Past those reeds, the fen does the killing for us.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Warden of Fenbridge
+|-
+! Position
+| 3, 304
+|-
+! Quest count
+| 6
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Muster at Fenbridge]]
+* [[Teeth of the Fen]]
+* [[The Deepfen Stirs]]
+* [[Back to the Shallows]]
+* [[Mounds of the Mirefen]]
+* [[The Deacon of the Mire]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Brother Aldric (NPC) (2)</title>
+    <ns>0</ns>
+    <id>51</id>
+    <revision>
+      <id>51</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="510">== Greeting ==
+The Light keep you above the water, $N. The dead in this fen do not sleep — they wade.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Priest of the Vale
+|-
+! Position
+| -8, 296
+|-
+! Quest count
+| 8
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Idols of the Deep]]
+* [[The Drowned Dead]]
+* [[Censers from the Deep]]
+* [[No Rest in the Reeds]]
+* [[Stopping the Summoning]]
+* [[The Sunken Bastion (2)|The Sunken Bastion]]
+* [[The Mistcaller]]
+* [[The Watch on the Peaks]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Provisioner Hale (NPC)</title>
+    <ns>0</ns>
+    <id>52</id>
+    <revision>
+      <id>52</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="637">== Greeting ==
+Dry boots, dry bread, dry powder — at Fenbridge you get two of the three on a good day.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Provisioner
+|-
+! Position
+| -4, 308
+|-
+! Quest count
+| 3
+|-
+! Vendor
+| Yes
+|}
+
+== Quests ==
+* [[Pelts for the Causeway]]
+* [[The Lost Caravan]]
+* [[The Glutton]]
+
+== Vendor stock ==
+* [[Fenbridge Rye Loaf]]
+* [[Marsh Mint Tea]]
+* [[Smoked Mirefen Eel]]
+* [[Silvermist Cordial]]
+* [[Bogiron Mace]]
+* [[Fenreed Staff]]
+* [[Mirefen Skinner]]
+* [[Bogiron Hauberk]]
+* [[Marshcloth Robe]]
+* [[Reedwoven Jerkin]]
+* [[Fenwalker Boots]]
+* [[Reedwoven Trousers]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Herbalist Yara (NPC)</title>
+    <ns>0</ns>
+    <id>53</id>
+    <revision>
+      <id>53</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="306">== Greeting ==
+Mind the thicket west of the road. The webs are thick as sailcloth this season.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Herbalist
+|-
+! Position
+| 10, 295
+|-
+! Quest count
+| 2
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Silk and Venom]]
+* [[The Broodmother]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Scout Maren (NPC)</title>
+    <ns>0</ns>
+    <id>54</id>
+    <revision>
+      <id>54</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="372">== Greeting ==
+Quiet feet and a short blade keep you breathing out here. Speak quick — I am due back in the reeds.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Marshal&apos;s Scout
+|-
+! Position
+| 6, 312
+|-
+! Quest count
+| 3
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Fetish and Bone]]
+* [[Robes in the Reeds]]
+* [[The Knight-Commander&apos;s Shame]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Captain Thessaly (NPC)</title>
+    <ns>0</ns>
+    <id>55</id>
+    <revision>
+      <id>55</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="466">== Greeting ==
+Two hundred years this wall has held, $C. It will not break on my watch — but it groans.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Highwatch Captain
+|-
+! Position
+| 4, 664
+|-
+! Quest count
+| 7
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[The Watch on the Peaks]]
+* [[Stalkers on the Ridge]]
+* [[The Captain&apos;s Bounty]]
+* [[Break the War-Camp]]
+* [[Warlord Drogmar]]
+* [[The Revenant Fields]]
+* [[Bones of the Vanguard]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Brother Aldric (NPC) (3)</title>
+    <ns>0</ns>
+    <id>56</id>
+    <revision>
+      <id>56</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="549">== Greeting ==
+From a chapel yard in the Vale to the roof of the world... the trail we have followed ends here. I can feel the mountain listening.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Priest of the Vale
+|-
+! Position
+| -10, 656
+|-
+! Quest count
+| 9
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Chants on the Wind]]
+* [[Orders from Below]]
+* [[The Phylactery Ring]]
+* [[Sigils of the Wyrm]]
+* [[Breaking the Seal]]
+* [[The Voice Below]]
+* [[The Sanctum Gate]]
+* [[The Grand Necromancer]]
+* [[Korzul the Gravewyrm]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Scout Maren (NPC) (2)</title>
+    <ns>0</ns>
+    <id>57</id>
+    <revision>
+      <id>57</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="372">== Greeting ==
+I tracked cultists through the fen at your side, and the trail led here. The peaks are worse, $C. Stay sharp.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Marshal&apos;s Scout
+|-
+! Position
+| 7, 670
+|-
+! Quest count
+| 3
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Ogres at the Foothills]]
+* [[Totems of War]]
+* [[The Bound Guardian]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Quartermaster Bree (NPC)</title>
+    <ns>0</ns>
+    <id>58</id>
+    <revision>
+      <id>58</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="591">== Greeting ==
+Wool, hardtack, and steel-shod boots — Highwatch runs on all three, and I am short of everything.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Highwatch Quartermaster
+|-
+! Position
+| -5, 668
+|-
+! Quest count
+| 2
+|-
+! Vendor
+| Yes
+|}
+
+== Quests ==
+* [[Winter Is Coming to Highwatch]]
+* [[Strange Wax]]
+
+== Vendor stock ==
+* [[Highwatch Trail Hardtack]]
+* [[Meltwater Flask]]
+* [[Roast Mountain Goat]]
+* [[Glacier Melt]]
+* [[Highwatch Breastplate]]
+* [[Peakwool Robe]]
+* [[Stalkerhide Jerkin]]
+* [[Cragwalker Boots]]
+* [[Windguard Leggings]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Armorer Hode (NPC)</title>
+    <ns>0</ns>
+    <id>59</id>
+    <revision>
+      <id>59</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="327">== Greeting ==
+Forge is hot and the grindstone is turning. If it cuts, I sell it.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Master Armorer
+|-
+! Position
+| -2, 672
+|-
+! Quest count
+| 0
+|-
+! Vendor
+| Yes
+|}
+
+== Vendor stock ==
+* [[Highwatch Warblade]]
+* [[Craghorn Staff]]
+* [[Icevein Dirk]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Loremaster Caddis (NPC)</title>
+    <ns>0</ns>
+    <id>60</id>
+    <revision>
+      <id>60</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="369">== Greeting ==
+Mind the loose shale, $C. The mountain has been... restless of late. I intend to learn why.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Title
+| Loremaster
+|-
+! Position
+| 12, 655
+|-
+! Quest count
+| 4
+|-
+! Vendor
+| No
+|}
+
+== Quests ==
+* [[Deeprock Trouble]]
+* [[The Mountain Wakes]]
+* [[Cores of the Storm]]
+* [[The Shardlord]]
+[[Category:NPCs]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wolves at the Door</title>
+    <ns>0</ns>
+    <id>61</id>
+    <revision>
+      <id>61</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="492">== Quest text ==
+The forest wolves grow bold, snapping at travelers on the north road. Thin their numbers, $N. Slay 8 Forest Wolves and Eastbrook will breathe easier.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 250
+|-
+! Copper reward
+| 75c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Forest Wolf slain: 8
+
+== Completion ==
+Fine work. The road feels safer already.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Old Wolf</title>
+    <ns>0</ns>
+    <id>62</id>
+    <revision>
+      <id>62</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="677">== Quest text ==
+There is one wolf no trap has held: Old Greyjaw. He has taken three hounds and a stable boy&apos;s arm. He prowls the deep woods north of the wolf runs. Bring me his fang.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 450
+|-
+! Copper reward
+| 1s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Wolves at the Door
+|}
+
+== Objectives ==
+* Old Greyjaw&apos;s Fang: 1
+
+== Completion ==
+So the old devil is dead at last. The stable boy will sleep easier — and so will I.
+
+== Rewards ==
+* [[Greyjaw&apos;s Pelt Leggings]]
+* [[Greyjaw&apos;s Pelt Leggings]]
+* [[Greyjaw&apos;s Pelt Leggings]]
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bristleback Hides</title>
+    <ns>0</ns>
+    <id>63</id>
+    <revision>
+      <id>63</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="525">== Quest text ==
+Boar hide makes the finest travel packs, and the meadows west of town are crawling with the beasts. Bring me 5 Bristly Boar Hides and I will make it worth your time.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 350
+|-
+! Copper reward
+| 1s 20c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Bristly Boar Hide: 5
+
+== Completion ==
+Ah, fine bristly hides! These will fetch a good price.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Webwood Menace</title>
+    <ns>0</ns>
+    <id>64</id>
+    <revision>
+      <id>64</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="569">== Quest text ==
+The lurkers in the eastern woods spin a silk I need for my poultices — and they have grown far too numerous besides. Cull 6 Webwood Lurkers and cut 4 silk glands from their bellies.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 420
+|-
+! Copper reward
+| 1s 40c
+|-
+! Minimum level
+| 2
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Webwood Lurker slain: 6
+* Webwood Silk Gland: 4
+
+== Completion ==
+Ugh, still twitching. Perfect. Here, you&apos;ve earned this.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Trouble at the Lake</title>
+    <ns>0</ns>
+    <id>65</id>
+    <revision>
+      <id>65</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="583">== Quest text ==
+Twenty years I have fished Mirror Lake, and never lost a net until those gurgling fish-men crawled out of the shallows. Drive the Mudfin back — slay 8 of them. And watch yourself: where there is one murloc, there are five.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 520
+|-
+! Copper reward
+| 1s 80c
+|-
+! Minimum level
+| 3
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Mudfin Skulker slain: 8
+
+== Completion ==
+Hah! That will teach them to mind their own mudholes.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rats in the Mine</title>
+    <ns>0</ns>
+    <id>66</id>
+    <revision>
+      <id>66</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="550">== Quest text ==
+We struck a fine copper vein and then those kobold vermin came boiling out of the hillside. My crew will not set foot in the dig until it is cleared. Put down 10 Tunnel Rat Diggers.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 620
+|-
+! Copper reward
+| 2s 20c
+|-
+! Minimum level
+| 4
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Tunnel Rat Digger slain: 10
+
+== Completion ==
+Ha! Back to work, lads! You have my thanks — and my coin.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Restless Dead</title>
+    <ns>0</ns>
+    <id>67</id>
+    <revision>
+      <id>67</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="572">== Quest text ==
+The old ruin on the northwest hill was a chapel once, and its yard a resting place. Something has stirred the dead from their sleep. Grant them peace, $N — return 8 Restless Bones to the earth.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 700
+|-
+! Copper reward
+| 2s 60c
+|-
+! Minimum level
+| 5
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Restless Bones laid to rest: 8
+
+== Completion ==
+May they rest now, and may the Light forgive whatever woke them.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stolen Supplies</title>
+    <ns>0</ns>
+    <id>68</id>
+    <revision>
+      <id>68</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="568">== Quest text ==
+Those bandits hit my last wagon and made off with four crates of goods — tools, salt, good Eastbrook linen. The crates are stacked around their camp in the southeast hills. Steal them back for me, would you?
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 550
+|-
+! Copper reward
+| 2s 50c
+|-
+! Minimum level
+| 3
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Stolen Supply Crate: 4
+
+== Completion ==
+My crates! Barely a scratch on them. You are a wonder.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Whispers Below</title>
+    <ns>0</ns>
+    <id>69</id>
+    <revision>
+      <id>69</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="654">== Quest text ==
+You have laid the dead to rest, but they will not stay resting — something calls them back. Search the chapel ruin for any trace of the one doing the calling. If you find a sigil or seal, bring it to me untouched.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 400
+|-
+! Copper reward
+| 1s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Restless Dead
+|}
+
+== Objectives ==
+* Gravecaller&apos;s Sigil: 1
+
+== Completion ==
+This sigil... it bears the mark of the Gravecallers, a sect I had prayed was extinct. This is worse than I feared, $N.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Names of the Dead</title>
+    <ns>0</ns>
+    <id>70</id>
+    <revision>
+      <id>70</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="755">== Quest text ==
+If the Gravecallers raised our dead, I must know whose graves they robbed. The chapel sexton kept a burial ledger, and the wind has scattered its pages across the chapel yard. Gather 3 of them for me, $N — the dead deserve to be called by their names.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 600
+|-
+! Copper reward
+| 2s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Whispers Below
+|}
+
+== Objectives ==
+* Weathered Ledger Page: 3
+
+== Completion ==
+These poor souls... and look here. Sexton Marrow — the chapel&apos;s own living caretaker — his grave the first disturbed. Morthen began with the very man who buried Eastbrook&apos;s dead.
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Silence the Call</title>
+    <ns>0</ns>
+    <id>71</id>
+    <revision>
+      <id>71</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="673">== Quest text ==
+Every name in that ledger is a soul Morthen means to drag from the earth, and the chapel yard already crawls with those he has called. Return 12 Restless Bones to their graves, $N, before the Gravecaller&apos;s whisper swells into a chorus.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 750
+|-
+! Copper reward
+| 3s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Names of the Dead
+|}
+
+== Objectives ==
+* Restless Bones silenced: 12
+
+== Completion ==
+The yard grows quieter — but the calling has not stopped. It rises from below now, $N. From the crypt itself.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Binding Rite</title>
+    <ns>0</ns>
+    <id>72</id>
+    <revision>
+      <id>72</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="777">== Quest text ==
+The crypt beneath the chapel must be unsealed if we are to stop the Gravecaller — but only a binding rite will let the living pass. I need 4 lumps of Blessed Tallow — the kobold diggers hoard candles by the crate — and 6 Ghostly Essences from the restless dead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 700
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Whispers Below
+|}
+
+== Objectives ==
+* Blessed Tallow: 4
+* Ghostly Essence: 6
+
+== Completion ==
+It is done. The way below stands open... and may the Light forgive me for opening it. Gather your strongest companions before you descend, $N. No one should face the Hollow alone.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Into the Hollow</title>
+    <ns>0</ns>
+    <id>73</id>
+    <revision>
+      <id>73</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="777">== Quest text ==
+Morthen the Gravecaller waits at the bottom of the Hollow Crypt, ringed by the elite dead he has raised. He is far beyond any one hero — take four companions, no fewer. End him, and the Vale&apos;s dead will finally sleep.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 1500
+|-
+! Copper reward
+| 1g 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Binding Rite
+|}
+
+== Objectives ==
+* Morthen the Gravecaller slain: 1
+
+== Completion ==
+The whispering has stopped. You have done what the whole Vale could not, $N — the dead sleep, and Eastbrook owes you everything it has.
+
+== Rewards ==
+* [[Gravecaller&apos;s Broadblade]]
+* [[Widowfang Dirk]]
+* [[Staff of the Hollow]]
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Sexton&apos;s Bell</title>
+    <ns>0</ns>
+    <id>74</id>
+    <revision>
+      <id>74</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="797">== Quest text ==
+The ledger named him and the crypt holds him: Sexton Marrow, the chapel&apos;s caretaker, the first man Morthen raised — guarding his master&apos;s door in death as faithfully as he kept the chapel in life. Take four companions into the Hollow Crypt and grant the old sexton the rest he was robbed of, $N.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 1000
+|-
+! Copper reward
+| 6s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Binding Rite
+|}
+
+== Objectives ==
+* Sexton Marrow laid to rest: 1
+
+== Completion ==
+So Marrow is free at last. Ring no bell for him — he heard enough of them in life.
+
+== Rewards ==
+* [[Marrowtread Boots]]
+* [[Sexton&apos;s Slippers]]
+* [[Gravewalker Softboots]]
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Gravecaller&apos;s Trail</title>
+    <ns>0</ns>
+    <id>75</id>
+    <revision>
+      <id>75</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="752">== Quest text ==
+Morthen is dead, yet a question gnaws at me: a sect that hid for a century does not spend itself on one village chapel. He kept a grimoire — his rites, his correspondence. If anything of it survives, it lies in the vestry of the ruined chapel above the crypt. Search the ruin and bring me whatever remains of his writings, $N.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 900
+|-
+! Copper reward
+| 4s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Into the Hollow
+|}
+
+== Objectives ==
+* Morthen&apos;s Grimoire: 1
+
+== Completion ==
+Morthen wrote to a &apos;Mistcaller&apos; in the northern fen. The sect is not dead, $N — it has merely been patient.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bandits of the Vale</title>
+    <ns>0</ns>
+    <id>76</id>
+    <revision>
+      <id>76</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="611">== Quest text ==
+A pack of cutthroats has made camp in the southwest hills. They have robbed three wagons this week. Drive them out — slay 10 Vale Bandits.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 550
+|-
+! Copper reward
+| 2s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Wolves at the Door
+|}
+
+== Objectives ==
+* Vale Bandit slain: 10
+
+== Completion ==
+Ten fewer knives in the dark. Take this — you have earned it.
+
+== Rewards ==
+* [[Redbrook Militia Blade]]
+* [[Vale Apprentice Staff]]
+* [[Keen Dirk]]
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Ringleader</title>
+    <ns>0</ns>
+    <id>77</id>
+    <revision>
+      <id>77</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="653">== Quest text ==
+The bandits answer to one man: Gorrak the Ruthless. Cut off the head and the body will scatter. He skulks at the heart of their camp. End him, $N.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Eastbrook Vale
+|-
+! XP reward
+| 800
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Bandits of the Vale
+|}
+
+== Objectives ==
+* Gorrak the Ruthless slain: 1
+
+== Completion ==
+Gorrak is dead? Then the Vale is free of his shadow. You have done Eastbrook a great service.
+
+== Rewards ==
+* [[Militia Chainvest]]
+* [[Valewoven Robe]]
+* [[Shadowstitch Jerkin]]
+[[Category:Quests]]
+[[Category:Eastbrook Vale]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger&apos;s Trail</title>
+    <ns>0</ns>
+    <id>78</id>
+    <revision>
+      <id>78</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="652">== Quest text ==
+Before you take the road north, Eastbrook has one last thorn in its side: Mogger. The brute has been trampling the lower meadow and driving the boars mad. Clear the meadow around his trail so we can see where he lairs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 650
+|-
+! Copper reward
+| 3s 50c
+|-
+! Minimum level
+| 6
+|-
+! Requires quest
+| The Gravecaller&apos;s Trail
+|}
+
+== Objectives ==
+* Wild Boar driven from the trail: 8
+
+== Completion ==
+Those tracks are fresh and deep enough to hold rain. Mogger is no camp tale, $N — and he is close.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger Must Fall</title>
+    <ns>0</ns>
+    <id>79</id>
+    <revision>
+      <id>79</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="706">== Quest text ==
+Mogger has split carts, flattened fences, and killed enough livestock to empty half the Vale. Do not face him alone. Take two strong companions into the eastern meadow and put the brute down for good.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 1200
+|-
+! Copper reward
+| 9s 0c
+|-
+! Minimum level
+| 6
+|-
+! Requires quest
+| Mogger&apos;s Trail
+|}
+
+== Objectives ==
+* Mogger slain: 1
+
+== Completion ==
+Mogger dead at last. Eastbrook&apos;s fields are safer, and you leave the Vale with one more tale worth retelling.
+
+== Rewards ==
+* [[Bristleback Maul]]
+* [[Sableweb Slippers]]
+* [[Mogger&apos;s Stomper Boots]]
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Muster at Fenbridge</title>
+    <ns>0</ns>
+    <id>80</id>
+    <revision>
+      <id>80</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="697">== Quest text ==
+Morthen&apos;s writings named a master in the northern marsh — a &apos;Mistcaller.&apos; Now Warden Fenwick has sounded the muster horn at Fenbridge, and I do not believe in coincidence, $N. Take the causeway north, pull the muster order from the gatepost, and present it to the Warden.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 300
+|-
+! Copper reward
+| 2s 0c
+|-
+! Minimum level
+| 6
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Fenbridge Muster Order: 1
+
+== Completion ==
+Aldric&apos;s seal, is it? Then you&apos;ll do. The fen has been swallowing my patrols whole, and I need every blade that floats.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Teeth of the Fen</title>
+    <ns>0</ns>
+    <id>81</id>
+    <revision>
+      <id>81</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="627">== Quest text ==
+The mire prowlers have learned what a supply mule sounds like, and now they hunt the causeway itself. Last week they dragged a courier into the reeds not fifty paces from this gate. Thin them out, $N — twelve dead prowlers ought to teach the rest fear.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 800
+|-
+! Copper reward
+| 3s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Mire Prowler slain: 12
+
+== Completion ==
+Twelve, and not a bite on you? The causeway breathes easier tonight.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Pelts for the Causeway</title>
+    <ns>0</ns>
+    <id>82</id>
+    <revision>
+      <id>82</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="628">== Quest text ==
+Every plank of that causeway rests on pilings wrapped in oiled prowler hide — the only thing the rot will not chew through. My stock is gone and the south spans are already sinking. Bring me 8 unspoiled pelts, $N, before we are all wading to Eastbrook.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 850
+|-
+! Copper reward
+| 3s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Mire Prowler Pelt: 8
+
+== Completion ==
+Good thick pelts, these. The causeway will outlast the both of us now.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Lost Caravan</title>
+    <ns>0</ns>
+    <id>83</id>
+    <revision>
+      <id>83</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="637">== Quest text ==
+A caravan out of Eastbrook went into the mist three days back and never rang the gate bell. The wreck is strewn the whole length of the causeway — crates, casks, the lot, sinking slow. Salvage 5 loads of goods before the marsh finishes the job.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 900
+|-
+! Copper reward
+| 3s 50c
+|-
+! Minimum level
+| 7
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Lost Caravan Goods: 5
+
+== Completion ==
+Waterlogged, but whole. Poor drivers... the fen keeps what it catches, $N. Remember that.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Deepfen Stirs</title>
+    <ns>0</ns>
+    <id>84</id>
+    <revision>
+      <id>84</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="666">== Quest text ==
+The Deepfen murlocs kept to their shallows for twenty years. Now they swarm the east bank like flies on a carcass — and my wardens say they are dragging things up from the lake bed. Whatever has them stirred, I want it stopped. Cull 12 of the snappers.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Mirefen Marsh
+|-
+! XP reward
+| 1000
+|-
+! Copper reward
+| 4s 0c
+|-
+! Minimum level
+| 7
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Deepfen Snapper slain: 12
+
+== Completion ==
+That will push them back to the mud for a while. But something set them digging, and I mean to learn what.
+[[Category:Quests]]
+[[Category:Mirefen Marsh]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Idols of the Deep</title>
+    <ns>0</ns>
+    <id>85</id>
+    <revision>
+      <id>85</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="720">== Quest text ==
+Fenwick&apos;s wardens say the fish-men dredge idols from the lake bottom and clutch them like holy relics. If those idols are what I fear, I must see them with my own eyes. Take 5 from the Deepfen snappers — they will not part with them kindly.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1050
+|-
+! Copper reward
+| 4s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Deepfen Stirs
+|}
+
+== Objectives ==
+* Waterlogged Idol: 5
+
+== Completion ==
+Gravecaller work — older than Morthen, older than me. The sect did not begin in Eastbrook, $N. It began here, and the lake has been keeping its secrets.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Back to the Shallows</title>
+    <ns>0</ns>
+    <id>86</id>
+    <revision>
+      <id>86</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="665">== Quest text ==
+Aldric says those idols are cult-make — which means the murlocs are hauling the marsh&apos;s old evil up one armful at a time. I will not have it washing onto my causeway. Go back to the shallows and break the dredging for good: 14 more snappers.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1100
+|-
+! Copper reward
+| 4s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Idols of the Deep
+|}
+
+== Objectives ==
+* Deepfen Snapper slain: 14
+
+== Completion ==
+Ruthless and thorough. If this marsh ever dries out, there&apos;s warden&apos;s work waiting for you.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Silk and Venom</title>
+    <ns>0</ns>
+    <id>87</id>
+    <revision>
+      <id>87</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="686">== Quest text ==
+Widow venom is the only thing that draws fen-rot from a wound — I bled a man of it just this morning. But the thicket west of the road has gone from nuisance to horror; the webs are taking deer whole now. Kill 10 widows and cut me 6 venom sacs, whole and unburst.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1200
+|-
+! Copper reward
+| 4s 50c
+|-
+! Minimum level
+| 8
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Mirefen Widow slain: 10
+* Widow Venom Sac: 6
+
+== Completion ==
+Whole sacs, every one. You have steadier hands than half the surgeons in the south, $N.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Broodmother</title>
+    <ns>0</ns>
+    <id>88</id>
+    <revision>
+      <id>88</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="704">== Quest text ==
+You have seen the webs — now ask yourself what spins cables thick as a man&apos;s wrist. The wardens call her the Broodmother, and her clutch hangs over Widow Thicket like a second canopy. Burn through 8 more widows and put the old mother down before that clutch opens.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1250
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Silk and Venom
+|}
+
+== Objectives ==
+* Mirefen Widow slain: 8
+* The Broodmother slain: 1
+
+== Completion ==
+Dead? Truly dead? Then the thicket is just trees again. The Light bless your blade, $N.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Drowned Dead</title>
+    <ns>0</ns>
+    <id>89</id>
+    <revision>
+      <id>89</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="701">== Quest text ==
+Travelers drowned on the causeway are walking out of the lakes, $N — still hung with the weeds they died in. This is no restless haunting. Drowning leaves no marks; it makes obedient corpses. Someone is filling this fen like a tithing box. Return 12 of the Drowned Dead to their rest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1400
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| 9
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Drowned Dead laid to rest: 12
+
+== Completion ==
+Each one you fell is a stolen soul set free. But the one who drowned them is still pouring water.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Censers from the Deep</title>
+    <ns>0</ns>
+    <id>90</id>
+    <revision>
+      <id>90</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="730">== Quest text ==
+North of the widow lake stands a chapel that drowned with its congregation when the marsh rose. The dead there carry rusted censers — funerary ones, the kind swung at a Gravecaller rite. Gather 4 from the chapel yard and I will read what rite was sung over that water.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1300
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Drowned Dead
+|}
+
+== Objectives ==
+* Rusted Censer: 4
+
+== Completion ==
+As I feared. These censers burned grave-ash, not incense. Someone consecrated that chapel to the drowning — and the rite is signed &apos;Voss.&apos;
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>No Rest in the Reeds</title>
+    <ns>0</ns>
+    <id>91</id>
+    <revision>
+      <id>91</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="825">== Quest text ==
+The rite on those censers binds the drowned to rise wherever the marsh touches them — and the marsh touches everything. There will be no rest in these reeds until the dead outnumber the living. We cannot unmake the rite yet, but we can empty it of soldiers. Lay 14 more of the Drowned Dead to rest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1500
+|-
+! Copper reward
+| 5s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Censers from the Deep
+|}
+
+== Objectives ==
+* Drowned Dead laid to rest: 14
+
+== Completion ==
+You give the dead more mercy than their masters ever did. Take this — you have more than earned it.
+
+== Rewards ==
+* [[Drownedguard Breastplate]]
+* [[Fenmist Robe]]
+* [[Eelskin Tunic]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mounds of the Mirefen</title>
+    <ns>0</ns>
+    <id>92</id>
+    <revision>
+      <id>92</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="690">== Quest text ==
+The Mirefen trolls have torn open the old barrow-mounds east of the far lake — burial mounds, $N, older than any kingdom of men. Whatever gold they think is down there, what they are letting OUT is worse. Drive them off the mounds: 12 trolls dead ought to do it.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1600
+|-
+! Copper reward
+| 6s 0c
+|-
+! Minimum level
+| 10
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Mirefen Troll slain: 12
+
+== Completion ==
+Trolls don&apos;t dig without a reason. Someone told them where to dig — and I&apos;d wager my gate it wears a grey robe.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fetish and Bone</title>
+    <ns>0</ns>
+    <id>93</id>
+    <revision>
+      <id>93</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="803">== Quest text ==
+I crawled the troll mounds two nights past. Those fetishes they plant are not troll-craft — the knots are wrong, the bones are man-bones, and every one points at the open barrows like a signpost. Bring me 8 of them and I will prove to Fenwick who is really paying for this dig.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1650
+|-
+! Copper reward
+| 6s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Mounds of the Mirefen
+|}
+
+== Objectives ==
+* Mirefen Troll Fetish: 8
+
+== Completion ==
+Same maker as the banners in the cult camp. The trolls are hired shovels, nothing more. Good work, $N.
+
+== Rewards ==
+* [[Trollhide Leggings]]
+* [[Trollhide Leggings]]
+* [[Trollhide Leggings]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Glutton</title>
+    <ns>0</ns>
+    <id>94</id>
+    <revision>
+      <id>94</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="729">== Quest text ==
+There&apos;s one troll the others won&apos;t dig beside — Grubjaw, the Glutton. He ate my last two pack-mules, harness and all, and my insurance man drowned years ago. He prowls the far eastern mounds, $N. Bring me his tusk and I will outfit you proper.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1700
+|-
+! Copper reward
+| 7s 0c
+|-
+! Minimum level
+| 11
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Grubjaw&apos;s Tusk: 1
+
+== Completion ==
+That tusk is long as my forearm! The mules are avenged, and Fenbridge owes you a round.
+
+== Rewards ==
+* [[Marshstrider Boots]]
+* [[Marshstrider Boots]]
+* [[Marshstrider Boots]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Robes in the Reeds</title>
+    <ns>0</ns>
+    <id>95</id>
+    <revision>
+      <id>95</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="668">== Quest text ==
+There — north past the third lake, where the mist never lifts. Grey robes, grey banners: Gravecallers, camped in the open like they already own the fen. They have stopped hiding, $N, which means they think they have already won. Prove them wrong. Cut down 12 of their cultists.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1800
+|-
+! Copper reward
+| 7s 0c
+|-
+! Minimum level
+| 11
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Gravecaller Cultist slain: 12
+
+== Completion ==
+Twelve robes face-down in the mud. Now they know the fen watches back.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stopping the Summoning</title>
+    <ns>0</ns>
+    <id>96</id>
+    <revision>
+      <id>96</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="735">== Quest text ==
+Maren&apos;s reports name summoners among the cultists — voices that call the drowned up out of the water like hounds to a whistle. Their ciphers will spell out the chain of command. Silence 8 summoners and bring me 4 of their ciphers.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1900
+|-
+! Copper reward
+| 7s 50c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Robes in the Reeds
+|}
+
+== Objectives ==
+* Gravecaller Summoner slain: 8
+* Gravecaller Cipher: 4
+
+== Completion ==
+Every cipher is countersigned &apos;Deacon Voss&apos; — and addressed onward to a &apos;Mistcaller&apos; in the Bastion. Morthen&apos;s master, $N. We have found him.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Deacon of the Mire</title>
+    <ns>0</ns>
+    <id>97</id>
+    <revision>
+      <id>97</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="813">== Quest text ==
+So a deacon of the Gravecallers stands at the heart of that camp, singing my drowned wardens up out of the lakes to serve him. His hymn ends today. Take the camp road north, $N, and put Deacon Voss in the ground — deep enough that nobody sings HIM back up.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2200
+|-
+! Copper reward
+| 10s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Stopping the Summoning
+|}
+
+== Objectives ==
+* Deacon Voss slain: 1
+
+== Completion ==
+Voss is dead and the mist over the camp is already thinning. You have broken their voice in the fen — now only the Bastion remains.
+
+== Rewards ==
+* [[Deacon&apos;s Cleaver]]
+* [[Staff of Drowned Prayers]]
+* [[Mistbinder Kris]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Sunken Bastion (2)</title>
+    <ns>0</ns>
+    <id>98</id>
+    <revision>
+      <id>98</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="698">== Quest text ==
+The Sunken Bastion — a knight&apos;s hold that drowned in the fen a century ago — is where Voss&apos;s letters point, and where this Mistcaller sings his drowning hymns. The cult has warded its door with grave-stones. Bring me one of the ward stones, $N, and I will unweave the seal.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1200
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| 12
+|-
+! Requires quest
+| The Deacon of the Mire
+|}
+
+== Objectives ==
+* Bastion Ward Stone: 1
+
+== Completion ==
+The ward parts like rotten rope. The door stands open... and the dark below it is listening.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Knight-Commander&apos;s Shame</title>
+    <ns>0</ns>
+    <id>99</id>
+    <revision>
+      <id>99</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="856">== Quest text ==
+Knight-Commander Olen held the Bastion when it sank — drowned at his post rather than abandon it. Every warden learns his name with pride. Now the Mistcaller has raised him as a puppet to guard the very door he died defending. That shame ends, $N. Take four companions below and grant Olen the rest he earned.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 1800
+|-
+! Copper reward
+| 8s 0c
+|-
+! Minimum level
+| 12
+|-
+! Requires quest
+| The Sunken Bastion
+|}
+
+== Objectives ==
+* Knight-Commander Olen laid to rest: 1
+
+== Completion ==
+Then his watch is finally over. I&apos;ll see his name cut into the gate myself. Thank you, $N.
+
+== Rewards ==
+* [[Knight-Commander&apos;s Greaves]]
+* [[Knight-Commander&apos;s Greaves]]
+* [[Knight-Commander&apos;s Greaves]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Mistcaller</title>
+    <ns>0</ns>
+    <id>100</id>
+    <revision>
+      <id>100</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="961">== Quest text ==
+At the bottom of the Bastion waits Vael the Mistcaller — Morthen&apos;s master, Voss&apos;s master, the voice that has drowned a hundred travelers to raise itself an army. He is far beyond any one hero: take four companions, no fewer. End him, $N, and the fen&apos;s dead may finally lie still.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2800
+|-
+! Copper reward
+| 25s 0c
+|-
+! Minimum level
+| 12
+|-
+! Requires quest
+| The Sunken Bastion
+|}
+
+== Objectives ==
+* Vael the Mistcaller slain: 1
+
+== Completion ==
+Vael is dead, and the mist is lifting for the first time in years. But Maren heard his last words, and they freeze my blood: &apos;The Wyrm stirs beneath the peaks.&apos; The sect serves something older than we ever guessed, $N. Rest while you can — the mountains are next.
+
+== Rewards ==
+* [[Mistcaller&apos;s Edge]]
+* [[Vael&apos;s Mist-Staff]]
+* [[Riptide Dirk]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Watch on the Peaks</title>
+    <ns>0</ns>
+    <id>101</id>
+    <revision>
+      <id>101</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="731">== Quest text ==
+Vael&apos;s last words have not left me, $N: the Wyrm stirs beneath the peaks. Captain Thessaly commands the wall at Highwatch, at the head of the mountain road north. A summons stands posted at her gate — take it up, and tell her Brother Aldric is climbing the mountain behind you.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 500
+|-
+! Copper reward
+| 5s 0c
+|-
+! Minimum level
+| 12
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Highwatch Summons: 1
+
+== Completion ==
+Aldric&apos;s word reaches far. If the priest of the Vale is climbing the mountain himself, then it is as bad as I feared. Welcome to Highwatch, $N.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stalkers on the Ridge</title>
+    <ns>0</ns>
+    <id>102</id>
+    <revision>
+      <id>102</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="573">== Quest text ==
+The ridge cats have come down from the high snows hungry, and my patrols bleed for it. Every stalker you put down is a soldier I keep on the wall. Thin them, $N — twelve, to start.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2200
+|-
+! Copper reward
+| 10s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Ridge Stalker slain: 12
+
+== Completion ==
+Twelve fewer shadows on the ridge. The patrols will breathe easier tonight.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Winter Is Coming to Highwatch</title>
+    <ns>0</ns>
+    <id>103</id>
+    <revision>
+      <id>103</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="718">== Quest text ==
+Winter on this mountain does not knock, $N — it kicks the door in. Eight ridge stalker pelts will line enough cloaks to see the wall through the first snows. The beasts prowl the ridges flanking the road south.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2300
+|-
+! Copper reward
+| 10s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Ridge Stalker Pelt: 8
+
+== Completion ==
+Thick as my arm, these. The watch will not freeze this year — take these treads for your trouble.
+
+== Rewards ==
+* [[Ridgestalker Treads]]
+* [[Ridgestalker Treads]]
+* [[Ridgestalker Treads]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deeprock Trouble</title>
+    <ns>0</ns>
+    <id>104</id>
+    <revision>
+      <id>104</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="660">== Quest text ==
+The kobolds at Deeprock Burrows are digging deeper than any candle-rat has business digging — straight down, as if something were calling them. Their tunnels run beneath our wall, $N. Collapse the matter: kill twelve Deeprock Tunnelers.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2500
+|-
+! Copper reward
+| 12s 0c
+|-
+! Minimum level
+| 14
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Deeprock Tunneler slain: 12
+
+== Completion ==
+Straight down, every shaft of it — kobolds do not dig like that on their own. I must consult my books.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Strange Wax</title>
+    <ns>0</ns>
+    <id>105</id>
+    <revision>
+      <id>105</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="657">== Quest text ==
+Caddis showed me a candle taken off one of those tunnelers — the wax glows, $N, and it is warm as a heartbeat. He wants more for study, and I want it off my requisition list. Bring back six lumps of the glowing wax.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2500
+|-
+! Copper reward
+| 12s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Deeprock Trouble
+|}
+
+== Objectives ==
+* Glowing Wax: 6
+
+== Completion ==
+Still warm. The Loremaster says the glow matches no flame he knows of. I say it is mountain trouble, and I say it kindly.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ogres at the Foothills</title>
+    <ns>0</ns>
+    <id>106</id>
+    <revision>
+      <id>106</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="662">== Quest text ==
+The Thornpeak clans never come this far east — yet here they are, camped in the eastern foothills with war paint on. Somebody is paying them, $N, and ogres do not take promises. Cut twelve of them down while I find out who holds the purse.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2900
+|-
+! Copper reward
+| 14s 0c
+|-
+! Minimum level
+| 15
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Thornpeak Ogre slain: 12
+
+== Completion ==
+Twelve down, and still they are not pulling back. Whoever bought them paid in something heavier than gold.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Totems of War</title>
+    <ns>0</ns>
+    <id>107</id>
+    <revision>
+      <id>107</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="644">== Quest text ==
+Around the war-camp the ogres have raised totems — crude things of hide and skull, but they mark a muster, not a raid. Tear down six of them and bring them to me. Mind the crushers on the perimeter, $N.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 2800
+|-
+! Copper reward
+| 14s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Ogres at the Foothills
+|}
+
+== Objectives ==
+* Ogre War Totem: 6
+
+== Completion ==
+Skull, hide... and look here — wyrm-scale bindings. These totems were gifts, $N. The cult is arming the clans.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Captain&apos;s Bounty</title>
+    <ns>0</ns>
+    <id>108</id>
+    <revision>
+      <id>108</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="629">== Quest text ==
+Maren&apos;s totems tell me all I need to know: the clans are bought, and my wall is their first errand. I will not wait for them to muster. Fourteen more Thornpeak Ogres, $N — and I will pay bounty on every one.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3000
+|-
+! Copper reward
+| 15s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Totems of War
+|}
+
+== Objectives ==
+* Thornpeak Ogre slain: 14
+
+== Completion ==
+Bounty paid in full. The foothills are quieter — now we deal with the ones doing the buying.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Break the War-Camp</title>
+    <ns>0</ns>
+    <id>109</id>
+    <revision>
+      <id>109</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="639">== Quest text ==
+Drogmar&apos;s war-camp squats in the eastern crags, and his crushers are the spine of it — each one worth three of my soldiers. Take companions; this is no errand for one blade. Break ten crushers and the warlord&apos;s muster breaks with them.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3600
+|-
+! Copper reward
+| 20s 0c
+|-
+! Minimum level
+| 16
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Thornpeak Crusher slain: 10
+
+== Completion ==
+Ten crushers down. The war-camp is a body without a spine — time to take the head.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Warlord Drogmar</title>
+    <ns>0</ns>
+    <id>110</id>
+    <revision>
+      <id>110</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="804">== Quest text ==
+Warlord Drogmar took the Wyrmcult&apos;s coin and swore the clans to the mountain&apos;s waking. He is the hammer they mean to swing at my wall — and when he slams the ground, $N, do not be standing near him. Take your companions into the war-camp and end him, for Highwatch.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4000
+|-
+! Copper reward
+| 25s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Break the War-Camp
+|}
+
+== Objectives ==
+* Warlord Drogmar slain: 1
+
+== Completion ==
+Drogmar, dead in his own camp. The clans will scatter to the high passes — you have bought my wall a winter, $N.
+
+== Rewards ==
+* [[Drogmar&apos;s Skullcleaver]]
+* [[Ogre Bonecharm Staff]]
+* [[Gutripper Shiv]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Mountain Wakes</title>
+    <ns>0</ns>
+    <id>111</id>
+    <revision>
+      <id>111</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="651">== Quest text ==
+Stormcrag has stood silent a thousand years, and now the very stones of it get up and walk. Elementals do not simply wake, $N — something beneath this mountain is turning in its sleep. Put twelve of them down so I may study what remains.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3600
+|-
+! Copper reward
+| 18s 0c
+|-
+! Minimum level
+| 16
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Stormcrag Elemental slain: 12
+
+== Completion ==
+The fragments hum like struck bells. The mountain is not angry, $N... it is being disturbed.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cores of the Storm</title>
+    <ns>0</ns>
+    <id>112</id>
+    <revision>
+      <id>112</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="648">== Quest text ==
+At each elemental&apos;s heart sits a storm core — a knot of lightning bound in stone. Six of them, set side by side, will tell me where the disturbance is centered. I suspect I already know, $N, and I dearly hope that I am wrong.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3700
+|-
+! Copper reward
+| 18s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Mountain Wakes
+|}
+
+== Objectives ==
+* Storm Core: 6
+
+== Completion ==
+Each core leans the same way, like iron filings to a lodestone. They point south, $N. To the Sanctum.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Shardlord</title>
+    <ns>0</ns>
+    <id>113</id>
+    <revision>
+      <id>113</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="773">== Quest text ==
+Among the elementals one burns brighter than the rest: Shardlord Kazzix, a storm given shoulders. Its heartshard would anchor every reading I have taken — if you can wrench it from the thing. It walks the far crags west of Stormcrag, beyond the second camp.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3800
+|-
+! Copper reward
+| 20s 0c
+|-
+! Minimum level
+| 17
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Kazzix&apos;s Heartshard: 1
+
+== Completion ==
+The heartshard! Still crackling — magnificent. Take these leggings; I sized them off a guess and a prayer.
+
+== Rewards ==
+* [[Stormshard Leggings]]
+* [[Stormshard Leggings]]
+* [[Stormshard Leggings]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Chants on the Wind</title>
+    <ns>0</ns>
+    <id>114</id>
+    <revision>
+      <id>114</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="697">== Quest text ==
+When the wind comes off the southern peaks, $N, it carries chanting. The Wyrmcult no longer hides — they have raised tents below the Sanctum and they sing to what sleeps beneath it. Silence twelve zealots. Every voice stilled buys the mountain another night of sleep.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4000
+|-
+! Copper reward
+| 20s 0c
+|-
+! Minimum level
+| 17
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Wyrmcult Zealot slain: 12
+
+== Completion ==
+The wind is quieter. But what troubles me is not the chanting, $N — it is that something may be chanting back.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Orders from Below</title>
+    <ns>0</ns>
+    <id>115</id>
+    <revision>
+      <id>115</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="743">== Quest text ==
+The zealots move with purpose now — watches set, supplies counted, like soldiers before a siege. Cultists who organize are cultists taking orders, $N. Kill eight more and bring me four sets of their written orders. I would know the hand that commands them.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3800
+|-
+! Copper reward
+| 18s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Chants on the Wind
+|}
+
+== Objectives ==
+* Wyrmcult Zealot slain: 8
+* Wyrmcult Orders: 4
+
+== Completion ==
+This script... I last saw its like in Morthen&apos;s grimoire, in Eastbrook. The same hand has guided every grave we have fought over, $N.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Phylactery Ring</title>
+    <ns>0</ns>
+    <id>116</id>
+    <revision>
+      <id>116</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="795">== Quest text ==
+The orders speak of a &quot;ring of phylacteries&quot; — soul-vessels, $N, set about the Sanctum to feed it. The cult&apos;s necromancers carry them like holy relics. Kill eight necromancers and bring me three phylacteries unbroken. I must know what souls they hold.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4200
+|-
+! Copper reward
+| 22s 0c
+|-
+! Minimum level
+| 18
+|-
+! Requires quest
+| Orders from Below
+|}
+
+== Objectives ==
+* Wyrmcult Necromancer slain: 8
+* Ritual Phylactery: 3
+
+== Completion ==
+Light forgive us. These hold the dead of the Vale and the fen — every corpse the Gravecallers ever raised, harvested. They were never building an army, $N. They were gathering a tithe.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Revenant Fields</title>
+    <ns>0</ns>
+    <id>117</id>
+    <revision>
+      <id>117</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="690">== Quest text ==
+East of the Sanctum road lies an old battlefield — the vanguard of the last army that tried to take this mountain, two hundred years buried. The cult has called them up, bones in rusted plate. Put twelve revenants back in the ground, $N.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4300
+|-
+! Copper reward
+| 22s 0c
+|-
+! Minimum level
+| 18
+|-
+! Requires quest
+| None
+|}
+
+== Objectives ==
+* Boneclad Revenant slain: 12
+
+== Completion ==
+They were soldiers once, like mine. Whatever called them up has no respect for the dead — or a use for them I do not care to learn.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bones of the Vanguard</title>
+    <ns>0</ns>
+    <id>118</id>
+    <revision>
+      <id>118</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="772">== Quest text ==
+The revenants are forming ranks, $N — true ranks, shield-lines and columns, drilling with no drummer. They are being mustered for the Sanctum gate. Break fourteen more before that march begins, and Highwatch will owe you its best steel.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4500
+|-
+! Copper reward
+| 24s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Revenant Fields
+|}
+
+== Objectives ==
+* Boneclad Revenant slain: 14
+
+== Completion ==
+The fields lie still again. Take this — it was made for the defenders of the wall, and no one has earned it more.
+
+== Rewards ==
+* [[Boneplate Vest]]
+* [[Revenant Silk Robe]]
+* [[Nightwalk Jerkin]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sigils of the Wyrm</title>
+    <ns>0</ns>
+    <id>119</id>
+    <revision>
+      <id>119</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="766">== Quest text ==
+It is time you knew the whole of it, $N. The Gravecallers serve Korzul the Gravewyrm — an ancient dragon sealed beneath this mountain — and every soul they have stolen since Eastbrook is a tithe poured into its waking. On the Sanctum Approach the cult has laid sigils to thin the seal. Bring me three; I would read the rite they are working.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 3600
+|-
+! Copper reward
+| 20s 0c
+|-
+! Minimum level
+| 18
+|-
+! Requires quest
+| The Phylactery Ring
+|}
+
+== Objectives ==
+* Gravewyrm Sigil: 3
+
+== Completion ==
+Yes... a waking-litany, generations in the writing. They are close, $N. Closer than I dared fear.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Breaking the Seal</title>
+    <ns>0</ns>
+    <id>120</id>
+    <revision>
+      <id>120</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="774">== Quest text ==
+The seal on the Sanctum was wrought with mountain-fire, and only mountain-fire will let us pass without tearing it wide open. The stormcrag elementals carry embers of that first forging in their cores. Bring me five Blessed Embers, $N — for if the cult opens that gate first, they will not be careful, and the Wyrm will not wake gently.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4200
+|-
+! Copper reward
+| 22s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Sigils of the Wyrm
+|}
+
+== Objectives ==
+* Blessed Embers: 5
+
+== Completion ==
+They burn blue and clean — the mountain remembers its old oath. With these I can unbind the gate for us alone.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Voice Below</title>
+    <ns>0</ns>
+    <id>121</id>
+    <revision>
+      <id>121</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="894">== Quest text ==
+Last night the whole cult camp knelt at once, $N — every zealot, every necromancer, all facing the Sanctum. Korzul speaks to them in their sleep now; Vael heard the same voice in the fen, and Morthen before him. Cut the congregation down — ten zealots, six necromancers — before that voice has hands enough to pull the gate open itself.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4400
+|-
+! Copper reward
+| 24s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| Breaking the Seal
+|}
+
+== Objectives ==
+* Wyrmcult Zealot slain: 10
+* Wyrmcult Necromancer slain: 6
+
+== Completion ==
+The kneeling has stopped. We have not silenced the voice, $N — only thinned its choir. It must be enough.
+
+== Rewards ==
+* [[Zealotsbane Blade]]
+* [[Emberwood Staff]]
+* [[Cultist Flayer]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Sanctum Gate</title>
+    <ns>0</ns>
+    <id>122</id>
+    <revision>
+      <id>122</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="821">== Quest text ==
+This is the last threshold, $N. The gate of the Gravewyrm Sanctum was locked with a keystone, and the cult shattered it into shards rather than see it turned against them. The shards lie scattered in the gate plaza, under the eyes of the boneclad dead. Bring me three, and I will open the way the Light intended — quietly.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4000
+|-
+! Copper reward
+| 20s 0c
+|-
+! Minimum level
+| None
+|-
+! Requires quest
+| The Voice Below
+|}
+
+== Objectives ==
+* Sanctum Key Shard: 3
+
+== Completion ==
+The shards sit true... and the gate knows its key. The way below stands open, $N. Gather the strongest companions you can find — what comes next, no one should face alone.
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Bound Guardian</title>
+    <ns>0</ns>
+    <id>123</id>
+    <revision>
+      <id>123</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="906">== Quest text ==
+My last sweep of the Sanctum&apos;s mouth found chains, $N — chains thick as a ship&apos;s mast, and something ogre-shaped straining inside them. The cult bound a champion at the threshold: Korgath, fed on rage for longer than either of us has been alive. Take four companions and put him down — and when the chains come off, do not let him corner you.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4200
+|-
+! Copper reward
+| 25s 0c
+|-
+! Minimum level
+| 18
+|-
+! Requires quest
+| The Sanctum Gate
+|}
+
+== Objectives ==
+* Korgath the Bound slain: 1
+
+== Completion ==
+Korgath, broken at last. Even his chains deserved a kinder end than that. The wraps are yours — wear them past the threshold he kept.
+
+== Rewards ==
+* [[Korgath&apos;s Chainwraps]]
+* [[Korgath&apos;s Chainwraps]]
+* [[Korgath&apos;s Chainwraps]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Grand Necromancer</title>
+    <ns>0</ns>
+    <id>124</id>
+    <revision>
+      <id>124</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="878">== Quest text ==
+Every thread we have followed — Morthen, Vael, the phylacteries — was spun by one hand: Grand Necromancer Velkhar, first of the Gravecallers, keeper of the waking rite. He stands in the ritual vault below, pouring two lands&apos; worth of stolen souls into the Wyrm. End him, $N, and the tithe ends with him.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 4500
+|-
+! Copper reward
+| 30s 0c
+|-
+! Minimum level
+| 18
+|-
+! Requires quest
+| The Sanctum Gate
+|}
+
+== Objectives ==
+* Grand Necromancer Velkhar slain: 1
+
+== Completion ==
+Velkhar is dead, and the rite is headless. But you felt it down there, did you not? The souls are already spent — the Wyrm is no longer asleep.
+
+== Rewards ==
+* [[Boneguard Breastplate]]
+* [[Staff of Velkhar]]
+* [[Shadowmeld Tunic]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Korzul the Gravewyrm</title>
+    <ns>0</ns>
+    <id>125</id>
+    <revision>
+      <id>125</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="987">== Quest text ==
+There is no rite left to stop, $N — only the Wyrm itself, half-woken in its hollow, gorged on the dead of the Vale and the fen. If it rises, the wall, the marsh, Eastbrook — everything we have defended falls in a single night. Take your companions into the Wyrm&apos;s Hollow and finish what we began in a chapel yard so long ago. The Light has carried you this far; carry it the rest of the way.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Zone
+| Thornpeak Heights
+|-
+! XP reward
+| 5300
+|-
+! Copper reward
+| 2g 50s 0c
+|-
+! Minimum level
+| 18
+|-
+! Requires quest
+| The Grand Necromancer
+|}
+
+== Objectives ==
+* Korzul the Gravewyrm slain: 1
+
+== Completion ==
+It is over. The dead of three lands may rest, the mountain sleeps unhaunted — and it is your name, $N, that every bell from here to Eastbrook rings tonight.
+
+== Rewards ==
+* [[Gravewyrm Scale Hauberk]]
+* [[Wyrmcult Grand Robe]]
+* [[Wyrmscale Jerkin]]
+[[Category:Quests]]
+[[Category:Thornpeak Heights]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Forest Wolf (Mob)</title>
+    <ns>0</ns>
+    <id>126</id>
+    <revision>
+      <id>126</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="255">== Overview ==
+Forest Wolf is a level 1-2 beast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| beast
+|-
+! Level
+| 1-2
+|-
+! Aggro radius
+| 10
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Cracked Wolf Fang]]
+[[Category:Mobs]]
+[[Category:beast]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Old Greyjaw (Mob)</title>
+    <ns>0</ns>
+    <id>127</id>
+    <revision>
+      <id>127</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="302">== Overview ==
+Old Greyjaw is a level 4 beast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| beast
+|-
+! Level
+| 4
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 1.8
+|}
+
+== Mechanics ==
+* Rare
+
+== Loot ==
+* [[Old Greyjaw&apos;s Fang]]
+* [[Cracked Wolf Fang]]
+[[Category:Mobs]]
+[[Category:beast]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wild Boar (Mob)</title>
+    <ns>0</ns>
+    <id>128</id>
+    <revision>
+      <id>128</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="272">== Overview ==
+Wild Boar is a level 2-3 beast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| beast
+|-
+! Level
+| 2-3
+|-
+! Aggro radius
+| 9
+|-
+! Attack speed
+| 2.2
+|}
+
+== Loot ==
+* [[Bristly Boar Hide]]
+* [[Tough Jerky]]
+[[Category:Mobs]]
+[[Category:beast]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Elder Bristleback (Mob)</title>
+    <ns>0</ns>
+    <id>129</id>
+    <revision>
+      <id>129</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="434">== Overview ==
+Elder Bristleback is a level 5 beast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| beast
+|-
+! Level
+| 5
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.4
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Bristleback Stomp
+* Enrage below 35%
+
+== Loot ==
+* [[Tough Jerky]]
+* [[Bristleback Maul]]
+* [[Mogger&apos;s Copper Cudgel]]
+* [[Hollowbone Hauberk]]
+* [[Hollowbound Legguards]]
+[[Category:Mobs]]
+[[Category:beast]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Webwood Lurker (Mob)</title>
+    <ns>0</ns>
+    <id>130</id>
+    <revision>
+      <id>130</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="291">== Overview ==
+Webwood Lurker is a level 2-4 spider.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| spider
+|-
+! Level
+| 2-4
+|-
+! Aggro radius
+| 10
+|-
+! Attack speed
+| 1.8
+|}
+
+== Loot ==
+* [[Webwood Silk Gland]]
+* [[Twitching Spider Leg]]
+[[Category:Mobs]]
+[[Category:spider]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sableweb Matriarch (Mob)</title>
+    <ns>0</ns>
+    <id>131</id>
+    <revision>
+      <id>131</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="415">== Overview ==
+Sableweb Matriarch is a level 6 spider.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| spider
+|-
+! Level
+| 6
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 1.7
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Venom Spray
+
+== Loot ==
+* [[Twitching Spider Leg]]
+* [[Sableweb Slippers]]
+* [[Valeborn Spellblade]]
+* [[Gravewoven Raiment]]
+* [[Gravepath Treads]]
+[[Category:Mobs]]
+[[Category:spider]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sableweb Hatchling (Mob)</title>
+    <ns>0</ns>
+    <id>132</id>
+    <revision>
+      <id>132</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="227">== Overview ==
+Sableweb Hatchling is a level 5 spider.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| spider
+|-
+! Level
+| 5
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 1.6
+|}
+[[Category:Mobs]]
+[[Category:spider]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger (Mob)</title>
+    <ns>0</ns>
+    <id>133</id>
+    <revision>
+      <id>133</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="397">== Overview ==
+Mogger is a level 6 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 6
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 2.2
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Ground Pound
+* Enrage below 30%
+
+== Loot ==
+* [[Linen Scrap]]
+* [[Mogger&apos;s Stomper Boots]]
+* [[Mogger&apos;s Shiv]]
+* [[Cryptstalker Jerkin]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger Lackey (Mob)</title>
+    <ns>0</ns>
+    <id>134</id>
+    <revision>
+      <id>134</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="230">== Overview ==
+Mogger Lackey is a level 5-6 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 5-6
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mudfin Skulker (Mob)</title>
+    <ns>0</ns>
+    <id>135</id>
+    <revision>
+      <id>135</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="282">== Overview ==
+Mudfin Skulker is a level 3-5 murloc.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| murloc
+|-
+! Level
+| 3-5
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 1.9
+|}
+
+== Loot ==
+* [[Slimy Murloc Scale]]
+* [[Linen Scrap]]
+[[Category:Mobs]]
+[[Category:murloc]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tunnel Rat Digger (Mob)</title>
+    <ns>0</ns>
+    <id>136</id>
+    <revision>
+      <id>136</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="301">== Overview ==
+Tunnel Rat Digger is a level 4-6 kobold.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| kobold
+|-
+! Level
+| 4-6
+|-
+! Aggro radius
+| 10
+|-
+! Attack speed
+| 2.1
+|}
+
+== Loot ==
+* [[Tallow Candle]]
+* [[Blessed Tallow]]
+* [[Linen Scrap]]
+[[Category:Mobs]]
+[[Category:kobold]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Vale Bandit (Mob)</title>
+    <ns>0</ns>
+    <id>137</id>
+    <revision>
+      <id>137</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="276">== Overview ==
+Vale Bandit is a level 3-5 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 3-5
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Red Bandana]]
+* [[Linen Scrap]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Restless Bones (Mob)</title>
+    <ns>0</ns>
+    <id>138</id>
+    <revision>
+      <id>138</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="282">== Overview ==
+Restless Bones is a level 5-7 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 5-7
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2.3
+|}
+
+== Loot ==
+* [[Bone Fragments]]
+* [[Ghostly Essence]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gorrak the Ruthless (Mob)</title>
+    <ns>0</ns>
+    <id>139</id>
+    <revision>
+      <id>139</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="366">== Overview ==
+Gorrak the Ruthless is a level 6 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 6
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 2.4
+|}
+
+== Mechanics ==
+* Boss
+
+== Loot ==
+* [[Red Bandana]]
+* [[Oiled Leather Boots]]
+* [[Quilted Trousers]]
+* [[Gorrak&apos;s Cruel Chopper]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mire Prowler (Mob)</title>
+    <ns>0</ns>
+    <id>140</id>
+    <revision>
+      <id>140</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="277">== Overview ==
+Mire Prowler is a level 7-8 beast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| beast
+|-
+! Level
+| 7-8
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Mire Prowler Pelt]]
+* [[Soggy Moccasin]]
+[[Category:Mobs]]
+[[Category:beast]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deepfen Snapper (Mob)</title>
+    <ns>0</ns>
+    <id>141</id>
+    <revision>
+      <id>141</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="288">== Overview ==
+Deepfen Snapper is a level 8-9 murloc.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| murloc
+|-
+! Level
+| 8-9
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 1.9
+|}
+
+== Loot ==
+* [[Waterlogged Idol]]
+* [[Slimy Murloc Scale]]
+[[Category:Mobs]]
+[[Category:murloc]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirejaw the Ravenous (Mob)</title>
+    <ns>0</ns>
+    <id>142</id>
+    <revision>
+      <id>142</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="423">== Overview ==
+Mirejaw the Ravenous is a level 10 murloc.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| murloc
+|-
+! Level
+| 10
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 1.8
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Ravenous Frenzy
+
+== Loot ==
+* [[Slimy Murloc Scale]]
+* [[Mirejaw Biteblade]]
+* [[Mirejaw Scale Vest]]
+* [[Fen Reaver Glaive]]
+* [[Mirejaw Oracle Staff]]
+[[Category:Mobs]]
+[[Category:murloc]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirejaw Frenzy (Mob)</title>
+    <ns>0</ns>
+    <id>143</id>
+    <revision>
+      <id>143</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="229">== Overview ==
+Mirejaw Frenzy is a level 9-10 murloc.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| murloc
+|-
+! Level
+| 9-10
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 1.7
+|}
+[[Category:Mobs]]
+[[Category:murloc]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirefen Widow (Mob)</title>
+    <ns>0</ns>
+    <id>144</id>
+    <revision>
+      <id>144</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Mirefen Widow is a level 8-10 spider.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| spider
+|-
+! Level
+| 8-10
+|-
+! Aggro radius
+| 10
+|-
+! Attack speed
+| 1.8
+|}
+
+== Loot ==
+* [[Widow Venom Sac]]
+* [[Twitching Spider Leg]]
+[[Category:Mobs]]
+[[Category:spider]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>The Broodmother (Mob)</title>
+    <ns>0</ns>
+    <id>145</id>
+    <revision>
+      <id>145</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="344">== Overview ==
+The Broodmother is a level 10 spider.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| spider
+|-
+! Level
+| 10
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 1.8
+|}
+
+== Mechanics ==
+* Boss
+
+== Loot ==
+* [[Marshstrider Boots]]
+* [[Broodmother&apos;s Silk Robe]]
+* [[Twitching Spider Leg]]
+[[Category:Mobs]]
+[[Category:spider]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drowned Dead (Mob)</title>
+    <ns>0</ns>
+    <id>146</id>
+    <revision>
+      <id>146</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="281">== Overview ==
+Drowned Dead is a level 9-11 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 9-11
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2.3
+|}
+
+== Loot ==
+* [[Bone Fragments]]
+* [[Cracked Fetish]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirefen Troll (Mob)</title>
+    <ns>0</ns>
+    <id>147</id>
+    <revision>
+      <id>147</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="306">== Overview ==
+Mirefen Troll is a level 10-12 troll.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| troll
+|-
+! Level
+| 10-12
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2.2
+|}
+
+== Loot ==
+* [[Mirefen Troll Fetish]]
+* [[Chipped Tusk]]
+* [[Bogiron Nugget]]
+[[Category:Mobs]]
+[[Category:troll]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Grubjaw the Glutton (Mob)</title>
+    <ns>0</ns>
+    <id>148</id>
+    <revision>
+      <id>148</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="303">== Overview ==
+Grubjaw the Glutton is a level 12 troll.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| troll
+|-
+! Level
+| 12
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 2.2
+|}
+
+== Mechanics ==
+* Rare
+
+== Loot ==
+* [[Grubjaw&apos;s Tusk]]
+* [[Chipped Tusk]]
+[[Category:Mobs]]
+[[Category:troll]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravecaller Cultist (Mob)</title>
+    <ns>0</ns>
+    <id>149</id>
+    <revision>
+      <id>149</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Gravecaller Cultist is a level 10-12 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 10-12
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Linen Scrap]]
+* [[Tallow Candle]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravecaller Summoner (Mob)</title>
+    <ns>0</ns>
+    <id>150</id>
+    <revision>
+      <id>150</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="278">== Overview ==
+Gravecaller Summoner is a level 11-12 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 11-12
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Gravecaller Cipher]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sister Nhalia (Mob)</title>
+    <ns>0</ns>
+    <id>151</id>
+    <revision>
+      <id>151</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="370">== Overview ==
+Sister Nhalia is a level 12 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 12
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 2
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Dirge of Nhalia
+
+== Loot ==
+* [[Tallow Candle]]
+* [[Nhalia&apos;s Funeral Wraps]]
+* [[Nhalia&apos;s Dirgeblade]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Nhalia Mourner (Mob)</title>
+    <ns>0</ns>
+    <id>152</id>
+    <revision>
+      <id>152</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="235">== Overview ==
+Nhalia Mourner is a level 11-12 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 11-12
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deacon Voss (Mob)</title>
+    <ns>0</ns>
+    <id>153</id>
+    <revision>
+      <id>153</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="334">== Overview ==
+Deacon Voss is a level 12 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 12
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 2.4
+|}
+
+== Mechanics ==
+* Boss
+* AoE: Drowning Hymn
+
+== Loot ==
+* [[Tallow Candle]]
+* [[Voss&apos;s Sanctified Mace]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ridge Stalker (Mob)</title>
+    <ns>0</ns>
+    <id>154</id>
+    <revision>
+      <id>154</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="264">== Overview ==
+Ridge Stalker is a level 13-14 beast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| beast
+|-
+! Level
+| 13-14
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 1.9
+|}
+
+== Loot ==
+* [[Ridge Stalker Pelt]]
+[[Category:Mobs]]
+[[Category:beast]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deeprock Tunneler (Mob)</title>
+    <ns>0</ns>
+    <id>155</id>
+    <revision>
+      <id>155</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="284">== Overview ==
+Deeprock Tunneler is a level 14-15 kobold.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| kobold
+|-
+! Level
+| 14-15
+|-
+! Aggro radius
+| 10
+|-
+! Attack speed
+| 2.1
+|}
+
+== Loot ==
+* [[Glowing Wax]]
+* [[Tallow Candle]]
+[[Category:Mobs]]
+[[Category:kobold]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ironvein Foreman (Mob)</title>
+    <ns>0</ns>
+    <id>156</id>
+    <revision>
+      <id>156</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="424">== Overview ==
+Ironvein Foreman is a level 16 kobold.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| kobold
+|-
+! Level
+| 16
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Powder Keg
+* Enrage below 30%
+
+== Loot ==
+* [[Glowing Wax]]
+* [[Ironvein Pickblade]]
+* [[Ironvein Lantern Staff]]
+* [[Gutripper Shiv]]
+* [[Deathlord Sabatons]]
+[[Category:Mobs]]
+[[Category:kobold]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ironvein Sapper (Mob)</title>
+    <ns>0</ns>
+    <id>157</id>
+    <revision>
+      <id>157</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="230">== Overview ==
+Ironvein Sapper is a level 15-16 kobold.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| kobold
+|-
+! Level
+| 15-16
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+[[Category:Mobs]]
+[[Category:kobold]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Thornpeak Ogre (Mob)</title>
+    <ns>0</ns>
+    <id>158</id>
+    <revision>
+      <id>158</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="257">== Overview ==
+Thornpeak Ogre is a level 15-16 ogre.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| ogre
+|-
+! Level
+| 15-16
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2.6
+|}
+
+== Loot ==
+* [[Ogre Toe Ring]]
+[[Category:Mobs]]
+[[Category:ogre]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Thornpeak Crusher (Mob)</title>
+    <ns>0</ns>
+    <id>159</id>
+    <revision>
+      <id>159</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="285">== Overview ==
+Thornpeak Crusher is a level 16-17 ogre.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| ogre
+|-
+! Level
+| 16-17
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.6
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Ogre Toe Ring]]
+[[Category:Mobs]]
+[[Category:ogre]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Warlord Drogmar (Mob)</title>
+    <ns>0</ns>
+    <id>160</id>
+    <revision>
+      <id>160</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="337">== Overview ==
+Warlord Drogmar is a level 17 ogre.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| ogre
+|-
+! Level
+| 17
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 2.6
+|}
+
+== Mechanics ==
+* Boss
+* Elite
+* AoE: Ground Slam
+
+== Loot ==
+* [[Drogmar&apos;s Warboots]]
+* [[Drogmar&apos;s Skullcleaver]]
+[[Category:Mobs]]
+[[Category:ogre]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stormcrag Elemental (Mob)</title>
+    <ns>0</ns>
+    <id>161</id>
+    <revision>
+      <id>161</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="319">== Overview ==
+Stormcrag Elemental is a level 17-18 elemental.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| elemental
+|-
+! Level
+| 17-18
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2.2
+|}
+
+== Loot ==
+* [[Storm Core]]
+* [[Blessed Embers]]
+* [[Inert Storm Shard]]
+[[Category:Mobs]]
+[[Category:elemental]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shardlord Kazzix (Mob)</title>
+    <ns>0</ns>
+    <id>162</id>
+    <revision>
+      <id>162</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="322">== Overview ==
+Shardlord Kazzix is a level 18 elemental.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| elemental
+|-
+! Level
+| 18
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.2
+|}
+
+== Mechanics ==
+* Rare
+
+== Loot ==
+* [[Kazzix&apos;s Heartshard]]
+* [[Inert Storm Shard]]
+[[Category:Mobs]]
+[[Category:elemental]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmcult Zealot (Mob)</title>
+    <ns>0</ns>
+    <id>163</id>
+    <revision>
+      <id>163</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="296">== Overview ==
+Wyrmcult Zealot is a level 17-19 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 17-19
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Wyrmcult Orders]]
+* [[Frayed Prayer Beads]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmcult Necromancer (Mob)</title>
+    <ns>0</ns>
+    <id>164</id>
+    <revision>
+      <id>164</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="295">== Overview ==
+Wyrmcult Necromancer is a level 18-19 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 18-19
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2
+|}
+
+== Loot ==
+* [[Ritual Phylactery]]
+* [[Linen Scrap]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Boneclad Revenant (Mob)</title>
+    <ns>0</ns>
+    <id>165</id>
+    <revision>
+      <id>165</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="267">== Overview ==
+Boneclad Revenant is a level 18-19 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 18-19
+|-
+! Aggro radius
+| 11
+|-
+! Attack speed
+| 2.3
+|}
+
+== Loot ==
+* [[Bone Fragments]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marrowlord Varkas (Mob)</title>
+    <ns>0</ns>
+    <id>166</id>
+    <revision>
+      <id>166</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="367">== Overview ==
+Marrowlord Varkas is a level 19 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 19
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 2.4
+|}
+
+== Mechanics ==
+* Elite
+* Rare
+* AoE: Marrow Rot
+
+== Loot ==
+* [[Bone Fragments]]
+* [[Marrowlord Boneboots]]
+* [[Necromancer&apos;s Legwraps]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Varkas Boneguard (Mob)</title>
+    <ns>0</ns>
+    <id>167</id>
+    <revision>
+      <id>167</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="233">== Overview ==
+Varkas Boneguard is a level 18-19 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 18-19
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.3
+|}
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Crypt Shambler (Mob)</title>
+    <ns>0</ns>
+    <id>168</id>
+    <revision>
+      <id>168</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="285">== Overview ==
+Crypt Shambler is a level 7-8 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 7-8
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.4
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Bone Fragments]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hollow Acolyte (Mob)</title>
+    <ns>0</ns>
+    <id>169</id>
+    <revision>
+      <id>169</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="276">== Overview ==
+Hollow Acolyte is a level 8 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 8
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Linen Scrap]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bonechill Widow (Mob)</title>
+    <ns>0</ns>
+    <id>170</id>
+    <revision>
+      <id>170</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="292">== Overview ==
+Bonechill Widow is a level 8-9 spider.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| spider
+|-
+! Level
+| 8-9
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 1.8
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Twitching Spider Leg]]
+[[Category:Mobs]]
+[[Category:spider]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sexton Marrow (Mob)</title>
+    <ns>0</ns>
+    <id>171</id>
+    <revision>
+      <id>171</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="308">== Overview ==
+Sexton Marrow is a level 9 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 9
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 2.2
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Quilted Trousers]]
+* [[Oiled Leather Boots]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Morthen the Gravecaller (Mob)</title>
+    <ns>0</ns>
+    <id>172</id>
+    <revision>
+      <id>172</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="396">== Overview ==
+Morthen the Gravecaller is a level 10 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 10
+|-
+! Aggro radius
+| 16
+|-
+! Attack speed
+| 2.6
+|}
+
+== Mechanics ==
+* Boss
+* Elite
+* AoE: Shadow Pulse
+
+== Loot ==
+* [[Cryptbone Greaves]]
+* [[Quilted Trousers]]
+* [[Oiled Leather Boots]]
+* [[Greyjaw Hide Boots]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bastion Revenant (Mob)</title>
+    <ns>0</ns>
+    <id>173</id>
+    <revision>
+      <id>173</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="291">== Overview ==
+Bastion Revenant is a level 12-13 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 12-13
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.3
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Bone Fragments]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tidebound Acolyte (Mob)</title>
+    <ns>0</ns>
+    <id>174</id>
+    <revision>
+      <id>174</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="293">== Overview ==
+Tidebound Acolyte is a level 12-13 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 12-13
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Linen Scrap]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drowned Thrall (Mob)</title>
+    <ns>0</ns>
+    <id>175</id>
+    <revision>
+      <id>175</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="223">== Overview ==
+Drowned Thrall is a level 11 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 11
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2
+|}
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Knight-Commander Olen (Mob)</title>
+    <ns>0</ns>
+    <id>176</id>
+    <revision>
+      <id>176</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="411">== Overview ==
+Knight-Commander Olen is a level 13 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 13
+|-
+! Aggro radius
+| 14
+|-
+! Attack speed
+| 2.2
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Trollhide Leggings]]
+* [[Marshstrider Boots]]
+* [[Fenmist Robe]]
+* [[Tideguard Greaves]]
+* [[Tideguard Sabatons]]
+* [[Eelscale Leggings]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Vael the Mistcaller (Mob)</title>
+    <ns>0</ns>
+    <id>177</id>
+    <revision>
+      <id>177</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="509">== Overview ==
+Vael the Mistcaller is a level 13 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 13
+|-
+! Aggro radius
+| 16
+|-
+! Attack speed
+| 2.4
+|}
+
+== Mechanics ==
+* Boss
+* Elite
+* AoE: Mist Surge
+
+== Loot ==
+* [[Trollhide Leggings]]
+* [[Marshstrider Boots]]
+* [[Fenmist Robe]]
+* [[Deepfen Pearl]]
+* [[Eelskin Tunic]]
+* [[Tidescale Vest]]
+* [[Drowned Prayer Leggings]]
+* [[Drowned Prayer Sandals]]
+* [[Eelscale Treads]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sanctum Boneguard (Mob)</title>
+    <ns>0</ns>
+    <id>178</id>
+    <revision>
+      <id>178</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="286">== Overview ==
+Sanctum Boneguard is a level 19 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 19
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.3
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Bone Fragments]]
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sanctum Drakonid (Mob)</title>
+    <ns>0</ns>
+    <id>179</id>
+    <revision>
+      <id>179</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="304">== Overview ==
+Sanctum Drakonid is a level 19-20 dragonkin.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| dragonkin
+|-
+! Level
+| 19-20
+|-
+! Aggro radius
+| 13
+|-
+! Attack speed
+| 2.2
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Cracked Wyrm Scale]]
+[[Category:Mobs]]
+[[Category:dragonkin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Raised Bonewalker (Mob)</title>
+    <ns>0</ns>
+    <id>180</id>
+    <revision>
+      <id>180</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="228">== Overview ==
+Raised Bonewalker is a level 18 undead.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| undead
+|-
+! Level
+| 18
+|-
+! Aggro radius
+| 12
+|-
+! Attack speed
+| 2.2
+|}
+[[Category:Mobs]]
+[[Category:undead]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Korgath the Bound (Mob)</title>
+    <ns>0</ns>
+    <id>181</id>
+    <revision>
+      <id>181</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="544">== Overview ==
+Korgath the Bound is a level 20 ogre.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| ogre
+|-
+! Level
+| 20
+|-
+! Aggro radius
+| 15
+|-
+! Attack speed
+| 2.8
+|}
+
+== Mechanics ==
+* Elite
+* Enrage below 30%
+
+== Loot ==
+* [[Boneplate Vest]]
+* [[Revenant Silk Robe]]
+* [[Nightwalk Jerkin]]
+* [[Zealotsbane Blade]]
+* [[Korgath&apos;s Chainwraps]]
+* [[Staff of Velkhar]]
+* [[Shadowmeld Tunic]]
+* [[Wyrmcult Grand Robe]]
+* [[Gravewyrm Sabatons]]
+* [[Wyrmcult Soulsteps]]
+* [[Wyrmshadow Treads]]
+[[Category:Mobs]]
+[[Category:ogre]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Grand Necromancer Velkhar (Mob)</title>
+    <ns>0</ns>
+    <id>182</id>
+    <revision>
+      <id>182</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="558">== Overview ==
+Grand Necromancer Velkhar is a level 20 humanoid.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| humanoid
+|-
+! Level
+| 20
+|-
+! Aggro radius
+| 15
+|-
+! Attack speed
+| 2
+|}
+
+== Mechanics ==
+* Elite
+
+== Loot ==
+* [[Boneplate Vest]]
+* [[Revenant Silk Robe]]
+* [[Nightwalk Jerkin]]
+* [[Emberwood Staff]]
+* [[Boneguard Breastplate]]
+* [[Shadowmeld Tunic]]
+* [[Staff of Velkhar]]
+* [[Gravewyrm Stalker&apos;s Treads]]
+* [[Deathlord Legguards]]
+* [[Necromancer&apos;s Soulsteps]]
+* [[Wyrmshadow Legguards]]
+[[Category:Mobs]]
+[[Category:humanoid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Korzul the Gravewyrm (Mob)</title>
+    <ns>0</ns>
+    <id>183</id>
+    <revision>
+      <id>183</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="576">== Overview ==
+Korzul the Gravewyrm is a level 20 dragonkin.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Family
+| dragonkin
+|-
+! Level
+| 20
+|-
+! Aggro radius
+| 18
+|-
+! Attack speed
+| 2.6
+|}
+
+== Mechanics ==
+* Boss
+* Elite
+* AoE: Necrotic Shockwave
+* Enrage below 30%
+
+== Loot ==
+* [[Boneplate Vest]]
+* [[Revenant Silk Robe]]
+* [[Nightwalk Jerkin]]
+* [[Cultist Flayer]]
+* [[Wyrmfang Greatblade]]
+* [[Staff of the Gravewyrm]]
+* [[Fang of Korzul]]
+* [[Deathlord Warplate]]
+* [[Necromancer&apos;s Starshroud]]
+* [[Wyrmshadow Harness]]
+[[Category:Mobs]]
+[[Category:dragonkin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Worn Shortsword</title>
+    <ns>0</ns>
+    <id>184</id>
+    <revision>
+      <id>184</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="408">== Overview ==
+Worn Shortsword is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 10c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 2-5
+|-
+! Speed
+| 2
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gnarled Staff</title>
+    <ns>0</ns>
+    <id>185</id>
+    <revision>
+      <id>185</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="472">== Overview ==
+Gnarled Staff is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 12c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 3-6
+|-
+! Speed
+| 2.9
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 1
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rusty Dagger</title>
+    <ns>0</ns>
+    <id>186</id>
+    <revision>
+      <id>186</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="408">== Overview ==
+Rusty Dagger is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 10c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 2-4
+|-
+! Speed
+| 1.8
+|-
+! Dagger
+| Yes
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Training Mace</title>
+    <ns>0</ns>
+    <id>187</id>
+    <revision>
+      <id>187</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="408">== Overview ==
+Training Mace is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 10c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 2-5
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rusty Hatchet</title>
+    <ns>0</ns>
+    <id>188</id>
+    <revision>
+      <id>188</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="408">== Overview ==
+Rusty Hatchet is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 10c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 2-5
+|-
+! Speed
+| 2.2
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Recruit&apos;s Tunic</title>
+    <ns>0</ns>
+    <id>189</id>
+    <revision>
+      <id>189</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="363">== Overview ==
+Recruit&apos;s Tunic is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 5c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 20
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Apprentice&apos;s Robe</title>
+    <ns>0</ns>
+    <id>190</id>
+    <revision>
+      <id>190</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="364">== Overview ==
+Apprentice&apos;s Robe is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 5c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 8
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Footpad&apos;s Jerkin</title>
+    <ns>0</ns>
+    <id>191</id>
+    <revision>
+      <id>191</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="364">== Overview ==
+Footpad&apos;s Jerkin is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 5c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 14
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Redbrook Militia Blade</title>
+    <ns>0</ns>
+    <id>192</id>
+    <revision>
+      <id>192</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="512">== Overview ==
+Redbrook Militia Blade is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 20c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 6-11
+|-
+! Speed
+| 2.2
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Vale Apprentice Staff</title>
+    <ns>0</ns>
+    <id>193</id>
+    <revision>
+      <id>193</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="526">== Overview ==
+Vale Apprentice Staff is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 20c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 7-12
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 3
+|-
+! STA
+| 1
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Keen Dirk</title>
+    <ns>0</ns>
+    <id>194</id>
+    <revision>
+      <id>194</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="488">== Overview ==
+Keen Dirk is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 20c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 4-8
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Militia Chainvest</title>
+    <ns>0</ns>
+    <id>195</id>
+    <revision>
+      <id>195</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="409">== Overview ==
+Militia Chainvest is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 90
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Valewoven Robe</title>
+    <ns>0</ns>
+    <id>196</id>
+    <revision>
+      <id>196</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="423">== Overview ==
+Valewoven Robe is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 30
+|-
+! INT
+| 3
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shadowstitch Jerkin</title>
+    <ns>0</ns>
+    <id>197</id>
+    <revision>
+      <id>197</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Shadowstitch Jerkin is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 55
+|-
+! AGI
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Oiled Leather Boots</title>
+    <ns>0</ns>
+    <id>198</id>
+    <revision>
+      <id>198</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="385">== Overview ==
+Oiled Leather Boots is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 25
+|-
+! AGI
+| 1
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Quilted Trousers</title>
+    <ns>0</ns>
+    <id>199</id>
+    <revision>
+      <id>199</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="382">== Overview ==
+Quilted Trousers is a uncommon armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 90c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 30
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Greyjaw&apos;s Pelt Leggings</title>
+    <ns>0</ns>
+    <id>200</id>
+    <revision>
+      <id>200</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="405">== Overview ==
+Greyjaw&apos;s Pelt Leggings is a uncommon armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 1s 10c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 35
+|-
+! STA
+| 1
+|-
+! AGI
+| 1
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Greyjaw Hide Boots</title>
+    <ns>0</ns>
+    <id>201</id>
+    <revision>
+      <id>201</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Greyjaw Hide Boots is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 1s 30c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 28
+|-
+! AGI
+| 1
+|-
+! STA
+| 1
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bristleback Maul</title>
+    <ns>0</ns>
+    <id>202</id>
+    <revision>
+      <id>202</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="519">== Overview ==
+Bristleback Maul is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 60c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 7-12
+|-
+! Speed
+| 2.8
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 2
+|-
+! STA
+| 1
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sableweb Slippers</title>
+    <ns>0</ns>
+    <id>203</id>
+    <revision>
+      <id>203</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="424">== Overview ==
+Sableweb Slippers is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 18
+|-
+! INT
+| 2
+|-
+! SPI
+| 1
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gorrak&apos;s Cruel Chopper</title>
+    <ns>0</ns>
+    <id>204</id>
+    <revision>
+      <id>204</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="525">== Overview ==
+Gorrak&apos;s Cruel Chopper is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 8-13
+|-
+! Speed
+| 2.4
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 2
+|-
+! STA
+| 1
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger&apos;s Stomper Boots</title>
+    <ns>0</ns>
+    <id>205</id>
+    <revision>
+      <id>205</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="414">== Overview ==
+Mogger&apos;s Stomper Boots is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 1s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 32
+|-
+! AGI
+| 2
+|-
+! STA
+| 1
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger&apos;s Copper Cudgel</title>
+    <ns>0</ns>
+    <id>206</id>
+    <revision>
+      <id>206</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="513">== Overview ==
+Mogger&apos;s Copper Cudgel is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 8s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 9-15
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 3
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mogger&apos;s Shiv</title>
+    <ns>0</ns>
+    <id>207</id>
+    <revision>
+      <id>207</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="494">== Overview ==
+Mogger&apos;s Shiv is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 8s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 6-11
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 4
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Valeborn Spellblade</title>
+    <ns>0</ns>
+    <id>208</id>
+    <revision>
+      <id>208</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="514">== Overview ==
+Valeborn Spellblade is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 8s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 8-14
+|-
+! Speed
+| 2.2
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 4
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cryptbone Greaves</title>
+    <ns>0</ns>
+    <id>209</id>
+    <revision>
+      <id>209</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="386">== Overview ==
+Cryptbone Greaves is a uncommon armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 1s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 48
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Freshly Baked Bread</title>
+    <ns>0</ns>
+    <id>210</id>
+    <revision>
+      <id>210</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="390">== Overview ==
+Freshly Baked Bread is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 6c
+|-
+! Buy value
+| 25c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 61
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Refreshing Spring Water</title>
+    <ns>0</ns>
+    <id>211</id>
+    <revision>
+      <id>211</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="397">== Overview ==
+Refreshing Spring Water is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 6c
+|-
+! Buy value
+| 25c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 76
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Simple Fishing Pole</title>
+    <ns>0</ns>
+    <id>212</id>
+    <revision>
+      <id>212</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="285">== Overview ==
+Simple Fishing Pole is a common tool.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| tool
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 4c
+|-
+! Buy value
+| 20c
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:tool]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Raw Mirror Trout</title>
+    <ns>0</ns>
+    <id>213</id>
+    <revision>
+      <id>213</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="388">== Overview ==
+Raw Mirror Trout is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 3c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 61
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tangled Weed</title>
+    <ns>0</ns>
+    <id>214</id>
+    <revision>
+      <id>214</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="273">== Overview ==
+Tangled Weed is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 1c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Roasted Boar Meat</title>
+    <ns>0</ns>
+    <id>215</id>
+    <revision>
+      <id>215</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="392">== Overview ==
+Roasted Boar Meat is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 12c
+|-
+! Buy value
+| 1s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 117
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Minor Healing Potion</title>
+    <ns>0</ns>
+    <id>216</id>
+    <revision>
+      <id>216</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="292">== Overview ==
+Minor Healing Potion is a common potion.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| potion
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 8c
+|-
+! Buy value
+| 40c
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:potion]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Minor Mana Potion</title>
+    <ns>0</ns>
+    <id>217</id>
+    <revision>
+      <id>217</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Minor Mana Potion is a common potion.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| potion
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 8c
+|-
+! Buy value
+| 40c
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:potion]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Conjured Spring Water</title>
+    <ns>0</ns>
+    <id>218</id>
+    <revision>
+      <id>218</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="398">== Overview ==
+Conjured Spring Water is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 76
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Conjured Mineral Water</title>
+    <ns>0</ns>
+    <id>219</id>
+    <revision>
+      <id>219</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Conjured Mineral Water is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 288
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Conjured Sparkling Water</title>
+    <ns>0</ns>
+    <id>220</id>
+    <revision>
+      <id>220</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="402">== Overview ==
+Conjured Sparkling Water is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 672
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eastbrook Arming Sword</title>
+    <ns>0</ns>
+    <id>221</id>
+    <revision>
+      <id>221</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="422">== Overview ==
+Eastbrook Arming Sword is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 40c
+|-
+! Buy value
+| 14s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 5-9
+|-
+! Speed
+| 2.2
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bronzework Mace</title>
+    <ns>0</ns>
+    <id>222</id>
+    <revision>
+      <id>222</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="416">== Overview ==
+Bronzework Mace is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 40c
+|-
+! Buy value
+| 14s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 6-10
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Vale Carving Knife</title>
+    <ns>0</ns>
+    <id>223</id>
+    <revision>
+      <id>223</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="419">== Overview ==
+Vale Carving Knife is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 20c
+|-
+! Buy value
+| 12s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 4-7
+|-
+! Speed
+| 1.8
+|-
+! Dagger
+| Yes
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hickory Shortstaff</title>
+    <ns>0</ns>
+    <id>224</id>
+    <revision>
+      <id>224</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="481">== Overview ==
+Hickory Shortstaff is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| 15s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 6-11
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 1
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eastbrook Chainmail Vest</title>
+    <ns>0</ns>
+    <id>225</id>
+    <revision>
+      <id>225</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="378">== Overview ==
+Eastbrook Chainmail Vest is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 1s 80c
+|-
+! Buy value
+| 18s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 60
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Valespun Robe</title>
+    <ns>0</ns>
+    <id>226</id>
+    <revision>
+      <id>226</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="367">== Overview ==
+Valespun Robe is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 1s 40c
+|-
+! Buy value
+| 14s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 22
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tanned Leather Jerkin</title>
+    <ns>0</ns>
+    <id>227</id>
+    <revision>
+      <id>227</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="375">== Overview ==
+Tanned Leather Jerkin is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 1s 60c
+|-
+! Buy value
+| 16s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 40
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hobnailed Boots</title>
+    <ns>0</ns>
+    <id>228</id>
+    <revision>
+      <id>228</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="363">== Overview ==
+Hobnailed Boots is a common armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 90c
+|-
+! Buy value
+| 9s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 18
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eastbrook Wool Trousers</title>
+    <ns>0</ns>
+    <id>229</id>
+    <revision>
+      <id>229</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="375">== Overview ==
+Eastbrook Wool Trousers is a common armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 1s 10c
+|-
+! Buy value
+| 11s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 24
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravecaller&apos;s Broadblade</title>
+    <ns>0</ns>
+    <id>230</id>
+    <revision>
+      <id>230</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="493">== Overview ==
+Gravecaller&apos;s Broadblade is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 8s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 9-16
+|-
+! Speed
+| 2.4
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 3
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Widowfang Dirk</title>
+    <ns>0</ns>
+    <id>231</id>
+    <revision>
+      <id>231</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="484">== Overview ==
+Widowfang Dirk is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 8s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 6-10
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 3
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Staff of the Hollow</title>
+    <ns>0</ns>
+    <id>232</id>
+    <revision>
+      <id>232</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="487">== Overview ==
+Staff of the Hollow is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 8s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 10-17
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 4
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marrowtread Boots</title>
+    <ns>0</ns>
+    <id>233</id>
+    <revision>
+      <id>233</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="407">== Overview ==
+Marrowtread Boots is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 5s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 45
+|-
+! STA
+| 2
+|-
+! STR
+| 1
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sexton&apos;s Slippers</title>
+    <ns>0</ns>
+    <id>234</id>
+    <revision>
+      <id>234</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="411">== Overview ==
+Sexton&apos;s Slippers is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 5s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 20
+|-
+! INT
+| 2
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewalker Softboots</title>
+    <ns>0</ns>
+    <id>235</id>
+    <revision>
+      <id>235</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="387">== Overview ==
+Gravewalker Softboots is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 5s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 32
+|-
+! AGI
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hollowbone Hauberk</title>
+    <ns>0</ns>
+    <id>236</id>
+    <revision>
+      <id>236</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="411">== Overview ==
+Hollowbone Hauberk is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 7s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 105
+|-
+! STR
+| 3
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewoven Raiment</title>
+    <ns>0</ns>
+    <id>237</id>
+    <revision>
+      <id>237</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="414">== Overview ==
+Gravewoven Raiment is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 7s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 38
+|-
+! INT
+| 4
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cryptstalker Jerkin</title>
+    <ns>0</ns>
+    <id>238</id>
+    <revision>
+      <id>238</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Cryptstalker Jerkin is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 7s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 65
+|-
+! AGI
+| 4
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hollowbound Legguards</title>
+    <ns>0</ns>
+    <id>239</id>
+    <revision>
+      <id>239</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="377">== Overview ==
+Hollowbound Legguards is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 62
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravepath Treads</title>
+    <ns>0</ns>
+    <id>240</id>
+    <revision>
+      <id>240</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="372">== Overview ==
+Gravepath Treads is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 42
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bristly Boar Hide</title>
+    <ns>0</ns>
+    <id>241</id>
+    <revision>
+      <id>241</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Bristly Boar Hide is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravecaller&apos;s Sigil</title>
+    <ns>0</ns>
+    <id>242</id>
+    <revision>
+      <id>242</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="291">== Overview ==
+Gravecaller&apos;s Sigil is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Blessed Tallow</title>
+    <ns>0</ns>
+    <id>243</id>
+    <revision>
+      <id>243</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="286">== Overview ==
+Blessed Tallow is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ghostly Essence</title>
+    <ns>0</ns>
+    <id>244</id>
+    <revision>
+      <id>244</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="287">== Overview ==
+Ghostly Essence is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Webwood Silk Gland</title>
+    <ns>0</ns>
+    <id>245</id>
+    <revision>
+      <id>245</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Webwood Silk Gland is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stolen Supply Crate</title>
+    <ns>0</ns>
+    <id>246</id>
+    <revision>
+      <id>246</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="291">== Overview ==
+Stolen Supply Crate is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Old Greyjaw&apos;s Fang</title>
+    <ns>0</ns>
+    <id>247</id>
+    <revision>
+      <id>247</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Old Greyjaw&apos;s Fang is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Weathered Ledger Page</title>
+    <ns>0</ns>
+    <id>248</id>
+    <revision>
+      <id>248</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="293">== Overview ==
+Weathered Ledger Page is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Morthen&apos;s Grimoire</title>
+    <ns>0</ns>
+    <id>249</id>
+    <revision>
+      <id>249</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Morthen&apos;s Grimoire is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cracked Wolf Fang</title>
+    <ns>0</ns>
+    <id>250</id>
+    <revision>
+      <id>250</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="278">== Overview ==
+Cracked Wolf Fang is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 4c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Red Bandana</title>
+    <ns>0</ns>
+    <id>251</id>
+    <revision>
+      <id>251</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="272">== Overview ==
+Red Bandana is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 6c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tough Jerky</title>
+    <ns>0</ns>
+    <id>252</id>
+    <revision>
+      <id>252</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="382">== Overview ==
+Tough Jerky is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 2c
+|-
+! Buy value
+| 25c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 61
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Slimy Murloc Scale</title>
+    <ns>0</ns>
+    <id>253</id>
+    <revision>
+      <id>253</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="279">== Overview ==
+Slimy Murloc Scale is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 5c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tallow Candle</title>
+    <ns>0</ns>
+    <id>254</id>
+    <revision>
+      <id>254</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="274">== Overview ==
+Tallow Candle is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 5c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Twitching Spider Leg</title>
+    <ns>0</ns>
+    <id>255</id>
+    <revision>
+      <id>255</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="281">== Overview ==
+Twitching Spider Leg is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 4c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bone Fragments</title>
+    <ns>0</ns>
+    <id>256</id>
+    <revision>
+      <id>256</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="275">== Overview ==
+Bone Fragments is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 7c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Linen Scrap</title>
+    <ns>0</ns>
+    <id>257</id>
+    <revision>
+      <id>257</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="272">== Overview ==
+Linen Scrap is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 3c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fenbridge Muster Order</title>
+    <ns>0</ns>
+    <id>258</id>
+    <revision>
+      <id>258</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="294">== Overview ==
+Fenbridge Muster Order is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mire Prowler Pelt</title>
+    <ns>0</ns>
+    <id>259</id>
+    <revision>
+      <id>259</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Mire Prowler Pelt is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Lost Caravan Goods</title>
+    <ns>0</ns>
+    <id>260</id>
+    <revision>
+      <id>260</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Lost Caravan Goods is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Waterlogged Idol</title>
+    <ns>0</ns>
+    <id>261</id>
+    <revision>
+      <id>261</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="288">== Overview ==
+Waterlogged Idol is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Widow Venom Sac</title>
+    <ns>0</ns>
+    <id>262</id>
+    <revision>
+      <id>262</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="287">== Overview ==
+Widow Venom Sac is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rusted Censer</title>
+    <ns>0</ns>
+    <id>263</id>
+    <revision>
+      <id>263</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="285">== Overview ==
+Rusted Censer is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirefen Troll Fetish</title>
+    <ns>0</ns>
+    <id>264</id>
+    <revision>
+      <id>264</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="292">== Overview ==
+Mirefen Troll Fetish is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Grubjaw&apos;s Tusk</title>
+    <ns>0</ns>
+    <id>265</id>
+    <revision>
+      <id>265</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="286">== Overview ==
+Grubjaw&apos;s Tusk is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravecaller Cipher</title>
+    <ns>0</ns>
+    <id>266</id>
+    <revision>
+      <id>266</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Gravecaller Cipher is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bastion Ward Stone</title>
+    <ns>0</ns>
+    <id>267</id>
+    <revision>
+      <id>267</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Bastion Ward Stone is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deacon&apos;s Cleaver</title>
+    <ns>0</ns>
+    <id>268</id>
+    <revision>
+      <id>268</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="506">== Overview ==
+Deacon&apos;s Cleaver is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 3s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 11-18
+|-
+! Speed
+| 2.4
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 4
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Staff of Drowned Prayers</title>
+    <ns>0</ns>
+    <id>269</id>
+    <revision>
+      <id>269</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="529">== Overview ==
+Staff of Drowned Prayers is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 3s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 12-20
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 5
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mistbinder Kris</title>
+    <ns>0</ns>
+    <id>270</id>
+    <revision>
+      <id>270</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="494">== Overview ==
+Mistbinder Kris is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 3s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 7-12
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 4
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drownedguard Breastplate</title>
+    <ns>0</ns>
+    <id>271</id>
+    <revision>
+      <id>271</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="417">== Overview ==
+Drownedguard Breastplate is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 3s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 130
+|-
+! STA
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fenmist Robe</title>
+    <ns>0</ns>
+    <id>272</id>
+    <revision>
+      <id>272</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="421">== Overview ==
+Fenmist Robe is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 3s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 45
+|-
+! INT
+| 5
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eelskin Tunic</title>
+    <ns>0</ns>
+    <id>273</id>
+    <revision>
+      <id>273</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="394">== Overview ==
+Eelskin Tunic is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 3s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 80
+|-
+! AGI
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Trollhide Leggings</title>
+    <ns>0</ns>
+    <id>274</id>
+    <revision>
+      <id>274</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Trollhide Leggings is a uncommon armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 2s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 55
+|-
+! STA
+| 3
+|-
+! STR
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marshstrider Boots</title>
+    <ns>0</ns>
+    <id>275</id>
+    <revision>
+      <id>275</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Marshstrider Boots is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 2s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 40
+|-
+! AGI
+| 2
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Broodmother&apos;s Silk Robe</title>
+    <ns>0</ns>
+    <id>276</id>
+    <revision>
+      <id>276</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="431">== Overview ==
+Broodmother&apos;s Silk Robe is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 3s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 42
+|-
+! INT
+| 4
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Voss&apos;s Sanctified Mace</title>
+    <ns>0</ns>
+    <id>277</id>
+    <revision>
+      <id>277</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="530">== Overview ==
+Voss&apos;s Sanctified Mace is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 4s 20c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 12-20
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 3
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirejaw Biteblade</title>
+    <ns>0</ns>
+    <id>278</id>
+    <revision>
+      <id>278</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="510">== Overview ==
+Mirejaw Biteblade is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 4s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 8-14
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 5
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirejaw Scale Vest</title>
+    <ns>0</ns>
+    <id>279</id>
+    <revision>
+      <id>279</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="424">== Overview ==
+Mirejaw Scale Vest is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 4s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 115
+|-
+! STR
+| 2
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Nhalia&apos;s Funeral Wraps</title>
+    <ns>0</ns>
+    <id>280</id>
+    <revision>
+      <id>280</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="429">== Overview ==
+Nhalia&apos;s Funeral Wraps is a uncommon armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 4s 80c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 48
+|-
+! INT
+| 5
+|-
+! SPI
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fen Reaver Glaive</title>
+    <ns>0</ns>
+    <id>281</id>
+    <revision>
+      <id>281</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="509">== Overview ==
+Fen Reaver Glaive is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 14s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 16-26
+|-
+! Speed
+| 2.4
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 5
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Nhalia&apos;s Dirgeblade</title>
+    <ns>0</ns>
+    <id>282</id>
+    <revision>
+      <id>282</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="501">== Overview ==
+Nhalia&apos;s Dirgeblade is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 14s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 10-16
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 6
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirejaw Oracle Staff</title>
+    <ns>0</ns>
+    <id>283</id>
+    <revision>
+      <id>283</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="514">== Overview ==
+Mirejaw Oracle Staff is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 14s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 16-27
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 6
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mistcaller&apos;s Edge</title>
+    <ns>0</ns>
+    <id>284</id>
+    <revision>
+      <id>284</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="509">== Overview ==
+Mistcaller&apos;s Edge is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 12s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 14-23
+|-
+! Speed
+| 2.3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 4
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Vael&apos;s Mist-Staff</title>
+    <ns>0</ns>
+    <id>285</id>
+    <revision>
+      <id>285</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="511">== Overview ==
+Vael&apos;s Mist-Staff is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 12s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 15-26
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 6
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Riptide Dirk</title>
+    <ns>0</ns>
+    <id>286</id>
+    <revision>
+      <id>286</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="493">== Overview ==
+Riptide Dirk is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 12s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 9-15
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 5
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Knight-Commander&apos;s Greaves</title>
+    <ns>0</ns>
+    <id>287</id>
+    <revision>
+      <id>287</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="383">== Overview ==
+Knight-Commander&apos;s Greaves is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 10s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 95
+|-
+! STA
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tidescale Vest</title>
+    <ns>0</ns>
+    <id>288</id>
+    <revision>
+      <id>288</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="386">== Overview ==
+Tidescale Vest is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 90
+|-
+! STA
+| 3
+|-
+! AGI
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tideguard Greaves</title>
+    <ns>0</ns>
+    <id>289</id>
+    <revision>
+      <id>289</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="409">== Overview ==
+Tideguard Greaves is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 125
+|-
+! STR
+| 3
+|-
+! STA
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tideguard Sabatons</title>
+    <ns>0</ns>
+    <id>290</id>
+    <revision>
+      <id>290</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="410">== Overview ==
+Tideguard Sabatons is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 105
+|-
+! STR
+| 2
+|-
+! STA
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drowned Prayer Leggings</title>
+    <ns>0</ns>
+    <id>291</id>
+    <revision>
+      <id>291</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="418">== Overview ==
+Drowned Prayer Leggings is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 48
+|-
+! INT
+| 6
+|-
+! SPI
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drowned Prayer Sandals</title>
+    <ns>0</ns>
+    <id>292</id>
+    <revision>
+      <id>292</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="417">== Overview ==
+Drowned Prayer Sandals is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 42
+|-
+! INT
+| 5
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eelscale Leggings</title>
+    <ns>0</ns>
+    <id>293</id>
+    <revision>
+      <id>293</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="397">== Overview ==
+Eelscale Leggings is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 86
+|-
+! AGI
+| 6
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eelscale Treads</title>
+    <ns>0</ns>
+    <id>294</id>
+    <revision>
+      <id>294</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="395">== Overview ==
+Eelscale Treads is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 11s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 72
+|-
+! AGI
+| 5
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fenbridge Rye Loaf</title>
+    <ns>0</ns>
+    <id>295</id>
+    <revision>
+      <id>295</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="393">== Overview ==
+Fenbridge Rye Loaf is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 25c
+|-
+! Buy value
+| 4s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 243
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marsh Mint Tea</title>
+    <ns>0</ns>
+    <id>296</id>
+    <revision>
+      <id>296</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="392">== Overview ==
+Marsh Mint Tea is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 25c
+|-
+! Buy value
+| 4s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 288
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Smoked Mirefen Eel</title>
+    <ns>0</ns>
+    <id>297</id>
+    <revision>
+      <id>297</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="394">== Overview ==
+Smoked Mirefen Eel is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 60c
+|-
+! Buy value
+| 10s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 432
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Silvermist Cordial</title>
+    <ns>0</ns>
+    <id>298</id>
+    <revision>
+      <id>298</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="397">== Overview ==
+Silvermist Cordial is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 60c
+|-
+! Buy value
+| 10s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 436
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bogiron Mace</title>
+    <ns>0</ns>
+    <id>299</id>
+    <revision>
+      <id>299</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="413">== Overview ==
+Bogiron Mace is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 2s 50c
+|-
+! Buy value
+| 25s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 8-14
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fenreed Staff</title>
+    <ns>0</ns>
+    <id>300</id>
+    <revision>
+      <id>300</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="476">== Overview ==
+Fenreed Staff is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 2s 50c
+|-
+! Buy value
+| 25s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 9-16
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 1
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mirefen Skinner</title>
+    <ns>0</ns>
+    <id>301</id>
+    <revision>
+      <id>301</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="417">== Overview ==
+Mirefen Skinner is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 2s 50c
+|-
+! Buy value
+| 25s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 6-10
+|-
+! Speed
+| 1.8
+|-
+! Dagger
+| Yes
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bogiron Hauberk</title>
+    <ns>0</ns>
+    <id>302</id>
+    <revision>
+      <id>302</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="369">== Overview ==
+Bogiron Hauberk is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 3s 0c
+|-
+! Buy value
+| 30s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 100
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marshcloth Robe</title>
+    <ns>0</ns>
+    <id>303</id>
+    <revision>
+      <id>303</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="368">== Overview ==
+Marshcloth Robe is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 2s 0c
+|-
+! Buy value
+| 20s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 32
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Reedwoven Jerkin</title>
+    <ns>0</ns>
+    <id>304</id>
+    <revision>
+      <id>304</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="370">== Overview ==
+Reedwoven Jerkin is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 2s 50c
+|-
+! Buy value
+| 25s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 62
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fenwalker Boots</title>
+    <ns>0</ns>
+    <id>305</id>
+    <revision>
+      <id>305</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="367">== Overview ==
+Fenwalker Boots is a common armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| 15s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 30
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Reedwoven Trousers</title>
+    <ns>0</ns>
+    <id>306</id>
+    <revision>
+      <id>306</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="370">== Overview ==
+Reedwoven Trousers is a common armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 1s 80c
+|-
+! Buy value
+| 18s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 40
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bogiron Nugget</title>
+    <ns>0</ns>
+    <id>307</id>
+    <revision>
+      <id>307</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="276">== Overview ==
+Bogiron Nugget is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 12c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Soggy Moccasin</title>
+    <ns>0</ns>
+    <id>308</id>
+    <revision>
+      <id>308</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="275">== Overview ==
+Soggy Moccasin is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 9c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cracked Fetish</title>
+    <ns>0</ns>
+    <id>309</id>
+    <revision>
+      <id>309</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="276">== Overview ==
+Cracked Fetish is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 14c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Chipped Tusk</title>
+    <ns>0</ns>
+    <id>310</id>
+    <revision>
+      <id>310</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="274">== Overview ==
+Chipped Tusk is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 15c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deepfen Pearl</title>
+    <ns>0</ns>
+    <id>311</id>
+    <revision>
+      <id>311</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="277">== Overview ==
+Deepfen Pearl is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Highwatch Summons</title>
+    <ns>0</ns>
+    <id>312</id>
+    <revision>
+      <id>312</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Highwatch Summons is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ridge Stalker Pelt</title>
+    <ns>0</ns>
+    <id>313</id>
+    <revision>
+      <id>313</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="290">== Overview ==
+Ridge Stalker Pelt is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Glowing Wax</title>
+    <ns>0</ns>
+    <id>314</id>
+    <revision>
+      <id>314</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="283">== Overview ==
+Glowing Wax is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ogre War Totem</title>
+    <ns>0</ns>
+    <id>315</id>
+    <revision>
+      <id>315</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="286">== Overview ==
+Ogre War Totem is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Storm Core</title>
+    <ns>0</ns>
+    <id>316</id>
+    <revision>
+      <id>316</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="282">== Overview ==
+Storm Core is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Kazzix&apos;s Heartshard</title>
+    <ns>0</ns>
+    <id>317</id>
+    <revision>
+      <id>317</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="291">== Overview ==
+Kazzix&apos;s Heartshard is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmcult Orders</title>
+    <ns>0</ns>
+    <id>318</id>
+    <revision>
+      <id>318</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="287">== Overview ==
+Wyrmcult Orders is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ritual Phylactery</title>
+    <ns>0</ns>
+    <id>319</id>
+    <revision>
+      <id>319</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Ritual Phylactery is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewyrm Sigil</title>
+    <ns>0</ns>
+    <id>320</id>
+    <revision>
+      <id>320</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="287">== Overview ==
+Gravewyrm Sigil is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Blessed Embers</title>
+    <ns>0</ns>
+    <id>321</id>
+    <revision>
+      <id>321</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="286">== Overview ==
+Blessed Embers is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sanctum Key Shard</title>
+    <ns>0</ns>
+    <id>322</id>
+    <revision>
+      <id>322</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="289">== Overview ==
+Sanctum Key Shard is a common quest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| quest
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| None
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:quest]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ridgestalker Treads</title>
+    <ns>0</ns>
+    <id>323</id>
+    <revision>
+      <id>323</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Ridgestalker Treads is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 50
+|-
+! AGI
+| 3
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Boneplate Vest</title>
+    <ns>0</ns>
+    <id>324</id>
+    <revision>
+      <id>324</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="419">== Overview ==
+Boneplate Vest is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 8s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 170
+|-
+! STA
+| 6
+|-
+! STR
+| 3
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Revenant Silk Robe</title>
+    <ns>0</ns>
+    <id>325</id>
+    <revision>
+      <id>325</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="426">== Overview ==
+Revenant Silk Robe is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 8s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 60
+|-
+! INT
+| 7
+|-
+! SPI
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Nightwalk Jerkin</title>
+    <ns>0</ns>
+    <id>326</id>
+    <revision>
+      <id>326</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="410">== Overview ==
+Nightwalk Jerkin is a uncommon armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 8s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 105
+|-
+! AGI
+| 7
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Zealotsbane Blade</title>
+    <ns>0</ns>
+    <id>327</id>
+    <revision>
+      <id>327</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="520">== Overview ==
+Zealotsbane Blade is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 9s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 18-29
+|-
+! Speed
+| 2.3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 6
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Emberwood Staff</title>
+    <ns>0</ns>
+    <id>328</id>
+    <revision>
+      <id>328</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="520">== Overview ==
+Emberwood Staff is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 9s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 20-33
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 8
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cultist Flayer</title>
+    <ns>0</ns>
+    <id>329</id>
+    <revision>
+      <id>329</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="494">== Overview ==
+Cultist Flayer is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 9s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 12-19
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 7
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drogmar&apos;s Warboots</title>
+    <ns>0</ns>
+    <id>330</id>
+    <revision>
+      <id>330</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="421">== Overview ==
+Drogmar&apos;s Warboots is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 9s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 85
+|-
+! STR
+| 3
+|-
+! STA
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ironvein Pickblade</title>
+    <ns>0</ns>
+    <id>331</id>
+    <revision>
+      <id>331</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="512">== Overview ==
+Ironvein Pickblade is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 9s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 13-21
+|-
+! Speed
+| 1.8
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 7
+|-
+! STA
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ironvein Lantern Staff</title>
+    <ns>0</ns>
+    <id>332</id>
+    <revision>
+      <id>332</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="528">== Overview ==
+Ironvein Lantern Staff is a uncommon weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 9s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 19-31
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 7
+|-
+! SPI
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Marrowlord Boneboots</title>
+    <ns>0</ns>
+    <id>333</id>
+    <revision>
+      <id>333</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="424">== Overview ==
+Marrowlord Boneboots is a uncommon armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| uncommon
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 10s 50c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 90
+|-
+! STA
+| 5
+|-
+! STR
+| 2
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:uncommon]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drogmar&apos;s Skullcleaver</title>
+    <ns>0</ns>
+    <id>334</id>
+    <revision>
+      <id>334</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="514">== Overview ==
+Drogmar&apos;s Skullcleaver is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 20s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 22-35
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 7
+|-
+! STA
+| 4
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ogre Bonecharm Staff</title>
+    <ns>0</ns>
+    <id>335</id>
+    <revision>
+      <id>335</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="514">== Overview ==
+Ogre Bonecharm Staff is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 20s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 24-38
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 9
+|-
+! SPI
+| 4
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gutripper Shiv</title>
+    <ns>0</ns>
+    <id>336</id>
+    <revision>
+      <id>336</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="496">== Overview ==
+Gutripper Shiv is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 20s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 14-22
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 8
+|-
+! STA
+| 3
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stormshard Leggings</title>
+    <ns>0</ns>
+    <id>337</id>
+    <revision>
+      <id>337</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="377">== Overview ==
+Stormshard Leggings is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 18s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 110
+|-
+! STA
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Korgath&apos;s Chainwraps</title>
+    <ns>0</ns>
+    <id>338</id>
+    <revision>
+      <id>338</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="378">== Overview ==
+Korgath&apos;s Chainwraps is a rare armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 22s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 125
+|-
+! STA
+| 6
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Boneguard Breastplate</title>
+    <ns>0</ns>
+    <id>339</id>
+    <revision>
+      <id>339</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="415">== Overview ==
+Boneguard Breastplate is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 25s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 210
+|-
+! STA
+| 7
+|-
+! STR
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Staff of Velkhar</title>
+    <ns>0</ns>
+    <id>340</id>
+    <revision>
+      <id>340</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="511">== Overview ==
+Staff of Velkhar is a rare weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| rare
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 25s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 27-43
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 10
+|-
+! SPI
+| 5
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shadowmeld Tunic</title>
+    <ns>0</ns>
+    <id>341</id>
+    <revision>
+      <id>341</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="399">== Overview ==
+Shadowmeld Tunic is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 25s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 130
+|-
+! AGI
+| 9
+|-
+! STA
+| 4
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewyrm Scale Hauberk</title>
+    <ns>0</ns>
+    <id>342</id>
+    <revision>
+      <id>342</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="417">== Overview ==
+Gravewyrm Scale Hauberk is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 30s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 230
+|-
+! STA
+| 8
+|-
+! STR
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmcult Grand Robe</title>
+    <ns>0</ns>
+    <id>343</id>
+    <revision>
+      <id>343</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="417">== Overview ==
+Wyrmcult Grand Robe is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 30s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 75
+|-
+! INT
+| 11
+|-
+! SPI
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmscale Jerkin</title>
+    <ns>0</ns>
+    <id>344</id>
+    <revision>
+      <id>344</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Wyrmscale Jerkin is a rare armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 30s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 145
+|-
+! AGI
+| 10
+|-
+! STA
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewyrm Stalker&apos;s Treads</title>
+    <ns>0</ns>
+    <id>345</id>
+    <revision>
+      <id>345</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="408">== Overview ==
+Gravewyrm Stalker&apos;s Treads is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 32s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 105
+|-
+! AGI
+| 10
+|-
+! STA
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gravewyrm Sabatons</title>
+    <ns>0</ns>
+    <id>346</id>
+    <revision>
+      <id>346</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="410">== Overview ==
+Gravewyrm Sabatons is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 32s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 145
+|-
+! STR
+| 5
+|-
+! STA
+| 6
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmcult Soulsteps</title>
+    <ns>0</ns>
+    <id>347</id>
+    <revision>
+      <id>347</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="413">== Overview ==
+Wyrmcult Soulsteps is a rare armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| rare
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 32s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 68
+|-
+! INT
+| 9
+|-
+! SPI
+| 5
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:rare]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deathlord Warplate</title>
+    <ns>0</ns>
+    <id>348</id>
+    <revision>
+      <id>348</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="413">== Overview ==
+Deathlord Warplate is a epic armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 270
+|-
+! STR
+| 8
+|-
+! STA
+| 10
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Necromancer&apos;s Starshroud</title>
+    <ns>0</ns>
+    <id>349</id>
+    <revision>
+      <id>349</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="422">== Overview ==
+Necromancer&apos;s Starshroud is a epic armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 92
+|-
+! INT
+| 14
+|-
+! SPI
+| 8
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmshadow Harness</title>
+    <ns>0</ns>
+    <id>350</id>
+    <revision>
+      <id>350</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="402">== Overview ==
+Wyrmshadow Harness is a epic armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 170
+|-
+! AGI
+| 13
+|-
+! STA
+| 7
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deathlord Legguards</title>
+    <ns>0</ns>
+    <id>351</id>
+    <revision>
+      <id>351</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="411">== Overview ==
+Deathlord Legguards is a epic armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 240
+|-
+! STR
+| 8
+|-
+! STA
+| 9
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Deathlord Sabatons</title>
+    <ns>0</ns>
+    <id>352</id>
+    <revision>
+      <id>352</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="410">== Overview ==
+Deathlord Sabatons is a epic armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 205
+|-
+! STR
+| 7
+|-
+! STA
+| 8
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Necromancer&apos;s Soulsteps</title>
+    <ns>0</ns>
+    <id>353</id>
+    <revision>
+      <id>353</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="419">== Overview ==
+Necromancer&apos;s Soulsteps is a epic armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 80
+|-
+! INT
+| 12
+|-
+! SPI
+| 7
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Necromancer&apos;s Legwraps</title>
+    <ns>0</ns>
+    <id>354</id>
+    <revision>
+      <id>354</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="418">== Overview ==
+Necromancer&apos;s Legwraps is a epic armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 86
+|-
+! INT
+| 13
+|-
+! SPI
+| 7
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmshadow Treads</title>
+    <ns>0</ns>
+    <id>355</id>
+    <revision>
+      <id>355</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="399">== Overview ==
+Wyrmshadow Treads is a epic armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 145
+|-
+! AGI
+| 11
+|-
+! STA
+| 7
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmshadow Legguards</title>
+    <ns>0</ns>
+    <id>356</id>
+    <revision>
+      <id>356</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="402">== Overview ==
+Wyrmshadow Legguards is a epic armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| epic
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 90s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 155
+|-
+! AGI
+| 12
+|-
+! STA
+| 7
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wyrmfang Greatblade</title>
+    <ns>0</ns>
+    <id>357</id>
+    <revision>
+      <id>357</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="512">== Overview ==
+Wyrmfang Greatblade is a epic weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| epic
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 80s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| warrior, paladin, shaman
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 30-48
+|-
+! Speed
+| 2.6
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! STR
+| 10
+|-
+! STA
+| 6
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Staff of the Gravewyrm</title>
+    <ns>0</ns>
+    <id>358</id>
+    <revision>
+      <id>358</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="517">== Overview ==
+Staff of the Gravewyrm is a epic weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| epic
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 80s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| mage, priest, warlock, druid
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 32-52
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 12
+|-
+! SPI
+| 6
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fang of Korzul</title>
+    <ns>0</ns>
+    <id>359</id>
+    <revision>
+      <id>359</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="497">== Overview ==
+Fang of Korzul is a epic weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| epic
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 80s 0c
+|-
+! Buy value
+| None
+|-
+! Required class
+| rogue, hunter
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 19-30
+|-
+! Speed
+| 1.7
+|-
+! Dagger
+| Yes
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! AGI
+| 11
+|-
+! STA
+| 5
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:epic]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Highwatch Trail Hardtack</title>
+    <ns>0</ns>
+    <id>360</id>
+    <revision>
+      <id>360</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="400">== Overview ==
+Highwatch Trail Hardtack is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 75c
+|-
+! Buy value
+| 12s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 552
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Meltwater Flask</title>
+    <ns>0</ns>
+    <id>361</id>
+    <revision>
+      <id>361</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="394">== Overview ==
+Meltwater Flask is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 75c
+|-
+! Buy value
+| 12s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 672
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Roast Mountain Goat</title>
+    <ns>0</ns>
+    <id>362</id>
+    <revision>
+      <id>362</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="398">== Overview ==
+Roast Mountain Goat is a common food.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| food
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| 25s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 874
+|-
+! Mana restored
+| 0
+|}
+[[Category:Items]]
+[[Category:food]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Glacier Melt</title>
+    <ns>0</ns>
+    <id>363</id>
+    <revision>
+      <id>363</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="394">== Overview ==
+Glacier Melt is a common drink.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| drink
+|-
+! Quality
+| common
+|-
+! Slot
+| None
+|-
+! Sell value
+| 1s 50c
+|-
+! Buy value
+| 25s 0c
+|-
+! Required class
+| Any
+|}
+
+== Consumable ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Health restored
+| 0
+|-
+! Mana restored
+| 900
+|}
+[[Category:Items]]
+[[Category:drink]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Highwatch Warblade</title>
+    <ns>0</ns>
+    <id>364</id>
+    <revision>
+      <id>364</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="419">== Overview ==
+Highwatch Warblade is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| 60s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 15-24
+|-
+! Speed
+| 2.3
+|-
+! Dagger
+| No
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Craghorn Staff</title>
+    <ns>0</ns>
+    <id>365</id>
+    <revision>
+      <id>365</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="477">== Overview ==
+Craghorn Staff is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| 60s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 16-27
+|-
+! Speed
+| 3
+|-
+! Dagger
+| No
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! INT
+| 2
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Icevein Dirk</title>
+    <ns>0</ns>
+    <id>366</id>
+    <revision>
+      <id>366</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="414">== Overview ==
+Icevein Dirk is a common weapon for mainhand.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| weapon
+|-
+! Quality
+| common
+|-
+! Slot
+| mainhand
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| 60s 0c
+|-
+! Required class
+| Any
+|}
+
+== Weapon ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Damage
+| 10-16
+|-
+! Speed
+| 1.8
+|-
+! Dagger
+| Yes
+|}
+[[Category:Items]]
+[[Category:weapon]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Highwatch Breastplate</title>
+    <ns>0</ns>
+    <id>367</id>
+    <revision>
+      <id>367</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="375">== Overview ==
+Highwatch Breastplate is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 7s 0c
+|-
+! Buy value
+| 70s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 160
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Peakwool Robe</title>
+    <ns>0</ns>
+    <id>368</id>
+    <revision>
+      <id>368</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="366">== Overview ==
+Peakwool Robe is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 5s 0c
+|-
+! Buy value
+| 50s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 50
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stalkerhide Jerkin</title>
+    <ns>0</ns>
+    <id>369</id>
+    <revision>
+      <id>369</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="371">== Overview ==
+Stalkerhide Jerkin is a common armor for chest.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| chest
+|-
+! Sell value
+| 6s 0c
+|-
+! Buy value
+| 60s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 95
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cragwalker Boots</title>
+    <ns>0</ns>
+    <id>370</id>
+    <revision>
+      <id>370</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="367">== Overview ==
+Cragwalker Boots is a common armor for feet.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| feet
+|-
+! Sell value
+| 4s 0c
+|-
+! Buy value
+| 40s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 55
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Windguard Leggings</title>
+    <ns>0</ns>
+    <id>371</id>
+    <revision>
+      <id>371</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="370">== Overview ==
+Windguard Leggings is a common armor for legs.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| armor
+|-
+! Quality
+| common
+|-
+! Slot
+| legs
+|-
+! Sell value
+| 4s 50c
+|-
+! Buy value
+| 45s 0c
+|-
+! Required class
+| Any
+|}
+
+== Stats ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! ARMOR
+| 70
+|}
+[[Category:Items]]
+[[Category:armor]]
+[[Category:common]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ogre Toe Ring</title>
+    <ns>0</ns>
+    <id>372</id>
+    <revision>
+      <id>372</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="275">== Overview ==
+Ogre Toe Ring is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 25c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Inert Storm Shard</title>
+    <ns>0</ns>
+    <id>373</id>
+    <revision>
+      <id>373</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="279">== Overview ==
+Inert Storm Shard is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 28c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Frayed Prayer Beads</title>
+    <ns>0</ns>
+    <id>374</id>
+    <revision>
+      <id>374</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="281">== Overview ==
+Frayed Prayer Beads is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 30c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cracked Wyrm Scale</title>
+    <ns>0</ns>
+    <id>375</id>
+    <revision>
+      <id>375</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="280">== Overview ==
+Cracked Wyrm Scale is a poor junk.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Kind
+| junk
+|-
+! Quality
+| poor
+|-
+! Slot
+| None
+|-
+! Sell value
+| 35c
+|-
+! Buy value
+| None
+|-
+! Required class
+| Any
+|}
+[[Category:Items]]
+[[Category:junk]]
+[[Category:poor]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Heroic Strike (Ability)</title>
+    <ns>0</ns>
+    <id>376</id>
+    <revision>
+      <id>376</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="502">== Description ==
+A strong attack that increases melee damage by $d. Activates on your next swing.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 15
+|-
+! Rank 3
+| Level 14, cost 15
+|-
+! Rank 4
+| Level 20, cost 15
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Battle Shout (Ability)</title>
+    <ns>0</ns>
+    <id>377</id>
+    <revision>
+      <id>377</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="431">== Description ==
+Increases your attack power by 20 for 2 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 10
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 10
+|-
+! Rank 3
+| Level 20, cost 10
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Charge (Ability)</title>
+    <ns>0</ns>
+    <id>378</id>
+    <revision>
+      <id>378</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="349">== Description ==
+Charges an enemy, generating 9 rage and stunning it for 1 sec. 8-25 yd range.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 15s
+|-
+! Range
+| 25 yd
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* charge
+* stun
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rend (Ability)</title>
+    <ns>0</ns>
+    <id>379</id>
+    <revision>
+      <id>379</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="448">== Description ==
+Wounds the target, causing them to bleed for $d damage over 9 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 10
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 10
+|-
+! Rank 3
+| Level 16, cost 10
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Thunder Clap (Ability)</title>
+    <ns>0</ns>
+    <id>380</id>
+    <revision>
+      <id>380</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="483">== Description ==
+Blasts nearby enemies for $d damage and slows their attacks by 10% for 10 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 4s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* aoeDamage
+* aoeAttackSpeed
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 20
+|-
+! Rank 3
+| Level 20, cost 20
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hamstring (Ability)</title>
+    <ns>0</ns>
+    <id>381</id>
+    <revision>
+      <id>381</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="435">== Description ==
+Maims the enemy for 5 damage, slowing its movement by 50% for 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 10
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* directDamage
+* slow
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 10
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bloodrage (Ability)</title>
+    <ns>0</ns>
+    <id>382</id>
+    <revision>
+      <id>382</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="336">== Description ==
+Generates 10 rage at the cost of health.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 60s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfDamagePctMax
+* gainResource
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Overpower (Ability)</title>
+    <ns>0</ns>
+    <id>383</id>
+    <revision>
+      <id>383</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="449">== Description ==
+Instant attack for weapon damage +5. Only usable after the target dodges. Cannot be dodged.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 5
+|-
+! Cooldown
+| 5s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 5
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Execute (Ability)</title>
+    <ns>0</ns>
+    <id>384</id>
+    <revision>
+      <id>384</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="373">== Description ==
+Attempt to finish off a wounded foe, causing $d damage. Only usable on enemies below 20% health.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Slam (Ability)</title>
+    <ns>0</ns>
+    <id>385</id>
+    <revision>
+      <id>385</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="322">== Description ==
+Slams the opponent for weapon damage plus $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cleave (Ability)</title>
+    <ns>0</ns>
+    <id>386</id>
+    <revision>
+      <id>386</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="344">== Description ==
+A sweeping strike that hits all enemies in front of you for $d damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 18
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* aoeDamage
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Defensive Stance (Ability)</title>
+    <ns>0</ns>
+    <id>387</id>
+    <revision>
+      <id>387</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="394">== Description ==
+A defensive combat stance: you generate 30% more threat but deal and take 10% less damage. Cast again to leave the stance.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 1s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sunder Armor (Ability)</title>
+    <ns>0</ns>
+    <id>388</id>
+    <revision>
+      <id>388</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="473">== Description ==
+Sunders the target&apos;s armor, reducing it by $d per application. Stacks up to 5 times. Generates a high amount of threat.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* sunder
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 15
+|}
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Taunt (Ability)</title>
+    <ns>0</ns>
+    <id>389</id>
+    <revision>
+      <id>389</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="375">== Description ==
+Taunts the target: your threat rises to match its most hated enemy and it is compelled to attack you for 3 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 10s
+|-
+! Range
+| 8 yd
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* taunt
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fireball (Ability)</title>
+    <ns>0</ns>
+    <id>390</id>
+    <revision>
+      <id>390</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="492">== Description ==
+Hurls a fiery ball that causes $d Fire damage plus additional damage over time.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| fire
+|}
+
+== Base effects ==
+* directDamage
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 6, cost 45
+|-
+! Rank 3
+| Level 12, cost 65
+|-
+! Rank 4
+| Level 18, cost 95
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Frost Armor (Ability)</title>
+    <ns>0</ns>
+    <id>391</id>
+    <revision>
+      <id>391</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="434">== Description ==
+Encases you in frost, increasing armor by 30 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| frost
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 30
+|-
+! Rank 3
+| Level 18, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Arcane Intellect (Ability)</title>
+    <ns>0</ns>
+    <id>392</id>
+    <revision>
+      <id>392</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="383">== Description ==
+Increases Intellect by 2 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Frostbolt (Ability)</title>
+    <ns>0</ns>
+    <id>393</id>
+    <revision>
+      <id>393</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="493">== Description ==
+Launches a bolt of frost, causing $d Frost damage and slowing movement by 40%.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| frost
+|}
+
+== Base effects ==
+* directDamage
+* slow
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 35
+|-
+! Rank 3
+| Level 14, cost 50
+|-
+! Rank 4
+| Level 20, cost 70
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Conjure Water (Ability)</title>
+    <ns>0</ns>
+    <id>394</id>
+    <revision>
+      <id>394</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="459">== Description ==
+Conjures 2 bottles of water, restoring mana when drunk. Higher ranks conjure purer water.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 40
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 70
+|-
+! Rank 3
+| Level 16, cost 110
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fire Blast (Ability)</title>
+    <ns>0</ns>
+    <id>395</id>
+    <revision>
+      <id>395</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="421">== Description ==
+Blasts the enemy for $d Fire damage. Instant.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 40
+|-
+! Cooldown
+| 8s
+|-
+! Range
+| 20 yd
+|-
+! School
+| fire
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 60
+|-
+! Rank 3
+| Level 18, cost 85
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Arcane Missiles (Ability)</title>
+    <ns>0</ns>
+    <id>396</id>
+    <revision>
+      <id>396</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="464">== Description ==
+Launches Arcane Missiles at the enemy, causing 8 Arcane damage each second for 3 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 50
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 75
+|-
+! Rank 3
+| Level 20, cost 105
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Polymorph (Ability)</title>
+    <ns>0</ns>
+    <id>397</id>
+    <revision>
+      <id>397</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="488">== Description ==
+Transforms the enemy into a sheep for up to 15 sec. The sheep wanders and heals rapidly. Any damage breaks the effect. Beasts and humanoids only.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 50
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* polymorph
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 18, cost 70
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Frost Nova (Ability)</title>
+    <ns>0</ns>
+    <id>398</id>
+    <revision>
+      <id>398</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="424">== Description ==
+Freezes all nearby enemies in place for up to 8 sec, dealing $d Frost damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 22s
+|-
+! Range
+| Melee/self
+|-
+! School
+| frost
+|}
+
+== Base effects ==
+* aoeRoot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 50
+|}
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Arcane Explosion (Ability)</title>
+    <ns>0</ns>
+    <id>399</id>
+    <revision>
+      <id>399</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="336">== Description ==
+A burst of Arcane energy hits all nearby enemies for $d Arcane damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 60
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* aoeDamage
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Scorch (Ability)</title>
+    <ns>0</ns>
+    <id>400</id>
+    <revision>
+      <id>400</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="315">== Description ==
+Scorches the enemy for $d Fire damage. Quick to cast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| fire
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ice Barrier (Ability)</title>
+    <ns>0</ns>
+    <id>401</id>
+    <revision>
+      <id>401</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="315">== Description ==
+Shields you in ice, absorbing 130 damage for 60 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Mage]]
+|-
+! Learn level
+| 20
+|-
+! Cost
+| 90
+|-
+! Cooldown
+| 30s
+|-
+! Range
+| Melee/self
+|-
+! School
+| frost
+|}
+
+== Base effects ==
+* absorb
+[[Category:Abilities]]
+[[Category:Mage]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sinister Strike (Ability)</title>
+    <ns>0</ns>
+    <id>402</id>
+    <revision>
+      <id>402</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="484">== Description ==
+An instant strike for weapon damage plus $d. Awards 1 combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 45
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 45
+|-
+! Rank 3
+| Level 14, cost 45
+|-
+! Rank 4
+| Level 20, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Eviscerate (Ability)</title>
+    <ns>0</ns>
+    <id>403</id>
+    <revision>
+      <id>403</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="439">== Description ==
+Finishing move that causes damage per combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* finisherDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 35
+|-
+! Rank 3
+| Level 18, cost 35
+|}
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Backstab (Ability)</title>
+    <ns>0</ns>
+    <id>404</id>
+    <revision>
+      <id>404</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="506">== Description ==
+Backstab the target for 150% weapon damage plus $d. Must be behind the target. Requires a dagger. Awards 1 combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 60
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 60
+|-
+! Rank 3
+| Level 18, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Gouge (Ability)</title>
+    <ns>0</ns>
+    <id>405</id>
+    <revision>
+      <id>405</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="471">== Description ==
+Strikes the target, incapacitating it for 4 sec. Any damage breaks the effect. Awards 1 combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 45
+|-
+! Cooldown
+| 10s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* directDamage
+* incapacitate
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Evasion (Ability)</title>
+    <ns>0</ns>
+    <id>406</id>
+    <revision>
+      <id>406</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="315">== Description ==
+Increases your dodge chance by 50% for 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 300s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Slice and Dice (Ability)</title>
+    <ns>0</ns>
+    <id>407</id>
+    <revision>
+      <id>407</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="360">== Description ==
+Finishing move that increases melee attack speed by 30%. Lasts longer per combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* finisherHaste
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Sprint (Ability)</title>
+    <ns>0</ns>
+    <id>408</id>
+    <revision>
+      <id>408</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="318">== Description ==
+Increases your movement speed by 70% for 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 300s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Kidney Shot (Ability)</title>
+    <ns>0</ns>
+    <id>409</id>
+    <revision>
+      <id>409</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="347">== Description ==
+Finishing move that stuns the target. Lasts 1 sec longer per combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 20s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* finisherStun
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ambush (Ability)</title>
+    <ns>0</ns>
+    <id>410</id>
+    <revision>
+      <id>410</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="404">== Description ==
+Ambush the target for 250% weapon damage plus $d. Must be stealthed and behind the target. Requires a dagger. Awards 1 combo point.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 60
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stealth (Ability)</title>
+    <ns>0</ns>
+    <id>411</id>
+    <revision>
+      <id>411</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="415">== Description ==
+Conceals you in the shadows: enemies barely notice you, but you move 30% slower. Attacking or taking damage breaks Stealth. Cast again to step out.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 2
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 10s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Adrenaline Rush (Ability)</title>
+    <ns>0</ns>
+    <id>412</id>
+    <revision>
+      <id>412</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="325">== Description ==
+Your blood runs hot, instantly restoring 60 energy.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Rogue]]
+|-
+! Learn level
+| 20
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 180s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* gainResource
+[[Category:Abilities]]
+[[Category:Rogue]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Seal of Righteousness (Ability)</title>
+    <ns>0</ns>
+    <id>413</id>
+    <revision>
+      <id>413</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="509">== Description ==
+Fills you with Holy power for 30 sec, causing each of your melee swings to deal 4 additional Holy damage. Unleash with Judgement.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* imbue
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 35
+|-
+! Rank 3
+| Level 16, cost 50
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Holy Light (Ability)</title>
+    <ns>0</ns>
+    <id>414</id>
+    <revision>
+      <id>414</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="437">== Description ==
+Heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* heal
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 60
+|-
+! Rank 3
+| Level 14, cost 95
+|-
+! Rank 4
+| Level 20, cost 140
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Devotion Aura (Ability)</title>
+    <ns>0</ns>
+    <id>415</id>
+    <revision>
+      <id>415</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="418">== Description ==
+Increases your armor by 40 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 0
+|-
+! Rank 3
+| Level 18, cost 0
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Judgement (Ability)</title>
+    <ns>0</ns>
+    <id>416</id>
+    <revision>
+      <id>416</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="350">== Description ==
+Unleashes your active Seal upon the enemy, consuming it to deal its judgement damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 10s
+|-
+! Range
+| 10 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* judgement
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Blessing of Might (Ability)</title>
+    <ns>0</ns>
+    <id>417</id>
+    <revision>
+      <id>417</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="460">== Description ==
+Places a Blessing on a friendly target, increasing attack power by 15 for 5 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* buffTarget
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 40
+|-
+! Rank 3
+| Level 20, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Divine Protection (Ability)</title>
+    <ns>0</ns>
+    <id>418</id>
+    <revision>
+      <id>418</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="394">== Description ==
+A holy shield absorbs 50 damage for 10 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 180s
+|-
+! Range
+| Melee/self
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* absorb
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 25
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Hammer of Justice (Ability)</title>
+    <ns>0</ns>
+    <id>419</id>
+    <revision>
+      <id>419</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="370">== Description ==
+Stuns the target for 3 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 60s
+|-
+! Range
+| 10 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* stun
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Lay on Hands (Ability)</title>
+    <ns>0</ns>
+    <id>420</id>
+    <revision>
+      <id>420</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="408">== Description ==
+A massive surge of healing: restores 250 health. 10 min cooldown.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 600s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* heal
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 18, cost 0
+|}
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Flash of Light (Ability)</title>
+    <ns>0</ns>
+    <id>421</id>
+    <revision>
+      <id>421</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="330">== Description ==
+A quick, efficient flash of Light that heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 12
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* heal
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Exorcism (Ability)</title>
+    <ns>0</ns>
+    <id>422</id>
+    <revision>
+      <id>422</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="329">== Description ==
+Banishes the wicked with Holy wrath, causing $d Holy damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 55
+|-
+! Cooldown
+| 15s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Consecration (Ability)</title>
+    <ns>0</ns>
+    <id>423</id>
+    <revision>
+      <id>423</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="348">== Description ==
+Consecrates the ground beneath you, searing nearby enemies for $d Holy damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 18
+|-
+! Cost
+| 60
+|-
+! Cooldown
+| 8s
+|-
+! Range
+| Melee/self
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* aoeDamage
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Righteous Fury (Ability)</title>
+    <ns>0</ns>
+    <id>424</id>
+    <revision>
+      <id>424</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="373">== Description ==
+Increases the threat generated by your Holy damage by 60% for 30 min. The tanking paladin&apos;s cornerstone.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Paladin]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Paladin]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Tame Beast (Ability)</title>
+    <ns>0</ns>
+    <id>425</id>
+    <revision>
+      <id>425</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="459">== Description ==
+Begins taming a beast to be your companion. It must be your level or lower and not an elite. Your pet follows you, attacks your enemies, and holds threat of its own. You may have one pet at a time.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 20 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* tamePet
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Dismiss Pet (Ability)</title>
+    <ns>0</ns>
+    <id>426</id>
+    <revision>
+      <id>426</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="305">== Description ==
+Releases your pet back to the wild.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* dismissPet
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Raptor Strike (Ability)</title>
+    <ns>0</ns>
+    <id>427</id>
+    <revision>
+      <id>427</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="499">== Description ==
+A strong melee attack that increases damage by 5. Activates on your next swing.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 25
+|-
+! Rank 3
+| Level 14, cost 35
+|-
+! Rank 4
+| Level 20, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Aspect of the Hawk (Ability)</title>
+    <ns>0</ns>
+    <id>428</id>
+    <revision>
+      <id>428</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="456">== Description ==
+Take on the aspect of the hawk, increasing attack power by 20 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 30
+|-
+! Rank 3
+| Level 18, cost 40
+|}
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Serpent Sting (Ability)</title>
+    <ns>0</ns>
+    <id>429</id>
+    <revision>
+      <id>429</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="429">== Description ==
+Stings the target, dealing $d Nature damage over 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 35 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 25
+|-
+! Rank 3
+| Level 16, cost 35
+|}
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Arcane Shot (Ability)</title>
+    <ns>0</ns>
+    <id>430</id>
+    <revision>
+      <id>430</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="426">== Description ==
+An instant shot that deals $d Arcane damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| 35 yd
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 40
+|-
+! Rank 3
+| Level 18, cost 55
+|}
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Concussive Shot (Ability)</title>
+    <ns>0</ns>
+    <id>431</id>
+    <revision>
+      <id>431</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="329">== Description ==
+Dazes the target, slowing movement by 50% for 4 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 12s
+|-
+! Range
+| 35 yd
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* directDamage
+* slow
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mongoose Bite (Ability)</title>
+    <ns>0</ns>
+    <id>432</id>
+    <revision>
+      <id>432</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="440">== Description ==
+Counterattack after the target dodges for weapon damage plus 12. Cannot be dodged.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 10
+|-
+! Cooldown
+| 5s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 10
+|}
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wing Clip (Ability)</title>
+    <ns>0</ns>
+    <id>433</id>
+    <revision>
+      <id>433</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="338">== Description ==
+Inflicts a wound that slows the enemy by 40% for 10 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* directDamage
+* slow
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Aspect of the Cheetah (Ability)</title>
+    <ns>0</ns>
+    <id>434</id>
+    <revision>
+      <id>434</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="348">== Description ==
+Take on the aspect of the cheetah, increasing movement speed by 30% for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Aimed Shot (Ability)</title>
+    <ns>0</ns>
+    <id>435</id>
+    <revision>
+      <id>435</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="314">== Description ==
+A carefully aimed shot that deals $d damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 50
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| 35 yd
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rapid Fire (Ability)</title>
+    <ns>0</ns>
+    <id>436</id>
+    <revision>
+      <id>436</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="318">== Description ==
+Increases your attack speed by 40% for 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Hunter]]
+|-
+! Learn level
+| 20
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 300s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Hunter]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Smite (Ability)</title>
+    <ns>0</ns>
+    <id>437</id>
+    <revision>
+      <id>437</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="447">== Description ==
+Smites the enemy for $d Holy damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 32
+|-
+! Rank 3
+| Level 14, cost 48
+|-
+! Rank 4
+| Level 20, cost 70
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Lesser Heal (Ability)</title>
+    <ns>0</ns>
+    <id>438</id>
+    <revision>
+      <id>438</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="402">== Description ==
+Heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* heal
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 6, cost 45
+|-
+! Rank 3
+| Level 12, cost 65
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Power Word: Fortitude (Ability)</title>
+    <ns>0</ns>
+    <id>439</id>
+    <revision>
+      <id>439</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="425">== Description ==
+Increases the target&apos;s Stamina by 3 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* buffTarget
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 55
+|-
+! Rank 3
+| Level 20, cost 80
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shadow Word: Pain (Ability)</title>
+    <ns>0</ns>
+    <id>440</id>
+    <revision>
+      <id>440</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="428">== Description ==
+A word of darkness causes $d Shadow damage over 18 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 38
+|-
+! Rank 3
+| Level 16, cost 55
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Power Word: Shield (Ability)</title>
+    <ns>0</ns>
+    <id>441</id>
+    <revision>
+      <id>441</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="426">== Description ==
+Shields the target, absorbing 48 damage for 30 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 45
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* absorb
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 70
+|-
+! Rank 3
+| Level 18, cost 100
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Renew (Ability)</title>
+    <ns>0</ns>
+    <id>442</id>
+    <revision>
+      <id>442</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="407">== Description ==
+Heals the target for $d over 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* hot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 50
+|-
+! Rank 3
+| Level 20, cost 75
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mind Blast (Ability)</title>
+    <ns>0</ns>
+    <id>443</id>
+    <revision>
+      <id>443</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="429">== Description ==
+Blasts the target&apos;s mind for $d Shadow damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 50
+|-
+! Cooldown
+| 8s
+|-
+! Range
+| 30 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 70
+|-
+! Rank 3
+| Level 20, cost 95
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Heal (Ability)</title>
+    <ns>0</ns>
+    <id>444</id>
+    <revision>
+      <id>444</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="405">== Description ==
+A slow but powerful prayer that heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 95
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* heal
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 20, cost 130
+|}
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mind Flay (Ability)</title>
+    <ns>0</ns>
+    <id>445</id>
+    <revision>
+      <id>445</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="352">== Description ==
+Assaults the target&apos;s mind with Shadow energy, causing 12 damage each second for 3 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 45
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 20 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* drainTick
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Flash Heal (Ability)</title>
+    <ns>0</ns>
+    <id>446</id>
+    <revision>
+      <id>446</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="308">== Description ==
+A fast prayer that heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Priest]]
+|-
+! Learn level
+| 20
+|-
+! Cost
+| 75
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| holy
+|}
+
+== Base effects ==
+* heal
+[[Category:Abilities]]
+[[Category:Priest]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Lightning Bolt (Ability)</title>
+    <ns>0</ns>
+    <id>447</id>
+    <revision>
+      <id>447</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="460">== Description ==
+Hurls a bolt of lightning for $d Nature damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 25
+|-
+! Rank 3
+| Level 14, cost 40
+|-
+! Rank 4
+| Level 20, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rockbiter Weapon (Ability)</title>
+    <ns>0</ns>
+    <id>448</id>
+    <revision>
+      <id>448</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="469">== Description ==
+Imbues your weapon with the fury of stone: each swing deals 5 additional damage for 5 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* imbue
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 30
+|-
+! Rank 3
+| Level 16, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Healing Wave (Ability)</title>
+    <ns>0</ns>
+    <id>449</id>
+    <revision>
+      <id>449</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="436">== Description ==
+Heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* heal
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 6, cost 40
+|-
+! Rank 3
+| Level 12, cost 65
+|-
+! Rank 4
+| Level 18, cost 90
+|}
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Earth Shock (Ability)</title>
+    <ns>0</ns>
+    <id>450</id>
+    <revision>
+      <id>450</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="453">== Description ==
+Instantly shocks the target with concussive force for $d Nature damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| 20 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 45
+|-
+! Rank 3
+| Level 16, cost 65
+|}
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Lightning Shield (Ability)</title>
+    <ns>0</ns>
+    <id>451</id>
+    <revision>
+      <id>451</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="461">== Description ==
+Surrounds you with crackling lightning: melee attackers take 13 Nature damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 40
+|-
+! Rank 3
+| Level 18, cost 55
+|}
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Flame Shock (Ability)</title>
+    <ns>0</ns>
+    <id>452</id>
+    <revision>
+      <id>452</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="416">== Description ==
+Sears the target with fire for 25 damage plus $d over 12 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| 20 yd
+|-
+! School
+| fire
+|}
+
+== Base effects ==
+* directDamage
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 55
+|}
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Frost Shock (Ability)</title>
+    <ns>0</ns>
+    <id>453</id>
+    <revision>
+      <id>453</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="373">== Description ==
+Instantly shocks the target with frost for $d Frost damage and slows its movement by 50% for 8 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 50
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| 20 yd
+|-
+! School
+| frost
+|}
+
+== Base effects ==
+* directDamage
+* slow
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ghost Wolf (Ability)</title>
+    <ns>0</ns>
+    <id>454</id>
+    <revision>
+      <id>454</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="342">== Description ==
+Turns you into a Ghost Wolf, increasing movement speed by 40% for 10 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Stormstrike (Ability)</title>
+    <ns>0</ns>
+    <id>455</id>
+    <revision>
+      <id>455</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="361">== Description ==
+Channels the storm through your weapon, instantly striking for weapon damage plus $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Shaman]]
+|-
+! Learn level
+| 20
+|-
+! Cost
+| 40
+|-
+! Cooldown
+| 12s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+[[Category:Abilities]]
+[[Category:Shaman]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shadow Bolt (Ability)</title>
+    <ns>0</ns>
+    <id>456</id>
+    <revision>
+      <id>456</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="470">== Description ==
+Sends a shadowy bolt at the enemy for $d Shadow damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 38
+|-
+! Rank 3
+| Level 14, cost 55
+|-
+! Rank 4
+| Level 20, cost 80
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Demon Skin (Ability)</title>
+    <ns>0</ns>
+    <id>457</id>
+    <revision>
+      <id>457</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="436">== Description ==
+Demonic skin increases your armor by 30 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* selfBuff
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 35
+|-
+! Rank 3
+| Level 20, cost 50
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Immolate (Ability)</title>
+    <ns>0</ns>
+    <id>458</id>
+    <revision>
+      <id>458</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="456">== Description ==
+Burns the enemy for 11 Fire damage and an additional $d over 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| fire
+|}
+
+== Base effects ==
+* directDamage
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 40
+|-
+! Rank 3
+| Level 16, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Corruption (Ability)</title>
+    <ns>0</ns>
+    <id>459</id>
+    <revision>
+      <id>459</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="433">== Description ==
+Corrupts the target, causing $d Shadow damage over 18 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 12, cost 55
+|-
+! Rank 3
+| Level 18, cost 75
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Life Tap (Ability)</title>
+    <ns>0</ns>
+    <id>460</id>
+    <revision>
+      <id>460</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="413">== Description ==
+Converts 30 health into 30 mana.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* lifeTap
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 0
+|-
+! Rank 3
+| Level 20, cost 0
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Curse of Agony (Ability)</title>
+    <ns>0</ns>
+    <id>461</id>
+    <revision>
+      <id>461</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="434">== Description ==
+Curses the target with agony: $d Shadow damage over 24 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 40
+|-
+! Rank 3
+| Level 20, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Drain Life (Ability)</title>
+    <ns>0</ns>
+    <id>462</id>
+    <revision>
+      <id>462</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="459">== Description ==
+Drains the target&apos;s life, transferring 7 health to you each second for 5 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 20 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* drainTick
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 50
+|-
+! Rank 3
+| Level 20, cost 70
+|}
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Fear (Ability)</title>
+    <ns>0</ns>
+    <id>463</id>
+    <revision>
+      <id>463</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="367">== Description ==
+Strikes terror into the enemy, leaving it cowering for up to 8 sec. Any damage breaks the effect.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 40
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 20 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* incapacitate
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Searing Pain (Ability)</title>
+    <ns>0</ns>
+    <id>464</id>
+    <revision>
+      <id>464</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="338">== Description ==
+Sears the enemy with agonizing fire for $d Fire damage. Quick to cast.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| fire
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shadowburn (Ability)</title>
+    <ns>0</ns>
+    <id>465</id>
+    <revision>
+      <id>465</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="338">== Description ==
+Instantly blasts the target with Shadow Flame for $d Shadow damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warlock]]
+|-
+! Learn level
+| 20
+|-
+! Cost
+| 70
+|-
+! Cooldown
+| 15s
+|-
+! Range
+| 20 yd
+|-
+! School
+| shadow
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Warlock]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Wrath (Ability)</title>
+    <ns>0</ns>
+    <id>466</id>
+    <revision>
+      <id>466</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="462">== Description ==
+Hurls a bolt of nature energy for $d Nature damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* directDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 32
+|-
+! Rank 3
+| Level 14, cost 48
+|-
+! Rank 4
+| Level 20, cost 70
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Healing Touch (Ability)</title>
+    <ns>0</ns>
+    <id>467</id>
+    <revision>
+      <id>467</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="435">== Description ==
+Heals a friendly target for $d.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* heal
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 8, cost 45
+|-
+! Rank 3
+| Level 14, cost 75
+|-
+! Rank 4
+| Level 20, cost 110
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mark of the Wild (Ability)</title>
+    <ns>0</ns>
+    <id>468</id>
+    <revision>
+      <id>468</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="462">== Description ==
+Places the Mark of the Wild on a friendly target, increasing armor by 25 for 30 min.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 1
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* buffTarget
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 35
+|-
+! Rank 3
+| Level 16, cost 50
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Moonfire (Ability)</title>
+    <ns>0</ns>
+    <id>469</id>
+    <revision>
+      <id>469</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="459">== Description ==
+Burns the enemy with moonfire for $d Arcane damage plus damage over time.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* directDamage
+* dot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 40
+|-
+! Rank 3
+| Level 16, cost 60
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Rejuvenation (Ability)</title>
+    <ns>0</ns>
+    <id>470</id>
+    <revision>
+      <id>470</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="439">== Description ==
+Heals the target for $d over 12 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 4
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* hot
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 10, cost 40
+|-
+! Rank 3
+| Level 16, cost 60
+|-
+! Rank 4
+| Level 20, cost 80
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Thorns (Ability)</title>
+    <ns>0</ns>
+    <id>471</id>
+    <revision>
+      <id>471</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="446">== Description ==
+Thorns sprout from the target: melee attackers take 3 Nature damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 6
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* buffTarget
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 14, cost 35
+|-
+! Rank 3
+| Level 20, cost 50
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Entangling Roots (Ability)</title>
+    <ns>0</ns>
+    <id>472</id>
+    <revision>
+      <id>472</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="383">== Description ==
+Roots the target in place for up to 12 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 8
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* root
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 50
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bear Form (Ability)</title>
+    <ns>0</ns>
+    <id>473</id>
+    <revision>
+      <id>473</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="413">== Description ==
+Shapeshift into a bear: armor +65%, attack power +15, your attacks build rage and generate 30% more threat. Cast again to return to caster form.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Maul (Ability)</title>
+    <ns>0</ns>
+    <id>474</id>
+    <revision>
+      <id>474</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="488">== Description ==
+A mauling attack that increases melee damage by $d and causes a high amount of threat. Activates on your next swing. Bear Form only.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 15
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponDamage
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 16, cost 15
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Growl (Ability)</title>
+    <ns>0</ns>
+    <id>475</id>
+    <revision>
+      <id>475</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="390">== Description ==
+Growls at the target: your threat rises to match its most hated enemy and it is compelled to attack you for 3 sec. Bear Form only.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 10s
+|-
+! Range
+| 8 yd
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* taunt
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Cat Form (Ability)</title>
+    <ns>0</ns>
+    <id>476</id>
+    <revision>
+      <id>476</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="440">== Description ==
+Shapeshift into a cat: attack power rises with your level, your attacks use energy and combo points, and you generate 29% less threat. Cast again to return to caster form.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 12
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Claw (Ability)</title>
+    <ns>0</ns>
+    <id>477</id>
+    <revision>
+      <id>477</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="434">== Description ==
+Claw the enemy for weapon damage plus $d. Awards 1 combo point. Cat Form only.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 12
+|-
+! Cost
+| 45
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+
+== Ranks ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Rank 2
+| Level 18, cost 45
+|}
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Ferocious Bite (Ability)</title>
+    <ns>0</ns>
+    <id>478</id>
+    <revision>
+      <id>478</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="340">== Description ==
+Finishing move that causes damage per combo point. Cat Form only.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 35
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* finisherDamage
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Swipe (Ability)</title>
+    <ns>0</ns>
+    <id>479</id>
+    <revision>
+      <id>479</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="342">== Description ==
+Swipe nearby enemies for $d damage. Causes extra threat. Bear Form only.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* aoeDamage
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Regrowth (Ability)</title>
+    <ns>0</ns>
+    <id>480</id>
+    <revision>
+      <id>480</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="332">== Description ==
+Heals a friendly target for $d and an additional amount over 21 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 14
+|-
+! Cost
+| 55
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* heal
+* hot
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Barkskin (Ability)</title>
+    <ns>0</ns>
+    <id>481</id>
+    <revision>
+      <id>481</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="332">== Description ==
+Your skin hardens like bark, increasing armor by 150 for 15 sec.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 16
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 60s
+|-
+! Range
+| Melee/self
+|-
+! School
+| nature
+|}
+
+== Base effects ==
+* selfBuff
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Starfire (Ability)</title>
+    <ns>0</ns>
+    <id>482</id>
+    <revision>
+      <id>482</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="326">== Description ==
+Calls down a bolt of stellar fire, causing $d Arcane damage.
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Druid]]
+|-
+! Learn level
+| 18
+|-
+! Cost
+| 80
+|-
+! Cooldown
+| 0s
+|-
+! Range
+| 30 yd
+|-
+! School
+| arcane
+|}
+
+== Base effects ==
+* directDamage
+[[Category:Abilities]]
+[[Category:Druid]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Mortal Strike (Ability)</title>
+    <ns>0</ns>
+    <id>483</id>
+    <revision>
+      <id>483</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="341">== Description ==
+A vicious strike dealing weapon damage plus $d. (Arms signature)
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Bloodthirst (Ability)</title>
+    <ns>0</ns>
+    <id>484</id>
+    <revision>
+      <id>484</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="336">== Description ==
+Instantly attack in a blood frenzy for $d. (Fury signature)
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 30
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Shield Slam (Ability)</title>
+    <ns>0</ns>
+    <id>485</id>
+    <revision>
+      <id>485</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="359">== Description ==
+Slam the target with your shield for $d and massive threat. (Protection signature)
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 20
+|-
+! Cooldown
+| 6s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* weaponStrike
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Whirlwind (Ability)</title>
+    <ns>0</ns>
+    <id>486</id>
+    <revision>
+      <id>486</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="346">== Description ==
+Spin in a deadly arc, striking all nearby enemies for $d. (Fury talent)
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 25
+|-
+! Cooldown
+| 10s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* aoeDamage
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>Berserker Rage (Ability)</title>
+    <ns>0</ns>
+    <id>487</id>
+    <revision>
+      <id>487</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="337">== Description ==
+Enter a berserker rage, generating 20 rage. (Warrior talent)
+
+== Facts ==
+{| class=&quot;wikitable article-facts&quot;
+|-
+! Class
+| [[Warrior]]
+|-
+! Learn level
+| 10
+|-
+! Cost
+| 0
+|-
+! Cooldown
+| 30s
+|-
+! Range
+| Melee/self
+|-
+! School
+| physical
+|}
+
+== Base effects ==
+* gainResource
+[[Category:Abilities]]
+[[Category:Warrior]]
+</text>
+    </revision>
+  </page>
+
+  <page>
+    <title>All Pages</title>
+    <ns>0</ns>
+    <id>488</id>
+    <revision>
+      <id>488</id>
+      <timestamp>2026-06-15T23:47:51Z</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="12330">== Complete index ==
+* [[Abilities]]
+* [[Adrenaline Rush (Ability)]]
+* [[Agents and Bots]]
+* [[Aimed Shot (Ability)]]
+* [[Ambush (Ability)]]
+* [[Apothecary Lin (NPC)]]
+* [[Apprentice&apos;s Robe]]
+* [[Arcane Explosion (Ability)]]
+* [[Arcane Intellect (Ability)]]
+* [[Arcane Missiles (Ability)]]
+* [[Arcane Shot (Ability)]]
+* [[Armorer Hode (NPC)]]
+* [[Ashen Coliseum]]
+* [[Aspect of the Cheetah (Ability)]]
+* [[Aspect of the Hawk (Ability)]]
+* [[Back to the Shallows]]
+* [[Backstab (Ability)]]
+* [[Bandits of the Vale]]
+* [[Barkskin (Ability)]]
+* [[Bastion Revenant (Mob)]]
+* [[Bastion Ward Stone]]
+* [[Battle Shout (Ability)]]
+* [[Bear Form (Ability)]]
+* [[Berserker Rage (Ability)]]
+* [[Blessed Embers]]
+* [[Blessed Tallow]]
+* [[Blessing of Might (Ability)]]
+* [[Bloodrage (Ability)]]
+* [[Bloodthirst (Ability)]]
+* [[Bogiron Hauberk]]
+* [[Bogiron Mace]]
+* [[Bogiron Nugget]]
+* [[Bone Fragments]]
+* [[Bonechill Widow (Mob)]]
+* [[Boneclad Revenant (Mob)]]
+* [[Boneguard Breastplate]]
+* [[Boneplate Vest]]
+* [[Bones of the Vanguard]]
+* [[Break the War-Camp]]
+* [[Breaking the Seal]]
+* [[Bristleback Hides]]
+* [[Bristleback Maul]]
+* [[Bristly Boar Hide]]
+* [[Bronzework Mace]]
+* [[Broodmother&apos;s Silk Robe]]
+* [[Brother Aldric (NPC) (2)]]
+* [[Brother Aldric (NPC) (3)]]
+* [[Brother Aldric (NPC)]]
+* [[Captain Thessaly (NPC)]]
+* [[Cat Form (Ability)]]
+* [[Censers from the Deep]]
+* [[Chants on the Wind]]
+* [[Charge (Ability)]]
+* [[Chipped Tusk]]
+* [[Classes]]
+* [[Claw (Ability)]]
+* [[Cleave (Ability)]]
+* [[Combat]]
+* [[Community Lore]]
+* [[Concussive Shot (Ability)]]
+* [[Conjure Water (Ability)]]
+* [[Conjured Mineral Water]]
+* [[Conjured Sparkling Water]]
+* [[Conjured Spring Water]]
+* [[Consecration (Ability)]]
+* [[Cores of the Storm]]
+* [[Corruption (Ability)]]
+* [[Cracked Fetish]]
+* [[Cracked Wolf Fang]]
+* [[Cracked Wyrm Scale]]
+* [[Craghorn Staff]]
+* [[Cragwalker Boots]]
+* [[Crypt Shambler (Mob)]]
+* [[Cryptbone Greaves]]
+* [[Cryptstalker Jerkin]]
+* [[Cultist Flayer]]
+* [[Curse of Agony (Ability)]]
+* [[Deacon Voss (Mob)]]
+* [[Deacon&apos;s Cleaver]]
+* [[Deathlord Legguards]]
+* [[Deathlord Sabatons]]
+* [[Deathlord Warplate]]
+* [[Deepfen Pearl]]
+* [[Deepfen Snapper (Mob)]]
+* [[Deeprock Trouble]]
+* [[Deeprock Tunneler (Mob)]]
+* [[Defensive Stance (Ability)]]
+* [[Demon Skin (Ability)]]
+* [[Development Timeline]]
+* [[Devotion Aura (Ability)]]
+* [[Dismiss Pet (Ability)]]
+* [[Divine Protection (Ability)]]
+* [[Drain Life (Ability)]]
+* [[Drogmar&apos;s Skullcleaver]]
+* [[Drogmar&apos;s Warboots]]
+* [[Drowned Dead (Mob)]]
+* [[Drowned Prayer Leggings]]
+* [[Drowned Prayer Sandals]]
+* [[Drowned Thrall (Mob)]]
+* [[Drownedguard Breastplate]]
+* [[Druid]]
+* [[Duels]]
+* [[Dungeons]]
+* [[Earth Shock (Ability)]]
+* [[Eastbrook Arming Sword]]
+* [[Eastbrook Chainmail Vest]]
+* [[Eastbrook Vale]]
+* [[Eastbrook Wool Trousers]]
+* [[Eelscale Leggings]]
+* [[Eelscale Treads]]
+* [[Eelskin Tunic]]
+* [[Elder Bristleback (Mob)]]
+* [[Emberwood Staff]]
+* [[Entangling Roots (Ability)]]
+* [[Evasion (Ability)]]
+* [[Eviscerate (Ability)]]
+* [[Execute (Ability)]]
+* [[Exorcism (Ability)]]
+* [[Fang of Korzul]]
+* [[Fear (Ability)]]
+* [[Fen Reaver Glaive]]
+* [[Fenbridge Muster Order]]
+* [[Fenbridge Rye Loaf]]
+* [[Fenmist Robe]]
+* [[Fenreed Staff]]
+* [[Fenwalker Boots]]
+* [[Ferocious Bite (Ability)]]
+* [[Fetish and Bone]]
+* [[Fire Blast (Ability)]]
+* [[Fireball (Ability)]]
+* [[Fisherman Brandt (NPC)]]
+* [[Fishing]]
+* [[Flame Shock (Ability)]]
+* [[Flash Heal (Ability)]]
+* [[Flash of Light (Ability)]]
+* [[Footpad&apos;s Jerkin]]
+* [[Foreman Odell (NPC)]]
+* [[Forest Wolf (Mob)]]
+* [[Frayed Prayer Beads]]
+* [[Freshly Baked Bread]]
+* [[Frost Armor (Ability)]]
+* [[Frost Nova (Ability)]]
+* [[Frost Shock (Ability)]]
+* [[Frostbolt (Ability)]]
+* [[Gameplay Systems]]
+* [[Ghost Wolf (Ability)]]
+* [[Ghostly Essence]]
+* [[Glacier Melt]]
+* [[Glowing Wax]]
+* [[Gnarled Staff]]
+* [[Gorrak the Ruthless (Mob)]]
+* [[Gorrak&apos;s Cruel Chopper]]
+* [[Gouge (Ability)]]
+* [[Grand Necromancer Velkhar (Mob)]]
+* [[Gravecaller Cipher]]
+* [[Gravecaller Cultist (Mob)]]
+* [[Gravecaller Summoner (Mob)]]
+* [[Gravecaller&apos;s Broadblade]]
+* [[Gravecaller&apos;s Sigil]]
+* [[Gravepath Treads]]
+* [[Gravewalker Softboots]]
+* [[Gravewoven Raiment]]
+* [[Gravewyrm Sabatons]]
+* [[Gravewyrm Sanctum]]
+* [[Gravewyrm Scale Hauberk]]
+* [[Gravewyrm Sigil]]
+* [[Gravewyrm Stalker&apos;s Treads]]
+* [[Greyjaw Hide Boots]]
+* [[Greyjaw&apos;s Pelt Leggings]]
+* [[Growl (Ability)]]
+* [[Grubjaw the Glutton (Mob)]]
+* [[Grubjaw&apos;s Tusk]]
+* [[Guilds]]
+* [[Gutripper Shiv]]
+* [[Hammer of Justice (Ability)]]
+* [[Hamstring (Ability)]]
+* [[Heal (Ability)]]
+* [[Healing Touch (Ability)]]
+* [[Healing Wave (Ability)]]
+* [[Herbalist Yara (NPC)]]
+* [[Heroic Strike (Ability)]]
+* [[Hickory Shortstaff]]
+* [[Highwatch Breastplate]]
+* [[Highwatch Summons]]
+* [[Highwatch Trail Hardtack]]
+* [[Highwatch Warblade]]
+* [[Hobnailed Boots]]
+* [[Hollow Acolyte (Mob)]]
+* [[Hollowbone Hauberk]]
+* [[Hollowbound Legguards]]
+* [[Holy Light (Ability)]]
+* [[Hunter]]
+* [[Ice Barrier (Ability)]]
+* [[Icevein Dirk]]
+* [[Idols of the Deep]]
+* [[Immolate (Ability)]]
+* [[Inert Storm Shard]]
+* [[Into the Hollow]]
+* [[Ironvein Foreman (Mob)]]
+* [[Ironvein Lantern Staff]]
+* [[Ironvein Pickblade]]
+* [[Ironvein Sapper (Mob)]]
+* [[Items]]
+* [[Judgement (Ability)]]
+* [[Kazzix&apos;s Heartshard]]
+* [[Keen Dirk]]
+* [[Kidney Shot (Ability)]]
+* [[Knight-Commander Olen (Mob)]]
+* [[Knight-Commander&apos;s Greaves]]
+* [[Korgath the Bound (Mob)]]
+* [[Korgath&apos;s Chainwraps]]
+* [[Korzul the Gravewyrm (Mob)]]
+* [[Korzul the Gravewyrm]]
+* [[Lay on Hands (Ability)]]
+* [[Lesser Heal (Ability)]]
+* [[Life Tap (Ability)]]
+* [[Lightning Bolt (Ability)]]
+* [[Lightning Shield (Ability)]]
+* [[Linen Scrap]]
+* [[Loremaster Caddis (NPC)]]
+* [[Lost Caravan Goods]]
+* [[Mage]]
+* [[Main Page]]
+* [[Mark of the Wild (Ability)]]
+* [[Marrowlord Boneboots]]
+* [[Marrowlord Varkas (Mob)]]
+* [[Marrowtread Boots]]
+* [[Marsh Mint Tea]]
+* [[Marshal Redbrook (NPC)]]
+* [[Marshcloth Robe]]
+* [[Marshstrider Boots]]
+* [[Maul (Ability)]]
+* [[MediaWiki:Common.css]]
+* [[Meltwater Flask]]
+* [[Militia Chainvest]]
+* [[Mind Blast (Ability)]]
+* [[Mind Flay (Ability)]]
+* [[Minor Healing Potion]]
+* [[Minor Mana Potion]]
+* [[Mire Prowler (Mob)]]
+* [[Mire Prowler Pelt]]
+* [[Mirefen Marsh]]
+* [[Mirefen Skinner]]
+* [[Mirefen Troll (Mob)]]
+* [[Mirefen Troll Fetish]]
+* [[Mirefen Widow (Mob)]]
+* [[Mirejaw Biteblade]]
+* [[Mirejaw Frenzy (Mob)]]
+* [[Mirejaw Oracle Staff]]
+* [[Mirejaw Scale Vest]]
+* [[Mirejaw the Ravenous (Mob)]]
+* [[Mistbinder Kris]]
+* [[Mistcaller&apos;s Edge]]
+* [[Mobile Play]]
+* [[Mobs]]
+* [[Mogger (Mob)]]
+* [[Mogger Lackey (Mob)]]
+* [[Mogger Must Fall]]
+* [[Mogger&apos;s Copper Cudgel]]
+* [[Mogger&apos;s Shiv]]
+* [[Mogger&apos;s Stomper Boots]]
+* [[Mogger&apos;s Trail]]
+* [[Mongoose Bite (Ability)]]
+* [[Moonfire (Ability)]]
+* [[Mortal Strike (Ability)]]
+* [[Morthen the Gravecaller (Mob)]]
+* [[Morthen&apos;s Grimoire]]
+* [[Mounds of the Mirefen]]
+* [[Mudfin Skulker (Mob)]]
+* [[Muster at Fenbridge]]
+* [[NPCs]]
+* [[Necromancer&apos;s Legwraps]]
+* [[Necromancer&apos;s Soulsteps]]
+* [[Necromancer&apos;s Starshroud]]
+* [[Nhalia Mourner (Mob)]]
+* [[Nhalia&apos;s Dirgeblade]]
+* [[Nhalia&apos;s Funeral Wraps]]
+* [[Nightwalk Jerkin]]
+* [[No Rest in the Reeds]]
+* [[Ogre Bonecharm Staff]]
+* [[Ogre Toe Ring]]
+* [[Ogre War Totem]]
+* [[Ogres at the Foothills]]
+* [[Oiled Leather Boots]]
+* [[Old Greyjaw (Mob)]]
+* [[Old Greyjaw&apos;s Fang]]
+* [[Orders from Below]]
+* [[Overpower (Ability)]]
+* [[Paladin]]
+* [[Parties]]
+* [[Peakwool Robe]]
+* [[Pelts for the Causeway]]
+* [[Polymorph (Ability)]]
+* [[Power Word: Fortitude (Ability)]]
+* [[Power Word: Shield (Ability)]]
+* [[Priest]]
+* [[Provisioner Hale (NPC)]]
+* [[Quartermaster Bree (NPC)]]
+* [[Quests]]
+* [[Quick Start]]
+* [[Quilted Trousers]]
+* [[Raised Bonewalker (Mob)]]
+* [[Rapid Fire (Ability)]]
+* [[Raptor Strike (Ability)]]
+* [[Rats in the Mine]]
+* [[Raw Mirror Trout]]
+* [[Recruit&apos;s Tunic]]
+* [[Red Bandana]]
+* [[Redbrook Militia Blade]]
+* [[Reedwoven Jerkin]]
+* [[Reedwoven Trousers]]
+* [[Refreshing Spring Water]]
+* [[Regrowth (Ability)]]
+* [[Rejuvenation (Ability)]]
+* [[Rend (Ability)]]
+* [[Renew (Ability)]]
+* [[Restless Bones (Mob)]]
+* [[Revenant Silk Robe]]
+* [[Ridge Stalker (Mob)]]
+* [[Ridge Stalker Pelt]]
+* [[Ridgestalker Treads]]
+* [[Righteous Fury (Ability)]]
+* [[Riptide Dirk]]
+* [[Ritual Phylactery]]
+* [[Roast Mountain Goat]]
+* [[Roasted Boar Meat]]
+* [[Robes in the Reeds]]
+* [[Rockbiter Weapon (Ability)]]
+* [[Rogue]]
+* [[Rusted Censer]]
+* [[Rusty Dagger]]
+* [[Rusty Hatchet]]
+* [[Sableweb Hatchling (Mob)]]
+* [[Sableweb Matriarch (Mob)]]
+* [[Sableweb Slippers]]
+* [[Sanctum Boneguard (Mob)]]
+* [[Sanctum Drakonid (Mob)]]
+* [[Sanctum Key Shard]]
+* [[Scorch (Ability)]]
+* [[Scout Maren (NPC) (2)]]
+* [[Scout Maren (NPC)]]
+* [[Seal of Righteousness (Ability)]]
+* [[Searing Pain (Ability)]]
+* [[Serpent Sting (Ability)]]
+* [[Sexton Marrow (Mob)]]
+* [[Sexton&apos;s Slippers]]
+* [[Shadow Bolt (Ability)]]
+* [[Shadow Word: Pain (Ability)]]
+* [[Shadowburn (Ability)]]
+* [[Shadowmeld Tunic]]
+* [[Shadowstitch Jerkin]]
+* [[Shaman]]
+* [[Shardlord Kazzix (Mob)]]
+* [[Shield Slam (Ability)]]
+* [[Sigils of the Wyrm]]
+* [[Silence the Call]]
+* [[Silk and Venom]]
+* [[Silvermist Cordial]]
+* [[Simple Fishing Pole]]
+* [[Sinister Strike (Ability)]]
+* [[Sister Nhalia (Mob)]]
+* [[Slam (Ability)]]
+* [[Slice and Dice (Ability)]]
+* [[Slimy Murloc Scale]]
+* [[Smite (Ability)]]
+* [[Smith Haldren (NPC)]]
+* [[Smoked Mirefen Eel]]
+* [[Soggy Moccasin]]
+* [[Sources Used]]
+* [[Sprint (Ability)]]
+* [[Staff of Drowned Prayers]]
+* [[Staff of Velkhar]]
+* [[Staff of the Gravewyrm]]
+* [[Staff of the Hollow]]
+* [[Stalkerhide Jerkin]]
+* [[Stalkers on the Ridge]]
+* [[Starfire (Ability)]]
+* [[Stealth (Ability)]]
+* [[Stolen Supplies]]
+* [[Stolen Supply Crate]]
+* [[Stopping the Summoning]]
+* [[Storm Core]]
+* [[Stormcrag Elemental (Mob)]]
+* [[Stormshard Leggings]]
+* [[Stormstrike (Ability)]]
+* [[Strange Wax]]
+* [[Sunder Armor (Ability)]]
+* [[Swipe (Ability)]]
+* [[Tallow Candle]]
+* [[Tame Beast (Ability)]]
+* [[Tangled Weed]]
+* [[Tanned Leather Jerkin]]
+* [[Taunt (Ability)]]
+* [[Teeth of the Fen]]
+* [[The Binding Rite]]
+* [[The Bound Guardian]]
+* [[The Broodmother (Mob)]]
+* [[The Broodmother]]
+* [[The Captain&apos;s Bounty]]
+* [[The Deacon of the Mire]]
+* [[The Deepfen Stirs]]
+* [[The Drowned Dead]]
+* [[The Glutton]]
+* [[The Grand Necromancer]]
+* [[The Gravecaller Saga]]
+* [[The Gravecaller&apos;s Trail]]
+* [[The Hollow Crypt]]
+* [[The Knight-Commander&apos;s Shame]]
+* [[The Lost Caravan]]
+* [[The Merchant (NPC)]]
+* [[The Mistcaller]]
+* [[The Mountain Wakes]]
+* [[The Names of the Dead]]
+* [[The Old Wolf]]
+* [[The Phylactery Ring]]
+* [[The Restless Dead]]
+* [[The Revenant Fields]]
+* [[The Ringleader]]
+* [[The Sanctum Gate]]
+* [[The Sexton&apos;s Bell]]
+* [[The Shardlord]]
+* [[The Sunken Bastion (2)]]
+* [[The Sunken Bastion]]
+* [[The Voice Below]]
+* [[The Watch on the Peaks]]
+* [[Thornpeak Crusher (Mob)]]
+* [[Thornpeak Heights]]
+* [[Thornpeak Ogre (Mob)]]
+* [[Thorns (Ability)]]
+* [[Thunder Clap (Ability)]]
+* [[Tidebound Acolyte (Mob)]]
+* [[Tideguard Greaves]]
+* [[Tideguard Sabatons]]
+* [[Tidescale Vest]]
+* [[Totems of War]]
+* [[Tough Jerky]]
+* [[Trader Wilkes (NPC)]]
+* [[Trading]]
+* [[Training Mace]]
+* [[Trollhide Leggings]]
+* [[Trouble at the Lake]]
+* [[Tunnel Rat Digger (Mob)]]
+* [[Twitching Spider Leg]]
+* [[Vael the Mistcaller (Mob)]]
+* [[Vael&apos;s Mist-Staff]]
+* [[Vale Apprentice Staff]]
+* [[Vale Bandit (Mob)]]
+* [[Vale Carving Knife]]
+* [[Valeborn Spellblade]]
+* [[Valespun Robe]]
+* [[Valewoven Robe]]
+* [[Varkas Boneguard (Mob)]]
+* [[Voss&apos;s Sanctified Mace]]
+* [[Warden Fenwick (NPC)]]
+* [[Warlock]]
+* [[Warlord Drogmar (Mob)]]
+* [[Warlord Drogmar]]
+* [[Warrior]]
+* [[Waterlogged Idol]]
+* [[Weathered Ledger Page]]
+* [[Webwood Lurker (Mob)]]
+* [[Webwood Menace]]
+* [[Webwood Silk Gland]]
+* [[Whirlwind (Ability)]]
+* [[Whispers Below]]
+* [[Widow Venom Sac]]
+* [[Widowfang Dirk]]
+* [[Wild Boar (Mob)]]
+* [[Windguard Leggings]]
+* [[Wing Clip (Ability)]]
+* [[Winter Is Coming to Highwatch]]
+* [[Wolves at the Door]]
+* [[World Market]]
+* [[Worn Shortsword]]
+* [[Wrath (Ability)]]
+* [[Wyrmcult Grand Robe]]
+* [[Wyrmcult Necromancer (Mob)]]
+* [[Wyrmcult Orders]]
+* [[Wyrmcult Soulsteps]]
+* [[Wyrmcult Zealot (Mob)]]
+* [[Wyrmfang Greatblade]]
+* [[Wyrmscale Jerkin]]
+* [[Wyrmshadow Harness]]
+* [[Wyrmshadow Legguards]]
+* [[Wyrmshadow Treads]]
+* [[Zealotsbane Blade]]
+* [[Zones]]
+[[Category:Wiki]]
+</text>
+    </revision>
+  </page>
+</mediawiki>
+

--- a/mediawiki/theme/Common.css
+++ b/mediawiki/theme/Common.css
@@ -1,0 +1,420 @@
+/* =========================================================================
+   World of Claudecraft Wiki — "Aged Grimoire" theme for Vector 2022.
+   Warm parchment reading surface, deep oak chrome, gold + wax-seal-red
+   accents, elegant serif display headings.
+   ========================================================================= */
+
+:root {
+  --woc-ink: #2a1c10;          /* primary text on parchment */
+  --woc-ink-soft: #5a4427;     /* secondary text */
+  --woc-parchment: #f3e8cc;    /* reading surface */
+  --woc-parchment-2: #ece0bf;  /* alt surface (zebra, facts) */
+  --woc-oak: #241710;          /* dark chrome base */
+  --woc-oak-2: #160e09;        /* darker chrome */
+  --woc-gold: #e7b54a;         /* primary accent */
+  --woc-gold-soft: #f0d28a;    /* accent text on dark */
+  --woc-seal: #8a1f1c;         /* wax-seal red */
+  --woc-rule: rgba(106, 74, 33, 0.30);
+  --woc-rule-strong: #9d7c43;
+  --woc-link: #1c5a7a;         /* lapis on parchment */
+  --woc-link-visited: #6a417e; /* aged plum */
+  --woc-display: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
+}
+
+/* ---- Page backdrop: photo pushed back behind a dark "table" overlay ---- */
+html {
+  background: #0d0906;
+}
+
+body {
+  background:
+    radial-gradient(ellipse at 50% -10%, rgba(231, 181, 74, 0.10), rgba(13, 9, 6, 0) 55%),
+    linear-gradient(rgba(15, 10, 7, 0.80), rgba(11, 7, 5, 0.93)),
+    url('/wiki/resources/assets/woc-loading-screen.jpg') center top / cover fixed,
+    var(--woc-oak-2);
+  color: var(--woc-ink);
+}
+
+.mw-page-container,
+.vector-header-container,
+.vector-sticky-header,
+.mw-footer-container {
+  background: transparent;
+}
+
+/* ---- Top header bar ---- */
+/* warm the stark white masthead so it reads as part of the parchment page */
+.vector-header.mw-header {
+  background: linear-gradient(180deg, #f7efd9, #ece0bd);
+  border-bottom: 1px solid rgba(157, 124, 67, 0.6);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.22);
+}
+
+.mw-logo-wordmark,
+.mw-logo-tagline {
+  color: #b9831f;
+  font-family: var(--woc-display);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  text-shadow: 0 1px 0 rgba(255, 252, 240, 0.6);
+}
+
+/* keep the header search field crisp on the warm bar */
+.vector-header .cdx-text-input__input,
+.vector-header .cdx-search-input input {
+  background: #fffaf0;
+  border-color: rgba(157, 124, 67, 0.5);
+}
+
+/* ---- Reading surface ---- */
+.mw-body,
+.vector-page-titlebar,
+.vector-page-toolbar {
+  background: var(--woc-parchment);
+  color: var(--woc-ink);
+  border-color: var(--woc-rule-strong);
+}
+
+.mw-body {
+  background:
+    radial-gradient(120% 90% at 100% 0, rgba(255, 255, 255, 0.22), rgba(255, 255, 255, 0) 60%),
+    var(--woc-parchment);
+  border: 1px solid var(--woc-rule-strong);
+  border-radius: 4px;
+  box-shadow:
+    0 1px 0 rgba(255, 246, 222, 0.5) inset,
+    0 22px 50px rgba(0, 0, 0, 0.42);
+}
+
+.vector-body {
+  color: var(--woc-ink);
+}
+
+/* ---- Side columns: dark oak panels ---- */
+/* NB: don't give .vector-settings panel chrome — an empty collapsed copy of
+   it lives in the right column and would render as a stray dark nub. */
+.vector-main-menu,
+.vector-toc,
+.vector-page-tools,
+.vector-appearance {
+  background: linear-gradient(180deg, rgba(45, 30, 19, 0.97), rgba(22, 14, 9, 0.98));
+  color: var(--woc-parchment);
+  border: 1px solid rgba(231, 181, 74, 0.28);
+  border-radius: 4px;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.34);
+  padding: 6px 10px 10px;
+}
+
+/* readable text + controls inside the dark side panels (incl. Appearance) */
+.vector-main-menu,
+.vector-main-menu *,
+.vector-toc,
+.vector-toc *,
+.vector-page-tools,
+.vector-page-tools *,
+.vector-appearance,
+.vector-appearance *,
+.vector-settings,
+.vector-settings * {
+  color: var(--woc-parchment);
+}
+
+.vector-main-menu a,
+.vector-toc a,
+.vector-page-tools a,
+.vector-appearance a {
+  color: var(--woc-gold-soft);
+}
+
+.vector-main-menu a:hover,
+.vector-toc a:hover,
+.vector-page-tools a:hover {
+  color: #fff;
+}
+
+.vector-toc .vector-toc-list-item-active > a,
+.vector-toc-list-item-active .vector-toc-text {
+  color: #fff;
+  font-weight: 600;
+}
+
+/* section / landmark labels */
+.mw-logo-wordmark,
+.mw-logo-tagline,
+.vector-main-menu-landmark,
+.vector-toc-landmark,
+.vector-page-tools-landmark,
+.vector-pinnable-header-label,
+.vector-pinnable-header h2,
+.vector-pinnable-header h3 {
+  color: var(--woc-gold);
+}
+
+/* keep the Appearance widget's labels legible */
+.vector-settings .cdx-field__label,
+.vector-settings .cdx-label,
+.vector-settings legend,
+.vector-appearance legend,
+.vector-pinnable-header-label {
+  color: var(--woc-gold-soft) !important;
+}
+
+/* tone down the white pin / collapse toggle buttons that sit on the oak panels */
+.vector-main-menu .vector-pinnable-header-toggle-button,
+.vector-toc .vector-pinnable-header-toggle-button,
+.vector-page-tools .vector-pinnable-header-toggle-button,
+.vector-appearance .vector-pinnable-header-toggle-button,
+.vector-pinnable-header-toggle-button {
+  background: rgba(231, 181, 74, 0.12);
+  color: var(--woc-gold-soft);
+  border-radius: 4px;
+}
+
+.vector-pinnable-header-toggle-button:hover {
+  background: rgba(231, 181, 74, 0.24);
+}
+
+/* the header divider under "Contents"/"Appearance" defaults to light grey,
+   which paints a harsh line across the dark oak panels — soften to gold */
+.vector-pinnable-header {
+  border-bottom: 1px solid rgba(231, 181, 74, 0.22) !important;
+}
+
+/* ---- Typography ---- */
+.mw-first-heading,
+.mw-parser-output h1,
+.mw-parser-output h2,
+.mw-parser-output h3,
+.mw-parser-output h4 {
+  font-family: var(--woc-display);
+  color: #281607;
+  font-weight: 600;
+  letter-spacing: 0.005em;
+}
+
+.mw-first-heading {
+  font-size: 2.45rem;
+  line-height: 1.12;
+  border-bottom: 2px solid var(--woc-gold);
+  padding-bottom: 0.25em;
+}
+
+.mw-parser-output h2 {
+  font-size: 1.6rem;
+  border-bottom: 1px solid var(--woc-rule);
+  padding-bottom: 0.22em;
+  margin-top: 1.4em;
+}
+
+.mw-parser-output h3 {
+  font-size: 1.22rem;
+  color: var(--woc-seal);
+  border: 0;
+}
+
+.mw-parser-output p,
+.mw-parser-output li {
+  line-height: 1.65;
+}
+
+/* ---- Links ---- */
+.mw-parser-output a,
+.mw-body-content a:not(.external):not(.image) {
+  color: var(--woc-link);
+  text-decoration-color: rgba(28, 90, 122, 0.4);
+  text-underline-offset: 2px;
+}
+
+.mw-parser-output a:visited {
+  color: var(--woc-link-visited);
+}
+
+.mw-parser-output a:hover {
+  color: #0f3e57;
+}
+
+.mw-parser-output a.new {
+  color: var(--woc-seal);
+}
+
+/* ---- Hero ---- */
+.woc-main,
+.woc-hero,
+.woc-card,
+.wikitable,
+.article-facts {
+  border-color: var(--woc-rule) !important;
+}
+
+.woc-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 264px;
+  gap: 22px;
+  padding: 26px 28px;
+  margin-bottom: 22px;
+  align-items: center;
+  background:
+    radial-gradient(140% 120% at 0 0, rgba(255, 255, 255, 0.45), rgba(255, 255, 255, 0) 55%),
+    linear-gradient(180deg, #f6edd4, #ecddb7);
+  border: 1px solid var(--woc-rule-strong);
+  border-radius: 6px;
+  box-shadow:
+    0 1px 0 rgba(255, 250, 232, 0.7) inset,
+    0 16px 34px rgba(0, 0, 0, 0.22);
+}
+
+.woc-hero h1 {
+  margin: 0.08em 0 0.28em;
+  font-family: var(--woc-display);
+  font-size: 3rem;
+  line-height: 1.04;
+  color: #271404;
+  border: 0;
+}
+
+.woc-kicker {
+  margin: 0 0 6px;
+  color: var(--woc-seal);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.woc-hero p {
+  color: #43321b;
+  font-size: 1.02rem;
+}
+
+.woc-card {
+  display: grid;
+  place-items: center;
+  padding: 14px;
+  background: radial-gradient(120% 120% at 50% 0, #34221580, transparent 70%), linear-gradient(180deg, #2c1c13, #160d08);
+  border: 1px solid rgba(231, 181, 74, 0.42);
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.3) inset, 0 12px 26px rgba(0, 0, 0, 0.4);
+}
+
+.woc-crest {
+  display: grid;
+  place-items: end center;
+  width: min(220px, 100%);
+  aspect-ratio: 1;
+  padding: 14px;
+  background:
+    linear-gradient(rgba(24, 15, 10, 0), rgba(24, 15, 10, 0.85)),
+    url('/wiki/resources/assets/worldofclaudecraft-logo.png') center / contain no-repeat;
+  color: var(--woc-gold-soft);
+  font-family: var(--woc-display);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-align: center;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8);
+}
+
+/* ---- Tables ---- */
+.wikitable,
+.article-facts {
+  background: var(--woc-parchment) !important;
+  border: 1px solid var(--woc-rule-strong) !important;
+  border-collapse: collapse;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.14);
+}
+
+.wikitable > * > tr > th,
+.wikitable > * > tr > td,
+.article-facts > * > tr > th,
+.article-facts > * > tr > td {
+  border: 1px solid var(--woc-rule) !important;
+  padding: 8px 12px;
+}
+
+/* column + top headers — light text on oak, now actually visible */
+.wikitable > * > tr > th,
+.article-facts > * > tr > th {
+  color: #fdeec8 !important;
+  background: linear-gradient(180deg, #4a3017, #2f1d0e) !important;
+  font-family: var(--woc-display);
+  font-weight: 600;
+  text-align: left;
+}
+
+/* row-header (key/value fact tables) gets a narrower, distinct tone */
+.article-facts > * > tr > th {
+  background: linear-gradient(180deg, #402a14, #281a0c) !important;
+  white-space: nowrap;
+  width: 1%;
+}
+
+.wikitable > * > tr:nth-child(even) > td,
+.article-facts > * > tr:nth-child(even) > td {
+  background: var(--woc-parchment-2);
+}
+
+/* ---- Categories / footer of article ---- */
+.catlinks {
+  background: rgba(64, 42, 20, 0.10);
+  border: 1px solid var(--woc-rule);
+  border-radius: 4px;
+  padding: 8px 12px;
+  color: var(--woc-ink-soft);
+}
+
+/* ---- Code / quotes ---- */
+.mw-parser-output pre,
+.mw-parser-output code,
+.mw-parser-output tt {
+  background: #efe2c0;
+  border: 1px solid var(--woc-rule);
+  border-radius: 4px;
+  color: #3a2710;
+}
+
+.mw-parser-output blockquote {
+  border-left: 3px solid var(--woc-gold);
+  background: rgba(231, 181, 74, 0.08);
+  padding: 0.5em 1em;
+  border-radius: 0 4px 4px 0;
+}
+
+/* ---- Site footer ---- */
+.mw-footer,
+.mw-footer li,
+.mw-footer-info,
+.mw-footer-places {
+  color: rgba(243, 232, 204, 0.72);
+}
+
+.mw-footer a {
+  color: var(--woc-gold-soft);
+}
+
+.mw-footer {
+  border-top: 1px solid rgba(231, 181, 74, 0.18);
+  margin-top: 8px;
+}
+
+/* ---- Responsive ---- */
+@media (max-width: 720px) {
+  .woc-hero {
+    grid-template-columns: 1fr;
+    padding: 20px;
+    text-align: center;
+  }
+
+  .woc-hero h1 {
+    font-size: 2.1rem;
+  }
+
+  .woc-card {
+    max-width: 230px;
+    margin: 0 auto;
+  }
+
+  .mw-first-heading {
+    font-size: 1.9rem;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build:server": "esbuild server/main.ts --bundle --platform=node --format=cjs --external:pg-native --external:bufferutil --external:utf-8-validate --outfile=dist-server/server.cjs",
     "server": "npm run build:server && node dist-server/server.cjs",
     "realms": "npm run build:server && node scripts/dev-realms.mjs",
-    "admin:grant": "node scripts/grant_admin.mjs"
+    "admin:grant": "node scripts/grant_admin.mjs",
+    "wiki:seed": "node scripts/mediawiki/build_seed.mjs"
   },
   "dependencies": {
     "n8ao": "^1.10.1",

--- a/scripts/mediawiki/build_seed.mjs
+++ b/scripts/mediawiki/build_seed.mjs
@@ -1,0 +1,321 @@
+import { build } from 'esbuild';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+
+const outDir = resolve('mediawiki/seed');
+const tmpDir = resolve('tmp/mediawiki-seed');
+const sourcePath = resolve(tmpDir, 'seed-source.ts');
+const bundlePath = resolve(tmpDir, 'seed-source.mjs');
+const outputPath = resolve(outDir, 'pages.xml');
+const execFileAsync = promisify(execFile);
+
+await mkdir(tmpDir, { recursive: true });
+await mkdir(outDir, { recursive: true });
+
+const css = await readFile('mediawiki/theme/Common.css', 'utf8');
+
+await writeFile(sourcePath, `
+import { ABILITIES, CLASSES, DUNGEON_LIST, ITEMS, MOBS, NPCS, QUEST_ORDER, QUESTS, ZONES } from '../../src/sim/data';
+
+const css = ${JSON.stringify(css)};
+const pages = [];
+const titleBy = {
+  class: new Map(),
+  ability: new Map(),
+  zone: new Map(),
+  dungeon: new Map(),
+  npc: new Map(),
+  quest: new Map(),
+  mob: new Map(),
+  item: new Map(),
+};
+
+function escXml(text) {
+  return String(text ?? '').replace(/[&<>"']/g, (ch) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' }[ch]));
+}
+
+function titleCase(id) {
+  return String(id).split('_').map((p) => p ? p[0].toUpperCase() + p.slice(1) : '').join(' ');
+}
+
+function money(copper) {
+  if (!copper) return 'None';
+  const gold = Math.floor(copper / 10000);
+  const silver = Math.floor((copper % 10000) / 100);
+  const c = copper % 100;
+  return [gold ? gold + 'g' : '', silver ? silver + 's' : '', c + 'c'].filter(Boolean).join(' ');
+}
+
+function link(title, label = title) {
+  return title === label ? '[[' + title + ']]' : '[[' + title + '|' + label + ']]';
+}
+
+function section(title, body) {
+  return '== ' + title + ' ==\\n' + body.trim() + '\\n\\n';
+}
+
+function bullets(items) {
+  return items.filter(Boolean).map((item) => '* ' + item).join('\\n');
+}
+
+function table(rows) {
+  return '{| class="wikitable article-facts"\\n' + rows.map(([k, v]) => '|-\\n! ' + k + '\\n| ' + v).join('\\n') + '\\n|}';
+}
+
+function categories(names) {
+  return '\\n' + names.filter(Boolean).map((name) => '[[Category:' + name + ']]').join('\\n') + '\\n';
+}
+
+function add(title, text, cats = []) {
+  pages.push({ title, text: text.trim() + categories(cats) });
+}
+
+function unique(base, used) {
+  if (!used.has(base)) { used.add(base); return base; }
+  let i = 2;
+  while (used.has(base + ' (' + i + ')')) i++;
+  const title = base + ' (' + i + ')';
+  used.add(title);
+  return title;
+}
+
+const usedTitles = new Set();
+
+for (const [id, cls] of Object.entries(CLASSES)) titleBy.class.set(id, unique(cls.name, usedTitles));
+for (const [id, ability] of Object.entries(ABILITIES)) titleBy.ability.set(id, unique(ability.name + ' (Ability)', usedTitles));
+for (const zone of ZONES) titleBy.zone.set(zone.id, unique(zone.name, usedTitles));
+for (const dungeon of DUNGEON_LIST) titleBy.dungeon.set(dungeon.id, unique(dungeon.name, usedTitles));
+for (const [id, npc] of Object.entries(NPCS)) titleBy.npc.set(id, unique(npc.name + ' (NPC)', usedTitles));
+for (const [id, quest] of Object.entries(QUESTS)) titleBy.quest.set(id, unique(quest.name, usedTitles));
+for (const [id, mob] of Object.entries(MOBS)) titleBy.mob.set(id, unique(mob.name + ' (Mob)', usedTitles));
+for (const [id, item] of Object.entries(ITEMS)) titleBy.item.set(id, unique(item.name, usedTitles));
+
+function zoneForQuest(id) {
+  const index = QUEST_ORDER.indexOf(id);
+  if (index < 0) return 'Unknown';
+  if (index < 12) return 'Eastbrook Vale';
+  if (index < 24) return 'Mirefen Marsh';
+  return 'Thornpeak Heights';
+}
+
+add('MediaWiki:Common.css', css, []);
+
+add('Main Page', \`
+<div class="woc-main">
+<div class="woc-hero">
+<div>
+<p class="woc-kicker">Community player encyclopedia</p>
+<h1>World of Claudecraft Wiki</h1>
+World of Claudecraft is a browser-playable, WoW-Classic-flavored micro-MMO with online persistence, offline play, deterministic simulation logic, and a launch-week community that quickly turned jokes, dungeon clears, level races, bug reports, and feature requests into game history.
+
+'''Start here:''' [[Quick Start]] · [[All Pages]] · [[Zones]] · [[Classes]] · [[Gameplay Systems]] · [[Community Lore]] · [[Development Timeline]]
+</div>
+<div class="woc-card"><div class="woc-crest">World of Claudecraft</div></div>
+</div>
+</div>
+\` + section('Featured portals', bullets([
+  link('Zones') + ' — Eastbrook Vale, Mirefen Marsh, Thornpeak Heights.',
+  link('Classes') + ' — all nine playable class kits.',
+  link('Quests') + ' — the full source-defined quest chain.',
+  link('Dungeons') + ' — Hollow Crypt, Sunken Bastion, and Gravewyrm Sanctum.',
+  link('Community Lore') + ' — launch-week player culture from Discord, Reddit, and X.',
+  link('Development Timeline') + ' — issue, PR, and release themes.',
+])), ['Wiki']);
+
+add('Quick Start', section('First hour route', bullets([
+  'Create an online character for persistence, or use offline play for a quick solo test.',
+  'Speak to ' + link(titleBy.npc.get('marshal_redbrook'), 'Marshal Redbrook') + ' for ' + link(titleBy.quest.get('q_wolves'), 'Wolves at the Door') + '.',
+  'Collect nearby Eastbrook quests before leaving town so wolf, boar, spider, lake, mine, bandit, and chapel objectives overlap.',
+  'Sell poor-quality junk, buy food and water, and keep your action bar filled.',
+  'Follow ' + link(titleBy.npc.get('brother_aldric'), 'Brother Aldric') + ' into the Gravecaller story once the Fallen Chapel quests open.',
+])) + section('Controls', table([
+  ['WASD', 'Move and turn'], ['Q / E', 'Strafe'], ['Space', 'Jump'], ['Tab', 'Target nearest enemy'],
+  ['F', 'Interact, loot, talk'], ['1-0, -, =', 'Action bar'], ['C / P / L / M / B / G', 'Character, spellbook, quest log, map, bags, arena'], ['Enter', 'Open chat'],
+])), ['Guides']);
+
+add('The Gravecaller Saga', section('Overview', 'The main story follows Brother Aldric from restless bones outside Eastbrook to Korzul the Gravewyrm beneath Thornpeak.') + section('Acts', bullets([
+  link(titleBy.zone.get('eastbrook_vale'), 'Eastbrook Vale') + ' — Morthen the Gravecaller and ' + link(titleBy.dungeon.get('hollow_crypt'), 'The Hollow Crypt') + '.',
+  link(titleBy.zone.get('mirefen_marsh'), 'Mirefen Marsh') + ' — Vael the Mistcaller and ' + link(titleBy.dungeon.get('sunken_bastion'), 'The Sunken Bastion') + '.',
+  link(titleBy.zone.get('thornpeak_heights'), 'Thornpeak Heights') + ' — Wyrmcult zealots, Highwatch, and ' + link(titleBy.dungeon.get('gravewyrm_sanctum'), 'Gravewyrm Sanctum') + '.',
+])), ['Lore', 'Quests']);
+
+add('Community Lore', section('Launch-week myths', bullets([
+  'Players raced toward level 20 within the first weekend, and Discord mentions multiple level-20 characters plus jokes about level-cap roles.',
+  'A community prediction around Bucky becoming world-first level 20 turned the level race into channel folklore.',
+  'An early dungeon-clear clip by profitwizard and friends circulated through Discord and X.',
+  'The first-guild debate included Cool People Guild and a WOC Pumpfun guild.',
+  'Players joked about a future "Wrath of the Claude King" expansion before the first weekend was over.',
+])) + section('Community requests', bullets([
+  'Fishing, professions, and skilling loops.',
+  'Player-facing leaderboards for level, class, arena Elo, boss kills, and guilds.',
+  'Discord Rich Presence, public guild discovery, target markers, mobile improvements, mana pacing, and anti-bot handling.',
+  'Arena rewards, arena accept/decline prompts, and countdown buff preservation.',
+])) + section('Outside reception', 'Recent Reddit threads framed World of Claudecraft as a viral open-source, Fable 5-built MMORPG with thousands of early players and hundreds of GitHub stars. The same discussions mixed excitement, skepticism about generated code quality, nostalgia for Fable, questions about the TypeScript/Three.js stack, and stories of players unexpectedly sticking around to grind.'), ['Community', 'Discord', 'Reddit', 'X']);
+
+add('Development Timeline', section('Release themes', table([
+  ['v0.3 baseline', 'Persistent multiplayer, account flow, classes, quests, dungeons, social systems, and classic MMO presentation.'],
+  ['v0.4 hardening', 'Moderation, reports, homepage polish, mobile controls, OpenGraph, bug fixes, and database correctness work.'],
+  ['v0.5 focus', 'Ashen Coliseum ranked arena, first fishing loop, security fixes, guild/social polish, QoL, and release testing.'],
+])) + section('Known active topics', bullets([
+  'Arena polish, Elo, leaderboards, and rewards.',
+  'Fishing and broader professions.',
+  'Guild discovery, /who, friend/guild status clarity, and chat alias behavior.',
+  'Security and correctness work around market inputs, rate limits, guild transactions, character names, report handling, and moderation.',
+  'Headless environment and agent support for Codex/Claude-driven players.',
+])), ['Development', 'GitHub']);
+
+add('Sources Used', section('Local sources', bullets([
+  'Repository README, design docs, screenshots, source code, tests, sim content, class definitions, dungeon data, and server routes.',
+  'GitHub CLI exports of 45 issues and 141 pull requests.',
+  'Discord export of 3,205 messages from the World of Claudecraft community general channel.',
+])) + section('External sources', bullets([
+  '[https://github.com/levy-street/world-of-claudecraft GitHub repository]',
+  '[https://www.reddit.com/r/artificial/comments/1u4h7k1/world_of_claudecraft_the_first_opensource_mmorpg/ r/artificial launch thread]',
+  '[https://www.reddit.com/r/ClaudeAI/comments/1u3m6a8/i_vibe_coded_the_first_mmorpg_with_fable_5/ r/ClaudeAI Fable 5 thread]',
+  '[https://www.reddit.com/r/vibecoding/comments/1u47wo5/world_of_claudecraft_first_mmorpg_vibecoded_with/ r/vibecoding launch thread]',
+  '[https://www.reddit.com/r/AI_Agents/comments/1u4hstu/agents_have_entered_the_world_of_claudecraft_open/ r/AI_Agents thread]',
+  '[https://x.com/i/communities/2030944892999135272 World Of Claudecraft X community]',
+])), ['Sources']);
+
+const systemRows = [
+  ['Combat', 'Vanilla-style combat math, resources, GCD, threat, leashing, death, food, drink, and recovery.'],
+  ['Parties', 'Five-player grouping, shared tap rights, shared kill credit, XP bonuses, party chat, and shared instances.'],
+  ['Guilds', 'Guild creation, ranks, roster management, invites, guild chat, and public-discovery roadmap requests.'],
+  ['Trading', 'Nearby players stage items and copper; both sides accept; walking apart cancels.'],
+  ['World Market', 'The Merchant runs player listings, purchases, cancellations, and collections.'],
+  ['Duels', 'Friendly PvP challenges end at 1 HP.'],
+  ['Ashen Coliseum', 'Ranked 1v1 arena with matchmaking, private arena instances, Elo, ladder, and leaderboard.'],
+  ['Fishing', 'First professions slice: pole purchase, water checks, casting, and starter catch results.'],
+  ['Mobile Play', 'Touch controls, joystick fixes, quest-log access, fullscreen polish, and launch-week mobile testing.'],
+  ['Agents and Bots', 'Headless training environment, Codex/Claude agent culture, and anti-bot roadmap.'],
+];
+add('Gameplay Systems', section('Systems index', bullets(systemRows.map(([name, desc]) => link(name) + ' — ' + desc))), ['Systems']);
+for (const [name, desc] of systemRows) {
+  add(name, section('Overview', desc), ['Systems']);
+}
+
+const portals = [
+  ['Zones', ZONES.map((z) => titleBy.zone.get(z.id))],
+  ['Classes', Object.keys(CLASSES).map((id) => titleBy.class.get(id))],
+  ['Dungeons', DUNGEON_LIST.map((d) => titleBy.dungeon.get(d.id))],
+  ['NPCs', Object.keys(NPCS).map((id) => titleBy.npc.get(id))],
+  ['Quests', QUEST_ORDER.map((id) => titleBy.quest.get(id)).filter(Boolean)],
+  ['Mobs', Object.keys(MOBS).map((id) => titleBy.mob.get(id))],
+  ['Items', Object.keys(ITEMS).map((id) => titleBy.item.get(id))],
+  ['Abilities', Object.keys(ABILITIES).map((id) => titleBy.ability.get(id))],
+];
+
+for (const [portal, titles] of portals) {
+  add(portal, section('Articles', bullets(titles.sort().map((title) => link(title)))), ['Portals']);
+}
+
+for (const zone of ZONES) {
+  const npcs = Object.entries(NPCS).filter(([, npc]) => npc.pos.z >= zone.zMin && npc.pos.z < zone.zMax).map(([id]) => titleBy.npc.get(id));
+  const quests = Object.keys(QUESTS).filter((id) => zoneForQuest(id) === zone.name).map((id) => titleBy.quest.get(id));
+  add(titleBy.zone.get(zone.id), section('Overview', zone.welcome) + section('Facts', table([
+    ['Level range', zone.levelRange[0] + '-' + zone.levelRange[1]], ['Hub', zone.hub.name], ['Biome', zone.biome], ['Graveyard', zone.graveyard.x + ', ' + zone.graveyard.z],
+  ])) + section('Points of interest', bullets(zone.pois.map((poi) => poi.label))) + section('NPCs', bullets(npcs.map((title) => link(title)))) + section('Quest chain', bullets(quests.map((title) => link(title)))), ['Zones', zone.biome]);
+}
+
+for (const [id, cls] of Object.entries(CLASSES)) {
+  add(titleBy.class.get(id), section('Overview', cls.name + ' starts with ' + (ITEMS[cls.startWeapon]?.name ?? cls.startWeapon) + ' and uses ' + cls.resourceType + '.') + section('Stats', table(Object.entries(cls.baseStats).map(([k, v]) => [k.toUpperCase(), String(v)]))) + section('Abilities', bullets(cls.abilities.map((abilityId) => link(titleBy.ability.get(abilityId), ABILITIES[abilityId]?.name ?? abilityId)))), ['Classes']);
+}
+
+for (const dungeon of DUNGEON_LIST) {
+  const bosses = dungeon.spawns.map((s) => MOBS[s.mobId]).filter((mob) => mob?.boss);
+  add(titleBy.dungeon.get(dungeon.id), section('Overview', dungeon.name + ' is a private party instance with ' + dungeon.spawns.length + ' source-defined spawns.') + section('Facts', table([
+    ['Interior', dungeon.interior], ['Spawn count', String(dungeon.spawns.length)], ['Door position', dungeon.doorPos.x + ', ' + dungeon.doorPos.z],
+  ])) + section('Bosses', bullets(bosses.map((mob) => link(titleBy.mob.get(mob.id), mob.name)))) + section('Spawn list', bullets(dungeon.spawns.map((spawn) => link(titleBy.mob.get(spawn.mobId), MOBS[spawn.mobId]?.name ?? spawn.mobId) + ' at ' + spawn.x + ', ' + spawn.z))), ['Dungeons']);
+}
+
+for (const [id, npc] of Object.entries(NPCS)) {
+  add(titleBy.npc.get(id), section('Greeting', npc.greeting) + section('Facts', table([
+    ['Title', npc.title ?? 'NPC'], ['Position', npc.pos.x + ', ' + npc.pos.z], ['Quest count', String(npc.questIds?.length ?? 0)], ['Vendor', npc.vendorItems?.length ? 'Yes' : npc.market ? 'World Market' : 'No'],
+  ])) + (npc.questIds?.length ? section('Quests', bullets(npc.questIds.map((qid) => link(titleBy.quest.get(qid), QUESTS[qid]?.name ?? qid)))) : '') + (npc.vendorItems?.length ? section('Vendor stock', bullets(npc.vendorItems.map((itemId) => link(titleBy.item.get(itemId), ITEMS[itemId]?.name ?? itemId)))) : ''), ['NPCs']);
+}
+
+for (const [id, quest] of Object.entries(QUESTS)) {
+  const objectives = quest.objectives.map((obj) => (obj.label ?? obj.type) + ': ' + (obj.count ?? 1));
+  const rewards = Object.values(quest.itemRewards ?? {}).map((itemId) => ITEMS[itemId]).filter(Boolean);
+  add(titleBy.quest.get(id), section('Quest text', quest.text) + section('Facts', table([
+    ['Zone', zoneForQuest(id)], ['XP reward', String(quest.xpReward)], ['Copper reward', money(quest.copperReward)], ['Minimum level', quest.minLevel ? String(quest.minLevel) : 'None'], ['Requires quest', quest.requiresQuest ? (QUESTS[quest.requiresQuest]?.name ?? quest.requiresQuest) : 'None'],
+  ])) + section('Objectives', bullets(objectives)) + section('Completion', quest.completionText) + (rewards.length ? section('Rewards', bullets(rewards.map((item) => link(titleBy.item.get(item.id), item.name)))) : ''), ['Quests', zoneForQuest(id)]);
+}
+
+for (const [id, mob] of Object.entries(MOBS)) {
+  const mechanics = [mob.boss ? 'Boss' : '', mob.elite ? 'Elite' : '', mob.rare ? 'Rare' : '', mob.aoePulse ? 'AoE: ' + mob.aoePulse.name : '', mob.enrage ? 'Enrage below ' + Math.round(mob.enrage.belowHpPct * 100) + '%' : ''].filter(Boolean);
+  const loot = mob.loot.map((entry) => entry.itemId ? ITEMS[entry.itemId] : null).filter(Boolean);
+  add(titleBy.mob.get(id), section('Overview', mob.name + ' is a level ' + (mob.minLevel === mob.maxLevel ? mob.minLevel : mob.minLevel + '-' + mob.maxLevel) + ' ' + mob.family + '.') + section('Facts', table([
+    ['Family', mob.family], ['Level', mob.minLevel === mob.maxLevel ? String(mob.minLevel) : mob.minLevel + '-' + mob.maxLevel], ['Aggro radius', String(mob.aggroRadius)], ['Attack speed', String(mob.attackSpeed)],
+  ])) + (mechanics.length ? section('Mechanics', bullets(mechanics)) : '') + (loot.length ? section('Loot', bullets(loot.map((item) => link(titleBy.item.get(item.id), item.name)))) : ''), ['Mobs', mob.family]);
+}
+
+for (const [id, item] of Object.entries(ITEMS)) {
+  add(titleBy.item.get(id), section('Overview', item.name + ' is a ' + (item.quality ?? 'common') + ' ' + item.kind + (item.slot ? ' for ' + item.slot : '') + '.') + section('Facts', table([
+    ['Kind', item.kind], ['Quality', item.quality ?? 'common'], ['Slot', item.slot ?? 'None'], ['Sell value', money(item.sellValue)], ['Buy value', money(item.buyValue)], ['Required class', item.requiredClass?.join(', ') ?? 'Any'],
+  ])) + (item.weapon ? section('Weapon', table([['Damage', item.weapon.min + '-' + item.weapon.max], ['Speed', String(item.weapon.speed)], ['Dagger', item.weapon.dagger ? 'Yes' : 'No']])) : '') + (item.stats ? section('Stats', table(Object.entries(item.stats).map(([k, v]) => [k.toUpperCase(), String(v)]))) : '') + (item.foodHp || item.drinkMana ? section('Consumable', table([['Health restored', String(item.foodHp ?? 0)], ['Mana restored', String(item.drinkMana ?? 0)]])) : ''), ['Items', item.kind, item.quality ?? 'common']);
+}
+
+for (const [id, ability] of Object.entries(ABILITIES)) {
+  add(titleBy.ability.get(id), section('Description', ability.description) + section('Facts', table([
+    ['Class', link(titleBy.class.get(ability.class), CLASSES[ability.class]?.name ?? ability.class)], ['Learn level', String(ability.learnLevel)], ['Cost', String(ability.cost)], ['Cooldown', ability.cooldown + 's'], ['Range', ability.range ? ability.range + ' yd' : 'Melee/self'], ['School', ability.school],
+  ])) + section('Base effects', bullets(ability.effects.map((effect) => effect.type))) + (ability.ranks?.length ? section('Ranks', table(ability.ranks.map((rank) => ['Rank ' + rank.rank, 'Level ' + rank.level + ', cost ' + rank.cost]))) : ''), ['Abilities', CLASSES[ability.class]?.name ?? ability.class]);
+}
+
+add('All Pages', section('Complete index', bullets(pages.map((page) => link(page.title)).sort())), ['Wiki']);
+
+const now = new Date().toISOString().replace(/\\.\\d{3}Z$/, 'Z');
+const body = pages.map((page, index) => \`
+  <page>
+    <title>\${escXml(page.title)}</title>
+    <ns>\${page.title.startsWith('MediaWiki:') ? 8 : page.title.startsWith('Category:') ? 14 : 0}</ns>
+    <id>\${index + 1}</id>
+    <revision>
+      <id>\${index + 1}</id>
+      <timestamp>\${now}</timestamp>
+      <contributor><username>WikiAdmin</username><id>1</id></contributor>
+      <comment>Seed World of Claudecraft wiki content</comment>
+      <model>wikitext</model>
+      <format>text/x-wiki</format>
+      <text xml:space="preserve" bytes="\${Buffer.byteLength(page.text)}">\${escXml(page.text)}</text>
+    </revision>
+  </page>\`).join('\\n');
+
+const xml = \`<?xml version="1.0" encoding="UTF-8"?>
+<mediawiki xmlns="http://www.mediawiki.org/xml/export-0.11/" version="0.11" xml:lang="en">
+  <siteinfo>
+    <sitename>World of Claudecraft Wiki</sitename>
+    <dbname>mediawiki</dbname>
+    <base>http://localhost:8080/wiki/index.php/Main_Page</base>
+    <generator>MediaWiki seed</generator>
+    <case>first-letter</case>
+    <namespaces>
+      <namespace key="0" case="first-letter" />
+      <namespace key="8" case="first-letter">MediaWiki</namespace>
+      <namespace key="14" case="first-letter">Category</namespace>
+    </namespaces>
+  </siteinfo>
+\${body}
+</mediawiki>
+\`;
+
+console.log(xml);
+`);
+
+await build({
+  entryPoints: [sourcePath],
+  bundle: true,
+  platform: 'node',
+  format: 'esm',
+  outfile: bundlePath,
+  logLevel: 'silent',
+});
+
+const { stdout } = await execFileAsync(process.execPath, [bundlePath], {
+  maxBuffer: 50 * 1024 * 1024,
+});
+await writeFile(outputPath, stdout);
+await rm(tmpDir, { recursive: true, force: true });
+console.log(`wrote ${outputPath}`);

--- a/server/main.ts
+++ b/server/main.ts
@@ -24,6 +24,10 @@ import { cacheControlFor, etagFor, isNotModified } from './static_cache';
 
 const PORT = Number(process.env.PORT ?? 8787);
 const STATIC_DIR = path.join(__dirname, '..', 'dist');
+// The wiki is served under the game's own origin at /wiki via a reverse proxy
+// to the MediaWiki backend (default: the local docker service). MediaWiki must
+// know the public origin to build correct links — set MEDIAWIKI_SERVER to it.
+const WIKI_UPSTREAM = new URL(process.env.WIKI_UPSTREAM ?? 'http://127.0.0.1:8080');
 // How long chat logs are kept (0 = forever); pruned at boot and daily.
 const CHAT_LOG_RETENTION_DAYS = Number(process.env.CHAT_LOG_RETENTION_DAYS ?? 90);
 
@@ -111,6 +115,43 @@ function isAdminRequest(req: http.IncomingMessage): boolean {
   const host = String(req.headers.host ?? '').toLowerCase();
   const urlPath = (req.url ?? '/').split('?')[0];
   return host.startsWith('admin.') || urlPath === '/admin' || urlPath === '/admin/';
+}
+
+// `/wiki` and everything under it belongs to the MediaWiki backend.
+function isWikiPath(urlPath: string): boolean {
+  return urlPath === '/wiki' || urlPath.startsWith('/wiki/');
+}
+
+// Reverse-proxy the wiki so it lives under the game's origin instead of a
+// separate port. Hop-by-hop headers are stripped and X-Forwarded-* set so the
+// backend can build correct absolute URLs; the upstream is a fixed env value
+// (no client-controlled target), and only /wiki paths ever reach here.
+function proxyToWiki(req: http.IncomingMessage, res: http.ServerResponse): void {
+  const headers: http.OutgoingHttpHeaders = { ...req.headers };
+  for (const h of ['connection', 'keep-alive', 'proxy-authenticate', 'proxy-authorization', 'te', 'trailer', 'transfer-encoding', 'upgrade']) {
+    delete headers[h];
+  }
+  const fwdHost = req.headers.host;
+  if (fwdHost) headers['x-forwarded-host'] = fwdHost;
+  headers['x-forwarded-proto'] = (req.headers['x-forwarded-proto'] as string) ?? 'http';
+  headers['x-forwarded-for'] = req.socket.remoteAddress ?? '';
+  headers.host = WIKI_UPSTREAM.host;
+
+  const upstream = http.request({
+    hostname: WIKI_UPSTREAM.hostname,
+    port: WIKI_UPSTREAM.port || 80,
+    method: req.method,
+    path: req.url,
+    headers,
+  }, (up) => {
+    res.writeHead(up.statusCode ?? 502, up.headers);
+    up.pipe(res);
+  });
+  upstream.on('error', () => {
+    if (!res.headersSent) res.writeHead(502, { 'Content-Type': 'text/plain' });
+    res.end('Wiki backend unavailable');
+  });
+  req.pipe(upstream);
 }
 
 function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void {
@@ -434,6 +475,7 @@ async function main(): Promise<void> {
     if (req.method === 'OPTIONS' && isApi) { res.writeHead(204); res.end(); return; }
     if (url.startsWith('/admin/api/')) void handleAdminApi(req, res, game);
     else if (url.startsWith('/api/')) void handleApi(req, res);
+    else if (isWikiPath(url.split('?')[0])) proxyToWiki(req, res);
     else serveStatic(req, res);
   });
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -170,6 +170,7 @@ export const en = {
   wiki: {
     title: "Game Wiki & Guide",
     desc: "Discover the secrets of the realm, class guides, and strategies.",
+    cta: "Open the Wiki",
   },
   news: {
     title: "News & Updates",
@@ -301,6 +302,7 @@ export const es: typeof en = {
   wiki: {
     title: "Wiki y Guía del Juego",
     desc: "Descubre los secretos del reino, guías de clase y estrategias.",
+    cta: "Abrir la Wiki",
   },
   news: {
     title: "Noticias y Actualizaciones",
@@ -432,6 +434,7 @@ export const es_ES: typeof en = {
   wiki: {
     title: "Wiki y guía del juego",
     desc: "Descubre los secretos del reino, guías de clase y estrategias.",
+    cta: "Abrir la Wiki",
   },
   news: {
     title: "Noticias y actualizaciones",
@@ -563,6 +566,7 @@ export const fr_FR: typeof en = {
   wiki: {
     title: "Wiki et guide du jeu",
     desc: "Découvrez les secrets du royaume, les guides de classe et les stratégies.",
+    cta: "Ouvrir le Wiki",
   },
   news: {
     title: "Actualités et mises à jour",
@@ -694,6 +698,7 @@ export const fr_CA: typeof en = {
   wiki: {
     title: "Wiki et guide du jeu",
     desc: "Découvrez les secrets du royaume, les guides de classe et les stratégies.",
+    cta: "Ouvrir le Wiki",
   },
   news: {
     title: "Actualités et mises à jour",
@@ -825,6 +830,7 @@ export const en_CA: typeof en = {
   wiki: {
     title: "Game Wiki & Guide",
     desc: "Discover the secrets of the realm, class guides, and strategies.",
+    cta: "Open the Wiki",
   },
   news: {
     title: "News & Updates",
@@ -956,6 +962,7 @@ export const it_IT: typeof en = {
   wiki: {
     title: "Wiki e guida del gioco",
     desc: "Scopri i segreti del reame, le guide di classe e le strategie.",
+    cta: "Apri la Wiki",
   },
   news: {
     title: "Notizie e aggiornamenti",
@@ -1087,6 +1094,7 @@ export const de_DE: typeof en = {
   wiki: {
     title: "Spiel-Wiki und Guides",
     desc: "Entdecke die Geheimnisse des Realms, Klassenguides und Strategien.",
+    cta: "Wiki öffnen",
   },
   news: {
     title: "Neuigkeiten und Updates",
@@ -1218,6 +1226,7 @@ export const zh_CN: typeof en = {
   wiki: {
     title: "游戏百科与指南",
     desc: "探索世界的秘密、职业指南以及战术策略。",
+    cta: "打开维基",
   },
   news: {
     title: "新闻与更新说明",
@@ -1349,6 +1358,7 @@ export const zh_TW: typeof en = {
   wiki: {
     title: "遊戲百科與指南",
     desc: "探索世界的秘密、職業指南以及戰術策略。",
+    cta: "開啟維基",
   },
   news: {
     title: "新聞與更新說明",
@@ -1480,6 +1490,7 @@ export const ko_KR: typeof en = {
   wiki: {
     title: "게임 위키 및 가이드",
     desc: "렐름의 비밀과 클래스 가이드, 전략 등을 확인해 보세요.",
+    cta: "위키 열기",
   },
   news: {
     title: "새소식 및 업데이트",
@@ -1611,6 +1622,7 @@ export const ja_JP: typeof en = {
   wiki: {
     title: "ゲームWiki & ガイド",
     desc: "レルムの秘密、クラスガイド、戦略を確認しましょう。",
+    cta: "Wikiを開く",
   },
   news: {
     title: "ニュース & アップデート",
@@ -1742,6 +1754,7 @@ export const pt_BR: typeof en = {
   wiki: {
     title: "Wiki e guia do jogo",
     desc: "Descubra os segredos do reino, guias de classes e estratégias.",
+    cta: "Abrir a Wiki",
   },
   news: {
     title: "Notícias e atualizações",
@@ -1873,6 +1886,7 @@ export const ru_RU: typeof en = {
   wiki: {
     title: "Вики и руководство",
     desc: "Откройте секреты игрового мира, руководства по классам и стратегии.",
+    cta: "Открыть вики",
   },
   news: {
     title: "Новости и обновления",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,9 @@ export default defineConfig({
       '/api': { target: 'http://127.0.0.1:8787', changeOrigin: true },
       '/admin/api': { target: 'http://127.0.0.1:8787', changeOrigin: true },
       '/ws': { target: 'ws://127.0.0.1:8787', ws: true },
+      // The player wiki (MediaWiki container). Keep the original Host so the
+      // wiki builds its links on this dev origin instead of bouncing to :8080.
+      '/wiki': { target: 'http://127.0.0.1:8080', changeOrigin: false },
     },
   },
   build: {


### PR DESCRIPTION
Adds a real **MediaWiki** player wiki for World of Claudecraft, served on the **game's own origin** at `/wiki` (no separate port), with seed content generated from in-game data and launch-week community research.

## What's included
- **Same-origin serving**: the game server **reverse-proxies** `/wiki/*` to the MediaWiki backend, and the **Vite dev server proxies `/wiki` too**, so the wiki lives at `<origin>/wiki` whether you're on the dev server, the game port, or the production domain. POST/login, cookies, and resources all pass through; non-wiki paths are unaffected.
- **Origin auto-detection**: MediaWiki derives `$wgServer` from the request (Forwarded headers / Host), so links resolve correctly on the dev origin (`:5173`), the game origin (`:8787`), and the prod domain **without per-environment config**. `MEDIAWIKI_SERVER` remains an optional override (recommended in production).
- **Homepage link**: the homepage **Wiki tab** now has an **"Open the Wiki"** button (localized across all 14 locales) that opens the wiki — replacing the old "Coming Soon" placeholder.
- **Service**: `docker-compose.yml` adds `mediawiki` (mediawiki:1.43) + `mediawiki-db` (mariadb:11). The game proxies to the `mediawiki` service via `WIKI_UPSTREAM`.
- **Seeded content**: `npm run wiki:seed` (`scripts/mediawiki/build_seed.mjs`) generates **488 pages** from `src/sim/data.ts` — zones, classes, abilities, quests, dungeons, NPCs, mobs, items — plus portals, lore, and a development timeline. The entrypoint installs the schema on first boot and re-imports when the seed hash changes.
- **Theme**: an "aged grimoire" Vector 2022 skin (`mediawiki/theme/Common.css`) — warm parchment surface, deep-oak chrome, gold + wax-seal-red accents, serif display headings.

## Design polish (audited with Playwright, desktop + mobile)
- 🐞 table row-headers were invisible (dark-on-dark) → now light-on-oak with zebra striping
- 🐞 footer text was invisible on the dark backdrop → now legible
- warmed the masthead to match the parchment, removed a stray collapsed-panel artifact, refined hero/links/tables/typography

## Compatibility & verification
Rebased onto latest `main` (v0.6) as a single commit. `npm run build:server`, `vite build`, and `tsc --noEmit` all pass. Verified end-to-end with Playwright: from-scratch Docker deploy (clean DB → schema install → seed import → polished render), the reverse proxy (HTML, CSS, load.php, admin login POST), origin auto-detection across dev/game/prod hosts, and the homepage "Open the Wiki" button opening the rendered wiki on the dev origin.

## Notes
- Running Compose requires a `.env` with at least `POSTGRES_PASSWORD`. New vars: `MEDIAWIKI_*` (optional `MEDIAWIKI_SERVER` override) and `WIKI_UPSTREAM`.
- The wiki is a standalone install (own MariaDB user table); it is **not** wired to game accounts — read-only published reference by default (only `WikiAdmin` can edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)