### PR TITLE
feat(wiki): public dev wiki at /dev (VitePress) + roadmap conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,17 @@ node scripts/smoke_rogue.mjs
 
 Browser or visual UI changes should be verified with a running dev server and browser automation when feasible.
 
+## Dev Wiki Sync Rules
+
+- The public dev wiki lives in `docs/wiki/*.md` (a VitePress site served at `/dev`) and is the source of truth for project direction: vision, roadmap, design lens, and the system-design backlog. The markdown is canonical; rebuild with `npm run devwiki:build`. It is dependency-isolated from the game (`docs/wiki/package.json`).
+- When a PR ships or changes a system, or shifts priorities, update the wiki **in the same PR**:
+  - Flip the status of the relevant design in `docs/wiki/system-designs/` (💡 Idea → 📐 Scoped → ✅ Ready → 🚧 In progress → 🏁 Shipped).
+  - Reflect behavior changes in `docs/wiki/current-state.md` (the implementation inventory).
+  - Move or annotate the matching item in `docs/wiki/roadmap.md`.
+  - Reference the affected wiki page(s) in the PR description.
+- Trivial PRs (typo, pure refactor, no behavior change) do not need wiki updates.
+- Keep wiki edits light: a status flip plus a line or two, not essays. Don't let wiki churn block a code PR — but don't let the roadmap silently drift from reality either.
+
 ## Git And Commit Rules
 
 - Do not commit unless the user explicitly asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,16 @@ correct*.
   run (`npx vitest run <file>`, `npm test`, `npm run build`, the S3 i18n guard
   `tests/localization_fixes.test.ts`), never on "looks done."
 
+## Dev wiki — keep it in sync
+The public dev wiki (`docs/wiki/*.md`, a VitePress site served at `/dev`) is the
+roadmap + system-design backlog — the **source of truth for project direction**.
+When a PR **ships or changes a system, or shifts priorities, update it in the same
+PR**: flip the relevant `docs/wiki/system-designs/` status, reflect it in
+`current-state.md`, move/annotate the `roadmap.md` item, and name the affected page
+in the PR description. Trivial/no-behavior PRs are exempt. Keep edits light (a status
+flip + a line). It's dependency-isolated; rebuild with `npm run devwiki:build`.
+
 ## Pointers
 `README.md` (host/develop/play + fidelity checklist) · `DEPLOY.md` (production) ·
-`CREDITS.md` (asset licenses) · `docs/design/` (design docs) · `docs/prd/` (feature specs).
+`CREDITS.md` (asset licenses) · `docs/wiki/` (dev wiki: vision/roadmap/system designs, at `/dev`) ·
+`docs/design/` (design docs) · `docs/prd/` (feature specs).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -6,6 +6,13 @@
 > https://worldofclaudecraft.com. Re-running
 > `ansible-playbook playbooks/setup_server.yml -e target_host=idyllic-games-prod`
 > pulls and redeploys. The guide below is the generic, standalone path.
+>
+> **Dev wiki note:** the public `/dev` development wiki is a **static VitePress
+> site** built from `docs/wiki/*.md` (`cd docs/wiki && npm ci && npm run build` →
+> `.vitepress/dist`), separate from the game build. Production fronts the stack
+> with **nginx** (not Caddy), so the `eastbrook_game` role in `ansible-scripts`
+> must (1) build the site on deploy and (2) serve `.vitepress/dist` at `/dev` with
+> extensionless-URL fallback (`try_files $uri $uri.html $uri/index.html =404;`).
 
 One EC2 instance runs everything: the game server, Postgres, MediaWiki, and Caddy
 (TLS reverse proxy). Sized for a small population — a `t4g.small`
@@ -58,6 +65,15 @@ the Elastic IP.
 ```bash
 ssh ubuntu@<elastic-ip>
 echo 'play.example.com {
+	# Public dev wiki — static VitePress build (docs/wiki/.vitepress/dist).
+	# handle_path strips /dev; try_files resolves VitePress clean URLs.
+	handle_path /dev/* {
+		root * /opt/eastbrook/docs/wiki/.vitepress/dist
+		try_files {path} {path}.html {path}/index.html
+		file_server
+		encode gzip
+	}
+	redir /dev /dev/
 	route /wiki* {
 		reverse_proxy localhost:8080
 	}
@@ -71,6 +87,26 @@ Caddy fetches and renews the Let's Encrypt certificate automatically;
 WebSockets are proxied with no extra config, and the client auto-selects
 `wss://` on https pages. Open `https://play.example.com` and you're live.
 
+### The public dev wiki (`/dev`)
+
+`worldofclaudecraft.com/dev` is a **static [VitePress](https://vitepress.dev) site**
+— a focused, searchable docs site for the development wiki (vision, roadmap, design
+lens, system designs). It is fully public; the same content lives openly in
+`docs/wiki/*.md` in the repo, which is the **source of truth**. The canonical way to
+change it is a **PR to the markdown**; the site rebuilds on deploy.
+
+It's deliberately **isolated from the game build** (its own `docs/wiki/package.json`,
+so VitePress never enters the game's dependency set). Build it separately:
+
+```bash
+cd /opt/eastbrook/docs/wiki && npm ci && npm run build   # → .vitepress/dist
+```
+
+The reverse proxy serves that `dist/` at `/dev` (see the Caddyfile above; use
+extensionless-URL fallback). Each page exposes a **Copy as Markdown** button, raw
+`/dev/raw/<page>.md` URLs, and `/dev/llms.txt` + `/dev/llms-full.txt` bundles so
+agents can ingest the docs directly.
+
 ## Updating the game
 
 ```bash
@@ -78,6 +114,7 @@ ssh ubuntu@<elastic-ip>
 cd /opt/eastbrook
 sudo git pull
 sudo docker compose up -d --build
+cd docs/wiki && npm ci && npm run build   # rebuild the /dev wiki from the markdown
 ```
 
 Players online during the restart are disconnected for a few seconds and

--- a/docs/wiki/.gitignore
+++ b/docs/wiki/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vitepress/dist/
+.vitepress/cache/

--- a/docs/wiki/.vitepress/config.mts
+++ b/docs/wiki/.vitepress/config.mts
@@ -1,0 +1,88 @@
+import { defineConfig } from 'vitepress'
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, dirname } from 'node:path'
+
+// World of Claudecraft — public dev wiki.
+// Source of truth is the markdown in docs/wiki/*.md; this just renders it as a
+// focused docs site (served at /dev). Deliberately isolated from the game build.
+export default defineConfig({
+  title: 'World of Claudecraft — Dev',
+  description: 'Public development wiki: vision, roadmap, design lens, and system designs.',
+  base: '/dev/',
+  cleanUrls: true,
+  lastUpdated: true,
+  // We link out to repo files (../README.md, ../prd/…) that aren't part of this site.
+  ignoreDeadLinks: true,
+  themeConfig: {
+    nav: [
+      { text: 'Roadmap', link: '/roadmap' },
+      { text: 'System Designs', link: '/system-designs/' },
+      { text: 'Play', link: 'https://worldofclaudecraft.com' },
+    ],
+    sidebar: [
+      {
+        text: 'Overview',
+        items: [
+          { text: 'Home', link: '/' },
+          { text: 'Vision', link: '/vision' },
+          { text: 'Current State', link: '/current-state' },
+          { text: 'Design Influences', link: '/design-influences' },
+          { text: 'Design Lens', link: '/design-lens' },
+          { text: 'Roadmap', link: '/roadmap' },
+        ],
+      },
+      {
+        text: 'System Designs',
+        items: [
+          { text: 'Backlog (TODO hub)', link: '/system-designs/' },
+          { text: 'Professions', link: '/system-designs/professions' },
+          { text: 'Equipment Slots', link: '/system-designs/equipment-slots' },
+        ],
+      },
+    ],
+    search: { provider: 'local' },
+    outline: { level: 'deep', label: 'On this page' },
+    docFooter: { prev: true, next: true },
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/levy-street/world-of-claudecraft' },
+    ],
+    editLink: {
+      pattern: 'https://github.com/levy-street/world-of-claudecraft/edit/main/docs/wiki/:path',
+      text: 'Edit this page on GitHub',
+    },
+    lastUpdatedText: 'Updated',
+  },
+
+  // Agent affordances: copy the raw source markdown of each page into the build
+  // (served at /dev/raw/<path>.md) and emit llms.txt / llms-full.txt bundles.
+  buildEnd(siteConfig) {
+    const { srcDir, outDir } = siteConfig
+    const pages: string[] = []
+    const walk = (dir: string) => {
+      for (const name of readdirSync(dir)) {
+        if (name === '.vitepress' || name === 'node_modules' || name.startsWith('.')) continue
+        const full = join(dir, name)
+        if (statSync(full).isDirectory()) walk(full)
+        else if (name.endsWith('.md')) pages.push(full)
+      }
+    }
+    walk(srcDir)
+    pages.sort()
+
+    let llms = '# World of Claudecraft — Dev Wiki\n\n'
+    llms += '> Public development wiki (vision, roadmap, system designs). '
+    llms += 'Each page\'s raw markdown is linked below; llms-full.txt has everything inline.\n\n'
+    let full = ''
+    for (const p of pages) {
+      const rel = relative(srcDir, p).split('\\').join('/')
+      const md = readFileSync(p, 'utf8')
+      const dest = join(outDir, 'raw', rel)
+      mkdirSync(dirname(dest), { recursive: true })
+      writeFileSync(dest, md)
+      llms += `- [${rel}](/dev/raw/${rel})\n`
+      full += `\n\n<!-- ===== ${rel} ===== -->\n\n${md}`
+    }
+    writeFileSync(join(outDir, 'llms.txt'), llms)
+    writeFileSync(join(outDir, 'llms-full.txt'), full.trim() + '\n')
+  },
+})

--- a/docs/wiki/.vitepress/theme/CopyMarkdown.vue
+++ b/docs/wiki/.vitepress/theme/CopyMarkdown.vue
@@ -1,0 +1,66 @@
+<script setup lang="ts">
+import { useData, withBase } from 'vitepress'
+import { ref, computed } from 'vue'
+
+const { page } = useData()
+const rawHref = computed(() => withBase('/raw/' + page.value.relativePath))
+const state = ref<'idle' | 'ok' | 'err'>('idle')
+
+async function copy() {
+  try {
+    const md = await (await fetch(rawHref.value)).text()
+    await navigator.clipboard.writeText(md)
+    state.value = 'ok'
+  } catch {
+    state.value = 'err'
+  }
+  setTimeout(() => (state.value = 'idle'), 1600)
+}
+
+const label = computed(() =>
+  state.value === 'ok' ? '✓ Copied' : state.value === 'err' ? '✗ Copy failed' : 'Copy as Markdown',
+)
+</script>
+
+<template>
+  <div class="copy-md">
+    <button type="button" @click="copy" title="Copy this page's raw Markdown for agents / LLMs">
+      {{ label }}
+    </button>
+    <a :href="rawHref" target="_blank" rel="noopener">View raw .md</a>
+    <a :href="withBase('/llms.txt')" target="_blank" rel="noopener" class="dim">llms.txt</a>
+  </div>
+</template>
+
+<style scoped>
+.copy-md {
+  display: flex;
+  gap: 0.85rem;
+  align-items: center;
+  margin: -0.5rem 0 1.25rem;
+  font-size: 0.8rem;
+}
+.copy-md button {
+  padding: 0.3rem 0.7rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-1);
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+}
+.copy-md button:hover {
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-elv);
+}
+.copy-md a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+.copy-md a:hover {
+  text-decoration: underline;
+}
+.copy-md a.dim {
+  color: var(--vp-c-text-3);
+}
+</style>

--- a/docs/wiki/.vitepress/theme/custom.css
+++ b/docs/wiki/.vitepress/theme/custom.css
@@ -1,0 +1,16 @@
+/* World of Claudecraft dev wiki — light brand tint over the default theme.
+   Structure (sidebar/TOC/search) is stock VitePress; this is only color. */
+:root {
+  --vp-c-brand-1: #c9a23a;
+  --vp-c-brand-2: #d8b24e;
+  --vp-c-brand-3: #b8902f;
+  --vp-c-brand-soft: rgba(201, 162, 58, 0.16);
+}
+.dark {
+  --vp-c-brand-1: #e3c45f;
+  --vp-c-brand-2: #f0d477;
+  --vp-c-brand-3: #c9a23a;
+}
+:root {
+  --vp-home-hero-name-color: var(--vp-c-brand-1);
+}

--- a/docs/wiki/.vitepress/theme/index.ts
+++ b/docs/wiki/.vitepress/theme/index.ts
@@ -1,0 +1,15 @@
+import DefaultTheme from "vitepress/theme";
+import { h } from "vue";
+import CopyMarkdown from "./CopyMarkdown.vue";
+import "./custom.css";
+
+// Extend the default theme with a "Copy as Markdown (for agents)" affordance
+// rendered just under each page title.
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      "doc-before": () => h(CopyMarkdown),
+    });
+  },
+};

--- a/docs/wiki/current-state.md
+++ b/docs/wiki/current-state.md
@@ -1,0 +1,126 @@
+# Current State — Implementation Inventory
+
+**Snapshot: v0.7.0 · 2026-06-16.** Derived from the code (`src/sim/`, `server/`, `src/net/`, `src/ui/`, `headless/`), not from memory. When you ship something, update its row here.
+
+**Legend:** ✅ **FULL** — implemented and playable · 🟡 **PARTIAL** — exists but narrow or placeholder · ❌ **ABSENT** — not built.
+
+---
+
+## At a glance
+
+| | |
+|---|---|
+| Version | **0.7.0** |
+| Level cap | **20** (`MAX_LEVEL`); post-cap prestige to virtual 200 |
+| Classes | **9** (all vanilla classes) |
+| Specs | **27** (3 talent specs per class) |
+| Abilities | **~138** (multi-rank, real vanilla scaling) |
+| Zones | **3** open-world (linear north strip) + 1 portal side-zone |
+| Quests | **~73** |
+| Dungeons | **4** (5-player); **0** raids |
+| Items | **74**; **4** equip slots of ~16 |
+| Languages | **12** (UI, sim text, server, admin) |
+| Hosts | Offline browser · Online server · Headless RL — all from one sim |
+
+---
+
+## Character systems
+
+| System | Status | Detail |
+|---|---|---|
+| Classes | ✅ FULL | 9 classes (`src/sim/content/classes.ts`): Warrior, Paladin, Hunter, Rogue, Priest, Shaman, Mage, Warlock, Druid. Per-class base stats, growth curves, HP/mana scaling, resource type, starting gear, ability kit. |
+| Talents & specs | ✅ FULL | 9 class trees + 27 spec trees, ~400 nodes (`talents.ts`, `talents_warrior.ts`, `talents_classic.ts`). 1 point/level from L10 = **11 points at cap**. Passive/active/choice nodes, signature ability + mastery passive per spec. Build strings (base64 import/export), **10 saved loadouts** per character, server-validated. |
+| Abilities | ✅ FULL | ~138 abilities with 2–3 ranks each, scaling to L20. Schools, cooldowns, cast times, CC, DoT/HoT — all talent-modifiable. |
+| Resources | ✅ FULL | Rage, Mana, Energy — real vanilla generation/cost. |
+| Primary stats | ✅ FULL | STR / AGI / STA / INT / SPI / Armor, with vanilla derived-stat rules (`recalcPlayerStats` in `entity.ts`). |
+| Equipment slots | 🟡 PARTIAL | **Only 4 slots:** `mainhand`, `chest`, `legs`, `feet` (`EquipSlot` in `types.ts`). Missing the other ~12 vanilla slots (head, shoulder, neck, back, wrist, hands, waist, rings ×2, trinkets ×2, ranged/offhand). |
+| Items | ✅ FULL (narrow) | 74 items, 4 quality tiers (poor→rare), weapon/armor/consumable/quest/junk. **No item sets / set bonuses. No enchanting. No epics tier-wise (rare is the top).** |
+| Character customization | 🟡 PARTIAL | Class + name + numeric `skin` index (0–7) + talent spec. **No races, no gender, no granular appearance (face/hair/color sliders).** |
+| Races | ❌ ABSENT | No race concept anywhere. All classes available to everyone. |
+
+## World & progression
+
+| System | Status | Detail |
+|---|---|---|
+| Zones | ✅ FULL (small) | 3 zones (`zone1/2/3.ts`): **Eastbrook Vale** (L1–7), **Mirefen Marsh** (L6–13), **Thornpeak Heights** (L13–20). One continuous north strip. Plus **The Drowned Temple** portal side-zone (L15–18). Each has a hub, graveyard, POIs, roads, biome. |
+| Leveling | ✅ FULL (to 20) | Levels 1–20, vanilla XP table, real group XP bonuses (1.166/1.3/1.43 for 3/4/5). Post-cap: lifetime-XP counter, prestige rank, milestones, leaderboard. **Known tuning note:** the XP curve spikes after ~level 9 — flagged for smoothing ([roadmap tuning](./roadmap.md#tuning--polish-ongoing-low-pressure)). The 1–9 and overall 1–20 shape is sound. |
+| Towns / hubs | ✅ FULL (narrow) | 4 hub settlements with quest givers, vendors, innkeepers, a market NPC. **No capital cities. No flight masters, stable masters, or class trainers as distinct NPCs** (abilities auto-learn). |
+| Quests | ✅ FULL | ~73 quests, kill/collect/hybrid, chained via `requiresQuest`, per-class rewards, group-recommended flags. **No escort/PvP/profession quest types; no daily/repeatable.** |
+| Dungeons | ✅ FULL | 4 instanced 5-player dungeons (`dungeons.ts`, `temple.ts`): Hollow Crypt, Sunken Bastion, Gravewyrm Sanctum, Drowned Temple. Bosses with real mechanics (enrage, AoE, adds, War Stomp). |
+| Raids | ❌ ABSENT | Party cap is 5; no raid instancing or difficulty. |
+| Mobs / NPCs | ✅ FULL | ~95 mob templates, ~40 spawn camps, elites, rares, 5 bosses. Living AI: aggro, social pulls, leash/reset, frenzy, flee, self-heal, cleave, pack rage, debuffs. |
+| Travel | 🟡 PARTIAL | Ground movement, swimming, graveyards + corpse runs. **No mounts, no flight paths, no fast travel, no taxi NPCs.** |
+| Factions | ❌ ABSENT | No Alliance/Horde split, no reputation factions, no faction-gated content. All players are one cooperative team. |
+
+## Multiplayer, social & moderation
+
+| System | Status | Detail |
+|---|---|---|
+| Authoritative server | ✅ FULL | HTTP + WS (`server/`), 20 Hz loop, interest-scoped delta snapshots (~90–130 yd), distance-tiered update rates, 16 KiB frame cap. |
+| Realms / sharding | ✅ FULL | Process-per-realm + shared Postgres; cross-realm picker UI; realm types (Normal/PvP/RP/RP-PvP). |
+| Persistence | ✅ FULL | Postgres; full character state as JSONB; 30 s autosave + on-disconnect + graceful shutdown; world/market state in `world_state`. |
+| Guilds | ✅ FULL | Create/disband, 100-member cap, leader/officer/member ranks, invites, guild + officer chat. |
+| Parties | ✅ FULL | 5-player, leader invites, shared XP/loot/quest credit, party chat, raid-style target markers. |
+| Friends / ignore | ✅ FULL | 50 each, presence tracking (zone/loc/status), mutual exclusion, chat filtering for ignores. |
+| Chat | ✅ FULL | say/yell/whisper/guild/officer/party/general/LFG/world; rate-limited; hard-word enforcement; 90-day logs. |
+| Auth / accounts | ✅ FULL | Scrypt, bearer tokens, per-IP + per-account throttle. |
+| Admin / moderation | ✅ FULL | Admin dashboard (live stats, queue), ban/suspend/mute, strike ladder, player reports, forced rename, chat filter config. |
+| Anti-cheat | 🟡 PARTIAL | Strong *implicit* protection (server authority, command validation) but no explicit movement/speed/teleport heuristics. |
+
+## Economy & PvP
+
+| System | Status | Detail |
+|---|---|---|
+| Currency | ✅ FULL (flat) | `copper` only — **no copper/silver/gold tiers** as separate denominations. |
+| Vendors | ✅ FULL | Fixed stock, buy/sell, 16-item buyback queue, class-gated items. |
+| Auction house | ✅ FULL | Server-authoritative "World Market": post/search/buy, expiry, seller collections, persisted across restarts. |
+| Player trading | ✅ FULL | Live, in-person, atomic swap (items + gold), item-lock during negotiation. |
+| Mail | ❌ ABSENT | No mailbox, no async item/gold delivery. |
+| Duels | ✅ FULL | Consensual 1v1, countdown, no XP/durability loss. |
+| Arena | ✅ FULL | Ranked 1v1, Elo/Glicko-style rating, matchmaking, decay, realm + global leaderboard. |
+| Battlegrounds | ❌ ABSENT | No instanced group PvP. |
+| World PvP | 🟡 PARTIAL | No faction hostility (no factions); duel/arena flagging + anti-grief only. |
+| Professions / crafting | ❌ ABSENT | No gathering, recipes, or crafted gear. Loot + vendors are the only item sources. |
+| LFG | 🟡 PARTIAL | LFG chat channel only — no matchmaking queue. |
+| Loot rules | 🟡 PARTIAL | Group share + tap rights + quest-priority; **no need/greed/pass UI.** |
+
+## RL environment & presentation
+
+| System | Status | Detail |
+|---|---|---|
+| RL env | ✅ FULL | `headless/env_server.ts` + `python/wow_env.py`. Gym-compatible, NDJSON protocol, Discrete(23) action space, float32 obs, configurable reward, deterministic episodes, ~200k steps/s single-core. Currently exposes 2 classes (warrior, mage). |
+| Renderer | ✅ FULL | Three.js, procedural geometry/VFX, quality tiers, character art via KayKit packs, 12 rigged creature families. |
+| HUD / UI | ✅ FULL | Classic unit frames, action bar, cast/channel bar, spellbook, paperdoll, quest log, world map, minimap, vendor/loot/AH windows, tooltips, FCT, combat log. |
+| Mobile / touch | ✅ FULL | Joystick, action buttons, haptics, left-handed, notch handling. |
+| Localization | ✅ FULL | 12 languages across UI, sim text, server messages, admin. |
+| Audio | ✅ FULL | Procedural WebAudio (no audio files). |
+
+---
+
+## Gap analysis — answering the questions the team keeps asking
+
+The dev questions that prompted this cycle, answered against the code, with the GDD's committed direction:
+
+| Question | Where we are | Committed direction (see [roadmap.md](./roadmap.md)) |
+|---|---|---|
+| **Starting zones?** | ✅ One starting zone (Eastbrook Vale, L1–7), shared by all 9 classes. | Stays single + shared **until factions/races land** — then race-specific starting experiences. Until then, improve the existing funnel. |
+| **Levels 1–60?** | 🟡 Currently **1–20**. Pipeline (zones→ranks→gear→dungeons) is proven *at 20*. | **Raise to 40 next** as one milestone to prove the pipeline scales; decide on 60 from evidence. *Not* a near-term 60 sprint. |
+| **Towns and hub cities?** | ✅ 4 functional hubs; ❌ no capital cities, ❌ no trainers/flight masters as NPCs. | Add a proper **capital/hub city** and real service NPCs (flight masters arrive with mounts/travel; trainers optional). |
+| **Factions?** | ❌ None — one cooperative playerbase. | **Add Alliance/Horde + reputation factions over time.** Big identity shift; sequenced *after* the 40 push because it reshapes new-player flow and world PvP. |
+| **Character customization?** | 🟡 Class + name + 8 skins + spec. ❌ No races/gender/appearance depth. | **Expand to races (with racials) + richer appearance.** Races are the headline of the Identity Expansion. |
+| **Item slots?** | 🟡 **4 of ~16** (`mainhand`/`chest`/`legs`/`feet`). | **Fill out all slots** — highest-fidelity-per-effort win, lands early (Now/Next). Unblocks set bonuses, deeper itemization, trinkets. |
+
+### The biggest gaps, ranked by "distance from vanilla feel"
+
+1. **Item slots (4 → ~16)** — the single most-felt gap; gear is half the game and we expose a quarter of it.
+2. **Professions / crafting** — an entire vanilla pillar is absent; also the economy's missing supply side.
+3. **Factions + races** — the core identity that makes it feel like *this* genre, not just a generic RPG.
+4. **Mounts / flight paths / mail** — the connective tissue of a lived-in world.
+5. **Level breadth (20 → 40 → ?)** — more world to grow into.
+6. **Raids + battlegrounds** — the endgame loops, once there's an endgame worth instancing.
+
+### Cross-cutting concerns to watch
+
+- **RL parity.** Every new system changes the observation/action space. The env currently exposes 2 of 9 classes; growth must keep the headless env honest or the "one sim, three hosts" pillar erodes.
+- **Community feedback has no intake.** Discussion happens in Discord but nothing structured pipes into planning. This is a *process* gap, not a code gap — addressed as a Now item in the roadmap.
+- **Determinism tax.** Every feature must route randomness through `Rng` and avoid wall-clock. Factions/professions/crafting all add RNG surfaces — budget for it.

--- a/docs/wiki/design-influences.md
+++ b/docs/wiki/design-influences.md
@@ -1,0 +1,82 @@
+# Design Influences
+
+What we draw from — and deliberately *reject* — when deciding where World of Claudecraft goes. Two sources: **vanilla WoW Classic** (the genre's high-water mark, and our fidelity north star) and **Titan Reforged / Chrono** (China's 2025 first-party server, for its modern retention loops). Everything here is filtered through our [pillars](./vision.md#design-pillars) and the [$WOC guardrails](./vision.md#the-woc-token-guardrails).
+
+> **The one-sentence stance:** *keep vanilla's journey, borrow Titan Reforged's retention loops — and whatever the token does (cosmetic or power, per the [fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything)), keep it out of the deterministic sim and server-authoritative.*
+
+---
+
+## Part 1 — Vanilla WoW Classic: the most-loved fundamentals
+
+Why Classic endured. For each: do we already honor it, should we preserve it, or should we add it.
+
+| Loved fundamental | Why players love it | Our status |
+|---|---|---|
+| **The leveling journey IS the game** | Slow, earned, every level meaningful; a new rank/ability from the trainer is a real reward — not a chore to skip. | ✅ Have (1–20, real XP curve). **Preserve as we raise the cap** — never trivialize the climb. |
+| **A dangerous, un-streamlined world** | Elite mobs, group quests in the open world, corpse runs, eat/drink downtime. Danger makes the world feel *real*. | ✅ Have (living AI, corpse runs, downtime). **Preserve.** |
+| **Talent builds & character identity** | Deep trees, meaningful choices, theorycrafting; your build is *you*. | ✅ Have (27 specs, ~400 nodes, loadouts). |
+| **Social fabric & server identity** | You *needed* people; reputations formed; no cross-realm anonymity. The community was the content. | 🟡 Partial (guilds/parties/friends, realm-scoped). **Protect against anonymizing "convenience."** |
+| **Dungeons as destinations** | Long, run-based, attunements/keys, class quests, dungeon sets; getting there is part of it. | ✅ Have (4 five-player dungeons). **Add depth: keys/attunements, dungeon sets.** |
+| **The gear chase & itemization** | Gear is rare and exciting; the "ding" blue drop; pre-raid BiS; world drops. | 🟡 Partial. **Biggest gap — only 4 of ~16 slots; no sets.** |
+| **Professions deeply integrated** | Gathering, crafting, recipes, profession economy — a second progression system. | ❌ Absent. **High-value add.** |
+| **Reputation grinds & attunements** | Long-term goals beyond level (rep bars, quartermasters, raid keys). | ❌ Absent. **Add — pairs with factions.** |
+| **World bosses & world PvP** | Emergent open-world conflict and spectacle (Kazzak-style). | ❌ Absent. **Add — see world events below.** |
+| **Player-driven economy & AH** | Server-specific markets, real supply/demand. | ✅ Have (World Market, trading). **Professions give it a supply side.** |
+| **Class fantasy & class quests** | Hunter pet taming, Warlock mount, Paladin charger — power that's *earned through story*. | 🟡 Partial (kits exist; no class quests). |
+| **Mounts at 40 / the long reward** | No instant gratification; the 40 mount is a milestone you *remember*. | ❌ Absent. **Tie to the cap-40 milestone (see roadmap).** |
+| **40-man raids as the social apex** | The endgame is *cooperative spectacle* with your guild. | ❌ Absent (party cap 5). **The cap-60 era.** |
+
+**What this tells us:** our combat/sim core is already deeply faithful; our gaps are the *world systems* that turn a good combat game into a *world* — itemization breadth, professions, reputation, mounts, world bosses, raids, and more levels to grow into.
+
+---
+
+## Part 2 — Titan Reforged / Chrono (China, 2025): modern retention loops
+
+### What it is
+A **China-exclusive, first-party** Blizzard + NetEase server (early access Nov 14, live Nov 18, 2025). A "raid rush" fusing **Vanilla + TBC + WotLK** rescaled to level 80. The **Chrono** variant ("时光/time") is the accelerated, weekly-rotating-raid flavor — the "timeforged" idea. The name echoes retail's old **Titanforged** loot (gear rolling *higher* than base), reworked here into a deliberate, *earned* upgrade ladder.
+
+> ⚠️ It is a **first-party product**, not a private server. We draw **design** inspiration, not anything else.
+
+### The features Chinese players love most (ranked)
+
+1. **The Titan System — account-wide, permanent power progression.** *The* headline. A power track on your **account**, not one character; everything you do feeds it. Kills the most-hated pain point: *"grinding to 60 on three characters."*
+2. **Dual earned currencies for all playstyles.** **Titan Fragments** (PvE: quests/dungeons/gathering/professions) + **Titan's Embers** (PvP + raids) → spend on **gear upgrades** and powerful items. Solo, social, PvP all earn.
+3. **Upgradeable gear & legendaries.** Loot — including famous legendaries — **upgrades to stay relevant** across phases. Nothing instantly obsolete.
+4. **Dynamic world events + dynamic world-boss loot.** Events spawn across the map for **Titan XP, cosmetics, gear** — reviving old zones and creating spontaneous group play.
+5. **Alt-friendly / catch-up by design.** Daily objectives + account-wide power keep alts and returners relevant without regrinding.
+6. **Reworked professions + lowered reputation barriers.** Professions impactful; rep grinds less punishing.
+7. **Endgame-first raid rush.** Fast leveling, then weekly **Fated-style** raid rotation at a single 25-player difficulty + tier-set redesigns.
+
+### Why it resonates (the cultural pattern)
+The through-line is **respect for player time + always-on numeric growth**. Chinese MMO audiences are multi-alt and efficiency-minded; **account-wide growth (账号养成)** is a beloved 国服 staple. Daily objectives + a power bar that always ticks up = the long-term loop they expect — modernizing the *grind* without touching combat identity, and marketed explicitly as **no pay-to-win**.
+
+---
+
+## Part 3 — What we adopt, adapt, and reject
+
+### ✅ Adopt (fits our pillars cleanly)
+- **An account-wide progression track — but COSMETIC/QoL, not power.** We already have lifetime-XP, prestige, and milestones; extend them into an account "Renown"-style track of titles, cosmetics, and conveniences. This is also the natural home for **$WOC cosmetic entitlements**.
+- **Dynamic world events that reward cosmetics + account XP.** Reuses zones, drives social play, fits "procedural everything," and rewards in exactly the lane the token guardrail allows.
+- **A dual-currency, earned upgrade loop** (a PvE currency + a PvP currency) feeding a **gear upgrade ladder** — so every playstyle progresses, and gear stays relevant. **Power is earned in-game, never bought.**
+- **Alt-friendly catch-up + daily/world objectives.** Cheap to honor; respects player time; deepens retention.
+
+### 🔁 Adapt (good idea, our flavor)
+- **Account power → account *cosmetic/prestige*.** We take the *always-on growth* feeling but keep raw stats earned per-character, on the journey.
+- **Raid rotation → our endgame, our scale.** Weekly featured content is great; we apply it to *our* 5/10-player content at *our* caps, not a 3-expansion rush.
+
+### 🔴 Reject (collides with our identity)
+- **The "raid rush" / skip-the-journey premise.** Titan Reforged is endgame-first; **we are journey-first vanilla.** We borrow its loops, not its skip. The climb stays sacred.
+- **Account-wide *raw power* — by default.** A roster-wide power bar collides with vanilla fidelity, so the **default (Fork B)** keeps account-wide rewards cosmetic/QoL. Under **Fork A** it's on the table — bounded only by the two structural guardrails (sim-external, server-authoritative), not by a no-power rule.
+- **Anything that anonymizes the social layer** for convenience (cross-realm everything, instant teleport-to-content). The community *is* the content.
+
+---
+
+## The synthesized design principles
+
+1. **Preserve the journey; modernize the grind.** Add catch-up, dailies, and upgrade loops — but never make leveling skippable or trivial.
+2. **Token stays structural; power-source is a choice.** The hard rule is only that $WOC never enters the deterministic sim and is server-authoritative. Whether power is earned-only (Fork B, the default) or partly token-driven (Fork A) is the open [fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything).
+3. **Reward every playstyle.** Dual currencies + world events mean solo, social, and PvP players all progress.
+4. **Always-on growth, the right way.** Give players a bar that always ticks up — make it a *cosmetic/prestige* bar, not a stat bar.
+5. **Protect the social fabric.** Server identity and real grouping over anonymizing convenience.
+
+**Sources:** [Massively OP](https://massivelyop.com/2025/09/24/world-of-warcraft-china-preps-exclusive-titan-reforged-servers-confirms-new-classic-content-coming-globally/) · [Wowhead — release/upgrades](https://www.wowhead.com/wotlk/news/chinas-titan-reforged-server-releases-november-18th-tier-set-redesign-379090) · [Wowhead — currencies/professions/world-boss loot](https://www.wowhead.com/wotlk/news/titan-reforged-server-preview-new-currencies-profession-changes-and-dynamic-379175) · [Warcraft Wiki — Chrono](https://warcraft.wiki.gg/wiki/Titan_Reforged_-_Chrono) · [SSEGold explainer](https://www.ssegold.com/wow-classic-titan-reforged-china-server-explained) · [LagoFast guide](https://www.lagofast.com/en/blog/wow-titan-forged-servers-guide/)

--- a/docs/wiki/design-lens.md
+++ b/docs/wiki/design-lens.md
@@ -1,0 +1,72 @@
+# Design Lens
+
+How we decide *what* to build and *how* to scope it. Run every feature, spike, or sprint through this before it becomes a [system design](./system-designs/index.md). Pairs with [design-influences.md](./design-influences.md) (what we borrow) and feeds [roadmap.md](./roadmap.md) (sequencing).
+
+---
+
+## The four gut-checks
+
+Ask these *before* writing a spec. If a feature can't answer at least two with conviction, it's probably polish, not a sprint.
+
+1. **How does this announce?** Is there a moment worth posting — a release note, a clip, a "professions are live" beat? Features that don't announce don't compound.
+2. **How does this meme?** Is it screenshottable / clippable / quotable? "Disenchanted my BiS by accident," an enchant glow, a world-boss wipe. Memes are free distribution.
+3. **How does this get more people through the gate?** Acquisition (new players), reactivation (returners), or retention (daily reason to log in)? Name which, honestly.
+4. **Are we playing defense or offense?** Offense creates an advantage others don't have (a vanilla pillar competitors lack, a novel loop). Defense closes a gap players complain about. Both are valid — but know which, and don't dress up defense as offense.
+
+Every system design records its answers to these four at the top. They're a forcing function, not paperwork.
+
+## Pillar fit (the veto)
+
+A feature that wins all four gut-checks still doesn't ship if it breaks a [pillar](./vision.md#design-pillars):
+
+- **One sim, three hosts** — logic lives in `src/sim/`, runs identically offline/online/headless.
+- **Determinism** — randomness through `Rng`, no wall-clock. Same seed ⇒ same world.
+- **Server-authoritative** — the client renders; it never decides outcomes.
+- **Token stays structural** — whatever $WOC does, it never enters the deterministic sim and is granted/verified server-side (the two [token guardrails](./vision.md#the-woc-token--guardrails)). *Whether* it confers power is a fork choice, not a veto.
+- **Journey-first** — modernize the grind, never make the climb skippable.
+
+---
+
+## The strategic fork (the decision that colors everything)
+
+We have two coherent directions. They aren't fully mutually exclusive, but they pull effort, design, and risk in different directions — so **pick a primary**. This is the single most important open decision; most roadmap arguments are really arguments about which fork we're on.
+
+### Fork A — Crypto-forward
+
+**Thesis:** the $WOC token is the headline; the game is the engine that gives it meaning.
+
+- **Optimize for performance over content depth.** Keep the sim and netcode extremely fast and cheap to run; depth is secondary to a tight, reliable, high-throughput loop.
+- **Add P2E + simple risk-to-earn loops.** Wagered duels/arenas, stake-to-enter events, seasonal earn ladders, sinks and faucets that make the economy the game.
+- **Implications:** performance benchmarks become first-class (a real dev outlet — see the [Performance Benchmarks](./system-designs/index.md) system design); token integration moves *up* the roadmap; economy design dominates.
+- **Still bounded by the two structural guardrails.** P2E is *allowed* — "no power" is not a rule (see [token guardrails](./vision.md#the-woc-token--guardrails)). But even P2E must stay **out of the deterministic sim** and **server-authoritative**: the wallet drives an *entitlement* the server reads, never a value the sim core touches. The RL env must still run identically with or without a token.
+- **⚠️ Identity weight — decide, don't drift.** P2E/risk-to-earn carries real regulatory, perception, and player-trust weight, and it's hard to walk back. It's a legitimate choice, not a guardrail violation — but make it consciously.
+
+### Fork B — Vibe-coded game
+
+**Thesis:** the game is the headline; it wins by being uniquely *maintainable and extensible* by AI-assisted contributors.
+
+- **Optimize for maintainability + extensibility.** Lean into the scaffolding that lets other people (and their agents) safely add content: clear [system-design specs](./system-designs/index.md), contribution ergonomics, strong tests, clean seams. (The model Fernando's been demonstrating — community-extensible, AI-built.)
+- **Content depth via the system-design backlog.** Professions, factions, the cap ladder — shipped as pluckable specs that contributors fill out and balance.
+- **Implications:** invest in the backlog quality, the contribution path, determinism/test guarantees, and docs. The project becomes a *platform* others build on; the token stays cosmetic-only and uncontroversial.
+- **Risk:** slower raw economic monetization; depends on attracting contributors.
+
+### How to use the fork
+
+- Until it's decided, the roadmap is written **Fork-B-default** (vanilla-faithful, cosmetic-only token, extensibility-first) because it preserves optionality — you can always turn on Fork A later, but P2E is hard to walk back.
+- Tag each system design with which fork it serves (`Both`, `Fork A`, `Fork B`). Anything tagged `Fork A` that touches token-for-power is **blocked** until the fork is explicitly chosen.
+
+> **Open decision:** which fork is primary? This belongs to the project owner, not the spec. Everything token-for-power waits on it.
+
+---
+
+## From idea to shipped (the workflow)
+
+```
+idea ─▶ design-lens gut-check ─▶ system design doc (scoped tiers) ─▶ pluck a spec ─▶ implement ─▶ ship ─▶ update current-state
+        (announce/meme/gate,        (status, lens answers,            (one tier =       (Claude or a
+         offense/defense, fork)      pillar fit, 1.0/2.0,             one sprint)        contributor
+                                     balance Qs, hook points,
+                                     acceptance/tests)
+```
+
+The [System Designs backlog](./system-designs/index.md) is where ideas that pass the lens live as scoped, pluckable specs. A "TODO" section inside a system design is a unit of work someone can pick up, balance, and build — without re-litigating the why.

--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -1,0 +1,48 @@
+# World of Claudecraft — Dev Wiki
+
+The single source of truth for **where the game is**, **where it's going**, and **why**.
+A **public development roadmap** for the dev team and contributors (not a player-facing
+manual). It lives in `docs/wiki/*.md` in the repo — edit it by PR — and renders at
+`worldofclaudecraft.com/dev`.
+
+> Snapshot: **v0.7.0** · level cap **20** · 9 classes · 3 zones · ~73 quests · 4 dungeons
+> Last reviewed: **2026-06-16**
+
+## Pages
+
+| Page | What it answers |
+|---|---|
+| [vision.md](./vision.md) | What this project *is*, the design pillars, the north star, and the hard guardrails (incl. the $WOC token stance). Read this first. |
+| [current-state.md](./current-state.md) | Grounded inventory of every system — FULL / PARTIAL / ABSENT — straight from the code, plus the gap analysis that maps to the questions the dev team keeps asking. |
+| [design-influences.md](./design-influences.md) | What we draw from (vanilla Classic's most-loved fundamentals + China's Titan Reforged retention loops) and what we deliberately reject. The "why" behind the roadmap. |
+| [design-lens.md](./design-lens.md) | How we decide *what* to build: the announce/meme/gate/offense-defense gut-checks, the pillar veto, and the **crypto-vs-vibe strategic fork**. Run features through this before they become specs. |
+| [roadmap.md](./roadmap.md) | The prioritized plan, spined on the **20 → 30 → 40 → 60** cap ladder: Now → Retention loops → Next → Cap rungs → Identity Expansion. What ships in what order, and why. |
+| [system-designs/index.md](./system-designs/index.md) | The **backlog of scoped, pluckable specs** (the TODO hub). Pick a tier, balance the numbers, build it. [Professions](./system-designs/professions.md) is the worked example. |
+
+## The four steering decisions this cycle (2026-06-16)
+
+These were decided deliberately and shape everything downstream. If you want to change one, change it *here* and ripple it through the pages.
+
+1. **Level cap: climb a deliberate ladder — 20 → 30 → 40 → 60.** Not a sprint. Each rung is a full vanilla-faithful tier (zones, ranks, gear, dungeons) with a measurement gate before the next: **30** is the cheap pipeline proof, **40** is the real test (and brings mounts + the first raid), **60** is the full endgame prize. The journey stays sacred — we never make leveling skippable. See [roadmap.md](./roadmap.md#high-level-goal-the-progression-ladder-20--30--40--60).
+2. **$WOC token: two structural guardrails, and power-vs-cosmetic left open.** The only non-negotiables are *the sim never sees it* and *authority stays server-side*. Whether the token confers power (P2E) or only cosmetics is an **open product decision** — the [strategic fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything), not a fixed rule. See [vision.md](./vision.md#the-woc-token-guardrails).
+3. **Factions + races: yes, over time.** We commit to the full vanilla identity — a two-faction split and playable races with racial traits — but it lands *after* the 40 push because it reshapes character creation, starting zones, and world PvP.
+4. **"Vanilla over time" is the directional bias.** When in doubt, move toward classic-era fidelity (real formulas, real systems) rather than inventing mechanics. Depth and breadth both matter; sequence them deliberately.
+
+## How to keep this wiki honest
+
+- **current-state.md is derived from code.** When you ship a system, update its row. A wiki that lies is worse than no wiki.
+- **roadmap.md is derived from decisions.** When priorities shift, move the item and note why — don't silently delete.
+- **vision.md changes rarely.** It's the constitution. Pillars and guardrails should be stable; if one bends, that's a big deal and worth a paragraph.
+- **system-designs/ is the work queue.** Ideas that pass the [Design Lens](./design-lens.md) become scoped, pluckable specs. A contributor (or Claude) picks a tier, balances the open numbers, and builds it — then updates current-state. That's the loop: idea → lens → spec → pluck → ship.
+- Cross-link liberally. Each page assumes you might land on it cold.
+
+## Related existing docs (not duplicated here)
+
+| Doc | Scope |
+|---|---|
+| `README.md` | Host/develop/play guide + the classic-fidelity checklist (formulas, per-class ranks). |
+| `docs/design/master-spec.md` | The full L6–20 content spec (zones 2–3, quests, dungeons, XP math). |
+| `docs/design/spell-ranks.md` | Every ability rank L1–20 for all 9 classes. |
+| `docs/design/ue5-overhaul-plan.md` · `graphics-plan.md` | Renderer / asset direction. |
+| `docs/prd/` | Per-feature PRDs (talents, max-level overflow — both now shipped). |
+| `CLAUDE.md` (root + per-dir) | Architecture invariants and conventions. **The "one sim, three hosts" rule governs every roadmap item.** |

--- a/docs/wiki/package-lock.json
+++ b/docs/wiki/package-lock.json
@@ -1,0 +1,2519 @@
+{
+  "name": "woc-dev-wiki",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "woc-dev-wiki",
+      "version": "0.0.0",
+      "devDependencies": {
+        "vitepress": "^1.6.3",
+        "vue": "^3.5.13"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.0.tgz",
+      "integrity": "sha512-kGvHfBa9oQCvZh0YXeguSToBD9GNJ+gzUZQ9KPTg+KSsM36obYcsKPoX0NnlJtPflHXu7RkMaIi44xs9meR6Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.0.tgz",
+      "integrity": "sha512-Zt2GjIm7vsaf7K23tk5JmtcVNc38G9p0C2L2Lrm06miyLE/NL2etHtHInvuLc1DjxTp7Y2nId4X/tzwo372K8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.0.tgz",
+      "integrity": "sha512-7BueMuWYg/KBA2EX9zsQ+3OAleEyrJcB+SV5Al/9pLjMQq5mXB/8M5HaUPqZwN812g5kLzj9j43VThlZgWq0hg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.0.tgz",
+      "integrity": "sha512-pJZIyhvUrs+B7c5Lw0iP5yP/NsqJMda7pKRYbfG4KtfGIVSMcAalZhdqL5UX8Z9DOC4KxO9tKV5RDeVjZU0VfQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.0.tgz",
+      "integrity": "sha512-RydkKDhx0GWTYuw0ndTXHGM8hD8hgwftKE65FfnJZb5bPc9CevOqv3qNPUQiviAwkqT9hQNH31uDGeV3yZkgfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.0.tgz",
+      "integrity": "sha512-XiS7gdFq/COWiwdWXZ8+RHuewfEo03TkGESk44zU8zTc/Z6R8fm4DNmV52swJKkeB2N9iC7NKpgpM22OOkcgTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.0.tgz",
+      "integrity": "sha512-LBEJ/q+hn1nJ0aYg5IcWgLNCPjWHTahWmpHNx1qUZMho+9CyWM6LaEnhac45UHjQm/j0m374HP685VrpL133lA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.0.tgz",
+      "integrity": "sha512-2/9jUXKH4IcdU5qxH6cbDH46ZBe46G7xr+MrcHwgEXZcUfdAvUgLSH53MAWuMgxvw0G5yoqiWMifHc62Os0fiQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.0.tgz",
+      "integrity": "sha512-80tKsQgxXWo+jK0v4YGCHqyTEXawhAKYyr3kOdN51ElfRqUFjZNPVhZk6vRiqSqXfvrH85ytacT3cbJR6+qolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.0.tgz",
+      "integrity": "sha512-4UjmAL8ywGW4rCfK6Qmgw3wIjbrO2wl2s4Eq56JTiN40L2t0XTv0HZkYAmr6nfeiXO0he/2crvZRX6SATSepag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.0.tgz",
+      "integrity": "sha512-LMpJPtIkfDsHIx5Ga+baNr22ntYbY+e2wT7MSIc/FjAnu9wnBFhx1H/GfhmP/c5/IvbThDX+3ilxPRjSfCI8aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.0.tgz",
+      "integrity": "sha512-tDymJ7nFOAoUuecma3usK6o94dp8m4HYFDGh4ByYQXWkv14cpmDn+nWdylmcZO0Qvco107vqDo4+Anksnl8w1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.0.tgz",
+      "integrity": "sha512-6IDSB5o5dkDPQ4LdOW0Yuw/qy5MdWlO2xDHgPVZgW4YDjbxvnX5PAiV7/WWZdWyVObScZZnnHpPbiqfYs/zBLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.0.tgz",
+      "integrity": "sha512-Yyyne4l//vDSdg4MhYJkaVne+KEPi833eCj3/T/87ernTwrvP6j9biXXZELsN8sLI/f2ndV/vugDIy2jdJQB6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.86",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.86.tgz",
+      "integrity": "sha512-t3jck5qPQuK1qy+bRn9eCoDQhIB7XSazKz1Fjp8hcan3XOAsTI5Mq/s3F0ekOKSvMQqkVORYK6ns6o6T9f5EMA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.38.tgz",
+      "integrity": "sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.38.tgz",
+      "integrity": "sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.38",
+        "@vue/shared": "3.5.38"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.38.tgz",
+      "integrity": "sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.38",
+        "@vue/runtime-core": "3.5.38",
+        "@vue/shared": "3.5.38",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.38.tgz",
+      "integrity": "sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38"
+      },
+      "peerDependencies": {
+        "vue": "3.5.38"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.0.tgz",
+      "integrity": "sha512-af+rI+tUVeS9KWHPAZQHIHPOIC3StPRR6IwQu2nz1aQoTL6Gs5Ty3KsHCgbXMHOpoh9QqSjq8F3KJ8xmaCZSBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/abtesting": "1.21.0",
+        "@algolia/client-abtesting": "5.55.0",
+        "@algolia/client-analytics": "5.55.0",
+        "@algolia/client-common": "5.55.0",
+        "@algolia/client-insights": "5.55.0",
+        "@algolia/client-personalization": "5.55.0",
+        "@algolia/client-query-suggestions": "5.55.0",
+        "@algolia/client-search": "5.55.0",
+        "@algolia/ingestion": "1.55.0",
+        "@algolia/monitoring": "1.55.0",
+        "@algolia/recommend": "5.55.0",
+        "@algolia/requester-browser-xhr": "5.55.0",
+        "@algolia/requester-fetch": "5.55.0",
+        "@algolia/requester-node-http": "5.55.0"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.38.tgz",
+      "integrity": "sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-sfc": "3.5.38",
+        "@vue/runtime-dom": "3.5.38",
+        "@vue/server-renderer": "3.5.38",
+        "@vue/shared": "3.5.38"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/wiki/package.json
+++ b/docs/wiki/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "woc-dev-wiki",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "World of Claudecraft public dev wiki (VitePress). Isolated from the game's dependency set on purpose.",
+  "scripts": {
+    "dev": "vitepress dev",
+    "build": "vitepress build",
+    "preview": "vitepress preview --port 4188"
+  },
+  "devDependencies": {
+    "vitepress": "^1.6.3",
+    "vue": "^3.5.13"
+  }
+}

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -1,0 +1,134 @@
+# Roadmap
+
+The prioritized plan. Derived from the [steering decisions](./index.md#the-four-steering-decisions-this-cycle-2026-06-16), the [gap analysis](./current-state.md#gap-analysis--answering-the-questions-the-team-keeps-asking), and the [design influences](./design-influences.md) (vanilla Classic + Titan Reforged). When priorities shift, move the item and note why — don't silently delete.
+
+> **Two companion docs make this actionable:** the [Design Lens](./design-lens.md) decides *what* earns a slot here (and frames the **crypto-vs-vibe [strategic fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything)** that colors the whole plan); the [System Designs backlog](./system-designs/index.md) turns each item into a scoped, pluckable spec. This page is the *sequence*; those are the *what* and the *how*.
+
+---
+
+## High-level goal: the progression ladder (20 → 30 → 40 → 60)
+
+The spine of the whole roadmap. We raise the cap in **deliberate rungs**, proving the content pipeline at each step before committing to the next. Each rung is a full vanilla-faithful tier (zones, ability ranks, gear, dungeons) — **the journey stays sacred; we never make leveling skippable** (see [design-influences](./design-influences.md#part-3--what-we-adopt-adapt-and-reject)).
+
+| Rung | Cap | Headline reward | What it delivers | Proves |
+|---|---|---|---|---|
+| **Today** | **20** | — | 3 zones, ~73 quests, 4 dungeons, 9 classes, talents. | The combat/sim core is solid. |
+| **Rung 1** | **→ 30** | New zone + dungeon | 1 new zone (L20–30), ability ranks to 30, a gear tier, 1 new 5-player dungeon, extended XP curve. | The content pipeline **scales cheaply**. The smallest honest proof. |
+| **Rung 2** | **→ 40** | 🐎 **Mounts** | 1–2 new zones (L30–40), ranks to 40, gear tier, 1–2 dungeons, **mounts unlock at 40** (vanilla-authentic), first **10-player raid**. | The pipeline holds at scale + endgame instancing works. |
+| **Rung 3** | **→ 60** | The full vanilla endgame | Multiple zones (L40–60), ranks to 60, epic gear tiers, dungeon keys/attunements, **world bosses, 40-man raids, reputation/attunement chains**. | We can run a *complete* classic endgame at our scale. |
+
+**Decision gates between rungs:** after each rung we measure (how long did it take to author? retention? did determinism + RL parity hold?) and only then green-light the next. 30 is a fast proof; 40 is the real test; 60 is the prize. **Mounts at 40 and raids at 40+ are the deliberate "long reward" hooks** vanilla taught us players remember.
+
+---
+
+## How we prioritize
+
+Five tie-breakers, applied in order:
+
+1. **Fidelity-per-effort.** Closing a vanilla gap players feel constantly beats a deep system few touch.
+2. **Unblocks-later-work.** Foundations first (item slots before set bonuses; capital city before flight network; pipeline before cap rungs).
+3. **Doesn't fight the pillars.** Respects "one sim, three hosts," determinism, server authority, and *earned-not-bought* — or it doesn't ship.
+4. **Provable.** Ship it, measure it, learn before betting bigger.
+5. **Journey-first.** Retention loops are welcome; skipping the climb is not.
+
+**Shape of the plan:** cheap-and-felt breadth first → the cosmetic/world-event retention loops (Titan-inspired) → climb the cap ladder rung by rung → the identity expansion (factions/races) lands with the 60 era.
+
+---
+
+## NOW — depth at current scale (target: v0.8)
+
+*Fill the vanilla gaps that need no cap raise. Fast fidelity wins; foundations for the ladder.*
+
+| # | Item | Why now | Scope / risk |
+|---|---|---|---|
+| 1 | **[Equipment Slots 2.0](./system-designs/equipment-slots.md) (→ 8)** | Highest fidelity-per-effort gap — gear is half the game and we expose a quarter. This is the first tier of an epic (4→8→12→17); 2.0 adds the armor core (head/shoulder/hands/waist). Unblocks sets, trinkets, the upgrade loop. | **Low.** Extend `EquipSlot` + `recalcPlayerStats`, author items, paperdoll frames. Later tiers (3.0 NEXT, 4.0 LATER) carry the harder rules. |
+| 2 | **Community feedback intake** | Discord exists but nothing pipes into planning; a roadmap players can *see* shape is a north-star promise. | **Low.** Triage labels + recurring digest into this wiki; optional in-client `/feedback`. |
+| 3 | **Mail system** | Async gold/item delivery is the economy's missing half; the AH already implies it. | **Low–Medium.** Mirrors AH collection patterns in `world_state`. |
+| 4 | **Need / greed / pass loot UI** | Group content exists; the loot *ceremony* that makes it social does not. | **Low.** Roll session + UI; server-authoritative via `Rng`. |
+| 5 | **$WOC cosmetic foundation (off-chain entitlements)** | Activates the token *safely* and early — the account entitlement layer must exist **before** anyone wires it into the sim. | **Medium.** Account entitlement store + cosmetic application. **Sim untouched** ([guardrails](./vision.md#the-woc-token-guardrails)). |
+
+---
+
+## RETENTION SYSTEMS — Titan-inspired, journey-safe (target: v0.8–v0.9)
+
+*The "always-on growth" loops Chinese players love. As specced here they're **cosmetic/QoL** (the de-risked, Fork-B-friendly version); if Fork A is chosen they can extend into earned power. See [design-influences](./design-influences.md#-adopt-fits-our-pillars-cleanly).*
+
+| # | Item | Why | Scope / risk |
+|---|---|---|---|
+| 6 | **Account-wide cosmetic/prestige track ("Renown")** | The single most-loved Titan idea, de-risked: a bar that always ticks up across your whole roster — rewarding **titles, cosmetics, conveniences**, not stats. Extends our existing lifetime-XP/prestige/milestones. Natural home for $WOC cosmetics. | **Medium.** Account-layer track, reward catalog, UI. **Cosmetic by design** (no stats in this version). |
+| 7 | **Dynamic world events** | Spontaneous open-world spawns granting account XP + cosmetics + (modest, earned) gear; revives zones, drives group play, seeds world bosses later. | **Medium.** Deterministic event scheduler (via `Rng`/tick, no wall-clock), event content, rewards. |
+| 8 | **Earned dual-currency upgrade loop** | A PvE currency + a PvP currency feeding a **gear upgrade ladder** so every playstyle progresses and gear stays relevant. Pairs with full slots (#1) + professions (#10). **Power earned in-game only.** | **Medium–High.** Two currencies, upgrade mechanic, sinks/sources balance. |
+
+---
+
+## NEXT — the connective tissue (target: v0.9)
+
+*Systems that make the world feel lived-in and give the economy a supply side. Each de-risks the cap rungs.*
+
+| # | Item | Why next | Scope / risk |
+|---|---|---|---|
+| 9 | **Mounts + flight paths + a capital hub** | Travel is the most-felt QoL gap as the world grows; **mounts are the cap-40 reward** (provision them now); a capital anchors social life. | **Medium–High.** Mount = movement-speed state (sim); flight network (waypoints); city zone + service NPCs. |
+| 10 | **Professions & crafting** | An entire vanilla pillar absent, and the economy's missing supply side (gather → recipe → crafted gear → AH). Pairs with full slots (#1) + upgrade loop (#8). | **High.** Gathering nodes (deterministic), recipes, skill-ups, crafted items, UI. Largest single system. |
+| 11 | **Reputation factions (PvE)** | A stepping-stone to full factions: quartermasters, rep grinds, rep-gated gear — *without* the Alliance/Horde split yet. Long-term goals beyond level. | **Medium.** Rep tracks + UI + gated vendors; reuses quest/vendor infra. |
+| 12 | **RL env parity catch-up** | Env exposes 2 of 9 classes; every system above widened the obs/action space. Keep the third host honest. | **Medium.** Expand obs/action coverage, more classes, determinism regression. |
+
+---
+
+## THE CAP RUNGS — climb the ladder (v1.0 → beyond)
+
+*Execute the 20 → 30 → 40 → 60 ladder above. Each rung is content-heavy but mechanically modest; gate on measurement between rungs.*
+
+| # | Item | Rung | Scope / risk |
+|---|---|---|---|
+| 13 | **Cap → 30** | Rung 1 | New zone (L20–30), ranks to 30, gear tier, 1 dungeon, XP curve. The cheap proof. **High (content).** |
+| 14 | **Cap → 40 + mounts + first 10-player raid** | Rung 2 | 1–2 zones (L30–40), ranks to 40, gear tier, 1–2 dungeons, mounts at 40, raid instancing beyond party-of-5. **High.** |
+| 15 | **Cap → 60 + endgame** | Rung 3 | Multiple zones (L40–60), ranks to 60, epic tiers, attunements/keys, **world bosses, 40-man raids, reputation/attunement chains**. The prize. **Very High.** |
+
+---
+
+## LATER — the Identity Expansion (the 60 era)
+
+*The biggest bet, sequenced with/after the 60 rung because it reshapes the new-player funnel and only pays off on a proven, populated base.*
+
+| # | Item | Why later | Scope / risk |
+|---|---|---|---|
+| 16 | **Factions: Alliance vs Horde** | Core vanilla identity; touches char creation, starting zones, world PvP, social — needs a stable base first. | **Very High.** |
+| 17 | **Playable races + racial traits** | The headline of character customization; race-specific starts finally make "starting zones?" a plural answer. | **Very High.** |
+| 18 | **Battlegrounds** | Structured PvP endgame; only meaningful once factions exist to fight over. | **High.** Gated on #16. |
+| 19 | **Set bonuses, trinkets & itemization depth** | With all slots (#1) + crafting (#10) + upgrade loop (#8) in place, deepen the gear chase. | **Medium.** |
+
+---
+
+## Tuning & polish (ongoing, low-pressure)
+
+The core 1–20 progression is sound; these are known, non-blocking refinements. Good "dev outlet" work between bigger sprints. Tracked as [System Designs](./system-designs/index.md) backlog rows.
+
+| Item | Note |
+|---|---|
+| **XP curve smoothing (post-L9)** | The curve spikes after level 9 — re-tune that stretch. Everything 1–9 and the overall 1–20 shape is fine. |
+| **Quest gap fill** | A few sparse stretches could use a handful more quests. Minor — not pressing. |
+| **Performance benchmarks** | Optimization is already good enough; the value is **codifying budgets** (sim steps/s, tick time, snapshot bytes, client FPS, bundle size) and regression-gating them. A clean outlet for devs who want to optimize — and **mandatory if [Fork A](./design-lens.md#fork-a--crypto-forward)** is chosen (`npm run bench`, `scripts/perf_tour.mjs`, `asset_budget.mjs` are the seeds). |
+| **QoL nitpicks** | Various small papercuts; batch them. Nothing glaring. |
+
+## Always-on (every milestone, not a phase)
+
+- **Determinism & "one sim, three hosts" are inviolable.** RNG through `Rng`, no wall-clock, sim logic stays in `src/sim/`.
+- **Journey-first.** No feature makes leveling skippable or trivial. We modernize the *grind*, not the *climb*.
+- **Token stays structural.** Whatever $WOC does, it never enters the deterministic sim and is granted/verified server-side (the two [token guardrails](./vision.md#the-woc-token--guardrails)). Power-vs-cosmetic is an open [fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything) decision, not a rule.
+- **i18n discipline.** Every player-visible string is a `t()` key in all 12 locales the moment it ships.
+- **RL parity is a feature.** A system that changes obs/action ships with its env update.
+- **The wiki stays true.** Ship a system → update [current-state.md](./current-state.md). Shift a priority → update this page.
+
+## One-screen summary
+
+```
+LADDER          20 ─→ 30 ─→ 40 (mounts + 1st raid) ─→ 60 (raids, world bosses, attunements)
+
+NOW (v0.8)      Item slots ·· Feedback intake ·· Mail ·· Loot rolls ·· $WOC cosmetic plumbing
+RETENTION       Account cosmetic track (Renown) ·· Dynamic world events ·· Earned upgrade currencies
+NEXT (v0.9)     Mounts + flight + capital ·· Professions/crafting ·· Rep factions (PvE) ·· RL parity
+CAP RUNGS       →30 (proof) ·· →40 (mounts, 10-man raid) ·· →60 (full endgame)
+LATER (60 era)  Alliance/Horde ·· Races + racials ·· Battlegrounds ·· Set bonuses
+```
+
+> **The throughline:** keep vanilla's journey, borrow Titan Reforged's always-on growth and earned upgrade loops, climb the cap ladder rung by rung — always vanilla-faithful, always one deterministic, server-authoritative sim. (Whether $WOC adds power or just cosmetics is the open [fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything).)

--- a/docs/wiki/system-designs/equipment-slots.md
+++ b/docs/wiki/system-designs/equipment-slots.md
@@ -1,0 +1,81 @@
+# Equipment Slots
+
+**Status:** 📐 Scoped (2.0 ready to pluck) · **Fork:** Both · **Roadmap phase:** epic — see [tier map](#tier--phase-map)
+(roadmap: [NOW #1](../roadmap.md#now--depth-at-current-scale-target-v08))
+
+> The full character sheet, shipped as a **complexity-ordered ladder** — not one big bang. Each tier adds ~4 slots and is its own pluckable sprint. Numbers are **proposed and tunable**.
+
+## Summary
+
+Today we expose **4 of vanilla's ~16 equipment slots** (`mainhand`, `chest`, `legs`, `feet`). Gear is half the game; showing a quarter of the paperdoll is our single most-felt itemization gap. This epic fills the rest **in tiers ordered by implementation complexity**, so each step ships cleanly and every "the paperdoll filled up more" moment is its own beat. Unblocks set bonuses, trinkets, enchant targets, and the earned-upgrade loop.
+
+## Design-lens answers
+
+- **Announce:** "Helms, gloves, belts — and later rings and trinkets." A visible character-sheet-grows beat per tier.
+- **Meme:** finally-have-a-helmet screenshots; showing off a full matched set; the paperdoll filling in.
+- **Gate:** **retention / depth** — deepens the gear chase and unblocks several other systems. Not an acquisition play.
+- **Offense or defense:** **defense** — table-stakes itemization that closes our biggest vanilla gap. (The *offense* comes from what it unblocks: sets, trinkets, enchanting.)
+
+## Pillar fit
+
+- **Deterministic / sim-side:** slots are pure stat aggregation in `src/sim/`; no new RNG except trinket procs (4.0), which go through `Rng`.
+- **Server-authoritative:** the server validates equip (class/slot/level rules) and recomputes stats; the client only requests.
+- **Token stays structural:** equip resolves server-side in the sim; the entitlement/token layer never reaches into a tick. (Whether gear power is ever token-linked is a Fork A call, bounded by the two guardrails — not a no-power rule.)
+- **Journey-first:** more slots to fill as you level; the chase grows with the player.
+
+## Tier → phase map
+
+| Tier | Slots | Total | New this tier | Roadmap phase | Complexity |
+|---|---|---|---|---|---|
+| **1.0** | mainhand, chest, legs, feet | **4** | *(baseline — already shipped)* | 🏁 Shipped | — |
+| **2.0** | + head, shoulder, hands, waist | **8** | 4 standard armor slots | **NOW (v0.8)** | Low |
+| **3.0** | + wrist, back, neck, offhand | **12** | armor + first stat-only (neck) + offhand rules | **NEXT (v0.9)** | Medium |
+| **4.0** | + ring ×2, trinket ×2, ranged/relic | **~17** | duplicate slots, on-use/proc trinkets, class-specific ranged | **LATER** (with [set bonuses #19](../roadmap.md#later--the-identity-expansion-the-60-era)) | High |
+
+## Scope tiers
+
+### Equipment Slots 2.0 — the armor core (→ 8) · **pluck this first**
+- Add **head, shoulder, hands, waist** — all standard armor slots that reuse the existing armor/stat path.
+- Work: extend the `EquipSlot` union + the slot list in `recalcPlayerStats`; author items for the new slots across the existing quality tiers; paperdoll UI gains 4 frames; render visible armor is **optional/stretch** (stats first).
+- Lowest complexity, biggest "feels complete" jump (doubles the visible character sheet).
+- **OUT:** jewelry, offhand, trinkets — different rules, later tiers.
+
+### Equipment Slots 3.0 — defensive + offhand (→ 12)
+- Add **wrist, back** (armor), **neck** (first **stat-only** slot — no armor value), and **offhand**.
+- **Offhand introduces real rules:** shields (armor + block) vs held/caster off-hands, which classes may use what, and **two-handed weapons that occupy mainhand and disable offhand** (a new `twoHand` item flag).
+- **OUT:** rings/trinkets/ranged.
+
+### Equipment Slots 4.0 — jewelry, procs, ranged (→ ~17)
+- Add **ring ×2, trinket ×2, ranged/relic**.
+- **Duplicate slots:** the equipment map needs distinct keys (`ring1`/`ring2`, `trinket1`/`trinket2`) and the paperdoll must target a specific index.
+- **Trinkets introduce equip effects:** on-use actives and passive procs (via `Rng`) — the most complex piece; lands with [set bonuses & itemization depth](../roadmap.md#later--the-identity-expansion-the-60-era).
+- **Ranged/relic** is class-specific (hunter ranged vs caster wand vs paladin/shaman relic).
+
+## Open balance questions (fill when plucking)
+
+- **Stat-budget rescale (critical):** adding slots must **not** simply multiply equipped power. Re-tune per-slot stat budgets so *total* equipped stats track the intended 1–20 power curve — going 4→8 slots roughly doubles gear power if budgets are unchanged. This is the main balance work of every tier.
+- Which armor slots carry how much of the budget (head/chest heavy, wrist/waist light, per vanilla feel).
+- Class/slot eligibility rules (cloth/leather/mail/plate by class; who can use shields/two-handers).
+- Neck/ring stat-only budgets; trinket proc rates and magnitudes (4.0) — must stay non-P2W and within a drop tier.
+
+## Hook points
+
+- `src/sim/types.ts` — extend the `EquipSlot` union (currently `'mainhand' | 'chest' | 'legs' | 'feet'`); add `twoHand` item flag (3.0).
+- `src/sim/entity.ts` — `recalcPlayerStats` iterates a hard-coded slot list (`['mainhand','chest','legs','feet']`); extend it. `PlayerEquipment` is `Partial<Record<EquipSlot,string>>`, so additive — except 4.0's duplicate slots need explicit `ring1/ring2/trinket1/trinket2` keys.
+- `src/sim/content/items.ts` — author items per new slot; `slot` field already exists.
+- `src/sim/sim.ts` / `server/game.ts` — equip validation (class/slot/level, two-hand/offhand rules); equipment persists in JSONB state (additive).
+- `src/ui/hud.ts` — paperdoll frames per slot; index-aware targeting for rings/trinkets.
+- `src/render/` — *optional* visible armor models per slot (stretch; stats work without it).
+- **i18n:** slot names and any new tooltips as `t()` keys in all 12 locales.
+
+## Acceptance criteria & tests
+
+- **Stat aggregation:** equipping each new slot adds its stats via `recalcPlayerStats`; unequipping reverts — deterministic, in `tests/`.
+- **Rules:** class/slot eligibility enforced server-side; two-hander clears/locks offhand (3.0); ring/trinket indices independent (4.0).
+- **Balance guard:** a test asserting total equipped stat budget at a given level stays within the intended band (catches the "doubled power" regression).
+- **Persistence:** expanded equipment round-trips through serialize/deserialize + autosave.
+
+## Dependencies
+
+- **Unblocks:** [Professions](./professions.md) enchanting (more enchant targets), set bonuses & [itemization depth](../roadmap.md#later--the-identity-expansion-the-60-era), the [earned upgrade loop](./index.md).
+- **4.0 lands with** the LATER "set bonuses, trinkets & itemization depth" roadmap item — they're the same itemization push.

--- a/docs/wiki/system-designs/index.md
+++ b/docs/wiki/system-designs/index.md
@@ -1,0 +1,98 @@
+# System Designs
+
+The backlog of **scoped, pluckable specs**. Each system design is a self-contained doc that passed the [Design Lens](../design-lens.md); a contributor or Claude can pick one *tier* (e.g. "Professions 1.0"), balance the open numbers, and build it — without re-deciding the why.
+
+This page is the **TODO hub**: the table below is the queue. [Professions](./professions.md) is the worked example of a fully-scoped design; the rest are stubs waiting to be filled out to the same standard.
+
+---
+
+## How to use this
+
+- **Picking up work?** Find a row with status **Scoped** or **Ready**, open it, choose a tier, and implement that tier. The spec tells you what to build, what to balance, where the hooks are, and how it's tested.
+- **Proposing work?** Run it through the [four gut-checks](../design-lens.md#the-four-gut-checks). If it passes, add a row here and write the design to the [template](#the-template) below. Link it from [roadmap.md](../roadmap.md) if it affects sequencing.
+- **Claude's job** on a plucked spec: fill the open balance numbers with vanilla-faithful values, keep determinism + server authority, write the tests, and update [current-state.md](../current-state.md) when it ships.
+
+**Status legend:** 💡 **Idea** (one line) · 📐 **Scoped** (tiers + balance Qs written) · ✅ **Ready** (hooks + tests specified, pluck it) · 🚧 **In progress** · 🏁 **Shipped**.
+
+**Fork tag:** which [strategic fork](../design-lens.md#the-strategic-fork-the-decision-that-colors-everything) it serves — `Both` / `Fork A` (crypto) / `Fork B` (vibe). `Fork A` items touching token-for-power are **blocked** until the fork is chosen.
+
+**Roadmap phase** (the canonical set — matches [roadmap.md](../roadmap.md)):
+
+| Phase | Meaning |
+|---|---|
+| **NOW** | Depth at current scale (v0.8). |
+| **RETENTION** | Titan-inspired cosmetic/world-event loops (v0.8–0.9). |
+| **NEXT** | Connective tissue: professions, mounts, rep factions (v0.9). |
+| **CAP:→30 / →40 / →60** | The cap-ladder **rungs** (v1.0+). "Rung" means *only* these. |
+| **LATER** | Identity expansion: factions, races, set bonuses (post-1.0). |
+| **TUNING** | Ongoing low-pressure polish. |
+| **ALWAYS-ON** | Every milestone (determinism, i18n, perf, RL parity). |
+
+**Epics map per tier** — a multi-tier design lands across several phases (e.g. Equipment Slots 2.0 = NOW, 3.0 = NEXT, 4.0 = LATER), so its row lists the tier→phase mapping rather than one phase.
+
+---
+
+## The backlog
+
+| System design | Status | Fork | One-line scope | Roadmap phase |
+|---|---|---|---|---|
+| **[Professions](./professions.md)** | 📐 Scoped | Both | Profession panel, auto-progressing skills; 1.0 = First Aid + Enchanting/Disenchant (no world nodes); 2.0 = Mining/Herbalism gathering nodes. | NEXT |
+| **[Equipment slots](./equipment-slots.md)** | 📐 Scoped | Both | Fill the paperdoll in tiers: 4 → 8 → 12 → ~17 slots. Unblocks sets, trinkets, enchanting targets. | 1.0 🏁 · 2.0 NOW · 3.0 NEXT · 4.0 LATER |
+| **Account cosmetic track ("Renown")** | 💡 Idea | Both | Always-on account bar rewarding titles/cosmetics/QoL — never stats. Home for $WOC cosmetics. | RETENTION |
+| **Dynamic world events** | 💡 Idea | Both | Deterministic open-world spawns granting account XP + cosmetics; shares the node/spawn framework with Professions 2.0. | RETENTION |
+| **Earned upgrade currencies** | 💡 Idea | Both | Dual PvE/PvP currency feeding a gear upgrade ladder; power earned in-game only. | RETENTION |
+| **Mail system** | 💡 Idea | Both | Async gold/item delivery; the economy's missing half. | NOW |
+| **Need/greed/pass loot** | 💡 Idea | Both | Loot roll session + UI; the social loot ceremony. | NOW |
+| **Mounts + flight + capital** | 💡 Idea | Both | Mount speed state, flight network, a capital hub; mount is the cap-40 reward. | NEXT |
+| **Reputation factions (PvE)** | 💡 Idea | Both | Rep tracks, quartermasters, gated gear — stepping stone to full factions. | NEXT |
+| **Performance benchmarks** | 💡 Idea | Both (esp. Fork A) | Codify perf budgets (sim steps/s, tick time, snapshot bytes, client FPS, bundle size) and regression-gate them. A real dev outlet; mandatory if Fork A. | always-on |
+| **XP curve smoothing (post-L9)** | 💡 Idea | Both | Re-tune the curve after level 9 — currently spikes. Core 1–20 progression is otherwise sound. | tuning |
+| **Quest gap fill** | 💡 Idea | Both | Add a handful of quests in sparse stretches. Low priority — not pressing. | tuning |
+| **$WOC cosmetic foundation** | 💡 Idea | Both | Off-chain account entitlement layer for cosmetics; sim untouched. | NOW |
+| **P2E / risk-to-earn loops** | 💡 Idea | **Fork A — gated** | Wagered duels/arenas, stake-to-enter events, earn ladders. Allowed in principle (no "no-power" rule), but **gated on choosing Fork A**; must stay sim-external + server-authoritative. | gated on fork |
+
+Counts are honest: only **Professions** is written to the template so far. The rest are placeholders — promoting one to 📐 Scoped means writing it out fully. That's the work this backlog exists to make easy.
+
+---
+
+## The template
+
+Copy this when writing a new system design. The headers are the contract — a plucker should be able to build from them alone.
+
+```markdown
+# <System Name>
+
+**Status:** 💡/📐/✅/🚧/🏁   **Fork:** Both / Fork A / Fork B   **Roadmap phase:** <NOW/RETENTION/NEXT/CAP:→30/LATER/TUNING> (per tier for epics)
+
+## Summary
+One paragraph: what it is, and how it fits our 1–20 micro-MMO (not retail-scale).
+
+## Design-lens answers
+- **Announce:** …
+- **Meme:** …
+- **Gate:** acquisition / reactivation / retention — which, and why.
+- **Offense or defense:** … (and which pillar gap, if defense)
+
+## Pillar fit
+How it stays deterministic, sim-side, server-authoritative, earned-not-bought, journey-first.
+
+## Scope tiers (the TODO sprints)
+### <Name> 1.0  — <the pluckable sprint>
+Concrete sub-features, each buildable. What's explicitly OUT of 1.0 and why.
+### <Name> 2.0  — <the next tier>
+What it adds, and what it depends on from 1.0.
+
+## Open balance questions (for the implementer to fill)
+Numbers/curves to tune, marked as proposed-not-final. This is the "Claude balances it" surface.
+
+## Hook points
+Where it lands in the codebase (file:area), from current-state knowledge.
+
+## Acceptance criteria & tests
+Determinism test, behavior tests, and the no-P2W / pillar invariants to assert.
+
+## Dependencies
+Other system designs it needs or unblocks.
+```
+
+See [Professions](./professions.md) for this template applied end-to-end.

--- a/docs/wiki/system-designs/professions.md
+++ b/docs/wiki/system-designs/professions.md
@@ -1,0 +1,95 @@
+# Professions
+
+**Status:** 📐 Scoped (1.0 ready to pluck) · **Fork:** Both · **Roadmap phase:** NEXT
+(see [roadmap.md](../roadmap.md), item #10)
+
+> The worked example for the [System Designs](./index.md) template. Numbers below are **proposed and tunable** — balancing them to vanilla feel at our 1–20 scale is part of plucking the spec.
+
+## Summary
+
+Classic professions, adapted to our **level 1–20 micro-MMO** (not retail's 1–300 grind). There are **no trainers**: you pick a profession from a **Profession panel**, and its skill rises **automatically through use** — exactly how abilities are already learned by level. Recipes and tiers **unlock at skill thresholds** with no extra step. The whole system is a second progression track that deepens the economy, rewards solo and social play, and gives the Auction House a supply side.
+
+**1.0** ships the professions that need **no new world systems** (they run off existing item flows): **First Aid** and **Enchanting/Disenchanting**. **2.0** adds **gathering** (Mining, Herbalism) once the world-node spawn framework exists.
+
+> **Scoping note (re: your "...then mining"):** Mining's *gathering* (ore veins) needs world spawn nodes, which is a shared framework with [Dynamic World Events](./index.md). To keep 1.0 tight and shippable, **Mining moves to 2.0** with the nodes. 1.0 is the framework + the two node-free professions. If you'd rather bootstrap Mining in 1.0 via ore as a mob drop (no veins), that's a one-line scope change — flagged in Open Questions.
+
+## Design-lens answers
+
+- **Announce:** "Professions are live — enchant your gear, disenchant drops, craft bandages." A genuine content drop with a release note and a clip.
+- **Meme:** "disenchanted my BiS by accident"; showing off an enchant glow; the profession panel filling up. Self-inflicted-loss stories travel.
+- **Gate:** **retention** first (a daily/solo reason to log in and a crafting loop), **reactivation** second (returners chase enchants). Light on acquisition.
+- **Offense or defense:** **offense** — professions are a core vanilla pillar that vibe-MMO competitors lack, and they pair with full equipment slots to close our single biggest "feels missing" area.
+
+## Pillar fit
+
+- **Deterministic:** skill-up rolls and 2.0 node spawns go through `Rng`; same seed ⇒ same skill-ups and node layout. No wall-clock.
+- **Sim-side:** all profession state and resolution live in `src/sim/`; runs offline/online/headless identically. (The RL env gains craft/gather actions — see [current-state RL parity](../current-state.md).)
+- **Server-authoritative:** the server resolves every craft/gather/disenchant/enchant; the client only requests and renders.
+- **Token stays structural:** skill, materials, and recipes are resolved **inside the sim, server-authoritative** — never injected by the entitlement/token layer mid-tick. (Whether $WOC ever sells profession boosts is a Fork A decision; even then it would grant a server-side entitlement the sim never reads directly.)
+- **Journey-first:** skill rises *with play*; nothing is skippable or purchasable.
+
+## Scope tiers
+
+### Shared framework (built in 1.0)
+
+- **Profession slots:** *propose* **2 primary + First Aid (secondary, always available)**. Tunable.
+- **Profession panel:** a new tab (sibling to Talents/Spellbook in `hud.ts`). Pick a profession from the list; shows current skill, unlocked recipes, and next unlock threshold.
+- **Skill range:** *propose* **1–100** (scaled down from classic 1–300 for a 1–20 world).
+- **Auto skill-up:** each successful craft/gather has a difficulty-colored chance to raise skill (orange = guaranteed-ish, yellow = likely, green = low, grey = none), rolled via `Rng`. Recipes auto-unlock at thresholds — no trainer, surfaced in the panel.
+- **Dropping a profession:** *propose* **parks** the skill (resume later) rather than wiping it — friendlier than classic and consistent with "earned." Tunable (could add a cooldown).
+
+### Professions 1.0 — node-free (the pluckable sprint)
+
+**A. First Aid (secondary)**
+- Input: **Cloth**, dropped by humanoid mobs (small content add to humanoid loot tables in `content/`).
+- Recipes by skill: Linen Bandage (skill 1) → Heavy Linen (20) → Wool (40) → Heavy Wool (60)… each a stronger heal-over-time.
+- Behavior: usable **out of combat only**; applies a **"Recently Bandaged"** debuff that blocks re-bandage for ~60s (classic anti-spam). *Propose* Linen heals ~ a third of a mid-level character's HP over 6s — tune against level-scaled HP.
+- Reuses the existing HoT mechanic.
+
+**B. Enchanting + Disenchanting** — a closed, node-free loop
+- **Disenchant:** destroy an uncommon/rare weapon or armor → **materials** (dust / lesser-greater essence / shard) scaled by the item's quality and level. Skill-up on disenchant. Quest items and equipped items excluded; confirm prompt to prevent the "deleted my BiS" meme becoming a support ticket.
+- **Enchant:** apply a **permanent stat bonus to an equipped slot** (e.g. +STA to chest, +AP to weapon), consuming materials. Tiered by skill.
+- **Balance:** enchant magnitudes are **small relative to gear budget** (*propose* +1–3 at our scale) so they enhance, not replace, drops — and never break vanilla math. This is an *earned* gear-power sink: surplus drops → mats → your own gear.
+- **Synergy:** benefits from [Full equipment slots](./index.md) but works on the current 4 slots day one.
+
+**Explicitly OUT of 1.0:** world gathering nodes, Mining/Herbalism, crafted gear from raw mats, Alchemy. All need 2.0's node framework.
+
+### Professions 2.0 — gathering + the node framework
+
+- **Mining** (ore veins) and **Herbalism** (herb nodes) as **deterministic world spawn nodes** — reuse the mob-camp spawn infra (`content/zoneN` + the sim spawn loop), interest-scoped like mobs, `Rng`-seeded positions and respawn timers.
+- **Smelting** (ore → bars), feeding a future Blacksmithing (3.0).
+- **Alchemy** (herbs → potions) — 2.0 or 3.0.
+- **Depends on:** the node-spawn framework (shared with [Dynamic World Events](./index.md) — build once, both consume it).
+
+## Open balance questions (fill when plucking)
+
+- Skill cap (1–100?) and the skill-up probability curve per difficulty color.
+- Profession slot count (2 primary + First Aid?).
+- Cloth drop rate; bandage heal values vs level-scaled HP and combat downtime.
+- Enchant magnitudes vs the per-slot gear stat budget (must not exceed a drop tier; must stay non-P2W).
+- Disenchant material yield tables by item quality × level.
+- 2.0: node density, respawn timers, ore/herb tiers by zone level band.
+- **Scope call:** Mining bootstrap in 1.0 via ore-as-mob-drop, or hold all gathering for 2.0? (Recommendation: hold for 2.0.)
+
+## Hook points
+
+- `src/sim/sim.ts` — `CharacterState`: add `professions` (skill per profession). Commands: `craft`, `disenchant`, `enchant`, `bandage`; skill-up via `Rng`.
+- `src/sim/content/items.ts` — cloth, bandages, enchant materials, enchant definitions; humanoid loot additions.
+- `src/sim/entity.ts` — `recalcPlayerStats`: apply enchant stat bonuses (and any 2.0 enchant slots).
+- `server/game.ts` — dispatch the new commands; persist `professions` in the JSONB character state (already JSONB, so additive).
+- `src/ui/hud.ts` — Profession panel (new tab); disenchant confirm dialog.
+- **2.0:** world node entity type + spawn loop (reuse camp-spawn code in `content/zoneN.ts` + sim), renderer for nodes.
+- **i18n:** every new player-visible string is a `t()` key in all 12 locales (profession names, recipe names, panel labels, the "Recently Bandaged" tooltip, confirm dialogs).
+
+## Acceptance criteria & tests
+
+- **Determinism:** same seed + same actions ⇒ identical skill-ups and (2.0) node layout — a `tests/professions.test.ts` assertion.
+- **First Aid:** bandage heals the expected HoT, blocked in combat, "Recently Bandaged" prevents stacking.
+- **Enchant/Disenchant:** disenchant yields match the table; enchant applies the stat via `recalcPlayerStats`; equipped/quest items can't be disenchanted.
+- **Sim-purity invariant:** assert the deterministic sim resolves skill/materials/recipes with **no read of token/entitlement state** — a determinism guard like the localization S3 guard. (Power-vs-cosmetic monetization is a product call; this test only protects the sim core.)
+- **Persistence:** professions round-trip through serialize/deserialize and the 30s autosave.
+
+## Dependencies
+
+- **Pairs with:** [Full equipment slots](./index.md) (more enchant targets), [Earned upgrade currencies](./index.md) (sibling gear-power loop).
+- **2.0 shares** the world-node spawn framework with [Dynamic World Events](./index.md) — sequence them together.

--- a/docs/wiki/vision.md
+++ b/docs/wiki/vision.md
@@ -1,0 +1,65 @@
+# Vision
+
+## The one-liner
+
+**World of Claudecraft is a classic-era MMORPG, rebuilt as a single deterministic simulation — playable as a real online game *and* runnable as a headless reinforcement-learning environment, from the exact same code.**
+
+It is faithful to vanilla-WoW-era design (real formulas, real systems, the grind that mattered), but small enough that one team can host it, reason about it, and grow it deliberately.
+
+## Why it exists — the dual mandate
+
+This is not "a game with an AI bolt-on." The two products are the *same artifact* viewed two ways:
+
+1. **A micro-MMO.** Accounts, persistent characters in Postgres, a live authoritative server, other players in the world with you. Also playable fully offline in the browser — the offline world behaves *identically* to the online one because it runs the same sim.
+2. **An RL environment.** The same `src/sim/` runs headless as a Gym-compatible env (NDJSON wire protocol, deterministic episodes, byte-reproducible from a seed). A classic-MMO is a genuinely hard control problem — sparse rewards, long horizons, deep action spaces — and we have a clean, fast, fully-observable one.
+
+Whatever we add to the game, we add to the research environment. That coupling is the moat.
+
+## Design pillars
+
+These are load-bearing. A feature that violates a pillar is wrong even if it's fun.
+
+1. **One sim, three hosts.** `src/sim/` is the source of truth and runs unchanged in the browser (offline), the server (online), and headless (RL). Behavior must be identical everywhere. Game logic never leaks into `render/`, `ui/`, `game/`, or `net/`.
+2. **Determinism is sacred.** Fixed 20 Hz tick (`DT = 1/20`). All randomness flows through `Rng` — never `Math.random`, `Date.now`, or `performance.now` in sim code. Same seed ⇒ same world, forever. This is what makes the RL env reproducible and the netcode debuggable.
+3. **Vanilla fidelity over invention.** Rage curves, hit tables, armor DR, XP curves, the 5-second rule — we use the *real* classic-era formulas (see the fidelity checklist in `README.md`). When a design question comes up, "what did vanilla do?" is the first answer we reach for. We bias toward classic systems even when they're less convenient than a modern shortcut.
+4. **The server is the authority; the client only renders.** Clients stream movement intent + commands at 20 Hz. The server runs the one shared sim and returns interest-scoped snapshots. All combat, loot, XP, quest credit, and economy resolve server-side. **This pillar is what makes the $WOC guardrail enforceable** (see below).
+5. **Procedural everything.** Terrain, creatures, icons, UI, VFX, and the soundtrack are generated from code, not asset files. It keeps the dependency set tiny, the repo self-contained, and the aesthetic coherent. (Asset packs are being layered in for character art via the UE5-overhaul plan, but procedural remains the default and fallback.)
+
+## North star — where we're going
+
+The destination is **the full vanilla experience at our scale, reached deliberately, not rushed.** Concretely, over time:
+
+- **Higher caps, more world — a deliberate ladder: 20 → 30 → 40 → 60.** Each rung is a full vanilla-faithful tier (new zones, ability ranks, gear, dungeons) with a measurement gate before the next. 30 proves the pipeline, 40 brings mounts + the first raid, 60 is the full endgame. The climb stays meaningful — we modernize the grind, never skip the journey. See [design-influences.md](./design-influences.md) for what we borrow (and reject) from vanilla Classic and Titan Reforged.
+- **The full character fantasy.** Every equipment slot (today 4 of ~16), professions and crafting, mounts and flight paths, mail — the connective tissue that makes a world feel lived-in.
+- **The vanilla identity.** A two-faction split and playable races with racial traits, world PvP and battlegrounds, raids. This is the big one, and it lands *after* the 40 push because it reshapes the new-player funnel.
+- **A community that steers us.** A real feedback intake (today the Discord exists but nothing pipes into planning). The roadmap should be visibly shaped by players.
+
+See [roadmap.md](./roadmap.md) for the sequencing and rationale.
+
+## The $WOC token — guardrails
+
+There is a $WOC token. **As of v0.7.0 it has zero integration in the repo.** When it is integrated, exactly **two** rules are non-negotiable. They are *structural* — they protect the engine and the authority model, not a particular monetization philosophy:
+
+> ### Token guardrails (non-negotiable — structural)
+> 1. **The sim never sees it.** `src/sim/` stays pure and deterministic. Token state lives *outside* the simulation, on the account/entitlement layer — so a player's wallet can never alter a tick's outcome **directly**, and the RL env runs identically whether a token exists or not. (Server-side game logic may *read* an entitlement to grant an effect — but the deterministic sim core never does.)
+> 2. **Authority stays server-side.** Entitlements are granted and verified by the server, the same way bans and mutes are. The client never asserts "I own this."
+
+**Deliberately NOT a guardrail:** whether the token confers *power, economic value, or only cosmetics* is an **open product decision**, not a fixed rule — it's the [crypto-vs-vibe strategic fork](./design-lens.md#the-strategic-fork-the-decision-that-colors-everything). Cosmetic-only is one valid answer (Fork B); P2E / risk-to-earn power loops are another (Fork A). Both are bounded *only* by the two structural guardrails above. The earlier "never power / cosmetic-only" stance is **not** a commitment — it's parked as an option until the fork is chosen.
+
+Integration itself is **deferred** (see roadmap).
+
+## Non-goals (what we are deliberately *not* building)
+
+- **Breaking the sim or its determinism for monetization.** Whatever the token ends up doing, it stays *outside* the deterministic core and server-authoritative (the two [structural guardrails](#the-woc-token--guardrails)). That line does not move — power vs cosmetic is open; *this* isn't.
+- **A modern-WoW feature sprint.** We move toward *classic* design, not retail conveniences (no LFR, no instant-max, no skip-the-journey shortcuts).
+- **Cap 60 as a near-term sprint.** We bump to 40 and *measure* first. Breadth without a proven pipeline is how content projects die.
+- **Splitting the sim for performance or convenience.** Large single-file modules are fine here; the "one sim" invariant outranks tidiness.
+- **A dependency-heavy stack.** Tiny dependency set is a feature.
+
+## Audience
+
+- **Players** who want the classic-MMO grind — character building, group dungeons, an economy, a ladder — without a subscription or a 15-year-old client.
+- **Self-hosters and tinkerers** who want a complete, readable MMO they can run and modify.
+- **RL researchers and agent builders** who want a hard, fast, deterministic, fully-observable control problem with a real game underneath.
+
+These three audiences are served by the *same build*. That's the whole idea.

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "server": "npm run build:server && node dist-server/server.cjs",
     "realms": "npm run build:server && node scripts/dev-realms.mjs",
     "admin:grant": "node scripts/grant_admin.mjs",
-    "wiki:seed": "node scripts/mediawiki/build_seed.mjs"
+    "wiki:seed": "node scripts/mediawiki/build_seed.mjs",
+    "devwiki:dev": "npm --prefix docs/wiki install && npm --prefix docs/wiki run dev",
+    "devwiki:build": "npm --prefix docs/wiki ci && npm --prefix docs/wiki run build"
   },
   "dependencies": {
     "n8ao": "^1.10.1",


### PR DESCRIPTION
## What this is

<img width="1459" height="1083" alt="image" src="https://github.com/user-attachments/assets/b7219ca5-27b9-4582-8040-d54140a7a49e" />

The **initial setup of the public development wiki** — the place our roadmap, design rationale, and a backlog of buildable system-design specs live. It renders as a focused, searchable docs site at **`worldofclaudecraft.com/dev`** when deployed (the public game reference wiki at `/wiki` is untouched).

The markdown in `docs/wiki/*.md` is the **source of truth**; the site is just a rendered view of it, so it's equally readable on GitHub and at `/dev`.

> ⚠️ **This is intentionally a placeholder structure to evolve.** It establishes the *conventions* for how we handle the roadmap (cap ladder, system-design backlog, status flow), not a finished plan. Content and process are expected to change as we use it.

## Why VitePress (and how it's isolated)

A focused docs site (grouped sidebar, on-page TOC, local search) reads far better than a general-purpose wiki for this. It's **dependency-isolated** from the game: its own `docs/wiki/package.json` / lockfile, so VitePress never enters the game's build or dependency set.

## What's included

**Wiki pages (`docs/wiki/`)**
- `vision.md` — pitch, design pillars, north star, the **$WOC token guardrails**.
- `current-state.md` — grounded FULL/PARTIAL/ABSENT inventory of every system + gap analysis.
- `design-influences.md` — what we borrow/reject from vanilla Classic + China's Titan Reforged.
- `design-lens.md` — how we decide *what* to build (announce/meme/gate/offense-defense) and the **crypto-vs-vibe strategic fork**.
- `roadmap.md` — the prioritized plan spined on the **20 → 30 → 40 → 60** cap ladder.
- `system-designs/` — the **TODO backlog of pluckable specs**, with a copy-paste template and two worked, tiered examples: **Professions** (1.0 → 2.0) and **Equipment Slots** (4 → 8 → 12 → 17).

**Agent affordances** (so agents/LLMs can ingest the docs)
- A per-page **“Copy as Markdown”** button.
- Raw markdown at **`/dev/raw/<page>.md`**.
- **`/dev/llms.txt`** (index) + **`/dev/llms-full.txt`** (everything inline).

**Roadmap-handling convention (the placeholder process)**
- Ideas pass the **Design Lens** → become **scoped system designs** (status: 💡 Idea → 📐 Scoped → ✅ Ready → 🚧 In progress → 🏁 Shipped) → a contributor/agent **plucks one tier**, balances the open numbers, and builds it.
- A canonical **roadmap-phase taxonomy** (NOW · RETENTION · NEXT · CAP:→30/→40/→60 · LATER · TUNING · ALWAYS-ON); epics map per tier.

**$WOC token stance** — reduced to **two structural guardrails** (the sim never sees it; authority stays server-side). Whether the token confers power (P2E) or only cosmetics is left as an **open strategic decision (the fork)**, not a fixed “no pay-to-win” rule.

**Process docs**
- `CLAUDE.md` / `AGENTS.md` — PRs that **ship or change a system, or shift priorities** update the wiki **in the same PR** (scoped — trivial PRs exempt; keep edits light).
- `DEPLOY.md` — `/dev` now serves the static VitePress build.

## How it deploys to `worldofclaudecraft.com/dev`

The site is a static build served by the reverse proxy:

```bash
cd docs/wiki && npm ci && npm run build   # → docs/wiki/.vitepress/dist
```

**Action required after merge (not automatic):** production fronts the stack with **nginx via Ansible**, so the `eastbrook_game` role in `ansible-scripts` must (1) run the build on deploy and (2) serve `.vitepress/dist` at `/dev` with extensionless-URL fallback (`try_files $uri $uri.html $uri/index.html =404;`). Until that's added, merging this won't make the URL live. (A standalone-Caddy example is in `DEPLOY.md`.)

## Run / preview locally

```bash
npm run devwiki:dev     # live-editing server
npm run devwiki:build   # static build
```

## Notes for reviewers

- No game code touched; this is docs + build tooling + process docs only.
- `docs/wiki/.vitepress/dist` and `node_modules` are gitignored; the lockfile is committed for reproducible `npm ci`.

## Follow-ups (not in this PR)

- Wire the nginx `/dev` block + build step in `ansible-scripts`.
- Optional `.github/pull_request_template.md` checkbox to operationalize the wiki-sync rule for human PRs.
- Decide the **crypto-vs-vibe fork** (the one open strategic decision that colors the roadmap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
