### PR TITLE
feat(content): Mirefen Widows leave the flesh exposed so crits bite deeper (Find Weakness)

### DIFF
--- a/scripts/shot_critvuln.mjs
+++ b/scripts/shot_critvuln.mjs
@@ -1,0 +1,83 @@
+// Screenshot the Find Weakness affix (Exposed Wound) in the offline client.
+// Boots the game, repurposes a nearby mob as a Mirefen Widow, forces its
+// on-hit bite onto the player, and captures the resulting crit-vulnerability
+// debuff on the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override is wiped by recalc);
+  // applyAura still lands, so the debuff icon shows. Force the proc deterministically.
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+  sim.rng.chance = () => true;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'mire_widow';
+  mob.name = 'Mirefen Widow';
+  mob.level = 10;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const cv = p.auras.find((a) => a.name === 'Exposed Wound');
+  return { hasDebuff: !!cv, value: cv?.value, remaining: cv?.remaining };
+});
+console.log('critvuln result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/critvuln_scene.png' });
+
+// Crop tightly around the buff/debuff bar (top-right) where the debuff shows.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/critvuln_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/critvuln_scene.png, critvuln_debuff.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -108,6 +108,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'mire_widow', name: 'Mirefen Widow', minLevel: 8, maxLevel: 10, family: 'spider',
     hpBase: 48, hpPerLevel: 19, dmgBase: 8, dmgPerLevel: 2.2, attackSpeed: 1.8,
     armorPerLevel: 10, moveSpeed: 8, aggroRadius: 10,
+    // Find Weakness: the widow's bite leaves the flesh raw, so critical blows
+    // against the victim bite 50% deeper for a few seconds.
+    critVuln: { chance: 0.3, critDamage: 0.5, duration: 8, name: 'Exposed Wound' },
     loot: [
       { copper: 38, chance: 1 },
       { itemId: 'widow_venom_sac', chance: 0.65, questId: 'q_widows' },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'critvuln',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'critvuln',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -2103,6 +2103,16 @@ export class Sim {
     return mult < 0 ? 0 : mult;
   }
 
+  // "Find Weakness" vulnerability: the largest active critvuln aura adds its
+  // fraction to the damage of CRITICAL hits the target takes (read in dealDamage).
+  private critVulnBonus(target: Entity): number {
+    let bonus = 0;
+    for (const a of target.auras) {
+      if (a.kind === 'critvuln' && a.value > bonus) bonus = a.value;
+    }
+    return bonus;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
@@ -3271,6 +3281,14 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // "Find Weakness": a critvuln debuff makes the target's exposed flesh take
+    // extra damage from CRITICAL hits only (any attacker, any school). Applied
+    // after the defensive-stance reduction, before absorb shields soak it.
+    if (crit && amount > 0 && source && source.id !== target.id) {
+      const bonus = this.critVulnBonus(target);
+      if (bonus > 0) amount = Math.round(amount * (1 + bonus));
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4167,6 +4185,18 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // Find Weakness: a landed hit can leave the victim's flesh exposed, so the
+    // next critical hits against them bite deeper. Hostile + player-only, like the
+    // other on-hit debuffs, so a friendly pet (mobSwing's other caller) never marks
+    // the party.
+    const cv = MOBS[mob.templateId]?.critVuln;
+    if (cv && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(cv.chance)) {
+      this.applyAura(target, {
+        id: `critvuln_${mob.templateId}`, name: cv.name, kind: 'critvuln',
+        remaining: cv.duration, duration: cv.duration, value: cv.critDamage,
+        sourceId: mob.id, school: (cv.school ?? 'physical') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'critvuln';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -268,6 +268,12 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // On-hit affix ("Find Weakness"): a landed melee swing has `chance` to leave the
+  // victim's flesh exposed, so CRITICAL hits against them (from anyone, any school)
+  // deal an extra `critDamage` fraction for `duration`s. Read once in the dealDamage
+  // funnel (crit-only). Distinct from a flat-damage vuln (expose/spellvuln) — this
+  // sharpens only the rare crits, the way a predator's bite finds the soft spot.
+  critVuln?: { chance: number; critDamage: number; duration: number; name: string; school?: Aura['school'] };
 }
 
 export type AbilityEffect =

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1842,7 +1842,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'critvuln'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_critvuln.test.ts
+++ b/tests/mob_critvuln.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+function critVulnAura(value: number, remaining = 8): Aura {
+  return {
+    id: 'critvuln_test', name: 'Exposed Wound', kind: 'critvuln',
+    remaining, duration: 8, value, sourceId: -1, school: 'physical',
+  };
+}
+
+describe('Find Weakness crit-vulnerability debuff', () => {
+  it('critVulnBonus reports the largest active critvuln aura', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    expect((sim as any).critVulnBonus(p)).toBe(0);
+    p.auras.push({ ...critVulnAura(0.3), id: 'a', sourceId: 1 });
+    p.auras.push({ ...critVulnAura(0.5), id: 'b', sourceId: 2 });
+    expect((sim as any).critVulnBonus(p)).toBe(0.5);
+  });
+
+  it('amplifies CRITICAL hits by the debuff fraction but leaves normal hits alone', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(910000, MOBS.mire_widow, 10, { x: 0, y: 0, z: 0 });
+
+    // normal hit — no amplification even with the debuff up
+    p.auras.length = 0;
+    p.auras.push(critVulnAura(0.5));
+    p.hp = 100000;
+    (sim as any).dealDamage(mob, p, 100, false, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(100);
+
+    // critical hit — amplified by +50%
+    p.auras.length = 0;
+    p.auras.push(critVulnAura(0.5));
+    p.hp = 100000;
+    (sim as any).dealDamage(mob, p, 100, true, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(150);
+
+    // critical hit without the debuff — unmodified
+    p.auras.length = 0;
+    p.hp = 100000;
+    (sim as any).dealDamage(mob, p, 100, true, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(100);
+  });
+
+  it('amplifies crits of any school (not just physical)', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(910001, MOBS.mire_widow, 10, { x: 0, y: 0, z: 0 });
+    p.auras.push(critVulnAura(0.5));
+    (sim as any).dealDamage(mob, p, 100, true, 'shadow', null, 'hit');
+    expect(100000 - p.hp).toBe(150);
+  });
+
+  it('a self-inflicted crit is never amplified', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    p.auras.push(critVulnAura(0.5));
+    (sim as any).dealDamage(p, p, 100, true, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(100);
+  });
+
+  it('a landed Mirefen Widow swing can inflict the Exposed Wound', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.mire_widow;
+    const saved = tmpl.critVuln!.chance;
+    tmpl.critVuln!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(910002, tmpl, 10, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'critvuln');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'critvuln')!;
+      expect(a.name).toBe('Exposed Wound');
+      expect(a.value).toBe(0.5);
+    } finally {
+      tmpl.critVuln!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts the debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mire_widow;
+    const saved = tmpl.critVuln!.chance;
+    tmpl.critVuln!.chance = 1;
+    try {
+      const pet = createMob(910003, tmpl, 10, { x: 0, y: 0, z: 0 });
+      pet.hostile = false;
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'critvuln')).toBe(false);
+    } finally {
+      tmpl.critVuln!.chance = saved;
+    }
+  });
+
+  it('a mob without critVuln applies no debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(910004, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'critvuln')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **`critVuln`** on-hit affix — *Find Weakness*. A landed melee swing has a chance to apply an **Exposed Wound** debuff that amplifies the damage of **critical hits only** (from any attacker, any school) against the victim for a few seconds.

It is the crit-only sibling of the existing flat-damage vulnerabilities: instead of amplifying *every* hit, it sharpens only the rare crits — the way a predator's bite finds the soft spot. Distinct from a healing-reduction (Mortal Strike) or an armor shred (corrode/sunder).

Attached to the **Mirefen Widow** (zone2, lvl 8–10): **30%** chance / **+50%** crit damage / **8s**. The widow had no prior affix and is uncontended.

## How it works (single seam)

- New `AuraKind` `'critvuln'` + `MobTemplate.critVuln` field.
- `critVulnBonus(target)` helper returns the largest active `critvuln` aura value.
- Read **once** in the `dealDamage` funnel, gated on `crit === true` — after the defensive-stance reduction and before absorb shields soak it. Because crit is already decided and carried into `dealDamage`, **no crit-roll site needs touching**.
- Proc roll lives in `mobSwing` beside the other on-hit debuffs, guarded `hostile + player target` so a friendly pet never marks the party.
- Added to `HARMFUL_AURA_KINDS`, `FRIENDLY_NPC_REJECTED_AURA_KINDS`, and the HUD `isDebuff` list so it renders as a red-bordered debuff.

## Verification

- New `tests/mob_critvuln.test.ts`: bonus selection, crit amplification (and that *normal* hits are untouched), any-school crits, self-crit exclusion, on-hit application, friendly-pet exclusion, and a no-affix control.
- **Full suite green (1400 passing)**, `tsc --noEmit` clean.
- Determinism-neutral: adding a field to an existing mob draws zero construction RNG (no new spawn/camp), so no fixed-seed tests shift.

## Screenshots

Captured offline via `scripts/shot_critvuln.mjs`.

| Exposed Wound debuff | In-world (Mirefen Widow) |
|---|---|
| ![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/crit-vuln/shots/crit_vuln_debuff.png) | ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/crit-vuln/shots/crit_vuln_scene.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)