### PR TITLE
feat(sim): steep miss-chance scaling against higher-level targets (anti-bot)

### DIFF
--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -804,24 +804,32 @@ export function rageFromTaking(damage: number, attackerLevel: number): number {
   return damage / (Math.max(1, attackerLevel) * 1.5);
 }
 
-// Vanilla spell hit table by level difference (target - caster):
-// equal: 96%, +1: 95%, +2: 94%, +3: 83%, beyond: -11%/level; lower: +1%/lvl, cap 99%.
-export function spellHitChance(casterLevel: number, targetLevel: number): number {
-  const diff = targetLevel - casterLevel;
-  let hit: number;
-  if (diff <= 0) hit = 96 + -diff * 1;
-  else if (diff === 1) hit = 95;
-  else if (diff === 2) hit = 94;
-  else hit = 83 - (diff - 3) * 11;
-  return Math.min(0.99, Math.max(0.01, hit / 100));
+// Attacking a target ABOVE your level adds a steep miss penalty (extra miss %),
+// tuned so +2 is ~19% and +4 is ~85% miss: fighting way-above-level enemies is meant
+// to be near-futile. The curve approximates 2.5 * diff^2.5, but is stored as an integer
+// table (level diffs are always integers) so it stays bit-for-bit deterministic across
+// engines — Math.pow with a fractional exponent is not guaranteed identical browser vs node.
+//   +1 -> 2.5   +2 -> 14   +3 -> 39   +4 -> 80   (+5 and beyond saturate past the clamp)
+const ABOVE_LEVEL_MISS_PCT = [0, 2.5, 14, 39, 80];
+function aboveLevelMissPct(diff: number): number {
+  if (diff <= 0) return 0;
+  return diff < ABOVE_LEVEL_MISS_PCT.length ? ABOVE_LEVEL_MISS_PCT[diff] : 100;
 }
 
-// Melee miss vs target by level difference (weapon skill = 5 * level):
-// 5% base, +1%/level above (cliff at +3 handled via extra penalty), -0.2%/level below.
+// Spell hit by level difference (target - caster): 96% at equal level, a gentle
+// +1%/level bonus below you, and the steep above-level penalty above. cap 99%, floor 5%.
+export function spellHitChance(casterLevel: number, targetLevel: number): number {
+  const diff = targetLevel - casterLevel;
+  const hit = diff <= 0 ? 96 + -diff * 1 : 96 - aboveLevelMissPct(diff);
+  return Math.min(0.99, Math.max(0.05, hit / 100));
+}
+
+// Melee miss vs target by level difference: 5% base, a gentle -0.2%/level below you,
+// and the steep above-level penalty above. cap 95%, floor 0.5%.
 export function meleeMissChance(attackerLevel: number, targetLevel: number): number {
   const diff = targetLevel - attackerLevel;
-  let miss = 5 + (diff > 0 ? diff * (diff > 2 ? 2 : 1) : diff * 0.2);
-  return Math.min(0.6, Math.max(0.005, miss / 100));
+  const miss = diff > 0 ? 5 + aboveLevelMissPct(diff) : 5 + diff * 0.2;
+  return Math.min(0.95, Math.max(0.005, miss / 100));
 }
 
 export function armorReduction(armor: number, attackerLevel: number): number {

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -88,16 +88,18 @@ describe('classic formulas', () => {
     expect(mobXpValue(2, 8)).toBe(0);
   });
 
-  it('spell hit has the +3 level cliff', () => {
-    expect(spellHitChance(5, 5)).toBeCloseTo(0.96);
-    expect(spellHitChance(5, 7)).toBeCloseTo(0.94);
-    expect(spellHitChance(5, 8)).toBeCloseTo(0.83);
+  it('spell hit falls off steeply above the caster level (anti-power-level)', () => {
+    expect(spellHitChance(5, 5)).toBeCloseTo(0.96); // equal level
+    expect(spellHitChance(3, 5)).toBeCloseTo(0.82); // +2 -> ~18% miss
+    expect(spellHitChance(3, 7)).toBeCloseTo(0.16); // +4 -> ~84% miss
   });
 
-  it('melee miss grows with level difference', () => {
-    expect(meleeMissChance(5, 5)).toBeCloseTo(0.05);
-    expect(meleeMissChance(5, 7)).toBeCloseTo(0.07);
-    expect(meleeMissChance(5, 8)).toBeGreaterThan(0.07);
+  it('melee/ranged miss scales steeply against higher-level targets', () => {
+    expect(meleeMissChance(5, 5)).toBeCloseTo(0.05); // equal level -> 5% base
+    expect(meleeMissChance(3, 5)).toBeCloseTo(0.19); // +2 (L3 vs L5) -> ~19%
+    expect(meleeMissChance(3, 7)).toBeCloseTo(0.85); // +4 (L3 vs L7) -> 85%
+    expect(meleeMissChance(3, 9)).toBeCloseTo(0.95); // +6 -> capped at 95%
+    // hunter Auto Shot + wands resolve through meleeMissChance too, so this covers them
   });
 
   it('abilities unlock at the right levels with ranks', () => {

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -181,6 +181,9 @@ describe('nine classes', () => {
     sim.castAbility('lightning_shield');
     sim.tick();
     const wolf = nearestMob(sim, 'forest_wolf');
+    // The level-based miss curve means a L1-2 wolf almost never lands a hit on an L8
+    // player, so match its level to the player to actually exercise the reflect.
+    wolf.level = p.level;
     teleport(sim, p.id, wolf.pos.x + 2, wolf.pos.z);
     const wolfHpBefore = wolf.hp;
     let zapped = false;


### PR DESCRIPTION
## Why — anti-bot / anti-cheat

Bot swarms power-level by parking on mobs several levels **above** them and grinding them down (see below — an L4 farming an army of higher Mirefen Widows). The existing vanilla-derived hit table was too lenient for that: a **+4-level** target was only ~13% melee miss / ~28% spell miss, so out-leveling-yourself farming stayed efficient. This makes attacking well-above-level targets **near-futile**, removing the incentive — without touching normal equal/lower-level play.

## The formula

For `Δ = targetLevel − attackerLevel > 0`, an extra miss penalty **≈ 2.5·Δ^2.5** is applied:
- **melee miss** = clamp(`5 + 2.5·Δ^2.5`, 0.5%‥95%)
- **spell hit** = clamp(`96 − 2.5·Δ^2.5`, 5%‥99%)

| Δ (levels above) | miss % |
|---|---|
| +1 | 7.5% |
| **+2** (e.g. L3 vs L5) | **~19%** |
| +3 | 44% |
| **+4** (e.g. L3 vs L7) | **85%** |
| +6 | 95% (capped) |

Equal/below-level is unchanged (5% melee base; gentle below-level bonus retained).

## Coverage — including hunters

Both core hit functions carry the penalty, so **every** attack path is covered:
- **Melee** swings → `meleeMissChance`
- **Hunter Auto Shot + wands** → `meleeMissChance` (the ranged auto path)
- **Spells / Arcane Shot / Serpent Sting** → `spellHitChance`
- Symmetric: a low-level mob swinging at a much-higher player now whiffs ~95% too.

## Determinism

The curve is stored as an **integer lookup table** (level diffs are always integers), *not* `Math.pow(Δ, 2.5)` — a fractional-exponent `Math.pow` is not guaranteed bit-identical across JS engines, which would break the sim's same-seed-same-world invariant (browser vs server).

## Tests / CI
- Updated `tests/sim.test.ts` (new curve assertions incl. the L3-vs-L5 / L3-vs-L7 anchors).
- Fixed `tests/social.test.ts` "lightning shield zaps attackers" — it relied on a **L1-2 wolf** landing hits on an **L8** player, which the new curve correctly prevents; the attacker is now leveled to actually exercise the reflect.
- Green locally: `tsc --noEmit`, `build:env`, `build:server`, `build`, and the deterministic combat tests. (A handful of unrelated wall-clock/flood tests flake under full-suite CPU load; they pass in isolation.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)