### PR TITLE
feat(content): Warlord Drogmar builds Battle Fury, ramping attack power the longer the fight drags on (Rampage)

### DIFF
--- a/scripts/shot_rampage.mjs
+++ b/scripts/shot_rampage.mjs
@@ -1,0 +1,89 @@
+// Screenshot the Battle Fury (Rampage) affix carrier — Warlord Drogmar — in the
+// offline client. Boots the game, repurposes a nearby mob as the warlord, stands
+// it in front of a god-moded player, drives a string of landed swings so the
+// self-stacking buff_ap aura builds, and captures the boss in-world (nameplate +
+// target frame). The fury is a self-BUFF on the mob (it has no enemy-debuff UI),
+// so the meaningful visual is the warlord himself; the ramp is asserted in
+// tests/mob_rampage.test.ts and reported on the console here.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Warlord Drogmar, stand it in front of us, and
+// drive a run of landed swings so Battle Fury stacks up to its cap.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+  p.dodgeChance = 0;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'warlord_drogmar';
+  mob.name = 'Warlord Drogmar';
+  mob.level = 17;
+  mob.scale = 1.5;
+  mob.hostile = true;
+  mob.maxHp = 800; mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const apBefore = sim.effectiveAttackPower(mob);
+  for (let i = 0; i < 12; i++) { p.hp = p.maxHp; sim.mobSwing(mob, p); }
+  const fury = mob.auras.find((a) => a.name === 'Battle Fury');
+  const apAfter = sim.effectiveAttackPower(mob);
+  return { apBefore, apAfter, hasFury: !!fury, stacks: fury?.stacks, furyValue: fury?.value };
+});
+console.log('rampage result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/rampage_full.png' });
+
+// Crop around the target frame (top-center boss frame) for a tight portrait.
+const box = await page.evaluate(() => {
+  const tf = document.querySelector('#target-frame');
+  if (!tf) return null;
+  const r = tf.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 24;
+  await page.screenshot({
+    path: 'tmp/rampage_target.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/rampage_full.png, rampage_target.png');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -117,6 +117,11 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     hpBase: 200, hpPerLevel: 30, dmgBase: 12, dmgPerLevel: 2.7, attackSpeed: 2.6,
     armorPerLevel: 28, moveSpeed: 7, aggroRadius: 14,
     aoePulse: { min: 22, max: 30, radius: 10, every: 12, name: 'Ground Slam' },
+    // The longer the warlord is left to swing, the harder he hits: every landed
+    // blow stokes his Battle Fury, stacking attack power up to a hard cap. A
+    // drawn-out fight snowballs, so burn him down or kite him off you to bleed
+    // the stacks back off.
+    rampage: { ap: 20, maxStacks: 5, duration: 10, name: 'Battle Fury', school: 'physical' },
     loot: [
       { copper: 2000, chance: 1 },
       { itemId: 'drogmar_warboots', chance: 0.3 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4126,6 +4126,27 @@ export class Sim {
         this.emit({ type: 'heal', targetId: mob.id, amount: heal });
       }
     }
+    // Battle Fury (Rampage): a landed swing whips this attacker into an escalating
+    // frenzy — a self-applied, stacking buff_ap aura (up to `maxStacks`) that grows
+    // its attack power, and thus its melee damage, the longer the fight drags on.
+    // Rides the existing buff_ap aura that effectiveAttackPower already folds into
+    // mob swing damage, so there is no new combat math. Hostile mobs only, so a
+    // friendly pet (mobSwing's other caller) never self-buffs off the party's kills;
+    // skip if the mob died to the defender's thorns/reflect earlier this swing. The
+    // single shared aura slot is bumped and refreshed each hit; left alone it falls
+    // off after `duration`s, so burning the mob down or kiting it out of melee both
+    // reset the ramp.
+    const rampage = MOBS[mob.templateId]?.rampage;
+    if (rampage && mob.hostile && !mob.dead) {
+      const existing = mob.auras.find((a) => a.id === `rampage_${mob.templateId}` && a.sourceId === mob.id);
+      const stacks = Math.min(rampage.maxStacks, (existing?.stacks ?? 0) + 1);
+      this.applyAura(mob, {
+        id: `rampage_${mob.templateId}`, name: rampage.name, kind: 'buff_ap',
+        remaining: rampage.duration, duration: rampage.duration,
+        value: rampage.ap * stacks, stacks,
+        sourceId: mob.id, school: rampage.school ?? 'physical',
+      });
+    }
     // Cleave: the swing splashes onto other players standing near the primary
     // target, each taking the hit reduced by their own armor. Hostile mobs only,
     // so a friendly pet swinging through mobSwing never cleaves its owner's party.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -185,6 +185,17 @@ export interface MobTemplate {
   // Mob mechanic: a one-time desperation self-heal the first time hp drops
   // below the threshold (healPct is a fraction of maxHp). Resets on evade/respawn.
   desperateHeal?: { belowHpPct: number; healPct: number };
+  // Self-buff affix ("Battle Fury" / Rampage): every landed melee swing whips the
+  // attacker into an escalating frenzy — a self-applied, stacking buff_ap aura (up
+  // to `maxStacks`) that grows its attack power, and thus its melee damage, the
+  // longer the fight drags on. Rides the existing buff_ap aura that
+  // effectiveAttackPower already folds into mob swing damage, so there is no new
+  // combat math. Unlike `enrage` (a one-shot threshold burst) or `packFrenzy` (a
+  // haste pulse on an ally's death), this ramps continuously while the mob keeps
+  // connecting. The single shared aura slot is refreshed each hit; left alone it
+  // falls off after `duration`s, undoing the ramp — so burning the mob down or
+  // kiting it out of melee both reset its fury.
+  rampage?: { ap: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
   // Support mechanic ("Mend"): while in combat, periodically heal every wounded
   // living friendly mob within `radius` (incl. itself) for `healMin..healMax`.
   // Telegraphed: the first cast lands one full `every` interval after combat

--- a/tests/mob_rampage.test.ts
+++ b/tests/mob_rampage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 42;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+
+// Spawn Warlord Drogmar next to a beefy player so the fury can ramp over many
+// landed swings without the target ever dropping.
+const setup = () => {
+  const sim = makeSim();
+  const player = sim.player;
+  player.maxHp = 100000;
+  player.hp = player.maxHp;
+  player.dodgeChance = 0; // never dodge: every swing lands and stokes the fury
+  const mob = createMob(990700, MOBS.warlord_drogmar, 17, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return { sim, player, mob };
+};
+
+const rampageStacks = (mob: any) =>
+  mob.auras.find((a: any) => a.id === `rampage_${mob.templateId}`)?.stacks ?? 0;
+
+// Swing repeatedly, keeping the target topped off so no swing kills it.
+const swingTimes = (sim: Sim, mob: any, target: any, n: number) => {
+  for (let i = 0; i < n; i++) {
+    target.hp = target.maxHp;
+    (sim as any).mobSwing(mob, target);
+  }
+};
+
+describe('mob Battle Fury (Rampage)', () => {
+  it('Warlord Drogmar carries the rampage mechanic', () => {
+    const r = MOBS.warlord_drogmar.rampage;
+    expect(r).toBeDefined();
+    expect(r!.name).toBe('Battle Fury');
+    expect(r!.ap).toBeGreaterThan(0);
+    expect(r!.maxStacks).toBeGreaterThan(1);
+  });
+
+  it('a landed hit applies a self buff_ap aura that grows the mob attack power', () => {
+    const { sim, player, mob } = setup();
+    const baseAp = (sim as any).effectiveAttackPower(mob);
+    swingTimes(sim, mob, player, 1);
+    expect(rampageStacks(mob)).toBe(1);
+    // one stack of +ap is now folded into the mob's effective attack power
+    expect((sim as any).effectiveAttackPower(mob)).toBe(baseAp + MOBS.warlord_drogmar.rampage!.ap);
+  });
+
+  it('stacks build with each landed swing up to the cap, and no further', () => {
+    const { sim, player, mob } = setup();
+    const { maxStacks, ap } = MOBS.warlord_drogmar.rampage!;
+    const baseAp = (sim as any).effectiveAttackPower(mob);
+    swingTimes(sim, mob, player, maxStacks + 10);
+    expect(rampageStacks(mob)).toBe(maxStacks);
+    // the single shared aura is valued at ap * maxStacks — never beyond the cap
+    expect((sim as any).effectiveAttackPower(mob)).toBe(baseAp + ap * maxStacks);
+    expect(mob.auras.filter((a: any) => a.id === `rampage_${mob.templateId}`).length).toBe(1);
+  });
+
+  it('a friendly pet never self-buffs (hostile guard)', () => {
+    const { sim, player, mob } = setup();
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    swingTimes(sim, mob, player, 5);
+    expect(rampageStacks(mob)).toBe(0);
+  });
+
+  it('the fury falls off after its duration, undoing the ramp', () => {
+    const { sim, player, mob } = setup();
+    swingTimes(sim, mob, player, 3);
+    expect(rampageStacks(mob)).toBeGreaterThan(0);
+    const baseAp = mob.attackPower;
+    // drop the player so the warlord stops swinging — otherwise it keeps landing
+    // hits during tick() and refreshes the fury forever. Now let it time out.
+    player.dead = true;
+    player.hp = 0;
+    for (let i = 0; i < 20 * (MOBS.warlord_drogmar.rampage!.duration + 2); i++) sim.tick();
+    expect(rampageStacks(mob)).toBe(0);
+    expect((sim as any).effectiveAttackPower(mob)).toBe(baseAp);
+  });
+});


### PR DESCRIPTION
## Battle Fury (Rampage) — a self-buff on-hit affix

Every existing on-hit affix in the game is a *victim debuff* (bleed, disarm, chill, sunder, mana burn, fear, …). This adds the first **self-buff** archetype: a mob that grows stronger the longer it's left swinging.

`rampage`: every landed melee swing whips the attacker into an escalating frenzy — a self-applied, **stacking `buff_ap` aura** (up to `maxStacks`) that grows its attack power, and thus its melee damage, the longer it keeps connecting.

### Why it's safe (rides an existing hook — no new combat math)
`effectiveAttackPower(mob)` already folds `buff_ap` auras into mob swing damage (`sim.ts`), so Battle Fury is pure data + a small handler. It does **not** touch the damage formula, the renderer, or `IWorld`.

It's also clearly distinct from the two existing self-scaling mechanics:
- `enrage` — a one-shot **threshold** burst (×dmg below X% HP).
- `packFrenzy` — a haste pulse on an **ally's death**.
- **Battle Fury** — ramps **continuously** while the mob stays in melee, and **decays**: the shared aura slot refreshes each hit and falls off after its duration, so **burning the mob down or kiting it out of melee both bleed the stacks back off**. A genuine tank-check.

### Carrier
**Warlord Drogmar** (Thornpeak Heights boss ogre) already slams the ground (`aoePulse: Ground Slam`) but carried no on-hit mechanic. Battle Fury fits a warlord perfectly: **+20 AP/stack, 5-stack cap, 10s window**. Left unchecked he reaches +100 AP and hits markedly harder — reward groups that focus him down or peel him.

### Changes (data-only + one handler)
- `types.ts` — new optional `rampage` field on `MobTemplate`, fully documented.
- `sim.ts` — handler in `mobSwing`, grouped with the other self-affecting affix (lifeleech); **hostile-guarded** so a friendly pet swinging through `mobSwing` never self-buffs off the party's kills.
- `content/zone3.ts` — assign Battle Fury to `warlord_drogmar`.

### Screenshots
Warlord Drogmar as a BOSS target (dragon-frame portrait, name, health):

![Warlord Drogmar boss frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rampage-affix/shots/drogmar-bossframe.png)

In-world (offline client; `scripts/shot_rampage.mjs` drives 12 landed swings — console confirms **5 stacks, AP 0 → 100**):

![Warlord Drogmar in-game](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rampage-affix/shots/drogmar-ingame.png)

### Tests
`npx vitest run tests/mob_rampage.test.ts` — passes:
- template flags resolve,
- a single landed hit applies the self `buff_ap` aura and raises `effectiveAttackPower`,
- stacks build per swing **up to the cap and no further** (one shared aura slot),
- a friendly pet never self-buffs (hostile guard),
- the fury **times out** and undoes the ramp.

Full sim suite green; the i18n S3 guard (`tests/localization_fixes.test.ts`) stays green — the affix name rides the same `aura`-event path as every existing affix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)