### PR TITLE
fix(render): fall back when high-tier assets are absent

### DIFF
--- a/src/render/sky.ts
+++ b/src/render/sky.ts
@@ -89,6 +89,10 @@ if (GFX.standardMaterials) {
   }
 }
 
+export function hasSkyHdriAssets(): boolean {
+  return Boolean(hdriStore.vale && hdriStore.marsh && hdriStore.peaks);
+}
+
 export interface SkyView {
   dome: THREE.Mesh;
   /** cross-fades the HDRI pair toward the biome band the camera is over */
@@ -176,7 +180,7 @@ function sunOffsetU(biome: BiomeId, sunDir: THREE.Vector3): number {
 }
 
 export function buildSky(lowGfx: boolean, sunDir: THREE.Vector3): SkyView {
-  if (lowGfx) {
+  if (lowGfx || !hasSkyHdriAssets()) {
     const dome = new THREE.Mesh(
       new THREE.SphereGeometry(DOME_RADIUS, 24, 16),
       new THREE.MeshBasicMaterial({ map: skyTexture(), side: THREE.BackSide, fog: false, depthWrite: false }),
@@ -192,9 +196,6 @@ export function buildSky(lowGfx: boolean, sunDir: THREE.Vector3): SkyView {
   }
 
   const sun = sunDir.clone().normalize();
-  if (!hdriStore.vale || !hdriStore.marsh || !hdriStore.peaks) {
-    throw new Error('sky HDRIs not preloaded (assetsReady must resolve before buildSky)');
-  }
   const tuneVec = (b: BiomeId): THREE.Vector2 =>
     new THREE.Vector2(HDRI_TUNE[b].gain, HDRI_TUNE[b].clamp);
   const start = biomeBlendAt(0);

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -59,6 +59,16 @@ if (GFX.terrainSplat) {
   kickTerrainTex('snowC', 'Snow010A_Color.jpg', true);
 }
 
+export function hasTerrainSplatAssets(): boolean {
+  return Boolean(
+    TERRAIN_TEX.grassC && TERRAIN_TEX.grassN
+      && TERRAIN_TEX.dirtC && TERRAIN_TEX.dirtN
+      && TERRAIN_TEX.rockC && TERRAIN_TEX.rockN
+      && TERRAIN_TEX.sandC && TERRAIN_TEX.sandN
+      && TERRAIN_TEX.mudC && TERRAIN_TEX.snowC,
+  );
+}
+
 // Per-layer constant roughness, eyeballed from the packs' roughness-map means
 // (saves four samplers vs. real roughness maps; terrain is never glossy
 // enough for the difference to read at gameplay camera distance).
@@ -400,7 +410,6 @@ function buildSplatMaterial(seed: number): THREE.MeshStandardMaterial {
   groundSplatMaps();
   const macro = macroNoiseTexture();
   const t = TERRAIN_TEX;
-  if (!t.grassC) throw new Error('terrain splat textures not preloaded (assetsReady must resolve before buildTerrain)');
   const mat = new THREE.MeshStandardMaterial({
     vertexColors: true,
     roughness: 1.0,
@@ -527,7 +536,7 @@ export interface TerrainView {
 }
 
 export function buildTerrain(seed: number): TerrainView {
-  const lowGfx = !GFX.terrainSplat;
+  const lowGfx = !GFX.terrainSplat || !hasTerrainSplatAssets();
   const mat = lowGfx ? buildLambertMaterial() : buildSplatMaterial(seed);
   const bands = lowGfx ? LOD_BANDS.low : LOD_BANDS.high;
   const group = new THREE.Group();

--- a/src/render/water.ts
+++ b/src/render/water.ts
@@ -35,6 +35,11 @@ if (GFX.standardMaterials) {
   kickWaterTex('n2', 'water_2_normal.jpg');
   kickWaterTex('broad', 'waternormals.jpg');
 }
+
+export function hasWaterShaderAssets(): boolean {
+  return Boolean(WATER_TEX.n1 && WATER_TEX.n2 && WATER_TEX.broad);
+}
+
 const DEEP_COLOR = new THREE.Color(0x0d3a52);
 const SHALLOW_COLOR = new THREE.Color(0x2d8077);
 const SKY_TINT = new THREE.Color(0x7fb2e0); // matches the sky horizon band
@@ -124,9 +129,6 @@ function buildShaderWater(seed: number): WaterView {
   // legacy procedural maps still get generated (unused) to preserve the
   // shared-LCG call order in textures.ts for everything generated after
   waterNormalMaps();
-  if (!WATER_TEX.n1 || !WATER_TEX.n2 || !WATER_TEX.broad) {
-    throw new Error('water normal textures not preloaded (assetsReady must resolve before buildWater)');
-  }
   const material = new THREE.ShaderMaterial({
     uniforms: {
       ...THREE.UniformsUtils.clone(THREE.UniformsLib.fog),
@@ -196,5 +198,5 @@ function buildPhongWater(): WaterView {
 }
 
 export function buildWater(seed: number): WaterView {
-  return GFX.standardMaterials ? buildShaderWater(seed) : buildPhongWater();
+  return GFX.standardMaterials && hasWaterShaderAssets() ? buildShaderWater(seed) : buildPhongWater();
 }

--- a/tests/render_asset_fallback.test.ts
+++ b/tests/render_asset_fallback.test.ts
@@ -1,0 +1,68 @@
+import * as THREE from 'three';
+import { describe, expect, it, vi } from 'vitest';
+
+function mockEmptyAssetLoads(): void {
+  vi.doMock('../src/render/assets/loader', () => ({
+    loadGltf: vi.fn(() => new Promise(() => {})),
+    loadHdr: vi.fn(() => new Promise(() => {})),
+    loadTexture: vi.fn(() => new Promise(() => {})),
+    releaseGltf: vi.fn(),
+  }));
+  const texture = (): THREE.DataTexture => {
+    const data = new Uint8Array([255, 255, 255, 255]);
+    const tex = new THREE.DataTexture(data, 1, 1, THREE.RGBAFormat);
+    tex.needsUpdate = true;
+    return tex;
+  };
+  vi.doMock('../src/render/textures', () => ({
+    groundDetailTexture: vi.fn(texture),
+    groundSplatMaps: vi.fn(() => ({
+      grass: texture(),
+      dirt: texture(),
+      rock: texture(),
+      sand: texture(),
+      mud: texture(),
+      snow: texture(),
+    })),
+    macroNoiseTexture: vi.fn(texture),
+    skyTexture: vi.fn(texture),
+    waterNormalish: vi.fn(texture),
+    waterNormalMaps: vi.fn(() => [texture(), texture()]),
+  }));
+}
+
+describe('render asset preload fallbacks', () => {
+  it('keeps sky construction non-fatal when HDRI assets were not preloaded', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+
+    const { buildSky, hasSkyHdriAssets } = await import('../src/render/sky');
+    expect(hasSkyHdriAssets()).toBe(false);
+
+    const sky = buildSky(false, new THREE.Vector3(90, 140, 50));
+    expect(sky.envTexture('vale')).toBe(null);
+    expect(sky.dome).toBeInstanceOf(THREE.Mesh);
+  });
+
+  it('keeps water construction non-fatal when shader normal maps were not preloaded', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+
+    const { buildWater, hasWaterShaderAssets } = await import('../src/render/water');
+    expect(hasWaterShaderAssets()).toBe(false);
+
+    const water = buildWater(20061);
+    expect(water.meshes.length).toBeGreaterThan(0);
+  });
+
+  it('keeps terrain construction non-fatal when splat textures were not preloaded', async () => {
+    vi.resetModules();
+    mockEmptyAssetLoads();
+
+    const { buildTerrain, hasTerrainSplatAssets } = await import('../src/render/terrain');
+    expect(hasTerrainSplatAssets()).toBe(false);
+
+    const terrain = buildTerrain(20061);
+    expect(terrain.group.children.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent renderer startup from throwing when late graphics tier resolution selects a high-tier path whose import-time preloads were skipped
- fall back to procedural sky, water, and terrain when the corresponding high-tier asset store is empty
- add regression coverage for empty preload stores across sky, water, and terrain builders

## Validation
- npx vitest run tests/render_asset_fallback.test.ts tests/gfx.test.ts
- npm run build
- backend-backed Puppeteer world entry for ?gfx=high and ?gfx=low was run locally before the final rebase