### PR TITLE
fix(seo): add crawl discovery signals

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 <meta name="orientation" content="landscape" />
 <title data-i18n="seo.title">World of ClaudeCraft: Classic-Style Web MMO</title>
 <meta name="description" data-i18n-content="seo.description" content="Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
 <link rel="manifest" href="/manifest.webmanifest" />
 
 <!-- Cloudflare Turnstile (bot gate on login/registration). Rendered explicitly
@@ -40,6 +41,7 @@
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
+<meta property="og:site_name" content="World of ClaudeCraft" />
 <meta property="og:title" data-i18n-content="seo.title" content="World of ClaudeCraft: Classic-Style Web MMO" />
 <meta property="og:description" data-i18n-content="seo.description" content="Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!" />
 <meta property="og:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
@@ -57,6 +59,7 @@
   "@context": "https://schema.org",
   "@type": "VideoGame",
   "name": "World of ClaudeCraft",
+  "alternateName": "World of Claudecraft",
   "genre": "MMORPG",
   "playMode": "MultiPlayer",
   "applicationCategory": "Game",
@@ -64,7 +67,11 @@
   "url": "https://worldofclaudecraft.com/",
   "image": "https://worldofclaudecraft.com/woc_logo_square.webp",
   "description": "Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!",
-  "inLanguage": "en"
+  "inLanguage": "en",
+  "sameAs": [
+    "https://github.com/levy-street/world-of-claudecraft",
+    "https://discord.gg/GjhnUsBtw"
+  ]
 }
 </script>
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://worldofclaudecraft.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://worldofclaudecraft.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://worldofclaudecraft.com/links</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.4</priority>
+  </url>
+</urlset>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2314,6 +2314,7 @@ function updateSeoMetadata(lang: SupportedLanguage): void {
       '@context': 'https://schema.org',
       '@type': 'VideoGame',
       name: 'World of ClaudeCraft',
+      alternateName: 'World of Claudecraft',
       genre: t('seo.genre'),
       playMode: t('seo.playMode'),
       applicationCategory: t('seo.applicationCategory'),
@@ -2322,6 +2323,10 @@ function updateSeoMetadata(lang: SupportedLanguage): void {
       image: 'https://worldofclaudecraft.com/woc_logo_square.webp',
       description: t('seo.description'),
       inLanguage: languageTag(lang),
+      sameAs: [
+        'https://github.com/levy-street/world-of-claudecraft',
+        'https://discord.gg/GjhnUsBtw',
+      ],
     }, null, 2);
   }
 }

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -5,6 +5,8 @@ const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8').rep
 const mainTs = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const hudTs = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const mobileControlsTs = readFileSync(new URL('../src/game/mobile_controls.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const robotsTxt = readFileSync(new URL('../public/robots.txt', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const sitemapXml = readFileSync(new URL('../public/sitemap.xml', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
 function splitGameUiTemplate(): { templateHtml: string; liveHtml: string } {
   const marker = '<template id="game-ui-template">';
@@ -32,6 +34,20 @@ describe('client HTML shell', () => {
     expect(liveHtml).not.toContain('Release Spirit');
     expect(liveHtml).not.toContain('Combat Log');
     expect(liveHtml).not.toContain('id="chat-input"');
+  });
+
+  it('ships crawlable SEO metadata and sitemap hints', () => {
+    expect(html).toContain('<meta name="robots" content="index, follow, max-image-preview:large" />');
+    expect(html).toContain('<link rel="canonical" href="https://worldofclaudecraft.com/" />');
+    expect(html).toContain('<meta property="og:site_name" content="World of ClaudeCraft" />');
+    expect(html).toContain('"alternateName": "World of Claudecraft"');
+    expect(html).toContain('"https://github.com/levy-street/world-of-claudecraft"');
+    expect(mainTs).toContain("alternateName: 'World of Claudecraft'");
+    expect(mainTs).toContain("'https://github.com/levy-street/world-of-claudecraft'");
+    expect(robotsTxt.trim()).toBe('User-agent: *\nAllow: /\n\nSitemap: https://worldofclaudecraft.com/sitemap.xml');
+    expect(robotsTxt).toContain('Sitemap: https://worldofclaudecraft.com/sitemap.xml');
+    expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/</loc>');
+    expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/links</loc>');
   });
 
   it('offers the quest log in the mobile controls drawer', () => {


### PR DESCRIPTION
## Summary
Improves search discovery signals for `worldofclaudecraft.com` on `release/v0.9`.

## Changes
- Adds `public/robots.txt` with a simple allow-all crawl policy and sitemap pointer.
- Adds `public/sitemap.xml` for the homepage and official links page.
- Adds explicit robots meta and Open Graph site name to the homepage shell.
- Adds `alternateName` and official `sameAs` links to static and runtime VideoGame JSON-LD.
- Adds shell coverage for the crawlable metadata and sitemap hints.

## Tested
- `npx vitest run tests/client_shell.test.ts` ✅
- `npm run build` ✅
- `npx tsc --noEmit` currently fails on latest `release/v0.9` i18n item typings unrelated to this SEO diff: `src/ui/i18n.en.ts` is missing several older item keys in merged entity translations.
