### PR TITLE
feat(content): Mire Prowlers mire the victim's swings on hit (Miring Pounce)

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -61,6 +61,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'soggy_moccasin', chance: 0.3 },
     ],
     scale: 0.95, color: 0x4d5656,
+    // Miring Pounce: the prowler drags its prey into the sucking mire, slowing
+    // the victim's swings (+30% swing interval) for 8s.
+    slowStrike: { chance: 0.3, mult: 1.3, duration: 8, name: 'Miring Pounce', school: 'physical' },
   },
   deepfen_murloc: {
     id: 'deepfen_murloc', name: 'Deepfen Snapper', minLevel: 8, maxLevel: 9, family: 'murloc',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4101,6 +4101,23 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+    // slowStrike: a landed hit may mire the victim, slowing their attack speed.
+    // Rides the existing `attackspeed` aura (swingIntervalMult: value > 1 = slower);
+    // refreshes by id and never stacks. Guarded on `hostile` so a friendly pet
+    // (mobSwing's other caller) never debuffs the party.
+    const slowStrike = MOBS[mob.templateId]?.slowStrike;
+    if (slowStrike && mob.hostile && !target.dead && this.rng.chance(slowStrike.chance)) {
+      this.applyAura(target, {
+        id: `slowstrike_${mob.templateId}`,
+        name: slowStrike.name,
+        kind: 'attackspeed',
+        remaining: slowStrike.duration,
+        duration: slowStrike.duration,
+        value: slowStrike.mult,
+        sourceId: mob.id,
+        school: (slowStrike.school as Aura['school']) ?? 'physical',
+      });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -199,6 +199,11 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit debuff: a chance per landed melee swing to mire the victim, slowing
+  // their ATTACK SPEED (an `attackspeed` aura, `mult` > 1 lengthens the swing
+  // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new
+  // combat math. Distinct from a movement snare (`slow`) or an AP cut (`debuff_ap`).
+  slowStrike?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/tests/mob_slowstrike.test.ts
+++ b/tests/mob_slowstrike.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+describe('Mire Prowler "Miring Pounce" attack-speed slow', () => {
+  it('swingIntervalMult lengthens the swing while the slow aura is active', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const base = (sim as any).swingIntervalMult(p);
+    expect(base).toBeCloseTo(1, 6);
+    p.auras.push({
+      id: 'slowstrike_mire_prowler', name: 'Miring Pounce', kind: 'attackspeed',
+      remaining: 8, duration: 8, value: 1.3, sourceId: -1, school: 'physical',
+    });
+    // value > 1 multiplies the interval → slower swings.
+    expect((sim as any).swingIntervalMult(p)).toBeCloseTo(1.3, 6);
+  });
+
+  it('a landed Mire Prowler swing can inflict the attack-speed slow', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.mire_prowler;
+    const saved = tmpl.slowStrike!.chance;
+    tmpl.slowStrike!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900600, tmpl, 8, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'attackspeed');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'attackspeed')!;
+      expect(a.name).toBe('Miring Pounce');
+      expect(a.value).toBe(1.3);
+      expect(a.duration).toBe(8);
+    } finally {
+      tmpl.slowStrike!.chance = saved;
+    }
+  });
+
+  it('refreshes in place and never stacks a second aura', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mire_prowler;
+    const saved = tmpl.slowStrike!.chance;
+    tmpl.slowStrike!.chance = 1;
+    try {
+      const mob = createMob(900601, tmpl, 8, { x: 0, y: 0, z: 0 });
+      for (let i = 0; i < 120; i++) { p.hp = p.maxHp; (sim as any).mobSwing(mob, p); }
+      expect(p.auras.filter((a) => a.kind === 'attackspeed').length).toBe(1);
+    } finally {
+      tmpl.slowStrike!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts the slow', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mire_prowler;
+    const saved = tmpl.slowStrike!.chance;
+    tmpl.slowStrike!.chance = 1;
+    try {
+      const pet = createMob(900602, tmpl, 8, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'attackspeed')).toBe(false);
+    } finally {
+      tmpl.slowStrike!.chance = saved;
+    }
+  });
+
+  it('a mob without slowStrike applies no attack-speed debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900603, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'attackspeed')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit mob affix, **`slowStrike`**: a chance per landed melee swing to slow the struck target's **attack speed** for a duration. The Mirefen Marsh **Mire Prowler** (L7-8 beast) gains **Miring Pounce** — 30% chance on hit to drag its prey into the sucking mire, lengthening their swing interval by +30% for 8s.

## Why it's a clean fit

The affix rides an **existing** combat hook with **no new combat math**: `swingIntervalMult()` already folds in any `attackspeed` aura (`m *= a.value`, so a value > 1 = slower swings — the same aura Thunder Clap puts on enemies). This mirrors how `corrode` rides the `sunder` aura and `mortalStrike` rides `mortal_wound`.

It fills a distinct slot in the on-hit affix family:
- movement snare → `slow`
- attack-power cut → `debuff_ap`
- **attack-speed slow → `slowStrike` (this PR)**

The HUD already classifies the `attackspeed` aura kind as a **red debuff**, so it renders correctly with **no UI change**. Guarded on `hostile` so a friendly pet swinging through `mobSwing` never debuffs the party.

## Changes

- `src/sim/types.ts` — new `slowStrike?` field on `MobTemplate`.
- `src/sim/sim.ts` — apply the `attackspeed` aura in `mobSwing` (after the Mortal Strike block; refreshes by id, never stacks).
- `src/sim/content/zone2.ts` — attach **Miring Pounce** to `mire_prowler`.
- `tests/mob_slowstrike.test.ts` — 5 cases (swing-interval math, forced proc, no-stack refresh, friendly-pet guard, affix-free mob).

## Verification

- `npx vitest run tests/mob_slowstrike.test.ts` — 5 passed.
- Full suite green: **1233 passed**, `tsc --noEmit` clean.
- Live offline-client check (`scripts/slowstrike_visual.mjs`) confirmed the proc lands and the swing-interval multiplier grows 1.0 → 1.3.

## Screenshots

Debuff tooltip on the player's buff bar:

![Miring Pounce tooltip](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mire-prowler-slowstrike-shots/shots/miring-pounce-tooltip.png)

In-world HUD:

![HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mire-prowler-slowstrike-shots/shots/miring-pounce-hud.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)