### PR TITLE
feat(content): Ironvein Sappers set the victim ablaze on hit (Cinderburn)

### DIFF
--- a/scripts/shot_cinder.mjs
+++ b/scripts/shot_cinder.mjs
@@ -1,0 +1,85 @@
+// Screenshot the Cinderburn affix (on-hit fire DoT) in the offline client.
+// Boots the game, repurposes a nearby mob as an Ironvein Sapper, forces its
+// on-hit cinder onto the player, and captures the resulting fire DoT debuff
+// on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as an Ironvein Sapper and drive its cinder onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live loop (applyAura re-derives maxHp from stamina, wiping a
+  // raw hp override) and the cinder roll fires independently of damage landing.
+  p.gm = true;
+  sim.rng.chance = () => true;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the demolitionist kobold and stand it next to us.
+  mob.templateId = 'ironvein_sapper';
+  mob.name = 'Ironvein Sapper';
+  mob.level = 16;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const cinder = p.auras.find((a) => a.id === 'cinder_ironvein_sapper');
+  return { hasCinder: !!cinder, name: cinder?.name, school: cinder?.school, value: cinder?.value, remaining: cinder?.remaining };
+});
+console.log('cinder result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/cinder_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right) to show the icon.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/cinder_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/cinder_scene.png, cinder_debuff.png');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -88,6 +88,8 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ironvein_sapper', name: 'Ironvein Sapper', minLevel: 15, maxLevel: 16, family: 'kobold',
     hpBase: 58, hpPerLevel: 20, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.0,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 12,
+    // The sapper's blasting powder clings and smolders: a struck foe catches fire.
+    cinder: { chance: 0.3, perTick: 5, interval: 3, duration: 12, name: 'Cinderburn', school: 'fire' },
     loot: [],
     scale: 0.85, color: 0x8f6b34,
   },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,19 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // cinder: the fire-school twin of venom — a landed swing may set a refreshing
+    // burning DoT (hostile mobs only, never a friendly pet — mobSwing is also the
+    // pet attack path). Reuses the same dot aura seam; school defaults 'fire'.
+    const cinder = MOBS[mob.templateId]?.cinder;
+    if (cinder && mob.hostile && !target.dead && this.rng.chance(cinder.chance)) {
+      this.applyAura(target, {
+        id: 'cinder_' + mob.templateId, name: cinder.name, kind: 'dot',
+        remaining: cinder.duration, duration: cinder.duration,
+        value: Math.max(1, Math.round(cinder.perTick)),
+        tickInterval: cinder.interval, tickTimer: cinder.interval,
+        sourceId: mob.id, school: (cinder.school as Aura['school']) ?? 'fire',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,10 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit debuff: the fire-school twin of `venom` — a chance per landed melee
+  // swing to set a stacking-refresh burning damage-over-time (cinder/ember mobs,
+  // demolitionists carrying blasting powder). Same DoT seam, school defaults 'fire'.
+  cinder?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_cinder.test.ts
+++ b/tests/mob_cinder.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn an Ironvein Sapper adjacent to the player and hand it back.
+function spawnSapper(sim: Sim, id = 980001, level = 16) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ironvein_sapper, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the cinder aura (the chance is 1 in these tests).
+function swingUntilCinder(sim: Sim, mob: any, target: any, tries = 60): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'cinder_ironvein_sapper')) return true;
+  }
+  return false;
+}
+
+describe('mob cinder (on-hit fire DoT)', () => {
+  it('the Ironvein Sapper carries cinder data tuned to a fire DoT', () => {
+    const c = MOBS.ironvein_sapper.cinder!;
+    expect(c).toBeDefined();
+    expect(c.school).toBe('fire');
+    expect(c.chance).toBeGreaterThan(0);
+    expect(c.perTick).toBeGreaterThan(0);
+    expect(c.interval).toBeGreaterThan(0);
+    expect(c.duration).toBeGreaterThan(c.interval);
+  });
+
+  it('a landed swing sets a burning DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.cinder!.chance;
+    MOBS.ironvein_sapper.cinder!.chance = 1;
+    try {
+      expect(swingUntilCinder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.cinder!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'cinder_ironvein_sapper')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('fire');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.ironvein_sapper.cinder!.duration);
+  });
+
+  it('the burning DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.cinder!.chance;
+    MOBS.ironvein_sapper.cinder!.chance = 1;
+    try {
+      expect(swingUntilCinder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.cinder!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 4; i++) sim.tick(); // 4s — past one tick interval, beats regen
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-cinder mob (forest wolf) sets no burning aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 16, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 60; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === 'cinder_forest_wolf')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated hits from the same sapper', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    // The sapper hits hard at L16, and applyAura re-derives maxHp from stamina
+    // (wiping any raw hp override), so a plain pool gets ground down across the
+    // ~180 swings below. gm keeps the player invulnerable; the cinder roll fires
+    // independently of damage landing, so the aura still applies.
+    player.gm = true;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.cinder!.chance;
+    MOBS.ironvein_sapper.cinder!.chance = 1;
+    try {
+      swingUntilCinder(sim, mob, player);
+      swingUntilCinder(sim, mob, player);
+      swingUntilCinder(sim, mob, player);
+    } finally {
+      MOBS.ironvein_sapper.cinder!.chance = orig;
+    }
+    const cinderAuras = player.auras.filter((a) => a.id === 'cinder_ironvein_sapper');
+    expect(cinderAuras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

The **Ironvein Sapper** — the demolitionist kobold the Ironvein Foreman summons to its Powder Keg — now smolders what it strikes. A landed swing has a chance to set **Cinderburn**, a refreshing fire-school damage-over-time.

This is the **fire twin of the existing `venom` on-hit DoT** (nature). It reuses the same `dot` aura seam, so there is **no new aura kind, combat math, or HUD change** — only a typed `cinder` field on `MobTemplate` and a venom-clone roll in `mobSwing` (hostile-guarded, so a friendly pet on the shared `mobSwing` path never burns the party). School defaults to `'fire'`.

| | |
|---|---|
| **Affix** | Cinderburn — 30% chance per landed swing, 5 fire / 3s for 12s |
| **Mob** | `ironvein_sapper` (Thornpeak Heights, lvl 15–16) |
| **DoT school coverage** | venom (nature) → **+ cinder (fire)** |

## Why it's low-risk

- **Determinism-neutral.** No new spawn or camp, so zero RNG is drawn at `Sim` construction — every fixed-seed test rolls the identical sequence. Full suite **1398 passing**, `tsc` clean.
- Mirrors the proven `venom` precedent line-for-line; reuses `kind:'dot'`.

## Tests

`tests/mob_cinder.test.ts` mirrors `tests/mob_venom.test.ts`: data shape, on-hit application, DoT ticking over time, no-aura on a non-cinder mob, and refresh-not-stack.

## Screenshots

| Cinderburn debuff | In-world |
|---|---|
| ![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/cinderburn-affix/shots/cinder_debuff.png) | ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/cinderburn-affix/shots/cinder_scene.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)