### PR TITLE
fix(pvp): hide duel stealth and add fear DR

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -1075,6 +1075,7 @@ export class GameServer {
 
   private canObserveEntity(viewer: Entity, e: Entity, d2: number): boolean {
     if (e.kind !== 'player' || !isStealthed(e)) return true;
+    if (this.sim.isHostileTo(viewer, e)) return false;
     const party = this.sim.partyOf(viewer.id);
     const sameParty = party?.members.includes(e.id) ?? false;
     const duel = this.sim.duelFor(viewer.id);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -78,8 +78,10 @@ const ARENA_K_FACTOR = 32; // Elo sensitivity per match
 const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
 const PVP_ROOT_DR_RESET = 18; // seconds before a repeated PvP root is fresh again
 const PVP_POLYMORPH_DR_RESET = 60;
+const PVP_FEAR_DR_RESET = 60;
 const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
 const PVP_POLYMORPH_DR_DURATIONS = [10, 5, 1] as const;
+const PVP_FEAR_DR_DURATIONS = [8, 4, 2, 1] as const;
 const SHAMAN_SHOCK_COOLDOWN_IDS = ['earth_shock', 'flame_shock', 'frost_shock'] as const;
 const DEMON_HEAL_CAST_ID = 'demon_heal';
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
@@ -1294,6 +1296,17 @@ export class Sim {
   private isRooted(e: Entity): boolean {
     return this.isStunned(e) || e.auras.some((a) => a.kind === 'root');
   }
+  private fearAura(e: Entity): Aura | undefined {
+    return e.auras.find((a) => a.id === 'fear_incap' && a.kind === 'incapacitate');
+  }
+  private updateFearMovement(e: Entity): boolean {
+    const aura = this.fearAura(e);
+    if (!aura || e.auras.some((a) => a.kind === 'root')) return false;
+    const angle = Number.isFinite(aura.value) ? aura.value : e.facing;
+    const dest = this.groundPos(e.pos.x + Math.sin(angle) * 10, e.pos.z + Math.cos(angle) * 10);
+    this.moveToward(e, dest, e.moveSpeed * FLEE_SPEED_MULT * this.moveSpeedMult(e));
+    return true;
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -1503,6 +1516,7 @@ export class Sim {
   private updatePlayerMovement(p: Entity, meta: PlayerMeta): void {
     if (this.updateChargeMovement(p)) return;
     if (this.updateFollowMovement(p, meta)) return;
+    if (this.updateFearMovement(p)) return;
     const inp = meta.moveInput;
     // Convention: facing f points along (sin f, cos f); the camera sits behind
     // the player, so screen-right is the world vector (-cos f, sin f).
@@ -2330,9 +2344,14 @@ export class Sim {
         }
         case 'incapacitate': {
           if (!target || target.dead) break;
+          const remaining = ability.id === 'fear'
+            ? this.diminishedCrowdControlDuration(p, target, 'fear', eff.duration)
+            : eff.duration;
+          if (remaining === null) break;
           this.applyAura(target, {
             id: ability.id + '_incap', name: ability.name, kind: 'incapacitate',
-            remaining: eff.duration, duration: eff.duration, value: 0,
+            remaining, duration: remaining,
+            value: ability.id === 'fear' ? this.rng.range(-Math.PI, Math.PI) : 0,
             sourceId: p.id, school: ability.school, breaksOnDamage: true,
           });
           if (ability.awardsCombo && !comboAwarded) { this.awardCombo(p, target, ability.awardsCombo); comboAwarded = true; }
@@ -2565,10 +2584,18 @@ export class Sim {
     }
     const existing = target.ccDr.get(category);
     const stage = existing && existing.resetAt > this.time ? existing.stage : 0;
-    const reset = category === 'polymorph' ? PVP_POLYMORPH_DR_RESET : PVP_ROOT_DR_RESET;
+    const reset = category === 'polymorph'
+      ? PVP_POLYMORPH_DR_RESET
+      : category === 'fear'
+        ? PVP_FEAR_DR_RESET
+        : PVP_ROOT_DR_RESET;
     if (category === 'polymorph') {
       target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + reset });
       return PVP_POLYMORPH_DR_DURATIONS[Math.min(stage, PVP_POLYMORPH_DR_DURATIONS.length - 1)];
+    }
+    if (category === 'fear') {
+      target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + reset });
+      return PVP_FEAR_DR_DURATIONS[Math.min(stage, PVP_FEAR_DR_DURATIONS.length - 1)];
     }
     if (stage >= PVP_CC_DR_MULTIPLIERS.length) return null;
     target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + reset });
@@ -3745,6 +3772,7 @@ export class Sim {
     if (mob.inCombat) this.updateBossMechanics(mob);
 
     if (this.isStunned(mob)) {
+      if (this.updateFearMovement(mob)) return;
       if (mob.auras.some((a) => a.kind === 'polymorph')) {
         mob.wanderTimer -= DT;
         if (mob.wanderTimer <= 0) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -76,8 +76,10 @@ const ARENA_BASE_RATING = 1500; // every character starts here, unranked
 const ARENA_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
 const ARENA_K_FACTOR = 32; // Elo sensitivity per match
 const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
-const PVP_CC_DR_RESET = 18; // seconds before a repeated PvP CC category is fresh again
+const PVP_ROOT_DR_RESET = 18; // seconds before a repeated PvP root is fresh again
+const PVP_POLYMORPH_DR_RESET = 60;
 const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
+const PVP_POLYMORPH_DR_DURATIONS = [10, 5, 1] as const;
 const SHAMAN_SHOCK_COOLDOWN_IDS = ['earth_shock', 'flame_shock', 'frost_shock'] as const;
 const DEMON_HEAL_CAST_ID = 'demon_heal';
 const SAY_RANGE = 25; // /say carries a short distance; /yell across a camp
@@ -2339,10 +2341,12 @@ export class Sim {
         }
         case 'polymorph': {
           if (!target || target.dead) break;
+          const remaining = this.diminishedCrowdControlDuration(p, target, 'polymorph', eff.duration);
+          if (remaining === null) break;
           target.hp = target.maxHp;
           this.applyAura(target, {
             id: ability.id, name: ability.name, kind: 'polymorph',
-            remaining: eff.duration, duration: eff.duration, value: 0,
+            remaining, duration: remaining, value: 0,
             tickInterval: 1, tickTimer: 1,
             sourceId: p.id, school: ability.school, breaksOnDamage: true,
           });
@@ -2561,8 +2565,13 @@ export class Sim {
     }
     const existing = target.ccDr.get(category);
     const stage = existing && existing.resetAt > this.time ? existing.stage : 0;
+    const reset = category === 'polymorph' ? PVP_POLYMORPH_DR_RESET : PVP_ROOT_DR_RESET;
+    if (category === 'polymorph') {
+      target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + reset });
+      return PVP_POLYMORPH_DR_DURATIONS[Math.min(stage, PVP_POLYMORPH_DR_DURATIONS.length - 1)];
+    }
     if (stage >= PVP_CC_DR_MULTIPLIERS.length) return null;
-    target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + PVP_CC_DR_RESET });
+    target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + reset });
     return duration * PVP_CC_DR_MULTIPLIERS[stage];
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -58,7 +58,7 @@ export interface Aura {
   stacks?: number; // sunder armor: applications stack up to the effect's cap
 }
 
-export type CrowdControlDrCategory = 'root' | 'polymorph';
+export type CrowdControlDrCategory = 'root' | 'polymorph' | 'fear';
 
 export interface CrowdControlDrState {
   stage: number;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -58,7 +58,7 @@ export interface Aura {
   stacks?: number; // sunder armor: applications stack up to the effect's cap
 }
 
-export type CrowdControlDrCategory = 'root';
+export type CrowdControlDrCategory = 'root' | 'polymorph';
 
 export interface CrowdControlDrState {
   stage: number;

--- a/tests/interest.test.ts
+++ b/tests/interest.test.ts
@@ -497,6 +497,30 @@ describe('client crowd protocol', () => {
     expect(client.entities.has(subject.pid)).toBe(false);
   });
 
+  it('prunes a previously visible duel opponent when they enter stealth', () => {
+    const rogueFc = fakeWs();
+    const rogue = joinServer(server, rogueFc, 3, 'ClientSneak', 'rogue');
+    server.sim.setPlayerLevel(10, viewer.pid);
+    server.sim.setPlayerLevel(10, rogue.pid);
+    const v = server.sim.entities.get(viewer.pid)!;
+    placeAt(server, rogue.pid, v.pos.x + 6, v.pos.z);
+
+    broadcast(server);
+    apply();
+    expect(client.entities.has(rogue.pid)).toBe(true);
+
+    server.sim.duelRequest(rogue.pid, viewer.pid);
+    server.sim.duelAccept(rogue.pid);
+    for (let i = 0; i < 20 * 5 && server.sim.duelFor(viewer.pid)?.state !== 'active'; i++) server.sim.tick();
+    server.sim.castAbility('stealth', rogue.pid);
+
+    viewerFc.sent.length = 0;
+    step(server);
+    apply();
+
+    expect(client.entities.has(rogue.pid)).toBe(false);
+  });
+
   it('merges lite records preserving identity fields', () => {
     broadcast(server);
     apply();

--- a/tests/interest.test.ts
+++ b/tests/interest.test.ts
@@ -400,6 +400,27 @@ describe('crowd interest management', () => {
     expect(inKeep(snap, rogue.pid)).toBe(false);
   });
 
+  it('hides stealthed active duel opponents even inside normal detection range', () => {
+    const rogueFc = fakeWs();
+    const rogue = joinServer(server, rogueFc, 3, 'CloseSneak', 'rogue');
+    server.sim.setPlayerLevel(10, viewer.pid);
+    server.sim.setPlayerLevel(10, rogue.pid);
+    const v = server.sim.entities.get(viewer.pid)!;
+    placeAt(server, rogue.pid, v.pos.x + 6, v.pos.z);
+    server.sim.duelRequest(rogue.pid, viewer.pid);
+    server.sim.duelAccept(rogue.pid);
+    for (let i = 0; i < 20 * 5 && server.sim.duelFor(viewer.pid)?.state !== 'active'; i++) server.sim.tick();
+    server.sim.castAbility('stealth', rogue.pid);
+
+    viewerFc.sent.length = 0;
+    step(server);
+    const snap = lastSnap(viewerFc.sent);
+
+    expect(server.sim.isHostileTo(server.sim.entities.get(viewer.pid)!, server.sim.entities.get(rogue.pid)!)).toBe(true);
+    expect(entRecord(snap, rogue.pid)).toBeNull();
+    expect(inKeep(snap, rogue.pid)).toBe(false);
+  });
+
   it('keeps stationary npcs visible out to the legacy 120yd radius', () => {
     const npc = [...server.sim.entities.values()].find((e) => e.kind === 'npc')!;
     // viewer 110yd from the npc, subject player at the same distance

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -3,7 +3,8 @@
 // polymorphed into a baby llama" griefing path can never regress.
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import type { Entity } from '../src/sim/types';
+import type { Entity, Vec3 } from '../src/sim/types';
+import { dist2d } from '../src/sim/types';
 
 function twoPlayers(clsA = 'mage', clsB = 'warrior') {
   const sim = new Sim({ seed: 42, playerClass: clsA as any, playerName: 'Caster', autoEquip: true });
@@ -43,6 +44,8 @@ function finishCast(sim: Sim, pid: number) {
     if (!sim.entities.get(pid)!.castingAbility) return;
   }
 }
+
+const pos = (e: Entity): Vec3 => ({ ...e.pos });
 
 const hasCc = (e: Entity) =>
   e.auras.some((au) => au.kind === 'polymorph' || au.kind === 'stun' || au.kind === 'incapacitate' || au.kind === 'root');
@@ -143,5 +146,45 @@ describe('PvP control abilities in active duels', () => {
     for (let i = 0; i < 20 * 61; i++) sim.tick();
 
     expect(castPolymorph()).toBe(10);
+  });
+
+  it('makes feared hostile players run in a deterministic panic direction', () => {
+    const { sim, aPid, b } = startDuel('warlock', 'warrior', 20);
+
+    const start = pos(b);
+    sim.castAbility('fear', aPid);
+    finishCast(sim, aPid);
+
+    const fear = b.auras.find((aura) => aura.id === 'fear_incap' && aura.kind === 'incapacitate');
+    expect(fear?.duration).toBe(8);
+
+    for (let i = 0; i < 20; i++) sim.tick();
+
+    expect(dist2d(start, b.pos)).toBeGreaterThan(2);
+    expect(b.auras.some((aura) => aura.id === 'fear_incap')).toBe(true);
+  });
+
+  it('diminishes repeated duel Fears to 8s, 4s, 2s, 1s and resets after 60s', () => {
+    const { sim, aPid, b } = startDuel('warlock', 'warrior', 20);
+
+    const castFear = () => {
+      b.auras = b.auras.filter((aura) => aura.id !== 'fear_incap');
+      const warlock = sim.entities.get(aPid)!;
+      warlock.gcdRemaining = 0;
+      warlock.resource = warlock.maxResource;
+      sim.castAbility('fear', aPid);
+      finishCast(sim, aPid);
+      return b.auras.find((aura) => aura.id === 'fear_incap')?.duration ?? 0;
+    };
+
+    expect(castFear()).toBe(8);
+    expect(castFear()).toBe(4);
+    expect(castFear()).toBe(2);
+    expect(castFear()).toBe(1);
+
+    b.auras = b.auras.filter((aura) => aura.id !== 'fear_incap');
+    for (let i = 0; i < 20 * 61; i++) sim.tick();
+
+    expect(castFear()).toBe(8);
   });
 });

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -121,4 +121,27 @@ describe('PvP control abilities in active duels', () => {
 
     expect(npc!.auras.some((au) => au.kind === 'polymorph')).toBe(false);
   });
+
+  it('diminishes repeated duel Polymorphs to 10s, 5s, 1s and resets after 60s', () => {
+    const { sim, aPid, b } = startDuel('mage', 'warrior', 20);
+
+    const castPolymorph = () => {
+      b.auras = b.auras.filter((aura) => aura.kind !== 'polymorph');
+      const mage = sim.entities.get(aPid)!;
+      mage.gcdRemaining = 0;
+      mage.resource = mage.maxResource;
+      sim.castAbility('polymorph', aPid);
+      finishCast(sim, aPid);
+      return b.auras.find((aura) => aura.kind === 'polymorph')?.duration ?? 0;
+    };
+
+    expect(castPolymorph()).toBe(10);
+    expect(castPolymorph()).toBe(5);
+    expect(castPolymorph()).toBe(1);
+
+    b.auras = b.auras.filter((aura) => aura.kind !== 'polymorph');
+    for (let i = 0; i < 20 * 61; i++) sim.tick();
+
+    expect(castPolymorph()).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary
- Hide stealthed hostile players in active duels, including close-range opponents and party members who become duel-hostile.
- Add duel PvP diminishing returns for Polymorph: 10s -> 5s -> 1s with a 60s reset.
- Make Fear actually force panic movement and add duel diminishing returns: 8s -> 4s -> 2s -> 1s with a 60s reset.
- Add regression coverage for server interest, client pruning, Polymorph DR, and Fear movement/DR.

## Root Cause
Stealth visibility was still using normal stealth detection for hostile duel opponents, so nearby duel enemies could receive/render the stealthed player. Fear applied an incapacitate aura, but the sim treated incapacitate as a stun and had no flee movement or PvP DR bucket.

## Validation
- `npx vitest run tests/pvp_safety.test.ts tests/interest.test.ts`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high`
