### PR TITLE
feat(content): Shardlord Kazzix sears foes with a Frostbite frost DoT on hit

### DIFF
--- a/scripts/shot_frostbite.mjs
+++ b/scripts/shot_frostbite.mjs
@@ -1,0 +1,84 @@
+// Screenshot the Frostbite affix in the offline client. Boots the game,
+// repurposes a nearby mob as Shardlord Kazzix, forces its on-hit frost DoT onto
+// the player, and captures the resulting frost debuff on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Shardlord Kazzix and drive its frost burn onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp bump is wiped by recalcPlayerStats);
+  // applyAura still lands, so the debuff renders.
+  p.gm = true;
+  // Force the on-hit roll so the frost DoT lands deterministically.
+  sim.rng.chance = () => true;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the rare ice elemental and stand it next to us.
+  mob.templateId = 'shardlord_kazzix';
+  mob.name = 'Shardlord Kazzix';
+  mob.level = 18;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const frost = p.auras.find((a) => a.id === 'frostbite_shardlord_kazzix');
+  return { hasFrostbite: !!frost, name: frost?.name, value: frost?.value, school: frost?.school, remaining: frost?.remaining };
+});
+console.log('frostbite result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/frostbite_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box && box.w > 0) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/frostbite_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -148,6 +148,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'kazzix_heartshard', chance: 1, questId: 'q_kazzix' },
       { itemId: 'inert_storm_shard', chance: 1 },
     ],
+    // The Shardlord's rimebound core sheathes its blows in killing cold, leaving
+    // a frost burn that gnaws at the victim long after the strike lands.
+    frostbite: { chance: 0.3, perTick: 6, interval: 3, duration: 12, name: 'Frostbite', school: 'frost' },
     scale: 1.3, color: 0xaed6f1,
   },
   wyrmcult_zealot: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,19 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // frostbite: a landed swing may sear the victim with a refreshing frost DoT
+    // (the frost twin of venom — chilling elementals). Hostile mobs only, never a
+    // friendly pet (mobSwing is also the pet attack path).
+    const frostbite = MOBS[mob.templateId]?.frostbite;
+    if (frostbite && mob.hostile && !target.dead && this.rng.chance(frostbite.chance)) {
+      this.applyAura(target, {
+        id: 'frostbite_' + mob.templateId, name: frostbite.name, kind: 'dot',
+        remaining: frostbite.duration, duration: frostbite.duration,
+        value: Math.max(1, Math.round(frostbite.perTick)),
+        tickInterval: frostbite.interval, tickTimer: frostbite.interval,
+        sourceId: mob.id, school: (frostbite.school as Aura['school']) ?? 'frost',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,9 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // damage-over-time frost burn on the struck target — the frost twin of venom
+  // (chilling/elemental creatures). Reuses the 'dot' aura; school defaults to 'frost'.
+  frostbite?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_frostbite.test.ts
+++ b/tests/mob_frostbite.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn a Shardlord adjacent to the player and hand it back.
+function spawnShardlord(sim: Sim, id = 970601, level = 18) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.shardlord_kazzix, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the frostbite aura (the chance is 1 in these tests).
+function swingUntilFrostbite(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'frostbite_shardlord_kazzix')) return true;
+  }
+  return false;
+}
+
+describe('mob frostbite (on-hit frost DoT)', () => {
+  it('Shardlord Kazzix carries frostbite data tuned to a frost DoT', () => {
+    const f = MOBS.shardlord_kazzix.frostbite!;
+    expect(f).toBeDefined();
+    expect(f.school).toBe('frost');
+    expect(f.chance).toBeGreaterThan(0);
+    expect(f.perTick).toBeGreaterThan(0);
+    expect(f.interval).toBeGreaterThan(0);
+    expect(f.duration).toBeGreaterThan(f.interval);
+  });
+
+  it('a landed frostbitten swing inflicts a frost DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnShardlord(sim);
+    const orig = MOBS.shardlord_kazzix.frostbite!.chance;
+    MOBS.shardlord_kazzix.frostbite!.chance = 1;
+    try {
+      expect(swingUntilFrostbite(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.shardlord_kazzix.frostbite!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'frostbite_shardlord_kazzix')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('frost');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.shardlord_kazzix.frostbite!.duration);
+  });
+
+  it('the frost DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnShardlord(sim);
+    const orig = MOBS.shardlord_kazzix.frostbite!.chance;
+    MOBS.shardlord_kazzix.frostbite!.chance = 1;
+    try {
+      expect(swingUntilFrostbite(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.shardlord_kazzix.frostbite!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    // interval is 3s; tick well past it (8s) so the DoT outpaces out-of-combat regen.
+    for (let i = 0; i < 20 * 8; i++) sim.tick();
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-frostbitten mob (forest wolf) applies no frost DoT aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(970650, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === 'frostbite_forest_wolf')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated strikes from the same Shardlord', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    // Shardlord Kazzix is a level-18 elite; god-mode the dummy so the barrage of forced
+    // swings can't kill it (death clears all auras). A raw maxHp bump won't do — the tick's
+    // recalcPlayerStats re-derives maxHp from stamina and wipes it; gm survives + still takes auras.
+    (player as any).gm = true;
+    const mob = spawnShardlord(sim);
+    const orig = MOBS.shardlord_kazzix.frostbite!.chance;
+    MOBS.shardlord_kazzix.frostbite!.chance = 1;
+    try {
+      swingUntilFrostbite(sim, mob, player);
+      swingUntilFrostbite(sim, mob, player);
+      swingUntilFrostbite(sim, mob, player);
+    } finally {
+      MOBS.shardlord_kazzix.frostbite!.chance = orig;
+    }
+    const frostAuras = player.auras.filter((a) => a.id === 'frostbite_shardlord_kazzix');
+    expect(frostAuras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds a **`frostbite`** on-hit affix — the **frost-school twin of `venom`** (the existing nature on-hit DoT). A landed swing from **Shardlord Kazzix** (the rare storm/ice elemental in Thornpeak Heights, lvl 18) may sear the victim with a refreshing frost damage-over-time burn: **30% chance / 6 per 3s / 12s**, named *"Frostbite"*.

Thematically the icy-blue Shardlord's rimebound core sheathes its blows in killing cold. Mechanically this claims the previously-uncovered **frost DoT school** — `venom`=nature already shipped; `chillOnHit` is a *slow*, not a DoT, so this is genuinely distinct.

## How

Mirrors the `venom` precedent exactly — minimal, surgical seam:

- **`types.ts`** — new optional `MobTemplate.frostbite` field (same shape as `venom`).
- **`sim.ts`** — a venom-clone roll block in `mobSwing`'s on-hit section; reuses the existing `kind: 'dot'` aura, `school` defaults to `'frost'`. Guarded on `mob.hostile` + `!target.dead` so a friendly pet (the other `mobSwing` caller) never debuffs an ally.
- **`content/zone3.ts`** — the data on `shardlord_kazzix`.

**Zero** new aura kind, combat math, or UI. **Determinism-neutral** (no new spawn/camp draws — every other content's spawns are byte-identical).

## Tests

`tests/mob_frostbite.test.ts` mirrors `mob_venom.test.ts`: data shape, on-hit application, DoT ticking over time, no-aura on a non-frostbitten mob, and refresh-not-stack.

- `npx vitest run` → **1398 passed**
- `npx tsc --noEmit` → clean
- i18n guards (`localization_fixes` + `localization_coverage`) → green (the debuff name ships raw exactly like every other on-hit affix name).

## Screenshots

The frost debuff on the player buff bar (red-bordered icon + timer) after a forced Frostbite proc, and the scene with Shardlord Kazzix targeted:

![Frostbite debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/frostbite-affix/shots/frostbite_debuff.png)

![Scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/frostbite-affix/shots/frostbite_scene.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)