### PR TITLE
feat(content): Mirefen Trolls rot the victim's sinews on hit (Withering Rot)

### DIFF
--- a/scripts/shot_wither.mjs
+++ b/scripts/shot_wither.mjs
@@ -1,0 +1,85 @@
+// Screenshot the Withering Rot affix in the offline client. Boots the game,
+// repurposes a nearby mob as a Mirefen Troll, forces its on-hit wither onto the
+// player, and captures the resulting Agility-draining debuff on the buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Mirefen Troll and drive its wither onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the withering troll and stand it next to us.
+  mob.templateId = 'fen_troll';
+  mob.name = 'Mirefen Troll';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const agiBefore = p.stats.agi;
+  const armorBefore = p.stats.armor;
+  for (let i = 0; i < 8; i++) sim.mobSwing(mob, p);
+  const rot = p.auras.find((a) => a.name === 'Withering Rot');
+  return {
+    agiBefore, agiAfter: p.stats.agi, armorBefore, armorAfter: p.stats.armor,
+    hasRot: !!rot, rotValue: rot?.value, rotRemaining: rot?.remaining,
+  };
+});
+console.log('wither result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/wither_full.png' });
+
+// Crop tightly around the buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/wither_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/wither_full.png, wither_frame.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -143,6 +143,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'fen_troll', name: 'Mirefen Troll', minLevel: 10, maxLevel: 12, family: 'troll',
     hpBase: 56, hpPerLevel: 21, dmgBase: 9, dmgPerLevel: 2.4, attackSpeed: 2.2,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 11,
+    // Withering Rot: the troll's fetid claws rot a struck victim's sinews, draining
+    // Agility (thinning their armor and dodge) for a few seconds.
+    wither: { chance: 0.3, agi: 18, duration: 8, name: 'Withering Rot', school: 'nature' },
     loot: [
       { copper: 50, chance: 1 },
       { itemId: 'troll_fetish', chance: 0.6, questId: 'q_troll_fetishes' },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -90,6 +90,7 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     if (a.kind === 'buff_ap') bonusAp += a.value;
     else if (a.kind === 'buff_armor') s.armor += a.value;
     else if (a.kind === 'buff_int') s.int += a.value;
+    else if (a.kind === 'buff_agi') s.agi += a.value;
     else if (a.kind === 'buff_sta') s.sta += a.value;
     else if (a.kind === 'buff_allstats') {
       s.str += a.value; s.agi += a.value; s.sta += a.value; s.int += a.value; s.spi += a.value;
@@ -107,6 +108,9 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     bonusDodge += m.dodge;
     if (m.staPct) s.sta = Math.round(s.sta * (1 + m.staPct));
   }
+  // Floor Agility at 0 so a draining debuff (negative buff_agi) can never push the
+  // derived armor/dodge below what zero Agility would give.
+  s.agi = Math.max(0, s.agi);
   s.armor += s.agi * 2;
   if (bearForm) {
     s.armor = Math.round(s.armor * 1.65);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4243,6 +4243,24 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Withering curse: a landed hit can rot the victim's sinews, draining Agility
+    // and so thinning their armor (agi*2) and dodge at once. Hostile mobs only, so a
+    // friendly pet (mobSwing's other caller) never debuffs the party; player targets
+    // only (mobs derive no stats from auras). Rides buff_agi with a negative value, so
+    // recalcPlayerStats folds it through with no new stat math.
+    const wither = MOBS[mob.templateId]?.wither;
+    if (wither && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(wither.chance)) {
+      this.applyAura(target, {
+        id: `wither_${mob.templateId}`,
+        name: wither.name,
+        kind: 'buff_agi',
+        remaining: wither.duration,
+        duration: wither.duration,
+        value: -Math.abs(wither.agi),
+        sourceId: mob.id,
+        school: wither.school ?? 'nature',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -45,7 +45,7 @@ export type AiState = 'idle' | 'chase' | 'attack' | 'flee' | 'evade' | 'dead';
 
 export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
-  | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
+  | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_agi' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
   | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
 
@@ -243,6 +243,12 @@ export interface MobTemplate {
   // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
   // resource math. Only meaningful on mana users — applied to them alone.
   enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to wither the victim's sinews,
+  // draining `agi` Agility for `duration`. Agility is a derived-stat hub — it feeds
+  // armor (agi*2), dodge and crit — so a single drain shreds both the victim's
+  // physical mitigation and their avoidance at once. Rides a `buff_agi` aura with a
+  // NEGATIVE value (recalcPlayerStats folds it through), so there is no new stat math.
+  wither?: { chance: number; agi: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to terrify the victim — a
   // fear that sends the struck player fleeing for `duration`s. Rides the existing
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`

--- a/tests/mob_wither.test.ts
+++ b/tests/mob_wither.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// A mage victim at the troll's own level: low melee avoidance and no level gap, so
+// the troll's swings land reliably (a big level gap would inflate miss/dodge and the
+// on-hit roll would rarely fire). We top hp up each swing so a hit never kills.
+const makeSim = (cls: PlayerClass = 'mage') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(12);
+  return sim;
+};
+
+const spawnTroll = (sim: Sim) => {
+  const mob = createMob(990700, MOBS.fen_troll, 12, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Swing until the Withering Rot buff_agi debuff lands (a swing can miss/dodge).
+const swingUntilWithered = (sim: Sim, mob: any, target: any, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_agi' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob withering curse (Withering Rot)', () => {
+  it('Mirefen Troll template carries the wither mechanic', () => {
+    expect(MOBS.fen_troll.wither).toBeDefined();
+    expect(MOBS.fen_troll.wither!.name).toBe('Withering Rot');
+  });
+
+  it('a landed hit applies a negative buff_agi aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    const wither = MOBS.fen_troll.wither!;
+    const old = wither.chance;
+    wither.chance = 1;
+    try {
+      expect(swingUntilWithered(sim, mob, player)).toBe(true);
+    } finally {
+      wither.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_agi');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Withering Rot');
+    expect(aura!.value).toBe(-wither.agi); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('nature');
+  });
+
+  it('the curse lowers the victim Agility and thins their armor', () => {
+    // A rogue has ample base Agility, so the drain lands without flooring at 0.
+    // Apply the aura through the normal path (recalcPlayerStats runs on apply).
+    const sim = makeSim('rogue');
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    const agiBefore = player.stats.agi;
+    const armorBefore = player.stats.armor;
+    const wither = MOBS.fen_troll.wither!;
+    expect(agiBefore).toBeGreaterThan(wither.agi); // precondition: no floor
+    (sim as any).applyAura(player, {
+      id: `wither_${mob.templateId}`, name: wither.name, kind: 'buff_agi',
+      remaining: wither.duration, duration: wither.duration,
+      value: -wither.agi, sourceId: mob.id, school: 'nature',
+    });
+    expect(player.stats.agi).toBe(agiBefore - wither.agi);
+    // Agility feeds armor at 2 per point, so the drain shaves it too.
+    expect(player.stats.armor).toBe(armorBefore - wither.agi * 2);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    const wither = MOBS.fen_troll.wither!;
+    const old = wither.chance;
+    wither.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilWithered(sim, mob, player);
+    } finally {
+      wither.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_agi' && a.value < 0).length).toBe(1);
+  });
+
+  it('a friendly pet never curses its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const wither = MOBS.fen_troll.wither!;
+    const old = wither.chance;
+    wither.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      wither.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_agi' && a.value < 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Withering Rot — an Agility-draining on-hit affix

Adds a `wither` on-hit affix: a landed melee swing has a chance to **drain the victim's Agility** for a few seconds. Because Agility is a derived-stat hub — it feeds **armor (`agi*2`)**, **dodge**, and crit — a single drain shreds both the victim's physical mitigation *and* their avoidance at once.

This is a defensive shred that's **distinct from the existing affixes**:
- `corrode` shaves *flat armor only* (pre-mitigation).
- `demoralize` saps *attack power only* (offense).
- `wither` lowers armor **and** dodge together, scaling off the victim's Agility.

It completes the stat-drain affix family alongside the Intellect-draining `enfeeble` (Maddening Whisper).

### Implementation (minimal, reuses existing seams)
- New `buff_agi` aura kind, applied with a **negative value** — exactly how `enfeeble` rides `buff_int`. `recalcPlayerStats` folds it through with no new stat math (it already recalcs on aura apply/expiry for any `buff_*` kind).
- Agility is **floored at 0** in the stat derivation so a large drain can't push armor/dodge below the zero-Agility baseline (mirrors the existing Intellect floor).
- The HUD already renders any negative-value `buff_*` aura as a debuff, so **no UI change** is needed.
- The on-hit roll is guarded on `mob.hostile` + a player target, so a tamed pet (the other `mobSwing` caller) never debuffs the party.

### Content
Attached to the **Mirefen Troll** (zone2, Mirefen Marsh, lvl 10–12) at **30% chance / −18 Agility / 8s** as *"Withering Rot"* — a fitting fetid-claw curse for a swamp troll.

### Determinism & i18n
- **Determinism-neutral**: no new spawns/camps, so Sim-construction RNG draw order is byte-identical.
- The debuff name ships as a raw string like the other affix debuffs (`Numbing Chill`, `Maddening Whisper`) — no new entity, so the localization guards stay green.

### Tests
`tests/mob_wither.test.ts` (mirrors `mob_enfeeble.test.ts`): template carries the mechanic, a landed hit applies the negative `buff_agi` aura with template values, the drain lowers Agility and thins armor by `agi*2`, it refreshes a single shared slot instead of stacking, and a friendly pet never applies it.

```
npx tsc --noEmit      # clean
npx vitest run        # 1397 passed (143 files)
```

### Screenshots
Captured offline via `scripts/shot_wither.mjs`. A warrior (base 20 Agility) takes the curse: **Agility 20 → 2, armor 110 → 74** (−36 = drain × 2).

| In-world (Mirefen Troll target + debuff) | Debuff icon (timer) |
|---|---|
| ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/wither-affix/shots/wither_full.png) | ![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/wither-affix/shots/wither_debuff.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)