### PR TITLE
Fix ghost wolf

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,6 +539,7 @@
     background-size: cover; background-position: center; background-repeat: no-repeat; pointer-events: none; }
   .action-btn:hover { border-color: var(--gold); }
   .action-btn:active { transform: translateY(1px); }
+  .action-btn.used { border-color: var(--color-border-focus); box-shadow: 0 0 10px #ffd100aa, inset 0 0 0 1px #ffd10077, inset 0 1px 0 #ffffff28; }
   .action-btn.empty { background: #0d0d13; cursor: default; box-shadow: inset 0 0 10px #000; }
   .action-btn .keybind { position: absolute; top: 1px; right: 3px; font-size: 9px; color: #ddd; font-family: var(--ui-font); }
   .action-btn .item-count { position: absolute; right: 3px; bottom: 1px; min-width: 10px; text-align: right;

--- a/index.html
+++ b/index.html
@@ -4044,6 +4044,7 @@
   }
   body.mobile-touch #actionbar.many-spells { grid-template-columns: none; }
   body.mobile-touch .action-btn { width: 42px; height: 42px; flex: 0 0 42px; border-radius: 7px; }
+  body.mobile-touch .action-btn:not(.used):not(.queued):not(.drop-target):hover { border-color: #4a3d1d; }
   body.mobile-touch .action-btn .icon-label { border-radius: 6px; }
   body.mobile-touch .action-btn .cd-text { font-size: 13px; }
   body.mobile-touch .action-btn .keybind { display: none; }

--- a/src/game/pointer_pick.ts
+++ b/src/game/pointer_pick.ts
@@ -14,6 +14,7 @@ export interface MousePickGesture {
 }
 
 export const DEFAULT_CLICK_PICK_MAX_MS = 280;
+export const DEFAULT_CLICK_PICK_DRAG_THRESHOLD = 18;
 
 export interface ClickPick {
   x: number;
@@ -27,5 +28,6 @@ export function clickPickFromMouseGesture(g: MousePickGesture): ClickPick | null
   const duration = Number.isFinite(g.pressDurationMs) ? Math.max(0, g.pressDurationMs ?? 0) : Number.POSITIVE_INFINITY;
   const maxClickDurationMs = g.maxClickDurationMs ?? DEFAULT_CLICK_PICK_MAX_MS;
   if (duration > maxClickDurationMs) return null;
+  if (g.button === 2 && g.movementDrag > (g.dragThreshold ?? DEFAULT_CLICK_PICK_DRAG_THRESHOLD)) return null;
   return { x: g.downX, y: g.downY, button: g.button };
 }

--- a/src/render/characters/anim_state.ts
+++ b/src/render/characters/anim_state.ts
@@ -1,0 +1,54 @@
+/** Renderer-derived animation inputs (same facts the old pose machine used). */
+export interface AnimState {
+  /** horizontal speed, world units/sec */
+  speed: number;
+  moving: boolean;
+  airborne: boolean;
+  /** moving against facing (players backpedaling) */
+  backwards: boolean;
+  /** use reversed forward locomotion instead of an authored walkBack clip */
+  reverseBackpedal?: boolean;
+  dead: boolean;
+  casting: boolean;
+  swimming: boolean;
+  sitting: boolean;
+}
+
+export type BaseState = 'idle' | 'walk' | 'walkBack' | 'run' | 'cast' | 'swim' | 'sit' | 'jump';
+
+const RUN_SPEED_THRESHOLD = 4.5; // u/s — sim walk/wander sits well below
+const DEFAULT_WALK_REF = 2.2;
+const DEFAULT_RUN_REF = 7;
+
+export function desiredBaseState(s: AnimState, hasWalkBackClip: boolean): BaseState {
+  if (s.swimming) return 'swim';
+  if (s.airborne) return 'jump';
+  if (s.casting) return 'cast';
+  if (s.sitting) return 'sit';
+  if (s.moving) {
+    if (s.backwards && hasWalkBackClip && !s.reverseBackpedal) return 'walkBack';
+    return s.speed >= RUN_SPEED_THRESHOLD ? 'run' : 'walk';
+  }
+  return 'idle';
+}
+
+export function locomotionTimeScale(
+  baseState: BaseState,
+  s: Pick<AnimState, 'speed' | 'backwards' | 'reverseBackpedal'>,
+  walkRef = DEFAULT_WALK_REF,
+  runRef = DEFAULT_RUN_REF,
+): number | null {
+  let timeScale: number;
+  if (baseState === 'walk' || baseState === 'walkBack') {
+    timeScale = clamp(s.speed / walkRef, 0.6, 1.8);
+  } else if (baseState === 'run') {
+    timeScale = clamp(s.speed / runRef, 0.6, 1.6);
+  } else {
+    return null;
+  }
+  return s.reverseBackpedal && s.backwards && baseState !== 'walkBack' ? -timeScale : timeScale;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, v));
+}

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -10,29 +10,13 @@ import type { EmoteClipSpec, VisualDef } from './manifest';
 import {
   applyMaterials, assembleModel, prepareVisual, skinTexture, tintedFarMaterials,
 } from './assets';
+import { desiredBaseState, locomotionTimeScale, type AnimState, type BaseState } from './anim_state';
 
-/** Renderer-derived animation inputs (same facts the old pose machine used). */
-export interface AnimState {
-  /** horizontal speed, world units/sec */
-  speed: number;
-  moving: boolean;
-  airborne: boolean;
-  /** moving against facing (players backpedaling) */
-  backwards: boolean;
-  dead: boolean;
-  casting: boolean;
-  swimming: boolean;
-  sitting: boolean;
-}
-
-type BaseState = 'idle' | 'walk' | 'walkBack' | 'run' | 'cast' | 'swim' | 'sit' | 'jump';
+export type { AnimState, BaseState } from './anim_state';
 
 const FADE = 0.22;
 const ONESHOT_FADE = 0.1;
-const RUN_SPEED_THRESHOLD = 4.5; // u/s — sim walk/wander sits well below
 const HIT_REACT_COOLDOWN = 0.9;
-const DEFAULT_WALK_REF = 2.2;
-const DEFAULT_RUN_REF = 7;
 // Lie_Idle already lays the rig flat — a touch of extra pitch reads as a
 // surface glide; clip-less rigs (creatures) get the full procedural prone
 const SWIM_PITCH_CLIP = 0.35;
@@ -202,10 +186,10 @@ export class CharacterVisual {
       }
       // foot-speed matching on locomotion cycles
       if (!this.currentIsOneShot && this.current) {
-        if (this.baseState === 'walk' || this.baseState === 'walkBack') {
-          this.current.timeScale = clamp(s.speed / (this.def.walkRef ?? DEFAULT_WALK_REF), 0.6, 1.8);
-        } else if (this.baseState === 'run') {
-          this.current.timeScale = clamp(s.speed / (this.def.runRef ?? DEFAULT_RUN_REF), 0.6, 1.6);
+        const timeScale = locomotionTimeScale(this.baseState, s, this.def.walkRef, this.def.runRef);
+        if (timeScale !== null) {
+          if (timeScale < 0 && this.current.time <= 1e-3) this.current.time = Math.max(0, this.current.getClip().duration - 1e-3);
+          this.current.timeScale = timeScale;
         }
       }
     }
@@ -337,15 +321,7 @@ export class CharacterVisual {
   // -------------------------------------------------------------------------
 
   private desiredBase(s: AnimState): BaseState {
-    if (s.swimming) return 'swim';
-    if (s.airborne) return 'jump';
-    if (s.casting) return 'cast';
-    if (s.sitting) return 'sit';
-    if (s.moving) {
-      if (s.backwards && this.def.clips.walkBack) return 'walkBack';
-      return s.speed >= RUN_SPEED_THRESHOLD ? 'run' : 'walk';
-    }
-    return 'idle';
+    return desiredBaseState(s, !!this.def.clips.walkBack);
   }
 
   private toGhostMaterial<T extends THREE.Material | THREE.Material[]>(material: T): T {
@@ -497,8 +473,4 @@ function firstLoadedEmoteClip(
 ): string | null {
   if (!spec) return null;
   return spec.clips.find((name) => action(name)) ?? null;
-}
-
-function clamp(v: number, lo: number, hi: number): number {
-  return Math.min(hi, Math.max(lo, v));
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1203,6 +1203,7 @@ export class Renderer {
         moving,
         airborne,
         backwards: loco.backwards,
+        reverseBackpedal: ghostWolf,
         dead: visuallyDead,
         casting: e.castingAbility !== null && !visuallyDead,
         swimming,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -487,6 +487,10 @@ function isShamanShock(abilityId: string): boolean {
   return (SHAMAN_SHOCK_COOLDOWN_IDS as readonly string[]).includes(abilityId) || abilityId === 'lightning_shock';
 }
 
+function ignoresDamagePushback(abilityId: string): boolean {
+  return abilityId === 'ghost_wolf';
+}
+
 function isPetClass(cls: PlayerClass): boolean {
   return cls === 'hunter' || cls === 'warlock';
 }
@@ -3132,11 +3136,13 @@ export class Sim {
     const ranged = CLASSES[meta.cls].ranged;
     if (ranged && d <= ranged.maxRange && d >= (ranged.wand ? 0 : ranged.minRange)) {
       if (!this.hasLineOfSight(p, t)) return;
+      this.breakGhostWolf(p);
       this.rangedSwing(p, t, ranged);
       p.swingTimer = ranged.speed * this.swingIntervalMult(p);
       return;
     }
     if (d > MELEE_RANGE) return;
+    this.breakGhostWolf(p);
 
     let bonus = 0;
     let abilityName: string | null = null;
@@ -3237,7 +3243,17 @@ export class Sim {
   // Damage / death
   // -------------------------------------------------------------------------
 
-  private dealDamage(source: Entity | null, target: Entity, amount: number, crit: boolean, school: string, ability: string | null, kind: 'hit' | 'miss' | 'dodge', noRage = false, threatOpts?: { flat?: number; mult?: number }): void {
+  private dealDamage(
+    source: Entity | null,
+    target: Entity,
+    amount: number,
+    crit: boolean,
+    school: string,
+    ability: string | null,
+    kind: 'hit' | 'miss' | 'dodge',
+    noRage = false,
+    threatOpts?: { flat?: number; mult?: number },
+  ): void {
     if (target.dead) return;
     if (target.gm) return; // GM characters are invulnerable — every damage path funnels here
     // A mob that broke leash (or a pet freed to the wild) is in 'evade': it has
@@ -3318,10 +3334,8 @@ export class Sim {
     // taking or dealing real damage breaks stealth
     if (amount > 0) {
       this.breakStealth(target);
-      this.breakGhostWolf(target);
       if (source && source.id !== target.id) {
         this.breakStealth(source);
-        this.breakGhostWolf(source);
       }
     }
 
@@ -3361,7 +3375,7 @@ export class Sim {
       // cancelling it (misses and fully absorbed hits don't push back)
       if (target.castingAbility && source && source.id !== target.id && amount > 0 && kind === 'hit') {
         if (target.castingAbility === FISHING_CAST_ID) this.cancelCast(target);
-        else this.pushbackCast(target);
+        else if (!ignoresDamagePushback(target.castingAbility)) this.pushbackCast(target);
       }
     }
 
@@ -5333,6 +5347,8 @@ export class Sim {
     p.hp = p.maxHp;
     p.resource = p.resourceType === 'mana' ? p.maxResource : p.resourceType === 'energy' ? 100 : 0;
     p.targetId = null;
+    p.autoAttack = false;
+    p.queuedOnSwing = null;
     p.combatTimer = 99;
     p.inCombat = false;
     this.emit({ type: 'respawn', pid: meta.entityId });

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1223,18 +1223,36 @@ export class Hud {
     if (barSlot === 0) {
       if (this.sim.player.autoAttack) this.sim.stopAutoAttack();
       else this.sim.startAutoAttack();
+      this.flashActionSlot(barSlot);
       return;
     }
     const action = this.actionForSlot(barSlot);
     if (action?.type === 'ability') {
       // cast by ability id: the server validates against its own known list,
       // so the client-side slot remap never desyncs slot semantics
-      if (this.abilityForSlot(barSlot)) this.sim.castAbility(action.id);
+      if (this.abilityForSlot(barSlot)) {
+        this.sim.castAbility(action.id);
+        this.flashActionSlot(barSlot);
+      }
     } else if (action?.type === 'item' && this.isHotbarItemId(action.id)) {
       if (this.tradeOpen) return;
       this.sim.useItem(action.id);
       if ($('#bags').style.display !== 'none') this.renderBags();
+      this.flashActionSlot(barSlot);
     }
+  }
+
+  private flashActionSlot(barSlot: number): void {
+    const btn = this.abilityButtons[barSlot]?.btn;
+    if (!btn) return;
+    this.flashActionButton(btn);
+  }
+
+  private flashActionButton(btn: HTMLButtonElement): void {
+    btn.classList.remove('used');
+    void btn.offsetWidth;
+    btn.classList.add('used');
+    window.setTimeout(() => btn.classList.remove('used'), 180);
   }
 
   private writeDraggedAction(dt: DataTransfer | null, action: Exclude<HotbarAction, null>): void {
@@ -1275,9 +1293,15 @@ export class Hud {
       btn.addEventListener('click', () => {
         // On touch, the click that ends a long-press peek inspects the slot
         // (tooltip already shown) instead of casting — release dismisses it.
-        if (this.peekGuard.consume()) { this.hideTooltip(); return; }
+        if (this.peekGuard.consume()) { this.hideTooltip(); btn.blur(); return; }
         audio.click();
         this.castSlot(slot);
+        btn.blur();
+      });
+      btn.addEventListener('keydown', (e) => {
+        if (e.key !== ' ' && e.key !== 'Spacebar') return;
+        e.preventDefault();
+        e.stopPropagation();
       });
       this.attachTooltip(btn, () => {
         if (slot === 0) {
@@ -5897,11 +5921,11 @@ export class Hud {
       this.capturingKey = null;
       if (code === null) {
         this.keybindNote = t('hud.options.keybindCancelled');
-      } else if (isReservedCode(code)) {
-        this.keybindNote = t('hud.options.keybindReserved', { key: keyLabel(code) });
       } else if (this.keybinds.bind(actionId, index, code)) {
         this.keybindNote = t('hud.options.keybindBound', { action: name, key: keyLabel(code) });
         this.refreshKeybindLabels();
+      } else if (isReservedCode(code)) {
+        this.keybindNote = t('hud.options.keybindReserved', { key: keyLabel(code) });
       }
       // re-render only if the menu is still open (player may have closed it)
       if (this.optionsOpen) this.renderKeybinds();

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -100,6 +100,13 @@ describe('binding', () => {
     expect(kb.actionForCode('Space')).toBe(null);
   });
 
+  it('lets Space move from Jump to an action slot without driving both', () => {
+    const kb = new Keybinds();
+    expect(kb.bind('slot1', 0, 'Space')).toBe(true);
+    expect(kb.actionForCode('Space')).toBe('slot1');
+    expect(kb.codeAt('jump', 0)).toBe(null);
+  });
+
   it('binds a secondary key without disturbing the primary', () => {
     const kb = new Keybinds();
     expect(kb.bind('slot1', 1, 'KeyZ')).toBe(true);
@@ -192,5 +199,14 @@ describe('persistence', () => {
     const kb = new Keybinds();
     expect(kb.actionForCode('KeyR')).toBe('slot0');
     expect(kb.codeAt('slot1', 0)).toBe(null);
+  });
+
+  it('does not let stored Space action-bar bindings also keep default Jump', () => {
+    localStorage.setItem('woc_keybinds', JSON.stringify({
+      slot1: ['Space', null],
+    }));
+    const kb = new Keybinds();
+    expect(kb.actionForCode('Space')).toBe('slot1');
+    expect(kb.codeAt('jump', 0)).toBe(null);
   });
 });

--- a/tests/locomotion.test.ts
+++ b/tests/locomotion.test.ts
@@ -2,8 +2,19 @@ import { describe, expect, it } from 'vitest';
 import {
   MOVE_HOLD_TIME, newLocoTrack, updateLocomotion,
 } from '../src/render/locomotion';
+import { desiredBaseState, locomotionTimeScale, type AnimState } from '../src/render/characters/anim_state';
 
 const FPS = 1 / 60;
+const BASE_ANIM_STATE: AnimState = {
+  speed: 0,
+  moving: false,
+  airborne: false,
+  backwards: false,
+  dead: false,
+  casting: false,
+  swimming: false,
+  sitting: false,
+};
 
 // steady forward walk: ~2.2 u/s gives ~0.0367u of travel per 60fps frame
 function walkStep(t: ReturnType<typeof newLocoTrack>, dt = FPS, speed = 2.2) {
@@ -76,5 +87,19 @@ describe('locomotion hysteresis', () => {
       if (!s.moving) everStopped = true;
     }
     expect(everStopped).toBe(false);
+  });
+});
+
+describe('locomotion animation state', () => {
+  it('uses authored walkBack for normal humanoid backpedal', () => {
+    const state = { ...BASE_ANIM_STATE, moving: true, backwards: true, speed: 3 };
+    expect(desiredBaseState(state, true)).toBe('walkBack');
+    expect(locomotionTimeScale('walkBack', state)).toBeGreaterThan(0);
+  });
+
+  it('reverses forward locomotion for Ghost Wolf-style backpedal', () => {
+    const state = { ...BASE_ANIM_STATE, moving: true, backwards: true, reverseBackpedal: true, speed: 7 };
+    expect(desiredBaseState(state, true)).toBe('run');
+    expect(locomotionTimeScale('run', state)).toBeLessThan(0);
   });
 });

--- a/tests/pointer_pick.test.ts
+++ b/tests/pointer_pick.test.ts
@@ -92,7 +92,7 @@ describe('mouse click-pick gesture resolution', () => {
     })).toEqual({ x: 210, y: 96, button: 2 });
   });
 
-  it('ignores pointer-locked movement deltas for short clicks', () => {
+  it('rejects pointer-locked right-button drags', () => {
     expect(clickPickFromMouseGesture({
       button: 2,
       downButton: 2,
@@ -101,6 +101,21 @@ describe('mouse click-pick gesture resolution', () => {
       upX: 0,
       upY: 0,
       movementDrag: 28,
+      releaseOnCanvas: false,
+      pointerLocked: true,
+      pressDurationMs: 80,
+    })).toBeNull();
+  });
+
+  it('allows small right-button movement noise for short clicks', () => {
+    expect(clickPickFromMouseGesture({
+      button: 2,
+      downButton: 2,
+      downX: 210,
+      downY: 96,
+      upX: 0,
+      upY: 0,
+      movementDrag: 8,
       releaseOnCanvas: false,
       pointerLocked: true,
       pressDurationMs: 80,

--- a/tests/threat.test.ts
+++ b/tests/threat.test.ts
@@ -1120,7 +1120,7 @@ describe('shaman travel and shock mechanics', () => {
     expect(sim.events).toContainEqual({ type: 'error', text: 'That ability is not ready yet.', pid: sim.player.id });
   });
 
-  it('Ghost Wolf toggles speed and breaks when the shaman deals or takes damage', () => {
+  it('Ghost Wolf toggles speed and survives damage events', () => {
     const sim = makeSim('shaman');
     sim.setPlayerLevel(16);
     sim.player.resource = sim.player.maxResource;
@@ -1134,19 +1134,151 @@ describe('shaman travel and shock mechanics', () => {
     sim.castAbility('ghost_wolf');
     expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(false);
 
+    for (let i = 0; i < 40; i++) sim.tick();
     sim.player.resource = sim.player.maxResource;
     sim.castAbility('ghost_wolf');
     for (let i = 0; i < 20 * 3; i++) sim.tick();
     const wolf = nearestMob(sim, 'forest_wolf');
     beefUp(wolf);
     hit(sim, sim.player, wolf, 10, 'nature');
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    hit(sim, wolf, sim.player, 10);
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+  });
+
+  it('Ghost Wolf does not drop when auto-attack cannot swing yet', () => {
+    const sim = makeSim('shaman');
+    sim.setPlayerLevel(16);
+    const wolf = nearestMob(sim, 'forest_wolf');
+    beefUp(wolf);
+    sim.player.resource = sim.player.maxResource;
+
+    sim.castAbility('ghost_wolf');
+    for (let i = 0; i < 20 * 3 && sim.player.castingAbility; i++) sim.tick();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    sim.startAutoAttack();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    teleport(sim, sim.player, wolf.pos.x + 20, wolf.pos.z);
+    sim.targetEntity(wolf.id);
+    sim.player.facing = Math.atan2(wolf.pos.x - sim.player.pos.x, wolf.pos.z - sim.player.pos.z);
+    sim.startAutoAttack();
+    for (let i = 0; i < 20; i++) sim.tick();
+    expect(sim.player.autoAttack).toBe(true);
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+  });
+
+  it('Ghost Wolf drops when auto-attack actually swings', () => {
+    const sim = makeSim('shaman');
+    sim.setPlayerLevel(16);
+    const wolf = nearestMob(sim, 'forest_wolf');
+    beefUp(wolf);
+    teleport(sim, sim.player, wolf.pos.x + 2, wolf.pos.z);
+    sim.targetEntity(wolf.id);
+    sim.player.facing = Math.atan2(wolf.pos.x - sim.player.pos.x, wolf.pos.z - sim.player.pos.z);
+    sim.player.resource = sim.player.maxResource;
+
+    sim.castAbility('ghost_wolf');
+    for (let i = 0; i < 20 * 3 && sim.player.castingAbility; i++) sim.tick();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    sim.startAutoAttack();
+    sim.tick();
     expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(false);
+  });
+
+  it('Ghost Wolf stays active while running and jumping', () => {
+    const sim = makeSim('shaman');
+    sim.setPlayerLevel(16);
+    sim.player.resource = sim.player.maxResource;
+
+    sim.castAbility('ghost_wolf');
+    for (let i = 0; i < 20 * 3 && sim.player.castingAbility; i++) sim.tick();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    sim.moveInput.forward = true;
+    for (let i = 0; i < 20 * 8; i++) {
+      sim.moveInput.jump = i % 20 < 3;
+      sim.tick();
+      expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+    }
+  });
+
+  it('Ghost Wolf stays active through Lightning Shield contact, jump, and respawn cleanup', () => {
+    const sim = makeSim('shaman');
+    sim.setPlayerLevel(16);
+    const wolf = nearestMob(sim, 'forest_wolf');
+    beefUp(wolf);
+    wolf.level = sim.player.level;
+    wolf.weapon = { min: 10, max: 10, speed: 2 };
+    teleport(sim, sim.player, wolf.pos.x + 20, wolf.pos.z);
+    sim.targetEntity(wolf.id);
+    sim.player.facing = Math.atan2(wolf.pos.x - sim.player.pos.x, wolf.pos.z - sim.player.pos.z);
+    sim.player.resource = sim.player.maxResource;
+
+    sim.castAbility('lightning_shield');
+    expect(sim.player.auras.some((a) => a.id === 'lightning_shield')).toBe(true);
+    for (let i = 0; i < 40; i++) sim.tick();
 
     sim.player.resource = sim.player.maxResource;
     sim.castAbility('ghost_wolf');
-    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    for (let i = 0; i < 20 * 3 && sim.player.castingAbility; i++) sim.tick();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    sim.startAutoAttack();
+    sim.moveInput.forward = true;
+    for (let i = 0; i < 20; i++) {
+      sim.moveInput.jump = i < 3;
+      sim.tick();
+    }
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    teleport(sim, sim.player, wolf.pos.x + 2, wolf.pos.z);
+    sim.player.facing = Math.atan2(wolf.pos.x - sim.player.pos.x, wolf.pos.z - sim.player.pos.z);
+    wolf.facing = Math.atan2(sim.player.pos.x - wolf.pos.x, sim.player.pos.z - wolf.pos.z);
+    (sim as any).mobSwing(wolf, sim.player);
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+
+    (sim as any).dealDamage(wolf, sim.player, sim.player.hp, false, 'physical', null, 'hit', true);
+    expect(sim.player.dead).toBe(true);
+    sim.releaseSpirit();
+    expect(sim.player.dead).toBe(false);
+    expect(sim.player.autoAttack).toBe(false);
+
+    sim.moveInput.forward = false;
+    sim.moveInput.jump = false;
+    sim.player.resource = sim.player.maxResource;
+    sim.castAbility('ghost_wolf');
+    for (let i = 0; i < 20 * 3 && sim.player.castingAbility; i++) sim.tick();
+    sim.moveInput.forward = true;
+    sim.moveInput.jump = true;
+    sim.tick();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
+  });
+
+  it('Ghost Wolf casting is not delayed by incoming damage or standalone jump input', () => {
+    const sim = makeSim('shaman');
+    sim.setPlayerLevel(16);
+    sim.player.resource = sim.player.maxResource;
+    const wolf = nearestMob(sim, 'forest_wolf');
+
+    sim.castAbility('ghost_wolf');
+    expect(sim.player.castingAbility).toBe('ghost_wolf');
+
+    const remBefore = sim.player.castRemaining;
     hit(sim, wolf, sim.player, 10);
-    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(false);
+    expect(sim.player.castingAbility).toBe('ghost_wolf');
+    expect(sim.player.castRemaining).toBe(remBefore);
+
+    sim.moveInput.jump = true;
+    sim.tick();
+    sim.moveInput.jump = false;
+    expect(sim.player.castingAbility).toBe('ghost_wolf');
+
+    for (let i = 0; i < 20 * 3 && sim.player.castingAbility; i++) sim.tick();
+    expect(sim.player.auras.some((a) => a.id === 'ghost_wolf')).toBe(true);
   });
 
   it('Ghost Wolf drops before casting shaman spells from the same button press', () => {


### PR DESCRIPTION

## Summary

Fixes several Ghost Wolf cancellation bugs and a hotbar focus/input issue found during shaman testing.

  - Ghost Wolf no longer cancels from taking damage, dealing passive/retaliation damage, jumping, running, Lightning Shield retaliation, or out-of-range attack attempts.
  - Ghost Wolf still cancels when the player actually begins an attack or casts another shaman spell.
  - Right-mouse camera drags over hostile mobs no longer resolve as hostile right-click attacks.
  - Hotbar buttons now show a short gold used-state when activated by mouse or keybind, then clear focus so Space does not re-trigger the last clicked ability.
  - Added regression tests for Ghost Wolf, pointer picking, and keybind exclusivity.

## Type of change

<!-- Check all that apply. -->

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

 - Commands:
    - `git diff --check`
    - `npm run test`
    - `npm run build`

- Manual steps:

- Rebased branch onto `release/v0.8`.
    - Started local server on `http://localhost:8788`.
    - Verified server health with `/api/status`.
    - Tested shaman Ghost Wolf with jump spam, running, Lightning Shield, mob damage, death/release cleanup, out-of-range attack attempts, and right-mouse camera drag over hostile mobs.
    - Verified Ghost Wolf still cancels when casting another spell or actually beginning an attack.
    - Verified hotbar gold used-state appears for mouse clicks and keybind activation, then clears.
    - Verified clicking a hotbar ability and then pressing Space only jumps and does not recast the focused ability.
    - Verified Ghost Wolf forward movement and backpedal animation.
    - Verified normal non-Ghost-Wolf backpedal still uses the regular backward animation.
    - Smoke-tested another class hotbar path.

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [ ] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.


