### PR TITLE
feat(content): Vale Bandits fling Blinding Powder to foul the victim's aim

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/shot_blind.mjs
+++ b/scripts/shot_blind.mjs
@@ -1,0 +1,92 @@
+// Screenshot the Blinding Powder affix in the offline client.
+// Boots the game, repurposes a nearby mob as a Vale Bandit, forces its on-hit
+// Blinding Powder onto the player, and captures the resulting blind debuff on
+// the player unit frame (plus the player's own swings whiffing).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Vale Bandit and drive its Blinding Powder onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the dirty-fighting bandit and stand it next to us.
+  mob.templateId = 'vale_bandit';
+  mob.name = 'Vale Bandit';
+  mob.hostile = true;
+  mob.maxHp = 100000; mob.hp = 100000;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the powder onto us, then take a few of our own swings so the FCT
+  // shows the blinded misses.
+  sim.MOBS_FORCE = null;
+  for (let i = 0; i < 6 && !p.auras.some((a) => a.kind === 'blind'); i++) sim.mobSwing(mob, p);
+  if (!p.auras.some((a) => a.kind === 'blind')) {
+    p.auras.push({
+      id: 'blind_vale_bandit', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 0.3, sourceId: mob.id, school: 'physical',
+    });
+  }
+  const blind = p.auras.find((a) => a.kind === 'blind');
+  let misses = 0;
+  for (let i = 0; i < 8; i++) { if (sim.meleeSwing(p, mob, 0, null, { cannotBeDodged: true }) === false) misses++; }
+  return { hasBlind: !!blind, blindValue: blind?.value, blindRemaining: blind?.remaining, misses };
+});
+console.log('blind result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/blind_full.png' });
+
+// Crop tightly around the player unit frame + buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/blind_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/blind_full.png, blind_frame.png');
+await browser.close();

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -204,6 +204,8 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.3 },
     ],
     scale: 1.0, color: 0x943126,
+    // A practiced thug flings a handful of road grit to foul your aim.
+    blind: { chance: 0.25, miss: 0.3, duration: 5, name: 'Blinding Powder', school: 'physical' },
   },
   restless_bones: {
     id: 'restless_bones', name: 'Restless Bones', minLevel: 5, maxLevel: 7, family: 'undead',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1333,6 +1333,14 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+
+  // Extra chance for the entity's own weapon swings to whiff while blinded.
+  // Returns the strongest active blind aura's value (0 when not blinded).
+  private blindMissBonus(e: Entity): number {
+    let bonus = 0;
+    for (const a of e.auras) if (a.kind === 'blind' && a.value > bonus) bonus = a.value;
+    return bonus;
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -3176,7 +3184,7 @@ export class Sim {
     const school = ranged.wand ? (ranged.school ?? 'arcane') : 'physical';
     const label = ranged.wand ? 'Wand' : 'Auto Shot';
     this.emit({ type: 'spellfx', sourceId: attacker.id, targetId: target.id, school, fx: 'projectile' });
-    const missChance = meleeMissChance(attacker.level, target.level);
+    const missChance = meleeMissChance(attacker.level, target.level) + this.blindMissBonus(attacker);
     if (this.rng.chance(missChance)) {
       this.emit({ type: 'damage', sourceId: attacker.id, targetId: target.id, amount: 0, crit: false, school, ability: label, kind: 'miss' });
       this.enterCombat(attacker, target);
@@ -3197,7 +3205,7 @@ export class Sim {
     attacker: Entity, target: Entity, bonus: number, abilityName: string | null,
     opts: { cannotBeDodged?: boolean; weaponMult?: number; threatFlat?: number; threatMult?: number },
   ): boolean {
-    const missChance = meleeMissChance(attacker.level, target.level);
+    const missChance = meleeMissChance(attacker.level, target.level) + this.blindMissBonus(attacker);
     const dodgeChance = opts.cannotBeDodged ? 0
       : (target.kind === 'player' ? target.dodgeChance : 0.05 + Math.max(0, target.level - attacker.level) * 0.005);
     const roll = this.rng.next();
@@ -4167,6 +4175,18 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // blinding powder: a thrown handful of grit can leave the victim's own
+    // weapon swings whiffing. Guarded on hostile + alive so a friendly pet
+    // (mobSwing's other caller) never blinds the party. Carries the added miss
+    // chance in the aura value, read back in melee/ranged swings via blindMissBonus.
+    const blind = MOBS[mob.templateId]?.blind;
+    if (blind && mob.hostile && !target.dead && this.rng.chance(blind.chance)) {
+      this.applyAura(target, {
+        id: `blind_${mob.templateId}`, name: blind.name, kind: 'blind',
+        remaining: blind.duration, duration: blind.duration, value: blind.miss,
+        sourceId: mob.id, school: (blind.school ?? 'physical') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'blind';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +256,11 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit mechanic: a landed melee swing has `chance` to blind the victim,
+  // adding `miss` to the chance their own melee/ranged swings whiff for
+  // `duration` seconds. The flip side of `silence`: it spoils weapon attacks
+  // rather than spells. The added miss chance is carried in the aura's `value`.
+  blind?: { chance: number; miss: number; duration: number; name: string; school?: string };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'blind'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_blind.test.ts
+++ b/tests/mob_blind.test.ts
@@ -1,0 +1,108 @@
+// Some thugs fight dirty: the Vale Bandit's "Blinding Powder" flings a handful of
+// road grit on a landed hit, fouling the victim's aim so their OWN weapon swings
+// whiff for a few seconds. Blind is the weapon-side twin of silence — where
+// silence locks out spells, blind spoils melee and ranged attacks. It leaves
+// spellcasting, movement and the victim's defenses untouched.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Vale Bandit adjacent to the player, hostile and ready to swing.
+function spawnBandit(sim: Sim, target: Entity): Entity {
+  const template = MOBS['vale_bandit'];
+  const mob = createMob((sim as any).nextId++, template, 5, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (blind chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob blind ("Blinding Powder")', () => {
+  it('seeds the blind mechanic on the Vale Bandit', () => {
+    expect(MOBS['vale_bandit'].blind).toEqual({
+      chance: 0.25, miss: 0.3, duration: 5, name: 'Blinding Powder', school: 'physical',
+    });
+  });
+
+  it('applies a blind aura carrying the added miss chance on a landed hit', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnBandit(sim, p);
+    MOBS['vale_bandit'].blind!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['vale_bandit'].blind!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'blind');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Blinding Powder');
+    expect(aura!.remaining).toBe(5);
+    expect(aura!.value).toBe(0.3); // the miss chance carried into combat math
+  });
+
+  it("makes the blinded victim's own swings whiff", () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    const dummy = spawnBandit(sim, p);
+    dummy.maxHp = 100000; dummy.hp = 100000;
+    // A total blind (100% added miss) guarantees the swing whiffs.
+    p.auras.push({
+      id: 'blind_x', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 1, sourceId: 999, school: 'physical',
+    });
+    const events: Array<{ kind?: string; sourceId: number }> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: any) => { events.push(e); orig(e); };
+    const connected = (sim as any).meleeSwing(p, dummy, 0, null, { cannotBeDodged: true });
+    expect(connected).toBe(false);
+    expect(events.some((e) => e.kind === 'miss' && e.sourceId === p.id)).toBe(true);
+  });
+
+  it('adds no miss chance when the victim is not blinded', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    // No blind aura → the swing math sees zero added miss chance.
+    expect((sim as any).blindMissBonus(p)).toBe(0);
+    p.auras.push({
+      id: 'blind_x', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 0.3, sourceId: 999, school: 'physical',
+    });
+    expect((sim as any).blindMissBonus(p)).toBe(0.3);
+  });
+
+  it('does not block spellcasting while blinded', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.auras.push({
+      id: 'blind_x', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 0.3, sourceId: 999, school: 'physical',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    sim.castAbility('fireball', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('a friendly pet swing never blinds its target', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnBandit(sim, p);
+    pet.hostile = false; // a tamed/friendly shape
+    pet.ownerId = p.id;
+    MOBS['vale_bandit'].blind!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['vale_bandit'].blind!.chance = 0.25;
+    expect(p.auras.some((a) => a.kind === 'blind')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Vale Bandits fling Blinding Powder

Vale Bandits fight dirty. A landed swing now has a **25% chance** to throw a handful of road grit in the victim's eyes — a **Blinding Powder** debuff that adds **+30% miss chance to the victim's own melee and ranged swings for 5s**.

Blind is the **weapon-side twin of `silence`**: where silence locks out *spell* casts, blind spoils *weapon* attacks — while leaving spellcasting, movement, and the victim's own defenses untouched. It fills the last clean, uncovered classic on-hit affix in this slot (distinct from `disarm`, which locks the weapon out entirely, and `slowStrike`, which only slows swing speed).

### Mechanic (mirrors the existing on-hit affix seam)
- `MobTemplate.blind` field + `'blind'` `AuraKind` in `types.ts`
- rolled in `mobSwing`'s on-hit block, guarded on `hostile` + alive so a friendly pet never blinds the party; the added miss chance rides in the aura's `value`
- read back via a small `blindMissBonus` helper added to the attacker's miss roll in `meleeSwing` and `rangedSwing`
- shown as a red debuff in the HUD aura strip

### Why it's low-risk
- **Determinism-neutral:** no new mob / camp / spawn, so **zero** construction RNG draws — every fixed-seed test downstream sees a byte-identical roll cursor.
- Attached to an existing mob (`vale_bandit`) → no new entity, so no new i18n surface.
- `npx tsc --noEmit` clean; **full suite 1392 passing** (incl. the localization guards), with new `tests/mob_blind.test.ts` mirroring `tests/mob_silence.test.ts`.

### Screenshots
Vale Bandit applies Blinding Powder (debuff visible top-left):

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/blind-affix/shots/blind_full.png)

The blinded player's own swing whiffs — **MISS** floating combat text:

![miss](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/blind-affix/shots/blind_miss.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
