### PR TITLE
fix(sim): mobs give up a target they can't reach (chase-stall) — follow-up to #563

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -243,7 +243,7 @@ function blankEntity(id: number): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
-    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, chaseStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff, skin: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -22,7 +22,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
-    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, chaseStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff, skin: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -46,6 +46,9 @@ const EVADE_SPEED_MULT = 1.6;
 // immune while resetting, a permanent stall = a permanently unkillable mob. If it
 // can't get closer to home for this long, it starts phasing through the blocker.
 const EVADE_STALL_TIMEOUT = 3;
+// Seconds a mob may fail to advance toward its target before giving it up — a mob
+// pinned out of reach (terrain/water/a prop) otherwise chases forever and never leashes.
+const CHASE_STALL_TIMEOUT = 5;
 // Heading offsets (radians) a mob tries when its straight path is blocked, so it
 // can slide around a prop instead of pinning on it. Desired heading (0) first;
 // only evaluated past the first entry when that straight step is obstructed.
@@ -3699,6 +3702,7 @@ export class Sim {
   // attacker. With no living threat left, it evades home instead of grabbing a
   // nearby bystander who never acted on the mob.
   private retargetMob(mob: Entity): void {
+    mob.chaseStall = 0;
     const next = this.highestThreatTarget(mob);
     if (next) {
       mob.aggroTargetId = next.id;
@@ -3913,10 +3917,27 @@ export class Sim {
         if (d <= MELEE_RANGE * 0.8) {
           mob.aiState = 'attack';
           mob.swingTimer = Math.min(mob.swingTimer, 0.4);
+          mob.chaseStall = 0;
           break;
         }
-        if (!this.isRooted(mob)) this.moveToward(mob, target.pos, mob.moveSpeed * this.moveSpeedMult(mob));
-        else mob.facing = angleTo(mob.pos, target.pos);
+        if (!this.isRooted(mob)) {
+          const px = mob.pos.x, pz = mob.pos.z;
+          this.moveToward(mob, target.pos, mob.moveSpeed * this.moveSpeedMult(mob));
+          // Give-up: a mob pinned out of reach of its target (terrain/water/a prop)
+          // would otherwise chase forever and never leash. After CHASE_STALL_TIMEOUT
+          // of no forward progress, drop this target and take the next on the threat
+          // table, or evade home if there is no one else (retargetMob).
+          const moved = Math.hypot(mob.pos.x - px, mob.pos.z - pz);
+          if (moved < mob.moveSpeed * DT * 0.25) mob.chaseStall += DT;
+          else mob.chaseStall = 0;
+          if (mob.chaseStall >= CHASE_STALL_TIMEOUT) {
+            mob.threat.delete(target.id);
+            this.retargetMob(mob);
+            break;
+          }
+        } else {
+          mob.facing = angleTo(mob.pos, target.pos);
+        }
         break;
       }
       case 'attack': {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -589,6 +589,7 @@ export interface Entity {
   spawnPos: Vec3;
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   evadeStall: number; // seconds an evading mob has failed to get closer to home; snaps it home if it can't path back (e.g. across water)
+  chaseStall: number; // seconds a chasing mob has failed to advance toward its target; gives the target up if it can't be reached
   fleeTimer: number; // seconds left in a low-HP panic flee; counts down in the 'flee' state
   hasFled: boolean; // a cowardly mob flees only once per pull; cleared when it resets at spawn
   wanderTarget: Vec3 | null;

--- a/tests/chase_stall.test.ts
+++ b/tests/chase_stall.test.ts
@@ -1,0 +1,51 @@
+// Follow-up to the combat-leash fix: a mob that cannot physically reach its target
+// (pinned behind terrain/water/a prop) must GIVE UP rather than chase forever and
+// never leash. After CHASE_STALL_TIMEOUT of no progress it drops the target and
+// retargets (next on threat) or evades home.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+function wildMob(sim: Sim): Entity {
+  return [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead && e.ownerId === null)!;
+}
+function lockChaser(mob: Entity, x: number, z: number, targetId: number) {
+  mob.pos = { x, z, y: mob.pos.y };
+  mob.prevPos = { ...mob.pos };
+  mob.spawnPos = { ...mob.pos };    // anchored at itself so it never leashes on its own
+  mob.leashAnchor = { ...mob.pos };
+  mob.hostile = true;
+  mob.aiState = 'chase';
+  mob.aggroTargetId = targetId;
+  mob.threat.set(targetId, 1000);
+}
+
+describe('mobs give up a target they cannot reach', () => {
+  it('drops an unreachable target after the stall timeout and evades', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    const mob = wildMob(sim);
+    (sim as any).moveToward = () => false; // simulate being unable to advance
+    lockChaser(mob, p.pos.x + 20, p.pos.z, p.id);
+
+    for (let i = 0; i < 20 * 3; i++) sim.tick();      // 3s < timeout: still chasing
+    expect(mob.aggroTargetId).toBe(p.id);
+
+    for (let i = 0; i < 20 * 4; i++) sim.tick();      // total 7s > CHASE_STALL_TIMEOUT
+    expect(mob.aggroTargetId).not.toBe(p.id);          // dropped
+    expect(mob.aiState === 'evade' || mob.aiState === 'idle').toBe(true);
+  });
+
+  it('a mob that can advance keeps chasing (no premature give-up)', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    const mob = wildMob(sim);
+    lockChaser(mob, p.pos.x + 15, p.pos.z, p.id);
+    for (let i = 0; i < 20 * 6; i++) sim.tick();       // 6s > timeout, but it can move
+    expect(mob.aggroTargetId).toBe(p.id);
+    expect(mob.aiState === 'attack' || mob.aiState === 'chase').toBe(true);
+  });
+});


### PR DESCRIPTION
**Follow-up to #563** (combat-leash). #563 stopped a stuck mob from pinning a *player* in combat; this stops the *mob* from spinning in `chase` against a target it can never reach.

## Why
The only thing that drops a mob's aggro is the leash check — `dist(mob, its spawn) > 45`. A mob that can't path to its target (pinned behind terrain/water/a prop) never moves, so it stays near its spawn, never leashes, and chases forever. There's a stall timer for `evade`, none for `chase`.

## Fix
Mirror the evade-stall: while chasing, if the mob makes no forward progress (`moved < 25%` of a normal step) for `CHASE_STALL_TIMEOUT = 5s`, it **drops the target from threat and `retargetMob`s** — picking the next-highest threat, or evading home if no one else is on the table. A mob that can advance resets the timer each tick; a kited mob still moves, so it never trips early (the leash handles kiting as before).

## Tests
`tests/chase_stall.test.ts`: an unreachable target is dropped after the timeout (mob evades); a mob that can advance keeps chasing. `tsc` clean; `sim`, `mob_flee` green.

Pairs with #563 — together: the player exits combat *and* the mob resets cleanly. Targets `release/v0.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
