### PR TITLE
fix(mobile): repair touch control hitboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3124,7 +3124,7 @@
      anywhere; the joystick rests dimmed at home until touched, then springs to
      the touch point with a gold "engaged" glow. */
   body.mobile-touch #mobile-move-zone {
-    position: absolute; left: 0; bottom: 0; width: 44%; height: 58%;
+    position: absolute; left: 0; bottom: 0; width: min(34vw, calc(50vw - 126px)); min-width: 142px; max-width: 300px; height: 58%;
     pointer-events: auto; touch-action: none; z-index: 1;
   }
   body.mobile-touch.mobile-chat-open #mobile-move-zone { pointer-events: none; }
@@ -3149,7 +3149,7 @@
   }
   body.mobile-touch #mobile-combat-controls {
     position: absolute; left: 50%; bottom: calc(4px + env(safe-area-inset-bottom)); transform: translateX(-50%);
-    display: grid; grid-template-columns: 124px repeat(4, 58px); gap: 8px; pointer-events: auto; align-items: end;
+    display: grid; grid-template-columns: 124px repeat(5, 58px); gap: 8px; pointer-events: auto; align-items: end; z-index: 30;
   }
   body.mobile-touch .mobile-btn {
     width: 58px; height: 54px; border: 2px solid #4a3d1d; border-radius: 8px;
@@ -3718,6 +3718,12 @@
 
   @media (orientation: portrait) {
     body.mobile-touch.game-active #rotate-device { display: flex; }
+    body.mobile-touch #mobile-combat-controls {
+      grid-template-columns: 96px repeat(5, 42px);
+      gap: 4px;
+    }
+    body.mobile-touch .mobile-btn { width: 42px; height: 44px; font-size: 16px; }
+    body.mobile-touch #mobile-attack-nearest { width: 96px; }
   }
 
   @media (orientation: landscape) {
@@ -3733,7 +3739,7 @@
     }
     body.mobile-touch .mobile-joy-label { bottom: -15px; font-size: 8px; color: #d7c987aa; }
     body.mobile-touch #mobile-combat-controls {
-      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px repeat(4, 54px); gap: 7px;
+      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px repeat(5, 54px); gap: 7px;
     }
     body.mobile-touch .mobile-btn { width: 54px; height: 48px; font-size: 20px; background: radial-gradient(circle at 35% 30%, #2d3048bf, #11121ec2 72%); }
     body.mobile-touch #mobile-attack-nearest { width: 115px; }

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -54,9 +54,21 @@ describe('client HTML shell', () => {
   });
 
   it('keeps the mobile More button in the combat row', () => {
-    expect(html).toContain('grid-template-columns: 124px repeat(4, 58px);');
-    expect(html).toContain('grid-template-columns: 115px repeat(4, 54px);');
+    const combatControls = html.slice(html.indexOf('<div id="mobile-combat-controls">'), html.indexOf('<div id="mobile-extra-controls">'));
+    const primaryButtons = [...combatControls.matchAll(/<button class="mobile-btn"/g)];
+
+    expect(primaryButtons).toHaveLength(6);
+    expect(html).toContain('grid-template-columns: 124px repeat(5, 58px);');
+    expect(html).toContain('grid-template-columns: 115px repeat(5, 54px);');
+    expect(html).toContain('grid-template-columns: 96px repeat(5, 42px);');
+    expect(html).toContain('pointer-events: auto; align-items: end; z-index: 30;');
     expect(html).toContain('body.mobile-touch #mobile-more {\n    position: static;');
+  });
+
+  it('keeps the mobile move zone clear of the centered skill bar', () => {
+    expect(html).toContain('width: min(34vw, calc(50vw - 126px));');
+    expect(html).toContain('min-width: 142px;');
+    expect(html).toContain('max-width: 300px;');
   });
 
   it('places mobile Autorun beside the spell bar', () => {


### PR DESCRIPTION
## What

Fixes two mobile HUD regressions on `release/v0.7`:

- The bottom combat row had six buttons but only five grid columns, causing the row to wrap/overlap the skill bar and contribute to horizontal overflow on narrow screens.
- The floating move joystick capture zone extended under the centered skill/action bar, so pressing the first skill button could spawn the movement joystick on top of it.

## Fix

- Give the mobile combat row one grid column per primary button (`Attack`, `Jump`, `Target`, `Use`, `Chat`, `More`) in base and landscape rules.
- Add a compact portrait layout for the six-button row so it fits within narrow phone viewports.
- Narrow the move capture zone so it stays clear of the centered skill bar while keeping the lower-left joystick touch target.
- Add static shell coverage for the six-button row, portrait grid, and move-zone bounds.

No `sim/`, `IWorld`, `net/`, server, or gameplay rule changes.

## Verification

- `npx vitest run tests/client_shell.test.ts tests/mobile_controls.test.ts`
- `npx tsc --noEmit`
- Chrome mobile/touch emulation verified:
  - Landscape: first skill button is no longer covered by `#mobile-move-zone`.
  - Landscape: More remains the top tap target and opens the tray without activating the joystick.
  - Portrait 390px wide: combat row fits inside the viewport and document width does not overflow.
