### PR TITLE
fix(mobile): stabilize scroll and XP HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,8 +207,14 @@
   [hidden] { display: none !important; }
   html, body {
     width: var(--app-vw); height: var(--app-vh); min-width: 100%; min-height: 100%;
-    overflow: hidden; background: #000; font-family: var(--ui-font); touch-action: none; overscroll-behavior: none;
+    overflow-x: hidden; overflow-y: hidden; background: #000; font-family: var(--ui-font);
+    touch-action: pan-y; overscroll-behavior-y: auto;
     -webkit-text-size-adjust: 100%;
+  }
+  body.game-active {
+    overflow: hidden;
+    touch-action: none;
+    overscroll-behavior: none;
   }
   #game-canvas { position: fixed; left: 0; top: 0; width: var(--app-vw); height: var(--app-vh); display: block; z-index: 0; }
   .click-move-marker {
@@ -320,7 +326,7 @@
   }
 
   #nameplates { position: fixed; left: 0; top: 0; width: var(--app-vw); height: var(--app-vh); overflow: hidden; pointer-events: none; z-index: 1; }
-  #ui { position: fixed; left: 0; top: 0; width: var(--app-vw); max-width: 100vw; height: var(--app-vh); overflow-x: hidden; pointer-events: none; z-index: 10; }
+  #ui { position: fixed; left: 0; top: 0; width: var(--app-vw); max-width: 100vw; height: var(--app-vh); overflow: hidden; pointer-events: none; z-index: 10; }
   #ui > * { pointer-events: auto; }
   #ui > .click-move-marker,
   #ui > .click-move-marker * { pointer-events: none; }
@@ -1206,6 +1212,9 @@
     padding: 0;
     overflow-x: hidden;
     overflow-y: auto;
+    touch-action: pan-y;
+    overscroll-behavior-y: auto;
+    -webkit-overflow-scrolling: touch;
   }
 
   /* Global Header Styling */
@@ -3106,6 +3115,29 @@
   body.mobile-touch #game-canvas { touch-action: none; }
   body.mobile-touch #ui { touch-action: none; }
   body.mobile-touch.game-active #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; opacity: var(--touch-opacity, 1); }
+  body.mobile-touch.game-active #ui,
+  body.mobile-touch.game-active #nameplates,
+  body.mobile-touch.game-active #mobile-controls {
+    overflow: hidden;
+    scrollbar-width: none;
+  }
+  body.mobile-touch.game-active #ui::-webkit-scrollbar,
+  body.mobile-touch.game-active #nameplates::-webkit-scrollbar,
+  body.mobile-touch.game-active #mobile-controls::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
+  }
+  body.mobile-touch.game-active::-webkit-scrollbar {
+    height: 0;
+  }
+  body.mobile-touch.game-active *::-webkit-scrollbar {
+    height: 0;
+  }
+  body.mobile-touch.game-active *::-webkit-scrollbar:horizontal {
+    height: 0;
+    display: none;
+  }
   body.mobile-touch .mobile-joystick {
     position: absolute; left: max(18px, env(safe-area-inset-left)); bottom: calc(26px + env(safe-area-inset-bottom));
     width: 122px; height: 122px; border-radius: 50%; pointer-events: auto; touch-action: none;
@@ -3244,10 +3276,12 @@
   body.mobile-touch #actionbar-row { pointer-events: auto; }
   body.mobile-touch #xpbar {
     position: fixed;
-    left: calc(max(18px, env(safe-area-inset-left)) + 132px);
-    bottom: calc(7px + env(safe-area-inset-bottom));
-    width: min(170px, calc(50vw - 164px));
-    min-width: 112px;
+    left: max(8px, env(safe-area-inset-left));
+    right: auto;
+    top: calc(max(8px, env(safe-area-inset-top)) + 70px);
+    bottom: auto;
+    width: 246px;
+    min-width: 0;
     height: 6px;
     display: block;
     margin: 0;
@@ -3311,13 +3345,7 @@
     padding: 0;
   }
   body.mobile-touch .community-link.donate {
-    width: auto;
-    min-width: 58px;
-    height: 36px;
-    padding: 0 7px;
-    gap: 4px;
-    font-size: 10px;
-    letter-spacing: 0.15px;
+    display: none;
   }
   body.mobile-touch .community-link svg {
     width: 22px;
@@ -3392,7 +3420,6 @@
     left: auto;
     right: min(calc(50% + 136px), calc(100vw - 222px - max(12px, env(safe-area-inset-right, 0px))));
   }
-  body.mobile-touch.mobile-left-handed #xpbar,
   body.mobile-touch.mobile-left-handed #castbar {
     left: auto; right: calc(max(18px, env(safe-area-inset-right)) + 132px);
   }
@@ -3771,10 +3798,11 @@
     body.mobile-touch #actionbar.many-spells { grid-template-columns: repeat(6, 40px); }
     body.mobile-touch .action-btn { width: 40px; height: 40px; }
     body.mobile-touch #xpbar {
-      left: calc(max(20px, env(safe-area-inset-left)) + 112px);
-      bottom: calc(6px + env(safe-area-inset-bottom));
-      width: min(160px, calc(50vw - 166px));
-      min-width: 100px;
+      left: max(6px, env(safe-area-inset-left));
+      top: calc(max(6px, env(safe-area-inset-top)) + 48px);
+      bottom: auto;
+      width: 180px;
+      min-width: 0;
       height: 5px;
     }
     body.mobile-touch #castbar {
@@ -4113,7 +4141,9 @@
   }
   body.mobile-touch .homepage-header {
     display: flex;
-    position: relative;
+    position: sticky;
+    top: 0;
+    z-index: 120;
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
@@ -4250,22 +4280,8 @@
       padding: 0;
       justify-content: center;
     }
-    .donate-cta {
-      gap: 5px;
-      padding: 7px 12px;
-      font-size: 11px;
-      letter-spacing: 0.25px;
-    }
-    .donate-cta svg {
-      width: 14px;
-      height: 14px;
-    }
     .community-link.donate {
-      height: 34px;
-      padding: 0 9px;
-      gap: 5px;
-      font-size: 10px;
-      letter-spacing: 0.15px;
+      display: none;
     }
     .social-link span { display: none; }
     .social-link svg { width: 18px; height: 18px; }

--- a/src/main.ts
+++ b/src/main.ts
@@ -175,7 +175,6 @@ window.addEventListener('orientationchange', () => {
   window.setTimeout(syncAppViewport, 800);
 });
 window.visualViewport?.addEventListener('resize', syncAppViewport);
-window.visualViewport?.addEventListener('scroll', syncAppViewport);
 document.addEventListener('fullscreenchange', syncAppViewport);
 
 function requestMobileFullscreenLandscape(): void {

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const mainTs = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
 function splitGameUiTemplate(): { templateHtml: string; liveHtml: string } {
   const marker = '<template id="game-ui-template">';
@@ -40,6 +41,42 @@ describe('client HTML shell', () => {
   it('only displays mobile touch controls after the game is active', () => {
     expect(html).toContain('body.mobile-touch.game-active #mobile-controls');
     expect(html).not.toContain('body.mobile-touch #mobile-controls { position: absolute; inset: 0; display: block;');
+  });
+
+  it('does not expose inert scrollbars on fixed mobile game overlays', () => {
+    expect(html).toContain('#ui { position: fixed; left: 0; top: 0; width: var(--app-vw); max-width: 100vw; height: var(--app-vh); overflow: hidden;');
+    expect(html).toContain('body.mobile-touch.game-active #ui,\n  body.mobile-touch.game-active #nameplates,\n  body.mobile-touch.game-active #mobile-controls {\n    overflow: hidden;\n    scrollbar-width: none;');
+    expect(html).toContain('body.mobile-touch.game-active #ui::-webkit-scrollbar,\n  body.mobile-touch.game-active #nameplates::-webkit-scrollbar,\n  body.mobile-touch.game-active #mobile-controls::-webkit-scrollbar');
+    expect(html).toContain('height: 0;\n    display: none;');
+    expect(html).toContain('body.mobile-touch.game-active::-webkit-scrollbar {\n    height: 0;');
+    expect(html).toContain('body.mobile-touch.game-active *::-webkit-scrollbar {\n    height: 0;');
+    expect(html).toContain('body.mobile-touch.game-active *::-webkit-scrollbar:horizontal {\n    height: 0;\n    display: none;');
+  });
+
+  it('hides only the in-game community donate affordance on mobile', () => {
+    expect(html).toContain('<a class="donate-cta"');
+    expect(html).toContain('<a class="community-link donate"');
+    expect(html).toContain('body.mobile-touch .community-link.donate {\n    display: none;');
+    expect(html).not.toContain('body.mobile-touch .donate-cta {\n    display: none;');
+  });
+
+  it('renders the mobile XP bar under the top-left player card', () => {
+    expect(html).toContain('body.mobile-touch #xpbar {\n    position: fixed;');
+    expect(html).toContain('left: max(8px, env(safe-area-inset-left));');
+    expect(html).toContain('top: calc(max(8px, env(safe-area-inset-top)) + 70px);');
+    expect(html).toContain('bottom: auto;');
+    expect(html).toContain('width: 246px;');
+    expect(html).toContain('height: 6px;\n    display: block;');
+    expect(html).not.toContain('body.mobile-touch.mobile-left-handed #xpbar,');
+  });
+
+  it('keeps the mobile homepage scrollable with a sticky header', () => {
+    expect(html).toContain('touch-action: pan-y; overscroll-behavior-y: auto;');
+    expect(html).toContain('body.game-active {\n    overflow: hidden;\n    touch-action: none;');
+    expect(html).toContain('-webkit-overflow-scrolling: touch;');
+    expect(html).toContain('body.mobile-touch .homepage-header {\n    display: flex;\n    position: sticky;\n    top: 0;\n    z-index: 120;');
+    expect(html).not.toContain('body.mobile-touch .homepage-header {\n    display: flex;\n    position: relative;');
+    expect(mainTs).not.toContain("visualViewport?.addEventListener('scroll', syncAppViewport)");
   });
 
   it('lays out mobile More tray buttons horizontally', () => {


### PR DESCRIPTION
## What

Fixes several mobile-only polish issues found on real iOS Chrome / iPhone 12 Pro landscape:

- The homepage navbar could stop behaving like a fixed/sticky top bar while scrolling on mobile WebKit.
- iOS browser chrome/visual viewport scroll events could rewrite app viewport CSS vars during homepage scrolling.
- A fixed, inert horizontal scrollbar-like artifact could appear along the bottom in-game HUD.
- The mobile XP bar was visually mistaken for a bottom scrollbar because it rendered under Attack/Jump near the movement joystick.
- The in-game right-side community rail Donate button should be hidden on mobile for now.

## Fix

- Let the homepage/start screen use normal vertical touch scrolling (`pan-y`) while keeping the game viewport locked only under `body.game-active`.
- Keep the mobile homepage header sticky for all touch mobile widths, not just narrow CSS viewports.
- Stop syncing `--app-vh` on `visualViewport.scroll`, avoiding iOS scroll-chrome layout churn on the main menu.
- Suppress horizontal WebKit scrollbars in mobile game-active overlays and body.
- Move the mobile XP bar to the top-left under the player frame instead of the bottom controls.
- Hide only the in-game `.community-link.donate` on mobile; homepage/header Donate remains visible.
- Add static shell coverage for the mobile scroll/header rules, inert scrollbar suppression, XP placement, and mobile Donate scope.

No `sim/`, `IWorld`, `net/`, server, or gameplay rule changes.

## Verification

- `npx vitest run tests/client_shell.test.ts`
- `npx tsc --noEmit`
- Chrome mobile/touch emulation verified at iPhone 12 Pro landscape (`844x390`, DPR 3):
  - Homepage start screen scrolls and the header remains sticky.
  - In-game fixed overlays/body report zero horizontal scrollbar height and no document overflow.
  - Logged in as local `titoisking`; XP bar renders under the top-left player card, not under Attack/Jump.
  - In-game community rail Donate is hidden on mobile while homepage Donate remains visible.

Screenshots captured locally under `tmp/mobile-debug/`.
