### PR TITLE
feat: anti-caster mobs silence the victim's spells on hit (Silencing Shriek)

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -169,6 +169,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'gravecaller_summoner', name: 'Gravecaller Summoner', minLevel: 11, maxLevel: 12, family: 'humanoid',
     hpBase: 46, hpPerLevel: 19, dmgBase: 10, dmgPerLevel: 2.5, attackSpeed: 2.0,
     armorPerLevel: 16, moveSpeed: 7, aggroRadius: 12,
+    silence: { chance: 0.3, duration: 4, name: 'Silencing Shriek', school: 'shadow' },
     loot: [
       { copper: 60, chance: 1 },
       { itemId: 'cult_cipher', chance: 0.6, questId: 'q_summoners' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1126,6 +1126,11 @@ export class Sim {
   private isRooted(e: Entity): boolean {
     return this.isStunned(e) || e.auras.some((a) => a.kind === 'root');
   }
+  // Silence locks out spell (non-physical) casts but leaves physical abilities,
+  // movement and melee untouched — unlike a stun, which freezes everything.
+  private isSilenced(e: Entity): boolean {
+    return e.auras.some((a) => a.kind === 'silence');
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template && (template.canSwim === true || template.family === 'murloc');
   }
@@ -1474,6 +1479,12 @@ export class Sim {
   private updateCasting(p: Entity, meta: PlayerMeta): void {
     if (!p.castingAbility) return;
     if (this.isStunned(p)) { this.cancelCast(p); return; }
+    // a silence breaks an in-progress spell, but never the fishing cast or a
+    // physical channel (e.g. an aimed-shot kind) — those aren't spells.
+    if (this.isSilenced(p) && p.castingAbility !== FISHING_CAST_ID) {
+      const cast = this.resolvedAbility(p.castingAbility, p.id);
+      if (cast && cast.def.school !== 'physical') { this.cancelCast(p); return; }
+    }
     p.castRemaining -= DT;
 
     if (p.channeling) {
@@ -1536,6 +1547,7 @@ export class Sim {
     if (!res || p.dead) return;
     const ability = res.def;
     if (this.isStunned(p)) { this.error(p.id, 'You are stunned!'); return; }
+    if (ability.school !== 'physical' && this.isSilenced(p)) { this.error(p.id, 'You are silenced!'); return; }
     if (p.castingAbility) { this.error(p.id, 'You are busy.'); return; }
     if (!ability.offGcd && p.gcdRemaining > 0) return; // silent, classic spams this
     const togglingOff = isToggleBuff(ability) && p.auras.some((a) => a.id === ability.id);
@@ -3137,6 +3149,17 @@ export class Sim {
     if (mob.enraged && enrage) dmg *= enrage.dmgMult;
     dmg *= 1 - armorReduction(this.effectiveArmor(target), mob.level);
     this.dealDamage(mob, target, Math.max(1, Math.round(dmg)), crit, 'physical', null, 'hit');
+    // silencing shriek: anti-caster mobs can lock the victim's spells on a hit.
+    // Guard on hostile + alive so a friendly pet (the other mobSwing caller)
+    // never silences the party. updateCasting interrupts any live spell next tick.
+    const silence = MOBS[mob.templateId]?.silence;
+    if (silence && mob.hostile && !target.dead && this.rng.chance(silence.chance)) {
+      this.applyAura(target, {
+        id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
+        remaining: silence.duration, duration: silence.duration, value: 0,
+        sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
     // thorns / lightning shield on the defender
     if (!mob.dead) {
       for (const a of target.auras) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -35,7 +35,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'silence';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -163,6 +163,8 @@ export interface MobTemplate {
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
   enrage?: { belowHpPct: number; dmgMult: number };
+  // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
+  silence?: { chance: number; duration: number; name: string; school?: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_silence.test.ts
+++ b/tests/mob_silence.test.ts
@@ -1,0 +1,108 @@
+// Anti-caster mobs (e.g. the Gravecaller Summoner's "Silencing Shriek") can lock
+// a victim out of spellcasting on a melee hit. Silence is distinct from a stun:
+// it blocks spell (non-physical) abilities and breaks an in-progress spell, but
+// leaves physical abilities, movement and auto-attack untouched.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Summoner adjacent to the player, engaged and ready to swing.
+function spawnSummoner(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_summoner'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (silence chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob silence ("Silencing Shriek")', () => {
+  it('seeds the silence mechanic on the Gravecaller Summoner', () => {
+    expect(MOBS['gravecaller_summoner'].silence).toEqual({
+      chance: 0.3, duration: 4, name: 'Silencing Shriek', school: 'shadow',
+    });
+  });
+
+  it('applies a silence aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnSummoner(sim, p);
+    MOBS['gravecaller_summoner'].silence!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_summoner'].silence!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'silence');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Silencing Shriek');
+    expect(aura!.remaining).toBe(4);
+  });
+
+  it('blocks a spell cast while silenced but allows physical abilities', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.auras.push({
+      id: 'silence_gravecaller_summoner', name: 'Silencing Shriek', kind: 'silence',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'shadow',
+    });
+    // Fireball is a spell (school: fire) — must be rejected with "You are silenced!".
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    sim.castAbility('fireball', p.id);
+    expect(errs).toContain('You are silenced!');
+  });
+
+  it('breaks an in-progress spell cast on the next tick', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    // Pretend a fireball is mid-cast (fire = a spell school).
+    p.castingAbility = 'fireball';
+    p.castRemaining = 2;
+    p.channeling = false;
+    p.auras.push({
+      id: 'silence_x', name: 'Silencing Shriek', kind: 'silence',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'shadow',
+    });
+    sim.tick();
+    expect(p.castingAbility).toBeNull();
+  });
+
+  it('does not block a physical ability while silenced', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    p.resource = 100;
+    p.auras.push({
+      id: 'silence_x', name: 'Silencing Shriek', kind: 'silence',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'shadow',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    // Heroic Strike is physical — silence must NOT be the reason it's blocked.
+    sim.castAbility('heroic_strike', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('a friendly pet swing never silences its target', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnSummoner(sim, p);
+    pet.hostile = false; // a tamed/friendly summoner shape
+    pet.ownerId = p.id;
+    MOBS['gravecaller_summoner'].silence!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['gravecaller_summoner'].silence!.chance = 0.3;
+    expect(p.auras.some((a) => a.kind === 'silence')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-WoW **anti-caster "Silencing Shriek"** — a data-driven, on-hit mob mechanic. A new optional `MobTemplate.silence = { chance, duration, name, school? }` lets a mob, on a landed melee hit, apply a new `silence` aura that **locks the victim out of spell (non-physical) casts** and **breaks any in-progress spell**, while leaving physical abilities, movement and auto-attack untouched.

This is distinct from a `stun` (which freezes everything): the gate keys off `AbilityDef.school` — a silenced warrior can still Heroic Strike, but a silenced mage can't Fireball. That's the meaningful classic distinction, and it's free because every ability already carries a `school`.

Seeded on the **Gravecaller Summoner** (Mirefen Marsh) at `30% / 4s` — a thematically perfect caster whose shriek punishes ranged kiters.

## How

- `types.ts` — add `'silence'` to `AuraKind`; add `MobTemplate.silence`.
- `sim.ts` —
  - new `isSilenced(e)` helper beside `isStunned`/`isRooted`;
  - `castAbility` rejects a non-physical ability while silenced (`"You are silenced!"`);
  - `updateCasting` cancels an in-progress spell (never the fishing cast or a physical channel);
  - `mobSwing` rolls `silence.chance` on a landed hit and applies the aura — guarded on `hostile && !target.dead` so a **friendly pet never silences the party** (same guard as cleave/venom/mortal-strike).
- `content/zone2.ts` — seed the Gravecaller Summoner.

**Aura-based by design:** no new `Entity` field and **no netcode change** — `updateAuras` already ticks/expires it and the online snapshot already mirrors `auras`, so it works online for free.

## Tests

`tests/mob_silence.test.ts` (6 cases): seeding, aura-on-hit, spell blocked vs physical allowed, in-progress spell interrupt, and the friendly-pet guard. Full suite: **654 passed**, `tsc` clean.

## Screenshot

A silenced mage facing a targeted Gravecaller Summoner — note the **Silencing Shriek** debuff and the floating **"You are silenced!"** when a Fireball is attempted:

![Silencing Shriek](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-silence/silence_after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)