### PR TITLE
feat(content): Deacon Voss brands the faithless with a Profane Rune (arcane DoT)

### DIFF
--- a/scripts/shot_arcane_rot.mjs
+++ b/scripts/shot_arcane_rot.mjs
@@ -1,0 +1,85 @@
+// Screenshot the Arcane Rot affix (Profane Rune) in the offline client.
+// Boots the game, repurposes a nearby mob as Deacon Voss, forces its on-hit
+// arcane brand onto the player, and captures the resulting DoT debuff icon on
+// the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Deacon Voss and drive his arcane brand onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz boss loop (a raw maxHp override gets re-derived
+  // from stamina by recalcPlayerStats each tick); applyAura still lands.
+  p.gm = true;
+  sim.rng.chance = () => true; // force the on-hit proc deterministically
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the corrupt deacon and stand it next to us.
+  mob.templateId = 'deacon_voss';
+  mob.name = 'Deacon Voss';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const rune = p.auras.find((a) => a.name === 'Profane Rune');
+  return { hasRune: !!rune, school: rune?.school, kind: rune?.kind, value: rune?.value, remaining: rune?.remaining };
+});
+console.log('arcane rot result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/arcane_rot_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/arcane_rot_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/arcane_rot_scene.png, arcane_rot_debuff.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -229,6 +229,8 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 200, hpPerLevel: 30, dmgBase: 11, dmgPerLevel: 2.5, attackSpeed: 2.4,
     armorPerLevel: 26, moveSpeed: 7, aggroRadius: 14, boss: true,
     aoePulse: { min: 10, max: 14, radius: 10, every: 12, name: 'Drowning Hymn' },
+    // The deacon brands the faithless with a searing arcane rune that festers.
+    arcaneRot: { chance: 0.3, perTick: 7, interval: 3, duration: 12, name: 'Profane Rune', school: 'arcane' },
     loot: [
       { copper: 600, chance: 1 },
       { itemId: 'tallow_candle', chance: 1 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,20 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // arcane rot: a landed swing may brand the victim with a searing arcane rune
+    // that festers as a refreshing DoT. The arcane-school twin of venom; reuses
+    // the `dot` aura. Guarded on hostile + alive so a friendly pet (the other
+    // mobSwing caller) never debuffs an ally.
+    const arcaneRot = MOBS[mob.templateId]?.arcaneRot;
+    if (arcaneRot && mob.hostile && !target.dead && this.rng.chance(arcaneRot.chance)) {
+      this.applyAura(target, {
+        id: 'arcaneRot_' + mob.templateId, name: arcaneRot.name, kind: 'dot',
+        remaining: arcaneRot.duration, duration: arcaneRot.duration,
+        value: Math.max(1, Math.round(arcaneRot.perTick)),
+        tickInterval: arcaneRot.interval, tickTimer: arcaneRot.interval,
+        sourceId: mob.id, school: (arcaneRot.school as Aura['school']) ?? 'arcane',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,12 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit arcane DoT: the arcane-school sibling of venom (nature) / bleed
+  // (physical) / soulrot (shadow) / frostbite (frost) / cinder (fire). A landed
+  // swing may brand the victim with a searing arcane rune that festers as a
+  // refreshing damage-over-time. Reuses the `dot` aura; only the default school
+  // differs. Carried by corrupt spellcasters that channel raw arcane energy.
+  arcaneRot?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_arcane_rot.test.ts
+++ b/tests/mob_arcane_rot.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn Deacon Voss adjacent to the player and hand it back.
+function spawnDeacon(sim: Sim, id = 980001, level = 12) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.deacon_voss, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the arcane-rot aura (the chance is 1 in tests).
+function swingUntilRot(sim: Sim, mob: any, target: any, tries = 60): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'arcaneRot_deacon_voss')) return true;
+  }
+  return false;
+}
+
+describe('mob arcane rot (on-hit arcane DoT)', () => {
+  it('Deacon Voss carries arcaneRot data tuned to an arcane DoT', () => {
+    const v = MOBS.deacon_voss.arcaneRot!;
+    expect(v).toBeDefined();
+    expect(v.school).toBe('arcane');
+    expect(v.chance).toBeGreaterThan(0);
+    expect(v.perTick).toBeGreaterThan(0);
+    expect(v.interval).toBeGreaterThan(0);
+    expect(v.duration).toBeGreaterThan(v.interval);
+  });
+
+  it('a landed swing brands the struck player with an arcane DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnDeacon(sim);
+    const orig = MOBS.deacon_voss.arcaneRot!.chance;
+    MOBS.deacon_voss.arcaneRot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.deacon_voss.arcaneRot!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'arcaneRot_deacon_voss')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('arcane');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.deacon_voss.arcaneRot!.duration);
+  });
+
+  it('the arcane DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnDeacon(sim);
+    const orig = MOBS.deacon_voss.arcaneRot!.chance;
+    MOBS.deacon_voss.arcaneRot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.deacon_voss.arcaneRot!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    // interval=3, so a ~7s window outpaces out-of-combat regen on a boundary tick.
+    for (let i = 0; i < 20 * 7; i++) sim.tick();
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a mob without arcaneRot (forest wolf) applies no arcane DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated brands from the same deacon', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnDeacon(sim);
+    const orig = MOBS.deacon_voss.arcaneRot!.chance;
+    MOBS.deacon_voss.arcaneRot!.chance = 1;
+    try {
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+    } finally {
+      MOBS.deacon_voss.arcaneRot!.chance = orig;
+    }
+    const rotAuras = player.auras.filter((a) => a.id === 'arcaneRot_deacon_voss');
+    expect(rotAuras.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What

Adds **Profane Rune**, an on-hit **arcane** damage-over-time affix, to **Deacon Voss** (Mirefen Marsh boss, lvl 12). The corrupt cult deacon already channels dark magic via *Drowning Hymn*; now a landed swing has a 30% chance to brand the victim with a searing arcane rune that festers for **7 damage per 3s over 12s**.

This closes the **last unclaimed DoT school**. The on-hit DoT family already covers:

| School | Affix | Carrier |
|---|---|---|
| nature | venom | Webwood Lurker (pre-existing) |
| physical | bleed | Ridge Stalker (#512) |
| shadow | soulrot | Restless Bones (#531) |
| frost | frostbite | Shardlord Kazzix (#532) |
| fire | cinder / smolder | Ironvein Sapper (#534 / #533) |
| **arcane** | **arcaneRot** | **Deacon Voss (this PR)** |

## How

Mirrors the `venom` seam exactly — the cheapest possible extension point:

- New `arcaneRot?` field on `MobTemplate` (`src/sim/types.ts`).
- A venom-clone block in `mobSwing` (`src/sim/sim.ts`), guarded on `mob.hostile && !target.dead` so a friendly pet (the other `mobSwing` caller) never debuffs the party. Reuses the existing `kind:'dot'` aura with `school` defaulting to `'arcane'`.
- One field on the `deacon_voss` template (`src/sim/content/zone2.ts`).

**Zero** new `AuraKind`, **zero** combat-math change, **zero** HUD change — `'arcane'` is already a member of `Aura['school']` and the DoT tick path is school-agnostic.

## Verification

- `tests/mob_arcane_rot.test.ts` (mirrors `mob_venom.test.ts`): data shape, on-hit application, DoT ticks over time, no-affix negative case, refresh-no-stack.
- **Determinism-neutral**: no new spawn or camp, so the construction RNG cursor never moves — every downstream fixed-seed roll is byte-identical.
- Full suite **1398 passing**, `tsc --noEmit` clean.

## Screenshots

The arcane debuff icon (purple rune, red debuff border, 12s timer) on the player buff bar, and the deacon in-world:

![Profane Rune debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/arcane-rot/shots/arcane_rot_debuff.png)

![Deacon Voss in the world](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/arcane-rot/shots/arcane_rot_scene.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)