### PR TITLE
feat(ui): minimap coordinate readout under the minimap

### DIFF
--- a/index.html
+++ b/index.html
@@ -649,6 +649,8 @@
   #minimap-wrap { position: absolute; right: 12px; top: 10px; width: 170px; text-align: center; }
   #zone-label { font-size: 13px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 3px #000; margin-bottom: 3px; letter-spacing: 0.5px; }
   #minimap { border-radius: 50%; border: 4px solid var(--border); outline: 1px solid #000; box-shadow: 0 0 14px #000c, inset 0 0 20px #0008; }
+  #minimap-coords { margin-top: 4px; display: inline-block; padding: 1px 8px; font-size: 11px; font-variant-numeric: tabular-nums;
+    color: #e8d9b0; background: #0008; border: 1px solid var(--border); border-radius: 9px; text-shadow: 1px 1px 2px #000; letter-spacing: 0.3px; }
 
   /* ---------- community HUD ---------- */
   /* Discord/GitHub: bottom-right, directly below the micro-menu, right-aligned with it. */
@@ -4343,6 +4345,7 @@
     <div id="minimap-wrap">
       <div id="zone-label" data-i18n="entities.zones.eastbrook_vale.name">Eastbrook Vale</div>
       <canvas id="minimap" width="162" height="162"></canvas>
+      <div id="minimap-coords" title="Your current world coordinates" aria-label="Coordinates">0, 0</div>
     </div>
 
     <div id="community-hud" data-i18n-aria="hud.core.communityLinks" aria-label="Community links">

--- a/scripts/minimap_coords_visual.mjs
+++ b/scripts/minimap_coords_visual.mjs
@@ -1,0 +1,53 @@
+// Screenshot the minimap coordinate readout through a real offline client.
+// Boots offline, walks to a couple of positions, and element-clips #minimap-wrap
+// so the new #minimap-coords pill is visible under the minimap.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1280,800', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 800 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(200);
+await page.type('#char-name', 'Wayra');
+await page.click('#offline-select .mini-class[data-class="hunter"]');
+await page.click('#btn-start-offline');
+await sleep(3000);
+await page.evaluate(() => document.querySelector('#mobile-preflight-continue')?.click());
+await sleep(500);
+
+async function shotAt(x, z, name) {
+  // place the player at a known spot; offline sim lets us set pos directly.
+  await page.evaluate((px, pz) => {
+    const p = window.__game.sim.player;
+    p.pos.x = px;
+    p.pos.z = pz;
+  }, x, z);
+  await sleep(400); // let updateMinimapCoords run a frame
+  const coords = await page.evaluate(() => document.querySelector('#minimap-coords')?.textContent);
+  console.log(`${name}: coords pill =`, JSON.stringify(coords));
+  const el = await page.$('#minimap-wrap');
+  await el.screenshot({ path: `tmp/${name}.png` });
+}
+
+await shotAt(52, 18, 'minimap_coords_a');
+await shotAt(-120, 240, 'minimap_coords_b');
+
+// a full-HUD shot for context
+await page.screenshot({ path: 'tmp/minimap_coords_full.png' });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 5).join('\n') : 'no page errors');
+await browser.close();

--- a/src/ui/coords.ts
+++ b/src/ui/coords.ts
@@ -1,0 +1,10 @@
+// Pure, DOM-free formatter for the minimap coordinate readout. Kept separate
+// from hud.ts so it can be unit-tested in isolation (mirrors xp_bar.ts /
+// clock.ts). The world uses yard-space x (east-west) and z (north-south); the
+// readout floors them to whole yards so the text stays stable as the player
+// walks, matching the coordinates the /where chat command reports.
+export function formatMinimapCoords(x: number, z: number): string {
+  const fx = Number.isFinite(x) ? Math.floor(x) : 0;
+  const fz = Number.isFinite(z) ? Math.floor(z) : 0;
+  return `${fx}, ${fz}`;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { formatMinimapCoords } from './coords';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -270,6 +271,7 @@ export class Hud {
   private hotDomSkippedWrites = 0;
   private minimapCtx: CanvasRenderingContext2D;
   private minimapBg: HTMLCanvasElement;
+  private lastCoordsText = ''; // cache so we only touch the DOM when coords change
   private mapBg: HTMLCanvasElement | null = null;
   private openLootMobId: number | null = null;
   private openVendorNpcId: number | null = null;
@@ -1749,7 +1751,7 @@ export class Hud {
       $('#arena-window').style.display = 'none';
     }
     this.arenaMatchSeen = inArenaMatch;
-    if (fastHud) this.updateMinimap();
+    if (fastHud) { this.updateMinimap(); this.updateMinimapCoords(); }
     if (slowHud && $('#social-window').classList.contains('open')) {
       const struct = this.socialStructSig();
       if (struct !== this.lastSocialStruct) {
@@ -1856,6 +1858,18 @@ export class Hud {
     }
     ctx.putImageData(img, 0, 0);
     return c;
+  }
+
+  // Classic-style coordinate readout pinned under the minimap. Reads only the
+  // player position (already mirrored online), and diffs against the last text
+  // so the DOM node is touched at most once per whole-yard step.
+  private updateMinimapCoords(): void {
+    const p = this.sim.player;
+    const text = formatMinimapCoords(p.pos.x, p.pos.z);
+    if (text === this.lastCoordsText) return;
+    this.lastCoordsText = text;
+    const el = $('#minimap-coords');
+    if (el) el.textContent = text;
   }
 
   private updateMinimap(): void {

--- a/tests/coords_format.test.ts
+++ b/tests/coords_format.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { formatMinimapCoords } from '../src/ui/coords';
+
+describe('formatMinimapCoords', () => {
+  it('floors both axes to whole yards', () => {
+    expect(formatMinimapCoords(52.9, 18.1)).toBe('52, 18');
+  });
+
+  it('handles the origin', () => {
+    expect(formatMinimapCoords(0, 0)).toBe('0, 0');
+  });
+
+  it('floors toward negative infinity for negative coordinates', () => {
+    expect(formatMinimapCoords(-3.2, -0.5)).toBe('-4, -1');
+  });
+
+  it('falls back to 0 for non-finite inputs', () => {
+    expect(formatMinimapCoords(NaN, Infinity)).toBe('0, 0');
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-style **coordinate readout** pinned under the minimap. It shows the player's current world position and updates live as you move — a small but commonly-missed HUD element that complements the existing zone label and minimap.

![Coordinate pill in Eastbrook Vale](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/minimap-coords/docs/pr-assets/minimap-coords/coords-eastbrook.png)
![Coordinate pill in Mirefen Marsh](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/minimap-coords/docs/pr-assets/minimap-coords/coords-mirefen.png)

In context (top-right of the HUD):

![Full HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/minimap-coords/docs/pr-assets/minimap-coords/full-hud.png)

## How

Pure presentation — **zero sim / IWorld / net / server changes** and no determinism or RL impact:

- New DOM-free helper `src/ui/coords.ts` (`formatMinimapCoords(x, z)`) floors both axes to whole yards (matching the coordinates `/where` reports) and guards non-finite input. Unit-tested in isolation, mirroring the `xp_bar.ts` pattern.
- `index.html`: a `#minimap-coords` pill inside `#minimap-wrap` plus gold-bordered CSS that matches the surrounding HUD.
- `src/ui/hud.ts`: `updateMinimapCoords()` runs right after `updateMinimap()`, reading only `IWorld.player.pos` (already mirrored in online snapshots, so it works **offline and online** for free). The text is diffed against the last value so the DOM node is touched at most once per whole-yard step.

## Testing

- `tests/coords_format.test.ts` — 4 cases (floor, origin, negative coords, non-finite fallback).
- Full suite green: **652 tests pass**, `tsc --noEmit` clean.
- Screenshots captured via `scripts/minimap_coords_visual.mjs` (offline client, real render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
