### PR TITLE
feat(content): warlocks can Summon Succubus, a fast melee demon

### DIFF
--- a/scripts/shot_succubus.mjs
+++ b/scripts/shot_succubus.mjs
@@ -1,0 +1,72 @@
+// Screenshot harness for the new warlock demon: Summon Succubus.
+// Boots the offline client, rolls a warlock, levels it to 20 so the spell is
+// known, then casts Summon Succubus and waits out the cast so the magenta melee
+// demon appears at the warlock's side. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Soulbinder');
+await page.click('#offline-select .mini-class[data-class="warlock"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Level the warlock to 20 (so Summon Succubus is known), refill mana, clear any
+// existing demon, and angle the camera so the summon lands in frame.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  sim.setPlayerLevel(20, p.id);
+  p.hp = p.maxHp; p.mana = p.maxMana;
+  // dismiss any auto-summoned imp so only the succubus is on screen
+  for (const e of [...sim.entities.values()]) {
+    if (e.kind === 'mob' && e.ownerId === p.id) sim.removeEntity?.(e.id);
+  }
+  g.input.camYaw = p.facing;
+  return { level: p.level, mana: p.mana };
+});
+console.log('setup:', JSON.stringify(setup));
+await page.screenshot({ path: 'tmp/succubus_01_before.png' });
+
+// Cast the real ability and tick out the 5s cast.
+await page.evaluate(() => { window.__game.sim.castAbility('summon_succubus'); });
+await new Promise((r) => setTimeout(r, 6500));
+
+const after = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'succubus' && !e.dead) {
+      // pin it beside the player and re-aim the camera for a clean framing
+      const p = sim.player;
+      e.pos.x = p.pos.x + 2.5; e.pos.z = p.pos.z + 1;
+      window.__game.input.camYaw = p.facing;
+      return { id: e.id, name: e.name, hp: e.hp, maxHp: e.maxHp, level: e.level };
+    }
+  }
+  return null;
+});
+console.log('succubus:', JSON.stringify(after));
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/succubus_02_summoned.png' });
+
+if (errors.length) { console.log('=== PAGE ERRORS ==='); for (const e of errors.slice(0, 20)) console.log(e); }
+else console.log('no page errors');
+await browser.close();

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -455,6 +455,7 @@ export const VISUALS: Record<string, VisualDef> = {
 const MOB_KEYS: Record<string, string> = {
   imp: 'mob_demon',
   voidwalker: 'mob_demon',
+  succubus: 'mob_demon',
   warlock_imp: 'mob_demon_flying',
   warlock_voidwalker: 'mob_demonalt',
   wild_boar: 'mob_boar',

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -148,7 +148,7 @@ export const CLASSES: Record<PlayerClass, ClassDef> = {
     startWeapon: 'gnarled_staff',
     startChest: 'apprentice_robe',
     ranged: { min: 3, max: 6, speed: 1.8, maxRange: 30, minRange: 0, wand: true, school: 'shadow' },
-    abilities: ['shadow_bolt', 'summon_imp', 'demon_skin', 'immolate', 'corruption', 'life_tap', 'summon_voidwalker', 'curse_of_agony', 'drain_life', 'fear', 'searing_pain', 'shadowburn'],
+    abilities: ['shadow_bolt', 'summon_imp', 'demon_skin', 'immolate', 'corruption', 'life_tap', 'summon_voidwalker', 'summon_succubus', 'curse_of_agony', 'drain_life', 'fear', 'searing_pain', 'shadowburn'],
     color: 0x9482c9,
   },
   druid: {
@@ -1064,6 +1064,13 @@ export const ABILITIES: Record<string, AbilityDef> = {
     requiresTarget: false,
     effects: [{ type: 'summonDemon', mobId: 'voidwalker' }],
     description: 'Summons a Voidwalker under the command of the Warlock. The Voidwalker is a sturdy demon that taunts your enemies and soaks up punishment. Summoning a new demon dismisses your current one. You may have one demon at a time.',
+  },
+  summon_succubus: {
+    id: 'summon_succubus', name: 'Summon Succubus', class: 'warlock', learnLevel: 20,
+    cost: 120, castTime: 5, cooldown: 0, range: 0, school: 'shadow',
+    requiresTarget: false,
+    effects: [{ type: 'summonDemon', mobId: 'succubus' }],
+    description: 'Summons a Succubus under the command of the Warlock. The Succubus is a swift demon that tears your enemies apart with savage melee strikes. Summoning a new demon dismisses your current one. You may have one demon at a time.',
   },
 
   // ====================== DRUID ======================

--- a/src/sim/content/warlock_pets.ts
+++ b/src/sim/content/warlock_pets.ts
@@ -23,4 +23,12 @@ export const WARLOCK_PET_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 45, moveSpeed: 5.0, aggroRadius: 8,
     loot: [], scale: 1.15, color: 0x3a3a6e,
   },
+  succubus: {
+    id: 'succubus', name: 'Succubus', minLevel: 1, maxLevel: 60, family: 'demon',
+    // melee DPS: fast attacks and the heaviest demon damage, but lightly armored
+    hpBase: 45, hpPerLevel: 18,
+    dmgBase: 7, dmgPerLevel: 2.0, attackSpeed: 1.8,
+    armorPerLevel: 15, moveSpeed: 5.4, aggroRadius: 8,
+    loot: [], scale: 0.92, color: 0xc23ad6,
+  },
 };


### PR DESCRIPTION
## What

Adds the **Succubus**, vanilla's third warlock demon (learned at **level 20**) — completing the gap between the ranged **Imp** (L1) and the tanky **Voidwalker** (L8). The Succubus is the *damage* demon: faster attacks and the heaviest demon melee, but lightly armored and squishier than the Voidwalker.

## How

All data + one presentation line — no engine changes. Reuses the existing `summonDemon` effect and the hunter-pet AI wholesale.

- **`src/sim/content/warlock_pets.ts`** — new `succubus` template (`family: 'demon'`, no taunt, no `petRanged`): `hpBase 45 / +18`, `dmgBase 7 / +2.0`, `attackSpeed 1.8`, light `armorPerLevel 15`, `scale 0.92`, magenta `0xc23ad6`.
- **`src/sim/content/classes.ts`** — `summon_succubus` ability (`learnLevel 20`, `120` mana, `5s` cast, shadow), appended to the warlock kit in learn order after Summon Voidwalker.
- **`src/render/characters/manifest.ts`** — map `succubus` to the slim `mob_demon` rig; the entity tint renders it magenta, distinct from the bulky Voidwalker.

## Screenshots

Level-20 warlock before / after casting Summon Succubus (offline client, `scripts/shot_succubus.mjs`):

| Before | Summoned |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/summon-succubus/shots/succubus-before.png) | ![summoned](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/summon-succubus/shots/succubus-summoned.png) |

## Testing

- `npx vitest run tests/progression.test.ts tests/sim.test.ts tests/talents.test.ts tests/localization_fixes.test.ts` — 163 passing (incl. the S3 i18n guard; the Succubus mirrors the Imp/Voidwalker text surfaces, so no new localization surface is introduced).
- `npx tsc --noEmit` and `npm run build` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)