### PR TITLE
feat(content): Wyrmcult Zealots seal a single spell school on hit (Wyrmward Sigil)

### DIFF
--- a/scripts/shot_lockout.mjs
+++ b/scripts/shot_lockout.mjs
@@ -1,0 +1,85 @@
+// Screenshot the school-lockout affix (Wyrmward Sigil) in the offline client.
+// Boots the game, repurposes a nearby mob as a Wyrmcult Zealot, forces its
+// on-hit lockout onto the player, and captures the resulting red fire-lockout
+// debuff icon in the top-right buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 400)); // panel reveal + auto-select warrior
+await page.type('#char-name', 'Brannok');
+await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override gets wiped by
+  // recalcPlayerStats); applyAura still lands so the debuff shows.
+  p.gm = true;
+  sim.rng.chance = () => true; // force the lockout proc deterministically
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as a Wyrmcult Zealot and stand it next to us.
+  mob.templateId = 'wyrmcult_zealot';
+  mob.name = 'Wyrmcult Zealot';
+  mob.level = 18;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 3.5; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input.camDist !== undefined) g.input.camDist = 10;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const sigil = p.auras.find((a) => a.kind === 'lockout');
+  // hold the aura open so the live tick doesn't expire it before capture
+  if (sigil) { sigil.remaining = 30; sigil.duration = 30; }
+  return { hasSigil: !!sigil, name: sigil?.name, school: sigil?.school, remaining: sigil?.remaining };
+});
+console.log('lockout result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/lockout_scene.png' });
+
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box && box.w > 0) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/lockout_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+await browser.close();
+console.log('done');

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -162,6 +162,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     // The zealot's fevered chanting claws at a caster's mind, draining Intellect
     // and shrinking their mana pool for a while.
     enfeeble: { chance: 0.3, int: 12, duration: 12, name: 'Maddening Whisper', school: 'shadow' },
+    // The Wyrmcult hoards their master's flame: a branding strike seals away the
+    // victim's fire magic so it can never rival the wyrm's, while leaving every
+    // other school free (a single-school counterspell, distinct from a full silence).
+    lockout: { chance: 0.25, duration: 6, name: 'Wyrmward Sigil', school: 'fire' },
     scale: 1.0, color: 0x76448a,
   },
   wyrmcult_necromancer: {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1333,6 +1333,11 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+  // A school lockout denies casts of one specific school only (a counterspell),
+  // leaving every other school — and physical abilities — untouched.
+  private isLockedOut(e: Entity, school: Aura['school']): boolean {
+    return e.auras.some((a) => a.kind === 'lockout' && a.school === school);
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -1799,6 +1804,11 @@ export class Sim {
       const cast = this.resolvedAbility(p.castingAbility, p.id);
       if (cast && cast.def.school !== 'physical') { this.cancelCast(p); return; }
     }
+    // a school lockout breaks an in-progress spell only when it matches the locked school.
+    if (p.castingAbility !== FISHING_CAST_ID) {
+      const cast = this.resolvedAbility(p.castingAbility, p.id);
+      if (cast && cast.def.school !== 'physical' && this.isLockedOut(p, cast.def.school)) { this.cancelCast(p); return; }
+    }
     p.castRemaining -= DT;
 
     if (p.channeling) {
@@ -1879,6 +1889,7 @@ export class Sim {
     const ability = res.def;
     if (this.isStunned(p)) { this.error(p.id, 'You are stunned!'); return; }
     if (ability.school !== 'physical' && this.isSilenced(p)) { this.error(p.id, 'You are silenced!'); return; }
+    if (ability.school !== 'physical' && this.isLockedOut(p, ability.school)) { this.error(p.id, 'You are silenced!'); return; }
     if (p.castingAbility) { this.error(p.id, 'You are busy.'); return; }
     if (!ability.offGcd && p.gcdRemaining > 0) return; // silent, classic spams this
     const togglingOff = isToggleBuff(ability) && p.auras.some((a) => a.id === ability.id);
@@ -4167,6 +4178,16 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // school lockout: a counterspell-on-hit that seals a single spell school. Same
+    // hostile + alive guard as silence so a friendly pet never locks out the party.
+    const lockout = MOBS[mob.templateId]?.lockout;
+    if (lockout && mob.hostile && !target.dead && this.rng.chance(lockout.chance)) {
+      this.applyAura(target, {
+        id: `lockout_${mob.templateId}`, name: lockout.name, kind: 'lockout',
+        remaining: lockout.duration, duration: lockout.duration, value: 0,
+        sourceId: mob.id, school: lockout.school,
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'lockout';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +256,10 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit mechanic: chance to lock out a SINGLE spell school (a school-specific
+  // counterspell) for a duration. Unlike `silence` (which blocks all non-physical
+  // casts), only casts whose `ability.school` matches `school` are denied/broken.
+  lockout?: { chance: number; duration: number; name: string; school: Aura['school'] };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1842,7 +1842,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'lockout'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_lockout.test.ts
+++ b/tests/mob_lockout.test.ts
@@ -1,0 +1,122 @@
+// The Wyrmcult Zealot's "Wyrmward Sigil" is a school-specific counterspell: a
+// landed melee hit can lock the victim out of ONE spell school (fire) for a few
+// seconds. Unlike a full silence, every other school — and physical abilities —
+// stays usable, and an in-progress cast only breaks if it matches the locked school.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Wyrmcult Zealot adjacent to the player, at the player's level for an
+// even hit table, engaged and ready to swing.
+function spawnZealot(sim: Sim, target: Entity): Entity {
+  const template = MOBS['wyrmcult_zealot'];
+  const mob = createMob((sim as any).nextId++, template, target.level, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (lockout chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob school lockout ("Wyrmward Sigil")', () => {
+  it('seeds the lockout mechanic on the Wyrmcult Zealot', () => {
+    expect(MOBS['wyrmcult_zealot'].lockout).toEqual({
+      chance: 0.25, duration: 6, name: 'Wyrmward Sigil', school: 'fire',
+    });
+  });
+
+  it('applies a fire-school lockout aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnZealot(sim, p);
+    MOBS['wyrmcult_zealot'].lockout!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['wyrmcult_zealot'].lockout!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'lockout');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Wyrmward Sigil');
+    expect(aura!.remaining).toBe(6);
+    expect(aura!.school).toBe('fire');
+  });
+
+  it('blocks a fire cast while locked out but leaves other schools free', () => {
+    const sim = makeSim('mage');
+    sim.setPlayerLevel(10); // so the mage knows both Fireball (fire) and Frostbolt (frost)
+    const p = sim.player;
+    p.auras.push({
+      id: 'lockout_wyrmcult_zealot', name: 'Wyrmward Sigil', kind: 'lockout',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'fire',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    // Fireball is fire — locked out, rejected with the silence message.
+    sim.castAbility('fireball', p.id);
+    expect(errs).toContain('You are silenced!');
+    // Frostbolt is frost — a fire lockout must NOT block it.
+    errs.length = 0;
+    sim.castAbility('frostbolt', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('breaks an in-progress fire cast on the next tick but spares other schools', () => {
+    const sim = makeSim('mage');
+    sim.setPlayerLevel(10);
+    const p = sim.player;
+    p.auras.push({
+      id: 'lockout_x', name: 'Wyrmward Sigil', kind: 'lockout',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'fire',
+    });
+    // A fireball mid-cast is the locked school → broken next tick.
+    p.castingAbility = 'fireball';
+    p.castRemaining = 2;
+    p.channeling = false;
+    sim.tick();
+    expect(p.castingAbility).toBeNull();
+    // A frostbolt mid-cast is a different school → survives.
+    p.castingAbility = 'frostbolt';
+    p.castRemaining = 2;
+    p.channeling = false;
+    sim.tick();
+    expect(p.castingAbility).toBe('frostbolt');
+  });
+
+  it('does not block a physical ability while locked out', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    p.resource = 100;
+    p.auras.push({
+      id: 'lockout_x', name: 'Wyrmward Sigil', kind: 'lockout',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'fire',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    // Heroic Strike is physical — a lockout must never be the reason it's blocked.
+    sim.castAbility('heroic_strike', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('a friendly pet swing never locks out its target', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnZealot(sim, p);
+    pet.hostile = false; // a tamed/friendly shape
+    pet.ownerId = p.id;
+    MOBS['wyrmcult_zealot'].lockout!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['wyrmcult_zealot'].lockout!.chance = 0.25;
+    expect(p.auras.some((a) => a.kind === 'lockout')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Wyrmward Sigil — a school-specific lockout

Adds a new on-hit affix: a **school-specific counterspell**. Where the existing `silence` affix locks out *all* non-physical casts, a **lockout** denies only casts whose school matches the sealed one — every other school, and all physical abilities, stay usable. An in-progress cast breaks only if it matches the locked school.

The **Wyrmcult Zealots** of Thornpeak Heights hoard their master's flame: a branding strike seals away the victim's **fire** magic (25% / 6s) so it can never rival the wyrm's, stacking thematically with their existing *Maddening Whisper* (Intellect drain).

### Screenshots
The red-bordered debuff in the player's buff bar (a warrior stand-in, mob reskinned to a Zealot for the capture):

![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/spell-lockout/shots/lockout_scene.png)
![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/spell-lockout/shots/lockout_debuff.png)

### What changed
- `types.ts`: new `'lockout'` AuraKind + `MobTemplate.lockout` field (the aura's `school` carries which school is sealed).
- `sim.ts`: `isLockedOut()` helper; a cast-time gate in `castAbility` and an in-progress-cast break in `updateCasting`, both beside the existing silence checks and **reusing the recognized "You are silenced!" message** (classic Counterspell's debuff is literally *"Counterspell — Silenced"*); on-hit proc in `mobSwing` next to `silence`, hostile + alive guarded so a friendly pet never procs.
- `hud.ts`: render `lockout` as a red debuff icon.
- `zone3.ts`: attach to `wyrmcult_zealot`.
- `tests/mob_lockout.test.ts`: applies on a landed hit; blocks fire but **not** frost; breaks a fire cast but spares a frost cast; never blocks a physical ability; a friendly pet never procs.

### Notes
- **Determinism-neutral** — an affix on an existing mob (no new spawn/camp) draws no construction RNG, so no seed-fixed combat test shifts.
- Full suite **1399 passing**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)