### PR TITLE
feat(content): Boneclad Revenants drain the victim's vitality on hit (Soul Siphon)

### DIFF
--- a/scripts/enervate_visual.mjs
+++ b/scripts/enervate_visual.mjs
@@ -1,0 +1,116 @@
+// Screenshots for the "Soul Siphon" enervate affix (Boneclad Revenant).
+// A landed hit drains the victim's Stamina, shrinking their max-HP pool, and
+// shows a red debuff on the buff bar. Runs the offline flow (no server). Needs
+// `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Brann', n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate(() => document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click());
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+// Level the warrior to 20 so a L18 Revenant's swing never one-shots it.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  p.hp = p.maxHp;
+});
+await wait(400);
+
+// Retemplate the nearest mob into a Boneclad Revenant, stage it in front of the
+// player, then force swings until the Soul Siphon drain lands.
+const result = await page.evaluate(async () => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let mob = null, best = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < best) { best = d; mob = e; }
+  }
+  if (!mob) return { ok: false, why: 'no mob nearby' };
+  mob.templateId = 'boneclad_revenant';
+  mob.name = 'Boneclad Revenant';
+  mob.hostile = true;
+  mob.level = 18;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z; mob.pos.y = p.pos.y;
+  const staBefore = p.stats.sta, maxHpBefore = p.maxHp;
+  let drained = false;
+  for (let i = 0; i < 400 && !drained; i++) {
+    p.hp = p.maxHp; // never let the swing kill us
+    sim.mobSwing(mob, p);
+    drained = p.auras.some((a) => a.kind === 'buff_sta' && a.value < 0);
+  }
+  // Set HP to ~70% of the (now-smaller) pool so the red HP bar reads clearly.
+  p.hp = Math.round(p.maxHp * 0.7);
+  return {
+    ok: drained, staBefore, staAfter: p.stats.sta,
+    maxHpBefore, maxHpAfter: p.maxHp,
+    aura: p.auras.find((a) => a.kind === 'buff_sta' && a.value < 0)?.name ?? null,
+  };
+});
+
+// Teleport the player away so combat ends and the 12s drain rides along, then
+// screenshot quickly before regen/recalc churn.
+await page.evaluate(() => {
+  const sim = window.__game.sim, p = sim.player;
+  p.pos.x -= 80;
+  p.prevPos = { ...p.pos };
+});
+await wait(160);
+await page.screenshot({ path: 'tmp/enervate-hud.png' });
+
+// Crop the buff bar (top-right, left of the minimap) for a legible debuff icon.
+try {
+  const clip = await page.evaluate(() => {
+    const el = document.querySelector('#buff-bar');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: Math.max(0, r.x - 12), y: Math.max(0, r.y - 8), width: Math.min(360, r.width + 24), height: Math.min(120, r.height + 50) };
+  });
+  if (clip && clip.width > 4) await page.screenshot({ path: 'tmp/enervate-buffbar.png', clip });
+} catch (e) { errors.push('buffbar crop: ' + e.message); }
+
+// Hover the debuff icon to surface its tooltip, then crop the top-right region.
+try {
+  await page.evaluate(() => {
+    const icon = document.querySelector('#buff-bar .buff.debuff') || document.querySelector('#buff-bar .buff');
+    if (!icon) return;
+    const r = icon.getBoundingClientRect();
+    const opts = { bubbles: false, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2 };
+    icon.dispatchEvent(new MouseEvent('mouseenter', opts));
+    icon.dispatchEvent(new MouseEvent('mousemove', { ...opts, bubbles: true }));
+  });
+  await wait(250);
+  await page.screenshot({ path: 'tmp/enervate-tooltip.png', clip: { x: 900, y: 0, width: 380, height: 230 } });
+} catch (e) { errors.push('tooltip: ' + e.message); }
+
+console.log('RESULT', JSON.stringify(result));
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -180,6 +180,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'boneclad_revenant', name: 'Boneclad Revenant', minLevel: 18, maxLevel: 19, family: 'undead',
     hpBase: 66, hpPerLevel: 23, dmgBase: 12, dmgPerLevel: 2.7, attackSpeed: 2.3,
     armorPerLevel: 18, moveSpeed: 6.5, aggroRadius: 11,
+    enervate: { chance: 0.3, sta: 14, duration: 12, name: 'Soul Siphon', school: 'shadow' },
     loot: [
       { copper: 100, chance: 1 },
       { itemId: 'bone_fragments', chance: 0.6 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -46,7 +46,10 @@ export type PlayerEquipment = Partial<Record<EquipSlot, string>>;
 // Vanilla rules: first 20 stamina gives 1 hp each, the rest 10 hp each.
 // First 20 intellect gives 1 mana each, the rest 15 mana each.
 function hpFromStamina(sta: number): number {
-  return Math.min(sta, 20) + Math.max(0, sta - 20) * 10;
+  // Floor at 0 so a Stamina-draining debuff (negative buff_sta) can never push
+  // the HP pool below its level-based base into negative territory.
+  const s = Math.max(0, sta);
+  return Math.min(s, 20) + Math.max(0, s - 20) * 10;
 }
 function manaFromIntellect(int: number): number {
   // Floor at 0 so an Intellect-draining debuff (negative buff_int) can never push

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4209,6 +4209,24 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Vitality drain: a landed hit can siphon the victim's Stamina, shrinking
+    // their maximum-HP pool. Hits every class (all players have Stamina), unlike
+    // the mana-only enfeeble. Hostile mobs only, so a friendly pet (mobSwing's
+    // other caller) never drains the party. Rides buff_sta with a negative value,
+    // so recalcPlayerStats folds it through to maxHp with no new HP math.
+    const enervate = MOBS[mob.templateId]?.enervate;
+    if (enervate && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(enervate.chance)) {
+      this.applyAura(target, {
+        id: `enervate_${mob.templateId}`,
+        name: enervate.name,
+        kind: 'buff_sta',
+        remaining: enervate.duration,
+        duration: enervate.duration,
+        value: -Math.abs(enervate.sta),
+        sourceId: mob.id,
+        school: enervate.school ?? 'shadow',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -235,6 +235,13 @@ export interface MobTemplate {
   // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
   // resource math. Only meaningful on mana users — applied to them alone.
   enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to drain `sta` Stamina from
+  // the victim for `duration`s, shrinking their maximum-HP pool (recalcPlayerStats
+  // re-derives maxHp from Stamina and scales current HP down with the smaller
+  // ceiling, clamped to a 1-HP floor — it never kills outright). Rides the
+  // existing buff_sta aura with a NEGATIVE value, so there is no new HP math.
+  // Affects every class (all players have Stamina), unlike enfeeble (mana only).
+  enervate?: { chance: number; sta: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to terrify the victim — a
   // fear that sends the struck player fleeing for `duration`s. Rides the existing
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`

--- a/tests/mob_enervate.test.ts
+++ b/tests/mob_enervate.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// Level the victim to 20 so a L18 Boneclad Revenant's swing never one-shots it
+// (death would clear the aura before we can read it).
+const makeSim = (cls: PlayerClass = 'warrior') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+const spawnRevenant = (sim: Sim) => {
+  const mob = createMob(990800, MOBS.boneclad_revenant, 18, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Swing until the Soul Siphon buff_sta debuff lands (a swing can miss/dodge).
+const swingUntilDrained = (sim: Sim, mob: any, target: any, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_sta' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob vitality drain (Soul Siphon)', () => {
+  it('Boneclad Revenant template carries the enervate mechanic', () => {
+    expect(MOBS.boneclad_revenant.enervate).toBeDefined();
+    expect(MOBS.boneclad_revenant.enervate!.name).toBe('Soul Siphon');
+  });
+
+  it('a landed hit applies a negative buff_sta aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      expect(swingUntilDrained(sim, mob, player)).toBe(true);
+    } finally {
+      enervate.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_sta');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Soul Siphon');
+    expect(aura!.value).toBe(-enervate.sta); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('shadow');
+  });
+
+  it('the drain lowers the victim Stamina and shrinks their max-HP pool', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const staBefore = player.stats.sta;
+    const maxHpBefore = player.maxHp;
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      swingUntilDrained(sim, mob, player);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.stats.sta).toBe(staBefore - enervate.sta);
+    expect(player.maxHp).toBeLessThan(maxHpBefore);
+  });
+
+  it('hits every class, not just mana users (warrior gets drained)', () => {
+    const sim = makeSim('warrior');
+    const player = sim.player;
+    expect(player.resourceType).not.toBe('mana');
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      expect(swingUntilDrained(sim, mob, player)).toBe(true);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_sta' && a.value < 0)).toBe(true);
+  });
+
+  it('never drops the victim below 1 HP (drain cannot kill outright)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      swingUntilDrained(sim, mob, player);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.hp).toBeGreaterThanOrEqual(1);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilDrained(sim, mob, player);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_sta' && a.value < 0).length).toBe(1);
+  });
+
+  it('a friendly pet never drains its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_sta' && a.value < 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit mob affix — **`enervate`** — to the reactive-enemy family on `release/v0.8`. A landed melee swing has a chance to **drain the victim's Stamina** for a few seconds, shrinking their **maximum-HP pool**.

This fills the one gap in the affix roster: every current affix attacks a player's *attack power* (demoralize), *mana ceiling* (enfeeble), *current mana* (manaBurn), *armor* (corrode), *healing* (mortalStrike), *attack/movement speed* (slowStrike/chillOnHit), or *control* (silence/dread/ensnare) — **none touches the HP pool itself**, and none of the stat-drains hit non-casters. `enervate` does both: it bites **every class**.

Carrier: **Boneclad Revenant** (undead, Thornpeak Heights L18-19) → **Soul Siphon** (30% chance / −14 Stamina / 12s, shadow).

## How

Rides the existing **`buff_sta` aura with a negative value** — `recalcPlayerStats` already derives `maxHp` from Stamina (`hpFromStamina`), so the smaller ceiling folds through with **zero new HP math**. The current-HP *fraction* is preserved under the lower ceiling and floored at 1, so the drain can rattle a player but **never kills outright**.

- `types.ts`: `enervate?: { chance; sta; duration; name; school? }` on `MobTemplate`.
- `sim.ts` (`mobSwing`): apply the negative `buff_sta` aura after the enfeeble block, guarded on `hostile` + player target (a tamed pet never drains the party).
- `entity.ts`: floor `hpFromStamina` at 0 so the drain can't push `maxHp` below its level base — mirrors the existing `manaFromIntellect` floor.
- `zone3.ts`: Boneclad Revenant carries Soul Siphon.
- The HUD already renders negative `buff_*` auras with the red debuff border (no UI change needed).

## Tests

`tests/mob_enervate.test.ts` — 7 cases: template carries the affix, a hit applies the negative `buff_sta` aura with template values, the drain lowers Stamina + shrinks max HP, it hits non-mana classes (warrior), it never drops the victim below 1 HP, it refreshes one shared slot (no stacking), and a friendly pet never drains. `tsc --noEmit`, the i18n guards, and the sim suite are all green. No i18n surface — affix names are plain data on the `aura` event, like every other affix in this family.

## Screenshots

Verified live: warrior Stamina **60→46**, max HP **812→672** (−140 = 14 × 10 HP/point past the first 20).

Debuff tooltip | Full HUD (debuff top-right)
:---:|:---:
![tooltip](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/enervate-shots/shots/soul-siphon-tooltip.png) | ![hud](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/enervate-shots/shots/soul-siphon-hud.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)