### PR TITLE
feat(content): Grubjaw the Glutton devours a buff off the victim on hit (Devour Magic)

### DIFF
--- a/scripts/shot_purge.mjs
+++ b/scripts/shot_purge.mjs
@@ -1,0 +1,101 @@
+// Screenshot the Devour Magic affix in the offline client. Boots the game,
+// repurposes a nearby mob as Grubjaw the Glutton, grants the player a couple of
+// real enhancement buffs, captures the buff bar, then drives Grubjaw's on-hit
+// purge to devour a buff and captures the bar again (one fewer buff = proof).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5174';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const bufBox = () => page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+const cropBar = async (file) => {
+  const box = await bufBox();
+  if (!box) return;
+  const pad = 18;
+  await page.screenshot({ path: file, clip: {
+    x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+    width: box.w + pad * 2, height: box.h + pad * 2,
+  } });
+};
+
+// Reskin nearest mob as Grubjaw, give the player two enhancement buffs.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // survive the live loop without wiping pushed auras via recalc
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'grubjaw';
+  mob.name = 'Grubjaw the Glutton';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const buff = (id, name, kind, value) => p.auras.push({
+    id, name, kind, remaining: 300, duration: 300, value, sourceId: p.id, school: 'arcane',
+  });
+  p.auras = p.auras.filter((a) => a.kind.startsWith('buff_') === false || a.value < 0);
+  buff('pwf', 'Power Word: Fortitude', 'buff_sta', 18);
+  buff('bshout', 'Battle Shout', 'buff_ap', 40);
+  return { buffNames: p.auras.filter((a) => a.kind.startsWith('buff_')).map((a) => a.name) };
+});
+console.log('before:', JSON.stringify(setup));
+await new Promise((r) => setTimeout(r, 500));
+await page.screenshot({ path: 'tmp/devour_scene.png' });
+await cropBar('tmp/devour_before.png');
+
+// Force the purge to land and devour one buff.
+const result = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const mob = sim.getEntity ? sim.getEntity(p.targetId) : [...sim.entities.values()].find((e) => e.id === p.targetId);
+  sim.rng.chance = () => true;
+  const before = p.auras.filter((a) => a.kind.startsWith('buff_') && a.value > 0).length;
+  // Swing until exactly one buff has been devoured, then stop.
+  for (let i = 0; i < 30; i++) {
+    sim.mobSwing(mob, p);
+    if (p.auras.filter((a) => a.kind.startsWith('buff_') && a.value > 0).length < before) break;
+  }
+  return { remaining: p.auras.filter((a) => a.kind.startsWith('buff_') && a.value > 0).map((a) => a.name) };
+});
+console.log('after :', JSON.stringify(result));
+await new Promise((r) => setTimeout(r, 400));
+await cropBar('tmp/devour_after.png');
+
+console.log('saved tmp/devour_scene.png, devour_before.png, devour_after.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -160,6 +160,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'grubjaw_tusk', chance: 1, questId: 'q_grubjaw' },
       { itemId: 'chipped_tusk', chance: 1 },
     ],
+    purgeOnHit: { chance: 0.3, name: 'Devour Magic' },
     scale: 1.3, color: 0x145a32,
   },
   gravecaller_cultist: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -130,6 +130,15 @@ const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
 function isHarmfulAura(kind: AuraKind): boolean {
   return HARMFUL_AURA_KINDS.has(kind);
 }
+// A "Devour Magic"-strippable beneficial enhancement: a positive buff_* stat
+// buff, a heal-over-time, an absorb shield, or a weapon imbue. Stances, forms,
+// stealth, righteous fury, thorns and every debuff (incl. negative buff_* drains
+// like enfeeble/wither) are deliberately left alone — only an active "magic"
+// enhancement is eaten. Mirrors the inverse of the HUD's debuff test.
+function isDevourableAura(a: Aura): boolean {
+  return (a.kind.startsWith('buff_') && a.value > 0)
+    || a.kind === 'hot' || a.kind === 'absorb' || a.kind === 'imbue';
+}
 const NEARBY_RANGE = 40; // /nearby scan radius — wider than say, tighter than yell
 const NEARBY_MAX = 10; // cap the /nearby list so a crowded camp can't spam chat
 const CHAT_BURST = 8; // messages a player may send back-to-back...
@@ -4286,6 +4295,30 @@ export class Sim {
         });
       }
     }
+    // Devour Magic: a landed hit can strip one beneficial enhancement buff off
+    // the player victim (classic warlock/demon Devour Magic). Hostile mobs only
+    // (a friendly pet — mobSwing's other caller — must never purge its owner's
+    // party) and players only. No-op when the victim carries no devourable buff.
+    const purge = MOBS[mob.templateId]?.purgeOnHit;
+    if (purge && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(purge.chance)) {
+      this.devourBeneficialAura(target, purge.name);
+    }
+  }
+
+  // Strip one beneficial enhancement aura from a player victim. Removes the
+  // first devourable buff (auras are in application order, so this is
+  // deterministic), recalcs the player's derived stats so a stripped
+  // buff_armor/buff_ap/buff_int actually un-folds, and surfaces the proc via the
+  // standard `aura` event (the full aura array on the next snapshot reflects the
+  // removal to online clients). Returns whether anything was devoured.
+  private devourBeneficialAura(target: Entity, name: string): boolean {
+    const idx = target.auras.findIndex(isDevourableAura);
+    if (idx < 0) return false;
+    target.auras.splice(idx, 1);
+    const meta = this.players.get(target.id);
+    if (meta) recalcPlayerStats(target, meta.cls, meta.equipment, meta.talentMods);
+    this.emit({ type: 'aura', targetId: target.id, name, gained: true });
+    return true;
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -268,6 +268,14 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // On-hit purge ("Devour Magic"): a landed melee swing has `chance` to strip
+  // one beneficial enhancement aura off the player victim — a positive buff_*
+  // stat buff, a heal-over-time, an absorb shield, or a weapon imbue. Forms,
+  // stances, stealth, and every debuff are left untouched. Removes nothing if
+  // the victim carries no such buff. Players only; offensive against a fellow
+  // mob is meaningless and a friendly pet (mobSwing's other caller) must never
+  // strip its owner's party. Rides the existing aura system — no new aura kind.
+  purgeOnHit?: { chance: number; name: string };
 }
 
 export type AbilityEffect =

--- a/tests/mob_purge.test.ts
+++ b/tests/mob_purge.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob, recalcPlayerStats } from '../src/sim/entity';
+import type { Aura, PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+
+const makeSim = (cls: PlayerClass = 'warrior') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+// Grubjaw at the player's level so its swings land on an even hit table.
+const spawnGrubjaw = (sim: Sim) => {
+  const mob = createMob(990700, MOBS.grubjaw, 20, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+const pushBuff = (target: any, kind: Aura['kind'], value: number, id = `test_${kind}`) => {
+  const aura: Aura = {
+    id, name: 'Test Buff', kind,
+    remaining: 300, duration: 300, value,
+    sourceId: target.id, school: 'arcane',
+  };
+  target.auras.push(aura);
+  return aura;
+};
+
+// Force-swing until the named beneficial buff is gone (a swing can miss/dodge).
+const swingUntilDevoured = (sim: Sim, mob: any, target: any, auraId: string, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp;
+    (sim as any).mobSwing(mob, target);
+    if (!target.auras.some((a: any) => a.id === auraId)) return true;
+  }
+  return false;
+};
+
+describe('mob purge affix (Devour Magic)', () => {
+  it('Grubjaw the Glutton carries the purge mechanic', () => {
+    expect(MOBS.grubjaw.purgeOnHit).toBeDefined();
+    expect(MOBS.grubjaw.purgeOnHit!.name).toBe('Devour Magic');
+  });
+
+  it('strips one beneficial buff on a landed hit and recalcs derived stats', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnGrubjaw(sim);
+    const armorBefore = player.stats.armor;
+    pushBuff(player, 'buff_armor', 80, 'test_buff_armor');
+    // recalc so the pushed buff folds into derived armor (mirrors applyAura).
+    const meta = (sim as any).players.get(player.id);
+    recalcPlayerStats(player, meta.cls, meta.equipment, meta.talentMods);
+    expect(player.stats.armor).toBe(armorBefore + 80);
+
+    const purge = MOBS.grubjaw.purgeOnHit!;
+    const old = purge.chance;
+    purge.chance = 1;
+    try {
+      expect(swingUntilDevoured(sim, mob, player, 'test_buff_armor')).toBe(true);
+    } finally {
+      purge.chance = old;
+    }
+    expect(player.auras.some((a) => a.id === 'test_buff_armor')).toBe(false);
+    expect(player.stats.armor).toBe(armorBefore); // un-folded after the strip
+  });
+
+  it('devours only one buff per proc, beneficial buffs only', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    spawnGrubjaw(sim);
+    player.auras = [];
+    pushBuff(player, 'buff_armor', 80, 'b1');
+    pushBuff(player, 'buff_ap', 40, 'b2');
+    const removed = (sim as any).devourBeneficialAura(player, 'Devour Magic');
+    expect(removed).toBe(true);
+    expect(player.auras.length).toBe(1); // exactly one eaten
+  });
+
+  it('never strips a debuff or a negative buff_* drain', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    spawnGrubjaw(sim);
+    player.auras = [];
+    pushBuff(player, 'dot', 5, 'd1'); // harmful DoT
+    pushBuff(player, 'buff_int', -18, 'd2'); // enfeeble-style stat drain
+    const removed = (sim as any).devourBeneficialAura(player, 'Devour Magic');
+    expect(removed).toBe(false);
+    expect(player.auras.length).toBe(2); // both left untouched
+  });
+
+  it('is a harmless no-op when the victim carries no beneficial buff', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnGrubjaw(sim);
+    player.auras = [];
+    const purge = MOBS.grubjaw.purgeOnHit!;
+    const old = purge.chance;
+    purge.chance = 1;
+    try {
+      for (let i = 0; i < 40; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      purge.chance = old;
+    }
+    expect(player.dead).toBe(false);
+  });
+
+  it('a friendly pet never purges its owner (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnGrubjaw(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    player.auras = [];
+    pushBuff(player, 'buff_armor', 80, 'pet_buff');
+    const purge = MOBS.grubjaw.purgeOnHit!;
+    const old = purge.chance;
+    purge.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      purge.chance = old;
+    }
+    expect(player.auras.some((a) => a.id === 'pet_buff')).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds **`purgeOnHit`** — the first offensive mob affix that *strips a beneficial buff off the player* instead of adding a debuff (classic warlock/demon **Devour Magic**). A landed melee swing has a chance to devour **one** enhancement aura from the victim: a positive `buff_*` stat buff, a heal-over-time, an absorb shield, or a weapon imbue. Forms, stances, stealth, and **every debuff** — including negative `buff_*` drains like Maddening Whisper/Withering Rot — are left untouched.

Attached to **Grubjaw the Glutton** (Mirefen Marsh rare troll, lvl 12) at 30% — a glutton that eats your magic.

## How it fits the engine

- **No new `AuraKind`, no new `Entity` field** → `src/net/online.ts` untouched. It rides the existing aura system: the strip is a `target.auras` splice + `recalcPlayerStats` (so a devoured `buff_armor`/`buff_ap` actually un-folds), surfaced via the standard `aura` event. Interest snapshots ship the full aura array, so the buff's disappearance mirrors to online clients automatically.
- `isDevourableAura` is the exact inverse of the HUD's debuff test, so it can never eat a drain or a debuff.
- Proc lives in `mobSwing`'s on-hit block, guarded `mob.hostile && target.kind==='player'` so a friendly pet (the other `mobSwing` caller) never purges its owner's party.
- **Determinism-neutral**: an affix field on an existing mob draws zero construction RNG (no new camp/spawn), so no fixed-seed combat test shifts.

## Tests

`tests/mob_purge.test.ts` — template wiring, one-buff-per-proc, recalc-after-strip, debuff/drain immunity, no-op when no buff, and the friendly-pet guard. Full suite **1399 green**, `tsc --noEmit` clean.

## Screenshots

Grubjaw targeted in-world:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/devour-magic/shots/devour_scene.png)

Player buff bar **before** (Power Word: Fortitude + Battle Shout) → **after** one swing (Fortitude devoured, Battle Shout survives):

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/devour-magic/shots/devour_before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/devour-magic/shots/devour_after.png) |

A purge removes a buff (no debuff icon appears), so the proof is the vanishing buff icon. Captured via `scripts/shot_purge.mjs` (reskins the nearest mob → Grubjaw for the shot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)