### PR TITLE
fix(ui): keep desktop community links visible

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -374,7 +374,7 @@ export class Hud {
       const target = ev.target as Node | null;
       if (!target) return;
       const communityMenu = document.getElementById('community-menu') as HTMLDetailsElement | null;
-      if (communityMenu?.open && !communityMenu.contains(target)) {
+      if (document.body.classList.contains('mobile-touch') && communityMenu?.open && !communityMenu.contains(target)) {
         communityMenu.open = false;
       }
       if (document.body.classList.contains('mobile-more-open')) {

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -84,12 +84,18 @@ describe('client HTML shell', () => {
 
   it('closes mobile community and More trays when tapping outside', () => {
     expect(hudTs).toContain("const communityMenu = document.getElementById('community-menu') as HTMLDetailsElement | null;");
-    expect(hudTs).toContain('if (communityMenu?.open && !communityMenu.contains(target)) {\n        communityMenu.open = false;\n      }');
+    expect(hudTs).toContain("if (document.body.classList.contains('mobile-touch') && communityMenu?.open && !communityMenu.contains(target)) {\n        communityMenu.open = false;\n      }");
+    expect(hudTs).not.toContain('if (communityMenu?.open && !communityMenu.contains(target)) {\n        communityMenu.open = false;\n      }');
     expect(hudTs).toContain("if (document.body.classList.contains('mobile-more-open')) {");
     expect(hudTs).toContain("document.body.classList.remove('mobile-more-open');");
     expect(hudTs).toContain("document.getElementById('mobile-controls')?.classList.remove('expanded');");
     expect(hudTs).toContain("more?.classList.remove('active');");
     expect(hudTs).toContain("document.getElementById('mobile-more-close')?.addEventListener('click', () => {");
+  });
+
+  it('keeps desktop community links open after HUD clicks', () => {
+    expect(mainTs).toContain('communityMenu.open = !isPhoneTouchDevice();');
+    expect(hudTs).toContain("document.body.classList.contains('mobile-touch') && communityMenu?.open");
   });
 
   it('renders the mobile XP bar as a ring around the top-left class circle', () => {


### PR DESCRIPTION
## Summary
Fixes a desktop HUD regression where the bottom-right community links disappeared after clicking elsewhere in-game.

## Changes
- Keeps the community `<details>` outside-click close behavior scoped to mobile touch mode.
- Preserves desktop's default always-open Discord/GitHub/Donate rail.
- Adds shell coverage so desktop community links stay open after HUD clicks while mobile can still close the compact community tray.

## Tested
- `npx vitest run tests/client_shell.test.ts`
- `npx tsc --noEmit`
- `npm run build`