### PR TITLE
feat(content): Marrowlord Varkas wraps itself in a Bone Carapace (Stoneskin)

### DIFF
--- a/scripts/shot_stoneskin.mjs
+++ b/scripts/shot_stoneskin.mjs
@@ -1,0 +1,112 @@
+// Screenshot the Stoneskin affix (Bone Carapace) in the offline client.
+// Boots the game, repurposes a nearby mob as Marrowlord Varkas, fires its
+// periodic self-shield through the real mob-AI path, and captures the boss
+// in-world (with the barrier nova), its target frame, and the combat-log line.
+// A mob self-buff has no player-debuff icon, so the proof is the log + the
+// console soak math (shield drains, HP spared).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live boss loop; applyAura/updateMob still work, and the
+  // barrier sits on the mob anyway so player invulnerability doesn't confound it.
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Marrowlord and stand it in front of us at its real level.
+  mob.templateId = 'marrowlord_varkas';
+  mob.name = 'Marrowlord Varkas';
+  mob.level = 19;
+  mob.hostile = true;
+  mob.maxHp = 4000; mob.hp = 4000;
+  mob.scale = 1.25;
+  // Must sit inside MELEE_RANGE or the mob-AI attack case breaks to 'chase'
+  // before the periodic self-shield block runs.
+  mob.pos.x = p.pos.x + 3.5; mob.pos.z = p.pos.z;
+  mob.spawnPos = { x: mob.pos.x, y: mob.pos.y, z: mob.pos.z };
+  mob.aiState = 'attack'; mob.aggroTargetId = p.id; mob.inCombat = true;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  g.input.camDist = 11;
+
+  // Fire the barrier through the real periodic path (emits the nova + log line).
+  mob.stoneskinTimer = 0.001;
+  sim.updateMob(mob);
+  const ward = mob.auras.find((a) => a.id === 'stoneskin_marrowlord_varkas');
+
+  // Prove the soak: a 100-damage hit is fully absorbed; HP is untouched.
+  const shieldBefore = ward?.value;
+  const hpBefore = mob.hp;
+  sim.dealDamage(p, mob, 100, false, 'physical', null, 'hit');
+  const shieldAfter = mob.auras.find((a) => a.id === 'stoneskin_marrowlord_varkas')?.value;
+
+  return {
+    hasWard: !!ward, name: ward?.name, kind: ward?.kind,
+    shieldBefore, shieldAfter, soaked: shieldBefore - shieldAfter,
+    hpBefore, hpAfter: mob.hp, hpSpared: hpBefore === mob.hp,
+  };
+});
+console.log('stoneskin result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 500));
+await page.screenshot({ path: 'tmp/stoneskin_scene.png' });
+
+// Crop the boss target frame (top-left): name + boss portrait.
+const tf = await page.evaluate(() => {
+  const el = document.querySelector('#target-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (tf && tf.w > 0) {
+  const pad = 14;
+  await page.screenshot({
+    path: 'tmp/stoneskin_targetframe.png',
+    clip: { x: Math.max(0, tf.x - pad), y: Math.max(0, tf.y - pad), width: tf.w + pad * 2, height: tf.h + pad * 2 },
+  });
+}
+
+// Switch to the combat log tab and crop it to show the "unleashes Bone Carapace!" line.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]') || document.querySelector('.chat-tab');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({
+  path: 'tmp/stoneskin_log.png',
+  clip: { x: 0, y: 620, width: 560, height: 280 },
+});
+
+console.log('saved tmp/stoneskin_scene.png, stoneskin_targetframe.png, stoneskin_log.png');
+await browser.close();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -241,7 +241,7 @@ function blankEntity(id: number): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -193,6 +193,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 44, moveSpeed: 6.5, aggroRadius: 13,
     aoePulse: { min: 30, max: 42, radius: 11, every: 9, name: 'Marrow Rot', school: 'shadow' },
     summonAdds: { mobId: 'varkas_boneguard', count: 2, atHpPct: [0.66, 0.33] },
+    stoneskin: { amount: 260, every: 14, duration: 8, name: 'Bone Carapace', school: 'shadow' },
     loot: [
       { copper: 650, chance: 1 },
       { itemId: 'bone_fragments', chance: 1 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first Stoneskin: one full interval after engage.
+  if (template.stoneskin) e.stoneskinTimer = template.stoneskin.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3977,6 +3977,25 @@ export class Sim {
             }
           }
         }
+        // Stoneskin: a periodic self-absorb barrier. Telegraphed via createMob,
+        // which seeds stoneskinTimer to one full interval so the first barrier
+        // never snaps up the instant combat opens. Reuses the `absorb` aura,
+        // which dealDamage already soaks before any health is lost.
+        const stoneskin = MOBS[mob.templateId]?.stoneskin;
+        if (stoneskin) {
+          mob.stoneskinTimer -= DT;
+          if (mob.stoneskinTimer <= 0) {
+            mob.stoneskinTimer = stoneskin.every;
+            const school = (stoneskin.school ?? 'physical') as Aura['school'];
+            this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+            this.emit({ type: 'log', text: `${mob.name} unleashes ${stoneskin.name}!`, color: '#c9c2b5', entityId: mob.id });
+            this.applyAura(mob, {
+              id: `stoneskin_${mob.templateId}`, name: stoneskin.name, kind: 'absorb',
+              remaining: stoneskin.duration, duration: stoneskin.duration, value: stoneskin.amount,
+              sourceId: mob.id, school,
+            });
+          }
+        }
         break;
       }
       case 'flee': {
@@ -4052,6 +4071,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.stoneskinTimer = MOBS[mob.templateId]?.stoneskin?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4539,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.stoneskinTimer = MOBS[mob.templateId]?.stoneskin?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -195,6 +195,10 @@ export interface MobTemplate {
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
   stomp?: { radius: number; every: number; duration: number; min?: number; max?: number; name: string; school?: string };
+  // Periodic self-shield: the mob wraps itself in a damage-absorbing barrier
+  // every `every` seconds, soaking up to `amount` damage for `duration` seconds.
+  // Reuses the existing `absorb` aura (soaked first in dealDamage) — no new combat math.
+  stoneskin?: { amount: number; every: number; duration: number; name: string; school?: string };
   // Melee mechanic: each landed swing also splashes onto other players near the
   // primary target for `mult` of the (pre-armor) hit. Classic-WoW Cleave.
   cleave?: { radius: number; mult: number; name?: string };
@@ -580,6 +584,7 @@ export interface Entity {
   petTauntTimer: number; // controlled pet Growl cooldown
   pulseTimer: number; // boss aoe pulse countdown
   stompTimer: number; // boss War Stomp stun-pulse countdown
+  stoneskinTimer: number; // periodic self-absorb barrier countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
   firedSummons: number; // summonAdds thresholds already triggered

--- a/tests/mob_stoneskin.test.ts
+++ b/tests/mob_stoneskin.test.ts
@@ -1,0 +1,107 @@
+// "Stoneskin" boss mechanic: a mob with a `stoneskin` template field
+// periodically wraps itself in a damage-absorbing barrier while in melee
+// combat. It is telegraphed — the first barrier only snaps up one full
+// interval after the fight begins — resets on evade/respawn, and reuses the
+// existing `absorb` aura, which dealDamage already soaks before any HP is lost.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+// Spawn a stoneskin boss locked in melee on the player and return it.
+function engagedWard(sim: Sim): Entity {
+  const mob = createMob(900200, MOBS.marrowlord_varkas, 19, { ...sim.player.pos });
+  mob.spawnPos = { ...sim.player.pos }; // sit on the player: in melee, no leash
+  mob.aiState = 'attack';
+  mob.aggroTargetId = sim.playerId;
+  mob.inCombat = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+const wardAura = (e: Entity) => e.auras.find((a) => a.id === 'stoneskin_marrowlord_varkas');
+
+describe('Stoneskin boss mechanic', () => {
+  it('Marrowlord Varkas carries a Bone Carapace', () => {
+    expect(MOBS.marrowlord_varkas.stoneskin?.name).toBe('Bone Carapace');
+    expect(MOBS.marrowlord_varkas.stoneskin?.amount).toBeGreaterThan(0);
+  });
+
+  it('is telegraphed: a freshly spawned warden waits one interval before its first barrier', () => {
+    const mob = createMob(900201, MOBS.marrowlord_varkas, 19, { x: 0, y: 0, z: 0 });
+    expect(mob.stoneskinTimer).toBe(MOBS.marrowlord_varkas.stoneskin!.every);
+  });
+
+  it('raises an absorb barrier on itself when the timer elapses and resets the timer', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    mob.stoneskinTimer = 0.001; // due now
+    (sim as any).updateMob(mob);
+
+    const aura = wardAura(mob);
+    expect(aura?.kind).toBe('absorb');
+    expect(aura?.name).toBe('Bone Carapace');
+    expect(aura?.value).toBe(MOBS.marrowlord_varkas.stoneskin!.amount);
+    expect(mob.stoneskinTimer).toBeCloseTo(MOBS.marrowlord_varkas.stoneskin!.every, 5);
+  });
+
+  it('soaks incoming damage: HP is spared while the barrier holds, then drains', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    // The boss sits on the player and swings during updateMob; keep the player
+    // alive (a dead attacker's blow won't land) so it can test-fire into the shield.
+    sim.player.gm = true;
+    mob.stoneskinTimer = 0.001;
+    (sim as any).updateMob(mob);
+
+    const amount = MOBS.marrowlord_varkas.stoneskin!.amount;
+    const hpBefore = mob.hp;
+
+    // A hit smaller than the shield: no HP lost, shield drains by that much.
+    (sim as any).dealDamage(sim.player, mob, 100, false, 'physical', null, 'hit');
+    expect(mob.hp).toBe(hpBefore);
+    expect(wardAura(mob)?.value).toBe(amount - 100);
+
+    // A hit that overruns the remaining shield: shield pops, overflow hits HP.
+    (sim as any).dealDamage(sim.player, mob, amount, false, 'physical', null, 'hit');
+    expect(wardAura(mob)).toBeUndefined();
+    expect(mob.hp).toBeLessThan(hpBefore);
+  });
+
+  it('does not raise a barrier before the timer elapses', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    mob.stoneskinTimer = 5; // not due yet
+    (sim as any).updateMob(mob);
+
+    expect(wardAura(mob)).toBeUndefined();
+    expect(mob.stoneskinTimer).toBeLessThan(5);
+  });
+
+  it('re-arms the telegraph delay when the mob evades home', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    mob.stoneskinTimer = 0;
+    (sim as any).resetEvadingMob(mob);
+    expect(mob.stoneskinTimer).toBe(MOBS.marrowlord_varkas.stoneskin!.every);
+  });
+
+  it('a normal mob without a stoneskin template never gains the barrier', () => {
+    const sim = makeSim();
+    const wolf = createMob(900202, MOBS.forest_wolf, 5, { ...sim.player.pos });
+    wolf.spawnPos = { ...sim.player.pos };
+    wolf.aiState = 'attack';
+    wolf.aggroTargetId = sim.playerId;
+    wolf.inCombat = true;
+    (sim as any).addEntity(wolf);
+    wolf.stoneskinTimer = 0.001;
+    (sim as any).updateMob(wolf);
+
+    expect(wolf.auras.some((a) => a.kind === 'absorb')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds **Stoneskin** — a periodic mob *self-shield* affix — and gives it to **Marrowlord Varkas** (Thornpeak rare elite undead boss, lvl 19) as **Bone Carapace**: every 14s while in melee combat the Marrowlord wraps itself in a barrier that absorbs the next **260 damage** for 8s, then fades.

It's a defensive/sustain mechanic — you have to burn through the shield before chipping his health — distinct from the existing mob mechanics: `thorns` (reflect), `rampage` (offense ramp), and `enrage`/`desperateHeal` (threshold bursts). It's the first **mob-side defensive** affix.

## How it works (minimal, reuses an existing primitive)

The barrier reuses the existing **`absorb`** aura, which `dealDamage` already soaks *before* any health is lost (sim.ts). So there is **no new combat math, no new `AuraKind`, and no HUD work** — exactly the pattern Rampage used by reusing `buff_ap`.

- `types.ts` — `MobTemplate.stoneskin { amount, every, duration, name, school? }` + `Entity.stoneskinTimer`
- `entity.ts` / `net/online.ts` — timer init + telegraph (first barrier waits one full interval after engage, like War Stomp / Mend)
- `sim.ts` — a periodic self-`absorb` block in the mob-AI `attack` case, plus the two evade/respawn timer resets
- `content/zone3.ts` — attach Bone Carapace to `marrowlord_varkas`

## Determinism & i18n

- **Determinism-neutral.** The absorb amount is a fixed template value (no `rng` draw) and it's attached to an *existing* mob (no new camp/spawn), so the construction-time RNG stream is unchanged — no fixed-seed combat test shifts.
- **Zero new strings.** The barrier announces itself via the already-recognized `${mob.name} unleashes ${name}!` log path; the S3 localization guard stays green.

## Tests

`tests/mob_stoneskin.test.ts` — telegraph delay, barrier applied + timer reset, **soak-then-drain** (a 100-dmg hit is fully absorbed with HP spared, then an overrunning hit pops the shield and overflows to HP), radius/no-template guards.

**Full suite: 1400 passing, `tsc` clean.**

## Screenshots

Bone Carapace fired through the real mob-AI path. The combat log shows the barrier going up and a subsequent hit landing **for 0** — fully soaked.

| Scene + boss frame | Combat log (barrier soaks the hit) |
|---|---|
| ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stoneskin-affix/shots/stoneskin_scene.png) | ![log](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stoneskin-affix/shots/stoneskin_log.png) |

![boss frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stoneskin-affix/shots/stoneskin_targetframe.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)