### PR TITLE
feat(ui): absorb-shield overlay on unit-frame health bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,6 +478,13 @@
   .mana .bar-fill { background-color: var(--color-mana); }
   .rage .bar-fill { background-color: var(--color-rage); }
   .energy .bar-fill { background-color: var(--color-energy); }
+  /* Damage-absorb shield overlay (Power Word: Shield, Ice Barrier, …): a hatched
+     translucent segment laid over the health bar, extending past current health. */
+  .bar-absorb { position: absolute; inset: 0; width: 100%; transform-origin: left; transform: scaleX(0);
+    background: repeating-linear-gradient(115deg, rgba(255,255,255,0.42) 0 5px, rgba(190,225,255,0.16) 5px 10px);
+    box-shadow: inset 0 0 6px rgba(255,255,255,0.4); pointer-events: none; transition: transform 0.12s linear; }
+  .bar-absorb.overshield { background: repeating-linear-gradient(115deg, rgba(255,236,160,0.55) 0 5px, rgba(255,214,90,0.24) 5px 10px);
+    box-shadow: inset 0 0 7px rgba(255,225,140,0.6); }
   .combo-row { display: flex; gap: 4px; margin-top: 4px; height: 10px; }
   .combo-pip { width: 12px; height: 10px; border-radius: 50%; border: 1px solid #5c2020; background: #2a0d0d; }
   .combo-pip.on { background: radial-gradient(circle at 35% 30%, #ff7a5e, #c0392b); box-shadow: 0 0 5px #ff5533aa; border-color: #ffad99; }
@@ -5288,7 +5295,7 @@
       </div>
       <div class="uf-bars">
         <div class="uf-name" id="tf-name"></div>
-        <div class="bar hp"><div class="bar-fill" id="tf-hp"></div><div class="bar-text" id="tf-hp-text"></div></div>
+        <div class="bar hp"><div class="bar-fill" id="tf-hp"></div><div class="bar-absorb" id="tf-absorb"></div><div class="bar-text" id="tf-hp-text"></div></div>
         <div class="combo-row" id="combo-row"></div>
         <div class="uf-buffs" id="tf-debuffs"></div>
       </div>
@@ -5343,7 +5350,7 @@
             </div>
             <div class="uf-bars">
               <div class="uf-name" id="pf-name"></div>
-              <div class="bar hp"><div class="bar-fill" id="pf-hp"></div><div class="bar-text" id="pf-hp-text"></div></div>
+              <div class="bar hp"><div class="bar-fill" id="pf-hp"></div><div class="bar-absorb" id="pf-absorb"></div><div class="bar-text" id="pf-hp-text"></div></div>
               <div class="bar mana" id="pf-resource"><div class="bar-fill" id="pf-res"></div><div class="bar-text" id="pf-res-text"></div></div>
             </div>
           </div>

--- a/scripts/absorb_shield_visual.mjs
+++ b/scripts/absorb_shield_visual.mjs
@@ -1,0 +1,89 @@
+// Visual capture for the absorb-shield bar overlay (Power Word: Shield etc.).
+// Boots the offline game, injects absorb auras onto the player/target entities
+// (purely to exercise the HUD render — fresh chars are too low level to cast),
+// and screenshots the unit frames. Needs `npm run dev` on :5173.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE, headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(200);
+await page.type('#char-name', 'Cleric');
+await page.click('#offline-select .mini-class[data-class="priest"]');
+await page.click('#btn-start-offline');
+await sleep(2500);
+
+// Helper run in the page: stamp an absorb aura on an entity's plain `.auras`
+// array (the HUD reads it each frame). Args are data only — no eval.
+async function pushAbsorb(args) {
+  await page.evaluate(({ which, hpFrac, valFrac, name, id }) => {
+    const sim = window.__game.sim;
+    const e = which === 'player' ? sim.player : sim.entities.get(sim.player.targetId);
+    if (!e) return;
+    e.hp = Math.round(e.maxHp * hpFrac);
+    e.auras = (e.auras || []).filter((a) => a.kind !== 'absorb');
+    e.auras.push({ id, name, kind: 'absorb', remaining: 30, duration: 30,
+      value: Math.round(e.maxHp * valFrac), sourceId: 0, school: 'holy' });
+  }, args);
+}
+
+// Clip a screenshot to a single element's bounding box (+ padding).
+async function shoot(sel, path, pad = 12) {
+  const b = await page.evaluate((s) => {
+    const el = document.querySelector(s);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: r.x, y: r.y, w: r.width, h: r.height };
+  }, sel);
+  if (!b) { console.log('no element', sel); return; }
+  await page.screenshot({ path, clip: { x: Math.max(0, b.x - pad), y: Math.max(0, b.y - pad), width: b.w + pad * 2, height: b.h + pad * 2 } });
+}
+
+// --- Shot 3 prep: target a nearby enemy so the target frame is visible ---
+const ok = await page.evaluate(() => {
+  const sim = window.__game.sim, p = sim.player;
+  let wolf = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; wolf = e; }
+    }
+  }
+  if (!wolf) return false;
+  p.pos.x = wolf.pos.x + 3; p.pos.z = wolf.pos.z;
+  sim.targetEntity(wolf.id);
+  return true;
+});
+console.log('target setup:', ok ? 'OK' : 'no mob found');
+
+// --- Shot 1: partial shield on the player frame ---
+await pushAbsorb({ which: 'player', hpFrac: 0.6, valFrac: 0.25, name: 'Power Word: Shield', id: 'power_word_shield' });
+await pushAbsorb({ which: 'target', hpFrac: 0.5, valFrac: 0.3, name: 'Ice Barrier', id: 'ice_barrier' });
+await sleep(500);
+await shoot('#player-frame', 'tmp/absorb_01_player_partial.png');
+// --- Shot 3: shield on a targeted enemy (target frame) ---
+await shoot('#target-frame', 'tmp/absorb_03_target.png');
+
+// --- Shot 2: overshield (absorb covers the whole bar -> gold) ---
+await pushAbsorb({ which: 'player', hpFrac: 0.85, valFrac: 0.9, name: 'Power Word: Shield', id: 'power_word_shield' });
+await sleep(400);
+await shoot('#player-frame', 'tmp/absorb_02_player_overshield.png');
+
+// Full HUD context shot
+await page.screenshot({ path: 'tmp/absorb_04_full.png' });
+
+console.log('screenshots written to tmp/absorb_0*.png');
+await browser.close();

--- a/src/ui/absorb_bar.ts
+++ b/src/ui/absorb_bar.ts
@@ -1,0 +1,44 @@
+// Pure derivation of the absorb-shield overlay for unit-frame health bars.
+//
+// Classic WoW renders active damage-absorb shields — Power Word: Shield,
+// Ice Barrier, the paladin holy shield, etc. — as a lighter segment laid over
+// the health bar that extends past current health toward the bar's right edge.
+// The sim already models these as `kind: 'absorb'` auras whose `value` is the
+// remaining damage they will soak (decremented in `dealDamage`). This module
+// turns that state into the fractions the HUD applies; kept DOM-free so the
+// math can be snapshot tested directly (mirrors xp_bar.ts).
+
+import type { Aura } from '../sim/types';
+
+export interface AbsorbBarInput {
+  hp: number;
+  maxHp: number;
+  auras: Aura[];
+}
+
+export interface AbsorbBarView {
+  total: number; // summed remaining absorb across all active shields
+  fillFrac: number; // 0..1 width of the shield overlay = (hp + absorb)/maxHp, clamped
+  overshield: boolean; // absorb reaches/passes the bar's right edge (fully shielded)
+}
+
+// Total remaining absorb across every shield aura on the entity. Negative or
+// spent shields contribute nothing.
+export function absorbTotal(auras: Aura[]): number {
+  let n = 0;
+  for (const a of auras) if (a.kind === 'absorb') n += Math.max(0, a.value);
+  return n;
+}
+
+export function absorbBarView(input: AbsorbBarInput): AbsorbBarView {
+  const max = Math.max(1, input.maxHp);
+  const hp = Math.max(0, input.hp);
+  const total = absorbTotal(input.auras);
+  const fillFrac = clamp01((hp + total) / max);
+  const overshield = total > 0 && hp + total >= max;
+  return { total, fillFrac, overshield };
+}
+
+function clamp01(v: number): number {
+  return Math.max(0, Math.min(1, v));
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { absorbBarView } from './absorb_bar';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -1578,6 +1579,7 @@ export class Hud {
     // player frame
     this.setText(this.pfLevelEl, String(p.level));
     this.setTransform(this.pfHpEl, `scaleX(${p.hp / Math.max(1, p.maxHp)})`);
+    this.updateAbsorb('#pf-absorb', p);
     this.setText(this.pfHpTextEl, `${p.hp} / ${p.maxHp}`);
     const resFrac = p.resource / Math.max(1, p.maxResource);
     this.setTransform(this.pfResEl, `scaleX(${resFrac})`);
@@ -1597,6 +1599,7 @@ export class Hud {
       this.setText(this.targetNameEl, entityDisplayName(target));
       this.setText(this.targetLevelEl, MOBS[target.templateId]?.boss ? '☠' : String(target.level));
       this.setTransform(this.targetHpEl, `scaleX(${target.hp / Math.max(1, target.maxHp)})`);
+      this.updateAbsorb('#tf-absorb', target.dead ? null : target);
       this.setText(this.targetHpTextEl, target.dead ? t('hud.core.dead') : `${target.hp} / ${target.maxHp}`);
       const targetNameColor = target.hostile ? 'var(--color-hostile)' : 'var(--color-friendly)';
       if (this.targetNameEl.style.color !== targetNameColor) this.targetNameEl.style.color = targetNameColor;
@@ -1832,6 +1835,15 @@ export class Hud {
       if (!this.nearbyMarketNpc()) this.closeMarket();
       else this.refreshMarket();
     }
+  }
+
+  // Overlay the absorb-shield segment on a unit-frame health bar. A null entity
+  // (no target / dead) hides it.
+  private updateAbsorb(sel: string, e: Entity | null): void {
+    const el = $(sel) as HTMLElement;
+    const v = e ? absorbBarView(e) : { fillFrac: 0, overshield: false, total: 0 };
+    el.style.transform = `scaleX(${v.fillFrac})`;
+    el.classList.toggle('overshield', v.overshield);
   }
 
   private renderAuras(el: HTMLElement, e: Entity, mode: 'all' | 'debuffs'): void {

--- a/tests/absorb_bar.test.ts
+++ b/tests/absorb_bar.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { Aura } from '../src/sim/types';
+import { absorbBarView, absorbTotal } from '../src/ui/absorb_bar';
+
+function shield(value: number): Aura {
+  return {
+    id: 'power_word_shield', name: 'Power Word: Shield', kind: 'absorb',
+    remaining: 30, duration: 30, value, sourceId: 1, school: 'holy',
+  };
+}
+
+function dot(value: number): Aura {
+  return {
+    id: 'shadow_word_pain', name: 'Shadow Word: Pain', kind: 'dot',
+    remaining: 18, duration: 18, value, sourceId: 1, school: 'shadow',
+  };
+}
+
+describe('absorb_bar view', () => {
+  it('reports no shield when there are no absorb auras', () => {
+    const v = absorbBarView({ hp: 60, maxHp: 100, auras: [dot(20)] });
+    expect(v.total).toBe(0);
+    expect(v.overshield).toBe(false);
+    // overlay coincides with the health fill so nothing extra is drawn
+    expect(v.fillFrac).toBeCloseTo(0.6);
+  });
+
+  it('sums only absorb auras and extends the overlay past current health', () => {
+    const v = absorbBarView({ hp: 50, maxHp: 100, auras: [shield(20), shield(10), dot(5)] });
+    expect(v.total).toBe(30);
+    expect(v.fillFrac).toBeCloseTo(0.8); // (50 + 30) / 100
+    expect(v.overshield).toBe(false);
+  });
+
+  it('clamps the overlay and flags an overshield when absorb covers the bar', () => {
+    const v = absorbBarView({ hp: 90, maxHp: 100, auras: [shield(48)] });
+    expect(v.fillFrac).toBe(1); // clamped, not 1.38
+    expect(v.overshield).toBe(true);
+  });
+
+  it('ignores spent shields (value <= 0)', () => {
+    expect(absorbTotal([shield(0), shield(-5), shield(15)])).toBe(15);
+  });
+
+  it('guards a zero maxHp against divide-by-zero', () => {
+    const v = absorbBarView({ hp: 0, maxHp: 0, auras: [shield(10)] });
+    expect(Number.isFinite(v.fillFrac)).toBe(true);
+    expect(v.overshield).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Classic WoW renders active **damage-absorb shields** — Power Word: Shield, Ice Barrier, the paladin holy shield, etc. — as a lighter segment laid over the health bar that extends past current health toward the bar's right edge. The sim already models these as `kind:'absorb'` auras (their `value` is the remaining damage they soak, decremented in `dealDamage`), but nothing surfaced them on the HUD. This adds that overlay to the **player and target unit frames**.

When the shield reaches the bar's right edge, the overlay turns **gold** to signal a full overshield.

## Screenshots

**Player frame — partial shield** (health + Power Word: Shield extending past current HP):

![player partial](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/absorb-shield/shots/absorb_01_player_partial.png)

**Player frame — overshield** (absorb covers the whole bar → gold hatch):

![player overshield](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/absorb-shield/shots/absorb_02_player_overshield.png)

**Target frame — shielded enemy** (Wild Boar under Ice Barrier):

![target shield](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/absorb-shield/shots/absorb_03_target.png)

**In context:**

![full hud](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/absorb-shield/shots/absorb_04_full.png)

## How

- **`src/ui/absorb_bar.ts`** — a DOM-free `absorbBarView`/`absorbTotal` view helper (mirrors the existing `xp_bar.ts` pattern), so the math is unit-tested directly. It sums absorb auras and returns the clamped overlay fraction `(hp + absorb)/maxHp` plus an `overshield` flag.
- **`src/ui/hud.ts`** — applies the overlay on the player + target frames each frame via a small `updateAbsorb` helper.
- **`index.html`** — a `.bar-absorb` overlay element inside each HP bar + hatched / overshield CSS.
- **`tests/absorb_bar.test.ts`** — clamp, overshield, multi-shield sum, spent-shield (value ≤ 0), and divide-by-zero guard.
- **`scripts/absorb_shield_visual.mjs`** — puppeteer capture for the overlay states.

## Why it's safe

Pure presentation read of existing `Entity.auras` — **no `src/sim/` changes, no `IWorld` changes, no determinism/RL impact.** Works identically offline and online since the auras already ride along in snapshots.

`npm test` → 653 passed; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)