### PR TITLE
feat(render): classic elite/boss "dragon frame" on mob nameplate health bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,6 +390,9 @@
   .np-name { font-size: 12px; font-weight: bold; font-family: var(--title-font); letter-spacing: 0.3px; }
   .np-hpbar { width: 78px; height: 6px; background: #2a0000; border: 1px solid #000; margin: 1px auto 0; border-radius: 2px; }
   .np-hpfill { height: 100%; background: linear-gradient(#48e060, #1d7a32); border-radius: 2px; }
+  /* classic "dragon frame" cue: elite mobs get a golden bar frame, bosses a red one */
+  .np-hpbar.elite { border-color: #f2c84b; box-shadow: 0 0 5px 1px #f2c84baa, inset 0 0 2px #ffe9a0cc; }
+  .np-hpbar.boss { border-color: #ff5a3c; box-shadow: 0 0 7px 1px #ff5a3ccc, inset 0 0 2px #ffd2a0dd; }
   .np-marker { font-size: 24px; font-weight: bold; height: 26px; font-family: var(--title-font); }
   .np-marker.avail { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }
   .np-marker.ready { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }

--- a/scripts/elite_nameplate_shot.mjs
+++ b/scripts/elite_nameplate_shot.mjs
@@ -1,0 +1,85 @@
+// Visual capture for the elite/boss nameplate "dragon frame" feature.
+// Boots the offline game, stages three live mobs in front of the camera —
+// a normal mob, an elite (gold bar frame), and a boss (red bar frame) — and
+// screenshots the nameplates so the classic-style framing is visible.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Adventurer');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Re-skin the three nearest living mobs as normal / elite / boss, line them up
+// abreast just in front of the player, and face the camera at them.
+const staged = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  const mobs = [...sim.entities.values()]
+    .filter((e) => e.templateId && !e.dead && e.kind === 'mob' && e.ownerId == null)
+    .sort((a, b) => Math.hypot(a.pos.x - p.pos.x, a.pos.z - p.pos.z) - Math.hypot(b.pos.x - p.pos.x, b.pos.z - p.pos.z))
+    .slice(0, 3);
+  const skins = [
+    { tpl: 'forest_wolf', name: 'Forest Wolf', level: 6 },
+    { tpl: 'crypt_shambler', name: 'Crypt Shambler', level: 8 },   // elite -> gold frame
+    { tpl: 'morthen', name: 'Morthen the Gravecaller', level: 10 }, // boss -> red frame
+  ];
+  // move everyone to verified-empty open terrain so nothing clutters the shot
+  p.pos.x = -200; p.pos.z = 0;
+  mobs.forEach((e, i) => {
+    const s = skins[i] ?? skins[0];
+    e.templateId = s.tpl;
+    e.name = s.name;
+    e.level = s.level;
+    e.hp = e.maxHp = 800;
+    e.pos.x = p.pos.x + (i - 1) * 9;
+    e.pos.z = p.pos.z + 9;
+    e.dead = false;
+  });
+  p.facing = 0; // look +z toward the line-up
+  g.input.camYaw = 0;
+  g.input.camPitch = 0.42; // look down so each bar floats above its mob against the sky
+  g.input.camDist = 13;    // frame all three abreast
+  window.__npMobIds = mobs.map((e) => e.id);
+  return mobs.map((e) => ({ name: e.name, tpl: e.templateId, lvl: e.level }));
+});
+console.log('staged:', JSON.stringify(staged));
+
+await new Promise((r) => setTimeout(r, 1200));
+// re-assert pose right before the shot: pin HP full and freeze positions so no
+// drift / fall-damage / combat text sneaks into the frame
+await page.evaluate(() => {
+  const g = window.__game;
+  const p = g.sim.player;
+  (window.__npMobIds || []).forEach((id, i) => {
+    const e = g.sim.entities.get(id);
+    if (!e) return;
+    e.hp = e.maxHp; e.dead = false; e.inCombat = false;
+    e.pos.x = p.pos.x + (i - 1) * 9; e.pos.z = p.pos.z + 9;
+  });
+});
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({ path: 'tmp/elite_nameplates.png' });
+console.log('saved tmp/elite_nameplates.png');
+// tight crop on the nameplate row for a readable close-up of the frames
+await page.screenshot({ path: 'tmp/elite_nameplates_crop.png', clip: { x: 470, y: 250, width: 700, height: 200 } });
+console.log('saved tmp/elite_nameplates_crop.png');
+
+await browser.close();

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1528,12 +1528,15 @@ export class Renderer {
         const diff = e.level - p.level;
         const template = MOBS[e.templateId];
         const elite = !!template?.elite;
+        const boss = !!template?.boss;
         const color = e.dead ? '#999' : diff >= 3 ? '#ff4444' : diff >= 1 ? '#ffaa33' : diff >= -2 ? '#ffe97a' : diff >= -5 ? '#7fdc4f' : '#9d9d9d';
         const mobName = e.ownerId !== null ? e.name : mobDisplayName(e.templateId);
         const name = e.dead ? t('worldContent.corpseName', { name: mobName }) : `[${e.level}${elite ? '+' : ''}] ${mobName}`;
         const hpDisplay = e.dead ? 'none' : '';
         const marker = e.lootable ? '$' : elite && !e.dead ? '◆' : '';
-        this.setNameplateStatic(v, `mob|${name}|${color}|${hpDisplay}|${marker}`, name, color, hpDisplay, marker, 'np-marker loot', '1');
+        // classic "dragon frame" cue: gold bar frame for elites, red for bosses (live mobs only)
+        const frame = e.dead ? '' : boss ? 'boss' : elite ? 'elite' : '';
+        this.setNameplateStatic(v, `mob|${name}|${color}|${hpDisplay}|${marker}|${frame}`, name, color, hpDisplay, marker, 'np-marker loot', '1', frame);
         this.setNameplateHp(v, e);
       }
     }
@@ -1548,12 +1551,15 @@ export class Renderer {
     marker: string,
     markerClass: string,
     opacity: string,
+    frame = '',
   ): void {
     if (sig === v.nameplateSig) return;
     v.nameplateSig = sig;
     v.nameEl.textContent = name;
     v.nameEl.style.color = color;
     v.hpBar.style.display = hpDisplay;
+    v.hpBar.classList.toggle('elite', frame === 'elite');
+    v.hpBar.classList.toggle('boss', frame === 'boss');
     v.markerEl.textContent = marker;
     v.markerEl.className = markerClass;
     v.nameplate.style.opacity = opacity;


### PR DESCRIPTION
## What

Gives elite and boss mobs a distinct **nameplate health-bar frame**, mirroring classic WoW's gold/red "dragon frame" danger cue.

Today elites are only marked by a `+` after the level and a small `◆` glyph — the health bar itself looks identical to a trash mob's, so you can't read a pull's danger at a glance. This styles the bar frame:

- **elite** (non-boss) → golden border + soft gold glow
- **boss** → red border + stronger red glow
- **normal** → unchanged plain bar

## Screenshot

Normal **Forest Wolf** (plain) · elite **Crypt Shambler** (gold) · boss **Morthen the Gravecaller** (red):

![elite/boss nameplate frames — close-up](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/elite-nameplate-frame/docs/screenshots/elite_nameplates_crop.png)

<details><summary>Full-scene view</summary>

![full scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/elite-nameplate-frame/docs/screenshots/elite_nameplates.png)

</details>

## How

Pure presentation. The renderer toggles `.elite`/`.boss` classes on the existing `np-hpbar` div from `MOBS[e.templateId]` (the static `MobTemplate.elite`/`.boss` flags), with two small CSS rules in `index.html`. Because `templateId` + the static `MOBS` table are identical offline (`Sim`) and online (`ClientWorld`), it works on both hosts for free — no `IWorld` change needed.

- The level-difficulty **name color** (red/orange/yellow/green/grey) is left untouched.
- **Live mobs only** — corpses keep the plain bar.

## Files

- `src/render/renderer.ts` — toggle `elite`/`boss` classes on the nameplate bar
- `index.html` — two `.np-hpbar.elite` / `.np-hpbar.boss` CSS rules
- `scripts/elite_nameplate_shot.mjs` — visual-capture script that stages a normal/elite/boss line-up (used for the screenshots above)

## Testing

- `npx tsc --noEmit` clean.
- Render/CSS-only (no sim logic), verified visually via the included capture script against `npm run dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)