### PR TITLE
docs(woc): Off-chain governance — feature stub for discussion

### DIFF
--- a/docs/prd/woc/governance.md
+++ b/docs/prd/woc/governance.md
@@ -1,0 +1,34 @@
+# Feature Stub — Off-chain governance
+
+> 🚧 **STATUS: STUB — opening discussion.** This is a *feature stub*, not an implementation. It exists to open a focused discussion thread around the **Off-chain governance** `$WOC` flywheel mechanic before any code is written.
+
+| | |
+|---|---|
+| **Tier** | 0 · Foundations |
+| **Ease** | 4/5 |
+| **Flywheel** | 3 |
+| **Sustainability** | Infra |
+| **Reg risk** | Med |
+
+## What
+Off-chain (Snapshot-style) holder voting on content priorities, the cosmetic catalog, and treasury spend.
+
+## Why it's a flywheel
+Ownership → engagement: holders who steer the game are more invested and evangelize it.
+
+## Proposed approach (for discussion)
+- A Snapshot space keyed to the $WOC mint.
+- Advisory votes first; binding scope decided later.
+- The server reflects outcomes; no on-chain execution in v1.
+
+## Constraints (non-negotiable)
+- **Cosmetic-only / no pay-to-win** — token utility is appearance, convenience, access, or realm-operation; never power.
+- **Non-custodial** — the chain owns assets; `src/sim/` stays pure (no network / wallet deps).
+
+## Open questions
+- Advisory or binding?
+- Quorum / proposal thresholds?
+- What is in-scope to vote on vs. dev-reserved?
+
+## Out of scope
+This PR adds **no implementation** — it is a stub to anchor discussion. Part of the proposed `$WOC` GameFi roadmap.


### PR DESCRIPTION
🚧 **Feature stub — opening discussion, not for merge.** This PR adds a stub spec for the **Off-chain governance** `$WOC` flywheel mechanic so we can discuss it in its own thread before any code is written. **No implementation is included.**

**Scores (roadmap):** Tier 0 · Ease 4/5 · Flywheel 3 · Infra · Reg risk Med

**What:** Off-chain (Snapshot-style) holder voting on content priorities, the cosmetic catalog, and treasury spend.

**Constraints:** cosmetic-only / no pay-to-win · non-custodial · `src/sim/` stays pure.

**To discuss:**
- Advisory or binding?
- Quorum / proposal thresholds?
- What is in-scope to vote on vs. dev-reserved?

Part of the proposed `$WOC` GameFi roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
