### PR TITLE
feat(render): ambient bird flock drifting across the sky

### DIFF
--- a/scripts/birds_shot.mjs
+++ b/scripts/birds_shot.mjs
@@ -1,0 +1,86 @@
+// Screenshots of the ambient bird flock (src/render/birds.ts) for the PR.
+// Boots the offline world, looks up at the sky, and captures the flock drifting
+// overhead. Needs `npm run dev` running. Browser via scripts/browser_path.mjs.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const OUT = 'tmp/birds';
+fs.mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Skylark');
+await page.click('#offline-select .mini-class[data-class="hunter"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 3000));
+
+// Open meadow on the vale plain, immortal photographer.
+await page.evaluate(() => {
+  const g = window.__game;
+  const p = g.sim.player;
+  p.maxHp = 99999; p.hp = 99999;
+  p.pos.x = 0; p.pos.z = -40;
+  p.facing = 0;
+  g.input.camYaw = Math.PI;
+  g.input.camPitch = -0.4; // pitch the orbit camera up toward the sky
+});
+
+// First: the flock as it naturally drifts overhead (lower pitch = more sky).
+for (let i = 0; i < 4; i++) {
+  await new Promise((r) => setTimeout(r, 1100));
+  await page.screenshot({ path: `${OUT}/birds_drift_${i}.png` });
+}
+
+// Then a staged hero shot: freeze the flock (update is a reassignable closure)
+// and arc a V-formation across the sky ahead of the camera so the silhouettes
+// fill the frame for the still.
+await page.evaluate(() => {
+  const g = window.__game;
+  const birds = g.renderer.birds;
+  birds.update = () => {}; // freeze positions for the photo
+  birds.group.visible = true;
+  const kids = birds.group.children;
+  const cam = g.renderer.camera;
+  cam.updateMatrixWorld();
+  // True forward from the camera, then a horizontal "right" perpendicular to it.
+  const fwd = kids[0].position.clone();
+  cam.getWorldDirection(fwd);
+  const rl = Math.hypot(fwd.x, fwd.z) || 1;
+  const rx = fwd.z / rl, rz = -fwd.x / rl; // right vector on the ground plane
+  const cy = g.input.camYaw;
+  kids.forEach((b, i) => {
+    const rank = Math.ceil(i / 2);
+    const side = i % 2 === 0 ? 1 : -1;
+    const ahead = 26 + rank * 6;
+    const lateral = side * rank * 7;
+    b.position.set(
+      cam.position.x + fwd.x * ahead + rx * lateral,
+      cam.position.y + fwd.y * ahead + 10 + rank * 1.4, // lift above the look line
+      cam.position.z + fwd.z * ahead + rz * lateral,
+    );
+    // Bank the flock gently toward the camera so the flat wings present some
+    // span instead of being seen edge-on from the near-horizontal third-person
+    // view; the flap then reads as a shallow V.
+    b.rotation.set(0, cy + Math.PI, 0.55);
+    b.scale.setScalar(1.7);
+    b.children[0].rotation.z = 0.5;  // wings mid-flap
+    b.children[1].rotation.z = -0.5;
+  });
+});
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({ path: `${OUT}/birds_hero.png` });
+
+await browser.close();
+console.log('wrote screenshots to', OUT);

--- a/src/render/birds.ts
+++ b/src/render/birds.ts
@@ -1,0 +1,175 @@
+import * as THREE from 'three';
+import { DUNGEON_X_THRESHOLD } from '../sim/data';
+import { GFX } from './gfx';
+
+// Ambient high-altitude BIRD FLOCK — a render-only flourish, no sim state.
+// A small V-formation of dark silhouettes drifts across the sky high above the
+// player, wings flapping in a travelling wave. Distinct from ground critters
+// and airborne motes: birds live in the sky band, far above terrain, and never
+// interact with the world. Follows the foliage/clouds contract: a fixed pool is
+// recycled around the moving player, never rebuilt, with no per-frame allocs.
+
+export interface BirdsView {
+  group: THREE.Group;
+  update(px: number, pz: number, dt: number): void;
+}
+
+// Local seeded PRNG — render convention is never to touch Math.random so the
+// flock is reproducible per world seed (mirrors foliage's hashing discipline).
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SPAWN_RADIUS = 120; // where a recycled flock re-enters around the player
+const DESPAWN_RADIUS = 165; // once the flock drifts past this it is recycled
+const ALT_MIN = 54;
+const ALT_MAX = 82;
+const SPEED_MIN = 5;
+const SPEED_MAX = 9;
+const WING_LEN = 1.7;
+const WING_CHORD = 0.75;
+const FLAP_AMP = 0.55;
+
+interface Bird {
+  obj: THREE.Group;
+  lw: THREE.Mesh;
+  rw: THREE.Mesh;
+  ox: number; // formation offset, flock-local (lateral)
+  oz: number; // formation offset, flock-local (along travel)
+  oy: number; // altitude jitter within the flock
+  flapSpeed: number;
+  flapPhase: number;
+  bobAmp: number;
+}
+
+function buildBird(mat: THREE.Material): Bird {
+  const obj = new THREE.Group();
+
+  // Each wing is a flat quad pivoting at the shoulder (origin), lying in the
+  // XZ plane and extending along ±X with its chord along Z. Flapping then rides
+  // a single rotation about the forward (Z) axis — no Euler-order surprises.
+  const leftGeo = new THREE.PlaneGeometry(WING_LEN, WING_CHORD);
+  leftGeo.rotateX(-Math.PI / 2);
+  leftGeo.translate(WING_LEN / 2, 0, 0);
+  const rightGeo = new THREE.PlaneGeometry(WING_LEN, WING_CHORD);
+  rightGeo.rotateX(-Math.PI / 2);
+  rightGeo.translate(-WING_LEN / 2, 0, 0);
+
+  const lw = new THREE.Mesh(leftGeo, mat);
+  const rw = new THREE.Mesh(rightGeo, mat);
+  obj.add(lw, rw);
+
+  return {
+    obj,
+    lw,
+    rw,
+    ox: 0,
+    oz: 0,
+    oy: 0,
+    flapSpeed: 0,
+    flapPhase: 0,
+    bobAmp: 0,
+  };
+}
+
+export function buildBirds(seed: number): BirdsView {
+  const rand = mulberry32((seed ^ 0x5f3b21) >>> 0);
+  const group = new THREE.Group();
+  group.name = 'birds';
+
+  // Dark, double-sided, fog-aware silhouettes — read as specks against the sky
+  // and fade into the haze at the rim like the clouds do.
+  const mat = new THREE.MeshBasicMaterial({
+    color: 0x2b2f38,
+    side: THREE.DoubleSide,
+    transparent: true,
+    opacity: 0.82,
+    fog: true,
+    depthWrite: false,
+  });
+
+  const count = GFX.standardMaterials ? 14 : 6;
+  const birds: Bird[] = [];
+  for (let i = 0; i < count; i++) {
+    const b = buildBird(mat);
+    // Loose V-formation: pairs fan out behind a leader, left/right alternating.
+    const rank = Math.ceil(i / 2);
+    const side = i % 2 === 0 ? 1 : -1;
+    b.ox = side * rank * (2.4 + rand() * 0.8);
+    b.oz = -rank * (2.6 + rand() * 0.9) - rand() * 1.5;
+    b.oy = (rand() - 0.5) * 3.0;
+    b.flapSpeed = 5.5 + rand() * 3.5;
+    b.flapPhase = rand() * Math.PI * 2;
+    b.bobAmp = 0.4 + rand() * 0.5;
+    const s = 0.7 + rand() * 0.7; // size variety = fake depth
+    b.obj.scale.setScalar(s);
+    birds.push(b);
+    group.add(b.obj);
+  }
+
+  // Flock state, in absolute world coords. Lazily seeded on the first update
+  // once we know where the player actually is.
+  let cx = 0;
+  let cz = 0;
+  let cy = (ALT_MIN + ALT_MAX) / 2;
+  let heading = 0;
+  let speed = SPEED_MIN;
+  let phase = 0;
+  let seeded = false;
+
+  function reseat(px: number, pz: number): void {
+    const bearing = rand() * Math.PI * 2;
+    cx = px + Math.sin(bearing) * SPAWN_RADIUS;
+    cz = pz + Math.cos(bearing) * SPAWN_RADIUS;
+    cy = ALT_MIN + rand() * (ALT_MAX - ALT_MIN);
+    // Aim roughly back across the player's neighbourhood, with a lateral skew
+    // so the flock crosses the sky rather than flying straight at the camera.
+    const toPlayer = Math.atan2(px - cx, pz - cz);
+    heading = toPlayer + (rand() - 0.5) * 1.3;
+    speed = SPEED_MIN + rand() * (SPEED_MAX - SPEED_MIN);
+  }
+
+  function update(px: number, pz: number, dt: number): void {
+    // No birds inside dungeons / arena interiors — the sky isn't rendered there.
+    group.visible = px <= DUNGEON_X_THRESHOLD;
+    if (!group.visible) return;
+
+    if (!seeded) {
+      reseat(px, pz);
+      seeded = true;
+    }
+
+    cx += Math.sin(heading) * speed * dt;
+    cz += Math.cos(heading) * speed * dt;
+    phase += dt;
+
+    const dx = cx - px;
+    const dz = cz - pz;
+    if (dx * dx + dz * dz > DESPAWN_RADIUS * DESPAWN_RADIUS) reseat(px, pz);
+
+    const sh = Math.sin(heading);
+    const ch = Math.cos(heading);
+    for (const b of birds) {
+      // Rotate the flock-local formation offset into world space by heading.
+      const wx = b.ox * ch + b.oz * sh;
+      const wz = -b.ox * sh + b.oz * ch;
+      const bob = Math.sin(phase * 0.6 + b.flapPhase) * b.bobAmp;
+      b.obj.position.set(cx + wx, cy + b.oy + bob, cz + wz);
+      b.obj.rotation.y = heading;
+
+      // Travelling-wave flap: rank further back lags, so the flock ripples.
+      const flap = Math.sin(phase * b.flapSpeed + b.flapPhase + b.oz * 0.5) * FLAP_AMP;
+      b.lw.rotation.z = flap;
+      b.rw.rotation.z = -flap;
+    }
+  }
+
+  return { group, update };
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -26,6 +26,7 @@ import { buildWater, WaterView } from './water';
 import { buildClouds, buildSky, SkyView } from './sky';
 import { buildFoliage, FoliageView } from './foliage';
 import { buildFish, FishView } from './fish';
+import { buildBirds, BirdsView } from './birds';
 import { shouldRenderStealthGhost } from './stealth';
 import { t } from '../ui/i18n';
 import { tEntity } from '../ui/entity_i18n';
@@ -237,6 +238,7 @@ export class Renderer {
   private terrainView: TerrainView;
   private foliage: FoliageView;
   private fish: FishView;
+  private birds: BirdsView;
   private fogScratch = new THREE.Color();
   private flames: THREE.Mesh[];
   private fireLights: THREE.PointLight[];
@@ -439,6 +441,8 @@ export class Renderer {
     this.scene.add(this.foliage.group);
     this.fish = buildFish(this.sim.cfg.seed);
     this.scene.add(this.fish.group);
+    this.birds = buildBirds(this.sim.cfg.seed);
+    this.scene.add(this.birds.group);
     const props = buildProps(this.sim.cfg.seed);
     this.scene.add(props.group);
     this.flames = props.flames;
@@ -1298,6 +1302,7 @@ export class Renderer {
     this.propsView.update(this.camera.position.x, this.camera.position.y, this.camera.position.z, fogFar);
     this.foliage.update(p.pos.x, p.pos.z, this.camera.position.x, this.camera.position.z, fogFar);
     this.fish.update(p.pos.x, p.pos.z, dt);
+    this.birds.update(p.pos.x, p.pos.z, dt);
 
     this.vfx.update(dt);
 

--- a/tests/birds.test.ts
+++ b/tests/birds.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { buildBirds } from '../src/render/birds';
+
+// DUNGEON_X_THRESHOLD = 600 (src/sim/data.ts): x beyond this is inside an
+// instance, where the sky — and the flock — must not render.
+const INDOORS_X = 700;
+
+describe('ambient bird flock', () => {
+  it('builds a non-empty flock under a single group', () => {
+    const { group } = buildBirds(1234);
+    expect(group.children.length).toBeGreaterThan(0);
+    // Every bird is a sub-group of two wing meshes.
+    for (const bird of group.children) {
+      expect(bird).toBeInstanceOf(THREE.Group);
+      expect(bird.children.length).toBe(2);
+    }
+  });
+
+  it('is reproducible for a given seed and varies across seeds', () => {
+    const a = buildBirds(42);
+    const b = buildBirds(42);
+    const c = buildBirds(43);
+    a.update(0, 0, 0.05);
+    b.update(0, 0, 0.05);
+    c.update(0, 0, 0.05);
+    const pos = (v: { group: THREE.Group }) => v.group.children[0].position.clone();
+    expect(pos(a).distanceTo(pos(b))).toBeLessThan(1e-9);
+    expect(pos(a).distanceTo(pos(c))).toBeGreaterThan(0);
+  });
+
+  it('hides the flock when the player is inside an instance', () => {
+    const { group, update } = buildBirds(7);
+    update(INDOORS_X, 0, 0.1);
+    expect(group.visible).toBe(false);
+    // Back outdoors it shows again.
+    update(0, 0, 0.1);
+    expect(group.visible).toBe(true);
+  });
+
+  it('keeps the flock within sky range of the player as they travel', () => {
+    const { group, update } = buildBirds(99);
+    // March the player a long way; the flock must recycle to stay nearby
+    // rather than being abandoned in the distance.
+    let px = 0;
+    for (let i = 0; i < 400; i++) {
+      px += 5; // 5 yd/step
+      if (px > 580) px = 0; // stay in the overworld band
+      update(px, 0, 0.1);
+    }
+    for (const bird of group.children) {
+      const dx = bird.position.x - px;
+      const dz = bird.position.z - 0;
+      // DESPAWN_RADIUS (165) plus the flock's back-formation extent.
+      expect(Math.hypot(dx, dz)).toBeLessThan(220);
+    }
+  });
+
+  it('flaps wings symmetrically and within amplitude', () => {
+    const { group, update } = buildBirds(5);
+    update(0, 0, 0.13);
+    for (const bird of group.children) {
+      const [lw, rw] = bird.children as THREE.Mesh[];
+      // Opposite wings mirror about the forward axis.
+      expect(lw.rotation.z).toBeCloseTo(-rw.rotation.z, 9);
+      expect(Math.abs(lw.rotation.z)).toBeLessThanOrEqual(0.56);
+    }
+  });
+});


### PR DESCRIPTION
## What

A render-only ambient flourish: a small **V-formation of birds** drifts high across the sky above the player, wings flapping in a travelling wave. It gives the overworld sky the same sense of *living* atmosphere that ground foliage and drifting clouds already give the land.

![Flock crossing the vale](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ambient-birds/docs/pr-assets/ambient-birds/01-flock-over-vale.png)

![Flock close-up](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ambient-birds/docs/pr-assets/ambient-birds/02-flock-closeup.png)

> The shots stage the flock lower and nearer than normal so the silhouettes read in a still; in play they ride high in the sky band and drift past as small specks.

## Why it's safe

- **Pure presentation — zero `sim`/`IWorld`/`net`/server changes.** The birds never touch world state, so it can't affect determinism, and it works identically offline and online for free.
- Follows the existing **`foliage.ts` / clouds contract**: a fixed pool is *recycled* around the moving player every frame (no per-frame allocations), the flock reseats when it drifts past the player.
- Randomness goes through a **local `mulberry32`** seeded by the world seed (no `Math.random`), matching render-layer convention.
- Count **scales with `GFX` tier** (14 high/ultra, 6 low) and the flock is **hidden inside dungeon/arena interiors** (`x > DUNGEON_X_THRESHOLD`) where the sky isn't drawn.

Distinct from ground wildlife and ground-level particles: these live in the sky band, far above terrain.

## Files

- `src/render/birds.ts` — `buildBirds(seed) -> { group, update(px, pz, dt) }`
- `src/render/renderer.ts` — built and updated beside `buildFoliage` (4 lines)
- `tests/birds.test.ts` — pool shape, seed determinism, indoor culling, player-follow recycling, symmetric flap
- `scripts/birds_shot.mjs` — offline screenshot harness

## Verification

- `npx tsc --noEmit` — clean
- `npm test` — **653 passed** (648 + 5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)