### PR TITLE
fix(mobile): add touch camera swipe controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -3360,6 +3360,28 @@
   #rotate-device { display: none; }
   body.mobile-touch #game-canvas { touch-action: none; }
   body.mobile-touch #ui { touch-action: none; }
+  body.mobile-touch.game-active,
+  body.mobile-touch.game-active #ui,
+  body.mobile-touch.game-active #nameplates,
+  body.mobile-touch.game-active #mobile-controls,
+  body.mobile-touch.game-active #mobile-controls *,
+  body.mobile-touch.game-active #bottom-bar,
+  body.mobile-touch.game-active #bottom-bar *,
+  body.mobile-touch.game-active .action-btn,
+  body.mobile-touch.game-active .mobile-btn {
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+  }
+  body.mobile-touch.game-active input,
+  body.mobile-touch.game-active textarea,
+  body.mobile-touch.game-active select,
+  body.mobile-touch.game-active [contenteditable=""],
+  body.mobile-touch.game-active [contenteditable="true"] {
+    user-select: text;
+    -webkit-user-select: text;
+    -webkit-touch-callout: default;
+  }
   body.mobile-touch.game-active #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; opacity: var(--touch-opacity, 1); }
   body.mobile-touch.game-active #ui,
   body.mobile-touch.game-active #nameplates,

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -108,6 +108,7 @@ export class Input {
       if (document.hidden) this.releaseCapture('hidden');
     });
     document.addEventListener('contextmenu', (e) => this.onContextMenu(e));
+    document.addEventListener('selectstart', (e) => this.onSelectStart(e));
     canvas.addEventListener('mousedown', (e) => this.onMouseDown(e));
     window.addEventListener('mouseup', (e) => this.onMouseUp(e));
     window.addEventListener('mousemove', (e) => this.onMouseMove(e));
@@ -127,6 +128,13 @@ export class Input {
 
   private onContextMenu(e: MouseEvent): void {
     if (this.shouldSuppressContextMenu(e.target)) e.preventDefault();
+  }
+
+  private onSelectStart(e: Event): void {
+    const body = document.body;
+    if (!body?.classList.contains('game-active') || !body.classList.contains('mobile-touch')) return;
+    if (this.isEditableContextTarget(e.target)) return;
+    e.preventDefault();
   }
 
   private shouldSuppressContextMenu(target: EventTarget | null): boolean {

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -3,6 +3,7 @@ import type { Input, TouchMoveInput } from './input';
 export const PHONE_TOUCH_QUERY = '(pointer: coarse) and (max-width: 940px), (pointer: coarse) and (max-height: 760px)';
 const DEADZONE = 0.22;
 const CAMERA_SENSITIVITY = 0.8;
+const SWIPE_LOOK_DEADZONE_PX = 6;
 // Pinch: each pixel the two fingers spread/close maps to this many yards of
 // camera distance. Tuned so a comfortable thumb-to-finger pinch sweeps roughly
 // the full 3..22yd zoom range in one gesture.
@@ -118,6 +119,12 @@ export class MobileControls {
   // two-finger pinch-to-zoom on the game view (phones have no scroll wheel)
   private pinchPointers = new Map<number, { x: number; y: number }>();
   private pinchPrevDist: number | null = null;
+  private swipeLookPointer: number | null = null;
+  private swipeLookStartX = 0;
+  private swipeLookStartY = 0;
+  private swipeLookLastX = 0;
+  private swipeLookLastY = 0;
+  private swipeLookActive = false;
 
   private canvas = document.getElementById('game-canvas') as HTMLElement | null;
   private root = document.getElementById('mobile-controls') as HTMLElement | null;
@@ -184,10 +191,22 @@ export class MobileControls {
       this.autorunButton?.classList.toggle('active', on);
     });
 
-    this.canvas?.addEventListener('pointerdown', (e) => this.onPinchDown(e));
-    this.canvas?.addEventListener('pointermove', (e) => this.onPinchMove(e));
-    this.canvas?.addEventListener('pointerup', (e) => this.onPinchEnd(e));
-    this.canvas?.addEventListener('pointercancel', (e) => this.onPinchEnd(e));
+    this.canvas?.addEventListener('pointerdown', (e) => {
+      this.onPinchDown(e);
+      this.onSwipeLookDown(e);
+    });
+    this.canvas?.addEventListener('pointermove', (e) => {
+      this.onPinchMove(e);
+      this.onSwipeLookMove(e);
+    });
+    this.canvas?.addEventListener('pointerup', (e) => {
+      this.onPinchEnd(e);
+      this.onSwipeLookEnd(e);
+    });
+    this.canvas?.addEventListener('pointercancel', (e) => {
+      this.onPinchEnd(e);
+      this.onSwipeLookEnd(e);
+    });
 
     this.bindButton('mobile-attack-nearest', () => this.callbacks.onAttackNearest());
     this.bindButton('mobile-jump', () => this.callbacks.onJump());
@@ -402,7 +421,10 @@ export class MobileControls {
   private onPinchDown(e: PointerEvent): void {
     if (!this.active || e.pointerType !== 'touch') return;
     this.pinchPointers.set(e.pointerId, { x: e.clientX, y: e.clientY });
-    if (this.pinchPointers.size === 2) this.pinchPrevDist = this.currentPinchDist();
+    if (this.pinchPointers.size === 2) {
+      this.releaseSwipeLook();
+      this.pinchPrevDist = this.currentPinchDist();
+    }
   }
 
   private onPinchMove(e: PointerEvent): void {
@@ -424,11 +446,63 @@ export class MobileControls {
   private releasePinch(): void {
     this.pinchPointers.clear();
     this.pinchPrevDist = null;
+    this.releaseSwipeLook();
   }
 
   private currentPinchDist(): number {
     const pts = [...this.pinchPointers.values()];
     return Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+  }
+
+  private onSwipeLookDown(e: PointerEvent): void {
+    if (!this.active || e.pointerType !== 'touch' || this.swipeLookPointer !== null || this.lookPointer !== null || this.pinchPointers.size > 1) return;
+    this.swipeLookPointer = e.pointerId;
+    this.swipeLookStartX = e.clientX;
+    this.swipeLookStartY = e.clientY;
+    this.swipeLookLastX = e.clientX;
+    this.swipeLookLastY = e.clientY;
+    this.swipeLookActive = false;
+    try { this.canvas?.setPointerCapture(e.pointerId); } catch { /* synthetic test event */ }
+  }
+
+  private onSwipeLookMove(e: PointerEvent): void {
+    if (!this.active || e.pointerId !== this.swipeLookPointer || this.pinchPointers.size > 1) return;
+    const totalDx = e.clientX - this.swipeLookStartX;
+    const totalDy = e.clientY - this.swipeLookStartY;
+    if (!this.swipeLookActive) {
+      if (Math.hypot(totalDx, totalDy) < SWIPE_LOOK_DEADZONE_PX) return;
+      this.swipeLookActive = true;
+      this.input.setTouchLook(true);
+      this.input.setTouchLookVector({ x: 0, y: 0 });
+    }
+    e.preventDefault();
+    const dx = e.clientX - this.swipeLookLastX;
+    const dy = e.clientY - this.swipeLookLastY;
+    this.swipeLookLastX = e.clientX;
+    this.swipeLookLastY = e.clientY;
+    this.input.applyTouchLookDelta(dx, dy);
+  }
+
+  private onSwipeLookEnd(e: PointerEvent): void {
+    if (e.pointerId !== this.swipeLookPointer) return;
+    if (this.swipeLookActive) e.preventDefault();
+    this.releaseSwipeLook();
+  }
+
+  private releaseSwipeLook(): void {
+    if (this.swipeLookPointer !== null) {
+      try {
+        if (this.canvas?.hasPointerCapture?.(this.swipeLookPointer)) {
+          this.canvas.releasePointerCapture(this.swipeLookPointer);
+        }
+      } catch { /* capture may already be gone on mobile browser gesture changes */ }
+    }
+    this.swipeLookPointer = null;
+    if (this.swipeLookActive) {
+      this.input.setTouchLook(false);
+      this.input.setTouchLookVector({ x: 0, y: 0 });
+    }
+    this.swipeLookActive = false;
   }
 }
 

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -53,6 +53,13 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch.game-active *::-webkit-scrollbar:horizontal {\n    height: 0;\n    display: none;');
   });
 
+  it('suppresses mobile in-game text selection and touch callouts without blocking inputs', () => {
+    expect(html).toContain('body.mobile-touch.game-active #mobile-controls *,\n  body.mobile-touch.game-active #bottom-bar,');
+    expect(html).toContain('body.mobile-touch.game-active .mobile-btn {\n    user-select: none;\n    -webkit-user-select: none;\n    -webkit-touch-callout: none;');
+    expect(html).toContain('body.mobile-touch.game-active input,\n  body.mobile-touch.game-active textarea,\n  body.mobile-touch.game-active select,');
+    expect(html).toContain('-webkit-user-select: text;\n    -webkit-touch-callout: default;');
+  });
+
   it('hides only the in-game community donate affordance on mobile', () => {
     expect(html).toContain('<a class="donate-cta"');
     expect(html).toContain('<a class="community-link donate"');

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -19,6 +19,7 @@ function makeInput() {
   const requestPointerLock = vi.fn();
   const exitPointerLock = vi.fn();
   let gameActive = true;
+  let mobileTouch = false;
   const canvas = {
     style: { cursor: '' },
     addEventListener: vi.fn((type: string, cb: (event: any) => void) => {
@@ -33,7 +34,11 @@ function makeInput() {
   };
   (globalThis as any).document = {
     activeElement: null,
-    body: { classList: { contains: (cls: string) => cls === 'game-active' && gameActive } },
+    body: {
+      classList: {
+        contains: (cls: string) => (cls === 'game-active' && gameActive) || (cls === 'mobile-touch' && mobileTouch),
+      },
+    },
     fullscreenElement: null,
     webkitFullscreenElement: null,
     pointerLockElement: null,
@@ -53,7 +58,16 @@ function makeInput() {
     onClickPick: vi.fn(),
   };
   const input = new Input(canvas as any, cb, new Keybinds());
-  return { canvas, canvasListeners, windowListeners, documentListeners, cb, input, setGameActive: (active: boolean) => { gameActive = active; } };
+  return {
+    canvas,
+    canvasListeners,
+    windowListeners,
+    documentListeners,
+    cb,
+    input,
+    setGameActive: (active: boolean) => { gameActive = active; },
+    setMobileTouch: (active: boolean) => { mobileTouch = active; },
+  };
 }
 
 beforeEach(() => {
@@ -274,6 +288,60 @@ describe('Input context menu guard', () => {
 
     documentListeners.get('contextmenu')!({
       target: { tagName: 'INPUT', closest: () => null },
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+});
+
+describe('Input mobile selection guard', () => {
+  it('suppresses text selection during active mobile gameplay', () => {
+    const { documentListeners, setMobileTouch } = makeInput();
+    const preventDefault = vi.fn();
+    setMobileTouch(true);
+
+    documentListeners.get('selectstart')!({
+      target: { tagName: 'DIV', closest: () => null },
+      preventDefault,
+    });
+
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
+  it('does not suppress selection before entering the game', () => {
+    const { documentListeners, setGameActive, setMobileTouch } = makeInput();
+    const preventDefault = vi.fn();
+    setGameActive(false);
+    setMobileTouch(true);
+
+    documentListeners.get('selectstart')!({
+      target: { tagName: 'DIV', closest: () => null },
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('does not suppress selection on desktop', () => {
+    const { documentListeners } = makeInput();
+    const preventDefault = vi.fn();
+
+    documentListeners.get('selectstart')!({
+      target: { tagName: 'DIV', closest: () => null },
+      preventDefault,
+    });
+
+    expect(preventDefault).not.toHaveBeenCalled();
+  });
+
+  it('keeps selection available in editable mobile controls', () => {
+    const { documentListeners, setMobileTouch } = makeInput();
+    const preventDefault = vi.fn();
+    setMobileTouch(true);
+
+    documentListeners.get('selectstart')!({
+      target: { tagName: 'TEXTAREA', closest: () => null },
       preventDefault,
     });
 

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -217,6 +217,7 @@ afterEach(() => {
 });
 
 function installMobileControlDom(): {
+  canvas: FakeElement;
   moveZone: FakeElement;
   moveJoystick: FakeElement;
   cameraJoystick: FakeElement;
@@ -224,6 +225,7 @@ function installMobileControlDom(): {
   windowTarget: EventTarget;
 } {
   const elements = new Map<string, FakeElement>([
+    ['game-canvas', new FakeElement({ left: 0, top: 0, right: 390, bottom: 844, width: 390, height: 844 })],
     ['mobile-controls', new FakeElement()],
     ['mobile-move-zone', new FakeElement({ left: 0, top: 0, right: 240, bottom: 240, width: 240, height: 240 })],
     ['mobile-move-joystick', new FakeElement()],
@@ -250,6 +252,7 @@ function installMobileControlDom(): {
   Object.defineProperty(globalThis, 'window', { value: windowTarget, configurable: true });
 
   return {
+    canvas: elements.get('game-canvas')!,
     moveZone: elements.get('mobile-move-zone')!,
     moveJoystick: elements.get('mobile-move-joystick')!,
     cameraJoystick: elements.get('mobile-camera-joystick')!,
@@ -258,12 +261,13 @@ function installMobileControlDom(): {
   };
 }
 
-function pointerEvent(type: string, init: { pointerId: number; clientX?: number; clientY?: number }): Event {
+function pointerEvent(type: string, init: { pointerId: number; clientX?: number; clientY?: number; pointerType?: string }): Event {
   const event = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperties(event, {
     pointerId: { value: init.pointerId },
     clientX: { value: init.clientX ?? 0 },
     clientY: { value: init.clientY ?? 0 },
+    pointerType: { value: init.pointerType ?? '' },
   });
   return event;
 }
@@ -359,5 +363,62 @@ describe('MobileControls pointer lifecycle', () => {
     emoteButton.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
 
     expect(emotes).toBe(1);
+  });
+
+  it('rotates the camera from a single-finger swipe on the game canvas', () => {
+    const { canvas } = installMobileControlDom();
+    const deltas: Array<{ dx: number; dy: number }> = [];
+    const lookActive: boolean[] = [];
+    const lookVectors: Array<{ x: number; y: number }> = [];
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: (active: boolean) => { lookActive.push(active); },
+      setTouchLookVector: (look: { x: number; y: number }) => { lookVectors.push(look); },
+      applyTouchLookDelta: (dx: number, dy: number) => { deltas.push({ dx, dy }); },
+      zoomBy: () => {},
+    } as unknown as Input;
+
+    new MobileControls(input, mobileCallbacks()).start();
+
+    canvas.dispatchEvent(pointerEvent('pointerdown', { pointerId: 12, pointerType: 'touch', clientX: 100, clientY: 100 }));
+    canvas.dispatchEvent(pointerEvent('pointermove', { pointerId: 12, pointerType: 'touch', clientX: 103, clientY: 102 }));
+    canvas.dispatchEvent(pointerEvent('pointermove', { pointerId: 12, pointerType: 'touch', clientX: 122, clientY: 109 }));
+    canvas.dispatchEvent(pointerEvent('pointermove', { pointerId: 12, pointerType: 'touch', clientX: 140, clientY: 120 }));
+    canvas.dispatchEvent(pointerEvent('pointerup', { pointerId: 12, pointerType: 'touch', clientX: 140, clientY: 120 }));
+
+    expect(deltas).toEqual([
+      { dx: 22, dy: 9 },
+      { dx: 18, dy: 11 },
+    ]);
+    expect(lookActive).toEqual([true, false]);
+    expect(lookVectors).toEqual([{ x: 0, y: 0 }, { x: 0, y: 0 }]);
+  });
+
+  it('cancels canvas swipe rotation when a second finger starts pinch zoom', () => {
+    const { canvas } = installMobileControlDom();
+    const deltas: Array<{ dx: number; dy: number }> = [];
+    const zooms: number[] = [];
+    const lookActive: boolean[] = [];
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: (active: boolean) => { lookActive.push(active); },
+      setTouchLookVector: () => {},
+      applyTouchLookDelta: (dx: number, dy: number) => { deltas.push({ dx, dy }); },
+      zoomBy: (delta: number) => { zooms.push(delta); },
+    } as unknown as Input;
+
+    new MobileControls(input, mobileCallbacks()).start();
+
+    canvas.dispatchEvent(pointerEvent('pointerdown', { pointerId: 21, pointerType: 'touch', clientX: 100, clientY: 100 }));
+    canvas.dispatchEvent(pointerEvent('pointermove', { pointerId: 21, pointerType: 'touch', clientX: 116, clientY: 100 }));
+    canvas.dispatchEvent(pointerEvent('pointerdown', { pointerId: 22, pointerType: 'touch', clientX: 200, clientY: 100 }));
+    canvas.dispatchEvent(pointerEvent('pointermove', { pointerId: 21, pointerType: 'touch', clientX: 130, clientY: 100 }));
+    canvas.dispatchEvent(pointerEvent('pointermove', { pointerId: 22, pointerType: 'touch', clientX: 220, clientY: 100 }));
+
+    expect(deltas).toEqual([{ dx: 16, dy: 0 }]);
+    expect(lookActive).toEqual([true, false]);
+    expect(zooms.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## What

Adds the requested ability to change the camera view by swiping directly on the game screen on mobile.

This also tightens related in-game mobile touch behavior:

- Single-finger swipes on the game canvas rotate the camera after a small deadzone.
- Screen swipe camera movement now marks touch-look as active, so the camera does not recenter while the left movement joystick is held.
- Starting a two-finger pinch cancels screen-swipe camera rotation and preserves pinch-to-zoom behavior.
- Mobile gameplay suppresses Chrome/iOS text selection and touch callouts on HUD controls while keeping chat/forms editable.

## Fix

- Route mobile canvas pointer gestures through `MobileControls` alongside the existing pinch zoom handler.
- Apply direct touch-look deltas for screen swipes instead of emulating the right joystick vector.
- Enter/exit touch-look state during active screen drag so camera follow treats the gesture like manual camera control.
- Add a `selectstart` guard and WebKit selection/callout CSS for active mobile gameplay overlays.

No `sim/`, `IWorld`, `net`, server, or gameplay rule changes.

## Verification

- `npx vitest run tests/mobile_controls.test.ts tests/input.test.ts tests/client_shell.test.ts`
- `npm run build`
