### PR TITLE
feat(content): Ironvein Sappers ignite a Smoldering Fuse fire DoT on hit

### DIFF
--- a/scripts/shot_smolder.mjs
+++ b/scripts/shot_smolder.mjs
@@ -1,0 +1,87 @@
+// Screenshot the Smoldering Fuse affix (on-hit fire DoT) in the offline client.
+// Boots the game, repurposes a nearby mob as an Ironvein Sapper, forces its
+// burning fuse onto the player, and captures the resulting fire DoT debuff on
+// the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as an Ironvein Sapper and drive its fuse onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (raw maxHp gets re-derived from stamina each
+  // tick by recalcPlayerStats); applyAura still lands on a gm player.
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+  sim.rng.chance = () => true; // guarantee the on-hit proc fires
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the smoldering sapper and stand it next to us (offset on +x/+z
+  // so the third-person camera frames it close).
+  mob.templateId = 'ironvein_sapper';
+  mob.name = 'Ironvein Sapper';
+  mob.level = 16;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 4; mob.pos.z = p.pos.z + 4;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input) g.input.camDist = 10;
+
+  for (let i = 0; i < 6; i++) sim.mobSwing(mob, p);
+  const fuse = p.auras.find((a) => a.name === 'Smoldering Fuse');
+  return { hasFuse: !!fuse, school: fuse?.school, value: fuse?.value, remaining: fuse?.remaining };
+});
+console.log('smolder result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/smolder_scene.png' });
+
+// Crop tightly around the top-right buff/debuff bar where the fire DoT renders.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box && box.w > 0) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/smolder_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/smolder_scene.png, tmp/smolder_debuff.png');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -88,6 +88,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ironvein_sapper', name: 'Ironvein Sapper', minLevel: 15, maxLevel: 16, family: 'kobold',
     hpBase: 58, hpPerLevel: 20, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.0,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 12,
+    smolder: { chance: 0.25, perTick: 5, interval: 3, duration: 12, name: 'Smoldering Fuse' },
     loot: [],
     scale: 0.85, color: 0x8f6b34,
   },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,18 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // smoldering fuse: a landed swing may ignite a refreshing fire DoT — the
+    // fire-school sibling of venom (same guards: hostile mobs only, never a pet).
+    const smolder = MOBS[mob.templateId]?.smolder;
+    if (smolder && mob.hostile && !target.dead && this.rng.chance(smolder.chance)) {
+      this.applyAura(target, {
+        id: 'smolder_' + mob.templateId, name: smolder.name, kind: 'dot',
+        remaining: smolder.duration, duration: smolder.duration,
+        value: Math.max(1, Math.round(smolder.perTick)),
+        tickInterval: smolder.interval, tickTimer: smolder.interval,
+        sourceId: mob.id, school: (smolder.school as Aura['school']) ?? 'fire',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,9 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // Burning fuse: a landed swing may set a refreshing fire DoT (the fire-school
+  // sibling of venom; sappers, ember-touched creatures). Defaults to the 'fire' school.
+  smolder?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_smolder.test.ts
+++ b/tests/mob_smolder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn an Ironvein Sapper adjacent to the player and hand it back. Spawned near
+// the player's level so the hit table lands reliably (a big level gap inflates miss).
+function spawnSapper(sim: Sim, id = 980001, level = 5) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ironvein_sapper, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the smolder aura (the chance is forced to 1 here).
+function swingUntilSmolder(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'smolder_ironvein_sapper')) return true;
+  }
+  return false;
+}
+
+describe('mob smolder (on-hit fire DoT)', () => {
+  it('the Ironvein Sapper carries smolder data tuned to a fire DoT', () => {
+    const s = MOBS.ironvein_sapper.smolder!;
+    expect(s).toBeDefined();
+    expect(s.name).toBe('Smoldering Fuse');
+    expect(s.chance).toBeGreaterThan(0);
+    expect(s.perTick).toBeGreaterThan(0);
+    expect(s.interval).toBeGreaterThan(0);
+    expect(s.duration).toBeGreaterThan(s.interval);
+  });
+
+  it('a landed swing ignites a fire DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.smolder!.chance;
+    MOBS.ironvein_sapper.smolder!.chance = 1;
+    try {
+      expect(swingUntilSmolder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.smolder!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'smolder_ironvein_sapper')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('fire');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.ironvein_sapper.smolder!.duration);
+  });
+
+  it('the fire DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.smolder!.chance;
+    MOBS.ironvein_sapper.smolder!.chance = 1;
+    try {
+      expect(swingUntilSmolder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.smolder!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    // interval = 3s; run ~7s so the DoT outpaces any out-of-combat regen.
+    for (let i = 0; i < 20 * 7; i++) sim.tick();
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-smoldering mob (forest wolf) applies no fire DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 5, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated hits from the same sapper', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.smolder!.chance;
+    MOBS.ironvein_sapper.smolder!.chance = 1;
+    try {
+      swingUntilSmolder(sim, mob, player);
+      swingUntilSmolder(sim, mob, player);
+      swingUntilSmolder(sim, mob, player);
+    } finally {
+      MOBS.ironvein_sapper.smolder!.chance = orig;
+    }
+    const auras = player.auras.filter((a) => a.id === 'smolder_ironvein_sapper');
+    expect(auras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Ironvein Sappers plant explosives in the Thornpeak tunnels — now a landed swing may light a **Smoldering Fuse** on the victim: a refreshing **fire-school** damage-over-time (5 fire damage every 3s for 12s, 25% chance).

This fills the **fire** slot in the existing on-hit DoT family, which until now only covered nature:

| Affix | School | Carrier |
|---|---|---|
| Venom | nature | Webwood Spider |
| **Smoldering Fuse** | **fire** | **Ironvein Sapper** |

## How

Mirrors the `venom` precedent exactly, so the change is tiny and low-risk:

- **`types.ts`** — new optional `smolder?` field on `MobTemplate` (same shape as `venom`).
- **`sim.ts`** — a venom-clone block in `mobSwing`'s on-hit section. It reuses the existing `kind:'dot'` aura primitive (school defaults to `'fire'`), so there is **zero new aura kind, combat math, or UI code**. Guarded on `mob.hostile && !target.dead` exactly like venom, so a friendly hunter pet (the other `mobSwing` caller) never debuffs the party.
- **`content/zone3.ts`** — attaches the affix to `ironvein_sapper`.

## Notes

- **Determinism-neutral**: no new spawn or camp, so it draws zero RNG at `Sim` construction — every fixed-seed test elsewhere is byte-identical. Full suite **1398 green**, `tsc` clean.
- New test `tests/mob_smolder.test.ts` mirrors `tests/mob_venom.test.ts` (data shape, on-hit application, DoT ticking, non-carrier control, refresh-not-stack).
- No new entity and no new player-facing string (the debuff name ships like every other on-hit affix name), so the localization guards stay green.

## Screenshots

The fire DoT on the player after a sapper's swing (note the campfire — fitting):

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/smolder-affix/shots/smolder_scene.png)

The Smoldering Fuse debuff on the buff bar (red-bordered fire icon, ticking timer):

![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/smolder-affix/shots/smolder_debuff.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)