### PR TITLE
feat(render): ambient drifting motes that give each zone living air

### DIFF
--- a/scripts/motes_shot.mjs
+++ b/scripts/motes_shot.mjs
@@ -1,0 +1,67 @@
+// Ambient motes: capture the drifting airborne specks in each biome.
+// Needs `npm run dev` (:5173). Writes PNGs into tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Drift');
+await page.click('#offline-select .mini-class[data-class="mage"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 3000));
+
+await page.evaluate(() => { const p = window.__game.sim.player; p.maxHp = p.hp = 99999; });
+
+// god-mode + teleport, low afternoon-ish camera angle so motes catch the light
+const tp = async (x, z, yaw = 0) => {
+  await page.evaluate((x, z, yaw) => {
+    const g = window.__game;
+    const p = g.sim.player;
+    if (p.dead) g.sim.releaseSpirit();
+    p.maxHp = p.hp = 99999;
+    p.pos.x = x; p.pos.z = z; p.facing = yaw;
+    g.input.camYaw = yaw;
+  }, x, z, yaw);
+  // let the mote field reseed + animate a few seconds for a lively frame
+  await new Promise((r) => setTimeout(r, 2500));
+};
+
+// vale meadow (gold pollen), marsh (green spores), peaks (pale snow dust)
+await tp(150, 210, 0.5);
+await page.screenshot({ path: 'tmp/motes_vale.png' });
+await tp(60, 360, 0.5);
+await page.screenshot({ path: 'tmp/motes_marsh.png' });
+await tp(40, 720, 0.5);
+await page.screenshot({ path: 'tmp/motes_peaks.png' });
+
+// confirm the field is actually populated + hidden indoors
+const stats = await page.evaluate(() => {
+  const g = window.__game;
+  const pts = g.renderer.motes.group.children[0];
+  const overworld = { visible: g.renderer.motes.group.visible, count: pts.geometry.attributes.position.count };
+  // jump into a dungeon strip (past DUNGEON_X_THRESHOLD) and re-sync
+  g.sim.player.pos.x = 100000; g.sim.player.pos.z = 0;
+  return overworld;
+});
+await new Promise((r) => setTimeout(r, 600));
+const indoors = await page.evaluate(() => window.__game.renderer.motes.group.visible);
+
+console.log('overworld motes:', JSON.stringify(stats), '| visible indoors:', indoors);
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 15).join('\n') : 'no page errors');
+await browser.close();

--- a/src/render/motes.ts
+++ b/src/render/motes.ts
@@ -1,0 +1,160 @@
+import * as THREE from 'three';
+import { DUNGEON_X_THRESHOLD, WORLD_MAX_X, WORLD_MAX_Z, WORLD_MIN_Z } from '../sim/data';
+import type { BiomeId } from '../sim/types';
+import { terrainHeight, zoneBiomeAt, WATER_LEVEL } from '../sim/world';
+import { GFX } from './gfx';
+
+// ---------------------------------------------------------------------------
+// Ambient motes — a render-only field of drifting airborne specks (pollen in
+// the vale, marsh spores, snow dust on the peaks) that float around the player
+// to give each zone a little living atmosphere. Pure presentation: it reads the
+// world's terrain height + biome and never touches sim state. The contract
+// mirrors the grass ring in foliage.ts — a player-centred pool that recycles
+// motes as you walk rather than rebuilding, and that hides itself indoors.
+// ---------------------------------------------------------------------------
+
+export interface MotesView {
+  group: THREE.Group;
+  update(px: number, pz: number, dt: number): void;
+}
+
+// per-biome speck colour — warm gold pollen, sickly green marsh spores, pale
+// blue snow dust; kept lighter than GRASS_TINT so they read as glints in air
+const MOTE_TINT: Record<BiomeId, number> = { vale: 0xf4e6a0, marsh: 0xb8d28a, peaks: 0xdce8f2 };
+
+const RADIUS = 26; // motes live within this ring of the player
+const FLOOR = 0.6; // min height above the sampled ground
+const CEIL = 3.4; // max height above the sampled ground
+
+// deterministic per-render RNG (render convention: never Math.random)
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// soft round glow sprite, built once on a canvas (no image assets)
+function moteSprite(): THREE.Texture {
+  const s = 32;
+  const cv = document.createElement('canvas');
+  cv.width = cv.height = s;
+  const g = cv.getContext('2d')!;
+  const grad = g.createRadialGradient(s / 2, s / 2, 0, s / 2, s / 2, s / 2);
+  grad.addColorStop(0, 'rgba(255,255,255,1)');
+  grad.addColorStop(0.4, 'rgba(255,255,255,0.5)');
+  grad.addColorStop(1, 'rgba(255,255,255,0)');
+  g.fillStyle = grad;
+  g.fillRect(0, 0, s, s);
+  const tex = new THREE.CanvasTexture(cv);
+  tex.colorSpace = THREE.SRGBColorSpace;
+  return tex;
+}
+
+export function buildMotes(seed: number): MotesView {
+  const group = new THREE.Group();
+  group.name = 'motes';
+
+  // count scales with tier — cheap THREE.Points, so high/ultra can afford a
+  // dense shimmer while low stays sparse
+  const count = GFX.standardMaterials ? 80 : 30;
+  const rng = mulberry32(seed ^ 0x57e3);
+
+  const positions = new Float32Array(count * 3);
+  const colors = new Float32Array(count * 3);
+  // per-mote animation state: drift phase, bob amplitude, base ground height
+  const phase = new Float32Array(count);
+  const bobAmp = new Float32Array(count);
+  const baseY = new Float32Array(count);
+  // horizontal home of each mote; the speck drifts a little around it
+  const homeX = new Float32Array(count);
+  const homeZ = new Float32Array(count);
+
+  const tmpColor = new THREE.Color();
+
+  // (re)home a single mote to a random spot inside the ring around the player,
+  // re-sampling terrain + biome tint. Returns false when the spot is unusable
+  // (out of bounds / over water) so the caller can leave the mote parked.
+  function place(i: number, px: number, pz: number): boolean {
+    const ang = rng() * Math.PI * 2;
+    const r = Math.sqrt(rng()) * RADIUS; // sqrt → even areal spread, not centre-clumped
+    const x = px + Math.cos(ang) * r;
+    const z = pz + Math.sin(ang) * r;
+    if (Math.abs(x) > WORLD_MAX_X - 8 || z < WORLD_MIN_Z + 8 || z > WORLD_MAX_Z - 8) return false;
+    const h = terrainHeight(x, z, seed);
+    if (h < WATER_LEVEL + 0.5) return false; // no motes hovering over open water
+    homeX[i] = x;
+    homeZ[i] = z;
+    baseY[i] = h;
+    phase[i] = rng() * Math.PI * 2;
+    bobAmp[i] = FLOOR + rng() * (CEIL - FLOOR);
+    positions[i * 3] = x;
+    positions[i * 3 + 1] = h + bobAmp[i];
+    positions[i * 3 + 2] = z;
+    tmpColor.setHex(MOTE_TINT[zoneBiomeAt(z)]);
+    colors[i * 3] = tmpColor.r;
+    colors[i * 3 + 1] = tmpColor.g;
+    colors[i * 3 + 2] = tmpColor.b;
+    return true;
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+
+  const mat = new THREE.PointsMaterial({
+    size: GFX.standardMaterials ? 0.5 : 0.7,
+    map: moteSprite(),
+    vertexColors: true,
+    transparent: true,
+    depthWrite: false, // glows shouldn't punch holes in what's behind them
+    blending: THREE.AdditiveBlending,
+    sizeAttenuation: true,
+    opacity: 0.85,
+  });
+
+  const points = new THREE.Points(geo, mat);
+  points.frustumCulled = false; // pool is centred on the player; bounds churn isn't worth it
+  group.add(points);
+
+  let seeded = false;
+  let t = 0;
+
+  return {
+    group,
+    update(px: number, pz: number, dt: number): void {
+      if (px > DUNGEON_X_THRESHOLD) {
+        group.visible = false; // dungeons live outside the strip — no motes indoors
+        seeded = false;
+        return;
+      }
+      group.visible = true;
+      if (!seeded) {
+        for (let i = 0; i < count; i++) {
+          if (!place(i, px, pz)) baseY[i] = -1e6; // park unusable motes far below
+        }
+        seeded = true;
+      }
+      t += dt;
+      for (let i = 0; i < count; i++) {
+        // recycle a mote once the player has wandered out of its ring
+        const dx = homeX[i] - px;
+        const dz = homeZ[i] - pz;
+        if (dx * dx + dz * dz > RADIUS * RADIUS) {
+          if (!place(i, px, pz)) { baseY[i] = -1e6; continue; }
+        }
+        if (baseY[i] < -1e5) continue; // parked
+        const ph = phase[i] + t * 0.6;
+        positions[i * 3] = homeX[i] + Math.sin(ph) * 0.5;
+        positions[i * 3 + 1] = baseY[i] + bobAmp[i] + Math.sin(ph * 1.3) * 0.35;
+        positions[i * 3 + 2] = homeZ[i] + Math.cos(ph * 0.8) * 0.5;
+      }
+      geo.attributes.position.needsUpdate = true;
+      geo.attributes.color.needsUpdate = true;
+    },
+  };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -26,6 +26,7 @@ import { buildWater, WaterView } from './water';
 import { buildClouds, buildSky, SkyView } from './sky';
 import { buildFoliage, FoliageView } from './foliage';
 import { buildFish, FishView } from './fish';
+import { buildMotes, MotesView } from './motes';
 import { shouldRenderStealthGhost } from './stealth';
 import { t } from '../ui/i18n';
 import { tEntity } from '../ui/entity_i18n';
@@ -237,6 +238,7 @@ export class Renderer {
   private terrainView: TerrainView;
   private foliage: FoliageView;
   private fish: FishView;
+  private motes: MotesView;
   private fogScratch = new THREE.Color();
   private flames: THREE.Mesh[];
   private fireLights: THREE.PointLight[];
@@ -439,6 +441,8 @@ export class Renderer {
     this.scene.add(this.foliage.group);
     this.fish = buildFish(this.sim.cfg.seed);
     this.scene.add(this.fish.group);
+    this.motes = buildMotes(this.sim.cfg.seed);
+    this.scene.add(this.motes.group);
     const props = buildProps(this.sim.cfg.seed);
     this.scene.add(props.group);
     this.flames = props.flames;
@@ -1298,6 +1302,7 @@ export class Renderer {
     this.propsView.update(this.camera.position.x, this.camera.position.y, this.camera.position.z, fogFar);
     this.foliage.update(p.pos.x, p.pos.z, this.camera.position.x, this.camera.position.z, fogFar);
     this.fish.update(p.pos.x, p.pos.z, dt);
+    this.motes.update(p.pos.x, p.pos.z, dt);
 
     this.vfx.update(dt);
 


### PR DESCRIPTION
## Ambient motes — drifting specks that give each zone living air

A small, render-only atmosphere touch: a field of slow **airborne motes** that
drift around the player — warm gold pollen in the vale, green spores over the
marsh, and pale snow dust on the peaks. It makes standing in the world feel
alive without changing a single thing about gameplay.

| Vale / meadow | Thornpeak Heights |
|---|---|
| ![vale](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ambient-motes/shots/motes_vale.png) | ![peaks](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ambient-motes/shots/motes_peaks.png) |

### What it does
- New `src/render/motes.ts` exports `buildMotes(seed) -> { group, update(px, pz, dt) }`,
  owned by the renderer and wired in right beside `buildFoliage`.
- Follows the existing **grass-ring contract** in `foliage.ts`: a player-centred
  pool that **recycles** motes as you walk (no per-frame rebuild), samples the
  deterministic `terrainHeight` + `zoneBiomeAt` from `sim/world`, skips
  out-of-bounds and over-water spots, and hides itself indoors past
  `DUNGEON_X_THRESHOLD`.
- Cost scales with the **GFX tier** (80 motes on high/ultra, 30 on low). Cheap
  `THREE.Points` with additive blending and a procedural canvas glow sprite —
  no GLB/manifest changes, no new assets.
- Deterministic local `mulberry32` RNG, **no `Math.random`** (render convention).

### Invariants respected
- **Pure presentation** — reads the world, never mutates sim state; no
  `IWorld`/server/headless changes, so offline + online + RL are untouched.
- No new dependencies; Three stays pinned at r0.165.

### Verification
- `npx tsc --noEmit` clean.
- New `scripts/motes_shot.mjs` drives the real offline client and confirms the
  field populates in the overworld and is **hidden indoors** past the dungeon
  threshold (`overworld motes: {visible:true,count:30} | visible indoors: false`
  on the swiftshader/low tier). Screenshots above are from that script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
