### PR TITLE
Add Ravenrift: ranked 5v5 capture-the-flag battleground

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ current game content and community research with `npm run wiki:seed`.
   and losses move a persistent **Elo rating** (everyone starts at 1500), and
   you return exactly where you queued. The panel shows your standing, the live
   online ladder, and the all-time leaderboard (`GET /api/arena/leaderboard`).
+- **Ravenrift** (5v5 ranked capture-the-flag): press `Y` (or the ⚑ button) and
+  *Enter the Queue* — solo, or **group up to 5 and queue your whole party
+  together**. Matchmaking forms two balanced teams of five and drops you into a
+  walled, open-air battleground with two keeps. **Steal the enemy banner and
+  run it to your keep to score — first team to 5 captures wins.** Weave the
+  cover to lose pursuers, grab **Sprint Runes** at the flag sections for a burst
+  of speed, and respawn at your keep when you fall (no graveyard run). A
+  separate **squad Elo** ladder tracks wins/losses (`GET /api/squad/leaderboard`).
 - **Multiplayer rules**: classic tap rights (first player to damage a mob owns
   its loot/XP/quest credit — others get "You don't have permission to loot
   that."), mobs retarget the next attacker when their victim dies (no free
@@ -212,7 +220,7 @@ zone map.
 | `Tab` | cycle nearest enemies · left-click target · right-click attack/loot/talk |
 | `1`–`9`, `0`, `-`, `=` | action bar |
 | `F` | interact (loot corpse / pick up object / talk) |
-| `C` `P` `L` `M` `B` `G` | character · spellbook · quest log · world map · bags · arena (Ashen Coliseum) |
+| `C` `P` `L` `M` `B` `G` `Y` | character · spellbook · quest log · world map · bags · arena (Ashen Coliseum) · Ravenrift (5v5 battleground) |
 | `V` / `R` / `Esc` | nameplates · autorun · close windows / clear target |
 
 ### Classic-fidelity checklist
@@ -296,6 +304,7 @@ node scripts/tour_temple.mjs    # screenshot tour of the Glimmermere + Drowned T
 node scripts/mp_integration.mjs # 26-check API/WS/persistence suite (server running)
 node scripts/social_e2e.mjs     # trade + duel over the wire (ALLOW_DEV_COMMANDS=1)
 node scripts/arena_visual.mjs   # two clients queue + fight a ranked 1v1 in the Ashen Coliseum
+node scripts/squad_visual.mjs   # several clients queue + play Ravenrift 5v5 capture-the-flag (ALLOW_DEV_COMMANDS=1)
 node scripts/crypt_raid.mjs     # five bots clear the Hollow Crypt (ALLOW_DEV_COMMANDS=1)
 ```
 

--- a/index.html
+++ b/index.html
@@ -1084,6 +1084,39 @@
   #arena-status .as-mid { font-family: var(--title-font); font-size: 11px; color: #ffb24a; opacity: 0.85; }
   #arena-status .as-timer { font-size: 11px; color: #d8cba0; margin-top: 4px; }
 
+  /* ---------- Ravenrift (5v5 capture the flag) — reuses .ladder-row above ---------- */
+  .bg-sub { font-family: var(--title-font); color: var(--gold, #c8a857); font-size: 12px; margin: 12px 0 5px; border-bottom: 1px solid #463a1c; padding-bottom: 3px; }
+  #bg-window { width: 380px; padding: 14px; }
+  #bg-window .btn { width: 100%; margin: 4px 0 0; box-sizing: border-box; text-align: center; }
+  #bg-window .btn.leave { background: linear-gradient(#3a4a5a, #243140 55%, #1a2430); color: #cfe6ff; }
+  .bg-rank { display: flex; align-items: baseline; gap: 10px; margin: 2px 0 6px; }
+  .bg-rank .rating { font-family: var(--title-font); font-size: 30px; color: #7fb8ff; text-shadow: 0 0 10px #3a78d166, 1px 1px 2px #000; }
+  .bg-rank .wl { font-size: 12px; color: #cfc6a8; }
+  .bg-rank .wl b { color: #7fdc4f; } .bg-rank .wl i { color: #ff7a6a; font-style: normal; }
+  .bg-note { font-size: 11.5px; color: #b6ad8c; line-height: 1.45; margin: 4px 0 2px; font-family: Georgia, serif; }
+  .bg-queue-status { font-size: 12px; color: #7fd4ff; margin-top: 6px; text-align: center; }
+
+  /* in-match scoreboard: pinned top centre */
+  #bg-scoreboard { position: absolute; top: 8px; left: 50%; transform: translateX(-50%); display: none;
+    text-align: center; pointer-events: none; z-index: 18; min-width: 320px;
+    background: linear-gradient(#10131add, #080a0edd); border: 1px solid #3a4a66;
+    border-radius: 9px; padding: 6px 18px 8px; box-shadow: 0 2px 16px #000a; }
+  .bg-score-line { display: flex; align-items: center; justify-content: center; gap: 14px; font-family: var(--title-font); }
+  .bg-score-line .team { font-size: 13px; letter-spacing: 0.5px; }
+  .bg-score-line .crimson { color: #ff6a62; } .bg-score-line .azure { color: #6aa6ff; }
+  .bg-score-line .num { font-size: 26px; text-shadow: 1px 1px 2px #000; }
+  .bg-score-line .flag { font-size: 13px; }
+  .bg-score-line .flag.home { opacity: 0.45; } .bg-score-line .flag.carried { color: #ffd24a; }
+  .bg-score-line .flag.dropped { color: #ff9a3c; }
+  .bg-score-line .dash { color: #998d6a; font-size: 18px; }
+  .bg-caps { font-size: 10.5px; color: #9aa6b8; margin-top: 1px; letter-spacing: 0.4px; }
+  .bg-roster { display: flex; justify-content: center; gap: 5px; margin-top: 4px; flex-wrap: wrap; }
+  .bg-pip { width: 9px; height: 9px; border-radius: 50%; border: 1px solid #000; }
+  .bg-pip.dead { opacity: 0.3; }
+  .bg-pip.flag { box-shadow: 0 0 6px 1px #ffd24a; border-color: #ffd24a; }
+  #bg-respawn { position: absolute; left: 50%; top: 54%; transform: translate(-50%,-50%); display: none; text-align: center;
+    color: #ff8d7a; font-family: var(--title-font); font-size: 22px; text-shadow: 2px 2px 6px #000; z-index: 60; pointer-events: none; }
+
   /* ---------- The World Market (the Merchant's auction house) ---------- */
   #market-window { width: 470px; display: none; flex-direction: column; }
   .mkt-tabs { display: flex; gap: 4px; margin: 2px 0 8px; }
@@ -5399,9 +5432,12 @@
       <canvas id="map-canvas" width="560" height="560"></canvas>
     </div>
     <div id="arena-window" class="window panel"></div>
+    <div id="bg-window" class="window panel"></div>
     <div id="leaderboard-window" class="window panel"></div>
     <div id="market-window" class="window panel"></div>
     <div id="arena-status"></div>
+    <div id="bg-scoreboard"></div>
+    <div id="bg-respawn"></div>
     <div id="options-menu" class="window panel"></div>
     <div id="emote-editor" class="window panel"></div>
     <div id="social-window" class="window panel"></div>
@@ -5414,6 +5450,7 @@
       <button class="micro-btn" id="mm-map" data-i18n-title="hud.keybinds.actions.map" data-i18n-aria="hud.keybinds.actions.map" title="World Map" aria-label="World Map" data-icon="map"><span class="keybind">m</span></button>
       <button class="micro-btn" id="mm-bag" data-i18n-title="itemUi.bags.title" data-i18n-aria="itemUi.bags.title" title="Bags" aria-label="Bags" data-icon="bags"><span class="keybind">b</span></button>
       <button class="micro-btn" id="mm-arena" data-i18n-title="hud.keybinds.actions.arena" data-i18n-aria="hud.keybinds.actions.arena" title="Arena (Ashen Coliseum)" aria-label="Arena (Ashen Coliseum)" data-icon="arena"><span class="keybind">g</span></button>
+      <button class="micro-btn" id="mm-bg" title="Ravenrift (5v5 Capture the Flag)" aria-label="Ravenrift (5v5 Capture the Flag)" data-icon="battleground"><span class="keybind">y</span></button>
       <button class="micro-btn" id="mm-leaderboard" data-i18n-title="game.leaderboard.title" data-i18n-aria="game.leaderboard.title" title="Leaderboard" aria-label="Leaderboard" data-icon="leaderboard"><span class="keybind">k</span></button>
       <button class="micro-btn" id="mm-emote" aria-label="Emotes" data-icon="emote"><span class="keybind">x</span></button>
       <button class="micro-btn" id="mm-music" data-i18n-title="hud.options.music" data-i18n-aria="hud.options.music" title="Music" aria-label="Music" data-icon="music"></button>

--- a/scripts/squad_visual.mjs
+++ b/scripts/squad_visual.mjs
@@ -1,0 +1,141 @@
+// Drives several real browser clients through Ravenrift, the 5v5 capture-the-flag
+// battleground: queue, a dev force-start (so a screenshot run needs fewer than
+// ten browsers), then a flag grab + capture + sprint rune. Screenshots -> tmp/.
+// Run the server first (serves the built client on :8787) with ALLOW_DEV_COMMANDS=1.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:8787';
+const N = Number(process.env.BG_CLIENTS ?? 6);
+fs.mkdirSync('tmp', { recursive: true });
+const uniq = Date.now().toString(36).slice(-5);
+// character names must be letters only — fold the timestamp's digits to letters
+const alpha = uniq.replace(/[0-9]/g, (d) => 'abcdefghij'[Number(d)]);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const errors = [];
+const CRIMSON = 0xd1413a, AZURE = 0x3a78d1;
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  protocolTimeout: 90000,
+  args: ['--no-sandbox', '--disable-setuid-sandbox', '--window-size=1280,760', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 760 },
+});
+
+async function login(page, charName, cls) {
+  page.on('pageerror', (e) => errors.push(`[${charName}] ` + e.message));
+  await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await sleep(500);
+  await page.evaluate((u, p) => {
+    document.querySelector('#btn-online').click();
+    document.querySelector('#login-user').value = u;
+    document.querySelector('#login-pass').value = p;
+    document.querySelector('#btn-register').click();
+  }, `sq_${charName}_${uniq}`, 'hunter22');
+  await page.waitForFunction(() => document.querySelector('#charselect-panel')?.style.display === 'block', { timeout: 10000, polling: 200 });
+  await page.evaluate((name, cls) => {
+    document.querySelector('#new-char-name').value = name;
+    document.querySelector(`#charselect-panel .mini-class[data-class="${cls}"]`).click();
+    document.querySelector('#btn-create-char').click();
+  }, charName, cls);
+  await sleep(600);
+  await page.evaluate((name) => {
+    [...document.querySelectorAll('.char-row')].find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('button')?.click();
+  }, charName);
+  await page.waitForFunction(() => window.__game?.world?.entities?.size > 5, { timeout: 25000, polling: 500 });
+}
+
+const names = ['Ravven', 'Bryn', 'Cael', 'Dax', 'Eira', 'Finn', 'Gust', 'Hale', 'Ivo', 'Jor'];
+const classes = ['warrior', 'paladin', 'hunter', 'rogue', 'mage', 'priest', 'shaman', 'warlock', 'druid', 'warrior'];
+const pages = [];
+console.log(`logging in ${N} champions…`);
+for (let i = 0; i < N; i++) {
+  const pg = await browser.newPage();
+  try { await login(pg, names[i] + alpha, classes[i % classes.length]); pages.push(pg); }
+  catch (e) { console.log(`client ${i} (${names[i]}) failed to enter: ${e.message.slice(0, 60)}`); }
+}
+console.log(`${pages.length} in world`);
+const hero = pages[0];
+
+// sturdy fighters so the demo isn't over in one hit
+for (const pg of pages) await pg.evaluate(() => window.__game.online.cmd({ cmd: 'dev_level', level: 14 }));
+await sleep(800);
+
+// --- 1. the Ravenrift panel: squad rating, queue, ladder ---
+await hero.bringToFront();
+await hero.evaluate(() => window.__game.hud.toggleBg());
+await sleep(700);
+await hero.screenshot({ path: 'tmp/squad1_panel.png' });
+console.log('panel rendered:', await hero.evaluate(() => document.querySelector('#bg-window')?.style.display === 'block') ? 'OK' : 'FAIL');
+await hero.evaluate(() => window.__game.hud.toggleBg());
+
+// --- 2. queue everyone, then dev force-start the match ---
+for (const pg of pages) await pg.evaluate(() => window.__game.world.bgQueueJoin());
+await sleep(500);
+await hero.evaluate(() => window.__game.online.cmd({ cmd: 'dev_bg_start' }));
+await hero.waitForFunction(() => window.__game.world.bgInfo?.match != null, { timeout: 12000, polling: 200 });
+console.log('match started; my team:', await hero.evaluate(() => window.__game.world.bgInfo.match.myTeam));
+
+// establishing shot: float the hero to mid-field and pull the camera up/back
+const flagPos = async (pg, color) => pg.evaluate((c) => {
+  const f = [...window.__game.world.entities.values()].find((e) => e.templateId === 'bg_flag' && e.color === c);
+  return f ? { x: f.pos.x, z: f.pos.z } : null;
+}, color);
+const myTeam = await hero.evaluate(() => window.__game.world.bgInfo.match.myTeam);
+const myColor = myTeam === 0 ? CRIMSON : AZURE;
+const foeColor = myTeam === 0 ? AZURE : CRIMSON;
+let myFlag = await flagPos(hero, myColor);
+const center = myFlag ? { x: myFlag.x, z: myFlag.z + (myTeam === 0 ? 30 : -30) } : null;
+if (center) await hero.evaluate((c) => window.__game.online.cmd({ cmd: 'dev_teleport', x: c.x, z: c.z }), center);
+await hero.evaluate(() => { window.__game.input.camDist = 22; window.__game.input.camPitch = 0.78; });
+await sleep(3500); // let the battleground build + everyone settle
+await hero.bringToFront();
+await hero.screenshot({ path: 'tmp/squad2_field.png' });
+console.log('on the battleground:', await hero.evaluate(() => window.__game.world.player.pos.x > 3800) ? 'OK' : 'FAIL');
+
+// the fight only goes live after the form-up countdown — runes and captures
+// don't register until then
+await toActive(hero);
+console.log('battle live:', await hero.evaluate(() => window.__game.world.bgInfo?.match?.state) === 'active' ? 'OK' : 'still counting');
+
+// --- 3. sprint rune ---
+const rune = await hero.evaluate(() => {
+  const r = [...window.__game.world.entities.values()].find((e) => e.templateId === 'bg_rune');
+  return r ? { x: r.pos.x, z: r.pos.z } : null;
+});
+if (rune) {
+  await hero.evaluate((r) => window.__game.online.cmd({ cmd: 'dev_teleport', x: r.x, z: r.z + 1 }), rune);
+  await hero.evaluate(() => { window.__game.input.camDist = 10; window.__game.input.camPitch = 0.35; });
+  await sleep(1400);
+  await hero.screenshot({ path: 'tmp/squad3_rune.png' });
+  console.log('grabbed sprint rune:', await hero.evaluate(() => window.__game.world.player.auras?.some((a) => a.kind === 'buff_speed')) ? 'OK' : '(maybe)');
+}
+
+// --- 4. grab the enemy flag, run it home, score ---
+const enemyFlag = await flagPos(hero, foeColor);
+if (enemyFlag) {
+  await hero.evaluate((f) => window.__game.online.cmd({ cmd: 'dev_teleport', x: f.x, z: f.z }), enemyFlag);
+  await sleep(900);
+  await hero.evaluate(() => { window.__game.input.camDist = 11; window.__game.input.camPitch = 0.4; });
+  await sleep(400);
+  await hero.screenshot({ path: 'tmp/squad4_carry.png' });
+  console.log('carrying enemy flag:', await hero.evaluate(() => window.__game.world.bgInfo.match.players.find((p) => p.pid === window.__game.world.playerId)?.carrying) ? 'OK' : 'FAIL');
+  // run it back to my own stand
+  myFlag = await flagPos(hero, myColor);
+  if (myFlag) {
+    await hero.evaluate((f) => window.__game.online.cmd({ cmd: 'dev_teleport', x: f.x, z: f.z }), myFlag);
+    await sleep(1100);
+    await hero.bringToFront();
+    await hero.screenshot({ path: 'tmp/squad5_capture.png' });
+    console.log('score after capture:', await hero.evaluate(() => window.__game.world.bgInfo.match.scores.join('–')));
+  }
+}
+
+async function toActive(pg) {
+  await pg.waitForFunction(() => window.__game.world.bgInfo?.match?.state === 'active', { timeout: 14000, polling: 200 }).catch(() => {});
+}
+
+console.log(errors.length ? 'PAGE ERRORS:\n' + errors.slice(0, 6).join('\n') : 'no page errors');
+await browser.close();

--- a/server/db.ts
+++ b/server/db.ts
@@ -503,6 +503,41 @@ export async function topArenaRatings(limit = 20): Promise<ArenaLeaderRow[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Ravenrift 5v5 squad ladder. Ratings/records live inside each character's
+// state JSONB (no schema migration); only characters who have played a match
+// appear. Realm-scoped; read through the server-side cache in main.ts.
+// ---------------------------------------------------------------------------
+
+export interface SquadLeaderRow {
+  name: string;
+  class: PlayerClass;
+  level: number;
+  rating: number;
+  wins: number;
+  losses: number;
+}
+
+export async function topSquadRatings(limit = 20): Promise<SquadLeaderRow[]> {
+  const res = await pool.query(
+    `SELECT name, class, level,
+            COALESCE((state->>'squadRating')::int, 1500) AS rating,
+            COALESCE((state->>'squadWins')::int, 0)     AS wins,
+            COALESCE((state->>'squadLosses')::int, 0)   AS losses
+       FROM characters
+      WHERE realm = $1
+        AND state IS NOT NULL
+        AND COALESCE((state->>'squadWins')::int, 0) + COALESCE((state->>'squadLosses')::int, 0) > 0
+      ORDER BY rating DESC, wins DESC, name ASC
+      LIMIT $2`,
+    [REALM, Math.max(1, Math.min(100, limit))],
+  );
+  return res.rows.map((r) => ({
+    name: r.name, class: r.class, level: r.level,
+    rating: Number(r.rating), wins: Number(r.wins), losses: Number(r.losses),
+  }));
+}
+
+// ---------------------------------------------------------------------------
 // Lifetime-XP leaderboard (Max-Level XP Overflow). Ranks characters by the
 // `lifetimeXp` stored in their state JSONB. Realm-scoped (FR-4.3) and backed by
 // the `characters_lifetime_xp` index. Read through the server-side cache in

--- a/server/game.ts
+++ b/server/game.ts
@@ -1048,6 +1048,10 @@ export class GameServer {
         break;
       }
       case 'arena_leave': sim.arenaQueueLeave(pid); break;
+      // Ravenrift (5v5 capture-the-flag) queue
+      case 'bg_queue': sim.bgQueueJoin(pid); break;
+      case 'bg_leave': sim.bgQueueLeave(pid); break;
+      case 'dev_bg_start': if (process.env.ALLOW_DEV_COMMANDS === '1') sim.devStartBg(); break;
 
       // post-cap cosmetic prestige (Max-Level XP Overflow)
       case 'prestige': sim.prestige(pid); break;
@@ -1303,6 +1307,7 @@ export class GameServer {
     maybe('trade', this.tradeWire(session.pid));
     maybe('duel', this.duelWire(session.pid));
     maybe('arena', this.sim.arenaInfoFor(session.pid));
+    maybe('bg', this.sim.bgInfoFor(session.pid));
     // market info is null unless the player is standing at the Merchant, so it
     // only rides the wire for players actually browsing the World Market
     maybe('market', this.sim.marketInfoFor(session.pid));

--- a/server/main.ts
+++ b/server/main.ts
@@ -6,7 +6,7 @@ import {
   ensureSchema, pool, createAccount, findAccount, getAccountsCount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacterCapped, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
-  findCharacterReportTargetByName, topArenaRatings, topLifetimeXp, chatMuteStatusForAccount,
+  findCharacterReportTargetByName, topArenaRatings, topSquadRatings, topLifetimeXp, chatMuteStatusForAccount,
 } from './db';
 import { virtualLevel } from '../src/sim/types';
 import { Sim } from '../src/sim/sim';
@@ -500,6 +500,10 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     if (req.method === 'GET' && url === '/api/arena/leaderboard') {
       // public all-time Ashen Coliseum ladder (top rated characters)
       return json(res, 200, { leaders: await topArenaRatings(20) });
+    }
+    if (req.method === 'GET' && url === '/api/squad/leaderboard') {
+      // public all-time Ravenrift 5v5 squad ladder
+      return json(res, 200, { leaders: await topSquadRatings(20) });
     }
     if (req.method === 'GET' && url === '/api/leaderboard') {
       // lifetime-XP leaderboard (Max-Level XP Overflow), served from the

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -31,7 +31,7 @@ export interface InputCallbacks {
   onTargetFriendly(): void;
   onCycleFriendly(): void;
   onAbility(slot: number): void;
-  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'talents' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena' | 'leaderboard'): void;
+  onUiKey(key: 'interact' | 'bags' | 'char' | 'spellbook' | 'talents' | 'questlog' | 'map' | 'nameplates' | 'escape' | 'chat' | 'meters' | 'social' | 'arena' | 'battleground' | 'leaderboard'): void;
   onEmoteWheel(open: boolean): void;
   onClickPick(x: number, y: number, button: number): void;
   /** When false, edge actions (spells, UI keys) are ignored. */
@@ -402,6 +402,7 @@ export class Input {
       case 'meters': this.cb.onUiKey('meters'); return;
       case 'social': this.cb.onUiKey('social'); return;
       case 'arena': this.cb.onUiKey('arena'); return;
+      case 'battleground': this.cb.onUiKey('battleground'); return;
       case 'leaderboard': this.cb.onUiKey('leaderboard'); return;
       case 'chat': this.cb.onUiKey('chat'); return;
     }

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -51,6 +51,7 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyH'] },
   { id: 'social', label: 'Friends & Guild', category: 'Interface', kind: 'edge', defaults: ['KeyO'] },
   { id: 'arena', label: 'Arena (Ashen Coliseum)', category: 'Interface', kind: 'edge', defaults: ['KeyG'] },
+  { id: 'battleground', label: 'Ravenrift (Battleground)', category: 'Interface', kind: 'edge', defaults: ['KeyY'] },
   { id: 'leaderboard', label: 'Leaderboard', category: 'Interface', kind: 'edge', defaults: ['KeyK'] },
   { id: 'chat', label: 'Open Chat', category: 'Interface', kind: 'edge', defaults: ['Enter', 'NumpadEnter'] },
   { id: 'emoteWheel', label: 'Emote Wheel', category: 'Interface', kind: 'held', defaults: ['KeyX'] },

--- a/src/main.ts
+++ b/src/main.ts
@@ -608,6 +608,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         case 'meters': hud.toggleMeters(); break;
         case 'social': hud.toggleSocial(); break;
         case 'arena': hud.toggleArena(); break;
+        case 'battleground': hud.toggleBg(); break;
         case 'leaderboard': hud.toggleLeaderboard(); break;
         case 'chat': openChat(); break;
         case 'escape':

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -11,7 +11,7 @@ import {
   emptyMoveInput,
 } from '../sim/types';
 import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
-import { isOverheadEmoteId, type ArenaInfo, type CharacterSearchResult, type DuelInfo, type FriendInfo, type IWorld, type LeaderboardEntry, type MarketInfo, type OverheadEmoteId, type PartyInfo, type PresenceStatus, type SocialInfo, type TradeInfo } from '../world_api';
+import { isOverheadEmoteId, type ArenaInfo, type BgInfo, type CharacterSearchResult, type DuelInfo, type FriendInfo, type IWorld, type LeaderboardEntry, type MarketInfo, type OverheadEmoteId, type PartyInfo, type PresenceStatus, type SocialInfo, type TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
 // REST
@@ -278,6 +278,7 @@ export class ClientWorld implements IWorld {
   duelInfo: DuelInfo | null = null;
   socialInfo: SocialInfo | null = null;
   arenaInfo: ArenaInfo | null = null;
+  bgInfo: BgInfo | null = null;
   marketInfo: MarketInfo | null = null;
   markers: Record<number, number> = {}; // entityId -> markerId, mirrored from the self-wire
   realm = '';
@@ -705,6 +706,7 @@ export class ClientWorld implements IWorld {
       if (s.trade !== undefined) this.tradeInfo = s.trade;
       if (s.duel !== undefined) this.duelInfo = s.duel;
       if (s.arena !== undefined) this.arenaInfo = s.arena;
+      if (s.bg !== undefined) this.bgInfo = s.bg;
       if (s.market !== undefined) this.marketInfo = s.market;
       // camera follows server-side facing changes when not mouselooking
       if (prevSelfFacing !== undefined && this.mouselookFacing === null) {
@@ -938,6 +940,12 @@ export class ClientWorld implements IWorld {
   }
   arenaQueueLeave(): void {
     this.cmd({ cmd: 'arena_leave' });
+  }
+  bgQueueJoin(): void {
+    this.cmd({ cmd: 'bg_queue' });
+  }
+  bgQueueLeave(): void {
+    this.cmd({ cmd: 'bg_leave' });
   }
   marketList(itemId: string, count: number, price: number): void {
     this.cmd({ cmd: 'market_list', item: itemId, count, price });

--- a/src/render/dungeon.ts
+++ b/src/render/dungeon.ts
@@ -21,6 +21,9 @@ import {
   ARENA_LAYOUT, CRYPT_LAYOUT, SANCTUM_LAYOUT, TEMPLE_LAYOUT, DUNGEON_WALL_X, TOMB_HD,
   DungeonLayout, GridPoint, WallStub,
 } from '../sim/dungeon_layout';
+import {
+  BASES, BG_HALF_X, BG_HALF_Z, COVER_CRATES, COVER_PILLARS, COVER_WALLS, SPEED_RUNES, TEAM_COLORS,
+} from '../sim/battleground_layout';
 
 const FLAME_EMISSIVE_HIGH = 2.2;
 // dungeon torch point lights: pumped + hung low so warm pools break up the
@@ -402,6 +405,135 @@ export class DungeonInteriors {
       kelpMesh.instanceMatrix.needsUpdate = true;
       group.add(kelpMesh);
     }
+  }
+
+  // Ravenrift battleground: an open-air walled field built from the same kit —
+  // a tiled courtyard floor, perimeter + keep + cover walls, then procedural
+  // team banners, flag stands and glowing sprint-rune pads.
+  private bgMats: { pole?: THREE.Material; stone?: THREE.Material; cloth: Map<number, THREE.Material>; rune?: THREE.Material } = { cloth: new Map() };
+
+  async buildBattleground(ox: number, oz: number): Promise<void> {
+    await ensureDungeonAssets();
+    const group = new THREE.Group();
+    const p = new Placements();
+    const quarter = Math.PI / 2;
+
+    // courtyard floor
+    for (let z = -BG_HALF_Z + 2; z <= BG_HALF_Z - 2; z += FLOOR_CELL) {
+      for (let x = -BG_HALF_X + 2; x <= BG_HALF_X - 2; x += FLOOR_CELL) {
+        const t = hash2(x * 1.31, z);
+        const kind = t < 0.66 ? 'floor_tile_large' : t < 0.8 ? 'floor_tile_large_rocks'
+          : t < 0.9 ? 'floor_dirt_large' : 'floor_dirt_large_rocky';
+        p.add(kind, x, FLOOR_Y, z, Math.floor(hash2(z, x) * 4) * quarter);
+      }
+    }
+    // perimeter ramparts
+    this.addWallRun(p, -BG_HALF_X, -BG_HALF_Z, -BG_HALF_X, BG_HALF_Z);
+    this.addWallRun(p, BG_HALF_X, -BG_HALF_Z, BG_HALF_X, BG_HALF_Z);
+    this.addWallRun(p, -BG_HALF_X, -BG_HALF_Z, BG_HALF_X, -BG_HALF_Z);
+    this.addWallRun(p, -BG_HALF_X, BG_HALF_Z, BG_HALF_X, BG_HALF_Z);
+    // keeps — a three-sided enclosure around each flag, open to the field
+    for (const base of BASES) {
+      const dir = base.team === 0 ? -1 : 1;
+      const backZ = base.flag.z + dir * 8;
+      const sideZ = base.flag.z + dir * 2;
+      this.addWallRun(p, -14, backZ, 14, backZ);
+      this.addWallRun(p, -14, sideZ - 6, -14, sideZ + 6);
+      this.addWallRun(p, 14, sideZ - 6, 14, sideZ + 6);
+    }
+    // central cover
+    for (const w of COVER_WALLS) {
+      if (Math.abs(w.hw - w.hd) < 2 && w.hw > 3) {
+        this.addWallRun(p, w.x - w.hw, w.z - w.hd, w.x + w.hw, w.z - w.hd);
+        this.addWallRun(p, w.x - w.hw, w.z + w.hd, w.x + w.hw, w.z + w.hd);
+        this.addWallRun(p, w.x - w.hw, w.z - w.hd, w.x - w.hw, w.z + w.hd);
+        this.addWallRun(p, w.x + w.hw, w.z - w.hd, w.x + w.hw, w.z + w.hd);
+      } else if (w.hd >= w.hw) {
+        this.addWallRun(p, w.x, w.z - w.hd, w.x, w.z + w.hd);
+      } else {
+        this.addWallRun(p, w.x - w.hw, w.z, w.x + w.hw, w.z);
+      }
+    }
+    for (const pl of COVER_PILLARS) p.add('pillar', pl.x, 0, pl.z, 0, [PILLAR_XZ_SCALE, MODULE_SCALE, PILLAR_XZ_SCALE]);
+    for (const c of COVER_CRATES) p.add(hash2(c.x, c.z) < 0.5 ? 'crates_stacked' : 'box_stacked', c.x, 0, c.z, hash2(c.z, c.x) * Math.PI, 1.0);
+    this.emit(group, p);
+
+    // team identity: banners flanking each keep + a glowing flag pedestal
+    for (const base of BASES) {
+      const color = TEAM_COLORS[base.team];
+      const facing = base.team === 0 ? 0 : Math.PI;
+      this.addBgBanner(group, base.banner.x - 9, base.banner.z, color, facing);
+      this.addBgBanner(group, base.banner.x + 9, base.banner.z, color, facing);
+      this.addBgFlagStand(group, base.flag.x, base.flag.z, color);
+    }
+    for (const rp of SPEED_RUNES) this.addBgRunePad(group, rp.x, rp.z);
+
+    group.position.set(ox, 0, oz);
+    this.scene.add(group);
+  }
+
+  // Tile 'wall' kit modules (8u long at MODULE_SCALE) along a segment.
+  private addWallRun(p: Placements, ax: number, az: number, bx: number, bz: number): void {
+    const dx = bx - ax, dz = bz - az;
+    const len = Math.hypot(dx, dz);
+    if (len < 0.1) return;
+    const n = Math.max(1, Math.round(len / 8));
+    const ry = Math.atan2(dx, dz) + Math.PI / 2;
+    for (let i = 0; i < n; i++) {
+      const t = (i + 0.5) / n;
+      p.add('wall', ax + dx * t, 0, az + dz * t, ry, MODULE_SCALE);
+    }
+  }
+
+  private bgMat(which: 'pole' | 'stone'): THREE.Material {
+    if (this.bgMats[which]) return this.bgMats[which]!;
+    const color = which === 'pole' ? 0x5a4636 : 0x8b8a86;
+    const mat = this.lowGfx
+      ? new THREE.MeshLambertMaterial({ color })
+      : new THREE.MeshStandardMaterial({ color, roughness: 0.9, metalness: 0 });
+    this.bgMats[which] = mat;
+    return mat;
+  }
+
+  private bgClothMat(color: number): THREE.Material {
+    let mat = this.bgMats.cloth.get(color);
+    if (!mat) {
+      mat = this.lowGfx
+        ? new THREE.MeshLambertMaterial({ color, side: THREE.DoubleSide })
+        : new THREE.MeshStandardMaterial({ color, roughness: 0.7, metalness: 0, side: THREE.DoubleSide, emissive: color, emissiveIntensity: 0.25 });
+      this.bgMats.cloth.set(color, mat);
+    }
+    return mat;
+  }
+
+  private addBgBanner(group: THREE.Group, x: number, z: number, color: number, facing: number): void {
+    const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.13, 0.13, 6.5, 6), this.bgMat('pole'));
+    pole.position.set(x, 3.25, z);
+    pole.castShadow = !this.lowGfx;
+    group.add(pole);
+    const cloth = new THREE.Mesh(new THREE.PlaneGeometry(2.6, 3.6), this.bgClothMat(color));
+    cloth.position.set(x, 4.4, z);
+    cloth.rotation.y = facing;
+    group.add(cloth);
+  }
+
+  private addBgFlagStand(group: THREE.Group, x: number, z: number, color: number): void {
+    const ped = new THREE.Mesh(new THREE.CylinderGeometry(1.5, 1.9, 0.7, 14), this.bgMat('stone'));
+    ped.position.set(x, 0.35, z);
+    ped.receiveShadow = !this.lowGfx;
+    group.add(ped);
+    this.addTorchGlow(group, x, z, color, 0.72, 1.3);
+  }
+
+  private addBgRunePad(group: THREE.Group, x: number, z: number): void {
+    this.addTorchGlow(group, x, z, 0xffd24a, 0.06, 1.1);
+    if (!this.bgMats.rune) {
+      this.bgMats.rune = new THREE.MeshBasicMaterial({ color: 0xffd24a, transparent: true, opacity: 0.7, blending: THREE.AdditiveBlending, depthWrite: false, side: THREE.DoubleSide });
+    }
+    const ring = new THREE.Mesh(new THREE.RingGeometry(1.4, 1.9, 22).rotateX(-Math.PI / 2), this.bgMats.rune);
+    ring.position.set(x, 0.09, z);
+    ring.renderOrder = 1;
+    group.add(ring);
   }
 
   // Hollow Crypt and Sunken Bastion share interior 'crypt'; the origin x-band

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -5,6 +5,7 @@ import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import {
   MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
   instanceOrigin, INSTANCE_SLOT_COUNT, ARENA_SLOT_COUNT, arenaOrigin, arenaOriginAt, isArenaPos, dungeonAt,
+  BG_SLOT_COUNT, battlegroundOrigin, isBgPos,
 } from '../sim/data';
 import { ARENA_LAYOUT, DUNGEON_WALL_X } from '../sim/dungeon_layout';
 import { cameraOcclusion } from '../sim/colliders';
@@ -686,6 +687,10 @@ export class Renderer {
   // interest churn leaks them (removeView only disposes per-view geometry).
   private doorStoneMat: THREE.Material | null = null;
   private sparkleMat: THREE.SpriteMaterial | null = null;
+  // Ravenrift flag/rune objects (shared caches; survive interest churn)
+  private bgPoleMat: THREE.Material | null = null;
+  private bgFlagMats = new Map<number, THREE.Material>();
+  private bgRuneMat: THREE.MeshBasicMaterial | null = null;
 
   private createView(e: Entity): void {
     const group = new THREE.Group();
@@ -750,6 +755,49 @@ export class Renderer {
       const glow = new THREE.PointLight(tint, 9, 15, 2);
       glow.position.y = 2.4;
       body!.add(glow);
+      objectMesh = body!;
+    } else if (e.kind === 'object' && e.templateId === 'bg_flag') {
+      // capture-the-flag banner: pole + team-coloured pennant, carried by runners
+      body = new THREE.Group();
+      height = 4.4;
+      this.bgPoleMat ??= new THREE.MeshLambertMaterial({ color: 0x4a3a2a });
+      const pole = new THREE.Mesh(new THREE.CylinderGeometry(0.1, 0.1, 4.2, 6), this.bgPoleMat);
+      pole.position.y = 2.1;
+      pole.castShadow = !this.lowGfx;
+      body!.add(pole);
+      let clothMat = this.bgFlagMats.get(e.color);
+      if (!clothMat) {
+        const m = new THREE.MeshBasicMaterial({ color: e.color, side: THREE.DoubleSide });
+        if (!this.lowGfx) m.color.multiplyScalar(1.4); // pop against the field via bloom
+        this.bgFlagMats.set(e.color, m);
+        clothMat = m;
+      }
+      const cloth = new THREE.Mesh(new THREE.PlaneGeometry(1.9, 1.25), clothMat);
+      cloth.position.set(0.95, 3.45, 0);
+      body!.add(cloth);
+      objectMesh = body!;
+    } else if (e.kind === 'object' && e.templateId === 'bg_rune') {
+      // speed powerup: a glowing ground glyph with a hovering ring
+      body = new THREE.Group();
+      height = 1.4;
+      if (!this.bgRuneMat) {
+        this.bgRuneMat = new THREE.MeshBasicMaterial({
+          color: e.color, transparent: true, opacity: 0.85, side: THREE.DoubleSide,
+          blending: THREE.AdditiveBlending, depthWrite: false,
+        });
+        if (!this.lowGfx) this.bgRuneMat.color.multiplyScalar(2);
+      }
+      const disc = new THREE.Mesh(new THREE.CircleGeometry(1.2, 22).rotateX(-Math.PI / 2), this.bgRuneMat);
+      disc.position.y = 0.12;
+      body!.add(disc);
+      const ring = new THREE.Mesh(new THREE.TorusGeometry(0.75, 0.13, 8, 18).rotateX(-Math.PI / 2), this.bgRuneMat);
+      ring.position.y = 0.85;
+      body!.add(ring);
+      if (!this.lowGfx) {
+        const l = new THREE.PointLight(e.color, 6, 9, 2);
+        l.position.y = 1.1;
+        body!.add(l);
+      }
       objectMesh = body!;
     } else if (e.kind === 'object') {
       const built = buildGroundQuestObject(e.objectItemId ?? '', e.id);
@@ -869,12 +917,19 @@ export class Renderer {
   // ---------------------------------------------------------------------
 
   private builtInteriors = new Set<string>();
-  private fogState: 'outdoor' | 'dungeon' | 'temple' | 'underwater' = 'outdoor';
+  private fogState: 'outdoor' | 'dungeon' | 'temple' | 'underwater' | 'battleground' = 'outdoor';
 
   private buildInterior(interior: string, ox: number, oz: number): void {
     this.dungeons ??= new DungeonInteriors(this.scene, this.lowGfx, this.flames, this.fireLights);
     void this.dungeons.buildInterior(interior, ox, oz).catch((err) => {
       console.error('Failed to build dungeon interior:', err);
+    });
+  }
+
+  private buildBg(ox: number, oz: number): void {
+    this.dungeons ??= new DungeonInteriors(this.scene, this.lowGfx, this.flames, this.fireLights);
+    void this.dungeons.buildBattleground(ox, oz).catch((err) => {
+      console.error('Failed to build battleground:', err);
     });
   }
 
@@ -893,8 +948,22 @@ export class Renderer {
   }
 
   private updateAmbience(px: number, camY: number, dt: number): void {
-    const inside = px > DUNGEON_X_THRESHOLD;
-    if (inside && isArenaPos(px)) {
+    const inBg = isBgPos(px);
+    const inside = px > DUNGEON_X_THRESHOLD && !inBg;
+    if (inBg) {
+      void ensureDungeonAssets().catch(() => undefined);
+      // build the Ravenrift battleground the player was matched into
+      const pz = this.sim.player.pos.z;
+      for (let i = 0; i < BG_SLOT_COUNT; i++) {
+        const key = `bg:${i}`;
+        if (this.builtInteriors.has(key)) continue;
+        const o = battlegroundOrigin(i);
+        if (Math.abs(px - o.x) < 220 && Math.abs(pz - o.z) < 200) {
+          this.builtInteriors.add(key);
+          this.buildBg(o.x, o.z);
+        }
+      }
+    } else if (inside && isArenaPos(px)) {
       void ensureDungeonAssets().catch(() => undefined);
       // build the Ashen Coliseum copy the player was matched into
       const pz = this.sim.player.pos.z;
@@ -925,9 +994,10 @@ export class Renderer {
     // the Drowned Temple reads as submerged: a teal murk instead of the
     // crypt's near-black, so its flooded halls feel underwater, not just dark
     const inTemple = inside && !isArenaPos(px) && dungeonAt(px)?.interior === 'temple';
-    const desired = inTemple ? 'temple'
-      : inside ? 'dungeon'
-        : camY < WATER_LEVEL - 0.05 ? 'underwater' : 'outdoor';
+    const desired = inBg ? 'battleground'
+      : inTemple ? 'temple'
+        : inside ? 'dungeon'
+          : camY < WATER_LEVEL - 0.05 ? 'underwater' : 'outdoor';
     const fog = this.scene.fog as THREE.Fog;
     if (desired !== this.fogState) {
       this.fogState = desired;
@@ -943,6 +1013,11 @@ export class Renderer {
         fog.color.setHex(0x17506e);
         fog.near = 2;
         fog.far = 48;
+      } else if (desired === 'battleground') {
+        // open-air, but a close haze hides the off-world void past the ramparts
+        fog.color.setHex(0xaecbe0);
+        fog.near = 50;
+        fog.far = 185;
       } else {
         const preset = this.outdoorFogPreset();
         fog.color.setHex(preset.color);

--- a/src/sim/battleground_layout.ts
+++ b/src/sim/battleground_layout.ts
@@ -1,0 +1,100 @@
+// Ravenrift — the 5v5 capture-the-flag battleground. Plain-data map geometry
+// (instance-local coordinates, y up, z along the length), the single source of
+// truth shared by BOTH the collider set (src/sim/colliders.ts) and the renderer
+// (src/render/dungeon.ts → buildBattleground), so what you fight around is what
+// you see. Sim layer: no three.js imports.
+import type { Collider } from './colliders';
+
+export type Team = 0 | 1; // 0 = Crimson (south, -z), 1 = Azure (north, +z)
+export const TEAM_NAMES = ['Crimson', 'Azure'] as const;
+export const TEAM_COLORS = [0xd1413a, 0x3a78d1] as const; // red, blue — flags/banners/blips
+
+// Field footprint. The play area is a walled rectangle; the two keeps sit at
+// the short ends with their flag at the heart of a three-sided enclosure.
+export const BG_HALF_X = 34;
+export const BG_HALF_Z = 60;
+export const BG_WALL_T = 1; // wall half-thickness (collider + module)
+export const BG_WALL_HEIGHT = 6;
+export const FLAG_Z = 48; // |z| of each team's flag stand
+
+export interface BaseDef {
+  team: Team;
+  flag: { x: number; z: number }; // flag home + capture point
+  spawns: { x: number; z: number }[]; // respawn ring behind the flag
+  banner: { x: number; z: number };
+}
+
+// Crimson keep opens toward +z (the field); Azure mirrors it on +z.
+export const BASES: BaseDef[] = [
+  {
+    team: 0,
+    flag: { x: 0, z: -FLAG_Z },
+    spawns: [{ x: -6, z: -54 }, { x: 0, z: -55 }, { x: 6, z: -54 }, { x: -3, z: -51 }, { x: 3, z: -51 }],
+    banner: { x: 0, z: -56 },
+  },
+  {
+    team: 1,
+    flag: { x: 0, z: FLAG_Z },
+    spawns: [{ x: 6, z: 54 }, { x: 0, z: 55 }, { x: -6, z: 54 }, { x: 3, z: 51 }, { x: -3, z: 51 }],
+    banner: { x: 0, z: 56 },
+  },
+];
+
+// Speed runes: one at each flag section plus two mid-field flanks. Stepping on
+// an active rune grants a sprint buff; it then recharges (see sim BG_RUNE_*).
+export const SPEED_RUNES: { x: number; z: number }[] = [
+  { x: 0, z: -36 }, // Crimson flag approach
+  { x: 0, z: 36 }, // Azure flag approach
+  { x: -24, z: 0 }, // west flank
+  { x: 24, z: 0 }, // east flank
+];
+
+// Central cover — staggered walls, a heart ruin, pillars and crate stacks that
+// break line of sight and carve out flanking lanes to weave enemies through.
+interface WallSeg { x: number; z: number; hw: number; hd: number; rot?: number }
+export const COVER_WALLS: WallSeg[] = [
+  { x: 0, z: 0, hw: 5, hd: 5 }, // heart ruin block
+  { x: -13, z: -16, hw: 1, hd: 8 }, // offset lane walls
+  { x: 13, z: 16, hw: 1, hd: 8 },
+  { x: 13, z: -16, hw: 1, hd: 5 },
+  { x: -13, z: 16, hw: 1, hd: 5 },
+  { x: -22, z: -30, hw: 6, hd: 1 }, // wing baffles near each base mouth
+  { x: 22, z: 30, hw: 6, hd: 1 },
+];
+export const COVER_PILLARS: { x: number; z: number }[] = [
+  { x: -18, z: -8 }, { x: 18, z: -8 }, { x: -18, z: 8 }, { x: 18, z: 8 },
+  { x: 0, z: -26 }, { x: 0, z: 26 },
+];
+export const COVER_CRATES: { x: number; z: number }[] = [
+  { x: -8, z: -32 }, { x: 8, z: 32 }, { x: 9, z: -22 }, { x: -9, z: 22 },
+];
+
+const PILLAR_R = 1.0;
+const CRATE_R = 0.8;
+
+/** Full BG collision set in instance-local coordinates. Flag stands and speed
+ *  runes are deliberately walkable (no collider). */
+export function battlegroundColliders(): Collider[] {
+  const out: Collider[] = [];
+  // perimeter
+  for (const sx of [-BG_HALF_X, BG_HALF_X]) {
+    out.push({ type: 'obb', x: sx, z: 0, hw: BG_WALL_T, hd: BG_HALF_Z, rot: 0 });
+  }
+  for (const sz of [-BG_HALF_Z, BG_HALF_Z]) {
+    out.push({ type: 'obb', x: 0, z: sz, hw: BG_HALF_X, hd: BG_WALL_T, rot: 0 });
+  }
+  // keeps: a three-sided enclosure around each flag, open toward centre
+  for (const base of BASES) {
+    const dir = base.team === 0 ? -1 : 1; // back wall is further from centre
+    const backZ = base.flag.z + dir * 8;
+    out.push({ type: 'obb', x: 0, z: backZ, hw: 14, hd: BG_WALL_T, rot: 0 });
+    for (const sx of [-14, 14]) {
+      out.push({ type: 'obb', x: sx, z: base.flag.z + dir * 2, hw: BG_WALL_T, hd: 6, rot: 0 });
+    }
+  }
+  // central cover
+  for (const w of COVER_WALLS) out.push({ type: 'obb', x: w.x, z: w.z, hw: w.hw, hd: w.hd, rot: w.rot ?? 0 });
+  for (const p of COVER_PILLARS) out.push({ type: 'circle', x: p.x, z: p.z, r: PILLAR_R });
+  for (const c of COVER_CRATES) out.push({ type: 'circle', x: c.x, z: c.z, r: CRATE_R });
+  return out;
+}

--- a/src/sim/colliders.ts
+++ b/src/sim/colliders.ts
@@ -1,8 +1,9 @@
 import { generateDecorations, groundHeight } from './world';
 import {
-  DUNGEON_X_THRESHOLD, INSTANCE_SLOT_COUNT, PROPS, arenaOriginAt, dungeonAt, instanceOrigin, isArenaPos,
+  DUNGEON_X_THRESHOLD, INSTANCE_SLOT_COUNT, PROPS, arenaOriginAt, bgOriginAt, dungeonAt, instanceOrigin, isArenaPos, isBgPos,
 } from './data';
 import { ARENA_LAYOUT, CRYPT_LAYOUT, SANCTUM_LAYOUT, TEMPLE_LAYOUT, layoutColliders } from './dungeon_layout';
+import { battlegroundColliders } from './battleground_layout';
 
 // Static world collision. Prop placement comes from the per-zone content
 // modules (merged into PROPS by sim/data.ts): the renderer builds its meshes
@@ -113,6 +114,7 @@ const CRYPT_COLLIDERS: Collider[] = layoutColliders(CRYPT_LAYOUT);
 const SANCTUM_COLLIDERS: Collider[] = layoutColliders(SANCTUM_LAYOUT);
 const TEMPLE_COLLIDERS: Collider[] = layoutColliders(TEMPLE_LAYOUT);
 const ARENA_COLLIDERS: Collider[] = layoutColliders(ARENA_LAYOUT);
+const BG_COLLIDERS: Collider[] = battlegroundColliders();
 
 // Interior collider sets keyed by DungeonDef.interior.
 const INTERIOR_COLLIDERS: Record<string, Collider[]> = {
@@ -223,6 +225,11 @@ function instanceLocal(x: number, z: number): { ox: number; oz: number; interior
 // Resolve a movement destination against all static geometry. Movers slide
 // along obstacles. `r` is the body radius.
 export function resolvePosition(seed: number, x: number, z: number, r = 0.5): { x: number; z: number } {
+  if (isBgPos(x)) {
+    const o = bgOriginAt(z);
+    const local = resolveAgainst(BG_COLLIDERS, x - o.x, z - o.z, r);
+    return { x: local.x + o.x, z: local.z + o.z };
+  }
   if (isArenaPos(x)) {
     const o = arenaOriginAt(z);
     const local = resolveAgainst(ARENA_COLLIDERS, x - o.x, z - o.z, r);
@@ -333,6 +340,10 @@ export function cameraOcclusion(
   bx: number, by: number, bz: number,
   pad = 0.35,
 ): number {
+  if (isBgPos(ax)) {
+    const o = bgOriginAt(az);
+    return sweepColliders(BG_COLLIDERS, ax - o.x, ay, az - o.z, bx - o.x, by, bz - o.z, pad, true);
+  }
   if (isArenaPos(ax)) {
     const o = arenaOriginAt(az);
     return sweepColliders(ARENA_COLLIDERS, ax - o.x, ay, az - o.z, bx - o.x, by, bz - o.z, pad, true);

--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -199,7 +199,9 @@ export function arenaOrigin(slot: number): { x: number; z: number } {
 }
 
 export function isArenaPos(x: number): boolean {
-  return x >= ARENA_X_MIN;
+  // Arena owns the band just past the dungeons, up to the Ravenrift band. The
+  // upper bound keeps a far-off battleground position from reading as an arena.
+  return x >= ARENA_X_MIN && x < BG_X_MIN;
 }
 
 // Nearest arena instance origin to a far-off position, matched by z-band (the
@@ -212,6 +214,40 @@ export function arenaOriginAt(z: number): { x: number; z: number; slot: number }
     if (d < bestD) { bestD = d; best = i; }
   }
   const o = arenaOrigin(best);
+  return { x: o.x, z: o.z, slot: best };
+}
+
+// ---------------------------------------------------------------------------
+// Ravenrift — 5v5 capture-the-flag battleground. Its match instances sit in
+// their own flat-ground x-band beyond the arena band (which is bounded above by
+// BG_X_MIN, so the two never overlap). Like dungeons/arenas, x beyond
+// DUNGEON_X_THRESHOLD means flat ground (world.groundHeight) + instance-local
+// collision against the battleground layout (sim/colliders.ts).
+// ---------------------------------------------------------------------------
+
+export const BG_X = 4200; // battleground instances share this x; slots stack along z
+export const BG_X_MIN = 3800; // x at/after this = a battleground instance, not an arena
+export const BG_SLOT_COUNT = 3; // concurrent 5v5 matches the world can host
+const BG_Z0 = -1500;
+const BG_SLOT_SPACING = 300; // > the field footprint (~120yd) so slots never overlap
+
+export function battlegroundOrigin(slot: number): { x: number; z: number } {
+  return { x: BG_X, z: BG_Z0 + slot * BG_SLOT_SPACING };
+}
+
+export function isBgPos(x: number): boolean {
+  return x >= BG_X_MIN;
+}
+
+// Nearest battleground instance origin to a far-off position, matched by z-band
+// (x is shared across slots). Mirrors arenaOriginAt.
+export function bgOriginAt(z: number): { x: number; z: number; slot: number } {
+  let best = 0, bestD = Infinity;
+  for (let i = 0; i < BG_SLOT_COUNT; i++) {
+    const d = Math.abs(z - battlegroundOrigin(i).z);
+    if (d < bestD) { bestD = d; best = i; }
+  }
+  const o = battlegroundOrigin(best);
   return { x: o.x, z: o.z, slot: best };
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,11 +1,12 @@
 import {
-  ABILITIES, ARENA_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, dungeonAt,
+  ABILITIES, ARENA_SLOT_COUNT, BG_SLOT_COUNT, CAMPS, CLASSES, DUNGEONS, DUNGEON_LIST, DungeonDef, arenaOrigin, battlegroundOrigin, dungeonAt,
   DUNGEON_X_THRESHOLD, GROUND_OBJECTS, GROUP_XP_BONUS, INSTANCE_SLOT_COUNT, isArenaPos,
   ITEMS, MOBS, NPCS, PLAYER_START, QUESTS, questRewardItemId, abilitiesKnownAt, instanceOrigin,
   DEEPFEN_SHALLOWS_LAKE,
   zoneAt, ZONES,
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B, ARENA_SPAWNS_A_2v2, ARENA_SPAWNS_B_2v2 } from './dungeon_layout';
+import { BASES, SPEED_RUNES, TEAM_COLORS, TEAM_NAMES, type Team } from './battleground_layout';
 import { lineOfSightClear, resolvePosition } from './colliders';
 import { findPath } from './pathfind';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
@@ -78,6 +79,22 @@ const ARENA_BASE_RATING = 1500; // every character starts here, unranked
 const ARENA_MIN_RATING = 100; // a rating floor so a losing streak can't go absurd
 const ARENA_K_FACTOR = 32; // Elo sensitivity per match
 const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
+// Ravenrift — 5v5 ranked capture-the-flag (reuses eloDelta; K is ARENA_K_FACTOR)
+const BG_BASE_RATING = 1500; // every character starts here on the squad ladder
+const BG_MIN_RATING = 100; // squad-rating floor so a losing streak can't go absurd
+const BG_LADDER_SIZE = 10; // live online squad standings shipped to clients
+const BG_TEAM_SIZE = 5; // players per team — a full match is 5v5
+const BG_COUNTDOWN = 8; // pre-match gate: form up at your keep
+const BG_CAPS_TO_WIN = 5; // first team to this many flag captures wins
+const BG_MAX_DURATION = 900; // safety cap; a timed-out match resolves on score
+const BG_RESPAWN_DELAY = 6; // seconds dead before you respawn at your keep
+const BG_FLAG_RETURN_TIME = 12; // a dropped flag auto-returns home after this
+const BG_PICKUP_RADIUS = 2.5; // walk this close to grab a flag / return your own
+const BG_CAPTURE_RADIUS = 4; // carry the enemy flag this close to your stand to score
+const BG_RUNE_RADIUS = 2.5; // step this close to a speed rune to claim it
+const BG_RUNE_COOLDOWN = 22; // a claimed rune recharges over this
+const BG_RUNE_SPEED = 1.4; // sprint multiplier the rune grants
+const BG_RUNE_DURATION = 8; // seconds of haste per rune
 const PVP_ROOT_DR_RESET = 18; // seconds before a repeated PvP root is fresh again
 const PVP_POLYMORPH_DR_RESET = 60;
 const PVP_FEAR_DR_RESET = 60;
@@ -247,6 +264,47 @@ export function eloDelta(winnerRating: number, loserRating: number, score = 1): 
   return Math.round(ARENA_K_FACTOR * (score - expected));
 }
 
+// --- Ravenrift 5v5 capture-the-flag ---
+
+interface BgFlag {
+  team: Team; // home team
+  home: Vec3; // world-space stand position
+  pos: Vec3; // current world position (== carrier while carried)
+  state: 'home' | 'carried' | 'dropped';
+  carrier: number | null; // pid carrying this (enemy) flag
+  dropTimer: number; // counts a dropped flag down to its auto-return
+  entityId: number; // the ground entity that renders the flag
+}
+
+interface BgRune {
+  pos: Vec3; // world
+  active: boolean;
+  cooldown: number; // seconds until it recharges
+  entityId: number; // -1 while spent (the rune mesh despawns on cooldown)
+}
+
+// A live battleground. Two teams of pids, per-team scores, the two flags, the
+// speed runes, and the per-player return/respawn bookkeeping.
+export interface BgMatch {
+  id: number;
+  slot: number;
+  teams: [number[], number[]]; // pids, index = team
+  scores: [number, number];
+  flags: [BgFlag, BgFlag];
+  runes: BgRune[];
+  state: 'countdown' | 'active';
+  timer: number; // countdown remaining, then elapsed once active
+  ret: Map<number, { x: number; z: number; facing: number }>; // where each player queued from
+  respawn: Map<number, number>; // pid -> seconds until respawn (absent = alive)
+  ratingAvg: [number, number]; // team average rating at start, for Elo
+}
+
+// A queued group: a whole party (or a solo) that matchmaking keeps together.
+interface BgQueueGroup {
+  pids: number[];
+  ratingAvg: number;
+}
+
 export interface InstanceSlot {
   dungeonId: string;
   slot: number;
@@ -322,6 +380,10 @@ export interface PlayerMeta {
   arenaRating: number;
   arenaWins: number;
   arenaLosses: number;
+  // Ravenrift 5v5 squad standing — persisted in CharacterState
+  squadRating: number;
+  squadWins: number;
+  squadLosses: number;
   // Talents & Specializations. `talents` is the active allocation; `talentMods`
   // is its precomputed flat struct — resolved only on allocation/respec/loadout
   // change (recomputeTalents), never walked on the combat or stat hot path.
@@ -403,6 +465,10 @@ export interface CharacterState {
   arenaRating?: number;
   arenaWins?: number;
   arenaLosses?: number;
+  // Ravenrift squad standing (optional so pre-Ravenrift saves load cleanly)
+  squadRating?: number;
+  squadWins?: number;
+  squadLosses?: number;
   // Talents & Specializations (JSONB; no schema migration). All optional so
   // characters saved before talents existed load cleanly (default: no points spent).
   talents?: TalentAllocation;
@@ -529,6 +595,12 @@ export class Sim {
   arenaMatches = new Map<number, ArenaMatch>(); // pid -> shared match (both pids)
   private arenaBusySlots = new Set<number>();
   private nextArenaMatchId = 1;
+  // Ravenrift: queued party-groups, live matches keyed by every member pid,
+  // and the set of busy battleground slots
+  bgQueue: BgQueueGroup[] = [];
+  bgMatches = new Map<number, BgMatch>(); // pid -> shared match (all members)
+  private bgBusySlots = new Set<number>();
+  private nextBgMatchId = 1;
   // per-player chat token bucket (anti-spam); refilled lazily by sim time
   private chatTokens = new Map<number, { tokens: number; at: number }>();
   // per-player set of opt-in global channels (world, lfg) joined via /join
@@ -696,6 +768,9 @@ export class Sim {
       arenaRating: opts?.state?.arenaRating ?? ARENA_BASE_RATING,
       arenaWins: opts?.state?.arenaWins ?? 0,
       arenaLosses: opts?.state?.arenaLosses ?? 0,
+      squadRating: opts?.state?.squadRating ?? BG_BASE_RATING,
+      squadWins: opts?.state?.squadWins ?? 0,
+      squadLosses: opts?.state?.squadLosses ?? 0,
       talents: emptyAllocation(),
       talentMods: emptyModifiers(),
       loadouts: [],
@@ -767,6 +842,11 @@ export class Sim {
       const team = this.arenaTeamOf(match, pid);
       this.endArenaMatch(match, team === 'A' ? 'B' : team === 'B' ? 'A' : null, 'forfeit');
     }
+    // battleground: drop out of the queue, and leave any live match (the team
+    // fights on a player down)
+    this.bgDequeue(pid);
+    const bg = this.bgMatches.get(pid);
+    if (bg) this.bgRemovePlayer(bg, pid);
     this.partyInvites.delete(pid);
     this.tradeInvites.delete(pid);
     this.duelInvites.delete(pid);
@@ -821,6 +901,9 @@ export class Sim {
       arenaRating: meta.arenaRating,
       arenaWins: meta.arenaWins,
       arenaLosses: meta.arenaLosses,
+      squadRating: meta.squadRating,
+      squadWins: meta.squadWins,
+      squadLosses: meta.squadLosses,
       talents: cloneAllocation(meta.talents),
       loadouts: meta.loadouts.map((l) => ({ name: l.name, alloc: cloneAllocation(l.alloc), bar: [...l.bar] })),
       activeLoadout: meta.activeLoadout,
@@ -1286,6 +1369,7 @@ export class Sim {
 
     this.updateDuels();
     this.updateArena();
+    this.updateBg();
     this.updateTradesAndInvites();
     this.updateInstances();
     this.updateMarket();
@@ -3436,6 +3520,13 @@ export class Sim {
       e.chargePath = [];
       e.followTargetId = null;
       this.emit({ type: 'playerDeath', pid: e.id });
+      // in a battleground you don't run to a graveyard — drop any flag you were
+      // carrying and queue a timed respawn back at your keep
+      const bg = this.bgMatches.get(e.id);
+      if (bg && bg.state === 'active') {
+        this.bgDropFlagsHeldBy(bg, e, killer);
+        bg.respawn.set(e.id, BG_RESPAWN_DELAY);
+      }
       for (const m of this.entities.values()) {
         if (m.kind === 'mob' && !m.dead && m.aggroTargetId === e.id && m.aiState !== 'dead') {
           // turn on the next nearby attacker; go home only if nobody is left
@@ -5332,6 +5423,9 @@ export class Sim {
     const { meta, e: p } = r;
     if (!p.dead) return;
     if (this.arenaMatches.has(p.id)) return;
+    // in a battleground the keep respawn is automatic and timed — releasing does
+    // nothing (you can't graveyard-walk out of the match)
+    if (this.bgMatches.has(p.id)) return;
     p.dead = false;
     // dying in a dungeon sends you to the graveyard of the zone its door is
     // in; dying outdoors, to your current zone's graveyard
@@ -5862,6 +5956,11 @@ export class Sim {
       if (duel && duel.state === 'active'
         && ((duel.a === attackerPlayer.id && duel.b === target.id)
           || (duel.b === attackerPlayer.id && duel.a === target.id))) return true;
+      // battleground: hostile to the other team, friendly to your own
+      const bg = this.bgMatches.get(attackerPlayer.id);
+      if (bg && bg.state === 'active' && this.bgMatches.get(target.id) === bg) {
+        return this.bgTeamOf(bg, attackerPlayer.id) !== this.bgTeamOf(bg, target.id);
+      }
       const match = this.arenaMatches.get(attackerPlayer.id);
       return !!match && match.state === 'active' && !match.defeated.has(attackerPlayer.id)
         && this.isArenaCrossTeam(match, attackerPlayer.id, target.id);
@@ -6787,6 +6886,508 @@ export class Sim {
   }
 
   // -------------------------------------------------------------------------
+  // Ravenrift — 5v5 ranked capture-the-flag battleground
+  // -------------------------------------------------------------------------
+
+  // A clean slate so the bout is decided by play, not by what each fighter
+  // walked in carrying: full health/resource, cooldowns and combat reset.
+  private resetForBg(e: Entity): void {
+    const meta = this.players.get(e.id);
+    if (meta) recalcPlayerStats(e, meta.cls, meta.equipment, meta.talentMods);
+    e.auras = [];
+    e.ccDr.clear();
+    e.hp = e.maxHp;
+    e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
+    e.targetId = null;
+    e.autoAttack = false;
+    e.queuedOnSwing = null;
+    e.castingAbility = null;
+    e.castRemaining = 0;
+    e.channeling = false;
+    e.comboPoints = 0;
+    e.comboTargetId = null;
+    e.cooldowns.clear();
+    e.gcdRemaining = 0;
+    e.swingTimer = 0;
+    e.chargeTargetId = null;
+    e.chargePath = [];
+    e.combatTimer = 99;
+    e.inCombat = false;
+    e.sitting = false;
+    e.eating = null;
+    e.drinking = null;
+  }
+
+  bgQueueJoin(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const id = r.meta.entityId;
+    if (this.bgMatches.has(id)) { this.error(id, 'You are already in a battleground.'); return; }
+    if (r.e.dead) { this.error(id, 'You cannot queue for Ravenrift while dead.'); return; }
+    if (r.e.pos.x > DUNGEON_X_THRESHOLD) { this.error(id, 'You cannot queue from inside an instance.'); return; }
+    // queue the whole party as one group (kept together by matchmaking); solo
+    // players queue alone. Any eligible member can put the party in.
+    const party = this.partyOf(id);
+    const members = party ? party.members.slice(0, BG_TEAM_SIZE) : [id];
+    if (this.bgGroupContaining(id)) {
+      this.emit({ type: 'bgQueued', position: this.bgQueueSize(), pid: id });
+      return;
+    }
+    for (const m of members) {
+      if (this.bgMatches.has(m) || this.bgGroupContaining(m)) { this.error(id, 'A party member is already queued or in a match.'); return; }
+    }
+    const ratingAvg = members.reduce((s, m) => s + (this.players.get(m)?.squadRating ?? BG_BASE_RATING), 0) / members.length;
+    this.bgQueue.push({ pids: [...members], ratingAvg });
+    for (const m of members) {
+      this.emit({ type: 'bgQueued', position: this.bgQueueSize(), pid: m });
+      this.emit({ type: 'log', text: party && members.length > 1
+        ? `Your party of ${members.length} joins the Ravenrift queue.`
+        : 'You join the Ravenrift queue. Need 10 champions to start a match…', color: '#7fd4ff', pid: m });
+    }
+  }
+
+  bgQueueLeave(pid?: number): void {
+    const r = this.resolve(pid);
+    if (!r) return;
+    const group = this.bgGroupContaining(r.meta.entityId);
+    if (!group) return;
+    this.bgQueue = this.bgQueue.filter((g) => g !== group);
+    for (const m of group.pids) {
+      this.emit({ type: 'bgUnqueued', pid: m });
+      this.emit({ type: 'log', text: 'You leave the Ravenrift queue.', color: '#7fd4ff', pid: m });
+    }
+  }
+
+  private bgGroupContaining(pid: number): BgQueueGroup | null {
+    return this.bgQueue.find((g) => g.pids.includes(pid)) ?? null;
+  }
+
+  private bgDequeue(pid: number): boolean {
+    const group = this.bgGroupContaining(pid);
+    if (!group) return false;
+    group.pids = group.pids.filter((p) => p !== pid);
+    if (group.pids.length === 0) this.bgQueue = this.bgQueue.filter((g) => g !== group);
+    return true;
+  }
+
+  private bgQueueSize(): number {
+    return this.bgQueue.reduce((s, g) => s + g.pids.length, 0);
+  }
+
+  private freeBgSlot(): number | null {
+    for (let i = 0; i < BG_SLOT_COUNT; i++) if (!this.bgBusySlots.has(i)) return i;
+    return null;
+  }
+
+  bgTeamOf(match: BgMatch, pid: number): Team {
+    return match.teams[1].includes(pid) ? 1 : 0;
+  }
+
+  bgMatchFor(pid: number): BgMatch | null {
+    return this.bgMatches.get(pid) ?? null;
+  }
+
+  private updateBg(): void {
+    this.matchmakeBg();
+    const seen = new Set<BgMatch>();
+    for (const match of this.bgMatches.values()) {
+      if (seen.has(match)) continue;
+      seen.add(match);
+      if (match.state === 'countdown') {
+        const before = Math.ceil(match.timer);
+        match.timer -= DT;
+        const after = Math.ceil(match.timer);
+        if (after < before && after > 0) {
+          for (const mp of this.bgAll(match)) this.emit({ type: 'bgCountdown', seconds: after, pid: mp });
+        }
+        if (match.timer <= 0) {
+          match.state = 'active';
+          match.timer = 0;
+          for (const mp of this.bgAll(match)) {
+            const e = this.entities.get(mp);
+            if (e) this.resetForBg(e);
+            this.emit({ type: 'log', text: 'The Ravenrift battle begins — take their flag!', color: '#ff5a3c', pid: mp });
+            this.emit({ type: 'bgStart', pid: mp });
+          }
+        }
+        continue;
+      }
+      match.timer += DT;
+      this.bgTickRespawns(match);
+      this.bgTickRunes(match);
+      this.bgTickFlags(match);
+      if (match.timer >= BG_MAX_DURATION) {
+        const w = match.scores[0] === match.scores[1] ? null : match.scores[0] > match.scores[1] ? 0 : 1;
+        this.endBgMatch(match, w, 'timeout');
+      }
+    }
+  }
+
+  private bgAll(match: BgMatch): number[] {
+    return [...match.teams[0], ...match.teams[1]];
+  }
+
+  private bgEmitAll(match: BgMatch, ev: (pid: number) => SimEvent): void {
+    for (const mp of this.bgAll(match)) this.emit(ev(mp));
+  }
+
+  private matchmakeBg(): void {
+    let guard = BG_SLOT_COUNT + 1;
+    while (guard-- > 0) {
+      // drop members who went offline/died/left while waiting
+      for (const g of this.bgQueue) g.pids = g.pids.filter((p) => this.entities.get(p) && !this.entities.get(p)!.dead && !this.bgMatches.has(p));
+      this.bgQueue = this.bgQueue.filter((g) => g.pids.length > 0);
+      if (this.bgQueueSize() < BG_TEAM_SIZE * 2 || this.freeBgSlot() === null) return;
+      // greedily pack whole groups into two teams of five, balancing headcount
+      const groups = [...this.bgQueue].sort((a, b) => b.pids.length - a.pids.length);
+      const teams: [number[], number[]] = [[], []];
+      const used: BgQueueGroup[] = [];
+      for (const g of groups) {
+        const canA = teams[0].length + g.pids.length <= BG_TEAM_SIZE;
+        const canB = teams[1].length + g.pids.length <= BG_TEAM_SIZE;
+        let t = -1;
+        if (canA && canB) t = teams[0].length <= teams[1].length ? 0 : 1;
+        else if (canA) t = 0;
+        else if (canB) t = 1;
+        if (t < 0) continue;
+        teams[t].push(...g.pids);
+        used.push(g);
+      }
+      if (teams[0].length !== BG_TEAM_SIZE || teams[1].length !== BG_TEAM_SIZE) return; // can't form 5v5 yet
+      this.bgQueue = this.bgQueue.filter((g) => !used.includes(g));
+      this.startBgMatch(teams[0], teams[1]);
+    }
+  }
+
+  private startBgMatch(teamA: number[], teamB: number[]): void {
+    const slot = this.freeBgSlot();
+    if (slot === null) { this.bgQueue.unshift({ pids: [...teamA, ...teamB], ratingAvg: BG_BASE_RATING }); return; }
+    this.bgBusySlots.add(slot);
+    const origin = battlegroundOrigin(slot);
+    const ret = new Map<number, { x: number; z: number; facing: number }>();
+    for (const pid of [...teamA, ...teamB]) {
+      const e = this.entities.get(pid);
+      if (e) ret.set(pid, { x: e.pos.x, z: e.pos.z, facing: e.facing });
+    }
+    const flags: [BgFlag, BgFlag] = ([0, 1] as Team[]).map((team) => {
+      const home = this.groundPos(origin.x + BASES[team].flag.x, origin.z + BASES[team].flag.z);
+      return { team, home, pos: { ...home }, state: 'home' as const, carrier: null, dropTimer: 0, entityId: -1 };
+    }) as [BgFlag, BgFlag];
+    const runes: BgRune[] = SPEED_RUNES.map((rp) => ({
+      pos: this.groundPos(origin.x + rp.x, origin.z + rp.z), active: true, cooldown: 0, entityId: -1,
+    }));
+    const match: BgMatch = {
+      id: this.nextBgMatchId++, slot, teams: [teamA, teamB], scores: [0, 0], flags, runes,
+      state: 'countdown', timer: BG_COUNTDOWN, ret,
+      respawn: new Map(),
+      ratingAvg: [this.bgTeamAvg(teamA), this.bgTeamAvg(teamB)],
+    };
+    for (const pid of this.bgAll(match)) this.bgMatches.set(pid, match);
+    for (const flag of flags) this.bgSpawnFlagEntity(flag);
+    for (const rune of runes) this.bgSpawnRuneEntity(rune);
+    // seat each team at its keep
+    for (const team of [0, 1] as Team[]) {
+      match.teams[team].forEach((pid, i) => this.bgSpawnPlayer(match, pid, team, i));
+    }
+    for (const team of [0, 1] as Team[]) {
+      for (const pid of match.teams[team]) {
+        this.emit({ type: 'bgFound', team, pid });
+        this.emit({ type: 'bgCountdown', seconds: BG_COUNTDOWN, pid });
+        this.emit({ type: 'log', text: `Ravenrift: you fight for the ${TEAM_NAMES[team]}. First to ${BG_CAPS_TO_WIN} captures wins.`, color: '#7fd4ff', pid });
+      }
+    }
+  }
+
+  private bgTeamAvg(pids: number[]): number {
+    if (pids.length === 0) return BG_BASE_RATING;
+    return pids.reduce((s, p) => s + (this.players.get(p)?.squadRating ?? BG_BASE_RATING), 0) / pids.length;
+  }
+
+  // Place a player at one of their keep's spawn points (round-robin by index),
+  // healed and reset for the fight.
+  private bgSpawnPlayer(match: BgMatch, pid: number, team: Team, index: number): void {
+    const e = this.entities.get(pid);
+    if (!e) return;
+    const origin = battlegroundOrigin(match.slot);
+    const spawns = BASES[team].spawns;
+    const sp = spawns[index % spawns.length];
+    e.pos = this.groundPos(origin.x + sp.x, origin.z + sp.z);
+    e.prevPos = { ...e.pos };
+    e.facing = team === 0 ? 0 : Math.PI; // face the field
+    e.prevFacing = e.facing;
+    this.rebucket(e);
+    this.resetForBg(e);
+  }
+
+  private bgSpawnFlagEntity(flag: BgFlag): void {
+    const e = createGroundObject(this.nextId++, '', `${TEAM_NAMES[flag.team]} Flag`, { ...flag.pos });
+    e.templateId = 'bg_flag';
+    e.objectItemId = null;
+    e.lootable = false;
+    e.color = TEAM_COLORS[flag.team];
+    this.addEntity(e);
+    flag.entityId = e.id;
+  }
+
+  private bgSpawnRuneEntity(rune: BgRune): void {
+    const e = createGroundObject(this.nextId++, '', 'Sprint Rune', { ...rune.pos });
+    e.templateId = 'bg_rune';
+    e.objectItemId = null;
+    e.lootable = false;
+    e.color = 0xffd24a;
+    this.addEntity(e);
+    rune.entityId = e.id;
+  }
+
+  private bgTickRespawns(match: BgMatch): void {
+    for (const [pid, t] of [...match.respawn]) {
+      const left = t - DT;
+      if (left > 0) { match.respawn.set(pid, left); continue; }
+      match.respawn.delete(pid);
+      const e = this.entities.get(pid);
+      if (!e) continue;
+      e.dead = false;
+      const team = this.bgTeamOf(match, pid);
+      const idx = match.teams[team].indexOf(pid);
+      this.bgSpawnPlayer(match, pid, team, idx < 0 ? 0 : idx);
+      this.emit({ type: 'respawn', pid });
+    }
+  }
+
+  private bgTickRunes(match: BgMatch): void {
+    for (const rune of match.runes) {
+      if (!rune.active) {
+        rune.cooldown -= DT;
+        if (rune.cooldown <= 0) { rune.active = true; this.bgSpawnRuneEntity(rune); }
+        continue;
+      }
+      // first live player to step on it claims the sprint
+      for (const pid of this.bgAll(match)) {
+        const e = this.entities.get(pid);
+        if (!e || e.dead) continue;
+        if (dist2d(e.pos, rune.pos) <= BG_RUNE_RADIUS) {
+          this.applyAura(e, {
+            id: 'sprint_rune', name: 'Sprint', kind: 'buff_speed', value: BG_RUNE_SPEED,
+            remaining: BG_RUNE_DURATION, duration: BG_RUNE_DURATION, sourceId: e.id, school: 'physical',
+          });
+          rune.active = false;
+          rune.cooldown = BG_RUNE_COOLDOWN;
+          if (rune.entityId >= 0) { this.dropEntity(rune.entityId); rune.entityId = -1; }
+          this.emit({ type: 'log', text: 'You seize a Sprint Rune!', color: '#ffd24a', pid });
+          break;
+        }
+      }
+    }
+  }
+
+  private bgTickFlags(match: BgMatch): void {
+    for (const flag of match.flags) {
+      if (flag.state === 'carried') {
+        const carrier = flag.carrier !== null ? this.entities.get(flag.carrier) : null;
+        if (!carrier || carrier.dead || this.bgMatches.get(flag.carrier!) !== match) {
+          this.bgDropFlag(match, flag, carrier ?? null);
+        } else {
+          flag.pos = { ...carrier.pos };
+          this.bgSyncFlagEntity(flag);
+          // captured: carry the enemy flag home to your own stand
+          const carrierTeam = this.bgTeamOf(match, flag.carrier!);
+          const ownHome = match.flags[carrierTeam].home;
+          if (dist2d(carrier.pos, ownHome) <= BG_CAPTURE_RADIUS) {
+            this.bgCapture(match, flag, carrierTeam);
+          }
+        }
+        continue;
+      }
+      // home or dropped: enemies grab it, friends return a dropped one
+      for (const pid of this.bgAll(match)) {
+        const e = this.entities.get(pid);
+        if (!e || e.dead) continue;
+        const team = this.bgTeamOf(match, pid);
+        const d = dist2d(e.pos, flag.pos);
+        if (team !== flag.team && d <= BG_PICKUP_RADIUS && !this.bgIsCarrying(match, pid)) {
+          flag.state = 'carried'; flag.carrier = pid;
+          this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'taken', team: flag.team, byName: this.players.get(pid)?.name ?? '?', scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+          break;
+        }
+        if (team === flag.team && flag.state === 'dropped' && d <= BG_PICKUP_RADIUS) {
+          this.bgReturnFlag(match, flag, this.players.get(pid)?.name ?? '?');
+          break;
+        }
+      }
+      if (flag.state === 'dropped') {
+        flag.dropTimer -= DT;
+        if (flag.dropTimer <= 0) this.bgReturnFlag(match, flag, '');
+        else this.bgSyncFlagEntity(flag);
+      }
+    }
+  }
+
+  private bgIsCarrying(match: BgMatch, pid: number): boolean {
+    return match.flags.some((f) => f.carrier === pid);
+  }
+
+  private bgSyncFlagEntity(flag: BgFlag): void {
+    const e = this.entities.get(flag.entityId);
+    if (!e) return;
+    e.pos = { ...flag.pos };
+    e.prevPos = { ...flag.pos };
+    this.rebucket(e);
+  }
+
+  private bgCapture(match: BgMatch, flag: BgFlag, scoringTeam: Team): void {
+    const carrierName = flag.carrier !== null ? this.players.get(flag.carrier)?.name ?? '?' : '?';
+    match.scores[scoringTeam]++;
+    this.bgReturnFlag(match, flag, '', true); // the captured flag resets home
+    this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'captured', team: flag.team, byName: carrierName, scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+    if (match.scores[scoringTeam] >= BG_CAPS_TO_WIN) this.endBgMatch(match, scoringTeam, 'caps');
+  }
+
+  // Returns a flag to its stand. `silent` skips the event (capture emits its own).
+  private bgReturnFlag(match: BgMatch, flag: BgFlag, byName: string, silent = false): void {
+    flag.state = 'home'; flag.carrier = null; flag.dropTimer = 0;
+    flag.pos = { ...flag.home };
+    this.bgSyncFlagEntity(flag);
+    if (!silent) {
+      this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'returned', team: flag.team, byName, scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+    }
+  }
+
+  private bgDropFlag(match: BgMatch, flag: BgFlag, at: Entity | null): void {
+    const carrierName = flag.carrier !== null ? this.players.get(flag.carrier)?.name ?? '?' : '?';
+    flag.state = 'dropped'; flag.carrier = null; flag.dropTimer = BG_FLAG_RETURN_TIME;
+    if (at) flag.pos = { ...at.pos };
+    this.bgSyncFlagEntity(flag);
+    this.bgEmitAll(match, (mp) => ({ type: 'bgFlag', action: 'dropped', team: flag.team, byName: carrierName, scoreCrimson: match.scores[0], scoreAzure: match.scores[1], pid: mp }));
+  }
+
+  private bgDropFlagsHeldBy(match: BgMatch, e: Entity, _killer: Entity | null): void {
+    for (const flag of match.flags) {
+      if (flag.carrier === e.id) this.bgDropFlag(match, flag, e);
+    }
+  }
+
+  private bgRemovePlayer(match: BgMatch, pid: number): void {
+    for (const flag of match.flags) {
+      if (flag.carrier === pid) this.bgDropFlag(match, flag, this.entities.get(pid) ?? null);
+    }
+    const team = this.bgTeamOf(match, pid);
+    match.teams[team] = match.teams[team].filter((p) => p !== pid);
+    match.respawn.delete(pid);
+    match.ret.delete(pid);
+    this.bgMatches.delete(pid);
+    // a fully-vacated side ends the match in the other team's favour
+    if (match.teams[0].length === 0 || match.teams[1].length === 0) {
+      const winner = match.teams[0].length === 0 && match.teams[1].length === 0
+        ? null : match.teams[0].length === 0 ? 1 : 0;
+      this.endBgMatch(match, winner, 'forfeit');
+    }
+  }
+
+  // winnerTeam null = draw
+  private endBgMatch(match: BgMatch, winnerTeam: Team | null, _reason: 'caps' | 'timeout' | 'forfeit'): void {
+    for (const pid of this.bgAll(match)) this.bgMatches.delete(pid);
+    this.bgBusySlots.delete(match.slot);
+    for (const flag of match.flags) if (flag.entityId >= 0 && this.entities.has(flag.entityId)) this.dropEntity(flag.entityId);
+    for (const rune of match.runes) if (rune.entityId >= 0 && this.entities.has(rune.entityId)) this.dropEntity(rune.entityId);
+
+    const score0 = winnerTeam === null ? 0.5 : winnerTeam === 0 ? 1 : 0;
+    const delta0 = eloDelta(match.ratingAvg[0], match.ratingAvg[1], score0);
+    const delta1 = eloDelta(match.ratingAvg[1], match.ratingAvg[0], 1 - score0);
+    for (const team of [0, 1] as Team[]) {
+      const delta = team === 0 ? delta0 : delta1;
+      for (const pid of match.teams[team]) {
+        const meta = this.players.get(pid);
+        const e = this.entities.get(pid);
+        if (!meta) continue;
+        const before = meta.squadRating;
+        meta.squadRating = Math.max(BG_MIN_RATING, before + delta);
+        if (winnerTeam === null) { /* draw: no W/L */ }
+        else if (winnerTeam === team) meta.squadWins++;
+        else meta.squadLosses++;
+        this.emit({
+          type: 'bgEnd', pid, draw: winnerTeam === null, won: winnerTeam === team,
+          scoreCrimson: match.scores[0], scoreAzure: match.scores[1],
+          ratingBefore: before, ratingAfter: meta.squadRating,
+        });
+        // restore the fighter to where they queued from, healed and out of combat
+        if (e) {
+          const ret = match.ret.get(pid);
+          if (ret) { e.pos = this.groundPos(ret.x, ret.z); e.prevPos = { ...e.pos }; e.facing = ret.facing; this.rebucket(e); }
+          e.auras = []; e.ccDr.clear(); e.dead = false;
+          recalcPlayerStats(e, meta.cls, meta.equipment, meta.talentMods);
+          e.hp = e.maxHp;
+          e.resource = e.resourceType === 'mana' ? e.maxResource : e.resourceType === 'energy' ? 100 : 0;
+          e.targetId = null; e.autoAttack = false; e.castingAbility = null; e.channeling = false;
+          e.combatTimer = 99; e.inCombat = false;
+          this.emit({ type: 'respawn', pid });
+        }
+      }
+    }
+  }
+
+  // Live squad standings of rated players currently online, best first.
+  squadLadder(): import('../world_api').SquadLadderEntry[] {
+    const rows: import('../world_api').SquadLadderEntry[] = [];
+    for (const meta of this.players.values()) {
+      if (!this.entities.get(meta.entityId)) continue;
+      rows.push({ pid: meta.entityId, name: meta.name, cls: meta.cls, rating: meta.squadRating, wins: meta.squadWins, losses: meta.squadLosses });
+    }
+    rows.sort((x, y) => y.rating - x.rating || y.wins - x.wins);
+    return rows.slice(0, BG_LADDER_SIZE);
+  }
+
+  bgInfoFor(pid: number): import('../world_api').BgInfo | null {
+    const meta = this.players.get(pid);
+    if (!meta) return null;
+    const match = this.bgMatches.get(pid);
+    let matchInfo: import('../world_api').BgMatchInfo | null = null;
+    if (match) {
+      const myTeam = this.bgTeamOf(match, pid);
+      const flags = match.flags.map((f): import('../world_api').BgFlagInfo => ({
+        state: f.state,
+        carrierName: f.carrier !== null ? this.players.get(f.carrier)?.name ?? null : null,
+        carrierTeam: f.carrier !== null ? this.bgTeamOf(match, f.carrier) : null,
+      })) as [import('../world_api').BgFlagInfo, import('../world_api').BgFlagInfo];
+      const players: import('../world_api').BgPlayerInfo[] = [];
+      for (const team of [0, 1] as Team[]) {
+        for (const mp of match.teams[team]) {
+          const e = this.entities.get(mp);
+          const m = this.players.get(mp);
+          if (!e || !m) continue;
+          players.push({ pid: mp, name: m.name, cls: m.cls, team, carrying: this.bgIsCarrying(match, mp), dead: e.dead, hp: e.hp, mhp: e.maxHp });
+        }
+      }
+      matchInfo = {
+        state: match.state, myTeam, capsToWin: BG_CAPS_TO_WIN,
+        scores: [match.scores[0], match.scores[1]], flags, players,
+        respawnIn: Math.ceil(match.respawn.get(pid) ?? 0),
+      };
+    }
+    const group = this.bgGroupContaining(pid);
+    return {
+      rating: meta.squadRating, wins: meta.squadWins, losses: meta.squadLosses,
+      queued: group !== null, queueSize: this.bgQueueSize(), queuedParty: group?.pids.length ?? 1,
+      match: matchInfo, ladder: this.squadLadder(),
+    };
+  }
+
+  // Dev/test only: force-start a battleground from whoever is queued, split into
+  // two teams even if there aren't a full ten. Server-gated behind
+  // ALLOW_DEV_COMMANDS so it never runs in production.
+  devStartBg(): void {
+    const pids = this.bgQueue.flatMap((g) => g.pids).filter((p) => this.entities.get(p) && !this.bgMatches.has(p));
+    if (pids.length < 2) return;
+    const take = pids.slice(0, BG_TEAM_SIZE * 2);
+    const half = Math.ceil(take.length / 2);
+    const teamA = take.slice(0, half);
+    const teamB = take.slice(half);
+    this.bgQueue = this.bgQueue
+      .map((g) => ({ ...g, pids: g.pids.filter((p) => !take.includes(p)) }))
+      .filter((g) => g.pids.length > 0);
+    this.startBgMatch(teamA, teamB);
+  }
+
+  // -------------------------------------------------------------------------
   // Trading
   // -------------------------------------------------------------------------
 
@@ -7370,6 +7971,10 @@ export class Sim {
 
   get arenaInfo(): import('../world_api').ArenaInfo | null {
     return this.primaryId === -1 ? null : this.arenaInfoFor(this.primaryId);
+  }
+
+  get bgInfo(): import('../world_api').BgInfo | null {
+    return this.primaryId === -1 ? null : this.bgInfoFor(this.primaryId);
   }
 
   get marketInfo(): import('../world_api').MarketInfo | null {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -663,6 +663,15 @@ export type SimEvent = { pid?: number } & (
   | { type: 'arenaCountdown'; seconds: number }
   | { type: 'arenaStart' }
   | { type: 'arenaEnd'; format: ArenaFormat; won: boolean; draw: boolean; oppName: string; ratingBefore: number; ratingAfter: number; allies: ArenaCombatant[]; enemies: ArenaCombatant[] }
+  // Ravenrift 5v5 capture-the-flag: queue state, match lifecycle, flag plays,
+  // and the squad-rating result. Personal (carry a `pid`).
+  | { type: 'bgQueued'; position: number }
+  | { type: 'bgUnqueued' }
+  | { type: 'bgFound'; team: number }
+  | { type: 'bgCountdown'; seconds: number }
+  | { type: 'bgStart' }
+  | { type: 'bgFlag'; action: 'taken' | 'dropped' | 'returned' | 'captured'; team: number; byName: string; scoreCrimson: number; scoreAzure: number }
+  | { type: 'bgEnd'; won: boolean; draw: boolean; scoreCrimson: number; scoreAzure: number; ratingBefore: number; ratingAfter: number }
   | { type: 'heal2'; sourceId: number; targetId: number; amount: number; crit: boolean; ability: string }
   // visual-only cue for the renderer: spell projectiles, dot ticks, aoe novas
   | { type: 'spellfx'; sourceId: number; targetId: number; school: string; fx: 'projectile' | 'tick' | 'nova' }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -298,6 +298,11 @@ export class Hud {
   // all-time ladder, fetched best-effort from the server (online only)
   private arenaAllTime: { name: string; class: string; level: number; rating: number; wins: number; losses: number }[] | null = null;
   private arenaLbFetchedAt = 0;
+  // Ravenrift 5v5 capture-the-flag panel + scoreboard
+  private lastBgSig = '';
+  private lastBgScoreSig = '';
+  private bgAllTime: { name: string; class: string; level: number; rating: number; wins: number; losses: number }[] | null = null;
+  private bgLbFetchedAt = 0;
   private lastCombatEventAt = 0;
   private lastZoneId = '';
   private mapZoneId = ''; // zone the cached map-window canvas was rendered for
@@ -452,6 +457,7 @@ export class Hud {
     $('#mm-social').addEventListener('click', () => this.toggleSocial());
     $('#mm-options')?.addEventListener('click', () => this.toggleOptionsMenu());
     $('#mm-arena').addEventListener('click', () => this.toggleArena());
+    $('#mm-bg')?.addEventListener('click', () => this.toggleBg());
     $('#mm-leaderboard').addEventListener('click', () => this.toggleLeaderboard());
     const emoteBtn = $('#mm-emote');
     emoteBtn.addEventListener('click', (ev) => {
@@ -1751,8 +1757,20 @@ export class Hud {
     $('#xpbar').classList.toggle('overflow', bar.postCap);
 
     const deadInArena = p.dead && !!this.sim.arenaInfo?.match;
+    // a battleground death is a timed keep respawn (no graveyard run): hide the
+    // release button and show the countdown instead
+    const bgMatch = this.sim.bgInfo?.match ?? null;
+    const deadInBg = p.dead && !!bgMatch;
+    const bgRespawnIn = bgMatch?.respawnIn ?? 0;
     this.setDisplay(this.deathOverlayEl, p.dead ? 'flex' : 'none');
-    this.setDisplay(this.releaseSpiritBtnEl, deadInArena ? 'none' : '');
+    this.setDisplay(this.releaseSpiritBtnEl, (deadInArena || deadInBg) ? 'none' : '');
+    const bgRespawnEl = $('#bg-respawn');
+    if (deadInBg && bgRespawnIn > 0) {
+      this.setText(bgRespawnEl, `Respawning at your keep in ${bgRespawnIn}…`);
+      this.setDisplay(bgRespawnEl, 'block');
+    } else {
+      this.setDisplay(bgRespawnEl, 'none');
+    }
 
     const inDungeon = p.pos.x > DUNGEON_X_THRESHOLD;
     const currentZone = zoneAt(p.pos.z);
@@ -1797,8 +1815,10 @@ export class Hud {
       this.updatePartyFrames();
       this.updateTradeWindow();
       this.updateArenaStatus();
+      this.updateBgScoreboard();
       if ($('#map-window').style.display === 'block') this.updateMapWindow();
       if ($('#arena-window').style.display === 'block') this.renderArenaWindow();
+      if ($('#bg-window').style.display === 'block') this.renderBgWindow();
       if (this.openLootMobId !== null) {
         const mob = sim.entities.get(this.openLootMobId);
         if (!mob || !mob.lootable || dist2d(p.pos, mob.pos) > 7) this.closeLoot();
@@ -2246,6 +2266,107 @@ export class Hud {
     if (sig !== this.lastArenaStatusSig) {
       this.lastArenaStatusSig = sig;
       el.innerHTML = `${vsBlock}<div class="as-timer">${esc(label)}</div>`;
+      el.style.display = 'block';
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Ravenrift — 5v5 capture-the-flag panel + in-match scoreboard
+  // -------------------------------------------------------------------------
+
+  toggleBg(): void {
+    const el = $('#bg-window');
+    if (el.style.display === 'block') { el.style.display = 'none'; return; }
+    this.closeOtherWindows('#bg-window');
+    el.style.display = 'block';
+    this.lastBgSig = '';
+    this.fetchBgLeaderboard();
+    this.renderBgWindow();
+  }
+
+  private fetchBgLeaderboard(): void {
+    const now = performance.now();
+    if (now - this.bgLbFetchedAt < 15000) return;
+    this.bgLbFetchedAt = now;
+    fetch('/api/squad/leaderboard')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (d && Array.isArray(d.leaders)) { this.bgAllTime = d.leaders; this.lastBgSig = ''; } })
+      .catch(() => { /* offline — live ladder only */ });
+  }
+
+  private renderBgWindow(): void {
+    const el = $('#bg-window');
+    const b = this.sim.bgInfo;
+    if (!b) {
+      el.innerHTML = `<div class="panel-title"><span>Ravenrift</span><span class="x-btn" data-close>✕</span></div>`
+        + `<div class="bg-note">Ravenrift is a ranked 5v5 capture-the-flag battleground for the live world. Play online, group up to 5, and queue together.</div>`;
+      el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; });
+      return;
+    }
+    const inMatch = b.match !== null;
+    const party = this.sim.partyInfo;
+    const partySize = party ? party.members.length : 1;
+    const ladderRow = (r: { pid?: number; name: string; cls?: string; class?: string; rating: number; wins: number; losses: number }, i: number) => {
+      const me = (r.pid !== undefined && r.pid === this.sim.playerId) || r.name === this.sim.player.name;
+      const clsKey = (r.cls ?? r.class ?? '') as keyof typeof CLASSES;
+      const cls = CLASSES[clsKey]?.name ?? (r.cls ?? r.class ?? '');
+      return `<div class="ladder-row${me ? ' me' : ''}"><span class="rank">${i + 1}</span>`
+        + `<span class="lr-name" title="${esc(r.name)} — ${esc(cls)}">${esc(r.name)}</span>`
+        + `<span class="lr-rating">${r.rating}</span><span class="lr-wl">${r.wins}-${r.losses}</span></div>`;
+    };
+    const online = b.ladder.map(ladderRow).join('') || `<div class="ladder-empty">No squads ranked yet — be the first.</div>`;
+    this.fetchBgLeaderboard();
+    const allTimeRows = (this.bgAllTime ?? []).map(ladderRow).join('');
+    const allTime = this.bgAllTime && this.bgAllTime.length > 0 ? `<div class="bg-sub">Ladder — All-Time</div>${allTimeRows}` : '';
+
+    let action: string;
+    if (inMatch) {
+      action = `<div class="bg-queue-status">⚑ Battle in progress — ${b.match!.scores[0]}–${b.match!.scores[1]}.</div>`;
+    } else if (b.queued) {
+      action = `<button class="btn leave" data-act="leave">Leave Queue</button>`
+        + `<div class="bg-queue-status">Searching… ${b.queueSize}/10 in queue${b.queuedParty > 1 ? ` · party of ${b.queuedParty}` : ''}.</div>`;
+    } else {
+      action = `<button class="btn" data-act="queue">Enter the Queue${partySize > 1 ? ` (party of ${partySize})` : ''}</button>`
+        + `<div class="bg-note">Two teams of five. Steal the enemy banner and run it to your keep — first to 5 captures wins. Grab Sprint Runes to fly across the field, and weave the cover to lose your pursuers. Group up to bring your squad.</div>`;
+    }
+
+    const sig = JSON.stringify([b.rating, b.wins, b.losses, b.queued, b.queueSize, b.queuedParty, inMatch, partySize, b.ladder, this.bgAllTime]);
+    if (sig === this.lastBgSig) return;
+    this.lastBgSig = sig;
+    el.innerHTML = `<div class="panel-title"><span>Ravenrift <span style="color:#998d6a;font-size:11px">5v5 Capture the Flag</span></span><span class="x-btn" data-close>✕</span></div>`
+      + `<div class="bg-rank"><span class="rating">${b.rating}</span><span class="wl">Squad Rating · <b>${b.wins}</b> wins / <i>${b.losses}</i> losses</span></div>`
+      + action
+      + `<div class="bg-sub">Ladder — Online</div>${online}${allTime}`;
+    el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; });
+    el.querySelector('[data-act="queue"]')?.addEventListener('click', () => { this.sim.bgQueueJoin(); audio.click(); });
+    el.querySelector('[data-act="leave"]')?.addEventListener('click', () => { this.sim.bgQueueLeave(); audio.click(); });
+  }
+
+  // The pinned in-match scoreboard: team scores, flag states, your team's pips.
+  private updateBgScoreboard(): void {
+    const el = $('#bg-scoreboard');
+    const b = this.sim.bgInfo;
+    const m = b?.match ?? null;
+    if (!m) {
+      if (el.style.display !== 'none') { el.style.display = 'none'; this.lastBgScoreSig = ''; }
+      return;
+    }
+    const flagGlyph = (i: number) => {
+      const f = m.flags[i];
+      return `<span class="flag ${f.state} ${i === 0 ? 'crimson' : 'azure'}" title="${i === 0 ? 'Crimson' : 'Azure'} flag: ${f.state}${f.carrierName ? ' by ' + esc(f.carrierName) : ''}">⚑</span>`;
+    };
+    const pips = (team: number) => m.players.filter((p) => p.team === team)
+      .map((p) => `<div class="bg-pip${p.dead ? ' dead' : ''}${p.carrying ? ' flag' : ''}" style="background:${team === 0 ? '#ff6a62' : '#6aa6ff'}" title="${esc(p.name)}${p.dead ? ' (down)' : ''}${p.carrying ? ' — carrying!' : ''}"></div>`).join('');
+    const sig = JSON.stringify([m.scores, m.flags.map((f) => f.state + (f.carrierName ?? '')), m.players.map((p) => [p.dead, p.carrying]), m.state, m.myTeam]);
+    if (sig !== this.lastBgScoreSig) {
+      this.lastBgScoreSig = sig;
+      const youCrimson = m.myTeam === 0;
+      el.innerHTML = `<div class="bg-score-line">`
+        + `<span class="team crimson">${flagGlyph(0)} Crimson${youCrimson ? ' (you)' : ''}</span>`
+        + `<span class="num crimson">${m.scores[0]}</span><span class="dash">–</span><span class="num azure">${m.scores[1]}</span>`
+        + `<span class="team azure">Azure${!youCrimson ? ' (you)' : ''} ${flagGlyph(1)}</span></div>`
+        + `<div class="bg-caps">${m.state === 'countdown' ? 'FORM UP…' : `FIRST TO ${m.capsToWin} CAPTURES`}</div>`
+        + `<div class="bg-roster">${pips(0)}<span style="width:10px"></span>${pips(1)}</div>`;
       el.style.display = 'block';
     }
   }
@@ -2716,6 +2837,42 @@ export class Hud {
             this.combatLog(t('hud.system.arenaDefeatLog', { name: ev.oppName, rating: ratingAfter, delta: ratingDelta }), '#ff7a6a');
             audio.death();
           }
+          break;
+        }
+        case 'bgQueued': this.log(`Queued for Ravenrift (${ev.position}/10).`, '#7fd4ff'); break;
+        case 'bgUnqueued': this.log('You leave the Ravenrift queue.', '#7fd4ff'); break;
+        case 'bgFound': {
+          const team = ev.team === 0 ? 'Crimson' : 'Azure';
+          this.showBanner(`Battle found — you fight for the ${team}!`);
+          audio.duelChallenge();
+          break;
+        }
+        case 'bgCountdown': this.showBanner(`Ravenrift begins in ${ev.seconds}…`); audio.duelCountdownTick(); break;
+        case 'bgStart': this.showBanner('Capture the flag!'); audio.duelStart(); break;
+        case 'bgFlag': {
+          const team = ev.team === 0 ? 'Crimson' : 'Azure';
+          const score = `${ev.scoreCrimson}–${ev.scoreAzure}`;
+          if (ev.action === 'captured') {
+            this.showBanner(`${ev.byName} captured the ${team} flag!  ${score}`);
+            this.combatLog(`${ev.byName} captured the ${team} flag. Score ${score}.`, '#ffd24a');
+            audio.questDone();
+          } else if (ev.action === 'taken') {
+            this.combatLog(`${ev.byName} has taken the ${team} flag!`, '#ff9a3c');
+          } else if (ev.action === 'dropped') {
+            this.combatLog(`The ${team} flag was dropped.`, '#cfc6a8');
+          } else {
+            this.combatLog(`The ${team} flag was returned.`, '#9fdc7f');
+          }
+          break;
+        }
+        case 'bgEnd': {
+          const delta = ev.ratingAfter - ev.ratingBefore;
+          const sign = delta >= 0 ? '+' : '';
+          const score = `${ev.scoreCrimson}–${ev.scoreAzure}`;
+          if (ev.draw) this.showBanner(`Ravenrift draw ${score} (${sign}${delta} rating)`);
+          else if (ev.won) { this.showBanner(`Victory!  Ravenrift ${score} — Rating ${ev.ratingAfter} (${sign}${delta})`); audio.duelEnd(); }
+          else { this.showBanner(`Defeat.  Ravenrift ${score} — Rating ${ev.ratingAfter} (${sign}${delta})`); audio.death(); }
+          this.combatLog(`Ravenrift ended ${score}. Squad rating ${ev.ratingAfter} (${sign}${delta}).`, ev.won ? '#7fdc4f' : '#ff7a6a');
           break;
         }
         case 'log': this.log(this.localizeSystemText(ev.text), ev.color ?? '#ccc'); break;

--- a/src/ui/sim_i18n.ts
+++ b/src/ui/sim_i18n.ts
@@ -1746,6 +1746,34 @@ function tArenaExtra(key: ArenaExtraKey, params?: InterpolationValues): string {
   return interpolate(table[key] ?? ARENA_EXTRA.en[key], params);
 }
 
+// Ravenrift 5v5 capture-the-flag emit strings. English is authoritative; other
+// locales fall back to English here and are filled from the registry at release
+// (the PR-tier S3 guard only requires recognition, not translation).
+type BgExtraKey =
+  | 'joinQueue' | 'leaveQueue' | 'partyJoinQueue' | 'battleBegins' | 'fightFor' | 'seizeRune'
+  | 'errInBattleground' | 'errQueueDead' | 'errMemberQueued';
+
+const BG_EXTRA_EN: Record<BgExtraKey, string> = {
+  joinQueue: 'You join the Ravenrift queue. Need 10 champions to start a match…',
+  leaveQueue: 'You leave the Ravenrift queue.',
+  partyJoinQueue: 'Your party of {count} joins the Ravenrift queue.',
+  battleBegins: 'The Ravenrift battle begins — take their flag!',
+  fightFor: 'Ravenrift: you fight for the {team}. First to {caps} captures wins.',
+  seizeRune: 'You seize a Sprint Rune!',
+  errInBattleground: 'You are already in a battleground.',
+  errQueueDead: 'You cannot queue for Ravenrift while dead.',
+  errMemberQueued: 'A party member is already queued or in a match.',
+};
+
+const BG_EXTRA: Partial<Record<SupportedLanguage, Partial<Record<BgExtraKey, string>>>> = {
+  en: BG_EXTRA_EN,
+};
+
+function tBg(key: BgExtraKey, params?: InterpolationValues): string {
+  const table = BG_EXTRA[getLanguage()] ?? {};
+  return interpolate(table[key] ?? BG_EXTRA_EN[key], params);
+}
+
 // EXACT (no-placeholder) sim messages: English -> key (auto-built; throws on collision).
 const EXACT: Record<string, SimMessageKey> = {};
 for (const key of Object.keys(enTable) as SimMessageKey[]) {
@@ -1800,6 +1828,16 @@ const RULES: Rule[] = [
   { re: /^(.+) cannot queue while dueling\.$/, build: (m) => tArenaExtra('memberDueling', { name: m[1] }) },
   { re: /^(.+) must finish trading before queueing\.$/, build: (m) => tArenaExtra('memberTrading', { name: m[1] }) },
   { re: /^(.+) cannot queue from inside an instance\.$/, build: (m) => tArenaExtra('memberInstance', { name: m[1] }) },
+  // Ravenrift 5v5 capture-the-flag
+  { re: /^You join the Ravenrift queue\. Need 10 champions to start a match[.…]{1,3}$/, build: () => tBg('joinQueue') },
+  { re: /^You leave the Ravenrift queue\.$/, build: () => tBg('leaveQueue') },
+  { re: /^Your party of (.+?) joins the Ravenrift queue\.$/, build: (m) => tBg('partyJoinQueue', { count: m[1] }) },
+  { re: /^The Ravenrift battle begins — take their flag!$/, build: () => tBg('battleBegins') },
+  { re: /^Ravenrift: you fight for the (.+?)\. First to (.+?) captures wins\.$/, build: (m) => tBg('fightFor', { team: m[1], caps: m[2] }) },
+  { re: /^You seize a Sprint Rune!$/, build: () => tBg('seizeRune') },
+  { re: /^You are already in a battleground\.$/, build: () => tBg('errInBattleground') },
+  { re: /^You cannot queue for Ravenrift while dead\.$/, build: () => tBg('errQueueDead') },
+  { re: /^A party member is already queued or in a match\.$/, build: () => tBg('errMemberQueued') },
 ];
 
 // Returns the localized form of a sim-emitted message, or null if not one of ours.

--- a/src/ui/ui_icons.ts
+++ b/src/ui/ui_icons.ts
@@ -20,7 +20,7 @@ export type UiIconName =
   | 'chat' | 'interact' | 'emote'
   // hand-authored geometrics
   | 'close' | 'prev' | 'next' | 'more' | 'meters'
-  | 'whisper' | 'music' | 'talents' | 'skull' | 'jump' | 'autorun' | 'nameplates' | 'vibrate';
+  | 'whisper' | 'music' | 'talents' | 'skull' | 'jump' | 'autorun' | 'nameplates' | 'vibrate' | 'battleground';
 
 // Inner SVG markup per icon (one or more <path>). Default fill rule is nonzero
 // (correct for game-icons.net art incl. overlaps); the two hand-authored cut-out
@@ -60,6 +60,8 @@ const ICONS: Record<UiIconName, string> = {
   autorun: '<path d="M136 264 256 152 376 264M136 392 256 280 376 392" stroke="currentColor" stroke-width="34" fill="none" stroke-linecap="round" stroke-linejoin="round"/>',
   // phone handset flanked by vibration waves (hand-authored to match the bar glyphs)
   vibrate: '<path fill-rule="evenodd" d="M196 80h120a24 24 0 0 1 24 24v304a24 24 0 0 1-24 24H196a24 24 0 0 1-24-24V104a24 24 0 0 1 24-24zm4 40v272h112V120H200z"/><path d="M96 176v160h28V176zM388 176v160h28V176zM40 216v80h26v-80zM446 216v80h26v-80z"/>',
+  // hand-authored capture-the-flag banner on a pole (Ravenrift battleground)
+  battleground: '<path d="M150 56h26v400h-26z"/><path d="M176 78h236l-52 66 52 66H176z"/>',
 };
 
 export function hasUiIcon(name: string): name is UiIconName {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -155,6 +155,58 @@ export interface ArenaInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Ravenrift — the ranked 5v5 capture-the-flag battleground. A separate squad
+// ladder from the arena; the HUD reads `bgInfo` and sends queue commands.
+// ---------------------------------------------------------------------------
+
+export interface SquadLadderEntry {
+  pid: number;
+  name: string;
+  cls: PlayerClass;
+  rating: number;
+  wins: number;
+  losses: number;
+}
+
+export interface BgFlagInfo {
+  state: 'home' | 'carried' | 'dropped';
+  carrierName: string | null;
+  carrierTeam: number | null;
+}
+
+export interface BgPlayerInfo {
+  pid: number;
+  name: string;
+  cls: PlayerClass;
+  team: number; // 0 = Crimson, 1 = Azure
+  carrying: boolean;
+  dead: boolean;
+  hp: number;
+  mhp: number;
+}
+
+export interface BgMatchInfo {
+  state: 'countdown' | 'active';
+  myTeam: number;
+  capsToWin: number;
+  scores: [number, number]; // [Crimson, Azure]
+  flags: [BgFlagInfo, BgFlagInfo]; // indexed by home team
+  players: BgPlayerInfo[];
+  respawnIn: number; // whole seconds until your keep respawn (0 = alive)
+}
+
+export interface BgInfo {
+  rating: number;
+  wins: number;
+  losses: number;
+  queued: boolean;
+  queueSize: number; // champions waiting across all groups
+  queuedParty: number; // size of your own queued group
+  match: BgMatchInfo | null;
+  ladder: SquadLadderEntry[];
+}
+
+// ---------------------------------------------------------------------------
 // The World Market (the Merchant's auction house). Listings are global and
 // shared by every player; collections are the per-player gold + items waiting
 // to be picked up (sale proceeds, expired/returned listings).
@@ -239,6 +291,7 @@ export interface IWorld {
   tradeInfo: TradeInfo | null;
   duelInfo: DuelInfo | null;
   arenaInfo: ArenaInfo | null;
+  bgInfo: BgInfo | null;
   marketInfo: MarketInfo | null;
   partyInvite(targetPid: number): void;
   partyAccept(): void;
@@ -279,6 +332,9 @@ export interface IWorld {
   searchCharacters(query: string): Promise<CharacterSearchResult[]>;
   arenaQueueJoin(format?: ArenaFormat): void;
   arenaQueueLeave(): void;
+  // Ravenrift 5v5 capture-the-flag
+  bgQueueJoin(): void;
+  bgQueueLeave(): void;
   // World Market
   marketList(itemId: string, count: number, price: number): void;
   marketBuy(listingId: number): void;

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -175,7 +175,8 @@ describe('persistence', () => {
     expect(kb.actionForCode('KeyH')).toBe('targetFriendly');
     expect(kb.actionForCode('Enter')).toBe('chat');
     expect(kb.actionForCode('Equal')).toBe('slot11');
-    expect(kb.actionForCode('KeyY')).toBe(null);
+    expect(kb.actionForCode('KeyY')).toBe('battleground'); // a newer action keeps its default
+    expect(kb.actionForCode('KeyZ')).toBe(null); // a key no action claims stays unbound
   });
 
   it('drops a retained default that a stored binding already claimed', () => {

--- a/tests/squad.test.ts
+++ b/tests/squad.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+import { isBgPos } from '../src/sim/data';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function tp(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos = { x, y: groundHeight(x, z, sim.cfg.seed), z };
+  e.prevPos = { ...e.pos };
+  (sim as any).rebucket(e);
+}
+
+// Ten solo players, queued, advanced one tick so matchmaking seats a 5v5.
+function tenInQueue(): { sim: Sim; pids: number[] } {
+  const sim = makeWorld();
+  const pids: number[] = [];
+  const classes = ['warrior', 'mage', 'priest', 'rogue', 'hunter'] as const;
+  for (let i = 0; i < 10; i++) {
+    const pid = sim.addPlayer(classes[i % 5], `P${i}`);
+    tp(sim, pid, (i % 5) * 2 - 4, -40);
+    pids.push(pid);
+  }
+  for (const pid of pids) sim.bgQueueJoin(pid);
+  sim.tick(); // matchmakeBg seats them
+  return { sim, pids };
+}
+
+function toActive(sim: Sim, match: any) {
+  for (let i = 0; i < 20 * 10 && match.state !== 'active'; i++) sim.tick();
+}
+
+describe('Ravenrift: queue + matchmaking', () => {
+  it('needs ten players; then forms two teams of five and seats them in a battleground', () => {
+    const sim = makeWorld();
+    const pids: number[] = [];
+    for (let i = 0; i < 9; i++) {
+      const pid = sim.addPlayer('warrior', `W${i}`);
+      tp(sim, pid, 0, -40);
+      pids.push(pid);
+      sim.bgQueueJoin(pid);
+    }
+    sim.tick();
+    expect(sim.bgMatchFor(pids[0])).toBe(null); // 9 isn't enough
+
+    const tenth = sim.addPlayer('mage', 'Tenth');
+    tp(sim, tenth, 0, -40);
+    sim.bgQueueJoin(tenth);
+    sim.tick();
+    const match = sim.bgMatchFor(pids[0])!;
+    expect(match).toBeTruthy();
+    expect(match.teams[0].length).toBe(5);
+    expect(match.teams[1].length).toBe(5);
+    // every fighter whisked onto the battleground sands
+    for (const pid of [...match.teams[0], ...match.teams[1]]) {
+      expect(isBgPos(sim.entities.get(pid)!.pos.x)).toBe(true);
+    }
+    expect(match.state).toBe('countdown');
+  });
+
+  it('keeps a queued party together on one team', () => {
+    const sim = makeWorld();
+    // a party of five
+    const leader = sim.addPlayer('warrior', 'Leader');
+    tp(sim, leader, 0, -40);
+    const party = [leader];
+    for (let i = 0; i < 4; i++) {
+      const m = sim.addPlayer('priest', `Mate${i}`);
+      tp(sim, m, 0, -40);
+      sim.partyInvite(m, leader);
+      sim.partyAccept(m);
+      party.push(m);
+    }
+    // plus five solos
+    const solos: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const s = sim.addPlayer('rogue', `Solo${i}`);
+      tp(sim, s, 0, -40);
+      solos.push(s);
+      sim.bgQueueJoin(s);
+    }
+    sim.bgQueueJoin(leader); // queues the whole party
+    sim.tick();
+    const match = sim.bgMatchFor(leader)!;
+    expect(match).toBeTruthy();
+    const teamOfLeader = match.teams[0].includes(leader) ? 0 : 1;
+    for (const m of party) expect(match.teams[teamOfLeader]).toContain(m);
+  });
+
+  it('refuses to queue from inside an instance', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'A');
+    tp(sim, a, 900, -1250); // a dungeon instance band (x past DUNGEON_X_THRESHOLD)
+    sim.bgQueueJoin(a);
+    expect((sim as any).bgGroupContaining(a)).toBe(null);
+  });
+});
+
+describe('Ravenrift: flags + scoring', () => {
+  it('grab the enemy flag, run it home, score — first to five wins', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    expect(match.state).toBe('active');
+
+    const carrier = match.teams[0][0];
+    const azure = match.flags[1]; // team 0 captures the Azure flag
+    const crimsonHome = match.flags[0].home;
+
+    let ended: any = null;
+    for (let cap = 0; cap < 5 && !ended; cap++) {
+      // onto the enemy flag → pick it up
+      tp(sim, carrier, azure.home.x, azure.home.z);
+      sim.tick();
+      expect(match.flags[1].state).toBe('carried');
+      expect(match.flags[1].carrier).toBe(carrier);
+      // run it back to your own stand → capture
+      tp(sim, carrier, crimsonHome.x, crimsonHome.z);
+      const evs = sim.tick();
+      const end = evs.find((e) => e.type === 'bgEnd');
+      if (end) ended = end;
+      expect(match.scores[0]).toBe(cap + 1);
+      // captured flag resets home (unless the match just ended)
+      if (!ended) expect(match.flags[1].state).toBe('home');
+    }
+    expect(match.scores[0]).toBe(5);
+    expect(ended).toBeTruthy();
+    expect(ended.won).toBe(true); // from carrier's (team 0) perspective
+    expect(sim.bgMatchFor(carrier)).toBe(null); // cleaned up
+  });
+
+  it('dying drops the flag and queues a keep respawn (no graveyard run)', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const carrier = match.teams[0][0];
+    const azure = match.flags[1];
+    tp(sim, carrier, azure.home.x, azure.home.z);
+    sim.tick();
+    expect(match.flags[1].carrier).toBe(carrier);
+
+    const e = sim.entities.get(carrier)!;
+    (sim as any).dealDamage(null, e, 99999, false, 'physical', null, 'hit');
+    sim.tick();
+    expect(e.dead).toBe(true);
+    expect(match.flags[1].state).toBe('dropped'); // flag dropped where they fell
+    expect(match.respawn.has(carrier)).toBe(true); // timed respawn queued
+    // releasing does nothing in a battleground
+    sim.releaseSpirit(carrier);
+    expect(e.dead).toBe(true);
+  });
+
+  it('a dropped flag a teammate touches returns home', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const crimsonFlag = match.flags[0];
+    const enemy = match.teams[1][0]; // Azure steals the Crimson flag
+    tp(sim, enemy, crimsonFlag.home.x, crimsonFlag.home.z);
+    sim.tick();
+    expect(match.flags[0].state).toBe('carried');
+    // enemy dies, flag drops
+    (sim as any).dealDamage(null, sim.entities.get(enemy)!, 99999, false, 'physical', null, 'hit');
+    sim.tick();
+    expect(match.flags[0].state).toBe('dropped');
+    // a Crimson defender walks over their own dropped flag → instant return
+    const defender = match.teams[0][1];
+    const fe = sim.entities.get(match.flags[0].entityId)!;
+    tp(sim, defender, fe.pos.x, fe.pos.z);
+    sim.tick();
+    expect(match.flags[0].state).toBe('home');
+  });
+});
+
+describe('Ravenrift: speed runes + teams', () => {
+  it('stepping on a sprint rune grants haste and spends the rune', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const runner = match.teams[0][0];
+    const rune = match.runes[0];
+    expect(rune.active).toBe(true);
+    tp(sim, runner, rune.pos.x, rune.pos.z);
+    sim.tick();
+    const e = sim.entities.get(runner)!;
+    expect(e.auras.some((a) => a.kind === 'buff_speed' && a.value > 1)).toBe(true);
+    expect(match.runes[0].active).toBe(false); // consumed, now recharging
+  });
+
+  it('enemies are hostile, teammates are not', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const a = sim.entities.get(match.teams[0][0])!;
+    const mate = sim.entities.get(match.teams[0][1])!;
+    const foe = sim.entities.get(match.teams[1][0])!;
+    expect(sim.isHostileTo(a, foe)).toBe(true);
+    expect(sim.isHostileTo(a, mate)).toBe(false);
+  });
+});
+
+describe('Ravenrift: ranking + forfeit', () => {
+  it('a win moves both teams\' squad Elo and records W/L', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const winnerPid = match.teams[0][0];
+    const loserPid = match.teams[1][0];
+    const r0 = sim.meta(winnerPid)!.squadRating;
+    const rL = sim.meta(loserPid)!.squadRating;
+    const carrier = winnerPid;
+    const azure = match.flags[1];
+    const crimsonHome = match.flags[0].home;
+    for (let cap = 0; cap < 5; cap++) {
+      tp(sim, carrier, azure.home.x, azure.home.z); sim.tick();
+      tp(sim, carrier, crimsonHome.x, crimsonHome.z); sim.tick();
+    }
+    expect(sim.meta(winnerPid)!.squadRating).toBeGreaterThan(r0);
+    expect(sim.meta(loserPid)!.squadRating).toBeLessThan(rL);
+    expect(sim.meta(winnerPid)!.squadWins).toBe(1);
+    expect(sim.meta(loserPid)!.squadLosses).toBe(1);
+    // restored to the overworld where they queued
+    expect(isBgPos(sim.entities.get(winnerPid)!.pos.x)).toBe(false);
+  });
+
+  it('a team that fully disconnects forfeits the match', () => {
+    const { sim, pids } = tenInQueue();
+    const match = sim.bgMatchFor(pids[0])!;
+    toActive(sim, match);
+    const winners = [...match.teams[0]];
+    const r0 = sim.meta(winners[0])!.squadRating;
+    for (const pid of [...match.teams[1]]) sim.removePlayer(pid);
+    expect(sim.bgMatchFor(winners[0])).toBe(null);
+    expect(sim.meta(winners[0])!.squadRating).toBeGreaterThan(r0);
+    expect(sim.meta(winners[0])!.squadWins).toBe(1);
+  });
+
+  it('squad ladder sorts online players by squad rating', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Low');
+    const b = sim.addPlayer('mage', 'High');
+    sim.meta(a)!.squadRating = 1400;
+    sim.meta(b)!.squadRating = 1700;
+    expect(sim.squadLadder().map((r) => r.name)).toEqual(['High', 'Low']);
+  });
+
+  it('squad rating round-trips through CharacterState', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('druid', 'Keeper');
+    sim.meta(a)!.squadRating = 1633;
+    sim.meta(a)!.squadWins = 7;
+    const state = sim.serializeCharacter(a)!;
+    expect(state.squadRating).toBe(1633);
+    const sim2 = makeWorld();
+    const a2 = sim2.addPlayer('druid', 'Keeper', { state });
+    expect(sim2.meta(a2)!.squadRating).toBe(1633);
+    expect(sim2.meta(a2)!.squadWins).toBe(7);
+  });
+});


### PR DESCRIPTION
A standalone re-implementation of the Ravenrift battleground, rebuilt on the current game so it merges cleanly. Queue solo or as a party of up to 5, get matched into two teams of five on a walled open-air battleground, steal the enemy banner and run it to your keep — first to 5 captures wins. Weave the central cover to lose pursuers, grab Sprint Runes at the flag sections for a burst of speed, and respawn at your keep when you fall. A persistent squad Elo ladder tracks wins/losses; both teams' rating moves zero-sum on the result.

Built to mirror the current Ashen Coliseum (arena) patterns it was first modeled on: a parallel queue/matchmaking/instance/Elo subsystem living in the deterministic sim core, so it's testable and behaves identically online and offline. A far-off flat-ground instance band (bounded against the arena band) reuses the dungeon ground/collision path; battleground_layout.ts is the shared geometry (bases, flags, cover, rune pads) for both colliders and renderer. The open-air map is built from the same KayKit kit (courtyard floor, ramparts, keeps, cover) plus procedural team banners, flag stands, glowing rune pads, and dynamic flag/rune entities that follow their carriers.

Wired through IWorld, the online client, the server command/snapshot path, the HUD (Ravenrift panel + in-match scoreboard: scores, flag states, roster pips, keep-respawn overlay), input (a rebindable battleground action, default Y, plus the ⚑ button), and a /api/squad/leaderboard endpoint. Sim-emitted strings are localized via sim_i18n (English authoritative; other locales fall back pending translation).

tests/squad.test.ts (12 tests): matchmaking incl. party-together and the instance guard, flag grab/capture/win, death-drops-flag + respawn, dropped-flag return, sprint runes, team hostility, team Elo, forfeit, ladder, persistence. scripts/squad_visual.mjs drives real clients through a match (dev force-start).

Verified: tsc clean, 1499 tests pass, client + server builds succeed.

<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

<!-- What does this PR change, and why? Link the motivation or design if there is one. -->

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
- Manual steps:

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> **Tip:** commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a scope where it fits (`feat(talents): ...`, `fix(net): ...`). It's a
> convention we like, not a requirement. Clear, descriptive messages are what
> matter most.

---

A complete checklist and a green CI run (tests, typecheck, and builds) are what
we look for before merging. Smaller, focused PRs land faster than large ones, and
reviewers may suggest changes, which is a normal and friendly part of the
process. Thank you for helping build World of ClaudeCraft. Questions? Join us on
[Discord](https://discord.gg/GjhnUsBtw).
