### PR TITLE
feat(quests): add The Codfather fishing quest

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -7,6 +7,8 @@ import type {
   CampDef, GroundObjectDef, ItemDef, MobTemplate, NpcDef, PlayerClass, QuestDef, ZoneDef, ZonePropsDef,
 } from '../types';
 
+export const DEEPFEN_SHALLOWS_LAKE = { x: -110, z: 310, radius: 35 };
+
 export const ZONE2_ZONE: ZoneDef = {
   id: 'mirefen_marsh',
   name: 'Mirefen Marsh',
@@ -17,7 +19,7 @@ export const ZONE2_ZONE: ZoneDef = {
   hub: { x: 0, z: 300, radius: 20, name: 'Fenbridge' },
   graveyard: { x: -18, z: 286 },
   lakes: [
-    { x: -110, z: 310, radius: 35 },
+    DEEPFEN_SHALLOWS_LAKE,
     { x: 60, z: 380, radius: 25 },
     { x: -40, z: 450, radius: 20 },
   ],
@@ -236,7 +238,7 @@ export const ZONE2_NPCS: Record<string, NpcDef> = {
   provisioner_hale: {
     id: 'provisioner_hale', name: 'Provisioner Hale', title: 'Provisioner',
     pos: { x: -4, z: 308 }, facing: Math.PI / 2, color: 0x1e8449,
-    questIds: ['q_prowler_pelts', 'q_fen_supplies', 'q_grubjaw'],
+    questIds: ['q_prowler_pelts', 'q_fen_supplies', 'q_the_codfather', 'q_grubjaw'],
     vendorItems: [
       'fenbridge_rye', 'marsh_mint_tea', 'smoked_eel', 'silvermist_cordial',
       'bogiron_mace', 'fenreed_staff', 'mirefen_skinner', 'bogiron_hauberk',
@@ -296,6 +298,15 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
     objectives: [{ type: 'collect', itemId: 'lost_caravan_goods', count: 5, label: 'Lost Caravan Goods' }],
     xpReward: 900, copperReward: 350, itemRewards: {},
     minLevel: 7,
+  },
+  q_the_codfather: {
+    id: 'q_the_codfather', name: 'The Codfather',
+    giverNpcId: 'provisioner_hale', turnInNpcId: 'provisioner_hale',
+    text: "The Codfather isn't just a fish, $N, he's a cold-blooded killer. Old-timers swear he eats Mire Prowlers for breakfast, and even the Mirefen Widows won't spin their webs near the Deepfen Shallows out of sheer terror. He rules those waters. Grab a fishing pole, drag that old devil out of his waters, and I will admit you have joined the family.",
+    completionText: "By the damp saints... The Codfather himself. Look at those whiskers. Fenbridge will eat stories off this catch for a year, $N.",
+    objectives: [{ type: 'collect', itemId: 'the_codfather', count: 1, label: 'The Codfather' }],
+    xpReward: 950, copperReward: 450, itemRewards: {},
+    minLevel: 6,
   },
   q_deepfen: {
     id: 'q_deepfen', name: 'The Deepfen Stirs',
@@ -474,7 +485,7 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
 
 export const ZONE2_QUEST_ORDER = [
   'q_fenbridge_muster', 'q_prowlers', 'q_prowler_pelts', 'q_fen_supplies',
-  'q_deepfen', 'q_idols', 'q_deepfen_purge', 'q_widows', 'q_broodmother',
+  'q_the_codfather', 'q_deepfen', 'q_idols', 'q_deepfen_purge', 'q_widows', 'q_broodmother',
   'q_drowned', 'q_drowned_censers', 'q_no_rest', 'q_trolls', 'q_troll_fetishes',
   'q_grubjaw', 'q_cult_camp', 'q_summoners', 'q_deacon', 'q_bastion_door',
   'q_olen', 'q_mistcaller',
@@ -556,6 +567,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
   fen_muster_order: { id: 'fen_muster_order', name: 'Fenbridge Muster Order', kind: 'quest', sellValue: 0, questId: 'q_fenbridge_muster' },
   mire_prowler_pelt: { id: 'mire_prowler_pelt', name: 'Mire Prowler Pelt', kind: 'quest', sellValue: 0, questId: 'q_prowler_pelts' },
   lost_caravan_goods: { id: 'lost_caravan_goods', name: 'Lost Caravan Goods', kind: 'quest', sellValue: 0, questId: 'q_fen_supplies' },
+  the_codfather: { id: 'the_codfather', name: 'The Codfather', kind: 'quest', sellValue: 0, questId: 'q_the_codfather' },
   waterlogged_idol: { id: 'waterlogged_idol', name: 'Waterlogged Idol', kind: 'quest', sellValue: 0, questId: 'q_idols' },
   widow_venom_sac: { id: 'widow_venom_sac', name: 'Widow Venom Sac', kind: 'quest', sellValue: 0, questId: 'q_widows' },
   rusted_censer: { id: 'rusted_censer', name: 'Rusted Censer', kind: 'quest', sellValue: 0, questId: 'q_drowned_censers' },

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -14,7 +14,7 @@ import {
   ZONE1_PROPS, ZONE1_QUESTS, ZONE1_QUEST_ORDER, ZONE1_ROADS, ZONE1_ZONE,
 } from './content/zone1';
 import {
-  ZONE2_CAMPS, ZONE2_ITEMS, ZONE2_MOBS, ZONE2_NPCS, ZONE2_OBJECTS, ZONE2_PROPS,
+  DEEPFEN_SHALLOWS_LAKE, ZONE2_CAMPS, ZONE2_ITEMS, ZONE2_MOBS, ZONE2_NPCS, ZONE2_OBJECTS, ZONE2_PROPS,
   ZONE2_QUESTS, ZONE2_QUEST_ORDER, ZONE2_ROADS, ZONE2_ZONE,
 } from './content/zone2';
 import {
@@ -149,6 +149,7 @@ export function zoneWelcomeText(zone: ZoneDef, questState: (questId: string) => 
 // Legacy single-zone exports (zone 1) — still referenced by tests and the
 // starter-town logic.
 export { GRAVEYARD_POS, LAKE, TOWN_RADIUS };
+export { DEEPFEN_SHALLOWS_LAKE };
 export const ZONE_NAME = ZONE1_ZONE.name;
 
 // ---------------------------------------------------------------------------

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2,6 +2,7 @@ import {
   ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
   ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, questRewardItemId, abilitiesKnownAt, instanceOrigin,
+  DEEPFEN_SHALLOWS_LAKE,
   zoneAt, ZONES,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B } from './dungeon_layout';
@@ -160,6 +161,9 @@ const SWIM_SURFACE_Y = WATER_LEVEL - 0.75; // body bobs just below the water lin
 const SWIM_DEPTH = 0.8; // ground this far under the water line = deep water
 const SWIM_SPEED_MULT = 0.65;
 const FISHING_SAMPLE_DISTANCES = [4, 8, 12, 16, 20, 24];
+const DEEPFEN_FISHING_SHORE_MARGIN = 10;
+const THE_CODFATHER_ITEM_ID = 'the_codfather';
+const THE_CODFATHER_QUEST_ID = 'q_the_codfather';
 const DOOR_TRIGGER_RADIUS = 2.0; // walking this close to a dungeon door teleports you
 const BODY_RADIUS = 0.5;
 const CHARGE_SPEED_MULT = 3; // warrior charge runs at 3x normal speed
@@ -4619,6 +4623,18 @@ export class Sim {
       groundHeight(p.pos.x + sin * d, p.pos.z + cos * d, this.cfg.seed) < WATER_LEVEL - SWIM_DEPTH);
   }
 
+  private isAtDeepfenShallowsFishingSpot(p: Entity): boolean {
+    const d = Math.hypot(p.pos.x - DEEPFEN_SHALLOWS_LAKE.x, p.pos.z - DEEPFEN_SHALLOWS_LAKE.z);
+    return d <= DEEPFEN_SHALLOWS_LAKE.radius + DEEPFEN_FISHING_SHORE_MARGIN;
+  }
+
+  private shouldCatchCodfather(p: Entity, meta: PlayerMeta): boolean {
+    const qp = meta.questLog.get(THE_CODFATHER_QUEST_ID);
+    return qp?.state === 'active'
+      && this.countItem(THE_CODFATHER_ITEM_ID, meta.entityId) === 0
+      && this.isAtDeepfenShallowsFishingSpot(p);
+  }
+
   private startFishing(p: Entity, meta: PlayerMeta): void {
     if (p.dead) { this.error(meta.entityId, "You can't do that while dead."); return; }
     if (p.inCombat) { this.error(meta.entityId, "You can't do that while in combat."); return; }
@@ -4634,6 +4650,10 @@ export class Sim {
   }
 
   private completeFishing(p: Entity, meta: PlayerMeta): void {
+    if (this.shouldCatchCodfather(p, meta)) {
+      this.addItem(THE_CODFATHER_ITEM_ID, 1, meta.entityId);
+      return;
+    }
     const roll = this.rng.next();
     if (roll < 0.7) {
       this.addItem('raw_mirror_trout', 1, meta.entityId);

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -9709,7 +9709,7 @@ phase11Entities.fr_CA = phase11Entities.fr_FR;
 // Phase 11 overlay extension: class quality-of-life abilities + Drowned Temple
 // (PR #390/#392). Merged into each locale's entities below.
 const DROWNED_ITEM_IDS = [
-  "briny_idol", "drowned_offering", "drownedmoon_kris", "drownedmoon_maul", "drownedmoon_scepter", "drownstep_sabatons", "drownstep_slippers", "drownstep_treads", "moongate_rubbing", "moonpale_scale", "moonscale_saber", "moonshroud_breastplate", "moonshroud_robe", "moonshroud_tunic", "pale_pearl", "palecoil_heartscale", "palecoil_rod", "selthes_seastriders", "tideglass_dirk", "tidewatchers_wraps", "ysols_pearl_greaves"
+  "briny_idol", "drowned_offering", "drownedmoon_kris", "drownedmoon_maul", "drownedmoon_scepter", "drownstep_sabatons", "drownstep_slippers", "drownstep_treads", "moongate_rubbing", "moonpale_scale", "moonscale_saber", "moonshroud_breastplate", "moonshroud_robe", "moonshroud_tunic", "pale_pearl", "palecoil_heartscale", "palecoil_rod", "selthes_seastriders", "tideglass_dirk", "tidewatchers_wraps", "ysols_pearl_greaves", "the_codfather"
 ] as const;
 
 const DROWNED_MOB_IDS = [
@@ -9725,7 +9725,7 @@ const phase11ExtraEn = {
       ["revive_pet", "Revive Pet", "Revives your dead pet and returns it to your side."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Briny Idol", "Drowned Offering", "Drowned Moon Kris", "Drowned Moon Maul", "Drowned Moon Scepter", "Drownstep Sabatons", "Drownstep Slippers", "Drownstep Treads", "Warding Rubbing", "Moonpale Scale", "Moonscale Saber", "Moonshroud Breastplate", "Moonshroud Robe", "Moonshroud Tunic", "Pale Pearl", "Sethrael's Heartscale", "Palecoil Rod", "Selthe's Sea-Striders", "Tideglass Dirk", "Tidewatcher's Wraps", "Ysolei's Pearl Greaves"
+      "Briny Idol", "Drowned Offering", "Drowned Moon Kris", "Drowned Moon Maul", "Drowned Moon Scepter", "Drownstep Sabatons", "Drownstep Slippers", "Drownstep Treads", "Warding Rubbing", "Moonpale Scale", "Moonscale Saber", "Moonshroud Breastplate", "Moonshroud Robe", "Moonshroud Tunic", "Pale Pearl", "Sethrael's Heartscale", "Palecoil Rod", "Selthe's Sea-Striders", "Tideglass Dirk", "Tidewatcher's Wraps", "Ysolei's Pearl Greaves", "The Codfather"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Choirmother Selthe", "Drowned Templeguard", "Drowned Votary", "Glimmermere Wader", "Glimmerscale Lurker", "Moonspawn", "Pale Choir Acolyte", "Pearlguard Sentinel", "Sethrael the Palecoil", "Fire Demon", "Void Demon", "Ysolei, Avatar of the Drowned Moon"
@@ -9770,6 +9770,12 @@ const phase11ExtraEn = {
         completion: "Ten back in the water. They feel no cold, {playerName}, and no fear — only the pull of that gate. Whatever sings to them, it sings loud.",
         objectives: { 0: { label: "Glimmermere Wader slain" } },
       },
+      q_the_codfather: {
+        title: "The Codfather",
+        text: "The Codfather isn't just a fish, {playerName}, he's a cold-blooded killer. Old-timers swear he eats Mire Prowlers for breakfast, and even the Mirefen Widows won't spin their webs near the Deepfen Shallows out of sheer terror. He rules those waters. Grab a fishing pole, drag that old devil out of his waters, and I will admit you have joined the family.",
+        completion: "By the damp saints... The Codfather himself. Look at those whiskers. Fenbridge will eat stories off this catch for a year, {playerName}.",
+        objectives: { 0: { label: "The Codfather" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "The Drowned Temple", enterText: "You step through the moongate — the air turns to cold water and pale light, and the singing closes over your head.", leaveText: "You surface through the moongate into the mountain night." },
@@ -9787,7 +9793,7 @@ const phase11Extra = {
       ["revive_pet", "Revivir mascota", "Revive a tu mascota muerta y la devuelve a tu lado."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Ídolo salobre", "Ofrenda ahogada", "Kris de la Luna Ahogada", "Maza de la Luna Ahogada", "Cetro de la Luna Ahogada", "Escarpes de Paso Ahogado", "Babuchas de Paso Ahogado", "Botas de Paso Ahogado", "Calco protector", "Escama de Lunapálida", "Sable de Escama Lunar", "Peto del Sudario Lunar", "Túnica del Sudario Lunar", "Sobreveste del Sudario Lunar", "Perla pálida", "Escama del corazón de Sethrael", "Vara de Espiral Pálida", "Zancadas marinas de Selthe", "Daga de Vidriomarea", "Vendas del Vigía de la Marea", "Grebas de perla de Ysolei"
+      "Ídolo salobre", "Ofrenda ahogada", "Kris de la Luna Ahogada", "Maza de la Luna Ahogada", "Cetro de la Luna Ahogada", "Escarpes de Paso Ahogado", "Babuchas de Paso Ahogado", "Botas de Paso Ahogado", "Calco protector", "Escama de Lunapálida", "Sable de Escama Lunar", "Peto del Sudario Lunar", "Túnica del Sudario Lunar", "Sobreveste del Sudario Lunar", "Perla pálida", "Escama del corazón de Sethrael", "Vara de Espiral Pálida", "Zancadas marinas de Selthe", "Daga de Vidriomarea", "Vendas del Vigía de la Marea", "Grebas de perla de Ysolei", "El Bacaladrino"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Selthe, madre del coro", "Guardián ahogado del templo", "Devoto ahogado", "Vadeador de Glimmermere", "Acechador de Escama Reluciente", "Engendro lunar", "Acólito del Coro Pálido", "Centinela de la Guardia de Perla", "Sethrael, la Espiral Pálida", "Demonio de fuego", "Demonio del vacío", "Ysolei, Avatar de la Luna Ahogada"
@@ -9832,6 +9838,12 @@ const phase11Extra = {
         completion: "Diez de vuelta al agua. No sienten frío, {playerName}, ni miedo: solo la atracción de esa puerta. Sea lo que sea lo que les canta, canta fuerte.",
         objectives: { 0: { label: "Vadeador de Glimmermere abatido" } },
       },
+      q_the_codfather: {
+        title: "El Bacaladrino",
+        text: "El Bacaladrino no es solo un pez, {playerName}, es un asesino de sangre fría. Los veteranos juran que desayuna merodeadores del lodazal, e incluso las viudas de Mirefen no tejen sus redes cerca de los Bajíos de Deepfen por puro terror. Gobierna esas aguas. Toma una caña de pescar, arranca a ese viejo demonio de sus aguas y admitiré que ya eres de la familia.",
+        completion: "Por los santos húmedos... El Bacaladrino en persona. Mira esos bigotes. Fenbridge vivirá un año entero contando historias de esta captura, {playerName}.",
+        objectives: { 0: { label: "El Bacaladrino" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "El Templo Ahogado", enterText: "Atraviesas la puerta lunar: el aire se vuelve agua fría y luz pálida, y el canto se cierra sobre tu cabeza.", leaveText: "Emerges a través de la puerta lunar a la noche de la montaña." },
@@ -9846,7 +9858,7 @@ const phase11Extra = {
       ["revive_pet", "Ranimer le familier", "Ranime votre familier mort et le ramène à vos côtés."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Idole saumâtre", "Offrande noyée", "Kriss de la Lune noyée", "Maillet de la Lune noyée", "Sceptre de la Lune noyée", "Solerets du Pas noyé", "Chaussons du Pas noyé", "Sandales du Pas noyé", "Frottis de protection", "Écaille de Pâlelune", "Sabre en écailles de lune", "Plastron du Linceul de lune", "Robe du Linceul de lune", "Tunique du Linceul de lune", "Perle blafarde", "Écaille de cœur de Sethrael", "Verge de Pâlanneau", "Arpenteuses des mers de Selthe", "Dague de verre de marée", "Bandes du Veille-marées", "Jambières de perle d'Ysolei"
+      "Idole saumâtre", "Offrande noyée", "Kriss de la Lune noyée", "Maillet de la Lune noyée", "Sceptre de la Lune noyée", "Solerets du Pas noyé", "Chaussons du Pas noyé", "Sandales du Pas noyé", "Frottis de protection", "Écaille de Pâlelune", "Sabre en écailles de lune", "Plastron du Linceul de lune", "Robe du Linceul de lune", "Tunique du Linceul de lune", "Perle blafarde", "Écaille de cœur de Sethrael", "Verge de Pâlanneau", "Arpenteuses des mers de Selthe", "Dague de verre de marée", "Bandes du Veille-marées", "Jambières de perle d'Ysolei", "Capitaine brochet"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Selthe, mère de chœur", "Garde du temple noyé", "Dévot noyé", "Pataugeur de Lac-miroitant", "Rôdeur aux écailles miroitantes", "Engeance de lune", "Acolyte du Chœur blafard", "Sentinelle de la Garde de perle", "Sethrael le Pâlanneau", "Démon de feu", "Démon du néant", "Ysolei, avatar de la Lune noyée"
@@ -9891,6 +9903,12 @@ const phase11Extra = {
         completion: "Dix rendus à l'eau. Ils ne ressentent ni le froid, {playerName}, ni la peur — seulement l'attrait de cette porte. Quoi qu'il leur chante, cela chante fort.",
         objectives: { 0: { label: "Pataugeur de Lac-miroitant tué" } },
       },
+      q_the_codfather: {
+        title: "Capitaine brochet",
+        text: "Capitaine brochet n'est pas qu'un poisson, {playerName}, c'est un tueur à sang froid. Les anciens jurent qu'il mange des rôdeurs du bourbier au petit-déjeuner, et même les veuves de Mirefen ne tissent pas leurs toiles près des hauts-fonds de Deepfen, tant elles le craignent. Il règne sur ces eaux. Prenez une canne à pêche, tirez ce vieux démon hors de ses eaux, et j'admettrai que vous faites partie de la famille.",
+        completion: "Je n'en crois pas mes yeux ! Capitaine brochet lui-même. Regardez moi ces moustaches diaboliques ! Tout Fenbridge parlera de votre belle prise durant un bon moment, {playerName}.",
+        objectives: { 0: { label: "Capitaine brochet" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "Le Temple noyé", enterText: "Tu franchis la porte de lune — l'air se mue en eau froide et en lumière blafarde, et le chant se referme au-dessus de ta tête.", leaveText: "Tu refais surface par la porte de lune dans la nuit de la montagne." },
@@ -9905,7 +9923,7 @@ const phase11Extra = {
       ["revive_pet", "Rianima Famiglio", "Rianima il tuo famiglio morto e lo richiama al tuo fianco."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Idolo Salmastro", "Offerta Annegata", "Kris della Luna Annegata", "Maglio della Luna Annegata", "Scettro della Luna Annegata", "Scarpe d'Arme di Passoannegato", "Pantofole di Passoannegato", "Stivali di Passoannegato", "Calco Protettivo", "Squama di Lunapallida", "Sciabola di Lunasquama", "Corazza del Sudario Lunare", "Veste del Sudario Lunare", "Tunica del Sudario Lunare", "Perla Pallida", "Squamacuore di Sethrael", "Verga di Spiropallido", "Camminamari di Selthe", "Pugnale di Vetromarea", "Fasce del Guardamarea", "Schinieri di Perla di Ysolei"
+      "Idolo Salmastro", "Offerta Annegata", "Kris della Luna Annegata", "Maglio della Luna Annegata", "Scettro della Luna Annegata", "Scarpe d'Arme di Passoannegato", "Pantofole di Passoannegato", "Stivali di Passoannegato", "Calco Protettivo", "Squama di Lunapallida", "Sciabola di Lunasquama", "Corazza del Sudario Lunare", "Veste del Sudario Lunare", "Tunica del Sudario Lunare", "Perla Pallida", "Squamacuore di Sethrael", "Verga di Spiropallido", "Camminamari di Selthe", "Pugnale di Vetromarea", "Fasce del Guardamarea", "Schinieri di Perla di Ysolei", "Il Pescadrino"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Selthe Madre del Coro", "Guardiano del Tempio Annegato", "Devoto Annegato", "Guadatore di Glimmermere", "Acquattato di Glimmerscaglia", "Progenie Lunare", "Accolito del Coro Pallido", "Sentinella della Guardia di Perla", "Sethrael lo Spiropallido", "Demone di Fuoco", "Demone del Vuoto", "Ysolei, Avatar della Luna Annegata"
@@ -9950,6 +9968,12 @@ const phase11Extra = {
         completion: "Dieci di nuovo nell'acqua. Non sentono il freddo, {playerName}, né la paura — solo il richiamo di quel cancello. Qualunque cosa canti per loro, canta forte.",
         objectives: { 0: { label: "Guadatore di Glimmermere ucciso" } },
       },
+      q_the_codfather: {
+        title: "Il Pescadrino",
+        text: "Il Pescadrino non è solo un pesce, {playerName}, è un assassino a sangue freddo. I vecchi giurano che mangi predatori del pantano a colazione, e persino le vedove di Mirefen non tessono le loro ragnatele vicino ai bassifondi di Deepfen per puro terrore. Governa quelle acque. Prendi una canna da pesca, trascina quel vecchio demonio fuori dalle sue acque e ammetterò che sei entrato nella famiglia.",
+        completion: "Per i santi fradici... Il Pescadrino in persona. Guarda quei baffi. Fenbridge vivrà per un anno raccontando storie su questa cattura, {playerName}.",
+        objectives: { 0: { label: "Il Pescadrino" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "Il Tempio Annegato", enterText: "Attraversi il cancello lunare — l'aria si fa acqua gelida e luce pallida, e il canto si richiude sopra la tua testa.", leaveText: "Riemergi attraverso il cancello lunare nella notte della montagna." },
@@ -9964,7 +9988,7 @@ const phase11Extra = {
       ["revive_pet", "Begleiter wiederbeleben", "Belebt deinen toten Begleiter wieder und ruft ihn an deine Seite zurück."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Salzlaken-Götze", "Ertränkte Opfergabe", "Kris des Ertränkten Mondes", "Streitkolben des Ertränkten Mondes", "Zepter des Ertränkten Mondes", "Ertränkungsschritt-Eisenschuhe", "Ertränkungsschritt-Schläppchen", "Ertränkungsschritt-Trittlinge", "Schutzzeichen-Abrieb", "Mondbleiche Schuppe", "Mondschuppen-Säbel", "Mondschleier-Brustpanzer", "Mondschleier-Robe", "Mondschleier-Wams", "Bleiche Perle", "Sethraels Herzschuppe", "Bleichwinder-Rute", "Selthes Meeresschreiter", "Gezeitenglas-Dolch", "Bandagen des Gezeitenwächters", "Ysoleis Perlenbeinschienen"
+      "Salzlaken-Götze", "Ertränkte Opfergabe", "Kris des Ertränkten Mondes", "Streitkolben des Ertränkten Mondes", "Zepter des Ertränkten Mondes", "Ertränkungsschritt-Eisenschuhe", "Ertränkungsschritt-Schläppchen", "Ertränkungsschritt-Trittlinge", "Schutzzeichen-Abrieb", "Mondbleiche Schuppe", "Mondschuppen-Säbel", "Mondschleier-Brustpanzer", "Mondschleier-Robe", "Mondschleier-Wams", "Bleiche Perle", "Sethraels Herzschuppe", "Bleichwinder-Rute", "Selthes Meeresschreiter", "Gezeitenglas-Dolch", "Bandagen des Gezeitenwächters", "Ysoleis Perlenbeinschienen", "Der Kabeljaupate"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Chormutter Selthe", "Ertränkte Tempelwache", "Ertränkter Andächtiger", "Schimmersee-Wäter", "Schimmerschuppen-Lauerer", "Mondbrut", "Akolyth des Bleichen Chors", "Perlwächter-Schildwache", "Sethrael der Bleichwinder", "Feuerdämon", "Leerendämon", "Ysolei, Avatar des Ertränkten Mondes"
@@ -10009,6 +10033,12 @@ const phase11Extra = {
         completion: "Zehn zurück im Wasser. Sie spüren keine Kälte, {playerName}, und keine Furcht — nur den Sog jenes Tores. Was auch immer ihnen singt, es singt laut.",
         objectives: { 0: { label: "Schimmersee-Wäter erschlagen" } },
       },
+      q_the_codfather: {
+        title: "Der Kabeljaupate",
+        text: "Der Kabeljaupate ist nicht nur ein Fisch, {playerName}, er ist ein kaltblütiger Mörder. Die Alten schwören, er frisst Moorpirscher zum Frühstück, und selbst die Mirefen-Witwen spinnen aus blanker Furcht keine Netze nahe den Deepfen-Untiefen. Er herrscht über diese Wasser. Schnapp dir eine Angel, zieh diesen alten Teufel aus seinen Gewässern, und ich gebe zu, dass du zur Familie gehörst.",
+        completion: "Bei den klammen Heiligen... Der Kabeljaupate höchstpersönlich. Sieh dir diese Barteln an. Fenbridge wird ein Jahr lang Geschichten von diesem Fang erzählen, {playerName}.",
+        objectives: { 0: { label: "Der Kabeljaupate" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "Der Ertränkte Tempel", enterText: "Du trittst durch das Mondtor — die Luft wird zu kaltem Wasser und bleichem Licht, und der Gesang schließt sich über deinem Haupt.", leaveText: "Du tauchst durch das Mondtor empor in die Bergnacht." },
@@ -10023,7 +10053,7 @@ const phase11Extra = {
       ["revive_pet", "复活宠物", "复活你死去的宠物，并将其召回身边。"],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "咸海神像", "溺亡祭品", "溺月波刃匕", "溺月巨锤", "溺月权杖", "溺踪战靴", "溺踪软鞋", "溺踪皮靴", "守誓拓文", "苍月之鳞", "月鳞军刀", "月帷胸甲", "月帷长袍", "月帷外衣", "苍白之珠", "瑟斯雷尔的心鳞", "苍盘法杖", "塞尔瑟的踏海者", "潮镜短刃", "守潮者裹手", "伊索蕾的珍珠护胫"
+      "咸海神像", "溺亡祭品", "溺月波刃匕", "溺月巨锤", "溺月权杖", "溺踪战靴", "溺踪软鞋", "溺踪皮靴", "守誓拓文", "苍月之鳞", "月鳞军刀", "月帷胸甲", "月帷长袍", "月帷外衣", "苍白之珠", "瑟斯雷尔的心鳞", "苍盘法杖", "塞尔瑟的踏海者", "潮镜短刃", "守潮者裹手", "伊索蕾的珍珠护胫", "鳕鱼教父"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "唱诗母塞尔瑟", "溺亡神殿卫", "溺亡信徒", "微光潭涉行者", "微光鳞潜伏者", "月之孽生", "苍白唱诗侍僧", "珍珠卫哨兵", "苍盘者瑟斯雷尔", "火焰恶魔", "虚空恶魔", "伊索蕾，溺月化身"
@@ -10068,6 +10098,12 @@ const phase11Extra = {
         completion: "十个都回到了水里。它们感觉不到寒冷，{playerName}，也毫无惧意——只有那门户的牵引。无论是什么在向它们歌唱，那歌声都唱得震天响。",
         objectives: { 0: { label: "微光潭涉行者已被消灭" } },
       },
+      q_the_codfather: {
+        title: "鳕鱼教父",
+        text: "鳕鱼教父不只是一条鱼，{playerName}，它是个冷血杀手。老人们发誓说它拿湿地徘徊者当早饭，就连米尔芬寡妇也会因恐惧而不敢在深沼浅滩附近结网。那片水域归它统治。拿上鱼竿，把那个老恶魔从它的水域里拖出来，我就承认你入了这个家族。",
+        completion: "湿地诸圣在上……鳕鱼教父本尊。看看那些胡须。芬桥会把这次收获讲上一整年，{playerName}。",
+        objectives: { 0: { label: "鳕鱼教父" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "溺亡神殿", enterText: "你踏过那道月门——空气化作冰冷的水与苍白的光，歌声在你头顶合拢。", leaveText: "你穿过月门，浮上山间的夜色之中。" },
@@ -10082,7 +10118,7 @@ const phase11Extra = {
       ["revive_pet", "復活寵物", "復活你已死亡的寵物，並使其重回你身邊。"],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "鹹海神像", "溺者供品", "溺月波刃匕", "溺月巨槌", "溺月權杖", "沉踏戰靴", "沉踏軟履", "沉踏踏靴", "守護拓印", "蒼月之鱗", "月鱗彎刀", "月帷胸甲", "月帷長袍", "月帷外衣", "蒼白珍珠", "賽斯瑞爾的心鱗", "蒼盤法杖", "瑟爾瑟的踏海靴", "潮鏡短劍", "守潮者護腕", "伊索蕾的珍珠脛甲"
+      "鹹海神像", "溺者供品", "溺月波刃匕", "溺月巨槌", "溺月權杖", "沉踏戰靴", "沉踏軟履", "沉踏踏靴", "守護拓印", "蒼月之鱗", "月鱗彎刀", "月帷胸甲", "月帷長袍", "月帷外衣", "蒼白珍珠", "賽斯瑞爾的心鱗", "蒼盤法杖", "瑟爾瑟的踏海靴", "潮鏡短劍", "守潮者護腕", "伊索蕾的珍珠脛甲", "鱈魚教父"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "唱詩之母瑟爾瑟", "溺亡神殿守衛", "溺亡信徒", "微光湖涉者", "微鱗潛伏者", "月之裔", "蒼白唱詩侍僧", "珍珠衛哨兵", "蒼盤者賽斯瑞爾", "火焰惡魔", "虛空惡魔", "伊索蕾，溺月化身"
@@ -10127,6 +10163,12 @@ const phase11Extra = {
         completion: "十隻已回歸水中。牠們感受不到寒冷，{playerName}，也感受不到恐懼——只感受得到那道門的牽引。無論是什麼在向牠們歌唱，那歌聲都響亮得很。",
         objectives: { 0: { label: "微光湖涉者已被擊殺" } },
       },
+      q_the_codfather: {
+        title: "鱈魚教父",
+        text: "鱈魚教父不只是一條魚，{playerName}，牠是個冷血殺手。老人們發誓說牠拿濕地徘徊者當早飯，就連米爾芬寡婦也會因恐懼而不敢在深沼淺灘附近結網。那片水域歸牠統治。拿上釣竿，把那個老惡魔從牠的水域裡拖出來，我就承認你入了這個家族。",
+        completion: "濕地諸聖在上……鱈魚教父本尊。看看那些鬚。芬橋會把這次收穫講上一整年，{playerName}。",
+        objectives: { 0: { label: "鱈魚教父" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "溺亡神殿", enterText: "你踏過月門——空氣化作冰冷的水與蒼白的光，歌聲在你頭頂之上闔攏。", leaveText: "你穿過月門浮出水面，回到山間的夜色之中。" },
@@ -10141,7 +10183,7 @@ const phase11Extra = {
       ["revive_pet", "소환수 소생", "죽은 소환수를 되살려 당신의 곁으로 되돌립니다."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "소금기 어린 우상", "익사한 제물", "익사한 달의 크리스 단검", "익사한 달의 대망치", "익사한 달의 홀", "드라운스텝 사바톤", "드라운스텝 슬리퍼", "드라운스텝 군화", "수호의 탁본", "창백한 달빛 비늘", "달비늘 세이버", "달수의 흉갑", "달수의 법복", "달수의 튜닉", "창백한 진주", "세스라엘의 심장 비늘", "페일코일 막대", "셀세의 바다걸음 장화", "조수유리 단검", "조수지기의 손싸개", "이솔레이의 진주 정강이받이"
+      "소금기 어린 우상", "익사한 제물", "익사한 달의 크리스 단검", "익사한 달의 대망치", "익사한 달의 홀", "드라운스텝 사바톤", "드라운스텝 슬리퍼", "드라운스텝 군화", "수호의 탁본", "창백한 달빛 비늘", "달비늘 세이버", "달수의 흉갑", "달수의 법복", "달수의 튜닉", "창백한 진주", "세스라엘의 심장 비늘", "페일코일 막대", "셀세의 바다걸음 장화", "조수유리 단검", "조수지기의 손싸개", "이솔레이의 진주 정강이받이", "대구 대부"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "성가대모 셀세", "익사한 신전 수호병", "익사한 신도", "글리머미어 물거리", "반짝비늘 잠복자", "달의 부산물", "창백한 성가대 수습 사제", "진주수호 파수병", "페일코일의 세스라엘", "화염 악마", "공허 악마", "이솔레이, 익사한 달의 화신"
@@ -10186,6 +10228,12 @@ const phase11Extra = {
         completion: "열 마리를 물속으로 되돌려 보냈군. 그것들은 추위도, 두려움도 느끼지 못한다네, {playerName} — 오직 저 관문의 끌림만을 느낄 뿐이지. 무엇이 그것들에게 노래하든, 그 노래는 참으로 크게 울리는군.",
         objectives: { 0: { label: "글리머미어 물거리 처치" } },
       },
+      q_the_codfather: {
+        title: "대구 대부",
+        text: "대구 대부는 그저 물고기가 아니라네, {playerName}. 냉혈한 살인자지. 노인들은 놈이 늪지 배회자를 아침으로 먹는다고 맹세하고, 미어펜 과부거미조차 순전한 공포 때문에 딥펜 여울 근처에는 거미줄을 치지 않는다네. 놈이 그 물을 지배하지. 낚싯대를 들고 그 늙은 악마를 제 물가에서 끌어내 오게. 그러면 자네가 가족이 되었다고 인정하지.",
+        completion: "축축한 성자들이시여... 대구 대부 그 자체로군. 저 수염 좀 보게. 펜브리지는 이 한 마리로 일 년 내내 이야깃거리를 삼을 걸세, {playerName}.",
+        objectives: { 0: { label: "대구 대부" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "익사한 신전", enterText: "당신은 달의 관문을 지나갑니다 — 공기가 차가운 물과 창백한 빛으로 변하고, 노랫소리가 당신의 머리 위로 닫혀 옵니다.", leaveText: "당신은 달의 관문을 통해 산속의 밤으로 떠오릅니다." },
@@ -10200,7 +10248,7 @@ const phase11Extra = {
       ["revive_pet", "ペット蘇生", "死んだペットを蘇生させ、自分のそばに呼び戻す。"],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "潮辛の偶像", "溺れし供物", "溺月のクリス", "溺月の大槌", "溺月の笏", "溺歩のサバトン", "溺歩のスリッパ", "溺歩のトレッド", "守護の拓本", "蒼白月の鱗", "月鱗のサーベル", "月帷子の胸甲", "月帷子のローブ", "月帷子のチュニック", "蒼白の真珠", "セスラエルの心鱗", "蒼渦のロッド", "セルセの潮渡り靴", "潮硝子の短剣", "潮見の手布", "イソレイの真珠脚甲"
+      "潮辛の偶像", "溺れし供物", "溺月のクリス", "溺月の大槌", "溺月の笏", "溺歩のサバトン", "溺歩のスリッパ", "溺歩のトレッド", "守護の拓本", "蒼白月の鱗", "月鱗のサーベル", "月帷子の胸甲", "月帷子のローブ", "月帷子のチュニック", "蒼白の真珠", "セスラエルの心鱗", "蒼渦のロッド", "セルセの潮渡り靴", "潮硝子の短剣", "潮見の手布", "イソレイの真珠脚甲", "タラのゴッドファーザー"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "聖歌母セルセ", "溺れし神殿守", "溺れし信徒", "煌めき沼の渡り手", "煌鱗の潜み者", "月の落とし子", "蒼白聖歌隊の侍祭", "真珠衛の歩哨", "蒼渦のセスラエル", "炎の魔物", "虚無の魔物", "イソレイ、溺月の化身"
@@ -10245,6 +10293,12 @@ const phase11Extra = {
         completion: "十体が水に還った。奴らは寒さも恐れも感じぬのだ、{playerName}——ただあの門の引き寄せだけを感じている。奴らに何が歌いかけているにせよ、その歌は大きく響いているのだ。",
         objectives: { 0: { label: "煌めき沼の渡り手を討伐した" } },
       },
+      q_the_codfather: {
+        title: "タラのゴッドファーザー",
+        text: "タラのゴッドファーザーはただの魚ではない、{playerName}。冷血の殺し屋だ。古老たちは、奴がミレの徘徊者を朝飯に食うと誓っているし、ミレフェンのウィドウでさえ恐怖のあまりディープフェン浅瀬の近くには巣を張らぬ。あの水域は奴のものだ。釣り竿を手に取り、その老いた悪魔を奴の水域から引きずり出せ。そうすれば、お前もファミリーの一員と認めよう。",
+        completion: "湿った聖人たちよ……タラのゴッドファーザーそのものだ。あのヒゲを見ろ。フェンブリッジはこの一匹の話で一年は食っていけるぞ、{playerName}。",
+        objectives: { 0: { label: "タラのゴッドファーザー" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "溺れし神殿", enterText: "月の門をくぐり抜けると——大気は冷たい水と蒼白の光に変わり、歌声が頭上で閉ざされていく。", leaveText: "月の門を抜けて、山の夜へと浮かび上がる。" },
@@ -10259,7 +10313,7 @@ const phase11Extra = {
       ["revive_pet", "Reviver Mascote", "Revive seu mascote morto e o traz de volta ao seu lado."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Ídolo Salobro", "Oferenda Afogada", "Kris da Lua Afogada", "Maça da Lua Afogada", "Cetro da Lua Afogada", "Soleretes do Passo Afogado", "Sapatilhas do Passo Afogado", "Botinas do Passo Afogado", "Decalque Protetor", "Escama Pálido-Lunar", "Sabre de Escama Lunar", "Peitoral do Sudário Lunar", "Túnica do Sudário Lunar", "Gibão do Sudário Lunar", "Pérola Pálida", "Escama do Coração de Sethrael", "Vara do Anel Pálido", "Anda-Mares de Selthe", "Adaga de Vidro-Maré", "Faixas do Vigia das Marés", "Grevas de Pérola de Ysolei"
+      "Ídolo Salobro", "Oferenda Afogada", "Kris da Lua Afogada", "Maça da Lua Afogada", "Cetro da Lua Afogada", "Soleretes do Passo Afogado", "Sapatilhas do Passo Afogado", "Botinas do Passo Afogado", "Decalque Protetor", "Escama Pálido-Lunar", "Sabre de Escama Lunar", "Peitoral do Sudário Lunar", "Túnica do Sudário Lunar", "Gibão do Sudário Lunar", "Pérola Pálida", "Escama do Coração de Sethrael", "Vara do Anel Pálido", "Anda-Mares de Selthe", "Adaga de Vidro-Maré", "Faixas do Vigia das Marés", "Grevas de Pérola de Ysolei", "O Bacalhau-Padrinho"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Mãe-do-Coro Selthe", "Guarda do Templo Afogado", "Devoto Afogado", "Vadeador de Glimmermere", "Espreitador de Escama Reluzente", "Cria da Lua", "Acólito do Coro Pálido", "Sentinela da Guarda Pérola", "Sethrael, o Anel Pálido", "Demônio de Fogo", "Demônio do Vazio", "Ysolei, Avatar da Lua Afogada"
@@ -10304,6 +10358,12 @@ const phase11Extra = {
         completion: "Dez de volta à água. Não sentem frio, {playerName}, nem medo — apenas a atração daquele portão. Seja o que for que canta para eles, canta bem alto.",
         objectives: { 0: { label: "Vadeador de Glimmermere abatido" } },
       },
+      q_the_codfather: {
+        title: "O Bacalhau-Padrinho",
+        text: "O Bacalhau-Padrinho não é só um peixe, {playerName}, é um assassino de sangue frio. Os veteranos juram que ele come espreitadores do pântano no café da manhã, e nem as viúvas de Mirefen tecem suas teias perto dos Baixios de Deepfen de tanto terror. Ele manda nessas águas. Pegue uma vara de pesca, arranque esse velho demônio das águas dele e admitirei que você entrou para a família.",
+        completion: "Pelos santos encharcados... O Bacalhau-Padrinho em pessoa. Veja esses bigodes. Fenbridge vai viver um ano inteiro de histórias com essa pescaria, {playerName}.",
+        objectives: { 0: { label: "O Bacalhau-Padrinho" } },
+      },
     },
     dungeons: {
       drowned_temple: { name: "O Templo Afogado", enterText: "Você atravessa o portão lunar — o ar se transforma em água fria e luz pálida, e o cântico se fecha sobre a sua cabeça.", leaveText: "Você emerge através do portão lunar para a noite da montanha." },
@@ -10318,7 +10378,7 @@ const phase11Extra = {
       ["revive_pet", "Оживление питомца", "Оживляет вашего павшего питомца и возвращает его к вам."],
     ]),
     items: phase11NameTranslations(DROWNED_ITEM_IDS, [
-      "Просоленный идол", "Подношение утопленников", "Крис Утонувшей луны", "Молот Утонувшей луны", "Скипетр Утонувшей луны", "Сабатоны Утопшего шага", "Туфли Утопшего шага", "Поступь Утопшего шага", "Оттиск оберега", "Чешуя Бледной луны", "Сабля из лунной чешуи", "Кираса Лунного савана", "Одеяние Лунного савана", "Туника Лунного савана", "Бледная жемчужина", "Сердечная чешуя Сетраэля", "Жезл Бледного кольца", "Морестопы Селте", "Кинжал Приливного стекла", "Обмотки Стража приливов", "Жемчужные поножи Изолеи"
+      "Просоленный идол", "Подношение утопленников", "Крис Утонувшей луны", "Молот Утонувшей луны", "Скипетр Утонувшей луны", "Сабатоны Утопшего шага", "Туфли Утопшего шага", "Поступь Утопшего шага", "Оттиск оберега", "Чешуя Бледной луны", "Сабля из лунной чешуи", "Кираса Лунного савана", "Одеяние Лунного савана", "Туника Лунного савана", "Бледная жемчужина", "Сердечная чешуя Сетраэля", "Жезл Бледного кольца", "Морестопы Селте", "Кинжал Приливного стекла", "Обмотки Стража приливов", "Жемчужные поножи Изолеи", "Крестная треска"
     ], 'drowned item'),
     mobs: phase11NameTranslations(DROWNED_MOB_IDS, [
       "Матерь хора Селте", "Утонувший храмовый страж", "Утонувший служитель", "Бродяга Мерцающего омута", "Затаившийся Мерцающечешуйный", "Лунное отродье", "Послушник Бледного хора", "Часовой Жемчужной стражи", "Сетраэль Бледное Кольцо", "Огненный демон", "Демон Пустоты", "Изолея, Воплощение Утонувшей луны"
@@ -10362,6 +10422,12 @@ const phase11Extra = {
         text: "С тех пор как открылись врата, в сумерках из омута выползают твари — раздувшиеся, бледные, с плавниками там, где должны быть руки. Бродяги Мерцающего омута, так зовут их старые оттиски. Они утаскивают всё живое за собой вниз. Истреби десятерых, прежде чем они сведут мою стражу на нет.",
         completion: "Десять вернулись в воду. Они не чувствуют ни холода, {playerName}, ни страха — лишь зов тех врат. Что бы ни пело им, поёт оно громко.",
         objectives: { 0: { label: "Бродяга Мерцающего омута повержен" } },
+      },
+      q_the_codfather: {
+        title: "Крестная треска",
+        text: "Крестная треска не просто рыба, {playerName}, а хладнокровный убийца. Старики клянутся, что она ест болотных рыскунов на завтрак, и даже мирефенские вдовы от ужаса не плетут паутину у отмелей Дипфена. Она правит этими водами. Возьми удочку, вытащи этого старого дьявола из его вод, и я признаю, что ты вошел в семью.",
+        completion: "Во имя промокших святых... Сама Крестная треска. Только взгляни на эти усы. Фенбридж будет целый год кормиться историями об этом улове, {playerName}.",
+        objectives: { 0: { label: "Крестная треска" } },
       },
     },
     dungeons: {

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1031,6 +1031,10 @@ const ITEM_RECIPES: Record<string, IconRecipe> = {
     { p: 'droplet', pal: 'sky', x: -4, y: 0, s: 1.1, rot: 1.55 },
     { p: 'fang', pal: 'silverWhite', x: 18, y: -1, s: 0.45, rot: 1.55 },
   ]),
+  the_codfather: r('treasure', 'gold', [
+    { p: 'droplet', pal: 'sky', x: -5, y: 0, s: 1.2, rot: 1.55 },
+    { p: 'fang', pal: 'gold', x: 18, y: -1, s: 0.5, rot: 1.55 },
+  ], ['sparkle']),
   tangled_weed: r('junk', 'venom', [{ p: 'tendrils', pal: 'venom' }]),
   roasted_boar: r('food', 'ember', ['meat']),
   conjured_water: r('arcane', 'sky', [{ p: 'potion', pal: 'sky' }], ['sparkle']),

--- a/tests/progression.test.ts
+++ b/tests/progression.test.ts
@@ -12,6 +12,7 @@ import { ALL_CLASSES, XP_TABLE, MAX_LEVEL, ZoneDef } from '../src/sim/types';
 import { terrainHeight, WATER_LEVEL } from '../src/sim/world';
 
 const WORLD_SEED = 20061; // production seed (main.ts / server/game.ts)
+const SCRIPTED_COLLECT_ITEMS = new Set(['the_codfather']);
 
 describe('content referential integrity', () => {
   it('every quest reference resolves (NPCs, mobs, items, chains)', () => {
@@ -46,14 +47,15 @@ describe('content referential integrity', () => {
     expect(problems).toEqual([]);
   });
 
-  it('every collect objective is obtainable from loot or ground objects', () => {
+  it('every collect objective is obtainable', () => {
     const problems: string[] = [];
     for (const q of Object.values(QUESTS)) {
       for (const obj of q.objectives) {
         if (obj.type !== 'collect' || !obj.itemId) continue;
         const fromLoot = Object.values(MOBS).some((m) => m.loot.some((l) => l.itemId === obj.itemId));
         const fromGround = GROUND_OBJECTS.some((g) => g.itemId === obj.itemId);
-        if (!fromLoot && !fromGround) problems.push(`${q.id}: ${obj.itemId} drops nowhere`);
+        const fromScript = SCRIPTED_COLLECT_ITEMS.has(obj.itemId);
+        if (!fromLoot && !fromGround && !fromScript) problems.push(`${q.id}: ${obj.itemId} has no acquisition source`);
       }
     }
     expect(problems).toEqual([]);

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -5,7 +5,7 @@ import {
   type SimEvent, dist2d, FISHING_CAST_ID, FISHING_CAST_TIME, MAX_LEVEL, xpForLevel, mobXpValue,
   rageConversion, rageFromDealing, rageFromTaking, spellHitChance, meleeMissChance,
 } from '../src/sim/types';
-import { LAKE, QUESTS, GROUND_OBJECTS, ITEMS, abilitiesKnownAt } from '../src/sim/data';
+import { DEEPFEN_SHALLOWS_LAKE, LAKE, QUESTS, GROUND_OBJECTS, ITEMS, abilitiesKnownAt } from '../src/sim/data';
 import { GROUND_PICKUP_LINES } from '../src/sim/content/ground_pickup_lines';
 import { terrainHeight, WATER_LEVEL } from '../src/sim/world';
 
@@ -59,6 +59,42 @@ function mirrorLakeFishingSpot(seed: number) {
     }
   }
   throw new Error('No dry Mirror Lake fishing spot found');
+}
+
+function deepfenFishingSpot(seed: number) {
+  for (let r = DEEPFEN_SHALLOWS_LAKE.radius * 0.7; r <= DEEPFEN_SHALLOWS_LAKE.radius + 10; r += 1) {
+    for (let i = 0; i < 72; i++) {
+      const a = (i / 72) * Math.PI * 2;
+      const x = DEEPFEN_SHALLOWS_LAKE.x + Math.cos(a) * r;
+      const z = DEEPFEN_SHALLOWS_LAKE.z + Math.sin(a) * r;
+      if (terrainHeight(x, z, seed) < WATER_LEVEL) continue;
+      const facing = Math.atan2(DEEPFEN_SHALLOWS_LAKE.x - x, DEEPFEN_SHALLOWS_LAKE.z - z);
+      if (hasFishableWaterAhead(x, z, facing, seed)) return { x, z, facing };
+    }
+  }
+  throw new Error('No dry Deepfen Shallows fishing spot found');
+}
+
+function despawnMobs(sim: Sim) {
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob') continue;
+    e.dead = true;
+    e.hp = 0;
+    e.pos.x += 10000;
+    e.pos.z += 10000;
+    e.prevPos = { ...e.pos };
+    e.spawnPos = { ...e.pos };
+    e.leashAnchor = { ...e.pos };
+    e.aiState = 'dead';
+    e.respawnTimer = 9999;
+    e.corpseTimer = 9999;
+    e.inCombat = false;
+    e.aggroTargetId = null;
+    e.targetId = null;
+    e.threat.clear();
+    e.auras = [];
+    e.castingAbility = null;
+  }
 }
 
 describe('classic formulas', () => {
@@ -826,6 +862,53 @@ describe('food, drink, vendor', () => {
       }));
     }
     expect(sim.countItem('simple_fishing_pole')).toBe(1);
+  });
+
+  it('catches The Codfather in Deepfen Shallows while its quest is active', () => {
+    const sim = makeSim('warrior');
+    const spot = deepfenFishingSpot(sim.cfg.seed);
+    const meta = sim.meta(sim.playerId)!;
+    meta.questLog.set('q_the_codfather', { questId: 'q_the_codfather', counts: [0], state: 'active' });
+    despawnMobs(sim);
+    teleportTo(sim, spot.x, spot.z);
+    sim.player.facing = spot.facing;
+    sim.addItem('simple_fishing_pole', 1);
+    sim.useItem('simple_fishing_pole');
+    expect(sim.player.castingAbility).toBe(FISHING_CAST_ID);
+
+    const events: SimEvent[] = [];
+    for (let i = 0; i < 20 * 6 && sim.player.castingAbility; i++) events.push(...sim.tick());
+
+    expect(sim.player.castingAbility).toBe(null);
+    expect(events).toContainEqual(expect.objectContaining({ type: 'castStop', success: true }));
+    expect(sim.countItem('the_codfather')).toBe(1);
+    expect(sim.questState('q_the_codfather')).toBe('ready');
+    expect(sim.countItem('simple_fishing_pole')).toBe(1);
+  });
+
+  it('does not catch The Codfather without the active quest or outside Deepfen Shallows', () => {
+    const deepfenSim = makeSim('warrior');
+    const deepfenSpot = deepfenFishingSpot(deepfenSim.cfg.seed);
+    despawnMobs(deepfenSim);
+    teleportTo(deepfenSim, deepfenSpot.x, deepfenSpot.z);
+    deepfenSim.player.facing = deepfenSpot.facing;
+    deepfenSim.addItem('simple_fishing_pole', 1);
+    deepfenSim.useItem('simple_fishing_pole');
+    for (let i = 0; i < 20 * 6 && deepfenSim.player.castingAbility; i++) deepfenSim.tick();
+    expect(deepfenSim.countItem('the_codfather')).toBe(0);
+  });
+
+  it('does not catch The Codfather outside Deepfen Shallows even with the active quest', () => {
+    const mirrorSim = makeSim('warrior');
+    const mirrorSpot = mirrorLakeFishingSpot(mirrorSim.cfg.seed);
+    mirrorSim.meta(mirrorSim.playerId)!.questLog.set('q_the_codfather', { questId: 'q_the_codfather', counts: [0], state: 'active' });
+    despawnMobs(mirrorSim);
+    teleportTo(mirrorSim, mirrorSpot.x, mirrorSpot.z);
+    mirrorSim.player.facing = mirrorSpot.facing;
+    mirrorSim.addItem('simple_fishing_pole', 1);
+    mirrorSim.useItem('simple_fishing_pole');
+    for (let i = 0; i < 20 * 6 && mirrorSim.player.castingAbility; i++) mirrorSim.tick();
+    expect(mirrorSim.countItem('the_codfather')).toBe(0);
   });
 
   it('movement cancels fishing before any catch is granted', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

Adds **The Codfather**, a Fenbridge quest designed to teach players that fishing is available and useful.

This PR:
- Introduces a narrative fishing objective from Provisioner Hale that sends players to Deepfen Shallows.
- Adds a special scripted fishing catch for `the_codfather`, limited to the active quest and the correct lake.
- Adds full localized quest text, a procedural item icon, and tests covering the special catch and progression integrity.

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
  - `npm test`

- Manual steps:
  1. setup player for level 6 and with a fishing pole : 
```
window.__game.online.cmd({ cmd: 'dev_level', level: 6 })
window.__game.online.cmd({ cmd: 'dev_give', item: 'simple_fishing_pole', count: 1 })
window.__game.online.cmd({ cmd: 'dev_teleport', x: -4, z: 308 })
```
2. Talk to provisioner Hale
3. Go fishing in Deepfen shallows
4. Complete quest


## Screenshots / recordings

<img width="1016" height="977" alt="Screenshot from 2026-06-16 18-46-58" src="https://github.com/user-attachments/assets/50e1c414-5578-4aa6-9b12-c3b6e40240d9" />

<img width="2196" height="1242" alt="Screenshot from 2026-06-16 18-47-38" src="https://github.com/user-attachments/assets/20f8ddae-1008-4363-88e1-c453cf3bbcf1" />

<img width="914" height="848" alt="Screenshot from 2026-06-16 18-48-01" src="https://github.com/user-attachments/assets/1e59ea02-6afb-4486-989e-b076869371c9" />



---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop only (no UI change)**

- [ ] **Tested on desktop and mobile.**
      - N/A for layout; no UI layout or controls changed.
- [ ] **Accessible.**
      - N/A; no interactive UI changed.

### Localization (i18n)

- [x] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [x] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> **Tip:** commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a scope where it fits (`feat(talents): ...`, `fix(net): ...`). It's a
> convention we like, not a requirement. Clear, descriptive messages are what
> matter most.

---

A complete checklist and a green CI run (tests, typecheck, and builds) are what
we look for before merging. Smaller, focused PRs land faster than large ones, and
reviewers may suggest changes, which is a normal and friendly part of the
process. Thank you for helping build World of ClaudeCraft. Questions? Join us on
[Discord](https://discord.gg/GjhnUsBtw).
