### PR TITLE
feat(content): The Broodmother's bite builds a stacking Brood Venom

### DIFF
--- a/scripts/shot_stackpoison.mjs
+++ b/scripts/shot_stackpoison.mjs
@@ -1,0 +1,94 @@
+// Screenshot the stacking-poison affix (Brood Venom) in the offline client.
+// Boots the game, repurposes a nearby mob as the Broodmother, forces its
+// on-hit poison onto the player repeatedly, and captures the ramped 5-stack
+// debuff (Brood Venom x5) on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 400)); // panel reveal auto-selects warrior
+await page.type('#char-name', 'Brannok');
+try { await page.click('#offline-select .mini-class[data-class="warrior"]'); } catch {}
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // survive the L10 boss; applyAura still lands
+  sim.rng.chance = () => true; // force every on-hit roll to proc
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Broodmother and stand it next to us.
+  mob.templateId = 'mirefen_broodmother';
+  mob.name = 'The Broodmother';
+  mob.level = 10;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Bite repeatedly to ramp the stacks to the cap (maxStacks = 5).
+  for (let i = 0; i < 16; i++) sim.mobSwing(mob, p);
+  const venom = p.auras.find((a) => a.name === 'Brood Venom');
+  return { hasVenom: !!venom, stacks: venom?.stacks, value: venom?.value, remaining: venom?.remaining };
+});
+console.log('stackPoison result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/stackpoison_scene.png' });
+
+// Crop tightly around the (top-right) buff/debuff bar showing Brood Venom x5.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/stackpoison_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+// Hover the debuff icon to surface its tooltip (shows "Brood Venom x5").
+if (box) {
+  await page.mouse.move(box.x + box.w / 2, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 500));
+  await page.screenshot({
+    path: 'tmp/stackpoison_tooltip.png',
+    clip: {
+      x: Math.max(0, box.x - 320), y: Math.max(0, box.y - 10),
+      width: 320 + box.w + 20, height: 170,
+    },
+  });
+}
+console.log('saved tmp/stackpoison_scene.png, stackpoison_debuff.png, stackpoison_tooltip.png');
+await browser.close();

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -119,6 +119,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'mirefen_broodmother', name: 'The Broodmother', minLevel: 10, maxLevel: 10, family: 'spider',
     hpBase: 150, hpPerLevel: 26, dmgBase: 9, dmgPerLevel: 2.4, attackSpeed: 1.8,
     armorPerLevel: 16, moveSpeed: 8, aggroRadius: 14, boss: true,
+    stackPoison: { chance: 0.35, perTick: 3, interval: 2, duration: 12, maxStacks: 5, name: 'Brood Venom', school: 'nature' },
     loot: [
       { copper: 300, chance: 1 },
       { itemId: 'marshstrider_boots', chance: 0.4 },

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,13 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // deadly poison: a landed swing may apply (or add a stack to) a ramping DoT.
+    // Guarded on hostile so a friendly pet (the other mobSwing caller) never
+    // poisons an ally. Per-tick damage scales with the stack count.
+    const stackPoison = MOBS[mob.templateId]?.stackPoison;
+    if (stackPoison && mob.hostile && !target.dead && this.rng.chance(stackPoison.chance)) {
+      this.applyStackPoison(mob, target, stackPoison);
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;
@@ -4285,6 +4292,30 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+  }
+
+  // Apply (or add a stack to) a ramping poison DoT on the victim. One shared
+  // `dot` slot found by id, its per-tick `value` recomputed as perTick*stacks
+  // (bumped up to `maxStacks`) and its timer fully refreshed each application —
+  // so the per-tick damage climbs the longer the creature keeps biting. The dot
+  // tick reads `value` directly, so storing perTick*stacks is what makes it ramp.
+  private applyStackPoison(mob: Entity, target: Entity, sp: NonNullable<MobTemplate['stackPoison']>): void {
+    const id = 'stackpoison_' + mob.templateId;
+    const existing = target.auras.find((a) => a.id === id && a.kind === 'dot');
+    if (existing) {
+      existing.stacks = Math.min(sp.maxStacks, (existing.stacks ?? 1) + 1);
+      existing.value = Math.max(1, Math.round(sp.perTick * existing.stacks));
+      existing.remaining = existing.duration;
+      this.emit({ type: 'aura', targetId: target.id, name: sp.name, gained: true });
+    } else {
+      this.applyAura(target, {
+        id, name: sp.name, kind: 'dot',
+        remaining: sp.duration, duration: sp.duration,
+        value: Math.max(1, Math.round(sp.perTick)),
+        tickInterval: sp.interval, tickTimer: sp.interval, stacks: 1,
+        sourceId: mob.id, school: (sp.school as Aura['school']) ?? 'nature',
+      });
     }
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,12 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit debuff: a *stacking* poison DoT. Unlike `venom` (a single fixed-value
+  // DoT that merely refreshes), each landed swing adds a stack — the per-tick
+  // damage is `perTick * stacks`, ramping up to `maxStacks` — so the longer the
+  // creature stays on its target the worse the venom bites (classic "Deadly
+  // Poison"). Reuses the `dot` aura kind; the shared slot carries the stack count.
+  stackPoison?: { chance: number; perTick: number; interval: number; duration: number; maxStacks: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/tests/mob_stack_poison.test.ts
+++ b/tests/mob_stack_poison.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+const AURA_ID = 'stackpoison_mirefen_broodmother';
+
+// Spawn the Broodmother adjacent to the player, level-matched so the hit table
+// is even (a big level gap would inflate her miss/dodge and starve the on-hit
+// roll). gm keeps the player alive through the swing loop; applyAura still lands.
+function spawnBroodmother(sim: Sim, id = 980001) {
+  const p = sim.entities.get(sim.playerId)!;
+  p.gm = true;
+  const mob = createMob(id, MOBS.mirefen_broodmother, p.level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing until
+// the poison reaches at least `stacks` applications (chance is forced to 1).
+function swingToStacks(sim: Sim, mob: any, target: any, stacks: number, tries = 200): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    const a = target.auras.find((x: any) => x.id === AURA_ID);
+    if (a && (a.stacks ?? 1) >= stacks) return true;
+  }
+  return false;
+}
+
+describe('mob stacking poison (ramping on-hit DoT)', () => {
+  it('the Broodmother carries stackPoison data tuned to a capped nature DoT', () => {
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    expect(sp).toBeDefined();
+    expect(sp.school).toBe('nature');
+    expect(sp.chance).toBeGreaterThan(0);
+    expect(sp.perTick).toBeGreaterThan(0);
+    expect(sp.interval).toBeGreaterThan(0);
+    expect(sp.duration).toBeGreaterThan(sp.interval);
+    expect(sp.maxStacks).toBeGreaterThan(1);
+  });
+
+  it('a landed bite applies a one-stack poison DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    const mob = spawnBroodmother(sim);
+    const orig = sp.chance;
+    sp.chance = 1;
+    try {
+      expect(swingToStacks(sim, mob, player, 1)).toBe(true);
+    } finally {
+      sp.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === AURA_ID)!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('nature');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.stacks).toBe(1);
+    expect(aura.value).toBe(Math.round(sp.perTick));
+    expect(aura.remaining).toBeCloseTo(sp.duration);
+  });
+
+  it('repeated bites ramp the per-tick damage with the stack count, capped at maxStacks', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    const mob = spawnBroodmother(sim);
+    const orig = sp.chance;
+    sp.chance = 1;
+    try {
+      expect(swingToStacks(sim, mob, player, sp.maxStacks)).toBe(true);
+      // Keep biting past the cap — the stack count must not exceed maxStacks.
+      for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, player);
+    } finally {
+      sp.chance = orig;
+    }
+    const auras = player.auras.filter((a) => a.id === AURA_ID);
+    expect(auras.length).toBe(1); // one shared slot, never duplicated
+    const aura = auras[0];
+    expect(aura.stacks).toBe(sp.maxStacks);
+    expect(aura.value).toBe(Math.round(sp.perTick * sp.maxStacks));
+  });
+
+  it('the poison DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    const mob = spawnBroodmother(sim);
+    player.gm = false; // gm gates dealDamage, which the DoT tick routes through
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const orig = sp.chance;
+    sp.chance = 1;
+    try {
+      expect(swingToStacks(sim, mob, player, 1)).toBe(true);
+    } finally {
+      sp.chance = orig;
+    }
+    // Park the mob far away so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 3; i++) sim.tick(); // 3s — at least one tick interval
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-poisonous mob (forest wolf) applies no stacking-poison aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.gm = true;
+    const wolf = createMob(980050, MOBS.forest_wolf, player.level, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === AURA_ID)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new on-hit affix, **`stackPoison`** — a *ramping* poison DoT. Every landed swing adds a stack; per-tick damage is `perTick * stacks`, climbing up to `maxStacks` and refreshing the timer on each bite. This is the classic **Deadly Poison** archetype: the longer the creature stays on its target, the worse the venom bites.

Attached to **The Broodmother** (`mirefen_broodmother`), the previously affix-less L10 boss spider in Mirefen Marsh — 35% chance / 3 per tick / 2s interval / 12s / **5-stack cap** ("Brood Venom"). At full stacks she ticks 15 nature damage.

## How it's distinct

- **`venom`** — a single fixed-value DoT that only *refreshes*. Brood Venom *ramps*.
- **`corrode`** — stacks, but reduces *armor*, not damage.

## Why it's low-risk

- **Reuses existing machinery:** the `dot` aura kind and the `stacks` field already on `Aura`. No new `AuraKind`, no combat-math change, no HUD wiring — the DoT tick already reads `aura.value`, and the aura display already renders the stack count. Mirrors the established `applyCorrosion` stacking helper.
- **Determinism-neutral:** a field on an *existing* mob draws zero construction-time RNG, so no fixed-seed combat test desyncs.
- **tsc clean; full suite 1398 green** (new `tests/mob_stack_poison.test.ts` covers data sanity, first-bite application, ramping + cap, single-slot, the DoT ticking, and the non-poisonous-mob negative case).

## Screenshots

Forced to the 5-stack cap (`stacks: 5, value: 15`) on a warrior via `scripts/shot_stackpoison.mjs`:

| In-world (Broodmother + debuff) | Brood Venom debuff icon |
|---|---|
| ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stacking-poison/shots/stackpoison_scene.png) | ![debuff](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/stacking-poison/shots/stackpoison_debuff.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)