### PR TITLE
feat(content): Elixir of the Bear — usable battle elixir that buffs Stamina

### DIFF
--- a/scripts/content_request_shots.mjs
+++ b/scripts/content_request_shots.mjs
@@ -1,0 +1,82 @@
+// Screenshots illustrating four absent content systems, for upstream feature-request issues:
+//   day/night cycle, weather, reputation/faction, enchanting/gems & sockets.
+// Each PNG shows the CURRENT state (the gap), not a proposed feature.
+// Runs the offline flow (no server). Needs `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const CLASS = process.env.GAME_CLASS ?? 'warrior';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Thorgar'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate((c) => document.querySelector(`#offline-select .mini-class[data-class="${c}"]`)?.click(), CLASS);
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+// God-mode so camp mobs don't kill the camera during the tour.
+await page.evaluate(() => { const p = window.__game.sim.player; p.maxHp = 99999; p.hp = 99999; });
+await wait(300);
+
+// 1) DAY/NIGHT: wide scene in the starter vale — lighting is fixed (no time-of-day).
+await page.screenshot({ path: 'tmp/cr_daynight_scene.png' });
+
+// 2) REPUTATION/FACTION: target a hostile mob at the starter camp — the target frame shows
+// name/level/HP only, no faction standing (hostility is a single boolean today).
+try {
+  await page.evaluate(() => {
+    const sim = window.__game.sim, p = sim.player;
+    sim.targetNearestEnemy();
+    // Fallback: if no hostile is in range, target the nearest living non-self entity
+    // so the target frame is populated for the screenshot.
+    if (!p.targetId) {
+      let best = null, bd = Infinity;
+      for (const e of sim.entities.values()) {
+        if (e.id === p.id || e.hp <= 0 || e.kind === 'object') continue;
+        const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z, d = dx * dx + dz * dz;
+        if (d < bd) { bd = d; best = e; }
+      }
+      if (best) sim.targetEntity(best.id);
+    }
+  });
+  await wait(600);
+} catch {}
+await page.screenshot({ path: 'tmp/cr_faction_target.png' });
+
+// 3) ENCHANTING/GEMS: open the character paperdoll — equipped gear has no enchant lines
+// or gem sockets; this is where gear-enhancement would surface.
+try {
+  await page.evaluate(() => window.__game.hud.toggleChar());
+  await wait(700);
+} catch {}
+await page.screenshot({ path: 'tmp/cr_enchant_char.png' });
+try { await page.evaluate(() => window.__game.hud.toggleChar()); } catch {}
+await wait(300);
+
+// 4) WEATHER: move north into Mirefen Marsh — sky is clear everywhere, no weather state.
+await page.evaluate(() => { window.__game.sim.player.pos.z = 300; });
+await wait(1500);
+await page.screenshot({ path: 'tmp/cr_weather_scene.png' });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/scripts/elixir_shot.mjs
+++ b/scripts/elixir_shot.mjs
@@ -1,0 +1,94 @@
+// Screenshots for the Battle Elixir (Elixir of the Bear) content addition.
+// Runs the offline flow (no server/Postgres) on a desktop viewport.
+// Needs `npm run dev` running. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const CLASS = process.env.GAME_CLASS ?? 'warrior';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// Crop a screenshot to an element's bounding box (+ padding), clamped to the viewport.
+const cropTo = async (sel, path, pad = 16) => {
+  const box = await page.evaluate((s, p) => {
+    const el = document.querySelector(s);
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    const x = Math.max(0, r.left - p), y = Math.max(0, r.top - p);
+    return {
+      x, y,
+      width: Math.min(1280 - x, r.width + p * 2),
+      height: Math.min(720 - y, r.height + p * 2),
+    };
+  }, sel, pad);
+  if (box && box.width > 4 && box.height > 4) await page.screenshot({ path, clip: box });
+};
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Thorgar'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate((c) => document.querySelector(`#offline-select .mini-class[data-class="${c}"]`)?.click(), CLASS);
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+// Stay alive for the camera, and stock a few elixirs.
+await page.evaluate(() => {
+  const p = window.__game.sim.player; p.maxHp = 99999; p.hp = 99999;
+  window.__game.sim.addItem('elixir_of_the_bear', 5);
+});
+await wait(300);
+
+// Dispatch hover events in-page (the menus fail puppeteer's clickable-point check).
+const hoverInPage = (sel, pick) => page.evaluate((s, p) => {
+  const els = [...document.querySelectorAll(s)];
+  const el = p ? els.find((e) => new RegExp(p, 'i').test(e.textContent)) ?? els[0] : els[0];
+  if (!el) return false;
+  const r = el.getBoundingClientRect();
+  const x = r.left + r.width / 2, y = r.top + r.height / 2;
+  for (const type of ['mouseover', 'mouseenter', 'mousemove']) {
+    el.dispatchEvent(new MouseEvent(type, { bubbles: true, clientX: x, clientY: y }));
+  }
+  return true;
+}, sel, pick ?? null);
+
+// 1) Open bags and hover the elixir to show its tooltip (name + "Elixir" kind).
+await page.evaluate(() => window.__game.hud.toggleBags());
+await wait(500);
+await hoverInPage('#bags .bag-item', 'Elixir of the Bear');
+await wait(400);
+await page.screenshot({ path: 'tmp/elixir_tooltip.png' });
+await cropTo('#tooltip', 'tmp/elixir_tooltip_crop.png', 12);
+
+// 2) Use the elixir; capture the buff bar with the "Might of the Bear" buff.
+await page.evaluate(() => window.__game.hud.toggleBags());
+await wait(200);
+await page.evaluate(() => window.__game.sim.useItem('elixir_of_the_bear'));
+await wait(600);
+await hoverInPage('#buff-bar > div');
+await wait(400);
+await page.screenshot({ path: 'tmp/elixir_buff.png' });
+await cropTo('#tooltip', 'tmp/elixir_buff_crop.png', 12);
+
+// 3) Full-frame shot for context.
+await page.screenshot({ path: 'tmp/elixir_scene.png' });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -152,6 +152,13 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     id: 'minor_mana_potion', name: 'Minor Mana Potion', kind: 'potion', quality: 'common',
     potionMana: 120, sellValue: 8, buyValue: 40,
   },
+  // --- battle elixir: a temporary stat buff on use (classic flask/elixir staple).
+  // Drops from the Mirefen brutes; +Stamina helps anyone push deeper into the marsh.
+  elixir_of_the_bear: {
+    id: 'elixir_of_the_bear', name: 'Elixir of the Bear', kind: 'elixir', quality: 'uncommon',
+    elixir: { aura: 'Might of the Bear', kind: 'buff_sta', value: 12, duration: 900 },
+    sellValue: 20, buyValue: 100,
+  },
   conjured_water: {
     id: 'conjured_water', name: 'Conjured Spring Water', kind: 'drink', quality: 'common',
     drinkMana: 76, sellValue: 0,

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -148,6 +148,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'troll_fetish', chance: 0.6, questId: 'q_troll_fetishes' },
       { itemId: 'chipped_tusk', chance: 0.4 },
       { itemId: 'bogiron_nugget', chance: 0.3 },
+      { itemId: 'elixir_of_the_bear', chance: 0.07 },
     ],
     scale: 1.15, color: 0x229954,
   },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4974,6 +4974,18 @@ export class Sim {
         p.resource = Math.min(p.maxResource, p.resource + def.potionMana!);
       }
       this.emit({ type: 'log', text: `You quaff ${def.name}.`, color: '#c9f', pid: meta.entityId });
+    } else if (def.kind === 'elixir') {
+      // Battle elixir: grant a temporary stat-buff aura. Usable in combat (classic),
+      // no shared potion cooldown; re-quaffing refreshes the buff via applyAura.
+      const elx = def.elixir;
+      if (!elx) return;
+      this.removeItem(itemId, 1, meta.entityId);
+      this.applyAura(p, {
+        id: `elixir_${itemId}`, name: elx.aura, kind: elx.kind,
+        remaining: elx.duration, duration: elx.duration, value: elx.value,
+        sourceId: p.id, school: 'nature',
+      });
+      this.emit({ type: 'log', text: `You quaff ${def.name}.`, color: '#c9f', pid: meta.entityId });
     } else if (def.kind === 'weapon' || def.kind === 'armor') {
       this.equipItem(itemId, meta.entityId);
     }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -97,7 +97,7 @@ export type ItemUse =
 export interface ItemDef {
   id: string;
   name: string;
-  kind: 'weapon' | 'armor' | 'quest' | 'junk' | 'food' | 'drink' | 'tool' | 'potion';
+  kind: 'weapon' | 'armor' | 'quest' | 'junk' | 'food' | 'drink' | 'tool' | 'potion' | 'elixir';
   slot?: EquipSlot;
   weapon?: WeaponInfo;
   stats?: Partial<Stats>;
@@ -115,6 +115,10 @@ export interface ItemDef {
   // potions: restored instantly, usable in combat, share a cooldown (#103)
   potionHp?: number;
   potionMana?: number;
+  // elixirs: a temporary stat-buff aura granted on use (classic battle elixirs).
+  // `aura` is a flavor name shown in the buff frame; `value` is the stat amount,
+  // `duration` the buff length in seconds. Folds through the normal aura/stat path.
+  elixir?: { aura: string; kind: AuraKind; value: number; duration: number };
   quality?: 'poor' | 'common' | 'uncommon' | 'rare' | 'epic'; // gray/white/green/blue/purple name colors
   requiredClass?: PlayerClass[];
 }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -133,6 +133,7 @@ const ITEM_KIND_LABEL_KEYS: Record<ItemDef['kind'], TranslationKey> = {
   drink: 'itemUi.kind.drink',
   tool: 'itemUi.kind.tool',
   potion: 'itemUi.kind.potion',
+  elixir: 'itemUi.kind.elixir',
 };
 const ITEM_STAT_LABEL_KEYS: Partial<Record<keyof Stats, TranslationKey>> = {
   armor: 'itemUi.stats.armor',

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -7128,6 +7128,7 @@ const ITEM_ENTITY_IDS = [
   "fang_of_korzul", "trail_hardtack", "meltwater_flask", "roast_mountain_goat", "glacier_melt", "highwatch_warblade", "craghorn_staff",
   "icevein_dirk", "highwatch_breastplate", "peakwool_robe", "stalkerhide_jerkin", "cragwalker_boots", "windguard_leggings",
   "ogre_toe_ring", "inert_storm_shard", "frayed_prayer_beads", "cracked_wyrm_scale",
+  "elixir_of_the_bear",
 ] as const;
 
 type ItemEntityId = typeof ITEM_ENTITY_IDS[number];
@@ -7174,6 +7175,7 @@ const itemNamesEn = {
       "Wyrmcult Grand Robe", "Wyrmscale Jerkin", "Wyrmfang Greatblade", "Staff of the Gravewyrm", "Fang of Korzul", "Highwatch Trail Hardtack", "Meltwater Flask",
       "Roast Mountain Goat", "Glacier Melt", "Highwatch Warblade", "Craghorn Staff", "Icevein Dirk", "Highwatch Breastplate", "Peakwool Robe", "Stalkerhide Jerkin",
       "Cragwalker Boots", "Windguard Leggings", "Ogre Toe Ring", "Inert Storm Shard", "Frayed Prayer Beads", "Cracked Wyrm Scale",
+      "Elixir of the Bear",
     ]),
   },
 };
@@ -7207,6 +7209,7 @@ const itemNames = {
         "Gran toga del Culto del Wyrm", "Jubón de escamas de wyrm", "Gran hoja Colmillo de Wyrm", "Bastón del Gravewyrm", "Colmillo de Korzul", "Galleta de viaje de Highwatch", "Frasco de agua de deshielo",
         "Cabra montesa asada", "Agua de glaciar", "Hoja de guerra de Highwatch", "Bastón de Cuernorroca", "Puñal Vena de Hielo", "Coraza de Highwatch", "Toga de lana de cumbre", "Jubón de piel de acechador",
         "Botas Caminarrocas", "Leotardos Guardavientos", "Anillo de dedo de ogro", "Fragmento de tormenta inerte", "Cuentas de oración deshilachadas", "Escama de wyrm agrietada",
+        "Elixir del Oso",
       ]),
     },
   },
@@ -7238,6 +7241,7 @@ const itemNames = {
         "Grande robe du Culte du Wyrm", "Pourpoint en écailles de wyrm", "Grande lame Croc-de-wyrm", "Bâton du Gravewyrm", "Croc de Korzul", "Biscuit de route de Highwatch", "Flasque d'eau de fonte",
         "Chèvre de montagne rôtie", "Fonte de glacier", "Lame de guerre de Highwatch", "Bâton de corne-roche", "Dague Veine-de-glace", "Cuirasse de Highwatch", "Robe en laine des cimes", "Pourpoint en peau de rôdeur",
         "Bottes Marchecrag", "Jambières Gardevent", "Anneau d'orteil ogre", "Éclat de tempête inerte", "Perles de prière effilochées", "Écaille de wyrm fendue",
+        "Élixir de l'Ours",
       ]),
     },
   },
@@ -7270,6 +7274,7 @@ const itemNames = {
         "Grande veste del Culto del Wyrm", "Giaco di scaglie di wyrm", "Spadone Zanna di Wyrm", "Bastone del Gravewyrm", "Zanna di Korzul", "Galletta da sentiero di Highwatch", "Fiasca di acqua di disgelo",
         "Capra di montagna arrosto", "Fusione glaciale", "Lama da guerra di Highwatch", "Bastone di Corno Roccioso", "Pugnale Venaghiaccio", "Corazza di Highwatch", "Veste di lana delle vette", "Giaco di pelle di predatore",
         "Stivali Camminarocce", "Gambiere Guardavento", "Anello da dito d'ogre", "Scheggia di tempesta inerte", "Grani di preghiera sfilacciati", "Scaglia di wyrm incrinata",
+        "Elisir dell'Orso",
       ]),
     },
   },
@@ -7300,6 +7305,7 @@ const itemNames = {
         "Große Robe des Wyrmkults", "Wyrmschuppenwams", "Wyrmzahn-Großklinge", "Stab des Gravewyrm", "Korzuls Fangzahn", "Highwatch-Reisezwieback", "Schmelzwasserflasche",
         "Gebratene Bergziege", "Gletscherschmelze", "Highwatch-Kriegsklinge", "Felshornstab", "Eisaderdolch", "Highwatch-Brustplatte", "Gipfelwollrobe", "Pirschhauttunika",
         "Felswandererstiefel", "Windwachtgamaschen", "Ogerzehenring", "Träger Sturmsplitter", "Ausgefranste Gebetsperlen", "Gesprungene Wyrmschuppe",
+        "Bärenelixir",
       ]),
     },
   },
@@ -7330,6 +7336,7 @@ const itemNames = {
         "龙教大长袍", "龙鳞皮甲", "龙牙巨刃", "墓龙法杖", "科祖尔之牙", "高望行军硬饼", "融雪水瓶",
         "烤山羊", "冰川融水", "高望战刃", "岩角法杖", "冰脉短匕", "高望胸甲", "峰羊毛长袍", "潜猎者皮甲",
         "岩行者长靴", "风卫护腿", "食人魔趾环", "惰性风暴碎片", "磨损的祈祷珠", "裂开的龙鳞",
+        "熊之灵药",
       ]),
     },
   },
@@ -7360,6 +7367,7 @@ const itemNames = {
         "龍教大長袍", "龍鱗皮甲", "龍牙巨刃", "墓龍法杖", "科祖爾之牙", "高望行軍硬餅", "融雪水瓶",
         "烤山羊", "冰川融水", "高望戰刃", "岩角法杖", "冰脈短匕", "高望胸甲", "峰羊毛長袍", "潛獵者皮甲",
         "岩行者長靴", "風衛護腿", "巨魔趾環", "惰性風暴碎片", "磨損的祈禱珠", "裂開的龍鱗",
+        "熊之靈藥",
       ]),
     },
   },
@@ -7390,6 +7398,7 @@ const itemNames = {
         "고룡교단 대로브", "고룡비늘 웃옷", "고룡송곳니 대검", "무덤고룡의 지팡이", "코르줄의 송곳니", "하이워치 여정 건빵", "눈녹은 물 플라스크",
         "구운 산양", "빙하 녹은물", "하이워치 전투검", "바위뿔 지팡이", "얼음맥 더크", "하이워치 흉갑", "봉우리양모 로브", "추적자가죽 웃옷",
         "바위걸음 장화", "바람수호 다리보호구", "오우거 발가락 반지", "비활성 폭풍 파편", "해진 기도 구슬", "갈라진 고룡 비늘",
+        "곰의 묘약",
       ]),
     },
   },
@@ -7420,6 +7429,7 @@ const itemNames = {
         "ワーム教団の大ローブ", "ワーム鱗のジャーキン", "ワーム牙の大剣", "墓ワームの杖", "コルズルの牙", "ハイウォッチの旅堅パン", "雪解け水のフラスコ",
         "焼き山羊肉", "氷河の融け水", "ハイウォッチの戦刃", "岩角の杖", "氷脈のダーク", "ハイウォッチの胸当て", "峰羊毛のローブ", "追跡者革のジャーキン",
         "岩歩きのブーツ", "風守りのレギンス", "オーガの足指輪", "不活性の嵐片", "ほつれた祈りの数珠", "割れたワームの鱗",
+        "熊の霊薬",
       ]),
     },
   },
@@ -7450,6 +7460,7 @@ const itemNames = {
         "Grande veste do Culto do Wyrm", "Gibão de escamas de wyrm", "Grande lâmina Presa de Wyrm", "Cajado do Gravewyrm", "Presa de Korzul", "Biscoito de trilha de Highwatch", "Frasco de água de degelo",
         "Cabra montesa assada", "Derretimento glacial", "Lâmina de guerra de Highwatch", "Cajado Chifre de Rocha", "Punhal Veiogelo", "Peitoral de Highwatch", "Veste de lã das alturas", "Gibão de pele de espreitador",
         "Botas Caminhapedra", "Perneiras Guardavento", "Anel de dedo de ogro", "Estilhaço de tempestade inerte", "Contas de oração desfiadas", "Escama de wyrm rachada",
+        "Elixir do Urso",
       ]),
     },
   },
@@ -7480,6 +7491,7 @@ const itemNames = {
         "Великая роба Культа Вирма", "Куртка из вирмовой чешуи", "Великий клинок Клык Вирма", "Посох Могильного Вирма", "Клык Корзула", "Походный сухарь Хайвотча", "Фляга талой воды",
         "Жареный горный козел", "Ледниковая талая вода", "Боевой клинок Хайвотча", "Посох Камнерога", "Кортик Ледяной Жилы", "Кираса Хайвотча", "Роба из горной шерсти", "Куртка из шкуры охотника",
         "Сапоги Камнехода", "Поножи Ветростража", "Кольцо на палец огра", "Инертный осколок бури", "Истрепанные молитвенные четки", "Треснувшая чешуя вирма",
+        "Эликсир Медведя",
       ]),
     },
   },
@@ -7882,7 +7894,7 @@ const mergeStringsEn = {
   },
   itemUi: {
     ...itemNames.en.itemUi,
-    kind: { ...itemNames.en.itemUi.kind, tool: "Tool", potion: "Potion" },
+    kind: { ...itemNames.en.itemUi.kind, tool: "Tool", potion: "Potion", elixir: "Elixir" },
     tooltip: {
       ...itemNames.en.itemUi.tooltip,
       useFishing: "Use: Fish in nearby waters.",
@@ -8020,7 +8032,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.es.itemUi,
-      kind: { ...itemNames.es.itemUi.kind, tool: "Herramienta", potion: "Poción" },
+      kind: { ...itemNames.es.itemUi.kind, tool: "Herramienta", potion: "Poción", elixir: "Elixir" },
       tooltip: {
         ...itemNames.es.itemUi.tooltip,
         useFishing: "Uso: pesca en aguas cercanas.",
@@ -8156,7 +8168,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.fr_FR.itemUi,
-      kind: { ...itemNames.fr_FR.itemUi.kind, tool: "Outil", potion: "Potion" },
+      kind: { ...itemNames.fr_FR.itemUi.kind, tool: "Outil", potion: "Potion", elixir: "Élixir" },
       tooltip: {
         ...itemNames.fr_FR.itemUi.tooltip,
         useFishing: "Utiliser : pêcher dans les eaux proches.",
@@ -8293,7 +8305,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.it_IT.itemUi,
-      kind: { ...itemNames.it_IT.itemUi.kind, tool: "Strumento", potion: "Pozione" },
+      kind: { ...itemNames.it_IT.itemUi.kind, tool: "Strumento", potion: "Pozione", elixir: "Elisir" },
       tooltip: {
         ...itemNames.it_IT.itemUi.tooltip,
         useFishing: "Uso: pesca nelle acque vicine.",
@@ -8428,7 +8440,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.de_DE.itemUi,
-      kind: { ...itemNames.de_DE.itemUi.kind, tool: "Werkzeug", potion: "Trank" },
+      kind: { ...itemNames.de_DE.itemUi.kind, tool: "Werkzeug", potion: "Trank", elixir: "Elixier" },
       tooltip: {
         ...itemNames.de_DE.itemUi.tooltip,
         useFishing: "Benutzen: Angelt in nahen Gewässern.",
@@ -8563,7 +8575,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.zh_CN.itemUi,
-      kind: { ...itemNames.zh_CN.itemUi.kind, tool: "工具", potion: "药水" },
+      kind: { ...itemNames.zh_CN.itemUi.kind, tool: "工具", potion: "药水", elixir: "药剂" },
       tooltip: {
         ...itemNames.zh_CN.itemUi.tooltip,
         useFishing: "使用：在附近水域钓鱼。",
@@ -8698,7 +8710,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.zh_TW.itemUi,
-      kind: { ...itemNames.zh_TW.itemUi.kind, tool: "工具", potion: "藥水" },
+      kind: { ...itemNames.zh_TW.itemUi.kind, tool: "工具", potion: "藥水", elixir: "藥劑" },
       tooltip: {
         ...itemNames.zh_TW.itemUi.tooltip,
         useFishing: "使用：在附近水域釣魚。",
@@ -8833,7 +8845,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.ko_KR.itemUi,
-      kind: { ...itemNames.ko_KR.itemUi.kind, tool: "도구", potion: "물약" },
+      kind: { ...itemNames.ko_KR.itemUi.kind, tool: "도구", potion: "물약", elixir: "비약" },
       tooltip: {
         ...itemNames.ko_KR.itemUi.tooltip,
         useFishing: "사용: 가까운 물가에서 낚시합니다.",
@@ -8968,7 +8980,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.ja_JP.itemUi,
-      kind: { ...itemNames.ja_JP.itemUi.kind, tool: "道具", potion: "ポーション" },
+      kind: { ...itemNames.ja_JP.itemUi.kind, tool: "道具", potion: "ポーション", elixir: "エリクサー" },
       tooltip: {
         ...itemNames.ja_JP.itemUi.tooltip,
         useFishing: "使用: 近くの水辺で釣りをします。",
@@ -9103,7 +9115,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.pt_BR.itemUi,
-      kind: { ...itemNames.pt_BR.itemUi.kind, tool: "Ferramenta", potion: "Poção" },
+      kind: { ...itemNames.pt_BR.itemUi.kind, tool: "Ferramenta", potion: "Poção", elixir: "Elixir" },
       tooltip: {
         ...itemNames.pt_BR.itemUi.tooltip,
         useFishing: "Uso: pesca em águas próximas.",
@@ -9238,7 +9250,7 @@ const mergeStrings = {
     },
     itemUi: {
       ...itemNames.ru_RU.itemUi,
-      kind: { ...itemNames.ru_RU.itemUi.kind, tool: "Инструмент", potion: "Зелье" },
+      kind: { ...itemNames.ru_RU.itemUi.kind, tool: "Инструмент", potion: "Зелье", elixir: "Эликсир" },
       tooltip: {
         ...itemNames.ru_RU.itemUi.tooltip,
         useFishing: "Использование: ловите рыбу в ближайшей воде.",

--- a/src/ui/sim_i18n.ts
+++ b/src/ui/sim_i18n.ts
@@ -79,6 +79,7 @@ const baseEnTable = {
   "loot.rollWin": "{winner} wins {item} ({roll})",
   "aura.tamed": "Tamed",
   "aura.causticSpores": "Caustic Spores",
+  "aura.elixirBear": "Might of the Bear",
 } as const;
 
 const petEnTable = {
@@ -190,6 +191,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} wins {item} ({roll})",
     "aura.tamed": "Tamed",
     "aura.causticSpores": "Caustic Spores",
+    "aura.elixirBear": "Might of the Bear",
   },
   es: {
     "error.lineOfSight": "Sin línea de visión.",
@@ -255,6 +257,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} gana {item} ({roll})",
     "aura.tamed": "Domado",
     "aura.causticSpores": "Esporas Cáusticas",
+    "aura.elixirBear": "Poder del Oso",
   },
   es_ES: {
     "error.lineOfSight": "Sin línea de visión.",
@@ -320,6 +323,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} gana {item} ({roll})",
     "aura.tamed": "Domado",
     "aura.causticSpores": "Esporas Cáusticas",
+    "aura.elixirBear": "Poder del Oso",
   },
   fr_FR: {
     "error.lineOfSight": "Pas de ligne de vue.",
@@ -385,6 +389,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} remporte {item} ({roll})",
     "aura.tamed": "Apprivoisé",
     "aura.causticSpores": "Spores Caustiques",
+    "aura.elixirBear": "Puissance de l'Ours",
   },
   fr_CA: {
     "error.lineOfSight": "Pas de ligne de vue.",
@@ -450,6 +455,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} remporte {item} ({roll})",
     "aura.tamed": "Apprivoisé",
     "aura.causticSpores": "Spores Caustiques",
+    "aura.elixirBear": "Puissance de l'Ours",
   },
   en_CA: {
     "error.lineOfSight": "Line of sight.",
@@ -515,6 +521,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} wins {item} ({roll})",
     "aura.tamed": "Tamed",
     "aura.causticSpores": "Caustic Spores",
+    "aura.elixirBear": "Might of the Bear",
   },
   it_IT: {
     "error.lineOfSight": "Nessuna linea di vista.",
@@ -580,6 +587,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} vince {item} ({roll})",
     "aura.tamed": "Addomesticato",
     "aura.causticSpores": "Spore Caustiche",
+    "aura.elixirBear": "Potenza dell'Orso",
   },
   de_DE: {
     "error.lineOfSight": "Kein Sichtkontakt.",
@@ -645,6 +653,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} gewinnt {item} ({roll})",
     "aura.tamed": "Gezähmt",
     "aura.causticSpores": "Ätzende Sporen",
+    "aura.elixirBear": "Macht des Bären",
   },
   zh_CN: {
     "error.lineOfSight": "目标不在视线内。",
@@ -710,6 +719,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner}赢得了{item}（{roll}）",
     "aura.tamed": "已驯服",
     "aura.causticSpores": "腐蚀孢子",
+    "aura.elixirBear": "巨熊之力",
   },
   zh_TW: {
     "error.lineOfSight": "目標不在視線內。",
@@ -775,6 +785,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} 擲骰獲得 {item}（{roll}）",
     "aura.tamed": "馴服",
     "aura.causticSpores": "腐蝕孢子",
+    "aura.elixirBear": "巨熊之力",
   },
   ko_KR: {
     "error.lineOfSight": "시야가 막혀 있습니다.",
@@ -840,6 +851,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner}님이 {item}을(를) 획득했습니다 ({roll})",
     "aura.tamed": "길들여짐",
     "aura.causticSpores": "부식성 포자",
+    "aura.elixirBear": "곰의 힘",
   },
   ja_JP: {
     "error.lineOfSight": "視線が通っていません。",
@@ -905,6 +917,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner}が{item}を獲得しました（{roll}）",
     "aura.tamed": "テイム",
     "aura.causticSpores": "腐食胞子",
+    "aura.elixirBear": "熊の力",
   },
   pt_BR: {
     "error.lineOfSight": "Sem linha de visão.",
@@ -970,6 +983,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} vence {item} ({roll})",
     "aura.tamed": "Domado",
     "aura.causticSpores": "Esporos Cáusticos",
+    "aura.elixirBear": "Força do Urso",
   },
   ru_RU: {
     "error.lineOfSight": "Нет прямой видимости.",
@@ -1035,6 +1049,7 @@ const BASE_DICT: Record<SupportedLanguage, Record<BaseSimMessageKey, string>> = 
     "loot.rollWin": "{winner} выигрывает {item} ({roll})",
     "aura.tamed": "Приручён",
     "aura.causticSpores": "Едкие споры",
+    "aura.elixirBear": "Мощь Медведя",
   },
 };
 
@@ -1500,6 +1515,7 @@ function locPetMode(mode: string): string {
 // Flavor aura names (not abilities, not talents) shown in the buff frame / combat log.
 const AURA_NAME_KEY: Record<string, SimMessageKey> = {
   Tamed: 'aura.tamed',
+  'Might of the Bear': 'aura.elixirBear',
   Summoned: 'aura.summoned',
   Fed: 'aura.fed',
   'Caustic Spores': 'aura.causticSpores',

--- a/tests/elixir.test.ts
+++ b/tests/elixir.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Entity } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+describe('battle elixir (Elixir of the Bear)', () => {
+  it('grants the stamina buff aura and raises max HP on use', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const p = sim.entities.get(pid)! as Entity;
+    const beforeMaxHp = p.maxHp;
+
+    sim.addItem('elixir_of_the_bear', 1, pid);
+    sim.useItem('elixir_of_the_bear', pid);
+
+    const aura = p.auras.find((a) => a.id === 'elixir_elixir_of_the_bear');
+    expect(aura, 'elixir aura applied').toBeTruthy();
+    expect(aura!.kind).toBe('buff_sta');
+    expect(aura!.value).toBe(12);
+    expect(aura!.name).toBe('Might of the Bear');
+    expect(p.maxHp, 'stamina buff raises max HP').toBeGreaterThan(beforeMaxHp);
+  });
+
+  it('consumes one elixir per use', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+
+    sim.addItem('elixir_of_the_bear', 2, pid);
+    sim.useItem('elixir_of_the_bear', pid);
+    expect(sim.countItem('elixir_of_the_bear', pid)).toBe(1);
+  });
+
+  it('does nothing when the player has no elixir', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const p = sim.entities.get(pid)! as Entity;
+
+    sim.useItem('elixir_of_the_bear', pid);
+    expect(p.auras.some((a) => a.id === 'elixir_elixir_of_the_bear')).toBe(false);
+  });
+
+  it('re-quaffing refreshes the buff without stacking it', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Aleph');
+    sim.tick();
+    const p = sim.entities.get(pid)! as Entity;
+
+    sim.addItem('elixir_of_the_bear', 2, pid);
+    sim.useItem('elixir_of_the_bear', pid);
+    for (let i = 0; i < 20 * 5; i++) sim.tick(); // let it tick down ~5s
+    sim.useItem('elixir_of_the_bear', pid);
+
+    const auras = p.auras.filter((a) => a.id === 'elixir_elixir_of_the_bear');
+    expect(auras.length, 'only one elixir aura, refreshed').toBe(1);
+    expect(auras[0].remaining).toBeGreaterThan(890);
+  });
+});


### PR DESCRIPTION
## What

Adds **Elixir of the Bear** (Uncommon) — the first consumable that grants a *temporary stat-buff aura*. Using it applies **Might of the Bear: +12 Stamina for 15 minutes**.

Until now `useItem()` only supported potions (instant HP/mana restore) and food/drink (HP/mana over time while seated). No item conferred a lasting buff — a classic battle-elixir staple that was missing. It drops at **7%** from **Mirefen Trolls** (zone 2), giving anyone pushing deeper into the marsh a little extra survivability.

| Item tooltip | Buff (15 min) |
|---|---|
| ![item tooltip](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/battle-elixir-shots/shots/elixir_item_tooltip.png) | ![buff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/battle-elixir-shots/shots/elixir_buff.png) |

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/battle-elixir-shots/shots/elixir_scene.png)

## How

- New `elixir` `ItemDef` kind + an `elixir` buff descriptor (`{ aura, kind, value, duration }`) on `ItemDef` (`src/sim/types.ts`).
- `useItem()` gains an `elixir` branch (`src/sim/sim.ts`): it applies the buff through the **existing** `applyAura` → `recalcPlayerStats` path, so the +Stamina flows into max HP with **no new combat math**. Re-quaffing refreshes the aura without stacking; usable in combat, no shared potion cooldown.
- Item defined in `src/sim/content/items.ts`; loot entry on `fen_troll` in `src/sim/content/zone2.ts`.
- **Full i18n** across all 14 locales: item name, the new `Elixir` item-kind label, and the `Might of the Bear` aura flavor name — coverage/parity guards stay green.

## Tests

- `tests/elixir.test.ts` (4 cases): aura applied + max HP rises, consumes one per use, no-op without the item, and re-quaff refreshes without stacking.
- Full suite green: **1232/1232**. `tsc` clean, `npm run build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)