### PR TITLE
feat(content): zone1 mob affix pack (blind, frenzy, soulrot, skullthump, hex, wardAllies)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/shot_blind.mjs
+++ b/scripts/shot_blind.mjs
@@ -1,0 +1,92 @@
+// Screenshot the Blinding Powder affix in the offline client.
+// Boots the game, repurposes a nearby mob as a Vale Bandit, forces its on-hit
+// Blinding Powder onto the player, and captures the resulting blind debuff on
+// the player unit frame (plus the player's own swings whiffing).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Vale Bandit and drive its Blinding Powder onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the dirty-fighting bandit and stand it next to us.
+  mob.templateId = 'vale_bandit';
+  mob.name = 'Vale Bandit';
+  mob.hostile = true;
+  mob.maxHp = 100000; mob.hp = 100000;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the powder onto us, then take a few of our own swings so the FCT
+  // shows the blinded misses.
+  sim.MOBS_FORCE = null;
+  for (let i = 0; i < 6 && !p.auras.some((a) => a.kind === 'blind'); i++) sim.mobSwing(mob, p);
+  if (!p.auras.some((a) => a.kind === 'blind')) {
+    p.auras.push({
+      id: 'blind_vale_bandit', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 0.3, sourceId: mob.id, school: 'physical',
+    });
+  }
+  const blind = p.auras.find((a) => a.kind === 'blind');
+  let misses = 0;
+  for (let i = 0; i < 8; i++) { if (sim.meleeSwing(p, mob, 0, null, { cannotBeDodged: true }) === false) misses++; }
+  return { hasBlind: !!blind, blindValue: blind?.value, blindRemaining: blind?.remaining, misses };
+});
+console.log('blind result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/blind_full.png' });
+
+// Crop tightly around the player unit frame + buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/blind_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/blind_full.png, blind_frame.png');
+await browser.close();

--- a/scripts/shot_frenzy.mjs
+++ b/scripts/shot_frenzy.mjs
@@ -1,0 +1,88 @@
+// Screenshot the reactive Frenzy affix (Blood Frenzy) in the offline client.
+// Boots the game, repurposes a nearby mob as Old Greyjaw, drives a player blow
+// through the real damage funnel with the proc forced, and captures the
+// "flies into a frenzy" combat-log line + the nova VFX on the wolf. The buff is
+// a self-haste on the mob (not a player debuff), so there is no debuff icon to
+// grab — the combat log is the reliable visual, as for other reactive traits.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Switch the chat panel to the combat-log tab up front.
+await page.evaluate(() => {
+  const tab = [...document.querySelectorAll('.chat-tab')].find((t) => t.dataset.logTab === 'combat');
+  if (tab) tab.click();
+});
+
+// Repurpose the nearest mob as Old Greyjaw and drive the real frenzy proc.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // invulnerable so the live 20Hz tick can't kill us mid-capture
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the rare wolf, stand it ~6yd out front, and keep it alive.
+  mob.templateId = 'old_greyjaw';
+  mob.name = 'Old Greyjaw';
+  mob.level = 4;
+  mob.hostile = true;
+  mob.maxHp = 100000; mob.hp = 100000;
+  mob.pos.x = p.pos.x + 4; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input.camDist !== undefined) g.input.camDist = 10;
+
+  // Force the proc and land a real player blow through the production path.
+  sim.rng.chance = () => true;
+  const before = sim.swingIntervalMult(mob);
+  sim.dealDamage(p, mob, 10, false, 'physical', null, 'hit', true);
+  const after = sim.swingIntervalMult(mob);
+  const aura = mob.auras.find((a) => a.id === 'blood_frenzy');
+  return {
+    hasFrenzy: !!aura, name: aura?.name, value: aura?.value, remaining: aura?.remaining,
+    swingBefore: before, swingAfter: after,
+  };
+});
+console.log('frenzy result:', JSON.stringify(result));
+
+// Let the nova VFX render, capture the full scene.
+await new Promise((r) => setTimeout(r, 250));
+await page.screenshot({ path: 'tmp/frenzy_scene.png' });
+
+// Crop the combat log (fixed bottom-left region — the panel reports 0 width).
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({
+  path: 'tmp/frenzy_log.png',
+  clip: { x: 8, y: 560, width: 470, height: 320 },
+});
+
+console.log('saved tmp/frenzy_scene.png, tmp/frenzy_log.png');
+await browser.close();

--- a/scripts/shot_skullthump.mjs
+++ b/scripts/shot_skullthump.mjs
@@ -1,0 +1,94 @@
+// Screenshot the Skullthump affix (on-hit stun) in the offline client.
+// Boots the game, repurposes a nearby mob as a Mogger Lackey, forces its
+// on-hit crushing blow onto the player, and captures the resulting stun
+// debuff in the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Mogger Lackey and drive its stun onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override is wiped by recalc).
+  p.gm = true;
+  sim.rng.chance = () => true; // force the on-hit proc deterministically
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the ogre lackey and stand it next to us.
+  mob.templateId = 'mogger_lackey';
+  mob.name = 'Mogger Lackey';
+  mob.level = 6;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const stun = p.auras.find((a) => a.name === 'Skullthump');
+  // The live affix is a brief 1s proc (proven by the swings + the unit test);
+  // hold the aura open here only so the still capture isn't a race with the loop.
+  if (stun) { stun.remaining = 8; stun.duration = 8; }
+  return { hasStun: !!stun, kind: stun?.kind };
+});
+console.log('skullthump result:', JSON.stringify(result));
+
+// Crop tightly around the buff/debuff bar (top-right) where the stun renders.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/skullthump_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+// Re-apply a fresh stun so the wide scene shot also shows the debuff on the bar.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const stun = p.auras.find((a) => a.name === 'Skullthump');
+  if (stun) { stun.remaining = 8; stun.duration = 8; }
+  else p.auras.push({ id: 'stun_mogger_lackey', name: 'Skullthump', kind: 'stun', remaining: 8, duration: 8, value: 0, sourceId: p.id, school: 'physical' });
+});
+await page.screenshot({ path: 'tmp/skullthump_scene.png' });
+
+console.log('saved tmp/skullthump_scene.png, skullthump_debuff.png');
+await browser.close();

--- a/scripts/shot_soulrot.mjs
+++ b/scripts/shot_soulrot.mjs
@@ -1,0 +1,89 @@
+// Screenshot the Soulrot affix (necrotic shadow DoT) in the offline client.
+// Boots the game, repurposes a nearby mob as Restless Bones, forces its
+// on-hit rot onto the player, and captures the resulting shadow DoT debuff
+// (and a ticking shadow damage number) on the player.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Restless Bones and drive its rot onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override is wiped by recalc).
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'restless_bones';
+  mob.name = 'Restless Bones';
+  mob.level = 6;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the on-hit proc deterministically, then swing until the rot festers.
+  const origChance = sim.rng.chance;
+  sim.rng.chance = () => true;
+  let rot = null;
+  for (let i = 0; i < 30 && !rot; i++) {
+    sim.mobSwing(mob, p);
+    rot = p.auras.find((a) => a.name === 'Soulrot');
+  }
+  sim.rng.chance = origChance;
+  return { hasRot: !!rot, value: rot?.value, school: rot?.school, remaining: rot?.remaining };
+});
+console.log('soulrot result:', JSON.stringify(result));
+
+// Let the DoT tick a couple of times so a shadow damage number floats up.
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/soulrot_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/soulrot_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+console.log('saved tmp/soulrot_scene.png, soulrot_debuff.png');
+await browser.close();

--- a/scripts/shot_ward_allies.mjs
+++ b/scripts/shot_ward_allies.mjs
@@ -1,0 +1,116 @@
+// Screenshot for Mogger's wardAllies support mechanic (Bracing Order).
+// Drives the offline world, repurposes nearby mobs into Mogger + two lackeys in
+// front of the player, forces the Bracing Order ward, and captures the scene,
+// the target frame, and the combat log showing the crew being shielded.
+// Requires `npm run dev` (pass GAME_URL if it landed on another port).
+//
+// Usage: node scripts/shot_ward_allies.mjs
+import { mkdirSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL || 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline → name → Start (warrior auto-selected).
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await new Promise((r) => setTimeout(r, 400));
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Wardwatch';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Stage: god-mode player; reskin three mobs into Mogger + two lackeys, lined
+  // up a few yards in front of the camera, and target Mogger for the frame.
+  await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.gm = true;
+    p.hp = p.maxHp;
+    // Relocate to a clear field away from the town hub so the shot isn't
+    // cluttered with friendly NPCs.
+    Object.assign(p.pos, sim.groundPos(80, 60));
+    p.prevPos = { ...p.pos };
+    p.facing = 0;
+    const mobs = [...sim.entities.values()].filter((e) => e.kind === 'mob' && !e.dead);
+    const fx = p.pos.x + Math.sin(p.facing) * 8;
+    const fz = p.pos.z + Math.cos(p.facing) * 8;
+    const ground = (x, z) => sim.groundPos(x, z);
+
+    const mogger = mobs[0];
+    window.__mogger = mogger.id;
+    mogger.templateId = 'mogger';
+    mogger.name = 'Mogger';
+    mogger.level = 6;
+    Object.assign(mogger.pos, ground(fx, fz));
+    mogger.prevPos = { ...mogger.pos };
+    mogger.hostile = true;
+
+    window.__lackeys = [];
+    for (let i = 1; i <= 2; i++) {
+      const l = mobs[i];
+      if (!l) break;
+      l.templateId = 'mogger_lackey';
+      l.name = 'Mogger Lackey';
+      l.level = 6;
+      Object.assign(l.pos, ground(fx + (i === 1 ? -3 : 3), fz - 1));
+      l.prevPos = { ...l.pos };
+      l.hostile = true;
+      window.__lackeys.push(l.id);
+    }
+    // Declutter: banish every other mob far away so only the crew is in frame.
+    const crew = new Set([mogger.id, ...window.__lackeys]);
+    for (const e of sim.entities.values()) {
+      if (e.kind === 'mob' && !crew.has(e.id)) { e.pos.x += 100000; e.prevPos = { ...e.pos }; }
+    }
+    // Target Mogger so the target frame names the warding boss.
+    p.targetId = mogger.id;
+    if (window.__game.hud?.setTarget) window.__game.hud.setTarget(mogger.id);
+  });
+
+  // Force the Bracing Order ward to fire repeatedly so the absorb is fresh on
+  // the crew and the combat-log lines accumulate.
+  for (let i = 0; i < 6; i++) {
+    await page.evaluate(() => {
+      const sim = window.__game.sim;
+      const mogger = sim.entities.get(window.__mogger);
+      if (!mogger) return;
+      mogger.inCombat = true;
+      mogger.combatTimer = 0;
+      mogger.wardTimer = 0.001; // fire now
+      sim.updateBossMechanics(mogger);
+    });
+    await new Promise((r) => setTimeout(r, 160));
+  }
+
+  await new Promise((r) => setTimeout(r, 200));
+  await page.screenshot({ path: `${OUT}/ward_scene.png` });
+  console.log('saved ward_scene.png (full scene)');
+
+  // Cropped close-up on Mogger + lackeys (the shielded crew).
+  await page.screenshot({ path: `${OUT}/ward_actors.png`, clip: { x: 420, y: 110, width: 480, height: 360 } });
+  console.log('saved ward_actors.png (close-up)');
+
+  // Cropped on the combat log showing the Bracing Order ward lines.
+  await page.screenshot({ path: `${OUT}/ward_log.png`, clip: { x: 8, y: 470, width: 580, height: 250 } });
+  console.log('saved ward_log.png (combat log)');
+} finally {
+  await browser.close();
+}

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,7 +225,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, wardTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -217,6 +217,8 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     scale: 1.0, color: 0xd5dbdb,
     // A grave-cold wail saps the strength from the living it strikes.
     demoralize: { ap: 20, duration: 8, name: 'Withering Wail' },
+    // Grave-touch: a clawing swing may fester a creeping necrotic rot (shadow DoT).
+    soulrot: { chance: 0.25, perTick: 4, interval: 3, duration: 12, name: 'Soulrot' },
   },
   gorrak: {
     id: 'gorrak', name: 'Gorrak the Ruthless', minLevel: 6, maxLevel: 6, family: 'humanoid',

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -181,6 +181,11 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.2 },
     ],
     scale: 0.8, color: 0x52be80,
+    // Mudfin Hex: the skulker's oracle-chant briefly turns a foe into a critter.
+    // Low chance and it breaks the instant the victim takes damage (the murloc's
+    // own next bite ends it), so it's a brief flavor incap — but a murloc pack
+    // can chain it just long enough to make a careless pull dangerous.
+    polymorphHex: { chance: 0.12, duration: 4, name: 'Mudfin Hex', school: 'nature' },
   },
   tunnel_rat: {
     id: 'tunnel_rat', name: 'Tunnel Rat Digger', minLevel: 4, maxLevel: 6, family: 'kobold',

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -204,6 +204,8 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.3 },
     ],
     scale: 1.0, color: 0x943126,
+    // A practiced thug flings a handful of road grit to foul your aim.
+    blind: { chance: 0.25, miss: 0.3, duration: 5, name: 'Blinding Powder', school: 'physical' },
   },
   restless_bones: {
     id: 'restless_bones', name: 'Restless Bones', minLevel: 5, maxLevel: 7, family: 'undead',

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -71,6 +71,9 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     id: 'old_greyjaw', name: 'Old Greyjaw', minLevel: 4, maxLevel: 4, family: 'beast', rare: true,
     hpBase: 110, hpPerLevel: 20, dmgBase: 5, dmgPerLevel: 2.0, attackSpeed: 1.8,
     armorPerLevel: 16, moveSpeed: 8.5, aggroRadius: 12,
+    // The old wolf turns savage as the fight wears on: each wound it takes can
+    // send it into a blood frenzy, swinging 30% faster for 8s.
+    frenzyOnHit: { chance: 0.25, hasteMult: 1.3, duration: 8, name: 'Blood Frenzy' },
     loot: [
       { copper: 60, chance: 1 },
       { itemId: 'greyjaw_fang', chance: 1, questId: 'q_greyjaw' },

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -168,6 +168,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     id: 'mogger_lackey', name: 'Mogger Lackey', minLevel: 5, maxLevel: 6, family: 'humanoid',
     hpBase: 44, hpPerLevel: 18, dmgBase: 6, dmgPerLevel: 2.0, attackSpeed: 2.0,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 12,
+    stunOnHit: { chance: 0.12, duration: 1, name: 'Skullthump', school: 'physical' },
     loot: [],
     scale: 0.95, color: 0x7b4b2b,
   },

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -155,6 +155,7 @@ export const ZONE1_MOBS: Record<string, MobTemplate> = {
     aoePulse: { min: 14, max: 20, radius: 8, every: 10, name: 'Ground Pound', school: 'physical' },
     summonAdds: { mobId: 'mogger_lackey', count: 2, atHpPct: [0.70] },
     enrage: { belowHpPct: 0.30, dmgMult: 1.6, hasteMult: 1.3 },
+    wardAllies: { radius: 12, every: 12, amount: 70, duration: 8, name: 'Bracing Order', school: 'physical' },
     loot: [
       { copper: 180, chance: 1 },
       { itemId: 'linen_scrap', chance: 1 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, wardTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first Ward the same way: one full interval after engage.
+  if (template.wardAllies) e.wardTimer = template.wardAllies.every;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,20 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // soulrot ("Soulrot"): a landed swing may fester a refreshing SHADOW DoT.
+    // Same on-hit DoT seam as venom, but shadow-school — the undead/necrotic
+    // flavour. Hostile mobs only (mobSwing is also the pet attack path, so a
+    // friendly pet must never rot the party).
+    const soulrot = MOBS[mob.templateId]?.soulrot;
+    if (soulrot && mob.hostile && !target.dead && this.rng.chance(soulrot.chance)) {
+      this.applyAura(target, {
+        id: 'soulrot_' + mob.templateId, name: soulrot.name, kind: 'dot',
+        remaining: soulrot.duration, duration: soulrot.duration,
+        value: Math.max(1, Math.round(soulrot.perTick)),
+        tickInterval: soulrot.interval, tickTimer: soulrot.interval,
+        sourceId: mob.id, school: (soulrot.school as Aura['school']) ?? 'shadow',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4286,6 +4286,27 @@ export class Sim {
         });
       }
     }
+    // Polymorph hex: a landed hit can briefly turn the victim into a critter,
+    // applying the same `polymorph` aura the mage's Polymorph uses — `isStunned`
+    // locks out every action and the aura is stripped the instant the victim
+    // takes damage (the caster's own next hit ends it), so it's a brief flavor
+    // incap, not a hard lock. Unlike the player-cast version we deliberately do
+    // NOT heal the victim to full on apply (a monster shouldn't restore its prey),
+    // but keep the aura's inherent regen tick. Guarded on `hostile` + a player
+    // target; `diminishedCrowdControlDuration` returns the full duration for a
+    // mob source (DR is PvP-only).
+    const hex = MOBS[mob.templateId]?.polymorphHex;
+    if (hex && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(hex.chance)) {
+      const remaining = this.diminishedCrowdControlDuration(mob, target, 'polymorph', hex.duration);
+      if (remaining !== null) {
+        this.applyAura(target, {
+          id: `hex_${mob.templateId}`, name: hex.name, kind: 'polymorph',
+          remaining, duration: remaining, value: 0,
+          tickInterval: 1, tickTimer: 1,
+          sourceId: mob.id, school: hex.school ?? 'nature', breaksOnDamage: true,
+        });
+      }
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -158,6 +158,7 @@ const SOCIAL_PULL_RADIUS: Partial<Record<MobFamily, number>> = {
   murloc: 8,
 };
 const PACK_FRENZY_AURA_ID = 'pack_frenzy'; // attack-speed buff granted to surviving packmates
+const BLOOD_FRENZY_AURA_ID = 'blood_frenzy'; // self attack-speed buff a wounded frenzyOnHit mob gains
 const SWIM_SURFACE_Y = WATER_LEVEL - 0.75; // body bobs just below the water line
 const SWIM_DEPTH = 0.8; // ground this far under the water line = deep water
 const SWIM_SPEED_MULT = 0.65;
@@ -3379,9 +3380,51 @@ export class Sim {
       }
     }
 
+    // Reactive "Frenzy": a wounded mob carrying frenzyOnHit may lash out faster.
+    // Rolls only for mobs that actually carry the trait (the helper bails before
+    // touching rng otherwise), so existing fixed-seed combat stays byte-identical.
+    if (kind === 'hit' && amount > 0 && !target.dead && target.hp > 0) {
+      this.maybeFrenzyOnHit(target, source);
+    }
+
     if (target.hp <= 0) {
       this.handleDeath(target, source);
     }
+  }
+
+  // Reactive beast "Frenzy": when a mob with the frenzyOnHit trait is struck by a
+  // player (or their pet), it has a chance to fly into a blood frenzy and swing
+  // faster for a few seconds. Modelled as a refreshable buff_haste self-aura — the
+  // same primitive packFrenzy uses — so it rides the normal aura tick and snapshot
+  // wire with no new Entity field. The struck mob buffs ITSELF, so there is no
+  // recursion risk (the buff is not damage) and no player-facing debuff string.
+  private maybeFrenzyOnHit(target: Entity, source: Entity | null): void {
+    const fr = MOBS[target.templateId]?.frenzyOnHit;
+    if (!fr) return; // non-carriers never reach rng — keeps determinism neutral
+    if (target.kind !== 'mob' || !target.hostile || target.ownerId !== null) return;
+    if (!source || source.id === target.id) return;
+    const fromPlayer = source.kind === 'player' || source.ownerId !== null;
+    if (!fromPlayer) return;
+    if (!this.rng.chance(fr.chance)) return;
+    const name = fr.name ?? 'Blood Frenzy';
+    const existing = target.auras.find((a) => a.id === BLOOD_FRENZY_AURA_ID);
+    if (existing) {
+      existing.remaining = fr.duration; // refresh on each further wound; don't stack
+      return;
+    }
+    target.auras.push({
+      id: BLOOD_FRENZY_AURA_ID,
+      name,
+      kind: 'buff_haste',
+      remaining: fr.duration,
+      duration: fr.duration,
+      value: fr.hasteMult,
+      sourceId: target.id,
+      school: 'physical',
+    });
+    this.emit({ type: 'aura', targetId: target.id, name, gained: true });
+    this.emit({ type: 'log', text: `${target.name} flies into a frenzy!`, color: '#ff8c00', entityId: target.id });
+    this.emit({ type: 'spellfx', sourceId: target.id, targetId: target.id, school: 'physical', fx: 'nova' });
   }
 
   private enterCombat(a: Entity, b: Entity): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4199,6 +4199,18 @@ export class Sim {
     if (ensnare && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(ensnare.chance)) {
       this.applyRootAura(mob, target, ensnare.name, `ensnare_${mob.templateId}`, ensnare.duration, ensnare.school ?? 'nature');
     }
+    // stunOnHit: a landed crushing blow may briefly stun the victim. Hostile mobs
+    // only (a friendly pet shares this swing path) and only stuns players. Reuses
+    // the `stun` aura the AoE stomp already applies, so isStunned()/the HUD handle
+    // it with no new wiring. Kept low-chance/short so it threatens without locking.
+    const stunOnHit = MOBS[mob.templateId]?.stunOnHit;
+    if (stunOnHit && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(stunOnHit.chance)) {
+      this.applyAura(target, {
+        id: `stun_${mob.templateId}`, name: stunOnHit.name, kind: 'stun',
+        remaining: stunOnHit.duration, duration: stunOnHit.duration, value: 0,
+        sourceId: mob.id, school: stunOnHit.school ?? 'physical',
+      });
+    }
     // slowStrike: a landed hit may mire the victim, slowing their attack speed.
     // Rides the existing `attackspeed` aura (swingIntervalMult: value > 1 = slower);
     // refreshes by id and never stacks. Guarded on `hostile` so a friendly pet

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4052,6 +4052,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.wardTimer = MOBS[mob.templateId]?.wardAllies?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4520,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.wardTimer = MOBS[mob.templateId]?.wardAllies?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4612,7 +4614,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly && !tmpl.wardAllies)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4658,6 +4660,35 @@ export class Sim {
           for (const ally of wounded) {
             const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
             this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
+      }
+    }
+    // Support "Ward": the defensive twin of Mend. Periodically wrap every living
+    // friendly mob in range (including the caster) in an absorb shield. Unlike
+    // Mend it targets healthy allies too — a barrier pre-empts the next blows.
+    // Refreshes each interval, replacing any partially-soaked ward (same aura id).
+    if (tmpl.wardAllies) {
+      mob.wardTimer -= DT;
+      if (mob.wardTimer <= 0) {
+        mob.wardTimer = tmpl.wardAllies.every;
+        const allies: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile) continue; // same-faction mobs only
+          if (dist2d(ally.pos, mob.pos) > tmpl.wardAllies.radius) continue;
+          allies.push(ally);
+        }
+        if (allies.length > 0) {
+          const school = tmpl.wardAllies.school ?? 'holy';
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} channels ${tmpl.wardAllies.name}.`, color: '#aad4ff', entityId: mob.id });
+          for (const ally of allies) {
+            this.applyAura(ally, {
+              id: `ward_${mob.templateId}`, name: tmpl.wardAllies.name, kind: 'absorb',
+              remaining: tmpl.wardAllies.duration, duration: tmpl.wardAllies.duration,
+              value: tmpl.wardAllies.amount, sourceId: mob.id, school,
+            });
           }
         }
       }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1333,6 +1333,14 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+
+  // Extra chance for the entity's own weapon swings to whiff while blinded.
+  // Returns the strongest active blind aura's value (0 when not blinded).
+  private blindMissBonus(e: Entity): number {
+    let bonus = 0;
+    for (const a of e.auras) if (a.kind === 'blind' && a.value > bonus) bonus = a.value;
+    return bonus;
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -3176,7 +3184,7 @@ export class Sim {
     const school = ranged.wand ? (ranged.school ?? 'arcane') : 'physical';
     const label = ranged.wand ? 'Wand' : 'Auto Shot';
     this.emit({ type: 'spellfx', sourceId: attacker.id, targetId: target.id, school, fx: 'projectile' });
-    const missChance = meleeMissChance(attacker.level, target.level);
+    const missChance = meleeMissChance(attacker.level, target.level) + this.blindMissBonus(attacker);
     if (this.rng.chance(missChance)) {
       this.emit({ type: 'damage', sourceId: attacker.id, targetId: target.id, amount: 0, crit: false, school, ability: label, kind: 'miss' });
       this.enterCombat(attacker, target);
@@ -3197,7 +3205,7 @@ export class Sim {
     attacker: Entity, target: Entity, bonus: number, abilityName: string | null,
     opts: { cannotBeDodged?: boolean; weaponMult?: number; threatFlat?: number; threatMult?: number },
   ): boolean {
-    const missChance = meleeMissChance(attacker.level, target.level);
+    const missChance = meleeMissChance(attacker.level, target.level) + this.blindMissBonus(attacker);
     const dodgeChance = opts.cannotBeDodged ? 0
       : (target.kind === 'player' ? target.dodgeChance : 0.05 + Math.max(0, target.level - attacker.level) * 0.005);
     const roll = this.rng.next();
@@ -4167,6 +4175,18 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // blinding powder: a thrown handful of grit can leave the victim's own
+    // weapon swings whiffing. Guarded on hostile + alive so a friendly pet
+    // (mobSwing's other caller) never blinds the party. Carries the added miss
+    // chance in the aura value, read back in melee/ranged swings via blindMissBonus.
+    const blind = MOBS[mob.templateId]?.blind;
+    if (blind && mob.hostile && !target.dead && this.rng.chance(blind.chance)) {
+      this.applyAura(target, {
+        id: `blind_${mob.templateId}`, name: blind.name, kind: 'blind',
+        remaining: blind.duration, duration: blind.duration, value: blind.miss,
+        sourceId: mob.id, school: (blind.school ?? 'physical') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,12 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit rot: a landed melee swing has `chance` to fester a refreshing SHADOW
+  // damage-over-time wound on the victim ("Soulrot"). The same on-hit DoT seam as
+  // `venom` (nature/poison) and `bleed` (physical), but shadow-school — the
+  // undead/necrotic flavour, and it bites every class (resisted by shadow, not
+  // nature/physical mitigation). Refreshes (never stacks) like venom.
+  soulrot?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: Aura['school'] };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -248,6 +248,11 @@ export interface MobTemplate {
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`
   // drives the panicked run with no new aura kind or movement hook.
   dread?: { chance: number; duration: number; name: string; school?: Aura['school'] };
+  // Polymorph-on-hit (murloc oracle's hex): a landed hit can briefly turn the
+  // victim into a harmless critter. Reuses the exact `polymorph` aura the mage's
+  // Polymorph applies — `isStunned` locks out all actions and the aura breaks the
+  // instant the victim takes damage — so no new aura kind, gating, or UI.
+  polymorphHex?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -268,6 +268,13 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // Reactive "Frenzy": when this creature is WOUNDED (takes a landed player hit)
+  // it has `chance` to fly into a blood frenzy, swinging faster (`hasteMult`,
+  // e.g. 1.3 = +30% swing speed) for `duration`s. Rides the existing buff_haste
+  // aura packFrenzy uses — no new combat math. Unlike packFrenzy (a death-rattle
+  // that buffs survivors) or enrage (a fixed HP threshold), this is a per-hit
+  // self-buff on the struck mob; it refreshes rather than stacks.
+  frenzyOnHit?: { chance: number; hasteMult: number; duration: number; name?: string };
 }
 
 export type AbilityEffect =

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -228,6 +228,10 @@ export interface MobTemplate {
   // existing root aura + crowd-control DR; no new aura kind. Players only; rooting a
   // fellow mob is meaningless and would let a friendly pet trivially lock enemies.
   ensnare?: { chance: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit debuff: a chance per landed crushing blow to briefly stun the victim.
+  // Reuses the `stun` aura kind (same one the AoE stomp applies); players only, and
+  // hostile-only so a friendly pet sharing the swing path never stuns the party.
+  stunOnHit?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // On-hit debuff: a chance per landed melee swing to mire the victim, slowing
   // their ATTACK SPEED (an `attackspeed` aura, `mult` > 1 lengthens the swing
   // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -191,6 +191,14 @@ export interface MobTemplate {
   // opens. Resets on evade/respawn. Routes through the normal heal path, so it
   // shows green floating text and grants no threat to the menders themselves.
   mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
+  // Support mechanic ("Ward"): the defensive twin of `mendAlly`. While in combat,
+  // periodically wrap every living friendly mob within `radius` (incl. itself) in
+  // a damage-absorbing barrier soaking a flat `amount` for `duration`s — a leader
+  // shielding the crew. Rides the existing `absorb` aura (soaked in dealDamage
+  // before any HP loss), so there is no new aura kind or combat math. Telegraphed:
+  // the first ward lands one full `every` interval after combat opens. Resets on
+  // evade/respawn. Refreshes each interval, replacing any partially-soaked ward.
+  wardAllies?: { radius: number; every: number; amount: number; duration: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -582,6 +590,7 @@ export interface Entity {
   stompTimer: number; // boss War Stomp stun-pulse countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
+  wardTimer: number; // wardAllies support-shield cast countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'blind';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +256,11 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit mechanic: a landed melee swing has `chance` to blind the victim,
+  // adding `miss` to the chance their own melee/ranged swings whiff for
+  // `duration` seconds. The flip side of `silence`: it spoils weapon attacks
+  // rather than spells. The added miss chance is carried in the aura's `value`.
+  blind?: { chance: number; miss: number; duration: number; name: string; school?: string };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'blind'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_blind.test.ts
+++ b/tests/mob_blind.test.ts
@@ -1,0 +1,108 @@
+// Some thugs fight dirty: the Vale Bandit's "Blinding Powder" flings a handful of
+// road grit on a landed hit, fouling the victim's aim so their OWN weapon swings
+// whiff for a few seconds. Blind is the weapon-side twin of silence — where
+// silence locks out spells, blind spoils melee and ranged attacks. It leaves
+// spellcasting, movement and the victim's defenses untouched.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Vale Bandit adjacent to the player, hostile and ready to swing.
+function spawnBandit(sim: Sim, target: Entity): Entity {
+  const template = MOBS['vale_bandit'];
+  const mob = createMob((sim as any).nextId++, template, 5, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (blind chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob blind ("Blinding Powder")', () => {
+  it('seeds the blind mechanic on the Vale Bandit', () => {
+    expect(MOBS['vale_bandit'].blind).toEqual({
+      chance: 0.25, miss: 0.3, duration: 5, name: 'Blinding Powder', school: 'physical',
+    });
+  });
+
+  it('applies a blind aura carrying the added miss chance on a landed hit', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnBandit(sim, p);
+    MOBS['vale_bandit'].blind!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['vale_bandit'].blind!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'blind');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Blinding Powder');
+    expect(aura!.remaining).toBe(5);
+    expect(aura!.value).toBe(0.3); // the miss chance carried into combat math
+  });
+
+  it("makes the blinded victim's own swings whiff", () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    const dummy = spawnBandit(sim, p);
+    dummy.maxHp = 100000; dummy.hp = 100000;
+    // A total blind (100% added miss) guarantees the swing whiffs.
+    p.auras.push({
+      id: 'blind_x', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 1, sourceId: 999, school: 'physical',
+    });
+    const events: Array<{ kind?: string; sourceId: number }> = [];
+    const orig = (sim as any).emit.bind(sim);
+    (sim as any).emit = (e: any) => { events.push(e); orig(e); };
+    const connected = (sim as any).meleeSwing(p, dummy, 0, null, { cannotBeDodged: true });
+    expect(connected).toBe(false);
+    expect(events.some((e) => e.kind === 'miss' && e.sourceId === p.id)).toBe(true);
+  });
+
+  it('adds no miss chance when the victim is not blinded', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    // No blind aura → the swing math sees zero added miss chance.
+    expect((sim as any).blindMissBonus(p)).toBe(0);
+    p.auras.push({
+      id: 'blind_x', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 0.3, sourceId: 999, school: 'physical',
+    });
+    expect((sim as any).blindMissBonus(p)).toBe(0.3);
+  });
+
+  it('does not block spellcasting while blinded', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.auras.push({
+      id: 'blind_x', name: 'Blinding Powder', kind: 'blind',
+      remaining: 5, duration: 5, value: 0.3, sourceId: 999, school: 'physical',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    sim.castAbility('fireball', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('a friendly pet swing never blinds its target', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnBandit(sim, p);
+    pet.hostile = false; // a tamed/friendly shape
+    pet.ownerId = p.id;
+    MOBS['vale_bandit'].blind!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['vale_bandit'].blind!.chance = 0.25;
+    expect(p.auras.some((a) => a.kind === 'blind')).toBe(false);
+  });
+});

--- a/tests/mob_frenzy_on_hit.test.ts
+++ b/tests/mob_frenzy_on_hit.test.ts
@@ -1,0 +1,104 @@
+// Reactive beast "Frenzy": when a mob carrying the frenzyOnHit trait is wounded
+// by a player (or their pet), it has a chance to fly into a blood frenzy and
+// swing faster for a few seconds. Old Greyjaw (a rare wolf) carries the trait.
+// This is the mob-side reactive twin of packFrenzy — a refreshable buff_haste
+// self-aura on the struck mob, not a player debuff.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const makeSim = () => new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+
+// Spawn a hostile Old Greyjaw next to the player and register it with the world.
+function spawnGreyjaw(sim: Sim): Entity {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob((sim as any).nextId++, MOBS.old_greyjaw, 4, { x: p.pos.x + 2, z: p.pos.z, y: p.pos.y });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+function frenzy(e: Entity) {
+  return e.auras.find((a) => a.id === 'blood_frenzy');
+}
+
+// Drive the production damage funnel; rng.chance is forced so the proc is deterministic.
+function strike(sim: Sim, mob: Entity, proc: boolean) {
+  (sim as any).rng.chance = () => proc;
+  (sim as any).dealDamage(sim.player, mob, 10, false, 'physical', null, 'hit', true);
+}
+
+describe('frenzyOnHit (Blood Frenzy)', () => {
+  it('old_greyjaw carries the frenzyOnHit trait', () => {
+    expect(MOBS.old_greyjaw.frenzyOnHit).toEqual({ chance: 0.25, hasteMult: 1.3, duration: 8, name: 'Blood Frenzy' });
+  });
+
+  it('a wounded carrier flies into a blood frenzy', () => {
+    const sim = makeSim();
+    const mob = spawnGreyjaw(sim);
+
+    strike(sim, mob, true);
+
+    const aura = frenzy(mob);
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Blood Frenzy');
+    expect(aura!.kind).toBe('buff_haste');
+    expect(aura!.value).toBe(1.3);
+    expect(aura!.remaining).toBe(8);
+  });
+
+  it('the frenzy actually shortens the swing interval', () => {
+    const sim = makeSim();
+    const mob = spawnGreyjaw(sim);
+    const before = (sim as any).swingIntervalMult(mob);
+
+    strike(sim, mob, true);
+
+    const after = (sim as any).swingIntervalMult(mob);
+    expect(after).toBeCloseTo(before / 1.3, 5);
+  });
+
+  it('does not frenzy when the proc roll fails', () => {
+    const sim = makeSim();
+    const mob = spawnGreyjaw(sim);
+
+    strike(sim, mob, false);
+
+    expect(frenzy(mob)).toBeUndefined();
+  });
+
+  it('refreshes rather than stacks on a second wound', () => {
+    const sim = makeSim();
+    const mob = spawnGreyjaw(sim);
+
+    strike(sim, mob, true);
+    frenzy(mob)!.remaining = 2; // let it tick down
+    strike(sim, mob, true);
+
+    const matches = mob.auras.filter((a) => a.id === 'blood_frenzy');
+    expect(matches.length).toBe(1); // one aura, refreshed
+    expect(matches[0].remaining).toBe(8);
+  });
+
+  it('a mob without the trait never frenzies (and draws no rng)', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const wolf = createMob((sim as any).nextId++, MOBS.forest_wolf, 2, { x: p.pos.x + 2, z: p.pos.z, y: p.pos.y });
+    sim.entities.set(wolf.id, wolf);
+
+    strike(sim, wolf, true); // even with a guaranteed proc, no trait → no aura
+
+    expect(wolf.auras.find((a) => a.id === 'blood_frenzy')).toBeUndefined();
+  });
+
+  it('a pet hit does not frenzy the wolf away from being player-driven', () => {
+    // sanity: the proc still fires for a player source; this asserts the source guard
+    const sim = makeSim();
+    const mob = spawnGreyjaw(sim);
+    (sim as any).rng.chance = () => true;
+    // a self-hit (source === target) must never proc
+    (sim as any).dealDamage(mob, mob, 10, false, 'physical', null, 'hit', true);
+    expect(frenzy(mob)).toBeUndefined();
+  });
+});

--- a/tests/mob_hex.test.ts
+++ b/tests/mob_hex.test.ts
@@ -1,0 +1,108 @@
+// Murloc oracles (the Mudfin Skulker's "Mudfin Hex") can briefly turn a victim
+// into a harmless critter on a melee hit. The hex reuses the exact `polymorph`
+// aura the mage's Polymorph applies: it locks out every action (isStunned) and
+// breaks the instant the victim takes damage. Unlike the player-cast version it
+// does NOT heal the victim to full on apply — a monster shouldn't restore its prey.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Mudfin Skulker adjacent to the player, hostile and ready to swing.
+function spawnSkulker(sim: Sim, target: Entity): Entity {
+  const mob = createMob((sim as any).nextId++, MOBS['mudfin_murloc'], 5, {
+    x: target.pos.x, y: target.pos.y, z: target.pos.z,
+  });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (the hex chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob polymorph hex ("Mudfin Hex")', () => {
+  it('seeds the hex mechanic on the Mudfin Skulker', () => {
+    expect(MOBS['mudfin_murloc'].polymorphHex).toEqual({
+      chance: 0.12, duration: 4, name: 'Mudfin Hex', school: 'nature',
+    });
+  });
+
+  it('applies a polymorph aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.gm = true; // survive the swing; applyAura still lands the hex
+    const mob = spawnSkulker(sim, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 0.12;
+    const aura = p.auras.find((a) => a.kind === 'polymorph');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Mudfin Hex');
+    expect(aura!.remaining).toBe(4);
+    expect(aura!.breaksOnDamage).toBe(true);
+  });
+
+  it('does NOT heal the victim to full when the hex lands', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.gm = true;
+    p.maxHp = 200; p.hp = 50; // wounded
+    const mob = spawnSkulker(sim, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 1;
+    swing(sim, mob, p);
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 0.12;
+    expect(p.auras.some((a) => a.kind === 'polymorph')).toBe(true);
+    // The mage's Polymorph sets hp = maxHp; a mob's hex must not. The bite itself
+    // deals damage, so a wounded victim only ends up MORE hurt, never topped off.
+    expect(p.hp).toBeLessThanOrEqual(50);
+    expect(p.hp).toBeLessThan(p.maxHp);
+  });
+
+  it('locks the victim out of casting while hexed', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.auras.push({
+      id: 'hex_mudfin_murloc', name: 'Mudfin Hex', kind: 'polymorph',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'nature',
+      breaksOnDamage: true,
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    sim.castAbility('fireball', p.id);
+    expect(errs).toContain('You are stunned!');
+    expect(p.castingAbility).toBeNull();
+  });
+
+  it('breaks the hex the instant the victim takes damage', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    p.auras.push({
+      id: 'hex_mudfin_murloc', name: 'Mudfin Hex', kind: 'polymorph',
+      remaining: 4, duration: 4, value: 0, sourceId: 999, school: 'nature',
+      breaksOnDamage: true,
+    });
+    (sim as any).dealDamage(null, p, 10, false, 'physical', null, 'hit');
+    expect(p.auras.some((a) => a.kind === 'polymorph')).toBe(false);
+  });
+
+  it('does not hex a non-player target', () => {
+    const sim = makeSim();
+    const a = spawnSkulker(sim, sim.player);
+    const b = spawnSkulker(sim, sim.player);
+    b.hostile = true;
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 1;
+    swing(sim, a, b); // murloc hitting another mob must not apply the hex
+    MOBS['mudfin_murloc'].polymorphHex!.chance = 0.12;
+    expect(b.auras.some((aura) => aura.kind === 'polymorph')).toBe(false);
+  });
+});

--- a/tests/mob_soulrot.test.ts
+++ b/tests/mob_soulrot.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn restless bones adjacent to the player and hand them back.
+function spawnBones(sim: Sim, id = 980001, level = 6) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.restless_bones, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the soulrot aura (the chance is forced to 1 here).
+function swingUntilRot(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'soulrot_restless_bones')) return true;
+  }
+  return false;
+}
+
+describe('mob soulrot (on-hit shadow DoT)', () => {
+  it('Restless Bones carry soulrot data tuned to a shadow DoT', () => {
+    const r = MOBS.restless_bones.soulrot!;
+    expect(r).toBeDefined();
+    // school defaults to shadow when omitted on the template; assert the runtime default below.
+    expect(r.chance).toBeGreaterThan(0);
+    expect(r.perTick).toBeGreaterThan(0);
+    expect(r.interval).toBeGreaterThan(0);
+    expect(r.duration).toBeGreaterThan(r.interval);
+  });
+
+  it('a landed grave-touch swing festers a shadow DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnBones(sim);
+    const orig = MOBS.restless_bones.soulrot!.chance;
+    MOBS.restless_bones.soulrot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.restless_bones.soulrot!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'soulrot_restless_bones')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('shadow');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.restless_bones.soulrot!.duration);
+  });
+
+  it('the shadow DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnBones(sim);
+    const orig = MOBS.restless_bones.soulrot!.chance;
+    MOBS.restless_bones.soulrot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.restless_bones.soulrot!.chance = orig;
+    }
+    // Park the mob far out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 7; i++) sim.tick(); // 7s — covers at least two 3s tick intervals
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-rotting mob (forest wolf) applies no shadow DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated grave-touches from the same mob', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnBones(sim);
+    const orig = MOBS.restless_bones.soulrot!.chance;
+    MOBS.restless_bones.soulrot!.chance = 1;
+    try {
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+    } finally {
+      MOBS.restless_bones.soulrot!.chance = orig;
+    }
+    const rotAuras = player.auras.filter((a) => a.id === 'soulrot_restless_bones');
+    expect(rotAuras.length).toBe(1);
+  });
+});

--- a/tests/mob_stun.test.ts
+++ b/tests/mob_stun.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+describe('Skullthump on-hit stun affix', () => {
+  it('the Mogger Lackey carries stunOnHit data tuned to a brief physical stun', () => {
+    const s = MOBS.mogger_lackey.stunOnHit!;
+    expect(s).toBeDefined();
+    expect(s.school).toBe('physical');
+    expect(s.chance).toBeGreaterThan(0);
+    expect(s.chance).toBeLessThanOrEqual(0.2); // gentle: lackeys can spawn in pairs
+    expect(s.duration).toBeGreaterThan(0);
+    expect(s.duration).toBeLessThanOrEqual(2);
+  });
+
+  it('a landed mogger_lackey swing can stun the player', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the stun
+    const tmpl = MOBS.mogger_lackey;
+    const saved = tmpl.stunOnHit!.chance;
+    tmpl.stunOnHit!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900700, tmpl, 6, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'stun');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'stun')!;
+      expect(a.name).toBe('Skullthump');
+      expect(a.id).toBe('stun_mogger_lackey');
+      expect((sim as any).isStunned(p)).toBe(true);
+    } finally {
+      tmpl.stunOnHit!.chance = saved;
+    }
+  });
+
+  it('the stun refreshes (does not infinitely stack) on repeated blows', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mogger_lackey;
+    const saved = tmpl.stunOnHit!.chance;
+    tmpl.stunOnHit!.chance = 1;
+    try {
+      const mob = createMob(900701, tmpl, 6, { x: 0, y: 0, z: 0 });
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(mob, p);
+      expect(p.auras.filter((a) => a.id === 'stun_mogger_lackey').length).toBe(1);
+    } finally {
+      tmpl.stunOnHit!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never stuns its target', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mogger_lackey;
+    const saved = tmpl.stunOnHit!.chance;
+    tmpl.stunOnHit!.chance = 1;
+    try {
+      const pet = createMob(900702, tmpl, 6, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+    } finally {
+      tmpl.stunOnHit!.chance = saved;
+    }
+  });
+
+  it('a mob without stunOnHit applies no stun', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900703, MOBS.forest_wolf, 6, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+  });
+});

--- a/tests/mob_ward_allies.test.ts
+++ b/tests/mob_ward_allies.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Mogger is the seeded carrier of the wardAllies support mechanic — a rare ogre
+// boss that shields his crew (mogger_lackeys) with a Bracing Order absorb.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string], hpFrac = 1) {
+  const mob = createMob(id, tmpl, 6, { x: 0, y: 0, z: 0 });
+  mob.hp = Math.round(mob.maxHp * hpFrac);
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+const ward = (e: Entity) => e.auras.find((a) => a.id === 'ward_mogger' && a.kind === 'absorb');
+
+describe('mob support shield (wardAllies)', () => {
+  it('seeds the mechanic on Mogger', () => {
+    expect(MOBS.mogger.wardAllies).toEqual({
+      radius: 12, every: 12, amount: 70, duration: 8, name: 'Bracing Order', school: 'physical',
+    });
+  });
+
+  it('shields a nearby ally once the cast timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9001, MOBS.mogger);
+    const ally = spawn(sim, 9002, MOBS.mogger_lackey);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    // Telegraphed: createMob seeds wardTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first ward.
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(ally)?.value).toBe(70);
+    expect(ward(ally)?.remaining).toBe(8);
+  });
+
+  it('does not cast before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9011, MOBS.mogger);
+    const ally = spawn(sim, 9012, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 11; i++) inner(sim).updateBossMechanics(mogger); // 11s < 12s
+    expect(ward(ally)).toBeUndefined();
+  });
+
+  it('shields every ally in range plus the caster (AoE, healthy too)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9021, MOBS.mogger);
+    const a = spawn(sim, 9022, MOBS.mogger_lackey); // full HP — a ward pre-empts damage
+    const b = spawn(sim, 9023, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(a)?.value).toBe(70);
+    expect(ward(b)?.value).toBe(70);
+    expect(ward(mogger)?.value).toBe(70); // the caster wards itself too
+  });
+
+  it('the absorb soaks incoming damage before any HP is lost', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9101, MOBS.mogger);
+    const ally = spawn(sim, 9102, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    const hpBefore = ally.hp;
+    // 50 damage < 70 shield → fully soaked, no HP loss, shield drops to 20.
+    (sim as unknown as { dealDamage(s: Entity | null, t: Entity, amt: number, crit: boolean, school: string, ability: string | null, kind: string): void })
+      .dealDamage(null, ally, 50, false, 'physical', null, 'hit');
+    expect(ally.hp).toBe(hpBefore);
+    expect(ward(ally)?.value).toBe(20);
+  });
+
+  it('ignores allies outside the ward radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9031, MOBS.mogger);
+    const far = spawn(sim, 9032, MOBS.mogger_lackey);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 12
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(far)).toBeUndefined();
+  });
+
+  it('does not ward mobs of the opposing faction (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9041, MOBS.mogger);
+    const friendlyMob = spawn(sim, 9042, MOBS.mogger_lackey);
+    friendlyMob.hostile = false; // flip faction
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(mogger);
+    expect(ward(friendlyMob)).toBeUndefined();
+  });
+
+  it('re-arms the telegraph after Mogger evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const mogger = spawn(sim, 9051, MOBS.mogger);
+    inner(sim).resetEvadingMob(mogger);
+    expect(mogger.wardTimer).toBe(MOBS.mogger.wardAllies!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const lackey = spawn(sim, 9061, MOBS.mogger_lackey);
+    const ally = spawn(sim, 9062, MOBS.mogger_lackey);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(lackey);
+    expect(ward(ally)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Consolidates several single-affix content PRs into one branch to cut the merge-conflict churn on the shared `src/sim/sim.ts` / `src/sim/types.ts` / i18n files. All members are additive zone1 (Eastbrook Vale) mob affixes; merged cleanly with no cross-conflicts, affix tests green, and no new `tsc` errors beyond the pre-existing base ones.

Supersedes / folds in:
- #516 Vale Bandits — Blinding Powder
- #526 Old Greyjaw — Blood Frenzy
- #531 Restless Bones — Soulrot (shadow DoT)
- #536 Mogger Lackeys — Skullthump (stun)
- #553 Mudfin Skulkers — Mudfin Hex (polymorph)
- #560 Mogger — Bracing Order (wardAllies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)