### PR TITLE
feat(content): add Weakening Hex affix to the Gravecaller Cultist

### DIFF
--- a/scripts/shot_hex.mjs
+++ b/scripts/shot_hex.mjs
@@ -1,0 +1,104 @@
+// Screenshot the Weakening Hex affix in the offline client. Boots the game,
+// repurposes a nearby mob as a Gravecaller Cultist, forces its on-hit hex onto
+// the player, and captures the resulting debuff on the player unit frame. Logs
+// the measured damage/healing reduction the hex applies.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Gravecaller Cultist and drive its hex onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the hexing cultist and stand it next to us.
+  mob.templateId = 'gravecaller_cultist';
+  mob.name = 'Gravecaller Cultist';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the hex, then measure the output reduction on a fresh dummy target.
+  for (let i = 0; i < 8 && !p.auras.some((a) => a.kind === 'hex'); i++) sim.mobSwing(mob, p);
+  const hex = p.auras.find((a) => a.kind === 'hex');
+  const dummyHp = 1e9;
+  mob.hp = dummyHp;
+  sim.dealDamage(p, mob, 1000, false, 'shadow', null, 'hit', true);
+  const hexedHit = dummyHp - mob.hp;
+  mob.hp = mob.maxHp;
+  return {
+    hasHex: !!hex, hexName: hex?.name, reduction: hex?.value, remaining: hex?.remaining,
+    fullHit: 1000, hexedHit,
+  };
+});
+console.log('hex result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/hex_full.png' });
+
+// Crop tightly around the player unit frame + buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/hex_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+// Hover the debuff icon to surface its tooltip, then capture it.
+if (box) {
+  // The hex is the rightmost icon in the bar; hover its centre to surface the tooltip.
+  await page.mouse.move(box.x + box.w - 14, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 600));
+  await page.screenshot({
+    path: 'tmp/hex_tooltip_crop.png',
+    clip: {
+      x: Math.max(0, box.x - 360), y: Math.max(0, box.y - 10),
+      width: 360 + box.w + 30, height: 170,
+    },
+  });
+}
+
+console.log('saved tmp/hex_full.png, hex_frame.png, hex_tooltip_crop.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -171,6 +171,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.3 },
       { itemId: 'tallow_candle', chance: 0.3 },
     ],
+    // The cultist's muttered curse weakens its prey: a hexed victim deals less
+    // damage and heals for less until the hex fades.
+    hex: { chance: 0.3, reductionPct: 0.2, duration: 10, name: 'Weakening Hex', school: 'shadow' },
     scale: 1.0, color: 0x6c3483,
   },
   gravecaller_summoner: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2103,10 +2103,22 @@ export class Sim {
     return mult < 0 ? 0 : mult;
   }
 
+  // Weakening Hex: while a `hex` aura rides the source, the damage AND healing it
+  // deals are scaled by (1 - value). Read by dealDamage (outgoing damage) and
+  // applyHeal (outgoing healing) so a hexed player's whole output is throttled.
+  private hexOutputMult(source: Entity | null): number {
+    if (!source) return 1;
+    let mult = 1;
+    for (const a of source.auras) {
+      if (a.kind === 'hex') mult *= 1 - a.value;
+    }
+    return mult < 0 ? 0 : mult;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
-    let healed = Math.round(amount * (crit ? 1.5 : 1) * this.healingTakenMult(target));
+    let healed = Math.round(amount * (crit ? 1.5 : 1) * this.hexOutputMult(source) * this.healingTakenMult(target));
     healed = Math.min(healed, target.maxHp - target.hp);
     target.hp += healed;
     this.emit({ type: 'heal2', sourceId: source.id, targetId: target.id, amount: healed, crit, ability });
@@ -3271,6 +3283,13 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Weakening Hex: a hexed source deals less damage (mirrors the healing cut in
+    // applyHeal). Self-damage paths (source === target) are left untouched.
+    if (source && source.id !== target.id) {
+      const hexMult = this.hexOutputMult(source);
+      if (hexMult !== 1) amount = Math.round(amount * hexMult);
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4285,6 +4304,23 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+    // Weakening Hex: a landed hit can curse the player victim, scaling the damage
+    // AND healing they deal by (1 - reductionPct) for a while. Guarded on
+    // `hostile` so a friendly pet (mobSwing's other caller) never hexes the party,
+    // and on a player target. Rides a dedicated `hex` aura read by hexOutputMult.
+    const hex = MOBS[mob.templateId]?.hex;
+    if (hex && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(hex.chance)) {
+      this.applyAura(target, {
+        id: `hex_${mob.templateId}`,
+        name: hex.name,
+        kind: 'hex',
+        remaining: hex.duration,
+        duration: hex.duration,
+        value: hex.reductionPct,
+        sourceId: mob.id,
+        school: hex.school ?? 'shadow',
+      });
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'hex';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -268,6 +268,14 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // On-hit affix ("Weakening Hex"): a landed melee swing has `chance` to curse
+  // the player victim, scaling BOTH the damage and the healing *they* deal by
+  // (1 - reductionPct) for `duration` seconds. Distinct from `demoralize` (flat
+  // attack-power cut, physical only) and `mortal_wound` (healing *received*):
+  // this throttles the victim's whole offensive/support output — classic witch-
+  // doctor / curse-of-weakness flavour. Rides a dedicated `hex` aura kind read in
+  // dealDamage (outgoing) and applyHeal (outgoing).
+  hex?: { chance: number; reductionPct: number; duration: number; name: string; school?: Aura['school'] };
 }
 
 export type AbilityEffect =

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'hex'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_hex.test.ts
+++ b/tests/mob_hex.test.ts
@@ -1,0 +1,110 @@
+// Witch-doctor mobs (e.g. the Gravecaller Cultist's "Weakening Hex") can curse a
+// victim on a melee hit, scaling BOTH the damage and the healing *they* deal by
+// (1 - reductionPct) for a while. The hex is distinct from `demoralize` (a flat
+// attack-power cut, physical only) and `mortal_wound` (healing *received*): it
+// throttles the hexed player's whole offensive/support output.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'priest' = 'priest') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Cultist adjacent to the player, hostile and ready to swing.
+function spawnCultist(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_cultist'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (hex chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+const HEX_AURA = {
+  id: 'hex_gravecaller_cultist', name: 'Weakening Hex', kind: 'hex' as const,
+  remaining: 10, duration: 10, value: 0.2, sourceId: 999, school: 'shadow' as const,
+};
+
+describe('mob hex ("Weakening Hex")', () => {
+  it('seeds the hex mechanic on the Gravecaller Cultist', () => {
+    expect(MOBS['gravecaller_cultist'].hex).toEqual({
+      chance: 0.3, reductionPct: 0.2, duration: 10, name: 'Weakening Hex', school: 'shadow',
+    });
+  });
+
+  it('applies a hex aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    MOBS['gravecaller_cultist'].hex!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_cultist'].hex!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'hex');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Weakening Hex');
+    expect(aura!.value).toBe(0.2);
+    expect(aura!.remaining).toBe(10);
+  });
+
+  it('hexOutputMult scales by (1 - reductionPct) per hex aura', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    expect((sim as any).hexOutputMult(p)).toBe(1);
+    p.auras.push({ ...HEX_AURA });
+    expect((sim as any).hexOutputMult(p)).toBeCloseTo(0.8, 6);
+    expect((sim as any).hexOutputMult(null)).toBe(1);
+  });
+
+  it('reduces the damage a hexed source deals', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    const dummy = spawnCultist(sim, p);
+    dummy.maxHp = 100000; dummy.hp = 100000;
+    // Baseline hit (unhexed).
+    (sim as any).dealDamage(p, dummy, 1000, false, 'shadow', null, 'hit', true);
+    const plain = 100000 - dummy.hp;
+    dummy.hp = 100000;
+    // Same hit while hexed.
+    p.auras.push({ ...HEX_AURA });
+    (sim as any).dealDamage(p, dummy, 1000, false, 'shadow', null, 'hit', true);
+    const hexed = 100000 - dummy.hp;
+    expect(hexed).toBeLessThan(plain);
+    expect(hexed).toBeCloseTo(plain * 0.8, 0);
+  });
+
+  it('reduces the healing a hexed source does', () => {
+    const sim = makeSim('priest');
+    const p = sim.player;
+    (sim as any).spellCrit = () => 0; // remove crit RNG so the ratio is exact
+    p.maxHp = 100000; p.hp = 1; // huge deficit so nothing is capped by overheal
+    (sim as any).applyHeal(p, p, 1000, 'Test Heal');
+    const plain = p.hp - 1;
+    p.hp = 1;
+    p.auras.push({ ...HEX_AURA });
+    (sim as any).applyHeal(p, p, 1000, 'Test Heal');
+    const hexed = p.hp - 1;
+    expect(hexed).toBeLessThan(plain);
+    expect(hexed).toBeCloseTo(plain * 0.8, 0);
+  });
+
+  it('a friendly pet swing never hexes its target', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnCultist(sim, p);
+    pet.hostile = false; // a tamed/friendly cultist shape
+    pet.ownerId = p.id;
+    MOBS['gravecaller_cultist'].hex!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['gravecaller_cultist'].hex!.chance = 0.3;
+    expect(p.auras.some((a) => a.kind === 'hex')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new classic on-hit melee affix — **`hex` ("Weakening Hex")** — and attaches it to the **Gravecaller Cultist** (zone2, Eastbrook Vale, lvl 10–12).

A landed swing has a chance to curse the player victim. While hexed, **both the damage and the healing they deal** are scaled by `(1 − reductionPct)` for `duration` seconds.

It fills a gap left by the existing roster:
- `demoralize` cuts attack power (flat, physical only),
- `mortal_wound` cuts healing **received**,
- **`hex` throttles the victim's whole offensive *and* support output** — classic curse-of-weakness / witch-doctor flavour.

Tuning on the cultist: **30% chance · −20% output · 10s**.

## How

- **`types.ts`** — add `hex` to the `AuraKind` union and a `hex?` field to `MobTemplate`.
- **`sim.ts`** — new `hexOutputMult(source)` helper, read in `dealDamage` (outgoing damage, with a `source !== target` guard) and `applyHeal` (outgoing healing). The aura is rolled + applied in `mobSwing`, guarded on `mob.hostile && target.kind === 'player'` so a friendly pet never hexes the party (mirrors the other on-hit affixes).
- **`hud.ts`** — classify the `hex` aura as a debuff (red border).
- **content** — attach the affix to `gravecaller_cultist`.
- **tests** — `tests/mob_hex.test.ts`: seed, on-hit application, output scaling (damage + healing), and the friendly-pet guard. Plus `scripts/shot_hex.mjs` to capture it.

## Notes

- No new entities or player-facing strings — the affix debuff name ships raw like the existing `Silencing Shriek` / `Withering Wail`, so the localization guards stay green.
- Determinism preserved: adding an affix to an **existing** mob (no new camp/spawn) leaves construction RNG draw order byte-identical.
- **Verification:** `tsc --noEmit` clean; full suite **1389/1389 green** (incl. `localization_fixes`, `localization_coverage`, `sim`, `social`, `progression`, `pvp_safety`).

## Screenshots

A Gravecaller Cultist hexes the player in Eastbrook Vale:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/hex-affix/shots/hex_full.png)

The Weakening Hex debuff on the player frame (red debuff border + timer):

![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/hex-affix/shots/hex_debuff.png)

The shot script also confirms the output cut: a 1000-damage strike lands for 800 while hexed (−20%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)