### PR TITLE
feat(render): combo-point pips over the target nameplate

### DIFF
--- a/index.html
+++ b/index.html
@@ -391,6 +391,13 @@
   .np-raidmark { width: 30px; height: 30px; margin: 0 auto 1px; background-size: contain;
     background-repeat: no-repeat; background-position: center;
     filter: drop-shadow(0 0 2px #000) drop-shadow(0 1px 1px #000); }
+  /* rogue/druid combo points — a centered row of pips over the nameplate,
+     display toggled in JS so it reserves no space when the player has none. */
+  .np-combo { display: flex; justify-content: center; gap: 3px; margin: 0 auto 2px; height: 7px; }
+  .np-combo-pip { width: 7px; height: 7px; border-radius: 50%; background: #3a1010;
+    border: 1px solid #000; box-sizing: border-box; }
+  .np-combo-pip.lit { background: radial-gradient(circle at 35% 30%, #ffe07a, #e8453a 70%);
+    box-shadow: 0 0 4px #ff6a3caa; border-color: #5a0c08; }
   .np-emote { display: inline-flex; align-items: center; justify-content: center; gap: 5px; min-width: 62px; height: 42px;
     padding: 3px 9px 3px 4px; margin: 0 auto 5px; border-radius: 999px; border: 2px solid #f2d27a;
     background: linear-gradient(#3a2a16, #16100a); color: #ffe9a3; font: 800 11px/1 var(--title-font);

--- a/src/render/nameplate_combo.ts
+++ b/src/render/nameplate_combo.ts
@@ -1,0 +1,16 @@
+// Pure derivation of how many combo-point pips to light over an entity's
+// nameplate. Combo points belong to the *local player* and are anchored to a
+// specific target (`comboTargetId`); the renderer draws them over whichever
+// entity matches. Kept DOM/Three-free so it can be unit-tested directly.
+import { Entity } from '../sim/types';
+
+// Combo points cap at 5 in the sim (Sim.addComboPoints).
+export const COMBO_PIP_MAX = 5;
+
+// Pips to show over `e` given the viewing player's combo state. Zero unless the
+// player has points built on this exact entity and it is still alive; clamped
+// into [0, COMBO_PIP_MAX] so a transient overshoot never overflows the row.
+export function comboPipsFor(player: Entity, e: Entity): number {
+  if (player.comboTargetId !== e.id || e.dead) return 0;
+  return Math.max(0, Math.min(COMBO_PIP_MAX, player.comboPoints));
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -29,6 +29,7 @@ import { t } from '../ui/i18n';
 import { tEntity } from '../ui/entity_i18n';
 import { raidMarkerDataUrl } from '../ui/icons';
 import { isProjectedNameplateAnchorVisible, nameplateScreenTransform } from './nameplate_projection';
+import { comboPipsFor, COMBO_PIP_MAX } from './nameplate_combo';
 import { stepCameraOcclusion, type CameraOcclusionState } from './camera_collision';
 
 const NAMEPLATE_RANGE = 55;
@@ -113,10 +114,13 @@ interface EntityView {
   emoteLabelEl: HTMLSpanElement;
   markerEl: HTMLDivElement;
   raidMarkEl: HTMLDivElement; // party raid/target marker, above the name
+  comboRow: HTMLDivElement; // rogue/druid combo-point pips, above the name
+  comboPips: HTMLDivElement[]; // the COMBO_PIP_MAX pip cells, lit left-to-right
   nameplateDisplay: string;
   nameplateTransform: string;
   nameplateSig: string;
   nameplateHpWidth: string;
+  comboSig: string; // cheap-diff for the combo pip row
   sparkle?: THREE.Sprite; // ground objects
   objectMesh?: THREE.Object3D;
   portal?: THREE.Mesh; // dungeon door swirl
@@ -788,6 +792,18 @@ export class Renderer {
     const raidMark = document.createElement('div');
     raidMark.className = 'np-raidmark';
     raidMark.style.display = 'none';
+    // combo-point pips (rogue/druid): hidden until the local player builds
+    // points on this entity; lit left-to-right as they accumulate
+    const comboRow = document.createElement('div');
+    comboRow.className = 'np-combo';
+    comboRow.style.display = 'none';
+    const comboPips: HTMLDivElement[] = [];
+    for (let i = 0; i < COMBO_PIP_MAX; i++) {
+      const pip = document.createElement('div');
+      pip.className = 'np-combo-pip';
+      comboRow.appendChild(pip);
+      comboPips.push(pip);
+    }
     const marker = document.createElement('div');
     marker.className = 'np-marker';
     const nameEl = document.createElement('div');
@@ -798,7 +814,7 @@ export class Renderer {
     const hpFill = document.createElement('div');
     hpFill.className = 'np-hpfill';
     hpBar.appendChild(hpFill);
-    np.append(emoteEl, raidMark, marker, nameEl, hpBar);
+    np.append(emoteEl, raidMark, comboRow, marker, nameEl, hpBar);
     this.nameplateLayer.appendChild(np);
 
     // object views gate their own casters; character shadows live in visual
@@ -806,8 +822,8 @@ export class Renderer {
     if (!visual) collectCasters(group, objectCasters);
     this.views.set(e.id, {
       group, visual, sheepVisual: null, bearVisual: null, catVisual: null, height, clickTarget,
-      nameplate: np, nameEl, hpBar, hpFill, emoteEl, emoteIconEl, emoteLabelEl, markerEl: marker, raidMarkEl: raidMark, sparkle, objectMesh, portal,
-      nameplateDisplay: 'none', nameplateTransform: '', nameplateSig: '', nameplateHpWidth: '',
+      nameplate: np, nameEl, hpBar, hpFill, emoteEl, emoteIconEl, emoteLabelEl, markerEl: marker, raidMarkEl: raidMark, comboRow, comboPips, sparkle, objectMesh, portal,
+      nameplateDisplay: 'none', nameplateTransform: '', nameplateSig: '', nameplateHpWidth: '', comboSig: '',
       objectCasters, shadowOn: true, isFar: false, lastOverheadEmoteKey: null,
       lastX: e.pos.x, lastZ: e.pos.z, skin: e.skin,
       loco: newLocoTrack(),
@@ -1478,6 +1494,9 @@ export class Renderer {
         v.raidMarkEl.style.display = 'none';
       }
 
+      // combo points the local player has built on this entity (rogue/druid)
+      this.setNameplateCombo(v, comboPipsFor(p, e));
+
       if (e.kind === 'object') {
         // dungeon doorways announce themselves
         const objName = objectDisplayName(e);
@@ -1546,6 +1565,19 @@ export class Renderer {
     if (width === v.nameplateHpWidth) return;
     v.nameplateHpWidth = width;
     v.hpFill.style.width = width;
+  }
+
+  // Light `count` of the COMBO_PIP_MAX pips over this nameplate; hide the row
+  // entirely at zero so non-combo classes/targets show nothing.
+  private setNameplateCombo(v: EntityView, count: number): void {
+    const n = Math.max(0, Math.min(COMBO_PIP_MAX, count));
+    const sig = `${n}`;
+    if (sig === v.comboSig) return;
+    v.comboSig = sig;
+    v.comboRow.style.display = n > 0 ? '' : 'none';
+    for (let i = 0; i < v.comboPips.length; i++) {
+      v.comboPips[i].classList.toggle('lit', i < n);
+    }
   }
 
   // Hang a speech bubble over an entity's head; it follows the entity and

--- a/tests/nameplate_combo.test.ts
+++ b/tests/nameplate_combo.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { comboPipsFor, COMBO_PIP_MAX } from '../src/render/nameplate_combo';
+
+function makeWorld() {
+  const sim = new Sim({ seed: 42, playerClass: 'rogue', noPlayer: true });
+  const pid = sim.addPlayer('rogue', 'Aleph');
+  const foe = sim.addPlayer('warrior', 'Bet');
+  sim.tick();
+  return { player: sim.entities.get(pid)!, foe: sim.entities.get(foe)! };
+}
+
+describe('comboPipsFor', () => {
+  it('lights one pip per combo point on the targeted entity', () => {
+    const { player, foe } = makeWorld();
+    player.comboPoints = 3;
+    player.comboTargetId = foe.id;
+    expect(comboPipsFor(player, foe)).toBe(3);
+  });
+
+  it('shows nothing on entities that are not the combo target', () => {
+    const { player, foe } = makeWorld();
+    player.comboPoints = 4;
+    player.comboTargetId = player.id; // points anchored elsewhere
+    expect(comboPipsFor(player, foe)).toBe(0);
+  });
+
+  it('shows nothing when no points are built', () => {
+    const { player, foe } = makeWorld();
+    player.comboPoints = 0;
+    player.comboTargetId = foe.id;
+    expect(comboPipsFor(player, foe)).toBe(0);
+  });
+
+  it('clears pips once the target is dead', () => {
+    const { player, foe } = makeWorld();
+    player.comboPoints = 5;
+    player.comboTargetId = foe.id;
+    foe.dead = true;
+    expect(comboPipsFor(player, foe)).toBe(0);
+  });
+
+  it('never exceeds the pip cap even on a transient overshoot', () => {
+    const { player, foe } = makeWorld();
+    player.comboPoints = 99;
+    player.comboTargetId = foe.id;
+    expect(comboPipsFor(player, foe)).toBe(COMBO_PIP_MAX);
+  });
+});


### PR DESCRIPTION
## What

Rogue/druid **combo points** now appear as a row of lit pips floating above the
**nameplate of the target you've built them on** — the classic on-target combo
display, complementing the existing player-frame combo row.

![combo pips on the target nameplate](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-nameplate-combo/combo-after.png)

Before / after (5 points built on the target):

![before and after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-nameplate-combo/combo-compare.png)

## Why

Combo points are core to rogue/druid pacing, but until now the only readout was
the player unit-frame row. In classic UIs the points also sit on the *target*, so
you can watch your finisher window without flicking your eyes back to your frame.
The data was already replicated to the client — it just wasn't drawn in the world.

## How

Pure presentation — **no `sim` / `IWorld` / `net` / server change**:

- New DOM pip row (`.np-combo`) per nameplate, built in `Renderer.addView`, driven
  each frame from the **local player's** existing `Entity.comboPoints` /
  `comboTargetId` (which `net/online.ts` already mirrors in snapshots, so it works
  online and offline).
- Pip count is derived by a tiny DOM/Three-free helper,
  `src/render/nameplate_combo.ts` (`comboPipsFor(player, entity)`), so it's
  unit-testable without a renderer context — mirrors the `nameplate_threat` shape.
- Cheap-diffed via a `comboSig` like the other nameplate fields; the row is
  `display:none` at zero points, so non-combo classes/targets show nothing.
- Pips clamp to the sim's cap of 5 (`COMBO_PIP_MAX`), and clear when the target
  dies — matching the sim's own combo reset.

## Tests

`tests/nameplate_combo.test.ts` (5 cases): lights one pip per point on the target,
shows nothing off-target / at zero / on a dead target, and never exceeds the cap.
Full suite green (1193 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
