### PR TITLE
feat(ui): heading compass strip beneath the minimap

### DIFF
--- a/index.html
+++ b/index.html
@@ -661,6 +661,27 @@
   #zone-label { font-size: 13px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 3px #000; margin-bottom: 3px; letter-spacing: 0.5px; }
   #minimap { border-radius: 50%; border: 4px solid var(--border); outline: 1px solid #000; box-shadow: 0 0 14px #000c, inset 0 0 20px #0008; }
 
+  /* heading compass — a horizontal rose strip beneath the minimap */
+  #compass { position: relative; width: 162px; margin: 5px auto 0; }
+  #compass-strip { position: relative; height: 18px; overflow: hidden;
+    border: 2px solid var(--border); border-radius: 5px;
+    background: linear-gradient(#1c1a14, #100f0b);
+    box-shadow: inset 0 0 8px #000a;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent); }
+  #compass-track { position: absolute; inset: 0; }
+  .compass-mark { position: absolute; top: 50%; transform: translate(-50%, -50%);
+    font-family: var(--title-font); font-size: 11px; color: #b9ad86;
+    text-shadow: 1px 1px 2px #000; pointer-events: none; white-space: nowrap; }
+  .compass-mark.major { font-size: 13px; color: var(--gold); font-weight: 700; }
+  /* the fixed centre caret marks the direction the player faces */
+  #compass-center { position: absolute; left: 50%; top: -2px; width: 0; height: 0;
+    transform: translateX(-50%); border-left: 5px solid transparent;
+    border-right: 5px solid transparent; border-top: 6px solid var(--gold);
+    filter: drop-shadow(0 1px 1px #000); }
+  #compass-heading { margin-top: 2px; font-family: var(--title-font); font-size: 12px;
+    color: var(--gold); letter-spacing: 1px; text-shadow: 1px 1px 2px #000; }
+
   /* ---------- community HUD ---------- */
   /* Discord/GitHub: bottom-right, directly below the micro-menu, right-aligned with it. */
   /* Discord/GitHub: standalone square buttons matching the micro-menu (no panel
@@ -5307,6 +5328,11 @@
     <div id="minimap-wrap">
       <div id="zone-label" data-i18n="entities.zones.eastbrook_vale.name">Eastbrook Vale</div>
       <canvas id="minimap" width="162" height="162"></canvas>
+      <div id="compass" aria-label="Heading compass">
+        <div id="compass-strip"><div id="compass-track"></div></div>
+        <div id="compass-center"></div>
+        <div id="compass-heading">N</div>
+      </div>
     </div>
 
     <div id="community-hud" data-i18n-aria="hud.core.communityLinks" aria-label="Community links">

--- a/scripts/compass_visual.mjs
+++ b/scripts/compass_visual.mjs
@@ -1,0 +1,63 @@
+// Visual proof of the heading-compass strip beneath the minimap. Boots the
+// offline game headless, then rotates the player's facing through the four
+// cardinals and a diagonal, clipping the #minimap-wrap region each time so the
+// rose strip + centre caret + heading readout are clearly legible. Needs
+// `npm run dev` running (port 5173). Screenshots land in tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(300);
+await page.type('#char-name', 'Pathfinder');
+await page.click('#offline-select .mini-class[data-class="hunter"]');
+await sleep(150);
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 5, { timeout: 20000, polling: 200 });
+await sleep(1200);
+
+// facing radians → expected heading (world convention: 0 = north, right = -)
+const SHOTS = [
+  ['north', 0, 'N'],
+  ['east', -Math.PI / 2, 'E'],
+  ['south', Math.PI, 'S'],
+  ['west', Math.PI / 2, 'W'],
+  ['northeast', -Math.PI / 4, 'NE'],
+];
+
+const clip = await page.evaluate(() => {
+  const r = document.querySelector('#minimap-wrap').getBoundingClientRect();
+  // pad so the full strip + heading text are captured with a margin
+  return { x: Math.floor(r.x) - 8, y: Math.floor(r.y) - 6, width: Math.ceil(r.width) + 16, height: Math.ceil(r.height) + 28 };
+});
+
+for (const [name, facing, expect] of SHOTS) {
+  const heading = await page.evaluate((f) => {
+    const me = window.__game.sim.player;
+    me.facing = f; me.prevFacing = f;
+    window.__game.hud.update(0);
+    return document.querySelector('#compass-heading').textContent;
+  }, facing);
+  await sleep(150);
+  await page.screenshot({ path: `tmp/compass_${name}.png`, clip });
+  console.log(`${heading === expect ? 'OK  ' : 'FAIL'}  facing ${name} → heading "${heading}" (expected ${expect})`);
+}
+
+// a full-HUD wide shot for context
+await page.screenshot({ path: 'tmp/compass_full_hud.png' });
+console.log('wrote tmp/compass_*.png');
+await browser.close();

--- a/src/ui/compass.ts
+++ b/src/ui/compass.ts
@@ -1,0 +1,74 @@
+// Pure derivation of the heading-compass HUD strip. Kept DOM-free (like
+// xp_bar.ts) so the angle math can be snapshot-tested without a browser.
+//
+// World convention (see hud.ts minimap notes): Entity.facing is in radians with
+// 0 = +Z = "north", and turning right (clockwise from above) DECREASES facing.
+// A magnetic bearing is therefore -facing, normalised to [0, 360): N=0, E=90,
+// S=180, W=270 — the standard clockwise compass rose.
+
+export interface CompassMark {
+  label: string; // 'N', 'NE', 'E', ...
+  offsetFrac: number; // -1 (left edge) .. 0 (centre) .. 1 (right edge)
+  major: boolean; // true for the four cardinals (N/E/S/W)
+}
+
+export interface CompassView {
+  bearing: number; // 0..360, where the player is looking
+  heading: string; // nearest rose point label to the bearing
+  marks: CompassMark[]; // rose points within the visible window, left→right
+}
+
+// 8-point rose at 45° spacing.
+const ROSE: { label: string; deg: number; major: boolean }[] = [
+  { label: 'N', deg: 0, major: true },
+  { label: 'NE', deg: 45, major: false },
+  { label: 'E', deg: 90, major: true },
+  { label: 'SE', deg: 135, major: false },
+  { label: 'S', deg: 180, major: true },
+  { label: 'SW', deg: 225, major: false },
+  { label: 'W', deg: 270, major: true },
+  { label: 'NW', deg: 315, major: false },
+];
+
+// Facing radians → compass bearing degrees in [0, 360).
+export function bearingDegrees(facing: number): number {
+  if (!Number.isFinite(facing)) return 0;
+  const deg = (-facing * 180) / Math.PI;
+  return ((deg % 360) + 360) % 360;
+}
+
+// Signed shortest angular distance b-a, wrapped to (-180, 180].
+function angleDelta(a: number, b: number): number {
+  let d = ((b - a + 540) % 360) - 180;
+  if (d <= -180) d += 360;
+  return d;
+}
+
+// Nearest rose label to a bearing (used for the centred heading readout).
+export function headingLabel(bearing: number): string {
+  let best = ROSE[0];
+  let bestAbs = 360;
+  for (const p of ROSE) {
+    const ad = Math.abs(angleDelta(bearing, p.deg));
+    if (ad < bestAbs) {
+      bestAbs = ad;
+      best = p;
+    }
+  }
+  return best.label;
+}
+
+// Build the visible strip. halfWindowDeg is how many degrees fit between the
+// centre and either edge (default 90° → a 180° field of view).
+export function compassView(facing: number, halfWindowDeg = 90): CompassView {
+  const bearing = bearingDegrees(facing);
+  const marks: CompassMark[] = [];
+  for (const p of ROSE) {
+    const delta = angleDelta(bearing, p.deg); // -180..180; >0 is to the right
+    if (Math.abs(delta) <= halfWindowDeg) {
+      marks.push({ label: p.label, offsetFrac: delta / halfWindowDeg, major: p.major });
+    }
+  }
+  marks.sort((a, b) => a.offsetFrac - b.offsetFrac);
+  return { bearing, heading: headingLabel(bearing), marks };
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { compassView } from './compass';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -272,6 +273,10 @@ export class Hud {
   private hotDomSkippedWrites = 0;
   private minimapCtx: CanvasRenderingContext2D;
   private minimapBg: HTMLCanvasElement;
+  // heading compass: a pool of rose-label spans built once, repositioned per frame
+  private compassMarks = new Map<string, HTMLElement>();
+  private compassHeadingEl: HTMLElement | null = null;
+  private lastCompassHeading = '';
   private mapBg: HTMLCanvasElement | null = null;
   private openLootMobId: number | null = null;
   private openVendorNpcId: number | null = null;
@@ -366,6 +371,7 @@ export class Hud {
       if (target && (this.emoteWheelEl?.contains(target) || document.getElementById('mm-emote')?.contains(target) || document.getElementById('mobile-emote')?.contains(target))) return;
       this.hideEmoteWheel();
     });
+    this.initCompass();
     this.releaseSpiritBtnEl.addEventListener('click', () => {
       if (this.sim.arenaInfo?.match) return;
       this.sim.releaseSpirit();
@@ -1816,7 +1822,7 @@ export class Hud {
       $('#arena-window').style.display = 'none';
     }
     this.arenaMatchSeen = inArenaMatch;
-    if (fastHud) this.updateMinimap();
+    if (fastHud) { this.updateMinimap(); this.updateCompass(); }
     if (slowHud && $('#social-window').classList.contains('open')) {
       const struct = this.socialStructSig();
       if (struct !== this.lastSocialStruct) {
@@ -1926,6 +1932,43 @@ export class Hud {
     }
     ctx.putImageData(img, 0, 0);
     return c;
+  }
+
+  // Build the compass rose-label pool once. Each of the 8 points gets a span
+  // that we later slide horizontally; positioning happens in updateCompass().
+  private initCompass(): void {
+    const track = $('#compass-track');
+    if (!track) return;
+    for (const label of ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']) {
+      const el = document.createElement('span');
+      el.className = 'compass-mark' + (label.length === 1 ? ' major' : '');
+      el.textContent = label;
+      track.appendChild(el);
+      this.compassMarks.set(label, el);
+    }
+    this.compassHeadingEl = $('#compass-heading');
+  }
+
+  private updateCompass(): void {
+    if (this.compassMarks.size === 0) return;
+    const view = compassView(this.sim.player.facing);
+    const visible = new Set<string>();
+    for (const m of view.marks) {
+      const el = this.compassMarks.get(m.label);
+      if (!el) continue;
+      visible.add(m.label);
+      // offsetFrac -1..1 → 0..100% across the strip; fade marks near the edges
+      el.style.left = `${(m.offsetFrac * 0.5 + 0.5) * 100}%`;
+      el.style.opacity = `${Math.max(0.2, 1 - Math.abs(m.offsetFrac) * 0.85)}`;
+      el.style.display = 'block';
+    }
+    for (const [label, el] of this.compassMarks) {
+      if (!visible.has(label)) el.style.display = 'none';
+    }
+    if (this.compassHeadingEl && view.heading !== this.lastCompassHeading) {
+      this.lastCompassHeading = view.heading;
+      this.compassHeadingEl.textContent = view.heading;
+    }
   }
 
   private updateMinimap(): void {

--- a/tests/compass.test.ts
+++ b/tests/compass.test.ts
@@ -1,0 +1,57 @@
+// Heading-compass pure model (src/ui/compass.ts). Verifies the facing→bearing
+// mapping under the world convention (facing 0 = north, turning right decreases
+// facing), the nearest-rose heading label, and the visible-strip windowing.
+import { describe, expect, it } from 'vitest';
+import { bearingDegrees, headingLabel, compassView } from '../src/ui/compass';
+
+describe('bearingDegrees', () => {
+  it('maps the four cardinals (facing 0 = north, right turn = +bearing)', () => {
+    expect(bearingDegrees(0)).toBeCloseTo(0); // north
+    expect(bearingDegrees(-Math.PI / 2)).toBeCloseTo(90); // turned right → east
+    expect(bearingDegrees(Math.PI)).toBeCloseTo(180); // south
+    expect(bearingDegrees(Math.PI / 2)).toBeCloseTo(270); // turned left → west
+  });
+
+  it('normalises into [0, 360) and guards non-finite input', () => {
+    expect(bearingDegrees(-2 * Math.PI)).toBeCloseTo(0);
+    expect(bearingDegrees(NaN)).toBe(0);
+    expect(bearingDegrees(Infinity)).toBe(0);
+  });
+});
+
+describe('headingLabel', () => {
+  it('picks the nearest rose point', () => {
+    expect(headingLabel(0)).toBe('N');
+    expect(headingLabel(44)).toBe('NE');
+    expect(headingLabel(90)).toBe('E');
+    expect(headingLabel(359)).toBe('N'); // wraps across 0
+  });
+});
+
+describe('compassView', () => {
+  it('centres the faced direction at offsetFrac 0', () => {
+    const v = compassView(0); // facing north
+    const north = v.marks.find((m) => m.label === 'N');
+    expect(north?.offsetFrac).toBeCloseTo(0);
+    expect(v.heading).toBe('N');
+  });
+
+  it('only includes rose points inside the ±window and sorts left→right', () => {
+    const v = compassView(0, 90); // window = N's ±90° → W..N..E inclusive
+    const labels = v.marks.map((m) => m.label);
+    expect(labels).toEqual(['W', 'NW', 'N', 'NE', 'E']);
+    expect(labels).not.toContain('S');
+    // offsetFracs must be ascending and bounded to [-1, 1]
+    for (let i = 1; i < v.marks.length; i++) {
+      expect(v.marks[i].offsetFrac).toBeGreaterThanOrEqual(v.marks[i - 1].offsetFrac);
+    }
+    expect(Math.min(...v.marks.map((m) => m.offsetFrac))).toBeGreaterThanOrEqual(-1);
+    expect(Math.max(...v.marks.map((m) => m.offsetFrac))).toBeLessThanOrEqual(1);
+  });
+
+  it('flags the four cardinals as major', () => {
+    const v = compassView(0);
+    expect(v.marks.find((m) => m.label === 'N')?.major).toBe(true);
+    expect(v.marks.find((m) => m.label === 'NE')?.major).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The minimap is **north-up and never rotates**, so nothing on the HUD tells you which way you're actually *facing*. This adds a classic-style **heading compass** under the minimap:

- an 8-point rose strip (N / NE / E / …) that scrolls smoothly as you turn,
- a fixed gold caret marking the direction you face,
- a heading readout (e.g. `NE`) below the strip.

| Facing North | Facing East | Facing North-East |
|---|---|---|
| ![north](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/compass-heading/docs/pr-assets/compass-heading/compass_north.png) | ![east](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/compass-heading/docs/pr-assets/compass-heading/compass_east.png) | ![ne](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/compass-heading/docs/pr-assets/compass-heading/compass_northeast.png) |

Full HUD for context:

![full hud](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/compass-heading/docs/pr-assets/compass-heading/compass_full_hud.png)

## How

Pure presentation. It reads only `IWorld.player.facing`, which is already mirrored to online clients via the snapshot `f` field — so it works **offline and online** with **zero `sim`/`IWorld`/`net`/server changes** and no determinism or RL impact.

- **`src/ui/compass.ts`** — DOM-free model (`bearingDegrees` / `headingLabel` / `compassView`) following the `xp_bar.ts` testable-module pattern. Honors the project's world convention (`facing 0 = +Z = north`, turning right decreases facing → bearing `= -facing`).
- **`src/ui/hud.ts`** — a pool of rose-label spans built once (`initCompass`) and repositioned each frame (`updateCompass`), called right beside `updateMinimap()`. No per-frame `innerHTML` churn.
- **`index.html`** — `#compass` markup under the minimap canvas + scoped CSS (edge-fade mask, gold caret, gold cardinals).

## Testing

- `tests/compass.test.ts` — facing→bearing mapping for all four cardinals, normalization/non-finite guards, nearest-label, and visible-window selection/sort. New module is fully unit-covered.
- Full suite: **654 passing**, `tsc --noEmit` clean.
- `scripts/compass_visual.mjs` — headless offline screenshot tour (the images above), which also asserts the rendered heading matches each facing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)