### PR TITLE
feat(content): Ironvein Foreman rallies his crew with a Rallying Banner (ally attack-power buff)

### DIFF
--- a/scripts/shot_rally.mjs
+++ b/scripts/shot_rally.mjs
@@ -1,0 +1,115 @@
+// Screenshot the Rally commander affix (Rallying Banner) in the offline client.
+// Boots the game, repurposes nearby mobs as an Ironvein Foreman and his sapper
+// crew, fires the periodic rally, and captures the boss in-world + target frame
+// + the combat log line. A mob ally-buff has no player-facing debuff icon
+// (mirrors the Rampage shot, PR #540), so the proof is the world scene, the
+// elite target frame, and the empowered allies' attack power in the console.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // survive the live hostile loop; aura application still works
+
+  // Collect the three nearest mobs: one becomes the Foreman, two his sappers.
+  const mobs = [...sim.entities.values()]
+    .filter((e) => e.kind === 'mob' && !e.dead)
+    .sort((a, b) => Math.hypot(a.pos.x - p.pos.x, a.pos.z - p.pos.z) - Math.hypot(b.pos.x - p.pos.x, b.pos.z - p.pos.z));
+
+  const foreman = mobs[0];
+  foreman.templateId = 'ironvein_foreman';
+  foreman.name = 'Ironvein Foreman';
+  foreman.level = 16;
+  foreman.hostile = true;
+  foreman.inCombat = true;
+  foreman.aggroTargetId = p.id;
+  foreman.pos.x = p.pos.x + 4; foreman.pos.z = p.pos.z + 5;
+
+  const sappers = mobs.slice(1, 3);
+  sappers.forEach((s, i) => {
+    s.templateId = 'ironvein_sapper';
+    s.name = 'Ironvein Sapper';
+    s.level = 16;
+    s.hostile = true;
+    s.inCombat = true;
+    s.pos.x = p.pos.x + (i === 0 ? 2 : 6); s.pos.z = p.pos.z + 6;
+  });
+
+  // Aim the camera at the Foreman so the elite target frame is shown.
+  sim.targetEntity(foreman.id);
+  p.facing = Math.atan2(foreman.pos.x - p.pos.x, foreman.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input.camDist !== undefined) g.input.camDist = 12;
+
+  const apBefore = sappers.map((s) => sim.effectiveAttackPower(s));
+  // Fire the rally immediately rather than waiting the 12s telegraph.
+  foreman.rallyTimer = 0.001;
+  sim.updateBossMechanics(foreman);
+  const apAfter = sappers.map((s) => sim.effectiveAttackPower(s));
+  const banner = sappers[0]?.auras.find((a) => a.name === 'Rallying Banner');
+
+  return {
+    apBefore, apAfter,
+    hasBanner: !!banner, bannerValue: banner?.value, bannerRemaining: banner?.remaining,
+    foremanBuffed: foreman.auras.some((a) => a.name === 'Rallying Banner'),
+  };
+});
+console.log('rally result:', JSON.stringify(result));
+
+// Open the combat-log tab to surface the "unleashes Rallying Banner!" line.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/rally_scene.png' });
+
+// Crop the boss/elite target frame (top-left of the HUD).
+const tf = await page.evaluate(() => {
+  const el = document.querySelector('#target-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (tf && tf.w > 0) {
+  const pad = 14;
+  await page.screenshot({
+    path: 'tmp/rally_frame.png',
+    clip: {
+      x: Math.max(0, tf.x - pad), y: Math.max(0, tf.y - pad),
+      width: tf.w + pad * 2, height: tf.h + pad * 2,
+    },
+  });
+}
+
+// Crop the combat log (bottom-left chat region).
+await page.screenshot({
+  path: 'tmp/rally_log.png',
+  clip: { x: 0, y: 640, width: 560, height: 240 },
+});
+
+console.log('saved tmp/rally_scene.png, rally_frame.png, rally_log.png');
+await browser.close();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,7 +225,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, rallyTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -73,6 +73,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 38, moveSpeed: 7, aggroRadius: 12,
     aoePulse: { min: 28, max: 38, radius: 8, every: 10, name: 'Powder Keg', school: 'fire' },
     summonAdds: { mobId: 'ironvein_sapper', count: 2, atHpPct: [0.50] },
+    rally: { radius: 14, every: 12, ap: 40, duration: 10, name: 'Rallying Banner' },
     enrage: { belowHpPct: 0.30, dmgMult: 1.45, hasteMult: 1.3 },
     loot: [
       { copper: 420, chance: 1 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, rallyTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first Rally the same way: one full interval after engage.
+  if (template.rally) e.rallyTimer = template.rally.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4052,6 +4052,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.rallyTimer = MOBS[mob.templateId]?.rally?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4520,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.rallyTimer = MOBS[mob.templateId]?.rally?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4612,7 +4614,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly && !tmpl.rally)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4658,6 +4660,40 @@ export class Sim {
           for (const ally of wounded) {
             const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
             this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
+      }
+    }
+    // Commander "Rally": periodically empower every friendly mob in range
+    // (including the caster) with a refreshing attack-power buff. The offensive
+    // twin of mendAlly — same telegraphed timer, same same-faction ally scan —
+    // but it grants buff_ap (folded by effectiveAttackPower) instead of healing.
+    if (tmpl.rally) {
+      mob.rallyTimer -= DT;
+      if (mob.rallyTimer <= 0) {
+        mob.rallyTimer = tmpl.rally.every;
+        const allies: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile) continue; // only same-faction mobs
+          if (dist2d(ally.pos, mob.pos) > tmpl.rally.radius) continue;
+          allies.push(ally);
+        }
+        if (allies.length > 0) {
+          const school = tmpl.rally.school ?? 'physical';
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} unleashes ${tmpl.rally.name}!`, color: '#ffcc33', entityId: mob.id });
+          for (const ally of allies) {
+            this.applyAura(ally, {
+              id: `rally_${mob.templateId}`,
+              name: tmpl.rally.name,
+              kind: 'buff_ap',
+              remaining: tmpl.rally.duration,
+              duration: tmpl.rally.duration,
+              value: tmpl.rally.ap,
+              sourceId: mob.id,
+              school,
+            });
           }
         }
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -191,6 +191,14 @@ export interface MobTemplate {
   // opens. Resets on evade/respawn. Routes through the normal heal path, so it
   // shows green floating text and grants no threat to the menders themselves.
   mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
+  // Commander mechanic ("Rallying Banner"): periodically empowers every friendly
+  // mob in range (including the caster) with a refreshing `buff_ap` aura worth
+  // `ap` attack power for `duration`s — the support twin of mendAlly, granting
+  // offense instead of healing. Rides the existing buff_ap aura that
+  // effectiveAttackPower already folds for mobs, so no new aura kind or combat
+  // math. Telegraphed like stomp/mendAlly: the first rally only lands one full
+  // interval after combat opens.
+  rally?: { radius: number; every: number; ap: number; duration: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -582,6 +590,7 @@ export interface Entity {
   stompTimer: number; // boss War Stomp stun-pulse countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
+  rallyTimer: number; // rally commander-buff cast countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/tests/mob_rally.test.ts
+++ b/tests/mob_rally.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Ironvein Foreman is the seeded carrier of the rally commander mechanic.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+  effectiveAttackPower(e: Entity): number;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string]) {
+  const mob = createMob(id, tmpl, 16, { x: 0, y: 0, z: 0 });
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+function buffAp(e: Entity): number {
+  return e.auras.filter((a) => a.kind === 'buff_ap').reduce((s, a) => s + a.value, 0);
+}
+
+describe('mob commander buff (rally)', () => {
+  it('seeds the mechanic on the Ironvein Foreman', () => {
+    expect(MOBS.ironvein_foreman.rally).toEqual({
+      radius: 14, every: 12, ap: 40, duration: 10, name: 'Rallying Banner',
+    });
+  });
+
+  it('empowers a nearby ally once the cast timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9001, MOBS.ironvein_foreman);
+    const ally = spawn(sim, 9002, MOBS.ironvein_sapper);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    const before = inner(sim).effectiveAttackPower(ally);
+    // Telegraphed: createMob seeds rallyTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first rally.
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(ally)).toBe(40);
+    expect(inner(sim).effectiveAttackPower(ally)).toBe(before + 40);
+  });
+
+  it('does not rally before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9011, MOBS.ironvein_foreman);
+    const ally = spawn(sim, 9012, MOBS.ironvein_sapper);
+    for (let i = 0; i < 20 * 11; i++) inner(sim).updateBossMechanics(foreman); // 11s < 12s
+    expect(buffAp(ally)).toBe(0);
+  });
+
+  it('empowers every ally in range plus the caster (AoE)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9021, MOBS.ironvein_foreman);
+    const a = spawn(sim, 9022, MOBS.ironvein_sapper);
+    const b = spawn(sim, 9023, MOBS.ironvein_sapper);
+    b.pos = { x: 8, y: 0, z: 0 };
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(a)).toBe(40);
+    expect(buffAp(b)).toBe(40);
+    expect(buffAp(foreman)).toBe(40); // the commander rallies itself too
+  });
+
+  it('ignores allies outside the rally radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9031, MOBS.ironvein_foreman);
+    const far = spawn(sim, 9032, MOBS.ironvein_sapper);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 14
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(far)).toBe(0);
+  });
+
+  it('does not empower opposing-faction mobs (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9041, MOBS.ironvein_foreman);
+    const enemyMob = spawn(sim, 9042, MOBS.ironvein_sapper);
+    enemyMob.hostile = false; // flip faction
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(enemyMob)).toBe(0);
+  });
+
+  it('refreshes rather than stacks on repeated casts', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9051, MOBS.ironvein_foreman);
+    const ally = spawn(sim, 9052, MOBS.ironvein_sapper);
+    for (let i = 0; i < 20 * 12 * 2 + 2; i++) inner(sim).updateBossMechanics(foreman);
+    expect(ally.auras.filter((a) => a.kind === 'buff_ap').length).toBe(1);
+    expect(buffAp(ally)).toBe(40);
+  });
+
+  it('re-arms the telegraph after the foreman evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9061, MOBS.ironvein_foreman);
+    inner(sim).resetEvadingMob(foreman);
+    expect(foreman.rallyTimer).toBe(MOBS.ironvein_foreman.rally!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const sapper = spawn(sim, 9071, MOBS.ironvein_sapper);
+    const ally = spawn(sim, 9072, MOBS.ironvein_sapper);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(sapper);
+    expect(buffAp(ally)).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds a new **commander** affix — `rally` — the offensive twin of the existing `mendAlly` support mechanic. On a telegraphed interval, a carrier mob empowers **every friendly mob in range (including itself)** with a refreshing **attack-power** buff for a few seconds, granting offense where mendAlly grants healing.

Attached to the **Ironvein Foreman** (Thornpeak Heights, lvl 16). He already summons a crew of sappers at 50% HP — now he periodically buffs that very crew, so the two mechanics compound into a proper leader fight.

**Rallying Banner:** 14 yd radius · every 12 s · **+40 attack power for 10 s**.

## How it fits the engine

- Rides the existing `buff_ap` aura that `effectiveAttackPower()` already folds for non-player entities (the same primitive demoralize/rampage use) → **no new AuraKind, no new combat math, no HUD change**.
- Mirrors `mendAlly` exactly: same telegraphed timer (`rallyTimer`, seeded one full interval after engage), same same-faction ally scan (skips players, pets, corpses, opposing faction), re-armed on evade/respawn.
- **Determinism-neutral:** an affix on an existing mob adds no camp/spawn, so no construction-RNG draws shift — every fixed-seed combat test stays byte-identical.
- Log line reuses the existing `unleashes …` phrasing, so **no new i18n** is required.

## Tests

- New `tests/mob_rally.test.ts` (9 cases): seed check, telegraph delay, single-ally empower, AoE incl. caster, radius cull, faction guard, refresh-not-stack, re-arm on reset, no-op on non-carriers.
- Full suite **1402 passing**, `tsc --noEmit` clean.

## Screenshots

Ironvein Foreman + sapper crew, the moment the banner fires:

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rally-affix/shots/rally_scene.png)

Elite target frame:

![target frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rally-affix/shots/rally_frame.png)

Combat log — the buff lands on the whole crew (and the Foreman himself):

![combat log](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/rally-affix/shots/rally_log.png)

A mob ally-buff has no player-facing debuff icon (same as the Rampage affix), so the proof is the world scene, the elite frame, the combat log, and the unit test (sapper AP 0 → 40 on cast).

🤖 Generated with [Claude Code](https://claude.com/claude-code)