### PR TITLE
fix(chat): harden slur filter and remove plaintext slurs from repo

### DIFF
--- a/server/chat_filter.ts
+++ b/server/chat_filter.ts
@@ -11,6 +11,53 @@
 //
 // Matching folds common leet/confusable substitutions so "n1gg3r"-style evasion
 // still resolves to the underlying word.
+//
+// The hard tier has TWO layers, OR'd together:
+//   1. An always-on baseline built on `obscenity` — the same library `auth.ts`
+//      uses to screen names. Its English dataset (which lives in the dependency,
+//      NOT in this repo) folds leet/confusables/spacing AND affixes, so leetspeak,
+//      diacritics, and suffixed forms all resolve to the underlying slur, while
+//      still passing the Scunthorpe trap ("despicable", "classy pass"). This
+//      layer is non-disableable.
+//   2. The admin-editable hard list, matched per-token (see `tokenMatchesHard`).
+//      It covers slurs the baseline dataset misses and any custom terms an
+//      operator adds. Whole-token matching keeps it from snagging innocent words.
+// This OR layering mirrors `offensiveName` in auth.ts.
+//
+// NOTE: this is open-source. The repo intentionally ships NO plaintext slur
+// list — the actual offensive wordlist is the `obscenity` dependency's dataset.
+// Operators seed extra hard words (the few the dataset omits) privately via the
+// CHAT_FILTER_HARD_LIST / CHAT_FILTER_HARD_FILE env vars (see chat_filter_db.ts)
+// and manage them thereafter from the admin dashboard.
+
+import { RegExpMatcher, englishDataset, englishRecommendedTransformers } from 'obscenity';
+
+// Built once at module load (the constructor compiles the dataset to a regex).
+const builtinSlurMatcher = new RegExpMatcher({
+  ...englishDataset.build(),
+  ...englishRecommendedTransformers,
+});
+
+/**
+ * The canonical built-in slur `text` hits via the always-on `obscenity`
+ * baseline, or null. Returns the dataset's canonical spelling for the matched
+ * term (so an affixed/obfuscated input still logs as a stable term).
+ */
+export function findBuiltinSlur(text: string): string | null {
+  // Scan the raw text and a de-obfuscated copy: obscenity does its own folding,
+  // but it misses diacritics and a few leet glyphs that `foldConfusables` flattens.
+  return matchBuiltinSlur(text) ?? matchBuiltinSlur(foldConfusables(text));
+}
+
+function matchBuiltinSlur(text: string): string | null {
+  const matches = builtinSlurMatcher.getAllMatches(text, true);
+  if (matches.length === 0) return null;
+  const meta = englishDataset.getPayloadWithPhraseMetadata(matches[0]);
+  return (
+    meta.phraseMetadata?.originalWord ??
+    text.slice(matches[0].startIndex, matches[0].endIndex + 1).toLowerCase()
+  );
+}
 
 const CONFUSABLE_CHARS: Record<string, string> = {
   '0': 'o',
@@ -18,25 +65,45 @@ const CONFUSABLE_CHARS: Record<string, string> = {
   '3': 'e',
   '4': 'a',
   '5': 's',
+  '6': 'g',
   '7': 't',
   '8': 'b',
+  '9': 'g',
   '!': 'i',
   '|': 'i',
   '@': 'a',
   '$': 's',
   '+': 't',
+  '©': 'c',
+  '€': 'e',
+  '£': 'l',
 };
 
-// Tokens we scan: letters, digits and the leet punctuation that folds into
-// letters. Everything else is a separator.
-const TOKEN_RE = /[A-Za-z0-9_@$!|+]+/g;
+const CONFUSABLE_RE = /[0-9!|@$+©€£]/g;
 
-/** Fold a token to its comparable core: lowercase, de-leet, strip non-letters. */
-export function normalizeWord(term: string): string {
-  return term
+// Tokens we scan: any Unicode letter/mark/number plus the leet punctuation that
+// folds into letters. Unicode-aware so accented/styled glyphs (î, ⓖ, 𝓰, ｇ) stay
+// inside one token rather than splitting an evasion apart. Else = separator.
+const TOKEN_RE = /[\p{L}\p{M}\p{N}_@$!|+©€£]+/gu;
+
+/**
+ * Fold text toward its comparable ASCII core *without* dropping separators:
+ * Unicode-decompose (NFKD — so fullwidth ｇ, circled ⓖ, math 𝓰, and ligatures
+ * resolve), strip combining diacritics (î→i, é→e), lowercase, then map
+ * leet/confusable glyphs to letters. This is what the obscenity baseline scans
+ * a copy of, so "nî99er" / "ni66@" de-obfuscate to the underlying slur.
+ */
+export function foldConfusables(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
     .toLowerCase()
-    .replace(/[0134578!|@$+]/g, (ch) => CONFUSABLE_CHARS[ch] ?? ch)
-    .replace(/[^a-z]/g, '');
+    .replace(CONFUSABLE_RE, (ch) => CONFUSABLE_CHARS[ch] ?? ch);
+}
+
+/** Fold a token to its comparable core: de-leet/deburr, then strip non-letters. */
+export function normalizeWord(term: string): string {
+  return foldConfusables(term).replace(/[^a-z]/g, '');
 }
 
 /** Split a raw blob (newline / comma / space separated) into normalized terms. */
@@ -74,20 +141,24 @@ function tokenMatchesHard(normalizedToken: string, terms: readonly string[]): bo
   return terms.some((term) => normalizedToken === term || singular === term);
 }
 
-/** First hard term a message hits, or null. The match drives enforcement. */
+/**
+ * First hard term a message hits, or null. The match drives enforcement.
+ * Checks the admin-editable list first, then falls through to the always-on
+ * `obscenity` baseline — so an empty or incomplete hard list never opens a hole.
+ */
 export function findHardWord(text: string, terms: readonly string[]): string | null {
-  if (terms.length === 0) return null;
   const tokens = text.match(TOKEN_RE);
-  if (!tokens) return null;
-  for (const tok of tokens) {
-    const normalized = normalizeWord(tok);
-    if (tokenMatchesHard(normalized, terms)) {
-      // Return the configured term that fired, for the incident log.
-      const singular = normalized.endsWith('s') ? normalized.slice(0, -1) : normalized;
-      return terms.find((term) => normalized === term || singular === term) ?? normalized;
+  if (tokens) {
+    for (const tok of tokens) {
+      const normalized = normalizeWord(tok);
+      if (tokenMatchesHard(normalized, terms)) {
+        // Return the configured term that fired, for the incident log.
+        const singular = normalized.endsWith('s') ? normalized.slice(0, -1) : normalized;
+        return terms.find((term) => normalized === term || singular === term) ?? normalized;
+      }
     }
   }
-  return null;
+  return findBuiltinSlur(text);
 }
 
 // -------------------------------------------------------------------------
@@ -170,18 +241,13 @@ export const DEFAULT_SOFT_WORDS: string[] = [
   'whore',
 ];
 
-// Slurs. These have to be stored in their real form to actually match input;
-// whole-token matching (above) keeps them from snagging innocent words.
-export const DEFAULT_HARD_WORDS: string[] = [
-  'nigger',
-  'nigga',
-  'faggot',
-  'chink',
-  'kike',
-  'tranny',
-  'gook',
-  'wetback',
-];
+// Slur seed list — intentionally EMPTY in this open-source repo. The always-on
+// `obscenity` baseline (its dataset ships in the dependency) enforces slurs out
+// of the box. The handful of slurs that dataset omits are seeded privately by
+// the operator via CHAT_FILTER_HARD_LIST / CHAT_FILTER_HARD_FILE (see
+// chat_filter_db.ts), then managed from the admin dashboard. Do NOT commit
+// slurs here.
+export const DEFAULT_HARD_WORDS: string[] = [];
 
 /** A live snapshot of the filter state, loaded from the DB and cached. */
 export interface ChatFilterState {

--- a/server/chat_filter_db.ts
+++ b/server/chat_filter_db.ts
@@ -24,20 +24,32 @@ export interface FilterWord {
   createdAt: string;
 }
 
-function envSeedSoftWords(): string[] {
-  // One-time migration nicety: fold any legacy CHAT_CENSOR_LIST / CHAT_CENSOR_FILE
-  // operator config into the initial soft seed. After first boot the list is
-  // DB-managed from the admin dashboard and these env vars are ignored.
-  let raw = process.env.CHAT_CENSOR_LIST ?? '';
-  const file = process.env.CHAT_CENSOR_FILE ?? '';
+// Fold an operator-supplied list + optional file into seed terms. Used for both
+// tiers; the env var names differ per tier. After first boot the list is
+// DB-managed from the admin dashboard and these env vars are ignored.
+function envSeedWords(listVar: string, fileVar: string): string[] {
+  let raw = process.env[listVar] ?? '';
+  const file = process.env[fileVar] ?? '';
   if (file) {
     try {
       raw += ` ${readFileSync(file, 'utf8')}`;
     } catch (err) {
-      console.warn(`could not read CHAT_CENSOR_FILE (${file}) for seed:`, err);
+      console.warn(`could not read ${fileVar} (${file}) for seed:`, err);
     }
   }
   return parseWordList(raw);
+}
+
+function envSeedSoftWords(): string[] {
+  // Legacy operator config for the cosmetic soft tier.
+  return envSeedWords('CHAT_CENSOR_LIST', 'CHAT_CENSOR_FILE');
+}
+
+function envSeedHardWords(): string[] {
+  // The hard (slur) tier ships no plaintext list in this open-source repo; the
+  // `obscenity` baseline enforces slurs, and operators seed the few it omits
+  // privately here. See DEFAULT_HARD_WORDS in chat_filter.ts.
+  return envSeedWords('CHAT_FILTER_HARD_LIST', 'CHAT_FILTER_HARD_FILE');
 }
 
 async function insertSeedWords(client: PoolClient, words: string[], tier: WordTier): Promise<void> {
@@ -65,7 +77,7 @@ export async function seedChatFilterDefaults(client: PoolClient): Promise<void> 
     await insertSeedWords(client, [...DEFAULT_SOFT_WORDS, ...envSeedSoftWords()], 'soft');
   }
   if (!byTier.get('hard')) {
-    await insertSeedWords(client, DEFAULT_HARD_WORDS, 'hard');
+    await insertSeedWords(client, [...DEFAULT_HARD_WORDS, ...envSeedHardWords()], 'hard');
   }
 }
 

--- a/tests/chat_filter.test.ts
+++ b/tests/chat_filter.test.ts
@@ -9,9 +9,34 @@ import {
   parseWordList,
 } from '../server/chat_filter';
 
+// This repository is open source and intentionally contains NO plaintext slurs.
+// The hard tier's real wordlist lives in the `obscenity` dependency; these
+// fixtures are base64-encoded and decoded only at runtime so the filter can be
+// exercised against genuine offensive input without the repo carrying it.
+const dec = (b64: string) => Buffer.from(b64, 'base64').toString('utf8');
+const F = {
+  slur: dec('bmlnZ2Vy'),
+  slurPlural: dec('bmlnZ2Vycw=='),
+  affixMan: dec('bmlnZ2VybWFu'),
+  affix2: dec('bmlnZ2VyZmFnZ290'),
+  leet: dec('bjFnZzNy'),
+  upper: dec('TklHR0VS'),
+  atSign: dec('bmlnZ0A='),
+  sixes: dec('bmk2NkA='),
+  diacritic9: dec('bsOuOTllcg=='),
+  diacritic2: dec('Y2jDrm5r'),
+  circled: dec('4pOd4pOY4pOW4pOW4pOU4pOh'),
+  math: dec('8J2Tt/Cdk7LwnZOw8J2TsPCdk67wnZO7'),
+  fullwidth: dec('bmnvvYfvvYdlcg=='),
+  variant2: dec('bmVncm9pZA=='),
+  gap1: dec('Z29vaw=='), // a slur the obscenity dataset omits (operator-seeded)
+  gap2: dec('d2V0YmFjaw=='),
+  benign: dec('c25pZ2dlcg=='), // a real, non-slur word that embeds the slur
+};
+
 describe('normalizeWord', () => {
   it('lowercases, de-leets confusables, and strips non-letters', () => {
-    expect(normalizeWord('N1GG3R')).toBe('nigger');
+    expect(normalizeWord(F.upper.replace(/I/g, '1').replace(/E/g, '3'))).toBe(F.slur); // leet + case
     expect(normalizeWord('f.u_c-k')).toBe('fuck');
     expect(normalizeWord('@$$')).toBe('ass');
     expect(normalizeWord('123')).toBe('ie'); // 1->i, 2 dropped, 3->e
@@ -42,22 +67,67 @@ describe('maskText (soft, cosmetic)', () => {
 
 describe('findHardWord (hard, punitive)', () => {
   it('matches whole tokens, including leet and plurals', () => {
-    expect(findHardWord('you are a nigger', ['nigger'])).toBe('nigger');
-    expect(findHardWord('n1gger', ['nigger'])).toBe('nigger');
-    expect(findHardWord('two niggers here', ['nigger'])).toBe('nigger'); // plural strip
-    expect(findHardWord('NIGGER', ['nigger'])).toBe('nigger'); // case-insensitive
+    expect(findHardWord(`you are a ${F.slur}`, [F.slur])).toBe(F.slur);
+    expect(findHardWord(F.leet, [F.slur])).toBe(F.slur);
+    expect(findHardWord(`two ${F.slurPlural} here`, [F.slur])).toBe(F.slur); // plural strip
+    expect(findHardWord(F.upper, [F.slur])).toBe(F.slur); // case-insensitive
   });
 
   it('does NOT substring-match innocent words (no false mutes)', () => {
     // The classic Scunthorpe trap: substring matching would wrongly fire here.
-    expect(findHardWord('that is despicable', ['spic'])).toBeNull();
+    expect(findHardWord('gobbledygook', [F.gap1])).toBeNull(); // gap1 is a substring of it
     expect(findHardWord('what a classy pass', ['ass'])).toBeNull();
     expect(findHardWord('assassin guild', ['ass'])).toBeNull();
   });
 
   it('returns null with no terms or no hit', () => {
     expect(findHardWord('anything', [])).toBeNull();
-    expect(findHardWord('perfectly fine message', ['nigger'])).toBeNull();
+    expect(findHardWord('perfectly fine message', [F.slur])).toBeNull();
+  });
+
+  describe('always-on obscenity baseline (closes the affix/empty-list hole)', () => {
+    it('catches slurs with appended/prepended affixes the whole-token list misses', () => {
+      // The reported bypass: an affixed slur did not equal the bare token.
+      expect(findHardWord(`you stupid ${F.affixMan}`, [])).toBe(F.slur);
+      expect(findHardWord(F.affix2, [])).toBe(F.slur);
+    });
+
+    it('catches slur variants not in the admin list at all', () => {
+      expect(findHardWord(`what a ${F.variant2}`, [])).toBeTruthy();
+    });
+
+    it('catches leet/confusable evasions even with an empty admin list', () => {
+      expect(findHardWord(F.leet, [])).toBe(F.slur);
+      expect(findHardWord(F.atSign, [])).toBeTruthy();
+    });
+
+    it('catches diacritics, extended leet (6/9→g), and styled Unicode glyphs', () => {
+      expect(findHardWord(F.diacritic2, [])).toBeTruthy(); // combining diacritic
+      expect(findHardWord(F.diacritic9, [])).toBeTruthy(); // accent + 9-as-g
+      expect(findHardWord(F.sixes, [])).toBeTruthy(); // 6-as-g + @
+      expect(findHardWord(F.circled, [])).toBeTruthy(); // circled letters
+      expect(findHardWord(F.math, [])).toBeTruthy(); // mathematical script
+      expect(findHardWord(F.fullwidth, [])).toBeTruthy(); // fullwidth letters
+    });
+
+    it('does not false-mute innocents that survive folding', () => {
+      // 9/6→g must not turn scores or laughter into a slur.
+      expect(findHardWord('i scored 99 gg', [])).toBeNull();
+      expect(findHardWord('biggie smalls', [])).toBeNull();
+      expect(findHardWord(`${F.benign} is a real word, no`, [])).toBeNull();
+    });
+
+    it('still passes the Scunthorpe trap (no false mutes on innocent words)', () => {
+      expect(findHardWord('that is despicable', [])).toBeNull();
+      expect(findHardWord('what a classy pass', [])).toBeNull();
+      expect(findHardWord('assassin guild', [])).toBeNull();
+      expect(findHardWord('perfectly fine message', [])).toBeNull();
+    });
+
+    it('the admin/operator list still covers slurs the baseline omits', () => {
+      expect(findHardWord(`go away ${F.gap1}`, [F.gap1])).toBe(F.gap1);
+      expect(findHardWord(`${F.gap2}s`, [F.gap2])).toBe(F.gap2); // plural strip
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
Closes the reported chat-filter bypass (a slur + suffix like `…man` slid past the hard tier) and removes the plaintext slur list from this open-source repo.

### Matching hardening
- **Always-on `obscenity` baseline** added to the hard (slur) tier — the same library `auth.ts` already uses to screen usernames — OR'd with the admin-editable list. Its dataset ships in the dependency, not our source.
- The old hard tier used **whole-token equality only**, so `nigger`+`man` → `niggerman` didn't match and `negroid` wasn't covered at all. The baseline resolves affixed/leet forms while still passing the Scunthorpe trap.
- **Stronger normalization**: Unicode NFKD + combining-diacritic stripping + expanded confusables (`6`/`9`→`g`, `©`/`€`/`£`) and a Unicode-aware tokenizer, fed to the baseline as a de-obfuscated copy. Now catches `nî99er`, `ni66@`, and circled/math/fullwidth glyphs.
- **No false mutes**: `despicable`, `classy pass`, `assassin`, `i scored 99 gg`, `snigger`, `biggie smalls`, `monkey` all stay clean. Deliberately did *not* add whole-message space-collapsing (it false-mutes `pen island` → penis, `shiitake`); this is a punitive filter, so a false mute is the expensive failure.

### Open-source hygiene
- Removed the plaintext slur seed list. Enforcement comes from the obscenity dataset; operators seed the few slurs it omits **privately** via `CHAT_FILTER_HARD_LIST` / `CHAT_FILTER_HARD_FILE` (mirrors the existing `CHAT_CENSOR_*` soft-tier pattern), then manage them from the admin dashboard.
- Tests use **base64-encoded fixtures** decoded at runtime — real offensive input is exercised, but the repo carries no readable slurs. A repo-wide grep for slurs now returns nothing (only the dictionary word `gobbledygook` used as an innocent Scunthorpe case).

### Known/accepted residue
- `obscenity` itself flags `the rapist` and `chinkapin` (a tree) — pre-existing behavior already live in the username filter; unchanged here.
- Deep edge cases left to the operator list rather than risking false mutes: fully space-separated letters, and a couple of obscure misspellings.

## Testing
- `tests/chat_filter.test.ts` — 20 cases (added affix/diacritic/Unicode + false-positive coverage)
- `npx vitest run tests/chat_filter.test.ts tests/chat.test.ts tests/admin.test.ts` → 100 pass
- `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)