### PR TITLE
feat(content): Ridge Stalkers open a bleeding wound on hit (Rending Claws)

### DIFF
--- a/scripts/shot_bleed.mjs
+++ b/scripts/shot_bleed.mjs
@@ -1,0 +1,97 @@
+// Screenshot the on-hit Bleed affix (Rending Claws) in the offline client.
+// Boots the game, repurposes a nearby mob as a Ridge Stalker, drives its
+// raking swipes onto the player until the physical bleed DoT lands, and
+// captures the resulting debuff on the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Ridge Stalker and drive its bleed onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the bleeding predator and stand it next to us.
+  mob.templateId = 'ridge_stalker';
+  mob.name = 'Ridge Stalker';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Swing until the bleed rolls (chance is 0.25 per landed hit), keeping the
+  // player topped up so swing damage never masks the DoT.
+  let bleed = null;
+  for (let i = 0; i < 200 && !bleed; i++) {
+    p.hp = p.maxHp;
+    sim.mobSwing(mob, p);
+    bleed = p.auras.find((a) => a.id === 'bleed_ridge_stalker');
+  }
+  return { hasBleed: !!bleed, name: bleed?.name, school: bleed?.school, value: bleed?.value, remaining: bleed?.remaining };
+});
+console.log('bleed result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/bleed_full.png' });
+
+// Crop tightly around the player buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/bleed_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+  // Hover the debuff icon to surface its tooltip.
+  await page.mouse.move(box.x + box.w / 2, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 500));
+  await page.screenshot({
+    path: 'tmp/bleed_tooltip_crop.png',
+    clip: {
+      x: Math.max(0, box.x - 300), y: Math.max(0, box.y - 10),
+      width: 300 + box.w + 20, height: 140,
+    },
+  });
+}
+
+console.log('saved tmp/bleed_full.png, bleed_frame.png, bleed_tooltip_crop.png');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -49,6 +49,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ridge_stalker', name: 'Ridge Stalker', minLevel: 13, maxLevel: 14, family: 'beast',
     hpBase: 58, hpPerLevel: 21, dmgBase: 10, dmgPerLevel: 2.5, attackSpeed: 1.9,
     armorPerLevel: 14, moveSpeed: 8, aggroRadius: 11,
+    // Rending Claws: the stalker's raking swipes can open a bleeding wound — a
+    // refreshing physical DoT (~5 every 3s for 9s). Distinct from poison: it is
+    // physical-school, so it bypasses poison cleanses and ignores nature resist.
+    bleed: { chance: 0.25, perTick: 5, interval: 3, duration: 9, name: 'Rending Claws', school: 'physical' },
     loot: [
       { copper: 60, chance: 1 },
       { itemId: 'ridge_stalker_pelt', chance: 0.6, questId: 'q_stalker_pelts' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,20 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // bleed ("Rend"): a landed swing may open a refreshing PHYSICAL DoT wound.
+    // Same on-hit DoT seam as venom, but physical-school — the predator/beast
+    // flavour (raking claws, gore). Hostile mobs only (mobSwing is also the pet
+    // attack path, so a friendly pet must never bleed the party).
+    const bleed = MOBS[mob.templateId]?.bleed;
+    if (bleed && mob.hostile && !target.dead && this.rng.chance(bleed.chance)) {
+      this.applyAura(target, {
+        id: 'bleed_' + mob.templateId, name: bleed.name, kind: 'dot',
+        remaining: bleed.duration, duration: bleed.duration,
+        value: Math.max(1, Math.round(bleed.perTick)),
+        tickInterval: bleed.interval, tickTimer: bleed.interval,
+        sourceId: mob.id, school: (bleed.school as Aura['school']) ?? 'physical',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,11 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit bleed: a landed melee swing has `chance` to open a refreshing PHYSICAL
+  // damage-over-time wound on the victim ("Rend"). Distinct from `venom` (a
+  // nature/poison DoT) — bleeds are physical-school, the predator/beast flavour
+  // of the same on-hit DoT seam. Refreshes (never stacks) like venom.
+  bleed?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: Aura['school'] };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_bleed.test.ts
+++ b/tests/mob_bleed.test.ts
@@ -1,0 +1,111 @@
+// Predators (e.g. the Ridge Stalker's "Rending Claws") can open a bleeding wound
+// on a landed melee swing: a refreshing PHYSICAL damage-over-time. Bleed shares
+// the on-hit DoT seam with venom, but is physical-school (not nature/poison), so
+// it bypasses poison cleanses and ignores nature resistance.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn a Ridge Stalker adjacent to the player and hand it back.
+function spawnStalker(sim: Sim, id = 980001, level = 13) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ridge_stalker, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the bleed aura (the chance is 1 in these tests).
+function swingUntilBleed(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'bleed_ridge_stalker')) return true;
+  }
+  return false;
+}
+
+describe('mob bleed (on-hit physical DoT)', () => {
+  it('the Ridge Stalker carries bleed data tuned to a physical DoT', () => {
+    const b = MOBS.ridge_stalker.bleed!;
+    expect(b).toBeDefined();
+    expect(b.school).toBe('physical');
+    expect(b.chance).toBeGreaterThan(0);
+    expect(b.perTick).toBeGreaterThan(0);
+    expect(b.interval).toBeGreaterThan(0);
+    expect(b.duration).toBeGreaterThan(b.interval);
+  });
+
+  it('a landed swing opens a physical-school bleed DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnStalker(sim);
+    const orig = MOBS.ridge_stalker.bleed!.chance;
+    MOBS.ridge_stalker.bleed!.chance = 1;
+    try {
+      expect(swingUntilBleed(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ridge_stalker.bleed!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'bleed_ridge_stalker')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('physical');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.ridge_stalker.bleed!.duration);
+  });
+
+  it('the bleed DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnStalker(sim);
+    const orig = MOBS.ridge_stalker.bleed!.chance;
+    MOBS.ridge_stalker.bleed!.chance = 1;
+    try {
+      expect(swingUntilBleed(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ridge_stalker.bleed!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 4; i++) sim.tick(); // 4s — at least one tick interval
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-bleeding mob (forest wolf) opens no bleed aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === 'bleed_ridge_stalker')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated swipes from the same stalker', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnStalker(sim);
+    const orig = MOBS.ridge_stalker.bleed!.chance;
+    MOBS.ridge_stalker.bleed!.chance = 1;
+    try {
+      swingUntilBleed(sim, mob, player);
+      swingUntilBleed(sim, mob, player);
+      swingUntilBleed(sim, mob, player);
+    } finally {
+      MOBS.ridge_stalker.bleed!.chance = orig;
+    }
+    const bleedAuras = player.auras.filter((a) => a.id === 'bleed_ridge_stalker');
+    expect(bleedAuras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit **`bleed`** affix — a refreshing **physical** damage-over-time wound that predators inflict with their swipes — and attaches it to the **Ridge Stalker** (Thornpeak Heights, `beast`, lvl 13-14) as **"Rending Claws"** (25% chance / 5 per 3s / 9s).

## Why it's distinct content

The only existing on-hit DoT affix is `venom`, which is a **nature/poison** DoT. `bleed` rides the same proven seam (the `dot` aura kind, rolled in `mobSwing`, ticked by the aura system) but is **physical-school**, which makes it mechanically different:

- bypasses poison cleanses,
- ignores nature resistance,
- rewards mobility/kiting over dispel.

This fills the classic-era "Rend / bleed-on-hit" predator niche that none of the current affixes (venom, corrode, silence, ensnare, slowStrike, manaBurn, enfeeble, dread, chillOnHit, demoralize, mortalStrike, lifeleech, thorns) cover.

## Changes

- **`src/sim/types.ts`** — new `MobTemplate.bleed` field (`chance, perTick, interval, duration, name, school`).
- **`src/sim/sim.ts`** — roll bleed in the on-hit block; **hostile mobs only** (the shared `mobSwing` path is also the pet attack path, so a friendly pet never bleeds the party); defaults to `physical` school; refreshes (keyed per template id) instead of stacking.
- **`src/sim/content/zone3.ts`** — Ridge Stalker gains Rending Claws.
- **`tests/mob_bleed.test.ts`** — mirrors `mob_venom`: data shape, aura applied on a landed hit, ticks damage over time, non-bleeders apply nothing, refresh-not-stack.
- **`scripts/shot_bleed.mjs`** — repro/screenshot harness (mirrors `shot_demoralize.mjs`).

## Determinism & tests

The affix adds **no construction-time RNG draws** (no new camp/spawn), so fixed-seed tests are byte-identical. Full suite green: **1388 passed**. `tsc --noEmit` clean.

## Screenshots

Rending Claws bleed applied to the player in the offline client — debuff icon with live countdown:

![bleed debuff frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/bleed-affix/shots/bleed_frame.png)

In-scene (player engaging a reskinned Ridge Stalker):

![bleed scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/bleed-affix/shots/bleed_full.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)