### PR TITLE
feat(content): add Brutok Skullsmasher, a rare elite ogre in Thornpeak Heights

### DIFF
--- a/scripts/rare_ogre_visual.mjs
+++ b/scripts/rare_ogre_visual.mjs
@@ -1,0 +1,64 @@
+// Screenshots of the new rare ogre (Brutok Skullsmasher) for the PR.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Thorgar');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 3000));
+
+// Level the player up to match the lvl-17 rare (so the nameplate isn't red-capped),
+// stand beside Brutok in the Thornpeak crags, and target him so the elite
+// nameplate + name show. recalcPlayerStats runs every tick and would reset an
+// hp override, so we re-pin level/hp each frame via a setInterval in-page.
+const found = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  const b = [...sim.entities.values()].find((e) => e.templateId === 'brutok_skullsmasher' && !e.dead);
+  if (!b) return false;
+  p.pos.x = b.pos.x + 4.5; p.pos.z = b.pos.z + 4.5;
+  p.pos.y = b.pos.y;
+  p.facing = Math.atan2(b.pos.x - p.pos.x, b.pos.z - p.pos.z);
+  window.__pin = setInterval(() => {
+    p.level = 20;
+    p.maxHp = 999999; p.hp = 999999;
+    // Offset the camera yaw from the facing so the ogre sits off-centre and
+    // isn't occluded by the player sprite; pull in a little for a readable name.
+    g.input.camYaw = p.facing + 0.55;
+    g.input.camPitch = 0.26;
+    g.input.camDist = 10;
+  }, 16);
+  sim.targetEntity(b.id);
+  return { name: b.name, level: b.level, hp: b.maxHp };
+});
+console.log('brutok:', JSON.stringify(found));
+await new Promise((r) => setTimeout(r, 1400));
+await page.screenshot({ path: 'tmp/brutok_01_nameplate.png' });
+
+// Engage for a combat shot — pinned god-mode means he can't win, and his
+// Skull Smash pulse / enrage fire while we trade blows.
+await page.evaluate(() => { window.__game.sim.startAutoAttack(); });
+await new Promise((r) => setTimeout(r, 2800));
+await page.screenshot({ path: 'tmp/brutok_02_combat.png' });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 15).join('\n') : 'no page errors');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -123,6 +123,28 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.5, color: 0x8c3b2e,
   },
+  brutok_skullsmasher: {
+    // The ogre family's rare elite — a hulking two-fisted mauler that prowls
+    // the crags above the Crusher warbands. Slow, heavily armored and brutal:
+    // it slams the ground in a physical shockwave and goes berserk when low.
+    // Fills the ogre rare gap beside Ironvein Foreman (kobold), Shardlord
+    // Kazzix (elemental) and Marrowlord Varkas (undead).
+    id: 'brutok_skullsmasher', name: 'Brutok Skullsmasher', minLevel: 17, maxLevel: 17, family: 'ogre', rare: true,
+    elite: true, ccImmune: true, respawnMult: 432,
+    hpBase: 360, hpPerLevel: 60, dmgBase: 16, dmgPerLevel: 3.6, attackSpeed: 2.7,
+    armorPerLevel: 30, moveSpeed: 7, aggroRadius: 13,
+    aoePulse: { min: 22, max: 30, radius: 10, every: 10, name: 'Skull Smash', school: 'physical', fx: 'nova' },
+    enrage: { belowHpPct: 0.30, dmgMult: 1.5 },
+    loot: [
+      { copper: 320, chance: 1 },
+      { itemId: 'cracked_ogre_tusk', chance: 1 },
+      { itemId: 'skullsmasher_warbelt', chance: 0.3 },
+      { itemId: 'brutoks_maul', chance: 0.25, rollGroup: 'brutok_chase' },
+      { itemId: 'crag_warden_cudgel', chance: 0.25, rollGroup: 'brutok_chase' },
+      { itemId: 'skullsplitter_dirk', chance: 0.25, rollGroup: 'brutok_chase' },
+    ],
+    scale: 1.45, color: 0x6e5235,
+  },
   stormcrag_elemental: {
     id: 'stormcrag_elemental', name: 'Stormcrag Elemental', minLevel: 17, maxLevel: 18, family: 'elemental',
     hpBase: 62, hpPerLevel: 22, dmgBase: 12, dmgPerLevel: 2.7, attackSpeed: 2.2,
@@ -525,6 +547,8 @@ export const ZONE3_CAMPS: CampDef[] = [
   { mobId: 'thornpeak_ogre', center: { x: -60, z: 730 }, radius: 18, count: 6 },
   { mobId: 'ogre_crusher', center: { x: -125, z: 740 }, radius: 18, count: 8 },
   { mobId: 'warlord_drogmar', center: { x: -132, z: 748 }, radius: 2, count: 1 },
+  // A lone rare ogre prowls the ridge north of the warband
+  { mobId: 'brutok_skullsmasher', center: { x: -45, z: 768 }, radius: 4, count: 1 },
   // Elementals: Stormcrag, far west
   { mobId: 'stormcrag_elemental', center: { x: 110, z: 760 }, radius: 20, count: 8 },
   { mobId: 'stormcrag_elemental', center: { x: 135, z: 795 }, radius: 16, count: 6 },
@@ -627,7 +651,25 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     id: 'marrowlord_boneboots', name: 'Marrowlord Boneboots', kind: 'armor', slot: 'feet', quality: 'uncommon',
     stats: { armor: 90, sta: 5, str: 2 }, sellValue: 1050, requiredClass: ['warrior', 'paladin', 'shaman'],
   },
+  // Brutok Skullsmasher (rare ogre) — guaranteed trophy + warbelt
+  skullsmasher_warbelt: {
+    id: 'skullsmasher_warbelt', name: "Skullsmasher's Warbelt", kind: 'armor', slot: 'chest', quality: 'uncommon',
+    stats: { armor: 96, sta: 5, str: 3 }, sellValue: 1050,
+  },
   // --- quest & dungeon blues (rare) ---
+  // Brutok Skullsmasher chase weapons (mutually exclusive: brutok_chase)
+  brutoks_maul: {
+    id: 'brutoks_maul', name: "Brutok's Maul", kind: 'weapon', slot: 'mainhand', quality: 'rare',
+    weapon: { min: 24, max: 37, speed: 2.7 }, stats: { str: 8, sta: 3 }, sellValue: 2000, requiredClass: ['warrior', 'paladin', 'shaman'],
+  },
+  crag_warden_cudgel: {
+    id: 'crag_warden_cudgel', name: 'Crag Warden Cudgel', kind: 'weapon', slot: 'mainhand', quality: 'rare',
+    weapon: { min: 23, max: 36, speed: 3.0 }, stats: { int: 8, spi: 4 }, sellValue: 2000, requiredClass: ['mage', 'priest', 'warlock', 'druid'],
+  },
+  skullsplitter_dirk: {
+    id: 'skullsplitter_dirk', name: 'Skullsplitter Dirk', kind: 'weapon', slot: 'mainhand', quality: 'rare',
+    weapon: { min: 15, max: 23, speed: 1.7, dagger: true }, stats: { agi: 8, sta: 3 }, sellValue: 2000, requiredClass: ['rogue', 'hunter'],
+  },
   drogmars_skullcleaver: {
     id: 'drogmars_skullcleaver', name: "Drogmar's Skullcleaver", kind: 'weapon', slot: 'mainhand', quality: 'rare',
     weapon: { min: 22, max: 35, speed: 2.6 }, stats: { str: 7, sta: 4 }, sellValue: 2000, requiredClass: ['warrior', 'paladin', 'shaman'],
@@ -785,6 +827,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
   },
   // --- junk (gray) ---
   ogre_toe_ring: { id: 'ogre_toe_ring', name: 'Ogre Toe Ring', kind: 'junk', quality: 'poor', sellValue: 25 },
+  cracked_ogre_tusk: { id: 'cracked_ogre_tusk', name: 'Cracked Ogre Tusk', kind: 'junk', quality: 'poor', sellValue: 42 },
   inert_storm_shard: { id: 'inert_storm_shard', name: 'Inert Storm Shard', kind: 'junk', quality: 'poor', sellValue: 28 },
   frayed_prayer_beads: { id: 'frayed_prayer_beads', name: 'Frayed Prayer Beads', kind: 'junk', quality: 'poor', sellValue: 30 },
   cracked_wyrm_scale: { id: 'cracked_wyrm_scale', name: 'Cracked Wyrm Scale', kind: 'junk', quality: 'poor', sellValue: 35 },

--- a/tests/rare_ogre_spawn.test.ts
+++ b/tests/rare_ogre_spawn.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS, ITEMS, CAMPS } from '../src/sim/data';
+
+// Brutok Skullsmasher — the ogre family's rare elite in Thornpeak Heights,
+// filling the ogre rare gap (ogres previously had only the Crusher elite and
+// the Drogmar boss). These tests pin the content contract (a tougher named
+// mob with a guaranteed quality drop and a mutually-exclusive rare chase
+// group) and verify the loot roll honours it deterministically through the
+// real Sim rng.
+
+describe('rare spawn: Brutok Skullsmasher', () => {
+  it('is defined as a rare elite ogre with sensible scaling', () => {
+    const b = MOBS['brutok_skullsmasher'];
+    expect(b).toBeTruthy();
+    expect(b.rare).toBe(true);
+    expect(b.elite).toBe(true);
+    expect(b.family).toBe('ogre');
+    // tougher than the trash ogres it prowls above (Thornpeak Crusher)
+    expect(b.hpBase).toBeGreaterThan(MOBS['ogre_crusher'].hpBase);
+    expect(b.respawnMult).toBeGreaterThan(1); // rares come back slowly
+    // has a signature pulse mechanic
+    expect(b.aoePulse?.name).toBe('Skull Smash');
+  });
+
+  it('spawns from a single-mob camp in the crags', () => {
+    const camps = CAMPS.filter((c) => c.mobId === 'brutok_skullsmasher');
+    expect(camps).toHaveLength(1);
+    expect(camps[0].count).toBe(1);
+  });
+
+  it('every loot itemId resolves and the chase group is all rare quality', () => {
+    const b = MOBS['brutok_skullsmasher'];
+    for (const l of b.loot) {
+      if (l.itemId) expect(ITEMS[l.itemId], `loot ${l.itemId}`).toBeTruthy();
+    }
+    const chase = b.loot.filter((l) => l.rollGroup === 'brutok_chase');
+    expect(chase.length).toBeGreaterThanOrEqual(2);
+    for (const l of chase) expect(ITEMS[l.itemId!].quality).toBe('rare');
+  });
+
+  it('always drops the guaranteed loot and at most one chase item', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', autoEquip: true });
+    const meta = [...(sim as any).players.values()][0];
+    // a throwaway corpse entity to receive rolled loot
+    const mob: any = { templateId: 'brutok_skullsmasher', loot: null, lootable: false };
+    const chaseIds = new Set(['brutoks_maul', 'crag_warden_cudgel', 'skullsplitter_dirk']);
+
+    for (let i = 0; i < 300; i++) {
+      mob.loot = null; mob.lootable = false;
+      (sim as any).rollLoot(mob, meta);
+      const items: string[] = (mob.loot?.items ?? []).map((s: any) => s.itemId);
+      // guaranteed entries (chance 1) are always present
+      expect(items).toContain('cracked_ogre_tusk');
+      expect(mob.loot.copper).toBeGreaterThan(0);
+      // the rollGroup is mutually exclusive: never more than one chase item
+      expect(items.filter((id) => chaseIds.has(id)).length).toBeLessThanOrEqual(1);
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds **Brutok Skullsmasher**, a rare elite **ogre** roaming the crags of Thornpeak Heights.

The ogre family was the only mob family in the game with **no rare elite** — it had the Thornpeak Crusher (elite) and Warlord Drogmar (elite boss), but nothing flagged `rare`. Every other family already has one: Old Greyjaw / Elder Bristleback (beast), Sableweb Matriarch (spider), Mogger / Sister Nhalia (humanoid), Mirejaw the Ravenous (murloc), Grubjaw (troll), Ironvein Foreman (kobold), Shardlord Kazzix (elemental), Marrowlord Varkas (undead). Brutok fills the ogre gap.

![Brutok Skullsmasher in Thornpeak Heights](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/rare-ogre-shots/shots/brutok-nameplate.png)

![Engaging Brutok](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/rare-ogre-shots/shots/brutok-combat.png)

## Details

Pure **data-as-code** — no `sim.ts`/engine changes. Everything is declarative on the existing `MobTemplate`/`CampDef`/`ItemDef` shapes:

- **Mob** (`brutok_skullsmasher`, level 17, `rare: true` + `elite: true`, `ccImmune`, `respawnMult: 432`): a slow, heavily-armored mauler that slams the ground in a physical shockwave (`aoePulse` "Skull Smash") and goes berserk below 30% HP (`enrage`). Tougher than the trash ogres it prowls above.
- **Camp**: a lone single-mob spawn on the ridge north of the Crusher warband.
- **Loot** mirrors the other rare elites — guaranteed copper + a trophy (`cracked_ogre_tusk`), an uncommon `skullsmasher_warbelt`, and a mutually-exclusive rare weapon chase group (`brutok_chase`) with a WAR / MAG / ROG archetype reward each.

## Tests

`tests/rare_ogre_spawn.test.ts` — verifies the rare/elite flags + scaling, the single-mob camp, that every loot id resolves and the chase group is all rare quality, and that `rollLoot` always yields the guaranteed drops while never dropping more than one chase item across 300 deterministic draws. The shared `tests/progression.test.ts` auto-covers the new item/camp ids and world bounds.

Full suite: **652 passing**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)