### PR TITLE
feat(ui): melee/ranged auto-attack swing-timer bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,6 +500,15 @@
     color: #fff; text-shadow: 1px 1px 2px #000; font-family: var(--title-font); }
   #castbar .timer { position: absolute; top: 0; right: 6px; line-height: 21px; font-size: 11px;
     color: #fff; text-shadow: 1px 1px 2px #000; font-family: var(--title-font); font-variant-numeric: tabular-nums; }
+  /* swing timer: sits just under the cast bar, steel-on-amber to read as melee */
+  #swingbar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 174px; width: 220px;
+    height: 12px; display: none; border: 1px solid var(--border); outline: 1px solid #000; border-radius: 3px;
+    background: #0c0a07; overflow: hidden; }
+  #swingbar .fill { height: 100%; width: 0%; background: linear-gradient(#ffcf7a, #d97b1e 60%, #8a4a10);
+    box-shadow: inset 0 1px 0 #fff4; transition: width 60ms linear; }
+  #swingbar.ready .fill { background: linear-gradient(#d8e8ff, #8fb6e6 60%, #5b86b8); }
+  #swingbar .label { position: absolute; inset: 0; text-align: center; font-size: 9px; line-height: 12px;
+    color: #fff; text-shadow: 1px 1px 1px #000; font-family: var(--title-font); letter-spacing: .5px; }
 
   /* ---------- bottom cluster ---------- */
   #bottom-bar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 6px; text-align: center; }
@@ -5303,6 +5312,7 @@
     <div id="trade-window" class="window panel"></div>
 
     <div id="castbar"><div class="fill"></div><div class="label"></div><div class="timer"></div></div>
+    <div id="swingbar"><div class="fill"></div><div class="label"></div></div>
 
     <div id="minimap-wrap">
       <div id="zone-label" data-i18n="entities.zones.eastbrook_vale.name">Eastbrook Vale</div>

--- a/scripts/swing_timer_visual.mjs
+++ b/scripts/swing_timer_visual.mjs
@@ -1,0 +1,97 @@
+// Visual check for the melee swing-timer bar (#swingbar).
+// Boots the offline game, engages auto-attack on a wolf, and captures the
+// swing bar at a few fill levels. Saves screenshots to tmp/ for the PR.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Swingblade');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// teleport beside the nearest wolf, target + face it, start auto-attack
+const fight = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  let wolf = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'forest_wolf' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; wolf = e; }
+    }
+  }
+  p.pos.x = wolf.pos.x + 2; p.pos.z = wolf.pos.z;
+  p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  sim.targetEntity(wolf.id);
+  sim.startAutoAttack();
+  // keep the wolf alive so the bar keeps cycling for the screenshots
+  wolf.maxHp = 100000; wolf.hp = 100000; wolf.hostile = false;
+  return { wolfId: wolf.id };
+});
+console.log('fight setup:', JSON.stringify(fight));
+
+// Keep the player attacking and grab the swing bar at three fill points.
+async function keepSwinging() {
+  await page.evaluate((id) => {
+    const g = window.__game;
+    const p = g.sim.player;
+    const w = g.sim.entities.get(id);
+    w.hp = w.maxHp; // never let it die
+    if (p.targetId !== id) g.sim.targetEntity(id);
+    p.facing = Math.atan2(w.pos.x - p.pos.x, w.pos.z - p.pos.z);
+    if (!p.autoAttack) g.sim.startAutoAttack();
+  }, fight.wolfId);
+}
+
+const swingState = () =>
+  page.evaluate(() => {
+    const p = window.__game.sim.player;
+    const bar = document.querySelector('#swingbar');
+    return {
+      swingTimer: +p.swingTimer.toFixed(2),
+      auto: p.autoAttack,
+      barShown: bar && bar.style.display === 'block',
+      fill: bar?.querySelector('.fill')?.style.width,
+      label: bar?.querySelector('.label')?.textContent,
+    };
+  });
+
+for (let i = 0; i < 6; i++) {
+  await keepSwinging();
+  await new Promise((r) => setTimeout(r, 350));
+  const s = await swingState();
+  console.log(`frame ${i}:`, JSON.stringify(s));
+  if (s.barShown) {
+    await page.screenshot({ path: `tmp/swing_${i}_${(s.fill || '0').replace('%', '')}.png` });
+  }
+}
+
+// A clean, cropped shot of the bar region for the PR.
+await keepSwinging();
+await new Promise((r) => setTimeout(r, 250));
+await page.screenshot({ path: 'tmp/swing_full.png' });
+await page.screenshot({
+  path: 'tmp/swing_crop.png',
+  clip: { x: 600, y: 560, width: 400, height: 200 },
+});
+console.log('saved tmp/swing_*.png');
+
+await browser.close();

--- a/server/game.ts
+++ b/server/game.ts
@@ -1258,6 +1258,7 @@ export class GameServer {
       prk: meta.prestigeRank,
       copper: meta.copper,
       gcd: round2(p.gcdRemaining),
+      swing: round2(p.swingTimer),
       combo: p.comboPoints,
       comboTgt: p.comboTargetId,
       target: p.targetId,

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -666,6 +666,7 @@ export class ClientWorld implements IWorld {
       e.comboTargetId = s.comboTgt ?? null;
       e.targetId = s.target ?? null;
       e.autoAttack = !!s.auto;
+      e.swingTimer = s.swing ?? e.swingTimer;
       e.queuedOnSwing = s.queued ?? null;
       e.stats = s.stats ?? e.stats;
       e.attackPower = s.ap ?? 0;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -281,6 +281,10 @@ export class Hud {
   private questDialogReturnFocus: HTMLElement | null = null;
   private questLogReturnFocus: HTMLElement | null = null;
   private lastPortraitTarget = -999;
+  // swing timer: the period is captured from the reset edge (swingTimer jumping
+  // up), so the bar tracks real swing speed including haste / ranged weapons.
+  private swingPeriod = 0;
+  private lastSwingTimer = 0;
   // trading: locally staged offer, pushed to the server on change
   private stagedTrade: { items: InvSlot[]; copper: number } = { items: [], copper: 0 };
   private tradeWasOpen = false;
@@ -1654,6 +1658,29 @@ export class Hud {
       this.setWidth(this.castbarFillEl, '0%');
       this.setText(this.castbarLabelEl, '');
       this.setText(this.castbarTimerEl, '');
+    }
+
+    // swing timer — fills between melee/ranged auto-attack swings. swingTimer
+    // counts DOWN to 0 (ready); we recover the full interval from the reset
+    // edge so the bar stays accurate under haste and for ranged weapons.
+    const sw = $('#swingbar');
+    if (p.autoAttack && target && !target.dead && target.kind !== 'object') {
+      if (p.swingTimer > this.lastSwingTimer + 1e-4 || this.swingPeriod <= 0) {
+        this.swingPeriod = Math.max(p.swingTimer, p.weapon.speed);
+      }
+      this.lastSwingTimer = p.swingTimer;
+      const frac = this.swingPeriod > 0
+        ? Math.min(1, Math.max(0, 1 - p.swingTimer / this.swingPeriod))
+        : 1;
+      sw.style.display = 'block';
+      (sw.querySelector('.fill') as HTMLElement).style.width = `${(frac * 100).toFixed(1)}%`;
+      sw.classList.toggle('ready', p.swingTimer <= 0);
+      (sw.querySelector('.label') as HTMLElement).textContent =
+        p.swingTimer <= 0 ? 'Swing' : `${p.swingTimer.toFixed(1)}s`;
+    } else {
+      sw.style.display = 'none';
+      this.lastSwingTimer = 0;
+      this.swingPeriod = 0;
     }
 
     // action bar

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -119,9 +119,20 @@ describe('delta snapshots', () => {
       expect(snap.self, `self.${key} resent although unchanged`).not.toHaveProperty(key);
     }
     // the always-on fields are still present every snapshot
-    for (const key of ['x', 'z', 'hp', 'mhp', 'res', 'gcd', 'xp', 'copper', 'target']) {
+    for (const key of ['x', 'z', 'hp', 'mhp', 'res', 'gcd', 'swing', 'xp', 'copper', 'target']) {
       expect(snap.self).toHaveProperty(key);
     }
+  });
+
+  it('mirrors the swing timer to the online client for the swing-timer HUD bar', () => {
+    const player = server.sim.entities.get(session.pid)!;
+    player.swingTimer = 1.7;
+    broadcast(server);
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.swing).toBeCloseTo(1.7, 1);
+    const client = bareClient(session.pid);
+    (client as any).applySnapshot(snap);
+    expect(client.player.swingTimer).toBeCloseTo(1.7, 1);
   });
 
   it('sell command forwards bounded stack quantities', () => {


### PR DESCRIPTION
## What

Adds a Classic-WoW-style **swing timer bar** under the cast bar. It fills between auto-attack swings so melee and ranged players can time their next swing — essential for weaving on-next-swing abilities (Heroic Strike, Raptor Strike) and special attacks against the swing rhythm.

- Shows only while auto-attacking a live target.
- **Amber** while the swing recharges; flashes **steel-blue "Swing"** the moment it's ready.
- Sits just below the cast bar, centered above the player frame.

## How

- The full swing interval is recovered from the **reset edge** of `Entity.swingTimer` (the value it jumps to after a swing), so the bar stays accurate under **haste** and for **ranged** weapon speeds — no need to expose `swingIntervalMult`.
- `swingTimer` already exists in the sim core, so the **offline `Sim` path needs no changes** (`IWorld.player` is the full `Entity`).
- For online play, `swingTimer` now rides the **self snapshot** (`server/game.ts`, alongside `gcd`) and is mirrored in `ClientWorld` (`src/net/online.ts`), keeping the *one-sim-three-hosts* seam honest — the bar is accurate online and offline.

## Tests

- `tests/snapshots.test.ts`: asserts `swing` is present every snapshot and round-trips into the client mirror.
- `scripts/swing_timer_visual.mjs`: drives a warrior into melee and captures the bar at multiple fill levels (screenshots below).
- Full suite green: **649/649**.

## Screenshots

_Swing bar mid-recharge (amber, countdown label) above the player frame:_

(images attached in the comment below)