### PR TITLE
feat(content): Wyrmcult Necromancers reflect spell damage on hit (Spectral Ward)

### DIFF
--- a/scripts/shot_spell_reflect.mjs
+++ b/scripts/shot_spell_reflect.mjs
@@ -1,0 +1,108 @@
+// Screenshot the Spectral Ward affix (mob spell reflect) in the offline client.
+// Boots the game as a mage, reskins a nearby mob as a Wyrmcult Necromancer,
+// stands it in front, and repeatedly lands spell hits on it so its ward lashes
+// flat shadow damage back at the caster — captured as the floating combat text
+// over the player and the "Spectral Ward hits you" combat-log lines.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Aevera');
+await page.click('#offline-select .mini-class[data-class="mage"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Reskin the nearest mob as the warded necromancer and plant it in front of us.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000; // survive the bout; gm would block the reflect
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'wyrmcult_necromancer';
+  mob.name = 'Wyrmcult Necromancer';
+  mob.level = 19; // match its real Thornpeak spawn level for the label
+  mob.hostile = true;
+  mob.maxHp = 100000; mob.hp = 100000;
+  mob.pos.x = p.pos.x + 6; mob.pos.z = p.pos.z + 6;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input) g.input.camDist = 10;
+  return { mobId: mob.id, ward: sim.constructor && null, name: mob.name };
+});
+console.log('spell-reflect setup:', JSON.stringify(setup));
+
+// Fire a burst of spell hits so the ward reflects repeatedly; capture mid-burst
+// while the floating "-9" combat text is still rising over the player.
+for (let i = 0; i < 10; i++) {
+  await page.evaluate(({ mobId, crit }) => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    const mob = sim.entities.get(mobId);
+    if (mob && !mob.dead) sim.dealDamage(p, mob, 45, crit, 'fire', 'Fireball', 'hit');
+  }, { mobId: setup.mobId, crit: i % 3 === 0 });
+  await new Promise((r) => setTimeout(r, 120));
+}
+
+await new Promise((r) => setTimeout(r, 250));
+await page.screenshot({ path: 'tmp/spell_reflect_full.png' });
+
+// One more burst, then immediately grab the scene to catch fresh FCT, and crop
+// the combat log (persistent) which lists the "Spectral Ward hits you" lines.
+const verdict = await page.evaluate(({ mobId }) => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const mob = sim.entities.get(mobId);
+  const before = p.hp;
+  for (let i = 0; i < 4; i++) sim.dealDamage(p, mob, 45, false, 'frost', 'Frostbolt', 'hit');
+  return { reflectedTotal: before - p.hp, mob: mob.name };
+}, { mobId: setup.mobId });
+console.log('spell-reflect verdict:', JSON.stringify(verdict));
+await new Promise((r) => setTimeout(r, 60));
+await page.screenshot({ path: 'tmp/spell_reflect_fct.png' });
+
+// Crop the combat log (bottom-left) showing the named reflect lines, and read
+// back its text so we can confirm the wording is "Spectral Ward hits you".
+const logBox = await page.evaluate(() => {
+  const el = document.querySelector('#combatlog');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height, text: el.innerText };
+});
+console.log('combat-log text:', logBox && JSON.stringify(logBox.text));
+// Switch to the Combat Log tab so the reflect lines are visible, then crop the
+// known bottom-left region directly (the panel measures 0-width via the DOM).
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 200));
+await page.screenshot({ path: 'tmp/spell_reflect_log.png', clip: { x: 6, y: 600, width: 440, height: 160 } });
+// Player-centred crop to frame the reflected damage text over the caster.
+await page.screenshot({ path: 'tmp/spell_reflect_scene.png', clip: { x: 430, y: 150, width: 740, height: 480 } });
+console.log('crops written');
+
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -174,6 +174,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.3 },
     ],
     manaBurn: { chance: 0.3, amount: 80, name: 'Mana Sear', school: 'shadow' },
+    // Spectral Ward: a shroud of dark wards that lashes back at any caster whose
+    // spell strikes the necromancer — the magic-school twin of melee thorns.
+    spellReflect: { value: 9, name: 'Spectral Ward', school: 'shadow' },
     scale: 1.0, color: 0x533566,
   },
   boneclad_revenant: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3379,9 +3379,25 @@ export class Sim {
       }
     }
 
+    this.reflectSpellWard(source, target, amount, kind, school);
+
     if (target.hp <= 0) {
       this.handleDeath(target, source);
     }
+  }
+
+  /**
+   * Innate "warded" mobs reflect flat damage onto a caster whose SPELL connects
+   * — the magic-school twin of melee thorns (which only punishes melee swings).
+   * Fires for any non-physical hit the mob survives; the reflected blow is
+   * mob-sourced, so it can never re-trigger a reflect (players carry no template).
+   */
+  private reflectSpellWard(source: Entity | null, target: Entity, amount: number, kind: 'hit' | 'miss' | 'dodge', school: string): void {
+    if (!source || source.kind !== 'player' || source.id === target.id) return;
+    if (target.kind !== 'mob' || target.hp <= 0 || kind !== 'hit' || amount <= 0 || school === 'physical') return;
+    const ward = MOBS[target.templateId]?.spellReflect;
+    if (!ward) return;
+    this.dealDamage(target, source, ward.value, false, ward.school ?? 'shadow', ward.name ?? 'Spell Reflection', 'hit', true);
   }
 
   private enterCombat(a: Entity, b: Entity): void {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -268,6 +268,10 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // Innate "warded" trait: casters take flat damage back on every connecting
+  // SPELL hit — the magic-school twin of `thorns` (which only punishes melee).
+  // Reflects on any non-physical damage instance the mob survives.
+  spellReflect?: { value: number; school?: Aura['school']; name?: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_spell_reflect.test.ts
+++ b/tests/mob_spell_reflect.test.ts
@@ -1,0 +1,93 @@
+// Innate "warded" mobs (Wyrmcult Necromancers) reflect flat damage onto any
+// caster whose SPELL connects — the magic-school twin of melee thorns. The
+// reflect lives in dealDamage, the single funnel every damage instance passes
+// through, so driving dealDamage directly exercises the exact production path.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'mage', autoEquip: true });
+}
+
+function spawnMob(sim: Sim, templateId: string, level: number): Entity {
+  const tpl = MOBS[templateId];
+  const id = (sim as any).nextId++;
+  const mob = createMob(id, tpl, level, { x: 1, y: 0, z: 0 });
+  mob.maxHp = 100000; // survive the scripted hits (death wipes state / suppresses the ward)
+  mob.hp = mob.maxHp;
+  sim.entities.set(id, mob);
+  return mob;
+}
+
+// drive the production damage funnel exactly as a landed spell would
+function spellHit(sim: Sim, caster: Entity, target: Entity, amount: number, school = 'fire') {
+  (sim as any).dealDamage(caster, target, amount, false, school, 'Fireball', 'hit');
+}
+
+describe('mob spell reflect (Spectral Ward)', () => {
+  it('reflects flat shadow damage onto a mage whose spell strikes the necromancer', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const necro = spawnMob(sim, 'wyrmcult_necromancer', 19);
+
+    const ward = MOBS['wyrmcult_necromancer'].spellReflect!;
+    const before = player.hp;
+    spellHit(sim, player, necro, 50);
+
+    // the caster eats exactly one ward reflect per connecting spell
+    expect(before - player.hp).toBe(ward.value);
+  });
+
+  it('does not reflect a physical (melee) hit — that is the thorns domain', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const necro = spawnMob(sim, 'wyrmcult_necromancer', 19);
+
+    const before = player.hp;
+    spellHit(sim, player, necro, 50, 'physical');
+
+    expect(player.hp).toBe(before);
+  });
+
+  it('a mob without the ward reflects nothing on a spell hit', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const plain = spawnMob(sim, 'boneclad_revenant', 19);
+    expect(MOBS['boneclad_revenant'].spellReflect).toBeUndefined();
+
+    const before = player.hp;
+    spellHit(sim, player, plain, 50);
+
+    expect(player.hp).toBe(before);
+  });
+
+  it('does not reflect when the killing blow drops the mob (no burst from a corpse)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const necro = spawnMob(sim, 'wyrmcult_necromancer', 19);
+    necro.hp = 5; // the incoming nuke is lethal
+
+    const before = player.hp;
+    spellHit(sim, player, necro, 50);
+
+    expect(necro.hp).toBe(0);
+    expect(player.hp).toBe(before);
+  });
+
+  it('the necromancer template carries a positive-value Spectral Ward', () => {
+    const ward = MOBS['wyrmcult_necromancer'].spellReflect;
+    expect(ward).toBeDefined();
+    expect(ward!.value).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Spectral Ward — mobs that punish casters

`release/v0.8` already ships a mob-side **`thorns`** trait (*Bristled Hide*): innate spiked mobs lash flat damage back at anyone who **melees** them. There was no magic-school equivalent — casters could always nuke a mob for free.

This adds **`spellReflect`**, the spell-side twin of `thorns`. A *warded* mob reflects a flat amount of its own school back at any caster whose **spell** connects.

**Wyrmcult Necromancer** (Thornpeak Heights, lvl 18–19) gains **Spectral Ward** — 9 shadow damage per spell hit — pairing naturally with its existing *Mana Sear* (mana burn). Melee it freely; nuke it and the dark wards bite back.

### Implementation
- **`types.ts`** — new `MobTemplate.spellReflect { value, school?, name? }`, mirroring `thorns`.
- **`sim.ts`** — `reflectSpellWard()` hooked at the tail of `dealDamage` (the single funnel every damage instance passes through). It fires only for a **player-sourced, non-physical** hit the **mob survives**. The reflected blow is *mob-sourced*, so by the `source.kind === 'player'` gate it can never re-trigger a reflect — recursion is structurally impossible, no flags needed.
- **`zone3.ts`** — Wyrmcult Necromancer wired with `Spectral Ward`.

### Notes
- **Determinism-neutral** — no new spawn/camp and no `Rng` draw, so the fixed-seed suite is byte-identical. Full suite **1397 green**, `tsc --noEmit` clean.
- **No new player-facing strings** — reflected damage renders as ordinary floating combat text / combat-log lines, exactly like melee thorns. Nothing for the localization guards to register.
- `tests/mob_spell_reflect.test.ts` mirrors `mob_thorns.test.ts`: reflects on a spell hit, ignores physical hits (thorns' domain), no-ops on an unwarded mob, and does **not** burst from a corpse when the spell lands the killing blow.

### Screenshots
A mage trades fire with the warded necromancer:

![Mage casting at the Wyrmcult Necromancer](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/spell-reflect/shots/spell_reflect_scene.png)

Every spell that lands draws a retaliatory shadow bite — *"Wyrmcult Necromancer hits you for 9"* after each cast:

![Combat log showing the Spectral Ward reflect](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/spell-reflect/shots/spell_reflect_log.png)
