### PR TITLE
feat(server): cap online sessions to one character per account

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -468,6 +468,14 @@ export class GameServer {
     meta: RequestMetadata & Partial<AccountChatMuteStatus> & { chatStrikes?: number } = {},
   ): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
+    // Anti-bot: only ONE character per account may be in the world at a time. An account can
+    // still own up to 10 characters (creation is unaffected) — this only caps *simultaneous*
+    // online sessions, which is what bot/multibox farms abuse. GMs are exempt for supervision.
+    if (!isGm) {
+      for (const s of this.clients.values()) {
+        if (s.accountId === accountId) return { error: 'another character on this account is already in the world' };
+      }
+    }
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
     if (isGm) {
       // GM characters: invulnerable, and always at the level cap (the row is

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -72,4 +72,31 @@ describe('GameServer sessions', () => {
     await Promise.resolve();
     expect(closePlaySession).toHaveBeenCalledWith(99);
   });
+
+  it('allows only one ONLINE character per account, and lets the account back in once it leaves', async () => {
+    const server = new GameServer();
+    const a = expectJoined(server.join(fakeWs(), 20, 201, 'Aone', 'warrior', null));
+
+    // same account, a different character is rejected while the first is online
+    expect(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null)).toEqual({
+      error: 'another character on this account is already in the world',
+    });
+
+    // a different account is unaffected
+    const b = expectJoined(server.join(fakeWs(), 21, 203, 'Bone', 'priest', null));
+    expect((server as any).sessionByCharacterId(203)).toBe(b);
+
+    // once the account's online character leaves, another of its characters may join
+    await server.leave(a, 'test');
+    const a2 = expectJoined(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null));
+    expect((server as any).sessionByCharacterId(202)).toBe(a2);
+  });
+
+  it('exempts GM characters from the one-per-account cap (for supervision)', () => {
+    const server = new GameServer();
+    expectJoined(server.join(fakeWs(), 30, 301, 'Gmaa', 'warrior', null));
+    // a second character on the same account joins because it is flagged GM
+    expectJoined(server.join(fakeWs(), 30, 302, 'Gmbb', 'warrior', null, true));
+    expect((server as any).sessionByCharacterId(302)).not.toBeNull();
+  });
 });


### PR DESCRIPTION
## Anti-bot: one character per account online

First of the anti-bot hardening measures. An account can still **own up to 10 characters** (creation is unchanged) — this only caps **simultaneous online sessions** to **one character per account**, which is what multibox/bot farms abuse.

### What changed
- `server/game.ts` `GameServer.join()` — alongside the existing `character already in world` guard, reject a join if any live session already belongs to the same `accountId`:
  > `another character on this account is already in the world`
  - **GMs are exempt** (so admins can supervise from a second character).
  - O(n) scan over live sessions (small player counts); no new state to keep in sync.

### Tests
`tests/game_sessions.test.ts` (3 passing):
- one online character per account; a different char on the same account is rejected while one is online
- a different account is unaffected
- the account can re-join another of its characters after the first **leaves**
- GM characters bypass the cap

### Notes
- Verified: `npx vitest run tests/game_sessions.test.ts` ✓ and `tsc --noEmit` ✓.
- Follow-up (separate PR): block programmatic `/api/login` (require a same-origin browser request), gated to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)