### PR TITLE
feat(content): Varkas Boneguards crack the victim's guard on hit (Cracked Guard)

### DIFF
--- a/scripts/shot_expose.mjs
+++ b/scripts/shot_expose.mjs
@@ -1,0 +1,106 @@
+// Screenshot script for the Expose affix (Cracked Guard).
+// Boots the offline client, parks a warrior next to a Varkas Boneguard, forces
+// its on-hit Expose proc, and captures the red Cracked Guard debuff on the
+// player frame plus a cropped close-up. Needs `npm run dev` on :5173.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Highwatch');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 1500));
+
+// Level up so the lvl18-19 Boneguard isn't trivially out of band, god-mode the
+// player so they survive the swings, and force the Expose proc to 100%.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  p.maxHp = 1e5; p.hp = 1e5;
+
+  // Varkas Boneguards only exist as Marrowlord Varkas's summoned adds, so find
+  // the Marrowlord (a rare in a static camp) and call up a real Boneguard.
+  let boss = null;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'marrowlord_varkas' && !e.dead) { boss = e; break; }
+  }
+  if (!boss) return { found: false };
+  // teleport beside the Marrowlord, then summon one authentic Boneguard
+  p.pos.x = boss.pos.x + 8; p.pos.z = boss.pos.z; p.pos.y = boss.pos.y;
+  boss.aggroTargetId = p.id;
+  sim.spawnBossAdds(boss, 'varkas_boneguard', 1);
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'varkas_boneguard' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - boss.pos.x, e.pos.z - boss.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  if (!mob) return { found: false };
+  // hide the boss so only the Boneguard frames in the shot, park the player ~6yd off
+  boss.pos.x = boss.pos.x - 40;
+  p.pos.x = mob.pos.x + 6; p.pos.z = mob.pos.z + 2; p.pos.y = mob.pos.y;
+  return { found: true, mobId: mob.id };
+});
+
+if (!setup.found) {
+  console.log('could not summon a varkas_boneguard from Marrowlord Varkas — FAIL');
+  await browser.close();
+  process.exit(1);
+}
+
+// Drive swings until Cracked Guard lands. The affix is a real 25% proc shipped
+// on the Boneguard, so ~120 swings makes it virtually certain — no need to mutate
+// the live template (which the sim closes over privately).
+const applied = await page.evaluate(async (mobId) => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  const mob = sim.entities.get(mobId);
+  let ok = false;
+  for (let i = 0; i < 120 && !ok; i++) {
+    sim.mobSwing(mob, p);
+    ok = p.auras.some((a) => a.kind === 'expose');
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  // pin the Boneguard a few yards directly in front of the player and stop it
+  // wandering, then aim the third-person camera down that line.
+  mob.pos.x = p.pos.x; mob.pos.z = p.pos.z + 5; mob.pos.y = p.pos.y;
+  mob.aiState = 'idle'; mob.aggroTargetId = null;
+  if (mob.vel) { mob.vel.x = 0; mob.vel.z = 0; }
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  g.input.camDist = 8;
+  if ('camPitch' in g.input) g.input.camPitch = 0.18;
+  sim.targetEntity(mob.id);
+  return ok;
+}, setup.mobId);
+
+await new Promise((r) => setTimeout(r, 800));
+console.log('Cracked Guard applied to player:', applied ? 'OK' : 'FAIL');
+
+await page.screenshot({ path: 'tmp/expose_full.png' });
+// close-up of the player's buff bar (top-right) where Cracked Guard shows as a
+// red-bordered debuff with its countdown.
+await page.screenshot({ path: 'tmp/expose_debuff.png', clip: { x: 1330, y: 2, width: 270, height: 96 } });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 10).join('\n') : 'no page errors');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -205,6 +205,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'varkas_boneguard', name: 'Varkas Boneguard', minLevel: 18, maxLevel: 19, family: 'undead',
     hpBase: 64, hpPerLevel: 22, dmgBase: 12, dmgPerLevel: 2.8, attackSpeed: 2.3,
     armorPerLevel: 20, moveSpeed: 6.5, aggroRadius: 12,
+    // Shattering Maul: a landed hit can crack the victim's guard, leaving them
+    // taking +18% physical damage from every attacker for 8s.
+    expose: { chance: 0.25, dmgIncrease: 0.18, duration: 8, name: 'Cracked Guard' },
     loot: [],
     scale: 1.0, color: 0xc9c2b5,
   },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3271,6 +3271,15 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Expose: a cracked-guard debuff amplifies the physical damage the victim
+    // takes (from any attacker) until it expires. Armor is already applied at the
+    // swing site, so this rides on top of the post-mitigation amount.
+    if (school === 'physical' && amount > 0) {
+      let exposeMult = 1;
+      for (const a of target.auras) if (a.kind === 'expose') exposeMult += a.value;
+      if (exposeMult !== 1) amount = Math.round(amount * exposeMult);
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4285,6 +4294,22 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+    // Expose: a landed hit can crack the victim's guard, raising the physical
+    // damage they take for a duration. Guarded on `hostile` so a friendly pet
+    // (mobSwing's other caller) never debuffs the party.
+    const expose = MOBS[mob.templateId]?.expose;
+    if (expose && mob.hostile && !target.dead && this.rng.chance(expose.chance)) {
+      this.applyAura(target, {
+        id: `expose_${mob.templateId}`,
+        name: expose.name,
+        kind: 'expose',
+        remaining: expose.duration,
+        duration: expose.duration,
+        value: expose.dmgIncrease,
+        sourceId: mob.id,
+        school: (expose.school as Aura['school']) ?? 'physical',
+      });
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'expose';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -218,6 +218,10 @@ export interface MobTemplate {
   // other on-hit affixes it sustains the attacker instead of debuffing the
   // victim. Optional `chance` gates the proc (defaults to every landed hit).
   lifeleech?: { healFrac: number; chance?: number; name?: string };
+  // Melee mechanic: a landed swing has `chance` to crack the victim's guard with
+  // an Expose debuff that raises the physical damage they take by `dmgIncrease`
+  // (e.g. 0.15 = +15%) for `duration` seconds. Stacks multiplicatively with armor.
+  expose?: { chance: number; dmgIncrease: number; duration: number; name: string; school?: string };
   // Combat mechanic: a landed melee hit has `chance` to corrode the victim's
   // armor: a stacking `sunder` debuff (up to `maxStacks`) so the victim takes
   // more physical damage from everyone until it expires. Rides the existing

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'expose'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_expose.test.ts
+++ b/tests/mob_expose.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+function exposeAura(value: number, remaining = 8): Aura {
+  return {
+    id: 'expose_test', name: 'Cracked Guard', kind: 'expose',
+    remaining, duration: 8, value, sourceId: -1, school: 'physical',
+  };
+}
+
+describe('Expose physical-vulnerability debuff', () => {
+  it('amplifies physical damage taken by the debuff fraction', () => {
+    const sim = makeSim();
+    const src = createMob(900600, MOBS.varkas_boneguard, 18, { x: 0, y: 0, z: 0 });
+
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    (sim as any).dealDamage(src, p, 100, false, 'physical', null, 'hit');
+    const baseline = 1_000_000 - p.hp;
+    expect(baseline).toBe(100);
+
+    p.auras.length = 0;
+    p.hp = 1_000_000;
+    p.auras.push(exposeAura(0.18));
+    (sim as any).dealDamage(src, p, 100, false, 'physical', null, 'hit');
+    const amplified = 1_000_000 - p.hp;
+    expect(amplified).toBe(118);
+  });
+
+  it('only amplifies physical damage, not spell schools', () => {
+    const sim = makeSim();
+    const src = createMob(900601, MOBS.varkas_boneguard, 18, { x: 0, y: 0, z: 0 });
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    p.auras.push(exposeAura(0.18));
+    (sim as any).dealDamage(src, p, 100, false, 'shadow', null, 'hit');
+    expect(1_000_000 - p.hp).toBe(100);
+  });
+
+  it('stacks additively across multiple Expose auras', () => {
+    const sim = makeSim();
+    const src = createMob(900602, MOBS.varkas_boneguard, 18, { x: 0, y: 0, z: 0 });
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    p.auras.push({ ...exposeAura(0.18), id: 'a', sourceId: 1 });
+    p.auras.push({ ...exposeAura(0.18), id: 'b', sourceId: 2 });
+    (sim as any).dealDamage(src, p, 100, false, 'physical', null, 'hit');
+    // 1 + 0.18 + 0.18 = 1.36
+    expect(1_000_000 - p.hp).toBe(136);
+  });
+
+  it('a landed Varkas Boneguard swing can inflict Cracked Guard', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.varkas_boneguard;
+    const saved = tmpl.expose!.chance;
+    tmpl.expose!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900610, tmpl, 18, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'expose');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'expose')!;
+      expect(a.name).toBe('Cracked Guard');
+      expect(a.value).toBe(0.18);
+    } finally {
+      tmpl.expose!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts Expose', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    const tmpl = MOBS.varkas_boneguard;
+    const saved = tmpl.expose!.chance;
+    tmpl.expose!.chance = 1;
+    try {
+      const pet = createMob(900611, tmpl, 18, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'expose')).toBe(false);
+    } finally {
+      tmpl.expose!.chance = saved;
+    }
+  });
+
+  it('a mob without the expose affix applies no debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    const mob = createMob(900612, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'expose')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Varkas Boneguards crack the victim's guard

Marrowlord Varkas's **Boneguards** fight like siege troops. A landed swing now has a **25% chance** to crack the victim's guard — a **Cracked Guard** debuff that makes them take **+18% physical damage from every attacker for 8s**.

`expose` is the classic *broken-guard vulnerability* and fills a clean, uncovered slot in the on-hit affix family. It is mechanically distinct from everything already in this slot:

- `mortal_wound` reduces *healing received* — not damage taken
- `corrode` / `sunder` shred *armor* (a pre-mitigation stat) — Expose rides on the *post-mitigation* damage and amplifies any school-physical hit
- `demoralize` saps *attack power* (the victim's offense) — Expose touches the victim's *defense*

The effect amplifies physical damage from **every** attacker, so it rewards focus-fire in a group while a Boneguard is loose.

### Mechanic (mirrors the existing on-hit affix seam)
- `MobTemplate.expose` field + `'expose'` `AuraKind` in `types.ts`
- rolled in `mobSwing`'s on-hit block, guarded on `hostile` + alive so a friendly pet never debuffs the party
- read back in `dealDamage` (physical school only); auras sum additively, so two stacks give +36%
- shown as a red debuff in the HUD aura strip

### Why it's low-risk
- **Determinism-neutral:** no new mob / camp / spawn, so **zero** construction RNG draws — every fixed-seed test downstream sees a byte-identical roll cursor.
- Attached to an existing mob (`varkas_boneguard`) → no new entity, so no new i18n surface; the debuff name ships raw like every other affix.
- `npx tsc --noEmit` clean; **full suite 1243 passing** (incl. the localization guards), with new `tests/mob_expose.test.ts` mirroring `tests/mob_mortal_strike.test.ts`.

### Screenshots
A summoned Varkas Boneguard with Cracked Guard applied to the player (debuff top-right):

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/expose-affix/shots/expose_full.png)

The red-bordered Cracked Guard debuff and its countdown on the player's buff bar:

![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/expose-affix/shots/expose_debuff.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
