### PR TITLE
feat(hunter): pet command bar, out-of-combat regen, Revive and Mend Pet

### DIFF
--- a/index.html
+++ b/index.html
@@ -364,6 +364,18 @@
      column must not push it up (it used to float ~150px above the bar) */
   #actionbar-stack { display: flex; flex-direction: column; }
   #actionbar { display: flex; gap: 4px; padding: 6px; }
+  #pet-bar { display: none; align-items: center; gap: 8px; padding: 4px 8px; margin: 0 auto 4px; width: max-content;
+    background: rgba(10,10,16,0.62); border: 1px solid #4a3d1d; border-radius: 6px; box-shadow: 0 2px 4px #0009; }
+  #pet-bar .pet-frame { display: flex; flex-direction: column; gap: 2px; min-width: 96px; }
+  #pet-bar .pet-name { font-family: var(--title-font); font-size: 12px; color: #d8c89a; text-shadow: 1px 1px 2px #000; }
+  #pet-bar .pet-frame .bar.hp { height: 10px; }
+  #pet-bar .pet-cmds { display: flex; gap: 4px; }
+  .pet-btn { width: 38px; height: 38px; position: relative; border: 2px solid #4a3d1d; border-radius: 6px; cursor: pointer;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009; }
+  .pet-btn:hover { border-color: var(--gold); }
+  .pet-btn:active { transform: translateY(1px); }
+  .pet-btn .icon-label { position: absolute; inset: 1px; border-radius: 4px; background-size: cover; background-position: center; background-repeat: no-repeat; pointer-events: none; }
+  .pet-btn.pet-revive { border-color: #3c6a3c; }
   .action-btn { width: 46px; height: 46px; position: relative; border: 2px solid #4a3d1d; border-radius: 6px;
     background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); color: #fff; cursor: pointer;
     font-family: var(--title-font); text-shadow: 1px 1px 2px #000;
@@ -3602,6 +3614,7 @@
               <div class="bar mana" id="pf-resource"><div class="bar-fill" id="pf-res"></div><div class="bar-text" id="pf-res-text"></div></div>
             </div>
           </div>
+          <div id="pet-bar"></div>
           <div id="xpbar"><div class="fill"></div><div class="ticks"></div><div class="label"></div></div>
           <div id="actionbar" class="panel"></div>
         </div>

--- a/scripts/smoke_hunter_pet.mjs
+++ b/scripts/smoke_hunter_pet.mjs
@@ -1,0 +1,138 @@
+// Hunter pet control E2E: tame, pet command bar (Attack/Follow/Stay via the UI),
+// out-of-combat regen, death -> Revive Pet. Drives the real client + the pet bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+let fail = 0;
+const check = (n, c, extra = '') => { console.log(`${c ? 'OK  ' : 'FAIL'} ${n}${extra ? ' | ' + extra : ''}`); if (!c) fail++; };
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE, headless: 'new',
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error' && !/project stats|404|Failed to load resource/i.test(m.text())) errors.push('CONSOLE: ' + m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 30000 });
+await page.click('#btn-offline');
+await sleep(200);
+await page.type('#char-name', 'Houndmaster');
+await page.click('#offline-select .mini-class[data-class="hunter"]');
+await page.click('#btn-start-offline');
+await sleep(1500);
+
+// level 12 so Tame (10), Revive (10) and Mend (12) are all known
+await page.evaluate(() => window.__game.sim.setPlayerLevel(12));
+
+// tame the nearest forest wolf
+const petId = await page.evaluate(async () => {
+  const sim = window.__game.sim, p = sim.player;
+  let wolf = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'forest_wolf' && !e.dead && e.ownerId === null) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; wolf = e; }
+    }
+  }
+  p.pos.x = wolf.pos.x + 6; p.pos.z = wolf.pos.z;
+  p.facing = Math.atan2(wolf.pos.x - p.pos.x, wolf.pos.z - p.pos.z);
+  window.__game.input.camYaw = p.facing;
+  sim.targetEntity(wolf.id);
+  sim.castAbility('tame_beast');
+  return wolf.id;
+});
+let tamed = false;
+for (let i = 0; i < 30 && !tamed; i++) { await sleep(400); tamed = await page.evaluate((id) => window.__game.sim.entities.get(id)?.ownerId === window.__game.sim.playerId, petId); }
+check('tame beast creates an owned pet', tamed);
+
+// the pet command bar appears with Attack/Follow/Stay
+const bar1 = await page.evaluate(() => {
+  const bar = document.querySelector('#pet-bar');
+  const vis = bar && getComputedStyle(bar).display !== 'none';
+  const shown = (cmd) => { const b = bar?.querySelector(`.pet-btn[data-cmd="${cmd}"]`); return b && getComputedStyle(b).display !== 'none'; };
+  return { vis: !!vis, attack: shown('attack'), follow: shown('follow'), stay: shown('stay'), revive: shown('revive') };
+});
+check('pet bar is visible', bar1.vis);
+check('pet bar shows Attack/Follow/Stay (not Revive) while alive', bar1.attack && bar1.follow && bar1.stay && !bar1.revive, JSON.stringify(bar1));
+
+// STAY via the UI button: move the owner, the pet holds position
+await page.click('#pet-bar .pet-btn[data-cmd="stay"]');
+const stayPos = await page.evaluate((id) => { const e = window.__game.sim.entities.get(id); return { x: e.pos.x, z: e.pos.z }; }, petId);
+await page.evaluate(() => { const p = window.__game.sim.player; p.pos.x += 20; });
+await sleep(3500);
+const stayD = await page.evaluate((a) => { const e = window.__game.sim.entities.get(a.id); return Math.hypot(e.pos.x - a.x, e.pos.z - a.z); }, { id: petId, ...stayPos });
+check('Stay: the pet holds position when you walk off', stayD < 3, `moved ${stayD.toFixed(1)}yd`);
+
+// FOLLOW via the UI button: the pet returns to your side
+await page.click('#pet-bar .pet-btn[data-cmd="follow"]');
+await sleep(8000);
+const followD = await page.evaluate((id) => { const sim = window.__game.sim, e = sim.entities.get(id), p = sim.player; return Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z); }, petId);
+check('Follow: the pet returns to your side', followD < 8, `dist ${followD.toFixed(1)}yd`);
+
+// out-of-combat regen
+await page.evaluate((id) => { window.__game.sim.entities.get(id).hp = 1; }, petId);
+await sleep(4000);
+const regenHp = await page.evaluate((id) => window.__game.sim.entities.get(id).hp, petId);
+check('the pet heals out of combat', regenHp > 1, `hp ${Math.round(regenHp)}`);
+
+// ATTACK via the UI: send the pet at a beefed boar
+const boarId = await page.evaluate((id) => {
+  const sim = window.__game.sim, p = sim.player;
+  let boar = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'wild_boar' && !e.dead && e.ownerId === null) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; boar = e; }
+    }
+  }
+  boar.maxHp = 5000; boar.hp = 5000;
+  p.pos.x = boar.pos.x + 6; p.pos.z = boar.pos.z;
+  const pet = sim.entities.get(id); pet.pos.x = p.pos.x + 1; pet.pos.z = p.pos.z;
+  sim.targetEntity(boar.id);
+  return boar.id;
+}, petId);
+await page.click('#pet-bar .pet-btn[data-cmd="attack"]');
+let onBoar = false;
+for (let i = 0; i < 30 && !onBoar; i++) { await sleep(400); onBoar = await page.evaluate((ids) => window.__game.sim.entities.get(ids.pet).aggroTargetId === ids.boar, { pet: petId, boar: boarId }); }
+check('Attack: the pet engages the target you sent it at', onBoar);
+
+// frame + screenshot: pet at your side with the bar up
+await page.evaluate((id) => {
+  const g = window.__game, sim = g.sim, p = sim.player, pet = sim.entities.get(id);
+  sim.petCommand('follow');
+  pet.pos.x = p.pos.x + Math.cos(p.facing) * 2.4 - Math.sin(p.facing) * 1.2;
+  pet.pos.z = p.pos.z - Math.sin(p.facing) * 2.4 - Math.cos(p.facing) * 1.2;
+  pet.pos.y = p.pos.y; pet.prevPos = { ...pet.pos };
+  g.input.camPitch = 0.5; g.input.camDist = 9;
+}, petId);
+await sleep(900);
+await page.screenshot({ path: 'tmp/hp1_pet_bar.png' });
+
+// DEATH -> the bar swaps to Revive; revive via the UI button
+await page.evaluate((id) => { const sim = window.__game.sim, e = sim.entities.get(id); sim.dealDamage(null, e, e.hp, false, 'physical', 'test', 'hit'); }, petId);
+await sleep(600);
+const deadBar = await page.evaluate(() => {
+  const bar = document.querySelector('#pet-bar');
+  const shown = (cmd) => { const b = bar?.querySelector(`.pet-btn[data-cmd="${cmd}"]`); return b && getComputedStyle(b).display !== 'none'; };
+  return { vis: getComputedStyle(bar).display !== 'none', revive: shown('revive'), attack: shown('attack') };
+});
+check('when the pet dies the bar offers Revive', deadBar.vis && deadBar.revive && !deadBar.attack, JSON.stringify(deadBar));
+await page.screenshot({ path: 'tmp/hp2_revive.png' });
+
+await page.click('#pet-bar .pet-btn[data-cmd="revive"]');
+let revived = false;
+for (let i = 0; i < 30 && !revived; i++) { await sleep(400); revived = await page.evaluate((id) => { const e = window.__game.sim.entities.get(id); return e && !e.dead && e.ownerId === window.__game.sim.playerId; }, petId); }
+check('Revive Pet brings the same pet back to life', revived);
+
+check('no page/console errors', errors.length === 0, errors.slice(0, 4).join(' || '));
+console.log(`\n${fail === 0 ? 'ALL PASS' : fail + ' FAILED'}`);
+await browser.close();
+process.exit(fail > 0 ? 1 : 0);

--- a/server/game.ts
+++ b/server/game.ts
@@ -693,6 +693,7 @@ export class GameServer {
       case 'castSlot': sim.castAbilityBySlot(msg.slot | 0, pid); break;
       case 'cast': if (typeof msg.ability === 'string') sim.castAbility(msg.ability, pid); break;
       case 'target': sim.targetEntity(typeof msg.id === 'number' ? msg.id : null, pid); break;
+      case 'pet': if (msg.action === 'attack' || msg.action === 'follow' || msg.action === 'stay') sim.petCommand(msg.action, pid); break;
       case 'tab': sim.tabTarget(pid); break;
       case 'targetNearest': sim.targetNearestEnemy(pid); break;
       case 'attack': sim.startAutoAttack(pid); break;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -215,7 +215,7 @@ function blankEntity(id: number): Entity {
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
-    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
+    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0, petStay: false, petCommandTarget: null,
     spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
@@ -641,6 +641,21 @@ export class ClientWorld implements IWorld {
       }
     }
     this.cmd({ cmd: 'target', id });
+  }
+
+  petCommand(cmd: 'attack' | 'follow' | 'stay'): void {
+    // optimistic local update so the bar feels responsive; the server re-resolves
+    const p = this.entities.get(this.playerId);
+    let pet: Entity | null = null;
+    for (const e of this.entities.values()) {
+      if (e.kind === 'mob' && e.ownerId === this.playerId && !e.dead) { pet = e; break; }
+    }
+    if (pet) {
+      if (cmd === 'stay') { pet.petStay = true; pet.petCommandTarget = null; }
+      else if (cmd === 'follow') { pet.petStay = false; pet.petCommandTarget = null; pet.aggroTargetId = null; }
+      else if (cmd === 'attack' && p) { pet.petStay = false; pet.petCommandTarget = p.targetId; }
+    }
+    this.cmd({ cmd: 'pet', action: cmd });
   }
   tabTarget(): void {
     this.cmd({ cmd: 'tab' });

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -101,7 +101,7 @@ export const CLASSES: Record<PlayerClass, ClassDef> = {
     startWeapon: 'rusty_hatchet',
     startChest: 'footpad_jerkin',
     ranged: { min: 5, max: 9, speed: 2.3, maxRange: 35, minRange: 8 },
-    abilities: ['raptor_strike', 'aspect_of_the_hawk', 'serpent_sting', 'arcane_shot', 'concussive_shot', 'mongoose_bite', 'wing_clip', 'aspect_of_the_cheetah', 'aimed_shot', 'rapid_fire', 'tame_beast', 'dismiss_pet'],
+    abilities: ['raptor_strike', 'aspect_of_the_hawk', 'serpent_sting', 'arcane_shot', 'concussive_shot', 'mongoose_bite', 'wing_clip', 'aspect_of_the_cheetah', 'aimed_shot', 'rapid_fire', 'tame_beast', 'dismiss_pet', 'revive_pet', 'mend_pet'],
     color: 0xabd473,
   },
   priest: {
@@ -658,6 +658,23 @@ export const ABILITIES: Record<string, AbilityDef> = {
     requiresTarget: false,
     effects: [{ type: 'dismissPet' }],
     description: 'Releases your pet back to the wild.',
+  },
+  revive_pet: {
+    id: 'revive_pet', name: 'Revive Pet', class: 'hunter', learnLevel: 10,
+    cost: 40, castTime: 3, cooldown: 0, range: 0, school: 'nature',
+    requiresTarget: false,
+    effects: [{ type: 'revivePet' }],
+    description: 'Returns your dead pet to life at your side with half its health. You must have a fallen pet to revive.',
+  },
+  mend_pet: {
+    id: 'mend_pet', name: 'Mend Pet', class: 'hunter', learnLevel: 12,
+    cost: 30, castTime: 0, cooldown: 0, range: 0, school: 'nature',
+    requiresTarget: false,
+    effects: [{ type: 'mendPet', total: 50, duration: 5, interval: 1 }],
+    ranks: [
+      { rank: 2, level: 18, cost: 50, effects: [{ type: 'mendPet', total: 90, duration: 5, interval: 1 }] },
+    ],
+    description: 'Heals your pet for $d health over 5 sec.',
   },
   raptor_strike: {
     id: 'raptor_strike', name: 'Raptor Strike', class: 'hunter', learnLevel: 1,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [],
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, firedSummons: 0, summonedIds: [], enraged: false,
-    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0,
+    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petTauntTimer: 0, petStay: false, petCommandTarget: null,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -130,6 +130,8 @@ const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_GROWL_INTERVAL = 8; // controlled pets can tank by forcing attention
+const PET_REGEN_INTERVAL_TICKS = 20; // out-of-combat pet HP regen cadence (1s at 20 Hz)
+const PET_REGEN_FRACTION = 0.06; // ...heals ~6% of max HP per tick: a few seconds to full
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
   'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
 ]);
@@ -2124,6 +2126,24 @@ export class Sim {
           this.releasePetToWild(pet);
           break;
         }
+        case 'revivePet': {
+          this.revivePet(p);
+          break;
+        }
+        case 'mendPet': {
+          const pet = this.petOf(p.id);
+          if (!pet) { this.error(p.id, 'You have no pet.'); break; }
+          const ticks = Math.max(1, Math.round(eff.duration / eff.interval));
+          this.applyAura(pet, {
+            id: 'mend_pet', name: 'Mend Pet', kind: 'hot',
+            remaining: eff.duration, duration: eff.duration,
+            value: Math.max(1, Math.round(eff.total / ticks)),
+            tickInterval: eff.interval, tickTimer: eff.interval,
+            sourceId: p.id, school: 'nature',
+          });
+          this.emit({ type: 'log', text: `You mend ${pet.name}.`, color: '#6f6', pid: p.id });
+          break;
+        }
       }
       if (target?.dead) target = null;
     }
@@ -2236,6 +2256,76 @@ export class Sim {
     return null;
   }
 
+  /** A player's dead-but-revivable pet (kept by handleDeath, not released wild). */
+  deadPetOf(ownerPid: number): Entity | null {
+    for (const e of this.entities.values()) {
+      if (e.kind === 'mob' && e.ownerId === ownerPid && e.dead) return e;
+    }
+    return null;
+  }
+
+  // Pet command bar: Attack the owner's current target, Follow (recall to heel),
+  // or Stay (hold position). Networked like any other player command.
+  petCommand(cmd: 'attack' | 'follow' | 'stay', pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const owner = r.e;
+    const pet = this.petOf(owner.id);
+    if (!pet) { this.error(owner.id, 'You have no pet.'); return; }
+    switch (cmd) {
+      case 'attack': {
+        const t = owner.targetId !== null ? this.entities.get(owner.targetId) : null;
+        if (!t || t.dead || t.kind !== 'mob' || !t.hostile || t.ownerId !== null) {
+          this.error(owner.id, 'You have no attackable target.');
+          return;
+        }
+        pet.petStay = false;
+        pet.petCommandTarget = t.id;
+        pet.aggroTargetId = t.id;
+        this.emit({ type: 'log', text: `${pet.name} attacks ${t.name}.`, color: '#8f8', pid: owner.id });
+        break;
+      }
+      case 'follow': {
+        pet.petStay = false;
+        pet.petCommandTarget = null;
+        pet.aggroTargetId = null;
+        pet.inCombat = false;
+        this.emit({ type: 'log', text: `${pet.name} follows you.`, color: '#9cf', pid: owner.id });
+        break;
+      }
+      case 'stay': {
+        pet.petStay = true;
+        pet.petCommandTarget = null;
+        this.emit({ type: 'log', text: `${pet.name} stays.`, color: '#9cf', pid: owner.id });
+        break;
+      }
+    }
+  }
+
+  /** Revive Pet (hunter, learned at 10): bring your dead pet back at your side. */
+  private revivePet(owner: Entity): void {
+    const pet = this.deadPetOf(owner.id);
+    if (!pet) { this.error(owner.id, 'You have no pet to revive.'); return; }
+    this.clearNonPlayerStatAuras(pet);
+    pet.auras = [];
+    pet.dead = false;
+    pet.aiState = 'idle';
+    pet.hp = Math.max(1, Math.round(pet.maxHp * 0.5)); // revived at half health
+    pet.inCombat = false;
+    pet.aggroTargetId = null;
+    pet.petStay = false;
+    pet.petCommandTarget = null;
+    pet.petTauntTimer = 0;
+    pet.corpseTimer = 0;
+    pet.respawnTimer = 0;
+    clearThreat(pet);
+    pet.pos = { ...owner.pos }; // returns to your side
+    pet.prevPos = { ...pet.pos };
+    this.rebucket(pet);
+    this.emit({ type: 'log', text: `${pet.name} is revived.`, color: '#6f6', pid: owner.id });
+    this.emit({ type: 'aura', targetId: pet.id, name: 'Revived', gained: true });
+  }
+
   private tameError(p: Entity, target: Entity): string | null {
     if (target.kind !== 'mob' || !target.hostile) return 'You cannot tame that.';
     const template = MOBS[target.templateId];
@@ -2250,7 +2340,11 @@ export class Sim {
   private completeTame(p: Entity, target: Entity): void {
     const err = this.tameError(p, target);
     if (err) { this.error(p.id, err); return; }
+    const oldDead = this.deadPetOf(p.id);
+    if (oldDead) this.releasePetToWild(oldDead); // abandon a dead pet to tame a new one
     target.ownerId = p.id;
+    target.petStay = false;
+    target.petCommandTarget = null;
     target.petTauntTimer = 0;
     target.hostile = false;
     target.aiState = 'idle';
@@ -2618,8 +2712,12 @@ export class Sim {
       e.aggroTargetId = null;
       clearThreat(e);
       if (e.ownerId !== null) {
-        this.emit({ type: 'log', text: `${e.name} dies.`, color: '#f66', pid: e.ownerId });
-        return; // pets drop no loot and grant no credit; they respawn wild
+        // the pet stays yours in death (a revivable corpse), not released to the wild
+        e.petStay = false;
+        e.petCommandTarget = null;
+        e.inCombat = false;
+        this.emit({ type: 'log', text: `${e.name} has died. Use Revive Pet to bring it back.`, color: '#f66', pid: e.ownerId });
+        return; // pets drop no loot and grant no credit
       }
 
       // credit goes to the tapping player (fall back to the killer)
@@ -2945,6 +3043,13 @@ export class Sim {
 
   private updateMob(mob: Entity): void {
     if (mob.dead) {
+      // a slain tamed pet stays YOURS (a revivable corpse) and does not respawn wild.
+      // If its owner has gone, let it decay like any other mob.
+      if (mob.ownerId !== null) {
+        const owner = this.entities.get(mob.ownerId);
+        if (!owner || owner.kind !== 'player' || !this.players.has(owner.id)) this.releasePetToWild(mob);
+        return;
+      }
       mob.corpseTimer -= DT;
       mob.respawnTimer -= DT;
       // dungeon mobs stay dead until the instance resets
@@ -3153,23 +3258,32 @@ export class Sim {
   private updatePet(pet: Entity): void {
     const owner = pet.ownerId !== null ? this.entities.get(pet.ownerId) : null;
     if (!owner || owner.kind !== 'player' || !this.players.has(owner.id)) {
-      this.releasePetToWild(pet);
+      if (!pet.dead) this.releasePetToWild(pet);
       return;
     }
+    if (pet.dead) return; // a dead pet waits for Revive Pet (handleDeath keeps it yours)
     if (this.isStunned(pet)) return;
     pet.petTauntTimer = Math.max(0, pet.petTauntTimer - DT);
 
     let target = pet.aggroTargetId !== null ? this.entities.get(pet.aggroTargetId) ?? null : null;
     if (target && (target.dead || target.kind !== 'mob' || !target.hostile)) target = null;
     if (target && dist2d(owner.pos, pet.pos) > PET_LEASH) target = null;
-    if (!target && !owner.dead) target = this.petPickTarget(pet, owner);
+    if (!target && !owner.dead) target = this.petAcquireTarget(pet, owner);
     pet.aggroTargetId = target?.id ?? null;
     pet.inCombat = target !== null;
+
+    // out-of-combat HP regen: a pet recovers quickly at your side (vanilla feel)
+    if (!pet.inCombat && pet.hp < pet.maxHp && this.tickCount % PET_REGEN_INTERVAL_TICKS === 0) {
+      const heal = Math.min(pet.maxHp - pet.hp, Math.max(2, Math.round(pet.maxHp * PET_REGEN_FRACTION)));
+      pet.hp += heal;
+      this.emit({ type: 'heal', targetId: pet.id, amount: heal });
+    }
 
     if (target) {
       const d = dist2d(pet.pos, target.pos);
       if (d > MELEE_RANGE * 0.8) {
-        if (!this.isRooted(pet)) this.moveToward(pet, target.pos, pet.moveSpeed * this.moveSpeedMult(pet));
+        // on Stay the pet holds its ground instead of chasing out of melee
+        if (!pet.petStay && !this.isRooted(pet)) this.moveToward(pet, target.pos, pet.moveSpeed * this.moveSpeedMult(pet));
         pet.swingTimer = Math.max(0, pet.swingTimer - DT);
       } else {
         pet.facing = angleTo(pet.pos, target.pos);
@@ -3186,8 +3300,9 @@ export class Sim {
       return;
     }
 
-    // heel
+    // no target: Stay holds position, otherwise heel to the owner
     pet.swingTimer = Math.max(0, pet.swingTimer - DT);
+    if (pet.petStay) return;
     const d = dist2d(pet.pos, owner.pos);
     if (d > PET_TELEPORT_DISTANCE) {
       pet.pos = { ...owner.pos };
@@ -3201,14 +3316,26 @@ export class Sim {
     }
   }
 
-  private petPickTarget(pet: Entity, owner: Entity): Entity | null {
+  // Pet target selection. An explicit Attack order (petCommandTarget) wins and
+  // sticks until that mob dies. Otherwise the pet defends the pair: it assists
+  // whatever you're attacking and whatever attacks you or it. On Stay it only
+  // defends itself (it won't run off to assist).
+  private petAcquireTarget(pet: Entity, owner: Entity): Entity | null {
+    if (pet.petCommandTarget !== null) {
+      const t = this.entities.get(pet.petCommandTarget);
+      if (t && !t.dead && t.kind === 'mob' && t.hostile && t.ownerId === null && dist2d(owner.pos, t.pos) <= PET_LEASH) {
+        return t;
+      }
+      pet.petCommandTarget = null; // order done or no longer valid
+    }
     let best: Entity | null = null;
     let bestD = PET_ASSIST_RANGE;
     for (const m of this.entities.values()) {
       if (m.kind !== 'mob' || m.dead || !m.hostile || m.ownerId !== null) continue;
-      const engagingUs = m.aggroTargetId === owner.id || m.aggroTargetId === pet.id;
-      const ownerOffense = owner.targetId === m.id && (owner.autoAttack || m.threat.has(owner.id));
-      if (!engagingUs && !ownerOffense) continue;
+      const attackingPet = m.aggroTargetId === pet.id; // it pulled aggro: always defend
+      const defendPair = !pet.petStay && (m.aggroTargetId === owner.id
+        || (owner.targetId === m.id && (owner.autoAttack || m.threat.has(owner.id))));
+      if (!attackingPet && !defendPair) continue;
       const d = dist2d(pet.pos, m.pos);
       if (d < bestD) { best = m; bestD = d; }
     }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -196,7 +196,9 @@ export type AbilityEffect =
   | { type: 'sunder'; armor: number; maxStacks: number } // sunder armor: stacking armor debuff + flat threat
   | { type: 'taunt' } // taunt/growl: match top threat and force-attack the caster
   | { type: 'tamePet' } // hunter tame beast: the targeted mob becomes the caster's pet
-  | { type: 'dismissPet' }; // release the caster's pet back to the wild
+  | { type: 'dismissPet' } // release the caster's pet back to the wild
+  | { type: 'revivePet' } // hunter: bring a dead pet back to life at the owner
+  | { type: 'mendPet'; total: number; duration: number; interval: number }; // hunter: heal-over-time on the pet
 
 export interface AbilityRank {
   rank: number;
@@ -463,6 +465,8 @@ export interface Entity {
   forcedTargetTimer: number; // seconds left on the forced-attack window
   ownerId: number | null; // controlled pets: owning player's entity id (null = wild)
   petTauntTimer: number; // controlled pet Growl cooldown
+  petStay: boolean; // pet command: hold position instead of following the owner
+  petCommandTarget: number | null; // pet command: an explicit Attack order (mob entity id)
   pulseTimer: number; // boss aoe pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -499,6 +499,75 @@ export class Hud {
   }
 
   // Shared entry point for hotbar clicks and the 1..0-= keybinds.
+  // The pet command bar (Attack / Follow / Stay, plus Revive when the pet is down).
+  // Shown only while you own a pet. Commands flow through IWorld.petCommand.
+  private buildPetBar(): void {
+    const bar = $('#pet-bar');
+    bar.innerHTML = '';
+    const frame = document.createElement('div');
+    frame.className = 'pet-frame';
+    const name = document.createElement('div');
+    name.className = 'pet-name';
+    name.id = 'pet-name';
+    const hp = document.createElement('div');
+    hp.className = 'bar hp';
+    const fill = document.createElement('div');
+    fill.className = 'bar-fill';
+    fill.id = 'pet-hp';
+    hp.appendChild(fill);
+    frame.append(name, hp);
+    const cmds = document.createElement('div');
+    cmds.className = 'pet-cmds';
+    const defs = [
+      { cmd: 'attack', icon: 'pet_attack', title: 'Attack \u2014 send your pet at your target' },
+      { cmd: 'follow', icon: 'pet_follow', title: 'Follow \u2014 call your pet back to your side' },
+      { cmd: 'stay', icon: 'pet_stay', title: 'Stay \u2014 hold position' },
+      { cmd: 'revive', icon: 'revive_pet', title: 'Revive Pet \u2014 bring your fallen pet back' },
+    ] as const;
+    for (const d of defs) {
+      const btn = document.createElement('button');
+      btn.className = 'pet-btn' + (d.cmd === 'revive' ? ' pet-revive' : '');
+      btn.dataset.cmd = d.cmd;
+      btn.title = d.title;
+      const lab = document.createElement('span');
+      lab.className = 'icon-label';
+      lab.style.backgroundImage = `url(${iconDataUrl('ability', d.icon)})`;
+      btn.appendChild(lab);
+      btn.addEventListener('click', () => {
+        audio.click();
+        if (d.cmd === 'revive') this.sim.castAbility('revive_pet');
+        else this.sim.petCommand(d.cmd as 'attack' | 'follow' | 'stay');
+      });
+      cmds.appendChild(btn);
+    }
+    bar.append(frame, cmds);
+  }
+
+  private updatePetBar(): void {
+    const bar = $('#pet-bar');
+    const myId = this.sim.playerId;
+    let pet: Entity | null = null;
+    let deadPet: Entity | null = null;
+    for (const e of this.sim.entities.values()) {
+      if (e.kind === 'mob' && e.ownerId === myId) {
+        if (e.dead) deadPet = e;
+        else pet = e;
+      }
+    }
+    const shown = pet ?? deadPet;
+    if (!shown) { bar.style.display = 'none'; return; }
+    if (bar.children.length === 0) this.buildPetBar();
+    bar.style.display = 'flex';
+    ($('#pet-name') as HTMLElement).textContent = shown.name;
+    const pct = shown.maxHp > 0 ? Math.max(0, Math.min(1, shown.hp / shown.maxHp)) * 100 : 0;
+    ($('#pet-hp') as HTMLElement).style.width = `${pct}%`;
+    const alive = !!pet;
+    for (const b of Array.from(bar.querySelectorAll('.pet-btn')) as HTMLElement[]) {
+      const isRevive = b.dataset.cmd === 'revive';
+      b.style.display = (isRevive ? !alive : alive) ? 'block' : 'none';
+    }
+  }
+
   castSlot(barSlot: number): void {
     if (barSlot === 0) {
       if (this.sim.player.autoAttack) this.sim.stopAutoAttack();
@@ -728,6 +797,8 @@ export class Hud {
       tf.style.display = 'none';
       this.lastPortraitTarget = -999;
     }
+
+    this.updatePetBar();
 
     // cast bar
     const cb = $('#castbar');

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -961,6 +961,11 @@ const ABILITY_RECIPES: Record<string, IconRecipe> = {
   hammer_of_justice: r('holy', 'gold', ['mace'], ['arcs']),
   lay_on_hands: r('holy', 'holyGold', [{ p: 'sunburst', ...BIG }, 'hand'], ['sparkle', 'glow']),
   // hunter
+  pet_attack: r('fury', 'blood', ['claw_slash'], ['motion']),
+  pet_follow: r('leather', 'bone', ['paw']),
+  pet_stay: r('steel', 'steel', ['hand']),
+  revive_pet: r('holy', 'holyGold', ['paw'], ['glow', 'sparkle']),
+  mend_pet: r('nature', 'leafGreen', ['heart', { p: 'paw', ...BR }], ['sparkle']),
   raptor_strike: r('earth', 'blood', ['claw_slash']),
   aspect_of_the_hawk: r('storm', 'sky', ['wing'], ['glow']),
   serpent_sting: r('nature', 'venom', ['fang'], ['drips']),

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -177,6 +177,7 @@ export interface IWorld {
   castAbility(abilityId: string): void;
   castAbilityBySlot(slot: number): void;
   targetEntity(id: number | null): void;
+  petCommand(cmd: 'attack' | 'follow' | 'stay'): void;
   tabTarget(): void;
   startAutoAttack(): void;
   stopAutoAttack(): void;

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -513,10 +513,7 @@ describe('hunter pets', () => {
     expect(sim.petOf(sim.playerId)).toBe(null);
   });
 
-  it('a tamed beast that dies respawns hostile, not a grey unattackable zombie', () => {
-    // Regression: respawnMob cleared ownerId ("back to the wild") but left
-    // hostile=false, so any tamed-then-killed beast respawned permanently
-    // neutral — grey on the unit frame and rejected with "Invalid attack target".
+  it('a dead pet stays yours (revivable) and does not respawn wild; Revive Pet brings it back', () => {
     const sim = new Sim({ seed: 42, playerClass: 'hunter', respawnSeconds: 2, autoEquip: true });
     sim.setPlayerLevel(10);
     const wolf = nearestMob(sim, 'forest_wolf');
@@ -526,19 +523,79 @@ describe('hunter pets', () => {
     sim.castAbility('tame_beast');
     for (let i = 0; i < 20 * 7; i++) sim.tick(); // 6s cast
     expect(wolf.ownerId).toBe(sim.playerId);
-    expect(wolf.hostile).toBe(false); // tamed pets are neutral
 
-    // the pet falls in combat and its corpse respawns at its old camp
-    const boar = nearestMob(sim, 'wild_boar');
-    wolf.hp = 1;
-    hit(sim, boar, wolf, 9999);
-    for (let i = 0; i < 20 * 5 && !wolf.dead; i++) sim.tick();
+    // the pet falls
+    (sim as any).dealDamage(null, wolf, wolf.hp, false, 'physical', 'test', 'hit');
     expect(wolf.dead).toBe(true);
 
-    for (let i = 0; i < 20 * 10 && wolf.dead; i++) sim.tick();
+    // it stays YOURS and does NOT respawn into the wild (it waits for Revive Pet)
+    for (let i = 0; i < 20 * 10; i++) sim.tick();
+    expect(wolf.dead).toBe(true);
+    expect(wolf.ownerId).toBe(sim.playerId);
+
+    // Revive Pet brings the same pet back at your side, alive and friendly
+    sim.player.resource = sim.player.maxResource;
+    sim.castAbility('revive_pet');
+    for (let i = 0; i < 20 * 4; i++) sim.tick(); // 3s cast
     expect(wolf.dead).toBe(false);
-    expect(wolf.ownerId).toBe(null); // back to the wild
-    expect(wolf.hostile).toBe(true); // ...and attackable again
+    expect(wolf.ownerId).toBe(sim.playerId);
+    expect(wolf.hostile).toBe(false);
+    expect(wolf.hp).toBeGreaterThan(0);
+    expect(dist2d(wolf.pos, sim.player.pos)).toBeLessThan(8); // returned to your side
+  });
+
+  it('Stay holds the pet in place; Follow recalls it to your side', () => {
+    const { sim, wolf: pet } = tamedSetup();
+    teleport(sim, sim.player, sim.player.pos.x + 28, sim.player.pos.z);
+    for (let i = 0; i < 20 * 6; i++) sim.tick();
+    expect(dist2d(pet.pos, sim.player.pos)).toBeLessThan(8); // follows by default
+
+    sim.petCommand('stay');
+    const stayPos = { ...pet.pos };
+    teleport(sim, sim.player, sim.player.pos.x + 28, sim.player.pos.z);
+    for (let i = 0; i < 20 * 6; i++) sim.tick();
+    expect(dist2d(pet.pos, stayPos)).toBeLessThan(2); // stayed put
+    expect(dist2d(pet.pos, sim.player.pos)).toBeGreaterThan(10);
+
+    sim.petCommand('follow');
+    for (let i = 0; i < 20 * 6; i++) sim.tick();
+    expect(dist2d(pet.pos, sim.player.pos)).toBeLessThan(8); // came back
+  });
+
+  it('Attack command sends the pet at your target and it builds its own threat', () => {
+    const { sim, wolf: pet } = tamedSetup();
+    const boar = nearestMob(sim, 'wild_boar');
+    beefUp(boar);
+    teleport(sim, sim.player, boar.pos.x + 6, boar.pos.z);
+    teleport(sim, pet, sim.player.pos.x + 1, sim.player.pos.z);
+    sim.targetEntity(boar.id); // the player does NOT attack; only the pet is sent
+    sim.petCommand('attack');
+    let petThreat = 0;
+    for (let i = 0; i < 20 * 15 && petThreat === 0; i++) { sim.tick(); petThreat = boar.threat.get(pet.id) ?? 0; }
+    expect(pet.aggroTargetId).toBe(boar.id);
+    expect(petThreat).toBeGreaterThan(0);
+    expect(boar.tappedById).toBe(sim.playerId);
+  });
+
+  it('a pet heals out of combat', () => {
+    const { sim, wolf: pet } = tamedSetup();
+    sim.tick();
+    expect(pet.inCombat).toBe(false);
+    pet.hp = 1;
+    for (let i = 0; i < 20 * 8; i++) sim.tick();
+    expect(pet.hp).toBeGreaterThan(1);
+  });
+
+  it('Mend Pet applies a heal-over-time to your pet', () => {
+    const { sim, wolf: pet } = tamedSetup();
+    sim.setPlayerLevel(12); // Mend Pet unlocks at 12
+    pet.hp = Math.max(1, pet.maxHp - 60);
+    const before = pet.hp;
+    sim.player.resource = sim.player.maxResource;
+    sim.castAbility('mend_pet');
+    expect(pet.auras.some((a) => a.id === 'mend_pet')).toBe(true);
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    expect(pet.hp).toBeGreaterThan(before);
   });
 
   it('tame validation: too-high level and elites are refused', () => {


### PR DESCRIPTION
## Summary
<img width="1600" height="900" alt="hp1_pet_bar" src="https://github.com/user-attachments/assets/7790bbc7-a767-40c7-a145-9302fdf247e3" />

Tamed pets were effectively uncontrollable. They would not reliably stay with you, they did not heal out of combat, and there was no way to direct them. This PR gives hunter pets real, vanilla-style control, built on the existing pet substrate so behavior is identical across the offline sim, the authoritative server, and the headless RL env.

What you get:

- A pet command bar in the HUD: Attack (send the pet at your current target), Follow (recall it to your side), and Stay (hold position). It shows the pet's name and health and appears only while you own a pet. Icons use the existing procedural icon system, so there are no new assets.
- Pet behavior modes. Stay holds ground and the pet will not chase out of melee; an Attack order sticks to that target until it dies; the default is defensive (assist what you attack, defend you and itself).
- Out-of-combat HP regen, so a pet recovers quickly at your side.
- Pet death persistence plus Revive Pet (learned at level 10). A slain pet now stays yours as a revivable corpse instead of running back to the wild, and Revive Pet brings the same pet back at half health by your side. If the owner leaves, the corpse decays like any other mob.
- Mend Pet (learned at level 12), a heal-over-time on the pet that reuses the existing hot-aura tick.

The new petCommand action is wired through IWorld, the offline Sim, the online ClientWorld (optimistic update plus the cmd), and the server command handler.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npm test` (652 passing; a pet-control block in `tests/threat.test.ts` covers Stay, Follow, the Attack command, out-of-combat regen, death persistence plus Revive, and Mend Pet)
  - `npm run build` and `npm run build:server` (succeed; no generated files change)
  - `node scripts/smoke_hunter_pet.mjs` (browser E2E, all 10 checks pass)
- Manual steps: played a Hunter offline, tamed a wolf, and used the pet bar. Stay holds the pet while you walk off; Follow recalls it; Attack sends it at your target; the pet heals while idle; killing it swaps the bar to a Revive button that brings the same pet back.

## Screenshots / recordings

The pet command bar (name, health, Attack / Follow / Stay):

(adding below)

## Notes

- The bar is class-agnostic: it appears for any pet owner, so it is ready for warlock demons too, but this PR only adds the hunter path.
- The three aggressive / defensive / passive stances are intentionally left out of this first version to keep it simple; they are an easy follow-up.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. Added tests for the new `sim/` behavior.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` and `npm run build:server` pass; no generated files change.

### Cross-platform

- ~Tested on desktop and mobile.~ Verified on desktop via the headless smoke. The pet bar is a small fixed toolbar; it has not been tuned for touch yet (a follow-up if pets ship to mobile).
- ~Accessible.~ N/A for this first pass; the buttons have title tooltips but no dedicated keybinds yet.

### Localization (i18n)

- [x] N/A for new i18n strings. The pet button tooltips and ability names follow the existing English content-data convention used by every ability; no new `t()` keys or HUD chrome strings were added.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I did not hand-edit generated files such as `src/render/assets/manifest.generated.ts`.

---

Generated with Claude Code (https://claude.com/claude-code).
