### PR TITLE
feat(content): Deeprock Tunnelers knock the victim off-balance on hit (Jarring Swing)

### DIFF
--- a/scripts/shot_stagger.mjs
+++ b/scripts/shot_stagger.mjs
@@ -1,0 +1,87 @@
+// Screenshot the Stagger affix (Off-Balance) in the offline client.
+// Boots the game, repurposes a nearby mob as a Deeprock Tunneler, forces its
+// on-hit Jarring Swing onto the player, and captures the resulting dodge-cut
+// debuff on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Deeprock Tunneler and drive its stagger onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // invulnerable through the live tick; applyAura still fires
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the staggering kobold and stand it next to us.
+  mob.templateId = 'deeprock_kobold';
+  mob.name = 'Deeprock Tunneler';
+  mob.level = 15;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const dodgeBefore = p.dodgeChance;
+  // Force a landed hit + a proc so the debuff appears for the capture.
+  sim.rng.next = () => 0.99;
+  sim.rng.chance = () => true;
+  sim.mobSwing(mob, p);
+  const dodgeAfter = p.dodgeChance;
+  const aura = p.auras.find((a) => a.name === 'Off-Balance');
+  return { dodgeBefore, dodgeAfter, hasAura: !!aura, value: aura?.value, remaining: aura?.remaining };
+});
+console.log('stagger result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/stagger_full.png' });
+
+// Crop tightly around the buff/debuff bar where Off-Balance shows.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/stagger_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/stagger_full.png, stagger_debuff.png');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -65,6 +65,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'tallow_candle', chance: 0.4 },
     ],
     scale: 0.85, color: 0x9c7a3c,
+    // Jarring Swing: a heavy mining-pick blow knocks the victim off-balance,
+    // cutting their dodge for 8s so the tunneler's strikes land more reliably.
+    staggerHit: { chance: 0.3, dodgeReduction: 0.05, duration: 8, name: 'Off-Balance' },
   },
   ironvein_foreman: {
     id: 'ironvein_foreman', name: 'Ironvein Foreman', minLevel: 16, maxLevel: 16, family: 'kobold', rare: true,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -132,7 +132,8 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
   e.rangedPower = cls === 'hunter' ? Math.round((s.agi * 2 + bonusAp) * (1 + (mods?.stats.apPct ?? 0))) : 0;
   // Crit: ~1% per 20 agi at low level
   e.critChance = 0.05 + s.agi * 0.0005 + (mods?.stats.crit ?? 0);
-  e.dodgeChance = 0.05 + s.agi * 0.0005 + bonusDodge;
+  // Floored at 0: an off-balance debuff (negative buff_dodge) can drive dodge to nothing.
+  e.dodgeChance = Math.max(0, 0.05 + s.agi * 0.0005 + bonusDodge);
 
   const hpFrac = e.maxHp > 0 ? e.hp / e.maxHp : 1;
   e.maxHp = def.baseHp + def.hpPerLevel * (lvl - 1) + hpFromStamina(s.sta);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4192,6 +4192,25 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+    // Staggering blow: a landed hit may knock the victim off-balance, cutting their
+    // dodge for a short while so attacks land more reliably. Hostile mobs only (a
+    // friendly pet shares this swing path) and only players have a meaningful dodge
+    // chance. Rides buff_dodge with a NEGATIVE value — recalcPlayerStats already
+    // folds buff_dodge into e.dodgeChance and it recalcs on expiry (buff* kind), so
+    // no new aura kind is needed.
+    const stagger = MOBS[mob.templateId]?.staggerHit;
+    if (stagger && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(stagger.chance)) {
+      this.applyAura(target, {
+        id: `stagger_${mob.templateId}`,
+        name: stagger.name,
+        kind: 'buff_dodge',
+        remaining: stagger.duration,
+        duration: stagger.duration,
+        value: -stagger.dodgeReduction,
+        sourceId: mob.id,
+        school: 'physical',
+      });
+    }
     // Ensnare: a landed hit may web the victim in place (root). Hostile mobs only
     // (a friendly pet shares this swing path) and only roots players — `applyRootAura`
     // applies crowd-control DR so repeated webs from the same mob shrink and break.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -223,6 +223,11 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // Melee mechanic: a landed swing has `chance` to knock the victim off-balance,
+  // cutting their dodge chance by `dodgeReduction` (a flat fraction, e.g. 0.05)
+  // for `duration` seconds — so the attacker (and everyone else) lands more hits.
+  // Rides the existing buff_dodge aura with a NEGATIVE value; no new aura kind.
+  staggerHit?: { chance: number; dodgeReduction: number; duration: number; name: string };
   // On-hit web mechanic: a landed melee swing has `chance` to ensnare the struck
   // player in place — a `root` aura for `duration`s (naga/spider snares). Rides the
   // existing root aura + crowd-control DR; no new aura kind. Players only; rooting a

--- a/tests/mob_stagger.test.ts
+++ b/tests/mob_stagger.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+
+// Staggering mobs knock a player victim off-balance on a landed hit, cutting
+// their dodge chance for the duration so the attacker (and its pack) land more
+// of their swings. It rides the existing buff_dodge aura with a NEGATIVE value,
+// so recalcPlayerStats folds it straight into the victim's dodgeChance.
+describe('mob stagger-on-hit', () => {
+  it('the Deeprock Tunneler template carries a Jarring Swing proc', () => {
+    expect(MOBS.deeprock_kobold.staggerHit).toMatchObject({
+      chance: 0.3, dodgeReduction: 0.05, duration: 8, name: 'Off-Balance',
+    });
+  });
+
+  it('a landed swing cuts the victim dodge via a negative buff_dodge aura', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Staggered');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+    victim.gm = true; // invulnerable for the test; applyAura still fires
+
+    const baseDodge = victim.dodgeChance;
+    expect(baseDodge).toBeGreaterThan(0.05);
+
+    const kobold = createMob((sim as any).nextId++, MOBS.deeprock_kobold, 15, { x: 0, y: 0, z: 0 });
+    kobold.hostile = true;
+    kobold.hp = kobold.maxHp;
+    (sim as any).addEntity(kobold);
+
+    // Force a landed hit (high roll clears miss+dodge) and a proc, so the test
+    // asserts the mechanic, not the RNG.
+    (sim as any).rng.next = () => 0.99;
+    (sim as any).rng.chance = () => true;
+    (sim as any).mobSwing(kobold, victim);
+
+    const aura = victim.auras.find((a) => a.name === 'Off-Balance');
+    expect(aura).toBeTruthy();
+    expect(aura!.kind).toBe('buff_dodge');
+    expect(aura!.value).toBe(-0.05);
+    expect(aura!.duration).toBe(8);
+    // recalcPlayerStats already folded the negative buff_dodge into dodgeChance.
+    expect(victim.dodgeChance).toBeCloseTo(Math.max(0, baseDodge - 0.05), 6);
+  });
+
+  it('re-applies (refreshes) rather than stacking on repeated hits', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Hounded');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+    victim.gm = true; // invulnerable for the test; applyAura still fires
+
+    const kobold = createMob((sim as any).nextId++, MOBS.deeprock_kobold, 15, { x: 0, y: 0, z: 0 });
+    kobold.hostile = true;
+    kobold.hp = kobold.maxHp;
+    (sim as any).addEntity(kobold);
+
+    (sim as any).rng.next = () => 0.99;
+    (sim as any).rng.chance = () => true;
+    for (let i = 0; i < 10; i++) (sim as any).mobSwing(kobold, victim);
+
+    const staggers = victim.auras.filter((a) => a.name === 'Off-Balance');
+    expect(staggers.length).toBe(1);
+    expect(staggers[0].value).toBe(-0.05);
+  });
+
+  it('the dodge floor keeps dodgeChance from going negative', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Floored');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+
+    // A reduction larger than the victim's whole dodge clamps to exactly 0.
+    (sim as any).applyAura(victim, {
+      id: 'stagger_test', name: 'Off-Balance', kind: 'buff_dodge',
+      remaining: 8, duration: 8, value: -1, sourceId: victim.id, school: 'physical',
+    });
+    expect(victim.dodgeChance).toBe(0);
+  });
+
+  it('an ordinary mob with no staggerHit field never applies the debuff', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Safe');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+    victim.gm = true; // invulnerable for the test; applyAura still fires
+
+    const wolf = createMob((sim as any).nextId++, MOBS.forest_wolf, 2, { x: 0, y: 0, z: 0 });
+    wolf.hostile = true;
+    wolf.hp = wolf.maxHp;
+    (sim as any).addEntity(wolf);
+
+    // Even with every swing landing and every proc roll true, a mob without the
+    // staggerHit field can never inflict Off-Balance.
+    (sim as any).rng.next = () => 0.99;
+    (sim as any).rng.chance = () => true;
+    for (let i = 0; i < 50; i++) (sim as any).mobSwing(wolf, victim);
+    expect(victim.auras.some((a) => a.name === 'Off-Balance')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **`staggerHit`** on-hit melee affix and gives it to the **Deeprock Tunneler** (zone 3, Thornpeak Heights kobold, lvl 14-15). A landed swing has a 30% chance to land a **Jarring Swing**, knocking the victim off-balance and cutting their **dodge by 5%** for 8s — so the tunneler (and its pack) land more of their strikes while you recover.

## Why this niche

The existing affixes *amplify* damage (`expose`/`spellvuln`) or change the *attacker's own* hit chance (`blind`), but nothing touched the victim's **avoidance**. `staggerHit` fills that defensive-avoidance gap: `blind` reduces your hit chance on offense, `staggerHit` reduces your dodge on defense.

## Implementation (minimal, reuses existing seams)

- It rides the existing **`buff_dodge`** aura with a **negative value** — `recalcPlayerStats` already folds `buff_dodge` into `e.dodgeChance`, already recalcs it on expiry (`buff*` kinds), and the HUD already renders a negative `buff_*` as a red debuff. **No new `AuraKind`, no UI change.**
- `dodgeChance` is now floored at `0` so a large reduction can't drive avoidance negative.
- Applied in the single `mobSwing` on-hit block, guarded on `hostile` + player target (a friendly pet sharing that path never debuffs the party).
- **Determinism-neutral**: no new spawns/camps/RNG draws at sim construction, so every other content's rolls are byte-identical.
- **Zero i18n**: the debuff name ships raw as the aura name, exactly like the other on-hit-affix debuffs.

## Tests

New `tests/mob_stagger.test.ts` (template carries the proc; a landed swing cuts dodge via a negative `buff_dodge`; refresh-not-stack; the dodge floor clamps at 0; an ordinary mob never applies it). Full suite **1397 passing**, `tsc --noEmit` clean.

## Screenshots

Captured offline via `scripts/shot_stagger.mjs` (dodge 0.06 → 0.01 on the proc):

| Off-Balance debuff | In world |
|---|---|
| ![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stagger-affix/shots/stagger_debuff.png) | ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stagger-affix/shots/stagger_full.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)