### PR TITLE
fix(mobile): improve touch spellbar and menu controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,6 +771,7 @@
   .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;
     background-color: #15151f; background-size: cover; background-position: center; background-repeat: no-repeat;
     border: 2px solid #4a3d1d; }
+  .spell-hotbar-toggle { display: none; }
 
   /* quest log */
   #quest-log-window { width: 520px; }
@@ -4117,6 +4118,7 @@
     padding: 4px;
     width: 100%;
     max-width: 100%;
+    min-height: 50px;
     box-sizing: border-box;
     overflow-x: auto;
     overflow-y: hidden;
@@ -4127,6 +4129,11 @@
   }
   body.mobile-touch #actionbar.many-spells { grid-template-columns: none; }
   body.mobile-touch .action-btn { width: 42px; height: 42px; flex: 0 0 42px; border-radius: 7px; }
+  body.mobile-touch.mobile-hotbar-dragging #actionbar { touch-action: none; }
+  body.mobile-touch .action-btn.mobile-drag-source {
+    border-color: var(--gold);
+    box-shadow: 0 0 12px #ffd100aa, inset 0 0 0 1px #ffd10077;
+  }
   body.mobile-touch .action-btn:not(.used):not(.queued):not(.drop-target):hover { border-color: #4a3d1d; }
   body.mobile-touch .action-btn .icon-label { border-radius: 6px; }
   body.mobile-touch .action-btn .cd-text { font-size: 13px; }
@@ -4338,13 +4345,19 @@
   }
   body.mobile-touch #bags {
     position: fixed;
-    left: 10px;
-    right: 10px;
-    bottom: 10px;
+    left: max(10px, env(safe-area-inset-left));
+    right: max(10px, env(safe-area-inset-right));
+    top: max(10px, env(safe-area-inset-top));
+    bottom: calc(72px + env(safe-area-inset-bottom));
     width: auto;
-    max-height: calc(38vh - 20px);
+    transform: none;
+    max-height: none;
     box-sizing: border-box;
-    overflow-y: auto;
+    overflow: hidden;
+    z-index: 95;
+  }
+  body.mobile-touch #bags .bag-grid {
+    min-height: 150px;
   }
   body.mobile-touch .vendor-item,
   body.mobile-touch .bag-item,
@@ -4456,6 +4469,31 @@
     padding: 0;
     box-sizing: border-box;
     font-size: 16px;
+  }
+  body.mobile-touch #spellbook .spell-row {
+    min-height: 52px;
+    padding-right: 4px;
+  }
+  body.mobile-touch #spellbook .spell-hotbar-toggle {
+    min-width: 40px;
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 40px;
+    border: 2px solid #4a3d1d;
+    border-radius: 7px;
+    background: radial-gradient(circle at 35% 30%, #2d3048e0, #11121ee0 72%);
+    color: var(--gold);
+    font: 700 22px/1 var(--ui-font);
+    box-shadow: inset 0 1px 0 #ffffff14, 0 2px 6px #0008;
+  }
+  body.mobile-touch #spellbook .spell-hotbar-toggle.remove {
+    color: #ffcf9c;
+    border-color: #8b4e2c;
+  }
+  body.mobile-touch #spellbook .spell-hotbar-toggle:disabled {
+    opacity: 0.45;
   }
   body.mobile-touch #quest-dialog .qd-list-item,
   body.mobile-touch #quest-log-window .ql-item,

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -276,10 +276,10 @@ export class MobileControls {
       if (!this.active) return;
       e.preventDefault();
       triggerHaptic(HAPTIC_TAP, this.hapticsOn);
-      cb();
       if (button.closest('#mobile-extra-controls')) {
         this.closeMoreModal();
       }
+      cb();
     });
   }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -209,6 +209,15 @@ const CHAT_TEMPLATE_KEYS = {
   say: 'hud.chat.templates.say',
 } satisfies Record<string, TranslationKey>;
 type HotbarForm = 'normal' | 'bear' | 'cat' | 'stealth';
+type MobileHotbarDrag = {
+  pointerId: number;
+  sourceIndex: number;
+  startX: number;
+  startY: number;
+  active: boolean;
+  timer: number;
+  targetIndex: number | null;
+};
 
 // world map: terrain is pre-rendered for the whole zone at this resolution
 // (cached per zone) and a sub-rect is blitted for the current zoom.
@@ -224,6 +233,8 @@ export class Hud {
   private knownAbilityIdsAtLastSlotSync: Set<string> | null = null;
   private activeHotbarForm: HotbarForm = 'normal';
   private dragAction: { action: Exclude<HotbarAction, null>; sourceIndex: number | null } | null = null;
+  private mobileHotbarDrag: MobileHotbarDrag | null = null;
+  private suppressNextActionClick = false;
   private optionsHooks: OptionsHooks | null = null;
   private reportHooks: ReportHooks | null = null;
   // Soft swear terms from the server (online only), masked in chat when the
@@ -964,6 +975,7 @@ export class Hud {
       touchTimer = undefined;
     };
     const showAt = (x: number, y: number, trigger: 'touch' | 'mouse' | 'focus') => {
+      if (this.mobileHotbarDrag?.active) return;
       // Touch-only path: showing the tooltip means the held control is being
       // inspected, so the release click should peek, not fire its action.
       this.peekGuard.tooltipShown(trigger);
@@ -1153,9 +1165,9 @@ export class Hud {
   // shortcuts. Abilities are keyed by id (known is class-ordered and shifts on
   // level-up, so indices would not survive). Persisted per class+character,
   // with separate form/stealth layouts because each state has a different kit.
-  private slotMapKey(): string {
+  private slotMapKey(form: HotbarForm = this.activeHotbarForm): string {
     const base = `woc_hotbar_${this.sim.cfg.playerClass}_${this.sim.player.name}`;
-    return this.activeHotbarForm === 'normal' ? base : `${base}_${this.activeHotbarForm}`;
+    return form === 'normal' ? base : `${base}_${form}`;
   }
 
   private playerHotbarForm(): HotbarForm {
@@ -1180,18 +1192,79 @@ export class Hud {
       stored = raw !== null;
       arr = JSON.parse(raw ?? 'null');
     } catch { /* corrupt */ }
-    this.loadedSlotMapFromStorage = stored || this.activeHotbarForm !== 'normal';
-    this.hotbarActions = parseHotbarActions(
+    const parsed = parseHotbarActions(
       arr,
       Hud.BAR_ABILITY_SLOTS,
       (id) => !!ABILITIES[id],
       (id) => this.isHotbarItemId(id),
     );
+    const emptyFormMap = this.activeHotbarForm !== 'normal' && parsed.every((action) => action === null);
+    if (emptyFormMap) {
+      let fallback: unknown = null;
+      try { fallback = JSON.parse(localStorage.getItem(this.slotMapKey('normal')) ?? 'null'); } catch { /* corrupt */ }
+      const normalActions = parseHotbarActions(
+        fallback,
+        Hud.BAR_ABILITY_SLOTS,
+        (id) => !!ABILITIES[id],
+        (id) => this.isHotbarItemId(id),
+      );
+      if (normalActions.some((action) => action !== null)) {
+        this.loadedSlotMapFromStorage = true;
+        this.hotbarActions = normalActions;
+        this.knownAbilityIdsAtLastSlotSync = null;
+        return;
+      }
+    }
+    this.loadedSlotMapFromStorage = stored;
+    this.hotbarActions = parsed;
     this.knownAbilityIdsAtLastSlotSync = null;
   }
 
   private saveSlotMap(): void {
     try { localStorage.setItem(this.slotMapKey(), JSON.stringify(this.hotbarActions)); } catch { /* storage unavailable */ }
+  }
+
+  private firstEmptyHotbarIndex(): number {
+    return this.hotbarActions.findIndex((action) => action === null);
+  }
+
+  private hotbarIndexForAbility(abilityId: string): number {
+    return this.hotbarActions.findIndex((action) => action?.type === 'ability' && action.id === abilityId);
+  }
+
+  private addAbilityToHotbar(abilityId: string): boolean {
+    if (this.hotbarIndexForAbility(abilityId) !== -1) return false;
+    const target = this.firstEmptyHotbarIndex();
+    if (target === -1) return false;
+    this.hotbarActions = placeAbilityOnSlot(this.hotbarActions, abilityId, target);
+    this.saveSlotMap();
+    return true;
+  }
+
+  private removeAbilityFromHotbar(abilityId: string): boolean {
+    const target = this.hotbarIndexForAbility(abilityId);
+    if (target === -1) return false;
+    this.hotbarActions = clearHotbarSlot(this.hotbarActions, target);
+    this.saveSlotMap();
+    return true;
+  }
+
+  private refreshSpellbookHotbarControls(): void {
+    document.querySelectorAll<HTMLButtonElement>('#spellbook .spell-hotbar-toggle').forEach((btn) => {
+      const id = btn.dataset.abilityId;
+      if (!id) return;
+      const onBar = this.hotbarIndexForAbility(id) !== -1;
+      btn.textContent = onBar ? '-' : '+';
+      btn.classList.toggle('remove', onBar);
+      btn.setAttribute('aria-pressed', onBar ? 'true' : 'false');
+      btn.disabled = !onBar && this.firstEmptyHotbarIndex() === -1;
+    });
+  }
+
+  private formToggleAbilityId(): string | null {
+    if (this.activeHotbarForm === 'bear') return 'bear_form';
+    if (this.activeHotbarForm === 'cat') return 'cat_form';
+    return null;
   }
 
   private syncActiveHotbarForm(): void {
@@ -1218,6 +1291,8 @@ export class Hud {
         if (!this.knownAbilityIdsAtLastSlotSync.has(id)) autoPlaceAbilityIds.add(id);
       }
     }
+    const formToggle = this.formToggleAbilityId();
+    if (formToggle && knownAbilityIds.includes(formToggle)) autoPlaceAbilityIds.add(formToggle);
     const synced = syncHotbarActions(this.hotbarActions, knownAbilityIds, autoPlaceAbilityIds);
     this.hotbarActions = synced.actions;
     if (synced.changed) this.saveSlotMap();
@@ -1314,9 +1389,11 @@ export class Hud {
       cdText.className = 'cdtext';
       btn.append(label, countEl, kb, cdOverlay, cdText);
       const slot = i;
+      btn.dataset.hotbarSlot = String(slot);
       // slot 0 is Attack for every class (auto-attack toggle — players
       // without right-click need a way in); the kit fills slots 1+
       btn.addEventListener('click', () => {
+        if (this.suppressNextActionClick) { this.suppressNextActionClick = false; btn.blur(); return; }
         // On touch, the click that ends a long-press peek inspects the slot
         // (tooltip already shown) instead of casting — release dismisses it.
         if (this.peekGuard.consume()) { this.hideTooltip(); btn.blur(); return; }
@@ -1405,6 +1482,7 @@ export class Hud {
           this.dragAction = null;
           this.clearActionDropTargets();
         });
+        this.bindMobileActionDrag(btn, slot);
         // right-click clears the slot so a full bar can make room for new spells
         btn.addEventListener('contextmenu', (e) => {
           e.preventDefault();
@@ -1421,6 +1499,90 @@ export class Hud {
 
   private clearActionDropTargets(): void {
     document.querySelectorAll('#actionbar .drop-target').forEach((el) => el.classList.remove('drop-target'));
+  }
+
+  private actionButtonSlotFromPoint(x: number, y: number): number | null {
+    const el = document.elementFromPoint(x, y)?.closest?.('.action-btn') as HTMLButtonElement | null;
+    const raw = el?.dataset.hotbarSlot;
+    if (!raw) return null;
+    const slot = Number(raw);
+    return Number.isInteger(slot) && slot >= 1 ? slot : null;
+  }
+
+  private clearMobileHotbarDrag(): void {
+    const drag = this.mobileHotbarDrag;
+    if (drag) window.clearTimeout(drag.timer);
+    this.mobileHotbarDrag = null;
+    document.body.classList.remove('mobile-hotbar-dragging');
+    document.querySelectorAll('#actionbar .mobile-drag-source').forEach((el) => el.classList.remove('mobile-drag-source'));
+    this.clearActionDropTargets();
+  }
+
+  private bindMobileActionDrag(btn: HTMLButtonElement, slot: number): void {
+    btn.addEventListener('pointerdown', (e) => {
+      if (!document.body.classList.contains('mobile-touch') || e.pointerType !== 'touch') return;
+      if (this.actionForSlot(slot)?.type !== 'ability') return;
+      this.clearMobileHotbarDrag();
+      const sourceIndex = slot - 1;
+      const drag: MobileHotbarDrag = {
+        pointerId: e.pointerId,
+        sourceIndex,
+        startX: e.clientX,
+        startY: e.clientY,
+        active: false,
+        targetIndex: null,
+        timer: window.setTimeout(() => {
+          const current = this.mobileHotbarDrag;
+          if (!current || current.pointerId !== e.pointerId) return;
+          current.active = true;
+          current.targetIndex = sourceIndex;
+          this.suppressNextActionClick = true;
+          document.body.classList.add('mobile-hotbar-dragging');
+          btn.classList.add('mobile-drag-source');
+          btn.classList.add('drop-target');
+          this.hideTooltip();
+          try { btn.setPointerCapture?.(e.pointerId); } catch { /* pointer already released */ }
+        }, 320),
+      };
+      this.mobileHotbarDrag = drag;
+    });
+
+    btn.addEventListener('pointermove', (e) => {
+      const drag = this.mobileHotbarDrag;
+      if (!drag || drag.pointerId !== e.pointerId) return;
+      const moved = Math.hypot(e.clientX - drag.startX, e.clientY - drag.startY);
+      if (!drag.active && moved > 9) {
+        this.clearMobileHotbarDrag();
+        return;
+      }
+      if (!drag.active) return;
+      e.preventDefault();
+      const targetSlot = this.actionButtonSlotFromPoint(e.clientX, e.clientY);
+      const targetIndex = targetSlot !== null ? targetSlot - 1 : null;
+      drag.targetIndex = targetIndex;
+      this.clearActionDropTargets();
+      const targetBtn = targetSlot !== null ? this.abilityButtons[targetSlot]?.btn : null;
+      if (targetBtn) targetBtn.classList.add('drop-target');
+      this.abilityButtons[drag.sourceIndex + 1]?.btn.classList.add('mobile-drag-source');
+    });
+
+    const finish = (e: PointerEvent) => {
+      const drag = this.mobileHotbarDrag;
+      if (!drag || drag.pointerId !== e.pointerId) return;
+      const wasActive = drag.active;
+      const targetIndex = drag.targetIndex;
+      if (wasActive) {
+        e.preventDefault();
+        this.suppressNextActionClick = true;
+        if (targetIndex !== null && targetIndex !== drag.sourceIndex) {
+          this.hotbarActions = swapHotbarSlots(this.hotbarActions, drag.sourceIndex, targetIndex);
+          this.saveSlotMap();
+        }
+      }
+      this.clearMobileHotbarDrag();
+    };
+    btn.addEventListener('pointerup', finish);
+    btn.addEventListener('pointercancel', finish);
   }
 
   // Repaint the keycap on every action button from the current bindings.
@@ -1663,6 +1825,7 @@ export class Hud {
     this.renderPetBar();
     const tgtDist = target && !target.dead ? dist2d(p.pos, target.pos) : null;
     this.actionbarEl.classList.toggle('many-spells', this.hotbarActions.filter((action) => action !== null).length > 10);
+    if ($('#spellbook').style.display === 'block') this.refreshSpellbookHotbarControls();
     for (let i = 0; i < this.abilityButtons.length; i++) {
       const ab = this.abilityButtons[i];
       const slotLabel = formatAbilityNumber(i + 1);
@@ -4248,6 +4411,27 @@ export class Hud {
         <div class="spell-text"><div class="spell-name">${esc(name)}${known && known.rank > 1 ? ` <span class="spell-rank">${esc(t('abilityUi.tooltip.rank', { rank: formatAbilityNumber(known.rank) }))}</span>` : ''}</div>
         <div class="spell-sub">${locked ? esc(t('abilityUi.spellbook.trainableAtLevel', { level: learnLevel })) : esc(summary)}</div></div>`;
       if (known) {
+        const onBar = this.hotbarIndexForAbility(known.def.id) !== -1;
+        const toggle = document.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'spell-hotbar-toggle' + (onBar ? ' remove' : '');
+        toggle.dataset.abilityId = known.def.id;
+        toggle.textContent = onBar ? '-' : '+';
+        toggle.setAttribute('aria-label', `${name} ${onBar ? '-' : '+'}`);
+        toggle.setAttribute('aria-pressed', onBar ? 'true' : 'false');
+        toggle.disabled = !onBar && this.firstEmptyHotbarIndex() === -1;
+        toggle.addEventListener('pointerdown', (ev) => ev.stopPropagation());
+        toggle.addEventListener('click', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          const changed = this.hotbarIndexForAbility(known.def.id) !== -1
+            ? this.removeAbilityFromHotbar(known.def.id)
+            : this.addAbilityToHotbar(known.def.id);
+          if (!changed) return;
+          audio.click();
+          this.refreshSpellbookHotbarControls();
+        });
+        row.appendChild(toggle);
         row.draggable = true;
         row.addEventListener('dragstart', (e) => {
           const action = { type: 'ability' as const, id: known.def.id };

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -152,6 +152,12 @@ describe('client HTML shell', () => {
     expect(mobileControlsTs).toContain('delete modal.dataset.windowMoved;');
     expect(mobileControlsTs).toContain('private closeMoreModal(): void {');
     expect(mobileControlsTs).toContain("document.getElementById('mobile-controls')?.classList.remove('expanded');");
+    const bindButton = mobileControlsTs.slice(
+      mobileControlsTs.indexOf('private bindButton'),
+      mobileControlsTs.indexOf('private closeMoreModal'),
+    );
+    expect(bindButton.indexOf("button.closest('#mobile-extra-controls')")).toBeGreaterThan(-1);
+    expect(bindButton.indexOf('this.closeMoreModal();')).toBeLessThan(bindButton.indexOf('cb();'));
     expect(hudTs).toContain(".filter((win) => win.id !== 'mobile-extra-controls')");
   });
 
@@ -217,7 +223,38 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch #actionbar {\n    display: flex;\n    flex-wrap: nowrap;');
     expect(html).toContain('overflow-x: auto;\n    overflow-y: hidden;');
     expect(html).toContain('touch-action: pan-x;');
+    expect(html).toContain('min-height: 50px;');
     expect(html).toContain('body.mobile-touch .action-btn { width: 42px; height: 42px; flex: 0 0 42px;');
+    expect(html).toContain('body.mobile-touch.mobile-hotbar-dragging #actionbar { touch-action: none; }');
+    expect(html).toContain('body.mobile-touch .action-btn.mobile-drag-source');
+  });
+
+  it('falls back to the normal hotbar when a form hotbar has no saved spells', () => {
+    expect(hudTs).toContain('const emptyFormMap = this.activeHotbarForm !== \'normal\' && parsed.every((action) => action === null);');
+    expect(hudTs).toContain("localStorage.getItem(this.slotMapKey('normal'))");
+    expect(hudTs).not.toContain('this.loadedSlotMapFromStorage = stored || this.activeHotbarForm !== \'normal\';');
+  });
+
+  it('keeps the active druid form toggle on its form action bar', () => {
+    expect(hudTs).toContain("if (this.activeHotbarForm === 'bear') return 'bear_form';");
+    expect(hudTs).toContain("if (this.activeHotbarForm === 'cat') return 'cat_form';");
+    expect(hudTs).toContain('if (formToggle && knownAbilityIds.includes(formToggle)) autoPlaceAbilityIds.add(formToggle);');
+  });
+
+  it('shows mobile spellbook add and remove controls for the spell bar', () => {
+    expect(html).toContain('.spell-hotbar-toggle { display: none; }');
+    expect(html).toContain('body.mobile-touch #spellbook .spell-hotbar-toggle {\n    min-width: 40px;\n    min-height: 40px;');
+    expect(html).toContain('body.mobile-touch #spellbook .spell-hotbar-toggle.remove');
+    expect(hudTs).toContain("toggle.className = 'spell-hotbar-toggle' + (onBar ? ' remove' : '');");
+    expect(hudTs).toContain('this.removeAbilityFromHotbar(known.def.id)');
+    expect(hudTs).toContain('this.addAbilityToHotbar(known.def.id)');
+  });
+
+  it('sizes the mobile Bags window as a usable modal', () => {
+    expect(html).toContain('body.mobile-touch #bags {\n    position: fixed;\n    left: max(10px, env(safe-area-inset-left));\n    right: max(10px, env(safe-area-inset-right));\n    top: max(10px, env(safe-area-inset-top));\n    bottom: calc(72px + env(safe-area-inset-bottom));\n    width: auto;\n    transform: none;');
+    expect(html).toContain('body.mobile-touch #bags .bag-grid {\n    min-height: 150px;');
+    expect(html).not.toContain('body.mobile-touch #bags {\n    position: fixed;\n    left: 10px;\n    right: 10px;\n    bottom: 10px;');
+    expect(html).not.toContain('max-height: calc(38vh - 20px);');
   });
 
   it('keeps the expanded mobile More tray inside the viewport', () => {


### PR DESCRIPTION
## Summary
Mobile touch control fixes targeting `release/v0.9`.

## Changes
- Adds mobile Spellbook `+` / `-` controls so learned spells can be added to or removed from the spellbar without desktop drag-and-drop.
- Adds long-press drag reordering for mobile spellbar ability slots while preserving horizontal scrolling for normal swipes.
- Prevents Druid Bear/Wolf form bars from collapsing or losing spell access by falling back to the normal bar and always keeping the active shapeshift toggle on the form bar.
- Gives the mobile spellbar a stable minimum height so it does not shrink into a narrow strip.
- Enlarges the mobile Bag modal and fixes More-menu action ordering so Bags opens on the first tap from More.

## Tested
- `npx vitest run tests/client_shell.test.ts tests/hotbar.test.ts`
- `npx tsc --noEmit`
- `npm run build`