### PR TITLE
fix(sim): mobs retreat at half speed to a random point, then re-engage

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -243,7 +243,7 @@ function blankEntity(id: number): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
-    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, fleeTarget: null, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff, skin: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -22,7 +22,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
-    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, fleeTarget: null, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff, skin: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -51,13 +51,21 @@ const EVADE_STALL_TIMEOUT = 3;
 // only evaluated past the first entry when that straight step is obstructed.
 const MOVE_SLIDE_FAN = [0, 0.5, -0.5, 1.0, -1.0, 1.6, -1.6];
 const BACKPEDAL_MULT = 0.65;
-// Low-HP flee ("fear"): a cowardly mob at or below this HP fraction panics, turns
-// and runs from its attacker for FLEE_DURATION seconds at FLEE_SPEED_MULT speed,
-// calling same-family allies within FLEE_HELP_RADIUS to assist. It flees only once
-// per pull, then recovers its nerve and re-engages if it survived.
+// Feared targets (the `fear_incap` aura, e.g. Warlock fear) flee at this x speed.
+// Distinct from the low-HP cowardly flee below.
+const FEAR_SPEED_MULT = 1.4;
+// Low-HP cowardly flee: a mob at or below FLEE_HP_THRESHOLD breaks off ONCE per pull
+// and RETREATS to a random point FLEE_RETREAT_MIN..MAX yards away from its attacker,
+// WALKING at MOB_FLEE_SPEED_MULT x its move speed. On arrival (within FLEE_ARRIVE_DIST)
+// -- or after the FLEE_MAX_DURATION safety cap if it cannot path there -- it turns and
+// fights normally. It calls same-family allies within FLEE_HELP_RADIUS to assist.
 const FLEE_HP_THRESHOLD = 0.2;
-const FLEE_DURATION = 5;
-const FLEE_SPEED_MULT = 1.4;
+const MOB_FLEE_SPEED_MULT = 0.5; // half walk speed (was a 1.4x panic sprint)
+const FLEE_RETREAT_MIN = 8; // yards
+const FLEE_RETREAT_MAX = 14; // yards (well within LEASH_DISTANCE = 45)
+const FLEE_RETREAT_SPREAD = 0.8; // +/- radians of jitter around "directly away"
+const FLEE_ARRIVE_DIST = 1.5; // yards; this close to the point counts as arrived
+const FLEE_MAX_DURATION = 8; // s; safety cap if rooted/blocked and it never arrives
 const FLEE_HELP_RADIUS = 8;
 // Only sentient, cowardly families flee; beasts/undead/elementals/dragonkin fight
 // to the death. Elites, rares, and bosses never flee regardless of family.
@@ -1325,7 +1333,7 @@ export class Sim {
     if (!aura || e.auras.some((a) => a.kind === 'root')) return false;
     const angle = Number.isFinite(aura.value) ? aura.value : e.facing;
     const dest = this.groundPos(e.pos.x + Math.sin(angle) * 10, e.pos.z + Math.cos(angle) * 10);
-    this.moveToward(e, dest, e.moveSpeed * FLEE_SPEED_MULT * this.moveSpeedMult(e));
+    this.moveToward(e, dest, e.moveSpeed * FEAR_SPEED_MULT * this.moveSpeedMult(e));
     return true;
   }
   // Silence locks out spell (non-physical) casts but leaves physical abilities,
@@ -2677,7 +2685,7 @@ export class Sim {
     mob.forcedTargetTimer = TAUNT_FORCE_SECONDS;
     if (mob.aiState === 'idle') this.aggroMob(mob, p, false);
     else if (mob.aiState === 'chase' || mob.aiState === 'attack') mob.aggroTargetId = p.id;
-    else if (mob.aiState === 'flee') { mob.aggroTargetId = p.id; mob.aiState = 'attack'; mob.fleeTimer = 0; }
+    else if (mob.aiState === 'flee') { mob.aggroTargetId = p.id; mob.aiState = 'attack'; mob.fleeTimer = 0; mob.fleeTarget = null; }
     this.enterCombat(p, mob);
   }
 
@@ -3990,22 +3998,26 @@ export class Sim {
           mob.aggroTargetId = null;
           clearThreat(mob);
           mob.leashAnchor = null;
+          mob.fleeTarget = null;
           break;
         }
         mob.fleeTimer -= DT;
-        if (mob.fleeTimer <= 0) {
-          // Recover nerve and turn to fight again; hasFled keeps it from re-fleeing.
+        const dest = mob.fleeTarget;
+        const arrived = !dest || dist2d(mob.pos, dest) <= FLEE_ARRIVE_DIST;
+        if (arrived || mob.fleeTimer <= 0) {
+          // Reached the retreat spot (or gave up): turn and fight normally.
+          // hasFled keeps it from re-fleeing this pull.
           mob.aiState = 'attack';
+          mob.fleeTarget = null;
+          mob.facing = angleTo(mob.pos, target.pos);
           mob.swingTimer = Math.min(mob.swingTimer, 0.4);
           break;
         }
-        // Run directly away from the attacker. A root pins it in place (it just
-        // cowers facing away); a stun is already handled by the early return above.
-        const away = angleTo(target.pos, mob.pos);
-        mob.facing = away;
+        // Walk to the chosen retreat point at half speed. A root pins it in place
+        // (it cowers facing its goal); a stun is handled by the early return above.
+        mob.facing = angleTo(mob.pos, dest);
         if (!this.isRooted(mob)) {
-          const fleePos = this.groundPos(mob.pos.x + Math.sin(away) * 10, mob.pos.z + Math.cos(away) * 10);
-          this.moveToward(mob, fleePos, mob.moveSpeed * FLEE_SPEED_MULT * this.moveSpeedMult(mob));
+          this.moveToward(mob, dest, mob.moveSpeed * MOB_FLEE_SPEED_MULT * this.moveSpeedMult(mob));
         }
         break;
       }
@@ -4044,6 +4056,7 @@ export class Sim {
     mob.leashAnchor = null;
     mob.evadeStall = 0;
     mob.fleeTimer = 0;
+    mob.fleeTarget = null;
     mob.hasFled = false;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
@@ -4070,10 +4083,21 @@ export class Sim {
     if (!this.canFlee(mob)) return false;
     mob.aiState = 'flee';
     mob.hasFled = true;
-    mob.fleeTimer = FLEE_DURATION;
+    mob.fleeTimer = FLEE_MAX_DURATION;
+    mob.fleeTarget = this.pickFleePoint(mob, target);
     this.emit({ type: 'log', text: `${mob.name} attempts to flee!`, color: '#ffd966', entityId: mob.id });
     this.callForHelp(mob, target);
     return true;
+  }
+
+  // A retreat point a short, random distance away from the attacker -- the mob walks
+  // here at half speed, then turns and fights. Direction is "directly away" jittered
+  // by +/-FLEE_RETREAT_SPREAD so a fleeing pack does not all run to the same spot.
+  private pickFleePoint(mob: Entity, target: Entity): Vec3 {
+    const away = angleTo(target.pos, mob.pos);
+    const ang = away + this.rng.range(-FLEE_RETREAT_SPREAD, FLEE_RETREAT_SPREAD);
+    const dist = this.rng.range(FLEE_RETREAT_MIN, FLEE_RETREAT_MAX);
+    return this.groundPos(mob.pos.x + Math.sin(ang) * dist, mob.pos.z + Math.cos(ang) * dist);
   }
 
   // A fleeing mob shouts for aid: nearby idle same-family mobs join the fight,

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -589,7 +589,8 @@ export interface Entity {
   spawnPos: Vec3;
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   evadeStall: number; // seconds an evading mob has failed to get closer to home; snaps it home if it can't path back (e.g. across water)
-  fleeTimer: number; // seconds left in a low-HP panic flee; counts down in the 'flee' state
+  fleeTimer: number; // safety cap (s) on a low-HP flee; counts down in the 'flee' state
+  fleeTarget: Vec3 | null; // retreat point a fleeing mob walks to before turning to fight
   hasFled: boolean; // a cowardly mob flees only once per pull; cleared when it resets at spawn
   wanderTarget: Vec3 | null;
   wanderTimer: number;

--- a/tests/mob_flee.test.ts
+++ b/tests/mob_flee.test.ts
@@ -1,7 +1,7 @@
-// Cowardly mobs (sentient families: humanoid/kobold/murloc/troll) panic at low HP
-// instead of fighting to the death: they turn and run from their attacker for a few
-// seconds, rallying nearby same-family allies, then recover their nerve. They flee
-// only ONCE per pull, and elites/bosses/beasts never flee.
+// Cowardly mobs (sentient families: humanoid/kobold/murloc/troll) break off at low HP
+// instead of fighting to the death: they RETREAT at half speed to a random point a
+// short way off, rallying nearby same-family allies, then turn and fight again. They
+// flee only ONCE per pull, and elites/bosses/beasts never flee.
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import { dist2d } from '../src/sim/types';
@@ -66,6 +66,42 @@ describe('cowardly mobs flee at low HP', () => {
 
     expect(mob.aiState === 'flee' || mob.hasFled).toBe(true);
     expect(dist2d(mob.pos, sim.player.pos)).toBeGreaterThan(before);
+  });
+
+  it('retreats at reduced (half) speed, not a panic sprint', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+
+    sim.tick(); // enters the flee state and picks a fixed retreat point
+    expect(mob.aiState).toBe('flee');
+    expect(mob.fleeTarget).not.toBeNull();
+
+    const from = { ...mob.pos };
+    sim.tick(); // first step of the retreat
+    const step = dist2d(mob.pos, from);
+    const fullWalkStep = mob.moveSpeed / 20; // DT = 1/20
+    expect(step).toBeGreaterThan(0);
+    expect(step).toBeLessThan(fullWalkStep * 0.75); // clearly slower than walking
+  });
+
+  it('retreats to its chosen point, then stops fleeing to re-engage', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+
+    sim.tick();
+    const target = { ...mob.fleeTarget! }; // capture before it is cleared on arrival
+
+    let stopped = false;
+    for (let i = 0; i < 20 * 12; i++) {
+      sim.tick();
+      if (mob.aiState !== 'flee') { stopped = true; break; }
+    }
+    expect(stopped).toBe(true);
+    expect(mob.aiState).not.toBe('flee');
+    // destination-based, not a fixed timer: it actually reached the retreat point
+    expect(dist2d(mob.pos, target)).toBeLessThan(2);
   });
 
   it('calls a nearby same-family ally into the fight when it flees', () => {


### PR DESCRIPTION
## What & why

Cowardly mobs (humanoid / kobold / murloc / troll) flee once per pull at low HP. The old behavior felt wrong; this reworks it to the requested "retreat, then turn and fight" pattern.

## Compare & contrast

| | **Before** | **After** |
|---|---|---|
| Speed | **1.4× move speed** (faster than the player — a panic *sprint*) | **0.5× move speed** (a half-speed *retreat*) |
| Direction | Recomputed **every tick** to point directly away from the player's *current* position (kites forever) | **One fixed random point** chosen at flee-start, 8–14 yds away, jittered ±0.8 rad around "directly away" (a pack scatters instead of stacking) |
| Stop condition | A fixed **5-second timer** | **Arrival** at the retreat point (`FLEE_ARRIVE_DIST`), with an 8s safety cap only for the rooted/blocked case |
| On stop | Recover nerve → `attack` | Reach point → face the player → `attack` (normal AI resumes; re-approaches and fights) |
| Unchanged | — | once-per-pull (`hasFled`), leash/evade, calls same-family allies, never for elites/rares/bosses/beasts |

Net effect: instead of outrunning you, a low-HP mob backs off a short way at a walk, then commits and fights.

## Implementation

- New `Entity.fleeTarget` (the chosen retreat point); set in a new `pickFleePoint()` via `this.rng` (deterministic).
- New constants: `MOB_FLEE_SPEED_MULT = 0.5`, `FLEE_RETREAT_MIN/MAX = 8/14`, `FLEE_RETREAT_SPREAD = 0.8`, `FLEE_ARRIVE_DIST = 1.5`, `FLEE_MAX_DURATION = 8`.
- Renamed `FLEE_SPEED_MULT → FEAR_SPEED_MULT`: that constant is **also** used by `updateFearMovement` (the `fear_incap` aura, e.g. Warlock Fear) — a *separate* mechanic that should keep its 1.4×. Decoupling them prevents this change from altering fear.
- `fleeTarget` cleared on arrival, re-aggro, leash-break, and spawn reset; mirrored in the `ClientWorld` entity literal (`online.ts`).

## Tests

- `tests/mob_flee.test.ts`: existing 8 cases still green; **+2** new — half-speed step (`< 0.75×` a full walk step) and destination-based stop (reaches the captured `fleeTarget`, then leaves the flee state).
- `npx tsc --noEmit` clean. Full suite green except two unrelated CPU-contention flakes (a security *flood* test and a pvp_safety duel test) that pass in isolation.

## Notes
- Determinism preserved (retreat point via `Rng`); same seed ⇒ same world.
- Targets `release/v0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
