### PR TITLE
feat(ui): add a Target-of-Target frame (#381)

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,6 +316,30 @@
   #target-frame .portrait-wrap { order: 2; }
   #target-frame .uf-bars { order: 1; margin-left: 0; margin-right: -8px; border-radius: 6px 0 0 6px; padding: 5px 14px 5px 8px; }
   #target-frame .level-chip { left: auto; right: -3px; }
+  /* Target-of-target: compact frame anchored to the lower-right of the target frame */
+  #target-of-target-frame {
+    position: absolute; right: -4px; bottom: -32px; z-index: 5;
+    display: none; align-items: center; gap: 5px;
+    padding: 3px 9px 3px 3px;
+    background: var(--panel-bg); border: 2px solid var(--border); outline: 1px solid #000;
+    border-radius: 18px; box-shadow: 0 2px 8px #000a; cursor: pointer;
+  }
+  #target-of-target-frame .tot-portrait {
+    width: 30px; height: 30px; border-radius: 50%; flex: 0 0 auto; overflow: hidden;
+    border: 2px solid var(--border); background: radial-gradient(circle at 35% 30%, #3a3a4e, #14141c);
+  }
+  #target-of-target-frame .tot-portrait canvas { border-radius: 50%; }
+  #target-of-target-frame .tot-info { display: flex; flex-direction: column; min-width: 0; }
+  #target-of-target-frame .tot-name {
+    font-size: 11px; font-weight: bold; font-family: var(--title-font); color: var(--gold);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 104px;
+    text-shadow: 1px 1px 1px #000;
+  }
+  #target-of-target-frame .tot-bar {
+    height: 6px; width: 104px; margin-top: 2px; overflow: hidden;
+    background: #1a1a1a; border: 1px solid #000; border-radius: 2px;
+  }
+  #target-of-target-frame .tot-hp { height: 100%; transform-origin: left; background-color: var(--color-hp); }
   .uf-name { font-size: 13px; font-weight: bold; font-family: var(--title-font); color: var(--gold);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-shadow: 1px 1px 2px #000; }
   .bar { position: relative; height: 15px; background: #1a1a1a; border: 1px solid #000; margin-top: 3px; border-radius: 2px; overflow: hidden; }
@@ -3553,6 +3577,13 @@
         <div class="bar hp"><div class="bar-fill" id="tf-hp"></div><div class="bar-text" id="tf-hp-text"></div></div>
         <div class="combo-row" id="combo-row"></div>
         <div class="uf-buffs" id="tf-debuffs"></div>
+      </div>
+      <div id="target-of-target-frame" title="Target of target">
+        <div class="tot-portrait"><canvas id="tot-portrait" width="30" height="30"></canvas></div>
+        <div class="tot-info">
+          <div class="tot-name" id="tot-name"></div>
+          <div class="tot-bar"><div class="tot-hp" id="tot-hp"></div></div>
+        </div>
       </div>
     </div>
 

--- a/scripts/tot_shot.mjs
+++ b/scripts/tot_shot.mjs
@@ -1,0 +1,73 @@
+// Screenshot the Target-of-Target frame (#381): boots offline, targets a wolf,
+// makes the wolf target the player, and captures the top-left HUD.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Tankadin');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Target a wolf and make it target the player so ToT reads "You".
+const info = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim, p = sim.player;
+  let wolf = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'forest_wolf' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; wolf = e; }
+    }
+  }
+  p.pos.x = wolf.pos.x + 4; p.pos.z = wolf.pos.z;
+  p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  sim.targetEntity(wolf.id);
+  wolf.targetId = p.id;        // the wolf is now hitting the player
+  wolf.hp = Math.round(wolf.maxHp * 0.7);
+  return { wolfId: wolf.id, wolfName: wolf.name };
+});
+console.log('setup:', JSON.stringify(info));
+await new Promise((r) => setTimeout(r, 600));
+
+// Re-assert each frame so combat AI doesn't clear it before the shot.
+for (let i = 0; i < 8; i++) {
+  await page.evaluate((id) => {
+    const g = window.__game, sim = g.sim, p = sim.player;
+    if (p.targetId !== id) sim.targetEntity(id);
+    const w = sim.entities.get(id);
+    if (w) w.targetId = p.id;
+  }, info.wolfId);
+  await new Promise((r) => setTimeout(r, 120));
+}
+
+const shown = await page.evaluate(() => {
+  const el = document.getElementById('target-of-target-frame');
+  return { display: getComputedStyle(el).display, name: document.getElementById('tot-name').textContent };
+});
+console.log('ToT frame:', JSON.stringify(shown));
+
+// Full HUD, then a tight crop of the unit frames.
+await page.screenshot({ path: 'tmp/tot_fullhud.png' });
+await page.screenshot({ path: 'tmp/tot_closeup.png', clip: { x: 0, y: 0, width: 420, height: 170 } });
+
+console.log(errors.length ? '\nERRORS:\n' + errors.slice(0, 10).join('\n') : 'no page errors');
+await browser.close();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -125,6 +125,7 @@ export class Hud {
   private openGossipNpcId: number | null = null;
   private selectedQuestLogId: string | null = null;
   private lastPortraitTarget = -999;
+  private lastTotPortrait = -999;
   // trading: locally staged offer, pushed to the server on change
   private stagedTrade: { items: InvSlot[]; copper: number } = { items: [], copper: 0 };
   private tradeWasOpen = false;
@@ -196,6 +197,18 @@ export class Hud {
         // Mirror Sim.setMarker's markable criteria (live wild hostile mob) so the
         // menu never appears for a pet/non-hostile mob where it would be a no-op.
         this.openMarkerMenu(t.id, t.name, (ev as MouseEvent).clientX, (ev as MouseEvent).clientY);
+      }
+    });
+
+    // classic WoW: clicking the target-of-target frame switches to that unit
+    $('#target-of-target-frame').addEventListener('click', (ev) => {
+      ev.stopPropagation();
+      const tid = this.sim.player.targetId;
+      const t = tid !== null ? this.sim.entities.get(tid) : null;
+      const totId = t ? t.targetId : null;
+      const tot = totId !== null ? this.sim.entities.get(totId) : null;
+      if (tot && tot.kind !== 'object' && !tot.dead && tot.id !== this.sim.playerId) {
+        this.sim.targetEntity(tot.id);
       }
     });
     $('#mm-char').addEventListener('click', () => this.toggleChar());
@@ -285,6 +298,29 @@ export class Hud {
     const s = canvas.width;
     ctx.clearRect(0, 0, s, s);
     ctx.drawImage(iconCanvas('crest', crestId, s), 0, 0, s, s);
+  }
+
+  // Classic target-of-target: a compact frame showing whom the current target
+  // is about to hit. Derived purely from the target's own `targetId` (already on
+  // every entity / snapshot), so it needs no new sim state. The "you" highlight
+  // is the key tank/PvP readability win — it shows aggro at a glance.
+  private updateTargetOfTarget(target: Entity): void {
+    const totFrame = $('#target-of-target-frame');
+    const view = targetOfTargetView(target, this.sim.entities, this.sim.playerId);
+    if (!view) {
+      totFrame.style.display = 'none';
+      this.lastTotPortrait = -999;
+      return;
+    }
+    totFrame.style.display = 'flex';
+    const nameEl = $('#tot-name') as HTMLElement;
+    nameEl.textContent = view.name;
+    nameEl.style.color = view.hostile ? 'var(--color-hostile)' : 'var(--color-friendly)';
+    ($('#tot-hp') as HTMLElement).style.transform = `scaleX(${view.hpFrac})`;
+    if (this.lastTotPortrait !== view.id) {
+      this.lastTotPortrait = view.id;
+      this.drawPortrait($('#tot-portrait') as unknown as HTMLCanvasElement, view.crestId);
+    }
   }
 
   private itemIcon(item: ItemDef): string {
@@ -707,6 +743,8 @@ export class Hud {
         this.drawPortrait($('#tf-portrait') as unknown as HTMLCanvasElement, crestId);
       }
       this.renderAuras($('#tf-debuffs'), target, 'debuffs');
+      // target-of-target: who/what the current target is about to hit
+      this.updateTargetOfTarget(target);
       // combo points
       const comboRow = $('#combo-row');
       if (p.resourceType === 'energy') {
@@ -727,6 +765,8 @@ export class Hud {
     } else {
       tf.style.display = 'none';
       this.lastPortraitTarget = -999;
+      $('#target-of-target-frame').style.display = 'none';
+      this.lastTotPortrait = -999;
     }
 
     // cast bar
@@ -4274,6 +4314,39 @@ export class Hud {
     }
     return closed;
   }
+}
+
+export interface TargetOfTargetView {
+  id: number;
+  name: string;
+  hpFrac: number;
+  hostile: boolean;
+  isSelf: boolean;
+  crestId: string;
+}
+
+// Pure resolution of the classic target-of-target frame: given the current
+// target, return a render-ready view of whom that target is hitting, or null
+// when nothing should show (no target's-target, an object, a corpse, or the
+// target pointing at itself). The viewer is shown as "You" and always flagged
+// hostile (something is attacking you) — the key tank/PvP readability cue.
+export function targetOfTargetView(
+  target: Pick<Entity, 'targetId' | 'id'>,
+  entities: Map<number, Entity>,
+  playerId: number,
+): TargetOfTargetView | null {
+  const totId = target.targetId;
+  const tot = totId !== null ? entities.get(totId) : null;
+  if (!tot || tot.kind === 'object' || tot.dead || tot.id === target.id) return null;
+  const isSelf = tot.id === playerId;
+  return {
+    id: tot.id,
+    name: isSelf ? 'You' : tot.name,
+    hpFrac: tot.hp / Math.max(1, tot.maxHp),
+    hostile: isSelf || tot.hostile,
+    isSelf,
+    crestId: tot.kind === 'npc' ? 'status_npc' : `family_${MOBS[tot.templateId]?.family ?? 'humanoid'}`,
+  };
 }
 
 function describeCost(known: ResolvedAbility, sim: IWorld): string {

--- a/tests/target_of_target.test.ts
+++ b/tests/target_of_target.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { targetOfTargetView } from '../src/ui/hud';
+import type { Entity } from '../src/sim/types';
+
+// Minimal entity stub — the view only reads a handful of fields.
+function ent(over: Partial<Entity>): Entity {
+  return {
+    id: 1, kind: 'mob', name: 'Thing', templateId: '', level: 1,
+    hp: 100, maxHp: 100, dead: false, hostile: true, targetId: null,
+    ...over,
+  } as unknown as Entity;
+}
+
+function world(...es: Entity[]): Map<number, Entity> {
+  return new Map(es.map((e) => [e.id, e] as const));
+}
+
+describe('targetOfTargetView', () => {
+  it('returns null when the target has no target', () => {
+    const target = ent({ id: 5, targetId: null });
+    expect(targetOfTargetView(target, world(target), 1)).toBeNull();
+  });
+
+  it('shows the viewer as "You" and hostile when the target hits the player', () => {
+    const me = ent({ id: 1, name: 'Hero', kind: 'player', hostile: false, hp: 60, maxHp: 120 });
+    const wolf = ent({ id: 5, name: 'Wolf', targetId: 1 });
+    const v = targetOfTargetView(wolf, world(me, wolf), 1)!;
+    expect(v.name).toBe('You');
+    expect(v.isSelf).toBe(true);
+    expect(v.hostile).toBe(true);
+    expect(v.hpFrac).toBeCloseTo(0.5);
+  });
+
+  it('shows another unit by name with friendly colour when not hostile', () => {
+    const ally = ent({ id: 7, name: 'Bet', kind: 'player', hostile: false });
+    const wolf = ent({ id: 5, name: 'Wolf', targetId: 7 });
+    const v = targetOfTargetView(wolf, world(ally, wolf), 1)!;
+    expect(v.name).toBe('Bet');
+    expect(v.isSelf).toBe(false);
+    expect(v.hostile).toBe(false);
+  });
+
+  it('hides when the target targets itself, an object, or a corpse', () => {
+    const wolf = ent({ id: 5, targetId: 5 });
+    expect(targetOfTargetView(wolf, world(wolf), 1)).toBeNull();
+
+    const obj = ent({ id: 8, kind: 'object' });
+    expect(targetOfTargetView(ent({ id: 5, targetId: 8 }), world(obj), 1)).toBeNull();
+
+    const corpse = ent({ id: 9, dead: true });
+    expect(targetOfTargetView(ent({ id: 5, targetId: 9 }), world(corpse), 1)).toBeNull();
+  });
+
+  it('falls back to a humanoid crest for players, status_npc for npcs', () => {
+    const npc = ent({ id: 2, kind: 'npc', name: 'Marshal' });
+    expect(targetOfTargetView(ent({ id: 5, targetId: 2 }), world(npc), 1)!.crestId).toBe('status_npc');
+
+    const pl = ent({ id: 3, kind: 'player', name: 'Gimel', templateId: '' });
+    expect(targetOfTargetView(ent({ id: 5, targetId: 3 }), world(pl), 1)!.crestId).toBe('family_humanoid');
+  });
+});


### PR DESCRIPTION
Closes #381.

## What

Adds the classic WoW **Target-of-Target (ToT)** frame — a compact portrait + name + health bar anchored to the lower-right of the target frame, showing who or what your current target is about to hit.

![ToT frame close-up](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/c788bfb/docs/pr-assets/tot/tot-frame-closeup.png)

In context (top-left HUD), targeting a Forest Wolf that is hitting the player — the ToT reads **YOU** in hostile red:

![ToT frame in the HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/c788bfb/docs/pr-assets/tot/tot-frame-fullhud.png)

## Why

This is a staple of the Classic default UI and a core readability tool:
- **Tanks** see at a glance whether a mob is on them or has slipped to a healer/DPS — without reading the threat meter.
- **Healers / DPS** see who a boss is about to hit, so they can pre-empt or peel.
- **PvP** — instantly shows who an enemy is focusing.

## How

Purely presentational. Every `Entity` (and every snapshot, via `target`) already carries `targetId`, so the target-of-target is fully derivable on the client with **no new sim or `IWorld` state**.

- `index.html` — `#target-of-target-frame` markup + CSS, nested **inside** `#target-frame` so it follows the frame's absolute position (including the mobile layout) for free.
- `src/ui/hud.ts` — `updateTargetOfTarget()` paints it from a new pure, exported `targetOfTargetView()` helper (resolves the unit, picks name/colour/crest, or returns `null` to hide). Clicking the frame targets that unit (classic behaviour).
- Hidden when the target has no live target, the target is dead, or it points at itself.

The viewer is shown as **You** and always flagged hostile (something is attacking you) — the key tank/PvP cue. ToT health uses the same `hp/maxHp` lookup as the target frame; portraits reuse the existing crest fallback (`status_npc` for NPCs, `family_*` for mobs/players).

## Tests

- `tests/target_of_target.test.ts` — 5 cases over `targetOfTargetView()` (self → "You"/hostile, ally by name/friendly, npc/player crest fallback, and the hide cases: no target, self-target, object, corpse).
- `scripts/tot_shot.mjs` — offline browser screenshot harness used for the images above.
- Full suite green: `653 passed`. `tsc --noEmit` clean.