### PR TITLE
feat: demoralizing mobs sap the victim's attack power on hit (Withering Wail)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/shot_demoralize.mjs
+++ b/scripts/shot_demoralize.mjs
@@ -1,0 +1,98 @@
+// Screenshot the Demoralizing affix (Withering Wail) in the offline client.
+// Boots the game, repurposes a nearby mob as Restless Bones, forces its
+// on-hit wail onto the player, and captures the resulting attack-power
+// debuff on the player unit frame.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Restless Bones and drive its wail onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the demoralizing undead and stand it next to us.
+  mob.templateId = 'restless_bones';
+  mob.name = 'Restless Bones';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const apBefore = sim.effectiveAttackPower(p);
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const apAfter = sim.effectiveAttackPower(p);
+  const wail = p.auras.find((a) => a.name === 'Withering Wail');
+  return { apBefore, apAfter, hasWail: !!wail, wailValue: wail?.value, wailRemaining: wail?.remaining };
+});
+console.log('demoralize result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/demoralize_full.png' });
+
+// Crop tightly around the player unit frame + buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/demoralize_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+// Hover the debuff icon to surface its tooltip, then capture the scene.
+if (box) {
+  await page.mouse.move(box.x + box.w / 2, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 500));
+  await page.screenshot({ path: 'tmp/demoralize_tooltip.png' });
+  // Tooltip renders to the left of the (top-right) buff bar.
+  await page.screenshot({
+    path: 'tmp/demoralize_tooltip_crop.png',
+    clip: {
+      x: Math.max(0, box.x - 300), y: Math.max(0, box.y - 10),
+      width: 300 + box.w + 20, height: 140,
+    },
+  });
+}
+
+console.log('saved tmp/demoralize_full.png, demoralize_frame.png, demoralize_tooltip.png');
+await browser.close();

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -210,6 +210,8 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'ghostly_essence', chance: 0.55, questId: 'q_rite' },
     ],
     scale: 1.0, color: 0xd5dbdb,
+    // A grave-cold wail saps the strength from the living it strikes.
+    demoralize: { ap: 20, duration: 8, name: 'Withering Wail' },
   },
   gorrak: {
     id: 'gorrak', name: 'Gorrak the Ruthless', minLevel: 6, maxLevel: 6, family: 'humanoid',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4101,6 +4101,22 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+
+    // Demoralizing affix: a successful hit saps the player victim's attack
+    // power for a few seconds, weakening the damage they deal back.
+    const demo = MOBS[mob.templateId]?.demoralize;
+    if (demo && !mob.dead && target.kind === 'player' && this.rng.chance(demo.chance ?? 1)) {
+      this.applyAura(target, {
+        id: 'mob_demoralize',
+        name: demo.name ?? 'Demoralized',
+        kind: 'buff_ap',
+        remaining: demo.duration,
+        duration: demo.duration,
+        value: -Math.abs(demo.ap),
+        sourceId: mob.id,
+        school: 'physical',
+      });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -205,6 +205,11 @@ export interface MobTemplate {
   petRanged?: { range: number; school: Aura['school'] };
   petRole?: PetRole;
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
+  // On-hit affix: a successful melee hit saps the player victim's attack power
+  // for a few seconds (classic Demoralizing Shout / Curse of Weakness), making
+  // the damage *they* deal weaker. `ap` is the attack-power reduction (applied
+  // as a negative buff_ap aura); `chance` defaults to 1 (every hit, refreshing).
+  demoralize?: { ap: number; duration: number; chance?: number; name?: string };
 }
 
 export type AbilityEffect =

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1774,7 +1774,10 @@ export class Hud {
     (el as any).__sig = sig;
     el.innerHTML = '';
     for (const a of e.auras) {
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind);
+      // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
+      // power) is a debuff even though it reuses a buff_* kind.
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+        || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');
       d.className = 'buff' + (isDebuff ? ' debuff' : '');

--- a/tests/mob_demoralize.test.ts
+++ b/tests/mob_demoralize.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+
+// Demoralizing mobs sap a player victim's attack power on a landed hit
+// (classic Demoralizing Shout / Curse of Weakness), so the damage *they*
+// deal back is weaker for the duration.
+describe('mob demoralize-on-hit', () => {
+  it('the Restless Bones template carries a Withering Wail proc', () => {
+    expect(MOBS.restless_bones.demoralize).toMatchObject({
+      ap: 20, duration: 8, name: 'Withering Wail',
+    });
+  });
+
+  it('a landed swing weakens the victim attack power via a negative buff_ap aura', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Weakened');
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+
+    const bones = createMob((sim as any).nextId++, MOBS.restless_bones, 7, { x: 0, y: 0, z: 0 });
+    bones.hostile = true;
+    bones.hp = bones.maxHp;
+    (sim as any).addEntity(bones);
+
+    const baseAp = (sim as any).effectiveAttackPower(victim);
+
+    (sim as any).mobSwing(bones, victim);
+
+    const aura = victim.auras.find((a) => a.name === 'Withering Wail');
+    expect(aura).toBeTruthy();
+    expect(aura!.kind).toBe('buff_ap');
+    expect(aura!.value).toBe(-20);
+    expect(aura!.duration).toBe(8);
+    // The negative buff_ap is consumed by effectiveAttackPower, so the victim
+    // now hits for less.
+    expect((sim as any).effectiveAttackPower(victim)).toBe(baseAp - 20);
+  });
+
+  it('re-applies (refreshes) rather than stacking on repeated hits', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Hounded');
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+
+    const bones = createMob((sim as any).nextId++, MOBS.restless_bones, 7, { x: 0, y: 0, z: 0 });
+    bones.hostile = true;
+    bones.hp = bones.maxHp;
+    (sim as any).addEntity(bones);
+
+    for (let i = 0; i < 10; i++) (sim as any).mobSwing(bones, victim);
+
+    const wails = victim.auras.filter((a) => a.name === 'Withering Wail');
+    expect(wails.length).toBe(1);
+    expect(wails[0].value).toBe(-20);
+  });
+
+  it('an ordinary mob with no demoralize field never applies the debuff', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Safe');
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+
+    const wolf = createMob((sim as any).nextId++, MOBS.forest_wolf, 2, { x: 0, y: 0, z: 0 });
+    wolf.hostile = true;
+    wolf.hp = wolf.maxHp;
+    (sim as any).addEntity(wolf);
+
+    for (let i = 0; i < 50; i++) (sim as any).mobSwing(wolf, victim);
+    expect(victim.auras.some((a) => a.kind === 'buff_ap')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **data-driven on-hit affix** to mobs: a successful melee hit can apply a temporary **attack-power debuff** to a player victim, weakening the damage *they* deal back. This is the classic **Demoralizing Shout / Curse of Weakness** archetype, and it ships on the **Restless Bones** (undead, L5–7) as a grave-cold *Withering Wail* (−20 attack power for 8s).

It fills a gap in the existing on-hit affix family: there are affixes that reduce the victim's *defense* (armor shred) and movement (chill), and that punish casters (silence) or attackers (thorns) — but none that reduce the victim's **outgoing damage**.

## How

Mirrors the existing `enrage` affix shape, so it stays declarative and host-agnostic (offline / server / headless all share it):

- **`types.ts`** — optional `demoralize?: { ap; duration; chance?; name? }` on `MobTemplate`.
- **`sim.ts`** — in `mobSwing`, after a landed hit on a player, apply a negative `buff_ap` aura. `effectiveAttackPower` already sums `buff_ap` auras, so the reduction flows into **both melee swings and ability damage** with no new combat-math hook. The aura refreshes (keyed by id+sourceId) rather than stacking.
- **`content/zone1.ts`** — Restless Bones gains `demoralize: { ap: 20, duration: 8, name: 'Withering Wail' }`.
- **`hud.ts`** — classify a negative-value `buff_*` aura as a debuff, so the icon renders with the red debuff border instead of a green buff frame.

## Tests

`tests/mob_demoralize.test.ts` (all green; full suite 652 passing): the template carries the proc; a landed swing applies the negative `buff_ap` aura and lowers `effectiveAttackPower` by the listed amount; repeated hits refresh rather than stack; a plain mob (Forest Wolf) never applies it.

## Screenshots

Captured from the offline client (`scripts/shot_demoralize.mjs`). After being struck by Restless Bones the player's attack power drops **46 → 26** and a *Withering Wail* debuff appears on the buff bar:

Debuff on the player buff bar (red debuff border + 8s timer):

![Withering Wail debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/demoralize-shots/shots/demoralize_frame.png)

In-world, with the debuff active (top-right):

![In-world scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/demoralize-shots/shots/demoralize_full.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)