### PR TITLE
feat(render): ambient critters — wandering wildlife near the player

### DIFF
--- a/scripts/critter_shot.mjs
+++ b/scripts/critter_shot.mjs
@@ -1,0 +1,88 @@
+// Screenshot tour for ambient critters: boots the offline game, stands in open
+// meadow, and captures the wandering wildlife — a wide ambient shot plus a tight
+// projected crop of the nearest critter. Writes PNGs to tmp/. Needs `npm run dev`
+// (:5173). Override URL with GAME_URL=.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const W = 1600, H = 900;
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: [`--window-size=${W},${H}`, '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: W, height: H },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Naturalist');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// god-mode + open meadow clear of hub props; pull the camera up for a wide framing
+await page.evaluate(() => {
+  const g = window.__game;
+  const p = g.sim.player;
+  p.pos.x = 150; p.pos.z = 210;
+  p.hp = p.maxHp = 999999;
+  g.renderer.camPitch = 0.45;
+  g.renderer.camDist = 16;
+});
+await new Promise((r) => setTimeout(r, 4000)); // let the pool populate + wander
+await page.screenshot({ path: 'tmp/critters_01_meadow.png' });
+
+// Find the nearest in-frame critter, project it to screen, and crop a detail shot.
+const crop = await page.evaluate(() => {
+  const g = window.__game;
+  const cam = g.renderer.camera;
+  const cf = g.renderer.critters;
+  if (!cf) return null;
+  const p = g.sim.player;
+  let best = null, bd = 1e9;
+  for (const m of cf.group.children) {
+    if (!m.visible) continue;
+    const d = Math.hypot(m.position.x - p.pos.x, m.position.z - p.pos.z);
+    if (d < bd) { bd = d; best = m; }
+  }
+  if (!best) return null;
+  const v = best.position.clone();
+  v.y += 0.25;
+  v.project(cam);
+  return {
+    sx: (v.x * 0.5 + 0.5) * window.innerWidth,
+    sy: (-v.y * 0.5 + 0.5) * window.innerHeight,
+    species: best.geometry.uuid,
+    dist: +bd.toFixed(1),
+  };
+});
+console.log('nearest critter:', JSON.stringify(crop));
+if (crop) {
+  const S = 280;
+  const x = Math.max(0, Math.min(W - S, Math.round(crop.sx - S / 2)));
+  const y = Math.max(0, Math.min(H - S, Math.round(crop.sy - S / 2)));
+  await page.screenshot({ path: 'tmp/critters_02_closeup.png', clip: { x, y, width: S, height: S } });
+}
+
+// walk toward them to provoke the flee behaviour
+await page.keyboard.down('w');
+await new Promise((r) => setTimeout(r, 1500));
+await page.keyboard.up('w');
+await page.screenshot({ path: 'tmp/critters_03_flee.png' });
+
+if (errors.length) {
+  console.log('=== PAGE ERRORS ===');
+  for (const e of errors.slice(0, 20)) console.log(e);
+} else {
+  console.log('no page errors');
+}
+await browser.close();

--- a/src/render/critters.ts
+++ b/src/render/critters.ts
@@ -1,0 +1,202 @@
+// Ambient critters — small decorative wildlife (rabbits, squirrels, songbirds)
+// that wander the overworld near the player for atmosphere. PRESENTATION ONLY:
+// these have no presence in the sim/IWorld, so they cost nothing on the wire and
+// "work online for free". A small pool follows the player like the grass ring
+// (foliage.ts): when one drifts past the cull radius it relocates ahead of the
+// camera onto valid ground. Procedural primitive geometry — no GLB assets.
+
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
+import {
+  DUNGEON_X_THRESHOLD, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z,
+} from '../sim/data';
+import { terrainHeight, WATER_LEVEL } from '../sim/world';
+import { GFX } from './gfx';
+
+export interface CritterField {
+  group: THREE.Group;
+  update(px: number, pz: number, dt: number): void;
+}
+
+const CULL_RADIUS = 36; // beyond this from the player a critter relocates
+const SPAWN_MIN = 16; // relocate ring around the player (min..max yd)
+const SPAWN_MAX = 30;
+const FLEE_DIST = 6; // critters bolt when the player gets this close
+const EDGE = 8; // keep clear of the world edges
+
+// A tiny seeded RNG so placement/wander variety stays off Math.random (matching
+// the render layer's deterministic-generation convention).
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0; a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+type Species = 'rabbit' | 'squirrel' | 'bird';
+
+// Build one merged body per species out of primitives, feet resting at y=0.
+function buildSpeciesGeo(species: Species): THREE.BufferGeometry {
+  const parts: THREE.BufferGeometry[] = [];
+  const sphere = (r: number, sx: number, sy: number, sz: number, x: number, y: number, z: number) => {
+    const g = new THREE.SphereGeometry(r, 8, 6);
+    g.scale(sx, sy, sz); g.translate(x, y, z); parts.push(g);
+  };
+  if (species === 'bird') {
+    sphere(0.10, 1, 0.9, 1.4, 0, 0.12, 0); // body
+    sphere(0.07, 1, 1, 1, 0, 0.20, 0.10); // head
+    const beak = new THREE.ConeGeometry(0.03, 0.08, 5);
+    beak.rotateX(Math.PI / 2); beak.translate(0, 0.20, 0.18); parts.push(beak);
+    for (const s of [-1, 1]) sphere(0.07, 1.4, 0.25, 0.8, s * 0.09, 0.13, 0); // wings
+  } else {
+    const big = species === 'rabbit';
+    sphere(0.18, 1, 0.9, 1.3, 0, 0.16, 0); // body
+    sphere(0.12, 1, 1, 1, 0, 0.26, 0.18); // head
+    if (big) {
+      for (const s of [-1, 1]) { // upright ears
+        const ear = new THREE.BoxGeometry(0.04, 0.18, 0.03);
+        ear.translate(s * 0.05, 0.40, 0.18); parts.push(ear);
+      }
+      sphere(0.06, 1, 1, 1, 0, 0.16, -0.18); // cottontail
+    } else {
+      sphere(0.13, 0.7, 1.5, 0.6, 0, 0.30, -0.20); // bushy squirrel tail
+    }
+  }
+  return mergeGeometries(parts.map((p) => p.toNonIndexed())) ?? parts[0];
+}
+
+const TINT: Record<Species, number> = {
+  rabbit: 0x9a8166, squirrel: 0xa05a30, bird: 0x6b8fb5,
+};
+
+interface Critter {
+  mesh: THREE.Mesh;
+  species: Species;
+  x: number; z: number;
+  heading: number; // radians
+  moving: boolean;
+  speed: number;
+  hopPhase: number;
+  turnT: number; // until next heading/pause decision
+  baseY: number; // hover height (birds) above ground
+}
+
+export function buildCritters(seed: number): CritterField {
+  const group = new THREE.Group();
+  group.name = 'critters';
+  const rng = mulberry32(seed ^ 0x6c12a7);
+  const count = GFX.standardMaterials ? 16 : 7;
+
+  const geos: Record<Species, THREE.BufferGeometry> = {
+    rabbit: buildSpeciesGeo('rabbit'),
+    squirrel: buildSpeciesGeo('squirrel'),
+    bird: buildSpeciesGeo('bird'),
+  };
+  const mats: Record<Species, THREE.Material> = {
+    rabbit: matFor('rabbit'), squirrel: matFor('squirrel'), bird: matFor('bird'),
+  };
+  function matFor(s: Species): THREE.Material {
+    const opts = { color: TINT[s], roughness: 0.85, metalness: 0 };
+    return GFX.standardMaterials
+      ? new THREE.MeshStandardMaterial(opts)
+      : new THREE.MeshLambertMaterial({ color: TINT[s] });
+  }
+
+  const pickSpecies = (): Species => {
+    const r = rng();
+    return r < 0.45 ? 'rabbit' : r < 0.75 ? 'squirrel' : 'bird';
+  };
+
+  const critters: Critter[] = [];
+  for (let i = 0; i < count; i++) {
+    const species = pickSpecies();
+    const mesh = new THREE.Mesh(geos[species], mats[species]);
+    mesh.castShadow = GFX.standardMaterials;
+    mesh.visible = false;
+    group.add(mesh);
+    critters.push({
+      mesh, species, x: 0, z: 0, heading: rng() * Math.PI * 2,
+      moving: false, speed: 0, hopPhase: 0, turnT: 0,
+      baseY: species === 'bird' ? 0.25 + rng() * 0.4 : 0,
+    });
+  }
+
+  const validGround = (x: number, z: number): boolean => {
+    if (Math.abs(x) > WORLD_MAX_X - EDGE) return false;
+    if (z < WORLD_MIN_Z + EDGE || z > WORLD_MAX_Z - EDGE) return false;
+    if (x > DUNGEON_X_THRESHOLD - 24) return false;
+    return terrainHeight(x, z, seed) > WATER_LEVEL + 0.8;
+  };
+
+  const relocate = (c: Critter, px: number, pz: number): void => {
+    for (let attempt = 0; attempt < 8; attempt++) {
+      const ang = rng() * Math.PI * 2;
+      const d = SPAWN_MIN + rng() * (SPAWN_MAX - SPAWN_MIN);
+      const x = px + Math.cos(ang) * d;
+      const z = pz + Math.sin(ang) * d;
+      if (validGround(x, z)) {
+        c.x = x; c.z = z; c.heading = rng() * Math.PI * 2;
+        c.turnT = 0.5 + rng() * 2; c.moving = false;
+        return;
+      }
+    }
+    // no valid spot this frame — hide and retry next tick
+    c.x = px; c.z = pz; c.mesh.visible = false;
+  };
+
+  return {
+    group,
+    update(px: number, pz: number, dt: number): void {
+      // no wildlife indoors (dungeons/arena live past the strip)
+      if (px > DUNGEON_X_THRESHOLD) {
+        if (group.visible) group.visible = false;
+        return;
+      }
+      group.visible = true;
+
+      for (const c of critters) {
+        const dx = c.x - px, dz = c.z - pz;
+        const dist = Math.hypot(dx, dz);
+        if (dist > CULL_RADIUS || !validGround(c.x, c.z)) {
+          relocate(c, px, pz);
+          continue;
+        }
+
+        // flee when the player closes in, else gentle wander
+        let fleeing = false;
+        if (dist < FLEE_DIST) {
+          c.heading = Math.atan2(dz, dx); // away from player
+          c.moving = true;
+          fleeing = true;
+        } else {
+          c.turnT -= dt;
+          if (c.turnT <= 0) {
+            c.moving = rng() > 0.35;
+            if (c.moving) c.heading += (rng() - 0.5) * 2.2;
+            c.turnT = 0.6 + rng() * 2.4;
+          }
+        }
+
+        const baseSpeed = c.species === 'bird' ? 2.4 : 1.5;
+        c.speed = c.moving ? (fleeing ? baseSpeed * 2.4 : baseSpeed) : 0;
+        if (c.speed > 0) {
+          c.x += Math.cos(c.heading) * c.speed * dt;
+          c.z += Math.sin(c.heading) * c.speed * dt;
+          c.hopPhase += dt * (c.species === 'bird' ? 18 : 9);
+        }
+
+        const groundY = terrainHeight(c.x, c.z, seed);
+        // rabbits/squirrels hop (sin arc while moving); birds bob in place
+        const motion = c.species === 'bird'
+          ? Math.sin(c.hopPhase) * 0.06
+          : (c.speed > 0 ? Math.abs(Math.sin(c.hopPhase)) * 0.16 : 0);
+        c.mesh.position.set(c.x, groundY + c.baseY + motion, c.z);
+        c.mesh.rotation.y = -c.heading + Math.PI / 2;
+        c.mesh.visible = true;
+      }
+    },
+  };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -26,6 +26,7 @@ import { buildWater, WaterView } from './water';
 import { buildClouds, buildSky, SkyView } from './sky';
 import { buildFoliage, FoliageView } from './foliage';
 import { buildFish, FishView } from './fish';
+import { buildCritters, CritterField } from './critters';
 import { shouldRenderStealthGhost } from './stealth';
 import { t } from '../ui/i18n';
 import { tEntity } from '../ui/entity_i18n';
@@ -237,6 +238,7 @@ export class Renderer {
   private terrainView: TerrainView;
   private foliage: FoliageView;
   private fish: FishView;
+  private critters: CritterField;
   private fogScratch = new THREE.Color();
   private flames: THREE.Mesh[];
   private fireLights: THREE.PointLight[];
@@ -439,6 +441,8 @@ export class Renderer {
     this.scene.add(this.foliage.group);
     this.fish = buildFish(this.sim.cfg.seed);
     this.scene.add(this.fish.group);
+    this.critters = buildCritters(this.sim.cfg.seed);
+    this.scene.add(this.critters.group);
     const props = buildProps(this.sim.cfg.seed);
     this.scene.add(props.group);
     this.flames = props.flames;
@@ -1298,6 +1302,7 @@ export class Renderer {
     this.propsView.update(this.camera.position.x, this.camera.position.y, this.camera.position.z, fogFar);
     this.foliage.update(p.pos.x, p.pos.z, this.camera.position.x, this.camera.position.z, fogFar);
     this.fish.update(p.pos.x, p.pos.z, dt);
+    this.critters.update(p.pos.x, p.pos.z, dt);
 
     this.vfx.update(dt);
 


### PR DESCRIPTION
## Ambient critters — wandering wildlife near the player

Classic-WoW overworlds are alive with little non-combat critters. This adds a small, render-only ambient-wildlife system so the meadows feel inhabited.

A player-centred pool of procedural critters — **rabbits**, **squirrels**, and **songbirds** — wanders the overworld near you. They hop/flutter, pause, change heading, and **bolt away when you get close**. As you travel, critters that fall behind quietly relocate ahead onto valid ground, exactly like the grass ring follows the player.

### Closeup & in-world
| Closeup (squirrel) | In meadow |
|---|---|
| ![closeup](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ambient-critters/docs/screenshots/ambient-critters-closeup.png) | ![meadow](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ambient-critters/docs/screenshots/ambient-critters-meadow.png) |

### How it fits the architecture
- **Presentation only.** Critters have no presence in `src/sim/` or `IWorld` — the renderer invents and animates them locally. So there's **zero wire cost** and it **works online for free** (same render path over `Sim` and `ClientWorld`).
- **No new assets.** Bodies are procedural primitive geometry (spheres/boxes merged) — no GLB, no `manifest.generated.ts` changes.
- **Follows the existing subsystem contract.** New `src/render/critters.ts` exports `buildCritters(seed) → { group, update(px,pz,dt) }`, modeled on the grass ring in `foliage.ts`: terrain-height–sampled placement (`terrainHeight`/`WATER_LEVEL`), dungeon-aware culling (`DUNGEON_X_THRESHOLD`), world-bounds clamping. Count scales with the `GFX` tier.
- **No `Math.random`** in placement/wander — a small seeded RNG keeps with the render layer's deterministic-generation convention.

### Wiring
`renderer.ts`: import + one field + `buildCritters(seed)` next to `buildFoliage`, and one `this.critters.update(p.pos.x, p.pos.z, dt)` call beside `foliage.update` in `sync()`.

### Testing
- `npx tsc --noEmit` clean.
- New `scripts/critter_shot.mjs` boots the offline game and captures the shots above (no critter-related console errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
