### PR TITLE
perf: improve static asset serving throughput

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -1,5 +1,4 @@
 import * as http from 'node:http';
-import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { WebSocketServer, WebSocket } from 'ws';
 import {
@@ -23,7 +22,7 @@ import { requestIp, rateLimited, authThrottled, recordAuthFailure, clearAuthFail
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
-import { cacheControlFor, etagFor, isNotModified } from './static_cache';
+import { createStaticHandler } from './static_files';
 
 const PORT = Number(process.env.PORT ?? 8787);
 const STATIC_DIR = path.join(__dirname, '..', 'dist');
@@ -113,80 +112,7 @@ function requestMetadata(req: http.IncomingMessage): { ip: string; userAgent: st
   };
 }
 
-const MIME: Record<string, string> = {
-  '.html': 'text/html', '.js': 'application/javascript', '.css': 'text/css',
-  '.png': 'image/png', '.svg': 'image/svg+xml', '.json': 'application/json',
-  '.glb': 'model/gltf-binary', '.gltf': 'model/gltf+json', '.bin': 'application/octet-stream',
-  '.hdr': 'application/octet-stream', '.ktx2': 'image/ktx2', '.wasm': 'application/wasm',
-  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp',
-};
-
-// The admin dashboard is reached via the admin.* subdomain (Caddy proxies it
-// to this same port) or /admin for local dev. The hostname only picks which
-// HTML shell is served — the admin API itself is gated by admin tokens.
-function isAdminRequest(req: http.IncomingMessage): boolean {
-  const host = String(req.headers.host ?? '').toLowerCase();
-  const urlPath = (req.url ?? '/').split('?')[0];
-  return host.startsWith('admin.') || urlPath === '/admin' || urlPath === '/admin/';
-}
-
-function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void {
-  const shell = isAdminRequest(req) ? 'admin.html' : 'index.html';
-  let urlPath = (req.url ?? '/').split('?')[0];
-  if (urlPath === '/wiki' || urlPath === '/wiki/' || urlPath.startsWith('/wiki/')) {
-    res.writeHead(302, { Location: WIKI_URL });
-    res.end();
-    return;
-  }
-  if (urlPath === '/' || urlPath === '/admin' || urlPath === '/admin/') urlPath = `/${shell}`;
-  // normalize once and reuse for BOTH file resolution and cache policy —
-  // otherwise /assets/../x would serve a mutable file with immutable caching
-  urlPath = path.posix.normalize(urlPath).replace(/^([.][.][/\\])+/, '');
-  const file = path.join(STATIC_DIR, urlPath);
-  const stats = file.startsWith(STATIC_DIR) && fs.existsSync(file) ? fs.statSync(file) : null;
-  if (!stats?.isFile()) {
-    // Asset paths must 404, not SPA-fall-back: a missing .glb served as index.html
-    // surfaces as a cryptic GLTFLoader parse error instead of a clear 404.
-    if (path.extname(urlPath) && path.extname(urlPath) !== '.html') {
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end('not found');
-      return;
-    }
-    // SPA fallback
-    const index = path.join(STATIC_DIR, shell);
-    if (fs.existsSync(index)) {
-      res.writeHead(200, { 'Content-Type': 'text/html', 'Cache-Control': 'no-cache' });
-      fs.createReadStream(index).pipe(res);
-    } else {
-      res.writeHead(404);
-      res.end('not found (run `npm run build` to serve the client from the game server)');
-    }
-    return;
-  }
-  const isReadMethod = req.method === 'GET' || req.method === 'HEAD';
-  const etag = etagFor(stats);
-  const validators = {
-    'Cache-Control': cacheControlFor(urlPath),
-    'ETag': etag,
-    'Last-Modified': stats.mtime.toUTCString(),
-  };
-  if (isReadMethod && isNotModified(req.headers, etag, stats.mtime)) {
-    res.writeHead(304, validators);
-    res.end();
-    return;
-  }
-  res.writeHead(200, {
-    ...validators,
-    'Content-Type': MIME[path.extname(file)] ?? 'application/octet-stream',
-    'Content-Length': stats.size,
-  });
-  if (req.method === 'HEAD') {
-    // don't read a multi-MB asset from disk just to discard the bytes
-    res.end();
-    return;
-  }
-  fs.createReadStream(file).pipe(res);
-}
+const serveStatic = createStaticHandler(STATIC_DIR, { wikiUrl: WIKI_URL });
 
 // ---------------------------------------------------------------------------
 // REST API
@@ -463,7 +389,15 @@ async function main(): Promise<void> {
     if (req.method === 'OPTIONS' && isApi) { res.writeHead(204); res.end(); return; }
     if (url.startsWith('/admin/api/')) void handleAdminApi(req, res, game);
     else if (url.startsWith('/api/')) void handleApi(req, res);
-    else serveStatic(req, res);
+    else void serveStatic(req, res).catch((err) => {
+      console.error('static file request failed:', err);
+      if (!res.headersSent) {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end('internal server error');
+      } else {
+        res.destroy();
+      }
+    });
   });
 
   // cap frame size: the largest legitimate client message is a small JSON

--- a/server/static_files.ts
+++ b/server/static_files.ts
@@ -1,0 +1,129 @@
+import * as http from 'node:http';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { cacheControlFor, etagFor, isNotModified } from './static_cache';
+
+const MIME: Record<string, string> = {
+  '.html': 'text/html', '.js': 'application/javascript', '.css': 'text/css',
+  '.png': 'image/png', '.svg': 'image/svg+xml', '.json': 'application/json',
+  '.glb': 'model/gltf-binary', '.gltf': 'model/gltf+json', '.bin': 'application/octet-stream',
+  '.hdr': 'application/octet-stream', '.ktx2': 'image/ktx2', '.wasm': 'application/wasm',
+  '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.webp': 'image/webp',
+};
+
+function isAdminRequest(req: http.IncomingMessage): boolean {
+  const host = String(req.headers.host ?? '').toLowerCase();
+  const urlPath = (req.url ?? '/').split('?')[0];
+  return host.startsWith('admin.') || urlPath === '/admin' || urlPath === '/admin/';
+}
+
+async function statPath(file: string): Promise<fs.Stats | null> {
+  try {
+    return await fs.promises.stat(file);
+  } catch {
+    return null;
+  }
+}
+
+function isWithinDir(dir: string, file: string): boolean {
+  const rel = path.relative(dir, file);
+  return rel === '' || (rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+function pipeStaticFile(res: http.ServerResponse, file: string): void {
+  fs.createReadStream(file)
+    .on('error', () => {
+      if (res.headersSent) {
+        res.destroy();
+        return;
+      }
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+    })
+    .pipe(res);
+}
+
+function sendText(req: http.IncomingMessage, res: http.ServerResponse, status: number, text: string): void {
+  res.writeHead(status, { 'Content-Type': 'text/plain' });
+  res.end(req.method === 'HEAD' ? undefined : text);
+}
+
+export function createStaticHandler(staticDir: string, opts: { wikiUrl?: string } = {}) {
+  const immutableStats = new Map<string, fs.Stats>();
+
+  async function statStaticPath(file: string, urlPath: string): Promise<fs.Stats | null> {
+    const immutable = cacheControlFor(urlPath).includes('immutable');
+    if (immutable) {
+      const cached = immutableStats.get(file);
+      if (cached) return cached;
+    }
+    const stats = await statPath(file);
+    if (immutable && stats?.isFile()) immutableStats.set(file, stats);
+    return stats;
+  }
+
+  return async function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+    const shell = isAdminRequest(req) ? 'admin.html' : 'index.html';
+    let urlPath = (req.url ?? '/').split('?')[0];
+    if (opts.wikiUrl && (urlPath === '/wiki' || urlPath === '/wiki/' || urlPath.startsWith('/wiki/'))) {
+      res.writeHead(302, { Location: opts.wikiUrl });
+      res.end();
+      return;
+    }
+    if (urlPath === '/' || urlPath === '/admin' || urlPath === '/admin/') urlPath = `/${shell}`;
+    // normalize once and reuse for BOTH file resolution and cache policy —
+    // otherwise /assets/../x would serve a mutable file with immutable caching
+    urlPath = path.posix.normalize(urlPath).replace(/^([.][.][/\\])+/, '');
+    const file = path.join(staticDir, urlPath);
+    const stats = isWithinDir(staticDir, file) ? await statStaticPath(file, urlPath) : null;
+    if (!stats?.isFile()) {
+      // Asset paths must 404, not SPA-fall-back: a missing .glb served as index.html
+      // surfaces as a cryptic GLTFLoader parse error instead of a clear 404.
+      if (path.extname(urlPath) && path.extname(urlPath) !== '.html') {
+        sendText(req, res, 404, 'not found');
+        return;
+      }
+      // SPA fallback
+      const index = path.join(staticDir, shell);
+      const indexStats = await statPath(index);
+      if (indexStats?.isFile()) {
+        res.writeHead(200, {
+          'Content-Type': 'text/html',
+          'Cache-Control': 'no-cache',
+          'Content-Length': indexStats.size,
+        });
+        if (req.method === 'HEAD') {
+          res.end();
+          return;
+        }
+        pipeStaticFile(res, index);
+      } else {
+        sendText(req, res, 404, 'not found (run `npm run build` to serve the client from the game server)');
+      }
+      return;
+    }
+    const isReadMethod = req.method === 'GET' || req.method === 'HEAD';
+    const etag = etagFor(stats);
+    const validators = {
+      'Cache-Control': cacheControlFor(urlPath),
+      'ETag': etag,
+      'Last-Modified': stats.mtime.toUTCString(),
+    };
+    if (isReadMethod && isNotModified(req.headers, etag, stats.mtime)) {
+      res.writeHead(304, validators);
+      res.end();
+      return;
+    }
+    res.writeHead(200, {
+      ...validators,
+      'Content-Type': MIME[path.extname(file)] ?? 'application/octet-stream',
+      'Content-Length': stats.size,
+    });
+    if (req.method === 'HEAD') {
+      // don't read a multi-MB asset from disk just to discard the bytes
+      res.end();
+      return;
+    }
+    pipeStaticFile(res, file);
+  };
+}

--- a/tests/static_files.test.ts
+++ b/tests/static_files.test.ts
@@ -1,0 +1,144 @@
+import * as http from 'node:http';
+import * as path from 'node:path';
+import { promises as fsPromises, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStaticHandler } from '../server/static_files';
+
+describe('createStaticHandler', () => {
+  let root = '';
+  let dir = '';
+  let server: http.Server;
+  let base = '';
+
+  beforeEach(async () => {
+    root = mkdtempSync(path.join(tmpdir(), 'woc-static-'));
+    dir = path.join(root, 'public');
+    mkdirSync(path.join(dir, 'assets'), { recursive: true });
+    mkdirSync(path.join(dir, 'media', 'models'), { recursive: true });
+    writeFileSync(path.join(dir, 'index.html'), '<main>game shell</main>');
+    writeFileSync(path.join(dir, 'admin.html'), '<main>admin shell</main>');
+    writeFileSync(path.join(dir, 'assets', 'main.abc123.js'), 'console.log("ok");');
+    writeFileSync(path.join(dir, 'media', 'models', 'knight.abc123.glb'), 'glbdata');
+    writeFileSync(path.join(root, 'outside.js'), 'outside static root');
+
+    const handler = createStaticHandler(dir, { wikiUrl: 'https://wiki.example.test/Main_Page' });
+    server = http.createServer((req, res) => {
+      void handler(req, res).catch((err) => {
+        res.writeHead(500, { 'Content-Type': 'text/plain' });
+        res.end(String(err));
+      });
+    });
+    server.keepAliveTimeout = 1;
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+    const addr = server.address();
+    if (addr === null || typeof addr === 'string') throw new Error('test server did not bind to a TCP port');
+    base = `http://127.0.0.1:${addr.port}`;
+  });
+
+  afterEach(async () => {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('serves hashed assets with immutable cache validators', async () => {
+    const res = await fetch(`${base}/assets/main.abc123.js`);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(res.headers.get('content-type')).toBe('application/javascript');
+    expect(res.headers.get('etag')).toMatch(/^W\/".+"$/);
+    expect(await res.text()).toBe('console.log("ok");');
+  });
+
+  it('caches metadata for immutable hashed assets after the first hit', async () => {
+    const statSpy = vi.spyOn(fsPromises, 'stat');
+    try {
+      await fetch(`${base}/assets/main.abc123.js`);
+      await fetch(`${base}/assets/main.abc123.js`);
+
+      const assetStats = statSpy.mock.calls.filter(([file]) =>
+        String(file).endsWith(path.join('assets', 'main.abc123.js')));
+      expect(assetStats).toHaveLength(1);
+    } finally {
+      statSpy.mockRestore();
+    }
+  });
+
+  it('handles HEAD and conditional GET without reading the asset body', async () => {
+    const head = await fetch(`${base}/media/models/knight.abc123.glb`, { method: 'HEAD' });
+    const etag = head.headers.get('etag');
+
+    expect(head.status).toBe(200);
+    expect(head.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    expect(head.headers.get('content-type')).toBe('model/gltf-binary');
+    expect(etag).toMatch(/^W\/".+"$/);
+    expect(await head.text()).toBe('');
+
+    const notModified = await fetch(`${base}/media/models/knight.abc123.glb`, {
+      headers: { 'If-None-Match': etag ?? '' },
+    });
+    expect(notModified.status).toBe(304);
+    expect(await notModified.text()).toBe('');
+  });
+
+  it('falls back to the right html shell for app routes', async () => {
+    const game = await fetch(`${base}/character/select`);
+    expect(game.status).toBe(200);
+    expect(game.headers.get('cache-control')).toBe('no-cache');
+    expect(game.headers.get('content-length')).toBe(String('<main>game shell</main>'.length));
+    expect(await game.text()).toBe('<main>game shell</main>');
+
+    const admin = await fetch(`${base}/admin`);
+    expect(admin.status).toBe(200);
+    expect(admin.headers.get('cache-control')).toBe('no-cache');
+    expect(await admin.text()).toBe('<main>admin shell</main>');
+  });
+
+  it('handles HEAD requests for app routes without streaming the html shell', async () => {
+    const res = await fetch(`${base}/character/select`, { method: 'HEAD' });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-cache');
+    expect(res.headers.get('content-type')).toBe('text/html');
+    expect(res.headers.get('content-length')).toBe(String('<main>game shell</main>'.length));
+    expect(await res.text()).toBe('');
+  });
+
+  it('does not serve html for missing typed assets', async () => {
+    const res = await fetch(`${base}/models/missing.glb`);
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toBe('text/plain');
+    expect(await res.text()).toBe('not found');
+  });
+
+  it('handles HEAD requests for missing typed assets without a body', async () => {
+    const res = await fetch(`${base}/models/missing.glb`, { method: 'HEAD' });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toBe('text/plain');
+    expect(await res.text()).toBe('');
+  });
+
+  it('does not serve files outside the static root', async () => {
+    const res = await fetch(`${base}/../outside.js`);
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get('content-type')).toBe('text/plain');
+    expect(await res.text()).toBe('not found');
+  });
+
+  it('redirects wiki routes before static fallback', async () => {
+    const res = await fetch(`${base}/wiki/classes`, { redirect: 'manual' });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://wiki.example.test/Main_Page');
+    expect(await res.text()).toBe('');
+  });
+});


### PR DESCRIPTION
Summary
- Move static file handling into a tested async handler.
- Avoid blocking filesystem metadata checks on asset requests.
- Cache metadata for immutable content-hashed assets.
- Preserve wiki redirects, SPA fallback, cache validators, and missing asset 404s.
- Avoid streaming fallback/404 bodies for HEAD requests.

Validation
- npm test
- npm test -- static_files.test.ts static_cache.test.ts
- npx tsc --noEmit
- npm run build
- npm run build:server
- npm run build:env
- npm audit --audit-level=moderate
