### PR TITLE
feat(ui): minimap clock showing local time (12/24h toggle)

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,6 +660,14 @@
   #minimap-wrap { position: absolute; right: 12px; top: 10px; width: 170px; text-align: center; }
   #zone-label { font-size: 13px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 3px #000; margin-bottom: 3px; letter-spacing: 0.5px; }
   #minimap { border-radius: 50%; border: 4px solid var(--border); outline: 1px solid #000; box-shadow: 0 0 14px #000c, inset 0 0 20px #0008; }
+  /* Digital clock pinned to the bottom of the minimap ring, classic-WoW style. */
+  #minimap-clock { position: absolute; left: 50%; bottom: -3px; transform: translateX(-50%);
+    min-width: 52px; padding: 1px 8px; cursor: pointer; user-select: none;
+    font-family: var(--font-ui); font-size: 12px; font-weight: 600; letter-spacing: .4px;
+    color: var(--gold); text-shadow: 1px 1px 2px #000;
+    background: radial-gradient(circle at 50% 30%, #2c2c3a, #14141d);
+    border: 2px solid var(--border); border-radius: 8px; box-shadow: 0 2px 4px #0009, inset 0 1px 0 #ffffff14; }
+  #minimap-clock:hover { color: #fff; border-color: #c9a86a; }
 
   /* ---------- community HUD ---------- */
   /* Discord/GitHub: bottom-right, directly below the micro-menu, right-aligned with it. */
@@ -5307,6 +5315,7 @@
     <div id="minimap-wrap">
       <div id="zone-label" data-i18n="entities.zones.eastbrook_vale.name">Eastbrook Vale</div>
       <canvas id="minimap" width="162" height="162"></canvas>
+      <div id="minimap-clock" title="Local time — click to toggle 12/24-hour">--:--</div>
     </div>
 
     <div id="community-hud" data-i18n-aria="hud.core.communityLinks" aria-label="Community links">

--- a/scripts/clock_shot.mjs
+++ b/scripts/clock_shot.mjs
@@ -1,0 +1,49 @@
+// Screenshots for the minimap clock feature: full HUD + a cropped close-up,
+// in both 12-hour and 24-hour formats.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Thorgar');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 3000));
+
+const clip = async (name) => {
+  await new Promise((r) => setTimeout(r, 300));
+  await page.screenshot({ path: `tmp/${name}_full.png` });
+  const box = await page.evaluate(() => {
+    const el = document.querySelector('#minimap-wrap');
+    const r = el.getBoundingClientRect();
+    return { x: r.x - 16, y: r.y - 8, w: r.width + 32, h: r.height + 28 };
+  });
+  await page.screenshot({ path: `tmp/${name}_clock.png`,
+    clip: { x: box.x, y: box.y, width: box.w, height: box.h } });
+};
+
+// default format (12-hour) then toggle to 24-hour via click
+await clip('clock_12h');
+await page.click('#minimap-clock');
+await clip('clock_24h');
+
+const text = await page.$eval('#minimap-clock', (e) => e.textContent);
+console.log('clock now reads:', JSON.stringify(text));
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'no console/page errors');
+await browser.close();

--- a/src/ui/clock.ts
+++ b/src/ui/clock.ts
@@ -1,0 +1,20 @@
+// Pure formatting for the minimap clock (no DOM) so it can be snapshot-tested
+// like xp_bar.ts. The HUD owns the DOM element and the per-frame update; this
+// module just turns a Date + a format flag into the displayed string.
+
+// Format the hours/minutes of `date` as a classic minimap clock readout.
+// `use24` → "08:05" / "17:42"; otherwise 12-hour "8:05 AM" / "5:42 PM".
+// Minutes are always zero-padded; 24-hour hours are zero-padded too, while the
+// 12-hour reading is unpadded (1–12) as classic clients show it.
+export function formatClockTime(date: Date, use24: boolean): string {
+  const h = date.getHours();
+  const m = date.getMinutes();
+  const mm = m < 10 ? `0${m}` : `${m}`;
+  if (use24) {
+    const hh = h < 10 ? `0${h}` : `${h}`;
+    return `${hh}:${mm}`;
+  }
+  const suffix = h < 12 ? 'AM' : 'PM';
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${h12}:${mm} ${suffix}`;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { formatClockTime } from './clock';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -272,6 +273,9 @@ export class Hud {
   private hotDomSkippedWrites = 0;
   private minimapCtx: CanvasRenderingContext2D;
   private minimapBg: HTMLCanvasElement;
+  private clockEl: HTMLElement | null = null;
+  private clock24 = false;          // 24-hour vs 12-hour AM/PM display
+  private lastClockText = '';       // avoid redundant DOM writes each frame
   private mapBg: HTMLCanvasElement | null = null;
   private openLootMobId: number | null = null;
   private openVendorNpcId: number | null = null;
@@ -392,6 +396,19 @@ export class Hud {
       document.getElementById('mobile-controls')?.classList.remove('expanded');
       document.getElementById('mobile-more')?.classList.remove('active');
     });
+    // classic-WoW minimap clock: real local time under the minimap; click it to
+    // flip between 12-hour (AM/PM) and 24-hour display. Real-time clocks are a
+    // UI-only concern, so `new Date()` here is fine (the sim-only time ban
+    // doesn't apply — cf. meters.ts using performance.now()).
+    this.clockEl = $('#minimap-clock');
+    this.clock24 = (() => { try { return localStorage.getItem('clock24h') === '1'; } catch { return false; } })();
+    this.clockEl?.addEventListener('click', () => {
+      this.clock24 = !this.clock24;
+      try { localStorage.setItem('clock24h', this.clock24 ? '1' : '0'); } catch { /* private mode */ }
+      this.lastClockText = ''; // force a redraw in the new format
+      this.updateClock();
+    });
+    this.updateClock();
     // classic MMOs: the player interaction menu opens from the target portrait
     $('#target-frame').addEventListener('contextmenu', (ev) => {
       ev.preventDefault();
@@ -1817,6 +1834,7 @@ export class Hud {
     }
     this.arenaMatchSeen = inArenaMatch;
     if (fastHud) this.updateMinimap();
+    if (fastHud) this.updateClock();
     if (slowHud && $('#social-window').classList.contains('open')) {
       const struct = this.socialStructSig();
       if (struct !== this.lastSocialStruct) {
@@ -1926,6 +1944,18 @@ export class Hud {
     }
     ctx.putImageData(img, 0, 0);
     return c;
+  }
+
+  // Refresh the minimap clock to the current real local time. Cheap to call
+  // every frame: the formatted string only changes once a minute, and we skip
+  // the DOM write whenever it is unchanged.
+  private updateClock(): void {
+    if (!this.clockEl) return;
+    const text = formatClockTime(new Date(), this.clock24);
+    if (text !== this.lastClockText) {
+      this.lastClockText = text;
+      this.clockEl.textContent = text;
+    }
   }
 
   private updateMinimap(): void {

--- a/tests/clock_format.test.ts
+++ b/tests/clock_format.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { formatClockTime } from '../src/ui/clock';
+
+// Build a Date at a fixed local H:M (date part is irrelevant to the formatter).
+const at = (h: number, m: number) => new Date(2026, 0, 1, h, m, 0, 0);
+
+describe('formatClockTime', () => {
+  it('formats 24-hour time with zero-padded hours and minutes', () => {
+    expect(formatClockTime(at(8, 5), true)).toBe('08:05');
+    expect(formatClockTime(at(17, 42), true)).toBe('17:42');
+    expect(formatClockTime(at(0, 0), true)).toBe('00:00');
+    expect(formatClockTime(at(23, 9), true)).toBe('23:09');
+  });
+
+  it('formats 12-hour time with AM/PM and unpadded hours', () => {
+    expect(formatClockTime(at(8, 5), false)).toBe('8:05 AM');
+    expect(formatClockTime(at(17, 42), false)).toBe('5:42 PM');
+  });
+
+  it('maps midnight and noon to 12 (not 0) in 12-hour mode', () => {
+    expect(formatClockTime(at(0, 0), false)).toBe('12:00 AM');
+    expect(formatClockTime(at(12, 30), false)).toBe('12:30 PM');
+  });
+
+  it('keeps minutes zero-padded in both modes', () => {
+    expect(formatClockTime(at(9, 3), false)).toBe('9:03 AM');
+    expect(formatClockTime(at(9, 3), true)).toBe('09:03');
+  });
+});


### PR DESCRIPTION
## Minimap clock

Adds a classic-WoW digital clock pinned to the bottom of the minimap ring. It
shows the player's **real local time** and **toggles between 12-hour (AM/PM) and
24-hour** display on click, persisting the choice to `localStorage`.

The minimap was the one classic HUD corner still missing its clock — this fills
that gap with a small, self-contained, render-free addition.

### Screenshots
| 12-hour (default) | 24-hour (after click) |
|---|---|
| ![12-hour](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/minimap-clock/shots/clock_12h.png) | ![24-hour](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/minimap-clock/shots/clock_24h.png) |

In the full HUD:

![HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/minimap-clock/shots/hud_full.png)

### Implementation notes
- Time formatting lives in a **pure, DOM-free module** `src/ui/clock.ts`
  (`formatClockTime(date, use24)`), mirroring the `xp_bar.ts` pattern, with unit
  tests in `tests/clock_format.test.ts` (midnight/noon → 12, zero-padding, AM/PM).
- The HUD owns the `#minimap-clock` element and refreshes it each frame in
  `updateClock()`, but **skips the DOM write** whenever the string is unchanged
  (it only changes once a minute).
- Uses `new Date()` in the **UI layer only** — the sim-only `Date.now`/
  `performance.now` ban does not apply here (cf. `meters.ts` using
  `performance.now()`). No `src/sim/` changes; determinism is untouched.
- Click handler flips the format and persists `localStorage('clock24h')`.

### Testing
- `npx vitest run tests/clock_format.test.ts` — passes (4 cases).
- `npx tsc --noEmit` — clean.
- Visual check via the new `scripts/clock_shot.mjs` tour (screenshots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
