### PR TITLE
feat(content): Restless Bones fester a necrotic Soulrot on hit (shadow DoT)

### DIFF
--- a/scripts/shot_soulrot.mjs
+++ b/scripts/shot_soulrot.mjs
@@ -1,0 +1,89 @@
+// Screenshot the Soulrot affix (necrotic shadow DoT) in the offline client.
+// Boots the game, repurposes a nearby mob as Restless Bones, forces its
+// on-hit rot onto the player, and captures the resulting shadow DoT debuff
+// (and a ticking shadow damage number) on the player.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Restless Bones and drive its rot onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override is wiped by recalc).
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'restless_bones';
+  mob.name = 'Restless Bones';
+  mob.level = 6;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the on-hit proc deterministically, then swing until the rot festers.
+  const origChance = sim.rng.chance;
+  sim.rng.chance = () => true;
+  let rot = null;
+  for (let i = 0; i < 30 && !rot; i++) {
+    sim.mobSwing(mob, p);
+    rot = p.auras.find((a) => a.name === 'Soulrot');
+  }
+  sim.rng.chance = origChance;
+  return { hasRot: !!rot, value: rot?.value, school: rot?.school, remaining: rot?.remaining };
+});
+console.log('soulrot result:', JSON.stringify(result));
+
+// Let the DoT tick a couple of times so a shadow damage number floats up.
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/soulrot_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/soulrot_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+console.log('saved tmp/soulrot_scene.png, soulrot_debuff.png');
+await browser.close();

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -217,6 +217,8 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     scale: 1.0, color: 0xd5dbdb,
     // A grave-cold wail saps the strength from the living it strikes.
     demoralize: { ap: 20, duration: 8, name: 'Withering Wail' },
+    // Grave-touch: a clawing swing may fester a creeping necrotic rot (shadow DoT).
+    soulrot: { chance: 0.25, perTick: 4, interval: 3, duration: 12, name: 'Soulrot' },
   },
   gorrak: {
     id: 'gorrak', name: 'Gorrak the Ruthless', minLevel: 6, maxLevel: 6, family: 'humanoid',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,20 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // soulrot ("Soulrot"): a landed swing may fester a refreshing SHADOW DoT.
+    // Same on-hit DoT seam as venom, but shadow-school — the undead/necrotic
+    // flavour. Hostile mobs only (mobSwing is also the pet attack path, so a
+    // friendly pet must never rot the party).
+    const soulrot = MOBS[mob.templateId]?.soulrot;
+    if (soulrot && mob.hostile && !target.dead && this.rng.chance(soulrot.chance)) {
+      this.applyAura(target, {
+        id: 'soulrot_' + mob.templateId, name: soulrot.name, kind: 'dot',
+        remaining: soulrot.duration, duration: soulrot.duration,
+        value: Math.max(1, Math.round(soulrot.perTick)),
+        tickInterval: soulrot.interval, tickTimer: soulrot.interval,
+        sourceId: mob.id, school: (soulrot.school as Aura['school']) ?? 'shadow',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,12 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit rot: a landed melee swing has `chance` to fester a refreshing SHADOW
+  // damage-over-time wound on the victim ("Soulrot"). The same on-hit DoT seam as
+  // `venom` (nature/poison) and `bleed` (physical), but shadow-school — the
+  // undead/necrotic flavour, and it bites every class (resisted by shadow, not
+  // nature/physical mitigation). Refreshes (never stacks) like venom.
+  soulrot?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: Aura['school'] };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_soulrot.test.ts
+++ b/tests/mob_soulrot.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn restless bones adjacent to the player and hand them back.
+function spawnBones(sim: Sim, id = 980001, level = 6) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.restless_bones, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the soulrot aura (the chance is forced to 1 here).
+function swingUntilRot(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'soulrot_restless_bones')) return true;
+  }
+  return false;
+}
+
+describe('mob soulrot (on-hit shadow DoT)', () => {
+  it('Restless Bones carry soulrot data tuned to a shadow DoT', () => {
+    const r = MOBS.restless_bones.soulrot!;
+    expect(r).toBeDefined();
+    // school defaults to shadow when omitted on the template; assert the runtime default below.
+    expect(r.chance).toBeGreaterThan(0);
+    expect(r.perTick).toBeGreaterThan(0);
+    expect(r.interval).toBeGreaterThan(0);
+    expect(r.duration).toBeGreaterThan(r.interval);
+  });
+
+  it('a landed grave-touch swing festers a shadow DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnBones(sim);
+    const orig = MOBS.restless_bones.soulrot!.chance;
+    MOBS.restless_bones.soulrot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.restless_bones.soulrot!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'soulrot_restless_bones')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('shadow');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.restless_bones.soulrot!.duration);
+  });
+
+  it('the shadow DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnBones(sim);
+    const orig = MOBS.restless_bones.soulrot!.chance;
+    MOBS.restless_bones.soulrot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.restless_bones.soulrot!.chance = orig;
+    }
+    // Park the mob far out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 7; i++) sim.tick(); // 7s — covers at least two 3s tick intervals
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-rotting mob (forest wolf) applies no shadow DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated grave-touches from the same mob', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnBones(sim);
+    const orig = MOBS.restless_bones.soulrot!.chance;
+    MOBS.restless_bones.soulrot!.chance = 1;
+    try {
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+    } finally {
+      MOBS.restless_bones.soulrot!.chance = orig;
+    }
+    const rotAuras = player.auras.filter((a) => a.id === 'soulrot_restless_bones');
+    expect(rotAuras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit affix, **`soulrot`**: a landed melee swing has a chance to fester a refreshing **shadow** damage-over-time wound on the victim.

It is the **shadow-school sibling** of the existing `venom` (nature/poison) and `bleed` (physical) on-hit DoTs — the same data-driven seam (a `kind: 'dot'` aura on a `tickInterval`), so it adds **zero new combat math, zero new aura kind, and no UI/i18n changes**. Unlike venom/bleed it is mitigated by **shadow** resistance and bites **every class**, giving the early undead a creeping, necrotic threat.

**Carrier:** the **Restless Bones** (Eastbrook Vale, L5–7) gain **"Soulrot"** — 25% chance, 4 shadow / 3s for 12s — alongside their existing *Withering Wail*. Grave-touched dead clawing rot into the living is about as classic as undead get.

## How

- New optional `soulrot?: { chance; perTick; interval; duration; name; school? }` field on `MobTemplate` (`src/sim/types.ts`), mirroring `venom`.
- On-hit roll in `mobSwing` beside the venom block (`src/sim/sim.ts`), guarded on `mob.hostile` (mobSwing is also the pet attack path) so a friendly pet never rots the party; school defaults to `shadow`.
- Attached to `restless_bones` in `src/sim/content/zone1.ts`.
- **Determinism-neutral:** no new spawns/camps, so no construction RNG draws shift — the full fixed-seed suite is byte-identical.
- `tests/mob_soulrot.test.ts` mirrors `tests/mob_venom.test.ts` (data shape, on-hit application, ticking damage, refresh-not-stack, and a non-carrier control).

## Verification

- `npx tsc --noEmit` — clean
- `npx vitest run` — **1397 passed (143 files)**

## Screenshots

The reskinned Restless Bones lands Soulrot on the player (purple shadow debuff, right):

![Soulrot debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/soulrot-affix/shots/soulrot_debuff.png)

In-world (Eastbrook Vale):

![Scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/soulrot-affix/shots/soulrot_scene.png)