### PR TITLE
docs(woc): Realm customization — feature stub for discussion

### DIFF
--- a/docs/prd/woc/realm-customization.md
+++ b/docs/prd/woc/realm-customization.md
@@ -1,0 +1,33 @@
+# Feature Stub — Realm customization
+
+> 🚧 **STATUS: STUB — opening discussion.** This is a *feature stub*, not an implementation. It exists to open a focused discussion thread around the **Realm customization** `$WOC` flywheel mechanic before any code is written.
+
+| | |
+|---|---|
+| **Tier** | 3 · Realm ownership |
+| **Ease** | 3/5 |
+| **Flywheel** | 4 |
+| **Sustainability** | Sink |
+| **Reg risk** | Low |
+
+## What
+Realm owners spend $WOC to customize their realm: name, type (PvP / RP), rules, and scheduled events.
+
+## Why it's a flywheel
+High flywheel — differentiated realms attract niche communities; customization is an ongoing sink.
+
+## Proposed approach (for discussion)
+- $WOC-priced realm config options.
+- Route through the burn / treasury split.
+- Guardrails so customization never becomes pay-to-win across realms.
+
+## Constraints (non-negotiable)
+- **Cosmetic-only / no pay-to-win** — token utility is appearance, convenience, access, or realm-operation; never power.
+- **Non-custodial** — the chain owns assets; `src/sim/` stays pure (no network / wallet deps).
+
+## Open questions
+- Which knobs are customizable?
+- Cosmetic / rules only — how do we prevent power divergence between realms?
+
+## Out of scope
+This PR adds **no implementation** — it is a stub to anchor discussion. Part of the proposed `$WOC` GameFi roadmap.


### PR DESCRIPTION
🚧 **Feature stub — opening discussion, not for merge.** This PR adds a stub spec for the **Realm customization** `$WOC` flywheel mechanic so we can discuss it in its own thread before any code is written. **No implementation is included.**

**Scores (roadmap):** Tier 3 · Ease 3/5 · Flywheel 4 · Sink · Reg risk Low

**What:** Realm owners spend $WOC to customize their realm: name, type (PvP / RP), rules, and scheduled events.

**Constraints:** cosmetic-only / no pay-to-win · non-custodial · `src/sim/` stays pure.

**To discuss:**
- Which knobs are customizable?
- Cosmetic / rules only — how do we prevent power divergence between realms?

Part of the proposed `$WOC` GameFi roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
