### PR TITLE
feat(content): wyrmcult necromancers sear casters' mana on hit (Mana Sear)

### DIFF
--- a/scripts/mana_burn_visual.mjs
+++ b/scripts/mana_burn_visual.mjs
@@ -1,0 +1,90 @@
+// Visual proof of the Mana Sear on-hit affix: a Wyrmcult Necromancer drains a
+// mage's mana on a landed swing. Boots the offline client as a mage, spawns a
+// necromancer next to the player, forces its Mana Sear to land, and captures the
+// player unit frame (mana bar dropping) + combat log line.
+//
+// Run the dev client first:  npx vite --port 5180 --strictPort &
+// then:  GAME_URL=http://localhost:5180 node scripts/mana_burn_visual.mjs
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5180';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  protocolTimeout: 60000,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1320,820', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1320, height: 820 },
+});
+
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR', e.message));
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await sleep(800);
+
+// Offline entry as a MAGE (mana user).
+await page.evaluate(() => {
+  document.querySelector('#btn-offline').click();
+  document.querySelector('#char-name').value = 'Lyra';
+  document.querySelector('#offline-select .mini-class[data-class="mage"]').click();
+  document.querySelector('#btn-start-offline').click();
+});
+await page.waitForFunction(() => window.__game?.sim && document.querySelector('#minimap-wrap'), { timeout: 20000, polling: 300 });
+await sleep(1500);
+
+// Level the mage up so it survives a level-18 necromancer's swing, then spawn the
+// necromancer right next to it and force Mana Sear to land.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  sim.setPlayerLevel(20);
+  const before = { res: Math.round(p.resource), max: Math.round(p.maxResource) };
+
+  // Build a Wyrmcult Necromancer beside the player. Private modules are reachable
+  // at runtime; createMob/MOBS come off the sim's own imports via a tiny eval-free
+  // path: reuse an existing entity as the carrier by retemplating it.
+  let necro = [...sim.entities.values()].find((e) => e.kind === 'mob' && e.templateId === 'wyrmcult_necromancer' && !e.dead);
+  if (!necro) {
+    // retemplate the nearest living mob into a necromancer carrier
+    necro = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead);
+    if (necro) { necro.templateId = 'wyrmcult_necromancer'; necro.name = 'Wyrmcult Necromancer'; necro.level = 18; }
+  }
+  if (necro) {
+    necro.pos = { x: p.pos.x + 2, y: p.pos.y, z: p.pos.z + 2 };
+    necro.hostile = true;
+    sim.targetEntity(necro.id, p.id);
+  }
+
+  // Force a few Mana Sear procs for a clearly visible dip (keep the mage alive by
+  // topping its real HP each swing — no fake HP override, so the frame reads true).
+  let procs = 0;
+  for (let i = 0; i < 200 && procs < 4; i++) {
+    p.hp = p.maxHp;
+    const r0 = p.resource;
+    sim.mobSwing(necro, p);
+    if (p.resource < r0) procs++;
+  }
+  p.hp = p.maxHp;
+  return { before, after: { res: Math.round(p.resource), max: Math.round(p.maxResource) }, procs, necro: !!necro };
+});
+console.log('mana before/after:', JSON.stringify(result));
+
+await sleep(150); // grab the frame before mana regen refills it
+
+const frame = await page.$('#player-frame');
+if (frame) await frame.screenshot({ path: 'tmp/mana_burn_frame.png' });
+
+// Switch to the Combat Log tab so the "You gain Mana Sear." lines are visible.
+await page.evaluate(() => document.querySelector('.chat-tab[data-log-tab="combat"]')?.click());
+await sleep(200);
+const log = await page.$('#chatlog-wrap');
+if (log) await log.screenshot({ path: 'tmp/mana_burn_log.png' });
+await page.screenshot({ path: 'tmp/mana_burn_full.png' });
+console.log('shots written to tmp/');
+
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -167,6 +167,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'ritual_phylactery', chance: 0.55, questId: 'q_necromancers' },
       { itemId: 'linen_scrap', chance: 0.3 },
     ],
+    manaBurn: { chance: 0.3, amount: 80, name: 'Mana Sear', school: 'shadow' },
     scale: 1.0, color: 0x533566,
   },
   boneclad_revenant: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4101,6 +4101,15 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+    // Mana Burn: a landed hit may sap a flat amount of mana from a mana-using
+    // victim (casters). No effect on rage/energy users. Guarded on `hostile` so
+    // a friendly pet (mobSwing's other caller) never drains an ally's mana. The
+    // mana bar visibly drops and the affix is surfaced via an `aura` log line.
+    const burn = MOBS[mob.templateId]?.manaBurn;
+    if (burn && mob.hostile && !target.dead && target.resourceType === 'mana' && target.resource > 0 && this.rng.chance(burn.chance)) {
+      target.resource = Math.max(0, target.resource - burn.amount);
+      this.emit({ type: 'aura', targetId: target.id, name: burn.name, gained: true });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -199,6 +199,10 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit mechanic ("Mana Burn"): a landed melee swing has `chance` to drain a
+  // flat `amount` of mana from a mana-using victim (casters). Rage/energy users
+  // are unaffected. Drains only what mana the victim still has; no overkill.
+  manaBurn?: { chance: number; amount: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/tests/mob_manaburn.test.ts
+++ b/tests/mob_manaburn.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+const makeSim = (cls: PlayerClass = 'mage') => new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+
+// Spawn a Wyrmcult Necromancer next to the player, force its Mana Sear to always
+// land, and swing until a hit connects (a swing can miss/dodge).
+const setup = (cls: PlayerClass = 'mage') => {
+  const sim = makeSim(cls);
+  const player = sim.player;
+  const mob = createMob(990600, MOBS.wyrmcult_necromancer, 18, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return { sim, player, mob };
+};
+
+const KEEP_ALIVE = 1e7; // a level-18 mob one-shots a low-level caster; keep the
+// victim alive so the post-hit drain (guarded on `!target.dead`) can fire.
+const swingUntilDrain = (sim: Sim, mob: any, target: any, max = 200) => {
+  for (let i = 0; i < max; i++) {
+    target.maxHp = KEEP_ALIVE;
+    target.hp = KEEP_ALIVE; // top up so a hit never kills (death would reset state)
+    const before = target.resource;
+    (sim as any).mobSwing(mob, target);
+    if (target.resource < before) return true;
+  }
+  return false;
+};
+
+describe('mob mana burn (Mana Sear)', () => {
+  it('Wyrmcult Necromancer template carries the manaBurn mechanic', () => {
+    expect(MOBS.wyrmcult_necromancer.manaBurn).toBeDefined();
+    expect(MOBS.wyrmcult_necromancer.manaBurn!.name).toBe('Mana Sear');
+  });
+
+  it('a landed hit drains the template amount of mana from a mana user', () => {
+    const { sim, player, mob } = setup('mage');
+    expect(player.resourceType).toBe('mana');
+    const burn = MOBS.wyrmcult_necromancer.manaBurn!;
+    player.resource = player.maxResource;
+    const old = burn.chance;
+    burn.chance = 1;
+    try {
+      const start = player.resource;
+      expect(swingUntilDrain(sim, mob, player)).toBe(true);
+      expect(player.resource).toBe(start - burn.amount);
+    } finally {
+      burn.chance = old;
+    }
+  });
+
+  it('drain clamps at zero — it never pushes mana negative', () => {
+    const { sim, player, mob } = setup('mage');
+    const burn = MOBS.wyrmcult_necromancer.manaBurn!;
+    player.resource = 10; // less than burn.amount (80)
+    const old = burn.chance;
+    burn.chance = 1;
+    try {
+      expect(swingUntilDrain(sim, mob, player)).toBe(true);
+      expect(player.resource).toBe(0);
+    } finally {
+      burn.chance = old;
+    }
+  });
+
+  it('a rage/energy user is unaffected (mana-only)', () => {
+    const { sim, player, mob } = setup('warrior');
+    expect(player.resourceType).not.toBe('mana');
+    const burn = MOBS.wyrmcult_necromancer.manaBurn!;
+    const old = burn.chance;
+    burn.chance = 1;
+    const startRes = player.resource;
+    try {
+      for (let i = 0; i < 50; i++) { player.maxHp = KEEP_ALIVE; player.hp = KEEP_ALIVE; (sim as any).mobSwing(mob, player); }
+    } finally {
+      burn.chance = old;
+    }
+    // rage may rise from taking hits, but the mob never *drains* it.
+    expect(player.resource).toBeGreaterThanOrEqual(startRes);
+  });
+
+  it('a friendly pet never drains its target (hostile guard)', () => {
+    const { sim, player, mob } = setup('mage');
+    mob.hostile = false; // emulate a tamed pet swinging
+    player.resource = player.maxResource;
+    const burn = MOBS.wyrmcult_necromancer.manaBurn!;
+    const old = burn.chance;
+    burn.chance = 1;
+    try {
+      for (let i = 0; i < 50; i++) { player.maxHp = KEEP_ALIVE; player.hp = KEEP_ALIVE; (sim as any).mobSwing(mob, player); }
+    } finally {
+      burn.chance = old;
+    }
+    expect(player.resource).toBe(player.maxResource);
+  });
+});


### PR DESCRIPTION
## What

Adds a new member to the mob on-hit affix family: **`manaBurn`** — a chance per landed melee swing to drain a flat amount of **mana** from a mana-using victim. It joins the existing `cleave` / `venom` / `corrode` / `mortalStrike` affixes and fills the gap none of them cover: attacking the victim's *resource pool* rather than their health, armor, or healing.

Carrier: the **Wyrmcult Necromancer** (Thornpeak Heights, L18–19) gains **Mana Sear** — 30% chance / 80 mana (shadow). It punishes casters who let a necromancer close to melee, giving the cult camp a distinct caster-threat identity.

## How

- New optional `manaBurn?: { chance; amount; name; school? }` on `MobTemplate` (`types.ts`), mirroring the shape of the sibling affixes.
- Resolved in `mobSwing()` right after the landed-hit point, alongside the other on-hit procs. Guards:
  - `mob.hostile` — a tamed pet (the other `mobSwing` caller) never drains an ally.
  - `target.resourceType === 'mana'` — rage/energy users are unaffected.
  - `target.resource > 0`, and the drain clamps at zero (`Math.max(0, …)`) so it never pushes mana negative.
- Surfaced through the **existing `aura` log event** + the visibly dropping mana bar — **no new `SimEvent`, no online-wire change, no new i18n keys** (affix names are data, like mob names).

## Tests

`tests/mob_manaburn.test.ts` (5 cases): template carries the affix, a landed hit drains the template amount, drain clamps at zero, mana-only (rage/energy untouched), and the hostile-pet guard. Full suite green (`1233` tests), `tsc` clean.

## Screenshots

Wyrmcult Necromancer searing a mage's mana — the unit-frame mana bar drops and the combat log shows the `Mana Sear` procs.

| In-game | Unit frame | Combat log |
|---|---|---|
| ![ingame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mana-burn/shots/mana-sear-ingame.png) | ![frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mana-burn/shots/mana-sear-frame.png) | ![log](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/mana-burn/shots/mana-sear-log.png) |

Repro harness: `scripts/mana_burn_visual.mjs` (offline client, drives `window.__game.sim`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)