### PR TITLE
fix(sim): leaving an instance drops you from its mobs' threat

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7180,6 +7180,17 @@ export class Sim {
     return instanceOrigin(DUNGEONS[inst.dungeonId].index, inst.slot);
   }
 
+  // The claimed instance an entity is currently standing in (same occupancy bands as
+  // updateInstances), or null if it is outdoors.
+  private instanceContaining(e: Entity): InstanceSlot | null {
+    for (const inst of this.instances) {
+      if (inst.partyKey === null) continue;
+      const o = this.instanceOriginOf(inst);
+      if (Math.abs(e.pos.x - o.x) < 120 && Math.abs(e.pos.z - o.z) < 250) return inst;
+    }
+    return null;
+  }
+
   // Walking into a dungeon door teleports you through it (no click needed).
   // Party members who walk in land in the same instance via instanceKeyFor.
   private dungeonDoorIds: number[] | null = null;
@@ -7248,6 +7259,18 @@ export class Sim {
     // that silently teleported outdoor callers to the Hollow Crypt door)
     const dungeon = dungeonAt(p.pos.x);
     if (!dungeon) return;
+    // Drop the departing player from every mob in this instance so they stop
+    // targeting someone who has left: each switches to whoever else is on its
+    // threat table, or de-aggros and returns home if no one remains (retargetMob).
+    const inst = this.instanceContaining(p);
+    if (inst) {
+      for (const id of inst.mobIds) {
+        const m = this.entities.get(id);
+        if (!m || m.dead) continue;
+        m.threat.delete(p.id);
+        if (m.aggroTargetId === p.id) this.retargetMob(m);
+      }
+    }
     p.pos = this.groundPos(dungeon.doorPos.x, dungeon.doorPos.z - 4);
     p.prevPos = { ...p.pos };
     this.rebucket(p);

--- a/tests/leave_instance_aggro.test.ts
+++ b/tests/leave_instance_aggro.test.ts
@@ -1,0 +1,28 @@
+// Leaving a dungeon must drop the departing player from every mob in that instance,
+// so a mob no longer targets someone who is gone: it switches to whoever else is on
+// its threat table, or de-aggros and returns home if no one remains.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+describe('leaving an instance drops you from its mobs', () => {
+  it('a mob stops targeting a player who left the dungeon', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    sim.enterDungeon('hollow_crypt');
+    const inst = (sim as any).instances.find((i: any) => i.partyKey !== null && i.mobIds.length > 0);
+    expect(inst).toBeTruthy();
+    const mob = sim.entities.get(inst.mobIds[0])!;
+    mob.aiState = 'chase';
+    mob.aggroTargetId = p.id;
+    mob.threat.set(p.id, 500);
+
+    sim.leaveDungeon();
+
+    expect(mob.aggroTargetId).not.toBe(p.id);
+    expect([...mob.threat.keys()]).not.toContain(p.id);
+  });
+});


### PR DESCRIPTION
## Why
When a player leaves a dungeon, the instance's mobs kept the player on their threat table and as their aggro target — staying aggroed on someone who's no longer there.

## Fix
`leaveDungeon` now, **before** teleporting the player out, removes them from every mob in that instance. Each affected mob then does exactly what you asked: it **switches to whoever else is on its threat table, or de-aggros and returns home** if no one remains (reuses the existing `retargetMob`). A small `instanceContaining()` helper finds the player's instance using the same occupancy bands as `updateInstances`.

## Tests
`tests/leave_instance_aggro.test.ts`: a mob targeting a player who then leaves the dungeon drops both the aggro target and the threat-table entry. `tsc` clean.

Targets `release/v0.8`. (Related to the aggro-cleanup work in #563/#564.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
