### PR TITLE
feat(content): Mogger braces his crew with a Bracing Order ally-shield (wardAllies)

### DIFF
--- a/scripts/shot_ward_allies.mjs
+++ b/scripts/shot_ward_allies.mjs
@@ -1,0 +1,116 @@
+// Screenshot for Mogger's wardAllies support mechanic (Bracing Order).
+// Drives the offline world, repurposes nearby mobs into Mogger + two lackeys in
+// front of the player, forces the Bracing Order ward, and captures the scene,
+// the target frame, and the combat log showing the crew being shielded.
+// Requires `npm run dev` (pass GAME_URL if it landed on another port).
+//
+// Usage: node scripts/shot_ward_allies.mjs
+import { mkdirSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL || 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline → name → Start (warrior auto-selected).
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await new Promise((r) => setTimeout(r, 400));
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Wardwatch';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Stage: god-mode player; reskin three mobs into Mogger + two lackeys, lined
+  // up a few yards in front of the camera, and target Mogger for the frame.
+  await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.gm = true;
+    p.hp = p.maxHp;
+    // Relocate to a clear field away from the town hub so the shot isn't
+    // cluttered with friendly NPCs.
+    Object.assign(p.pos, sim.groundPos(80, 60));
+    p.prevPos = { ...p.pos };
+    p.facing = 0;
+    const mobs = [...sim.entities.values()].filter((e) => e.kind === 'mob' && !e.dead);
+    const fx = p.pos.x + Math.sin(p.facing) * 8;
+    const fz = p.pos.z + Math.cos(p.facing) * 8;
+    const ground = (x, z) => sim.groundPos(x, z);
+
+    const mogger = mobs[0];
+    window.__mogger = mogger.id;
+    mogger.templateId = 'mogger';
+    mogger.name = 'Mogger';
+    mogger.level = 6;
+    Object.assign(mogger.pos, ground(fx, fz));
+    mogger.prevPos = { ...mogger.pos };
+    mogger.hostile = true;
+
+    window.__lackeys = [];
+    for (let i = 1; i <= 2; i++) {
+      const l = mobs[i];
+      if (!l) break;
+      l.templateId = 'mogger_lackey';
+      l.name = 'Mogger Lackey';
+      l.level = 6;
+      Object.assign(l.pos, ground(fx + (i === 1 ? -3 : 3), fz - 1));
+      l.prevPos = { ...l.pos };
+      l.hostile = true;
+      window.__lackeys.push(l.id);
+    }
+    // Declutter: banish every other mob far away so only the crew is in frame.
+    const crew = new Set([mogger.id, ...window.__lackeys]);
+    for (const e of sim.entities.values()) {
+      if (e.kind === 'mob' && !crew.has(e.id)) { e.pos.x += 100000; e.prevPos = { ...e.pos }; }
+    }
+    // Target Mogger so the target frame names the warding boss.
+    p.targetId = mogger.id;
+    if (window.__game.hud?.setTarget) window.__game.hud.setTarget(mogger.id);
+  });
+
+  // Force the Bracing Order ward to fire repeatedly so the absorb is fresh on
+  // the crew and the combat-log lines accumulate.
+  for (let i = 0; i < 6; i++) {
+    await page.evaluate(() => {
+      const sim = window.__game.sim;
+      const mogger = sim.entities.get(window.__mogger);
+      if (!mogger) return;
+      mogger.inCombat = true;
+      mogger.combatTimer = 0;
+      mogger.wardTimer = 0.001; // fire now
+      sim.updateBossMechanics(mogger);
+    });
+    await new Promise((r) => setTimeout(r, 160));
+  }
+
+  await new Promise((r) => setTimeout(r, 200));
+  await page.screenshot({ path: `${OUT}/ward_scene.png` });
+  console.log('saved ward_scene.png (full scene)');
+
+  // Cropped close-up on Mogger + lackeys (the shielded crew).
+  await page.screenshot({ path: `${OUT}/ward_actors.png`, clip: { x: 420, y: 110, width: 480, height: 360 } });
+  console.log('saved ward_actors.png (close-up)');
+
+  // Cropped on the combat log showing the Bracing Order ward lines.
+  await page.screenshot({ path: `${OUT}/ward_log.png`, clip: { x: 8, y: 470, width: 580, height: 250 } });
+  console.log('saved ward_log.png (combat log)');
+} finally {
+  await browser.close();
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,7 +225,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, wardTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -155,6 +155,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     aoePulse: { min: 14, max: 20, radius: 8, every: 10, name: 'Ground Pound', school: 'physical' },
     summonAdds: { mobId: 'mogger_lackey', count: 2, atHpPct: [0.70] },
     enrage: { belowHpPct: 0.30, dmgMult: 1.6, hasteMult: 1.3 },
+    wardAllies: { radius: 12, every: 12, amount: 70, duration: 8, name: 'Bracing Order', school: 'physical' },
     loot: [
       { copper: 180, chance: 1 },
       { itemId: 'linen_scrap', chance: 1 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, wardTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first Ward the same way: one full interval after engage.
+  if (template.wardAllies) e.wardTimer = template.wardAllies.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4052,6 +4052,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.wardTimer = MOBS[mob.templateId]?.wardAllies?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4520,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.wardTimer = MOBS[mob.templateId]?.wardAllies?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4612,7 +4614,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly && !tmpl.wardAllies)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4658,6 +4660,35 @@ export class Sim {
           for (const ally of wounded) {
             const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
             this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
+      }
+    }
+    // Support "Ward": the defensive twin of Mend. Periodically wrap every living
+    // friendly mob in range (including the caster) in an absorb shield. Unlike
+    // Mend it targets healthy allies too — a barrier pre-empts the next blows.
+    // Refreshes each interval, replacing any partially-soaked ward (same aura id).
+    if (tmpl.wardAllies) {
+      mob.wardTimer -= DT;
+      if (mob.wardTimer <= 0) {
+        mob.wardTimer = tmpl.wardAllies.every;
+        const allies: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile) continue; // same-faction mobs only
+          if (dist2d(ally.pos, mob.pos) > tmpl.wardAllies.radius) continue;
+          allies.push(ally);
+        }
+        if (allies.length > 0) {
+          const school = tmpl.wardAllies.school ?? 'holy';
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} channels ${tmpl.wardAllies.name}.`, color: '#aad4ff', entityId: mob.id });
+          for (const ally of allies) {
+            this.applyAura(ally, {
+              id: `ward_${mob.templateId}`, name: tmpl.wardAllies.name, kind: 'absorb',
+              remaining: tmpl.wardAllies.duration, duration: tmpl.wardAllies.duration,
+              value: tmpl.wardAllies.amount, sourceId: mob.id, school,
+            });
           }
         }
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -191,6 +191,14 @@ export interface MobTemplate {
   // opens. Resets on evade/respawn. Routes through the normal heal path, so it
   // shows green floating text and grants no threat to the menders themselves.
   mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
+  // Support mechanic ("Ward"): the defensive twin of `mendAlly`. While in combat,
+  // periodically wrap every living friendly mob within `radius` (incl. itself) in
+  // a damage-absorbing barrier soaking a flat `amount` for `duration`s — a leader
+  // shielding the crew. Rides the existing `absorb` aura (soaked in dealDamage
+  // before any HP loss), so there is no new aura kind or combat math. Telegraphed:
+  // the first ward lands one full `every` interval after combat opens. Resets on
+  // evade/respawn. Refreshes each interval, replacing any partially-soaked ward.
+  wardAllies?: { radius: number; every: number; amount: number; duration: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -582,6 +590,7 @@ export interface Entity {
   stompTimer: number; // boss War Stomp stun-pulse countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
+  wardTimer: number; // wardAllies support-shield cast countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/tests/mob_ward_allies.test.ts
+++ b/tests/mob_ward_allies.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Mogger is the seeded carrier of the wardAllies support mechanic — a rare ogre
+// boss that shields his crew (mogger_lackeys) with a Bracing Order absorb.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string], hpFrac = 1) {
+  const mob = createMob(id, tmpl, 6, { x: 0, y: 0, z: 0 });
+  mob.hp = Math.round(mob.maxHp * hpFrac);
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+const ward = (e: Entity) => e.auras.find((a) => a.id === 'ward_mogger' && a.kind === 'absorb');
+
+describe('mob support shield (wardAllies)', () => {
+  it('seeds the mechanic on Mogger', () => {
+    expect(MOBS.mogger.wardAllies).toEqual({
+      radius: 12, every: 12, amount: 70, duration: 8, name: 'Bracing Order', school: 'physical',
+    });
+  });
+
+  it('shields a nearby ally once the cast timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9001, MOBS.mogger);
+    const ally = spawn(sim, 9002, MOBS.mogger_lackey);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    // Telegraphed: createMob seeds wardTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first ward.
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(ally)?.value).toBe(70);
+    expect(ward(ally)?.remaining).toBe(8);
+  });
+
+  it('does not cast before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9011, MOBS.mogger);
+    const ally = spawn(sim, 9012, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 11; i++) inner(sim).updateBossMechanics(mogger); // 11s < 12s
+    expect(ward(ally)).toBeUndefined();
+  });
+
+  it('shields every ally in range plus the caster (AoE, healthy too)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9021, MOBS.mogger);
+    const a = spawn(sim, 9022, MOBS.mogger_lackey); // full HP — a ward pre-empts damage
+    const b = spawn(sim, 9023, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(a)?.value).toBe(70);
+    expect(ward(b)?.value).toBe(70);
+    expect(ward(mogger)?.value).toBe(70); // the caster wards itself too
+  });
+
+  it('the absorb soaks incoming damage before any HP is lost', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9101, MOBS.mogger);
+    const ally = spawn(sim, 9102, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    const hpBefore = ally.hp;
+    // 50 damage < 70 shield → fully soaked, no HP loss, shield drops to 20.
+    (sim as unknown as { dealDamage(s: Entity | null, t: Entity, amt: number, crit: boolean, school: string, ability: string | null, kind: string): void })
+      .dealDamage(null, ally, 50, false, 'physical', null, 'hit');
+    expect(ally.hp).toBe(hpBefore);
+    expect(ward(ally)?.value).toBe(20);
+  });
+
+  it('ignores allies outside the ward radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9031, MOBS.mogger);
+    const far = spawn(sim, 9032, MOBS.mogger_lackey);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 12
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(far)).toBeUndefined();
+  });
+
+  it('does not ward mobs of the opposing faction (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9041, MOBS.mogger);
+    const friendlyMob = spawn(sim, 9042, MOBS.mogger_lackey);
+    friendlyMob.hostile = false; // flip faction
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(friendlyMob)).toBeUndefined();
+  });
+
+  it('re-arms the telegraph after Mogger evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9051, MOBS.mogger);
+    inner(sim).resetEvadingMob(mogger);
+    expect(mogger.wardTimer).toBe(MOBS.mogger.wardAllies!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const lackey = spawn(sim, 9061, MOBS.mogger_lackey);
+    const ally = spawn(sim, 9062, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(lackey);
+    expect(ward(ally)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Adds the **`wardAllies`** mob affix — the **defensive twin of `mendAlly`**. While in combat a carrier periodically wraps every same-faction mob in range (including itself) in a damage-absorbing barrier soaking a flat amount before any HP is lost.

This fills the missing slot on the **support / commander axis**:

| Axis member | Effect |
|---|---|
| `mendAlly` | periodic ally **heal** |
| `packFrenzy` | ally **haste** on an ally's death |
| **`wardAllies` (this PR)** | periodic ally **damage-absorb shield** |

Attached to **Mogger** (rare ogre boss, Eastbrook Vale) at **70 absorb / every 12s / 8s**, named *"Bracing Order"*. Mogger already summons two lackeys at 70% HP, so the ward shields the very crew he calls in — a leader bracing his gang.

## How it works (minimal seam)

Rides the **existing `absorb` aura**, which `dealDamage` already soaks *before* any HP loss with no player/mob gate — so there is **no new `AuraKind`, combat math, or HUD wiring**. The mechanic mirrors `mendAlly` exactly:

- `MobTemplate.wardAllies` field + `Entity.wardTimer` (defaulted in `entity.ts` and the `net/online.ts` mob literal).
- An ally-scan block at the tail of `updateBossMechanics`, gated by the existing combat early-return.
- Telegraphed (first ward lands one full interval after engage) and re-armed on evade/respawn, exactly like Mend.
- Refreshes each interval (same aura id), replacing any partially-soaked ward.

## Tests & checks

- New `tests/mob_ward_allies.test.ts` (9 cases): seeding, telegraph delay, AoE-incl-self, **absorb actually soaks incoming damage before HP loss**, radius cull, faction guard, evade re-arm, no-op for non-carriers.
- `tsc --noEmit` clean.
- **Full suite: 1402 passing** (determinism-neutral — it's an existing mob with no new camp/spawn, so no seed-fixed combat test shifts).

> Note: per maintainer convention the affix/log text follows the existing language-agnostic pattern (the cast log reuses the already-recognized `"channels"` verb), so no new player strings are introduced.

## Screenshots

Mogger flanked by his warded lackeys, and the combat log showing the *Bracing Order* cast:

![Mogger and his crew](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ward-allies/shots/ward_actors.png)
![Scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ward-allies/shots/ward_scene.png)
![Combat log — Mogger channels Bracing Order](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ward-allies/shots/ward_log.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)