### PR TITLE
fix(mobile): polish release menu screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2562,6 +2562,7 @@
   .realm-pop.high { color: #ff9030; }
   .realm-pop.full { color: #ff5040; }
   .realm-pop.offline { color: #888; }
+  .realm-meta { display: contents; }
 
   /* ---------- chat ---------- */
   #chat-input { position: absolute; left: 12px; bottom: 204px; width: 370px; display: none; z-index: 25;
@@ -3732,6 +3733,61 @@
     margin-top: 0;
     width: min(360px, calc(100vw - 48px));
   }
+  body.mobile-touch .realm-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    padding: 10px;
+  }
+  body.mobile-touch .realm-row > div:first-child {
+    min-width: 0;
+  }
+  body.mobile-touch .realm-name,
+  body.mobile-touch .realm-sub {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  body.mobile-touch .realm-name .rn-chars,
+  body.mobile-touch .realm-name .rn-rec {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: middle;
+  }
+  body.mobile-touch .realm-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 2px;
+    min-width: 48px;
+  }
+  body.mobile-touch .realm-type,
+  body.mobile-touch .realm-pop {
+    min-width: 0;
+    line-height: 1.1;
+    text-align: right;
+    white-space: nowrap;
+  }
+  body.mobile-touch .realm-pop {
+    font-size: 11px;
+  }
+  body.mobile-touch .portal-ring,
+  body.mobile-touch .portal-ring-reverse,
+  body.mobile-touch .nebula-overlay {
+    animation: none;
+  }
+  body.mobile-touch .portal-ring,
+  body.mobile-touch .portal-ring-reverse {
+    filter: none;
+    opacity: 0.18;
+  }
+  body.mobile-touch .nebula-overlay {
+    mix-blend-mode: normal;
+    opacity: 0.78;
+  }
+  body.mobile-touch .embers-container {
+    display: none;
+  }
   body.mobile-touch .class-row { grid-template-columns: repeat(2, minmax(138px, 1fr)); gap: 8px; width: min(340px, 92vw); }
   body.mobile-touch .class-card { padding: 9px 8px 8px; }
   body.mobile-touch #title-logo { width: min(360px, 82vw); margin-bottom: 18px; }
@@ -4065,8 +4121,11 @@
 
   body.mobile-touch #charselect-panel {
     width: min(380px, calc(100vw - 48px));
-    max-height: calc(100vh - 112px);
-    overflow-y: auto;
+    min-height: calc(var(--app-vh) - 178px);
+    max-height: none;
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
   }
   body.mobile-touch #charselect-panel .auth-title {
     font-size: 21px;
@@ -4108,14 +4167,54 @@
     border-top: 0;
     margin-top: 0;
     padding-top: 0;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel .charselect-layout {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    gap: 12px;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel .charselect-col-left {
+    flex-direction: column;
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel .charselect-col-right {
+    display: flex;
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
   }
   body.mobile-touch #charselect-panel #char-list {
+    flex: 1 1 auto;
     max-height: none;
     border: 0;
     background: transparent;
     padding: 0;
     margin: 0;
     overflow: visible;
+  }
+  body.mobile-touch #charselect-panel #online-class-details {
+    flex: 1 1 auto;
+    width: 100%;
+    height: auto;
+    min-height: 0;
+    max-height: none;
+    margin-bottom: 0;
+    overflow: visible;
+  }
+  body.mobile-touch #charselect-panel #online-class-details .class-details-content {
+    min-height: 100%;
+    height: auto;
+  }
+  body.mobile-touch #charselect-panel #online-class-details .class-details-grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
   }
   body.mobile-touch .char-row {
     display: grid;

--- a/src/main.ts
+++ b/src/main.ts
@@ -195,9 +195,6 @@ function preventMobileZoom(): void {
   document.addEventListener('gesturestart', prevent, { passive: false });
   document.addEventListener('gesturechange', prevent, { passive: false });
   document.addEventListener('gestureend', prevent, { passive: false });
-  document.addEventListener('touchmove', (e) => {
-    if (e.touches.length > 1) e.preventDefault();
-  }, { passive: false });
   document.addEventListener('touchend', (e) => {
     const now = Date.now();
     if (now - lastTouchEnd <= 320) e.preventDefault();
@@ -1327,8 +1324,10 @@ function showRealmList(dir?: import('./net/online').RealmDirectory): void {
       return `<div class="realm-row" data-name="${escapeHtml(r.name)}" data-url="${escapeHtml(r.url)}">
         <div><div class="realm-name">${escapeHtml(r.name)}${charTag}<span class="rn-rec" data-rec hidden>${escapeHtml(t('realm.recommended'))}</span></div>
           <div class="realm-sub" data-sub>${escapeHtml(t('realm.checkingStatus'))}</div></div>
-        <div class="realm-type">${escapeHtml(typeLabel)}</div>
-        <div class="realm-pop offline" data-pop>-</div>
+        <div class="realm-meta">
+          <div class="realm-type">${escapeHtml(typeLabel)}</div>
+          <div class="realm-pop offline" data-pop>-</div>
+        </div>
       </div>`;
     }).join('');
     listEl.querySelectorAll('.realm-row').forEach((row) => row.addEventListener('click', () => {
@@ -2687,6 +2686,7 @@ function wireStartScreens(): void {
 
   // Dynamically initialize background embers
   const initBackgroundEmbers = () => {
+    if (isPhoneTouchDevice()) return;
     const backdrop = $('#start-screen-backdrop');
     if (!backdrop) return;
     


### PR DESCRIPTION
## What

This polishes the mobile pre-game menu flow for the v0.8 release branch:

- Realm list rows could squeeze `Normal` and `Low` into a cramped horizontal layout on phones.
- Main-menu scrolling and taps on iOS could feel laggy because every document `touchmove` was registered as cancelable.
- Animated/blurred homepage backdrop effects were expensive on mobile while scrolling.
- The mobile character-select card used nested vertical scroll containers instead of taking the available page height.
- The mobile create-character class details card had its own inner scroll, and Starting Stats / Equipment could remain side-by-side.

## Fix

- Wrap realm type/population metadata and stack it vertically on mobile.
- Remove the global non-passive `touchmove` zoom guard while keeping iOS gesture and double-tap prevention.
- Skip homepage ember particles on phone touch devices and disable costly mobile backdrop animation/blur.
- Make the mobile character-select panel and character list flex into the available height with visible overflow instead of nested scrollbars.
- Stack the mobile create layout vertically, stretch the class details card, and render Starting Stats / Equipment as a vertical flex column.

No `sim/`, `IWorld`, `net`, server, or gameplay rule changes.

## Verification

- `npm run build`
- Chrome mobile/touch emulation verified at `390x844`, DPR 3:
  - Realm list shows `Normal` above `Low` with no horizontal overflow.
  - Homepage mobile backdrop has no ember particles and no animated blurred portal layers.
  - Character-select card has no inner scroll and fills the available mobile page area.
  - Create-character class details card has no inner scroll.
  - Starting Stats and Equipment stack vertically on mobile.
  - No browser console/page errors during login and realm/character navigation.
