### PR TITLE
feat(content): Thornpeak Ogres concuss the victim on hit (Concussive Blow)

### DIFF
--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -95,6 +95,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'thornpeak_ogre', name: 'Thornpeak Ogre', minLevel: 15, maxLevel: 16, family: 'ogre',
     hpBase: 66, hpPerLevel: 23, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.6,
     armorPerLevel: 22, moveSpeed: 7, aggroRadius: 11,
+    concuss: { chance: 0.2, duration: 2, name: 'Concussive Blow' },
     loot: [
       { copper: 75, chance: 1 },
       { itemId: 'ogre_toe_ring', chance: 0.35 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4286,6 +4286,22 @@ export class Sim {
         });
       }
     }
+    // Concussive Blow: a landed hit can briefly STUN the victim (single-target,
+    // distinct from War Stomp's AoE slam). Hostile mobs only so a friendly pet
+    // never stuns an ally; CC DR is PvP-only so a mob source always lands full.
+    const concuss = MOBS[mob.templateId]?.concuss;
+    if (concuss && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(concuss.chance)) {
+      this.applyAura(target, {
+        id: `concuss_${mob.templateId}`,
+        name: concuss.name,
+        kind: 'stun',
+        remaining: concuss.duration,
+        duration: concuss.duration,
+        value: 0,
+        sourceId: mob.id,
+        school: concuss.school ?? 'physical',
+      });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -218,6 +218,10 @@ export interface MobTemplate {
   // other on-hit affixes it sustains the attacker instead of debuffing the
   // victim. Optional `chance` gates the proc (defaults to every landed hit).
   lifeleech?: { healFrac: number; chance?: number; name?: string };
+  // Melee mechanic: a landed swing has `chance` to land a concussive blow that
+  // STUNS the victim for `duration`s (can't move, cast, or act). The single-target
+  // cousin of War Stomp's AoE slam — rides the existing `stun` aura, no new kind.
+  concuss?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to corrode the victim's
   // armor: a stacking `sunder` debuff (up to `maxStacks`) so the victim takes
   // more physical damage from everyone until it expires. Rides the existing

--- a/tests/mob_concuss.test.ts
+++ b/tests/mob_concuss.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+describe('Concussive Blow stun-on-hit affix', () => {
+  it('a landed thornpeak_ogre swing can stun the victim', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the stun
+    const tmpl = MOBS.thornpeak_ogre;
+    const saved = tmpl.concuss!.chance;
+    tmpl.concuss!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900600, tmpl, 16, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        p.auras.length = 0; // a fresh swing each loop; isolate the stun aura
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'stun');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'stun')!;
+      expect(a.name).toBe('Concussive Blow');
+      expect(a.duration).toBe(2);
+      expect((sim as any).isStunned(p)).toBe(true);
+    } finally {
+      tmpl.concuss!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never stuns', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.thornpeak_ogre;
+    const saved = tmpl.concuss!.chance;
+    tmpl.concuss!.chance = 1;
+    try {
+      const pet = createMob(900601, tmpl, 16, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) {
+        p.hp = p.maxHp;
+        (sim as any).mobSwing(pet, p);
+      }
+      expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+    } finally {
+      tmpl.concuss!.chance = saved;
+    }
+  });
+
+  it('a mob without the concuss affix applies no stun', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900602, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+  });
+
+  it('the refreshing stun never stacks into multiple auras', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.thornpeak_ogre;
+    const saved = tmpl.concuss!.chance;
+    tmpl.concuss!.chance = 1;
+    try {
+      const mob = createMob(900603, tmpl, 16, { x: 0, y: 0, z: 0 });
+      for (let i = 0; i < 30; i++) {
+        p.hp = p.maxHp; // a fatal swing would clear auras; keep the victim alive
+        (sim as any).mobSwing(mob, p);
+      }
+      expect(p.auras.filter((a) => a.kind === 'stun').length).toBeLessThanOrEqual(1);
+    } finally {
+      tmpl.concuss!.chance = saved;
+    }
+  });
+});


### PR DESCRIPTION
## What

Adds a **`concuss`** on-hit melee affix to `MobTemplate`: a landed swing has `chance` to land a **Concussive Blow** that *stuns* the struck player for `duration`s — they can't move, cast, or use abilities. It's the single-target cousin of War Stomp's AoE ground slam.

**Carrier:** the existing **Thornpeak Ogre** (zone3, L15-16) — Concussive Blow, **20% chance, 2s stun**. Ogres clobbering you into a daze is about as classic as it gets.

## How

- New optional `concuss?: { chance; duration; name; school? }` field on `MobTemplate` (`src/sim/types.ts`), mirroring the shape of the existing `venom` / `mortalStrike` affixes.
- Applied in `mobSwing` right after the Mortal Strike block, guarded on `mob.hostile && target.kind === 'player' && !target.dead` so a **friendly pet** (the other `mobSwing` caller) never stuns an ally.
- **Reuses the existing `stun` aura kind** — no new aura kind, no movement hook, no HUD change:
  - `isStunned()` already gates the victim's movement, casting, and abilities.
  - the client already renders `stun` as a red debuff.
- CC diminishing returns are PvP-only, so a mob source always lands the full duration. The aura refreshes by id and never stacks into duplicates.
- Attached to an **already-spawning** mob (no new camp) so world-spawn RNG is untouched — determinism preserved.

## Tests

`tests/mob_concuss.test.ts` (4 cases): a landed ogre swing stuns the victim (and `isStunned` flips true); a friendly pet swing never stuns; a mob without the affix applies no stun; the refreshing stun never stacks. Full suite (**1241 tests**) green; `tsc --noEmit` clean.

## Screenshots

The stunned player, with the affix-forced "You are stunned!" feedback when they try to act:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/concuss-shots/shots/concuss_scene.png)

![stunned](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/concuss-shots/shots/concuss_stunned_message.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)