### PR TITLE
docs(woc): Arena Championship (PvP, $WOC earnings) — feature stub for discussion

### DIFF
--- a/docs/prd/woc/arena-championship.md
+++ b/docs/prd/woc/arena-championship.md
@@ -1,0 +1,37 @@
+# Feature Stub — Arena Championship (PvP, $WOC earnings)
+
+> 🚧 **STATUS: STUB — opening discussion.** This is a *feature stub*, not an implementation. It exists to open a focused discussion thread around the **Arena Championship (PvP, $WOC earnings)** `$WOC` flywheel mechanic before any code is written.
+
+| | |
+|---|---|
+| **Tier** | 4 · Competitive & seasons |
+| **Ease** | 3/5 |
+| **Flywheel** | 4 |
+| **Sustainability** | Rake / Emission |
+| **Reg risk** | High |
+
+## What
+A seasonal ranked PvP championship; a $WOC prize pool (entry fees + treasury) pays out to top finishers, plus an NFT champion trophy.
+
+## Why it's a flywheel
+A recurring spectacle and payout narrative that drives engagement; entry fees feed the sink.
+
+## Proposed approach (for discussion)
+- A seasonal bracket on top of the Elo ladder.
+- Prize pool from entries + treasury, with a transparent payout table.
+- An NFT champion trophy (cosmetic).
+
+## Constraints (non-negotiable)
+- **Cosmetic-only / no pay-to-win** — token utility is appearance, convenience, access, or realm-operation; never power.
+- **Non-custodial** — the chain owns assets; `src/sim/` stays pure (no network / wallet deps).
+
+## Regulatory note
+**⚠ Cash-prize / paid-entry tournaments are gambling exposure** in many jurisdictions. Same discipline as Arena GambleFi — counsel + jurisdiction gating before launch.
+
+## Open questions
+- Entry fee + payout structure?
+- Season cadence?
+- Anti-cheat for stakes-on-the-line PvP?
+
+## Out of scope
+This PR adds **no implementation** — it is a stub to anchor discussion. Part of the proposed `$WOC` GameFi roadmap.


### PR DESCRIPTION
🚧 **Feature stub — opening discussion, not for merge.** This PR adds a stub spec for the **Arena Championship (PvP, $WOC earnings)** `$WOC` flywheel mechanic so we can discuss it in its own thread before any code is written. **No implementation is included.**

**Scores (roadmap):** Tier 4 · Ease 3/5 · Flywheel 4 · Rake / Emission · Reg risk High

**What:** A seasonal ranked PvP championship; a $WOC prize pool (entry fees + treasury) pays out to top finishers, plus an NFT champion trophy.

**⚠ Cash-prize / paid-entry tournaments are gambling exposure** in many jurisdictions. Same discipline as Arena GambleFi — counsel + jurisdiction gating before launch.

**Constraints:** cosmetic-only / no pay-to-win · non-custodial · `src/sim/` stays pure.

**To discuss:**
- Entry fee + payout structure?
- Season cadence?
- Anti-cheat for stakes-on-the-line PvP?

Part of the proposed `$WOC` GameFi roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
