### PR TITLE
fix(mobile): polish menu and xp spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3544,11 +3544,11 @@
   body.mobile-touch #actionbar-row { pointer-events: auto; }
   body.mobile-touch #xpbar {
     position: fixed;
-    left: max(8px, env(safe-area-inset-left));
+    left: calc(max(8px, env(safe-area-inset-left)) + 52px);
     right: auto;
     top: calc(max(8px, env(safe-area-inset-top)) + 70px);
     bottom: auto;
-    width: 246px;
+    width: 194px;
     min-width: 0;
     height: 6px;
     display: block;
@@ -3653,9 +3653,18 @@
   }
   body.mobile-touch #target-frame {
     left: max(8px, env(safe-area-inset-left));
-    top: calc(max(8px, env(safe-area-inset-top)) + 64px);
+    top: calc(max(8px, env(safe-area-inset-top)) + 90px);
     transform: scale(0.82);
     transform-origin: left top;
+  }
+  body.mobile-touch #party-frames {
+    position: fixed;
+    left: max(8px, env(safe-area-inset-left));
+    top: calc(max(8px, env(safe-area-inset-top)) + 92px);
+    z-index: 5;
+  }
+  body.mobile-touch #party-frames.below-target {
+    top: calc(max(8px, env(safe-area-inset-top)) + 148px);
   }
   body.mobile-touch #buff-bar { right: max(10px, env(safe-area-inset-right)); top: max(140px, env(safe-area-inset-top)); max-width: 180px; }
   body.mobile-touch #minimap-wrap { right: max(8px, env(safe-area-inset-right)); top: max(8px, env(safe-area-inset-top)); transform: scale(0.72); transform-origin: right top; }
@@ -4077,6 +4086,18 @@
   }
 
   @media (orientation: landscape) {
+    body.mobile-touch .mode-row {
+      flex-direction: row;
+      align-items: stretch;
+      width: min(620px, calc(100vw - 96px));
+      gap: 14px;
+    }
+    body.mobile-touch .mode-card {
+      flex: 1 1 0;
+      width: auto;
+      max-width: none;
+      padding: 16px 14px;
+    }
     body.mobile-touch .mobile-joystick {
       width: 100px; height: 100px; bottom: calc(15px + env(safe-area-inset-bottom));
       opacity: 0.72; border-color: #d2bd6a66;
@@ -4121,10 +4142,10 @@
     body.mobile-touch #actionbar.many-spells { grid-template-columns: repeat(6, 40px); }
     body.mobile-touch .action-btn { width: 40px; height: 40px; }
     body.mobile-touch #xpbar {
-      left: max(6px, env(safe-area-inset-left));
+      left: calc(max(6px, env(safe-area-inset-left)) + 38px);
       top: calc(max(6px, env(safe-area-inset-top)) + 48px);
       bottom: auto;
-      width: 180px;
+      width: 142px;
       min-width: 0;
       height: 5px;
     }
@@ -4158,8 +4179,15 @@
     }
     body.mobile-touch #target-frame {
       left: max(6px, env(safe-area-inset-left));
-      top: calc(max(6px, env(safe-area-inset-top)) + 50px);
+      top: calc(max(6px, env(safe-area-inset-top)) + 68px);
       transform: scale(0.6);
+    }
+    body.mobile-touch #party-frames {
+      left: max(6px, env(safe-area-inset-left));
+      top: calc(max(6px, env(safe-area-inset-top)) + 70px);
+    }
+    body.mobile-touch #party-frames.below-target {
+      top: calc(max(6px, env(safe-area-inset-top)) + 112px);
     }
     body.mobile-touch #buff-bar { right: calc(98px + env(safe-area-inset-right)); top: max(8px, env(safe-area-inset-top)); max-width: 160px; transform: scale(0.85); transform-origin: right top; }
     body.mobile-touch #minimap-wrap { right: max(6px, env(safe-area-inset-right)); top: max(6px, env(safe-area-inset-top)); transform: scale(0.46); }

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -69,11 +69,14 @@ describe('client HTML shell', () => {
 
   it('renders the mobile XP bar under the top-left player card', () => {
     expect(html).toContain('body.mobile-touch #xpbar {\n    position: fixed;');
-    expect(html).toContain('left: max(8px, env(safe-area-inset-left));');
+    expect(html).toContain('left: calc(max(8px, env(safe-area-inset-left)) + 52px);');
     expect(html).toContain('top: calc(max(8px, env(safe-area-inset-top)) + 70px);');
     expect(html).toContain('bottom: auto;');
-    expect(html).toContain('width: 246px;');
+    expect(html).toContain('width: 194px;');
     expect(html).toContain('height: 6px;\n    display: block;');
+    expect(html).toContain('body.mobile-touch #target-frame {\n    left: max(8px, env(safe-area-inset-left));\n    top: calc(max(8px, env(safe-area-inset-top)) + 90px);');
+    expect(html).toContain('body.mobile-touch #party-frames {\n    position: fixed;\n    left: max(8px, env(safe-area-inset-left));\n    top: calc(max(8px, env(safe-area-inset-top)) + 92px);');
+    expect(html).toContain('body.mobile-touch #party-frames.below-target {\n    top: calc(max(8px, env(safe-area-inset-top)) + 148px);');
     expect(html).not.toContain('body.mobile-touch.mobile-left-handed #xpbar,');
   });
 
@@ -90,6 +93,12 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch #mobile-extra-controls .mobile-btn');
     expect(html).toContain('flex-direction: row;');
     expect(html).toContain('body.mobile-touch #mobile-extra-controls .mobile-btn .ui-icon');
+  });
+
+  it('lays out the mobile mode cards side-by-side in landscape', () => {
+    expect(html).toContain('@media (orientation: landscape) {\n    body.mobile-touch .mode-row {\n      flex-direction: row;');
+    expect(html).toContain('width: min(620px, calc(100vw - 96px));');
+    expect(html).toContain('body.mobile-touch .mode-card {\n      flex: 1 1 0;\n      width: auto;');
   });
 
   it('omits Meters from the mobile More tray while keeping the desktop window', () => {


### PR DESCRIPTION
## What

Polishes two remaining mobile layout issues on the v0.8 release branch:

- The in-game mobile XP bar sat too close to the target frame / party frames and could overlap the circular status affordance.
- On mobile landscape, the main menu `Play Online` and `Play Offline` cards still stacked vertically instead of using the available horizontal space.

## Fix

- Shorten and offset the mobile XP bar so it sits under the top-left player card without colliding with target or party UI.
- Push the mobile target frame and party frames lower to preserve a clear gap below the XP bar in portrait and landscape.
- Add a mobile landscape override that lays the mode cards side-by-side with equal widths and compact padding.

No `sim/`, `IWorld`, `net`, server, or gameplay rule changes.

## Verification

- `npx vitest run tests/client_shell.test.ts`
- `npm run build`
