### PR TITLE
fix: keep space as gameplay input

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -358,6 +358,7 @@ export class Input {
     if (e.code === 'Escape') { this.cb.onUiKey('escape'); return; }
     if (this.cb.canUseGameKeys && !this.cb.canUseGameKeys()) return;
     if (e.code === 'Tab') e.preventDefault();
+    if (e.code === 'Space') e.preventDefault?.();
     const action = this.keybinds.actionForCode(e.code);
     if (action === null) return;
     if (actionKind(action) === 'held') {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1085,8 +1085,7 @@ export class Hud {
   private focusFirstInteractive(root: HTMLElement, preferredSelector?: string): void {
     window.setTimeout(() => {
       const target = (preferredSelector ? root.querySelector<HTMLElement>(preferredSelector) : null)
-        ?? root.querySelector<HTMLElement>('button:not([disabled]):not([data-close]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])')
-        ?? root.querySelector<HTMLElement>('button:not([disabled])');
+        ?? root.querySelector<HTMLElement>('button:not([disabled]):not([data-close]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])');
       (target ?? root).focus();
     }, 0);
   }
@@ -4642,7 +4641,7 @@ export class Hud {
   toggleQuestLog(): void {
     const el = $('#quest-log-window');
     if (el.style.display === 'block') { this.closeQuestLog(); return; }
-    this.questLogReturnFocus = this.currentFocusableElement() ?? $('#mm-quest');
+    this.questLogReturnFocus = this.currentFocusableElement();
     this.closeOtherWindows('#quest-log-window');
     this.renderQuestLog();
     el.style.display = 'block';
@@ -4651,9 +4650,9 @@ export class Hud {
   private closeQuestLog(restoreFocus = true): void {
     $('#quest-log-window').style.display = 'none';
     this.hideTooltip();
-    const target = this.questLogReturnFocus ?? $('#mm-quest');
+    const target = this.questLogReturnFocus;
     this.questLogReturnFocus = null;
-    if (restoreFocus) this.restoreFocus(target, $('#mm-quest'));
+    if (restoreFocus) this.restoreFocus(target);
   }
 
   renderQuestLog(): void {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -362,6 +362,19 @@ describe('Input Escape handling', () => {
   });
 });
 
+describe('Input Space handling', () => {
+  it('prevents native Space button activation while preserving jump input', () => {
+    const { input, windowListeners } = makeInput();
+    (globalThis as any).document.activeElement = { tagName: 'BUTTON' };
+    const preventDefault = vi.fn();
+
+    windowListeners.get('keydown')!({ code: 'Space', repeat: false, preventDefault });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(input.readMoveInput().jump).toBe(true);
+  });
+});
+
 describe('Input movement is not cancelled by a camera drag', () => {
   // Discord regression: walking with W (or any held key) then right/left-drag to
   // look around and releasing the button stopped movement, because exiting


### PR DESCRIPTION
## Summary

- Prevent Space from triggering native focused-button activation while game keys are active, preserving Space as jump/gameplay input.
- Stop Quest Log keybind close from restoring focus to the `#mm-quest` launcher button.
- Avoid auto-focusing close buttons as the first interactive element in empty panels.

## Root Cause

After opening and closing Quest Log with `L`, focus could be restored to the Quest Log micro-menu button. Browsers activate focused buttons when Space is pressed, so the jump key could reopen the menu.

## Validation

- `npx vitest run tests/input.test.ts`
- `npm run build`
- Browser verified: `L -> L -> Space` keeps Quest Log closed and Space remains gameplay input.