### PR TITLE
feat(content): drowned undead rot the victim's vitality on hit (Bog Rot)

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -132,6 +132,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 52, hpPerLevel: 20, dmgBase: 8, dmgPerLevel: 2.3, attackSpeed: 2.3,
     armorPerLevel: 14, moveSpeed: 6.5, aggroRadius: 11,
     lifeleech: { healFrac: 0.5, chance: 0.35, name: 'Drowning Grasp' },
+    // A clammy, fevered touch that rots the living from within, wasting away
+    // their constitution (Stamina) and shrinking their health pool.
+    plague: { chance: 0.3, sta: 12, duration: 12, name: 'Bog Rot' },
     loot: [
       { copper: 42, chance: 1 },
       { itemId: 'bone_fragments', chance: 0.5 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4209,6 +4209,25 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Plague: a landed hit can rot the victim's vitality, draining Stamina and
+    // thus shrinking their health pool (recalcPlayerStats folds the smaller
+    // Stamina through to a smaller maxHp; current HP scales down with it).
+    // Players only; hostile mobs only, so a friendly pet (mobSwing's other
+    // caller) never debuffs the party. Rides buff_sta with a negative value, so
+    // there is no new HP math. Refreshes by id and never stacks.
+    const plague = MOBS[mob.templateId]?.plague;
+    if (plague && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(plague.chance)) {
+      this.applyAura(target, {
+        id: `plague_${mob.templateId}`,
+        name: plague.name,
+        kind: 'buff_sta',
+        remaining: plague.duration,
+        duration: plague.duration,
+        value: -Math.abs(plague.sta),
+        sourceId: mob.id,
+        school: plague.school ?? 'nature',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -235,6 +235,13 @@ export interface MobTemplate {
   // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
   // resource math. Only meaningful on mana users — applied to them alone.
   enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit disease ("plague"): a landed melee swing has `chance` to rot the
+  // victim's vitality, draining `sta` Stamina for `duration`. recalcPlayerStats
+  // folds the smaller Stamina through to a smaller maxHp (and current HP scales
+  // down with the shrunken pool), so there is no new HP math. Rides the existing
+  // buff_sta aura with a NEGATIVE value. Unlike enfeeble (casters only) it
+  // afflicts everyone, since Stamina matters to every class.
+  plague?: { chance: number; sta: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to terrify the victim — a
   // fear that sends the struck player fleeing for `duration`s. Rides the existing
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`

--- a/tests/mob_plague.test.ts
+++ b/tests/mob_plague.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+// Force a drowned_dead swing to land its plague, returning the applied aura (or
+// undefined). Resets the player's HP each iteration so a connecting swing never
+// kills before the disease is observed.
+function forcePlague(sim: Sim, p: any, mob: any): any {
+  for (let i = 0; i < 80; i++) {
+    p.maxHp = 100000; p.hp = 100000;
+    (sim as any).mobSwing(mob, p);
+    const a = p.auras.find((x: any) => x.id === 'plague_drowned_dead');
+    if (a) return a;
+  }
+  return undefined;
+}
+
+describe('Plague Stamina-drain affix (Bog Rot)', () => {
+  it('a landed drowned_dead swing drains the victim Stamina and shrinks max HP', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    // A disease-free twin in an identical sim — same seed/class/level, so its
+    // recalculated maxHp is exactly what ours would be without the plague.
+    const cleanMaxHp = makeSim().entities.get(sim.playerId)!.maxHp;
+    const baseSta = p.stats.sta;
+    const tmpl = MOBS.drowned_dead;
+    const saved = tmpl.plague!.chance;
+    tmpl.plague!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const a = forcePlague(sim, p, createMob(910700, tmpl, 10, { x: 0, y: 0, z: 0 }));
+      expect(a).toBeDefined();
+      expect(a.kind).toBe('buff_sta');
+      expect(a.name).toBe('Bog Rot');
+      expect(a.value).toBe(-12);
+      expect(a.school).toBe('nature');
+      // Stamina and the health pool both shrank under the disease.
+      expect(p.stats.sta).toBe(baseSta - 12);
+      expect(p.maxHp).toBeLessThan(cleanMaxHp);
+    } finally {
+      tmpl.plague!.chance = saved;
+    }
+  });
+
+  it('the drained Stamina is restored when the disease expires', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const baseSta = p.stats.sta;
+    const tmpl = MOBS.drowned_dead;
+    const saved = tmpl.plague!.chance;
+    tmpl.plague!.chance = 1;
+    try {
+      const a = forcePlague(sim, p, createMob(910701, tmpl, 10, { x: 0, y: 0, z: 0 }));
+      expect(a).toBeDefined();
+      expect(p.stats.sta).toBe(baseSta - 12);
+      a.remaining = 0; // let this tick expire it
+      sim.tick();
+      expect(p.auras.some((x) => x.id === 'plague_drowned_dead')).toBe(false);
+      expect(p.stats.sta).toBe(baseSta); // Stamina fully restored
+    } finally {
+      tmpl.plague!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never plagues its target', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const tmpl = MOBS.drowned_dead;
+    const saved = tmpl.plague!.chance;
+    tmpl.plague!.chance = 1;
+    try {
+      const pet = createMob(910702, tmpl, 10, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 80; i++) { p.maxHp = 100000; p.hp = 100000; (sim as any).mobSwing(pet, p); }
+      expect(p.auras.some((a) => a.id === 'plague_drowned_dead')).toBe(false);
+    } finally {
+      tmpl.plague!.chance = saved;
+    }
+  });
+
+  it('a mob without the plague affix applies no Stamina debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const mob = createMob(910703, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 60; i++) { p.maxHp = 100000; p.hp = 100000; (sim as any).mobSwing(mob, p); }
+    expect(p.auras.some((a) => a.kind === 'buff_sta' && a.value < 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit **disease** affix, `plague`: a landed melee swing has a chance to rot the victim's vitality, draining **Stamina** for a duration — which shrinks their **maximum health pool** (current HP scales down with it). It's the constitution-sapping cousin of the existing `enfeeble` Intellect curse, but because Stamina matters to every class it afflicts **everyone**, not just mana users.

Carrier: **Drowned Dead** (Mirefen Marsh) gain **"Bog Rot"** — 30% chance, −12 Stamina for 12s — alongside their existing Drowning Grasp lifeleech. Thematically apt for fevered, waterlogged undead in a fetid swamp.

## How it works

- New `plague?: { chance; sta; duration; name; school? }` on `MobTemplate`.
- Proc lives in `mobSwing` (after the `enfeeble` block), guarded to hostile mobs vs. living players only — a friendly hunter pet (which shares `mobSwing`) never debuffs the party.
- Rides the existing **`buff_sta` aura** with a negative value. `recalcPlayerStats` already folds Stamina through to `maxHp` (preserving the HP fraction), so there is **no new HP math**, no new aura kind, no new movement/combat hook, and no new `SimEvent`. The HUD already renders a negative `buff_*` aura as a red debuff.
- Attached to an **already-spawning** mob, so world-spawn RNG is untouched — the full suite stays green with zero brittle-test fixes.

## Tests

`tests/mob_plague.test.ts` (4 cases): a landed swing drains Stamina and shrinks max HP; the drain is fully restored on expiry; a friendly pet never plagues; a mob without the affix applies nothing. Full suite: **1362 passing**, `tsc` clean.

## Screenshots

Bog Rot landed on a level-20 warrior: Stamina 60→48, max HP 812→692.

| Shrunken health pool | "Bog Rot" debuff |
|---|---|
| ![player frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/plague-shots/shots/01-shrunken-health-pool.png) | ![debuff tooltip](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/plague-shots/shots/02-bog-rot-debuff.png) |

![full HUD](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/plague-shots/shots/03-full-hud.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)