### PR TITLE
Hotfix: allow two active account sessions

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -50,6 +50,7 @@ const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
 const WHO_RESULT_LIMIT = 50;
+const MAX_ACTIVE_SESSIONS_PER_ACCOUNT = 2;
 const RESTART_COUNTDOWN_TOTAL_SECONDS = 600;
 const RESTART_COUNTDOWN_STEPS = [
   { atSeconds: 0, text: 'Server restart in 10 minutes.' },
@@ -520,12 +521,16 @@ export class GameServer {
     meta: RequestMetadata & Partial<AccountChatMuteStatus> & { chatStrikes?: number } = {},
   ): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
-    // Anti-bot: only ONE character per account may be in the world at a time. An account can
-    // still own up to 10 characters (creation is unaffected) — this only caps *simultaneous*
-    // online sessions, which is what bot/multibox farms abuse. GMs are exempt for supervision.
+    // Anti-bot: cap simultaneous online characters per account. Accounts can
+    // still own up to 10 characters; this only limits live sessions. GMs are
+    // exempt for supervision.
     if (!isGm) {
+      let activeForAccount = 0;
       for (const s of this.clients.values()) {
-        if (s.accountId === accountId) return { error: 'another character on this account is already in the world' };
+        if (s.accountId === accountId) activeForAccount++;
+      }
+      if (activeForAccount >= MAX_ACTIVE_SESSIONS_PER_ACCOUNT) {
+        return { error: 'too many characters on this account are already in the world' };
       }
     }
     const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -73,30 +73,34 @@ describe('GameServer sessions', () => {
     expect(closePlaySession).toHaveBeenCalledWith(99);
   });
 
-  it('allows only one ONLINE character per account, and lets the account back in once it leaves', async () => {
+  it('allows two ONLINE characters per account, and lets the account back in once one leaves', async () => {
     const server = new GameServer();
     const a = expectJoined(server.join(fakeWs(), 20, 201, 'Aone', 'warrior', null));
+    const a2 = expectJoined(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null));
 
-    // same account, a different character is rejected while the first is online
-    expect(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null)).toEqual({
-      error: 'another character on this account is already in the world',
+    expect((server as any).sessionByCharacterId(202)).toBe(a2);
+
+    // same account, a third character is rejected while two are online
+    expect(server.join(fakeWs(), 20, 204, 'Athree', 'rogue', null)).toEqual({
+      error: 'too many characters on this account are already in the world',
     });
 
     // a different account is unaffected
     const b = expectJoined(server.join(fakeWs(), 21, 203, 'Bone', 'priest', null));
     expect((server as any).sessionByCharacterId(203)).toBe(b);
 
-    // once the account's online character leaves, another of its characters may join
+    // once one of the account's online characters leaves, another of its characters may join
     await server.leave(a, 'test');
-    const a2 = expectJoined(server.join(fakeWs(), 20, 202, 'Atwo', 'mage', null));
-    expect((server as any).sessionByCharacterId(202)).toBe(a2);
+    const a3 = expectJoined(server.join(fakeWs(), 20, 204, 'Athree', 'rogue', null));
+    expect((server as any).sessionByCharacterId(204)).toBe(a3);
   });
 
-  it('exempts GM characters from the one-per-account cap (for supervision)', () => {
+  it('exempts GM characters from the per-account session cap (for supervision)', () => {
     const server = new GameServer();
     expectJoined(server.join(fakeWs(), 30, 301, 'Gmaa', 'warrior', null));
-    // a second character on the same account joins because it is flagged GM
-    expectJoined(server.join(fakeWs(), 30, 302, 'Gmbb', 'warrior', null, true));
-    expect((server as any).sessionByCharacterId(302)).not.toBeNull();
+    expectJoined(server.join(fakeWs(), 30, 302, 'Gmbb', 'warrior', null));
+    // a third character on the same account joins because it is flagged GM
+    expectJoined(server.join(fakeWs(), 30, 303, 'Gmcc', 'warrior', null, true));
+    expect((server as any).sessionByCharacterId(303)).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Increase the simultaneous non-GM online character cap per account from 1 to 2.
- Keep the cap enforced by rejecting the third active character on the same account.
- Preserve the GM supervision exemption.

## Validation
- `npx vitest run tests/game_sessions.test.ts`
- `npm run test`
- `npm run build`
- `npm run build:server`

## Notes
- This addresses households or shared setups that were effectively locked down to one active account session after the latest release hardening.