### PR TITLE
feat(content): Gravecaller Menders tax the victim's reserves on hit (Draining Litany)

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -195,6 +195,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     // wounds shut on a slow cadence. Pull it away from the camp — or drop it
     // first — or the fight never ends.
     mendAlly: { healMin: 26, healMax: 38, radius: 14, every: 6, name: 'Grave Mending', school: 'shadow' },
+    // Draining Litany: the mender siphons the victim's vigour to fuel its grave
+    // prayers, inflating every ability the victim uses by 40% for 8s on a hit.
+    costTax: { chance: 0.3, pct: 0.4, duration: 8, name: 'Draining Litany', school: 'shadow' },
     loot: [
       { copper: 58, chance: 1 },
       { itemId: 'cult_cipher', chance: 0.4, questId: 'q_summoners' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'cost_tax',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'cost_tax',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -1213,7 +1213,23 @@ export class Sim {
   resolvedAbility(abilityId: string, pid?: number): ResolvedAbility | null {
     const r = this.resolve(pid);
     if (!r) return null;
-    return r.meta.known.find((k) => k.def.id === abilityId) ?? null;
+    const found = r.meta.known.find((k) => k.def.id === abilityId) ?? null;
+    if (!found) return null;
+    // A "draining curse" (cost_tax aura) inflates the resource cost of every
+    // ability the victim uses. Resolve it here, the single choke point all cost
+    // checks/spends read, so the affordability check and the spend stay in
+    // lockstep. Return a shallow copy so the cached known-list entry is never
+    // mutated.
+    const tax = this.costTaxMult(r.e);
+    if (tax > 1 && found.cost > 0) return { ...found, cost: Math.ceil(found.cost * tax) };
+    return found;
+  }
+
+  // Highest active cost_tax aura, expressed as a cost multiplier (1 = no tax).
+  private costTaxMult(e: Entity): number {
+    let pct = 0;
+    for (const a of e.auras) if (a.kind === 'cost_tax' && a.value > pct) pct = a.value;
+    return 1 + pct;
   }
 
   // -------------------------------------------------------------------------
@@ -4167,6 +4183,17 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // draining curse: a landed hit can leave a cost-tax debuff that inflates the
+    // victim's ability costs. Guarded on hostile + alive so a friendly pet (the
+    // other mobSwing caller) never debuffs the party.
+    const costTax = MOBS[mob.templateId]?.costTax;
+    if (costTax && mob.hostile && !target.dead && this.rng.chance(costTax.chance)) {
+      this.applyAura(target, {
+        id: `cost_tax_${mob.templateId}`, name: costTax.name, kind: 'cost_tax',
+        remaining: costTax.duration, duration: costTax.duration, value: costTax.pct,
+        sourceId: mob.id, school: (costTax.school ?? 'shadow') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,8 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence'
+  | 'cost_tax';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +257,10 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit "draining curse": a landed swing has `chance` to inflate every
+  // ability the victim uses by `pct` (e.g. 0.4 = +40% resource cost) for
+  // `duration` seconds — taxes mana/rage/energy alike, not a stat drain.
+  costTax?: { chance: number; pct: number; duration: number; name: string; school?: string };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'cost_tax'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1094,6 +1094,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_imbue: r('holy', 'holyGold', ['sword', { p: 'sunburst', ...TL }]),
   aura_buff_allstats: r('arcane', 'arcanePink', ['gem']),
   aura_thorns: r('nature', 'leafGreen', ['leaf', { p: 'claw_slash', ...BR }]),
+  aura_cost_tax: r('shadow', 'shadowPurple', ['gem', { p: 'droplet', ...BR }], ['drips']),
   aura_form_bear: r('earth', 'earthBrown', ['paw']),
 };
 

--- a/tests/mob_cost_tax.test.ts
+++ b/tests/mob_cost_tax.test.ts
@@ -1,0 +1,88 @@
+// The Gravecaller Mender's "Draining Litany" is a cost-tax curse: a landed hit
+// can leave the victim's abilities more expensive (mana/rage/energy alike) for a
+// few seconds. Unlike a silence (full lockout) or a stat drain, it inflates the
+// resolved resource cost — resolved at the single resolvedAbility() choke point,
+// so the affordability check and the actual spend always agree.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Mender adjacent to the player, engaged and ready to swing.
+function spawnMender(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_mender'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (the cost-tax chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+const taxAura = (sourceId: number, pct = 0.4) => ({
+  id: 'cost_tax_gravecaller_mender', name: 'Draining Litany', kind: 'cost_tax' as const,
+  remaining: 8, duration: 8, value: pct, sourceId, school: 'shadow' as const,
+});
+
+describe('mob cost-tax ("Draining Litany")', () => {
+  it('seeds the cost-tax mechanic on the Gravecaller Mender', () => {
+    expect(MOBS['gravecaller_mender'].costTax).toEqual({
+      chance: 0.3, pct: 0.4, duration: 8, name: 'Draining Litany', school: 'shadow',
+    });
+  });
+
+  it('applies a cost_tax aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnMender(sim, p);
+    MOBS['gravecaller_mender'].costTax!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_mender'].costTax!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'cost_tax');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Draining Litany');
+    expect(aura!.remaining).toBe(8);
+    expect(aura!.value).toBe(0.4);
+  });
+
+  it('inflates the resolved resource cost of an ability while taxed', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const base = sim.resolvedAbility('fireball', p.id)!.cost;
+    expect(base).toBeGreaterThan(0);
+    p.auras.push(taxAura(999));
+    expect(sim.resolvedAbility('fireball', p.id)!.cost).toBe(Math.ceil(base * 1.4));
+  });
+
+  it('takes the strongest tax when more than one is active and leaves cost intact with none', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const base = sim.resolvedAbility('fireball', p.id)!.cost;
+    expect(sim.resolvedAbility('fireball', p.id)!.cost).toBe(base); // no aura → untouched
+    p.auras.push(taxAura(999, 0.2));
+    p.auras.push(taxAura(998, 0.5));
+    expect(sim.resolvedAbility('fireball', p.id)!.cost).toBe(Math.ceil(base * 1.5));
+  });
+
+  it('a friendly pet swing never taxes its target', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnMender(sim, p);
+    pet.hostile = false; // a tamed/friendly mender shape
+    pet.ownerId = p.id;
+    MOBS['gravecaller_mender'].costTax!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['gravecaller_mender'].costTax!.chance = 0.3;
+    expect(p.auras.some((a) => a.kind === 'cost_tax')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

The **Gravecaller Mender** already keeps its cultist pack alive with Grave Mending. Now its grave-prayers siphon the victim's vigour to fuel that healing: a landed hit has a **30% chance** to apply **Draining Litany** for **8s**, inflating the **resource cost of every ability the victim uses by 40%** — mana, rage and energy alike.

This is a genuinely new affix seam, distinct from every existing one:

| Affix | What it taxes |
|---|---|
| silence | locks out spells entirely |
| mortal_wound | healing *received* |
| demoralize (`debuff_ap`) | attack power |
| sunder / corrode | armor |
| **cost_tax (new)** | **ability resource cost** |

## How

- New `cost_tax` aura kind, resolved at the **single `resolvedAbility()` choke point** that all cost checks and spends read — so the affordability check and the actual spend always agree (no "cast then clamp to 0" inconsistency).
- `costTaxMult(e)` reads the strongest active tax; `resolvedAbility` returns a shallow copy with `cost: ceil(base * mult)` so the cached known-list entry is never mutated.
- Applied in `mobSwing`'s on-hit block, guarded on `hostile` + alive so a friendly pet (the other `mobSwing` caller) never debuffs the party.
- Added to the harmful-aura sets, the HUD debuff classifier, and a procedural `aura_cost_tax` icon.

## Determinism & i18n

- **Determinism-neutral**: no new spawn or camp, so no construction RNG draws shift — every fixed-seed roll is byte-identical.
- The debuff name ships raw like the other on-hit affix names; no new localized entities.

## Tests

`tests/mob_cost_tax.test.ts` (mirrors `mob_silence.test.ts`): seeds the template, applies the aura on a forced hit, asserts the resolved Fireball cost inflates to `ceil(base * 1.4)`, takes the strongest of stacked taxes, and confirms a friendly pet never taxes. **Full suite green: 1397 passed; `tsc --noEmit` clean.**

## Screenshots

A mage takes a Mender's hit — Fireball's resolved mana cost jumps **30 → 42** (+40%) and the red-bordered Draining Litany debuff appears on the unit frame:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/draining-litany/shots/draining_litany_scene.png)

![debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/draining-litany/shots/draining_litany_icon.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)