### PR TITLE
feat(content): enfeebling mobs drain a caster's Intellect on hit (Maddening Whisper)

### DIFF
--- a/scripts/enfeeble_visual.mjs
+++ b/scripts/enfeeble_visual.mjs
@@ -1,0 +1,134 @@
+// Screenshots for the "Maddening Whisper" enfeeble affix (Wyrmcult Zealot).
+// A landed hit drains the caster's Intellect, shrinking the mana pool, and shows
+// a red debuff on the buff bar. Runs the offline flow (no server). Needs
+// `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Lyra'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate(() => document.querySelector('#offline-select .mini-class[data-class="mage"]')?.click());
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+// Level the mage to 20 so a L17 Zealot's swing never one-shots it, and capture
+// the mana numbers before the curse for the console summary.
+await page.evaluate(() => {
+  const g = window.__game, sim = g.sim;
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  p.resource = p.maxResource; // start full
+});
+await wait(400);
+
+// Retemplate the nearest mob into a Wyrmcult Zealot, stage it in front of the
+// player, then force a few swings so the Maddening Whisper curse lands.
+const result = await page.evaluate(async () => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let mob = null, best = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < best) { best = d; mob = e; }
+  }
+  if (!mob) return { ok: false, why: 'no mob nearby' };
+  mob.templateId = 'wyrmcult_zealot';
+  mob.name = 'Wyrmcult Zealot';
+  mob.hostile = true;
+  mob.level = 17;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z; mob.pos.y = p.pos.y;
+  const intBefore = p.stats.int, maxManaBefore = p.maxResource;
+  // The data table chance is 0.3; swing repeatedly until the curse lands (most
+  // swings land — the L20 mage rarely misses being hit by a L17 mob).
+  let cursed = false;
+  for (let i = 0; i < 200 && !cursed; i++) {
+    p.hp = p.maxHp; // never let the swing kill us
+    sim.mobSwing(mob, p);
+    cursed = p.auras.some((a) => a.kind === 'buff_int' && a.value < 0);
+  }
+  return {
+    ok: cursed, intBefore, intAfter: p.stats.int,
+    maxManaBefore, maxManaAfter: p.maxResource,
+    aura: p.auras.find((a) => a.kind === 'buff_int' && a.value < 0)?.name ?? null,
+  };
+});
+
+if (!result.ok) {
+  // The data table chance is 0.3 — swing many more times to guarantee a proc.
+  await page.evaluate(() => {
+    const sim = window.__game.sim, p = sim.player;
+    let mob = null, best = 1e9;
+    for (const e of sim.entities.values()) {
+      if (e.templateId === 'wyrmcult_zealot' && !e.dead) { mob = e; break; }
+    }
+    if (!mob) return;
+    for (let i = 0; i < 400; i++) {
+      p.hp = p.maxHp;
+      sim.mobSwing(mob, p);
+      if (p.auras.some((a) => a.kind === 'buff_int' && a.value < 0)) break;
+    }
+  });
+}
+
+// Teleport the player away so combat ends and the 12s curse rides along, then
+// screenshot quickly before regen/recalc churn.
+await page.evaluate(() => {
+  const sim = window.__game.sim, p = sim.player;
+  p.pos.x -= 80;
+  p.prevPos = { ...p.pos };
+});
+await wait(160);
+await page.screenshot({ path: 'tmp/enfeeble-hud.png' });
+
+// Crop the buff bar (top-right, left of the minimap) for a legible debuff icon.
+try {
+  const clip = await page.evaluate(() => {
+    const el = document.querySelector('#buff-bar');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: Math.max(0, r.x - 12), y: Math.max(0, r.y - 8), width: Math.min(360, r.width + 24), height: Math.min(120, r.height + 50) };
+  });
+  if (clip && clip.width > 4) await page.screenshot({ path: 'tmp/enfeeble-buffbar.png', clip });
+} catch (e) { errors.push('buffbar crop: ' + e.message); }
+
+// Hover the debuff icon to surface its tooltip, then crop the top-right region.
+try {
+  await page.evaluate(() => {
+    const icon = document.querySelector('#buff-bar .buff.debuff') || document.querySelector('#buff-bar .buff');
+    if (!icon) return;
+    const r = icon.getBoundingClientRect();
+    const opts = { bubbles: false, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2 };
+    icon.dispatchEvent(new MouseEvent('mouseenter', opts));
+    icon.dispatchEvent(new MouseEvent('mousemove', { ...opts, bubbles: true }));
+  });
+  await wait(250);
+  await page.screenshot({ path: 'tmp/enfeeble-tooltip.png', clip: { x: 900, y: 0, width: 380, height: 230 } });
+} catch (e) { errors.push('tooltip: ' + e.message); }
+
+console.log('RESULT', JSON.stringify(result));
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -156,6 +156,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'wyrmcult_orders', chance: 0.5, questId: 'q_cult_orders' },
       { itemId: 'frayed_prayer_beads', chance: 0.35 },
     ],
+    // The zealot's fevered chanting claws at a caster's mind, draining Intellect
+    // and shrinking their mana pool for a while.
+    enfeeble: { chance: 0.3, int: 12, duration: 12, name: 'Maddening Whisper', school: 'shadow' },
     scale: 1.0, color: 0x76448a,
   },
   wyrmcult_necromancer: {

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -49,7 +49,10 @@ function hpFromStamina(sta: number): number {
   return Math.min(sta, 20) + Math.max(0, sta - 20) * 10;
 }
 function manaFromIntellect(int: number): number {
-  return Math.min(int, 20) + Math.max(0, int - 20) * 15;
+  // Floor at 0 so an Intellect-draining debuff (negative buff_int) can never push
+  // the mana pool below its level-based base into negative territory.
+  const i = Math.max(0, int);
+  return Math.min(i, 20) + Math.max(0, i - 20) * 15;
 }
 
 // Recompute all derived stats for the player from class, level, gear, buffs, and

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4101,6 +4101,24 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+    // Maddening curse: a landed hit can fog a caster's mind, draining Intellect
+    // and thus shrinking their mana pool. Mana users only (it does nothing to
+    // rage/energy users); hostile mobs only, so a friendly pet (mobSwing's other
+    // caller) never debuffs the party. Rides buff_int with a negative value, so
+    // recalcPlayerStats folds it through to maxResource with no new math.
+    const enfeeble = MOBS[mob.templateId]?.enfeeble;
+    if (enfeeble && mob.hostile && !target.dead && target.resourceType === 'mana' && this.rng.chance(enfeeble.chance)) {
+      this.applyAura(target, {
+        id: `enfeeble_${mob.templateId}`,
+        name: enfeeble.name,
+        kind: 'buff_int',
+        remaining: enfeeble.duration,
+        duration: enfeeble.duration,
+        value: -Math.abs(enfeeble.int),
+        sourceId: mob.id,
+        school: enfeeble.school ?? 'shadow',
+      });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -199,6 +199,12 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to fog the victim's mind,
+  // draining `int` Intellect for `duration` and thus shrinking a caster's mana
+  // pool (recalcPlayerStats clamps current mana down with the smaller ceiling).
+  // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
+  // resource math. Only meaningful on mana users — applied to them alone.
+  enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1774,7 +1774,8 @@ export class Hud {
     (el as any).__sig = sig;
     el.innerHTML = '';
     for (const a of e.auras) {
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind);
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+        || (a.kind.startsWith('buff_') && a.value < 0); // a negative stat aura (e.g. an Intellect-draining curse) is a debuff
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');
       d.className = 'buff' + (isDebuff ? ' debuff' : '');

--- a/tests/mob_enfeeble.test.ts
+++ b/tests/mob_enfeeble.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// A mage so the victim is a mana user; level it up so a L17 Zealot's swing
+// never one-shots it (death would clear the aura before we can read it).
+const makeSim = (cls: PlayerClass = 'mage') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+const spawnZealot = (sim: Sim) => {
+  const mob = createMob(990600, MOBS.wyrmcult_zealot, 17, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Swing until the maddening-whisper buff_int debuff lands (a swing can miss/dodge).
+const swingUntilCursed = (sim: Sim, mob: any, target: any, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_int' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob enfeebling curse (Maddening Whisper)', () => {
+  it('Wyrmcult Zealot template carries the enfeeble mechanic', () => {
+    expect(MOBS.wyrmcult_zealot.enfeeble).toBeDefined();
+    expect(MOBS.wyrmcult_zealot.enfeeble!.name).toBe('Maddening Whisper');
+  });
+
+  it('a landed hit applies a negative buff_int aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnZealot(sim);
+    const enfeeble = MOBS.wyrmcult_zealot.enfeeble!;
+    const old = enfeeble.chance;
+    enfeeble.chance = 1;
+    try {
+      expect(swingUntilCursed(sim, mob, player)).toBe(true);
+    } finally {
+      enfeeble.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_int');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Maddening Whisper');
+    expect(aura!.value).toBe(-enfeeble.int); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('shadow');
+  });
+
+  it('the curse lowers the victim Intellect and shrinks their mana pool', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnZealot(sim);
+    const intBefore = player.stats.int;
+    const maxManaBefore = player.maxResource;
+    const enfeeble = MOBS.wyrmcult_zealot.enfeeble!;
+    const old = enfeeble.chance;
+    enfeeble.chance = 1;
+    try {
+      swingUntilCursed(sim, mob, player);
+    } finally {
+      enfeeble.chance = old;
+    }
+    expect(player.stats.int).toBe(intBefore - enfeeble.int);
+    expect(player.maxResource).toBeLessThan(maxManaBefore);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnZealot(sim);
+    const enfeeble = MOBS.wyrmcult_zealot.enfeeble!;
+    const old = enfeeble.chance;
+    enfeeble.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilCursed(sim, mob, player);
+    } finally {
+      enfeeble.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_int' && a.value < 0).length).toBe(1);
+  });
+
+  it('never curses a non-mana victim (warrior uses rage)', () => {
+    const sim = makeSim('warrior');
+    const player = sim.player;
+    expect(player.resourceType).not.toBe('mana');
+    const mob = spawnZealot(sim);
+    const enfeeble = MOBS.wyrmcult_zealot.enfeeble!;
+    const old = enfeeble.chance;
+    enfeeble.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      enfeeble.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_int')).toBe(false);
+  });
+
+  it('a friendly pet never curses its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnZealot(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const enfeeble = MOBS.wyrmcult_zealot.enfeeble!;
+    const old = enfeeble.chance;
+    enfeeble.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      enfeeble.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_int' && a.value < 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit mob affix, **`enfeeble`**: a chance per landed melee swing to fog a *caster's* mind, draining their **Intellect** for a duration and thus shrinking their **mana pool**. The Thornpeak Heights **Wyrmcult Zealot** (L17-19 humanoid) gains **Maddening Whisper** — 30% chance on hit to drain **-12 Intellect for 12s**.

## Why it's a clean fit

The affix rides an **existing** stat path with **no new resource math**: a negative `buff_int` aura is folded by `recalcPlayerStats` (`entity.ts` `s.int += a.value`) straight into `maxResource`. This mirrors how `corrode` rides the `sunder` aura and `mortalStrike` rides `mortal_wound`.

It fills a distinct slot in the on-hit affix family — none of the existing mechanics touch a caster's resource *ceiling*:
- armor shred → `corrode`
- healing cut → `mortalStrike`
- damage-over-time → `venom`
- **Intellect drain / smaller mana pool → `enfeeble` (this PR)**

`recalcPlayerStats` preserves the current mana *fraction* while lowering the ceiling, so the curse clamps a caster's effective mana down for its duration — a sustained handicap rather than a one-time chip.

## Changes

- `src/sim/types.ts` — new `enfeeble?` field on `MobTemplate`.
- `src/sim/sim.ts` — apply the negative `buff_int` aura in `mobSwing` (after the Mortal Strike block). Guarded on `hostile` (a friendly pet swinging through `mobSwing` never debuffs the party) and on `resourceType === 'mana'` (no effect on rage/energy users). Refreshes by id+sourceId, never stacks.
- `src/sim/entity.ts` — floor `manaFromIntellect` at 0 so an Intellect drain can never push the mana pool negative.
- `src/ui/hud.ts` — classify a negative stat aura (`buff_*` with `value < 0`) as a red debuff, so the curse renders correctly on the buff bar.
- `src/sim/content/zone3.ts` — attach **Maddening Whisper** to `wyrmcult_zealot`.
- `tests/mob_enfeeble.test.ts` — 6 cases (template carries the affix, forced proc applies the negative `buff_int`, the curse lowers Intellect and shrinks max mana, single-slot refresh, non-mana victim is never cursed, friendly-pet hostile guard).

## Verification

- `npx vitest run tests/mob_enfeeble.test.ts` — 6 passed.
- Full suite green: **1234 passed**; `tsc --noEmit` clean.
- Live offline-client check (`scripts/enfeeble_visual.mjs`) confirmed the proc lands: a L20 mage's Intellect dropped **82 → 70** and max mana **1506 → 1326**, and the debuff renders red with its name and timer.

## Screenshots

Buff-bar tooltip on the cursed caster:

![Maddening Whisper tooltip](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/enfeeble-on-hit/shots/maddening-whisper-tooltip.png)

In-world HUD:

![HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/enfeeble-on-hit/shots/maddening-whisper-hud.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
