### PR TITLE
feat(content): webwood spiders ensnare the victim in place on hit (Sticky Web)

### DIFF
--- a/scripts/shot_ensnare.mjs
+++ b/scripts/shot_ensnare.mjs
@@ -1,0 +1,86 @@
+// Screenshot harness for the Webwood Lurker "Sticky Web" ensnare affix.
+// Runs the offline client (no server/Postgres), forces the on-hit web proc, and
+// captures the red root debuff on the player frame + the "rooted" movement block.
+// Needs `npm run dev` running. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 800 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await tap('#btn-offline');
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Webbed'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap('#offline-select .mini-class[data-class="warrior"]');
+await tap('#btn-start-offline');
+await wait(3000);
+
+// God-mode the player and force the web proc from a repurposed nearby mob.
+const info = await page.evaluate(() => {
+  const game = window.__game;
+  const sim = game.sim;
+  const p = sim.player;
+  p.maxHp = 99999; p.hp = 99999;
+  // Repurpose the nearest living mob as a Webwood Lurker carrying the affix.
+  let best = null, bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.id === p.id) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  if (!best) return { ok: false, reason: 'no mob nearby' };
+  best.templateId = 'webwood_spider';
+  best.hostile = true;
+  // Swing repeatedly until the 25% web proc lands a root (misses/dodges possible).
+  for (let i = 0; i < 120 && !p.auras.some((a) => a.kind === 'root'); i++) {
+    p.hp = 99999; // stay alive through every landed swing
+    sim.mobSwing(best, p);
+  }
+  const rooted = p.auras.find((a) => a.kind === 'root');
+  return {
+    ok: !!rooted,
+    auraName: rooted?.name ?? null,
+    moveBlocked: sim.isRooted ? sim.isRooted(p) : null,
+  };
+});
+
+await wait(400);
+await page.screenshot({ path: 'tmp/ensnare_rooted.png' });
+
+// Crop the player unit frame + buff/debuff bar if present.
+const frame = await page.evaluate(() => {
+  const el = document.querySelector('#buff-bar') || document.querySelector('#player-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: Math.max(0, r.x - 8), y: Math.max(0, r.y - 8), width: r.width + 16, height: r.height + 16 };
+});
+if (frame && frame.width > 4 && frame.height > 4) {
+  await page.screenshot({ path: 'tmp/ensnare_debuff_crop.png', clip: frame });
+}
+
+console.log('ensnare result:', JSON.stringify(info));
+if (errors.length) console.log('PAGE ERRORS:\n' + errors.join('\n'));
+console.log('wrote tmp/ensnare_rooted.png' + (frame ? ', tmp/ensnare_debuff_crop.png' : ''));
+await browser.close();
+process.exit(info.ok ? 0 : 1);

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -111,6 +111,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     hpBase: 30, hpPerLevel: 15, dmgBase: 4, dmgPerLevel: 1.7, attackSpeed: 1.8,
     armorPerLevel: 8, moveSpeed: 8, aggroRadius: 10,
     venom: { chance: 0.35, perTick: 2, interval: 2, duration: 10, name: 'Spider Venom', school: 'nature' },
+    ensnare: { chance: 0.25, duration: 3, name: 'Sticky Web', school: 'nature' },
     loot: [
       { copper: 14, chance: 1 },
       { itemId: 'webwood_silk', chance: 0.55, questId: 'q_spiders' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4101,6 +4101,13 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+    // Ensnare: a landed hit may web the victim in place (root). Hostile mobs only
+    // (a friendly pet shares this swing path) and only roots players — `applyRootAura`
+    // applies crowd-control DR so repeated webs from the same mob shrink and break.
+    const ensnare = MOBS[mob.templateId]?.ensnare;
+    if (ensnare && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(ensnare.chance)) {
+      this.applyRootAura(mob, target, ensnare.name, `ensnare_${mob.templateId}`, ensnare.duration, ensnare.school ?? 'nature');
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -199,6 +199,11 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit web mechanic: a landed melee swing has `chance` to ensnare the struck
+  // player in place — a `root` aura for `duration`s (naga/spider snares). Rides the
+  // existing root aura + crowd-control DR; no new aura kind. Players only; rooting a
+  // fellow mob is meaningless and would let a friendly pet trivially lock enemies.
+  ensnare?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/tests/mob_ensnare.test.ts
+++ b/tests/mob_ensnare.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+describe('Ensnare web-root affix', () => {
+  it('a landed webwood_spider swing can root the player in place', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the root
+    const tmpl = MOBS.webwood_spider;
+    const saved = tmpl.ensnare!.chance;
+    tmpl.ensnare!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900600, tmpl, 5, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'root');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'root')!;
+      expect(a.name).toBe('Sticky Web');
+      expect((sim as any).isRooted(p)).toBe(true);
+    } finally {
+      tmpl.ensnare!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never roots its target', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.webwood_spider;
+    const saved = tmpl.ensnare!.chance;
+    tmpl.ensnare!.chance = 1;
+    try {
+      const pet = createMob(900601, tmpl, 5, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'root')).toBe(false);
+    } finally {
+      tmpl.ensnare!.chance = saved;
+    }
+  });
+
+  it('a mob without ensnare applies no root', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900602, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'root')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **on-hit `ensnare` affix**: a landed melee swing has a chance to **root** the struck player in place for a short duration. It rides the engine's existing `root` aura and crowd-control diminishing-returns path — **no new aura kind, no new combat-math hook**.

Carrier: the **Webwood Lurker** (`webwood_spider`). The venomous web-spinner now also pins its prey — **Sticky Web (25% / 3s)** — reinforcing the classic "don't get caught alone in the Webwood" feel. Because `applyRootAura` already applies CC DR, repeated webs from the same spider shrink and eventually break, so it can't perma-lock a player.

This fills a gap in the existing mob on-hit affix family (venom DoT, cleave, mortal-strike wound, corrode armor-shred, enrage): nothing previously **rooted** the victim, even though `root` is a fully-wired aura that gates movement and emits a "You are rooted in place and cannot move." message — until now only player abilities (Entangling Roots, Frost Nova) used it.

## How

- `types.ts` — new optional `ensnare?: { chance; duration; name; school? }` on `MobTemplate` (mirrors the `venom`/`mortalStrike` shape).
- `sim.ts` `mobSwing` — after the Mortal Strike block, a guarded proc calls the existing `applyRootAura(...)`. Guard is `mob.hostile && target.kind === 'player' && !target.dead` so a **friendly pet** (which shares the `mobSwing` path) never webs an ally, and rooting a fellow mob (meaningless) is skipped.
- `zone1.ts` — adds the affix to the existing Webwood Lurker. No new spawns, so the deterministic world is unchanged.
- No UI change: `root` is already classified as a hostile **red debuff** by the HUD aura renderer.

## Tests

`tests/mob_ensnare.test.ts`:
- a forced proc lands a `root` aura (`Sticky Web`) and `isRooted` blocks movement;
- a friendly pet swing (`hostile = false`) never roots;
- a mob without the affix applies nothing.

Full suite green: **1231 passed**, `tsc --noEmit` clean.

## Screenshots

Verified live in the offline client via `scripts/shot_ensnare.mjs` (result: `Sticky Web` applied, movement blocked). The player frame shows the new red web debuff alongside Spider Venom:

![Sticky Web + Spider Venom debuffs](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mob-ensnare-shots/shots/ensnare_debuff_crop.png)

![Webbed in Eastbrook Vale](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mob-ensnare-shots/shots/ensnare_rooted.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)