### PR TITLE
feat(ui): item tooltip comparison vs equipped gear

### DIFF
--- a/index.html
+++ b/index.html
@@ -1219,6 +1219,11 @@
   #tooltip .tt-desc { color: #ffd100; margin-top: 4px; font-size: 11.5px; }
   #tooltip .tt-stat { color: #fff; font-size: 11.5px; }
   #tooltip .tt-green { color: #1eff00; font-size: 11.5px; }
+  #tooltip .tt-red { color: #ff5040; font-size: 11.5px; }
+  /* item comparison block (hover an equippable item to see the worn one + deltas) */
+  #tooltip .tt-cmp { margin-top: 6px; padding-top: 5px; border-top: 1px solid #3a3526; }
+  #tooltip .tt-cmp-head { color: #8a7f5e; font-size: 10px; text-transform: uppercase; letter-spacing: .5px; margin-top: 3px; }
+  #tooltip .tt-cmp-body { opacity: .7; }
 
   /* ---------- floating combat text ---------- */
   .fct { position: absolute; font-weight: bold; pointer-events: none; text-shadow: 1px 1px 3px #000;

--- a/scripts/item_compare_visual.mjs
+++ b/scripts/item_compare_visual.mjs
@@ -1,0 +1,91 @@
+// Visual proof of the item tooltip comparison. Boots the offline game, drops a
+// chest upgrade and a weapon into the bags, and hovers each to capture the
+// "Currently equipped" comparison block with stat deltas.
+//   node scripts/item_compare_visual.mjs    (needs `npm run dev` on :5173)
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Adventurer');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Drop an upgrade chest, a weapon, and a sidegrade into the bags.
+const inv = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.addItem('militia_vest', 1, sim.player.id);   // uncommon chest upgrade vs Recruit's Tunic
+  sim.addItem('eastbrook_chain_vest', 1, sim.player.id);
+  return { equippedChest: sim.equipment.chest, equippedMain: sim.equipment.mainhand, inv: sim.inventory.map((s) => s.itemId) };
+});
+console.log('inventory set:', JSON.stringify(inv));
+
+await page.keyboard.press('b'); // open bags
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({ path: 'tmp/cmp_1_bags.png' });
+
+// Hover the upgrade chest to raise its comparison tooltip.
+async function hoverItem(name, shot) {
+  const ok = await page.evaluate((nm) => {
+    const rows = [...document.querySelectorAll('#bags .bag-item')];
+    const row = rows.find((r) => r.textContent.includes(nm));
+    if (!row) return false;
+    const b = row.getBoundingClientRect();
+    const x = b.x + b.width / 2, y = b.y + b.height / 2;
+    for (const type of ['mouseenter', 'mouseover', 'mousemove']) {
+      row.dispatchEvent(new MouseEvent(type, { bubbles: true, clientX: x, clientY: y }));
+    }
+    return true;
+  }, name);
+  if (!ok) { console.log('row not found:', name); return; }
+  await new Promise((r) => setTimeout(r, 250));
+  const tip = await page.evaluate(() => {
+    const tt = document.querySelector('#tooltip');
+    return { shown: tt && tt.style.display === 'block', hasCmp: !!tt?.querySelector('.tt-cmp'), text: tt?.innerText?.replace(/\n/g, ' | ') };
+  });
+  console.log(`tooltip[${name}]:`, JSON.stringify(tip));
+  await page.screenshot({ path: shot });
+  // also a tight, zoomed crop of just the tooltip for legibility in the PR
+  const box = await page.evaluate(() => {
+    const tt = document.querySelector('#tooltip');
+    const b = tt.getBoundingClientRect();
+    return { x: b.x, y: b.y, w: b.width, h: b.height };
+  });
+  const pad = 6;
+  await page.screenshot({
+    path: shot.replace('.png', '_crop.png'),
+    clip: { x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad), width: box.w + pad * 2, height: box.h + pad * 2 },
+  });
+}
+
+await hoverItem('Militia Chainvest', 'tmp/cmp_2_chest_compare.png');
+await hoverItem('Eastbrook Chainmail Vest', 'tmp/cmp_3_chest2_compare.png');
+
+// Now equip the upgrade and hover the old tunic to show a downgrade (red deltas).
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.equipItem('militia_vest'); // Recruit's Tunic swaps back into the bags
+});
+await new Promise((r) => setTimeout(r, 300));
+await page.keyboard.press('b'); // close + reopen to re-render the bag list
+await new Promise((r) => setTimeout(r, 150));
+await page.keyboard.press('b');
+await new Promise((r) => setTimeout(r, 250));
+await hoverItem("Recruit's Tunic", 'tmp/cmp_4_downgrade.png');
+
+await browser.close();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { itemStatDeltas } from './item_compare';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -1004,7 +1005,7 @@ export class Hud {
     this.tooltipEl.style.display = 'none';
   }
 
-  private itemTooltip(item: ItemDef): string {
+  private itemTooltip(item: ItemDef, compare = true): string {
     const qColor = QUALITY_COLOR[item.quality ?? 'common'] ?? '#fff';
     let html = `<div class="tt-title" style="color:${qColor}">${esc(itemDisplayName(item))}</div>`;
     html += `<div class="tt-sub">${esc(t('itemUi.tooltip.qualityKind', {
@@ -1047,6 +1048,31 @@ export class Hud {
       html += `<div class="tt-sub">${esc(t('itemUi.tooltip.classes', { classes: item.requiredClass.map(classDisplayName).join(', ') }))}</div>`;
     }
     if (item.sellValue > 0) html += `<div class="tt-sub">${esc(t('itemUi.tooltip.sellPrice', { money: formatLocalizedMoney(item.sellValue) }))}</div>`;
+    if (compare) html += this.itemCompareBlock(item);
+    return html;
+  }
+
+  // Classic-WoW item comparison: when hovering an equippable item, append the
+  // item currently worn in that slot plus the stat change you'd see if you
+  // swapped to it (green = gain, red = loss). Reads IWorld.equipment, so it
+  // works identically offline and online.
+  private itemCompareBlock(item: ItemDef): string {
+    if (!item.slot) return '';
+    const equippedId = this.sim.equipment[item.slot];
+    if (!equippedId || equippedId === item.id) return '';
+    const equipped = ITEMS[equippedId];
+    if (!equipped) return '';
+    const deltas = itemStatDeltas(item, equipped)
+      .map((d) => {
+        const cls = d.delta > 0 ? 'tt-green' : 'tt-red';
+        const sign = d.delta > 0 ? '+' : '−'; // proper minus sign
+        return `<div class="${cls}">${sign}${Math.abs(d.delta).toFixed(d.decimals)} ${esc(t(`itemUi.stats.${d.stat}` as TranslationKey))}</div>`;
+      })
+      .join('');
+    let html = `<div class="tt-cmp"><div class="tt-cmp-head">${esc(t('itemUi.tooltip.currentlyEquipped'))}</div>`;
+    html += `<div class="tt-cmp-body">${this.itemTooltip(equipped, false)}</div>`;
+    if (deltas) html += `<div class="tt-cmp-head">${esc(t('itemUi.tooltip.ifYouEquip'))}</div>${deltas}`;
+    html += `</div>`;
     return html;
   }
 

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -5436,6 +5436,7 @@ const itemStringsEn = {
     },
     tooltip: {
       qualityKind: "{quality} {kind}",
+      currentlyEquipped: "Currently equipped", ifYouEquip: "If you equip this",
       damageSpeed: "{min} - {max} Damage  Speed {speed}",
       dps: "({dps} damage per second)",
       dagger: "Dagger",
@@ -5544,6 +5545,7 @@ const itemStrings = {
       stats: { armor: "Armadura", str: "Fuerza", agi: "Agilidad", sta: "Aguante", int: "Intelecto", spi: "Espíritu", attackPower: "Poder de ataque", dps: "Daño/seg", critChance: "Prob. de crítico", dodge: "Esquiva" },
       tooltip: {
         qualityKind: "{kind} {quality}", damageSpeed: "{min} - {max} de daño  Velocidad {speed}", dps: "({dps} de daño por segundo)", dagger: "Daga", armorStat: "{value} de armadura", stat: "+{value} {stat}",
+        currentlyEquipped: "Equipado actualmente", ifYouEquip: "Si equipas esto",
         useFood: "Uso: restaura {amount} de salud durante {seconds} s. Debes permanecer sentado mientras comes.", useDrink: "Uso: restaura {amount} de maná durante {seconds} s. Debes permanecer sentado mientras bebes.", questItem: "Objeto de misión", classes: "Clases: {classes}", sellPrice: "Precio de venta: {money}",
         clickBuy: "Haz clic para comprar", clickSell: "Haz clic para vender", clickEquip: "Haz clic para equipar", clickConsume: "Haz clic para consumir", clickTradeOffer: "Haz clic para ofrecer en el comercio", clickMarketList: "Haz clic para ponerlo en el mercado", cannotMarket: "No se puede vender en el mercado", cannotVendor: "No se puede vender a comerciantes", clickDestroy: "Haz clic para destruir",
       },
@@ -5567,6 +5569,7 @@ const itemStrings = {
       stats: { armor: "Armure", str: "Force", agi: "Agilité", sta: "Endurance", int: "Intelligence", spi: "Esprit", attackPower: "Puissance d'attaque", dps: "Dégâts/s", critChance: "Chances de critique", dodge: "Esquive" },
       tooltip: {
         qualityKind: "{kind} {quality}", damageSpeed: "{min} - {max} points de dégâts  Vitesse {speed}", dps: "({dps} dégâts par seconde)", dagger: "Dague", armorStat: "{value} armure", stat: "+{value} {stat}",
+        currentlyEquipped: "Actuellement équipé", ifYouEquip: "Si vous équipez ceci",
         useFood: "Utiliser : rend {amount} points de vie en {seconds} s. Vous devez rester assis en mangeant.", useDrink: "Utiliser : rend {amount} points de mana en {seconds} s. Vous devez rester assis en buvant.", questItem: "Objet de quête", classes: "Classes : {classes}", sellPrice: "Prix de vente : {money}",
         clickBuy: "Cliquer pour acheter", clickSell: "Cliquer pour vendre", clickEquip: "Cliquer pour équiper", clickConsume: "Cliquer pour consommer", clickTradeOffer: "Cliquer pour proposer en échange", clickMarketList: "Cliquer pour mettre au marché", cannotMarket: "Ne peut pas être vendu au marché", cannotVendor: "Ne peut pas être vendu aux marchands", clickDestroy: "Cliquer pour détruire",
       },
@@ -5591,6 +5594,7 @@ const itemStrings = {
       stats: { armor: "Armatura", str: "Forza", agi: "Agilità", sta: "Tempra", int: "Intelletto", spi: "Spirito", attackPower: "Potenza d'attacco", dps: "Danni/sec", critChance: "Prob. critico", dodge: "Schivata" },
       tooltip: {
         qualityKind: "{kind} {quality}", damageSpeed: "{min} - {max} danni  Velocità {speed}", dps: "({dps} danni al secondo)", dagger: "Pugnale", armorStat: "{value} armatura", stat: "+{value} {stat}",
+        currentlyEquipped: "Attualmente equipaggiato", ifYouEquip: "Se equipaggi questo",
         useFood: "Usa: ripristina {amount} salute in {seconds} s. Devi restare seduto mentre mangi.", useDrink: "Usa: ripristina {amount} mana in {seconds} s. Devi restare seduto mentre bevi.", questItem: "Oggetto missione", classes: "Classi: {classes}", sellPrice: "Prezzo di vendita: {money}",
         clickBuy: "Clicca per comprare", clickSell: "Clicca per vendere", clickEquip: "Clicca per equipaggiare", clickConsume: "Clicca per consumare", clickTradeOffer: "Clicca per offrire nello scambio", clickMarketList: "Clicca per mettere sul mercato", cannotMarket: "Non può essere venduto al mercato", cannotVendor: "Non può essere venduto ai mercanti", clickDestroy: "Clicca per distruggere",
       },
@@ -5613,6 +5617,7 @@ const itemStrings = {
       stats: { armor: "Rüstung", str: "Stärke", agi: "Beweglichkeit", sta: "Ausdauer", int: "Intelligenz", spi: "Willenskraft", attackPower: "Angriffskraft", dps: "Schaden/Sek.", critChance: "Krit. Chance", dodge: "Ausweichen" },
       tooltip: {
         qualityKind: "{quality} {kind}", damageSpeed: "{min} - {max} Schaden  Tempo {speed}", dps: "({dps} Schaden pro Sekunde)", dagger: "Dolch", armorStat: "{value} Rüstung", stat: "+{value} {stat}",
+        currentlyEquipped: "Derzeit angelegt", ifYouEquip: "Wenn du dies anlegst",
         useFood: "Benutzen: Stellt über {seconds} Sek. {amount} Gesundheit wieder her. Ihr müsst beim Essen sitzen bleiben.", useDrink: "Benutzen: Stellt über {seconds} Sek. {amount} Mana wieder her. Ihr müsst beim Trinken sitzen bleiben.", questItem: "Questgegenstand", classes: "Klassen: {classes}", sellPrice: "Verkaufspreis: {money}",
         clickBuy: "Zum Kaufen klicken", clickSell: "Zum Verkaufen klicken", clickEquip: "Zum Anlegen klicken", clickConsume: "Zum Verbrauchen klicken", clickTradeOffer: "Zum Anbieten im Handel klicken", clickMarketList: "Zum Einstellen auf dem Markt klicken", cannotMarket: "Kann nicht auf dem Markt verkauft werden", cannotVendor: "Kann nicht an Händler verkauft werden", clickDestroy: "Zum Zerstören klicken",
       },
@@ -5635,6 +5640,7 @@ const itemStrings = {
       stats: { armor: "护甲", str: "力量", agi: "敏捷", sta: "耐力", int: "智力", spi: "精神", attackPower: "攻击强度", dps: "每秒伤害", critChance: "暴击几率", dodge: "躲闪" },
       tooltip: {
         qualityKind: "{quality}{kind}", damageSpeed: "{min} - {max} 伤害  速度 {speed}", dps: "（每秒 {dps} 伤害）", dagger: "匕首", armorStat: "{value} 护甲", stat: "+{value} {stat}",
+        currentlyEquipped: "当前装备", ifYouEquip: "装备后",
         useFood: "使用：在 {seconds} 秒内恢复 {amount} 点生命值。进食时必须保持坐下。", useDrink: "使用：在 {seconds} 秒内恢复 {amount} 点法力值。饮水时必须保持坐下。", questItem: "任务物品", classes: "职业：{classes}", sellPrice: "出售价格：{money}",
         clickBuy: "点击购买", clickSell: "点击出售", clickEquip: "点击装备", clickConsume: "点击使用", clickTradeOffer: "点击加入交易", clickMarketList: "点击上架市场", cannotMarket: "不能在市场出售", cannotVendor: "不能卖给商人", clickDestroy: "点击摧毁",
       },
@@ -5657,6 +5663,7 @@ const itemStrings = {
       stats: { armor: "護甲", str: "力量", agi: "敏捷", sta: "耐力", int: "智力", spi: "精神", attackPower: "攻擊強度", dps: "每秒傷害", critChance: "爆擊機率", dodge: "閃躲" },
       tooltip: {
         qualityKind: "{quality}{kind}", damageSpeed: "{min} - {max} 傷害  速度 {speed}", dps: "（每秒 {dps} 傷害）", dagger: "匕首", armorStat: "{value} 護甲", stat: "+{value} {stat}",
+        currentlyEquipped: "目前裝備", ifYouEquip: "裝備後",
         useFood: "使用：在 {seconds} 秒內恢復 {amount} 點生命值。進食時必須保持坐下。", useDrink: "使用：在 {seconds} 秒內恢復 {amount} 點法力值。飲水時必須保持坐下。", questItem: "任務物品", classes: "職業：{classes}", sellPrice: "出售價格：{money}",
         clickBuy: "點擊購買", clickSell: "點擊出售", clickEquip: "點擊裝備", clickConsume: "點擊使用", clickTradeOffer: "點擊加入交易", clickMarketList: "點擊上架市場", cannotMarket: "不能在市場出售", cannotVendor: "不能賣給商人", clickDestroy: "點擊摧毀",
       },
@@ -5679,6 +5686,7 @@ const itemStrings = {
       stats: { armor: "방어도", str: "힘", agi: "민첩성", sta: "체력", int: "지능", spi: "정신력", attackPower: "전투력", dps: "초당 피해", critChance: "치명타율", dodge: "회피" },
       tooltip: {
         qualityKind: "{quality} {kind}", damageSpeed: "{min} - {max} 피해  속도 {speed}", dps: "(초당 피해 {dps})", dagger: "단검", armorStat: "방어도 {value}", stat: "+{value} {stat}",
+        currentlyEquipped: "현재 착용 중", ifYouEquip: "이것을 착용하면",
         useFood: "사용 효과: {seconds}초에 걸쳐 생명력 {amount} 회복. 먹는 동안 앉아 있어야 합니다.", useDrink: "사용 효과: {seconds}초에 걸쳐 마나 {amount} 회복. 마시는 동안 앉아 있어야 합니다.", questItem: "퀘스트 아이템", classes: "직업: {classes}", sellPrice: "판매 가격: {money}",
         clickBuy: "클릭하여 구매", clickSell: "클릭하여 판매", clickEquip: "클릭하여 장착", clickConsume: "클릭하여 사용", clickTradeOffer: "클릭하여 거래에 올리기", clickMarketList: "클릭하여 시장에 올리기", cannotMarket: "시장에서 판매할 수 없음", cannotVendor: "상인에게 판매할 수 없음", clickDestroy: "클릭하여 파괴",
       },
@@ -5701,6 +5709,7 @@ const itemStrings = {
       stats: { armor: "防御力", str: "筋力", agi: "敏捷性", sta: "スタミナ", int: "知力", spi: "精神力", attackPower: "攻撃力", dps: "秒間ダメージ", critChance: "クリティカル率", dodge: "回避" },
       tooltip: {
         qualityKind: "{quality} {kind}", damageSpeed: "{min} - {max} ダメージ  速度 {speed}", dps: "（秒間 {dps} ダメージ）", dagger: "短剣", armorStat: "防御力 {value}", stat: "+{value} {stat}",
+        currentlyEquipped: "現在の装備", ifYouEquip: "これを装備すると",
         useFood: "使用: {seconds}秒かけて体力を{amount}回復します。食事中は座ったままでいる必要があります。", useDrink: "使用: {seconds}秒かけてマナを{amount}回復します。飲んでいる間は座ったままでいる必要があります。", questItem: "クエストアイテム", classes: "クラス: {classes}", sellPrice: "売却価格: {money}",
         clickBuy: "クリックして購入", clickSell: "クリックして売却", clickEquip: "クリックして装備", clickConsume: "クリックして使用", clickTradeOffer: "クリックして取引に出す", clickMarketList: "クリックして市場に出す", cannotMarket: "市場では売却できません", cannotVendor: "商人には売却できません", clickDestroy: "クリックして破棄",
       },
@@ -5723,6 +5732,7 @@ const itemStrings = {
       stats: { armor: "Armadura", str: "Força", agi: "Agilidade", sta: "Vigor", int: "Intelecto", spi: "Espírito", attackPower: "Poder de ataque", dps: "Dano/s", critChance: "Chance crítica", dodge: "Esquiva" },
       tooltip: {
         qualityKind: "{kind} {quality}", damageSpeed: "{min} - {max} de dano  Velocidade {speed}", dps: "({dps} de dano por segundo)", dagger: "Adaga", armorStat: "{value} de armadura", stat: "+{value} {stat}",
+        currentlyEquipped: "Atualmente equipado", ifYouEquip: "Se você equipar isto",
         useFood: "Usar: restaura {amount} de vida ao longo de {seconds} s. É preciso permanecer sentado enquanto come.", useDrink: "Usar: restaura {amount} de mana ao longo de {seconds} s. É preciso permanecer sentado enquanto bebe.", questItem: "Item de missão", classes: "Classes: {classes}", sellPrice: "Preço de venda: {money}",
         clickBuy: "Clique para comprar", clickSell: "Clique para vender", clickEquip: "Clique para equipar", clickConsume: "Clique para consumir", clickTradeOffer: "Clique para oferecer na troca", clickMarketList: "Clique para colocar no mercado", cannotMarket: "Não pode ser vendido no mercado", cannotVendor: "Não pode ser vendido a mercadores", clickDestroy: "Clique para destruir",
       },
@@ -5745,6 +5755,7 @@ const itemStrings = {
       stats: { armor: "Броня", str: "Сила", agi: "Ловкость", sta: "Выносливость", int: "Интеллект", spi: "Дух", attackPower: "Сила атаки", dps: "Урон/сек", critChance: "Шанс крита", dodge: "Уклонение" },
       tooltip: {
         qualityKind: "{quality} {kind}", damageSpeed: "{min} - {max} урона  Скорость {speed}", dps: "({dps} урона в секунду)", dagger: "Кинжал", armorStat: "{value} брони", stat: "+{value} {stat}",
+        currentlyEquipped: "Сейчас надето", ifYouEquip: "Если надеть это",
         useFood: "Использование: восстанавливает {amount} здоровья за {seconds} сек. Нужно оставаться сидя во время еды.", useDrink: "Использование: восстанавливает {amount} маны за {seconds} сек. Нужно оставаться сидя во время питья.", questItem: "Предмет задания", classes: "Классы: {classes}", sellPrice: "Цена продажи: {money}",
         clickBuy: "Нажмите, чтобы купить", clickSell: "Нажмите, чтобы продать", clickEquip: "Нажмите, чтобы экипировать", clickConsume: "Нажмите, чтобы использовать", clickTradeOffer: "Нажмите, чтобы предложить в обмене", clickMarketList: "Нажмите, чтобы выставить на рынок", cannotMarket: "Нельзя продать на рынке", cannotVendor: "Нельзя продать торговцам", clickDestroy: "Нажмите, чтобы уничтожить",
       },

--- a/src/ui/item_compare.ts
+++ b/src/ui/item_compare.ts
@@ -1,0 +1,33 @@
+// Pure item-comparison helper (no DOM), so the stat-delta math can be unit
+// tested directly the way xp_bar.ts / player_context_menu.ts are. The HUD turns
+// these deltas into coloured tooltip lines; see Hud.itemCompareBlock.
+import type { ItemDef, Stats } from '../sim/types';
+
+// Stable stat identifier; the HUD maps it to a localized label via t().
+export type CompareStat = 'dps' | 'armor' | 'str' | 'agi' | 'sta' | 'int' | 'spi';
+
+export interface StatDelta {
+  stat: CompareStat;
+  delta: number; // candidate minus equipped; positive = upgrade
+  decimals: number; // formatting precision (weapon DPS is fractional)
+}
+
+function weaponDps(w: ItemDef['weapon']): number {
+  return w ? (w.min + w.max) / 2 / w.speed : 0;
+}
+
+// Ordered, human-readable stat lines. Only changes worth showing are returned:
+// integer stats need a full point of difference, DPS a tenth — so a same-for-
+// same swap yields an empty list (the HUD then shows no "If you equip" section).
+export function itemStatDeltas(item: ItemDef, equipped: ItemDef): StatDelta[] {
+  const out: StatDelta[] = [];
+  const dpsDelta = weaponDps(item.weapon) - weaponDps(equipped.weapon);
+  if (Math.abs(dpsDelta) >= 0.05) out.push({ stat: 'dps', delta: dpsDelta, decimals: 1 });
+
+  const stats: Array<keyof Stats & CompareStat> = ['armor', 'str', 'agi', 'sta', 'int', 'spi'];
+  for (const k of stats) {
+    const delta = (item.stats?.[k] ?? 0) - (equipped.stats?.[k] ?? 0);
+    if (Math.abs(delta) >= 0.5) out.push({ stat: k, delta, decimals: 0 });
+  }
+  return out;
+}

--- a/tests/item_compare.test.ts
+++ b/tests/item_compare.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { itemStatDeltas } from '../src/ui/item_compare';
+import type { ItemDef } from '../src/sim/types';
+
+function armor(id: string, stats: Partial<ItemDef['stats']>): ItemDef {
+  return { id, name: id, kind: 'armor', slot: 'chest', sellValue: 1, stats: stats as any };
+}
+function weapon(id: string, min: number, max: number, speed: number): ItemDef {
+  return { id, name: id, kind: 'weapon', slot: 'mainhand', sellValue: 1, weapon: { min, max, speed } };
+}
+
+describe('itemStatDeltas', () => {
+  it('reports positive deltas for an upgrade and negative for a downgrade', () => {
+    const candidate = armor('better', { armor: 50, str: 5, sta: 3 });
+    const equipped = armor('worse', { armor: 40, str: 2, sta: 8 });
+    const deltas = itemStatDeltas(candidate, equipped);
+    const byStat = Object.fromEntries(deltas.map((d) => [d.stat, d.delta]));
+    expect(byStat['armor']).toBe(10);
+    expect(byStat['str']).toBe(3);
+    expect(byStat['sta']).toBe(-5);
+    expect(byStat['agi']).toBeUndefined(); // unchanged stats are omitted
+  });
+
+  it('omits trivial differences (an identical swap yields no lines)', () => {
+    const same = armor('a', { armor: 40, str: 2 });
+    const dup = armor('b', { armor: 40, str: 2 });
+    expect(itemStatDeltas(same, dup)).toEqual([]);
+  });
+
+  it('computes a fractional weapon DPS delta at one decimal of precision', () => {
+    // 10-20 @ 2.0s = 7.5 dps vs 8-12 @ 2.0s = 5.0 dps -> +2.5
+    const candidate = weapon('big', 10, 20, 2.0);
+    const equipped = weapon('small', 8, 12, 2.0);
+    const dps = itemStatDeltas(candidate, equipped).find((d) => d.stat === 'dps');
+    expect(dps).toBeDefined();
+    expect(dps!.delta).toBeCloseTo(2.5, 5);
+    expect(dps!.decimals).toBe(1);
+  });
+
+  it('treats a missing equipped stat as zero (full value counts as a gain)', () => {
+    const candidate = armor('statful', { armor: 30, int: 12 });
+    const equipped = armor('plain', { armor: 30 });
+    const byStat = Object.fromEntries(itemStatDeltas(candidate, equipped).map((d) => [d.stat, d.delta]));
+    expect(byStat['int']).toBe(12);
+    expect(byStat['armor']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Hovering an **equippable** item now shows your **currently-equipped** item right below it, plus the **stat change** you'd get by swapping — green for gains, red for losses. It's the classic-WoW "shift-to-compare" convenience (always-on here), so you no longer have to open the character sheet and do the arithmetic in your head.

| Upgrade (green) | Downgrade (red) | In the bags |
|---|---|---|
| ![upgrade](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/item-tooltip-compare/upgrade.png) | ![downgrade](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/item-tooltip-compare/downgrade.png) | ![in bags](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/item-tooltip-compare/in-bags.png) |

The equipped sub-tooltip keeps its quality colour (note the uncommon-green *Militia Chainvest* above), and the delta list covers weapon **DPS** and **armor / str / agi / sta / int / spi**. A same-for-same swap shows no delta section.

## How

- **`src/ui/item_compare.ts`** — pure `itemStatDeltas(item, equipped)` returning ordered `{label, delta, decimals}` entries, skipping trivial differences (a full point for integer stats, a tenth for DPS). DOM-free so the math is unit-tested directly, mirroring `xp_bar.ts` / `player_context_menu.ts`.
- **`Hud.itemTooltip`** gains a `compare` flag (default on). `itemCompareBlock` reads `IWorld.equipment`, renders the worn item dimmed under a *Currently equipped* header, then the coloured deltas. The flag is passed `false` when rendering the equipped sub-tooltip, so it never recurses.
- **`index.html`** — `.tt-red` + `.tt-cmp*` tooltip styles.

Because every item tooltip (bags, vendor, World Market, quest rewards) routes through `itemTooltip`, comparison appears everywhere for free.

## Scope / safety

- **Presentation-only:** zero changes to `sim/`, `IWorld`, `net/`, or the server. `equipment` is already on `IWorld` and mirrored in online snapshots, so it works identically offline and online.
- New test `tests/item_compare.test.ts` (upgrade/downgrade signs, omitted trivial swaps, fractional DPS, missing-stat-as-zero). **652 tests pass, `tsc` clean.**
- `scripts/item_compare_visual.mjs` is the browser repro used for the screenshots above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)