### PR TITLE
feat(xp): classic Rested XP — inn-rested bonus that doubles kill XP (#308)

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,6 +506,9 @@
   #xpbar { width: 612px; height: 10px; background: #14101e; border: 1px solid #000; outline: 1px solid #3a3148;
     margin: 0 auto 4px; position: relative; border-radius: 2px; overflow: hidden; }
   #xpbar .fill { height: 100%; width: 0%; background: linear-gradient(#b85eff, #6a1bb0); transition: background .3s; }
+  /* Rested XP overlay (classic inn-rested bonus): a blue segment ahead of the fill. */
+  #xpbar .rested { position: absolute; top: 0; height: 100%; left: 0; width: 0%; background: linear-gradient(#5fb0ff, #2b6fd0); opacity: 0.5; }
+  #xpbar.rested { outline-color: #2b6fd0; box-shadow: 0 0 6px #4a9eff55; }
   #xpbar .ticks { position: absolute; inset: 0; display: flex; }
   #xpbar .ticks i { flex: 1; border-right: 1px solid #00000055; }
   #xpbar .label { position: absolute; inset: 0; font-size: 9px; color: #fff; text-align: center; line-height: 10px; text-shadow: 1px 1px 1px #000; opacity: 0; transition: opacity .15s; }
@@ -5348,7 +5351,7 @@
             </div>
           </div>
           <div id="petbar" class="panel"></div>
-          <div id="xpbar"><div class="fill"></div><div class="ticks"></div><div class="label"></div></div>
+          <div id="xpbar"><div class="fill"></div><div class="rested"></div><div class="ticks"></div><div class="label"></div></div>
           <div id="actionbar" class="panel"></div>
         </div>
         <div id="meters-window" class="panel">

--- a/scripts/rested_xp_visual.mjs
+++ b/scripts/rested_xp_visual.mjs
@@ -1,0 +1,58 @@
+// Visual capture for the Rested XP feature (#308). Boots the offline client,
+// gives the player a rested pool, and screenshots the XP-bar rested overlay
+// (hover label) plus the "+rested" floating combat text on a rested kill award.
+// Requires `npm run dev` running. Output → tmp/rested/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const OUT = 'tmp/rested';
+fs.mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Innkeeper');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Seed a partial XP bar (25%) with a rested pool ahead of it so the blue
+// rested overlay reads clearly mid-bar.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.xp = 40;
+  sim.meta(sim.playerId).restedXp = 120;
+});
+await new Promise((r) => setTimeout(r, 300));
+await page.hover('#xpbar');
+await new Promise((r) => setTimeout(r, 300));
+await page.screenshot({ path: `${OUT}/01_rested_bar.png`, clip: { x: 480, y: 760, width: 640, height: 130 } });
+
+// Trigger a rested kill award to show the blue "+rested" floating text.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const meta = sim.meta(sim.playerId);
+  meta.restedXp = 200;
+  sim.grantXp(60, meta, { fromKill: true });
+});
+await new Promise((r) => setTimeout(r, 120));
+await page.screenshot({ path: `${OUT}/02_rested_fct.png`, clip: { x: 560, y: 170, width: 480, height: 260 } });
+
+const state = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  return { xp: sim.xp, restedXp: sim.restedXp, level: sim.player.level };
+});
+console.log('final state:', JSON.stringify(state));
+console.log('saved screenshots to', OUT);
+await browser.close();

--- a/server/game.ts
+++ b/server/game.ts
@@ -1255,6 +1255,7 @@ export class GameServer {
       rtype: p.resourceType,
       xp: meta.xp,
       lxp: meta.lifetimeXp,
+      rxp: Math.round(meta.restedXp),
       prk: meta.prestigeRank,
       copper: meta.copper,
       gcd: round2(p.gcdRemaining),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -263,6 +263,8 @@ export class ClientWorld implements IWorld {
   // Post-cap progression (Max-Level XP Overflow), mirrored from snapshot self.
   lifetimeXp = 0;
   prestigeRank = 0;
+  // Rested XP pool, mirrored from snapshot self.
+  restedXp = 0;
   unlockedMilestones: string[] = [];
   known: ResolvedAbility[] = [];
   // Talents & Specializations, mirrored from snapshot self (display + staging).
@@ -680,6 +682,7 @@ export class ClientWorld implements IWorld {
         : null;
       this.xp = s.xp ?? 0;
       this.lifetimeXp = s.lxp ?? 0;
+      this.restedXp = s.rxp ?? 0;
       this.prestigeRank = s.prk ?? 0;
       if (s.milestones !== undefined) this.unlockedMilestones = s.milestones;
       this.copper = s.copper ?? 0;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,7 +1,7 @@
 import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
-  ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, questRewardItemId, abilitiesKnownAt, instanceOrigin,
+  ITEMS, MOBS, NPCS, PLAYER_START, PROPS, QUESTS, questRewardItemId, abilitiesKnownAt, instanceOrigin,
   DEEPFEN_SHALLOWS_LAKE,
   zoneAt, ZONES,
 } from './data';
@@ -69,6 +69,16 @@ const FALL_SAFE_DISTANCE = 12; // yards of free fall before damage
 const OBJECT_RESPAWN = 30;
 const PARTY_MAX = 5;
 const PARTY_XP_RANGE = 80; // yards: members this close share kill xp/credit
+// Rested XP (classic inn-rested bonus). Resting inside an inn footprint accrues a
+// pool that doubles KILL xp (200%) until spent — vanilla's signature casual-pacing
+// lever. Vanilla rate is 5% of a level per 8 in-game hours, capped at 1.5 levels.
+// The sim has no day/night clock, so "in-game hours" map to a fixed sim-seconds
+// constant (determinism: accrual is keyed off sim time via DT, never wall-clock).
+const RESTED_SECONDS_PER_GAME_HOUR = 60; // 1 in-game hour = 60 sim seconds
+const RESTED_FILL_FRACTION = 0.05; // a full "bubble" = 5% of the level's XP-to-level
+const RESTED_FILL_HOURS = 8; // accrued per this many in-game hours of resting
+const RESTED_CAP_LEVELS = 1.5; // pool clamps to 1.5 levels of XP, as in vanilla
+const RESTED_INN_PADDING = 2; // yards of slack around the inn footprint that still counts as resting
 const DUEL_COUNTDOWN = 3;
 // Ashen Coliseum 1v1 arena
 const ARENA_COUNTDOWN = 5; // gates pre-fight: heal up, no swings land yet
@@ -310,6 +320,9 @@ export interface PlayerMeta {
   lifetimeXp: number;
   prestigeRank: number;
   unlockedMilestones: Set<string>;
+  // Classic Rested XP pool (copper-less XP units). Accrues while resting in an
+  // inn, spent to double kill XP. Persisted in CharacterState.
+  restedXp: number;
   known: ResolvedAbility[];
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;
@@ -390,6 +403,8 @@ export interface CharacterState {
   lifetimeXp?: number;
   prestigeRank?: number;
   unlockedMilestones?: string[];
+  // Rested XP pool. Optional so pre-rested-XP saves load cleanly (defaults to 0).
+  restedXp?: number;
   copper: number;
   hp: number;
   resource: number;
@@ -687,6 +702,7 @@ export class Sim {
       lifetimeXp: 0,
       prestigeRank: 0,
       unlockedMilestones: new Set(),
+      restedXp: 0,
       known: [],
       questLog: new Map(),
       questsDone: new Set(),
@@ -717,6 +733,7 @@ export class Sim {
       // existing characters from day one.
       meta.lifetimeXp = s.lifetimeXp ?? (xpToReachLevel(player.level) + Math.max(0, s.xp));
       meta.prestigeRank = s.prestigeRank ?? 0;
+      meta.restedXp = Math.max(0, s.restedXp ?? 0);
       if (s.unlockedMilestones) for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
@@ -808,6 +825,7 @@ export class Sim {
       lifetimeXp: meta.lifetimeXp,
       prestigeRank: meta.prestigeRank,
       unlockedMilestones: [...meta.unlockedMilestones],
+      restedXp: meta.restedXp,
       copper: meta.copper,
       hp: e.hp,
       resource: e.resource,
@@ -886,6 +904,9 @@ export class Sim {
   }
   get lifetimeXp(): number {
     return this.primary.lifetimeXp;
+  }
+  get restedXp(): number {
+    return this.primary.restedXp;
   }
   get prestigeRank(): number {
     return this.primary.prestigeRank;
@@ -1243,6 +1264,7 @@ export class Sim {
         this.updateCasting(p, meta);
         this.updatePlayerAutoAttack(p, meta);
         this.updateRegen(p, meta);
+        this.updateRested(p, meta);
       }
       this.updateTimers(p);
       this.updateAuras(p);
@@ -3499,7 +3521,7 @@ export class Sim {
           // routes the award to lifetimeXp even at the cap, so the party gate no
           // longer blocks max-level members — it just forwards every positive award.
           const xpGain = Math.round((mobXpValue(e.level, mE.level) * eliteMult * bonus) / eligible.length);
-          if (xpGain > 0) this.grantXp(xpGain, member);
+          if (xpGain > 0) this.grantXp(xpGain, member, { fromKill: true });
           this.onMobKilledForQuests(e, member);
         }
         this.rollLoot(e, meta, eligible);
@@ -3507,9 +3529,52 @@ export class Sim {
     }
   }
 
-  grantXp(amount: number, meta: PlayerMeta = this.primary): void {
+  // True while the player is standing in (or just beside) an inn footprint and
+  // out of combat — the classic "resting" state that accrues rested XP.
+  private isResting(p: Entity): boolean {
+    if (p.inCombat) return false;
+    for (const b of PROPS.buildings) {
+      if (b.kind !== 'inn') continue;
+      // Point-in-rotated-rect: bring the player into the inn's local frame.
+      const dx = p.pos.x - b.x;
+      const dz = p.pos.z - b.z;
+      const cos = Math.cos(-b.rot);
+      const sin = Math.sin(-b.rot);
+      const lx = dx * cos - dz * sin;
+      const lz = dx * sin + dz * cos;
+      if (Math.abs(lx) <= b.w / 2 + RESTED_INN_PADDING && Math.abs(lz) <= b.d / 2 + RESTED_INN_PADDING) return true;
+    }
+    return false;
+  }
+
+  // Accrue rested XP while resting in an inn. Vanilla: 5% of the level's
+  // XP-to-level per 8 in-game hours, clamped to 1.5 levels. Deterministic —
+  // paced off DT, never wall-clock. No accrual at the cap (no level bar).
+  private updateRested(p: Entity, meta: PlayerMeta): void {
+    if (p.level >= MAX_LEVEL) return;
+    const cap = RESTED_CAP_LEVELS * xpForLevel(p.level);
+    if (meta.restedXp >= cap) {
+      meta.restedXp = cap;
+      return;
+    }
+    if (!this.isResting(p)) return;
+    const fillSeconds = RESTED_FILL_HOURS * RESTED_SECONDS_PER_GAME_HOUR;
+    const perSecond = (RESTED_FILL_FRACTION * xpForLevel(p.level)) / fillSeconds;
+    meta.restedXp = Math.min(cap, meta.restedXp + perSecond * DT);
+  }
+
+  grantXp(amount: number, meta: PlayerMeta = this.primary, opts?: { fromKill?: boolean }): void {
     const p = this.entities.get(meta.entityId);
     if (!p || amount <= 0) return;
+    // Rested XP bonus: classic vanilla only doubles KILL xp (not quests), and
+    // never past the cap (no level bar to advance). The bonus equals the rested
+    // amount drawn down, so the effective award is up to 2x while the pool lasts.
+    let restedBonus = 0;
+    if (opts?.fromKill && p.level < MAX_LEVEL && meta.restedXp > 0) {
+      restedBonus = Math.min(meta.restedXp, amount);
+      meta.restedXp -= restedBonus;
+      amount += restedBonus;
+    }
     // Lifetime XP accrues for EVERY award, including at the cap — this is what
     // makes post-cap progression work. It feeds the virtual level, the
     // leaderboard, and cosmetic milestones. The level bar below only advances
@@ -3517,7 +3582,7 @@ export class Sim {
     // rather than being discarded to gold/zero (FR-1.4).
     this.accrueLifetimeXp(amount, meta, p);
     meta.counters.xpGained += amount;
-    this.emit({ type: 'xp', amount, pid: p.id });
+    this.emit({ type: 'xp', amount, pid: p.id, ...(restedBonus > 0 ? { rested: restedBonus } : {}) });
 
     if (p.level >= MAX_LEVEL) return; // bar frozen at cap; lifetimeXp already credited
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -621,7 +621,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'damage'; sourceId: number; targetId: number; amount: number; crit: boolean; school: string; ability: string | null; kind: 'hit' | 'miss' | 'dodge' | 'parry' }
   | { type: 'heal'; targetId: number; amount: number }
   | { type: 'death'; entityId: number; killerId: number }
-  | { type: 'xp'; amount: number }
+  | { type: 'xp'; amount: number; rested?: number }
   | { type: 'levelup'; level: number }
   // post-cap cosmetic progression (Max-Level XP Overflow): crossing a virtual
   // level past the cap, and unlocking a cosmetic lifetime-XP milestone

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1744,12 +1744,17 @@ export class Hud {
     // xp bar — pre-cap shows the level bar; post-cap fills toward the next
     // virtual level (Max-Level XP Overflow), with distinct prestige/gold styling.
     const showOverflow = (this.optionsHooks?.settings.get('showOverflowXp') ?? 1) >= 0.5;
-    const bar = xpBarView({ level: p.level, xp: sim.xp, lifetimeXp: sim.lifetimeXp, showOverflow });
+    const bar = xpBarView({ level: p.level, xp: sim.xp, lifetimeXp: sim.lifetimeXp, restedXp: sim.restedXp, showOverflow });
     this.setWidth(this.xpFillEl, `${(bar.fillFrac * 100).toFixed(1)}%`);
     $('#xpbar').style.setProperty('--xp-fill', bar.fillFrac.toFixed(4));
     $('#player-frame').style.setProperty('--xp-fill', bar.fillFrac.toFixed(4));
+    // Rested overlay sits ahead of the fill (classic inn-rested bonus preview).
+    const restedEl = $('#xpbar .rested') as HTMLElement;
+    restedEl.style.left = `${(bar.fillFrac * 100).toFixed(1)}%`;
+    restedEl.style.width = `${(bar.restedFrac * 100).toFixed(1)}%`;
     this.setText(this.xpLabelEl, bar.label);
     $('#xpbar').classList.toggle('overflow', bar.postCap);
+    $('#xpbar').classList.toggle('rested', bar.restedFrac > 0);
 
     const deadInArena = p.dead && !!this.sim.arenaInfo?.match;
     this.setDisplay(this.deathOverlayEl, p.dead ? 'flex' : 'none');
@@ -2539,7 +2544,12 @@ export class Hud {
         }
         case 'xp': {
           this.fct(sim.player, t('hud.core.xpFloat', { amount: ev.amount }), '#b974ff', false);
-          this.log(t('hud.core.xpGain', { amount: ev.amount }), '#a980d8');
+          if (ev.rested && ev.rested > 0) {
+            this.fct(sim.player, t('hud.core.xpFloatRested', { amount: ev.rested }), '#4a9eff', false);
+            this.log(t('hud.core.xpGainRested', { amount: ev.amount, rested: ev.rested }), '#a980d8');
+          } else {
+            this.log(t('hud.core.xpGain', { amount: ev.amount }), '#a980d8');
+          }
           break;
         }
         case 'levelup': {

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -2612,6 +2612,8 @@ const hudStringsEn = {
       levelLog: "You have reached level {level}!",
       xpGain: "You gain {amount} experience.",
       xpFloat: "+{amount} XP",
+      xpFloatRested: "+{amount} rested",
+      xpGainRested: "You gain {amount} experience ({rested} bonus from resting).",
       deathTitle: "You have died.",
       releaseSpirit: "Release Spirit",
       chatTab: "Chat",
@@ -2952,6 +2954,8 @@ const hudStrings = {
         levelLog: "Has alcanzado el nivel {level}.",
         xpGain: "Ganas {amount} de experiencia.",
         xpFloat: "+{amount} XP",
+        xpFloatRested: "+{amount} descansado",
+        xpGainRested: "Ganas {amount} de experiencia ({rested} de bonificación por descansar).",
         deathTitle: "Has muerto.",
         releaseSpirit: "Liberar espíritu",
         chatTab: "Chat",
@@ -3073,6 +3077,8 @@ const hudStrings = {
         levelLog: "Vous avez atteint le niveau {level} !",
         xpGain: "Vous gagnez {amount} points d'expérience.",
         xpFloat: "+{amount} XP",
+        xpFloatRested: "+{amount} repos",
+        xpGainRested: "Vous gagnez {amount} points d'expérience ({rested} bonus de repos).",
         deathTitle: "Vous êtes mort.",
         releaseSpirit: "Libérer l'esprit",
         chatTab: "Discussion",
@@ -3195,6 +3201,8 @@ const hudStrings = {
         levelLog: "Hai raggiunto il livello {level}!",
         xpGain: "Guadagni {amount} esperienza.",
         xpFloat: "+{amount} PE",
+        xpFloatRested: "+{amount} riposo",
+        xpGainRested: "Guadagni {amount} esperienza ({rested} bonus dal riposo).",
         deathTitle: "Sei morto.",
         releaseSpirit: "Libera spirito",
         chatTab: "Chat",
@@ -3315,6 +3323,8 @@ const hudStrings = {
         levelLog: "Ihr habt Stufe {level} erreicht!",
         xpGain: "Ihr erhaltet {amount} Erfahrung.",
         xpFloat: "+{amount} EP",
+        xpFloatRested: "+{amount} ausgeruht",
+        xpGainRested: "Ihr erhaltet {amount} Erfahrung ({rested} Bonus durch Ausruhen).",
         deathTitle: "Ihr seid gestorben.",
         releaseSpirit: "Geist freigeben",
         chatTab: "Chat",
@@ -3435,6 +3445,8 @@ const hudStrings = {
         levelLog: "你已达到 {level} 级！",
         xpGain: "你获得 {amount} 点经验。",
         xpFloat: "+{amount} 经验",
+        xpFloatRested: "+{amount} 休息",
+        xpGainRested: "你获得 {amount} 点经验（休息奖励 {rested} 点）。",
         deathTitle: "你已经死亡。",
         releaseSpirit: "释放灵魂",
         chatTab: "聊天",
@@ -3555,6 +3567,8 @@ const hudStrings = {
         levelLog: "你已達到 {level} 級！",
         xpGain: "你獲得 {amount} 點經驗值。",
         xpFloat: "+{amount} 經驗值",
+        xpFloatRested: "+{amount} 休息",
+        xpGainRested: "你獲得 {amount} 點經驗值（休息獎勵 {rested} 點）。",
         deathTitle: "你已經死亡。",
         releaseSpirit: "釋放靈魂",
         chatTab: "聊天",
@@ -3675,6 +3689,8 @@ const hudStrings = {
         levelLog: "{level} 레벨이 되었습니다!",
         xpGain: "경험치 {amount}을 획득했습니다.",
         xpFloat: "+{amount} 경험치",
+        xpFloatRested: "+{amount} 휴식",
+        xpGainRested: "경험치 {amount}을 획득했습니다 (휴식 보너스 {rested}).",
         deathTitle: "사망했습니다.",
         releaseSpirit: "영혼 풀어주기",
         chatTab: "채팅",
@@ -3795,6 +3811,8 @@ const hudStrings = {
         levelLog: "レベル {level}になりました！",
         xpGain: "{amount}の経験値を獲得しました。",
         xpFloat: "+{amount} 経験値",
+        xpFloatRested: "+{amount} 休息",
+        xpGainRested: "{amount}の経験値を獲得しました（休息ボーナス {rested}）。",
         deathTitle: "死亡しました。",
         releaseSpirit: "霊魂を解放",
         chatTab: "チャット",
@@ -3915,6 +3933,8 @@ const hudStrings = {
         levelLog: "Você alcançou o nível {level}!",
         xpGain: "Você ganha {amount} de experiência.",
         xpFloat: "+{amount} XP",
+        xpFloatRested: "+{amount} descanso",
+        xpGainRested: "Você ganha {amount} de experiência ({rested} de bônus por descanso).",
         deathTitle: "Você morreu.",
         releaseSpirit: "Liberar espírito",
         chatTab: "Chat",
@@ -4035,6 +4055,8 @@ const hudStrings = {
         levelLog: "Вы достигли уровня {level}!",
         xpGain: "Вы получаете {amount} опыта.",
         xpFloat: "+{amount} опыта",
+        xpFloatRested: "+{amount} отдых",
+        xpGainRested: "Вы получаете {amount} опыта ({rested} бонус за отдых).",
         deathTitle: "Вы погибли.",
         releaseSpirit: "Освободить дух",
         chatTab: "Чат",
@@ -10473,6 +10495,7 @@ export const gameStrings = {
     totalXp: "total XP",
     lv: "Lv",
     toNext: "to next",
+    rested: "Rested",
   },
   progression: {
     heading: "Progression",
@@ -10594,7 +10617,7 @@ const gameStringsEnCA: typeof gameStrings = {
 };
 
 const gameStringsEs: typeof gameStrings = {
-  xp: { suffix: "EXP", maxLevel: "NIVEL MÁX.", totalXp: "EXP total", lv: "Nv", toNext: "para el siguiente" },
+  xp: { suffix: "EXP", maxLevel: "NIVEL MÁX.", totalXp: "EXP total", lv: "Nv", toNext: "para el siguiente", rested: "Descansado" },
   progression: {
     heading: "Progreso",
     totalXp: "EXP total",
@@ -10704,7 +10727,7 @@ const gameStringsEs: typeof gameStrings = {
 const gameStringsEsES: typeof gameStrings = gameStringsEs;
 
 const gameStringsFrFR: typeof gameStrings = {
-  xp: { suffix: "EXP", maxLevel: "NIVEAU MAX.", totalXp: "EXP totale", lv: "Niv.", toNext: "avant le suivant" },
+  xp: { suffix: "EXP", maxLevel: "NIVEAU MAX.", totalXp: "EXP totale", lv: "Niv.", toNext: "avant le suivant", rested: "Reposé" },
   progression: {
     heading: "Progression",
     totalXp: "EXP totale",
@@ -10814,7 +10837,7 @@ const gameStringsFrFR: typeof gameStrings = {
 const gameStringsFrCA: typeof gameStrings = gameStringsFrFR;
 
 const gameStringsItIT: typeof gameStrings = {
-  xp: { suffix: "PE", maxLevel: "LIVELLO MAX", totalXp: "PE totali", lv: "Liv", toNext: "al prossimo" },
+  xp: { suffix: "PE", maxLevel: "LIVELLO MAX", totalXp: "PE totali", lv: "Liv", toNext: "al prossimo", rested: "Riposato" },
   progression: { heading: "Progressione", totalXp: "PE totali", virtualLevel: "Livello virtuale", prestigeRank: "Rango prestigio", milestones: "Traguardi", none: "Ancora nessuno", virtualLevelUp: "Livello virtuale" },
   leaderboard: { title: "Classifica", subtitle: "PE totali", rank: "Posizione", name: "Nome", realmCol: "Reame", level: "Liv", vlevel: "Liv.V", lifetimeXp: "PE totali", yourRank: "La tua posizione", empty: "Non ci sono ancora campioni: lascia il primo segno.", loading: "Caricamento classifica...", unranked: "Non classificato", you: "Tu", globalSubtitle: "Migliori campioni di tutti i reami", retry: "Impossibile caricare la classifica. Riprova." },
   milestone: { unlocked: "Traguardo sbloccato", veteran: "Veterano", champion: "Campione", paragon: "Esemplare", mythic: "Mitico", eternal: "Eterno" },
@@ -10826,7 +10849,7 @@ const gameStringsItIT: typeof gameStrings = {
 };
 
 const gameStringsDeDE: typeof gameStrings = {
-  xp: { suffix: "EP", maxLevel: "MAX. STUFE", totalXp: "EP gesamt", lv: "St.", toNext: "bis zur nächsten" },
+  xp: { suffix: "EP", maxLevel: "MAX. STUFE", totalXp: "EP gesamt", lv: "St.", toNext: "bis zur nächsten", rested: "Ausgeruht" },
   progression: { heading: "Fortschritt", totalXp: "EP gesamt", virtualLevel: "Virtuelle Stufe", prestigeRank: "Prestigerang", milestones: "Meilensteine", none: "Noch keine", virtualLevelUp: "Virtuelle Stufe" },
   leaderboard: { title: "Rangliste", subtitle: "Lebenszeit-EP", rank: "Rang", name: "Name", realmCol: "Realm", level: "St.", vlevel: "V.St.", lifetimeXp: "Lebenszeit-EP", yourRank: "Euer Rang", empty: "Noch keine Champions; setzt als Erste ein Zeichen.", loading: "Rangliste wird geladen...", unranked: "Ohne Rang", you: "Ihr", globalSubtitle: "Beste Champions aller Realms", retry: "Rangliste konnte nicht geladen werden. Versucht es erneut." },
   milestone: { unlocked: "Meilenstein freigeschaltet", veteran: "Veteran", champion: "Champion", paragon: "Paragon", mythic: "Mythisch", eternal: "Ewig" },
@@ -10838,7 +10861,7 @@ const gameStringsDeDE: typeof gameStrings = {
 };
 
 const gameStringsZhCN: typeof gameStrings = {
-  xp: { suffix: "经验", maxLevel: "满级", totalXp: "总经验", lv: "等级", toNext: "到下一级" },
+  xp: { suffix: "经验", maxLevel: "满级", totalXp: "总经验", lv: "等级", toNext: "到下一级", rested: "充分休息" },
   progression: { heading: "进度", totalXp: "总经验", virtualLevel: "虚拟等级", prestigeRank: "声望阶级", milestones: "里程碑", none: "尚无", virtualLevelUp: "虚拟等级" },
   leaderboard: { title: "排行榜", subtitle: "终身经验", rank: "名次", name: "名称", realmCol: "服务器", level: "等级", vlevel: "虚等", lifetimeXp: "终身经验", yourRank: "你的排名", empty: "还没有冠军；成为第一个留下传说的人。", loading: "正在加载排名...", unranked: "未上榜", you: "你", globalSubtitle: "所有服务器的顶尖冠军", retry: "无法加载排行榜。请重试。" },
   milestone: { unlocked: "里程碑解锁", veteran: "老兵", champion: "冠军", paragon: "典范", mythic: "神话", eternal: "永恒" },
@@ -10850,7 +10873,7 @@ const gameStringsZhCN: typeof gameStrings = {
 };
 
 const gameStringsZhTW: typeof gameStrings = {
-  xp: { suffix: "經驗", maxLevel: "滿級", totalXp: "總經驗", lv: "等級", toNext: "到下一級" },
+  xp: { suffix: "經驗", maxLevel: "滿級", totalXp: "總經驗", lv: "等級", toNext: "到下一級", rested: "充分休息" },
   progression: { heading: "進度", totalXp: "總經驗", virtualLevel: "虛擬等級", prestigeRank: "威望階級", milestones: "里程碑", none: "尚無", virtualLevelUp: "虛擬等級" },
   leaderboard: { title: "排行榜", subtitle: "終身經驗", rank: "名次", name: "名稱", realmCol: "伺服器", level: "等級", vlevel: "虛等", lifetimeXp: "終身經驗", yourRank: "你的排名", empty: "還沒有冠軍；成為第一個留下傳說的人。", loading: "正在載入排名...", unranked: "未上榜", you: "你", globalSubtitle: "所有伺服器的頂尖冠軍", retry: "無法載入排行榜。請再試一次。" },
   milestone: { unlocked: "里程碑解鎖", veteran: "老兵", champion: "冠軍", paragon: "典範", mythic: "神話", eternal: "永恆" },
@@ -10918,7 +10941,7 @@ const gameStringsZhTW: typeof gameStrings = {
 };
 
 const gameStringsKoKR: typeof gameStrings = {
-  xp: { suffix: "경험치", maxLevel: "최대 레벨", totalXp: "총 경험치", lv: "레벨", toNext: "다음까지" },
+  xp: { suffix: "경험치", maxLevel: "최대 레벨", totalXp: "총 경험치", lv: "레벨", toNext: "다음까지", rested: "휴식" },
   progression: { heading: "진행도", totalXp: "총 경험치", virtualLevel: "가상 레벨", prestigeRank: "명예 등급", milestones: "이정표", none: "아직 없음", virtualLevelUp: "가상 레벨" },
   leaderboard: { title: "순위표", subtitle: "누적 경험치", rank: "순위", name: "이름", realmCol: "서버", level: "레벨", vlevel: "가상", lifetimeXp: "누적 경험치", yourRank: "내 순위", empty: "아직 영웅이 없습니다. 첫 흔적을 남겨 보세요.", loading: "순위 불러오는 중...", unranked: "순위 없음", you: "나", globalSubtitle: "모든 서버의 최고 영웅", retry: "순위표를 불러오지 못했습니다. 다시 시도하세요." },
   milestone: { unlocked: "이정표 해제", veteran: "베테랑", champion: "용사", paragon: "귀감", mythic: "신화", eternal: "영원" },
@@ -10928,7 +10951,7 @@ const gameStringsKoKR: typeof gameStrings = {
 };
 
 const gameStringsJaJP: typeof gameStrings = {
-  xp: { suffix: "経験値", maxLevel: "最大レベル", totalXp: "総経験値", lv: "Lv", toNext: "次まで" },
+  xp: { suffix: "経験値", maxLevel: "最大レベル", totalXp: "総経験値", lv: "Lv", toNext: "次まで", rested: "休息" },
   progression: { heading: "進行", totalXp: "総経験値", virtualLevel: "仮想レベル", prestigeRank: "威信ランク", milestones: "到達点", none: "まだなし", virtualLevelUp: "仮想レベル" },
   leaderboard: { title: "ランキング", subtitle: "累計経験値", rank: "順位", name: "名前", realmCol: "レルム", level: "Lv", vlevel: "仮Lv", lifetimeXp: "累計経験値", yourRank: "あなたの順位", empty: "まだ英雄はいません。最初の名を刻みましょう。", loading: "ランキングを読み込み中...", unranked: "順位なし", you: "あなた", globalSubtitle: "全レルムの上位英雄", retry: "ランキングを読み込めませんでした。もう一度お試しください。" },
   milestone: { unlocked: "到達点解除", veteran: "古参", champion: "勇者", paragon: "範士", mythic: "神話", eternal: "永遠" },
@@ -10938,7 +10961,7 @@ const gameStringsJaJP: typeof gameStrings = {
 };
 
 const gameStringsPtBR: typeof gameStrings = {
-  xp: { suffix: "EXP", maxLevel: "NÍVEL MAX.", totalXp: "EXP total", lv: "Nv", toNext: "para o próximo" },
+  xp: { suffix: "EXP", maxLevel: "NÍVEL MAX.", totalXp: "EXP total", lv: "Nv", toNext: "para o próximo", rested: "Descansado" },
   progression: { heading: "Progressão", totalXp: "EXP total", virtualLevel: "Nível virtual", prestigeRank: "Grau de prestígio", milestones: "Marcos", none: "Nenhum ainda", virtualLevelUp: "Nível virtual" },
   leaderboard: { title: "Classificação", subtitle: "EXP vitalícia", rank: "Posição", name: "Nome", realmCol: "Reino", level: "Nv", vlevel: "Nv.V", lifetimeXp: "EXP vitalícia", yourRank: "Sua posição", empty: "Ainda não há campeões; seja o primeiro a deixar sua marca.", loading: "Carregando classificação...", unranked: "Sem ranking", you: "Você", globalSubtitle: "Maiores campeões de todos os reinos", retry: "Não foi possível carregar a classificação. Tente novamente." },
   milestone: { unlocked: "Marco desbloqueado", veteran: "Veterano", champion: "Campeão", paragon: "Paragão", mythic: "Mítico", eternal: "Eterno" },
@@ -11006,7 +11029,7 @@ const gameStringsPtBR: typeof gameStrings = {
 };
 
 const gameStringsRuRU: typeof gameStrings = {
-  xp: { suffix: "опыт", maxLevel: "МАКС. УРОВЕНЬ", totalXp: "всего опыта", lv: "Ур.", toNext: "до следующего" },
+  xp: { suffix: "опыт", maxLevel: "МАКС. УРОВЕНЬ", totalXp: "всего опыта", lv: "Ур.", toNext: "до следующего", rested: "Отдохнувший" },
   progression: { heading: "Прогресс", totalXp: "Всего опыта", virtualLevel: "Виртуальный уровень", prestigeRank: "Ранг престижа", milestones: "Вехи", none: "Пока нет", virtualLevelUp: "Виртуальный уровень" },
   leaderboard: { title: "Рейтинг", subtitle: "Опыт за все время", rank: "Место", name: "Имя", realmCol: "Мир", level: "Ур.", vlevel: "Вирт.", lifetimeXp: "Опыт за все время", yourRank: "Ваше место", empty: "Чемпионов пока нет; станьте первым.", loading: "Загрузка рейтинга...", unranked: "Без места", you: "Вы", globalSubtitle: "Лучшие чемпионы всех миров", retry: "Не удалось загрузить рейтинг. Попробуйте еще раз." },
   milestone: { unlocked: "Веха открыта", veteran: "Ветеран", champion: "Чемпион", paragon: "Образец", mythic: "Мифический", eternal: "Вечный" },

--- a/src/ui/xp_bar.ts
+++ b/src/ui/xp_bar.ts
@@ -10,10 +10,14 @@ export interface XpBarInput {
   xp: number; // current level-bar XP (server-authoritative)
   lifetimeXp: number; // monotonic lifetime total (server-authoritative)
   showOverflow: boolean; // settings toggle; false → classic "MAX LEVEL"
+  restedXp?: number; // classic inn-rested pool; doubles kill XP until spent
 }
 
 export interface XpBarView {
   fillFrac: number; // 0..1 width of the fill
+  // 0..1 width of the rested overlay segment that sits AHEAD of the fill (the
+  // portion of the bar the rested bonus will cover). 0 when not rested / at cap.
+  restedFrac: number;
   label: string; // hover label
   postCap: boolean; // true → distinct prestige/gold styling
 }
@@ -31,9 +35,16 @@ export function xpBarView(input: XpBarInput): XpBarView {
   if (!atCap) {
     const need = xpForLevel(level);
     const frac = need > 0 ? xp / need : 0;
+    const rested = Math.max(0, input.restedXp ?? 0);
+    // Rested overlay spans from the current fill up to where the rested pool
+    // would carry the bar (clamped to the bar end), so it reads as a preview of
+    // the bonus to come.
+    const restedFrac = rested > 0 && need > 0 ? clamp01((xp + rested) / need) - clamp01(frac) : 0;
+    const restedLabel = rested > 0 ? `  ·  ${t('game.xp.rested')} +${formatXp(rested)}` : '';
     return {
       fillFrac: clamp01(frac),
-      label: `${formatXp(xp)} / ${formatXp(need)} ${t('game.xp.suffix')} (${Math.floor(frac * 100)}%)`,
+      restedFrac: Math.max(0, restedFrac),
+      label: `${formatXp(xp)} / ${formatXp(need)} ${t('game.xp.suffix')} (${Math.floor(frac * 100)}%)${restedLabel}`,
       postCap: false,
     };
   }
@@ -43,6 +54,7 @@ export function xpBarView(input: XpBarInput): XpBarView {
   if (!showOverflow) {
     return {
       fillFrac: 1,
+      restedFrac: 0,
       label: `${t('game.xp.maxLevel')}  ·  ${formatXp(lifetimeXp)} ${t('game.xp.totalXp')}`,
       postCap: false,
     };
@@ -57,7 +69,7 @@ export function xpBarView(input: XpBarInput): XpBarView {
     `${t('game.xp.lv')} ${MAX_LEVEL} (+${extra})  ·  ` +
     `${formatXp(lifetimeXp)} ${t('game.xp.totalXp')}  ·  ` +
     `${pct}% ${t('game.xp.toNext')}`;
-  return { fillFrac: clamp01(prog.into / prog.span), label, postCap: true };
+  return { fillFrac: clamp01(prog.into / prog.span), restedFrac: 0, label, postCap: true };
 }
 
 function clamp01(v: number): number {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -198,6 +198,8 @@ export interface IWorld {
   lifetimeXp: number;
   prestigeRank: number;
   unlockedMilestones: string[];
+  // Classic Rested XP pool (inn-rested kill-XP bonus); 0 when not rested.
+  restedXp: number;
   known: ResolvedAbility[];
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;

--- a/tests/localization_coverage.test.ts
+++ b/tests/localization_coverage.test.ts
@@ -288,6 +288,7 @@ describe("i18n Localization Key Coverage", () => {
     action: "Open Chat",
     amount: 42,
     base: 14,
+    rested: 18,
     buyer: "Mira",
     classes: "Warrior, Mage",
     className: "Mage",

--- a/tests/rested_xp.test.ts
+++ b/tests/rested_xp.test.ts
@@ -1,0 +1,131 @@
+// Classic Rested XP (#308): inn-rested pool that doubles kill XP until spent.
+//
+// Covers accrual while resting in an inn (and only there, out of combat), the
+// 1.5-level cap, kill-XP consumption (2x, kills only — not quests), the xp-bar
+// rested overlay fraction, and CharacterState persistence round-trip.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { DT, xpForLevel } from '../src/sim/types';
+import { PROPS } from '../src/sim/data';
+import { xpBarView } from '../src/ui/xp_bar';
+import { terrainHeight } from '../src/sim/world';
+
+function makeSim(): Sim {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+function teleport(sim: Sim, e: any, x: number, z: number) {
+  e.pos.x = x; e.pos.z = z; e.pos.y = terrainHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+const inn = PROPS.buildings.find((b) => b.kind === 'inn')!;
+
+describe('rested XP — accrual', () => {
+  it('accrues while resting inside an inn footprint', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    teleport(sim, sim.player, inn.x, inn.z);
+    expect(sim.restedXp).toBe(0);
+    for (let i = 0; i < 100; i++) sim.tick();
+    // 5% of the level's XP per 8 in-game hours (= 8*60 sim seconds) for 100 ticks.
+    const perSecond = (0.05 * xpForLevel(sim.player.level)) / (8 * 60);
+    const expected = perSecond * DT * 100;
+    expect(sim.restedXp).toBeCloseTo(expected, 4);
+    expect(meta.restedXp).toBeGreaterThan(0);
+  });
+
+  it('does NOT accrue while standing away from any inn', () => {
+    const sim = makeSim();
+    teleport(sim, sim.player, -300, 0); // verified clear of inns
+    for (let i = 0; i < 100; i++) sim.tick();
+    expect(sim.restedXp).toBe(0);
+  });
+
+  it('clamps the pool to 1.5 levels of XP', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    teleport(sim, sim.player, inn.x, inn.z);
+    meta.restedXp = 999_999_999;
+    sim.tick();
+    expect(sim.restedXp).toBe(1.5 * xpForLevel(sim.player.level));
+  });
+});
+
+describe('rested XP — consumption', () => {
+  it('doubles kill XP and draws the pool down', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    meta.restedXp = 1000;
+    const before = sim.xp;
+    sim.grantXp(100, meta, { fromKill: true });
+    expect(sim.xp).toBe(before + 200); // 100 base + 100 rested bonus
+    expect(meta.restedXp).toBe(900);
+  });
+
+  it('caps the bonus at the awarded amount (never more than 2x)', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    meta.restedXp = 30; // less than the award
+    const before = sim.xp;
+    sim.grantXp(100, meta, { fromKill: true });
+    expect(sim.xp).toBe(before + 130);
+    expect(meta.restedXp).toBe(0);
+  });
+
+  it('does NOT consume rested XP for non-kill awards (e.g. quests)', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    meta.restedXp = 1000;
+    const before = sim.xp;
+    sim.grantXp(100, meta); // no fromKill → quest-style award
+    expect(sim.xp).toBe(before + 100);
+    expect(meta.restedXp).toBe(1000);
+  });
+
+  it('emits the rested bonus on the xp event', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    meta.restedXp = 1000;
+    const events = sim.tick(); // drain any boot events first
+    sim.grantXp(100, meta, { fromKill: true });
+    const drained = sim.tick();
+    const xpEv = [...events, ...drained].find((e) => e.type === 'xp');
+    expect(xpEv).toBeTruthy();
+    expect((xpEv as any).rested).toBe(100);
+  });
+});
+
+describe('rested XP — xp-bar overlay', () => {
+  it('reports a rested overlay fraction ahead of the fill', () => {
+    const need = xpForLevel(1);
+    const view = xpBarView({ level: 1, xp: need * 0.2, lifetimeXp: 0, restedXp: need * 0.3, showOverflow: false });
+    expect(view.fillFrac).toBeCloseTo(0.2, 5);
+    expect(view.restedFrac).toBeCloseTo(0.3, 5);
+  });
+
+  it('clamps the overlay to the end of the bar', () => {
+    const need = xpForLevel(1);
+    const view = xpBarView({ level: 1, xp: need * 0.8, lifetimeXp: 0, restedXp: need * 0.9, showOverflow: false });
+    expect(view.restedFrac).toBeCloseTo(0.2, 5); // 0.8 + 0.9 clamps to 1.0
+  });
+
+  it('is zero with no rested pool', () => {
+    const view = xpBarView({ level: 1, xp: 10, lifetimeXp: 0, showOverflow: false });
+    expect(view.restedFrac).toBe(0);
+  });
+});
+
+describe('rested XP — persistence', () => {
+  it('round-trips restedXp through CharacterState', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    meta.restedXp = 4242;
+    const state = sim.serializeCharacter(sim.playerId)!;
+    expect(state.restedXp).toBe(4242);
+
+    const sim2 = new Sim({ seed: 1, playerClass: 'warrior' });
+    const pid = sim2.addPlayer('warrior', 'Reloaded', { state });
+    expect(sim2.meta(pid)!.restedXp).toBe(4242);
+  });
+});


### PR DESCRIPTION
Closes #308.

Adds the classic-WoW **Rested XP** mechanic: characters accumulate a "rested" pool while resting in an inn, and that pool is spent to grant **200% kill XP** until it runs out — one of vanilla's signature casual-pacing levers, currently entirely absent from the sim.

## Behavior (vanilla-accurate)
- **Accrual** — while resting inside an inn footprint (rotated point-in-rect over the existing `PROPS` inn buildings) **and out of combat**, accrue **5% of the current level's XP-to-level per 8 in-game hours**. The sim has no day/night clock, so "in-game hours" map to a named sim-seconds constant — accrual is paced off `DT`/the sim clock, **never wall-clock** (determinism invariant).
- **Cap** — clamped to **1.5 levels** of XP, exactly as vanilla.
- **Consumption** — in `grantXp`, the **kill** path only (not quests, matching vanilla) draws down the pool for up to a **2x** award while rested remains. No accrual/consumption at the level cap.

## Architecture
Pure sim-core mechanic threaded through the `IWorld` seam so it works offline **and** online:
- New persisted `restedXp` on `PlayerMeta` + `CharacterState` (optional → pre-feature saves load as `0`), round-tripped through serialize/deserialize.
- One new tick step (`updateRested`) + the consumption branch in the single `grantXp` chokepoint; the `xp` `SimEvent` carries the bonus amount.
- Exposed on `IWorld.restedXp`; mirrored in the server self-snapshot (`rxp`) and applied in `ClientWorld`.
- All balance numbers are named consts (`RESTED_*`) in the `sim.ts` const block — no inline magic numbers.

## HUD
- A blue **rested overlay** segment sits ahead of the XP fill (computed in the pure, snapshot-tested `xpBarView`), with a hover label `· Rested +N`.
- A blue **"+rested"** floating combat text on a rested kill award. New i18n key `game.xp.rested`.

### XP bar with rested overlay (hover label)
![rested bar](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rested-xp/01_rested_bar.png)

### "+rested" floating combat text on a rested kill
![rested fct](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rested-xp/02_rested_fct.png)

## Tests
`tests/rested_xp.test.ts` — inn-only/out-of-combat accrual, 1.5-level cap, kill-only 2x consumption + the event payload, the bar-overlay fraction (incl. end-of-bar clamp), and `CharacterState` persistence round-trip. Full suite green (659 passed). Visual capture: `scripts/rested_xp_visual.mjs`.

## Scope
Ships **inn-resting accrual** in the sim core; vanilla's logged-out accrual is left to a follow-up that can credit rested XP at character-load time on the server. Cap-only (no post-cap rested), faithful to vanilla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)