### PR TITLE
feat(content): Nhalia Mourners curse casters' tongues on hit (Curse of Tongues)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -221,6 +221,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'nhalia_mourner', name: 'Nhalia Mourner', minLevel: 11, maxLevel: 12, family: 'humanoid',
     hpBase: 46, hpPerLevel: 17, dmgBase: 8, dmgPerLevel: 2.3, attackSpeed: 2.0,
     armorPerLevel: 14, moveSpeed: 7, aggroRadius: 12,
+    // Curse of Tongues: the mourners' dirge garbles a caster's incantations, slowing
+    // their spell cast times by 30% for 10s on a landed hit (30% chance).
+    tongues: { chance: 0.3, mult: 1.3, duration: 10, name: 'Dirge of Tongues', school: 'shadow' },
     loot: [],
     scale: 0.95, color: 0x332044,
   },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'tongues',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'tongues',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -1333,6 +1333,14 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+  // Curse of Tongues: returns the spell cast-time multiplier (>=1) imposed by any
+  // active `tongues` aura, or 1 when unafflicted. Non-stacking across sources — the
+  // strongest curse wins (refresh-by-id keeps a single source from compounding).
+  private tonguesMult(e: Entity): number {
+    let m = 1;
+    for (const a of e.auras) if (a.kind === 'tongues') m = Math.max(m, a.value);
+    return m;
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -2006,11 +2014,13 @@ export class Sim {
     }
 
     if (res.castTime > 0 && !togglingOff) {
+      // Curse of Tongues stretches the resolved (already haste-adjusted) cast time.
+      const castTime = res.castTime * this.tonguesMult(p);
       p.castingAbility = ability.id;
-      p.castTotal = res.castTime;
-      p.castRemaining = res.castTime;
+      p.castTotal = castTime;
+      p.castRemaining = castTime;
       p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
-      this.emit({ type: 'castStart', entityId: p.id, ability: ability.id, time: res.castTime });
+      this.emit({ type: 'castStart', entityId: p.id, ability: ability.id, time: castTime });
       return;
     }
 
@@ -4214,6 +4224,23 @@ export class Sim {
         value: slowStrike.mult,
         sourceId: mob.id,
         school: (slowStrike.school as Aura['school']) ?? 'physical',
+      });
+    }
+    // Curse of Tongues: a landed hit may garble the victim's incantations, stretching
+    // their spell cast times (`tonguesMult` reads this at cast-start). Refreshes by id
+    // and never stacks. Guarded on `hostile` so a friendly pet (mobSwing's other
+    // caller) never curses an ally; players only, since only players hard-cast here.
+    const tongues = MOBS[mob.templateId]?.tongues;
+    if (tongues && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(tongues.chance)) {
+      this.applyAura(target, {
+        id: `tongues_${mob.templateId}`,
+        name: tongues.name,
+        kind: 'tongues',
+        remaining: tongues.duration,
+        duration: tongues.duration,
+        value: tongues.mult,
+        sourceId: mob.id,
+        school: (tongues.school as Aura['school']) ?? 'shadow',
       });
     }
     // Mana Burn: a landed hit may sap a flat amount of mana from a mana-using

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'tongues';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -233,6 +233,13 @@ export interface MobTemplate {
   // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new
   // combat math. Distinct from a movement snare (`slow`) or an AP cut (`debuff_ap`).
   slowStrike?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse ("Curse of Tongues"): a landed melee swing has `chance` to garble
+  // the victim's incantations, stretching their SPELL CAST TIMES by `mult` (>1 =
+  // slower) for `duration`s. Read at cast-start so it composes with the already
+  // haste-resolved cast time — no new combat math. Distinct from `slowStrike` (melee
+  // swing speed) and `silence` (a full spell lockout): a casting victim still casts,
+  // just slower. Inert against rage/energy melee classes that never hard-cast.
+  tongues?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
   // On-hit mechanic ("Mana Burn"): a landed melee swing has `chance` to drain a
   // flat `amount` of mana from a mana-using victim (casters). Rage/energy users
   // are unaffected. Drains only what mana the victim still has; no overkill.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'tongues'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1083,6 +1083,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_incapacitate: r('storm', 'sky', ['eye']),
   aura_polymorph: r('arcane', 'pink', ['sheep_head']),
   aura_attackspeed: r('storm', 'ice', ['axe', { p: 'snowflake', ...BR }]),
+  aura_tongues: r('shadow', 'shadowPurple', ['skull'], ['motion']),
   aura_buff_sta: r('blood', 'blood', ['heart']),
   aura_buff_ap: r('fury', 'gold', ['fist']),
   aura_buff_armor: r('steel', 'steel', ['shield']),

--- a/tests/mob_tongues.test.ts
+++ b/tests/mob_tongues.test.ts
@@ -1,0 +1,108 @@
+// The Nhalia Mourners' funeral dirge ("Dirge of Tongues") can curse a caster on a
+// melee hit, stretching their spell cast times. Curse of Tongues is distinct from a
+// silence (a full spell lockout) and from slowStrike (melee swing speed): a cursed
+// victim still casts, just slower. It is read at cast-start, so it composes with the
+// already haste-resolved cast time.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Nhalia Mourner adjacent to the player, hostile and ready to swing.
+function spawnMourner(sim: Sim, target: Entity): Entity {
+  const template = MOBS['nhalia_mourner'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (the curse chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob curse of tongues ("Dirge of Tongues")', () => {
+  it('seeds the tongues mechanic on the Nhalia Mourner', () => {
+    expect(MOBS['nhalia_mourner'].tongues).toEqual({
+      chance: 0.3, mult: 1.3, duration: 10, name: 'Dirge of Tongues', school: 'shadow',
+    });
+  });
+
+  it('applies a tongues aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnMourner(sim, p);
+    MOBS['nhalia_mourner'].tongues!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['nhalia_mourner'].tongues!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'tongues');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Dirge of Tongues');
+    expect(aura!.remaining).toBe(10);
+    expect(aura!.value).toBe(1.3);
+  });
+
+  // Point the player at a hostile, in-range, in-arc dummy so a hostile spell can begin.
+  function aimAt(sim: Sim, p: Entity): Entity {
+    const mob = spawnMourner(sim, { ...p, pos: { x: p.pos.x + 3, y: p.pos.y, z: p.pos.z } } as Entity);
+    mob.pos = { x: p.pos.x + 3, y: p.pos.y, z: p.pos.z };
+    mob.maxHp = 100000; mob.hp = 100000;
+    p.targetId = mob.id;
+    p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+    return mob;
+  }
+
+  it('stretches a spell cast time while cursed', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    p.resource = p.maxResource;
+    aimAt(sim, p);
+    // Baseline cast time with no curse.
+    sim.castAbility('fireball', p.id);
+    const baseCast = p.castTotal;
+    expect(baseCast).toBeGreaterThan(0);
+    (sim as any).cancelCast(p);
+
+    // Apply the curse and recast — the cast time should be 30% longer.
+    p.auras.push({
+      id: 'tongues_nhalia_mourner', name: 'Dirge of Tongues', kind: 'tongues',
+      remaining: 10, duration: 10, value: 1.3, sourceId: 999, school: 'shadow',
+    });
+    p.gcdRemaining = 0;
+    sim.castAbility('fireball', p.id);
+    expect(p.castTotal).toBeCloseTo(baseCast * 1.3, 5);
+  });
+
+  it('does not block the cast outright (distinct from silence)', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    p.resource = p.maxResource;
+    aimAt(sim, p);
+    p.auras.push({
+      id: 'tongues_x', name: 'Dirge of Tongues', kind: 'tongues',
+      remaining: 10, duration: 10, value: 1.3, sourceId: 999, school: 'shadow',
+    });
+    sim.castAbility('fireball', p.id);
+    expect(p.castingAbility).toBe('fireball');
+  });
+
+  it('a friendly pet swing never curses an ally', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const mob = spawnMourner(sim, p);
+    mob.hostile = false; // friendly (mobSwing's other caller)
+    MOBS['nhalia_mourner'].tongues!.chance = 1;
+    swing(sim, mob, p);
+    MOBS['nhalia_mourner'].tongues!.chance = 0.3;
+    expect(p.auras.find((a) => a.kind === 'tongues')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit **`tongues`** affix — a classic-era *Curse of Tongues*. A landed melee swing has a chance to garble the victim's incantations, **stretching their spell cast times** for a duration. Attached to the **Nhalia Mourner** (Mirefen Marsh, lvl 11-12) as **"Dirge of Tongues"** — 30% chance, +30% cast time, 10s.

## Why it's distinct

The mourners are a shadow funeral cult with no on-hit affix yet, so it's a natural thematic fit. Curse of Tongues fills a real gap among the shipped affixes:

- **vs `slowStrike`** — that slows *melee swing speed* (`attackspeed` aura); this slows *spell cast speed*.
- **vs `silence`** — that's a full spell *lockout*; here the caster still casts, just slower.
- Rage/energy melee classes that never hard-cast are naturally unaffected.

## How

- New harmful `tongues` `AuraKind`; `MobTemplate.tongues` field mirroring `slowStrike`.
- `tonguesMult(entity)` is read at **cast-start**, multiplying the already haste-resolved cast time — no new combat math, composes cleanly.
- On-hit roll lives in `mobSwing` right after `slowStrike`, guarded on `hostile` + `target.kind === 'player'` so a friendly pet never curses an ally.
- Surfaced as a HUD debuff with a procedural shadow icon.

**Determinism-neutral:** no new spawn/camp, so zero construction RNG draws — the whole suite stays byte-identical. `npx tsc --noEmit` clean, **1391/1391 tests green**, new `tests/mob_tongues.test.ts` mirrors `mob_silence.test.ts`.

## Screenshots

Stretched cast bar (Fireball at 1.95s = 1.5s × 1.3) with the cursed mourner in front:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/curse-of-tongues/shots/curse-of-tongues-scene.png)

The "Dirge of Tongues" debuff on the player frame (red debuff border + timer):

![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/curse-of-tongues/shots/curse-of-tongues-debuff.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)