### PR TITLE
[codex] Fix arena and duel PvP ability targeting

### DIFF
--- a/src/game/interactions.ts
+++ b/src/game/interactions.ts
@@ -4,7 +4,10 @@ import type { IWorld } from '../world_api';
 
 export interface PickInteractionWorld {
   player: IWorld['player'];
+  playerId?: IWorld['playerId'];
   entities: IWorld['entities'];
+  duelInfo?: IWorld['duelInfo'];
+  arenaInfo?: IWorld['arenaInfo'];
   targetEntity(id: number | null): void;
   enterDungeon(dungeonId: string): void;
   leaveDungeon(): void;
@@ -36,6 +39,13 @@ export function hoverCursorKind(
   return 'default';
 }
 
+function isActivePvpOpponent(world: PickInteractionWorld, e: Entity): boolean {
+  if (e.kind !== 'player' || e.dead) return false;
+  if (e.id === (world.playerId ?? world.player.id)) return false;
+  if (world.duelInfo?.state === 'active' && world.duelInfo.otherPid === e.id) return true;
+  return world.arenaInfo?.match?.state === 'active' && world.arenaInfo.match.oppPid === e.id;
+}
+
 export function handlePickedEntity(
   world: PickInteractionWorld,
   hud: PickInteractionHud,
@@ -64,7 +74,7 @@ export function handlePickedEntity(
     } else if (e.kind === 'npc') {
       if (d <= INTERACT_RANGE + 2) hud.openQuestDialog(id);
       else hud.showError('Too far away.');
-    } else if (e.kind === 'mob' && !e.dead && e.hostile) {
+    } else if ((e.kind === 'mob' && !e.dead && e.hostile) || isActivePvpOpponent(world, e)) {
       world.startAutoAttack();
     }
   } else if (button === 0) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2339,6 +2339,7 @@ export class Sim {
         }
         case 'polymorph': {
           if (!target || target.dead) break;
+          target.hp = target.maxHp;
           this.applyAura(target, {
             id: ability.id, name: ability.name, kind: 'polymorph',
             remaining: eff.duration, duration: eff.duration, value: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2001,7 +2001,13 @@ export class Sim {
 
   private applyChannelTick(p: Entity, res: ResolvedAbility): void {
     const target = p.targetId !== null ? this.entities.get(p.targetId) : null;
-    if (!target || target.dead) { this.cancelCast(p); return; }
+    if (!target || target.dead || !this.isHostileTo(p, target)) { this.cancelCast(p); return; }
+    const maxRange = res.def.range > 0 ? res.def.range : MELEE_RANGE;
+    if (dist2d(p.pos, target.pos) > maxRange) {
+      this.error(p.id, 'Out of range.');
+      this.cancelCast(p);
+      return;
+    }
     if (this.lineOfSightBlocked(p, target, res.def)) {
       this.error(p.id, 'Line of sight.');
       this.cancelCast(p);
@@ -2341,7 +2347,7 @@ export class Sim {
         }
         case 'aoeDamage': {
           this.emit({ type: 'spellfx', sourceId: p.id, targetId: p.id, school: ability.school, fx: 'nova' });
-          for (const m of this.mobsInRadius(p.pos, eff.radius)) {
+          for (const m of this.hostilesInRadius(p, p.pos, eff.radius)) {
             if (!this.hasLineOfSight(p, m)) continue;
             let dmg = this.rng.range(eff.min, eff.max);
             // Armor only mitigates physical damage, mirroring the single-target
@@ -2353,7 +2359,7 @@ export class Sim {
           break;
         }
         case 'aoeAttackSpeed': {
-          for (const m of this.mobsInRadius(p.pos, eff.radius)) {
+          for (const m of this.hostilesInRadius(p, p.pos, eff.radius)) {
             if (m.dead) continue;
             if (!this.hasLineOfSight(p, m)) continue;
             this.applyAura(m, {
@@ -2365,7 +2371,7 @@ export class Sim {
           break;
         }
         case 'aoeAttackPower': {
-          for (const m of this.mobsInRadius(p.pos, eff.radius)) {
+          for (const m of this.hostilesInRadius(p, p.pos, eff.radius)) {
             if (m.dead) continue;
             this.applyAura(m, {
               id: ability.id + '_ap', name: ability.name, kind: 'debuff_ap',
@@ -2373,7 +2379,7 @@ export class Sim {
               sourceId: p.id, school: ability.school,
             });
             this.enterCombat(p, m);
-            if (m.hostile) addThreat(m, p.id, 10 * this.threatMod(p, ability.school));
+            if (m.kind === 'mob' && m.hostile) addThreat(m, p.id, 10 * this.threatMod(p, ability.school));
           }
           break;
         }
@@ -2837,13 +2843,13 @@ export class Sim {
     const pet = this.petOf(r.e.id);
     if (!pet) { this.error(r.e.id, 'You have no living pet.'); return; }
     const target = r.e.targetId !== null ? this.entities.get(r.e.targetId) : null;
-    if (!target || target.kind !== 'mob' || target.dead || !target.hostile || target.ownerId !== null) {
+    if (!target || target.dead || !this.isHostileTo(pet, target)) {
       this.error(r.e.id, 'Your pet needs a hostile target.');
       return;
     }
     pet.aggroTargetId = target.id;
     pet.inCombat = true;
-    addThreat(target, pet.id, 1);
+    if (target.kind === 'mob' && target.hostile) addThreat(target, pet.id, 1);
   }
 
   petTaunt(pid?: number): void {
@@ -3187,26 +3193,28 @@ export class Sim {
       }
     }
 
+    const sourcePlayer = this.pvpController(source);
+
     // duels end at 1 hp — nobody dies
     const duel = target.kind === 'player' ? this.duels.get(target.id) : undefined;
-    if (duel && duel.state === 'active' && source && (source.id === duel.a || source.id === duel.b)) {
+    if (duel && duel.state === 'active' && sourcePlayer && (sourcePlayer.id === duel.a || sourcePlayer.id === duel.b)) {
       if (target.hp - amount < 1) {
         amount = Math.max(0, target.hp - 1);
         target.hp = 1;
-        this.emit({ type: 'damage', sourceId: source.id, targetId: target.id, amount, crit, school, ability, kind });
-        this.endDuel(duel, source.id);
+        this.emit({ type: 'damage', sourceId: source?.id ?? -1, targetId: target.id, amount, crit, school, ability, kind });
+        this.endDuel(duel, sourcePlayer.id);
         return;
       }
     }
 
     // arena bouts also end at 1 hp — the loser yields, nobody actually dies
     const match = target.kind === 'player' ? this.arenaMatches.get(target.id) : undefined;
-    if (match && match.state === 'active' && source && (source.id === match.a || source.id === match.b)) {
+    if (match && match.state === 'active' && sourcePlayer && (sourcePlayer.id === match.a || sourcePlayer.id === match.b)) {
       if (target.hp - amount < 1) {
         amount = Math.max(0, target.hp - 1);
         target.hp = 1;
-        this.emit({ type: 'damage', sourceId: source.id, targetId: target.id, amount, crit, school, ability, kind });
-        this.endArenaMatch(match, source.id, 'defeat');
+        this.emit({ type: 'damage', sourceId: source?.id ?? -1, targetId: target.id, amount, crit, school, ability, kind });
+        this.endArenaMatch(match, sourcePlayer.id, 'defeat');
         return;
       }
     }
@@ -4092,7 +4100,7 @@ export class Sim {
     }
 
     let target = pet.aggroTargetId !== null ? this.entities.get(pet.aggroTargetId) ?? null : null;
-    if (target && (target.dead || target.kind !== 'mob' || !target.hostile)) target = null;
+    if (target && (target.dead || !this.isHostileTo(pet, target))) target = null;
     if (target && dist2d(owner.pos, pet.pos) > PET_LEASH) target = null;
     if (!target && !owner.dead) target = this.petPickTarget(pet, owner);
     pet.aggroTargetId = target?.id ?? null;
@@ -4114,7 +4122,7 @@ export class Sim {
         pet.swingTimer = Math.max(0, pet.swingTimer - DT);
       } else {
         pet.facing = angleTo(pet.pos, target.pos);
-        if (!ranged && pet.petTauntTimer <= 0) {
+        if (target.kind === 'mob' && !ranged && pet.petTauntTimer <= 0) {
           this.applyTaunt(pet, target);
           pet.petTauntTimer = PET_GROWL_INTERVAL;
         }
@@ -4184,9 +4192,9 @@ export class Sim {
     let best: Entity | null = null;
     let bestD = pet.petMode === 'aggressive' ? PET_AGGRESSIVE_RANGE : PET_ASSIST_RANGE;
     for (const m of this.entities.values()) {
-      if (m.kind !== 'mob' || m.dead || !m.hostile || m.ownerId !== null) continue;
-      const engagingUs = m.aggroTargetId === owner.id || m.aggroTargetId === pet.id;
-      const ownerOffense = owner.targetId === m.id && (owner.autoAttack || m.threat.has(owner.id));
+      if (m.id === pet.id || m.dead || !this.isHostileTo(pet, m)) continue;
+      const engagingUs = m.kind === 'mob' && (m.aggroTargetId === owner.id || m.aggroTargetId === pet.id);
+      const ownerOffense = owner.targetId === m.id && (owner.autoAttack || (m.kind === 'mob' && m.threat.has(owner.id)));
       const aggressive = pet.petMode === 'aggressive' && dist2d(pet.pos, m.pos) <= PET_AGGRESSIVE_RANGE;
       if (!engagingUs && !ownerOffense && !aggressive) continue;
       const d = dist2d(pet.pos, m.pos);
@@ -5499,17 +5507,40 @@ export class Sim {
   }
 
   // -------------------------------------------------------------------------
-  // Hostility: mobs are hostile to players; players are hostile to each other
-  // only while dueling.
+  // Hostility: mobs are hostile to players; controlled pets inherit their
+  // owner's PvP hostility during active duels and arena matches.
   // -------------------------------------------------------------------------
 
+  private pvpController(e: Entity | null): Entity | null {
+    if (!e) return null;
+    if (e.kind === 'player') return e;
+    if (e.kind === 'mob' && e.ownerId !== null) {
+      const owner = this.entities.get(e.ownerId);
+      return owner?.kind === 'player' ? owner : null;
+    }
+    return null;
+  }
+
   isHostileTo(attacker: Entity, target: Entity): boolean {
-    if (target.kind === 'mob') return target.hostile;
-    if (target.kind === 'player' && attacker.kind === 'player') {
-      const duel = this.duels.get(attacker.id);
-      if (duel && duel.state === 'active' && (duel.a === target.id || duel.b === target.id)) return true;
-      const match = this.arenaMatches.get(attacker.id);
-      return !!match && match.state === 'active' && (match.a === target.id || match.b === target.id);
+    if (target.kind === 'mob') {
+      if (target.ownerId !== null) {
+        const owner = this.entities.get(target.ownerId);
+        return !!owner && owner.kind === 'player' && this.isHostileTo(attacker, owner);
+      }
+      return target.hostile;
+    }
+    if (target.kind === 'player') {
+      const attackerPlayer = this.pvpController(attacker);
+      if (!attackerPlayer) return false;
+      if (attackerPlayer.id === target.id) return false;
+      const duel = this.duels.get(attackerPlayer.id);
+      if (duel && duel.state === 'active'
+        && ((duel.a === attackerPlayer.id && duel.b === target.id)
+          || (duel.b === attackerPlayer.id && duel.a === target.id))) return true;
+      const match = this.arenaMatches.get(attackerPlayer.id);
+      return !!match && match.state === 'active'
+        && ((match.a === attackerPlayer.id && match.b === target.id)
+          || (match.b === attackerPlayer.id && match.a === target.id));
     }
     return false;
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1906,9 +1906,13 @@ export class Sim {
           if (behindDiff < Math.PI / 2) { this.error(p.id, 'You must be behind your target.'); return; }
         }
         if (eff.type === 'polymorph') {
-          if (target.kind !== 'mob') { this.error(p.id, 'This creature cannot be polymorphed.'); return; }
-          const fam = MOBS[target.templateId]?.family;
-          if (fam === 'undead' || target.templateId === 'gorrak') { this.error(p.id, 'This creature cannot be polymorphed.'); return; }
+          if (target.kind === 'mob') {
+            const fam = MOBS[target.templateId]?.family;
+            if (fam === 'undead' || target.templateId === 'gorrak') { this.error(p.id, 'This creature cannot be polymorphed.'); return; }
+          } else if (target.kind !== 'player') {
+            this.error(p.id, 'This creature cannot be polymorphed.');
+            return;
+          }
         }
         if (eff.type === 'judgement' && !p.auras.some((a) => a.kind === 'imbue' && a.value2 !== undefined)) {
           this.error(p.id, 'You have no active Seal.');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -929,10 +929,10 @@ export class Hud {
       if (touchTimer !== undefined) window.clearTimeout(touchTimer);
       touchTimer = undefined;
     };
-    const showAt = (x: number, y: number) => {
+    const showAt = (x: number, y: number, trigger: 'touch' | 'mouse' | 'focus') => {
       // Touch-only path: showing the tooltip means the held control is being
       // inspected, so the release click should peek, not fire its action.
-      this.peekGuard.peek();
+      this.peekGuard.tooltipShown(trigger);
       this.tooltipEl.innerHTML = html();
       this.tooltipEl.style.display = 'block';
       const tw = this.tooltipEl.offsetWidth, th = this.tooltipEl.offsetHeight;
@@ -941,11 +941,12 @@ export class Hud {
     };
     const showNearElement = () => {
       const rect = el.getBoundingClientRect();
-      showAt(rect.right, rect.top + rect.height / 2);
+      showAt(rect.right, rect.top + rect.height / 2, 'focus');
     };
     el.addEventListener('mouseenter', () => {
       if (mobile()) return;
-      showNearElement();
+      const rect = el.getBoundingClientRect();
+      showAt(rect.right, rect.top + rect.height / 2, 'mouse');
     });
     el.addEventListener('mousemove', (e) => {
       if (mobile()) return;
@@ -963,7 +964,7 @@ export class Hud {
       this.peekGuard.press();
       this.tooltipEl.style.display = 'none';
       const x = e.clientX, y = e.clientY;
-      touchTimer = window.setTimeout(() => showAt(x, y), TOOLTIP_PEEK_MS);
+      touchTimer = window.setTimeout(() => showAt(x, y, 'touch'), TOOLTIP_PEEK_MS);
     });
     el.addEventListener('pointerup', clearTouchTimer);
     el.addEventListener('pointercancel', clearTouchTimer);

--- a/src/ui/touch_peek.ts
+++ b/src/ui/touch_peek.ts
@@ -11,6 +11,8 @@
 /** Default hold (ms) before a touch press is treated as a tooltip peek. */
 export const TOOLTIP_PEEK_MS = 950;
 
+export type TooltipTriggerKind = 'touch' | 'mouse' | 'focus';
+
 export class TouchPeekGuard {
   private peeked = false;
 
@@ -22,6 +24,11 @@ export class TouchPeekGuard {
   /** The long-press tooltip was shown for the held control. */
   peek(): void {
     this.peeked = true;
+  }
+
+  /** A tooltip became visible; only touch long-press tooltips suppress release clicks. */
+  tooltipShown(kind: TooltipTriggerKind): void {
+    if (kind === 'touch') this.peek();
   }
 
   /**

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -323,3 +323,42 @@ describe('arena: crowd control diminishing returns', () => {
     expect(warrior.auras.find((aura) => aura.kind === 'root')?.duration).toBe(4);
   });
 });
+
+describe('arena: class ability target filters', () => {
+  const aoeCases: Array<{ cls: PlayerClass; ability: string; level: number; setup?: (sim: Sim, pid: number) => void }> = [
+    { cls: 'warrior', ability: 'thunder_clap', level: 20 },
+    { cls: 'mage', ability: 'arcane_explosion', level: 20 },
+    { cls: 'paladin', ability: 'consecration', level: 20 },
+    {
+      cls: 'druid',
+      ability: 'swipe',
+      level: 20,
+      setup: (sim, pid) => {
+        const druid = sim.entities.get(pid)!;
+        sim.castAbility('bear_form', pid);
+        druid.gcdRemaining = 0;
+        druid.resource = druid.maxResource;
+      },
+    },
+  ];
+
+  it.each(aoeCases)('lets $cls $ability hit active arena opponents', ({ cls, ability, level, setup }) => {
+    const { sim, a, b } = queueDuo(cls, 'warrior');
+    startBout(sim);
+    const caster = sim.entities.get(a)!;
+    const target = sim.entities.get(b)!;
+    sim.setPlayerLevel(level, a);
+    sim.setPlayerLevel(level, b);
+    target.pos.x = caster.pos.x;
+    target.pos.z = caster.pos.z + 3;
+    target.prevPos = { ...target.pos };
+    caster.resource = caster.maxResource;
+    caster.gcdRemaining = 0;
+    setup?.(sim, a);
+
+    const startHp = target.hp;
+    sim.castAbility(ability, a);
+
+    expect(target.hp).toBeLessThan(startHp);
+  });
+});

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -349,9 +349,7 @@ describe('arena: class ability target filters', () => {
     const target = sim.entities.get(b)!;
     sim.setPlayerLevel(level, a);
     sim.setPlayerLevel(level, b);
-    target.pos.x = caster.pos.x;
-    target.pos.z = caster.pos.z + 3;
-    target.prevPos = { ...target.pos };
+    teleport(sim, b, caster.pos.x, caster.pos.z + 3);
     caster.resource = caster.maxResource;
     caster.gcdRemaining = 0;
     setup?.(sim, a);

--- a/tests/duel.test.ts
+++ b/tests/duel.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { groundHeight } from '../src/sim/world';
-import type { Aura } from '../src/sim/types';
+import type { Aura, Entity } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -17,10 +17,10 @@ function teleport(sim: Sim, pid: number, x: number, z: number) {
 
 // Start an accepted duel between two adjacent players and run the countdown
 // out so the bout is live.
-function startedDuel(): { sim: Sim; a: number; b: number } {
+function startedDuel(aClass: 'warrior' | 'mage' | 'hunter' | 'warlock' = 'warrior', bClass: 'warrior' | 'mage' | 'hunter' | 'warlock' = 'mage'): { sim: Sim; a: number; b: number } {
   const sim = makeWorld();
-  const a = sim.addPlayer('warrior', 'Aleph');
-  const b = sim.addPlayer('mage', 'Bet');
+  const a = sim.addPlayer(aClass, 'Aleph', { autoEquip: true });
+  const b = sim.addPlayer(bClass, 'Bet', { autoEquip: true });
   teleport(sim, a, 0, -40);
   teleport(sim, b, 4, -40);
   sim.duelRequest(b, a);
@@ -32,6 +32,19 @@ function startedDuel(): { sim: Sim; a: number; b: number } {
     if (d && d.state === 'active') break;
   }
   return { sim, a, b };
+}
+
+function givePet(sim: Sim, ownerPid: number): Entity {
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) {
+      e.ownerId = ownerPid;
+      e.hostile = false;
+      e.hp = e.maxHp;
+      teleport(sim, e.id, sim.entities.get(ownerPid)!.pos.x + 1, sim.entities.get(ownerPid)!.pos.z);
+      return e;
+    }
+  }
+  throw new Error('no wild mob available to adopt as a pet');
 }
 
 // A bleed/poison style damage-over-time applied by the opponent.
@@ -84,5 +97,66 @@ describe('duel: non-lethal cleanup', () => {
 
     for (let i = 0; i < 20 * 3; i++) sim.tick();
     expect(eb.dead).toBe(false);
+  });
+});
+
+describe('duel: PvP combat affordances', () => {
+  it('lets a commanded pet attack an active duel opponent', () => {
+    const { sim, a, b } = startedDuel('hunter', 'mage');
+    const pet = givePet(sim, a);
+    const eb = sim.entities.get(b)!;
+    const startHp = eb.hp;
+
+    sim.targetEntity(b, a);
+    sim.petAttack(a);
+    for (let i = 0; i < 20 * 5 && eb.hp === startHp; i++) sim.tick();
+
+    expect(pet.aggroTargetId).toBe(b);
+    expect(eb.hp).toBeLessThan(startHp);
+  });
+
+  it('treats pet damage as owner PvP damage for non-lethal duel endings', () => {
+    const { sim, a, b } = startedDuel('hunter', 'mage');
+    const pet = givePet(sim, a);
+    const eb = sim.entities.get(b)!;
+
+    (sim as any).dealDamage(pet, eb, eb.hp + 1000, false, 'physical', 'Pet Bite', 'hit');
+
+    expect((sim as any).duels.has(b)).toBe(false);
+    expect(eb.dead).toBe(false);
+    expect(eb.hp).toBe(1);
+  });
+
+  it('lets warlock self and hostile spells work against active duel opponents', () => {
+    const { sim, a, b } = startedDuel('warlock', 'warrior');
+    const warlock = sim.entities.get(a)!;
+    const warrior = sim.entities.get(b)!;
+    sim.setPlayerLevel(20, a);
+    sim.setPlayerLevel(20, b);
+    warlock.resource = Math.floor(warlock.maxResource / 2);
+    warlock.hp = warlock.maxHp - 50;
+    warlock.targetId = b;
+    warlock.facing = Math.atan2(warrior.pos.x - warlock.pos.x, warrior.pos.z - warlock.pos.z);
+
+    const hpBeforeTap = warlock.hp;
+    const manaBeforeTap = warlock.resource;
+    sim.castAbility('life_tap', a);
+    expect(warlock.hp).toBeLessThan(hpBeforeTap);
+    expect(warlock.resource).toBeGreaterThan(manaBeforeTap);
+
+    warlock.gcdRemaining = 0;
+    warlock.resource = warlock.maxResource;
+    sim.castAbility('curse_of_agony', a);
+    expect(warrior.auras.some((aura) => aura.id === 'curse_of_agony')).toBe(true);
+
+    warlock.gcdRemaining = 0;
+    warlock.resource = warlock.maxResource;
+    const warriorHpBeforeDrain = warrior.hp;
+    const warlockHpBeforeDrain = warlock.hp;
+    sim.castAbility('drain_life', a);
+    for (let i = 0; i < 20 * 2; i++) sim.tick();
+
+    expect(warrior.hp).toBeLessThan(warriorHpBeforeDrain);
+    expect(warlock.hp).toBeGreaterThan(warlockHpBeforeDrain);
   });
 });

--- a/tests/duel.test.ts
+++ b/tests/duel.test.ts
@@ -115,6 +115,15 @@ describe('duel: PvP combat affordances', () => {
     expect(eb.hp).toBeLessThan(startHp);
   });
 
+  it('does not make a dueling pet hostile to its owner', () => {
+    const { sim, a } = startedDuel('hunter', 'mage');
+    const pet = givePet(sim, a);
+    const owner = sim.entities.get(a)!;
+
+    expect(sim.isHostileTo(pet, owner)).toBe(false);
+    expect(sim.isHostileTo(owner, pet)).toBe(false);
+  });
+
   it('treats pet damage as owner PvP damage for non-lethal duel endings', () => {
     const { sim, a, b } = startedDuel('hunter', 'mage');
     const pet = givePet(sim, a);

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { hoverCursorKind, isAttackHoverTarget } from '../src/game/interactions';
+import { handlePickedEntity, hoverCursorKind, isAttackHoverTarget } from '../src/game/interactions';
 import type { Entity } from '../src/sim/types';
 
 function stubEntity(partial: Partial<Entity> & Pick<Entity, 'id' | 'kind'>): Entity {
@@ -95,5 +95,37 @@ describe('hoverCursorKind', () => {
 
   it('returns default for empty pick', () => {
     expect(hoverCursorKind(undefined, 1, new Set())).toBe('default');
+  });
+});
+
+describe('handlePickedEntity', () => {
+  it('starts auto-attack when right-clicking an active duel opponent', () => {
+    const player = stubEntity({ id: 1, kind: 'player' });
+    const opponent = stubEntity({ id: 2, kind: 'player', pos: { x: 3, y: 0, z: 0 } });
+    let targetId: number | null = null;
+    let attacks = 0;
+    const world: any = {
+      playerId: 1,
+      player,
+      entities: new Map([[1, player], [2, opponent]]),
+      duelInfo: { otherPid: 2, otherName: 'Bet', state: 'active' },
+      arenaInfo: null,
+      targetEntity: (id: number | null) => { targetId = id; },
+      enterDungeon: () => {},
+      leaveDungeon: () => {},
+      pickUpObject: () => {},
+      startAutoAttack: () => { attacks++; },
+    };
+    const hud = {
+      openLoot: () => {},
+      openQuestDialog: () => {},
+      showError: () => {},
+      closeContextMenu: () => {},
+    };
+
+    handlePickedEntity(world, hud, 2, 2, 10, 20);
+
+    expect(targetId).toBe(2);
+    expect(attacks).toBe(1);
   });
 });

--- a/tests/interest.test.ts
+++ b/tests/interest.test.ts
@@ -379,6 +379,27 @@ describe('crowd interest management', () => {
     expect(inKeep(snap, rogue.pid)).toBe(false);
   });
 
+  it('hides stealthed active duel opponents outside hostile detection range', () => {
+    const rogueFc = fakeWs();
+    const rogue = joinServer(server, rogueFc, 3, 'DuelSneak', 'rogue');
+    server.sim.setPlayerLevel(10, viewer.pid);
+    server.sim.setPlayerLevel(10, rogue.pid);
+    const v = server.sim.entities.get(viewer.pid)!;
+    placeAt(server, rogue.pid, v.pos.x + 30, v.pos.z);
+    server.sim.duelRequest(rogue.pid, viewer.pid);
+    server.sim.duelAccept(rogue.pid);
+    for (let i = 0; i < 20 * 5 && server.sim.duelFor(viewer.pid)?.state !== 'active'; i++) server.sim.tick();
+    server.sim.castAbility('stealth', rogue.pid);
+
+    viewerFc.sent.length = 0;
+    step(server);
+    const snap = lastSnap(viewerFc.sent);
+
+    expect(server.sim.isHostileTo(server.sim.entities.get(viewer.pid)!, server.sim.entities.get(rogue.pid)!)).toBe(true);
+    expect(entRecord(snap, rogue.pid)).toBeNull();
+    expect(inKeep(snap, rogue.pid)).toBe(false);
+  });
+
   it('keeps stationary npcs visible out to the legacy 120yd radius', () => {
     const npc = [...server.sim.entities.values()].find((e) => e.kind === 'npc')!;
     // viewer 110yd from the npc, subject player at the same distance

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -20,6 +20,30 @@ function twoPlayers(clsA = 'mage', clsB = 'warrior') {
   return { sim, aPid, bPid, a, b };
 }
 
+function startDuel(clsA = 'mage', clsB = 'warrior', level = 20) {
+  const setup = twoPlayers(clsA, clsB);
+  const { sim, aPid, bPid, a, b } = setup;
+  sim.setPlayerLevel(level, aPid);
+  sim.setPlayerLevel(level, bPid);
+  a.resource = a.maxResource;
+  a.facing = Math.atan2(b.pos.x - a.pos.x, b.pos.z - a.pos.z);
+  sim.duelRequest(bPid, aPid);
+  sim.duelAccept(bPid);
+  for (let i = 0; i < 20 * 5; i++) {
+    sim.tick();
+    if (sim.duelFor(aPid)?.state === 'active') break;
+  }
+  sim.targetEntity(bPid, aPid);
+  return setup;
+}
+
+function finishCast(sim: Sim, pid: number) {
+  for (let i = 0; i < 20 * 4; i++) {
+    sim.tick();
+    if (!sim.entities.get(pid)!.castingAbility) return;
+  }
+}
+
 const hasCc = (e: Entity) =>
   e.auras.some((au) => au.kind === 'polymorph' || au.kind === 'stun' || au.kind === 'incapacitate' || au.kind === 'root');
 
@@ -64,5 +88,35 @@ describe('PvP safety outside duels (#96)', () => {
     sim.startAutoAttack(aPid);
     for (let i = 0; i < 20 * 6; i++) sim.tick();
     expect(b.hp).toBeLessThan(startHp); // duel combat works
+  });
+});
+
+describe('PvP control abilities in active duels', () => {
+  it.each([
+    { cls: 'mage', ability: 'polymorph', aura: 'polymorph' },
+    { cls: 'warlock', ability: 'fear', aura: 'incapacitate' },
+    { cls: 'paladin', ability: 'hammer_of_justice', aura: 'stun' },
+    { cls: 'druid', ability: 'entangling_roots', aura: 'root' },
+  ])('$ability works on hostile players', ({ cls, ability, aura }) => {
+    const { sim, aPid, b } = startDuel(cls, 'warrior');
+
+    sim.castAbility(ability, aPid);
+    finishCast(sim, aPid);
+
+    expect(b.auras.some((au) => au.kind === aura)).toBe(true);
+  });
+
+  it('does not polymorph non-hostile NPCs', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'mage', playerName: 'Caster', autoEquip: true });
+    const npc = [...sim.entities.values()].find((e) => e.kind === 'npc');
+    expect(npc).toBeDefined();
+    sim.setPlayerLevel(20);
+    sim.player.resource = sim.player.maxResource;
+    sim.targetEntity(npc!.id);
+
+    sim.castAbility('polymorph');
+    finishCast(sim, sim.primaryId);
+
+    expect(npc!.auras.some((au) => au.kind === 'polymorph')).toBe(false);
   });
 });

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -99,11 +99,13 @@ describe('PvP control abilities in active duels', () => {
     { cls: 'druid', ability: 'entangling_roots', aura: 'root' },
   ])('$ability works on hostile players', ({ cls, ability, aura }) => {
     const { sim, aPid, b } = startDuel(cls, 'warrior');
+    if (ability === 'polymorph') b.hp = Math.max(1, b.maxHp - 120);
 
     sim.castAbility(ability, aPid);
     finishCast(sim, aPid);
 
     expect(b.auras.some((au) => au.kind === aura)).toBe(true);
+    if (ability === 'polymorph') expect(b.hp).toBe(b.maxHp);
   });
 
   it('does not polymorph non-hostile NPCs', () => {

--- a/tests/touch_peek.test.ts
+++ b/tests/touch_peek.test.ts
@@ -25,6 +25,24 @@ describe('TouchPeekGuard', () => {
     expect(g.consume()).toBe(false);
   });
 
+  it('does not suppress clicks when a desktop hover or focus shows the tooltip', () => {
+    const g = new TouchPeekGuard();
+    g.press();
+    g.tooltipShown('focus');
+    expect(g.consume()).toBe(false);
+
+    g.press();
+    g.tooltipShown('mouse');
+    expect(g.consume()).toBe(false);
+  });
+
+  it('suppresses clicks when a touch long-press shows the tooltip', () => {
+    const g = new TouchPeekGuard();
+    g.press();
+    g.tooltipShown('touch');
+    expect(g.consume()).toBe(true);
+  });
+
   it('a fresh press clears a stale peek from a previous control', () => {
     const g = new TouchPeekGuard();
     g.press();


### PR DESCRIPTION
## Summary
- Route arena/duel hostile targeting through shared PvP hostility for pets, AoE effects, and right-click attacks.
- Allow Polymorph on hostile players while keeping NPC/non-hostile grief protection intact.
- Make Polymorph immediately heal the affected target to full health.
- Preserve desktop action-bar single-click casting by only suppressing release clicks after touch long-press tooltip peeks.

## Root Cause
Several combat paths still filtered only wild hostile mobs after duels/arena introduced hostile players. `aoeDamage` used `mobsInRadius`, pet commands required mob targets, Polymorph rejected non-mobs after the shared hostile check, and the tooltip peek guard treated desktop focus/hover like a mobile long press.

## Validation
- `npx vitest run tests/pvp_safety.test.ts tests/interest.test.ts tests/touch_peek.test.ts`
- `npx vitest run tests/threat.test.ts tests/hotbar.test.ts tests/input.test.ts tests/mobile_controls.test.ts tests/interactions.test.ts tests/arena.test.ts tests/duel.test.ts`
- `npm test` (121 files, 1223 tests)
- `npm run build`
- `npm audit --audit-level=high` (0 vulnerabilities)