### PR TITLE
feat(content): add Wraithbinder Maldrec, a rare elite undead at the Fallen Chapel

### DIFF
--- a/scripts/shot_wraithbinder.mjs
+++ b/scripts/shot_wraithbinder.mjs
@@ -1,0 +1,108 @@
+// Screenshot tour: Wraithbinder Maldrec, the rare elite undead at the Fallen
+// Chapel (Eastbrook Vale). Boots the offline client, teleports to the chapel,
+// god-modes the player, and captures the encounter — the Grave Chill nova, the
+// raised Restless Bones adds, and the elite nameplate. Needs `npm run dev`.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+// Pick "Offline" from the server-select dropdown, then Play → offline char setup.
+await page.click('#server-select-trigger');
+await new Promise((r) => setTimeout(r, 150));
+await page.click('#server-opt-offline');
+await new Promise((r) => setTimeout(r, 150));
+await page.click('#btn-play');
+await new Promise((r) => setTimeout(r, 400));
+await page.type('#char-name', 'Lightbringer');
+const picked = await page.evaluate(() => {
+  const el = document.querySelector('#offline-select [data-class="warrior"]');
+  if (el) { el.click(); return true; }
+  return false;
+});
+console.log('class picked:', picked);
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 1500));
+
+// Level up so the lvl-7 elite is a fair fight to stand next to, then god-mode.
+await page.evaluate(() => window.__game.sim.setPlayerLevel(12));
+
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  let boss = null;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'wraithbinder_maldrec') boss = e;
+  }
+  if (!boss) return { ok: false };
+  // Stand the player a short way off the boss so third-person camera frames both.
+  p.pos.x = boss.pos.x - 6; p.pos.z = boss.pos.z - 6;
+  p.pos.y = boss.pos.y;
+  p.maxHp = 100000; p.hp = 100000; // god-mode the camera operator
+  sim.targetEntity(boss.id);
+  p.facing = Math.atan2(boss.pos.x - p.pos.x, boss.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  g.input.camDist = 11;
+  return { ok: true, bossId: boss.id, name: boss.name, hp: boss.hp, level: boss.level };
+});
+console.log('boss found:', JSON.stringify(setup));
+if (!setup.ok) { console.log('FAIL: wraithbinder_maldrec not spawned'); await browser.close(); process.exit(1); }
+
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/wb_01_approach.png' });
+
+// Engage: swing until the boss drops below the first summon threshold so the
+// raised Restless Bones adds appear, and the Grave Chill nova has pulsed.
+let adds = 0, pulses = 0, low = false;
+for (let i = 0; i < 80; i++) {
+  const s = await page.evaluate(({ id, i }) => {
+    const g = window.__game;
+    const sim = g.sim;
+    const p = sim.player;
+    const b = sim.entities.get(id);
+    if (!b || b.dead) return { dead: true };
+    p.hp = p.maxHp;
+    if (p.targetId !== id) sim.targetEntity(id);
+    p.facing = Math.atan2(b.pos.x - p.pos.x, b.pos.z - p.pos.z);
+    // chip the boss down slowly so we linger in the add/nova phase
+    if (i % 3 === 0) b.hp = Math.max(b.maxHp * 0.45, b.hp - b.maxHp * 0.05);
+    let summoned = 0;
+    for (const e of sim.entities.values()) {
+      if (e.templateId === 'restless_bones' && !e.dead) {
+        const d = Math.hypot(e.pos.x - b.pos.x, e.pos.z - b.pos.z);
+        if (d < 10) summoned++;
+      }
+    }
+    return { dead: false, hpPct: b.hp / b.maxHp, summoned };
+  }, { id: setup.bossId, i });
+  if (s.dead) break;
+  adds = Math.max(adds, s.summoned);
+  if (s.hpPct <= 0.5) low = true;
+  if (low && adds >= 2) break;
+  await new Promise((r) => setTimeout(r, 250));
+}
+console.log('phase reached — nearby restless bones:', adds);
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({ path: 'tmp/wb_02_summons.png' });
+
+// Tight nameplate/target-frame shot.
+await page.evaluate(() => { window.__game.input.camDist = 8; });
+await new Promise((r) => setTimeout(r, 500));
+await page.screenshot({ path: 'tmp/wb_03_nameplate.png' });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 10).join('\n') : 'no page errors');
+await browser.close();

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -246,6 +246,10 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     id: 'gravepath_treads', name: 'Gravepath Treads', kind: 'armor', slot: 'feet', quality: 'rare',
     stats: { armor: 42, sta: 2 }, sellValue: 600,
   },
+  maldrecs_soulbinder: {
+    id: 'maldrecs_soulbinder', name: "Maldrec's Soulbinder", kind: 'weapon', slot: 'mainhand', quality: 'rare',
+    weapon: { min: 11, max: 18, speed: 3.0 }, stats: { int: 4, spi: 3 }, sellValue: 850,
+  },
   // --- quest items ---
   boar_hide: { id: 'boar_hide', name: 'Bristly Boar Hide', kind: 'quest', sellValue: 0, questId: 'q_boars' },
   gravecaller_sigil: { id: 'gravecaller_sigil', name: "Gravecaller's Sigil", kind: 'quest', sellValue: 0, questId: 'q_whispers' },

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -218,6 +218,27 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     // A grave-cold wail saps the strength from the living it strikes.
     demoralize: { ap: 20, duration: 8, name: 'Withering Wail' },
   },
+  wraithbinder_maldrec: {
+    id: 'wraithbinder_maldrec', name: 'Wraithbinder Maldrec', minLevel: 7, maxLevel: 7, family: 'undead', rare: true,
+    elite: true, ccImmune: true, respawnMult: 432,
+    hpBase: 320, hpPerLevel: 60, dmgBase: 12, dmgPerLevel: 3.4, attackSpeed: 2.3,
+    armorPerLevel: 28, moveSpeed: 6.8, aggroRadius: 13,
+    // A fallen Gravecaller who bound his own soul to the chapel dead. A pulse of
+    // grave-cold shadow rolls off him, and he tears the restless bones from the
+    // ground to fight at his side, growing frantic as he is unmade.
+    aoePulse: { min: 13, max: 19, radius: 9, every: 9, name: 'Grave Chill', school: 'shadow' },
+    summonAdds: { mobId: 'restless_bones', count: 2, atHpPct: [0.65, 0.35] },
+    enrage: { belowHpPct: 0.30, dmgMult: 1.5, hasteMult: 1.3 },
+    loot: [
+      { copper: 160, chance: 1 },
+      { itemId: 'bone_fragments', chance: 1 },
+      { itemId: 'maldrecs_soulbinder', chance: 0.25 },
+      { itemId: 'hollowbone_hauberk', chance: 0.25, rollGroup: 'maldrec_chase' },
+      { itemId: 'gravewoven_raiment', chance: 0.25, rollGroup: 'maldrec_chase' },
+      { itemId: 'cryptstalker_jerkin', chance: 0.25, rollGroup: 'maldrec_chase' },
+    ],
+    scale: 1.22, color: 0x6f7f8f,
+  },
   gorrak: {
     id: 'gorrak', name: 'Gorrak the Ruthless', minLevel: 6, maxLevel: 6, family: 'humanoid',
     hpBase: 160, hpPerLevel: 30, dmgBase: 8, dmgPerLevel: 2.4, attackSpeed: 2.4,
@@ -535,6 +556,17 @@ export const ZONE1_CAMPS: CampDef[] = [
   { mobId: 'gorrak', center: { x: 92, z: -92 }, radius: 2, count: 1 },
   // Undead: ruins northeast
   { mobId: 'restless_bones', center: { x: 80, z: 78 }, radius: 18, count: 8 },
+];
+
+// Spawned LAST in the merged CAMPS array (see data.ts) so these appended draws
+// fall after every other zone's camp spawns — and the camp loop is the final
+// RNG consumer at construction (ground objects, dungeon doors and addPlayer draw
+// none). Keeping the rare elite at the tail means adding it shifts no other
+// content's deterministic spawn rolls, so fixed-seed tests stay stable.
+export const ZONE1_CHAPEL_CAMPS: CampDef[] = [
+  // A pair of bone guardians flank the chapel's broken altar; their binder lurks within.
+  { mobId: 'restless_bones', center: { x: 88, z: 90 }, radius: 6, count: 2 },
+  { mobId: 'wraithbinder_maldrec', center: { x: 88, z: 92 }, radius: 3, count: 1 },
 ];
 
 

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -10,7 +10,7 @@ import type {
 } from './types';
 import { BASE_ITEMS } from './content/items';
 import {
-  GRAVEYARD_POS, LAKE, TOWN_RADIUS, ZONE1_CAMPS, ZONE1_MOBS, ZONE1_NPCS, ZONE1_OBJECTS,
+  GRAVEYARD_POS, LAKE, TOWN_RADIUS, ZONE1_CAMPS, ZONE1_CHAPEL_CAMPS, ZONE1_MOBS, ZONE1_NPCS, ZONE1_OBJECTS,
   ZONE1_PROPS, ZONE1_QUESTS, ZONE1_QUEST_ORDER, ZONE1_ROADS, ZONE1_ZONE,
 } from './content/zone1';
 import {
@@ -69,7 +69,10 @@ export const QUEST_ORDER: string[] = [
   ...ZONE1_QUEST_ORDER, ...ZONE2_QUEST_ORDER, ...ZONE3_QUEST_ORDER, ...TEMPLE_QUEST_ORDER,
 ];
 
-export const CAMPS: CampDef[] = [...ZONE1_CAMPS, ...ZONE2_CAMPS, ...ZONE3_CAMPS, ...TEMPLE_CAMPS];
+// ZONE1_CHAPEL_CAMPS is appended LAST so the rare elite's spawn draws fall after
+// every other camp — see the note on its export in content/zone1.ts (keeps
+// fixed-seed determinism stable when adding it).
+export const CAMPS: CampDef[] = [...ZONE1_CAMPS, ...ZONE2_CAMPS, ...ZONE3_CAMPS, ...TEMPLE_CAMPS, ...ZONE1_CHAPEL_CAMPS];
 
 export const GROUND_OBJECTS: GroundObjectDef[] = [...ZONE1_OBJECTS, ...ZONE2_OBJECTS, ...ZONE3_OBJECTS, ...TEMPLE_OBJECTS];
 


### PR DESCRIPTION
## What

Eastbrook Vale's **Fallen Chapel** held only common Restless Bones — the starter zone had no rare/elite undead. **Wraithbinder Maldrec** (level 7 rare elite) fills that gap: a fallen Gravecaller who bound his own soul to the chapel dead.

He spawns at the chapel altar `(88, 92)`, flanked by a pair of Restless Bones guards.

![Encounter — Grave Chill + raised adds](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/wraithbinder-maldrec/shots/wb_02_summons.png)
![Elite nameplate at the altar](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/wraithbinder-maldrec/shots/wb_03_nameplate.png)
![Approach — Eastbrook Vale](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/wraithbinder-maldrec/shots/wb_01_approach.png)

## Mechanics (all reuse already-wired affixes — zero sim/render changes)

- **Grave Chill** — `aoePulse` shadow nova (13–19, r9, every 9s)
- **Raise Dead** — `summonAdds` raising the existing `restless_bones` at 65%/35% HP (no new add template)
- **Enrage** below 30% HP (×1.5 dmg, ×1.3 haste)

## Loot

- **Maldrec's Soulbinder** — signature rare caster staff (int/spi), 25%
- One-of-three class-locked chase set reusing the existing undead rares: `hollowbone_hauberk` (WAR) / `gravewoven_raiment` (MAG) / `cryptstalker_jerkin` (ROG)

## Determinism

The two new camps are appended **last** in the merged `CAMPS` array (`ZONE1_CHAPEL_CAMPS`), so their spawn-RNG draws fall after every other zone's camps. The camp loop is construction's final RNG consumer (ground objects, dungeon doors and `addPlayer` draw none), so adding this elite **shifts no other content's fixed-seed spawn rolls** — the suite stays green without editing unrelated tests.

`npm test` → green except the pre-existing i18n coverage checks for the new display names, which are intentionally left for a follow-up (per repo i18n process). `tsc --noEmit` clean.

A reusable capture script (`scripts/shot_wraithbinder.mjs`) is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)