### PR TITLE
fix(chat): keep the sticky whisper channel after whispering a /dnd player

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -5410,7 +5410,10 @@ export class Sim {
           // Withhold the whisper, but still echo the sender's own line so they
           // see what they tried to send.
           this.emit({ type: 'chat', fromPid: r.meta.entityId, from: r.meta.name, to: target.name, text: msg, channel: 'whisper', pid: r.meta.entityId });
-          return { channel: 'whisper', message: msg };
+          // Carry `target` so the sender's sticky whisper channel still updates —
+          // a withheld DND whisper is still a whisper they sent, so a bare
+          // follow-up must continue the whisper rather than fall back to /say.
+          return { channel: 'whisper', message: msg, target: target.name };
         }
       }
       // classic-WoW "/r": the recipient's reply target is whoever last

--- a/tests/chat.test.ts
+++ b/tests/chat.test.ts
@@ -839,6 +839,26 @@ describe('/afk and /dnd presence', () => {
     expect(chatEvents(out).some((m) => m.channel === 'whisper' && m.pid === b && m.to === 'Aleph')).toBe(true);
   });
 
+  it('a /dnd whisper still reports the recipient so the sender’s reply channel sticks', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+    sim.tick();
+
+    sim.chat('/dnd raiding', a);
+    sim.tick();
+
+    // The whisper to a DND player is withheld from the recipient, but the
+    // returned SentChat must still carry the resolved recipient: the server
+    // uses `sent.target` to set the sender's sticky whisper channel. Without
+    // it, Bet's next bare line falls back to /say and leaks what was meant to
+    // be a private reply.
+    const sent = sim.chat('/w Aleph ping', b);
+    expect(sent).not.toBeNull();
+    expect(sent!.channel).toBe('whisper');
+    expect(sent!.target).toBe('Aleph');
+  });
+
   it('repeating the bare command toggles the status off', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');


### PR DESCRIPTION
A player who whispers someone in **Do Not Disturb** can have their *next* line silently broadcast to /say.

## The bug
When the target is in `/dnd`, the sim withholds delivery to the recipient and returns a `SentChat` **without** `target`:

```ts
// src/sim/sim.ts — DND-withhold branch
return { channel: 'whisper', message: msg };          // no `target`
```

The normal-delivery branch a few lines down *does* carry it:

```ts
return { channel: 'whisper', message: msg, target: target.name };
```

The server sets the sender's sticky whisper channel from `sent.target`:

```ts
// server/game.ts
if (sent.channel === 'whisper') {
  if (sent.target) session.rememberedChat = { channel: 'whisper', target: sent.target };
} else {
  session.rememberedChat = { channel: sent.channel };
}
```

So a withheld DND whisper enters the `whisper` branch but `sent.target` is `undefined` → **neither** branch runs → `rememberedChat` stays at its prior value (default `say`). Repro: with your sticky channel at the default, `/w Bob hi` (Bob is `/dnd`) → then a bare `are you there?` → it goes to **/say**, publicly broadcasting what was meant as a private follow-up.

## The fix
Carry `target` on the DND-withhold return as well — the sender still sent a whisper, so their reply channel should stick to that recipient regardless of the recipient's DND state. One line; aligns the two return paths. (DND still withholds delivery to the recipient — only the sender's own channel state changes.)

## Verification
- New `tests/chat.test.ts` case asserts the DND whisper return carries the recipient (fails before the change: `expected undefined to be 'Aleph'`).
- Full local CI gate green: `npm test` (1238 passed) · `npx tsc --noEmit` · `npm run build:env` · `npm run build:server` · `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
