### PR TITLE
feat(ui): combat indicator on the player unit frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -454,6 +454,15 @@
     display: flex; align-items: center; justify-content: center;
     text-shadow: 1px 1px 1px #000; z-index: 3;
   }
+  /* crossed-swords combat indicator on the player portrait (classic WoW) */
+  .combat-flash {
+    position: absolute; top: -4px; right: -4px; width: 22px; height: 22px;
+    display: none; align-items: center; justify-content: center;
+    color: #ff5040; font-size: 15px; line-height: 1; z-index: 4;
+    pointer-events: none; text-shadow: 0 0 4px #000, 0 0 6px #ff5040;
+  }
+  #player-frame.combat .combat-flash { display: flex; animation: pf-combat-pulse 1s ease-in-out infinite; }
+  #player-frame.combat .portrait { border-color: #e74c3c; box-shadow: 0 0 8px #e74c3c99, inset 0 0 12px #0009; }
   .uf-bars { width: 190px; margin-left: -8px; padding: 5px 8px 5px 14px;
     background: var(--panel-bg); border: 2px solid var(--border); outline: 1px solid #000;
     border-radius: 0 6px 6px 0; box-shadow: 0 2px 10px #000a; }
@@ -4369,6 +4378,7 @@
             <div class="portrait-wrap">
               <div class="portrait"><canvas id="pf-portrait" width="54" height="54"></canvas></div>
               <div class="level-chip" id="pf-level">1</div>
+              <div class="combat-flash" id="pf-combat" title="In Combat">⚔</div>
             </div>
             <div class="uf-bars">
               <div class="uf-name" id="pf-name"></div>

--- a/scripts/player_combat_indicator_shot.mjs
+++ b/scripts/player_combat_indicator_shot.mjs
@@ -1,0 +1,69 @@
+// Screenshot the player-frame combat indicator (crossed swords + red portrait
+// ring) in its out-of-combat and in-combat states. Boots the offline world,
+// aggroes a nearby wild mob onto the player to engage combat, and crops the
+// player unit frame for a clean before/after comparison.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Valdris');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 1500));
+
+const clip = async (name) => {
+  const el = await page.$('#player-frame');
+  const box = await el.boundingBox();
+  const pad = 14;
+  await page.screenshot({
+    path: `tmp/${name}.png`,
+    clip: { x: box.x - pad, y: box.y - pad, width: box.width + pad * 2, height: box.height + pad * 2 },
+  });
+  console.log(`wrote tmp/${name}.png`);
+};
+
+// out of combat
+await new Promise((r) => setTimeout(r, 400));
+await clip('combat_indicator_off');
+
+// aggro the nearest wild mob onto the player to enter combat
+const ok = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.hostile) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  if (!mob) return false;
+  mob.pos.x = p.pos.x + 4; mob.pos.z = p.pos.z;
+  mob.aggroTargetId = p.id;
+  sim.targetEntity(mob.id);
+  return true;
+});
+console.log('aggroed mob:', ok);
+
+// let the HUD update loop pick up the combat state and start the pulse
+await new Promise((r) => setTimeout(r, 700));
+await clip('combat_indicator_on');
+
+if (errors.length) console.log('errors:', errors.join('\n'));
+await browser.close();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1727,6 +1727,9 @@ export class Hud {
       );
       music.update(zone, inCombat);
 
+      // classic combat indicator: crossed swords + red ring on the player portrait
+      $('#player-frame').classList.toggle('combat', inCombat);
+
       this.updateQuestTracker();
       this.updatePartyFrames();
       this.updateTradeWindow();


### PR DESCRIPTION
## What

Classic WoW flashes a crossed-swords icon on your **own** unit frame (and reddens the portrait ring) while you are in combat, so you always know your engagement state at a glance — independent of any target. The party-member frames in this game already show a pulsing combat badge, but the player's own frame had no such cue. This adds it.

| Out of combat | In combat |
|---|---|
| ![off](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/player-combat-indicator/docs/screenshots/combat-indicator-off.png) | ![on](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/player-combat-indicator/docs/screenshots/combat-indicator-on.png) |

## How

- Reuses the combat estimate the HUD **already computes** for the soundtrack (`hud.ts`): a mob aggroed on you, or a combat event within the last 5s. No new data.
- Toggles a `combat` class on `#player-frame`; CSS shows a pulsing crossed-swords badge over the portrait (reusing the existing `pf-combat-pulse` keyframe used by party frames) and a red portrait ring.
- **No sim / `IWorld` change.** The indicator is derived entirely from already-mirrored client state, so it works offline and online for free.

## Testing

- `npx tsc --noEmit` passes.
- Visual verified via the included `scripts/player_combat_indicator_shot.mjs` harness (boots the offline world, aggroes a wild mob, crops the player frame for the before/after shots above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)