### PR TITLE
feat(content): Mudfin Skulkers hex foes into critters on hit (Mudfin Hex)

### DIFF
--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -181,6 +181,11 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.2 },
     ],
     scale: 0.8, color: 0x52be80,
+    // Mudfin Hex: the skulker's oracle-chant briefly turns a foe into a critter.
+    // Low chance and it breaks the instant the victim takes damage (the murloc's
+    // own next bite ends it), so it's a brief flavor incap — but a murloc pack
+    // can chain it just long enough to make a careless pull dangerous.
+    polymorphHex: { chance: 0.12, duration: 4, name: 'Mudfin Hex', school: 'nature' },
   },
   tunnel_rat: {
     id: 'tunnel_rat', name: 'Tunnel Rat Digger', minLevel: 4, maxLevel: 6, family: 'kobold',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4286,6 +4286,27 @@ export class Sim {
         });
       }
     }
+    // Polymorph hex: a landed hit can briefly turn the victim into a critter,
+    // applying the same `polymorph` aura the mage's Polymorph uses — `isStunned`
+    // locks out every action and the aura is stripped the instant the victim
+    // takes damage (the caster's own next hit ends it), so it's a brief flavor
+    // incap, not a hard lock. Unlike the player-cast version we deliberately do
+    // NOT heal the victim to full on apply (a monster shouldn't restore its prey),
+    // but keep the aura's inherent regen tick. Guarded on `hostile` + a player
+    // target; `diminishedCrowdControlDuration` returns the full duration for a
+    // mob source (DR is PvP-only).
+    const hex = MOBS[mob.templateId]?.polymorphHex;
+    if (hex && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(hex.chance)) {
+      const remaining = this.diminishedCrowdControlDuration(mob, target, 'polymorph', hex.duration);
+      if (remaining !== null) {
+        this.applyAura(target, {
+          id: `hex_${mob.templateId}`, name: hex.name, kind: 'polymorph',
+          remaining, duration: remaining, value: 0,
+          tickInterval: 1, tickTimer: 1,
+          sourceId: mob.id, school: hex.school ?? 'nature', breaksOnDamage: true,
+        });
+      }
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -248,6 +248,11 @@ export interface MobTemplate {
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`
   // drives the panicked run with no new aura kind or movement hook.
   dread?: { chance: number; duration: number; name: string; school?: Aura['school'] };
+  // Polymorph-on-hit (murloc oracle's hex): a landed hit can briefly turn the
+  // victim into a harmless critter. Reuses the exact `polymorph` aura the mage's
+  // Polymorph applies — `isStunned` locks out all actions and the aura breaks the
+  // instant the victim takes damage — so no new aura kind, gating, or UI.
+  polymorphHex?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/tests/mob_hex.test.ts
+++ b/tests/mob_hex.test.ts
@@ -1,0 +1,108 @@
+// Murloc oracles (the Mudfin Skulker's "Mudfin Hex") can briefly turn a victim
+// into a harmless critter on a melee hit. The hex reuses the exact `polymorph`
+// aura the mage's Polymorph applies: it locks out every action (isStunned) and
+// breaks the instant the victim takes damage. Unlike the player-cast version it
+// does NOT heal the victim to full on apply — a monster shouldn't restore its prey.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Mudfin Skulker adjacent to the player, hostile and ready to swing.
+function spawnSkulker(sim: Sim, target: Entity): Entity {
+  const mob = createMob((sim as any).nextId++, MOBS['mudfin_murloc'], 5, {
+    x: target.pos.x, y: target.pos.y, z: target.pos.z,
+  });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (the hex chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob polymorph hex ("Mudfin Hex")', () => {
+  it('seeds the hex mechanic on the Mudfin Skulker', () => {
+    expect(MOBS['mudfin_murloc'].polymorphHex).toEqual({
+      chance: 0.12, duration: 4, name: 'Mudfin Hex', school: 'nature',
+    });
+  });
+
+  it('applies a polymorph aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.gm = true; // survive the swing; applyAura still lands the hex
+    const mob = spawnSkulker(sim, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 0.12;
+    const aura = p.auras.find((a) => a.kind === 'polymorph');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Mudfin Hex');
+    expect(aura!.remaining).toBe(4);
+    expect(aura!.breaksOnDamage).toBe(true);
+  });
+
+  it('does NOT heal the victim to full when the hex lands', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.gm = true;
+    p.maxHp = 200; p.hp = 50; // wounded
+    const mob = spawnSkulker(sim, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 1;
+    swing(sim, mob, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 0.12;
+    expect(p.auras.some((a) => a.kind === 'polymorph')).toBe(true);
+    // The mage's Polymorph sets hp = maxHp; a mob's hex must not. The bite itself
+    // deals damage, so a wounded victim only ends up MORE hurt, never topped off.
+    expect(p.hp).toBeLessThanOrEqual(50);
+    expect(p.hp).toBeLessThan(p.maxHp);
+  });
+
+  it('locks the victim out of casting while hexed', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.auras.push({
+      id: 'hex_mudfin_murloc', name: 'Mudfin Hex', kind: 'polymorph',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'nature',
+      breaksOnDamage: true,
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    sim.castAbility('fireball', p.id);
+    expect(errs).toContain('You are stunned!');
+    expect(p.castingAbility).toBeNull();
+  });
+
+  it('breaks the hex the instant the victim takes damage', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    p.auras.push({
+      id: 'hex_mudfin_murloc', name: 'Mudfin Hex', kind: 'polymorph',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'nature',
+      breaksOnDamage: true,
+    });
+    (sim as any).dealDamage(null, p, 10, false, 'physical', null, 'hit');
+    expect(p.auras.some((a) => a.kind === 'polymorph')).toBe(false);
+  });
+
+  it('does not hex a non-player target', () => {
+    const sim = makeSim();
+    const a = spawnSkulker(sim, sim.player);
+    const b = spawnSkulker(sim, sim.player);
+    b.hostile = true;
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 1;
+    swing(sim, a, b); // murloc hitting another mob must not apply the hex
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 0.12;
+    expect(b.auras.some((aura) => aura.kind === 'polymorph')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Murloc oracles — the **Mudfin Skulker** (Eastbrook woods, lvl 3–5) — can briefly **hex the victim into a harmless critter** on a landed melee hit (12% chance, 4s). While hexed the player can't act, and the hex breaks the instant it takes damage — the murloc's own next bite usually ends it — so it's a brief flavor incap, not a hard lock. A murloc pack, though, can chain it just long enough to make a careless pull dangerous.

This is the classic murloc-oracle "Hex", and it's the first **mob-applied polymorph** in the game.

## How

The whole point is **primitive reuse** — the `polymorph` aura the mage's Polymorph already applies carries everything a hex needs, so there is **no new aura kind, gating, HUD, combat math, or `online.ts` change**:

- `isStunned()` already treats `polymorph` as a full action lockout (movement, casting, auto-attack).
- `breaksOnDamage` is handled generically in `dealDamage`.
- HUD `isDebuff` already lists `polymorph`, and the `aura_polymorph` (critter) icon is already drawn.
- `polymorph` is already in both harmful-aura sets.

New code is just:
- `MobTemplate.polymorphHex` field (`src/sim/types.ts`)
- a small on-hit block in `mobSwing` mirroring the existing `dread` block (`src/sim/sim.ts`)
- the field on `mudfin_murloc` (`src/sim/content/zone1.ts`)

**One deliberate divergence from the player-cast version:** a mob's hex does **not** `hp = maxHp` the victim on apply (a monster shouldn't restore its prey); the aura's inherent regen tick is kept for fidelity.

## Determinism & tests

Adding an on-hit affix to an **existing** mob draws `this.rng` only when that mob fights — it never runs at `Sim` construction, so no fixed-seed roll shifts. **Determinism-neutral; full suite 1399 green, `tsc` clean.**

`tests/mob_hex.test.ts` covers: the mechanic is seeded on the mob; a landed hit applies the `polymorph` aura; it does **not** full-heal the victim; it locks out casting (`You are stunned!`); it breaks on damage; and it never hexes a non-player target.

## Screenshots

The critter debuff on the player's buff bar (red border, ticking timer), and the scene in Eastbrook Vale with the Mudfin Skulker targeted:

![Mudfin Hex debuff icon](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/polymorph-hex/shots/hex_debuff.png)

![Mudfin Hex scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/polymorph-hex/shots/hex_scene.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
