### PR TITLE
feat(content): mender mobs heal their wounded allies on a slow cadence (Grave Mending)

### DIFF
--- a/scripts/shot_mender.mjs
+++ b/scripts/shot_mender.mjs
@@ -1,0 +1,109 @@
+// Screenshot for the Gravecaller Mender support-heal mechanic (mendAlly).
+// Drives the offline world, repurposes two nearby mobs into a Mender + a wounded
+// ally right in front of the player, forces the Grave Mending cast, and captures
+// the green heal floating-combat-text rising over the healed ally.
+// Requires `npm run dev` on :5173.
+//
+// Usage: node scripts/shot_mender.mjs
+import { mkdirSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline → name → pick class → Start.
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Mendwatch';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+    document.querySelector('.mini-class[data-class="priest"]')?.click();
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Stage the scene: god-mode the player, repurpose two mobs into a Mender and a
+  // wounded ally a few yards in front of the camera.
+  await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.hp = p.maxHp;
+    const mobs = [...sim.entities.values()].filter((e) => e.kind === 'mob' && !e.dead);
+    const fx = p.pos.x + Math.sin(p.facing) * 7;
+    const fz = p.pos.z + Math.cos(p.facing) * 7;
+    const ground = (x, z) => sim.groundPos(x, z);
+
+    const mender = mobs[0];
+    const ally = mobs[1];
+    window.__mender = mender.id;
+    window.__ally = ally.id;
+
+    mender.templateId = 'gravecaller_mender';
+    mender.name = 'Gravecaller Mender';
+    Object.assign(mender.pos, ground(fx - 2, fz));
+    mender.prevPos = { ...mender.pos };
+    mender.hostile = true;
+
+    ally.name = 'Gravecaller Cultist';
+    Object.assign(ally.pos, ground(fx + 2, fz));
+    ally.prevPos = { ...ally.pos };
+    ally.hostile = true;
+    ally.maxHp = 600;
+  });
+
+  // Force repeated Grave Mending casts so the green heal text is on screen,
+  // re-wounding the ally each beat. Capture mid-rise.
+  for (let i = 0; i < 8; i++) {
+    await page.evaluate(() => {
+      const sim = window.__game.sim;
+      const mender = sim.entities.get(window.__mender);
+      const ally = sim.entities.get(window.__ally);
+      if (!mender || !ally) return;
+      ally.hp = Math.round(ally.maxHp * 0.4); // keep it wounded so the mend has work to do
+      mender.inCombat = true;
+      mender.combatTimer = 0;
+      mender.mendTimer = 0; // fire now
+    });
+    await new Promise((r) => setTimeout(r, 180));
+  }
+
+  // Fire one clean cast and grab the floating green heal numbers mid-rise.
+  await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const mender = sim.entities.get(window.__mender);
+    const ally = sim.entities.get(window.__ally);
+    if (mender && ally) { ally.hp = Math.round(ally.maxHp * 0.4); mender.inCombat = true; mender.mendTimer = 0; }
+  });
+  await new Promise((r) => setTimeout(r, 110));
+  await page.screenshot({ path: `${OUT}/mender-heal-fct.png`, clip: { x: 430, y: 90, width: 470, height: 360 } });
+  console.log('saved mender-heal-fct.png (heal numbers)');
+
+  await new Promise((r) => setTimeout(r, 80));
+  await page.screenshot({ path: `${OUT}/mender-heal.png` });
+  console.log('saved mender-heal.png (full scene)');
+
+  // Cropped close-up on the two actors + the rising green heal numbers.
+  await page.screenshot({ path: `${OUT}/mender-heal-actors.png`, clip: { x: 430, y: 90, width: 470, height: 360 } });
+  console.log('saved mender-heal-actors.png (close-up)');
+
+  // Cropped on the combat log showing the repeated Grave Mending cast lines.
+  await page.screenshot({ path: `${OUT}/mender-heal-log.png`, clip: { x: 8, y: 470, width: 560, height: 250 } });
+  console.log('saved mender-heal-log.png (combat log)');
+} finally {
+  await browser.close();
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -200,7 +200,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -177,6 +177,21 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     ],
     scale: 1.0, color: 0x884ea0,
   },
+  gravecaller_mender: {
+    id: 'gravecaller_mender', name: 'Gravecaller Mender', minLevel: 11, maxLevel: 12, family: 'humanoid',
+    hpBase: 44, hpPerLevel: 18, dmgBase: 8, dmgPerLevel: 2.2, attackSpeed: 2.1,
+    armorPerLevel: 16, moveSpeed: 7, aggroRadius: 12,
+    // Grave Mending: keeps its cultist pack alive, knitting every wounded ally's
+    // wounds shut on a slow cadence. Pull it away from the camp — or drop it
+    // first — or the fight never ends.
+    mendAlly: { healMin: 26, healMax: 38, radius: 14, every: 6, name: 'Grave Mending', school: 'shadow' },
+    loot: [
+      { copper: 58, chance: 1 },
+      { itemId: 'cult_cipher', chance: 0.4, questId: 'q_summoners' },
+      { itemId: 'tallow_candle', chance: 0.3 },
+    ],
+    scale: 1.0, color: 0x9b59b6,
+  },
   sister_nhalia: {
     id: 'sister_nhalia', name: 'Sister Nhalia', minLevel: 12, maxLevel: 12, family: 'humanoid', rare: true,
     elite: true, canSwim: true, ccImmune: true, respawnMult: 648,
@@ -508,6 +523,7 @@ export const ZONE2_CAMPS: CampDef[] = [
   { mobId: 'gravecaller_cultist', center: { x: 15, z: 470 }, radius: 20, count: 7 },
   { mobId: 'gravecaller_cultist', center: { x: -25, z: 490 }, radius: 16, count: 6 },
   { mobId: 'gravecaller_summoner', center: { x: -5, z: 500 }, radius: 12, count: 4 },
+  { mobId: 'gravecaller_mender', center: { x: 18, z: 472 }, radius: 8, count: 2 },
   { mobId: 'sister_nhalia', center: { x: 24, z: 492 }, radius: 5, count: 1 },
   { mobId: 'deacon_voss', center: { x: 0, z: 510 }, radius: 2, count: 1 },
 ];

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -182,6 +182,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   e.swingTimer = 0;
   // Telegraph the first War Stomp: delay it one full interval after engage.
   if (template.stomp) e.stompTimer = template.stomp.every;
+  // Telegraph the first Mend the same way: one full interval after engage.
+  if (template.mendAlly) e.mendTimer = template.mendAlly.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3985,6 +3985,7 @@ export class Sim {
     mob.enraged = false;
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
+    mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4333,6 +4334,7 @@ export class Sim {
     mob.enraged = false;
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
+    mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4396,7 +4398,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4419,6 +4421,31 @@ export class Sim {
         this.emit({ type: 'heal', targetId: mob.id, amount: heal });
         this.emit({ type: 'log', text: `${mob.name} draws on a desperate second wind!`, color: '#66ff99', entityId: mob.id });
         this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school: 'nature', fx: 'nova' });
+      }
+    }
+    // Support "Mend": periodically heal every wounded friendly mob in range
+    // (including the caster). Telegraphed via createMob seeding mendTimer to a
+    // full interval, so the first cast never lands the instant combat opens.
+    if (tmpl.mendAlly) {
+      mob.mendTimer -= DT;
+      if (mob.mendTimer <= 0) {
+        mob.mendTimer = tmpl.mendAlly.every;
+        const wounded: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile || ally.hp >= ally.maxHp) continue; // only wounded same-faction mobs
+          if (dist2d(ally.pos, mob.pos) > tmpl.mendAlly.radius) continue;
+          wounded.push(ally);
+        }
+        if (wounded.length > 0) {
+          const school = tmpl.mendAlly.school ?? 'nature';
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} channels ${tmpl.mendAlly.name}.`, color: '#66ff99', entityId: mob.id });
+          for (const ally of wounded) {
+            const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
+            this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
       }
     }
   }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -177,6 +177,12 @@ export interface MobTemplate {
   // Mob mechanic: a one-time desperation self-heal the first time hp drops
   // below the threshold (healPct is a fraction of maxHp). Resets on evade/respawn.
   desperateHeal?: { belowHpPct: number; healPct: number };
+  // Support mechanic ("Mend"): while in combat, periodically heal every wounded
+  // living friendly mob within `radius` (incl. itself) for `healMin..healMax`.
+  // Telegraphed: the first cast lands one full `every` interval after combat
+  // opens. Resets on evade/respawn. Routes through the normal heal path, so it
+  // shows green floating text and grants no threat to the menders themselves.
+  mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -517,6 +523,7 @@ export interface Entity {
   petTauntTimer: number; // controlled pet Growl cooldown
   pulseTimer: number; // boss aoe pulse countdown
   stompTimer: number; // boss War Stomp stun-pulse countdown
+  mendTimer: number; // mendAlly support-heal cast countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/src/ui/phase9_i18n.ts
+++ b/src/ui/phase9_i18n.ts
@@ -4,7 +4,7 @@ const MOB_IDS = [
   'forest_wolf', 'old_greyjaw', 'wild_boar', 'webwood_spider', 'mudfin_murloc', 'tunnel_rat',
   'vale_bandit', 'restless_bones', 'gorrak', 'mire_prowler', 'deepfen_murloc', 'mire_widow',
   'mirefen_broodmother', 'drowned_dead', 'fen_troll', 'grubjaw', 'gravecaller_cultist',
-  'gravecaller_summoner', 'deacon_voss', 'ridge_stalker', 'deeprock_kobold', 'thornpeak_ogre',
+  'gravecaller_summoner', 'gravecaller_mender', 'deacon_voss', 'ridge_stalker', 'deeprock_kobold', 'thornpeak_ogre',
   'ogre_crusher', 'warlord_drogmar', 'stormcrag_elemental', 'shardlord_kazzix',
   'wyrmcult_zealot', 'wyrmcult_necromancer', 'boneclad_revenant', 'crypt_shambler',
   'hollow_acolyte', 'bonechill_widow', 'sexton_marrow', 'morthen', 'bastion_revenant',
@@ -1134,7 +1134,7 @@ const esData: LocaleData = {
   mobs: [
     'Lobo del bosque', 'Viejo Greyjaw', 'Jabalí salvaje', 'Acechador de Webwood', 'Merodeador Aletabarro', 'Excavador Rata de Túnel',
     'Bandido del Valle', 'Huesos inquietos', 'Gorrak el Despiadado', 'Merodeador del lodazal', 'Chasqueador de Deepfen', 'Viuda de Mirefen',
-    'La Madre de la nidada', 'Muerto ahogado', 'Trol de Mirefen', 'Grubjaw el Glotón', 'Cultista Gravecaller', 'Invocador Gravecaller',
+    'La Madre de la nidada', 'Muerto ahogado', 'Trol de Mirefen', 'Grubjaw el Glotón', 'Cultista Gravecaller', 'Invocador Gravecaller', 'Sanador Gravecaller',
     'Diácono Voss', 'Acechador de la cresta', 'Tunelador de Deep Rock', 'Ogro de Thornpeak', 'Triturador de Thornpeak', 'Señor de la guerra Drogmar',
     'Elemental de Stormcrag', 'Señor de fragmentos Kazzix', 'Fanático del Culto del Wyrm', 'Nigromante del Culto del Wyrm', 'Aparecido de hueso',
     'Tambaleante de la Cripta', 'Acólito del Hueco', 'Viuda Huesofrío', 'Sacristán Marrow', 'Morthen el Gravecaller', 'Aparecido del Bastión',
@@ -1202,7 +1202,7 @@ const frData: LocaleData = {
   mobs: [
     'Loup des bois', 'Vieux Greyjaw', 'Sanglier sauvage', 'Rôdeur de Webwood', 'Rôdeur Aileron-de-boue', 'Terrassier Rat des tunnels',
     'Bandit du Val', 'Ossements agités', "Gorrak l'Impitoyable", 'Rôdeur du bourbier', 'Happeur de Deepfen', 'Veuve de Mirefen',
-    'La Mère des couvées', 'Mort noyé', 'Troll de Mirefen', 'Grubjaw le Glouton', 'Cultiste Gravecaller', 'Invocateur Gravecaller',
+    'La Mère des couvées', 'Mort noyé', 'Troll de Mirefen', 'Grubjaw le Glouton', 'Cultiste Gravecaller', 'Invocateur Gravecaller', 'Guérisseur Gravecaller',
     'Diacre Voss', 'Traqueur de crête', 'Tunnelier de Deeprock', 'Ogre de Thornpeak', 'Broyeur de Thornpeak', 'Seigneur de guerre Drogmar',
     'Élémentaire de Stormcrag', 'Seigneur des éclats Kazzix', 'Zélote du Culte du Wyrm', 'Nécromancien du Culte du Wyrm', "Revenant caparaçonné d'os",
     'Traînard de la crypte', 'Acolyte du Creux', 'Veuve Frissos', 'Sacristain Marrow', 'Morthen le Gravecaller', 'Revenant du Bastion',
@@ -1269,7 +1269,7 @@ const deData: LocaleData = {
   mobs: [
     'Waldwolf', 'Alter Greyjaw', 'Wilder Eber', 'Webwood-Lauerer', 'Schlammflossen-Schleicher', 'Tunnelratten-Gräber',
     'Talbandit', 'Ruhelose Knochen', 'Gorrak der Gnadenlose', 'Moorpirscher', 'Deepfen-Schnapper', 'Mirefen-Witwe',
-    'Die Brutmutter', 'Ertrunkener Toter', 'Mirefen-Troll', 'Grubjaw der Vielfraß', 'Gravecaller-Kultist', 'Gravecaller-Beschwörer',
+    'Die Brutmutter', 'Ertrunkener Toter', 'Mirefen-Troll', 'Grubjaw der Vielfraß', 'Gravecaller-Kultist', 'Gravecaller-Beschwörer', 'Gravecaller-Heiler',
     'Diakon Voss', 'Gratpirscher', 'Deeprock-Tunnelgräber', 'Thornpeak-Oger', 'Thornpeak-Zermalmer', 'Kriegsherr Drogmar',
     'Stormcrag-Elementar', 'Splitterlord Kazzix', 'Wyrmkult-Eiferer', 'Wyrmkult-Nekromant', 'Knochengepanzerter Wiedergänger',
     'Gruftschlurfer', 'Akolyth der Höhlung', 'Knochenkälte-Witwe', 'Küster Marrow', 'Morthen der Gravecaller', 'Bastion-Wiedergänger',
@@ -1336,7 +1336,7 @@ const itData: LocaleData = {
   mobs: [
     'Lupo della foresta', 'Vecchio Greyjaw', 'Cinghiale selvatico', 'Predatore di Webwood', 'Predatore Pinnalimo', 'Scavatore ratto di galleria',
     'Bandito della Valle', 'Ossa irrequiete', 'Gorrak lo Spietato', 'Predatore del pantano', 'Murloc di Deepfen', 'Vedova di Mirefen',
-    'Madre della covata', 'Morto annegato', 'Troll di Mirefen', 'Grubjaw il Goloso', 'Cultista Gravecaller', 'Evocatore Gravecaller',
+    'Madre della covata', 'Morto annegato', 'Troll di Mirefen', 'Grubjaw il Goloso', 'Cultista Gravecaller', 'Evocatore Gravecaller', 'Guaritore Gravecaller',
     'Diacono Voss', 'Braccatore della cresta', 'Coboldo di Deeprock', 'Ogre di Thornpeak', 'Frantumatore ogre', 'Signore della guerra Drogmar',
     'Elementale di Stormcrag', 'Signore dei frammenti Kazzix', 'Zelota del Culto del Wyrm', 'Negromante del Culto del Wyrm',
     'Revenant corazzato di ossa', 'Barcollante della cripta', 'Accolito del Vuoto', 'Vedova Freddosso', 'Sagrestano Marrow',
@@ -1404,7 +1404,7 @@ const zhCnData: LocaleData = {
   mobs: [
     '森林狼', '老灰颚', '野猪', '网木潜伏者', '泥鳍潜伏者', '地道鼠掘地者', '谷地强盗', '不宁骸骨', '无情者戈拉克',
     '泥沼潜伏兽', '深沼钳咬鱼人', '泥沼寡妇蛛', '蛛母', '溺亡死者', '泥沼巨魔', '贪食者格鲁布颚', '唤墓者教徒',
-    '唤墓者召唤师', '执事沃斯', '山脊潜猎者', '深岩掘地者', '荆峰食人魔', '荆峰粉碎者', '督军德罗格玛',
+    '唤墓者召唤师', '唤墓者医者', '执事沃斯', '山脊潜猎者', '深岩掘地者', '荆峰食人魔', '荆峰粉碎者', '督军德罗格玛',
     '风暴岩元素', '碎片领主卡兹克斯', '龙教狂热者', '龙教死灵法师', '骨甲亡魂', '墓穴蹒跚者', '空洞侍僧',
     '寒骨寡妇蛛', '司事马罗', '唤墓者莫森', '堡垒亡魂', '潮缚侍僧', '溺亡奴仆', '骑士指挥官奥伦',
     '唤雾者维尔', '圣所骨卫', '圣所龙人', '复生骨行者', '被缚者科加斯', '大死灵法师维尔卡', '墓龙科祖尔',
@@ -1464,7 +1464,7 @@ const zhTwData: LocaleData = {
   mobs: [
     '森林狼', '老灰顎', '野豬', '網木潛伏者', '泥鰭潛伏者', '地道鼠掘地者', '谷地強盜', '不寧骸骨',
     '無情者戈拉克', '泥沼潛伏獸', '深沼鉗咬魚人', '泥沼寡婦蛛', '蛛母', '溺亡死者', '泥沼巨魔',
-    '貪食者格魯布顎', '喚墓者教徒', '喚墓者召喚師', '執事沃斯', '山脊潛獵者', '深岩掘地者',
+    '貪食者格魯布顎', '喚墓者教徒', '喚墓者召喚師', '喚墓者醫者', '執事沃斯', '山脊潛獵者', '深岩掘地者',
     '荊峰食人魔', '荊峰粉碎者', '督軍德羅格瑪', '風暴岩元素', '碎片領主卡茲克斯', '龍教狂熱者',
     '龍教死靈法師', '骨甲亡魂', '墓穴蹣跚者', '空洞侍僧', '寒骨寡婦蛛', '司事馬羅', '喚墓者莫森',
     '堡壘亡魂', '潮縛侍僧', '溺亡奴僕', '騎士指揮官奧倫', '喚霧者維爾', '聖所骨衛', '聖所龍人',
@@ -1526,7 +1526,7 @@ const koData: LocaleData = {
   mobs: [
     '숲늑대', '늙은 그레이죠', '야생 멧돼지', '그물나무 잠복자', '진흙지느러미 잠복자', '굴쥐 채굴꾼', '계곡 도적',
     '불안한 뼈무더기', '무자비한 고라크', '수렁 배회자', '딥펜 무는이', '마이어펜 과부거미', '거미어미',
-    '익사한 망자', '마이어펜 트롤', '대식가 그럽죠', '무덤부름 교단원', '무덤부름 소환사', '부제 보스',
+    '익사한 망자', '마이어펜 트롤', '대식가 그럽죠', '무덤부름 교단원', '무덤부름 소환사', '무덤부름 치유사', '부제 보스',
     '산등성이 추적자', '깊은바위 굴꾼', '쏜피크 오우거', '쏜피크 분쇄자', '전쟁군주 드로그마르',
     '스톰크래그 정령', '파편군주 카직스', '고룡교단 광신도', '고룡교단 강령술사', '뼈갑옷 망령',
     '묘실 비틀거림꾼', '공허의 수행사제', '뼈서리 과부거미', '성구지기 매로우', '무덤부름 모르덴',
@@ -1592,7 +1592,7 @@ const jaData: LocaleData = {
     '森の狼', '老グレイジョー', '野生の猪', 'ウェブウッドの潜伏者', '泥ひれの潜伏者', 'トンネルラット掘り',
     '谷の盗賊', '安らがぬ骨', '無慈悲なるゴラック', '沼の徘徊者', 'ディープフェンのスナッパー', 'マイアフェンのウィドウ',
     '群れの母', '溺れ死者', 'マイアフェン・トロル', '大食いグラブジョー', 'グレイブコーラーの信徒',
-    'グレイブコーラーの召喚師', '助祭ヴォス', '尾根の追跡者', 'ディープロックの坑夫', 'ソーンピーク・オーガ',
+    'グレイブコーラーの召喚師', 'グレイブコーラーの癒し手', '助祭ヴォス', '尾根の追跡者', 'ディープロックの坑夫', 'ソーンピーク・オーガ',
     'ソーンピークの粉砕者', '将軍ドログマー', 'ストームクラッグの精霊', '破片卿カジックス',
     'ワーム教団の狂信者', 'ワーム教団の死霊術師', '骨まといの亡霊', '墓所のよろめき手',
     '虚ろの侍祭', '骨冷えのウィドウ', '墓守マロウ', '墓呼びのモーセン', '砦の亡霊',
@@ -1658,7 +1658,7 @@ const ptData: LocaleData = {
   mobs: [
     'Lobo da floresta', 'Velho Greyjaw', 'Javali selvagem', 'Espreitador de Webwood', 'Espreitador Barbatana-de-lodo', 'Escavador rato de túnel',
     'Bandido do Vale', 'Ossos inquietos', 'Gorrak o Impiedoso', 'Espreitador do brejo', 'Murloc de Deepfen', 'Viúva de Mirefen',
-    'Mãe da ninhada', 'Morto afogado', 'Troll de Mirefen', 'Grubjaw o Glutão', 'Cultista Gravecaller', 'Invocador Gravecaller',
+    'Mãe da ninhada', 'Morto afogado', 'Troll de Mirefen', 'Grubjaw o Glutão', 'Cultista Gravecaller', 'Invocador Gravecaller', 'Curandeiro Gravecaller',
     'Diácono Voss', 'Rastreador da crista', 'Kobold de Deeprock', 'Ogro de Thornpeak', 'Esmagador ogro', 'Senhor da guerra Drogmar',
     'Elemental de Stormcrag', 'Senhor dos fragmentos Kazzix', 'Zelote do Culto do Wyrm', 'Necromante do Culto do Wyrm',
     'Revenante encouraçado de ossos', 'Cambaleante da cripta', 'Acólito do Vazio', 'Viúva Frio-osso', 'Sacristão Marrow',
@@ -1727,7 +1727,7 @@ const ruData: LocaleData = {
   mobs: [
     'Лесной волк', 'Старый Серочелюст', 'Дикий кабан', 'Паук-скрытень Вебвуда', 'Илогривый скрытень', 'Копатель Туннельная Крыса',
     'Долинный бандит', 'Беспокойные кости', 'Горрак Безжалостный', 'Болотный хищник', 'Глубинный щелкун', 'Мирефенская вдова',
-    'Матка выводка', 'Утопший мертвец', 'Мирефенский тролль', 'Грубджо Обжора', 'Культист Могильного Зова', 'Призыватель Могильного Зова',
+    'Матка выводка', 'Утопший мертвец', 'Мирефенский тролль', 'Грубджо Обжора', 'Культист Могильного Зова', 'Призыватель Могильного Зова', 'Лекарь Могильного Зова',
     'Дьякон Восс', 'Хребтовый охотник', 'Глубокоскальный туннельщик', 'Огр Терновых Пиков', 'Крушитель Терновых Пиков',
     'Воевода Дрогмар', 'Элементаль Грозового Утеса', 'Осколочный владыка Каззикс', 'Фанатик Культа Вирма',
     'Некромант Культа Вирма', 'Костепанцирный ревенант', 'Склепный шатун', 'Послушник Пустоти', 'Ледяная вдова',

--- a/tests/localization_fixes.test.ts
+++ b/tests/localization_fixes.test.ts
@@ -522,6 +522,7 @@ describe("S3: every sim.ts emit is recognized (drift guard)", () => {
     "Abilities on cooldown (5): Aki.",
     "Active effects (5): Aki.",
     "Aki attempts to flee!",
+    "Aki channels Aki.",
     "Aki draws on a desperate second wind!",
     "Aki flies into a frenzy!",
     "Aki is Aki: Aki",

--- a/tests/mob_mend_ally.test.ts
+++ b/tests/mob_mend_ally.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Gravecaller Mender is the seeded carrier of the mendAlly support mechanic.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string], hpFrac = 1) {
+  const mob = createMob(id, tmpl, 12, { x: 0, y: 0, z: 0 });
+  mob.hp = Math.round(mob.maxHp * hpFrac);
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+describe('mob support heal (mendAlly)', () => {
+  it('seeds the mechanic on the Gravecaller Mender', () => {
+    expect(MOBS.gravecaller_mender.mendAlly).toEqual({
+      healMin: 26, healMax: 38, radius: 14, every: 6, name: 'Grave Mending', school: 'shadow',
+    });
+  });
+
+  it('heals a wounded nearby ally once the cast timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mender = spawn(sim, 9001, MOBS.gravecaller_mender);
+    const ally = spawn(sim, 9002, MOBS.gravecaller_cultist, 0.4);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    const before = ally.hp;
+    // Telegraphed: createMob seeds mendTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first cast.
+    for (let i = 0; i < 20 * 6 + 1; i++) inner(sim).updateBossMechanics(mender);
+    expect(ally.hp).toBeGreaterThan(before);
+    expect(ally.hp).toBeLessThanOrEqual(ally.maxHp);
+  });
+
+  it('does not cast before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mender = spawn(sim, 9011, MOBS.gravecaller_mender);
+    const ally = spawn(sim, 9012, MOBS.gravecaller_cultist, 0.4);
+    const before = ally.hp;
+    for (let i = 0; i < 20 * 5; i++) inner(sim).updateBossMechanics(mender); // 5s < 6s
+    expect(ally.hp).toBe(before);
+  });
+
+  it('heals every wounded ally in range at once (AoE)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mender = spawn(sim, 9021, MOBS.gravecaller_mender, 0.5);
+    const a = spawn(sim, 9022, MOBS.gravecaller_cultist, 0.4);
+    const b = spawn(sim, 9023, MOBS.gravecaller_summoner, 0.4);
+    const beforeA = a.hp, beforeB = b.hp, beforeSelf = mender.hp;
+    for (let i = 0; i < 20 * 6 + 1; i++) inner(sim).updateBossMechanics(mender);
+    expect(a.hp).toBeGreaterThan(beforeA);
+    expect(b.hp).toBeGreaterThan(beforeB);
+    expect(mender.hp).toBeGreaterThan(beforeSelf); // the caster mends itself too
+  });
+
+  it('ignores allies outside the heal radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mender = spawn(sim, 9031, MOBS.gravecaller_mender);
+    const far = spawn(sim, 9032, MOBS.gravecaller_cultist, 0.4);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 14
+    const before = far.hp;
+    for (let i = 0; i < 20 * 6 + 1; i++) inner(sim).updateBossMechanics(mender);
+    expect(far.hp).toBe(before);
+  });
+
+  it('does not heal hostiles of the opposing faction (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mender = spawn(sim, 9041, MOBS.gravecaller_mender);
+    const friendlyMob = spawn(sim, 9042, MOBS.gravecaller_cultist, 0.4);
+    friendlyMob.hostile = false; // flip faction
+    const before = friendlyMob.hp;
+    for (let i = 0; i < 20 * 6 + 1; i++) inner(sim).updateBossMechanics(mender);
+    expect(friendlyMob.hp).toBe(before);
+  });
+
+  it('re-arms the telegraph after the mender evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mender = spawn(sim, 9051, MOBS.gravecaller_mender);
+    inner(sim).resetEvadingMob(mender);
+    expect(mender.mendTimer).toBe(MOBS.gravecaller_mender.mendAlly!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const cultist = spawn(sim, 9061, MOBS.gravecaller_cultist, 0.4);
+    const ally = spawn(sim, 9062, MOBS.gravecaller_summoner, 0.4);
+    const before = ally.hp;
+    for (let i = 0; i < 20 * 6 + 1; i++) inner(sim).updateBossMechanics(cultist);
+    expect(ally.hp).toBe(before);
+  });
+});

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -1154,6 +1154,12 @@ describe('shaman travel and shock mechanics', () => {
     sim.setPlayerLevel(16);
     const wolf = nearestMob(sim, 'forest_wolf');
     beefUp(wolf);
+    // This test is about Ghost Wolf's toggle/recast semantics, not the wolf's
+    // auto-attacks. A landed melee swing breaks the form (damage cancels Ghost
+    // Wolf), so root the wolf in place (it can never close the 12yd gap) to keep
+    // the form-checks independent of hit-table RNG. It stays alive and in range
+    // of the ranged shocks the test casts at it.
+    wolf.moveSpeed = 0;
     teleport(sim, sim.player, wolf.pos.x + 12, wolf.pos.z);
     sim.targetEntity(wolf.id);
     sim.player.facing = Math.atan2(wolf.pos.x - sim.player.pos.x, wolf.pos.z - sim.player.pos.z);


### PR DESCRIPTION
## What

Adds a **`mendAlly`** support mechanic to `MobTemplate` — the first *ally-facing* behavior in the mob kit. Every existing mob mechanic is offensive (`venom`, `cleave`, `mortalStrike`, `corrode`, `stomp`, `aoePulse`…) or self-only (`desperateHeal`, `enrage`); none let a mob keep its friends alive. A "kill/interrupt the healer first" creature is a classic-MMO staple that was missing here.

While in combat, a mender periodically heals **every wounded friendly mob within range** (including itself) for `healMin..healMax`. It routes through the existing `applyHeal` path, so it shows green heal floating-combat-text and — by design — grants the menders **no threat**. Telegraphed exactly like War Stomp: the first cast lands one full `every` interval after engage, and the timer re-arms on evade/respawn.

**Carrier:** the **Gravecaller Mender**, a humanoid support caster (Lvl 11–12) spawned with the gravecaller cultist pack in **Mirefen Marsh**. Pull it off the pack — or drop it first — or the fight drags on as it knits the cultists' wounds shut.

```ts
mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
// gravecaller_mender:
mendAlly: { healMin: 26, healMax: 38, radius: 14, every: 6, name: 'Grave Mending', school: 'shadow' }
```

## How

- Implemented in `updateBossMechanics` (already invoked each tick while `mob.inCombat`), so the heal works at range — unlike the melee-gated pulse/stomp mechanics. New `mendTimer` field on `Entity`, mirroring `stompTimer` (init in `entity.ts`, telegraph seed in `createMob`, re-arm on evade/respawn).
- **Sim-core only.** No `IWorld` / RL action-space changes. Balance numbers live in the template data, not inline.
- i18n: localized the new mob name in **every** locale (`phase9_i18n.ts`) and registered the new combat-log line.

## Screenshots

Grave Mending firing on the cultist pack (offline client):

| Combat log (proof) | Nameplate / heal nova |
|---|---|
| ![combat log](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mender-shots/shots/mender-heal-log.png) | ![close-up](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mender-shots/shots/mender-heal-fct.png) |

![full scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/mender-shots/shots/mender-heal.png)

## Testing

- `tests/mob_mend_ally.test.ts` (new, 8 cases): seeding, telegraphed first cast, AoE heal of all wounded allies + self, out-of-range skip, opposing-faction skip, re-arm on reset, and no-op for mobs lacking the mechanic.
- Hardened the unrelated **Ghost Wolf** threat test that silently depended on a low-level wolf *missing* the player for 3s — any new spawn shifts the shared world-gen RNG stream and flipped that roll. Rooted the test wolf so a landed swing can't incidentally break the form; the test's intent (Ghost Wolf toggle/recast semantics) is unchanged.
- `npm test` → **1236 passing**, `tsc --noEmit` clean, `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)