### PR TITLE
feat(content): Sister Nhalia siphons a caster's Spirit on hit (Spirit Siphon)

### DIFF
--- a/scripts/shot_siphon_spirit.mjs
+++ b/scripts/shot_siphon_spirit.mjs
@@ -1,0 +1,87 @@
+// Screenshot the Spirit Siphon affix in the offline client. Boots the game as a
+// mage (a mana user, so the Spirit drain applies), repurposes a nearby mob as
+// Sister Nhalia, forces her on-hit siphon onto the player, and captures the
+// resulting Spirit debuff (negative buff_spi) on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Aelwyn');
+await page.click('#offline-select .mini-class[data-class="mage"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Sister Nhalia and drive her siphon onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm keeps us alive through the live boss loop; applyAura still lands. (A raw
+  // maxHp override would be wiped by recalcPlayerStats re-deriving HP each tick.)
+  p.gm = true;
+  sim.rng.chance = () => true; // force the proc deterministically for the capture
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the shadow priestess and stand it next to us.
+  mob.templateId = 'sister_nhalia';
+  mob.name = 'Sister Nhalia';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const spiBefore = p.stats.spi;
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const siphon = p.auras.find((a) => a.name === 'Spirit Siphon');
+  return { spiBefore, spiAfter: p.stats.spi, hasSiphon: !!siphon, value: siphon?.value, remaining: siphon?.remaining };
+});
+console.log('siphon result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/siphon_spirit_scene.png' });
+
+// Crop tightly around the buff/debuff bar (top-right) where the red-bordered
+// Spirit Siphon debuff icon renders.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/siphon_spirit_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/siphon_spirit_scene.png, siphon_spirit_debuff.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -208,6 +208,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 330, hpPerLevel: 60, dmgBase: 16, dmgPerLevel: 3.8, attackSpeed: 2.0,
     armorPerLevel: 30, moveSpeed: 7, aggroRadius: 13,
     aoePulse: { min: 18, max: 26, radius: 11, every: 9, name: 'Dirge of Nhalia', school: 'shadow' },
+    // Spirit Siphon: the priestess's touch drains a caster's Spirit, choking
+    // their out-of-combat mana regen for the duration (see siphonSpirit affix).
+    siphonSpirit: { chance: 0.3, spi: 14, duration: 10, name: 'Spirit Siphon', school: 'shadow' },
     summonAdds: { mobId: 'nhalia_mourner', count: 2, atHpPct: [0.65, 0.35] },
     loot: [
       { copper: 350, chance: 1 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -90,6 +90,7 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     if (a.kind === 'buff_ap') bonusAp += a.value;
     else if (a.kind === 'buff_armor') s.armor += a.value;
     else if (a.kind === 'buff_int') s.int += a.value;
+    else if (a.kind === 'buff_spi') s.spi += a.value;
     else if (a.kind === 'buff_sta') s.sta += a.value;
     else if (a.kind === 'buff_allstats') {
       s.str += a.value; s.agi += a.value; s.sta += a.value; s.int += a.value; s.spi += a.value;
@@ -117,6 +118,9 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     s.agi += Math.max(2, Math.floor(lvl / 2));
   }
   if (mods?.stats.armorPct) s.armor = Math.round(s.armor * (1 + mods.stats.armorPct));
+  // Floor Spirit at 0 so a Spirit-siphoning debuff (negative buff_spi) can never
+  // drive out-of-combat regen (updateRegen reads stats.spi) below zero.
+  s.spi = Math.max(0, s.spi);
 
   e.stats = s;
   const weapon = (equipment.mainhand && ITEMS[equipment.mainhand]?.weapon) || { min: 1, max: 2, speed: 2 };

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4243,6 +4243,25 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Spirit Siphon: a landed hit can drain a caster's Spirit, slowing their
+    // out-of-combat mana/health regen (updateRegen reads stats.spi). Mana users
+    // only (it does nothing to rage/energy users); hostile mobs only, so a
+    // friendly pet (mobSwing's other caller) never debuffs the party. Rides
+    // buff_spi with a negative value, so recalcPlayerStats folds it through with
+    // no new regen math; it expires like any buff* aura.
+    const siphon = MOBS[mob.templateId]?.siphonSpirit;
+    if (siphon && mob.hostile && !target.dead && target.resourceType === 'mana' && this.rng.chance(siphon.chance)) {
+      this.applyAura(target, {
+        id: `siphon_spirit_${mob.templateId}`,
+        name: siphon.name,
+        kind: 'buff_spi',
+        remaining: siphon.duration,
+        duration: siphon.duration,
+        value: -Math.abs(siphon.spi),
+        sourceId: mob.id,
+        school: siphon.school ?? 'shadow',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -46,7 +46,7 @@ export type AiState = 'idle' | 'chase' | 'attack' | 'flee' | 'evade' | 'dead';
 export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
-  | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
+  | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_spi' | 'buff_allstats' | 'thorns' | 'form_bear'
   | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
 
 export interface Aura {
@@ -265,6 +265,15 @@ export interface MobTemplate {
   // the damage *they* deal weaker. `ap` is the attack-power reduction (applied
   // as a negative buff_ap aura); `chance` defaults to 1 (every hit, refreshing).
   demoralize?: { ap: number; duration: number; chance?: number; name?: string };
+  // On-hit curse: a landed melee swing has `chance` to siphon the victim's
+  // Spirit for `duration`, slowing their out-of-combat mana/health regen
+  // (updateRegen reads `stats.spi`). Rides a `buff_spi` aura with a NEGATIVE
+  // value — recalcPlayerStats folds it and floors Spirit at 0, so there is no
+  // new regen math. Distinct from manaBurn (one-shot mana drain) and enfeeble
+  // (Intellect → mana-pool size): this attacks the REGEN axis. Only meaningful
+  // on mana users; applied to them alone. Hostile mobs only (a friendly pet,
+  // mobSwing's other caller, never debuffs the party).
+  siphonSpirit?: { chance: number; spi: number; duration: number; name: string; school?: Aura['school'] };
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };

--- a/tests/mob_siphon_spirit.test.ts
+++ b/tests/mob_siphon_spirit.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// A mage so the victim is a mana user; level it up so Sister Nhalia's L12 elite
+// swing never one-shots it (death would clear the aura before we can read it).
+const makeSim = (cls: PlayerClass = 'mage') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+// Spawn Nhalia at the player's level so the hit table is even — an L12 elite
+// swinging at an L20 mage misses almost every time, and the on-hit affix only
+// fires on a connecting hit. The victim is set gm in the swing loops so her
+// elite swing can't kill it mid-test (death clears auras).
+const spawnNhalia = (sim: Sim) => {
+  const mob = createMob(990700, MOBS.sister_nhalia, sim.player.level, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Spirit regen tick mirror (updateRegen): mana recovers by spi/3 + 4 + lvl/5.
+const spiritRegen = (p: any) => Math.round(p.stats.spi / 3 + 4 + Math.floor(p.level / 5));
+
+// Swing until the Spirit Siphon (negative buff_spi) debuff lands (a swing can miss/dodge).
+const swingUntilSiphoned = (sim: Sim, mob: any, target: any, max = 300) => {
+  target.gm = true; // invulnerable so an elite swing can't kill it (applyAura still lands)
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_spi' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob Spirit Siphon (Sister Nhalia)', () => {
+  it('Sister Nhalia template carries the siphonSpirit mechanic', () => {
+    expect(MOBS.sister_nhalia.siphonSpirit).toBeDefined();
+    expect(MOBS.sister_nhalia.siphonSpirit!.name).toBe('Spirit Siphon');
+  });
+
+  it('a landed hit applies a negative buff_spi aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      expect(swingUntilSiphoned(sim, mob, player)).toBe(true);
+    } finally {
+      siphon.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_spi');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Spirit Siphon');
+    expect(aura!.value).toBe(-siphon.spi); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('shadow');
+  });
+
+  it('the siphon lowers Spirit and thus the out-of-combat mana regen rate', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const spiBefore = player.stats.spi;
+    const regenBefore = spiritRegen(player);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      swingUntilSiphoned(sim, mob, player);
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.stats.spi).toBe(spiBefore - siphon.spi);
+    expect(spiritRegen(player)).toBeLessThan(regenBefore);
+  });
+
+  it('Spirit is floored at 0 even if the drain exceeds the victim pool', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const oldChance = siphon.chance;
+    const oldSpi = siphon.spi;
+    siphon.chance = 1;
+    siphon.spi = 100000; // absurd drain
+    try {
+      swingUntilSiphoned(sim, mob, player);
+    } finally {
+      siphon.chance = oldChance;
+      siphon.spi = oldSpi;
+    }
+    expect(player.stats.spi).toBe(0);
+    expect(player.stats.spi).toBeGreaterThanOrEqual(0);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilSiphoned(sim, mob, player);
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_spi' && a.value < 0).length).toBe(1);
+  });
+
+  it('never siphons a non-mana victim (warrior uses rage)', () => {
+    const sim = makeSim('warrior');
+    const player = sim.player;
+    expect(player.resourceType).not.toBe('mana');
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_spi')).toBe(false);
+  });
+
+  it('a friendly pet never siphons its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_spi' && a.value < 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Spirit Siphon — a new on-hit affix that attacks the *regen* axis

Sister Nhalia, the shadow priestess of Mirefen Marsh, gains a new on-hit affix: a landed melee swing has a chance to **siphon the victim's Spirit** for a few seconds, choking their out-of-combat mana/health regen (`updateRegen` reads `stats.spi`).

This fills a genuinely uncovered classic niche. It is **distinct** from the existing caster-harassment affixes:

| Affix | Axis it attacks |
|---|---|
| `manaBurn` (Mana Sear) | one-shot drain of *current* mana |
| `enfeeble` (Maddening Whisper) | Intellect → shrinks the *mana pool* |
| **`siphonSpirit` (Spirit Siphon)** | **Spirit → slows mana/health *regen*** |

### How it works (minimal seam, rides existing machinery)
- New `MobTemplate.siphonSpirit { chance, spi, duration, name, school? }`.
- On-hit roll in `mobSwing` beside `enfeeble` — applies a `buff_spi` aura with a **negative value**. Mana users only; hostile mobs only (a friendly pet, `mobSwing`'s other caller, never debuffs the party).
- `recalcPlayerStats` folds `buff_spi` (with a new floor at 0) and re-derives on expiry like any `buff*` kind. The HUD already renders any negative `buff_*` as a red debuff — **no UI change**.
- **No new combat math.** Determinism-neutral (existing mob, no new spawn/camp). Full suite **1400 tests green**, `tsc` clean.

Tuning: Sister Nhalia (Mirefen Marsh, lvl 12) — **30% / −14 Spirit / 10s**, "Spirit Siphon" (shadow).

Test: `tests/mob_siphon_spirit.test.ts` (aura values, Spirit→regen reduction, 0-floor, single-slot refresh, mana-user guard, friendly-pet guard).

### Screenshots
Mage victim, Sister Nhalia's siphon forced — Spirit 22 → 8 (−14), debuff on the player buff bar:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/siphon-spirit/shots/siphon_spirit_scene.png)
![debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/siphon-spirit/shots/siphon_spirit_debuff.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)