### PR TITLE
feat(content): Marrowlord Varkas hurls foes back with a Crushing Sweep (knockback)

### DIFF
--- a/scripts/shot_knockback.mjs
+++ b/scripts/shot_knockback.mjs
@@ -1,0 +1,82 @@
+// Screenshot the Knockback affix (Crushing Sweep) in the offline client.
+// Boots the game, repurposes the nearest mob as Marrowlord Varkas, captures the
+// player standing toe-to-toe with it, forces the on-hit shove, then captures the
+// player hurled back with the "unleashes Crushing Sweep!" line in the combat log.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Stand the Marrowlord toe-to-toe with us, look at it. (before the shove)
+await page.evaluate(() => {
+  const g = window.__game, sim = g.sim, p = sim.player;
+  p.gm = true; // an L19 elite shouldn't kill us mid-demo
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'marrowlord_varkas';
+  mob.name = 'Marrowlord Varkas';
+  mob.level = 19; mob.hostile = true; mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2.5; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing; g.input.camDist = 9;
+  window.__mobId = mob.id;
+});
+await new Promise((r) => setTimeout(r, 800));
+await page.screenshot({ path: 'tmp/knockback_before.png' });
+
+// Force the on-hit shove and confirm the displacement via the real swing path.
+const result = await page.evaluate(() => {
+  const g = window.__game, sim = g.sim, p = sim.player;
+  const mob = sim.entities.get(window.__mobId);
+  const before = Math.hypot(p.pos.x - mob.pos.x, p.pos.z - mob.pos.z);
+  // drive real swings until we're flung; guarantee the demo lands if RNG is shy
+  let moved = false;
+  for (let i = 0; i < 60 && !moved; i++) {
+    sim.mobSwing(mob, p);
+    moved = Math.hypot(p.pos.x - mob.pos.x, p.pos.z - mob.pos.z) > before + 1;
+  }
+  if (!moved) sim.applyKnockback(mob, p, 6);
+  const after = Math.hypot(p.pos.x - mob.pos.x, p.pos.z - mob.pos.z);
+  // keep facing the (now distant) Marrowlord
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  return { before, after };
+});
+console.log('knockback gap before/after:', JSON.stringify(result));
+
+// Surface the combat log so the "unleashes Crushing Sweep!" line shows.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]') ||
+              document.querySelector('[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/knockback_after.png' });
+
+console.log('saved tmp/knockback_before.png, knockback_after.png');
+await browser.close();

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -193,6 +193,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 44, moveSpeed: 6.5, aggroRadius: 13,
     aoePulse: { min: 30, max: 42, radius: 11, every: 9, name: 'Marrow Rot', school: 'shadow' },
     summonAdds: { mobId: 'varkas_boneguard', count: 2, atHpPct: [0.66, 0.33] },
+    knockback: { chance: 0.25, distance: 6, name: 'Crushing Sweep' },
     loot: [
       { copper: 650, chance: 1 },
       { itemId: 'bone_fragments', chance: 1 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2606,6 +2606,43 @@ export class Sim {
     });
   }
 
+  // On-hit knockback: hurl `target` up to `distance` yards straight away from
+  // `source`. Instantaneous displacement (no aura) walked in small steps so it can
+  // be terrain-clamped exactly like a warrior charge — the shove stops at the last
+  // safe footing before deep water or a cliff rather than stranding the victim off
+  // the world. Returns the yards actually moved (0 if blocked immediately).
+  private applyKnockback(source: Entity, target: Entity, distance: number): number {
+    let dx = target.pos.x - source.pos.x;
+    let dz = target.pos.z - source.pos.z;
+    let len = Math.hypot(dx, dz);
+    if (len < 1e-4) {
+      // exactly overlapping: shove along the mob's facing so the direction is stable
+      dx = Math.sin(source.facing); dz = Math.cos(source.facing); len = 1;
+    }
+    const ux = dx / len, uz = dz / len;
+    const STEP = 0.5;
+    let moved = 0;
+    let cx = target.pos.x, cz = target.pos.z;
+    while (moved < distance) {
+      const adv = Math.min(STEP, distance - moved);
+      const nx = cx + ux * adv, nz = cz + uz * adv;
+      const h0 = groundHeight(cx, cz, this.cfg.seed);
+      const h1 = groundHeight(nx, nz, this.cfg.seed);
+      if (h1 < WATER_LEVEL - SWIM_DEPTH) break;                // would land in deep water
+      if (h1 > h0 && (h1 - h0) / adv > MAX_CLIMB_SLOPE) break; // would slam into a cliff
+      cx = nx; cz = nz; moved += adv;
+    }
+    if (moved <= 0) return 0;
+    const resolved = resolvePosition(this.cfg.seed, cx, cz, BODY_RADIUS);
+    target.pos.x = resolved.x;
+    target.pos.z = resolved.z;
+    target.pos.y = groundHeight(resolved.x, resolved.z, this.cfg.seed);
+    target.vy = 0;
+    target.onGround = true;
+    target.fallStartY = target.pos.y;
+    return moved;
+  }
+
   private diminishedCrowdControlDuration(
     source: Entity,
     target: Entity,
@@ -4198,6 +4235,19 @@ export class Sim {
     const ensnare = MOBS[mob.templateId]?.ensnare;
     if (ensnare && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(ensnare.chance)) {
       this.applyRootAura(mob, target, ensnare.name, `ensnare_${mob.templateId}`, ensnare.duration, ensnare.school ?? 'nature');
+    }
+    // Knockback: a landed hit can physically hurl the player victim straight back.
+    // Hostile mobs only (a friendly pet shares this swing path) and players only —
+    // shoving a fellow mob is meaningless. Pure positional displacement (no aura),
+    // terrain-clamped so it never strands the victim off the world; surfaced via a
+    // spellfx nova + the same "unleashes" log line War Stomp uses.
+    const knockback = MOBS[mob.templateId]?.knockback;
+    if (knockback && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(knockback.chance)) {
+      if (this.applyKnockback(mob, target, knockback.distance) > 0) {
+        const school = (knockback.school ?? 'physical') as Aura['school'];
+        this.emit({ type: 'spellfx', sourceId: mob.id, targetId: target.id, school, fx: 'nova' });
+        this.emit({ type: 'log', text: `${mob.name} unleashes ${knockback.name}!`, color: '#ff9933', entityId: mob.id });
+      }
     }
     // slowStrike: a landed hit may mire the victim, slowing their attack speed.
     // Rides the existing `attackspeed` aura (swingIntervalMult: value > 1 = slower);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -233,6 +233,13 @@ export interface MobTemplate {
   // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new
   // combat math. Distinct from a movement snare (`slow`) or an AP cut (`debuff_ap`).
   slowStrike?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit knockback: a landed melee swing has `chance` to physically hurl the
+  // struck player `distance` yards straight away from the mob — an instantaneous
+  // positional shove, not an aura. The displacement is terrain-clamped (it stops
+  // before deep water and cliffs, reusing the charge-movement safety checks), so a
+  // knockback can never strand the victim off the world. Players only; shoving a
+  // fellow mob is meaningless and a friendly pet shares this swing path.
+  knockback?: { chance: number; distance: number; name: string; school?: Aura['school'] };
   // On-hit mechanic ("Mana Burn"): a landed melee swing has `chance` to drain a
   // flat `amount` of mana from a mana-using victim (casters). Rage/energy users
   // are unaffected. Drains only what mana the victim still has; no overkill.

--- a/tests/mob_knockback.test.ts
+++ b/tests/mob_knockback.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+const dist2d = (a: { x: number; z: number }, b: { x: number; z: number }) =>
+  Math.hypot(a.x - b.x, a.z - b.z);
+
+describe('Knockback on-hit affix (Crushing Sweep)', () => {
+  it('a landed marrowlord_varkas swing hurls the player straight away from the mob', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; // an L19 elite would otherwise grind the warrior down mid-loop
+    // flat starting ground (Eastbrook town) so the shove isn't terrain-clamped
+    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const tmpl = MOBS.marrowlord_varkas;
+    const saved = tmpl.knockback!.chance;
+    tmpl.knockback!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      // spawn at the player's level for an even hit table, on top of the player
+      const mob = createMob(900700, tmpl, p.level, { x: 0, y: 0, z: 0 });
+      const startGap = dist2d(p.pos, mob.pos);
+      let moved = false;
+      for (let i = 0; i < 80 && !moved; i++) {
+        (sim as any).mobSwing(mob, p);
+        moved = dist2d(p.pos, mob.pos) > startGap + 1;
+      }
+      expect(moved).toBe(true);
+      // pushed outward along the +x line it started on (away, not toward, the mob)
+      expect(p.pos.x).toBeGreaterThan(2);
+      expect(dist2d(p.pos, mob.pos)).toBeGreaterThan(startGap + 3);
+    } finally {
+      tmpl.knockback!.chance = saved;
+    }
+  });
+
+  it('applyKnockback shoves the exact distance over open ground and reports it', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const mob = createMob(900701, MOBS.marrowlord_varkas, p.level, { x: 0, y: 0, z: 0 });
+    const moved = (sim as any).applyKnockback(mob, p, 6);
+    expect(moved).toBeGreaterThan(0);
+    expect(moved).toBeLessThanOrEqual(6);
+    expect(p.pos.x).toBeGreaterThan(2); // displaced along the mob→player axis
+  });
+
+  it('a friendly pet swing (hostile=false) never knocks its target back', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const tmpl = MOBS.marrowlord_varkas;
+    const saved = tmpl.knockback!.chance;
+    tmpl.knockback!.chance = 1;
+    try {
+      const pet = createMob(900702, tmpl, p.level, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      const startGap = dist2d(p.pos, pet.pos);
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(dist2d(p.pos, pet.pos)).toBeLessThan(startGap + 1);
+    } finally {
+      tmpl.knockback!.chance = saved;
+    }
+  });
+
+  it('a mob without knockback never displaces the player', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const mob = createMob(900703, MOBS.forest_wolf, p.level, { x: 0, y: 0, z: 0 });
+    const startGap = dist2d(p.pos, mob.pos);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(dist2d(p.pos, mob.pos)).toBeLessThan(startGap + 1);
+  });
+});


### PR DESCRIPTION
## What

Adds the first **positional** on-hit affix: **knockback**. A landed melee swing has a chance to physically hurl the struck player straight away from the mob — an instantaneous shove, not an aura.

Attached to **Marrowlord Varkas** (rare elite undead, Thornpeak Heights, lvl 19) as **Crushing Sweep** — 25% chance / 6 yd. The Marrowlord already pulses *Marrow Rot* and summons *Boneguards*; the knockback is a different axis (displacement) and composes cleanly.

## Why it's a new mechanic

Every prior on-hit affix applies an **aura** (a stat/DoT/lockout the renderer reads passively). Knockback instead mutates the victim's `pos` directly, so the seam is movement code, not the aura system. Since the server is authoritative and the renderer interpolates from `pos` each frame, the shove propagates to the client with zero new wiring.

## How

- `types.ts` — new `MobTemplate.knockback { chance, distance, name, school? }`.
- `sim.ts` — `applyKnockback(source, target, distance)` walks the victim outward in 0.5 yd steps, **terrain-clamped with the exact deep-water / cliff checks the warrior charge uses**, so a shove can never strand the victim off the world. Hooked in `mobSwing` after the ensnare block (hostile mobs + player targets only — a friendly pet shares this swing path). Surfaced via a `spellfx` nova + the same `"${mob.name} unleashes ${name}!"` log line War Stomp uses.
- `content/zone3.ts` — the affix on Marrowlord Varkas.
- `tests/mob_knockback.test.ts` — forces the proc and asserts the victim is displaced outward; covers the friendly-pet guard, the no-affix case, and the helper's terrain-clamped return value.

## Verification

- `npx tsc --noEmit` clean.
- Full suite **1397 passing** (incl. the S3 i18n guard — determinism-neutral: an existing mob, no new spawn/camp, so no construction RNG draws shift).
- **Zero i18n burden** — the affix name rides the raw log path (interpolated template), exactly like War Stomp / stomp.

## Screenshots

Toe-to-toe with the Marrowlord, then flung 6 yd back across the plaza (gap 2.5 → 8.5 yd):

| Before the swing | After Crushing Sweep |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/knockback-affix/shots/knockback_before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/knockback-affix/shots/knockback_after.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)