### PR TITLE
feat(content): Gravecaller Summoners blight the wound, devouring incoming healing (Grave Blight)

### DIFF
--- a/scripts/shot_heal_absorb.mjs
+++ b/scripts/shot_heal_absorb.mjs
@@ -1,0 +1,95 @@
+// Screenshot the Heal-Absorb affix (Grave Blight) in the offline client.
+// Boots the game, repurposes a nearby mob as a Gravecaller Summoner, forces
+// its on-hit blight onto the player, and captures the resulting heal-absorb
+// debuff on the player buff bar — plus a console proof that a follow-up heal
+// is devoured by the shield.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm keeps the player alive through the live 20Hz loop without maxHp being
+  // wiped by recalcPlayerStats; applyAura/applyHeal still resolve normally.
+  p.gm = true;
+  p.maxHp = 100000; p.hp = 60000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Gravecaller Summoner and stand it next to us.
+  mob.templateId = 'gravecaller_summoner';
+  mob.name = 'Gravecaller Summoner';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the blight to land, then prove a heal is devoured by the shield.
+  sim.entities; // touch
+  const MOBS = mob; // not used; the affix reads its own template
+  for (let i = 0; i < 10; i++) sim.mobSwing(mob, p);
+  const blight = p.auras.find((a) => a.kind === 'heal_absorb');
+  const before = blight?.value;
+  const hpBefore = p.hp;
+  sim.applyHeal(p, p, 80, 'Test Heal');
+  const after = (p.auras.find((a) => a.kind === 'heal_absorb') || {}).value;
+  const hpAfter = p.hp;
+  return {
+    hasBlight: !!blight, name: blight?.name, shieldBefore: before, shieldAfter: after,
+    healedHp: hpAfter - hpBefore, remaining: blight?.remaining,
+  };
+});
+console.log('heal_absorb result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/heal_absorb_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/heal_absorb_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+console.log('saved tmp/heal_absorb_scene.png, heal_absorb_debuff.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -181,6 +181,11 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     // Low dread proc so this mob doesn't routinely stack two panic effects
     // (silence + fear) on one victim — keeps the encounter from feeling like a lockout.
     dread: { chance: 0.12, duration: 4, name: 'Wail of the Grave', school: 'shadow' },
+    // Grave Blight: a landed hit can sear undeath into the wound, devouring the
+    // next 120 healing the victim receives before it fades. A sustain-denial axis
+    // that complements (not compounds) the summoner's silence/fear lockout —
+    // healers must out-pace the blight or top off after it lapses.
+    healAbsorb: { chance: 0.25, amount: 120, duration: 10, name: 'Grave Blight', school: 'shadow' },
     loot: [
       { copper: 60, chance: 1 },
       { itemId: 'cult_cipher', chance: 0.6, questId: 'q_summoners' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2103,10 +2103,31 @@ export class Sim {
     return mult < 0 ? 0 : mult;
   }
 
+  // Consume the victim's Heal-Absorb shields (classic necrotic blight): each such
+  // aura holds a remaining budget of healing it devours. Drains `healed` against
+  // every active shield, decrementing their stored budget and dropping any that
+  // run dry. Returns the healing that survives (>= 0). A no-op when none are set.
+  private consumeHealAbsorb(target: Entity, healed: number): number {
+    if (healed <= 0) return healed;
+    let remaining = healed;
+    let depleted = false;
+    for (const a of target.auras) {
+      if (a.kind !== 'heal_absorb' || a.value <= 0) continue;
+      const eaten = Math.min(remaining, a.value);
+      a.value -= eaten;
+      remaining -= eaten;
+      if (a.value <= 0) depleted = true;
+      if (remaining <= 0) break;
+    }
+    if (depleted) target.auras = target.auras.filter((a) => !(a.kind === 'heal_absorb' && a.value <= 0));
+    return remaining;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
     let healed = Math.round(amount * (crit ? 1.5 : 1) * this.healingTakenMult(target));
+    healed = this.consumeHealAbsorb(target, healed);
     healed = Math.min(healed, target.maxHp - target.hp);
     target.hp += healed;
     this.emit({ type: 'heal2', sourceId: source.id, targetId: target.id, amount: healed, crit, ability });
@@ -4190,6 +4211,24 @@ export class Sim {
         value: ms.healReduction,
         sourceId: mob.id,
         school: (ms.school as Aura['school']) ?? 'physical',
+      });
+    }
+    // Heal-Absorb: a landed hit can brand the victim with a necrotic blight that
+    // devours the next chunk of incoming healing. The sibling of Mortal Strike —
+    // where Mortal Strike scales every heal down, this eats a fixed pool then
+    // fades. Guarded on `hostile` so a friendly pet (mobSwing's other caller)
+    // never blights an ally.
+    const ha = MOBS[mob.templateId]?.healAbsorb;
+    if (ha && mob.hostile && !target.dead && this.rng.chance(ha.chance)) {
+      this.applyAura(target, {
+        id: `heal_absorb_${mob.templateId}`,
+        name: ha.name,
+        kind: 'heal_absorb',
+        remaining: ha.duration,
+        duration: ha.duration,
+        value: ha.amount,
+        sourceId: mob.id,
+        school: (ha.school as Aura['school']) ?? 'shadow',
       });
     }
     // Ensnare: a landed hit may web the victim in place (root). Hostile mobs only

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'heal_absorb';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -213,6 +213,11 @@ export interface MobTemplate {
   // Melee mechanic: a landed swing has `chance` to inflict a Mortal Wound debuff
   // that reduces all healing the victim receives by `healReduction` for `duration`.
   mortalStrike?: { chance: number; healReduction: number; duration: number; name: string; school?: string };
+  // Heal-absorb mechanic: a landed swing has `chance` to brand the victim with a
+  // necrotic blight that devours the next `amount` points of incoming healing
+  // (a consumable shield, not a percentage) before fading after `duration`.
+  // Distinct from mortalStrike, which scales every heal down for its whole life.
+  healAbsorb?: { chance: number; amount: number; duration: number; name: string; school?: string };
   // On-hit lifesteal: a landed melee swing heals the mob for `healFrac` of the
   // damage it just dealt (drowned undead, leeches, vampiric beasts). Unlike the
   // other on-hit affixes it sustains the attacker instead of debuffing the

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'heal_absorb'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1094,6 +1094,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_imbue: r('holy', 'holyGold', ['sword', { p: 'sunburst', ...TL }]),
   aura_buff_allstats: r('arcane', 'arcanePink', ['gem']),
   aura_thorns: r('nature', 'leafGreen', ['leaf', { p: 'claw_slash', ...BR }]),
+  aura_heal_absorb: r('shadow', 'shadowPurple', ['heart'], ['drips']),
   aura_form_bear: r('earth', 'earthBrown', ['paw']),
 };
 

--- a/tests/mob_heal_absorb.test.ts
+++ b/tests/mob_heal_absorb.test.ts
@@ -1,0 +1,82 @@
+// Necrotic mobs (e.g. the Gravecaller Summoner's "Grave Blight") can brand a
+// victim on a melee hit with a heal-absorb shield: the next chunk of incoming
+// healing is devoured before any of it lands. This is the sibling of Mortal
+// Strike — where Mortal Strike scales every heal down for its whole duration,
+// Grave Blight eats a FIXED pool of healing once, then fades.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Summoner adjacent to the player, engaged and ready to swing.
+function spawnSummoner(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_summoner'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob heal-absorb ("Grave Blight")', () => {
+  it('seeds the heal-absorb mechanic on the Gravecaller Summoner', () => {
+    expect(MOBS['gravecaller_summoner'].healAbsorb).toEqual({
+      chance: 0.25, amount: 120, duration: 10, name: 'Grave Blight', school: 'shadow',
+    });
+  });
+
+  it('applies a heal_absorb aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnSummoner(sim, p);
+    MOBS['gravecaller_summoner'].healAbsorb!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_summoner'].healAbsorb!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'heal_absorb');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Grave Blight');
+    expect(aura!.value).toBe(120);
+    expect(aura!.remaining).toBe(10);
+  });
+
+  it('devours healing up to its budget, then leaves the rest, depleting the shield', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.auras.push({
+      id: 'heal_absorb_test', name: 'Grave Blight', kind: 'heal_absorb',
+      remaining: 10, duration: 10, value: 120, sourceId: 999, school: 'shadow',
+    });
+    // A 50-point heal is fully eaten; the shield drains to 70 and remains.
+    expect((sim as any).consumeHealAbsorb(p, 50)).toBe(0);
+    expect(p.auras.find((a) => a.kind === 'heal_absorb')!.value).toBe(70);
+    // A 200-point heal eats the remaining 70 and 130 survives; the shield drops.
+    expect((sim as any).consumeHealAbsorb(p, 200)).toBe(130);
+    expect(p.auras.some((a) => a.kind === 'heal_absorb')).toBe(false);
+  });
+
+  it('blocks real healing while a shield is active, then heals normally after it lapses', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 1000; p.hp = 500;
+    // A shield larger than any heal (crit included) absorbs the whole heal.
+    p.auras.push({
+      id: 'heal_absorb_test', name: 'Grave Blight', kind: 'heal_absorb',
+      remaining: 10, duration: 10, value: 100000, sourceId: 999, school: 'shadow',
+    });
+    (sim as any).applyHeal(p, p, 200, 'Test Heal');
+    expect(p.hp).toBe(500); // fully absorbed
+    // Drop the shield and the same heal now lands (>= base, crit may add more).
+    p.auras = p.auras.filter((a) => a.kind !== 'heal_absorb');
+    (sim as any).applyHeal(p, p, 200, 'Test Heal');
+    expect(p.hp).toBeGreaterThanOrEqual(700);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **`healAbsorb`** on-hit affix — the *consumable* sibling of Mortal Strike — and attaches it to the **Gravecaller Summoner** (Mirefen Marsh, lvl 11-12) as **Grave Blight**.

Where Mortal Strike (`mortal_wound`) scales **every** heal the victim receives down by a percentage for its whole duration, **Grave Blight** brands the victim with a necrotic heal-absorb shield that **devours a fixed pool** of the next incoming healing, then fades. Same anti-healing theme, a genuinely different mechanic: a depleting budget rather than a multiplier.

- **`25%` chance / `120` healing absorbed / `10s`** — a sustain-denial axis that *complements* the summoner's existing silence + fear lockout instead of compounding the panic.

## How

- **`types.ts`** — new `healAbsorb` `MobTemplate` field + `heal_absorb` `AuraKind`.
- **`sim.ts`** — `consumeHealAbsorb()` drains the active shield(s) inside the single `applyHeal` funnel (decrementing each shield's stored budget, dropping any that run dry); the on-hit roll lives beside Mortal Strike in `mobSwing`, `hostile`-guarded so a friendly pet never blights an ally.
- **`hud.ts` / `icons.ts`** — classified as a debuff in the HUD aura strip, with a new `aura_heal_absorb` icon (a corrupted heart).
- **`content/zone2.ts`** — attached to `gravecaller_summoner`.

## Invariants

- **Determinism-neutral** — no new spawns/camps, so the shared construction RNG cursor is unchanged and no fixed-seed test shifts.
- **Zero new player strings / i18n** — the debuff name ships raw, exactly like every other on-hit affix (`Silencing Shriek`, `Mortal Wound`, …); the i18n guards stay green.

## Tests

New `tests/mob_heal_absorb.test.ts` (seed, on-hit application, shield depletion math, and end-to-end heal suppression via `applyHeal`). **Full suite 1396 passing, `tsc --noEmit` clean.**

## Screenshots

The Grave Blight debuff on the player buff bar (left icon, ticking 9s), and the scene with the reskinned Gravecaller Summoner targeted:

![Grave Blight debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/heal-absorb/shots/heal_absorb_debuff.png)

![Scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/heal-absorb/shots/heal_absorb_scene.png)

Console proof from `scripts/shot_heal_absorb.mjs`: with the shield at `120`, an 80-point heal lands for `0` HP and drains the shield to `40`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)