### PR TITLE
feat(ui): Recount-style DPS meter

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,7 +639,9 @@
     border-radius: 2px; overflow: hidden; }
   .mt-row.aggro { border-color: #c0392b; }
   .mt-fill { position: absolute; inset: 0; border-radius: 1px; }
-  .mt-label { position: absolute; left: 5px; top: 0; line-height: 17px; font-size: 11px; color: #fff;
+  .mt-rank { position: absolute; left: 4px; top: 0; line-height: 17px; font-size: 10px; color: #d8c89a;
+    text-shadow: 1px 1px 1px #000; font-variant-numeric: tabular-nums; min-width: 14px; }
+  .mt-label { position: absolute; left: 22px; top: 0; line-height: 17px; font-size: 11px; color: #fff;
     text-shadow: 1px 1px 1px #000; font-weight: bold; }
   .mt-num { position: absolute; right: 5px; top: 0; line-height: 17px; font-size: 10px; color: #ffe;
     text-shadow: 1px 1px 1px #000; }

--- a/src/ui/i18n.ts
+++ b/src/ui/i18n.ts
@@ -2733,6 +2733,7 @@ const hudStringsEn = {
       target: "Target: {name}",
       noTargetEngaged: "No target engaged.",
       segmentSummary: "{label} - {duration}",
+      partyTotal: "{label} - {duration} · {total} ({dps}/s)",
       olderSegment: "Older segment",
       newerSegment: "Newer segment",
       close: "Close meters",
@@ -3034,7 +3035,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "Daño", healing: "Sanación", threat: "Amenaza", damageShort: "Daño", healingShort: "Sanar", current: "Actual", lastFight: "Último combate", fightIndex: "Combate -{index}", allSession: "Total (sesión)", title: "{tab} - {view}", noCombat: "Aún no hay combate registrado.", target: "Objetivo: {name}", noTargetEngaged: "No hay objetivo enfrentado.", segmentSummary: "{label} - {duration}", olderSegment: "Segmento anterior", newerSegment: "Segmento siguiente", close: "Cerrar medidores",
+        damage: "Daño", healing: "Sanación", threat: "Amenaza", damageShort: "Daño", healingShort: "Sanar", current: "Actual", lastFight: "Último combate", fightIndex: "Combate -{index}", allSession: "Total (sesión)", title: "{tab} - {view}", noCombat: "Aún no hay combate registrado.", target: "Objetivo: {name}", noTargetEngaged: "No hay objetivo enfrentado.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "Segmento anterior", newerSegment: "Segmento siguiente", close: "Cerrar medidores",
       },
       chat: {
         rightClickName: "Clic derecho en {name}",
@@ -3155,7 +3156,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "Dégâts", healing: "Soins", threat: "Menace", damageShort: "Dég.", healingShort: "Soins", current: "Actuel", lastFight: "Dernier combat", fightIndex: "Combat -{index}", allSession: "Tout (session)", title: "{tab} - {view}", noCombat: "Aucun combat enregistré.", target: "Cible : {name}", noTargetEngaged: "Aucune cible engagée.", segmentSummary: "{label} - {duration}", olderSegment: "Segment précédent", newerSegment: "Segment suivant", close: "Fermer les compteurs",
+        damage: "Dégâts", healing: "Soins", threat: "Menace", damageShort: "Dég.", healingShort: "Soins", current: "Actuel", lastFight: "Dernier combat", fightIndex: "Combat -{index}", allSession: "Tout (session)", title: "{tab} - {view}", noCombat: "Aucun combat enregistré.", target: "Cible : {name}", noTargetEngaged: "Aucune cible engagée.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "Segment précédent", newerSegment: "Segment suivant", close: "Fermer les compteurs",
       },
       chat: {
         rightClickName: "Clic droit sur {name}",
@@ -3277,7 +3278,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "Danni", healing: "Cure", threat: "Minaccia", damageShort: "Danni", healingShort: "Cure", current: "Attuale", lastFight: "Ultimo scontro", fightIndex: "Scontro -{index}", allSession: "Tutto (sessione)", title: "{tab} - {view}", noCombat: "Nessun combattimento registrato.", target: "Bersaglio: {name}", noTargetEngaged: "Nessun bersaglio ingaggiato.", segmentSummary: "{label} - {duration}", olderSegment: "Segmento precedente", newerSegment: "Segmento successivo", close: "Chiudi misuratori",
+        damage: "Danni", healing: "Cure", threat: "Minaccia", damageShort: "Danni", healingShort: "Cure", current: "Attuale", lastFight: "Ultimo scontro", fightIndex: "Scontro -{index}", allSession: "Tutto (sessione)", title: "{tab} - {view}", noCombat: "Nessun combattimento registrato.", target: "Bersaglio: {name}", noTargetEngaged: "Nessun bersaglio ingaggiato.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "Segmento precedente", newerSegment: "Segmento successivo", close: "Chiudi misuratori",
       },
       chat: {
         rightClickName: "Clic destro su {name}",
@@ -3397,7 +3398,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "Schaden", healing: "Heilung", threat: "Bedrohung", damageShort: "Schad.", healingShort: "Heil.", current: "Aktuell", lastFight: "Letzter Kampf", fightIndex: "Kampf -{index}", allSession: "Alles (Sitzung)", title: "{tab} - {view}", noCombat: "Noch kein Kampf aufgezeichnet.", target: "Ziel: {name}", noTargetEngaged: "Kein Ziel im Kampf.", segmentSummary: "{label} - {duration}", olderSegment: "Älteres Segment", newerSegment: "Neueres Segment", close: "Anzeigen schließen",
+        damage: "Schaden", healing: "Heilung", threat: "Bedrohung", damageShort: "Schad.", healingShort: "Heil.", current: "Aktuell", lastFight: "Letzter Kampf", fightIndex: "Kampf -{index}", allSession: "Alles (Sitzung)", title: "{tab} - {view}", noCombat: "Noch kein Kampf aufgezeichnet.", target: "Ziel: {name}", noTargetEngaged: "Kein Ziel im Kampf.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "Älteres Segment", newerSegment: "Neueres Segment", close: "Anzeigen schließen",
       },
       chat: {
         rightClickName: "Rechtsklick auf {name}",
@@ -3517,7 +3518,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "伤害", healing: "治疗", threat: "仇恨", damageShort: "伤害", healingShort: "治疗", current: "当前", lastFight: "上一场战斗", fightIndex: "战斗 -{index}", allSession: "全部（本次会话）", title: "{tab} - {view}", noCombat: "尚无战斗记录。", target: "目标：{name}", noTargetEngaged: "未交战目标。", segmentSummary: "{label} - {duration}", olderSegment: "较早片段", newerSegment: "较新片段", close: "关闭统计",
+        damage: "伤害", healing: "治疗", threat: "仇恨", damageShort: "伤害", healingShort: "治疗", current: "当前", lastFight: "上一场战斗", fightIndex: "战斗 -{index}", allSession: "全部（本次会话）", title: "{tab} - {view}", noCombat: "尚无战斗记录。", target: "目标：{name}", noTargetEngaged: "未交战目标。", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "较早片段", newerSegment: "较新片段", close: "关闭统计",
       },
       chat: {
         rightClickName: "右键点击 {name}",
@@ -3637,7 +3638,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "傷害", healing: "治療", threat: "仇恨", damageShort: "傷害", healingShort: "治療", current: "目前", lastFight: "上一場戰鬥", fightIndex: "戰鬥 -{index}", allSession: "全部（本次連線）", title: "{tab} - {view}", noCombat: "尚無戰鬥紀錄。", target: "目標：{name}", noTargetEngaged: "沒有交戰目標。", segmentSummary: "{label} - {duration}", olderSegment: "較早片段", newerSegment: "較新片段", close: "關閉統計",
+        damage: "傷害", healing: "治療", threat: "仇恨", damageShort: "傷害", healingShort: "治療", current: "目前", lastFight: "上一場戰鬥", fightIndex: "戰鬥 -{index}", allSession: "全部（本次連線）", title: "{tab} - {view}", noCombat: "尚無戰鬥紀錄。", target: "目標：{name}", noTargetEngaged: "沒有交戰目標。", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "較早片段", newerSegment: "較新片段", close: "關閉統計",
       },
       chat: {
         rightClickName: "右鍵點擊 {name}",
@@ -3757,7 +3758,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "피해", healing: "치유", threat: "위협", damageShort: "피해", healingShort: "치유", current: "현재", lastFight: "지난 전투", fightIndex: "전투 -{index}", allSession: "전체 (세션)", title: "{tab} - {view}", noCombat: "아직 기록된 전투가 없습니다.", target: "대상: {name}", noTargetEngaged: "교전 중인 대상이 없습니다.", segmentSummary: "{label} - {duration}", olderSegment: "이전 구간", newerSegment: "다음 구간", close: "미터 닫기",
+        damage: "피해", healing: "치유", threat: "위협", damageShort: "피해", healingShort: "치유", current: "현재", lastFight: "지난 전투", fightIndex: "전투 -{index}", allSession: "전체 (세션)", title: "{tab} - {view}", noCombat: "아직 기록된 전투가 없습니다.", target: "대상: {name}", noTargetEngaged: "교전 중인 대상이 없습니다.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "이전 구간", newerSegment: "다음 구간", close: "미터 닫기",
       },
       chat: {
         rightClickName: "{name} 우클릭",
@@ -3877,7 +3878,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "ダメージ", healing: "回復", threat: "脅威", damageShort: "ダメ", healingShort: "回復", current: "現在", lastFight: "前回の戦闘", fightIndex: "戦闘 -{index}", allSession: "全体（セッション）", title: "{tab} - {view}", noCombat: "まだ戦闘記録がありません。", target: "対象: {name}", noTargetEngaged: "交戦中の対象がいません。", segmentSummary: "{label} - {duration}", olderSegment: "前の区間", newerSegment: "次の区間", close: "メーターを閉じる",
+        damage: "ダメージ", healing: "回復", threat: "脅威", damageShort: "ダメ", healingShort: "回復", current: "現在", lastFight: "前回の戦闘", fightIndex: "戦闘 -{index}", allSession: "全体（セッション）", title: "{tab} - {view}", noCombat: "まだ戦闘記録がありません。", target: "対象: {name}", noTargetEngaged: "交戦中の対象がいません。", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "前の区間", newerSegment: "次の区間", close: "メーターを閉じる",
       },
       chat: {
         rightClickName: "{name}を右クリック",
@@ -3997,7 +3998,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "Dano", healing: "Cura", threat: "Ameaça", damageShort: "Dano", healingShort: "Cura", current: "Atual", lastFight: "Última luta", fightIndex: "Luta -{index}", allSession: "Tudo (sessão)", title: "{tab} - {view}", noCombat: "Nenhum combate registrado ainda.", target: "Alvo: {name}", noTargetEngaged: "Nenhum alvo engajado.", segmentSummary: "{label} - {duration}", olderSegment: "Segmento anterior", newerSegment: "Segmento seguinte", close: "Fechar medidores",
+        damage: "Dano", healing: "Cura", threat: "Ameaça", damageShort: "Dano", healingShort: "Cura", current: "Atual", lastFight: "Última luta", fightIndex: "Luta -{index}", allSession: "Tudo (sessão)", title: "{tab} - {view}", noCombat: "Nenhum combate registrado ainda.", target: "Alvo: {name}", noTargetEngaged: "Nenhum alvo engajado.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "Segmento anterior", newerSegment: "Segmento seguinte", close: "Fechar medidores",
       },
       chat: {
         rightClickName: "Clique direito em {name}",
@@ -4117,7 +4118,7 @@ const hudStrings = {
         },
       },
       meters: {
-        damage: "Урон", healing: "Исцеление", threat: "Угроза", damageShort: "Урон", healingShort: "Исц.", current: "Текущий", lastFight: "Последний бой", fightIndex: "Бой -{index}", allSession: "Все (сеанс)", title: "{tab} - {view}", noCombat: "Боевые данные еще не записаны.", target: "Цель: {name}", noTargetEngaged: "Нет цели в бою.", segmentSummary: "{label} - {duration}", olderSegment: "Предыдущий сегмент", newerSegment: "Следующий сегмент", close: "Закрыть счетчики",
+        damage: "Урон", healing: "Исцеление", threat: "Угроза", damageShort: "Урон", healingShort: "Исц.", current: "Текущий", lastFight: "Последний бой", fightIndex: "Бой -{index}", allSession: "Все (сеанс)", title: "{tab} - {view}", noCombat: "Боевые данные еще не записаны.", target: "Цель: {name}", noTargetEngaged: "Нет цели в бою.", segmentSummary: "{label} - {duration}", partyTotal: "{label} - {duration} · {total} ({dps}/s)", olderSegment: "Предыдущий сегмент", newerSegment: "Следующий сегмент", close: "Закрыть счетчики",
       },
       chat: {
         rightClickName: "ПКМ по {name}",

--- a/src/ui/meters.ts
+++ b/src/ui/meters.ts
@@ -12,7 +12,7 @@
 import type { IWorld } from '../world_api';
 import type { SimEvent } from '../sim/types';
 import { CLASSES } from '../sim/data';
-import { t, type TranslationKey } from './i18n';
+import { t, formatNumber, type TranslationKey } from './i18n';
 import { tEntity } from './entity_i18n';
 
 const ENCOUNTER_END_SECONDS = 5;
@@ -288,26 +288,43 @@ export class Meters {
       .sort((a, b) => b.value - a.value);
 
     const top = rows[0]?.value ?? 1;
+    // party aggregate across the visible rows — drives each row's % share and,
+    // for the dmg/heal tabs, the Recount-style party total/DPS in the subtitle.
+    const total = rows.reduce((s, r) => s + r.value, 0);
+    if (!isThreat && total > 0) {
+      this.subEl.textContent = t('hud.meters.partyTotal', {
+        label: encounterLabel,
+        duration: fmtDuration(enc.duration),
+        total: fmtNum(total),
+        dps: fmtNum(total / enc.duration),
+      });
+    }
     this.rowsEl.innerHTML = '';
-    for (const { t, value } of rows) {
+    let rank = 0;
+    for (const { t: tally, value } of rows) {
+      rank++;
       const row = document.createElement('div');
       row.className = 'mt-row';
       const fill = document.createElement('div');
       fill.className = 'mt-fill';
       fill.style.width = `${Math.max(4, (value / top) * 100)}%`;
-      const color = t.cls && (CLASSES as Record<string, { color: number }>)[t.cls]?.color;
+      const color = tally.cls && (CLASSES as Record<string, { color: number }>)[tally.cls]?.color;
       fill.style.background = color ? `#${color.toString(16).padStart(6, '0')}cc` : '#888888cc';
+      const rankEl = document.createElement('span');
+      rankEl.className = 'mt-rank';
+      rankEl.textContent = `${rank}.`;
       const label = document.createElement('span');
       label.className = 'mt-label';
-      const hasAggro = isThreat && aggroPid === t.pid;
-      label.textContent = t.name;
+      const hasAggro = isThreat && aggroPid === tally.pid;
+      label.textContent = tally.name;
       const num = document.createElement('span');
       num.className = 'mt-num';
+      const pct = formatNumber(total > 0 ? value / total : 0, { style: 'percent', maximumFractionDigits: 0 });
       num.textContent = isThreat
-        ? fmtNum(value)
-        : `${fmtNum(value)} (${fmtNum(value / enc.duration)}/s)`;
+        ? `${fmtNum(value)} · ${pct}`
+        : `${fmtNum(value)} (${fmtNum(value / enc.duration)}/s · ${pct})`;
       if (hasAggro) row.classList.add('aggro');
-      row.append(fill, label, num);
+      row.append(fill, rankEl, label, num);
       this.rowsEl.appendChild(row);
     }
   }


### PR DESCRIPTION
## Summary
Restyles the existing combat meter (`src/ui/meters.ts`) to read like the classic **Recount** addon. The data layer (per-player + party damage/healing/threat, encounter segmentation) was already in place — this is a presentation pass on the damage/healing/threat panel.

## What changed
- **Ranked rows** — each row is now numbered by rank (`1.`, `2.`, …), like Recount.
- **Per-row % share** — the number column shows `total (DPS/s · %)`, so you can see each player's contribution to the group total (individual *and* relative).
- **Party total line** — the subtitle now shows the party's combined total + party DPS for the Damage/Healing tabs.
- New `.mt-rank` styling in `index.html`.
- Adds the `hud.meters.partyTotal` i18n key to every locale.

## Notes
- Threat tab also gains a `· %` share column.
- Online caveat (pre-existing): damage events are interest-scoped by distance server-side, so a far-away party member's contribution isn't visible — unchanged by this PR.

## Testing
- `npx vitest run tests/meters.test.ts` — green (data layer unchanged)
- `npx vitest run tests/localization_fixes.test.ts tests/localization_coverage.test.ts` — green
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)