### PR TITLE
feat(warlock): add demon pet system (Imp and Voidwalker)

### DIFF
--- a/scripts/smoke_warlock.mjs
+++ b/scripts/smoke_warlock.mjs
@@ -1,0 +1,179 @@
+// Warlock pet E2E: Summon Imp auto-firebolts a wolf while the player idles;
+// Summon Voidwalker (lvl 10) charges in, melees, and taunts like a hunter pet.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+let fail = 0;
+const check = (name, cond, extra = '') => {
+  console.log(`${cond ? 'OK  ' : 'FAIL'} ${name}${extra ? ' | ' + extra : ''}`);
+  if (!cond) fail++;
+};
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error' && !/project stats|404|Failed to load resource/i.test(m.text())) errors.push('CONSOLE: ' + m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(200);
+await page.type('#char-name', 'Warlockname');
+await page.click('#offline-select .mini-class[data-class="warlock"]');
+await page.click('#btn-start-offline');
+await sleep(1500);
+
+// ---- Summon Imp unlocks at level 5 ----
+await page.evaluate(() => { window.__game.sim.setPlayerLevel(5); });
+const known = await page.evaluate(() => window.__game.sim.known.map((k) => k.def.id));
+check('Summon Imp in warlock kit at lvl 5', known.includes('summon_imp'), known.join(','));
+
+// summon the imp (3s cast) and confirm the pet appears
+await page.evaluate(() => { window.__game.sim.player.resource = window.__game.sim.player.maxResource; });
+let imp = null;
+for (let i = 0; i < 40 && !imp; i++) {
+  imp = await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    if (!p.castingAbility && p.gcdRemaining <= 0 && !sim.petOf(p.id)) sim.castAbility('summon_imp');
+    const pet = sim.petOf(p.id);
+    return pet ? { id: pet.id, templateId: pet.templateId, hp: pet.hp } : null;
+  });
+  if (!imp) await sleep(400);
+}
+check('Summon Imp conjures a pet', !!imp && imp.templateId === 'warlock_imp', imp ? imp.templateId : 'none');
+
+// pull a wolf, then IDLE the player — only the imp fights. If the wolf bleeds, the imp auto-firebolts.
+const wolfId = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let wolf = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'forest_wolf' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; wolf = e; }
+    }
+  }
+  p.pos.x = wolf.pos.x + 12; p.pos.z = wolf.pos.z;
+  p.resource = p.maxResource;
+  sim.targetEntity(wolf.id);
+  p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
+  window.__game.input.camYaw = p.facing;
+  sim.castAbility('shadow_bolt'); // one pull so the imp starts assisting
+  return wolf.id;
+});
+await sleep(800);
+const hpAtPull = await page.evaluate((id) => window.__game.sim.entities.get(id).hp, wolfId);
+
+// from here the player does nothing; keep them alive so only the imp's damage moves the wolf bar
+let impEngaged = false, wolfHp = hpAtPull;
+for (let i = 0; i < 60; i++) {
+  const s = await page.evaluate((id) => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.hp = p.maxHp;            // player is a bystander
+    p.autoAttack = false;
+    const w = sim.entities.get(id);
+    const pet = sim.petOf(p.id);
+    return { whp: w ? w.hp : 0, wdead: !w || w.dead, petTarget: pet ? pet.aggroTargetId : null };
+  }, wolfId);
+  if (s.petTarget === wolfId) impEngaged = true;
+  wolfHp = s.whp;
+  if (s.wdead || hpAtPull - wolfHp >= 10) break;
+  await sleep(500);
+}
+check('imp assists the owner (targets the wolf)', impEngaged);
+check('imp auto-firebolts: wolf HP drops while player idles', hpAtPull - wolfHp >= 1, `pull=${Math.round(hpAtPull)} -> ${Math.round(wolfHp)}`);
+await page.screenshot({ path: 'tmp/wl1_imp_firebolt.png' });
+
+// ---- Summon Voidwalker at level 10 ----
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.setPlayerLevel(10);
+  // shake aggro and move somewhere quiet before re-summoning
+  const p = sim.player;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.aggroTargetId === p.id) { e.aiState = 'evade'; e.aggroTargetId = null; }
+  }
+  p.hp = p.maxHp; p.resource = p.maxResource;
+});
+const known10 = await page.evaluate(() => window.__game.sim.known.map((k) => k.def.id));
+check('Summon Voidwalker known at lvl 10', known10.includes('summon_voidwalker'));
+
+let vw = null;
+for (let i = 0; i < 50 && !vw; i++) {
+  vw = await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    const pet = sim.petOf(p.id);
+    if ((!pet || pet.templateId !== 'warlock_voidwalker') && !p.castingAbility && p.gcdRemaining <= 0) {
+      sim.castAbility('summon_voidwalker');
+    }
+    const now = sim.petOf(p.id);
+    return now && now.templateId === 'warlock_voidwalker' ? { id: now.id, maxHp: now.maxHp } : null;
+  });
+  if (!vw) await sleep(400);
+}
+check('Summon Voidwalker conjures the tank demon', !!vw, vw ? `maxHp=${vw.maxHp}` : 'none');
+
+// engage a fresh wolf: the voidwalker should run in, melee, and Growl (taunt)
+const wolf2 = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let wolf = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'forest_wolf' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; wolf = e; }
+    }
+  }
+  wolf.maxHp = 4000; wolf.hp = 4000; // survive long enough to observe the tank loop
+  p.pos.x = wolf.pos.x + 8; p.pos.z = wolf.pos.z;
+  p.resource = p.maxResource;
+  sim.targetEntity(wolf.id);
+  p.autoAttack = true; // wand the wolf so the pet reliably assists
+  p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
+  window.__game.input.camYaw = p.facing;
+  sim.castAbility('shadow_bolt');
+  return wolf.id;
+});
+let taunted = false, vwThreat = false;
+for (let i = 0; i < 80 && !(taunted && vwThreat); i++) {
+  const s = await page.evaluate((ids) => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.hp = p.maxHp;
+    const w = sim.entities.get(ids.wolf);
+    if (w && !w.dead) { sim.targetEntity(w.id); p.autoAttack = true; }
+    const pet = sim.petOf(p.id);
+    return {
+      forced: w ? w.forcedTargetId : null,
+      wAggro: w ? w.aggroTargetId : null,
+      petTarget: pet ? pet.aggroTargetId : null,
+      petThreat: w && pet ? (w.threat.get(pet.id) ?? 0) : 0,
+      petId: pet ? pet.id : null,
+    };
+  }, { wolf: wolf2 });
+  if (s.petId && s.forced === s.petId) taunted = true;
+  if (s.petThreat > 0) vwThreat = true;
+  await sleep(500);
+}
+check('voidwalker builds its own threat', vwThreat);
+check('voidwalker taunts (Growl): wolf forced onto the pet', taunted);
+await page.screenshot({ path: 'tmp/wl2_voidwalker_tank.png' });
+
+check('no page/console errors', errors.length === 0, errors.slice(0, 5).join(' || '));
+console.log(`\n${fail === 0 ? 'ALL PASS' : fail + ' FAILED'}`);
+await browser.close();
+process.exit(fail > 0 ? 1 : 0);

--- a/scripts/smoke_warlock.mjs
+++ b/scripts/smoke_warlock.mjs
@@ -54,7 +54,8 @@ for (let i = 0; i < 40 && !imp; i++) {
 }
 check('Summon Imp conjures a pet', !!imp && imp.templateId === 'warlock_imp', imp ? imp.templateId : 'none');
 
-// pull a wolf, then IDLE the player — only the imp fights. If the wolf bleeds, the imp auto-firebolts.
+// pull a BEEFED wolf, then IDLE the player — only the imp fights. The imp should heel
+// right at your side and Firebolt your target, so the wolf bleeds while you do nothing.
 const wolfId = await page.evaluate(() => {
   const sim = window.__game.sim;
   const p = sim.player;
@@ -65,7 +66,8 @@ const wolfId = await page.evaluate(() => {
       if (dd < d) { d = dd; wolf = e; }
     }
   }
-  p.pos.x = wolf.pos.x + 12; p.pos.z = wolf.pos.z;
+  wolf.maxHp = 4000; wolf.hp = 4000; // survive so the imp keeps firing at your side
+  p.pos.x = wolf.pos.x + 10; p.pos.z = wolf.pos.z;
   p.resource = p.maxResource;
   sim.targetEntity(wolf.id);
   p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
@@ -76,25 +78,29 @@ const wolfId = await page.evaluate(() => {
 await sleep(800);
 const hpAtPull = await page.evaluate((id) => window.__game.sim.entities.get(id).hp, wolfId);
 
-// from here the player does nothing; keep them alive so only the imp's damage moves the wolf bar
-let impEngaged = false, wolfHp = hpAtPull;
-for (let i = 0; i < 60; i++) {
+// player idles; wait until the imp is both DAMAGING the wolf and HEELED to your side.
+let impEngaged = false, wolfHp = hpAtPull, impDist = 99;
+for (let i = 0; i < 80; i++) {
   const s = await page.evaluate((id) => {
     const sim = window.__game.sim;
     const p = sim.player;
-    p.hp = p.maxHp;            // player is a bystander
-    p.autoAttack = false;
+    p.hp = p.maxHp; p.autoAttack = false; // bystander
     const w = sim.entities.get(id);
     const pet = sim.petOf(p.id);
-    return { whp: w ? w.hp : 0, wdead: !w || w.dead, petTarget: pet ? pet.aggroTargetId : null };
+    return {
+      whp: w ? w.hp : 0, wdead: !w || w.dead,
+      petTarget: pet ? pet.aggroTargetId : null,
+      petDist: pet ? Math.hypot(pet.pos.x - p.pos.x, pet.pos.z - p.pos.z) : 99,
+    };
   }, wolfId);
   if (s.petTarget === wolfId) impEngaged = true;
-  wolfHp = s.whp;
-  if (s.wdead || hpAtPull - wolfHp >= 10) break;
+  wolfHp = s.whp; impDist = s.petDist;
+  if ((hpAtPull - wolfHp >= 10) && impDist <= 5) break; // damaging AND heeled close
   await sleep(500);
 }
 check('imp assists the owner (targets the wolf)', impEngaged);
 check('imp auto-firebolts: wolf HP drops while player idles', hpAtPull - wolfHp >= 1, `pull=${Math.round(hpAtPull)} -> ${Math.round(wolfHp)}`);
+check('imp heels close to the player (stands at your side)', impDist <= 5, `dist=${impDist.toFixed(1)}yd`);
 await page.screenshot({ path: 'tmp/wl1_imp_firebolt.png' });
 
 // ---- Summon Voidwalker at level 10 ----

--- a/scripts/smoke_warlock.mjs
+++ b/scripts/smoke_warlock.mjs
@@ -101,6 +101,24 @@ for (let i = 0; i < 80; i++) {
 check('imp assists the owner (targets the wolf)', impEngaged);
 check('imp auto-firebolts: wolf HP drops while player idles', hpAtPull - wolfHp >= 1, `pull=${Math.round(hpAtPull)} -> ${Math.round(wolfHp)}`);
 check('imp heels close to the player (stands at your side)', impDist <= 5, `dist=${impDist.toFixed(1)}yd`);
+// frame a clear showcase: imp at your side, firing; camera looks down + zoomed out
+await page.evaluate((id) => {
+  const g = window.__game, sim = g.sim, p = sim.player;
+  const w = sim.entities.get(id);
+  if (w) p.facing = Math.atan2(w.pos.x - p.pos.x, w.pos.z - p.pos.z);
+  const pet = sim.petOf(p.id);
+  if (pet) { // put the imp at the player's side and a touch toward the camera (foreground)
+    const fx = Math.sin(p.facing), fz = Math.cos(p.facing);   // forward (toward wolf)
+    const sx = Math.cos(p.facing), sz = -Math.sin(p.facing);  // sideways
+    pet.pos.x = p.pos.x + sx * 2.4 - fx * 1.4;
+    pet.pos.z = p.pos.z + sz * 2.4 - fz * 1.4;
+    pet.pos.y = p.pos.y;
+    pet.prevPos = { ...pet.pos };
+  }
+  g.input.camPitch = 0.5; // 3/4 view
+  g.input.camDist = 9;    // zoom in so the imp reads clearly
+}, wolfId);
+await sleep(900);
 await page.screenshot({ path: 'tmp/wl1_imp_firebolt.png' });
 
 // ---- Summon Voidwalker at level 10 ----
@@ -177,6 +195,16 @@ for (let i = 0; i < 80 && !(taunted && vwThreat); i++) {
 }
 check('voidwalker builds its own threat', vwThreat);
 check('voidwalker taunts (Growl): wolf forced onto the pet', taunted);
+// frame a clear showcase: the voidwalker tanking the wolf, camera down + zoomed out
+await page.evaluate((ids) => {
+  const g = window.__game, sim = g.sim, p = sim.player;
+  const w = sim.entities.get(ids.wolf);
+  const pet = sim.petOf(p.id);
+  if (w) p.facing = Math.atan2(w.pos.x - p.pos.x, w.pos.z - p.pos.z);
+  g.input.camPitch = 0.5;
+  g.input.camDist = 11;
+}, { wolf: wolf2 });
+await sleep(900);
 await page.screenshot({ path: 'tmp/wl2_voidwalker_tank.png' });
 
 check('no page/console errors', errors.length === 0, errors.slice(0, 5).join(' || '));

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -215,7 +215,7 @@ function blankEntity(id: number): Entity {
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
-    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
+    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0, summoned: false,
     spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -203,6 +203,16 @@ export const VISUALS: Record<string, VisualDef> = {
     url: `${CREATURES}/spider.glb`, height: 1.4,
     clips: SPIDER, tint: 'entity', tintStrength: 0.35,
   },
+  // warlock demon pet: small fel-red demon (demonalt uses the 14-clip biped rig)
+  mob_imp: {
+    url: `${CREATURES}/demonalt.glb`, height: 1.1,
+    clips: BIPED14, tint: 'entity', tintStrength: 0.5,
+  },
+  // warlock voidwalker: a larger hovering void demon (demon.glb uses the floating rig)
+  mob_voidwalker: {
+    url: `${CREATURES}/demon.glb`, height: 2.0,
+    clips: FLOATING, tint: 'entity', tintStrength: 0.45,
+  },
   mob_murloc: {
     url: `${CREATURES}/frog.glb`, height: 1.7,
     clips: BIPED14, tint: 'entity', tintStrength: 0.45,
@@ -329,6 +339,8 @@ export const VISUALS: Record<string, VisualDef> = {
 // ---------------------------------------------------------------------------
 
 const MOB_KEYS: Record<string, string> = {
+  warlock_imp: 'mob_imp',
+  warlock_voidwalker: 'mob_voidwalker',
   wild_boar: 'mob_boar',
   elder_bristleback: 'mob_boar',
   // gravecaller cult + necromancers: dark-robed casters

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -653,7 +653,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     description: 'Begins taming a beast to be your companion. It must be your level or lower and not an elite. Your pet follows you, attacks your enemies, and holds threat of its own. You may have one pet at a time.',
   },
   dismiss_pet: {
-    id: 'dismiss_pet', name: 'Dismiss Pet', class: 'hunter', learnLevel: 1,
+    id: 'dismiss_pet', name: 'Dismiss Pet', class: 'hunter', learnLevel: 5,
     cost: 0, castTime: 0, cooldown: 0, range: 0, school: 'nature',
     requiresTarget: false,
     effects: [{ type: 'dismissPet' }],

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -148,7 +148,7 @@ export const CLASSES: Record<PlayerClass, ClassDef> = {
     startWeapon: 'gnarled_staff',
     startChest: 'apprentice_robe',
     ranged: { min: 3, max: 6, speed: 1.8, maxRange: 30, minRange: 0, wand: true, school: 'shadow' },
-    abilities: ['shadow_bolt', 'demon_skin', 'immolate', 'corruption', 'life_tap', 'curse_of_agony', 'drain_life', 'fear', 'searing_pain', 'shadowburn'],
+    abilities: ['summon_imp', 'summon_voidwalker', 'shadow_bolt', 'demon_skin', 'immolate', 'corruption', 'life_tap', 'curse_of_agony', 'drain_life', 'fear', 'searing_pain', 'shadowburn', 'dismiss_pet'],
     color: 0x9482c9,
   },
   druid: {
@@ -653,11 +653,11 @@ export const ABILITIES: Record<string, AbilityDef> = {
     description: 'Begins taming a beast to be your companion. It must be your level or lower and not an elite. Your pet follows you, attacks your enemies, and holds threat of its own. You may have one pet at a time.',
   },
   dismiss_pet: {
-    id: 'dismiss_pet', name: 'Dismiss Pet', class: 'hunter', learnLevel: 10,
+    id: 'dismiss_pet', name: 'Dismiss Pet', class: 'hunter', learnLevel: 1,
     cost: 0, castTime: 0, cooldown: 0, range: 0, school: 'nature',
     requiresTarget: false,
     effects: [{ type: 'dismissPet' }],
-    description: 'Releases your pet back to the wild.',
+    description: 'Dismisses your pet — a tamed beast returns to the wild; a summoned demon is banished.',
   },
   raptor_strike: {
     id: 'raptor_strike', name: 'Raptor Strike', class: 'hunter', learnLevel: 1,
@@ -1043,6 +1043,20 @@ export const ABILITIES: Record<string, AbilityDef> = {
     requiresTarget: true,
     effects: [{ type: 'directDamage', min: 56, max: 66 }],
     description: 'Instantly blasts the target with Shadow Flame for $d Shadow damage.',
+  },
+  summon_imp: {
+    id: 'summon_imp', name: 'Summon Imp', class: 'warlock', learnLevel: 5,
+    cost: 45, castTime: 3, cooldown: 0, range: 0, school: 'shadow',
+    requiresTarget: false,
+    effects: [{ type: 'summonPet', mobId: 'warlock_imp' }],
+    description: 'Summons an Imp under the command of the Warlock. The Imp assails your foes with Firebolts and holds threat of its own. You may have one demon at a time; summoning again replaces it.',
+  },
+  summon_voidwalker: {
+    id: 'summon_voidwalker', name: 'Summon Voidwalker', class: 'warlock', learnLevel: 10,
+    cost: 70, castTime: 5, cooldown: 0, range: 0, school: 'shadow',
+    requiresTarget: false,
+    effects: [{ type: 'summonPet', mobId: 'warlock_voidwalker' }],
+    description: 'Summons a Voidwalker demon. The Voidwalker is a durable melee guardian that taunts your foes and holds their attention. You may have one demon at a time; summoning again replaces it.',
   },
 
   // ====================== DRUID ======================

--- a/src/sim/content/pets.ts
+++ b/src/sim/content/pets.ts
@@ -1,27 +1,33 @@
 // src/sim/content/pets.ts — class pet templates (summoned, not spawned in the world).
 // These mob templates are never placed in a camp; the sim conjures them from an
 // ability effect (e.g. the warlock's Summon Imp/Voidwalker) and assigns them an owner.
+//
+// Balance (level cap 20). Reference — warlock Shadow Bolt avg/ hit: 15.5 (L1) ->
+// 27.5 (L8) -> 47.5 (L14) -> 76 (L20), i.e. ~9 -> 25 DPS. Pets are tuned to sit
+// clearly below the master's own output and to scale smoothly with level.
 
 import type { MobTemplate } from '../types';
 
 export const PET_MOBS: Record<string, MobTemplate> = {
-  // Warlock starter demon. A ranged Firebolt caster (see `petRanged`): it stands
-  // off and nukes rather than meleeing, and is conjured/despawned, never tamed.
+  // Imp (learned L5) — ranged DPS demon. Heels at your side and auto-casts Firebolt
+  // at your target. Firebolt = min..max + perLevel*(level-1) every `speed`s, tuned to
+  // ~45% of the warlock's Shadow Bolt DPS: ~11/hit @L5 -> ~29/hit @L20 (~4 -> ~11 DPS).
+  // Squishy (it never melees), so HP stays low.
   warlock_imp: {
     id: 'warlock_imp', name: 'Imp', minLevel: 1, maxLevel: 1, family: 'humanoid',
-    hpBase: 24, hpPerLevel: 6, dmgBase: 1, dmgPerLevel: 0.4, attackSpeed: 2.0,
-    armorPerLevel: 1, moveSpeed: 7, aggroRadius: 0, loot: [],
+    hpBase: 28, hpPerLevel: 7, dmgBase: 1, dmgPerLevel: 0.4, attackSpeed: 2.0,
+    armorPerLevel: 2, moveSpeed: 7, aggroRadius: 0, loot: [],
     scale: 0.6, color: 0xff5522, // fel-red tint applied by the renderer
-    // Firebolt scales with the pet's (owner's) level: base + perLevel * (level - 1).
-    petRanged: { min: 4, max: 6, range: 30, speed: 2.0, school: 'fire', name: 'Firebolt', perLevel: 1.3 },
+    petRanged: { min: 4, max: 8, range: 30, speed: 2.5, school: 'fire', name: 'Firebolt', perLevel: 1.2 },
   },
-  // Warlock tank demon. A durable melee guardian that taunts (petGrowls) to hold
-  // threat, the demonic analogue of a hunter's tamed beast. Melee damage/HP scale
-  // through createMob; summoned/despawned, never tamed.
+  // Voidwalker (learned L10) — tank demon. Durable melee guardian that Growls/taunts
+  // to hold threat (petGrowls), the demonic analogue of a tamed beast. HP ~1.5x the
+  // warlock's (60+20/lvl: 240 @L10, 440 @L20), high armor, deliberately modest damage —
+  // it holds aggro by taunting, not by out-DPSing. HP/damage scale via createMob.
   warlock_voidwalker: {
     id: 'warlock_voidwalker', name: 'Voidwalker', minLevel: 1, maxLevel: 1, family: 'humanoid',
-    hpBase: 60, hpPerLevel: 18, dmgBase: 2, dmgPerLevel: 1.0, attackSpeed: 2.0,
-    armorPerLevel: 14, moveSpeed: 7, aggroRadius: 0, loot: [],
+    hpBase: 60, hpPerLevel: 20, dmgBase: 2, dmgPerLevel: 1.2, attackSpeed: 2.0,
+    armorPerLevel: 16, moveSpeed: 7, aggroRadius: 0, loot: [],
     scale: 1.4, color: 0x6a3aa0, // void-purple tint applied by the renderer
     petGrowls: true, // tank demon: Growls/taunts like a tamed beast
   },

--- a/src/sim/content/pets.ts
+++ b/src/sim/content/pets.ts
@@ -1,0 +1,28 @@
+// src/sim/content/pets.ts — class pet templates (summoned, not spawned in the world).
+// These mob templates are never placed in a camp; the sim conjures them from an
+// ability effect (e.g. the warlock's Summon Imp/Voidwalker) and assigns them an owner.
+
+import type { MobTemplate } from '../types';
+
+export const PET_MOBS: Record<string, MobTemplate> = {
+  // Warlock starter demon. A ranged Firebolt caster (see `petRanged`): it stands
+  // off and nukes rather than meleeing, and is conjured/despawned, never tamed.
+  warlock_imp: {
+    id: 'warlock_imp', name: 'Imp', minLevel: 1, maxLevel: 1, family: 'humanoid',
+    hpBase: 24, hpPerLevel: 6, dmgBase: 1, dmgPerLevel: 0.4, attackSpeed: 2.0,
+    armorPerLevel: 1, moveSpeed: 7, aggroRadius: 0, loot: [],
+    scale: 0.6, color: 0xff5522, // fel-red tint applied by the renderer
+    // Firebolt scales with the pet's (owner's) level: base + perLevel * (level - 1).
+    petRanged: { min: 4, max: 6, range: 30, speed: 2.0, school: 'fire', name: 'Firebolt', perLevel: 1.3 },
+  },
+  // Warlock tank demon. A durable melee guardian that taunts (petGrowls) to hold
+  // threat, the demonic analogue of a hunter's tamed beast. Melee damage/HP scale
+  // through createMob; summoned/despawned, never tamed.
+  warlock_voidwalker: {
+    id: 'warlock_voidwalker', name: 'Voidwalker', minLevel: 1, maxLevel: 1, family: 'humanoid',
+    hpBase: 60, hpPerLevel: 18, dmgBase: 2, dmgPerLevel: 1.0, attackSpeed: 2.0,
+    armorPerLevel: 14, moveSpeed: 7, aggroRadius: 0, loot: [],
+    scale: 1.4, color: 0x6a3aa0, // void-purple tint applied by the renderer
+    petGrowls: true, // tank demon: Growls/taunts like a tamed beast
+  },
+};

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -22,6 +22,7 @@ import {
   ZONE3_QUESTS, ZONE3_QUEST_ORDER, ZONE3_ROADS, ZONE3_ZONE,
 } from './content/zone3';
 import { DUNGEON_DEFS, DUNGEON_MOBS } from './content/dungeons';
+import { PET_MOBS } from './content/pets';
 
 export { CLASSES, ABILITIES, abilitiesKnownAt } from './content/classes';
 export type { ClassDef } from './content/classes';
@@ -39,7 +40,7 @@ export const ITEMS: Record<string, ItemDef> = {
 };
 
 export const MOBS: Record<string, MobTemplate> = {
-  ...ZONE1_MOBS, ...ZONE2_MOBS, ...ZONE3_MOBS, ...DUNGEON_MOBS,
+  ...ZONE1_MOBS, ...ZONE2_MOBS, ...ZONE3_MOBS, ...DUNGEON_MOBS, ...PET_MOBS,
 };
 
 export const NPCS: Record<string, NpcDef> = {

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
-    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
+    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0, summoned: false,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -24,7 +24,7 @@ import type { LeaderboardEntry } from '../world_api';
 import {
   AbilityDef, AbilityEffect, Aura, AuraKind, CAST_PUSHBACK_SEC, CHANNEL_PUSHBACK_FRACTION, CONSUME_DURATION,
   CONSUME_TICKS, CrowdControlDrCategory, DT, Entity, EquipSlot, FISHING_CAST_ID, FISHING_CAST_TIME, GCD,
-  INTERACT_RANGE, InvSlot, LootEntry, LootSlot, MELEE_RANGE, MAX_LEVEL, MobFamily,
+  INTERACT_RANGE, InvSlot, LootEntry, LootSlot, MELEE_RANGE, MAX_LEVEL, MobFamily, MobTemplate,
   MoveInput, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
   rageFromDealing, rageFromTaking, spellHitChance, xpForLevel,
@@ -2121,7 +2121,12 @@ export class Sim {
           const pet = this.petOf(p.id);
           if (!pet) { this.error(p.id, 'You have no pet.'); break; }
           this.emit({ type: 'log', text: `You dismiss ${pet.name}.`, color: '#999', pid: p.id });
-          this.releasePetToWild(pet);
+          if (pet.summoned) this.despawnPet(pet);
+          else this.releasePetToWild(pet);
+          break;
+        }
+        case 'summonPet': {
+          this.summonPet(p, eff.mobId);
           break;
         }
       }
@@ -2295,6 +2300,45 @@ export class Sim {
       m.threat.delete(pet.id);
       if (m.aggroTargetId === pet.id && !m.dead && m.aiState !== 'dead') this.retargetMob(m);
     }
+  }
+
+  /** Warlock demon summon: conjure a fresh pet from a template, owned by the
+   *  caster. Replaces any existing pet. Unlike a tamed beast, a summoned pet
+   *  despawns (rather than returning to the wild) on dismiss, owner logout, or
+   *  death — see `despawnPet` and the dead-branch of `updateMob`. */
+  private summonPet(owner: Entity, mobId: string): void {
+    const template = MOBS[mobId];
+    if (!template) { this.error(owner.id, 'Summon failed.'); return; }
+    const existing = this.petOf(owner.id);
+    if (existing) this.despawnPet(existing);
+    // place the demon just behind the caster
+    const pos = this.groundPos(
+      owner.pos.x + Math.sin(owner.facing + Math.PI) * 2,
+      owner.pos.z + Math.cos(owner.facing + Math.PI) * 2,
+    );
+    const pet = createMob(this.nextId++, template, owner.level, pos);
+    pet.ownerId = owner.id;
+    pet.summoned = true;
+    pet.petTauntTimer = 0;
+    pet.hostile = false;
+    pet.aiState = 'idle';
+    pet.tappedById = null;
+    pet.spawnPos = { ...pos };
+    this.addEntity(pet);
+    this.emit({ type: 'spellfx', sourceId: owner.id, targetId: pet.id, school: 'shadow', fx: 'nova' });
+    this.emit({ type: 'log', text: `You summon ${pet.name}.`, color: '#a6f', pid: owner.id });
+    this.emit({ type: 'aura', targetId: pet.id, name: 'Summoned', gained: true });
+  }
+
+  /** Remove a summoned pet from the world entirely — no corpse, no respawn.
+   *  Mobs that were fighting it forget it. */
+  private despawnPet(pet: Entity): void {
+    for (const m of this.entities.values()) {
+      if (m.kind !== 'mob' || m.id === pet.id) continue;
+      m.threat.delete(pet.id);
+      if (m.aggroTargetId === pet.id && !m.dead && m.aiState !== 'dead') this.retargetMob(m);
+    }
+    this.dropEntity(pet.id);
   }
 
   // -------------------------------------------------------------------------
@@ -2945,6 +2989,8 @@ export class Sim {
 
   private updateMob(mob: Entity): void {
     if (mob.dead) {
+      // a slain summoned demon leaves no corpse and never respawns — it vanishes
+      if (mob.summoned) { this.dropEntity(mob.id); return; }
       mob.corpseTimer -= DT;
       mob.respawnTimer -= DT;
       // dungeon mobs stay dead until the instance resets
@@ -3153,7 +3199,9 @@ export class Sim {
   private updatePet(pet: Entity): void {
     const owner = pet.ownerId !== null ? this.entities.get(pet.ownerId) : null;
     if (!owner || owner.kind !== 'player' || !this.players.has(owner.id)) {
-      this.releasePetToWild(pet);
+      // owner logged out / left: a summoned demon vanishes; a tamed beast goes home
+      if (pet.summoned) this.despawnPet(pet);
+      else this.releasePetToWild(pet);
       return;
     }
     if (this.isStunned(pet)) return;
@@ -3162,18 +3210,26 @@ export class Sim {
     let target = pet.aggroTargetId !== null ? this.entities.get(pet.aggroTargetId) ?? null : null;
     if (target && (target.dead || target.kind !== 'mob' || !target.hostile)) target = null;
     if (target && dist2d(owner.pos, pet.pos) > PET_LEASH) target = null;
+    // stick to a target only while it's still your target or it has aggroed the pet
+    // (it pulled aggro) — otherwise drop it and re-mirror whatever you're attacking
+    if (target && owner.targetId !== target.id && target.aggroTargetId !== pet.id) target = null;
     if (!target && !owner.dead) target = this.petPickTarget(pet, owner);
     pet.aggroTargetId = target?.id ?? null;
     pet.inCombat = target !== null;
 
     if (target) {
+      // ranged demon pets (imp Firebolt) stand off and nuke instead of meleeing
+      const ranged = MOBS[pet.templateId]?.petRanged;
+      if (ranged) { this.petCastRanged(pet, owner, target, ranged); return; }
       const d = dist2d(pet.pos, target.pos);
       if (d > MELEE_RANGE * 0.8) {
         if (!this.isRooted(pet)) this.moveToward(pet, target.pos, pet.moveSpeed * this.moveSpeedMult(pet));
         pet.swingTimer = Math.max(0, pet.swingTimer - DT);
       } else {
         pet.facing = angleTo(pet.pos, target.pos);
-        if (pet.petTauntTimer <= 0) {
+        // Growl is the tank pet's threat tool: tamed beasts and tank demons (voidwalker)
+        // taunt; DPS demons (imp) don't. petGrowls opts a summoned pet into tanking.
+        if (pet.petTauntTimer <= 0 && (!pet.summoned || !!MOBS[pet.templateId]?.petGrowls)) {
           this.applyTaunt(pet, target);
           pet.petTauntTimer = PET_GROWL_INTERVAL;
         }
@@ -3188,6 +3244,13 @@ export class Sim {
 
     // heel
     pet.swingTimer = Math.max(0, pet.swingTimer - DT);
+    this.petHeel(pet, owner);
+  }
+
+  // Follow the owner at heel: warp in if left far behind, otherwise jog to the
+  // owner's side and stop close (PET_FOLLOW_DISTANCE). Shared by the idle pet and
+  // the ranged imp, which heels next to you while it fires.
+  private petHeel(pet: Entity, owner: Entity): void {
     const d = dist2d(pet.pos, owner.pos);
     if (d > PET_TELEPORT_DISTANCE) {
       pet.pos = { ...owner.pos };
@@ -3206,13 +3269,47 @@ export class Sim {
     let bestD = PET_ASSIST_RANGE;
     for (const m of this.entities.values()) {
       if (m.kind !== 'mob' || m.dead || !m.hostile || m.ownerId !== null) continue;
-      const engagingUs = m.aggroTargetId === owner.id || m.aggroTargetId === pet.id;
-      const ownerOffense = owner.targetId === m.id && (owner.autoAttack || m.threat.has(owner.id));
-      if (!engagingUs && !ownerOffense) continue;
+      // attack what you attack (your current target, once you've engaged it)...
+      const yourTarget = owner.targetId === m.id && (owner.autoAttack || m.threat.has(owner.id));
+      // ...otherwise only defend itself if a mob has aggroed onto the pet.
+      const attackingPet = m.aggroTargetId === pet.id;
+      if (!yourTarget && !attackingPet) continue;
       const d = dist2d(pet.pos, m.pos);
       if (d < bestD) { best = m; bestD = d; }
     }
     return best;
+  }
+
+  // Ranged pet brain (warlock imp): heel next to the owner (stand close, like an
+  // idle pet) and fire at the owner's target whenever it's within `range`. The pet
+  // builds its own threat through dealDamage, exactly like a melee pet's swings.
+  private petCastRanged(pet: Entity, owner: Entity, target: Entity, ranged: NonNullable<MobTemplate['petRanged']>): void {
+    this.petHeel(pet, owner);
+    const d = dist2d(pet.pos, target.pos);
+    if (d > ranged.range) {
+      pet.swingTimer = Math.max(0, pet.swingTimer - DT);
+      return;
+    }
+    pet.facing = angleTo(pet.pos, target.pos);
+    pet.swingTimer -= DT;
+    if (pet.swingTimer <= 0) {
+      this.petFirebolt(pet, target, ranged);
+      pet.swingTimer = ranged.speed * this.swingIntervalMult(pet);
+    }
+  }
+
+  private petFirebolt(pet: Entity, target: Entity, ranged: NonNullable<MobTemplate['petRanged']>): void {
+    if (target.dead) return;
+    const school = ranged.school as Aura['school'];
+    this.emit({ type: 'spellfx', sourceId: pet.id, targetId: target.id, school, fx: 'projectile' });
+    if (this.rng.next() >= spellHitChance(pet.level, target.level)) {
+      this.emit({ type: 'damage', sourceId: pet.id, targetId: target.id, amount: 0, crit: false, school, ability: ranged.name, kind: 'miss' });
+      return;
+    }
+    let dmg = this.rng.range(ranged.min, ranged.max) + (ranged.perLevel ?? 0) * (pet.level - 1);
+    const crit = this.rng.chance(0.05);
+    if (crit) dmg *= 1.5; // spell crits are +50% in vanilla
+    this.dealDamage(pet, target, Math.max(1, Math.round(dmg)), crit, school, ranged.name, 'hit');
   }
 
   // Step `e` one tick toward `dest`. With `ignoreObstacles`, the mover phases

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -159,6 +159,12 @@ export interface MobTemplate {
   respawnMult?: number;
   // Boss mechanic: periodic AoE pulse around the mob while in combat.
   aoePulse?: { min: number; max: number; radius: number; every: number; name: string; school?: string; fx?: 'nova' | 'projectile' };
+  // Pet behavior: a ranged single-target attack (warlock imp Firebolt). When set, an
+  // owned pet stands off at `range` and casts this instead of running into melee.
+  petRanged?: { min: number; max: number; range: number; speed: number; school: string; name: string; perLevel?: number };
+  // Pet behavior: this pet taunts (Growl) to hold threat, like a tamed beast. Summoned
+  // pets default to no taunt (DPS demons); set true for tank demons (warlock voidwalker).
+  petGrowls?: boolean;
   // Boss mechanic: spawn adds when hp first drops below each threshold (descending fractions).
   summonAdds?: { mobId: string; count: number; atHpPct: number[] };
   // Boss mechanic: damage multiplier once hp drops below the threshold.
@@ -196,7 +202,8 @@ export type AbilityEffect =
   | { type: 'sunder'; armor: number; maxStacks: number } // sunder armor: stacking armor debuff + flat threat
   | { type: 'taunt' } // taunt/growl: match top threat and force-attack the caster
   | { type: 'tamePet' } // hunter tame beast: the targeted mob becomes the caster's pet
-  | { type: 'dismissPet' }; // release the caster's pet back to the wild
+  | { type: 'dismissPet' } // release the caster's pet back to the wild
+  | { type: 'summonPet'; mobId: string }; // warlock: conjure a demon pet from a mob template
 
 export interface AbilityRank {
   rank: number;
@@ -463,6 +470,7 @@ export interface Entity {
   forcedTargetTimer: number; // seconds left on the forced-attack window
   ownerId: number | null; // controlled pets: owning player's entity id (null = wild)
   petTauntTimer: number; // controlled pet Growl cooldown
+  summoned: boolean; // pet was conjured (warlock demon), not tamed: despawns on dismiss/owner-leave/death
   pulseTimer: number; // boss aoe pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -984,6 +984,8 @@ const ABILITY_RECIPES: Record<string, IconRecipe> = {
   lightning_shield: r('storm', 'sky', ['shield', { p: 'lightning', s: 0.6 }], ['glow']),
   flame_shock: r('fire', 'ember', ['flame'], ['arcs']),
   // warlock
+  summon_imp: r('shadow', 'ember', ['skull', { p: 'flame', ...BR, pal: 'ember' }], ['glow']),
+  summon_voidwalker: r('shadow', 'shadowPurple', ['shield', { p: 'eye', ...TL }], ['glow']),
   shadow_bolt: r('shadow', 'shadowPurple', ['bolt'], ['glow']),
   demon_skin: r('shadow', 'venom', [{ p: 'chestplate', pal: 'venom' }]),
   immolate: r('fire', 'ember', ['flame'], ['crack', 'glow']),

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -605,6 +605,15 @@ describe('warlock demon pets', () => {
     expect(mob.forcedTargetId).not.toBe(imp.id); // DPS demon: no Growl/taunt
   });
 
+  it('the imp heels close to the owner instead of parking at range', () => {
+    const { sim, imp } = summonSetup();
+    const owner = sim.player;
+    teleport(sim, imp, owner.pos.x + 12, owner.pos.z); // shove it away, no target
+    sim.targetEntity(null);
+    for (let i = 0; i < 20 * 10; i++) sim.tick();
+    expect(dist2d(imp.pos, owner.pos)).toBeLessThan(6); // jogged back to your side
+  });
+
   it('dismiss despawns the demon entirely - no corpse, no respawn', () => {
     const { sim, imp } = summonSetup();
     sim.castAbility('dismiss_pet');

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -453,7 +453,8 @@ describe('hunter pets', () => {
     const boar = nearestMob(sim, 'wild_boar');
     teleport(sim, sim.player, boar.pos.x + 4, boar.pos.z);
     teleport(sim, pet, boar.pos.x + 5, boar.pos.z);
-    hit(sim, sim.player, boar, 5); // boar comes for the hunter
+    sim.targetEntity(boar.id); // you attack the boar; the pet assists your target
+    hit(sim, sim.player, boar, 5);
     let petThreat = 0;
     for (let i = 0; i < 20 * 20 && petThreat === 0; i++) {
       sim.tick();
@@ -479,7 +480,8 @@ describe('hunter pets', () => {
     beefUp(boar);
     teleport(sim, sim.player, boar.pos.x + 4, boar.pos.z);
     teleport(sim, pet, boar.pos.x + 5, boar.pos.z);
-    hit(sim, sim.player, boar, 5); // boar comes for the hunter; pet assists
+    sim.targetEntity(boar.id); // you attack the boar; the pet assists and taunts
+    hit(sim, sim.player, boar, 5);
 
     // let the boar transfer onto the tanking pet
     for (let i = 0; i < 20 * 20 && boar.aggroTargetId !== pet.id; i++) sim.tick();
@@ -553,6 +555,138 @@ describe('hunter pets', () => {
     const events = sim.tick();
     expect(events.some((e) => e.type === 'error' && /too high level/.test(e.text))).toBe(true);
     expect(wolf.ownerId).toBe(null);
+  });
+});
+
+describe('warlock demon pets', () => {
+  function summonSetup() {
+    const sim = new Sim({ seed: 42, playerClass: 'warlock', autoEquip: true });
+    sim.setPlayerLevel(5); // Summon Imp unlocks at level 5
+    sim.player.resource = sim.player.maxResource;
+    sim.castAbility('summon_imp');
+    for (let i = 0; i < 20 * 4; i++) sim.tick(); // 3s cast + settle
+    const imp = sim.petOf(sim.playerId)!;
+    return { sim, imp };
+  }
+
+  it('summon imp conjures an owned, non-hostile demon pet', () => {
+    const { sim, imp } = summonSetup();
+    expect(imp).toBeTruthy();
+    expect(imp.templateId).toBe('warlock_imp');
+    expect(imp.ownerId).toBe(sim.playerId);
+    expect(imp.summoned).toBe(true);
+    expect(imp.hostile).toBe(false);
+  });
+
+  it('the imp firebolts the target the owner is fighting, builds its own threat, and never growls', () => {
+    const { sim, imp } = summonSetup();
+    const mob = nearestMob(sim);
+    beefUp(mob);
+    teleport(sim, sim.player, mob.pos.x + 10, mob.pos.z);
+    teleport(sim, imp, mob.pos.x + 10, mob.pos.z);
+    sim.targetEntity(mob.id);
+    hit(sim, sim.player, mob, 5); // owner engages -> the imp assists
+
+    let petThreat = 0;
+    let fireFromImp = false;
+    for (let i = 0; i < 20 * 20 && !(petThreat > 0 && fireFromImp); i++) {
+      const evs = sim.tick();
+      for (const ev of evs) {
+        if (ev.type === 'damage' && ev.sourceId === imp.id && ev.school === 'fire' && ev.amount > 0) {
+          fireFromImp = true;
+        }
+      }
+      petThreat = mob.threat.get(imp.id) ?? 0;
+    }
+    expect(imp.aggroTargetId).toBe(mob.id);
+    expect(fireFromImp).toBe(true); // it nukes with Firebolt, not melee
+    expect(petThreat).toBeGreaterThan(0);
+    expect(mob.tappedById).toBe(sim.playerId); // pet damage taps for the owner
+    expect(mob.forcedTargetId).not.toBe(imp.id); // DPS demon: no Growl/taunt
+  });
+
+  it('dismiss despawns the demon entirely - no corpse, no respawn', () => {
+    const { sim, imp } = summonSetup();
+    sim.castAbility('dismiss_pet');
+    sim.tick();
+    expect(sim.petOf(sim.playerId)).toBe(null);
+    expect(sim.entities.get(imp.id)).toBeUndefined();
+  });
+
+  it('summoning again replaces the existing demon (one pet at a time)', () => {
+    const { sim, imp } = summonSetup();
+    sim.player.resource = sim.player.maxResource;
+    sim.castAbility('summon_imp');
+    for (let i = 0; i < 20 * 4; i++) sim.tick();
+    const imp2 = sim.petOf(sim.playerId)!;
+    expect(imp2.id).not.toBe(imp.id);
+    expect(sim.entities.get(imp.id)).toBeUndefined();
+    const pets = [...sim.entities.values()].filter(
+      (e) => e.kind === 'mob' && e.ownerId === sim.playerId && !e.dead,
+    );
+    expect(pets).toHaveLength(1);
+  });
+
+  it('a slain imp vanishes and does not respawn', () => {
+    const { sim, imp } = summonSetup();
+    (sim as any).dealDamage(null, imp, imp.hp, false, 'fire', 'test', 'hit');
+    expect(imp.dead).toBe(true);
+    sim.tick(); // updateMob dead-branch drops summoned pets
+    expect(sim.entities.get(imp.id)).toBeUndefined();
+    expect(sim.petOf(sim.playerId)).toBe(null);
+  });
+
+  it('imp Firebolt damage scales with the pet (owner) level', () => {
+    function maxImpHit(level: number): number {
+      const sim = new Sim({ seed: 7, playerClass: 'warlock', autoEquip: true });
+      sim.setPlayerLevel(level);
+      sim.player.resource = sim.player.maxResource;
+      sim.castAbility('summon_imp');
+      for (let i = 0; i < 20 * 4; i++) sim.tick();
+      const imp = sim.petOf(sim.playerId)!;
+      const mob = nearestMob(sim);
+      beefUp(mob);
+      teleport(sim, sim.player, mob.pos.x + 10, mob.pos.z);
+      teleport(sim, imp, mob.pos.x + 10, mob.pos.z);
+      sim.targetEntity(mob.id);
+      hit(sim, sim.player, mob, 5);
+      let best = 0;
+      for (let i = 0; i < 20 * 15; i++) {
+        for (const ev of sim.tick()) {
+          if (ev.type === 'damage' && ev.sourceId === imp.id && ev.school === 'fire') best = Math.max(best, ev.amount);
+        }
+      }
+      return best;
+    }
+    expect(maxImpHit(15)).toBeGreaterThan(maxImpHit(5));
+  });
+
+  it('summon voidwalker conjures a melee tank demon that taunts (Growls)', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warlock', autoEquip: true });
+    sim.setPlayerLevel(10);
+    sim.player.resource = sim.player.maxResource;
+    sim.castAbility('summon_voidwalker');
+    for (let i = 0; i < 20 * 6; i++) sim.tick(); // 5s cast
+    const vw = sim.petOf(sim.playerId)!;
+    expect(vw.templateId).toBe('warlock_voidwalker');
+    expect(vw.summoned).toBe(true);
+    expect(vw.maxHp).toBeGreaterThan(150); // tanky
+
+    const mob = nearestMob(sim);
+    beefUp(mob);
+    teleport(sim, sim.player, mob.pos.x + 4, mob.pos.z);
+    teleport(sim, vw, mob.pos.x + 3, mob.pos.z);
+    sim.targetEntity(mob.id);
+    hit(sim, sim.player, mob, 5);
+    let petThreat = 0;
+    for (let i = 0; i < 20 * 20 && !(petThreat > 0 && mob.forcedTargetId === vw.id); i++) {
+      sim.tick();
+      petThreat = mob.threat.get(vw.id) ?? 0;
+    }
+    expect(vw.aggroTargetId).toBe(mob.id);
+    expect(petThreat).toBeGreaterThan(0);
+    expect(mob.forcedTargetId).toBe(vw.id); // voidwalker Growls/taunts (tank demon)
+    expect(mob.aggroTargetId).toBe(vw.id);
   });
 });
 


### PR DESCRIPTION
## Summary

<img width="1600" height="900" alt="wl1_imp_firebolt" src="https://github.com/user-attachments/assets/81a47d63-d195-4c9b-9461-30fb61b49c69" />

<img width="1600" height="900" alt="wl2_voidwalker_tank" src="https://github.com/user-attachments/assets/91404032-9daf-48f0-b944-5eaa5fa57aef" />


Warlocks shipped as a pure DoT and nuke class with no companion. This PR adds a
demon pet system for Warlocks, built on top of the existing Hunter pet substrate
(`ownerId`, `petOf`, and the `updatePet` leash/heel/Growl loop) so behavior is
identical across the offline sim, the authoritative server, and the headless RL
env.

Two pets, on a clean level progression:

- Summon Imp (learned at level 5): a ranged demon that heels at your side (about
  3.5 yards) and auto-casts Firebolt at your current target. Pure DPS, it does
  not taunt.
- Summon Voidwalker (learned at level 10): a durable melee tank that Growls and
  taunts to hold threat, the demonic analogue of a tamed beast.

Shared rules: one demon at a time (re-summoning replaces it); summoned demons
despawn entirely (no corpse, no respawn) on dismiss, owner logout, or death,
unlike a tamed beast that returns to the wild; the pet attacks what you attack
and only breaks off to defend itself if a mob pulls aggro onto it. Dismiss Pet is
now learnable at level 5 (it arrives with Summon Imp, and is also available to
Hunters).

Balance is tuned against the warlock's own output at the level-20 cap. Shadow
Bolt averages 15.5 per hit at level 1 and 76 at level 20. The Imp Firebolt is a
steady secondary at roughly 45 percent of that nuke's DPS (about 11 per hit at
level 5, about 29 at level 20, every 2.5s). The Voidwalker is a soak-and-hold
tank with about 1.5 times the warlock's HP (60 plus 20 per level), high armor,
and deliberately modest damage; it keeps aggro by taunting, not by out-DPSing.
The reasoning is documented inline in `src/sim/content/pets.ts`.

No new dependencies and no new art: the render path reuses two models that
already ship but were previously unreferenced, `demonalt.glb` (biped) for the
Imp and `demon.glb` (floating rig) for the hovering Voidwalker. Ability icons use
the existing procedural canvas-recipe system, so there are no raster assets.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npm test` (656 passing; added a `warlock demon pets` block in `tests/threat.test.ts` covering summon, auto-Firebolt and own-threat, Firebolt level scaling, heel-close, Voidwalker taunt and threat, and dismiss / replace / death despawn)
  - `npm run build`, `npm run build:server`, `npm run build:env` (all succeed)
  - `node scripts/smoke_warlock.mjs` (browser E2E, all checks pass)
- Manual steps: played a Warlock offline. At level 5, Summon Imp conjures the imp, which heels at your side and Firebolts your target while you stand still. At level 10, Summon Voidwalker replaces it; the Voidwalker charges in, melees, and taunts the target onto itself.

## Screenshots / recordings

Adding below: a Warlock with the Imp Firebolting a wolf, and a Warlock with the
Voidwalker tanking.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. Added tests for the new `sim/` behavior.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build`, `npm run build:server`, and `npm run build:env` all pass; no generated files (for example `manifest.generated.ts`) changed.

### Cross-platform

- ~Tested on desktop and mobile.~ No new HUD layout or touch targets; the only UI surface is two procedural ability icons in the existing action bar and spellbook. Verified on desktop via the headless smoke.
- ~Accessible.~ N/A: no new interactive UI elements.

### Localization (i18n)

- [x] N/A for new i18n strings. This PR adds no new `t()` keys or HUD chrome strings. Ability names, descriptions, and pet combat-log lines are English content-data strings, the same convention every existing ability and the existing hunter-pet logs already use.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I did not hand-edit generated files such as `src/render/assets/manifest.generated.ts`. The demon models were already present in the manifest, and the build leaves it unchanged.

---

Generated with Claude Code (https://claude.com/claude-code).
