### PR TITLE
fix(camera): bypass follow-cam in Mouse Camera mode

### DIFF
--- a/src/game/camera_follow.ts
+++ b/src/game/camera_follow.ts
@@ -22,6 +22,17 @@ const CLICK_MOVE_BIG_TURN_FLOOR = 0.18;
 const CLICK_MOVE_SMALL_TURN = 0.35;
 const MAX_AUTO_YAW_SPEED = 3.6; // rad/sec; caps all non-manual camera follow motion
 
+// The follow/settle system below must be bypassed whenever the camera is under
+// the player's direct manual control: classic right-mouse mouselook OR the
+// always-on Mouse Camera mode. Both lock the character's facing to camYaw, so
+// letting auto-follow run makes it chase a facing that IS the camera yaw and it
+// fights the drag (~45° of drift). Mouse Camera mode reports mouselook=false on
+// desktop (no touch-look, no pointer-lock), so it must be folded in here
+// explicitly — otherwise it never takes the same smooth path right-mouse uses.
+export function cameraIsManual(mouselookActive: boolean, mouseCameraMode: boolean): boolean {
+  return mouselookActive || mouseCameraMode;
+}
+
 export function wrapAngle(d: number): number {
   while (d > Math.PI) d -= 2 * Math.PI;
   while (d < -Math.PI) d += 2 * Math.PI;

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ import { tServer } from './ui/server_i18n';
 import { tEntity } from './ui/entity_i18n';
 import { hydrateIcons } from './ui/ui_icons';
 import { createPerfMonitor } from './game/perf';
-import { updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
+import { cameraIsManual, updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
 
 
 const WORLD_SEED = 20061; // fixed: World of ClaudeCraft is a persistent place
@@ -818,7 +818,9 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       interpFacing,
       frameDt,
       lastInterpFacing,
-      mouselook: input.isMouselookActive(),
+      // Mouse Camera mode is camera-authoritative just like right-mouse mouselook,
+      // so the follow system must be bypassed (it reports mouselook=false on desktop).
+      mouselook: cameraIsManual(input.isMouselookActive(), input.isMouseCameraMode()),
       moving: mi.forward || mi.strafeLeft || mi.strafeRight || clickMoving,
       clickMoving,
       orbiting: input.leftDown && input.isCameraDragActive(),

--- a/tests/camera_follow.test.ts
+++ b/tests/camera_follow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { updateFollowCameraYaw, wrapAngle } from '../src/game/camera_follow';
+import { cameraIsManual, updateFollowCameraYaw, wrapAngle } from '../src/game/camera_follow';
 
 describe('camera follow', () => {
   it('wraps angles to the shortest signed turn', () => {
@@ -106,6 +106,43 @@ describe('camera follow', () => {
     });
     expect(next.camYaw).toBeLessThan(Math.PI);
     expect(next.camYaw).toBeGreaterThan(Math.PI - 0.04);
+  });
+
+  it('treats mouse-camera mode as manual control even though mouselook reports false', () => {
+    // Right-mouse mouselook already counts as manual; Mouse Camera mode reports
+    // mouselook=false on desktop but must be folded in so it takes the same path.
+    expect(cameraIsManual(true, false)).toBe(true);   // classic right-mouse mouselook
+    expect(cameraIsManual(false, true)).toBe(true);   // Mouse Camera mode (always on)
+    expect(cameraIsManual(true, true)).toBe(true);
+    expect(cameraIsManual(false, false)).toBe(false); // classic, hands off — follow runs
+  });
+
+  it('keeps the camera locked to the drag in mouse-camera mode (no follow drift)', () => {
+    // Reproduces the bug: in Mouse Camera mode the player walks forward while
+    // dragging the camera, and the sim locks facing to camYaw every frame. Routed
+    // through the manual flag (cameraIsManual=true) the follow system is bypassed,
+    // so the camera tracks the drag exactly. With the old wiring (mouselook=false)
+    // the follow code fights the drag and the view drifts tens of degrees.
+    const simulate = (manual: boolean): number => {
+      const dt = 1 / 60;
+      const dragPerFrame = 0.03;
+      let camYaw = Math.PI;
+      let intended = Math.PI;
+      let lastInterpFacing: number | null = camYaw;
+      for (let f = 0; f < 90; f++) {
+        camYaw += dragPerFrame;        // the player's drag this frame
+        intended += dragPerFrame;      // where the drag actually asked the camera to point
+        const next = updateFollowCameraYaw({
+          camYaw, interpFacing: camYaw, frameDt: dt, lastInterpFacing,
+          mouselook: manual, moving: true, orbiting: false,
+        });
+        camYaw = next.camYaw;
+        lastInterpFacing = next.lastInterpFacing;
+      }
+      return Math.abs(wrapAngle(camYaw - intended));
+    };
+    expect(simulate(true)).toBeCloseTo(0, 6);   // fixed: camera goes exactly where dragged
+    expect(simulate(false)).toBeGreaterThan(0.5); // old wiring: drifts >0.5 rad (~30°+)
   });
 
   it('settles click-to-move turns more softly when the facing jump is large', () => {


### PR DESCRIPTION
## What

Mouse Camera mode (the optional OSRS-style, camera-relative movement scheme) is meant to be **camera-authoritative** — exactly like holding right-mouse for mouselook: the character's facing is locked to `camYaw` and you rotate the view by dragging. But on desktop the mode reports `isMouselookActive() === false`, so `updateCamera` left the auto-follow/settle system (`updateFollowCameraYaw`) running. Since facing *is* `camYaw` in this mode, the follow code chased its own tail and fought the drag.

Measured against the real follow module, dragging the camera while walking drifted the view **~40–52°** off where the player aimed (transiently up to ~180°). Right-mouse mouselook avoids this only because it sets the `mouselook` flag, which bypasses follow.

## Fix

Fold Mouse Camera mode into a small named predicate, `cameraIsManual(mouselookActive, mouseCameraMode)`, and use it for the follow-bypass flag so the mode takes the same path right-mouse already uses.

- **Classic mode is unchanged**: `cameraIsManual(x, false) === x`.
- Drift in Mouse Camera mode goes to **exactly 0** — the camera tracks the drag precisely, which is the whole intent of the mode.

## Tests

- New regression coverage in `tests/camera_follow.test.ts`: the predicate contract, plus a multi-frame drag-drift test (fixed path = 0 drift; old wiring > 0.5 rad). This control path previously had **zero** test coverage, which is how it rotted through the follow-cam rework.
- Full suite green (1489 passed, 7 skipped), `tsc --noEmit` clean.
- Verified live on a tunneled test instance: dragging while moving now tracks the cursor instead of fighting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)