### PR TITLE
fix(chat): hard list is the sole slur-mute trigger (+ admin mute tooling)

### DIFF
--- a/server/admin.ts
+++ b/server/admin.ts
@@ -11,8 +11,8 @@ import {
   forceCharacterRename, ignoreReport, moderateAccount, muteAccountChat, moderationQueue, moderationReportsForAccount,
 } from './moderation_db';
 import {
-  addFilterWord, chatModerationForAccount, getFilterConfig, liftChatMute, listFilterWords,
-  removeFilterWord, resetChatStrikes, updateFilterConfig, type WordTier,
+  addFilterWord, chatModeratedAccounts, chatModerationForAccount, getFilterConfig, liftChatMute,
+  listFilterWords, removeFilterWord, resetChatStrikes, updateFilterConfig, type WordTier,
 } from './chat_filter_db';
 import type { GameServer } from './game';
 
@@ -205,12 +205,13 @@ export async function handleAdminApi(
     if (req.method !== 'GET') return fail(res, 405, 'method not allowed');
 
     if (path === '/admin/api/chat-filter') {
-      const [soft, hard, config] = await Promise.all([
+      const [soft, hard, config, accounts] = await Promise.all([
         listFilterWords('soft'),
         listFilterWords('hard'),
         getFilterConfig(),
+        chatModeratedAccounts(),
       ]);
-      return ok(res, { soft, hard, config });
+      return ok(res, { soft, hard, config, accounts });
     }
 
     if (path === '/admin/api/overview') {

--- a/server/admin_db.ts
+++ b/server/admin_db.ts
@@ -236,6 +236,7 @@ export interface AccountDetail {
   moderationReason: string;
   chatMutedUntil: string | null;
   chatMuteReason: string;
+  chatStrikes: number;
   playtimeSeconds: number;
   characters: {
     id: number;
@@ -264,6 +265,7 @@ export async function accountDetail(accountId: number): Promise<AccountDetail | 
               COALESCE(moderation_reason, '') AS moderation_reason,
               chat_muted_until,
               COALESCE(chat_mute_reason, '') AS chat_mute_reason,
+              COALESCE(chat_strikes, 0) AS chat_strikes,
               COALESCE((SELECT sum(EXTRACT(EPOCH FROM (COALESCE(s.ended_at, now()) - s.started_at)))
                         FROM play_sessions s WHERE s.account_id = accounts.id), 0)::bigint AS playtime_seconds
        FROM accounts WHERE id = $1`,
@@ -297,6 +299,7 @@ export async function accountDetail(accountId: number): Promise<AccountDetail | 
     moderationReason: a.moderation_reason,
     chatMutedUntil: a.chat_muted_until,
     chatMuteReason: a.chat_mute_reason,
+    chatStrikes: Number(a.chat_strikes ?? 0),
     playtimeSeconds: Number(a.playtime_seconds),
     characters: characters.rows.map((c) => ({
       id: c.id,

--- a/server/chat_filter.ts
+++ b/server/chat_filter.ts
@@ -5,59 +5,26 @@
 //     normalized soft list to each client in `hello`; the client masks matches
 //     locally *iff* the player's profanity filter is on. The server itself
 //     never alters soft words, so toggling the filter off shows raw text.
-//   - "hard" words (slurs): enforced server-side and non-bypassable. A message
-//     containing one is blocked entirely and the sender is warned, then
-//     escalated to timed, account-wide chat mutes (see `escalate`).
+//   - "hard" words (slurs): enforced server-side. A message containing one is
+//     blocked and the sender is warned, then escalated to timed, account-wide
+//     chat mutes (see `escalate`). The two tiers never interact: a soft word is
+//     never punitive, and a hard word is never merely masked.
 //
-// Matching folds common leet/confusable substitutions so "n1gg3r"-style evasion
-// still resolves to the underlying word.
+// The hard tier is driven SOLELY by the admin-managed hard list (see
+// `tokenMatchesHard`): a message is punished only when one of its tokens, after
+// normalization, equals a configured hard word (or its trailing-"s" plural).
+// Normalization folds leet/confusable/diacritic/Unicode obfuscation, so
+// "n1gg3r"/"nî99er"-style spellings of a LISTED word still resolve to it.
+// Whole-token (not substring) matching keeps innocent words safe with NO
+// whitelist needed — "snigger", "assassin", "classy pass" can never match.
+// Affixed forms the list does not contain (e.g. <slur> + a suffix) are NOT
+// caught unless an operator adds them.
 //
-// The hard tier has TWO layers, OR'd together:
-//   1. An always-on baseline built on `obscenity` — the same library `auth.ts`
-//      uses to screen names. Its English dataset (which lives in the dependency,
-//      NOT in this repo) folds leet/confusables/spacing AND affixes, so leetspeak,
-//      diacritics, and suffixed forms all resolve to the underlying slur, while
-//      still passing the Scunthorpe trap ("despicable", "classy pass"). This
-//      layer is non-disableable.
-//   2. The admin-editable hard list, matched per-token (see `tokenMatchesHard`).
-//      It covers slurs the baseline dataset misses and any custom terms an
-//      operator adds. Whole-token matching keeps it from snagging innocent words.
-// This OR layering mirrors `offensiveName` in auth.ts.
-//
-// NOTE: this is open-source. The repo intentionally ships NO plaintext slur
-// list — the actual offensive wordlist is the `obscenity` dependency's dataset.
-// Operators seed extra hard words (the few the dataset omits) privately via the
+// NOTE: this is open-source and intentionally ships NO plaintext slur list
+// (DEFAULT_HARD_WORDS is empty). Operators seed the hard list privately via the
 // CHAT_FILTER_HARD_LIST / CHAT_FILTER_HARD_FILE env vars (see chat_filter_db.ts)
-// and manage them thereafter from the admin dashboard.
-
-import { RegExpMatcher, englishDataset, englishRecommendedTransformers } from 'obscenity';
-
-// Built once at module load (the constructor compiles the dataset to a regex).
-const builtinSlurMatcher = new RegExpMatcher({
-  ...englishDataset.build(),
-  ...englishRecommendedTransformers,
-});
-
-/**
- * The canonical built-in slur `text` hits via the always-on `obscenity`
- * baseline, or null. Returns the dataset's canonical spelling for the matched
- * term (so an affixed/obfuscated input still logs as a stable term).
- */
-export function findBuiltinSlur(text: string): string | null {
-  // Scan the raw text and a de-obfuscated copy: obscenity does its own folding,
-  // but it misses diacritics and a few leet glyphs that `foldConfusables` flattens.
-  return matchBuiltinSlur(text) ?? matchBuiltinSlur(foldConfusables(text));
-}
-
-function matchBuiltinSlur(text: string): string | null {
-  const matches = builtinSlurMatcher.getAllMatches(text, true);
-  if (matches.length === 0) return null;
-  const meta = englishDataset.getPayloadWithPhraseMetadata(matches[0]);
-  return (
-    meta.phraseMetadata?.originalWord ??
-    text.slice(matches[0].startIndex, matches[0].endIndex + 1).toLowerCase()
-  );
-}
+// at first boot, then manage it from the admin dashboard. With an empty hard
+// list NOTHING is enforced, so seeding is required for slur enforcement.
 
 const CONFUSABLE_CHARS: Record<string, string> = {
   '0': 'o',
@@ -142,23 +109,23 @@ function tokenMatchesHard(normalizedToken: string, terms: readonly string[]): bo
 }
 
 /**
- * First hard term a message hits, or null. The match drives enforcement.
- * Checks the admin-editable list first, then falls through to the always-on
- * `obscenity` baseline — so an empty or incomplete hard list never opens a hole.
+ * First hard term a message hits, or null. This is the SOLE punitive trigger:
+ * only a token that — after normalization — equals a configured hard word (or
+ * its trailing-"s" plural) counts. An empty list enforces nothing.
  */
 export function findHardWord(text: string, terms: readonly string[]): string | null {
+  if (terms.length === 0) return null;
   const tokens = text.match(TOKEN_RE);
-  if (tokens) {
-    for (const tok of tokens) {
-      const normalized = normalizeWord(tok);
-      if (tokenMatchesHard(normalized, terms)) {
-        // Return the configured term that fired, for the incident log.
-        const singular = normalized.endsWith('s') ? normalized.slice(0, -1) : normalized;
-        return terms.find((term) => normalized === term || singular === term) ?? normalized;
-      }
+  if (!tokens) return null;
+  for (const tok of tokens) {
+    const normalized = normalizeWord(tok);
+    if (tokenMatchesHard(normalized, terms)) {
+      // Return the configured term that fired, for the incident log.
+      const singular = normalized.endsWith('s') ? normalized.slice(0, -1) : normalized;
+      return terms.find((term) => normalized === term || singular === term) ?? normalized;
     }
   }
-  return findBuiltinSlur(text);
+  return null;
 }
 
 // -------------------------------------------------------------------------
@@ -241,12 +208,11 @@ export const DEFAULT_SOFT_WORDS: string[] = [
   'whore',
 ];
 
-// Slur seed list — intentionally EMPTY in this open-source repo. The always-on
-// `obscenity` baseline (its dataset ships in the dependency) enforces slurs out
-// of the box. The handful of slurs that dataset omits are seeded privately by
-// the operator via CHAT_FILTER_HARD_LIST / CHAT_FILTER_HARD_FILE (see
-// chat_filter_db.ts), then managed from the admin dashboard. Do NOT commit
-// slurs here.
+// Slur seed list — intentionally EMPTY in this open-source repo. The hard tier
+// is the SOLE punitive trigger, so an operator MUST seed the slur list privately
+// via CHAT_FILTER_HARD_LIST / CHAT_FILTER_HARD_FILE (see chat_filter_db.ts) at
+// first boot — otherwise nothing is enforced — then manage it from the admin
+// dashboard. Do NOT commit slurs here.
 export const DEFAULT_HARD_WORDS: string[] = [];
 
 /** A live snapshot of the filter state, loaded from the DB and cached. */

--- a/server/chat_filter_db.ts
+++ b/server/chat_filter_db.ts
@@ -266,6 +266,33 @@ export async function chatModerationForAccount(accountId: number, limit = 25): P
   };
 }
 
+export interface ChatModeratedAccount {
+  id: number;
+  username: string;
+  isAdmin: boolean;
+  chatStrikes: number;
+  chatMutedUntil: string | null;
+}
+
+/** Accounts that are currently chat-muted or carry strikes — the chat-filter dash list. */
+export async function chatModeratedAccounts(limit = 200): Promise<ChatModeratedAccount[]> {
+  const res = await pool.query(
+    `SELECT id, username, is_admin, COALESCE(chat_strikes, 0) AS chat_strikes, chat_muted_until
+       FROM accounts
+      WHERE (chat_muted_until IS NOT NULL AND chat_muted_until > now()) OR COALESCE(chat_strikes, 0) > 0
+      ORDER BY chat_muted_until DESC NULLS LAST, chat_strikes DESC, id
+      LIMIT $1`,
+    [Math.min(500, Math.max(1, limit))],
+  );
+  return res.rows.map((r) => ({
+    id: Number(r.id),
+    username: r.username,
+    isAdmin: r.is_admin,
+    chatStrikes: Number(r.chat_strikes ?? 0),
+    chatMutedUntil: r.chat_muted_until ? new Date(r.chat_muted_until).toISOString() : null,
+  }));
+}
+
 /** Clear an active mute. Returns the account id touched (for live disconnect/notice). */
 export async function liftChatMute(accountId: number): Promise<boolean> {
   const res = await pool.query(

--- a/server/chat_filter_db.ts
+++ b/server/chat_filter_db.ts
@@ -46,9 +46,10 @@ function envSeedSoftWords(): string[] {
 }
 
 function envSeedHardWords(): string[] {
-  // The hard (slur) tier ships no plaintext list in this open-source repo; the
-  // `obscenity` baseline enforces slurs, and operators seed the few it omits
-  // privately here. See DEFAULT_HARD_WORDS in chat_filter.ts.
+  // The hard (slur) tier ships no plaintext list in this open-source repo and is
+  // the SOLE punitive trigger, so the operator MUST seed the slur list here at
+  // first boot — with nothing seeded, nothing is enforced. Managed from the admin
+  // dashboard thereafter. See DEFAULT_HARD_WORDS in chat_filter.ts.
   return envSeedWords('CHAT_FILTER_HARD_LIST', 'CHAT_FILTER_HARD_FILE');
 }
 

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -298,6 +298,16 @@ function handleModerationActionClick(e: Event, source: 'account' | 'moderation')
     window.alert(t('alert.noteRequired'));
     return false;
   };
+  // Lift mute / reset strikes: non-destructive, no note/confirm. Available for
+  // any account (incl. admins) so an auto-muted operator can clear it themselves.
+  const chatModBtn = target.closest('button[data-lift-mute], button[data-reset-strikes]') as HTMLButtonElement | null;
+  if (chatModBtn && Number.isFinite(accountId)) {
+    const endpoint = chatModBtn.dataset.liftMute !== undefined ? 'lift-mute' : 'reset-strikes';
+    void apiPost(`/admin/api/moderation/accounts/${accountId}/${endpoint}`, {})
+      .then(() => { if (source === 'account') void refreshOpenAccountDetail(accountId); else void openModerationAccount(accountId); })
+      .catch((err: unknown) => { if (!handleAuthFailure(err)) window.alert(err instanceof Error ? localizeAdminError(err.message) : t('alert.actionFailed')); });
+    return true;
+  }
   const forceRenameBtn = target.closest('button[data-force-rename-character]') as HTMLButtonElement | null;
   if (forceRenameBtn) {
     if (!requireNote()) return true;

--- a/src/admin/main.ts
+++ b/src/admin/main.ts
@@ -587,9 +587,19 @@ function wireChatFilterEvents(): void {
       .catch((err: unknown) => chatFilterError(err, 'add word'));
   });
 
-  // Remove a word, or save the escalation config.
+  // Remove a word, save the escalation config, or lift/reset an account's chat mute.
   $('chat-filter').addEventListener('click', (e) => {
     const target = e.target as HTMLElement;
+    const chatModBtn = target.closest('button[data-lift-mute], button[data-reset-strikes]') as HTMLButtonElement | null;
+    if (chatModBtn) {
+      const accountId = Number((chatModBtn.closest('[data-action-account-id]') as HTMLElement | null)?.dataset.actionAccountId);
+      if (!Number.isFinite(accountId)) return;
+      const endpoint = chatModBtn.dataset.liftMute !== undefined ? 'lift-mute' : 'reset-strikes';
+      void apiPost(`/admin/api/moderation/accounts/${accountId}/${endpoint}`, {})
+        .then(() => refreshChatFilter())
+        .catch((err: unknown) => chatFilterError(err, 'chat moderation'));
+      return;
+    }
     const del = target.closest('button[data-del-word]') as HTMLButtonElement | null;
     if (del) {
       void apiPost(`/admin/api/chat-filter/words/${Number(del.dataset.delWord)}/delete`, {})

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -1,8 +1,8 @@
 import { escapeHtml, fmtCopper, fmtDate, fmtDuration, fmtRelative } from './format';
 import { classLabel, zoneLabel, t } from './i18n';
 import type {
-  AccountDetail, AccountRow, CharacterRow, ChatFilterData, ChatModerationDetail, FilterWord,
-  LivePlayer, ModerationAccountDetail, ModerationQueueRow,
+  AccountDetail, AccountRow, CharacterRow, ChatFilterData, ChatModeratedAccount,
+  ChatModerationDetail, FilterWord, LivePlayer, ModerationAccountDetail, ModerationQueueRow,
 } from './types';
 
 // Pure HTML-string renderers for the dashboard tables. All dynamic values go
@@ -312,7 +312,29 @@ export function renderChatFilter(data: ChatFilterData): string {
       <div class="panel-title">Hard words <span class="hint">slurs — message blocked + escalating mutes; never shown to anyone, not toggleable</span></div>
       <form class="word-add" data-add-tier="hard"><input placeholder="add a hard word" maxlength="64" /><button>Add</button></form>
       ${renderWordChips(data.hard)}
+    </div>
+    <div class="panel">
+      <div class="panel-title">Chat-moderated accounts <span class="hint">currently muted or carrying strikes — lift or reset here</span></div>
+      ${renderChatModeratedAccounts(data.accounts)}
     </div>`;
+}
+
+function renderChatModeratedAccounts(accounts: ChatModeratedAccount[]): string {
+  if (accounts.length === 0) return '<div class="empty">no muted or striked accounts</div>';
+  const rows = accounts.map((a) => {
+    const muted = a.chatMutedUntil !== null && new Date(a.chatMutedUntil).getTime() > Date.now();
+    const muteCell = muted
+      ? `<span class="badge warn">muted until ${fmtDate(a.chatMutedUntil)}</span>`
+      : '<span class="badge">not muted</span>';
+    const actions = `${muted ? '<button data-lift-mute="1">Lift mute</button>' : ''}${a.chatStrikes > 0 ? ' <button data-reset-strikes="1">Reset strikes</button>' : ''}`;
+    return `<tr data-action-account-id="${a.id}">
+      <td>${escapeHtml(a.username)}${a.isAdmin ? ' <span class="badge">admin</span>' : ''}</td>
+      <td class="num">${a.chatStrikes}</td>
+      <td>${muteCell}</td>
+      <td>${actions}</td>
+    </tr>`;
+  }).join('');
+  return `<table><thead><tr><th>Account</th><th class="num">Strikes</th><th>Mute</th><th>Actions</th></tr></thead><tbody>${rows}</tbody></table>`;
 }
 
 function reasonLabel(reason: string): string {

--- a/src/admin/tables.ts
+++ b/src/admin/tables.ts
@@ -119,7 +119,16 @@ export function renderAccountDetail(d: AccountDetail, includeAdminControls = fal
     <div class="account-admin-controls">
       <div class="account-status"><b>${t('detail.status')}</b> <span class="badge">${t('accounts.badgeAdmin')}</span> ${accountStatus}</div>
     </div>` : '';
-  return `<div class="account-detail" data-action-account-id="${d.id}">${adminControls}<div class="detail-grid">
+  // Chat-mute controls are shown for EVERY account (admins included): the chat
+  // filter auto-mutes admins too, and ban/suspend gating must not strand them.
+  const activeChatMute = d.chatMutedUntil !== null && new Date(d.chatMutedUntil).getTime() > Date.now();
+  const chatModControls = includeAdminControls ? `
+    <div class="account-admin-controls chat-mod-controls" data-action-account-id="${d.id}">
+      <div class="account-status"><b>Chat:</b> ${activeChatMute ? `<span class="badge warn">muted until ${fmtDate(d.chatMutedUntil)}</span>` : '<span class="badge">not muted</span>'} &middot; strikes: <b>${d.chatStrikes}</b></div>
+      ${activeChatMute ? '<button data-lift-mute="1">Lift chat mute</button>' : ''}
+      ${d.chatStrikes > 0 ? '<button data-reset-strikes="1">Reset chat strikes</button>' : ''}
+    </div>` : '';
+  return `<div class="account-detail" data-action-account-id="${d.id}">${adminControls}${chatModControls}<div class="detail-grid">
     <div><h4>${t('detail.charactersHeader')}</h4>${chars}</div>
     <div><h4>${t('detail.sessionsHeader', { value: fmtDuration(d.playtimeSeconds) })}</h4>${sessions}</div>
   </div></div>`;

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -89,6 +89,7 @@ export interface AccountDetail {
   moderationReason: string;
   chatMutedUntil: string | null;
   chatMuteReason: string;
+  chatStrikes: number;
   playtimeSeconds: number;
   characters: {
     id: number;

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -181,8 +181,17 @@ export interface EscalationConfig {
   muteLadderSeconds: number[];
 }
 
+export interface ChatModeratedAccount {
+  id: number;
+  username: string;
+  isAdmin: boolean;
+  chatStrikes: number;
+  chatMutedUntil: string | null;
+}
+
 export interface ChatFilterData {
   soft: FilterWord[];
   hard: FilterWord[];
   config: EscalationConfig;
+  accounts: ChatModeratedAccount[];
 }

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -219,7 +219,7 @@ describe('admin api auth', () => {
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9, username: 'badactor', createdAt: '', lastLogin: null, isAdmin: false,
       bannedAt: null, suspendedUntil: null, moderationReason: '',
-      chatMutedUntil: null, chatMuteReason: '',
+      chatMutedUntil: null, chatMuteReason: '', chatStrikes: 0,
       playtimeSeconds: 0, characters: [], recentSessions: [],
     });
     vi.mocked(moderationReportsForAccount).mockResolvedValue([]);
@@ -478,7 +478,7 @@ describe('admin api chat filter', () => {
     vi.mocked(accountDetail).mockResolvedValue({
       id: 9, username: 'badactor', createdAt: '', lastLogin: null, isAdmin: false,
       bannedAt: null, suspendedUntil: null, moderationReason: '',
-      chatMutedUntil: null, chatMuteReason: '',
+      chatMutedUntil: null, chatMuteReason: '', chatStrikes: 0,
       playtimeSeconds: 0, characters: [], recentSessions: [],
     });
     vi.mocked(moderationReportsForAccount).mockResolvedValue([]);

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -34,6 +34,7 @@ vi.mock('../server/moderation_db', () => ({
 }));
 vi.mock('../server/chat_filter_db', () => ({
   addFilterWord: vi.fn(),
+  chatModeratedAccounts: vi.fn(async () => []),
   chatModerationForAccount: vi.fn(),
   getFilterConfig: vi.fn(),
   liftChatMute: vi.fn(),

--- a/tests/chat_filter.test.ts
+++ b/tests/chat_filter.test.ts
@@ -10,9 +10,9 @@ import {
 } from '../server/chat_filter';
 
 // This repository is open source and intentionally contains NO plaintext slurs.
-// The hard tier's real wordlist lives in the `obscenity` dependency; these
-// fixtures are base64-encoded and decoded only at runtime so the filter can be
-// exercised against genuine offensive input without the repo carrying it.
+// The hard tier's wordlist is operator-seeded at runtime (never in the repo);
+// these fixtures are base64-encoded and decoded only at runtime so the filter
+// can be exercised against genuine offensive input without the repo carrying it.
 const dec = (b64: string) => Buffer.from(b64, 'base64').toString('utf8');
 const F = {
   slur: dec('bmlnZ2Vy'),
@@ -29,7 +29,7 @@ const F = {
   math: dec('8J2Tt/Cdk7LwnZOw8J2TsPCdk67wnZO7'),
   fullwidth: dec('bmnvvYfvvYdlcg=='),
   variant2: dec('bmVncm9pZA=='),
-  gap1: dec('Z29vaw=='), // a slur the obscenity dataset omits (operator-seeded)
+  gap1: dec('Z29vaw=='), // an operator-seeded slur
   gap2: dec('d2V0YmFjaw=='),
   benign: dec('c25pZ2dlcg=='), // a real, non-slur word that embeds the slur
 };
@@ -65,69 +65,44 @@ describe('maskText (soft, cosmetic)', () => {
   });
 });
 
-describe('findHardWord (hard, punitive)', () => {
-  it('matches whole tokens, including leet and plurals', () => {
+describe('findHardWord (hard, punitive — the admin hard list is the SOLE trigger)', () => {
+  it('matches a LISTED word through leet, case, plurals, diacritics, and Unicode', () => {
     expect(findHardWord(`you are a ${F.slur}`, [F.slur])).toBe(F.slur);
-    expect(findHardWord(F.leet, [F.slur])).toBe(F.slur);
-    expect(findHardWord(`two ${F.slurPlural} here`, [F.slur])).toBe(F.slur); // plural strip
+    expect(findHardWord(F.leet, [F.slur])).toBe(F.slur); // n1gg3r → nigger
     expect(findHardWord(F.upper, [F.slur])).toBe(F.slur); // case-insensitive
+    expect(findHardWord(`two ${F.slurPlural} here`, [F.slur])).toBe(F.slur); // trailing-s plural
+    expect(findHardWord(F.diacritic9, [F.slur])).toBe(F.slur); // accent + 9-as-g
+    expect(findHardWord(F.math, [F.slur])).toBe(F.slur); // mathematical-script glyphs
+    expect(findHardWord(F.fullwidth, [F.slur])).toBe(F.slur); // fullwidth glyphs
   });
 
-  it('does NOT substring-match innocent words (no false mutes)', () => {
-    // The classic Scunthorpe trap: substring matching would wrongly fire here.
-    expect(findHardWord('gobbledygook', [F.gap1])).toBeNull(); // gap1 is a substring of it
+  it('enforces NOTHING with an empty hard list (the list is the only trigger)', () => {
+    expect(findHardWord(F.slur, [])).toBeNull();
+    expect(findHardWord(F.affixMan, [])).toBeNull();
+    expect(findHardWord('anything goes', [])).toBeNull();
+  });
+
+  it('does NOT substring-match innocent words (whole-token; no whitelist needed)', () => {
+    expect(findHardWord(F.benign, [F.slur])).toBeNull(); // "snigger" embeds the slur
     expect(findHardWord('what a classy pass', ['ass'])).toBeNull();
     expect(findHardWord('assassin guild', ['ass'])).toBeNull();
-  });
-
-  it('returns null with no terms or no hit', () => {
-    expect(findHardWord('anything', [])).toBeNull();
+    expect(findHardWord('that is despicable', ['spic'])).toBeNull();
     expect(findHardWord('perfectly fine message', [F.slur])).toBeNull();
   });
 
-  describe('always-on obscenity baseline (closes the affix/empty-list hole)', () => {
-    it('catches slurs with appended/prepended affixes the whole-token list misses', () => {
-      // The reported bypass: an affixed slur did not equal the bare token.
-      expect(findHardWord(`you stupid ${F.affixMan}`, [])).toBe(F.slur);
-      expect(findHardWord(F.affix2, [])).toBe(F.slur);
-    });
+  it('does NOT catch affixed/variant forms unless the operator lists them', () => {
+    // Accepted trade-off: <slur>+suffix and unrelated variants are distinct
+    // tokens, so a bare listing does not reach them...
+    expect(findHardWord(`you stupid ${F.affixMan}`, [F.slur])).toBeNull();
+    expect(findHardWord(`what a ${F.variant2}`, [F.slur])).toBeNull();
+    // ...but an operator can add the exact variant, and then it matches.
+    expect(findHardWord(F.affixMan, [F.affixMan])).toBe(F.affixMan);
+    expect(findHardWord(`what a ${F.variant2}`, [F.variant2])).toBe(F.variant2);
+  });
 
-    it('catches slur variants not in the admin list at all', () => {
-      expect(findHardWord(`what a ${F.variant2}`, [])).toBeTruthy();
-    });
-
-    it('catches leet/confusable evasions even with an empty admin list', () => {
-      expect(findHardWord(F.leet, [])).toBe(F.slur);
-      expect(findHardWord(F.atSign, [])).toBeTruthy();
-    });
-
-    it('catches diacritics, extended leet (6/9→g), and styled Unicode glyphs', () => {
-      expect(findHardWord(F.diacritic2, [])).toBeTruthy(); // combining diacritic
-      expect(findHardWord(F.diacritic9, [])).toBeTruthy(); // accent + 9-as-g
-      expect(findHardWord(F.sixes, [])).toBeTruthy(); // 6-as-g + @
-      expect(findHardWord(F.circled, [])).toBeTruthy(); // circled letters
-      expect(findHardWord(F.math, [])).toBeTruthy(); // mathematical script
-      expect(findHardWord(F.fullwidth, [])).toBeTruthy(); // fullwidth letters
-    });
-
-    it('does not false-mute innocents that survive folding', () => {
-      // 9/6→g must not turn scores or laughter into a slur.
-      expect(findHardWord('i scored 99 gg', [])).toBeNull();
-      expect(findHardWord('biggie smalls', [])).toBeNull();
-      expect(findHardWord(`${F.benign} is a real word, no`, [])).toBeNull();
-    });
-
-    it('still passes the Scunthorpe trap (no false mutes on innocent words)', () => {
-      expect(findHardWord('that is despicable', [])).toBeNull();
-      expect(findHardWord('what a classy pass', [])).toBeNull();
-      expect(findHardWord('assassin guild', [])).toBeNull();
-      expect(findHardWord('perfectly fine message', [])).toBeNull();
-    });
-
-    it('the admin/operator list still covers slurs the baseline omits', () => {
-      expect(findHardWord(`go away ${F.gap1}`, [F.gap1])).toBe(F.gap1);
-      expect(findHardWord(`${F.gap2}s`, [F.gap2])).toBe(F.gap2); // plural strip
-    });
+  it('matches operator-seeded words and their plurals', () => {
+    expect(findHardWord(`go away ${F.gap1}`, [F.gap1])).toBe(F.gap1);
+    expect(findHardWord(`${F.gap2}s`, [F.gap2])).toBe(F.gap2); // plural strip
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes a chat-filter regression where **everyday swearing triggered the slur-mute escalation**, and adds the admin tooling to see and clear chat mutes.

### The bug (regression from #422)
#343 introduced the two-tier filter: **soft** words (everyday swearing) are a cosmetic client-side mask, **hard** words (slurs) are server-enforced (warn → escalating account-wide mutes). #422 then bolted an always-on `obscenity` baseline onto the **hard** tier to catch affixed slur evasions (`nigger`+`man`). But `obscenity`'s English dataset flags **general profanity, not just slurs** — only ~16 of its 69 words are slurs; the rest are exactly the soft-tier swears. So after #422, `fuck`/`shit`/`bitch`/… all matched the hard tier and routed players into warn → mute. Worked in dev (#343), broke in prod (post-#422).

### The fix — hard list is the sole punitive trigger
`findHardWord` now matches **only the admin-managed hard list** (whole-token, plural-aware), with #422's strong normalization kept so obfuscated spellings of a **listed** word still resolve (`n1gg3r`, `nî99er`, fullwidth/math-script glyphs). The two tiers are now fully independent — a soft word can never be punitive.

- Dropped the `obscenity` baseline from the chat filter. `obscenity` **stays a dependency** — `auth.ts` still uses it for username screening; this only removes it from chat.
- Repo still ships **zero plaintext slurs** (`DEFAULT_HARD_WORDS = []`); operators seed the slur list privately via `CHAT_FILTER_HARD_FILE`/`CHAT_FILTER_HARD_LIST` at first boot, then manage it from the dashboard. **An empty hard list now enforces nothing — seeding is required.**
- **Accepted trade-off:** affixed/variant forms not on the list (`niggerman`, `negroid`) are no longer auto-caught; admins add variants. Leet/diacritic/Unicode forms of *listed* words are still caught.

### Admin tooling (so operators can actually manage mutes)
The filter auto-mutes **any** account, admins included — but the dashboard previously gated all moderation behind `!isAdmin`, and lift/reset lived only on the report-queue-driven moderation page, so an auto-muted operator had no way to clear it. This PR adds:
- **Account detail → Chat moderation block** (every account, admins included): mute status + strike count + **Lift chat mute** / **Reset chat strikes**.
- **Chat-filter tab → "Chat-moderated accounts" panel**: lists every account currently muted or carrying strikes with inline Lift/Reset, so you can see and clear chat bans from one place. Backed by a new `chatModeratedAccounts()` query folded into `GET /admin/api/chat-filter`.
- Surfaced `chatStrikes` on `AccountDetail` (server query + types) for the status line.

## Testing
- `tsc --noEmit` clean · **1232/1232 Vitest tests pass** · `npm run build` green.
- `tests/chat_filter.test.ts` rewritten to assert the new contract: listed words (+ leet/diacritic/Unicode forms) trigger; an **empty list never triggers**; **soft words never trigger**; Scunthorpe innocents (`snigger`, `assassin`, `classy pass`) never trigger; affixed/variant forms only trigger when explicitly listed.
- Admin fixtures/mocks updated for the new `chatStrikes` field and `chatModeratedAccounts`.

## Note for reviewers
This bundles one bug fix (the filter) with two admin-dashboard features (mute controls + the accounts list). They're independent and could be split into two PRs if preferred — happy to do that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
