### PR TITLE
feat(ui): pulsing low-health screen vignette

### DIFF
--- a/index.html
+++ b/index.html
@@ -1237,6 +1237,25 @@
     font-size: 38px; font-weight: bold; text-shadow: 0 0 18px #00000088, 2px 2px 6px #000; opacity: 0;
     transition: opacity 1.2s; pointer-events: none; font-family: var(--title-font); letter-spacing: 1px; white-space: nowrap; }
 
+  /* ---------- low-health screen vignette ---------- */
+  /* Pulsing red edge glow that fades in as the player nears death. Opacity and
+     pulse cadence are driven from JS via the --lhv-* custom properties; the
+     element stays hidden (display:none) until .active is set. Sits above the
+     world but below the HUD frames, and never eats pointer events. */
+  #low-health-vignette { position: fixed; inset: 0; display: none; z-index: 4; pointer-events: none;
+    --lhv-opacity: 0; --lhv-pulse: 1.6s;
+    background: radial-gradient(ellipse at center,
+      rgba(120,0,0,0) 42%, rgba(150,0,0,0.35) 74%, rgba(190,0,0,0.85) 100%);
+    animation: lhv-breathe var(--lhv-pulse) ease-in-out infinite; }
+  #low-health-vignette.active { display: block; }
+  @keyframes lhv-breathe {
+    0%, 100% { opacity: calc(var(--lhv-opacity) * 0.55); }
+    50%      { opacity: var(--lhv-opacity); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    #low-health-vignette { animation: none; opacity: var(--lhv-opacity); }
+  }
+
   /* ---------- death overlay ---------- */
   #death-overlay { position: absolute; inset: 0; background: radial-gradient(ellipse at center, #40000077 0%, #300000bb 100%);
     display: none; align-items: center; justify-content: center; flex-direction: column; gap: 18px; z-index: 30; }
@@ -5424,6 +5443,7 @@
 
     <div id="error-msg"></div>
     <div id="banner"></div>
+    <div id="low-health-vignette"></div>
 
     <div id="death-overlay">
       <h2 data-i18n="hud.core.deathTitle">You have died.</h2>

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { lowHealthVignette } from './low_health';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -1554,6 +1555,22 @@ export class Hud {
   // Frame update
   // -------------------------------------------------------------------------
 
+  // Pulsing red screen edge that fades in as the player nears death. Driven
+  // from the pure lowHealthVignette() curve; purely presentational (CSS vars on
+  // a fixed overlay), works on every GFX tier since it's DOM, not a post pass.
+  private updateLowHealthVignette(hp: number, maxHp: number): void {
+    const el = document.getElementById('low-health-vignette');
+    if (!el) return;
+    const v = lowHealthVignette(hp, maxHp);
+    if (!v.active) {
+      el.classList.remove('active');
+      return;
+    }
+    el.style.setProperty('--lhv-opacity', v.opacity.toFixed(3));
+    el.style.setProperty('--lhv-pulse', `${v.pulseSeconds.toFixed(3)}s`);
+    el.classList.add('active');
+  }
+
   update(): void {
     const sim = this.sim;
     const p = sim.player;
@@ -1579,6 +1596,7 @@ export class Hud {
     this.setText(this.pfLevelEl, String(p.level));
     this.setTransform(this.pfHpEl, `scaleX(${p.hp / Math.max(1, p.maxHp)})`);
     this.setText(this.pfHpTextEl, `${p.hp} / ${p.maxHp}`);
+    this.updateLowHealthVignette(p.hp, p.maxHp);
     const resFrac = p.resource / Math.max(1, p.maxResource);
     this.setTransform(this.pfResEl, `scaleX(${resFrac})`);
     this.setText(this.pfResTextEl, `${Math.round(p.resource)} / ${p.maxResource}`);

--- a/src/ui/low_health.ts
+++ b/src/ui/low_health.ts
@@ -1,0 +1,38 @@
+// Pure derivation of the low-health screen vignette — a pulsing red full-screen
+// glow that fades in as the player nears death (classic WoW's "FullScreenGlow").
+// Kept DOM-free so the intensity curve can be unit-tested directly; the HUD just
+// applies the returned values to a fixed overlay element each frame.
+
+// Below this HP fraction the vignette begins to show; at full HP it is hidden.
+export const LOW_HEALTH_THRESHOLD = 0.35;
+// Peak opacity reached as HP approaches 0 (kept < 1 so the world stays readable).
+const MAX_OPACITY = 0.92;
+// Pulse cadence, in Hz, at the threshold (slow "breathing") and near death (fast).
+const PULSE_HZ_MIN = 0.6;
+const PULSE_HZ_MAX = 2.0;
+
+export interface LowHealthVignette {
+  active: boolean; // false → overlay hidden (above threshold or dead)
+  opacity: number; // 0..MAX_OPACITY base opacity for the overlay
+  pulseSeconds: number; // one full breathe cycle; shorter = more frantic
+}
+
+// Maps live HP to the vignette state. `dead` players show nothing (the death
+// overlay owns the screen then). The opacity is eased (pow < 1) so the warning
+// is felt early in the danger band rather than only at the very bottom.
+export function lowHealthVignette(hp: number, maxHp: number): LowHealthVignette {
+  const off: LowHealthVignette = { active: false, opacity: 0, pulseSeconds: 0 };
+  if (maxHp <= 0 || hp <= 0) return off; // dead or invalid → no vignette
+  const frac = hp / maxHp;
+  if (frac >= LOW_HEALTH_THRESHOLD) return off;
+
+  // t: 0 at the threshold, 1 at 0 HP.
+  const t = clamp01((LOW_HEALTH_THRESHOLD - frac) / LOW_HEALTH_THRESHOLD);
+  const opacity = Math.pow(t, 0.8) * MAX_OPACITY;
+  const pulseHz = PULSE_HZ_MIN + (PULSE_HZ_MAX - PULSE_HZ_MIN) * t;
+  return { active: true, opacity, pulseSeconds: 1 / pulseHz };
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}

--- a/tests/low_health.test.ts
+++ b/tests/low_health.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { lowHealthVignette, LOW_HEALTH_THRESHOLD } from '../src/ui/low_health';
+
+describe('low-health vignette', () => {
+  it('is hidden at full / comfortable HP', () => {
+    expect(lowHealthVignette(100, 100).active).toBe(false);
+    expect(lowHealthVignette(50, 100).active).toBe(false);
+  });
+
+  it('is hidden exactly at the threshold and active just below it', () => {
+    const max = 100;
+    expect(lowHealthVignette(LOW_HEALTH_THRESHOLD * max, max).active).toBe(false);
+    expect(lowHealthVignette(LOW_HEALTH_THRESHOLD * max - 1, max).active).toBe(true);
+  });
+
+  it('intensifies (more opaque, faster pulse) as HP drops', () => {
+    const high = lowHealthVignette(30, 100); // ~14% into the band
+    const low = lowHealthVignette(5, 100); // near death
+    expect(high.active).toBe(true);
+    expect(low.active).toBe(true);
+    expect(low.opacity).toBeGreaterThan(high.opacity);
+    expect(low.pulseSeconds).toBeLessThan(high.pulseSeconds); // shorter = faster
+  });
+
+  it('keeps opacity in a readable range (never fully opaque)', () => {
+    expect(lowHealthVignette(1, 100).opacity).toBeLessThan(1);
+    expect(lowHealthVignette(1, 100).opacity).toBeGreaterThan(0);
+  });
+
+  it('shows nothing when dead or HP/maxHp are degenerate', () => {
+    expect(lowHealthVignette(0, 100).active).toBe(false);
+    expect(lowHealthVignette(-5, 100).active).toBe(false);
+    expect(lowHealthVignette(10, 0).active).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a **low-health screen vignette** — the classic WoW "FullScreenGlow" red edge that fades in as the player nears death, a long-standing fidelity gap (the only red-screen feedback today is the floating combat text and the death overlay).

It begins below **35% HP** and intensifies as HP drops: the glow grows more opaque **and** pulses faster, from a slow "breathe" in the danger band to a frantic flicker near death. It clears the moment you heal back up or die (the death overlay owns the screen then).

| Healthy (no glow) | Wounded ~25% | Critical ~7% |
|---|---|---|
| ![healthy](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/low-health-vignette/lhv-healthy.png) | ![wounded](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/low-health-vignette/lhv-wounded.png) | ![critical](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/low-health-vignette/lhv-critical.png) |

## How

- **Pure helper** `src/ui/low_health.ts` — `lowHealthVignette(hp, maxHp)` returns `{ active, opacity, pulseSeconds }`. DOM-free so the intensity curve is unit-tested directly, mirroring `xp_bar.ts` / `nameplate_projection.ts`.
- **HUD** applies it each frame in `Hud.update()` (right after the player-frame HP) by setting two CSS custom properties (`--lhv-opacity`, `--lhv-pulse`) and toggling `.active` on a fixed `#low-health-vignette` overlay. No JS animation loop — the pulse is a CSS `@keyframes`, so the cost is two `setProperty` calls/frame and the browser composites the pulse.
- **`index.html`** holds the overlay markup + CSS (`pointer-events:none`, sits above the world but below the HUD frames).

### Why a DOM overlay and not a post-processing pass
The natural-looking home would be the `GradeShader` vignette in `src/render/post.ts`, but `GFX.composer` is **false on the `low` tier** (it renders direct, skipping the whole post chain) — low-end players would never see it. A DOM overlay reaches every GFX tier and is cheaper.

## Scope / safety
- **Presentation-only:** zero changes to `sim/`, `IWorld`, `net/`, or the server. HP is already on `IWorld` (`player.hp` / `player.maxHp`).
- Respects `prefers-reduced-motion` (static glow, no pulse).
- New test `tests/low_health.test.ts` (threshold edges, monotonic ramp, dead/degenerate guards). **653 tests pass, `tsc` clean.**