### PR TITLE
feat(ui): classic "resting" indicator on the player unit frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -460,6 +460,18 @@
   #target-frame .portrait-wrap { order: 2; }
   #target-frame .uf-bars { order: 1; margin-left: 0; margin-right: -8px; border-radius: 6px 0 0 6px; padding: 5px 14px 5px 8px; }
   #target-frame .level-chip { left: auto; right: -3px; }
+  /* "resting" zZz marker on the player portrait while seated / eating / drinking */
+  .rest-indicator {
+    position: absolute; top: -6px; right: -6px; width: 22px; height: 22px;
+    border-radius: 50%; z-index: 3; display: none;
+    align-items: center; justify-content: center;
+    color: #aee3ff; font-weight: bold; font-size: 13px; font-style: italic;
+    text-shadow: 0 0 6px #4fc3ff, 1px 1px 1px #000;
+    background: radial-gradient(circle at 40% 35%, #14304a, #08141c);
+    border: 2px solid #4fc3ff88; box-shadow: 0 0 8px #4fc3ff66;
+  }
+  .rest-indicator.on { display: flex; animation: rest-pulse 2s ease-in-out infinite; }
+  @keyframes rest-pulse { 0%, 100% { opacity: 1; transform: translateY(0); } 50% { opacity: 0.55; transform: translateY(-2px); } }
   .uf-name { font-size: 13px; font-weight: bold; font-family: var(--title-font); color: var(--gold);
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-shadow: 1px 1px 2px #000; }
   .bar { position: relative; height: 15px; background: #1a1a1a; border: 1px solid #000; margin-top: 3px; border-radius: 2px; overflow: hidden; }
@@ -4369,6 +4381,7 @@
             <div class="portrait-wrap">
               <div class="portrait"><canvas id="pf-portrait" width="54" height="54"></canvas></div>
               <div class="level-chip" id="pf-level">1</div>
+              <div class="rest-indicator" id="pf-rest" title="Resting">z</div>
             </div>
             <div class="uf-bars">
               <div class="uf-name" id="pf-name"></div>

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/resting_indicator_shot.mjs
+++ b/scripts/resting_indicator_shot.mjs
@@ -1,0 +1,69 @@
+// Captures the player unit-frame "resting" zZz indicator in the offline client.
+// Run the dev client first (npm run dev), then:
+//   GAME_URL=http://localhost:5173 node scripts/resting_indicator_shot.mjs
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as CHROME } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const OUT = 'docs/pr-assets/resting-indicator';
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: CHROME,
+  headless: 'new',
+  protocolTimeout: 60000,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1280,760', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 760 },
+});
+
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.error('pageerror:', e.message));
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await sleep(800);
+
+// Offline boot flow: char-name -> pick class -> start.
+await page.evaluate(() => {
+  document.querySelector('#btn-offline').click();
+  document.querySelector('#char-name').value = 'Resty';
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]').click();
+  document.querySelector('#btn-start-offline').click();
+});
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 5, { timeout: 20000, polling: 300 });
+await sleep(800);
+
+async function clipPlayerFrame(name) {
+  await sleep(700); // let the per-frame HUD pick up the state + a pulse beat
+  const box = await page.evaluate(() => {
+    const r = document.querySelector('#player-frame').getBoundingClientRect();
+    return { x: Math.max(0, r.x - 10), y: Math.max(0, r.y - 12), width: r.width + 20, height: r.height + 22 };
+  });
+  await page.screenshot({ path: `${OUT}/${name}.png`, clip: box });
+  console.log('shot:', name);
+}
+
+// 1) Standing — no indicator.
+await clipPlayerFrame('standing');
+
+// 2) Resting (bare sit).
+await page.evaluate(() => { window.__game.sim.player.sitting = true; });
+await clipPlayerFrame('resting');
+
+// 3) Eating + drinking (recovering).
+await page.evaluate(() => {
+  const p = window.__game.sim.player;
+  p.sitting = true;
+  p.eating = { itemId: 'bread', remaining: 18 };
+  p.drinking = { itemId: 'water', remaining: 18 };
+});
+await clipPlayerFrame('recovering');
+
+// 4) Full HUD context shot while resting.
+await page.evaluate(() => { window.__game.sim.player.eating = null; window.__game.sim.player.drinking = null; });
+await sleep(500);
+await page.screenshot({ path: `${OUT}/full-hud.png` });
+console.log('shot: full-hud');
+
+await browser.close();
+console.log('done ->', OUT);

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { restView } from './rest_indicator';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -296,6 +297,7 @@ export class Hud {
   private arenaAllTime: { name: string; class: string; level: number; rating: number; wins: number; losses: number }[] | null = null;
   private arenaLbFetchedAt = 0;
   private lastCombatEventAt = 0;
+  private lastResting = false;
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
   private mapZoom = 1; // world-map zoom: 1 = whole zone, up to MAP_MAX_ZOOM
@@ -1726,6 +1728,16 @@ export class Hud {
         currentZone.id, currentZone.biome, inHub, inDungeon, dungeon?.id ?? null,
       );
       music.update(zone, inCombat);
+
+      // classic "resting" zZz on the player portrait while seated / recovering.
+      // Reads the seated booleans IWorld exposes; works offline + online alike.
+      const rest = restView({ sitting: !!p.sitting, eating: !!p.eating, drinking: !!p.drinking });
+      if (rest.resting !== this.lastResting) {
+        this.lastResting = rest.resting;
+        const restEl = $('#pf-rest');
+        restEl.classList.toggle('on', rest.resting);
+        restEl.title = rest.label;
+      }
 
       this.updateQuestTracker();
       this.updatePartyFrames();

--- a/src/ui/rest_indicator.ts
+++ b/src/ui/rest_indicator.ts
@@ -1,0 +1,30 @@
+// Pure derivation of the player unit-frame "resting" indicator state. Kept
+// UI-framework-free (no DOM) so the label precedence can be snapshot tested
+// directly, mirroring xp_bar.ts. Reads only the three booleans the sim already
+// exposes on the player Entity (and which ride along in online snapshots), so
+// the indicator works identically offline and online with zero sim/net change.
+
+export interface RestStateInput {
+  sitting: boolean;
+  eating: boolean;
+  drinking: boolean;
+}
+
+export interface RestView {
+  resting: boolean; // any seated state → show the indicator
+  label: string; // tooltip / aria text ('' when not resting)
+  glyph: string; // single-char marker shown on the portrait
+}
+
+// Label precedence: recovering (eating/drinking) is the more informative state,
+// so it wins over a plain seat. Eating and drinking can run at once (separate
+// slots); we surface the combined "Recovering" rather than picking one. A bare
+// sit (no consumable) reads as classic "Resting".
+export function restView(input: RestStateInput): RestView {
+  const { sitting, eating, drinking } = input;
+  if (eating && drinking) return { resting: true, label: 'Eating & drinking', glyph: 'z' };
+  if (eating) return { resting: true, label: 'Eating', glyph: 'z' };
+  if (drinking) return { resting: true, label: 'Drinking', glyph: 'z' };
+  if (sitting) return { resting: true, label: 'Resting', glyph: 'z' };
+  return { resting: false, label: '', glyph: 'z' };
+}

--- a/tests/rest_indicator.test.ts
+++ b/tests/rest_indicator.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { restView } from '../src/ui/rest_indicator';
+
+describe('rest indicator view', () => {
+  it('hides when standing and doing nothing', () => {
+    const v = restView({ sitting: false, eating: false, drinking: false });
+    expect(v.resting).toBe(false);
+    expect(v.label).toBe('');
+  });
+
+  it('shows "Resting" for a bare sit', () => {
+    expect(restView({ sitting: true, eating: false, drinking: false }))
+      .toMatchObject({ resting: true, label: 'Resting' });
+  });
+
+  it('eating and drinking take precedence over a sit', () => {
+    expect(restView({ sitting: true, eating: true, drinking: false }).label).toBe('Eating');
+    expect(restView({ sitting: true, eating: false, drinking: true }).label).toBe('Drinking');
+  });
+
+  it('surfaces the combined state when eating and drinking at once', () => {
+    expect(restView({ sitting: true, eating: true, drinking: true }).label).toBe('Eating & drinking');
+  });
+
+  it('eating/drinking imply resting even without the sitting flag set', () => {
+    // online snapshots can carry eat/drk independently of the union sit flag
+    expect(restView({ sitting: false, eating: true, drinking: false }).resting).toBe(true);
+    expect(restView({ sitting: false, eating: false, drinking: true }).resting).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-WoW **resting** marker — a softly pulsing `zZz` badge on the player's portrait — that appears whenever the character is **seated**: sitting, eating, or drinking. It fills the small gap where the sim already tracks these seated states (and even feeds them to the RL observation in `obs.ts`) but the HUD never surfaced them to the player.

| Standing | Resting (sit) | Recovering (eat/drink) |
|---|---|---|
| ![standing](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/resting-indicator/docs/pr-assets/resting-indicator/standing.png) | ![resting](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/resting-indicator/docs/pr-assets/resting-indicator/resting.png) | ![recovering](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/resting-indicator/docs/pr-assets/resting-indicator/recovering.png) |

Full HUD context:

![full hud](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/resting-indicator/docs/pr-assets/resting-indicator/full-hud.png)

## How

**Pure UI — zero sim / net / server changes.** It reads only the seated booleans that already exist on the player `Entity` (`sitting`/`eating`/`drinking`) and that already ride along in online snapshots (`sit`/`eat`/`drk` in `server/game.ts` → `net/online.ts`), so it works identically offline and online for free.

- `src/ui/rest_indicator.ts` — small DOM-free `restView()` deriving the indicator state + tooltip label, mirroring the `xp_bar.ts` testable-module pattern. Label precedence: eating/drinking ("recovering") wins over a bare sit; both at once → "Eating & drinking".
- `src/ui/hud.ts` — toggles a `#pf-rest` element in the per-frame update, only when the resting state actually changes (no per-frame DOM churn).
- `index.html` — `#pf-rest` markup in the player portrait + scoped CSS (pulse keyframe).

## Tests

- `tests/rest_indicator.test.ts` — 5 cases covering visibility + label precedence.
- Full suite green: **653 tests pass**, `tsc --noEmit` clean.
- Screenshot repro: `scripts/resting_indicator_shot.mjs` (offline, drives `window.__game`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)