### PR TITLE
feat(chat): add /talents readout of specialization and point spend

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/talents_command_shot.mjs
+++ b/scripts/talents_command_shot.mjs
@@ -1,0 +1,64 @@
+// Offline screenshot of the /talents chat readout for the PR.
+// Boots the game headless, levels to 20, picks Arms + spends points, then
+// types /talents in the real chat box and captures the chat log.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Talia');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Level to 20 and spend a representative Arms build.
+await page.evaluate(() => {
+  const g = window.__game;
+  g.sim.setPlayerLevel(20);
+  g.sim.applyTalents({
+    spec: 'arms',
+    ranks: { war_toughness: 3, war_cruelty: 2, arms_imp_overpower: 2, arms_deep_wounds: 3 },
+    choices: {},
+  });
+});
+await new Promise((r) => setTimeout(r, 400));
+
+// Type the command through the actual chat input (Enter opens it). The readout
+// is delivered as a self-only `error` event, which the HUD shows as a centered
+// banner (#error-msg) that fades after ~1.6s — capture inside that window.
+await page.keyboard.press('Enter');
+await new Promise((r) => setTimeout(r, 150));
+await page.type('#chat-input', '/talents', { delay: 12 });
+await page.keyboard.press('Enter');
+await new Promise((r) => setTimeout(r, 250));
+
+const banner = await page.evaluate(() => document.querySelector('#error-msg')?.textContent);
+console.log('readout banner:', JSON.stringify(banner));
+await page.screenshot({ path: 'tmp/talents_command.png' });
+
+// Re-issue so the banner is at full opacity, then crop it tight for legibility.
+await page.keyboard.press('Enter');
+await new Promise((r) => setTimeout(r, 150));
+await page.type('#chat-input', '/talents', { delay: 12 });
+await page.keyboard.press('Enter');
+await new Promise((r) => setTimeout(r, 120));
+const box = await page.evaluate(() => {
+  const r = document.querySelector('#error-msg').getBoundingClientRect();
+  return { x: Math.max(0, r.x - 30), y: Math.max(0, r.y - 16), width: Math.min(1600, r.width + 60), height: r.height + 32 };
+});
+await page.screenshot({ path: 'tmp/talents_command_banner.png', clip: box });
+
+await browser.close();
+console.log('saved tmp/talents_command.png');

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5211,6 +5211,14 @@ export class Sim {
       return null;
     }
 
+    // "/talents" (aliases "/talent", "/spec") — self-only readout of the
+    // player's specialization and how their talent points are spent. Returns
+    // null (unlogged); no server interceptor, so it works online for free.
+    if (/^\/(?:talents|talent|spec)(?:\s|$)/i.test(raw)) {
+      this.error(r.meta.entityId, this.talentsReadout(r.meta, r.e));
+      return null;
+    }
+
     // "/help" (or "/?" / "/commands") lists the available chat commands as a
     // system notice to the asker only. Like /who, it produces no chat message,
     // so it works identically offline and online without server wiring.
@@ -7450,6 +7458,36 @@ export class Sim {
       return `${name} is queued for your next melee swing (costs ${queued.cost} ${res}; you have ${have}).`;
     }
     return `${name} is queued for your next melee swing, but you cannot afford it (costs ${queued.cost} ${res}; you have ${have}) — it will fizzle.`;
+  }
+
+  // Self-only readout for "/talents": the player's specialization and how their
+  // talent points are split across the Class tree and the chosen spec tree.
+  // Points are derived live from level (talentPointsAtLevel), so the total stays
+  // correct after a level-up even if the allocation hasn't been touched since.
+  private talentsReadout(meta: PlayerMeta, e: Entity): string {
+    const ct = talentsFor(meta.cls);
+    if (!ct) return 'Your class has no talent tree yet.';
+    const total = talentPointsAtLevel(e.level);
+    if (total <= 0) return `You have not unlocked talents yet — they begin at level ${FIRST_TALENT_LEVEL}.`;
+    const spent = pointsSpent(meta.talents);
+    // Split spent points by tree (cold path: walk the allocation once on demand).
+    const byId = new Map(ct.nodes.map((n) => [n.id, n] as const));
+    let classPts = 0;
+    let specPts = 0;
+    for (const id in meta.talents.ranks) {
+      const node = byId.get(id);
+      if (!node) continue;
+      if (node.tree === 'class') classPts += meta.talents.ranks[id];
+      else specPts += meta.talents.ranks[id];
+    }
+    const specName = meta.talents.spec
+      ? ct.specs.find((s) => s.id === meta.talents.spec)?.name ?? meta.talents.spec
+      : null;
+    const head = specName ?? 'no specialization';
+    const breakdown = specName ? `Class ${classPts}, ${specName} ${specPts}` : `Class ${classPts}`;
+    const unspent = total - spent;
+    const tail = unspent > 0 ? ` ${unspent} unspent.` : '';
+    return `Talents: ${head} — ${spent}/${total} points spent (${breakdown}).${tail}`;
   }
 }
 

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -519,6 +519,9 @@ describe("S3: every sim.ts emit is recognized (drift guard)", () => {
   // regression in the localized surface still fails here. Strings below are the guard's
   // concrete (placeholder-substituted) forms.
   const ALLOW_V07_SLASH = new Set<string>([
+    "Talents: Aki — Aki/Aki points spent (Aki).Aki",
+    "You have not unlocked talents yet — they begin at level 5.",
+    "Your class has no talent tree yet.",
     "Abilities on cooldown (5): Aki.",
     "Active effects (5): Aki.",
     "Aki attempts to flee!",

--- a/tests/talents_command.test.ts
+++ b/tests/talents_command.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { SimEvent } from '../src/sim/types';
+import { MAX_LEVEL } from '../src/sim/types';
+import { talentsFor } from '../src/sim/content/talents';
+
+// "/talents" emits a self-only `error` event (the same self-reply channel /who
+// uses) and returns null, so we collect the text from the next tick's events.
+function readout(sim: Sim, cmd: string): string | undefined {
+  sim.tick();                       // drain any setup events first
+  expect(sim.chat(cmd)).toBeNull(); // readouts are never logged as chat
+  const errs = sim.tick().filter((e: SimEvent): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error');
+  return errs.at(-1)?.text;
+}
+
+describe('/talents readout', () => {
+  it('reports not-yet-unlocked below the talent level', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior' }); // fresh = level 1
+    const text = readout(sim, '/talents');
+    expect(text).toBe('You have not unlocked talents yet — they begin at level 10.');
+  });
+
+  it('shows spec, spent/total and the per-tree split', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior' });
+    sim.setPlayerLevel(MAX_LEVEL); // 11 points available at level 20
+    expect(sim.applyTalents({ spec: 'arms', ranks: { war_toughness: 3 }, choices: {} })).toBe(true);
+
+    const armsName = talentsFor('warrior')!.specs.find((s) => s.id === 'arms')!.name;
+    const text = readout(sim, '/talents');
+    expect(text).toBe(`Talents: ${armsName} — 3/11 points spent (Class 3, ${armsName} 0). 8 unspent.`);
+  });
+
+  it('reports no specialization when none is chosen', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior' });
+    sim.setPlayerLevel(MAX_LEVEL);
+    expect(sim.applyTalents({ spec: null, ranks: { war_toughness: 2 }, choices: {} })).toBe(true);
+
+    const text = readout(sim, '/talents');
+    expect(text).toBe('Talents: no specialization — 2/11 points spent (Class 2). 9 unspent.');
+  });
+
+  it('omits the unspent suffix when all points are spent and aliases resolve', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior' });
+    sim.setPlayerLevel(MAX_LEVEL);
+    // 11 points, all in the class tree (Toughness/Cruelty cap at 3 each here).
+    expect(sim.applyTalents({
+      spec: null,
+      ranks: { war_toughness: 3, war_cruelty: 3, war_deflection: 3, war_imp_thunder_clap: 2 },
+      choices: {},
+    })).toBe(true);
+
+    const text = readout(sim, '/talent'); // alias
+    expect(text).toBe('Talents: no specialization — 11/11 points spent (Class 11).');
+    expect(readout(sim, '/spec')).toBe(text); // alias parity
+  });
+});


### PR DESCRIPTION
## What

Adds a self-only **`/talents`** chat command (aliases **`/talent`**, **`/spec`**) to the deterministic sim core. It reads back the player's specialization and how their talent points are split across the **Class** tree and the chosen **spec** tree:

```
Talents: Arms — 10/11 points spent (Class 5, Arms 5). 1 unspent.
```

- No spec chosen → `Talents: no specialization — 2/11 points spent (Class 2). 9 unspent.`
- Below the talent level → `You have not unlocked talents yet — they begin at level 10.`
- All points spent → the `N unspent.` suffix is dropped.

This rounds out the chat-readout family (`/who` and friends) for the v0.6 talents/specialization system, which previously had no way to query your build from chat.

## How

- New private `talentsReadout(meta, e)` in `Sim`, placed right after the `/who` block in `chat()` (before the unknown-command fall-through).
- The point **total** is derived live from level via `talentPointsAtLevel(e.level)`, so it stays correct after a level-up even if the allocation hasn't been touched — the same defensive approach the other readouts use.
- The per-tree split walks the allocation **once on demand** (cold path), honoring the talents framework's "never walk the tree on a hot path" invariant.
- Spec name resolves through `talentsFor(cls).specs`; classes without a tree get an honest fallback.
- Emitted as a self-only `error` event and returns `null` (unlogged). There's **no server interceptor**, so it works in online play for free via `routeRememberedChat`, exactly like the `/who` reply.

Touches only `src/sim/sim.ts` (both imports it needs — `pointsSpent`, `FIRST_TALENT_LEVEL` — were already imported). No new `Entity`/`PlayerMeta` fields, no `IWorld` change.

## Tests

`tests/talents_command.test.ts` — 4 cases: not-yet-unlocked, spec + per-tree split, no-specialization, and all-points-spent with `/talent`/`/spec` alias parity. Full suite green; `tsc --noEmit` clean.

## Screenshots

`scripts/talents_command_shot.mjs` drives the offline client (level 20, Arms build) and types `/talents` in the real chat box.

| Readout banner | In-game |
|---|---|
| ![readout](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/talents-command/shots/talents-command-readout.png) | ![in-game](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/talents-command/shots/talents-command-ingame.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
