### PR TITLE
feat: frost-touched mobs chill the victim's movement on hit (Numbing Chill)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/mob_chill_visual.mjs
+++ b/scripts/mob_chill_visual.mjs
@@ -1,0 +1,92 @@
+// Visual capture for the Stormcrag Elemental's "Numbing Chill" on-hit slow.
+// Boots the offline game, finds a Stormcrag Elemental, god-modes the player,
+// forces swings until the chill debuff lands, and screenshots the HUD.
+// Needs `npm run dev` (:5173). Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Frostbit');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Find a Stormcrag Elemental, stand in melee, and go invulnerable so the
+// camera survives the beating while we wait for the proc.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'stormcrag_elemental' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  if (!mob) return { found: false };
+  p.pos.x = mob.pos.x + 2; p.pos.z = mob.pos.z;
+  p.pos.y = mob.pos.y;
+  p.maxHp = 100000; p.hp = 100000; // survive the swings
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  return { found: true, mobId: mob.id, mobLevel: mob.level, mobName: mob.name };
+});
+console.log('setup:', JSON.stringify(setup));
+if (!setup.found) { console.log('No Stormcrag Elemental found in the offline world'); await browser.close(); process.exit(1); }
+
+// Force swings until the Numbing Chill debuff appears on the player.
+const proc = await page.evaluate((mobId) => {
+  const sim = window.__game.sim;
+  const mob = sim.entities.get(mobId);
+  const p = sim.player;
+  for (let i = 0; i < 400; i++) {
+    sim.mobSwing(mob, p);
+    p.hp = p.maxHp; // keep topped up
+    const a = p.auras.find((x) => x.name === 'Numbing Chill');
+    if (a) {
+      // Step clear of the elemental so the live loop stops the beating; the
+      // 6-second chill aura rides along and stays on the buff bar for the shot.
+      p.pos.z += 60; p.prevPos = { ...p.pos };
+      return { chilled: true, swings: i + 1, remaining: a.remaining, value: a.value };
+    }
+  }
+  return { chilled: false };
+}, setup.mobId);
+console.log('proc:', JSON.stringify(proc));
+
+await new Promise((r) => setTimeout(r, 150));
+await page.screenshot({ path: 'tmp/chill_full.png' });
+// Crop tightly around the player buff/debuff bar so the Numbing Chill icon reads.
+const rect = await page.evaluate(() => {
+  const el = document.querySelector('#buff-bar');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.x, y: r.y, width: r.width, height: r.height };
+});
+console.log('buff-bar rect:', JSON.stringify(rect));
+if (rect && rect.width > 4 && rect.height > 4) {
+  await page.screenshot({ path: 'tmp/chill_hud.png', clip: {
+    x: 1300, y: 0, width: 300, height: 130,
+  } });
+}
+console.log('saved tmp/chill_full.png and tmp/chill_hud.png');
+
+await browser.close();
+process.exit(proc.chilled ? 0 : 2);

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -135,6 +135,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'inert_storm_shard', chance: 0.4 },
     ],
     scale: 1.1, color: 0x5dade2,
+    // A touch of the storm's cold numbs the limbs: each landed swing has a
+    // chance to slow the victim to half speed for a few seconds.
+    chillOnHit: { chance: 0.35, mult: 0.5, duration: 6, name: 'Numbing Chill' },
   },
   shardlord_kazzix: {
     id: 'shardlord_kazzix', name: 'Shardlord Kazzix', minLevel: 18, maxLevel: 18, family: 'elemental', rare: true,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4101,6 +4101,16 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+
+    // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
+    const chill = MOBS[mob.templateId]?.chillOnHit;
+    if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {
+      this.applyAura(target, {
+        id: mob.templateId + '_chill', name: chill.name, kind: 'slow',
+        remaining: chill.duration, duration: chill.duration, value: chill.mult,
+        sourceId: mob.id, school: 'frost',
+      });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -205,6 +205,10 @@ export interface MobTemplate {
   petRanged?: { range: number; school: Aura['school'] };
   petRole?: PetRole;
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
+  // On-hit chill: a landed melee swing has `chance` to slow the victim's
+  // movement to `mult` of normal for `duration` seconds (frost school). Reuses
+  // the standard `slow` aura, so it rides the same movement path as Frostbolt.
+  chillOnHit?: { chance: number; mult: number; duration: number; name: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_chill.test.ts
+++ b/tests/mob_chill.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+import type { Entity } from '../src/sim/types';
+
+// Spawn a Stormcrag Elemental and register it with the sim.
+function spawnElemental(sim: Sim): Entity {
+  const mob = createMob((sim as any).nextId++, MOBS.stormcrag_elemental, 18, { x: 0, y: 0, z: 0 });
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+function placePlayer(sim: Sim, pid: number, x: number, z: number): Entity {
+  const e = sim.entities.get(pid)!;
+  e.pos = { x, y: 0, z };
+  e.prevPos = { ...e.pos };
+  e.maxHp = 100000;
+  e.hp = 100000;
+  return e;
+}
+
+describe('mob chill-on-hit', () => {
+  it('the Stormcrag Elemental template carries a Numbing Chill proc', () => {
+    expect(MOBS.stormcrag_elemental.chillOnHit).toMatchObject({
+      chance: 0.35, mult: 0.5, duration: 6, name: 'Numbing Chill',
+    });
+  });
+
+  it('a landed swing can apply a movement-slowing chill to the victim', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Frostbit');
+    const victim = placePlayer(sim, pid, 1, 0);
+    const elemental = spawnElemental(sim);
+
+    const baseSpeed = (sim as any).moveSpeedMult(victim);
+    expect(baseSpeed).toBe(1);
+
+    let chilled = false;
+    for (let i = 0; i < 200 && !chilled; i++) {
+      (sim as any).mobSwing(elemental, victim);
+      chilled = victim.auras.some((a) => a.kind === 'slow' && a.name === 'Numbing Chill');
+    }
+    expect(chilled).toBe(true);
+
+    const aura = victim.auras.find((a) => a.name === 'Numbing Chill')!;
+    expect(aura.kind).toBe('slow');
+    expect(aura.school).toBe('frost');
+    expect(aura.value).toBe(0.5);
+    // the slow aura actually drags movement down through the shared path
+    expect((sim as any).moveSpeedMult(victim)).toBe(0.5);
+  });
+
+  it('an ordinary mob with no chill field never applies the slow', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Safe');
+    const victim = placePlayer(sim, pid, 1, 0);
+    const wolf = createMob((sim as any).nextId++, MOBS.forest_wolf, 3, { x: 0, y: 0, z: 0 });
+    wolf.hostile = true; wolf.hp = wolf.maxHp;
+    (sim as any).addEntity(wolf);
+
+    for (let i = 0; i < 200; i++) (sim as any).mobSwing(wolf, victim);
+    expect(victim.auras.some((a) => a.kind === 'slow')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **on-hit chill** to the mob toolkit: a landed melee swing has a chance to **slow the victim's movement** for a few seconds. It reuses the existing `slow` aura primitive, so the slow rides the exact same movement path as the Mage's Frostbolt — no new movement code.

The frost-themed **Stormcrag Elemental** (Thornpeak Heights) is the first carrier: its `Numbing Chill` procs at 35% per landed hit for a 50% slow over 6s. Distinct from the existing boss mechanics (`aoePulse`, `summonAdds`, `enrage`) — this is the first *on-hit debuff* proc on a regular (non-boss) mob.

## How

- **`types.ts`** — new optional `chillOnHit?: { chance; mult; duration; name }` field on `MobTemplate` (declarative data, like the other mob mechanics).
- **`sim.ts`** — resolved in `mobSwing()` *after* a landed hit (past the miss/dodge early-returns): roll `chance`, then apply a frost-school `slow` aura via the existing `applyAura`. Guarded by `!mob.dead && !target.dead`.
- **`zone3.ts`** — Stormcrag Elemental gains `Numbing Chill` (35% / 0.5x / 6s). All tuning lives on the template, not inline.
- **`tests/mob_chill.test.ts`** — asserts the proc lands a movement-slowing aura, drags `moveSpeedMult` to 0.5, and that a chill-less mob (forest wolf) never applies it.
- **`scripts/mob_chill_visual.mjs`** — offline screenshot tour, matching the repo's `*_visual.mjs` convention.

Determinism preserved (chance rolled through `this.rng`, no new draw-order changes elsewhere). `tsc` clean; **all 651 tests pass**.

## Screenshots

The Numbing Chill debuff on the player's buff bar (note the frost icon + duration timer):

![Numbing Chill debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-chill-on-hit/docs/screenshots/mob-chill-debuff.png)

In the world — caught among the Stormcrag Elementals in Thornpeak Heights:

![Stormcrag Elementals](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mob-chill-on-hit/docs/screenshots/mob-chill-world.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)