### PR TITLE
feat(render): show overhead cast bars over casting mobs and players

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,12 @@
   .np-name { font-size: 12px; font-weight: bold; font-family: var(--title-font); letter-spacing: 0.3px; }
   .np-hpbar { width: 78px; height: 6px; background: #2a0000; border: 1px solid #000; margin: 1px auto 0; border-radius: 2px; }
   .np-hpfill { height: 100%; background: linear-gradient(#48e060, #1d7a32); border-radius: 2px; }
+  .np-castbar { position: relative; width: 78px; height: 8px; background: #1a1205; border: 1px solid #000;
+    margin: 1px auto 0; border-radius: 2px; overflow: hidden; }
+  .np-castfill { height: 100%; background: linear-gradient(#ffe27a, #d99a18); border-radius: 1px; transition: width 0.05s linear; }
+  .np-castbar.channel .np-castfill { background: linear-gradient(#7ad0ff, #2f7fd6); }
+  .np-castlabel { position: absolute; inset: 0; font-size: 8px; line-height: 8px; font-weight: bold;
+    color: #fff; text-shadow: 1px 1px 1px #000; letter-spacing: 0.2px; }
   .np-marker { font-size: 24px; font-weight: bold; height: 26px; font-family: var(--title-font); }
   .np-marker.avail { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }
   .np-marker.ready { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }

--- a/src/render/cast_bar.ts
+++ b/src/render/cast_bar.ts
@@ -1,0 +1,29 @@
+// Pure presentation logic for the overhead spell cast/channel bar. Kept DOM-free
+// (like nameplate_projection.ts / locomotion.ts) so the fill + label rules are
+// unit-testable without a WebGL context. The renderer turns this into DOM.
+import { Entity, FISHING_CAST_ID } from '../sim/types';
+import { ABILITIES } from '../sim/data';
+
+export interface CastBarState {
+  /** whether the bar should be shown at all this frame */
+  visible: boolean;
+  /** channels drain (true); hardcasts fill toward completion (false) */
+  channel: boolean;
+  /** 0..1 width fraction — casts grow toward 1, channels shrink toward 0 */
+  fill: number;
+  /** ability display name (fishing and unknown ids handled) */
+  label: string;
+}
+
+const HIDDEN: CastBarState = { visible: false, channel: false, fill: 0, label: '' };
+
+export function castBarState(e: Entity): CastBarState {
+  // corpses, doors/crates, and idle entities show nothing; guard the divide too
+  if (e.dead || e.kind === 'object' || !e.castingAbility || e.castTotal <= 0) return HIDDEN;
+  const remaining = Math.max(0, Math.min(1, e.castRemaining / e.castTotal));
+  const fill = e.channeling ? remaining : 1 - remaining;
+  const label = e.castingAbility === FISHING_CAST_ID
+    ? 'Fishing'
+    : ABILITIES[e.castingAbility]?.name ?? e.castingAbility;
+  return { visible: true, channel: e.channeling, fill, label };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -33,6 +33,7 @@ import { raidMarkerDataUrl } from '../ui/icons';
 import { isProjectedNameplateAnchorVisible, nameplateScreenTransform } from './nameplate_projection';
 import { comboPipsFor, COMBO_PIP_MAX } from './nameplate_combo';
 import { stepCameraOcclusion, type CameraOcclusionState } from './camera_collision';
+import { castBarState } from './cast_bar';
 
 const NAMEPLATE_RANGE = 55;
 const NAMEPLATE_RANGE_SQ = NAMEPLATE_RANGE * NAMEPLATE_RANGE;
@@ -120,6 +121,9 @@ interface EntityView {
   emoteIconEl: HTMLImageElement;
   emoteLabelEl: HTMLSpanElement;
   markerEl: HTMLDivElement;
+  castBar: HTMLDivElement; // overhead spell cast/channel bar, below the hp bar
+  castFill: HTMLDivElement;
+  castLabel: HTMLDivElement;
   raidMarkEl: HTMLDivElement; // party raid/target marker, above the name
   comboRow: HTMLDivElement; // rogue/druid combo-point pips, above the name
   comboPips: HTMLDivElement[]; // the COMBO_PIP_MAX pip cells, lit left-to-right
@@ -826,7 +830,16 @@ export class Renderer {
     const hpFill = document.createElement('div');
     hpFill.className = 'np-hpfill';
     hpBar.appendChild(hpFill);
-    np.append(emoteEl, raidMark, comboRow, marker, nameEl, hpBar);
+    // overhead cast bar — hidden until the entity starts casting/channeling
+    const castBar = document.createElement('div');
+    castBar.className = 'np-castbar';
+    castBar.style.display = 'none';
+    const castFill = document.createElement('div');
+    castFill.className = 'np-castfill';
+    const castLabel = document.createElement('div');
+    castLabel.className = 'np-castlabel';
+    castBar.append(castFill, castLabel);
+    np.append(emoteEl, raidMark, comboRow, marker, nameEl, hpBar, castBar);
     this.nameplateLayer.appendChild(np);
 
     // object views gate their own casters; character shadows live in visual
@@ -834,7 +847,7 @@ export class Renderer {
     if (!visual) collectCasters(group, objectCasters);
     this.views.set(e.id, {
       group, visual, sheepVisual: null, bearVisual: null, catVisual: null, height, clickTarget,
-      nameplate: np, nameEl, hpBar, hpFill, emoteEl, emoteIconEl, emoteLabelEl, markerEl: marker, raidMarkEl: raidMark, comboRow, comboPips, sparkle, objectMesh, portal,
+      nameplate: np, nameEl, hpBar, hpFill, emoteEl, emoteIconEl, emoteLabelEl, markerEl: marker, raidMarkEl: raidMark, comboRow, comboPips, castBar, castFill, castLabel, sparkle, objectMesh, portal,
       nameplateDisplay: 'none', nameplateTransform: '', nameplateSig: '', nameplateHpWidth: '', comboSig: '',
       objectCasters, shadowOn: true, isFar: false, lastOverheadEmoteKey: null,
       lastX: e.pos.x, lastZ: e.pos.z, skin: e.skin,
@@ -1561,6 +1574,8 @@ export class Renderer {
         this.setNameplateStatic(v, `mob|${name}|${color}|${hpDisplay}|${marker}`, name, color, hpDisplay, marker, 'np-marker loot', '1');
         this.setNameplateHp(v, e);
       }
+
+      this.updateCastBar(v, e);
     }
   }
 
@@ -1602,6 +1617,22 @@ export class Renderer {
     for (let i = 0; i < v.comboPips.length; i++) {
       v.comboPips[i].classList.toggle('lit', i < n);
     }
+  }
+
+  // Overhead spell cast/channel bar. The fill + label rules live in the DOM-free
+  // castBarState() helper (cast_bar.ts); here we just push them to the DOM. Casts
+  // fill up toward completion, channels drain down — both honest to the live
+  // cast fields the sim and the online snapshot already expose.
+  private updateCastBar(v: EntityView, e: Entity): void {
+    const st = castBarState(e);
+    if (!st.visible) {
+      if (v.castBar.style.display !== 'none') v.castBar.style.display = 'none';
+      return;
+    }
+    v.castBar.style.display = '';
+    v.castBar.classList.toggle('channel', st.channel);
+    v.castFill.style.width = `${(st.fill * 100).toFixed(1)}%`;
+    v.castLabel.textContent = st.label;
   }
 
   // Hang a speech bubble over an entity's head; it follows the entity and

--- a/tests/cast_bar.test.ts
+++ b/tests/cast_bar.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { castBarState } from '../src/render/cast_bar';
+import { Entity } from '../src/sim/types';
+
+// castBarState reads only a handful of cast fields, so a minimal partial entity
+// cast to Entity is enough to exercise every branch without a WebGL context.
+function caster(over: Partial<Entity>): Entity {
+  return {
+    kind: 'mob', dead: false,
+    castingAbility: 'fireball', castRemaining: 2.5, castTotal: 2.5, channeling: false,
+    ...over,
+  } as Entity;
+}
+
+describe('overhead cast bar', () => {
+  it('is hidden when nothing is being cast', () => {
+    expect(castBarState(caster({ castingAbility: null })).visible).toBe(false);
+  });
+
+  it('hides for corpses, objects, and a zero-length cast (no divide-by-zero)', () => {
+    expect(castBarState(caster({ dead: true })).visible).toBe(false);
+    expect(castBarState(caster({ kind: 'object' })).visible).toBe(false);
+    expect(castBarState(caster({ castTotal: 0 })).visible).toBe(false);
+  });
+
+  it('fills a hardcast upward toward completion', () => {
+    // 2.5s left of a 2.5s cast → just started → ~empty
+    expect(castBarState(caster({ castRemaining: 2.5, castTotal: 2.5 })).fill).toBeCloseTo(0);
+    // 0.5s left → 80% done
+    const mid = castBarState(caster({ castRemaining: 0.5, castTotal: 2.5 }));
+    expect(mid.fill).toBeCloseTo(0.8);
+    expect(mid.channel).toBe(false);
+    expect(mid.label).toBe('Fireball');
+  });
+
+  it('drains a channel downward as it ticks', () => {
+    const ch = castBarState(caster({
+      castingAbility: 'arcane_missiles', channeling: true, castRemaining: 1.5, castTotal: 3,
+    }));
+    expect(ch.channel).toBe(true);
+    expect(ch.fill).toBeCloseTo(0.5); // half the channel left → half-full, draining
+    expect(ch.label).toBe('Arcane Missiles');
+  });
+
+  it('labels fishing and falls back to the raw id for unknown abilities', () => {
+    expect(castBarState(caster({ castingAbility: 'fishing' })).label).toBe('Fishing');
+    expect(castBarState(caster({ castingAbility: 'made_up_spell' })).label).toBe('made_up_spell');
+  });
+
+  it('clamps the fill fraction to 0..1 against transient overshoot', () => {
+    expect(castBarState(caster({ castRemaining: 9, castTotal: 2.5 })).fill).toBe(0);
+    expect(castBarState(caster({ castRemaining: -1, castTotal: 2.5 })).fill).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds a small **cast/channel progress bar** to the overhead nameplate of any mob or player that is casting a spell. Hardcasts fill up toward completion; channels drain down as they tick.

![Cast bars in the world](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/970eb0b4727012126cf31c4874dc4868707a48cc/docs/pr-assets/cast-bars/hero.png)

Close-up — a gold **Fireball** hardcast (filling) and a blue **Arcane Missiles** channel (draining), each above the unit's health bar:

![Cast bar detail](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/970eb0b4727012126cf31c4874dc4868707a48cc/docs/pr-assets/cast-bars/zoom.png)

## Why

The cast-bar data is **already streamed to every client** — `server/game.ts` emits `cast`/`castRem`/`castTot`/`chan` in the interest snapshot and `ClientWorld` (`src/net/online.ts`) mirrors them back onto each `Entity`. But only the *local* player ever saw a cast bar (the HUD one); enemy and other-player casts were invisible. This closes a classic-fidelity gap (knowing when to interrupt/dodge an enemy cast) using data the renderer already had.

## How

- New cast/channel bar element appended to each nameplate in `Renderer.createView`, updated in the existing `updateNameplates` loop via a new `updateCastBar`.
- The fill + label rules live in a **DOM-free helper** `src/render/cast_bar.ts` (`castBarState`), mirroring the existing `nameplate_projection.ts` / `locomotion.ts` pattern, so they are unit-testable without a WebGL context.
- Casts fill (`1 - remaining/total`); channels drain (`remaining/total`) and get a distinct blue tint. The `FISHING_CAST_ID` sentinel is labelled "Fishing"; unknown ids fall back to the raw id. The fraction is clamped to 0..1 against transient overshoot.
- Bar visibility rides the existing nameplate gating (range/occlusion/**V** nameplate toggle), so it inherits all the existing show/hide rules for free.

**No sim, server, or `IWorld` changes** — pure renderer. Works in offline and online play identically.

## Test

`tests/cast_bar.test.ts` — idle/corpse/object/zero-length hidden cases, hardcast fill direction, channel drain direction, fishing + unknown-id labels, and 0..1 clamping. Full suite green (655 tests) and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)