### PR TITLE
feat(content): Deepfen Snappers drum up the school with a Tide Cadence (ally haste)

### DIFF
--- a/scripts/shot_warcry.mjs
+++ b/scripts/shot_warcry.mjs
@@ -1,0 +1,112 @@
+// Screenshot for the Deepfen Snapper ally-haste mechanic (warcry / Tide Cadence).
+// Drives the offline world, repurposes three nearby mobs into a murloc school in
+// front of the player, forces the Tide Cadence pulse, and captures the buffed
+// pack, the combat log, and a snapper's target frame carrying the haste buff.
+// Requires `npm run dev` (pass GAME_URL if it landed off :5173).
+//
+// Usage: node scripts/shot_warcry.mjs
+import { mkdirSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL || 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline (auto-selects warrior) → name → Start.
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await new Promise((r) => setTimeout(r, 400));
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Tidewatch';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Stage the scene: god-mode the player, repurpose three mobs into a Deepfen
+  // murloc school clustered a few yards in front of the camera.
+  await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.gm = true;
+    p.hp = p.maxHp;
+    const mobs = [...sim.entities.values()].filter((e) => e.kind === 'mob' && !e.dead);
+    const fx = p.pos.x + Math.sin(p.facing) * 7;
+    const fz = p.pos.z + Math.cos(p.facing) * 7;
+    const ground = (x, z) => sim.groundPos(x, z);
+    const offsets = [[-2.5, 0], [2.5, 0.5], [0, 2.5]];
+    window.__school = [];
+    for (let i = 0; i < 3 && i < mobs.length; i++) {
+      const m = mobs[i];
+      m.templateId = 'deepfen_murloc';
+      m.name = 'Deepfen Snapper';
+      m.level = 9;
+      Object.assign(m.pos, ground(fx + offsets[i][0], fz + offsets[i][1]));
+      m.prevPos = { ...m.pos };
+      m.hostile = true;
+      m.inCombat = true;
+      m.combatTimer = 0;
+      window.__school.push(m.id);
+    }
+    // Target the lead snapper so its target frame (and buff) is on screen.
+    p.targetId = window.__school[0];
+    if (window.__game.input) window.__game.input.targetId = window.__school[0];
+  });
+
+  // Drive several Tide Cadence pulses so the whole school carries the haste buff.
+  for (let i = 0; i < 6; i++) {
+    await page.evaluate(() => {
+      const sim = window.__game.sim;
+      for (const id of window.__school) {
+        const m = sim.entities.get(id);
+        if (!m) continue;
+        m.inCombat = true;
+        m.warcryTimer = 0; // fire the pulse now
+        sim.updateBossMechanics?.(m) ?? sim['updateBossMechanics'](m);
+      }
+    });
+    await new Promise((r) => setTimeout(r, 160));
+  }
+
+  // Report the applied auras as proof.
+  const proof = await page.evaluate(() => {
+    const sim = window.__game.sim;
+    return window.__school.map((id) => {
+      const m = sim.entities.get(id);
+      const a = m?.auras.find((x) => x.id === 'warcry_deepfen_murloc');
+      return { name: m?.name, haste: a ? a.value : null, remaining: a ? Math.round(a.remaining * 10) / 10 : null };
+    });
+  });
+  console.log('Tide Cadence auras:', JSON.stringify(proof));
+
+  await new Promise((r) => setTimeout(r, 120));
+  await page.screenshot({ path: `${OUT}/warcry-scene.png` });
+  console.log('saved warcry-scene.png (full scene — the buffed murloc school)');
+
+  await page.screenshot({ path: `${OUT}/warcry-actors.png`, clip: { x: 420, y: 90, width: 470, height: 360 } });
+  console.log('saved warcry-actors.png (close-up on the school)');
+
+  // Combat log showing the repeated "channels Tide Cadence" lines.
+  await page.screenshot({ path: `${OUT}/warcry-log.png`, clip: { x: 8, y: 470, width: 560, height: 250 } });
+  console.log('saved warcry-log.png (combat log)');
+
+  // Target frame of the lead snapper (top-left), which carries the haste buff.
+  await page.screenshot({ path: `${OUT}/warcry-targetframe.png`, clip: { x: 0, y: 0, width: 420, height: 150 } });
+  console.log('saved warcry-targetframe.png (target frame)');
+} finally {
+  await browser.close();
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,7 +225,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, warcryTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -79,6 +79,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     scale: 0.85, color: 0x45b39d,
     // Acid Spit: a snapper's bite corrodes armor, stacking so a swarm shreds you fast.
     corrode: { chance: 0.35, armor: 20, maxStacks: 5, duration: 15, name: 'Acid Spit', school: 'nature' },
+    // Tide Cadence: a snapper drums up the school, quickening the whole pack's
+    // bites — the swarm's signature pressure when you pull more than one.
+    warcry: { radius: 12, every: 10, hasteMult: 1.25, duration: 6, name: 'Tide Cadence', school: 'frost' },
   },
   mirejaw_the_ravenous: {
     id: 'mirejaw_the_ravenous', name: 'Mirejaw the Ravenous', minLevel: 10, maxLevel: 10, family: 'murloc', rare: true,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, warcryTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first War Cadence the same way: one full interval after engage.
+  if (template.warcry) e.warcryTimer = template.warcry.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4052,6 +4052,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.warcryTimer = MOBS[mob.templateId]?.warcry?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4520,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.warcryTimer = MOBS[mob.templateId]?.warcry?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4612,7 +4614,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly && !tmpl.warcry)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4658,6 +4660,46 @@ export class Sim {
           for (const ally of wounded) {
             const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
             this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
+      }
+    }
+    // Support "War Cadence": periodically quicken every nearby friendly mob's
+    // swings (including the caster) by re-applying a refreshing buff_haste aura.
+    // Same telegraph as Mend; rides swingIntervalMult's existing buff_haste fold.
+    if (tmpl.warcry) {
+      mob.warcryTimer -= DT;
+      if (mob.warcryTimer <= 0) {
+        mob.warcryTimer = tmpl.warcry.every;
+        const allies: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile) continue; // same-faction only
+          if (dist2d(ally.pos, mob.pos) > tmpl.warcry.radius) continue;
+          allies.push(ally);
+        }
+        if (allies.length > 0) {
+          const school = tmpl.warcry.school ?? 'physical';
+          const auraId = `warcry_${mob.templateId}`;
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} channels ${tmpl.warcry.name}.`, color: '#ffd27f', entityId: mob.id });
+          for (const ally of allies) {
+            const existing = ally.auras.find((a) => a.id === auraId);
+            if (existing) {
+              existing.remaining = tmpl.warcry.duration; // refresh on each pulse; never stack
+              continue;
+            }
+            ally.auras.push({
+              id: auraId,
+              name: tmpl.warcry.name,
+              kind: 'buff_haste',
+              remaining: tmpl.warcry.duration,
+              duration: tmpl.warcry.duration,
+              value: tmpl.warcry.hasteMult,
+              sourceId: mob.id,
+              school,
+            });
+            this.emit({ type: 'aura', targetId: ally.id, name: tmpl.warcry.name, gained: true });
           }
         }
       }

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -191,6 +191,12 @@ export interface MobTemplate {
   // opens. Resets on evade/respawn. Routes through the normal heal path, so it
   // shows green floating text and grants no threat to the menders themselves.
   mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
+  // Support "War Cadence": periodically quicken the swing speed of every nearby
+  // friendly mob (including the caster) by `hasteMult` for `duration`s. Rides the
+  // existing buff_haste primitive (the same aura packFrenzy uses, already folded
+  // into swingIntervalMult), so it needs no new combat math. Telegraphed and
+  // reset on evade/respawn exactly like mendAlly.
+  warcry?: { radius: number; every: number; hasteMult: number; duration: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -582,6 +588,7 @@ export interface Entity {
   stompTimer: number; // boss War Stomp stun-pulse countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
+  warcryTimer: number; // warcry ally-haste pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/tests/mob_warcry.test.ts
+++ b/tests/mob_warcry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Deepfen Snapper is the seeded carrier of the warcry (ally-haste) mechanic.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string]) {
+  const mob = createMob(id, tmpl, 9, { x: 0, y: 0, z: 0 });
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+const HASTE = (e: Entity) => e.auras.find((a) => a.id === 'warcry_deepfen_murloc');
+
+describe('mob ally-haste (warcry)', () => {
+  it('seeds the mechanic on the Deepfen Snapper', () => {
+    expect(MOBS.deepfen_murloc.warcry).toEqual({
+      radius: 12, every: 10, hasteMult: 1.25, duration: 6, name: 'Tide Cadence', school: 'frost',
+    });
+  });
+
+  it('hastens a nearby ally once the pulse timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9001, MOBS.deepfen_murloc);
+    const ally = spawn(sim, 9002, MOBS.deepfen_murloc);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    // Telegraphed: createMob seeds warcryTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first pulse.
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    const aura = HASTE(ally);
+    expect(aura).toBeDefined();
+    expect(aura!.kind).toBe('buff_haste');
+    expect(aura!.value).toBe(1.25);
+  });
+
+  it('does not pulse before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9011, MOBS.deepfen_murloc);
+    const ally = spawn(sim, 9012, MOBS.deepfen_murloc);
+    for (let i = 0; i < 20 * 9; i++) inner(sim).updateBossMechanics(caller); // 9s < 10s
+    expect(HASTE(ally)).toBeUndefined();
+  });
+
+  it('hastens every ally in range plus the caster (AoE), without stacking', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9021, MOBS.deepfen_murloc);
+    const a = spawn(sim, 9022, MOBS.deepfen_murloc);
+    a.pos = { x: 4, y: 0, z: 0 };
+    const b = spawn(sim, 9023, MOBS.deepfen_murloc);
+    b.pos = { x: 0, y: 0, z: 6 };
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(HASTE(a)).toBeDefined();
+    expect(HASTE(b)).toBeDefined();
+    expect(HASTE(caller)).toBeDefined(); // the caller drums up itself too
+    // a second pulse only refreshes the single aura — never a second copy
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(a.auras.filter((x) => x.id === 'warcry_deepfen_murloc')).toHaveLength(1);
+  });
+
+  it('ignores allies outside the radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9031, MOBS.deepfen_murloc);
+    const far = spawn(sim, 9032, MOBS.deepfen_murloc);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 12
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(HASTE(far)).toBeUndefined();
+  });
+
+  it('does not buff mobs of the opposing faction (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9041, MOBS.deepfen_murloc);
+    const friendlyMob = spawn(sim, 9042, MOBS.deepfen_murloc);
+    friendlyMob.hostile = false; // flip faction
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(HASTE(friendlyMob)).toBeUndefined();
+  });
+
+  it('re-arms the telegraph after the caller evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9051, MOBS.deepfen_murloc);
+    inner(sim).resetEvadingMob(caller);
+    expect(caller.warcryTimer).toBe(MOBS.deepfen_murloc.warcry!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const cultist = spawn(sim, 9061, MOBS.gravecaller_cultist);
+    const ally = spawn(sim, 9062, MOBS.deepfen_murloc);
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(cultist);
+    expect(ally.auras.some((a) => a.kind === 'buff_haste')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds a new mob support mechanic, **`warcry`**, and seeds it on the **Deepfen Snapper** (Mirefen Marsh murloc, lvl 8–9) as **Tide Cadence**.

Every `every` seconds while in combat, the carrier drums up the school: it re-applies a refreshing `buff_haste` aura to every nearby friendly mob (including itself), quickening their swing speed by `hasteMult` for `duration` seconds. Deepfen Snappers swarm in schools of 6–8, so this is the pack's signature pressure — pull more than one and the whole school bites faster.

Tuning: **12 yd / every 10 s / +25 % swing haste / 6 s**.

## Why it's low-risk

- **Haste twin of the existing `mendAlly`** support cadence (periodic ally heal) — the new block mirrors it exactly (same telegraph, same evade/respawn re-arm, same same-faction radius scan).
- **Pure primitive reuse:** it rides the existing `buff_haste` aura — the same one `packFrenzy` applies — which `swingIntervalMult` already folds for any entity. So **zero new `AuraKind`, combat math, or HUD wiring**.
- **Determinism-neutral:** an affix/trait on an *existing* mob draws no RNG at `Sim` construction (no new spawn or camp), so every fixed-seed combat test is untouched.
- `tsc --noEmit` clean; **full suite 1401 passing** (incl. the localization guard — the debuff/buff name ships via the standard aura event and the log line reuses the recognized `channels` verb, so no new i18n strings).

## Test

New `tests/mob_warcry.test.ts` (8 cases) mirrors `mob_mend_ally.test.ts`: seeding, telegraphed first pulse, AoE-to-all-allies-plus-caster, no-stacking refresh, radius gating, faction gating, evade re-arm, and the no-mechanic no-op.

## Screenshots

The whole school carrying the buff, the combat log, and a snapper's target frame with the Tide Cadence buff icon:

| The buffed murloc school | Combat log | Target frame (buff icon) |
|---|---|---|
| ![scene](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ally-haste/shots/warcry-scene.png) | ![log](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ally-haste/shots/warcry-log.png) | ![frame](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets/ally-haste/shots/warcry-targetframe.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)