### PR TITLE
fix(sim): enemy mobs always hit players at >=80% (cap mob->player miss)

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -40,8 +40,8 @@ import {
   type Entity,
   MELEE_ARC,
   MELEE_RANGE,
-  meleeMissChance,
   normAngle,
+  swingMissChance,
 } from '../types';
 import { spendResource } from './casting_lifecycle';
 import { blindMissBonus, isDisarmed, isStunned } from './cc';
@@ -159,7 +159,7 @@ export function rangedSwing(
   // The shot/bolt is in flight: its miss roll and damage land when it reaches the
   // target (projectile_travel), and fizzle if the target dies before impact.
   scheduleProjectile(ctx, attacker, target, (atk, tgt) => {
-    const missChance = meleeMissChance(atk.level, tgt.level) + blindMissBonus(atk);
+    const missChance = swingMissChance(atk, tgt) + blindMissBonus(atk);
     if (ctx.rng.chance(missChance)) {
       ctx.emit({
         type: 'damage',
@@ -199,7 +199,7 @@ export function meleeSwing(
     threatMult?: number;
   },
 ): boolean {
-  const missChance = meleeMissChance(attacker.level, target.level) + blindMissBonus(attacker);
+  const missChance = swingMissChance(attacker, target) + blindMissBonus(attacker);
   const dodgeChance = opts.cannotBeDodged
     ? 0
     : target.kind === 'player'

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -281,7 +281,6 @@ import {
   MELEE_RANGE,
   type MobFamily,
   type MoveInput,
-  meleeMissChance,
   normAngle,
   type OverheadEmoteId,
   type PetMode,
@@ -293,6 +292,7 @@ import {
   type SimEvent,
   type SkinCatalog,
   type SkinRank,
+  swingMissChance,
   TURN_SPEED,
   type Vec3,
   virtualLevel,
@@ -3646,7 +3646,7 @@ export class Sim {
   }
 
   mobSwing(mob: Entity, target: Entity): void {
-    const missChance = meleeMissChance(mob.level, target.level);
+    const missChance = swingMissChance(mob, target);
     const dodgeChance = target.kind === 'player' ? target.dodgeChance : 0.05;
     const roll = this.rng.next();
     if (roll < missChance) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1943,6 +1943,24 @@ export function meleeMissChance(attackerLevel: number, targetLevel: number): num
   return Math.min(0.95, Math.max(0.005, miss / 100));
 }
 
+// Enemy mobs always connect at least this often against a player (or player-owned
+// pet), regardless of level difference.
+export const MOB_VS_PLAYER_MAX_MISS = 0.2;
+
+// Per-swing miss chance with the above-level penalty applied DIRECTIONALLY. The
+// steep penalty in meleeMissChance is an anti-power-level deterrent for PLAYERS
+// hitting higher-level mobs; because it keys off (target - attacker) level it would
+// otherwise also fire in reverse, making a low-level mob whiff on a higher-level
+// player most of the time. A hostile wild mob swinging at a player (or a player-owned
+// pet) caps its miss at MOB_VS_PLAYER_MAX_MISS (>= 80% hit); player/pet -> mob keeps
+// the full scaling. Dodge and blind are separate, intended effects the caller layers on.
+export function swingMissChance(attacker: Entity, target: Entity): number {
+  const miss = meleeMissChance(attacker.level, target.level);
+  const mobAttacker = attacker.kind === 'mob' && attacker.hostile && attacker.ownerId === null;
+  const playerSide = target.kind === 'player' || target.ownerId !== null;
+  return mobAttacker && playerSide ? Math.min(miss, MOB_VS_PLAYER_MAX_MISS) : miss;
+}
+
 export function armorReduction(armor: number, attackerLevel: number): number {
   const a = Math.max(0, armor);
   return Math.min(0.75, a / (a + 85 * attackerLevel + 400));

--- a/tests/mob_hit_floor.test.ts
+++ b/tests/mob_hit_floor.test.ts
@@ -5,8 +5,8 @@
 // the penalty player -> mob ONLY: a hostile wild mob always connects >= 80% against a
 // player (or a player-owned pet), while player/pet -> mob keeps the full scaling.
 import { describe, expect, it } from 'vitest';
-import { MOB_VS_PLAYER_MAX_MISS, meleeMissChance, swingMissChance } from '../src/sim/types';
 import type { Entity } from '../src/sim/types';
+import { MOB_VS_PLAYER_MAX_MISS, meleeMissChance, swingMissChance } from '../src/sim/types';
 
 // swingMissChance only reads kind / level / hostile / ownerId, so a minimal stub is
 // enough to exercise the directional guard without standing up a whole world.

--- a/tests/mob_hit_floor.test.ts
+++ b/tests/mob_hit_floor.test.ts
@@ -1,0 +1,52 @@
+// PR #443 added a steep miss penalty for attacking ABOVE your level (an anti-power-
+// level / anti-bot deterrent). Because meleeMissChance keys off (target - attacker)
+// level, that penalty is symmetric and also fired when a LOW-level mob swung at a
+// HIGHER-level player, making enemies whiff ~85% of the time. swingMissChance makes
+// the penalty player -> mob ONLY: a hostile wild mob always connects >= 80% against a
+// player (or a player-owned pet), while player/pet -> mob keeps the full scaling.
+import { describe, expect, it } from 'vitest';
+import { MOB_VS_PLAYER_MAX_MISS, meleeMissChance, swingMissChance } from '../src/sim/types';
+import type { Entity } from '../src/sim/types';
+
+// swingMissChance only reads kind / level / hostile / ownerId, so a minimal stub is
+// enough to exercise the directional guard without standing up a whole world.
+function ent(over: Partial<Entity>): Entity {
+  return { kind: 'mob', level: 1, hostile: true, ownerId: null, ...over } as unknown as Entity;
+}
+
+describe('enemy mobs always hit players at >= 80% (PR #443 penalty is player -> mob only)', () => {
+  it('a low-level wild mob vs a higher-level player has its miss capped at 20%', () => {
+    const mob = ent({ kind: 'mob', level: 1, hostile: true, ownerId: null });
+    const player = ent({ kind: 'player', level: 10, ownerId: null });
+    // The raw #443 formula would make the mob whiff most of the time...
+    expect(meleeMissChance(mob.level, player.level)).toBeGreaterThan(MOB_VS_PLAYER_MAX_MISS);
+    // ...but the swing guard floors the hit at 80%.
+    expect(swingMissChance(mob, player)).toBeLessThanOrEqual(MOB_VS_PLAYER_MAX_MISS);
+  });
+
+  it('a player attacking a higher-level mob keeps the full above-level penalty', () => {
+    const player = ent({ kind: 'player', level: 6, ownerId: null });
+    const mob = ent({ kind: 'mob', level: 10, hostile: true, ownerId: null });
+    expect(swingMissChance(player, mob)).toBe(meleeMissChance(player.level, mob.level));
+    expect(swingMissChance(player, mob)).toBeGreaterThan(MOB_VS_PLAYER_MAX_MISS);
+  });
+
+  it('a mob swinging at a player-owned pet is also capped (the pet is player-side)', () => {
+    const mob = ent({ kind: 'mob', level: 1, hostile: true, ownerId: null });
+    const pet = ent({ kind: 'mob', level: 10, ownerId: 99 }); // ownerId set -> owned pet
+    expect(swingMissChance(mob, pet)).toBeLessThanOrEqual(MOB_VS_PLAYER_MAX_MISS);
+  });
+
+  it('a player-owned pet attacking a higher mob is NOT capped (attacker is player-side)', () => {
+    const pet = ent({ kind: 'mob', level: 1, hostile: true, ownerId: 99 });
+    const mob = ent({ kind: 'mob', level: 10, hostile: true, ownerId: null });
+    expect(swingMissChance(pet, mob)).toBe(meleeMissChance(pet.level, mob.level));
+  });
+
+  it('equal / below level is unchanged for both directions', () => {
+    const mob = ent({ kind: 'mob', level: 10, hostile: true, ownerId: null });
+    const player = ent({ kind: 'player', level: 10, ownerId: null });
+    // mob -> player at equal level is already well under the cap, so it is untouched.
+    expect(swingMissChance(mob, player)).toBe(meleeMissChance(mob.level, player.level));
+  });
+});

--- a/tests/parity/golden/affix_mob.json
+++ b/tests/parity/golden/affix_mob.json
@@ -9,8 +9,8 @@
     "applyTaunt player-cast arm (taunt ability, ~4279)",
     "class:warrior"
   ],
-  "draws": 67,
-  "drawDigest": "80476701",
+  "draws": 71,
+  "drawDigest": "60069de6",
   "frames": [
     {
       "tick": 0,
@@ -100,33 +100,33 @@
       "tick": 20,
       "time": 1,
       "nextId": 391,
-      "state": "739bb371",
-      "events": "7aaac460",
+      "state": "a6f7de29",
+      "events": "3bcebefe",
       "rng": {
-        "draws": 15,
-        "digest": "c18c727a"
+        "draws": 14,
+        "digest": "97283cfb"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 391,
-      "state": "84d8bd3f",
-      "events": "40a7d5b3",
+      "state": "a2814025",
+      "events": "b1081a8d",
       "rng": {
-        "draws": 27,
-        "digest": "7af51137"
+        "draws": 28,
+        "digest": "9c413583"
       }
     },
     {
       "tick": 50,
       "time": 2.5,
       "nextId": 391,
-      "state": "a2b83c42",
-      "events": "5b5dc793",
+      "state": "4d2a0484",
+      "events": "73540386",
       "rng": {
-        "draws": 53,
-        "digest": "4e713ade"
+        "draws": 57,
+        "digest": "390c5ea3"
       },
       "label": "taunt",
       "players": [
@@ -139,7 +139,7 @@
           "companionUpgrades": {},
           "counters": {
             "damageDealt": 200,
-            "damageTaken": 197
+            "damageTaken": 194
           },
           "delveClears": {},
           "delveDaily": {},
@@ -165,11 +165,11 @@
               "id": "bleed_ridge_stalker",
               "kind": "dot",
               "name": "Rending Claws",
-              "remaining": 8.45,
+              "remaining": 8.5,
               "school": "physical",
               "sourceId": 390,
               "tickInterval": 3,
-              "tickTimer": 2.45,
+              "tickTimer": 2.5,
               "value": 5
             }
           ],
@@ -184,7 +184,7 @@
           "dodgeChance": 0.066,
           "fallStartY": 1.5,
           "fiveSecondRule": 101.5,
-          "hp": 389,
+          "hp": 392,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -202,7 +202,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "resource": 10.102564,
+          "resource": 12.025641,
           "resourceType": "rage",
           "spawnPos": {
             "x": 2,
@@ -299,7 +299,7 @@
         {
           "aggroTargetId": 388,
           "aiState": "attack",
-          "combatTimer": 0.55,
+          "combatTimer": 0.5,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -345,11 +345,11 @@
       "tick": 54,
       "time": 2.7,
       "nextId": 391,
-      "state": "5fc56af1",
+      "state": "49316be9",
       "events": "741638a5",
       "rng": {
-        "draws": 67,
-        "digest": "80476701"
+        "draws": 71,
+        "digest": "60069de6"
       },
       "label": "final",
       "players": [
@@ -362,7 +362,7 @@
           "companionUpgrades": {},
           "counters": {
             "damageDealt": 200,
-            "damageTaken": 197
+            "damageTaken": 194
           },
           "delveClears": {},
           "delveDaily": {},
@@ -388,11 +388,11 @@
               "id": "bleed_ridge_stalker",
               "kind": "dot",
               "name": "Rending Claws",
-              "remaining": 8.25,
+              "remaining": 8.3,
               "school": "physical",
               "sourceId": 390,
               "tickInterval": 3,
-              "tickTimer": 2.25,
+              "tickTimer": 2.3,
               "value": 5
             }
           ],
@@ -408,7 +408,7 @@
           "dodgeChance": 0.066,
           "fallStartY": 1.5,
           "fiveSecondRule": 101.7,
-          "hp": 389,
+          "hp": 392,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -426,7 +426,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "resource": 10.102564,
+          "resource": 12.025641,
           "resourceType": "rage",
           "spawnPos": {
             "x": 2,
@@ -524,7 +524,7 @@
         {
           "aggroTargetId": 388,
           "aiState": "attack",
-          "combatTimer": 0.75,
+          "combatTimer": 0.7,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,

--- a/tests/parity/golden/c3_aura_runner.json
+++ b/tests/parity/golden/c3_aura_runner.json
@@ -10,8 +10,8 @@
     "pulseGroundAoE over 2+ in-radius hostiles: rng.range per target, stable order",
     "class:paladin"
   ],
-  "draws": 788,
-  "drawDigest": "1372051e",
+  "draws": 799,
+  "drawDigest": "e49e2dea",
   "frames": [
     {
       "tick": 0,
@@ -516,275 +516,275 @@
       "tick": 65,
       "time": 3.25,
       "nextId": 392,
-      "state": "c37f1e7a",
-      "events": "4ac0f3a9",
+      "state": "35f98b95",
+      "events": "58c933f3",
       "rng": {
-        "draws": 102,
-        "digest": "4f9afb2d"
+        "draws": 104,
+        "digest": "23a19e04"
       }
     },
     {
       "tick": 70,
       "time": 3.5,
       "nextId": 392,
-      "state": "486a7ffe",
+      "state": "6029e511",
       "events": "741638a5",
       "rng": {
-        "draws": 123,
-        "digest": "50c0d574"
+        "draws": 125,
+        "digest": "7a127aaf"
       }
     },
     {
       "tick": 75,
       "time": 3.75,
       "nextId": 392,
-      "state": "ab40c07d",
+      "state": "62fc0434",
       "events": "741638a5",
       "rng": {
-        "draws": 150,
-        "digest": "c1dcedf2"
+        "draws": 152,
+        "digest": "9679fcdc"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 392,
-      "state": "cab3bdfc",
+      "state": "a931ae80",
       "events": "741638a5",
       "rng": {
-        "draws": 154,
-        "digest": "b541a4a8"
+        "draws": 156,
+        "digest": "6a78189c"
       }
     },
     {
       "tick": 85,
       "time": 4.25,
       "nextId": 392,
-      "state": "772d3273",
+      "state": "579c5c99",
       "events": "741638a5",
       "rng": {
-        "draws": 190,
-        "digest": "0512f3b6"
+        "draws": 192,
+        "digest": "7abffeeb"
       }
     },
     {
       "tick": 90,
       "time": 4.5,
       "nextId": 392,
-      "state": "8e2ea8d9",
+      "state": "dd3fb4fb",
       "events": "741638a5",
       "rng": {
-        "draws": 215,
-        "digest": "c89cc4fb"
+        "draws": 219,
+        "digest": "ab6dedec"
       }
     },
     {
       "tick": 95,
       "time": 4.75,
       "nextId": 392,
-      "state": "eb25501c",
+      "state": "9b5c83ac",
       "events": "741638a5",
       "rng": {
-        "draws": 257,
-        "digest": "ce32395b"
+        "draws": 259,
+        "digest": "3960c351"
       }
     },
     {
       "tick": 100,
       "time": 5,
       "nextId": 392,
-      "state": "b6816e4f",
+      "state": "e9d2dc03",
       "events": "741638a5",
       "rng": {
-        "draws": 279,
-        "digest": "bd85ac99"
+        "draws": 280,
+        "digest": "6e3a5a9d"
       }
     },
     {
       "tick": 105,
       "time": 5.25,
       "nextId": 392,
-      "state": "35dc7f23",
-      "events": "bd9000e2",
+      "state": "4b20f72a",
+      "events": "20e7a938",
       "rng": {
-        "draws": 301,
-        "digest": "186f149f"
+        "draws": 307,
+        "digest": "7bafabf5"
       }
     },
     {
       "tick": 110,
       "time": 5.5,
       "nextId": 392,
-      "state": "d08f407f",
+      "state": "343228c4",
       "events": "741638a5",
       "rng": {
-        "draws": 323,
-        "digest": "46d881f5"
+        "draws": 329,
+        "digest": "923e0e5b"
       }
     },
     {
       "tick": 115,
       "time": 5.75,
       "nextId": 392,
-      "state": "d0322aac",
+      "state": "42a29fcd",
       "events": "741638a5",
       "rng": {
-        "draws": 359,
-        "digest": "5e5aea9f"
+        "draws": 362,
+        "digest": "4701388b"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 392,
-      "state": "610adb0e",
+      "state": "574855a3",
       "events": "741638a5",
       "rng": {
-        "draws": 382,
-        "digest": "16f2d69d"
+        "draws": 388,
+        "digest": "7fef96af"
       }
     },
     {
       "tick": 125,
       "time": 6.25,
       "nextId": 392,
-      "state": "c3404626",
+      "state": "748834dd",
       "events": "741638a5",
       "rng": {
-        "draws": 427,
-        "digest": "5ce39d1a"
+        "draws": 432,
+        "digest": "1ca64a97"
       }
     },
     {
       "tick": 130,
       "time": 6.5,
       "nextId": 392,
-      "state": "df2c9f5a",
+      "state": "59fb7751",
       "events": "741638a5",
       "rng": {
-        "draws": 456,
-        "digest": "c4c28b32"
+        "draws": 463,
+        "digest": "db751be6"
       }
     },
     {
       "tick": 135,
       "time": 6.75,
       "nextId": 392,
-      "state": "8ca29411",
+      "state": "92ea091a",
       "events": "741638a5",
       "rng": {
-        "draws": 495,
-        "digest": "655e0f11"
+        "draws": 494,
+        "digest": "0864e07f"
       }
     },
     {
       "tick": 140,
       "time": 7,
       "nextId": 392,
-      "state": "b5ac1359",
+      "state": "82aac566",
       "events": "741638a5",
       "rng": {
-        "draws": 521,
-        "digest": "2abb1790"
+        "draws": 526,
+        "digest": "0fa14110"
       }
     },
     {
       "tick": 145,
       "time": 7.25,
       "nextId": 392,
-      "state": "73dc2b5e",
-      "events": "f3aa7b5c",
+      "state": "52a060f1",
+      "events": "a4ce19ca",
       "rng": {
-        "draws": 550,
-        "digest": "a6df342e"
+        "draws": 555,
+        "digest": "3a3f1482"
       }
     },
     {
       "tick": 150,
       "time": 7.5,
       "nextId": 392,
-      "state": "073edc8e",
+      "state": "8b0caa03",
       "events": "741638a5",
       "rng": {
-        "draws": 582,
-        "digest": "82cf2f6d"
+        "draws": 589,
+        "digest": "1f8b8482"
       }
     },
     {
       "tick": 155,
       "time": 7.75,
       "nextId": 392,
-      "state": "a905e237",
+      "state": "da2e51da",
       "events": "741638a5",
       "rng": {
-        "draws": 618,
-        "digest": "d38908e7"
+        "draws": 628,
+        "digest": "b91b074b"
       }
     },
     {
       "tick": 160,
       "time": 8,
       "nextId": 392,
-      "state": "12410e1b",
+      "state": "cb71fb78",
       "events": "741638a5",
       "rng": {
-        "draws": 643,
-        "digest": "bb3c5a84"
+        "draws": 655,
+        "digest": "e0259c48"
       }
     },
     {
       "tick": 165,
       "time": 8.25,
       "nextId": 392,
-      "state": "0a20bc89",
+      "state": "2ea88096",
       "events": "741638a5",
       "rng": {
-        "draws": 671,
-        "digest": "981f9f76"
+        "draws": 681,
+        "digest": "d160db96"
       }
     },
     {
       "tick": 170,
       "time": 8.5,
       "nextId": 392,
-      "state": "da166c6f",
+      "state": "dda50fa6",
       "events": "741638a5",
       "rng": {
-        "draws": 702,
-        "digest": "92be878f"
+        "draws": 708,
+        "digest": "a8fc1e6c"
       }
     },
     {
       "tick": 175,
       "time": 8.75,
       "nextId": 392,
-      "state": "f9f32244",
+      "state": "7842f9d9",
       "events": "741638a5",
       "rng": {
-        "draws": 736,
-        "digest": "91dfc695"
+        "draws": 746,
+        "digest": "b024879e"
       }
     },
     {
       "tick": 180,
       "time": 9,
       "nextId": 392,
-      "state": "c553d332",
+      "state": "d90c643d",
       "events": "741638a5",
       "rng": {
-        "draws": 778,
-        "digest": "a3c23ee5"
+        "draws": 786,
+        "digest": "71278582"
       }
     },
     {
       "tick": 182,
       "time": 9.1,
       "nextId": 392,
-      "state": "318a48fc",
-      "events": "ff945feb",
+      "state": "a4646b04",
+      "events": "8ab51886",
       "rng": {
-        "draws": 788,
-        "digest": "1372051e"
+        "draws": 799,
+        "digest": "e49e2dea"
       },
       "label": "final",
       "players": [
@@ -796,7 +796,8 @@
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 263
+            "damageDealt": 268,
+            "damageTaken": 32
           },
           "delveClears": {},
           "delveDaily": {},
@@ -828,7 +829,7 @@
           "dodgeChance": 0.068,
           "fallStartY": 1.5,
           "fiveSecondRule": 6,
-          "hp": 798,
+          "hp": 766,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -846,7 +847,7 @@
             "z": -2
           },
           "potionCooldownUntil": -1,
-          "resource": 660,
+          "resource": 600,
           "resourceType": "mana",
           "spawnPos": {
             "x": 2,
@@ -982,7 +983,7 @@
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 39871,
+          "hp": 39866,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -1015,7 +1016,7 @@
           "threat": [
             [
               388,
-              130
+              135
             ]
           ],
           "weapon": {

--- a/tests/parity/golden/c4a_casting_lifecycle.json
+++ b/tests/parity/golden/c4a_casting_lifecycle.json
@@ -323,140 +323,140 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 392,
-      "state": "7e221f66",
-      "events": "dc622207",
+      "state": "ce3189ea",
+      "events": "5d99c3f9",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 10,
       "time": 0.5,
       "nextId": 392,
-      "state": "ccbfea5a",
+      "state": "48908b1c",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 15,
       "time": 0.75,
       "nextId": 392,
-      "state": "8216ba4a",
+      "state": "7a9d8245",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 20,
       "time": 1,
       "nextId": 392,
-      "state": "7da4cb9e",
+      "state": "bddd9cdd",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 25,
       "time": 1.25,
       "nextId": 392,
-      "state": "70e6960f",
+      "state": "d07e7bef",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 30,
       "time": 1.5,
       "nextId": 392,
-      "state": "b44ad8be",
+      "state": "c3b34ffc",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 35,
       "time": 1.75,
       "nextId": 392,
-      "state": "1cae91cd",
+      "state": "d60c3102",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 392,
-      "state": "94adb404",
+      "state": "23c791a3",
       "events": "741638a5",
       "rng": {
-        "draws": 3,
-        "digest": "232163ca"
+        "draws": 5,
+        "digest": "fafaf5ab"
       }
     },
     {
       "tick": 45,
       "time": 2.25,
       "nextId": 392,
-      "state": "18a76e65",
+      "state": "4c713fed",
       "events": "dc622207",
       "rng": {
-        "draws": 22,
-        "digest": "ccf87dc0"
+        "draws": 24,
+        "digest": "df66d8be"
       }
     },
     {
       "tick": 50,
       "time": 2.5,
       "nextId": 392,
-      "state": "fa3706a3",
+      "state": "b366c583",
       "events": "741638a5",
       "rng": {
-        "draws": 46,
-        "digest": "eab21a47"
+        "draws": 48,
+        "digest": "278176a2"
       }
     },
     {
       "tick": 55,
       "time": 2.75,
       "nextId": 392,
-      "state": "c54476f6",
+      "state": "01d126ad",
       "events": "741638a5",
       "rng": {
-        "draws": 64,
-        "digest": "c1f6906b"
+        "draws": 66,
+        "digest": "1004689a"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 392,
-      "state": "b6b4aec5",
-      "events": "575fdf9f",
+      "state": "dd11282c",
+      "events": "741638a5",
       "rng": {
-        "draws": 80,
-        "digest": "cdfb4afc"
+        "draws": 82,
+        "digest": "e2e5902a"
       }
     },
     {
       "tick": 65,
       "time": 3.25,
       "nextId": 392,
-      "state": "5c2ff2ac",
-      "events": "b9524916",
+      "state": "15d1dd14",
+      "events": "741638a5",
       "rng": {
         "draws": 103,
         "digest": "efb9e6cc"
@@ -466,132 +466,132 @@
       "tick": 70,
       "time": 3.5,
       "nextId": 392,
-      "state": "52b29432",
-      "events": "741638a5",
+      "state": "ea22734d",
+      "events": "575fdf9f",
       "rng": {
-        "draws": 127,
-        "digest": "faa8b9df"
+        "draws": 124,
+        "digest": "a995ff0f"
       }
     },
     {
       "tick": 75,
       "time": 3.75,
       "nextId": 392,
-      "state": "07af1246",
-      "events": "741638a5",
+      "state": "1ac4b97c",
+      "events": "86382be0",
       "rng": {
-        "draws": 151,
-        "digest": "f527e679"
+        "draws": 149,
+        "digest": "60af83e6"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 392,
-      "state": "92996cdb",
+      "state": "1739fb68",
       "events": "741638a5",
       "rng": {
-        "draws": 158,
-        "digest": "878ecdcb"
+        "draws": 162,
+        "digest": "310e2512"
       }
     },
     {
       "tick": 85,
       "time": 4.25,
       "nextId": 392,
-      "state": "c997f808",
+      "state": "03cc3191",
       "events": "dc622207",
       "rng": {
-        "draws": 195,
-        "digest": "4065e5b2"
+        "draws": 197,
+        "digest": "2245de47"
       }
     },
     {
       "tick": 90,
       "time": 4.5,
       "nextId": 392,
-      "state": "4330ab18",
+      "state": "5cc16734",
       "events": "741638a5",
       "rng": {
-        "draws": 220,
-        "digest": "96647263"
+        "draws": 225,
+        "digest": "de973eac"
       }
     },
     {
       "tick": 95,
       "time": 4.75,
       "nextId": 392,
-      "state": "63d41846",
+      "state": "008f1a68",
       "events": "741638a5",
       "rng": {
-        "draws": 263,
-        "digest": "0a6ec37b"
+        "draws": 266,
+        "digest": "94e76999"
       }
     },
     {
       "tick": 100,
       "time": 5,
       "nextId": 392,
-      "state": "bce350a3",
+      "state": "8016e1d2",
       "events": "741638a5",
       "rng": {
-        "draws": 280,
-        "digest": "6e3a5a9d"
+        "draws": 283,
+        "digest": "c4feb384"
       }
     },
     {
       "tick": 105,
       "time": 5.25,
       "nextId": 392,
-      "state": "6b63589e",
-      "events": "5a2ebe34",
+      "state": "ee0ab4c1",
+      "events": "741638a5",
       "rng": {
-        "draws": 299,
-        "digest": "e4389d78"
+        "draws": 303,
+        "digest": "5e5c04dc"
       }
     },
     {
       "tick": 110,
       "time": 5.5,
       "nextId": 392,
-      "state": "fe4189a0",
+      "state": "bef9fe98",
       "events": "741638a5",
       "rng": {
-        "draws": 316,
-        "digest": "ba079ebf"
+        "draws": 323,
+        "digest": "46d881f5"
       }
     },
     {
       "tick": 115,
       "time": 5.75,
       "nextId": 392,
-      "state": "c89d7330",
-      "events": "741638a5",
+      "state": "f74add36",
+      "events": "5a2ebe34",
       "rng": {
-        "draws": 350,
-        "digest": "48c3cf3b"
+        "draws": 362,
+        "digest": "4701388b"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 392,
-      "state": "9090e039",
+      "state": "7d272d02",
       "events": "741638a5",
       "rng": {
-        "draws": 374,
-        "digest": "29a91cba"
+        "draws": 384,
+        "digest": "a21ba11c"
       }
     },
     {
       "tick": 123,
       "time": 6.15,
       "nextId": 392,
-      "state": "b2d34ef6",
+      "state": "7f76c221",
       "events": "37971221",
       "rng": {
-        "draws": 406,
-        "digest": "8ce32db8"
+        "draws": 411,
+        "digest": "f1455cd5"
       },
       "label": "priest-silence-cancel",
       "players": [
@@ -602,8 +602,8 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 93,
-            "damageTaken": 40
+            "damageDealt": 67,
+            "damageTaken": 52
           },
           "delveClears": {},
           "delveDaily": {},
@@ -663,15 +663,15 @@
         {
           "aiState": "idle",
           "attackPower": 10,
-          "castTotal": 3,
-          "combatTimer": 1,
+          "castTotal": 3.5,
+          "combatTimer": 0.5,
           "critChance": 0.056,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.056,
           "facing": 0.54042,
           "fallStartY": -0.371544,
-          "fiveSecondRule": 3.2,
-          "hp": 19960,
+          "fiveSecondRule": 2.7,
+          "hp": 19948,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -832,15 +832,15 @@
               "id": "fireball",
               "kind": "dot",
               "name": "Fireball",
-              "remaining": 3,
+              "remaining": 3.5,
               "school": "fire",
               "sourceId": 388,
               "tickInterval": 2,
-              "tickTimer": 1,
+              "tickTimer": 1.5,
               "value": 2
             }
           ],
-          "combatTimer": 1,
+          "combatTimer": 0.5,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -848,7 +848,7 @@
           "fallStartY": -0.371544,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199907,
+          "hp": 199933,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -883,7 +883,7 @@
           "threat": [
             [
               388,
-              94
+              68
             ]
           ],
           "wanderTarget": {
@@ -904,40 +904,40 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 392,
-      "state": "01030b62",
+      "state": "bae7495b",
       "events": "74882547",
       "rng": {
-        "draws": 417,
-        "digest": "edb2e1ef"
+        "draws": 421,
+        "digest": "36d7c20a"
       }
     },
     {
       "tick": 130,
       "time": 6.5,
       "nextId": 392,
-      "state": "632e7c42",
+      "state": "07f6e09a",
       "events": "741638a5",
       "rng": {
-        "draws": 451,
-        "digest": "66b1ef89"
+        "draws": 457,
+        "digest": "db64a726"
       }
     },
     {
       "tick": 135,
       "time": 6.75,
       "nextId": 392,
-      "state": "e2a1a813",
+      "state": "0dac26a1",
       "events": "741638a5",
       "rng": {
-        "draws": 486,
-        "digest": "8eaff15f"
+        "draws": 488,
+        "digest": "0b554cd5"
       }
     },
     {
       "tick": 140,
       "time": 7,
       "nextId": 392,
-      "state": "815f0211",
+      "state": "e411321c",
       "events": "741638a5",
       "rng": {
         "draws": 513,
@@ -948,22 +948,22 @@
       "tick": 145,
       "time": 7.25,
       "nextId": 392,
-      "state": "141fff8c",
-      "events": "68fd6d7a",
+      "state": "d37a77cf",
+      "events": "7b69a5ef",
       "rng": {
-        "draws": 541,
-        "digest": "e0ec0396"
+        "draws": 538,
+        "digest": "f0ef76bf"
       }
     },
     {
       "tick": 145,
       "time": 7.25,
       "nextId": 392,
-      "state": "ed8d22e8",
+      "state": "5eca6275",
       "events": "d58ff44f",
       "rng": {
-        "draws": 541,
-        "digest": "e0ec0396"
+        "draws": 538,
+        "digest": "f0ef76bf"
       },
       "label": "warlock-channel-pushback",
       "players": [
@@ -974,8 +974,8 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 95,
-            "damageTaken": 40
+            "damageDealt": 67,
+            "damageTaken": 52
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1037,15 +1037,15 @@
         {
           "aiState": "idle",
           "attackPower": 10,
-          "castTotal": 3,
-          "combatTimer": 0.1,
+          "castTotal": 3.5,
+          "combatTimer": 1.6,
           "critChance": 0.056,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.056,
           "facing": 0.54042,
           "fallStartY": -0.371544,
-          "fiveSecondRule": 4.3,
-          "hp": 19960,
+          "fiveSecondRule": 3.8,
+          "hp": 19948,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -1215,11 +1215,11 @@
               "id": "fireball",
               "kind": "dot",
               "name": "Fireball",
-              "remaining": 1.9,
+              "remaining": 2.4,
               "school": "fire",
               "sourceId": 388,
               "tickInterval": 2,
-              "tickTimer": 1.9,
+              "tickTimer": 0.4,
               "value": 2
             }
           ],
@@ -1230,7 +1230,7 @@
           "fallStartY": -0.371544,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199905,
+          "hp": 199933,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -1265,7 +1265,7 @@
           "threat": [
             [
               388,
-              96
+              68
             ]
           ],
           "wanderTarget": {
@@ -1286,22 +1286,22 @@
       "tick": 150,
       "time": 7.5,
       "nextId": 392,
-      "state": "ae975caf",
+      "state": "448b8424",
       "events": "cfd5b114",
       "rng": {
-        "draws": 581,
-        "digest": "1bead0ee"
+        "draws": 574,
+        "digest": "4f593508"
       }
     },
     {
       "tick": 153,
       "time": 7.65,
       "nextId": 392,
-      "state": "2a2dda2d",
-      "events": "f55a7986",
+      "state": "cfc833e4",
+      "events": "0960f7a7",
       "rng": {
-        "draws": 597,
-        "digest": "b5e34abb"
+        "draws": 596,
+        "digest": "eb7df1f1"
       },
       "label": "warlock-fishing-cancel",
       "players": [
@@ -1312,8 +1312,8 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 95,
-            "damageTaken": 40
+            "damageDealt": 69,
+            "damageTaken": 52
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1376,15 +1376,14 @@
         {
           "aiState": "idle",
           "attackPower": 10,
-          "castTotal": 3,
-          "combatTimer": 0.5,
+          "castTotal": 3.5,
           "critChance": 0.056,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.056,
           "facing": 0.54042,
           "fallStartY": -0.371544,
-          "fiveSecondRule": 4.7,
-          "hp": 19960,
+          "fiveSecondRule": 4.2,
+          "hp": 19948,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -1549,11 +1548,11 @@
               "id": "fireball",
               "kind": "dot",
               "name": "Fireball",
-              "remaining": 1.5,
+              "remaining": 2,
               "school": "fire",
               "sourceId": 388,
               "tickInterval": 2,
-              "tickTimer": 1.5,
+              "tickTimer": 2,
               "value": 2
             }
           ],
@@ -1564,7 +1563,7 @@
           "fallStartY": -0.371544,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199892,
+          "hp": 199918,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -1599,7 +1598,7 @@
           "threat": [
             [
               388,
-              96
+              70
             ],
             [
               390,
@@ -1624,7 +1623,7 @@
       "tick": 155,
       "time": 7.75,
       "nextId": 392,
-      "state": "5ca30000",
+      "state": "7494f5a2",
       "events": "741638a5",
       "rng": {
         "draws": 610,
@@ -1635,7 +1634,7 @@
       "tick": 158,
       "time": 7.9,
       "nextId": 392,
-      "state": "d3b7bdf2",
+      "state": "6a2637f4",
       "events": "741638a5",
       "rng": {
         "draws": 624,
@@ -1650,8 +1649,8 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 95,
-            "damageTaken": 40
+            "damageDealt": 69,
+            "damageTaken": 52
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1714,15 +1713,15 @@
         {
           "aiState": "idle",
           "attackPower": 10,
-          "castTotal": 3,
-          "combatTimer": 0.75,
+          "castTotal": 3.5,
+          "combatTimer": 0.25,
           "critChance": 0.056,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.056,
           "facing": 0.54042,
           "fallStartY": -0.371544,
-          "fiveSecondRule": 4.95,
-          "hp": 19960,
+          "fiveSecondRule": 4.45,
+          "hp": 19948,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -1888,11 +1887,11 @@
               "id": "fireball",
               "kind": "dot",
               "name": "Fireball",
-              "remaining": 1.25,
+              "remaining": 1.75,
               "school": "fire",
               "sourceId": 388,
               "tickInterval": 2,
-              "tickTimer": 1.25,
+              "tickTimer": 1.75,
               "value": 2
             }
           ],
@@ -1904,7 +1903,7 @@
           "fallStartY": -0.371544,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 199892,
+          "hp": 199918,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -1939,7 +1938,7 @@
           "threat": [
             [
               388,
-              96
+              70
             ],
             [
               390,

--- a/tests/parity/golden/c5_auto_attack.json
+++ b/tests/parity/golden/c5_auto_attack.json
@@ -14,8 +14,8 @@
     "rangedSwing Wand (mage, arcane, no armor, no dead zone)",
     "stopAutoAttack public entry"
   ],
-  "draws": 508,
-  "drawDigest": "6ec74e22",
+  "draws": 524,
+  "drawDigest": "bb89984b",
   "frames": [
     {
       "tick": 0,
@@ -35,275 +35,275 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 398,
-      "state": "9280485d",
-      "events": "18b48b61",
+      "state": "a0adde97",
+      "events": "d38a5ccd",
       "rng": {
-        "draws": 12,
-        "digest": "b2e0c83d"
+        "draws": 16,
+        "digest": "76cf2232"
       }
     },
     {
       "tick": 10,
       "time": 0.5,
       "nextId": 398,
-      "state": "5d602f73",
-      "events": "05110b22",
+      "state": "1168de52",
+      "events": "b8ca369d",
       "rng": {
-        "draws": 15,
-        "digest": "e421ce41"
+        "draws": 19,
+        "digest": "106b80d2"
       }
     },
     {
       "tick": 15,
       "time": 0.75,
       "nextId": 398,
-      "state": "6b35f744",
+      "state": "76a43563",
       "events": "21391abc",
       "rng": {
-        "draws": 15,
-        "digest": "e421ce41"
+        "draws": 19,
+        "digest": "106b80d2"
       }
     },
     {
       "tick": 20,
       "time": 1,
       "nextId": 398,
-      "state": "9cb0fa34",
-      "events": "10a7b9a8",
+      "state": "f3e37070",
+      "events": "b32298be",
       "rng": {
-        "draws": 18,
-        "digest": "ec7ffe3f"
+        "draws": 22,
+        "digest": "c0f15e96"
       }
     },
     {
       "tick": 25,
       "time": 1.25,
       "nextId": 398,
-      "state": "d26f4a70",
+      "state": "47a24502",
       "events": "21391abc",
       "rng": {
-        "draws": 18,
-        "digest": "ec7ffe3f"
+        "draws": 22,
+        "digest": "c0f15e96"
       }
     },
     {
       "tick": 30,
       "time": 1.5,
       "nextId": 398,
-      "state": "d2e4489f",
+      "state": "986acb5f",
       "events": "741638a5",
       "rng": {
-        "draws": 18,
-        "digest": "ec7ffe3f"
+        "draws": 22,
+        "digest": "c0f15e96"
       }
     },
     {
       "tick": 35,
       "time": 1.75,
       "nextId": 398,
-      "state": "9d3e050b",
+      "state": "c6ce4657",
       "events": "21391abc",
       "rng": {
-        "draws": 18,
-        "digest": "ec7ffe3f"
+        "draws": 22,
+        "digest": "c0f15e96"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 398,
-      "state": "07fe516a",
-      "events": "f8380d1c",
+      "state": "69d733e3",
+      "events": "38879e8f",
       "rng": {
-        "draws": 21,
-        "digest": "b14ae70e"
+        "draws": 25,
+        "digest": "34f63655"
       }
     },
     {
       "tick": 45,
       "time": 2.25,
       "nextId": 398,
-      "state": "8a4e76e7",
-      "events": "c9a4bd09",
+      "state": "bc3398ac",
+      "events": "c2243470",
       "rng": {
-        "draws": 56,
-        "digest": "89db4fd0"
+        "draws": 66,
+        "digest": "b6949540"
       }
     },
     {
       "tick": 50,
       "time": 2.5,
       "nextId": 398,
-      "state": "551f279e",
-      "events": "8580297b",
+      "state": "ff97ed15",
+      "events": "f0321c25",
       "rng": {
-        "draws": 81,
-        "digest": "87867c50"
+        "draws": 91,
+        "digest": "1c05f7c3"
       }
     },
     {
       "tick": 55,
       "time": 2.75,
       "nextId": 398,
-      "state": "6d8304c4",
+      "state": "fcd51bde",
       "events": "21391abc",
       "rng": {
-        "draws": 93,
-        "digest": "e53395e6"
+        "draws": 103,
+        "digest": "563e4e07"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 398,
-      "state": "99bc774b",
+      "state": "e5d57117",
       "events": "7d3769c6",
       "rng": {
-        "draws": 116,
-        "digest": "af9d8218"
+        "draws": 128,
+        "digest": "55009736"
       }
     },
     {
       "tick": 65,
       "time": 3.25,
       "nextId": 398,
-      "state": "a0494547",
+      "state": "b43725ad",
       "events": "21391abc",
       "rng": {
-        "draws": 137,
-        "digest": "dd07dd3a"
+        "draws": 148,
+        "digest": "1ed7f5ef"
       }
     },
     {
       "tick": 70,
       "time": 3.5,
       "nextId": 398,
-      "state": "410a6a8b",
+      "state": "2d285ad7",
       "events": "741638a5",
       "rng": {
-        "draws": 158,
-        "digest": "a3ca8b3e"
+        "draws": 169,
+        "digest": "e71cefca"
       }
     },
     {
       "tick": 75,
       "time": 3.75,
       "nextId": 398,
-      "state": "299466f1",
+      "state": "4e846b18",
       "events": "82678c01",
       "rng": {
-        "draws": 182,
-        "digest": "0dc68243"
+        "draws": 193,
+        "digest": "d945fccc"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 398,
-      "state": "87d79a2a",
+      "state": "78169da7",
       "events": "741638a5",
       "rng": {
-        "draws": 201,
-        "digest": "cb36a9d7"
+        "draws": 216,
+        "digest": "fc5370cf"
       }
     },
     {
       "tick": 85,
       "time": 4.25,
       "nextId": 398,
-      "state": "b8e7342f",
-      "events": "ea1b1a7d",
+      "state": "13f15436",
+      "events": "386397fc",
       "rng": {
-        "draws": 240,
-        "digest": "5c232555"
+        "draws": 258,
+        "digest": "25c55ffa"
       }
     },
     {
       "tick": 90,
       "time": 4.5,
       "nextId": 398,
-      "state": "4cba7143",
-      "events": "408c80ba",
+      "state": "0b9f3d67",
+      "events": "8d3b0320",
       "rng": {
-        "draws": 267,
-        "digest": "9c20c02f"
+        "draws": 289,
+        "digest": "329800bc"
       }
     },
     {
       "tick": 95,
       "time": 4.75,
       "nextId": 398,
-      "state": "c089cc3d",
+      "state": "78ee066d",
       "events": "7f3343c9",
       "rng": {
-        "draws": 296,
-        "digest": "6ed574d4"
+        "draws": 315,
+        "digest": "ccf6ee96"
       }
     },
     {
       "tick": 100,
       "time": 5,
       "nextId": 398,
-      "state": "a7bbb069",
+      "state": "44df9d4d",
       "events": "741638a5",
       "rng": {
-        "draws": 327,
-        "digest": "01a2ba27"
+        "draws": 342,
+        "digest": "a17e533e"
       }
     },
     {
       "tick": 105,
       "time": 5.25,
       "nextId": 398,
-      "state": "d56f8b8d",
+      "state": "1295e4c5",
       "events": "21391abc",
       "rng": {
-        "draws": 359,
-        "digest": "48ba1a24"
+        "draws": 372,
+        "digest": "c50d6ea5"
       }
     },
     {
       "tick": 110,
       "time": 5.5,
       "nextId": 398,
-      "state": "e22173aa",
-      "events": "44d367fe",
+      "state": "9d200bb5",
+      "events": "e74402e3",
       "rng": {
-        "draws": 388,
-        "digest": "7be3015e"
+        "draws": 396,
+        "digest": "346ccc0d"
       }
     },
     {
       "tick": 115,
       "time": 5.75,
       "nextId": 398,
-      "state": "84ca597e",
+      "state": "8e7223f5",
       "events": "21391abc",
       "rng": {
-        "draws": 410,
-        "digest": "581bd2d5"
+        "draws": 418,
+        "digest": "43a127ed"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 398,
-      "state": "ac261114",
-      "events": "6f7f76a3",
+      "state": "842efd93",
+      "events": "a9c81340",
       "rng": {
-        "draws": 461,
-        "digest": "d1b9b937"
+        "draws": 473,
+        "digest": "d9ceee98"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 398,
-      "state": "ac261114",
+      "state": "842efd93",
       "events": "741638a5",
       "rng": {
-        "draws": 461,
-        "digest": "d1b9b937"
+        "draws": 473,
+        "digest": "d9ceee98"
       },
       "label": "swings",
       "players": [
@@ -314,8 +314,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 149,
-            "damageTaken": 6
+            "damageDealt": 147,
+            "damageTaken": 22
           },
           "delveClears": {},
           "delveDaily": {},
@@ -337,7 +337,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 75
+            "damageDealt": 75,
+            "damageTaken": 7
           },
           "delveClears": {},
           "delveDaily": {},
@@ -359,7 +360,8 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 53
+            "damageDealt": 72,
+            "damageTaken": 27
           },
           "delveClears": {},
           "delveDaily": {},
@@ -381,7 +383,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 112
+            "damageDealt": 84
           },
           "delveClears": {},
           "delveDaily": {},
@@ -403,7 +405,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 24
+            "damageDealt": 15
           },
           "delveClears": {},
           "delveDaily": {},
@@ -424,13 +426,13 @@
           "aiState": "idle",
           "attackPower": 102,
           "autoAttack": true,
-          "combatTimer": 2,
+          "combatTimer": 1.55,
           "critChance": 0.067,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.067,
           "fallStartY": -1.553351,
           "fiveSecondRule": 105,
-          "hp": 79994,
+          "hp": 79978,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -484,7 +486,7 @@
           "dodgeChance": 0.0835,
           "fallStartY": -3.203049,
           "fiveSecondRule": 105,
-          "hp": 80000,
+          "hp": 79993,
           "id": 389,
           "inCombat": true,
           "kind": "player",
@@ -544,7 +546,7 @@
           "dodgeChance": 0.0835,
           "fallStartY": -3.063027,
           "fiveSecondRule": 6,
-          "hp": 80000,
+          "hp": 79973,
           "id": 390,
           "inCombat": true,
           "kind": "player",
@@ -554,7 +556,7 @@
           "maxResource": 457,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": 7.25,
+          "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
             "y": -3.063027,
@@ -697,7 +699,7 @@
         {
           "aggroTargetId": 388,
           "aiState": "attack",
-          "combatTimer": 2,
+          "combatTimer": 1.55,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -705,7 +707,7 @@
           "fallStartY": -1.689975,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499851,
+          "hp": 499853,
           "id": 393,
           "inCombat": true,
           "kind": "mob",
@@ -741,7 +743,7 @@
           "threat": [
             [
               388,
-              328
+              326
             ]
           ],
           "weapon": {
@@ -817,7 +819,7 @@
           "fallStartY": -3.078543,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499947,
+          "hp": 499928,
           "id": 395,
           "inCombat": true,
           "kind": "mob",
@@ -850,7 +852,7 @@
           "threat": [
             [
               390,
-              54
+              73
             ]
           ],
           "weapon": {
@@ -870,7 +872,7 @@
           "fallStartY": 2.785314,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499888,
+          "hp": 499916,
           "id": 396,
           "inCombat": true,
           "kind": "mob",
@@ -905,7 +907,7 @@
           "threat": [
             [
               391,
-              114
+              86
             ]
           ],
           "weapon": {
@@ -925,7 +927,7 @@
           "fallStartY": 2.551396,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499976,
+          "hp": 499985,
           "id": 397,
           "inCombat": true,
           "kind": "mob",
@@ -960,7 +962,7 @@
           "threat": [
             [
               392,
-              26
+              17
             ]
           ],
           "weapon": {
@@ -975,22 +977,22 @@
       "tick": 125,
       "time": 6.25,
       "nextId": 398,
-      "state": "b61b8d8d",
-      "events": "34df3a9b",
+      "state": "e6d59b71",
+      "events": "ca191fda",
       "rng": {
-        "draws": 501,
-        "digest": "7f421b8a"
+        "draws": 518,
+        "digest": "43746d41"
       }
     },
     {
       "tick": 126,
       "time": 6.3,
       "nextId": 398,
-      "state": "0da4967f",
+      "state": "2475a885",
       "events": "741638a5",
       "rng": {
-        "draws": 508,
-        "digest": "6ec74e22"
+        "draws": 524,
+        "digest": "bb89984b"
       },
       "label": "after-stop",
       "players": [
@@ -1001,8 +1003,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 199,
-            "damageTaken": 8
+            "damageDealt": 196,
+            "damageTaken": 24
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1024,7 +1026,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 75
+            "damageDealt": 75,
+            "damageTaken": 17
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1046,7 +1049,8 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 53
+            "damageDealt": 72,
+            "damageTaken": 34
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1068,7 +1072,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 112
+            "damageDealt": 84
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1090,7 +1094,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 24
+            "damageDealt": 15
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1117,7 +1121,7 @@
           "dodgeChance": 0.067,
           "fallStartY": -1.553351,
           "fiveSecondRule": 105.3,
-          "hp": 79992,
+          "hp": 79976,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -1163,13 +1167,13 @@
         {
           "aiState": "idle",
           "attackPower": 98,
-          "combatTimer": 0.9,
+          "combatTimer": 0.25,
           "critChance": 0.0835,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0835,
           "fallStartY": -3.203049,
           "fiveSecondRule": 105.3,
-          "hp": 80000,
+          "hp": 79983,
           "id": 389,
           "inCombat": true,
           "kind": "player",
@@ -1217,13 +1221,13 @@
           "aiState": "idle",
           "attackPower": 95,
           "autoAttack": true,
-          "combatTimer": 1.9,
+          "combatTimer": 0.25,
           "critChance": 0.0835,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0835,
           "fallStartY": -3.063027,
           "fiveSecondRule": 6.3,
-          "hp": 80000,
+          "hp": 79966,
           "id": 390,
           "inCombat": true,
           "kind": "player",
@@ -1233,7 +1237,7 @@
           "maxResource": 457,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": 7.25,
+          "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
             "y": -3.063027,
@@ -1384,7 +1388,7 @@
           "fallStartY": -1.689975,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499801,
+          "hp": 499804,
           "id": 393,
           "inCombat": true,
           "kind": "mob",
@@ -1420,7 +1424,7 @@
           "threat": [
             [
               388,
-              437
+              434
             ]
           ],
           "weapon": {
@@ -1432,7 +1436,7 @@
         {
           "aggroTargetId": 389,
           "aiState": "attack",
-          "combatTimer": 0.9,
+          "combatTimer": 0.25,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -1488,7 +1492,7 @@
         {
           "aggroTargetId": 390,
           "aiState": "attack",
-          "combatTimer": 1.9,
+          "combatTimer": 0.25,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -1496,7 +1500,7 @@
           "fallStartY": -3.078543,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499947,
+          "hp": 499928,
           "id": 395,
           "inCombat": true,
           "kind": "mob",
@@ -1529,7 +1533,7 @@
           "threat": [
             [
               390,
-              54
+              73
             ]
           ],
           "weapon": {
@@ -1549,7 +1553,7 @@
           "fallStartY": 2.785314,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499888,
+          "hp": 499916,
           "id": 396,
           "inCombat": true,
           "kind": "mob",
@@ -1584,7 +1588,7 @@
           "threat": [
             [
               391,
-              114
+              86
             ]
           ],
           "weapon": {
@@ -1604,7 +1608,7 @@
           "fallStartY": 2.551396,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499976,
+          "hp": 499985,
           "id": 397,
           "inCombat": true,
           "kind": "mob",
@@ -1639,7 +1643,7 @@
           "threat": [
             [
               392,
-              26
+              17
             ]
           ],
           "weapon": {
@@ -1654,11 +1658,11 @@
       "tick": 126,
       "time": 6.3,
       "nextId": 398,
-      "state": "0da4967f",
+      "state": "2475a885",
       "events": "741638a5",
       "rng": {
-        "draws": 508,
-        "digest": "6ec74e22"
+        "draws": 524,
+        "digest": "bb89984b"
       },
       "label": "final",
       "players": [
@@ -1669,8 +1673,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 199,
-            "damageTaken": 8
+            "damageDealt": 196,
+            "damageTaken": 24
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1692,7 +1696,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 75
+            "damageDealt": 75,
+            "damageTaken": 17
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1714,7 +1719,8 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 53
+            "damageDealt": 72,
+            "damageTaken": 34
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1736,7 +1742,7 @@
           "cls": "hunter",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 112
+            "damageDealt": 84
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1758,7 +1764,7 @@
           "cls": "mage",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 24
+            "damageDealt": 15
           },
           "delveClears": {},
           "delveDaily": {},
@@ -1785,7 +1791,7 @@
           "dodgeChance": 0.067,
           "fallStartY": -1.553351,
           "fiveSecondRule": 105.3,
-          "hp": 79992,
+          "hp": 79976,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -1831,13 +1837,13 @@
         {
           "aiState": "idle",
           "attackPower": 98,
-          "combatTimer": 0.9,
+          "combatTimer": 0.25,
           "critChance": 0.0835,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0835,
           "fallStartY": -3.203049,
           "fiveSecondRule": 105.3,
-          "hp": 80000,
+          "hp": 79983,
           "id": 389,
           "inCombat": true,
           "kind": "player",
@@ -1885,13 +1891,13 @@
           "aiState": "idle",
           "attackPower": 95,
           "autoAttack": true,
-          "combatTimer": 1.9,
+          "combatTimer": 0.25,
           "critChance": 0.0835,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.0835,
           "fallStartY": -3.063027,
           "fiveSecondRule": 6.3,
-          "hp": 80000,
+          "hp": 79966,
           "id": 390,
           "inCombat": true,
           "kind": "player",
@@ -1901,7 +1907,7 @@
           "maxResource": 457,
           "moveSpeed": 7,
           "onGround": true,
-          "overpowerUntil": 7.25,
+          "overpowerUntil": -1,
           "petMode": "defensive",
           "pos": {
             "y": -3.063027,
@@ -2052,7 +2058,7 @@
           "fallStartY": -1.689975,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499801,
+          "hp": 499804,
           "id": 393,
           "inCombat": true,
           "kind": "mob",
@@ -2088,7 +2094,7 @@
           "threat": [
             [
               388,
-              437
+              434
             ]
           ],
           "weapon": {
@@ -2100,7 +2106,7 @@
         {
           "aggroTargetId": 389,
           "aiState": "attack",
-          "combatTimer": 0.9,
+          "combatTimer": 0.25,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -2156,7 +2162,7 @@
         {
           "aggroTargetId": 390,
           "aiState": "attack",
-          "combatTimer": 1.9,
+          "combatTimer": 0.25,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -2164,7 +2170,7 @@
           "fallStartY": -3.078543,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499947,
+          "hp": 499928,
           "id": 395,
           "inCombat": true,
           "kind": "mob",
@@ -2197,7 +2203,7 @@
           "threat": [
             [
               390,
-              54
+              73
             ]
           ],
           "weapon": {
@@ -2217,7 +2223,7 @@
           "fallStartY": 2.785314,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499888,
+          "hp": 499916,
           "id": 396,
           "inCombat": true,
           "kind": "mob",
@@ -2252,7 +2258,7 @@
           "threat": [
             [
               391,
-              114
+              86
             ]
           ],
           "weapon": {
@@ -2272,7 +2278,7 @@
           "fallStartY": 2.551396,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 499976,
+          "hp": 499985,
           "id": 397,
           "inCombat": true,
           "kind": "mob",
@@ -2307,7 +2313,7 @@
           "threat": [
             [
               392,
-              26
+              17
             ]
           ],
           "weapon": {

--- a/tests/parity/golden/paladin_consecration.json
+++ b/tests/parity/golden/paladin_consecration.json
@@ -8,8 +8,8 @@
     "updateGroundAoEs first-in-tick (~2256)",
     "pulseGroundAoE both callers (immediate ~4097 + deferred ~3052)"
   ],
-  "draws": 908,
-  "drawDigest": "c80759b7",
+  "draws": 932,
+  "drawDigest": "34d01e34",
   "frames": [
     {
       "tick": 0,
@@ -144,77 +144,77 @@
       "tick": 100,
       "time": 5,
       "nextId": 390,
-      "state": "aed428e8",
-      "events": "8ee385d4",
+      "state": "27373b14",
+      "events": "80c51631",
       "rng": {
-        "draws": 267,
-        "digest": "5c982a13"
+        "draws": 270,
+        "digest": "afc4bc0b"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 390,
-      "state": "7fdc160d",
+      "state": "ae15a779",
       "events": "741638a5",
       "rng": {
-        "draws": 381,
-        "digest": "8fa1e5e8"
+        "draws": 387,
+        "digest": "8fade9d9"
       }
     },
     {
       "tick": 140,
       "time": 7,
       "nextId": 390,
-      "state": "320b602a",
-      "events": "721cba51",
+      "state": "cd8b62cd",
+      "events": "ec943e25",
       "rng": {
-        "draws": 500,
-        "digest": "9999daa2"
+        "draws": 501,
+        "digest": "9e9280f3"
       }
     },
     {
       "tick": 160,
       "time": 8,
       "nextId": 390,
-      "state": "b1eea714",
+      "state": "3ca2018b",
       "events": "741638a5",
       "rng": {
-        "draws": 621,
-        "digest": "c4b0f36c"
+        "draws": 627,
+        "digest": "ee13bd7f"
       }
     },
     {
       "tick": 180,
       "time": 9,
       "nextId": 390,
-      "state": "62d43bd9",
-      "events": "810b221f",
+      "state": "1b45a319",
+      "events": "123352bf",
       "rng": {
-        "draws": 757,
-        "digest": "5cf7ae3d"
+        "draws": 765,
+        "digest": "84d7375c"
       }
     },
     {
       "tick": 200,
       "time": 10,
       "nextId": 390,
-      "state": "cdf84d16",
+      "state": "0f885284",
       "events": "741638a5",
       "rng": {
-        "draws": 906,
-        "digest": "39ca68f3"
+        "draws": 931,
+        "digest": "5764acf5"
       }
     },
     {
       "tick": 201,
       "time": 10.05,
       "nextId": 390,
-      "state": "2197284a",
+      "state": "8bcebb48",
       "events": "741638a5",
       "rng": {
-        "draws": 908,
-        "digest": "c80759b7"
+        "draws": 932,
+        "digest": "34d01e34"
       },
       "label": "final",
       "players": [
@@ -226,7 +226,8 @@
           "cls": "paladin",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 164
+            "damageDealt": 164,
+            "damageTaken": 22
           },
           "delveClears": {},
           "delveDaily": {},
@@ -246,13 +247,13 @@
         {
           "aiState": "idle",
           "attackPower": 120,
-          "combatTimer": 2.05,
+          "combatTimer": 1.95,
           "critChance": 0.068,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.068,
           "fallStartY": 1.5,
           "fiveSecondRule": 10,
-          "hp": 50000,
+          "hp": 49978,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -297,7 +298,7 @@
         {
           "aggroTargetId": 388,
           "aiState": "attack",
-          "combatTimer": 2.05,
+          "combatTimer": 1.95,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,

--- a/tests/parity/golden/pet_ai.json
+++ b/tests/parity/golden/pet_ai.json
@@ -10,8 +10,8 @@
     "updatePet melee arm: close + auto-taunt + mobSwing (PET_COMBAT_LINGER owner inCombat)",
     "petFollow heel transition (pets return to a moved owner)"
   ],
-  "draws": 767,
-  "drawDigest": "03acdc9c",
+  "draws": 774,
+  "drawDigest": "0bd67d24",
   "frames": [
     {
       "tick": 0,
@@ -103,77 +103,77 @@
       "tick": 20,
       "time": 1,
       "nextId": 393,
-      "state": "ea9e482c",
-      "events": "9a02482a",
+      "state": "07c9fb2c",
+      "events": "b0470cfd",
       "rng": {
-        "draws": 12,
-        "digest": "4b8464f5"
+        "draws": 14,
+        "digest": "547eb3f4"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 393,
-      "state": "b653ba47",
+      "state": "7b61bbef",
       "events": "741638a5",
       "rng": {
-        "draws": 12,
-        "digest": "4b8464f5"
+        "draws": 14,
+        "digest": "547eb3f4"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 393,
-      "state": "8b6fa743",
-      "events": "c8d3f5bd",
+      "state": "7e371e25",
+      "events": "e3881dca",
       "rng": {
-        "draws": 105,
-        "digest": "f2f0d704"
+        "draws": 107,
+        "digest": "d09ae079"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 393,
-      "state": "39d8567a",
+      "state": "4f69baac",
       "events": "741638a5",
       "rng": {
-        "draws": 184,
-        "digest": "d899576a"
+        "draws": 186,
+        "digest": "993e9583"
       }
     },
     {
       "tick": 100,
       "time": 5,
       "nextId": 393,
-      "state": "b9de7a92",
-      "events": "e0e68294",
+      "state": "bf99b7fa",
+      "events": "267268c2",
       "rng": {
-        "draws": 296,
-        "digest": "32cb27cb"
+        "draws": 307,
+        "digest": "f29e4e6d"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 393,
-      "state": "5cab6517",
+      "state": "4f148d23",
       "events": "741638a5",
       "rng": {
-        "draws": 410,
-        "digest": "4d7b872d"
+        "draws": 418,
+        "digest": "4856616c"
       }
     },
     {
       "tick": 120,
       "time": 6,
       "nextId": 393,
-      "state": "d7a95da9",
+      "state": "8b3b9445",
       "events": "741638a5",
       "rng": {
-        "draws": 410,
-        "digest": "4d7b872d"
+        "draws": 418,
+        "digest": "4856616c"
       },
       "label": "heel",
       "players": [
@@ -257,14 +257,14 @@
         },
         {
           "aiState": "idle",
-          "combatTimer": 1.8,
+          "combatTimer": 1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": 1.428006,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 162,
+          "hp": 132,
           "id": 389,
           "inCombat": true,
           "kind": "mob",
@@ -301,7 +301,7 @@
         {
           "aggroTargetId": 389,
           "aiState": "attack",
-          "combatTimer": 1.8,
+          "combatTimer": 1,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -309,7 +309,7 @@
           "fallStartY": 37.026485,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 49947,
+          "hp": 49946,
           "id": 390,
           "inCombat": true,
           "kind": "mob",
@@ -345,7 +345,7 @@
           "threat": [
             [
               389,
-              54
+              55
             ]
           ],
           "wanderTarget": {
@@ -369,7 +369,7 @@
           "facing": -1.570796,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 378,
+          "hp": 366,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -407,7 +407,7 @@
         {
           "aggroTargetId": 391,
           "aiState": "attack",
-          "combatTimer": 1.65,
+          "combatTimer": 1.6,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -416,7 +416,7 @@
           "fiveSecondRule": 99,
           "forcedTargetTimer": -0.05,
           "hostile": true,
-          "hp": 49937,
+          "hp": 49940,
           "id": 392,
           "inCombat": true,
           "kind": "mob",
@@ -457,7 +457,7 @@
             ],
             [
               391,
-              64
+              61
             ]
           ],
           "weapon": {
@@ -472,44 +472,44 @@
       "tick": 140,
       "time": 7,
       "nextId": 393,
-      "state": "585bb84f",
+      "state": "0102c2fd",
       "events": "741638a5",
       "rng": {
-        "draws": 515,
-        "digest": "694b49e5"
+        "draws": 517,
+        "digest": "9df7f4ef"
       }
     },
     {
       "tick": 160,
       "time": 8,
       "nextId": 393,
-      "state": "9fdfe9e1",
+      "state": "3e347ba9",
       "events": "741638a5",
       "rng": {
-        "draws": 629,
-        "digest": "9fbd2a98"
+        "draws": 633,
+        "digest": "6bb30c95"
       }
     },
     {
       "tick": 180,
       "time": 9,
       "nextId": 393,
-      "state": "236faecf",
+      "state": "80d6b3ed",
       "events": "741638a5",
       "rng": {
-        "draws": 767,
-        "digest": "03acdc9c"
+        "draws": 774,
+        "digest": "0bd67d24"
       }
     },
     {
       "tick": 180,
       "time": 9,
       "nextId": 393,
-      "state": "236faecf",
+      "state": "80d6b3ed",
       "events": "741638a5",
       "rng": {
-        "draws": 767,
-        "digest": "03acdc9c"
+        "draws": 774,
+        "digest": "0bd67d24"
       },
       "label": "final",
       "players": [
@@ -592,14 +592,14 @@
         },
         {
           "aiState": "idle",
-          "combatTimer": 4.8,
+          "combatTimer": 4,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
           "facing": 1.657375,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 162,
+          "hp": 135,
           "id": 389,
           "kind": "mob",
           "level": 12,
@@ -633,7 +633,7 @@
         },
         {
           "aiState": "evade",
-          "combatTimer": 4.8,
+          "combatTimer": 4,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -641,7 +641,7 @@
           "fallStartY": 37.026485,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 49947,
+          "hp": 49946,
           "id": 390,
           "inCombat": true,
           "kind": "mob",
@@ -690,7 +690,7 @@
           "facing": 1.66582,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 378,
+          "hp": 374,
           "id": 391,
           "kind": "mob",
           "level": 12,
@@ -731,7 +731,7 @@
         },
         {
           "aiState": "evade",
-          "combatTimer": 4.65,
+          "combatTimer": 4.6,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -739,7 +739,7 @@
           "fallStartY": 39.397438,
           "fiveSecondRule": 99,
           "hostile": true,
-          "hp": 49937,
+          "hp": 49940,
           "id": 392,
           "inCombat": true,
           "kind": "mob",

--- a/tests/parity/golden/pet_commands.json
+++ b/tests/parity/golden/pet_commands.json
@@ -16,8 +16,8 @@
     "petTaunt -> applyTaunt manual arm + PET_GROWL_INTERVAL cooldown",
     "stowPetForDelve/restorePetFromDelveStash (serializePet/restorePet round-trip)"
   ],
-  "draws": 156,
-  "drawDigest": "6a78189c",
+  "draws": 158,
+  "drawDigest": "878ecdcb",
   "frames": [
     {
       "tick": 0,
@@ -1648,33 +1648,33 @@
       "tick": 60,
       "time": 3,
       "nextId": 397,
-      "state": "1f4502c3",
-      "events": "4a181d87",
+      "state": "98f025f7",
+      "events": "a19c527c",
       "rng": {
-        "draws": 80,
-        "digest": "cdfb4afc"
+        "draws": 82,
+        "digest": "e2e5902a"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 397,
-      "state": "296a1b91",
+      "state": "dd75f145",
       "events": "669474ea",
       "rng": {
-        "draws": 156,
-        "digest": "6a78189c"
+        "draws": 158,
+        "digest": "878ecdcb"
       }
     },
     {
       "tick": 80,
       "time": 4,
       "nextId": 397,
-      "state": "296a1b91",
+      "state": "dd75f145",
       "events": "741638a5",
       "rng": {
-        "draws": 156,
-        "digest": "6a78189c"
+        "draws": 158,
+        "digest": "878ecdcb"
       },
       "label": "demon-heal-tick",
       "players": [
@@ -1685,7 +1685,9 @@
           "autoEquip": true,
           "cls": "hunter",
           "companionUpgrades": {},
-          "counters": {},
+          "counters": {
+            "damageTaken": 10
+          },
           "delveClears": {},
           "delveDaily": {},
           "entityId": 388,
@@ -1724,13 +1726,13 @@
         {
           "aiState": "idle",
           "attackPower": 83,
-          "combatTimer": 103,
+          "combatTimer": 1.95,
           "critChance": 0.079,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.079,
           "fallStartY": 1.5,
           "fiveSecondRule": 103,
-          "hp": 50000,
+          "hp": 49990,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -1785,7 +1787,7 @@
           "forcedTargetId": 390,
           "forcedTargetTimer": 1,
           "hostile": true,
-          "hp": 49975,
+          "hp": 49983,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -1826,7 +1828,7 @@
             ],
             [
               394,
-              25
+              17
             ]
           ],
           "weapon": {
@@ -1936,11 +1938,11 @@
       "tick": 80,
       "time": 4,
       "nextId": 398,
-      "state": "7c6180d8",
+      "state": "9eec8b90",
       "events": "fea91c51",
       "rng": {
-        "draws": 156,
-        "digest": "6a78189c"
+        "draws": 158,
+        "digest": "878ecdcb"
       },
       "label": "demon-faded",
       "players": [
@@ -1951,7 +1953,9 @@
           "autoEquip": true,
           "cls": "hunter",
           "companionUpgrades": {},
-          "counters": {},
+          "counters": {
+            "damageTaken": 10
+          },
           "delveClears": {},
           "delveDaily": {},
           "entityId": 388,
@@ -1990,13 +1994,13 @@
         {
           "aiState": "idle",
           "attackPower": 83,
-          "combatTimer": 103,
+          "combatTimer": 1.95,
           "critChance": 0.079,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.079,
           "fallStartY": 1.5,
           "fiveSecondRule": 103,
-          "hp": 50000,
+          "hp": 49990,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -2051,7 +2055,7 @@
           "forcedTargetId": 390,
           "forcedTargetTimer": 1,
           "hostile": true,
-          "hp": 49975,
+          "hp": 49983,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -2092,7 +2096,7 @@
             ],
             [
               394,
-              25
+              17
             ]
           ],
           "weapon": {
@@ -2162,11 +2166,11 @@
       "tick": 80,
       "time": 4,
       "nextId": 400,
-      "state": "b76f3913",
+      "state": "47192443",
       "events": "5f9f8407",
       "rng": {
-        "draws": 156,
-        "digest": "6a78189c"
+        "draws": 158,
+        "digest": "878ecdcb"
       },
       "label": "demon-despawned",
       "players": [
@@ -2177,7 +2181,9 @@
           "autoEquip": true,
           "cls": "hunter",
           "companionUpgrades": {},
-          "counters": {},
+          "counters": {
+            "damageTaken": 10
+          },
           "delveClears": {},
           "delveDaily": {},
           "entityId": 388,
@@ -2216,13 +2222,13 @@
         {
           "aiState": "idle",
           "attackPower": 83,
-          "combatTimer": 103,
+          "combatTimer": 1.95,
           "critChance": 0.079,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.079,
           "fallStartY": 1.5,
           "fiveSecondRule": 103,
-          "hp": 50000,
+          "hp": 49990,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -2277,7 +2283,7 @@
           "forcedTargetId": 390,
           "forcedTargetTimer": 1,
           "hostile": true,
-          "hp": 49975,
+          "hp": 49983,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -2318,7 +2324,7 @@
             ],
             [
               394,
-              25
+              17
             ]
           ],
           "weapon": {
@@ -2437,11 +2443,11 @@
       "tick": 80,
       "time": 4,
       "nextId": 400,
-      "state": "b76f3913",
+      "state": "47192443",
       "events": "741638a5",
       "rng": {
-        "draws": 156,
-        "digest": "6a78189c"
+        "draws": 158,
+        "digest": "878ecdcb"
       },
       "label": "final",
       "players": [
@@ -2452,7 +2458,9 @@
           "autoEquip": true,
           "cls": "hunter",
           "companionUpgrades": {},
-          "counters": {},
+          "counters": {
+            "damageTaken": 10
+          },
           "delveClears": {},
           "delveDaily": {},
           "entityId": 388,
@@ -2491,13 +2499,13 @@
         {
           "aiState": "idle",
           "attackPower": 83,
-          "combatTimer": 103,
+          "combatTimer": 1.95,
           "critChance": 0.079,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.079,
           "fallStartY": 1.5,
           "fiveSecondRule": 103,
-          "hp": 50000,
+          "hp": 49990,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -2552,7 +2560,7 @@
           "forcedTargetId": 390,
           "forcedTargetTimer": 1,
           "hostile": true,
-          "hp": 49975,
+          "hp": 49983,
           "id": 391,
           "inCombat": true,
           "kind": "mob",
@@ -2593,7 +2601,7 @@
             ],
             [
               394,
-              25
+              17
             ]
           ],
           "weapon": {

--- a/tests/parity/golden/solo_rogue.json
+++ b/tests/parity/golden/solo_rogue.json
@@ -8,8 +8,8 @@
     "meleeSwing weaponStrike (sinister_strike via castAbility ~3736)",
     "combo points"
   ],
-  "draws": 141,
-  "drawDigest": "3d03a3d5",
+  "draws": 143,
+  "drawDigest": "9dafb67b",
   "frames": [
     {
       "tick": 0,
@@ -101,44 +101,44 @@
       "tick": 20,
       "time": 1,
       "nextId": 390,
-      "state": "dbccf12f",
-      "events": "f9b79d6c",
+      "state": "35f9fd0f",
+      "events": "71b126e6",
       "rng": {
-        "draws": 7,
-        "digest": "14806c1c"
+        "draws": 9,
+        "digest": "8ecad8de"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 390,
-      "state": "fb9326a4",
+      "state": "1f4b6ff4",
       "events": "33a84e8d",
       "rng": {
-        "draws": 13,
-        "digest": "3fc203d8"
+        "draws": 15,
+        "digest": "843b3bf7"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 390,
-      "state": "e5155f8f",
+      "state": "3d670381",
       "events": "fd9e884b",
       "rng": {
-        "draws": 89,
-        "digest": "2c06bf7c"
+        "draws": 90,
+        "digest": "0f3d4b16"
       }
     },
     {
       "tick": 72,
       "time": 3.6,
       "nextId": 390,
-      "state": "b042b2df",
+      "state": "0bd1b16b",
       "events": "741638a5",
       "rng": {
-        "draws": 141,
-        "digest": "3d03a3d5"
+        "draws": 143,
+        "digest": "9dafb67b"
       },
       "label": "final",
       "players": [
@@ -150,7 +150,8 @@
           "cls": "rogue",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 79
+            "damageDealt": 79,
+            "damageTaken": 9
           },
           "delveClears": {},
           "delveDaily": {},
@@ -180,7 +181,7 @@
           "facing": 1.570796,
           "fallStartY": 1.5,
           "fiveSecondRule": 102.6,
-          "hp": 50000,
+          "hp": 49991,
           "id": 388,
           "inCombat": true,
           "kind": "player",

--- a/tests/parity/golden/solo_warrior.json
+++ b/tests/parity/golden/solo_warrior.json
@@ -10,8 +10,8 @@
     "base mobSwing (mob swings the player)",
     "rollLoot via mob death (L1, ~5876/6036)"
   ],
-  "draws": 163,
-  "drawDigest": "3a2585bb",
+  "draws": 171,
+  "drawDigest": "aaf5d249",
   "frames": [
     {
       "tick": 0,
@@ -101,44 +101,44 @@
       "tick": 20,
       "time": 1,
       "nextId": 390,
-      "state": "760d8854",
-      "events": "3d7f30e3",
+      "state": "107ce7c4",
+      "events": "bcbeedf1",
       "rng": {
-        "draws": 4,
-        "digest": "16110a33"
+        "draws": 6,
+        "digest": "93f0e12e"
       }
     },
     {
       "tick": 40,
       "time": 2,
       "nextId": 390,
-      "state": "2b72447b",
+      "state": "1e199695",
       "events": "741638a5",
       "rng": {
-        "draws": 4,
-        "digest": "16110a33"
+        "draws": 6,
+        "digest": "93f0e12e"
       }
     },
     {
       "tick": 60,
       "time": 3,
       "nextId": 390,
-      "state": "132795fe",
-      "events": "4ecbc29e",
+      "state": "3170db8d",
+      "events": "4da9aa1f",
       "rng": {
-        "draws": 95,
-        "digest": "a28d26f7"
+        "draws": 98,
+        "digest": "92f0a886"
       }
     },
     {
       "tick": 72,
       "time": 3.6,
       "nextId": 390,
-      "state": "31822ff8",
+      "state": "b5990b0e",
       "events": "2865f00f",
       "rng": {
-        "draws": 145,
-        "digest": "837b1a1a"
+        "draws": 153,
+        "digest": "5d6b4ea1"
       },
       "label": "kill",
       "players": [
@@ -150,7 +150,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 7073,
+            "damageDealt": 7074,
+            "damageTaken": 11,
             "kills": 1
           },
           "delveClears": {},
@@ -177,7 +178,7 @@
           "facing": 1.570796,
           "fallStartY": 1.5,
           "fiveSecondRule": 102.6,
-          "hp": 50000,
+          "hp": 49989,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -241,13 +242,7 @@
           },
           "level": 2,
           "loot": {
-            "copper": 10,
-            "items": [
-              {
-                "count": 1,
-                "itemId": "wolf_fang"
-              }
-            ]
+            "copper": 10
           },
           "lootFfaTimer": 60,
           "lootRecipientIds": [
@@ -290,11 +285,11 @@
       "tick": 76,
       "time": 3.8,
       "nextId": 390,
-      "state": "9be86a36",
+      "state": "d490a79e",
       "events": "741638a5",
       "rng": {
-        "draws": 163,
-        "digest": "3a2585bb"
+        "draws": 171,
+        "digest": "aaf5d249"
       },
       "label": "final",
       "players": [
@@ -306,7 +301,8 @@
           "cls": "warrior",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 7073,
+            "damageDealt": 7074,
+            "damageTaken": 11,
             "kills": 1
           },
           "delveClears": {},
@@ -334,7 +330,7 @@
           "facing": 1.570796,
           "fallStartY": 1.5,
           "fiveSecondRule": 102.8,
-          "hp": 50000,
+          "hp": 49989,
           "id": 388,
           "inCombat": true,
           "kind": "player",
@@ -398,13 +394,7 @@
           },
           "level": 2,
           "loot": {
-            "copper": 10,
-            "items": [
-              {
-                "count": 1,
-                "itemId": "wolf_fang"
-              }
-            ]
+            "copper": 10
           },
           "lootFfaTimer": 59.8,
           "lootRecipientIds": [

--- a/tests/parity/golden/warlock_pet.json
+++ b/tests/parity/golden/warlock_pet.json
@@ -9,8 +9,8 @@
     "applyTaunt pet auto-taunt arm (~8110)",
     "applyTaunt pet manual-taunt arm (petTaunt, ~4885)"
   ],
-  "draws": 1053,
-  "drawDigest": "133d4dcf",
+  "draws": 1050,
+  "drawDigest": "a67794aa",
   "frames": [
     {
       "tick": 0,
@@ -156,77 +156,77 @@
       "tick": 120,
       "time": 6,
       "nextId": 391,
-      "state": "5258ad54",
-      "events": "10f4737c",
+      "state": "c107d322",
+      "events": "aa09ef79",
       "rng": {
-        "draws": 365,
-        "digest": "c19bea6a"
+        "draws": 366,
+        "digest": "e513d33c"
       }
     },
     {
       "tick": 140,
       "time": 7,
       "nextId": 391,
-      "state": "f6f29551",
+      "state": "f6a99abf",
       "events": "480f5d27",
       "rng": {
-        "draws": 493,
-        "digest": "00c4329c"
+        "draws": 495,
+        "digest": "3b351463"
       }
     },
     {
       "tick": 160,
       "time": 8,
       "nextId": 391,
-      "state": "c219c29c",
-      "events": "9c410b7b",
+      "state": "7527c8f9",
+      "events": "e9138877",
       "rng": {
-        "draws": 630,
-        "digest": "62fc8fe6"
+        "draws": 636,
+        "digest": "d50b74c3"
       }
     },
     {
       "tick": 180,
       "time": 9,
       "nextId": 391,
-      "state": "d0089227",
-      "events": "f53bdc97",
+      "state": "6f09952b",
+      "events": "59ed44d0",
       "rng": {
-        "draws": 769,
-        "digest": "27ac6cee"
+        "draws": 774,
+        "digest": "89995251"
       }
     },
     {
       "tick": 200,
       "time": 10,
       "nextId": 391,
-      "state": "c54376ba",
-      "events": "1b638bbe",
+      "state": "50901fd2",
+      "events": "2b72be58",
       "rng": {
-        "draws": 929,
-        "digest": "3507d179"
+        "draws": 943,
+        "digest": "b9ebae32"
       }
     },
     {
       "tick": 220,
       "time": 11,
       "nextId": 391,
-      "state": "9b67deb9",
-      "events": "c0b843fe",
+      "state": "e4d1c091",
+      "events": "59ed44d0",
       "rng": {
-        "draws": 1024,
-        "digest": "155ff9f0"
+        "draws": 1021,
+        "digest": "c5358026"
       }
     },
     {
       "tick": 220,
       "time": 11,
       "nextId": 391,
-      "state": "5b27336c",
+      "state": "00f1f58a",
       "events": "741638a5",
       "rng": {
-        "draws": 1024,
-        "digest": "155ff9f0"
+        "draws": 1021,
+        "digest": "c5358026"
       },
       "label": "pet-taunt",
       "players": [
@@ -238,7 +238,7 @@
           "cls": "warlock",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 20
+            "damageDealt": 22
           },
           "delveClears": {},
           "delveDaily": {},
@@ -318,7 +318,7 @@
           "facing": 1.892547,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 378,
+          "hp": 350,
           "id": 389,
           "inCombat": true,
           "kind": "mob",
@@ -366,7 +366,7 @@
           "forcedTargetId": 389,
           "forcedTargetTimer": 3,
           "hostile": true,
-          "hp": 49953,
+          "hp": 49954,
           "id": 390,
           "inCombat": true,
           "kind": "mob",
@@ -403,11 +403,11 @@
           "threat": [
             [
               388,
-              21
+              23
             ],
             [
               389,
-              29
+              26
             ]
           ],
           "weapon": {
@@ -422,11 +422,11 @@
       "tick": 224,
       "time": 11.2,
       "nextId": 391,
-      "state": "cd09af30",
-      "events": "3c2ff05a",
+      "state": "59ce163f",
+      "events": "5f4ade4f",
       "rng": {
-        "draws": 1053,
-        "digest": "133d4dcf"
+        "draws": 1050,
+        "digest": "a67794aa"
       },
       "label": "final",
       "players": [
@@ -438,7 +438,7 @@
           "cls": "warlock",
           "companionUpgrades": {},
           "counters": {
-            "damageDealt": 20
+            "damageDealt": 22
           },
           "delveClears": {},
           "delveDaily": {},
@@ -519,7 +519,7 @@
           "facing": 1.570796,
           "fallStartY": 1.5,
           "fiveSecondRule": 99,
-          "hp": 378,
+          "hp": 341,
           "id": 389,
           "inCombat": true,
           "kind": "mob",
@@ -558,7 +558,7 @@
         {
           "aggroTargetId": 389,
           "aiState": "attack",
-          "combatTimer": 0.2,
+          "combatTimer": 0.15,
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
@@ -568,7 +568,7 @@
           "forcedTargetId": 389,
           "forcedTargetTimer": 2.8,
           "hostile": true,
-          "hp": 49940,
+          "hp": 49944,
           "id": 390,
           "inCombat": true,
           "kind": "mob",
@@ -605,11 +605,11 @@
           "threat": [
             [
               388,
-              21
+              23
             ],
             [
               389,
-              42
+              36
             ]
           ],
           "weapon": {

--- a/tests/social.test.ts
+++ b/tests/social.test.ts
@@ -279,7 +279,10 @@ describe('nine classes', () => {
       for (let i = 0; i < 20 * 40; i++) {
         const evs = sim.tick();
         for (const e of evs) {
-          if (e.type === 'damage' && e.ability === 'Lightning Shield' && e.targetId === wolf.id) {
+          // The 3-charge cap and 5s internal cooldown are shield-wide, not per-attacker
+          // (a wandering low-level mob can also land a hit now that it connects >= 80%),
+          // so count every Lightning Shield reflect regardless of which attacker it hits.
+          if (e.type === 'damage' && e.ability === 'Lightning Shield') {
             reflects++;
             reflectTicks.push(i);
           }


### PR DESCRIPTION
## The bug

[PR #443](https://github.com/levy-street/world-of-claudecraft/pull/443) added a steep miss penalty for attacking **above** your level (`ABOVE_LEVEL_MISS_PCT` in `meleeMissChance` / `spellHitChance`) — an anti-power-level / anti-bot deterrent so players can't farm way-higher mobs.

But the penalty is **symmetric**: `meleeMissChance(attacker, target)` keys off `target − attacker` level, so it also fires when a **low-level mob swings at a higher-level player**. Result: enemies whiff on you constantly (e.g. a mob 4 levels below you misses ~85% of the time). Miss scaling should be **player → mob only**, never mob → player.

## The fix

New `Sim.swingMissChance(attacker, target)`:
- **Enemy mob → player (or player-owned pet):** miss is capped at `MOB_VS_PLAYER_MAX_MISS = 0.2`, i.e. **mobs always hit you ≥ 80%** of the time.
- **Player / pet → mob:** unchanged — keeps the full #443 above-level scaling.

It routes the three shared swing sites (`mobSwing`, `rangedSwing`, `meleeSwing`) through the guard. The direct player melee swing and player/pet spell-hit paths are left as-is. `meleeMissChance` itself is **not** touched, so #443's unit tests and the player-side deterrent are intact.

> Note: dodge is unaffected — it's a separate, intended player defensive stat. This only addresses the **miss** scaling from #443.

## Tests

`tests/mob_hit_floor.test.ts`:
- low-level mob vs higher-level player → miss ≤ 20% (raw formula would be > 20%),
- mob vs equal-level player → unaffected (~5% base),
- **player vs higher-level mob → steep #443 penalty preserved**.

`tsc --noEmit` clean; `sim.test.ts` (incl. the #443 miss tests), `mob_flee`, `pvp_safety`, `progression`, `trivial_mob_passive` all green.

## Notes
- Determinism preserved (same `rng` draw structure).
- Hotfix targeting `release/v0.8`, where #443 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
