### PR TITLE
feat(ui): minimap zoom control (discrete presets)

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,6 +660,18 @@
   #minimap-wrap { position: absolute; right: 12px; top: 10px; width: 170px; text-align: center; }
   #zone-label { font-size: 13px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 3px #000; margin-bottom: 3px; letter-spacing: 0.5px; }
   #minimap { border-radius: 50%; border: 4px solid var(--border); outline: 1px solid #000; box-shadow: 0 0 14px #000c, inset 0 0 20px #0008; }
+  /* minimap zoom control: a compact gold pill pinned to the bottom rim of the
+     round minimap. Vertical centre holds the live zoom readout (e.g. "2×"). */
+  #minimap-zoom { position: absolute; left: 50%; bottom: -6px; transform: translateX(-50%);
+    display: flex; align-items: center; gap: 4px; padding: 1px 4px; z-index: 2;
+    background: radial-gradient(circle at 50% 30%, #2c2c3a, #15151f); border: 1px solid #4a3d1d;
+    border-radius: 9px; box-shadow: 0 1px 3px #000a; }
+  .minimap-zoom-btn { width: 17px; height: 17px; padding: 0; line-height: 1; font-size: 14px; font-weight: bold;
+    color: #d8c89a; background: none; border: none; cursor: pointer; border-radius: 4px; font-family: var(--title-font); }
+  .minimap-zoom-btn:hover:not(:disabled) { color: #fff; background: #ffffff1a; }
+  .minimap-zoom-btn:disabled { opacity: 0.3; cursor: default; }
+  #minimap-zoom-label { min-width: 24px; font-size: 11px; color: var(--gold); font-family: var(--title-font);
+    text-shadow: 1px 1px 2px #000; letter-spacing: 0.3px; }
 
   /* ---------- community HUD ---------- */
   /* Discord/GitHub: bottom-right, directly below the micro-menu, right-aligned with it. */
@@ -5307,6 +5319,11 @@
     <div id="minimap-wrap">
       <div id="zone-label" data-i18n="entities.zones.eastbrook_vale.name">Eastbrook Vale</div>
       <canvas id="minimap" width="162" height="162"></canvas>
+      <div id="minimap-zoom" aria-label="Minimap zoom">
+        <button class="minimap-zoom-btn" id="minimap-zoom-out" title="Zoom out" aria-label="Zoom out minimap">&minus;</button>
+        <span id="minimap-zoom-label" aria-live="polite">1×</span>
+        <button class="minimap-zoom-btn" id="minimap-zoom-in" title="Zoom in" aria-label="Zoom in minimap">+</button>
+      </div>
     </div>
 
     <div id="community-hud" data-i18n-aria="hud.core.communityLinks" aria-label="Community links">

--- a/scripts/minimap_zoom_visual.mjs
+++ b/scripts/minimap_zoom_visual.mjs
@@ -1,0 +1,77 @@
+// Captures the minimap zoom control at each preset (1x / 1.5x / 2x / 3x) plus a
+// full-HUD shot, driving the real offline client via window.__game. Screenshots
+// land in tmp/. Run the dev client first (npm run dev), then:
+//   GAME_URL=http://localhost:5173 node scripts/minimap_zoom_visual.mjs
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const errors = [];
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  protocolTimeout: 60000,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1280,800', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 800 },
+});
+
+const page = await browser.newPage();
+page.on('pageerror', (e) => errors.push(e.message));
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await sleep(800);
+
+// offline boot: btn-offline -> name -> class -> start (input id is char-name)
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(400);
+await page.evaluate(() => {
+  document.querySelector('#char-name').value = 'Scout';
+  document.querySelector('#offline-select .mini-class[data-class="hunter"]').click();
+  document.querySelector('#btn-start-offline').click();
+});
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 5, { timeout: 20000, polling: 400 });
+await sleep(500);
+// dismiss the mobile preflight if it appears
+await page.evaluate(() => document.querySelector('#mobile-preflight-continue')?.click());
+await sleep(400);
+
+// crop tight to the minimap (+ its zoom pill, which hangs ~6px below the canvas)
+async function clipMinimap(name) {
+  const rect = await page.evaluate(() => {
+    const r = document.querySelector('#minimap-wrap').getBoundingClientRect();
+    return { x: r.x - 6, y: r.y - 6, width: r.width + 12, height: r.height + 22 };
+  });
+  await page.screenshot({ path: `tmp/${name}.png`, clip: rect });
+}
+
+// reset to a known state, then step the control like a player would
+await page.evaluate(() => { localStorage.removeItem('minimapZoom'); });
+for (const [z, file] of [[1, 'mmzoom-1x'], [1.5, 'mmzoom-1_5x'], [2, 'mmzoom-2x'], [3, 'mmzoom-3x']]) {
+  await page.evaluate((target) => {
+    // drive through the public buttons so the readout + disabled states update
+    document.querySelector('#minimap-zoom-out').click(); // floor to 1x
+    document.querySelector('#minimap-zoom-out').click();
+    const steps = [1, 1.5, 2, 3].indexOf(target);
+    for (let i = 0; i < steps; i++) document.querySelector('#minimap-zoom-in').click();
+  }, z);
+  await sleep(500);
+  await clipMinimap(file);
+  const shown = await page.evaluate(() => document.querySelector('#minimap-zoom-label').textContent);
+  console.log(`zoom ${z}x -> label "${shown}"`);
+}
+
+// a full-HUD shot at 2x so the control reads in context
+await page.evaluate(() => {
+  document.querySelector('#minimap-zoom-out').click();
+  document.querySelector('#minimap-zoom-out').click();
+  document.querySelector('#minimap-zoom-in').click();
+  document.querySelector('#minimap-zoom-in').click();
+});
+await sleep(500);
+await page.screenshot({ path: 'tmp/mmzoom-full-hud.png' });
+
+console.log(errors.length ? 'PAGE ERRORS:\n' + errors.slice(0, 8).join('\n') : 'no page errors');
+await browser.close();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { clampMinimapZoom, nextMinimapZoom, isMinMinimapZoom, isMaxMinimapZoom, formatMinimapZoom, MINIMAP_ZOOM_DEFAULT } from './minimap_zoom';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -272,6 +273,10 @@ export class Hud {
   private hotDomSkippedWrites = 0;
   private minimapCtx: CanvasRenderingContext2D;
   private minimapBg: HTMLCanvasElement;
+  // Minimap zoom: a multiplier on the minimap's base pixels-per-yard. Discrete
+  // presets (see minimap_zoom.ts), persisted to localStorage. 1 = shipped look.
+  private minimapZoom = MINIMAP_ZOOM_DEFAULT;
+  private minimapZoomLabel: HTMLElement | null = null;
   private mapBg: HTMLCanvasElement | null = null;
   private openLootMobId: number | null = null;
   private openVendorNpcId: number | null = null;
@@ -366,6 +371,7 @@ export class Hud {
       if (target && (this.emoteWheelEl?.contains(target) || document.getElementById('mm-emote')?.contains(target) || document.getElementById('mobile-emote')?.contains(target))) return;
       this.hideEmoteWheel();
     });
+    this.initMinimapZoom(mm);
     this.releaseSpiritBtnEl.addEventListener('click', () => {
       if (this.sim.arenaInfo?.match) return;
       this.sim.releaseSpirit();
@@ -1928,6 +1934,43 @@ export class Hud {
     return c;
   }
 
+  // Build the minimap zoom control: load the persisted level, wire the +/-
+  // buttons and a scroll-wheel handler over the minimap canvas. Pure DOM glue;
+  // all stepping/clamping math lives in minimap_zoom.ts.
+  private initMinimapZoom(mm: HTMLElement): void {
+    const saved = Number(localStorage.getItem('minimapZoom'));
+    this.minimapZoom = clampMinimapZoom(saved);
+    this.minimapZoomLabel = $('#minimap-zoom-label');
+    const inBtn = document.querySelector('#minimap-zoom-in');
+    const outBtn = document.querySelector('#minimap-zoom-out');
+    inBtn?.addEventListener('click', (e) => { e.stopPropagation(); this.setMinimapZoom(nextMinimapZoom(this.minimapZoom, +1)); });
+    outBtn?.addEventListener('click', (e) => { e.stopPropagation(); this.setMinimapZoom(nextMinimapZoom(this.minimapZoom, -1)); });
+    // scroll over the minimap to zoom (up = in), without scrolling the page
+    mm.addEventListener('wheel', (e) => {
+      e.preventDefault();
+      this.setMinimapZoom(nextMinimapZoom(this.minimapZoom, (e as WheelEvent).deltaY < 0 ? +1 : -1));
+    }, { passive: false });
+    this.syncMinimapZoomUi();
+  }
+
+  private setMinimapZoom(z: number): void {
+    const next = clampMinimapZoom(z);
+    if (next === this.minimapZoom) return;
+    this.minimapZoom = next;
+    localStorage.setItem('minimapZoom', String(next));
+    this.syncMinimapZoomUi();
+  }
+
+  // Reflect the current zoom in the readout and disable the +/- buttons at the
+  // ends so the control communicates its own limits.
+  private syncMinimapZoomUi(): void {
+    if (this.minimapZoomLabel) this.minimapZoomLabel.textContent = formatMinimapZoom(this.minimapZoom);
+    const inBtn = document.querySelector('#minimap-zoom-in') as HTMLButtonElement | null;
+    const outBtn = document.querySelector('#minimap-zoom-out') as HTMLButtonElement | null;
+    if (inBtn) inBtn.disabled = isMaxMinimapZoom(this.minimapZoom);
+    if (outBtn) outBtn.disabled = isMinMinimapZoom(this.minimapZoom);
+  }
+
   private updateMinimap(): void {
     const ctx = this.minimapCtx;
     const S = 162;
@@ -1939,7 +1982,9 @@ export class Hud {
     ctx.arc(S / 2, S / 2, S / 2 - 2, 0, Math.PI * 2);
     ctx.clip();
     ctx.imageSmoothingEnabled = false;
-    const pxPerYard = 1.7;
+    // 1.7 is the historical base scale; the zoom multiplier shrinks the world
+    // radius shown so markers spread out as you zoom in (default 1 = unchanged).
+    const pxPerYard = 1.7 * this.minimapZoom;
     const bg = this.minimapBg;
     const bgPxPerYard = bg.width / (WORLD_MAX_X - WORLD_MIN_X);
     const sw = S / (pxPerYard / bgPxPerYard);

--- a/src/ui/minimap_zoom.ts
+++ b/src/ui/minimap_zoom.ts
@@ -1,0 +1,48 @@
+// Pure derivation of the minimap zoom state. Kept UI-framework-free (no DOM) so
+// the discrete zoom stepping + label formatting can be snapshot tested directly,
+// mirroring xp_bar.ts. The HUD owns persistence (localStorage) and applies the
+// returned multiplier to the minimap's pixels-per-yard scale.
+
+// Fixed zoom presets, ascending. 1 = the historical shipped scale (unchanged
+// look at default), up to a 3x close-in view. Higher = more zoomed in (more
+// pixels per yard, so a smaller world radius fills the minimap circle).
+export const MINIMAP_ZOOM_LEVELS = [1, 1.5, 2, 3] as const;
+
+export const MINIMAP_ZOOM_DEFAULT: number = MINIMAP_ZOOM_LEVELS[0];
+
+// Snap an arbitrary value (e.g. a stale/garbage localStorage entry) to the
+// nearest valid preset, falling back to the default for non-finite input.
+export function clampMinimapZoom(z: number): number {
+  if (!Number.isFinite(z)) return MINIMAP_ZOOM_DEFAULT;
+  let best: number = MINIMAP_ZOOM_LEVELS[0];
+  let bestDist = Math.abs(z - best);
+  for (const lvl of MINIMAP_ZOOM_LEVELS) {
+    const d = Math.abs(z - lvl);
+    if (d < bestDist) { best = lvl; bestDist = d; }
+  }
+  return best;
+}
+
+// Step one preset in the given direction (+1 = zoom in, -1 = zoom out),
+// clamped at the ends (no wrap-around). Returns the current level unchanged
+// when already at a boundary.
+export function nextMinimapZoom(current: number, dir: number): number {
+  const idx = MINIMAP_ZOOM_LEVELS.indexOf(clampMinimapZoom(current) as typeof MINIMAP_ZOOM_LEVELS[number]);
+  const next = Math.max(0, Math.min(MINIMAP_ZOOM_LEVELS.length - 1, idx + Math.sign(dir)));
+  return MINIMAP_ZOOM_LEVELS[next];
+}
+
+export function isMinMinimapZoom(z: number): boolean {
+  return clampMinimapZoom(z) === MINIMAP_ZOOM_LEVELS[0];
+}
+
+export function isMaxMinimapZoom(z: number): boolean {
+  return clampMinimapZoom(z) === MINIMAP_ZOOM_LEVELS[MINIMAP_ZOOM_LEVELS.length - 1];
+}
+
+// Compact readout, e.g. "1×" / "1.5×" / "2×". Trailing-zero-free so 1.5 stays
+// "1.5×" but 2.0 reads "2×".
+export function formatMinimapZoom(z: number): string {
+  const v = clampMinimapZoom(z);
+  return `${Number(v.toFixed(1))}×`;
+}

--- a/tests/minimap_zoom.test.ts
+++ b/tests/minimap_zoom.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MINIMAP_ZOOM_LEVELS,
+  MINIMAP_ZOOM_DEFAULT,
+  clampMinimapZoom,
+  nextMinimapZoom,
+  isMinMinimapZoom,
+  isMaxMinimapZoom,
+  formatMinimapZoom,
+} from '../src/ui/minimap_zoom';
+
+describe('minimap zoom', () => {
+  it('default is the first (1x) preset = unchanged shipped scale', () => {
+    expect(MINIMAP_ZOOM_DEFAULT).toBe(1);
+    expect(MINIMAP_ZOOM_LEVELS[0]).toBe(1);
+  });
+
+  it('clamps arbitrary / garbage values to the nearest preset', () => {
+    expect(clampMinimapZoom(1.4)).toBe(1.5);
+    expect(clampMinimapZoom(2.4)).toBe(2);
+    expect(clampMinimapZoom(99)).toBe(3);
+    expect(clampMinimapZoom(0)).toBe(1);
+    expect(clampMinimapZoom(NaN)).toBe(MINIMAP_ZOOM_DEFAULT);
+    expect(clampMinimapZoom(Infinity)).toBe(MINIMAP_ZOOM_DEFAULT);
+  });
+
+  it('steps through presets and clamps at the ends (no wrap)', () => {
+    expect(nextMinimapZoom(1, +1)).toBe(1.5);
+    expect(nextMinimapZoom(1.5, +1)).toBe(2);
+    expect(nextMinimapZoom(2, +1)).toBe(3);
+    expect(nextMinimapZoom(3, +1)).toBe(3); // clamped at max
+    expect(nextMinimapZoom(2, -1)).toBe(1.5);
+    expect(nextMinimapZoom(1, -1)).toBe(1); // clamped at min
+  });
+
+  it('reports boundary state', () => {
+    expect(isMinMinimapZoom(1)).toBe(true);
+    expect(isMinMinimapZoom(1.5)).toBe(false);
+    expect(isMaxMinimapZoom(3)).toBe(true);
+    expect(isMaxMinimapZoom(2)).toBe(false);
+  });
+
+  it('formats a compact, trailing-zero-free readout', () => {
+    expect(formatMinimapZoom(1)).toBe('1×');
+    expect(formatMinimapZoom(1.5)).toBe('1.5×');
+    expect(formatMinimapZoom(2)).toBe('2×');
+    expect(formatMinimapZoom(3)).toBe('3×');
+  });
+});


### PR DESCRIPTION
## What

Adds a **zoom control to the minimap** — a compact gold `− 1× +` pill on the bottom rim of the round minimap. Classic-WoW lets you zoom the minimap; ours was fixed while the *world map* already has a full zoom system. This closes that gap.

- Discrete presets: **1× / 1.5× / 2× / 3×** (default **1× = the unchanged shipped scale**).
- `+`/`−` buttons **and scroll-wheel** over the minimap step the zoom; buttons disable at the ends.
- The chosen level **persists** to `localStorage`.

| 1× (default, full zone) | 3× (zoomed in) |
|---|---|
| ![1x](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/minimap-zoom/docs/pr-assets/minimap-zoom/mmzoom-1x.png) | ![3x](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/minimap-zoom/docs/pr-assets/minimap-zoom/mmzoom-3x.png) |

In context (2×):

![full hud](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/minimap-zoom/docs/pr-assets/minimap-zoom/mmzoom-full-hud.png)

## How

Pure presentation, mirroring the established `xp_bar.ts` testable-helper pattern:

- **New `src/ui/minimap_zoom.ts`** — DOM-free helper holding all stepping / clamping / label math (`nextMinimapZoom`, `clampMinimapZoom`, `formatMinimapZoom`, boundary checks). Unit-tested in `tests/minimap_zoom.test.ts`.
- **`src/ui/hud.ts`** — `initMinimapZoom` wires the buttons + wheel and loads the saved level; `updateMinimap` scales the base `pxPerYard` (1.7) by the multiplier; `syncMinimapZoomUi` updates the readout and disabled states.
- **`index.html`** — `#minimap-zoom` markup inside `#minimap-wrap` + scoped CSS.

**No `src/sim/`, `IWorld`, `net/`, or server changes** — it reads only the player position the HUD already has, so it works offline + online and has zero determinism / RL impact.

## Tests

- `npx vitest run tests/minimap_zoom.test.ts` ✅ (5 cases: default, clamp/garbage, stepping with end-clamp, boundary state, label formatting)
- Full suite **653 passing**, `tsc --noEmit` clean.
- Screenshots captured via `scripts/minimap_zoom_visual.mjs` (offline tour, no dev commands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)