### PR TITLE
feat(content): Gravecaller Cultists curse the victim with frailty on hit (Curse of Frailty)

### DIFF
--- a/scripts/curse_visual.mjs
+++ b/scripts/curse_visual.mjs
@@ -1,0 +1,112 @@
+// Screenshots for the "Curse of Frailty" vulnerability affix (Gravecaller Cultist).
+// A landed hit curses the victim so they take more damage from every source, shown
+// as a red debuff on the buff bar. Runs the offline flow (no server). Needs
+// `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Garrosh'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate(() => document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click());
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.setPlayerLevel(20);
+});
+await wait(400);
+
+// Retemplate the nearest mob into a Gravecaller Cultist, stage it in front of the
+// player at level+3 (a lower-level attacker mostly MISSES a higher-level player —
+// #443 miss scaling — so bump its level to make forced swings reliably connect),
+// then force swings until the Curse of Frailty lands. Also measure the damage
+// amplification on a fixed test hit for the PR write-up.
+const result = await page.evaluate(async () => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let mob = null, best = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < best) { best = d; mob = e; }
+  }
+  if (!mob) return { ok: false, why: 'no mob nearby' };
+  mob.templateId = 'gravecaller_cultist';
+  mob.name = 'Gravecaller Cultist';
+  mob.hostile = true;
+  mob.level = p.level + 3;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z; mob.pos.y = p.pos.y;
+
+  p.maxHp = 100000;
+  let cursed = false;
+  for (let i = 0; i < 600 && !cursed; i++) {
+    p.hp = p.maxHp; // never let the swing kill us
+    sim.mobSwing(mob, p);
+    cursed = p.auras.some((a) => a.kind === 'vulnerability');
+  }
+  const aura = p.auras.find((a) => a.kind === 'vulnerability');
+  return { ok: cursed, amp: aura?.value ?? null, aura: aura?.name ?? null };
+});
+
+// Teleport the player away so combat ends and the 10s curse rides along, then
+// screenshot quickly before it expires.
+await page.evaluate(() => {
+  const sim = window.__game.sim, p = sim.player;
+  p.pos.x -= 80;
+  p.prevPos = { ...p.pos };
+});
+await wait(160);
+await page.screenshot({ path: 'tmp/curse-hud.png' });
+
+// Crop the buff bar (top-right, left of the minimap) for a legible debuff icon.
+try {
+  const clip = await page.evaluate(() => {
+    const el = document.querySelector('#buff-bar');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: Math.max(0, r.x - 12), y: Math.max(0, r.y - 8), width: Math.min(360, r.width + 24), height: Math.min(120, r.height + 50) };
+  });
+  if (clip && clip.width > 4) await page.screenshot({ path: 'tmp/curse-buffbar.png', clip });
+} catch (e) { errors.push('buffbar crop: ' + e.message); }
+
+// Hover the debuff icon to surface its tooltip, then crop the top-right region.
+try {
+  await page.evaluate(() => {
+    const icon = document.querySelector('#buff-bar .buff.debuff') || document.querySelector('#buff-bar .buff');
+    if (!icon) return;
+    const r = icon.getBoundingClientRect();
+    const opts = { bubbles: false, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2 };
+    icon.dispatchEvent(new MouseEvent('mouseenter', opts));
+    icon.dispatchEvent(new MouseEvent('mousemove', { ...opts, bubbles: true }));
+  });
+  await wait(250);
+  await page.screenshot({ path: 'tmp/curse-tooltip.png', clip: { x: 900, y: 0, width: 380, height: 230 } });
+} catch (e) { errors.push('tooltip: ' + e.message); }
+
+console.log('RESULT', JSON.stringify(result));
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -166,6 +166,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'gravecaller_cultist', name: 'Gravecaller Cultist', minLevel: 10, maxLevel: 12, family: 'humanoid',
     hpBase: 50, hpPerLevel: 20, dmgBase: 9, dmgPerLevel: 2.4, attackSpeed: 2.0,
     armorPerLevel: 20, moveSpeed: 7, aggroRadius: 11,
+    // The cultist's hex leaves the victim taking more damage from everyone —
+    // a soft-up that rewards a group focusing the cursed player's target down.
+    vulnerability: { chance: 0.2, amp: 0.15, duration: 10, name: 'Curse of Frailty', school: 'shadow' },
     loot: [
       { copper: 55, chance: 1 },
       { itemId: 'linen_scrap', chance: 0.3 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -123,7 +123,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'vulnerability',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -185,7 +185,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'vulnerability',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -3242,6 +3242,15 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Curse of frailty: a cursed victim takes more damage from every source. The
+    // offensive mirror of Defensive Stance's cut above. Multiple curses stack
+    // additively (sum of amps) so layered curses can't multiply out of control.
+    if (amount > 0) {
+      let vuln = 0;
+      for (const a of target.auras) if (a.kind === 'vulnerability') vuln += a.value;
+      if (vuln > 0) amount = Math.round(amount * (1 + vuln));
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4251,6 +4260,23 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+    // Curse of frailty: a landed hit may curse the victim so they take more
+    // damage from every source (a `vulnerability` aura read in dealDamage).
+    // Players only, hostile mobs only, so a friendly pet (mobSwing's other
+    // caller) never softens an ally. Refreshes by id, never stacks past one.
+    const vuln = MOBS[mob.templateId]?.vulnerability;
+    if (vuln && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(vuln.chance)) {
+      this.applyAura(target, {
+        id: `vulnerability_${mob.templateId}`,
+        name: vuln.name,
+        kind: 'vulnerability',
+        remaining: vuln.duration,
+        duration: vuln.duration,
+        value: vuln.amp,
+        sourceId: mob.id,
+        school: vuln.school ?? 'shadow',
+      });
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -39,7 +39,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'vulnerability';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -240,6 +240,13 @@ export interface MobTemplate {
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`
   // drives the panicked run with no new aura kind or movement hook.
   dread?: { chance: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to lay a curse of frailty on
+  // the victim, raising all damage they take by `amp` (e.g. 0.15 = +15%) from
+  // every source for `duration`s. Introduces the `vulnerability` aura kind, read
+  // once in dealDamage as a damage multiplier (the offensive mirror of Defensive
+  // Stance's 10% cut). Players only — amplifying a fellow mob would let a friendly
+  // pet soften enemies for its owner.
+  vulnerability?: { chance: number; amp: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1789,7 +1789,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'vulnerability'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_vulnerability.test.ts
+++ b/tests/mob_vulnerability.test.ts
@@ -1,0 +1,97 @@
+// Cursing mobs (e.g. the Gravecaller Cultist's "Curse of Frailty") can lay a
+// vulnerability hex on a melee hit: while it lingers the victim takes more
+// damage from EVERY source. It is the offensive mirror of Defensive Stance's
+// damage cut — a single multiplier read in dealDamage, no new resource math.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Cultist adjacent to the player, hostile and ready to swing.
+function spawnCultist(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_cultist'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob vulnerability ("Curse of Frailty")', () => {
+  it('seeds the curse mechanic on the Gravecaller Cultist', () => {
+    expect(MOBS['gravecaller_cultist'].vulnerability).toEqual({
+      chance: 0.2, amp: 0.15, duration: 10, name: 'Curse of Frailty', school: 'shadow',
+    });
+  });
+
+  it('applies a vulnerability aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 1; // deterministic
+    swing(sim, mob, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 0.2;
+    const aura = p.auras.find((a) => a.kind === 'vulnerability');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Curse of Frailty');
+    expect(aura!.remaining).toBe(10);
+    expect(aura!.value).toBe(0.15);
+  });
+
+  it('makes the cursed victim take more damage from any source', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000;
+
+    // Baseline: an uncursed 1000-damage hit removes exactly 1000.
+    p.hp = 100000;
+    (sim as any).dealDamage(null, p, 1000, false, 'physical', 'Test', 'hit', true);
+    expect(p.hp).toBe(99000);
+
+    // Cursed: the same hit is amplified by amp (0.15) → 1150 removed.
+    p.hp = 100000;
+    p.auras.push({
+      id: 'vulnerability_gravecaller_cultist', name: 'Curse of Frailty', kind: 'vulnerability',
+      remaining: 10, duration: 10, value: 0.15, sourceId: 999, school: 'shadow',
+    });
+    (sim as any).dealDamage(null, p, 1000, false, 'physical', 'Test', 'hit', true);
+    expect(p.hp).toBe(98850);
+  });
+
+  it('a friendly pet swinging never curses its ally', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    mob.hostile = false; // friendly pets route through mobSwing too
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 1;
+    swing(sim, mob, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 0.2;
+    expect(p.auras.find((a) => a.kind === 'vulnerability')).toBeUndefined();
+  });
+
+  it('refreshes rather than stacks a second curse from the same mob', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 1;
+    swing(sim, mob, p);
+    const aura = p.auras.find((a) => a.kind === 'vulnerability')!;
+    aura.remaining = 3; // let it tick down
+    swing(sim, mob, p); // a second landed hit
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 0.2;
+    const curses = p.auras.filter((a) => a.kind === 'vulnerability');
+    expect(curses).toHaveLength(1);
+    expect(curses[0].remaining).toBe(10); // timer fully refreshed, not doubled
+  });
+});


### PR DESCRIPTION
## What

Gives the **Gravecaller Cultist** (Mirefen Marsh, L10–12) a new on-hit curse. A landed swing has a **20% chance** to lay **Curse of Frailty** on the victim: a **10s** debuff that raises **all damage they take by 15%** from every source.

It's the offensive mirror of Defensive Stance's 10% damage *cut* — a single multiplier read once in `dealDamage`. Multiple curses sum **additively** (not multiplicatively) so layered curses can't spiral.

The cultist line had no victim-debuff affix before this (its summoner sibling silences/fears, its mender heals), so the curse gives the cultist its own identity and rewards a group focusing the cursed player's target down faster.

## Why a new aura kind (unlike recent affixes)

Recent on-hit affixes *ride* an existing aura because the engine already reads it — corrode rides `sunder` (armor), Mortal Strike rides `mortal_wound` (healing), Bog Rot/enfeeble ride `buff_sta`/`buff_int`. "Increased damage taken" has **no pre-existing hook**, so this adds the first new affix aura kind: `vulnerability`. It is registered harmful, rejected by friendly NPCs, and rendered as a red debuff in the HUD.

## Determinism

Safe by the usual rule: the affix is attached to an **already-spawning** mob (no new camp → the shared `Rng` stream is untouched), and the new `dealDamage` branch **draws no randomness** and is a **no-op until a `vulnerability` aura is present** (which no existing scenario produces). The full suite — **1363 tests** — stays green with **zero** brittle-test fixes.

## Changes
- `src/sim/types.ts` — `vulnerability` added to `AuraKind`; `vulnerability?` field on `MobTemplate`.
- `src/sim/sim.ts` — damage amplification in `dealDamage` (after the Defensive Stance block); proc block in `mobSwing`; `vulnerability` added to the harmful + friendly-NPC-rejected aura sets.
- `src/ui/hud.ts` — `vulnerability` classified as a debuff (red).
- `src/sim/content/zone2.ts` — Curse of Frailty on `gravecaller_cultist`.
- `tests/mob_vulnerability.test.ts` — seed, proc, **damage amplification** (1000 → 1150), friendly pet never curses an ally, refresh-not-stack.
- `scripts/curse_visual.mjs` — screenshot harness.

## Screenshots

Curse of Frailty as a red debuff with its tooltip (offline warrior, after a cursed cultist swing):

![Curse of Frailty tooltip](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/curse-shots/shots/curse-tooltip.png)
![Curse of Frailty debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/media/curse-shots/shots/curse-buffbar.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)