### PR TITLE
feat(ui): subzone banner when entering a named landmark

### DIFF
--- a/index.html
+++ b/index.html
@@ -1197,6 +1197,9 @@
   #banner { position: absolute; left: 50%; top: 28%; transform: translateX(-50%); color: var(--gold);
     font-size: 38px; font-weight: bold; text-shadow: 0 0 18px #00000088, 2px 2px 6px #000; opacity: 0;
     transition: opacity 1.2s; pointer-events: none; font-family: var(--title-font); letter-spacing: 1px; white-space: nowrap; }
+  #subzone-banner { position: absolute; left: 50%; top: 35%; transform: translateX(-50%); color: #fff;
+    font-size: 22px; font-weight: bold; text-shadow: 0 0 14px #00000088, 1px 1px 4px #000; opacity: 0;
+    transition: opacity 1.2s; pointer-events: none; font-family: var(--title-font); letter-spacing: 1px; white-space: nowrap; }
 
   /* ---------- death overlay ---------- */
   #death-overlay { position: absolute; inset: 0; background: radial-gradient(ellipse at center, #40000077 0%, #300000bb 100%);
@@ -3877,6 +3880,7 @@
       white-space: normal;
       overflow-wrap: anywhere;
     }
+    body.mobile-touch #subzone-banner { top: 25%; font-size: 18px; }
     body.mobile-touch #error-msg { top: 16%; font-size: 16px; }
     body.mobile-touch #mobile-preflight .preflight-panel { width: min(520px, 84vw); padding: 18px 22px; }
     body.mobile-touch #mobile-preflight h2 { font-size: 22px; }
@@ -4453,6 +4457,7 @@
 
     <div id="error-msg"></div>
     <div id="banner"></div>
+    <div id="subzone-banner"></div>
 
     <div id="death-overlay">
       <h2 data-i18n="hud.core.deathTitle">You have died.</h2>

--- a/scripts/subzone_visual.mjs
+++ b/scripts/subzone_visual.mjs
@@ -1,0 +1,45 @@
+// Visual check for the subzone banner: enter offline, walk into two named
+// landmarks and screenshot the banner each time.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Wanderer');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 1500));
+
+async function shot(name, poi) {
+  // teleport into the landmark, face it, let a frame run so the banner fires
+  await page.evaluate(({ x, z }) => {
+    const g = window.__game;
+    const p = g.sim.player;
+    p.pos.x = x; p.pos.z = z;
+  }, poi);
+  await new Promise((r) => setTimeout(r, 300));
+  const txt = await page.evaluate(() => document.querySelector('#subzone-banner').textContent);
+  console.log(`${name}: subzone banner = "${txt}"`);
+  await page.screenshot({ path: `tmp/${name}.png` });
+}
+
+// Boar Meadow lies at (65,0) in Eastbrook Vale; Wolf Run at (-2,70).
+await shot('subzone-boar-meadow', { x: 65, z: 0 });
+await shot('subzone-wolf-run', { x: -2, z: 70 });
+
+await browser.close();
+console.log('done');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -16,6 +16,7 @@ import {
   dist2d, xpForLevel, MAX_LEVEL, MELEE_RANGE, MILESTONES, virtualLevel, canPrestige, xpUntilNextPrestige,
 } from '../sim/types';
 import { xpBarView, formatXp } from './xp_bar';
+import { nearestSubzone } from './subzone';
 import { terrainHeight, WATER_LEVEL, roadDistance, generateDecorations } from '../sim/world';
 import type { Decoration } from '../sim/world';
 import { Meters } from './meters';
@@ -237,6 +238,7 @@ export class Hud {
   private combatLogEl = $('#combatlog');
   private errorEl = $('#error-msg');
   private bannerEl = $('#banner');
+  private subzoneEl = $('#subzone-banner');
   private tooltipEl = $('#tooltip');
   // Distinguishes a touch long-press "peek" (inspect, no action) from a tap.
   private peekGuard = new TouchPeekGuard();
@@ -268,6 +270,8 @@ export class Hud {
   private hotWriteCache = new Map<HTMLElement, string>();
   private hotDomWrites = 0;
   private hotDomSkippedWrites = 0;
+  private subzoneTimer: number | undefined;
+  private lastSubzone: string | null = null;
   private minimapCtx: CanvasRenderingContext2D;
   private minimapBg: HTMLCanvasElement;
   private mapBg: HTMLCanvasElement | null = null;
@@ -1710,6 +1714,15 @@ export class Hud {
         }
       }
 
+      // subzone text: a smaller banner when you step into a named landmark
+      // (classic "subzone" display). POIs are the same labels the minimap pins.
+      const subzone = inDungeon ? null
+        : nearestSubzone(p.pos.x, p.pos.z, currentZone.pois, this.lastSubzone);
+      if (subzone !== this.lastSubzone) {
+        this.lastSubzone = subzone;
+        if (subzone) this.showSubzone(subzone);
+      }
+
       // soundtrack: pick the zone theme and layer in combat percussion.
       // Combat = a mob is on us, or we traded blows in the last few seconds
       // (the wire protocol doesn't ship the inCombat flag).
@@ -2953,6 +2966,13 @@ export class Hud {
     this.bannerEl.style.opacity = '1';
     clearTimeout(this.bannerTimer);
     this.bannerTimer = window.setTimeout(() => { this.bannerEl.style.opacity = '0'; }, 2600);
+  }
+
+  showSubzone(text: string): void {
+    this.subzoneEl.textContent = text;
+    this.subzoneEl.style.opacity = '1';
+    clearTimeout(this.subzoneTimer);
+    this.subzoneTimer = window.setTimeout(() => { this.subzoneEl.style.opacity = '0'; }, 2600);
   }
 
   // -------------------------------------------------------------------------

--- a/src/ui/subzone.ts
+++ b/src/ui/subzone.ts
@@ -1,0 +1,44 @@
+// Pure subzone-detection helper for the HUD's classic "subzone text" banner.
+// No DOM — kept separate from hud.ts so it can be unit-tested (cf. xp_bar.ts).
+import type { ZoneDef } from '../sim/types';
+
+// Enter a subzone within this many yards of its landmark; keep it until you
+// move SUBZONE_DEADBAND yards further out, so straddling the edge of a POI
+// doesn't re-fire the banner every step (mirrors the zone-banner dead-band).
+export const SUBZONE_RADIUS = 32;
+export const SUBZONE_DEADBAND = 8;
+
+// The named landmark the player is standing in, or null in open wilderness.
+// `current` is the subzone the HUD is already showing; passing it back in
+// applies the hysteresis above so a player loitering on the boundary keeps the
+// same subzone instead of flickering between it and "nowhere".
+export function nearestSubzone(
+  x: number,
+  z: number,
+  pois: ZoneDef['pois'],
+  current: string | null,
+): string | null {
+  let nearest: string | null = null;
+  let bestD2 = SUBZONE_RADIUS * SUBZONE_RADIUS;
+  for (const poi of pois) {
+    const dx = x - poi.x;
+    const dz = z - poi.z;
+    const d2 = dx * dx + dz * dz;
+    if (d2 < bestD2) {
+      bestD2 = d2;
+      nearest = poi.label;
+    }
+  }
+  // Outside every enter-radius but still close to the one we're already in?
+  // Stick with it until we clear the wider dead-band radius.
+  if (nearest === null && current !== null) {
+    const cur = pois.find((q) => q.label === current);
+    if (cur) {
+      const dx = x - cur.x;
+      const dz = z - cur.z;
+      const r = SUBZONE_RADIUS + SUBZONE_DEADBAND;
+      if (dx * dx + dz * dz < r * r) return current;
+    }
+  }
+  return nearest;
+}

--- a/tests/subzone.test.ts
+++ b/tests/subzone.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { SUBZONE_DEADBAND, SUBZONE_RADIUS, nearestSubzone } from '../src/ui/subzone';
+
+const pois = [
+  { x: 0, z: 0, label: 'Eastbrook' },
+  { x: 100, z: 0, label: 'Boar Meadow' },
+];
+
+describe('nearestSubzone', () => {
+  it('returns null in open wilderness, far from every landmark', () => {
+    expect(nearestSubzone(50, 50, pois, null)).toBeNull();
+  });
+
+  it('picks the landmark the player is standing in', () => {
+    expect(nearestSubzone(5, 5, pois, null)).toBe('Eastbrook');
+    expect(nearestSubzone(100, 3, pois, null)).toBe('Boar Meadow');
+  });
+
+  it('picks the nearer of two in-range landmarks', () => {
+    const close = [
+      { x: 0, z: 0, label: 'A' },
+      { x: 20, z: 0, label: 'B' },
+    ];
+    expect(nearestSubzone(2, 0, close, null)).toBe('A');
+    expect(nearestSubzone(18, 0, close, null)).toBe('B');
+  });
+
+  it('keeps the current subzone within the dead-band (hysteresis)', () => {
+    // just past the enter-radius but inside radius+deadband of Eastbrook
+    const x = SUBZONE_RADIUS + SUBZONE_DEADBAND - 1;
+    expect(nearestSubzone(x, 0, pois, null)).toBeNull();
+    expect(nearestSubzone(x, 0, pois, 'Eastbrook')).toBe('Eastbrook');
+  });
+
+  it('drops the subzone once clear of the dead-band', () => {
+    const x = SUBZONE_RADIUS + SUBZONE_DEADBAND + 1;
+    expect(nearestSubzone(x, 0, pois, 'Eastbrook')).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

Adds a classic-style **subzone banner** — the smaller text that appears below the zone name as you move between named landmarks within a zone (think *Goldshire* under *Elwynn Forest*).

The HUD already fires a large **zone** banner on band crossings (`lastZoneId` + a dead-band to stop border flicker). This adds the finer-grained subzone layer on top of it.

## How

- Subzones key off each zone's existing `pois` — the *same* landmark labels the minimap already pins — so **no sim/`IWorld` data is needed**. It stays entirely within `src/ui/`, respecting the dependency direction.
- The pick logic is a **pure, unit-tested helper** (`src/ui/subzone.ts`, mirroring `xp_bar.ts`) with an enter-radius (32yd) plus an 8yd dead-band hysteresis, so loitering on a landmark's edge doesn't re-fire the banner every step.
- `hud.ts` calls it once per frame after the zone-transition block and shows/fades a new `#subzone-banner` element (white, smaller, just below the gold zone banner). Mobile positioning included.

## Tests

`tests/subzone.test.ts` — 5 cases covering wilderness (null), in-landmark pick, nearest-of-two, dead-band hysteresis, and clearing once clear of the band. `scripts/subzone_visual.mjs` drives the offline client for the screenshots below.

## Screenshots

| Boar Meadow | Wolf Run |
|---|---|
| ![Boar Meadow](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/subzone-banner/shots/subzone-boar-meadow.png) | ![Wolf Run](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/subzone-banner/shots/subzone-wolf-run.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)