### PR TITLE
feat(render): threat-aware nameplate coloring for mobs aggroed on you

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,9 @@
   .np-name { font-size: 12px; font-weight: bold; font-family: var(--title-font); letter-spacing: 0.3px; }
   .np-hpbar { width: 78px; height: 6px; background: #2a0000; border: 1px solid #000; margin: 1px auto 0; border-radius: 2px; }
   .np-hpfill { height: 100%; background: linear-gradient(#48e060, #1d7a32); border-radius: 2px; }
+  /* threat plate: this mob is aggroed on me — red bar + soft glow */
+  .nameplate.np-threat .np-hpbar { border-color: #ff5a4a; box-shadow: 0 0 6px #ff3b2e99; }
+  .nameplate.np-threat .np-hpfill { background: linear-gradient(#ff6b5e, #a01818); }
   .np-marker { font-size: 24px; font-weight: bold; height: 26px; font-family: var(--title-font); }
   .np-marker.avail { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }
   .np-marker.ready { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }

--- a/scripts/threat_nameplate_shot.mjs
+++ b/scripts/threat_nameplate_shot.mjs
@@ -1,0 +1,89 @@
+// Captures the threat-aware nameplate feature offline: a nearby mob's nameplate
+// HP bar tints red once it is aggroed on the local player.
+// Needs the dev client running:  npm run dev   (default :5173)
+//   GAME_URL=http://localhost:5173 node scripts/threat_nameplate_shot.mjs
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  protocolTimeout: 60000,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1280,760',
+    '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 760 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERR', e.message));
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await sleep(800);
+await page.evaluate(() => {
+  document.querySelector('#btn-offline').click();
+  document.querySelector('#char-name').value = 'Thorgar';
+  document.querySelector('#char-name').dispatchEvent(new Event('input', { bubbles: true }));
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]').click();
+  document.querySelector('#btn-start-offline').click();
+});
+await sleep(1200);
+await page.evaluate(() => document.querySelector('#mobile-preflight-continue')?.click());
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 3, { timeout: 20000, polling: 300 });
+await sleep(800);
+
+// Plant a mob 7yd directly in front of the player and target it so the camera
+// frames it and the selection ring shows (proves threat tint is distinct).
+const placed = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.entities.get(sim.playerId);
+  const mob = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead);
+  if (!mob || !p) return false;
+  const dx = Math.sin(p.facing), dz = Math.cos(p.facing);
+  mob.pos = { x: p.pos.x + dx * 7, y: p.pos.y, z: p.pos.z + dz * 7 };
+  mob.aggroTargetId = null;
+  sim.targetEntity ? sim.targetEntity(mob.id) : (p.targetId = mob.id);
+  window.__mobId = mob.id;
+  return true;
+});
+console.log('mob placed:', placed);
+// zoom the camera in so the nameplate reads clearly
+await page.evaluate(() => { const i = window.__game.input; if (i) i.camDist = 6; });
+await sleep(900);
+
+// clip tightly around the mob's nameplate so before/after are directly comparable
+const clipFor = () => page.evaluate(() => {
+  const np = document.querySelector('.nameplate.np-threat') ||
+    [...document.querySelectorAll('.nameplate')].find((n) => n.querySelector('.np-hpbar'));
+  if (!np) return null;
+  const r = np.getBoundingClientRect();
+  const cx = r.left + r.width / 2;
+  return { x: Math.max(0, cx - 160), y: Math.max(0, r.top - 20), width: 320, height: 90 };
+});
+
+let clip = await clipFor();
+await page.screenshot({ path: 'tmp/threat-before.png', clip: clip ?? undefined });
+console.log('before shot (mob idle)', clip);
+
+// Now the mob aggroes on the player → nameplate should turn red.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const mob = sim.entities.get(window.__mobId);
+  mob.aggroTargetId = sim.playerId;
+});
+await sleep(700);
+clip = await clipFor();
+await page.screenshot({ path: 'tmp/threat-after.png', clip: clip ?? undefined });
+console.log('after shot (mob aggroed)', clip);
+
+const cls = await page.evaluate(() => {
+  // confirm the renderer toggled the class on the mob's nameplate
+  return document.querySelector('.nameplate.np-threat') ? 'np-threat present' : 'np-threat MISSING';
+});
+console.log('DOM check:', cls);
+
+await browser.close();

--- a/src/render/nameplate_threat.ts
+++ b/src/render/nameplate_threat.ts
@@ -1,0 +1,17 @@
+import type { Entity } from '../sim/types';
+
+// Classic-WoW "threat plates": a hostile mob that is actively aggroed on the
+// local player gets its nameplate health bar tinted red, so you can spot at a
+// glance which enemies are coming for *you* (distinct from the ground selection
+// ring, which marks the unit *you* have targeted).
+//
+// Pure so it can be unit-tested without a DOM/renderer; the renderer just
+// toggles a CSS class from the boolean.
+export function isMobThreateningViewer(e: Entity, viewerId: number): boolean {
+  return (
+    e.kind === 'mob' &&
+    !e.dead &&
+    e.ownerId === null && // a friendly/owned pet is never a threat to its owner
+    e.aggroTargetId === viewerId
+  );
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -33,6 +33,7 @@ import { raidMarkerDataUrl } from '../ui/icons';
 import { isProjectedNameplateAnchorVisible, nameplateScreenTransform } from './nameplate_projection';
 import { comboPipsFor, COMBO_PIP_MAX } from './nameplate_combo';
 import { stepCameraOcclusion, type CameraOcclusionState } from './camera_collision';
+import { isMobThreateningViewer } from './nameplate_threat';
 
 const NAMEPLATE_RANGE = 55;
 const NAMEPLATE_RANGE_SQ = NAMEPLATE_RANGE * NAMEPLATE_RANGE;
@@ -1560,6 +1561,8 @@ export class Renderer {
         const marker = e.lootable ? '$' : elite && !e.dead ? '◆' : '';
         this.setNameplateStatic(v, `mob|${name}|${color}|${hpDisplay}|${marker}`, name, color, hpDisplay, marker, 'np-marker loot', '1');
         this.setNameplateHp(v, e);
+        // threat plate: tint the bar red when this mob is aggroed on me
+        v.nameplate.classList.toggle('np-threat', isMobThreateningViewer(e, this.sim.playerId));
       }
     }
   }

--- a/tests/nameplate_threat.test.ts
+++ b/tests/nameplate_threat.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { isMobThreateningViewer } from '../src/render/nameplate_threat';
+
+const ME = 7;
+const mob = (overrides: any) => ({
+  id: 1,
+  kind: 'mob',
+  dead: false,
+  ownerId: null,
+  aggroTargetId: null,
+  ...overrides,
+}) as any;
+
+describe('threat-aware nameplate policy', () => {
+  it('flags a living wild mob aggroed on me', () => {
+    expect(isMobThreateningViewer(mob({ aggroTargetId: ME }), ME)).toBe(true);
+  });
+
+  it('ignores a mob aggroed on someone else', () => {
+    expect(isMobThreateningViewer(mob({ aggroTargetId: 99 }), ME)).toBe(false);
+  });
+
+  it('ignores a mob with no target', () => {
+    expect(isMobThreateningViewer(mob({ aggroTargetId: null }), ME)).toBe(false);
+  });
+
+  it('never flags a dead mob (corpse)', () => {
+    expect(isMobThreateningViewer(mob({ aggroTargetId: ME, dead: true }), ME)).toBe(false);
+  });
+
+  it('never flags my own controlled pet, even if its aggro field points at me', () => {
+    expect(isMobThreateningViewer(mob({ aggroTargetId: ME, ownerId: ME }), ME)).toBe(false);
+  });
+
+  it('only applies to mobs, not players/npcs/objects', () => {
+    expect(isMobThreateningViewer(mob({ kind: 'player', aggroTargetId: ME }), ME)).toBe(false);
+    expect(isMobThreateningViewer(mob({ kind: 'npc', aggroTargetId: ME }), ME)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Classic-WoW **threat plates**: a hostile mob whose aggro is on the local player now shows a **red, softly-glowing nameplate health bar**. At a glance you can tell which enemies are coming for *you* — especially useful in packs and group play where the existing ground **selection ring** only marks the unit *you* targeted, not the ones targeting *you*.

| Idle (not aggroed) | Aggroed on me (threat) |
|---|---|
| green bar | red glowing bar |

![before/after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets/threat-nameplate/threat-nameplate.png)

## How

Pure presentation — **no `sim`/`IWorld`/`net`/`server` changes**:

- The renderer reads `Entity.aggroTargetId` + `IWorld.playerId` through a new pure helper `isMobThreateningViewer()` (`src/render/nameplate_threat.ts`) and toggles a `.np-threat` class on the mob nameplate branch of `updateNameplates()`.
- `aggroTargetId` is already on the wire online: the server emits it as `aggro` (`server/game.ts:171`) and its interest-scope rule (`game.ts:210`, `e.aggroTargetId === viewer.id`) guarantees a mob attacking you stays streamed — so the red plate is reliable online as well as offline, for free.
- `index.html` adds the `.np-threat` red bar + glow CSS beside the existing `.np-hpfill` rule.

Guards: only living, wild mobs (`ownerId === null`, so your own pet never lights up); corpses and players/NPCs/objects are excluded.

## Tests

- `tests/nameplate_threat.test.ts` — 6 cases on the pure helper (aggro on me / on someone else / no target / dead / own pet / non-mob kinds). hud/renderer are DOM-coupled, so logic lives in a pure, testable helper (same pattern as the existing `src/render/stealth.ts`).
- Full suite: **654 passing**, `tsc --noEmit` clean.

Screenshots reproduced via `scripts/threat_nameplate_shot.mjs` (offline; needs `npm run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)