### PR TITLE
feat(content): Mogger Lackeys crack the skull, briefly stunning on hit (Skullthump)

### DIFF
--- a/scripts/shot_skullthump.mjs
+++ b/scripts/shot_skullthump.mjs
@@ -1,0 +1,94 @@
+// Screenshot the Skullthump affix (on-hit stun) in the offline client.
+// Boots the game, repurposes a nearby mob as a Mogger Lackey, forces its
+// on-hit crushing blow onto the player, and captures the resulting stun
+// debuff in the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Mogger Lackey and drive its stun onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override is wiped by recalc).
+  p.gm = true;
+  sim.rng.chance = () => true; // force the on-hit proc deterministically
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the ogre lackey and stand it next to us.
+  mob.templateId = 'mogger_lackey';
+  mob.name = 'Mogger Lackey';
+  mob.level = 6;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const stun = p.auras.find((a) => a.name === 'Skullthump');
+  // The live affix is a brief 1s proc (proven by the swings + the unit test);
+  // hold the aura open here only so the still capture isn't a race with the loop.
+  if (stun) { stun.remaining = 8; stun.duration = 8; }
+  return { hasStun: !!stun, kind: stun?.kind };
+});
+console.log('skullthump result:', JSON.stringify(result));
+
+// Crop tightly around the buff/debuff bar (top-right) where the stun renders.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/skullthump_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+// Re-apply a fresh stun so the wide scene shot also shows the debuff on the bar.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const stun = p.auras.find((a) => a.name === 'Skullthump');
+  if (stun) { stun.remaining = 8; stun.duration = 8; }
+  else p.auras.push({ id: 'stun_mogger_lackey', name: 'Skullthump', kind: 'stun', remaining: 8, duration: 8, value: 0, sourceId: p.id, school: 'physical' });
+});
+await page.screenshot({ path: 'tmp/skullthump_scene.png' });
+
+console.log('saved tmp/skullthump_scene.png, skullthump_debuff.png');
+await browser.close();

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -168,6 +168,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     id: 'mogger_lackey', name: 'Mogger Lackey', minLevel: 5, maxLevel: 6, family: 'humanoid',
     hpBase: 44, hpPerLevel: 18, dmgBase: 6, dmgPerLevel: 2.0, attackSpeed: 2.0,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 12,
+    stunOnHit: { chance: 0.12, duration: 1, name: 'Skullthump', school: 'physical' },
     loot: [],
     scale: 0.95, color: 0x7b4b2b,
   },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4199,6 +4199,18 @@ export class Sim {
     if (ensnare && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(ensnare.chance)) {
       this.applyRootAura(mob, target, ensnare.name, `ensnare_${mob.templateId}`, ensnare.duration, ensnare.school ?? 'nature');
     }
+    // stunOnHit: a landed crushing blow may briefly stun the victim. Hostile mobs
+    // only (a friendly pet shares this swing path) and only stuns players. Reuses
+    // the `stun` aura the AoE stomp already applies, so isStunned()/the HUD handle
+    // it with no new wiring. Kept low-chance/short so it threatens without locking.
+    const stunOnHit = MOBS[mob.templateId]?.stunOnHit;
+    if (stunOnHit && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(stunOnHit.chance)) {
+      this.applyAura(target, {
+        id: `stun_${mob.templateId}`, name: stunOnHit.name, kind: 'stun',
+        remaining: stunOnHit.duration, duration: stunOnHit.duration, value: 0,
+        sourceId: mob.id, school: stunOnHit.school ?? 'physical',
+      });
+    }
     // slowStrike: a landed hit may mire the victim, slowing their attack speed.
     // Rides the existing `attackspeed` aura (swingIntervalMult: value > 1 = slower);
     // refreshes by id and never stacks. Guarded on `hostile` so a friendly pet

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -228,6 +228,10 @@ export interface MobTemplate {
   // existing root aura + crowd-control DR; no new aura kind. Players only; rooting a
   // fellow mob is meaningless and would let a friendly pet trivially lock enemies.
   ensnare?: { chance: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit debuff: a chance per landed crushing blow to briefly stun the victim.
+  // Reuses the `stun` aura kind (same one the AoE stomp applies); players only, and
+  // hostile-only so a friendly pet sharing the swing path never stuns the party.
+  stunOnHit?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // On-hit debuff: a chance per landed melee swing to mire the victim, slowing
   // their ATTACK SPEED (an `attackspeed` aura, `mult` > 1 lengthens the swing
   // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new

--- a/tests/mob_stun.test.ts
+++ b/tests/mob_stun.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+describe('Skullthump on-hit stun affix', () => {
+  it('the Mogger Lackey carries stunOnHit data tuned to a brief physical stun', () => {
+    const s = MOBS.mogger_lackey.stunOnHit!;
+    expect(s).toBeDefined();
+    expect(s.school).toBe('physical');
+    expect(s.chance).toBeGreaterThan(0);
+    expect(s.chance).toBeLessThanOrEqual(0.2); // gentle: lackeys can spawn in pairs
+    expect(s.duration).toBeGreaterThan(0);
+    expect(s.duration).toBeLessThanOrEqual(2);
+  });
+
+  it('a landed mogger_lackey swing can stun the player', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the stun
+    const tmpl = MOBS.mogger_lackey;
+    const saved = tmpl.stunOnHit!.chance;
+    tmpl.stunOnHit!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900700, tmpl, 6, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'stun');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'stun')!;
+      expect(a.name).toBe('Skullthump');
+      expect(a.id).toBe('stun_mogger_lackey');
+      expect((sim as any).isStunned(p)).toBe(true);
+    } finally {
+      tmpl.stunOnHit!.chance = saved;
+    }
+  });
+
+  it('the stun refreshes (does not infinitely stack) on repeated blows', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mogger_lackey;
+    const saved = tmpl.stunOnHit!.chance;
+    tmpl.stunOnHit!.chance = 1;
+    try {
+      const mob = createMob(900701, tmpl, 6, { x: 0, y: 0, z: 0 });
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(mob, p);
+      expect(p.auras.filter((a) => a.id === 'stun_mogger_lackey').length).toBe(1);
+    } finally {
+      tmpl.stunOnHit!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never stuns its target', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mogger_lackey;
+    const saved = tmpl.stunOnHit!.chance;
+    tmpl.stunOnHit!.chance = 1;
+    try {
+      const pet = createMob(900702, tmpl, 6, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+    } finally {
+      tmpl.stunOnHit!.chance = saved;
+    }
+  });
+
+  it('a mob without stunOnHit applies no stun', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900703, MOBS.forest_wolf, 6, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit affix — **`stunOnHit`** — and puts it on the **Mogger Lackey** (Eastbrook woods, lvl 5-6). A landed crushing blow has a **12% chance** to apply **"Skullthump"**, a brief **1 second** physical stun. It gives the Mogger pack fight a bit of classic melee tension — an ogre brute that can rock you for a moment — without being oppressive on a leveller.

## Why it's low-risk

- **Reuses the existing `stun` aura kind** — the same one the AoE `stomp` affix already applies. So `isStunned()` (which already gates movement, casting, and auto-attack) and the HUD debuff rendering pick it up with **zero new wiring**. The only new code is a `MobTemplate.stunOnHit` field + a block in `mobSwing` that mirrors `ensnare`.
- **Hostile- and player-guarded**, exactly like `ensnare`/`venom`, so a friendly hunter pet (which shares the `mobSwing` path) never stuns the party.
- **Determinism-neutral** — no new spawns or camps, so no construction-time RNG draws shift. Existing fixed-seed tests are untouched.
- Numbers kept gentle (12% / 1s) because lackeys can spawn in pairs.

## Tuning

| field | value |
|---|---|
| chance | 0.12 |
| duration | 1s |
| school | physical |
| name | Skullthump |

## Tests

New `tests/mob_stun.test.ts` (mirrors `tests/mob_ensnare.test.ts`): data sanity, a forced proc lands a `stun` aura and `isStunned()` returns true, refresh-not-stack, a friendly pet never stuns, and a non-affix mob applies nothing.

- Full suite: **1398 passed**
- `tsc --noEmit`: clean

## Screenshots

The red-bordered stun debuff on the player buff bar, and the encounter:

![debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/skullthump-affix/shots/skullthump_debuff.png)

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/skullthump-affix/shots/skullthump_scene.png)

> Capture note: the live proc is a brief 1s stun (proven by the swings + the unit test); `scripts/shot_skullthump.mjs` holds the aura open only so the still isn't a race with the 20 Hz loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
