### PR TITLE
RFC: elizaOS agents as players & pet familiars (auto Solana wallets, on-chain paid gate) — stub, not for merge

### DIFF
--- a/bridge/CLAUDE.md
+++ b/bridge/CLAUDE.md
@@ -1,0 +1,25 @@
+# bridge/ — elizaOS multi-agent host (STUB / RFC)
+
+A separate Node service that hosts many elizaOS agents and connects each to a WoC realm as an
+ordinary WebSocket client. **Not yet wired into the root build/CI.** Spec: `docs/prd/eliza-agents.md`.
+
+## Invariants — keep these
+- **Never import `src/sim/` (or `server/`) for mutation.** The bridge is a *client*. It speaks only
+  the public REST + WS protocol that `scripts/mp_integration.mjs` demonstrates. All game outcomes
+  stay server-authoritative.
+- **No private keys in git.** Secrets live in `SecretVault` (encrypted at rest); the repo only ever
+  sees `bridge/.secrets/` (gitignored) or external KMS rows. `.env` stays uncommitted.
+- **Spending is bounded by a non-LLM policy.** The LLM can request actions but cannot exceed the
+  configured per-quote / per-hour lamport caps.
+
+## Conventions
+- ESM + TypeScript `strict`, 2-space indent — matches the repo root.
+- Tiny dep set: `@elizaos/core`, `@woc/plugin-claudecraft`, `@elizaos/plugin-wallet`,
+  `@solana/web3.js`, `ws`, `pg`, `bs58`. Don't add more without need.
+- Mirror `headless/`'s structure: a thin entrypoint + a small `src/` of focused modules.
+
+## Dev loop (target)
+1. `npm run server` (WoC on :8787), optionally `ALLOW_DEV_COMMANDS=1`.
+2. `node bridge/index.ts` with `WOC_SERVER_URL=http://localhost:8787`, `WOC_PAY_CLUSTER=devnet`,
+   and (dev only) `WOC_SKIP_PAYMENT=1` to bypass the paid gate while iterating.
+3. Watch the agent move in the browser client (`npm run dev`, :5173) as a second player.

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,39 @@
+# bridge/ (STUB / RFC)
+
+> **Not for merge.** Non-functional scaffolding for the multi-agent host that runs elizaOS
+> agents against a WoC realm. Spec: [`docs/prd/eliza-agents.md`](../docs/prd/eliza-agents.md).
+> Outside the root `tsconfig` include → **not typechecked or built by CI**.
+
+A top-level Node service — the sibling of [`headless/`](../headless) — that hosts **N elizaOS
+`AgentRuntime` instances**, each with its own character, auto-provisioned Solana wallet, and a
+single WebSocket connection to the realm. It owns the lifecycle:
+
+```
+created ──provision wallet──► pay (on-chain) ──► entitled ──connect WS──► playing ──► idle ──► stopped
+```
+
+## Shape
+
+```
+index.ts                    # entrypoint: load roster, start AgentManager, HTTP control plane
+src/
+  AgentManager.ts           # lifecycle state machine across all agents
+  AgentHost.ts              # one runtime + its WocConnectionService; per-agent supervision
+  wallet/
+    provision.ts            # generate a Solana keypair, store the secret encrypted (SecretVault)
+    SecretVault.ts          # encrypted-at-rest secret store interface (env | pg | kms | Steward)
+  payment/
+    flow.ts                 # quote -> pay -> verify-payment -> entitlement
+  control/
+    http.ts                 # POST /agents, POST /agents/:id/stop, GET /agents
+```
+
+## Why a separate service (not in `server/` or `src/`)
+
+It is just a cluster of well-behaved WS **clients** — it must never import `src/sim` for mutation
+and gets no privileged server path. The game's authority and determinism invariants are untouched.
+
+## Security posture (v1)
+
+Custodial: the bridge holds agent private keys, **encrypted at rest, decrypted only in-process**,
+**never in git**. A non-LLM spend cap bounds on-chain spending. See PRD §6.

--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -1,0 +1,25 @@
+// STUB (RFC) — bridge entrypoint. Mirrors headless/env_server.ts as a thin top-level service.
+// Loads the agent roster, starts the lifecycle manager, and exposes a small control plane.
+// TODO(eliza): real config loading, graceful shutdown, structured logging.
+
+import { AgentManager } from './src/AgentManager.js';
+
+async function main(): Promise<void> {
+  const cfg = {
+    wocServerUrl: process.env.WOC_SERVER_URL ?? 'http://localhost:8787',
+    payCluster: process.env.WOC_PAY_CLUSTER ?? 'devnet',
+    skipPayment: process.env.WOC_SKIP_PAYMENT === '1', // DEV ONLY — never in prod
+  };
+
+  const manager = new AgentManager(cfg);
+  await manager.start();
+
+  // TODO(eliza): start control/http.ts (POST /agents, POST /agents/:id/stop, GET /agents)
+  // TODO(eliza): handle SIGINT/SIGTERM -> manager.stopAll()
+  throw new Error('TODO(eliza): bridge main loop');
+}
+
+main().catch((err) => {
+  console.error('[bridge] fatal', err);
+  process.exitCode = 1;
+});

--- a/bridge/package.json
+++ b/bridge/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@woc/bridge",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "STUB (RFC) — multi-agent host running elizaOS agents against a WoC realm.",
+  "scripts": {
+    "dev": "echo 'TODO(eliza): node --loader for index.ts against npm run server'",
+    "test": "echo 'TODO(eliza): vitest provisioning + payment flow (devnet/mocked)'"
+  },
+  "dependencies": {
+    "@solana/web3.js": "^1.95.0",
+    "bs58": "^6.0.0",
+    "pg": "^8.21.0",
+    "ws": "^8.21.0"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "^2.0.0-beta"
+  },
+  "comment": "STUB — not wired into the root workspace/build/CI. See docs/prd/eliza-agents.md."
+}

--- a/bridge/src/AgentHost.ts
+++ b/bridge/src/AgentHost.ts
@@ -1,0 +1,29 @@
+// STUB (RFC) — one elizaOS runtime + its WocConnectionService, supervised.
+// Builds the character (with the provisioned wallet secret), registers @woc/plugin-claudecraft +
+// @elizaos/plugin-wallet, runs the payment handshake, then connects the WS and begins play.
+// TODO(eliza): import { AgentRuntime } from '@elizaos/core'.
+
+import type { AgentRecord } from './AgentManager.js';
+
+export class AgentHost {
+  // private runtime: AgentRuntime;
+  constructor(private readonly record: AgentRecord) {}
+
+  async start(): Promise<void> {
+    // const character = {
+    //   name, system, bio,
+    //   plugins: ['@woc/plugin-claudecraft', '@elizaos/plugin-wallet'],
+    //   secrets: { SOLANA_PRIVATE_KEY: <from SecretVault> },
+    //   settings: { WOC_SERVER_URL, WOC_PAY_RECIPIENT, WOC_PAY_CLUSTER },
+    // };
+    // this.runtime = new AgentRuntime({ character, plugins: [...] });
+    // await this.runtime.initialize();
+    // const svc = this.runtime.getService('woc'); await svc.connect(this.record.mode);
+    void this.record;
+    throw new Error('TODO(eliza): AgentHost.start');
+  }
+
+  async stop(): Promise<void> {
+    // await this.runtime?.stop();
+  }
+}

--- a/bridge/src/AgentManager.ts
+++ b/bridge/src/AgentManager.ts
@@ -1,0 +1,48 @@
+// STUB (RFC) — lifecycle state machine across all hosted agents.
+// created -> entitled -> playing -> idle -> stopped. Bounds LLM fan-out with a concurrency cap.
+// TODO(eliza): persistence of AgentRecord rows; horizontal sharding by agentId hash.
+
+import { AgentHost } from './AgentHost.js';
+
+export interface BridgeConfig {
+  wocServerUrl: string;
+  payCluster: string;
+  skipPayment: boolean;
+}
+
+export type AgentState = 'created' | 'entitled' | 'playing' | 'idle' | 'stopped' | 'blocked';
+
+export interface AgentRecord {
+  id: string;
+  characterId: number; // WoC character id
+  wocToken: string; // bearer token for REST + WS
+  address: string; // Solana pubkey
+  mode: 'player' | 'familiar';
+  ownerPid?: number; // familiar: the human player's pid to assist
+  state: AgentState;
+}
+
+export class AgentManager {
+  private hosts = new Map<string, AgentHost>();
+
+  constructor(private readonly cfg: BridgeConfig) {}
+
+  async start(): Promise<void> {
+    // TODO(eliza): load roster -> for each: provision wallet -> pay/entitle -> AgentHost.start
+    void this.cfg;
+    throw new Error('TODO(eliza): AgentManager.start');
+  }
+
+  async createAgent(_spec: Partial<AgentRecord>): Promise<AgentRecord> {
+    throw new Error('TODO(eliza): AgentManager.createAgent');
+  }
+
+  async stop(_id: string): Promise<void> {
+    throw new Error('TODO(eliza): AgentManager.stop');
+  }
+
+  async stopAll(): Promise<void> {
+    for (const host of this.hosts.values()) await host.stop();
+    this.hosts.clear();
+  }
+}

--- a/bridge/src/payment/flow.ts
+++ b/bridge/src/payment/flow.ts
@@ -1,0 +1,36 @@
+// STUB (RFC) — client-side on-chain paid flow (Solana).
+// quote -> sign transfer (agent wallet -> recipient, memo=quoteId) -> sendAndConfirm('finalized')
+//       -> verify-payment -> entitlement. Amounts/recipient/cluster are configurable.
+// The server verifies finalized commitment + exact recipient/amount + memo==quoteId (replay guard).
+// TODO(eliza): import { Connection, Transaction, SystemProgram, PublicKey, sendAndConfirmTransaction } from '@solana/web3.js'.
+
+export interface Quote {
+  quoteId: string;
+  lamports: number;
+  recipient: string; // base58 treasury address
+  memo: string; // == quoteId, embedded in the tx to bind it to this grant
+}
+
+export interface Entitlement {
+  kind: 'agent_player' | 'familiar';
+  entitled: boolean;
+  expiresAt: number | null;
+}
+
+export interface WocRestClient {
+  post(path: string, body: unknown): Promise<unknown>;
+}
+
+export async function payAndVerify(
+  _client: WocRestClient,
+  _kind: Entitlement['kind'],
+): Promise<Entitlement> {
+  // const quote = await client.post('/api/agent/quote', { kind }) as Quote;
+  // enforce the non-LLM spend policy here (see WocPaymentService.SpendPolicy)
+  // build Transaction: SystemProgram.transfer({ fromPubkey, toPubkey: recipient, lamports }) + memoIx(quote.memo)
+  // const sig = await sendAndConfirmTransaction(conn, tx, [keypair], { commitment: 'finalized' });
+  // const ent = await client.post('/api/agent/verify-payment', { quoteId: quote.quoteId, signature: sig, address });
+  // if (!ent.entitled) throw new PaymentError('verification failed');
+  // return ent;
+  throw new Error('TODO(eliza): payAndVerify');
+}

--- a/bridge/src/wallet/provision.ts
+++ b/bridge/src/wallet/provision.ts
@@ -1,0 +1,32 @@
+// STUB (RFC) — per-agent Solana wallet auto-provisioning.
+// On agent creation: generate a Keypair, store the base58 secret in an encrypted SecretVault,
+// return the public address. Recommended for v1 over Steward (simpler; v1 scope is hold/earn only).
+// TODO(eliza): import { Keypair } from '@solana/web3.js'; import bs58 from 'bs58'.
+
+export interface SecretVault {
+  get(agentId: string, key: string): Promise<string | null>;
+  put(agentId: string, key: string, value: string): Promise<void>; // encrypted at rest
+}
+
+export interface ProvisionedWallet {
+  address: string; // base58 pubkey
+}
+
+/** Idempotent: returns the existing wallet if one is already vaulted for this agent. */
+export async function provisionWallet(
+  agentId: string,
+  vault: SecretVault,
+): Promise<ProvisionedWallet> {
+  const existing = await vault.get(agentId, 'SOLANA_PRIVATE_KEY');
+  if (existing) {
+    // return { address: addressFromSecret(existing) };
+    throw new Error('TODO(eliza): derive address from existing secret');
+  }
+  // const kp = Keypair.generate();
+  // const secretB58 = bs58.encode(kp.secretKey);   // format @elizaos/plugin-wallet expects
+  // await vault.put(agentId, 'SOLANA_PRIVATE_KEY', secretB58);
+  // return { address: kp.publicKey.toBase58() };
+  void agentId;
+  void vault;
+  throw new Error('TODO(eliza): provisionWallet — generate + vault keypair');
+}

--- a/docs/prd/eliza-agents.md
+++ b/docs/prd/eliza-agents.md
@@ -1,0 +1,194 @@
+# PRD — elizaOS Agents (Players + Pet Familiars) with Auto Wallets
+
+| | |
+|---|---|
+| **Status** | Draft / Proposed — **RFC, stub PR, not for merge** |
+| **Owner** | TBD |
+| **Created** | 2026-06-16 |
+| **Source demand** | Product direction: let [elizaOS](https://github.com/elizaos/eliza) agents play WoC as autonomous players or as a human's AI companion; monetize as a paid feature. |
+| **Related systems** | Auth/WS (`server/main.ts`, `src/net/online.ts`), command layer (`server/game.ts`), sim entities + pets (`src/sim/sim.ts`, `src/sim/entity.ts`, `src/sim/types.ts`), persistence (`server/db.ts`), reference headless client (`scripts/mp_integration.mjs`), top-level non-sim service precedent (`headless/env_server.ts`) |
+| **Locked decisions** | Solana only · on-chain crypto paid gate · real sim companion entity for familiars · wallet role v1 = identity + hold/earn |
+| **Scale** | Flagship milestone (not one PR). Three new components + a server/sim seam; staged in 5 phases. This PR is **scaffolding + spec only** to anchor discussion. |
+
+---
+
+## 1. Summary
+
+Let **elizaOS agents ("elizas")** participate in World of Claudecraft in two modes:
+
+- **Player mode** — an eliza is its own character; it connects exactly like a human client and quests/fights/chats autonomously.
+- **Pet familiar mode** — an eliza drives a **companion entity owned by a human player**, fighting alongside them.
+
+Each eliza **automatically gets a Solana wallet** (identity + hold/earn in v1). The whole capability is a **paid feature gated by an on-chain Solana payment**.
+
+The integration is deliberately **additive and isolated**: it never weakens the server's "trust nothing from the client" model, and it never violates the `src/sim/` determinism / no-web3 invariants. All money/web3 lives in `server/` only; the sim never learns money exists.
+
+---
+
+## 2. Background & motivation
+
+Two existing systems make this far cheaper than it sounds:
+
+1. **WoC already has a headless-client contract.** `scripts/mp_integration.mjs` proves an external process can speak the full REST-auth → WebSocket protocol: `{t:'auth'}` → stream `{t:'input', mi}` + `{t:'cmd', …}`, and merge delta-encoded `{t:'snap'}` snapshots. An eliza *player* is just another well-behaved WS client — **no new transport**.
+2. **WoC already has owner-bound pets.** Hunter pets are `kind:'mob'` with `ownerId` set, driven by `updatePet` (`src/sim/sim.ts`) with follow/leash/taunt. A *familiar* reuses this verbatim. Critically, the existing pet code already:
+   - routes kill credit to the owner — `target.tappedById = source.ownerId` (`src/sim/sim.ts`),
+   - grants pet deaths no loot/XP — `if (e.ownerId !== null) { …; return; }` (`src/sim/sim.ts`).
+   - **Therefore an agent familiar cannot inject economy value** — it can only help the human it is bound to, with **zero new credit logic**.
+
+Monetization is greenfield (no payment/wallet/billing code exists today), so we add it cleanly.
+
+elizaOS provides the agent runtime and an `actions`/`providers`/`evaluators`/`services` plugin model, plus `@elizaos/plugin-wallet` (Solana). **Caveat:** elizaOS v2 is **beta** — pinning the exact API is Phase 0.
+
+---
+
+## 3. Architecture
+
+Three components — two new and living **outside** the sim invariants:
+
+```
+ bridge/  (NEW)  ── REST /api/agent/* + WS /ws ──►  server/  (authoritative)
+ hosts N runtimes                                   + server/billing.ts + server/solana.ts (NEW)
+ + Solana wallets   ◄── snapshots · events ──       + agent/billing tables, is_agent
+        │ loads                                              │ calls pure methods
+        ▼                                                    ▼
+ @woc/plugin-claudecraft  (NEW)                      src/sim/  (deterministic, NO web3)
+ Service + Actions + Providers                       + summonFamiliar/despawnFamiliar
+ + 20Hz steering control loop                        + Entity.familiarAgentId
+```
+
+### 3.1 Component A — WoC server + sim changes (`server/`, `src/sim/`)
+
+**Player connection — reuse the existing path.** An eliza player is an ordinary account + character + token. Minimal server changes:
+- `is_agent` boolean on `accounts` (denormalized onto `characters` for cheap in-loop reads) → moderation, leaderboard segregation, paid gate. Thread through `GameServer.join` → `ClientSession.isAgent`. **The sim stays agnostic** (no `Entity` change for "is agent").
+- WS-upgrade connection throttle with an `AGENT_BRIDGE_IPS` allowlist (today only REST register/login is throttled).
+- **Per-session command rate limit** (new) — token bucket on `ClientSession` mirroring `consumeChatToken` (`server/game.ts`); `input`/`cmd` are currently unthrottled per session.
+- **Paid gate** in `authenticateWebSocket` (`server/main.ts`): if `account.is_agent` and no active entitlement → reject `{t:'auth'}` with `{t:'error', error:'agent entitlement required'}`. Humans bypass entirely.
+
+**Pet familiar entity — reuse `kind:'mob'` + `ownerId`; do NOT add a new `EntityKind`.** A new `'familiar'` kind would ripple through dozens of `kind==='mob'` branches for no behavioral gain. Instead:
+- One new **runtime-only** field `Entity.familiarAgentId: number | null` (declare in `src/sim/types.ts`, init in `src/sim/entity.ts` `baseEntity`) to distinguish an agent-driven familiar from a plain tamed beast. Never serialized.
+- New pure sim methods `Sim.summonFamiliar(ownerPid, opts)` (modeled on `completeTame`; spawns a non-tamable `familiar_*` template from `src/sim/content/`) and `Sim.despawnFamiliar(pid)` (familiars have no wild home → drop rather than `releasePetToWild`). Hook owner logout in `removePlayer`.
+- Determinism preserved: decisions enter as discrete commands applied at the next `tick()`, using only `this.rng`.
+
+**Familiar control transport — the eliza gets its own authed WS session bound to the human's familiar** (preferred over relaying through the owner's socket — keeps per-agent rate-limiting/backpressure/moderation clean):
+- Extend the auth frame: `{t:'auth', token, character, mode:'familiar', ownerCharacter}`. The token identifies the **agent's own** account+character; `ownerCharacter` is the human to assist.
+- `authenticateWebSocket` branches on `mode==='familiar'` → requires `is_agent` + entitlement → `game.joinFamiliarControl(...)`.
+- **Consent gate:** the human must first issue a `bind_familiar` cmd naming the agent. No uninvited familiars.
+- New `dispatchFamiliarMessage` accepts only a whitelist (`familiar_target`, `familiar_cast`, `familiar_move`, `familiar_heel`/`attack`/`passive`), each validated against the familiar owned by `ownerPid` and refused unless the caller is the bound `familiarAgentId`. Movement the agent omits falls back to `updatePet`.
+- **Scoped observation feed** reusing the existing interest query + `canObserveEntity` (so it cannot see stealthed players a normal client could not).
+
+**On-chain paid gate — server only.** New modules (no raw SQL — they call `db.ts`):
+- `server/solana.ts` — thin `@solana/web3.js` (+ `@solana/spl-token`) wrapper: fetch/confirm a tx, check SPL balance, verify an ed25519 signed nonce. Mockable for tests.
+- `server/billing.ts` — build a quote; verify a payment (finalized commitment, correct recipient/amount, memo == quoteId, replay-guarded via `onchain_payments.tx_sig UNIQUE`) or a token-hold; write entitlements.
+
+New REST endpoints in `server/main.ts` (bearer-authed, IP-rate-limited like register/login):
+`POST /api/agent/wallet/challenge` · `/wallet/verify` · `/quote` · `/verify-payment` · `/verify-hold` · `GET /api/agent/entitlements`.
+
+New Postgres tables (added to `db.ts` `SCHEMA`, inside the existing `ensureSchema` advisory lock):
+
+```sql
+account_wallets(id, account_id→accounts, chain DEFAULT 'solana', address, verified_at, created_at,
+                UNIQUE(chain, address));
+onchain_payments(id, account_id, chain, tx_sig, from_address, to_address, amount, mint, reference,
+                 status, confirmed_at, created_at, UNIQUE(chain, tx_sig));   -- tx_sig UNIQUE = replay guard
+agent_entitlements(id, account_id, kind /* 'agent_player'|'familiar' */, status, source /* 'payment'|'hold' */,
+                   payment_id→onchain_payments, granted_at, expires_at, created_at);
+-- + ALTER accounts/characters ADD COLUMN is_agent BOOLEAN DEFAULT FALSE
+```
+
+**Two choke points:** at connect (`authenticateWebSocket`) and at `summon_familiar` (`dispatchMessage`, defense in depth). A periodic sweep disconnects sessions whose (hold-based) entitlement lapsed.
+
+**sim/ vs server/ boundary (invariant audit):** no `src/sim/` file imports `@solana/web3.js`, `pg`, `ws`, or anything in `server/`. Familiar behavior is deterministic sim; wallet/payment/entitlement is server-only; the control session + binding + scoped feed + command whitelist live in `server/game.ts`.
+
+### 3.2 Component B — `@woc/plugin-claudecraft` (elizaOS plugin)
+
+What one agent uses to perceive and act in WoC. Stubbed in this PR under `packages/plugin-claudecraft/`.
+- **Actions** map 1:1 to `dispatchMessage` cmds (`WOC_CAST`, `WOC_TARGET`, `WOC_MOVE_TO`, `WOC_ACCEPT_QUEST`, `WOC_CHAT`, …). Combat/quest actions forward a one-shot `{t:'cmd'}`; movement actions **set a goal** on the service (never emit raw `mi`).
+- **Providers** inject perception into the prompt (`WOC_GAME_STATE`: self HP/res, nearby entities, threats, target; `WOC_QUESTS`; `WOC_WALLET`).
+- **Service** `WocConnectionService` holds the WS + the world mirror + the control loop.
+
+### 3.3 Component C — `bridge/` (multi-agent host)
+
+A new top-level Node service (sibling of `headless/`) hosting **N `AgentRuntime` instances**, each with its own character + wallet + WS. Stubbed in this PR under `bridge/`.
+- **Wallet auto-provisioning** (recommended: generated keypair + `@elizaos/plugin-wallet`, **not** Steward for v1): on agent creation, generate a `Keypair`, base58-encode the secret into an encrypted `SecretVault` (AES-GCM at rest, master key from env/KMS, **never in git**), inject as character secret `SOLANA_PRIVATE_KEY`, register the public address via `POST /api/agent/wallet`. `SecretVault` is an interface so Steward/KMS slot in later. This is **custodial** — must be documented.
+- **On-chain pay flow** (`@solana/web3.js`): `quote → sign transfer (agent wallet → recipient, memo=quoteId) → sendAndConfirm('finalized') → verify-payment → entitlement → connect`. Owner-funded variant: if the agent wallet is empty, surface the address (via `WOC_WALLET`) so the human can fund it.
+- **Scaling:** vertical first (~20–50 runtimes/process, bounded by LLM concurrency); horizontal by sharding agents across bridge processes (each is just more independent WS clients).
+
+---
+
+## 4. The load-bearing idea — two clocks
+
+The LLM must **not** emit 20 movement frames/sec.
+
+- **Clock A — deterministic control loop (20 Hz, in the Service, no LLM):** ingest WS → update `WorldMirror` (delta-merge ported from `mp_integration.mjs`) → `steering.tick(goal, world)` → send `{t:'input', mi, facing}`. The server accepts an **absolute `facing`** (`src/sim/move_input.ts`), so steering is mostly "point at destination, hold `f:1`, stop within range" — no `tl/tr` ramping. Pure and unit-testable.
+- **Clock B — LLM decisions (event/interval-driven, sets goals):** invoked on salient events (entered combat, HP band crossed, target died, quest step done, whisper, loot, leash broken) and an idle interval. Emits Actions that set goals / fire one-shot commands. One decision ("kill that wolf") → `WOC_TARGET` + `WOC_MOVE_TO` + `WOC_ATTACK` + `WOC_CAST`; Clock A then closes distance for seconds with **zero** further LLM calls.
+
+LLM = "what to do"; deterministic loop = "how to move there." Keeps token cost bounded and movement server-friendly.
+
+---
+
+## 5. Phased delivery
+
+| Phase | Deliverable |
+|---|---|
+| **0 — Verify** | Clone elizaOS to a reference dir; pin exact `Service`/`Action`/`Provider`/`Plugin` shapes + `@elizaos/plugin-wallet` Solana secret encoding. De-risks the #1 (v2-beta API churn) uncertainty. |
+| **1 — Player MVP, no payments** | Plugin + bridge + `WocConnectionService` two-clock loop; one agent quests against local `npm run server`. Dev bypass `WOC_SKIP_PAYMENT=1` (dev-only, like `ALLOW_DEV_COMMANDS`). |
+| **2 — Wallets + paid gate** | `server/solana.ts`+`billing.ts`, new tables/endpoints, `is_agent`, connect-time gate; bridge provisioning + pay flow on devnet. |
+| **3 — Familiar mode** | `summonFamiliar`/`despawnFamiliar` + `familiarAgentId`, `familiar_*` template, `joinFamiliarControl`/`dispatchFamiliarMessage`, consent `bind_familiar`, scoped feed; bridge familiar binding. |
+| **4 — Hardening** | Command rate limit, entitlement-expiry sweep, leaderboard segregation, spend caps, prompt-injection guards, moderation review. |
+
+---
+
+## 6. Security & fairness
+
+- **Hard, non-LLM spend cap** in `WocPaymentService` (max lamports/quote, max quotes/hour) — the LLM cannot move money, exactly as it can't override Clock A movement.
+- **Prompt-injection:** in-world chat/social text is untrusted and must never trigger payment/wallet actions.
+- **Key custody:** encrypted at rest, decrypted only in-process; a vault compromise drains all agent wallets — gate any future withdrawals behind spend caps / Steward / user-held keys.
+- **Server trust boundary intact:** the bridge gets no privileged WS path; every action still passes `dispatchMessage` validation.
+- **Moderation:** agents are full accounts → existing ban/suspend/report paths cover them; `is_agent` enables agent-specific policy + human/agent leaderboard split.
+- **Familiar consent gate** prevents uninvited-familiar griefing.
+
+---
+
+## 7. Acceptance criteria
+
+- **Player mode:** an entitled agent registers → connects `/ws` → autonomously accepts a quest, navigates to and kills the objective mob, loots, and turns in — visible as a second player in the browser client. An **unentitled** agent is rejected at `auth` with `agent entitlement required`.
+- **Familiar mode:** a human summons a familiar and `bind_familiar`s an agent; the agent drives `familiar_target`/`familiar_cast`; the **human** receives the XP/loot events; the familiar is owner-bound in snapshots; an **unbound** agent is rejected.
+- **Wallet:** each agent has a unique Solana address, surfaced via `WOC_WALLET`; the secret is encrypted at rest and never in git.
+- **Paid gate:** a finalized Solana payment with `memo==quoteId` grants an entitlement; a replayed `tx_sig` is rejected.
+- **Invariants:** `npx tsc --noEmit` + `npm test` green; no `src/sim/` file imports web3/`pg`/`ws`/`server`.
+
+---
+
+## 8. Testing
+
+**Vitest (deterministic, no DB/net):**
+- Extend `tests/fixes.test.ts` (already sets `pet.ownerId`) with a `familiar` suite: `summonFamiliar` ownership; `updatePet` follow/leash; external `familiar_target` override; **owner** kill credit/XP; familiar death grants nothing; `despawnFamiliar` on logout.
+- Extend `tests/threat.test.ts` for familiar hate-table/taunt.
+- New `tests/billing.test.ts` against a **fake `solana.ts`** (mirror the in-memory `SocialDb` fake pattern): replay guard, amount/recipient validation, entitlement grant/expiry, signed-nonce verify.
+- New `tests/entitlement_gate.test.ts` for the gate decision in isolation.
+- Plugin package: `worldMirror` (delta-merge vs recorded snapshots), `steering` (goal→input reaches a waypoint in bounded ticks).
+
+**E2E (`scripts/*.mjs`, running server + Postgres, `ALLOW_DEV_COMMANDS=1`):**
+- `scripts/agent_player_e2e.mjs` (model on `mp_integration.mjs`): no entitlement → error; granted → `hello`; drive movement + cmd; exercise the rate limiter.
+- `scripts/familiar_control_e2e.mjs`: human summons + binds; agent drives; assert the human receives XP/loot; assert an unbound agent is rejected.
+
+---
+
+## 9. Open risks
+
+- **elizaOS v2 is beta** — API churn is the #1 risk; isolate elizaOS coupling to `services/` + `index.ts`, pin the version (Phase 0).
+- **Steward availability** — assumed immature for v1; the `SecretVault` interface lets it slot in later.
+- **Entitlement expiry mid-session** — must have the disconnect sweep, or a hold can be sold after connecting.
+- **On-chain reorg/replay** — require `finalized` + `tx_sig UNIQUE`.
+- **Custodial key model** — must be documented to users before any transfer/withdraw capability ships.
+
+---
+
+## 10. Scope of THIS PR
+
+**Discussion scaffolding only — not for merge.** Contains:
+- this PRD;
+- non-functional stub trees under `packages/plugin-claudecraft/` and `bridge/` (outside the root `tsconfig` include → not typechecked/built by CI), with interfaces + `TODO(eliza)` markers;
+- compile-clean seam stubs `server/billing.ts` + `server/solana.ts` (no web3 imports yet, not wired into `server/main.ts`).
+
+No changes to `src/sim/`, `server/main.ts`, `server/game.ts`, `server/db.ts`, or the build config. Those edits land in Phases 1–4 once the approach is agreed.

--- a/packages/plugin-claudecraft/README.md
+++ b/packages/plugin-claudecraft/README.md
@@ -1,0 +1,35 @@
+# @woc/plugin-claudecraft (STUB / RFC)
+
+> **Not for merge.** Non-functional scaffolding for the elizaOS ↔ World of Claudecraft
+> integration. Spec: [`docs/prd/eliza-agents.md`](../../docs/prd/eliza-agents.md).
+> This tree lives outside the root `tsconfig` include, so it is **not typechecked or
+> built by CI**. It depends on `@elizaos/core` (not yet a repo dependency).
+
+An elizaOS plugin that lets one agent perceive and act in WoC.
+
+## Shape
+
+```
+src/
+  index.ts                      # the exported Plugin object
+  types.ts                      # WoC wire types (mirror of the server's snap/self/event shapes)
+  services/
+    WocConnectionService.ts     # WS + 20Hz control loop + world mirror + event router
+    WocPaymentService.ts        # on-chain quote/pay/verify + HARD spend cap
+  actions/
+    index.ts                    # WOC_CAST, WOC_MOVE_TO, WOC_TARGET, WOC_ACCEPT_QUEST, WOC_CHAT, ...
+  providers/
+    index.ts                    # WOC_GAME_STATE, WOC_QUESTS, WOC_WALLET
+  lib/
+    worldMirror.ts              # delta-merge ported from scripts/mp_integration.mjs
+    steering.ts                 # goal -> {mi, facing} per tick (absolute-facing steering)
+```
+
+## The two-clock model (why this exists)
+
+- **Clock A** — a deterministic 20 Hz loop inside `WocConnectionService` turns the
+  current *goal* into `{t:'input', mi, facing}`. No LLM in this loop.
+- **Clock B** — the elizaOS runtime invokes the LLM on salient events / intervals;
+  its Actions **set goals** and fire one-shot `{t:'cmd'}` — they never emit raw input.
+
+See the PRD §4.

--- a/packages/plugin-claudecraft/package.json
+++ b/packages/plugin-claudecraft/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@woc/plugin-claudecraft",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "STUB (RFC) — elizaOS plugin letting an agent play World of Claudecraft as a player or pet familiar.",
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "echo 'TODO(eliza): tsup ESM + dts'",
+    "test": "echo 'TODO(eliza): vitest worldMirror + steering'"
+  },
+  "peerDependencies": {
+    "@elizaos/core": "^2.0.0-beta"
+  },
+  "dependencies": {
+    "ws": "^8.21.0"
+  },
+  "comment": "STUB PACKAGE — not wired into the root workspace/build/CI yet. See docs/prd/eliza-agents.md."
+}

--- a/packages/plugin-claudecraft/src/actions/index.ts
+++ b/packages/plugin-claudecraft/src/actions/index.ts
@@ -1,0 +1,89 @@
+// STUB (RFC) — elizaOS Actions. Each maps 1:1 to a server dispatchMessage case (server/game.ts).
+// Movement actions SET A GOAL on WocConnectionService; combat/quest actions forward a one-shot cmd.
+// The LLM never emits raw movement input — it only sets goals and fires discrete commands.
+// TODO(eliza): import { type Action } from '@elizaos/core' and fill validate/handler/examples.
+
+// Minimal local mirror of the elizaOS Action shape so this stub reads without the dependency.
+interface ActionLike {
+  name: string;
+  similes?: string[];
+  description: string;
+  parameters?: Record<string, { type: string; optional?: boolean }>;
+  // validate(runtime, message, state, options): Promise<boolean>
+  // handler(runtime, message, state, options, callback): Promise<ActionResult>
+}
+
+export const wocMoveTo: ActionLike = {
+  name: 'WOC_MOVE_TO',
+  similes: ['GO_TO', 'WALK_TO', 'APPROACH'],
+  description: 'Move toward a target entity id or a world point. The body steers itself (Clock A).',
+  parameters: {
+    targetId: { type: 'number', optional: true },
+    x: { type: 'number', optional: true },
+    z: { type: 'number', optional: true },
+    stopRange: { type: 'number', optional: true },
+  },
+  // handler: svc.setGoal(targetId != null ? {kind:'follow',...} : {kind:'waypoint',...})
+};
+
+export const wocTarget: ActionLike = {
+  name: 'WOC_TARGET',
+  description: 'Set the current target by entity id.',
+  parameters: { id: { type: 'number' } },
+  // handler: svc.cmd({ cmd:'target', id })
+};
+
+export const wocCast: ActionLike = {
+  name: 'WOC_CAST',
+  description: 'Cast an ability by id on the current target (e.g. "frostbolt", "battle_shout").',
+  parameters: { ability: { type: 'string' }, targetId: { type: 'number', optional: true } },
+  // handler: if(targetId) svc.cmd({cmd:'target',id:targetId}); svc.cmd({ cmd:'cast', ability })
+};
+
+export const wocAttack: ActionLike = {
+  name: 'WOC_ATTACK',
+  description: 'Start auto-attacking the current target.',
+  // handler: svc.cmd({ cmd:'attack' })
+};
+
+export const wocAcceptQuest: ActionLike = {
+  name: 'WOC_ACCEPT_QUEST',
+  description: 'Accept a quest by id from a nearby quest-giver.',
+  parameters: { quest: { type: 'string' } },
+  // handler: svc.cmd({ cmd:'accept', quest })
+};
+
+export const wocTurninQuest: ActionLike = {
+  name: 'WOC_TURNIN_QUEST',
+  description: 'Turn in a completed quest by id.',
+  parameters: { quest: { type: 'string' } },
+  // handler: svc.cmd({ cmd:'turnin', quest })
+};
+
+export const wocChat: ActionLike = {
+  name: 'WOC_CHAT',
+  description: 'Send a chat message (say/party/whisper via prefix).',
+  parameters: { text: { type: 'string' } },
+  // handler: svc.cmd({ cmd:'chat', text })
+};
+
+export const wocBindFamiliar: ActionLike = {
+  name: 'WOC_BIND_FAMILIAR',
+  description: 'Familiar mode: bind this agent to drive the owner-summoned companion entity.',
+  parameters: { ownerCharacter: { type: 'string' } },
+  // handler: reconnect with { mode:'familiar', ownerCharacter }; requires the human to have issued bind_familiar
+};
+
+// TODO(eliza): WOC_CAST_SLOT, WOC_TAB, WOC_TARGET_NEAREST, WOC_STOP_ATTACK, WOC_INTERACT, WOC_LOOT,
+//              WOC_EQUIP, WOC_USE, WOC_BUY, WOC_SELL, WOC_PARTY_INVITE, WOC_PARTY_ACCEPT, WOC_SUMMON.
+
+export const allActions: ActionLike[] = [
+  wocMoveTo,
+  wocTarget,
+  wocCast,
+  wocAttack,
+  wocAcceptQuest,
+  wocTurninQuest,
+  wocChat,
+  wocBindFamiliar,
+];

--- a/packages/plugin-claudecraft/src/index.ts
+++ b/packages/plugin-claudecraft/src/index.ts
@@ -1,0 +1,21 @@
+// STUB (RFC) — the exported elizaOS Plugin object for World of Claudecraft.
+// Not wired into any build yet. See docs/prd/eliza-agents.md.
+// TODO(eliza): import { type Plugin } from '@elizaos/core' and type `claudecraftPlugin` as Plugin.
+
+import { WocConnectionService } from './services/WocConnectionService.js';
+import { WocPaymentService } from './services/WocPaymentService.js';
+import { allActions } from './actions/index.js';
+import { allProviders } from './providers/index.js';
+
+export const claudecraftPlugin = {
+  name: 'claudecraft',
+  description: 'Play World of Claudecraft: perceive the world, set goals, cast, quest, chat.',
+  services: [WocConnectionService, WocPaymentService],
+  actions: allActions,
+  providers: allProviders,
+  // evaluators: [] — TODO(eliza): a reflection evaluator that scores recent play and adjusts goals.
+};
+
+export default claudecraftPlugin;
+export { WocConnectionService, WocPaymentService };
+export * from './types.js';

--- a/packages/plugin-claudecraft/src/lib/steering.ts
+++ b/packages/plugin-claudecraft/src/lib/steering.ts
@@ -1,0 +1,55 @@
+// STUB (RFC) — deterministic steering (Clock A).
+// Converts a high-level Goal into one movement-intent frame per 20Hz tick.
+// Because the server accepts an ABSOLUTE facing angle (src/sim/move_input.ts), steering is
+// mostly: point at the destination, hold forward, stop within range. No tl/tr ramping.
+// This module is pure (no LLM, no network) and is the unit-test target.
+
+import type { Goal, MoveInput, WireSelf, WireEntity } from '../types.js';
+
+export interface InputFrame {
+  mi: MoveInput;
+  facing?: number;
+}
+
+const STOP: InputFrame = { mi: {} };
+
+function angleTo(a: { x: number; z: number }, b: { x: number; z: number }): number {
+  return Math.atan2(b.z - a.z, b.x - a.x);
+}
+
+function dist2d(a: { x: number; z: number }, b: { x: number; z: number }): number {
+  const dx = b.x - a.x;
+  const dz = b.z - a.z;
+  return Math.sqrt(dx * dx + dz * dz);
+}
+
+/** Resolve a goal's destination point from the live world view. */
+function resolveDest(
+  goal: Goal,
+  self: WireSelf,
+  entityById: (id: number) => WireEntity | undefined,
+): { x: number; z: number } | null {
+  switch (goal.kind) {
+    case 'idle':
+      return null;
+    case 'waypoint':
+      return { x: goal.x, z: goal.z };
+    case 'follow': {
+      const e = entityById(goal.targetId);
+      return e ? { x: e.x, z: e.z } : null;
+    }
+  }
+}
+
+/** One tick of steering. Returns the input frame to send this tick. */
+export function tick(
+  goal: Goal,
+  self: WireSelf,
+  entityById: (id: number) => WireEntity | undefined,
+): InputFrame {
+  const dest = resolveDest(goal, self, entityById);
+  if (!dest) return STOP; // nothing to do — let Clock B (the LLM) replan
+  const stopRange = goal.kind === 'idle' ? 0 : goal.stopRange;
+  if (dist2d(self, dest) <= stopRange) return STOP; // arrived — hold position
+  return { mi: { f: 1 }, facing: angleTo(self, dest) };
+}

--- a/packages/plugin-claudecraft/src/lib/worldMirror.ts
+++ b/packages/plugin-claudecraft/src/lib/worldMirror.ts
@@ -1,0 +1,35 @@
+// STUB (RFC) — client-side world mirror.
+// Ports the delta-merge from scripts/mp_integration.mjs (mergeSelf / mergeEnts) so the
+// agent has a single ground-truth view of the world assembled from delta-encoded snapshots.
+// TODO(eliza): port the exact DELTA_SELF_KEYS / ENTITY_IDENTITY_KEYS + snap.keep handling.
+
+import type { WireEntity, WireSelf } from '../types.js';
+
+/** Identity fields that only appear on a "full" entity record; carried forward on lite records. */
+const ENTITY_IDENTITY_KEYS = ['k', 'tid', 'nm', 'lv', 'own'] as const;
+
+/** Heavy self fields that are omitted when unchanged and must be carried forward. */
+const DELTA_SELF_KEYS = ['inv', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'party'] as const;
+
+export class WorldMirror {
+  self: WireSelf | null = null;
+  entities = new Map<number, WireEntity>();
+
+  /** Apply one `{t:'snap'}` frame. */
+  applySnapshot(_snap: unknown): void {
+    // TODO(eliza): mergeSelf(prev, next) over DELTA_SELF_KEYS; mergeEnts over identity keys + keep[].
+    void ENTITY_IDENTITY_KEYS;
+    void DELTA_SELF_KEYS;
+    throw new Error('TODO(eliza): WorldMirror.applySnapshot');
+  }
+
+  /** Entities within `radius` yards of self, nearest first. */
+  nearbyEntities(_radius: number): WireEntity[] {
+    throw new Error('TODO(eliza): WorldMirror.nearbyEntities');
+  }
+
+  /** Mobs whose aggro target is self (in combat with us). */
+  threateningSelf(): WireEntity[] {
+    throw new Error('TODO(eliza): WorldMirror.threateningSelf');
+  }
+}

--- a/packages/plugin-claudecraft/src/providers/index.ts
+++ b/packages/plugin-claudecraft/src/providers/index.ts
@@ -1,0 +1,33 @@
+// STUB (RFC) — elizaOS Providers. They inject WoC perception into the agent's prompt (Clock B).
+// TODO(eliza): import { type Provider } from '@elizaos/core'; read from WocConnectionService.world.
+
+interface ProviderLike {
+  name: string;
+  description: string;
+  // get(runtime, message, state): Promise<{ text, values, data }>
+}
+
+export const wocGameStateProvider: ProviderLike = {
+  name: 'WOC_GAME_STATE',
+  description:
+    'Self HP/resource/level, current target, threats, and the nearest ~12 entities — the agent’s perception.',
+  // get: build a compact text summary from svc.world.self + svc.world.nearbyEntities(40) + threateningSelf()
+};
+
+export const wocQuestsProvider: ProviderLike = {
+  name: 'WOC_QUESTS',
+  description: 'Active quest objectives with progress, and which nearby NPCs offer turn-ins.',
+  // get: read self.qlog / self.qdone from the mirror
+};
+
+export const wocWalletProvider: ProviderLike = {
+  name: 'WOC_WALLET',
+  description: 'The agent’s Solana address, cached balance, and current entitlement status.',
+  // get: address from @elizaos/plugin-wallet; entitlement from GET /api/agent/entitlements
+};
+
+export const allProviders: ProviderLike[] = [
+  wocGameStateProvider,
+  wocQuestsProvider,
+  wocWalletProvider,
+];

--- a/packages/plugin-claudecraft/src/services/WocConnectionService.ts
+++ b/packages/plugin-claudecraft/src/services/WocConnectionService.ts
@@ -1,0 +1,63 @@
+// STUB (RFC) — the persistent connection + control loop for one agent.
+// Holds the WebSocket to a WoC realm, the WorldMirror, and the 20Hz steering loop (Clock A).
+// Actions call setGoal()/cmd(); the LLM (Clock B) is invoked elsewhere by the elizaOS runtime.
+// TODO(eliza): extends @elizaos/core Service; register the 'woc' service type via module augmentation.
+
+import type { Goal, ConnectMode } from '../types.js';
+import { WorldMirror } from '../lib/worldMirror.js';
+import { tick as steer } from '../lib/steering.js';
+
+// import { Service, type IAgentRuntime } from '@elizaos/core';
+// declare module '@elizaos/core' { interface ServiceTypeRegistry { woc: WocConnectionService } }
+
+const TICK_MS = 50; // 20 Hz — matches the server loop
+
+export class WocConnectionService /* extends Service */ {
+  static serviceType = 'woc' as const;
+  capabilityDescription = 'Live connection to a World of Claudecraft realm: world mirror + control loop.';
+
+  world = new WorldMirror();
+  private goal: Goal = { kind: 'idle' };
+  private mode: ConnectMode = 'player';
+  private ws: unknown = null; // WebSocket
+  private loop: ReturnType<typeof setInterval> | null = null;
+
+  // static async start(runtime: IAgentRuntime): Promise<WocConnectionService> { ... }
+
+  /** REST auth (or reuse token) -> WS auth -> {hello}, then begin the control loop. */
+  async connect(_mode: ConnectMode): Promise<void> {
+    // TODO(eliza): wocClient.authWs({ t:'auth', token, character, mode, ownerCharacter? }) -> {hello}
+    throw new Error('TODO(eliza): WocConnectionService.connect');
+  }
+
+  /** Clock A: 20Hz — drain WS, update mirror, steer toward the current goal. */
+  private startControlLoop(): void {
+    this.loop = setInterval(() => {
+      const self = this.world.self;
+      if (!self) return;
+      const frame = steer(this.goal, self, (id) => this.world.entities.get(id));
+      this.send({ t: 'input', ...frame });
+    }, TICK_MS);
+  }
+
+  /** Actions set goals; they never emit raw input. */
+  setGoal(goal: Goal): void {
+    this.goal = goal;
+  }
+
+  /** One-shot command forwarded straight to the server's dispatchMessage. */
+  cmd(payload: Record<string, unknown>): void {
+    this.send({ t: 'cmd', ...payload });
+  }
+
+  private send(_obj: Record<string, unknown>): void {
+    // TODO(eliza): this.ws.send(JSON.stringify(_obj))
+    void this.ws;
+  }
+
+  async stop(): Promise<void> {
+    if (this.loop) clearInterval(this.loop);
+    this.loop = null;
+    // TODO(eliza): close ws
+  }
+}

--- a/packages/plugin-claudecraft/src/services/WocPaymentService.ts
+++ b/packages/plugin-claudecraft/src/services/WocPaymentService.ts
@@ -1,0 +1,33 @@
+// STUB (RFC) — on-chain entitlement handshake + HARD spend cap.
+// The agent gets a quote, pays from its own Solana wallet, submits the signature, and receives
+// an entitlement BEFORE WocConnectionService.connect() is allowed to enter the world.
+// The spend cap is deterministic and NOT LLM-overridable — money moves only within these bounds.
+// TODO(eliza): use @elizaos/plugin-wallet for the keypair; @solana/web3.js for the transfer.
+
+export interface SpendPolicy {
+  maxLamportsPerQuote: number;
+  maxQuotesPerHour: number;
+}
+
+export interface Entitlement {
+  kind: 'agent_player' | 'familiar';
+  entitled: boolean;
+  expiresAt: number | null;
+}
+
+export class WocPaymentService {
+  static serviceType = 'woc_payment' as const;
+  capabilityDescription = 'On-chain (Solana) paid-gate handshake for agent entitlement.';
+
+  constructor(private readonly policy: SpendPolicy) {}
+
+  /** quote -> sign transfer (wallet -> recipient, memo=quoteId) -> sendAndConfirm('finalized') -> verify. */
+  async payAndVerify(_kind: Entitlement['kind']): Promise<Entitlement> {
+    // 1. POST /api/agent/quote { kind } -> { quoteId, lamports, recipient, memo }
+    // 2. enforce this.policy (reject if lamports > maxLamportsPerQuote or over rate)
+    // 3. build + sign SystemProgram.transfer + memo, sendAndConfirmTransaction(commitment:'finalized')
+    // 4. POST /api/agent/verify-payment { quoteId, signature, address } -> Entitlement
+    void this.policy;
+    throw new Error('TODO(eliza): WocPaymentService.payAndVerify');
+  }
+}

--- a/packages/plugin-claudecraft/src/types.ts
+++ b/packages/plugin-claudecraft/src/types.ts
@@ -1,0 +1,73 @@
+// STUB (RFC) — WoC wire types as seen by an external client.
+// Mirrors the compact wire format produced by server/game.ts (snap/self/event).
+// Kept as a hand-maintained mirror so the plugin never imports from src/sim or server.
+// TODO(eliza): finalize against server/game.ts wireEntity()/selfWireJson().
+
+/** Movement intent — booleans + absolute facing (radians). See src/sim/move_input.ts. */
+export interface MoveInput {
+  f?: 0 | 1; // forward
+  b?: 0 | 1; // backward
+  tl?: 0 | 1; // turn left
+  tr?: 0 | 1; // turn right
+  sl?: 0 | 1; // strafe left
+  sr?: 0 | 1; // strafe right
+  j?: 0 | 1; // jump
+}
+
+export type EntityKind = 'player' | 'mob' | 'npc' | 'object';
+
+/** A nearby entity in the delta-merged world mirror (full + lite fields collapsed). */
+export interface WireEntity {
+  id: number;
+  k?: EntityKind; // identity field — present only on "full" records
+  tid?: string; // template id
+  nm?: string; // name
+  lv?: number; // level
+  x: number;
+  y: number;
+  z: number;
+  f?: number; // facing
+  hp?: number;
+  mhp?: number;
+  dead?: 0 | 1;
+  h?: 0 | 1; // hostile
+  aggro?: number; // current aggro target id
+  own?: number; // owner id (pet/familiar)
+}
+
+/** Self (the agent's own player) — the heavy, delta-encoded record. */
+export interface WireSelf {
+  id: number;
+  nm: string;
+  tid: string; // class
+  lv: number;
+  hp: number;
+  mhp: number;
+  res: number;
+  mres: number;
+  rtype: string; // 'mana' | 'rage' | 'energy'
+  x: number;
+  y: number;
+  z: number;
+  f: number;
+  target?: number;
+  copper?: number;
+  // ...the full set lives in server/game.ts; add as the plugin needs them.
+}
+
+export type GameEvent =
+  | { type: 'damage'; pid: number; fromPid?: number; amount: number; from?: string }
+  | { type: 'heal'; pid: number; amount: number; from?: string }
+  | { type: 'death'; pid: number; fromPid?: number; from?: string }
+  | { type: 'xp'; pid: number; amount: number; from?: string }
+  | { type: 'loot'; pid: number; item: { id: string; count: number } }
+  | { type: 'chat'; channel: string; from: string; text: string }
+  | { type: 'log'; text: string };
+
+/** A high-level goal the deterministic control loop executes (set by an Action). */
+export type Goal =
+  | { kind: 'idle' }
+  | { kind: 'waypoint'; x: number; z: number; stopRange: number }
+  | { kind: 'follow'; targetId: number; stopRange: number };
+
+export type ConnectMode = 'player' | 'familiar';

--- a/server/billing.ts
+++ b/server/billing.ts
@@ -1,0 +1,88 @@
+// STUB (RFC) — on-chain entitlement logic for agent accounts. server/-only; no src/sim/ import.
+// Carries NO raw SQL: it calls db.ts functions (the only SQL home) via the BillingStore seam below,
+// and talks to the chain through SolanaClient. Both seams are injected so this is unit-testable
+// against in-memory fakes (mirror the SocialDb fake pattern in tests/).
+// TODO(eliza): wire BillingStore to real db.ts functions and SolanaClient to server/solana.ts.
+
+import type { SolanaClient } from './solana';
+
+export type EntitlementKind = 'agent_player' | 'familiar';
+
+export interface Quote {
+  quoteId: string;
+  kind: EntitlementKind;
+  recipient: string; // treasury address
+  lamports: number;
+  mint: string | null;
+  memo: string; // == quoteId, must appear in the paying tx
+  expiresAt: number;
+}
+
+export interface Entitlement {
+  kind: EntitlementKind;
+  status: 'active' | 'expired' | 'revoked';
+  expiresAt: number | null;
+}
+
+/** The narrow set of persistence ops billing needs — implemented by db.ts (SQL lives there). */
+export interface BillingStore {
+  recordPayment(row: {
+    accountId: number;
+    txSig: string;
+    from: string;
+    to: string;
+    amount: number;
+    mint: string | null;
+    reference: string;
+  }): Promise<{ id: number } | null>; // null if txSig already consumed (UNIQUE replay guard)
+  grantEntitlement(row: {
+    accountId: number;
+    kind: EntitlementKind;
+    source: 'payment' | 'hold';
+    paymentId: number | null;
+    expiresAt: number | null;
+  }): Promise<void>;
+  activeEntitlement(accountId: number, kind: EntitlementKind): Promise<Entitlement | null>;
+}
+
+export interface BillingConfig {
+  treasury: string;
+  priceLamports: Record<EntitlementKind, number>;
+  mint: string | null;
+}
+
+export class Billing {
+  constructor(
+    private readonly chain: SolanaClient,
+    private readonly store: BillingStore,
+    private readonly cfg: BillingConfig,
+  ) {}
+
+  /** Build a payable quote tying a payment to a specific account + entitlement. */
+  quote(_accountId: number, _kind: EntitlementKind): Quote {
+    void this.cfg;
+    throw new Error('TODO(eliza): Billing.quote');
+  }
+
+  /**
+   * Verify a finalized Solana payment, then grant the entitlement.
+   * Must check: finalized commitment, recipient === treasury, amount >= price, memo === quoteId,
+   * and that the tx_sig has not been consumed before (replay guard via store.recordPayment).
+   */
+  async verifyPayment(_accountId: number, _quoteId: string, _signature: string): Promise<Entitlement> {
+    void this.chain;
+    void this.store;
+    throw new Error('TODO(eliza): Billing.verifyPayment');
+  }
+
+  /** Grant a time-boxed entitlement from a current SPL token-hold check. */
+  async verifyHold(_accountId: number, _kind: EntitlementKind): Promise<Entitlement> {
+    throw new Error('TODO(eliza): Billing.verifyHold');
+  }
+
+  /** The gate decision read at WS connect and at summon_familiar. Pure given an entitlement. */
+  async requireEntitlement(accountId: number, kind: EntitlementKind): Promise<boolean> {
+    const ent = await this.store.activeEntitlement(accountId, kind);
+    return ent !== null && ent.status === 'active';
+  }
+}

--- a/server/solana.ts
+++ b/server/solana.ts
@@ -1,0 +1,33 @@
+// STUB (RFC) — thin Solana RPC wrapper. ALL web3 lives here in server/, NEVER in src/sim/.
+// Keeps @solana/web3.js behind a small, mockable seam so billing.ts can be unit-tested with a fake.
+// This stub is intentionally dependency-free so it typechecks before @solana/web3.js is installed.
+// TODO(eliza): back these with @solana/web3.js (+ @solana/spl-token, tweetnacl for ed25519).
+//
+// Boundary note: no file under src/sim/ may import this module. See docs/prd/eliza-agents.md §3.1.
+
+export interface ConfirmedTransfer {
+  signature: string;
+  from: string;
+  to: string;
+  lamports: number;
+  mint: string | null; // null = native SOL, else SPL mint
+  memo: string | null;
+  finalized: boolean;
+}
+
+/** Read a transaction by signature and normalize it for billing verification. */
+export interface SolanaClient {
+  /** Fetch + confirm a transfer at 'finalized' commitment. Returns null if not found/unconfirmed. */
+  getConfirmedTransfer(signature: string): Promise<ConfirmedTransfer | null>;
+
+  /** Current SPL token balance (base units) for `mint` held by `owner`. */
+  getTokenBalance(owner: string, mint: string): Promise<bigint>;
+
+  /** Verify an ed25519 signature of `message` by `address` (wallet-control challenge). */
+  verifySignedMessage(address: string, message: string, signatureB58: string): boolean;
+}
+
+/** Real implementation (TODO) — constructs a Connection to the configured cluster. */
+export function createSolanaClient(_rpcUrl: string): SolanaClient {
+  throw new Error('TODO(eliza): createSolanaClient — wire @solana/web3.js');
+}


### PR DESCRIPTION
> 🛑 **Draft / RFC — NOT FOR MERGE.** This PR is scaffolding + a spec to anchor design
> discussion. No load-bearing code changes; `src/sim/`, `server/main.ts`, `server/game.ts`,
> `server/db.ts`, and the build config are untouched.

## What this proposes

Let **elizaOS agents ("elizas")** play World of Claudecraft in two modes, each with an
**auto-provisioned Solana wallet**, behind an **on-chain paid entitlement**:

- **Player mode** — an eliza is its own character; connects exactly like a human WS client.
- **Pet familiar mode** — an eliza drives an **owner-bound companion entity** that fights
  alongside a human, reusing the existing hunter-pet plumbing (`ownerId`, follow/leash/taunt).

Full design: [`docs/prd/eliza-agents.md`](docs/prd/eliza-agents.md).

## Why it's cheap to build on what's here

- **Headless-client contract already exists** — `scripts/mp_integration.mjs` proves an external
  process can speak the REST-auth → WS protocol. A player-agent is just another WS client; **no new transport**.
- **Owner-bound pets already exist** — and the pet code already routes kill-credit to the owner and
  grants pet deaths no loot/XP, so **an agent familiar can't inject economy value** with zero new credit logic.
- **Monetization is greenfield** — added cleanly in `server/` only; the sim never learns money exists.

## The load-bearing idea — two clocks

The LLM must not emit 20 movement frames/sec.
- **Clock A** (deterministic, 20 Hz, in the Service): goal → `{t:'input', mi, facing}` via absolute-facing steering.
- **Clock B** (LLM, event/interval-driven): sets *goals* and fires one-shot `{t:'cmd'}` — never raw input.

## What's in this PR (stub only)

| Path | What |
|---|---|
| `docs/prd/eliza-agents.md` | Full PRD: architecture, 5-phase plan, SQL schema, security, acceptance criteria, tests |
| `packages/plugin-claudecraft/` | elizaOS plugin stub — Service + Actions + Providers + steering/world-mirror lib. **Outside root tsconfig → not typechecked/built by CI.** |
| `bridge/` | Multi-agent host stub (sibling of `headless/`): lifecycle, wallet provisioning, on-chain pay flow. Also outside CI. |
| `server/billing.ts`, `server/solana.ts` | Compile-clean seam stubs (no web3 imports, not wired into `main.ts`) showing the server-only money boundary |

## Locked product decisions (baked into the spec)

Solana only · on-chain crypto paid gate · real sim companion entity for familiars · wallet role v1 = identity + hold/earn.

## CI

`npx tsc --noEmit` clean · `npm test` green (648 tests). Stub trees are excluded from the typecheck/build path; the two `server/` stubs compile but are unimported.

## Open questions for review

1. **Familiar control transport** — agent gets its own authed WS session bound to the human's familiar (proposed), vs relaying through the owner's socket?
2. **Wallet custody** — generated keypair + `@elizaos/plugin-wallet` (proposed for v1) vs Steward from the start?
3. **Entitlement model** — perpetual per-payment vs time-boxed token-hold (or both)?
4. **elizaOS v2-beta API churn** — Phase 0 pins exact shapes before any real code; acceptable?

## NOT in scope here

Any edits to `src/sim/`, the server WS/auth/dispatch/db, build config, or new dependencies. Those land in Phases 1–4 once the approach is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
