### PR TITLE
feat(server): require a browser request for /api/login + /api/register

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -23,6 +23,7 @@ import { requestIp, rateLimited, authThrottled, recordAuthFailure, clearAuthFail
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
+import { webLoginEnforced, isWebClientRequest } from './web_login_guard';
 import { cacheControlFor, etagFor, isNotModified } from './static_cache';
 
 const PORT = Number(process.env.PORT ?? 8787);
@@ -207,9 +208,16 @@ function maybeCors(req: http.IncomingMessage, res: http.ServerResponse): void {
   }
 }
 
+// Anti-bot: when enabled, /api/login + /api/register require a same-origin browser
+// request (a recognised Origin header), so only the web client can obtain a token.
+const REQUIRE_WEB_LOGIN = webLoginEnforced();
+
 async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
   const url = (req.url ?? '').split('?')[0];
   try {
+    if (REQUIRE_WEB_LOGIN && req.method === 'POST' && (url === '/api/register' || url === '/api/login') && !isWebClientRequest(req)) {
+      return json(res, 403, { error: 'logins are only allowed from the game client' });
+    }
     if (req.method === 'POST' && (url === '/api/register' || url === '/api/login') && rateLimited(req)) {
       return json(res, 429, { error: 'too many attempts — wait a minute and try again' });
     }

--- a/server/web_login_guard.ts
+++ b/server/web_login_guard.ts
@@ -1,0 +1,50 @@
+import type { IncomingMessage } from 'node:http';
+import { REALM_ORIGINS } from './realm';
+
+// Anti-bot: programmatic clients (curl, headless scripts, multibox farms) call
+// /api/login and /api/register directly with no browser Origin header. A real
+// same-origin browser POST always sends an Origin equal to the page's origin, so
+// requiring a recognised Origin on the auth endpoints lets only the web client
+// obtain a token. A determined attacker can still spoof Origin, but this stops
+// casual scripting and the existing multibox tooling outright.
+
+// Whether the Origin guard is active. Enforced in production, or when
+// REQUIRE_WEB_LOGIN=1; disabled for local dev, the Vitest suite, and the .mjs
+// e2e (which call the API directly with no Origin). REQUIRE_WEB_LOGIN=0 forces it off.
+export function webLoginEnforced(env: NodeJS.ProcessEnv = process.env): boolean {
+  const v = (env.REQUIRE_WEB_LOGIN ?? '').toLowerCase();
+  if (v === '1' || v === 'true') return true;
+  if (v === '0' || v === 'false') return false;
+  return env.NODE_ENV === 'production';
+}
+
+// True when the request carries an Origin that belongs to this site — i.e. it
+// came from a page we served, not a raw API client. Accepts: an explicitly
+// allow-listed origin (WEB_ORIGINS or a configured REALM_ORIGINS entry), the same
+// host the request was sent to (Host / X-Forwarded-Host), or localhost for dev.
+export function isWebClientRequest(
+  req: Pick<IncomingMessage, 'headers'>,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const origin = req.headers.origin;
+  if (typeof origin !== 'string' || origin === '') return false;
+  const allow = new Set<string>([
+    ...REALM_ORIGINS,
+    ...String(env.WEB_ORIGINS ?? '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  ]);
+  if (allow.has(origin)) return true;
+  let host: string;
+  try {
+    host = new URL(origin).host;
+  } catch {
+    return false;
+  }
+  if (host === '') return false;
+  const fwd = String(req.headers['x-forwarded-host'] ?? '').split(',')[0].trim();
+  const reqHost = String(req.headers.host ?? '');
+  if (host === fwd || host === reqHost) return true;
+  return /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/.test(host);
+}

--- a/tests/web_login_guard.test.ts
+++ b/tests/web_login_guard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { isWebClientRequest, webLoginEnforced } from '../server/web_login_guard';
+
+const req = (headers: Record<string, string>) => ({ headers }) as any;
+
+describe('web login guard (anti-bot)', () => {
+  it('enforces in production, is off in dev/test, and honours REQUIRE_WEB_LOGIN', () => {
+    expect(webLoginEnforced({ NODE_ENV: 'production' } as any)).toBe(true);
+    expect(webLoginEnforced({ NODE_ENV: 'test' } as any)).toBe(false);
+    expect(webLoginEnforced({ NODE_ENV: 'development' } as any)).toBe(false);
+    expect(webLoginEnforced({ NODE_ENV: 'production', REQUIRE_WEB_LOGIN: '0' } as any)).toBe(false);
+    expect(webLoginEnforced({ NODE_ENV: 'development', REQUIRE_WEB_LOGIN: '1' } as any)).toBe(true);
+  });
+
+  it('rejects requests with no Origin (curl / headless scripts / multibox)', () => {
+    expect(isWebClientRequest(req({}))).toBe(false);
+    expect(isWebClientRequest(req({ 'user-agent': 'Mozilla/5.0' }))).toBe(false); // spoofed UA, still no Origin
+  });
+
+  it('accepts a same-origin browser POST (Origin host matches Host / X-Forwarded-Host)', () => {
+    expect(isWebClientRequest(req({ origin: 'https://play.example.com', host: 'play.example.com' }))).toBe(true);
+    expect(
+      isWebClientRequest(req({ origin: 'https://play.example.com', 'x-forwarded-host': 'play.example.com' })),
+    ).toBe(true);
+  });
+
+  it('accepts an explicit WEB_ORIGINS allow-list entry and localhost dev', () => {
+    expect(
+      isWebClientRequest(req({ origin: 'https://play.example.com' }), { WEB_ORIGINS: 'https://play.example.com' } as any),
+    ).toBe(true);
+    expect(isWebClientRequest(req({ origin: 'http://localhost:5173', host: '127.0.0.1:8787' }))).toBe(true);
+  });
+
+  it('rejects a foreign origin', () => {
+    expect(isWebClientRequest(req({ origin: 'https://evil.example.com', host: 'play.example.com' }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Anti-bot: block programmatic logins via the API

Second of the anti-bot measures (follow-up to #439, one-character-per-account). Programmatic clients — `curl`, headless scripts, the multibox tooling — call `/api/login` and `/api/register` directly with **no browser `Origin` header**. A real same-origin browser POST always sends `Origin`, so requiring a recognised Origin on the auth endpoints means only the web client can obtain a token.

### What changed
- **`server/web_login_guard.ts`** (new, pure, unit-tested):
  - `webLoginEnforced(env)` — guard is on in **production** (or `REQUIRE_WEB_LOGIN=1`); off for local dev, the Vitest suite, and the `scripts/*.mjs` e2e (which hit the API directly). `REQUIRE_WEB_LOGIN=0` force-disables.
  - `isWebClientRequest(req, env)` — accepts an Origin that matches the request `Host`/`X-Forwarded-Host`, an optional `WEB_ORIGINS` allow-list, a configured `REALM_ORIGINS` entry, or `localhost` (dev). No Origin → rejected.
- **`server/main.ts`** — one guard in `handleApi`: when enforced, a login/register POST without a valid web Origin gets `403 { error: 'logins are only allowed from the game client' }`. Wired ahead of the existing rate-limit check.

### Why gated to production
Keeps `npm test`, local dev, and the headless e2e working unchanged (they have no Origin), while hardening prod. A determined attacker can still spoof `Origin`, but this stops casual scripting and the current multibox tooling outright; pair it with #439 for defence-in-depth.

### Deploy note
After enabling in prod, smoke-test a real browser login once — if your proxy strips `Origin`/`Host`, set `WEB_ORIGINS=https://your-site` (or `REQUIRE_WEB_LOGIN=0` to roll back instantly). Fails safe: only enforces when enabled.

### Tests / CI
- `tests/web_login_guard.test.ts` — 5 cases (prod/dev gating + env override, no-Origin reject, same-host accept, `WEB_ORIGINS`/localhost accept, foreign-origin reject).
- Full local run green: **653 tests**, `tsc --noEmit`, `build:env`, `build:server`, `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)