### PR TITLE
fix(ui): respect mobile safe areas on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -4598,7 +4598,9 @@
     max-width: min(360px, 92vw); margin-top: 18px; line-height: 1.45; font-size: 10px;
   }
   body.mobile-touch #mode-select {
-    max-width: min(440px, calc(100vw - 24px));
+    width: 100%;
+    max-width: min(440px, calc(100vw - 32px - env(safe-area-inset-left) - env(safe-area-inset-right)));
+    margin-inline: auto;
     padding: 20px 18px 18px;
   }
   body.mobile-touch .play-console {
@@ -4730,7 +4732,8 @@
 
   @media (orientation: landscape) {
     body.mobile-touch .play-console {
-      width: min(460px, calc(100vw - 80px));
+      width: 100%;
+      max-width: 460px;
       gap: 12px;
     }
     body.mobile-touch .server-select-caption { margin-bottom: 5px; }
@@ -5621,7 +5624,16 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: var(--spacing-sm) var(--spacing-md);
+    padding-top: calc(var(--spacing-sm) + env(safe-area-inset-top));
+    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+    padding-bottom: var(--spacing-sm);
+    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+  }
+  body.mobile-touch #homepage-views-container {
+    padding-top: var(--spacing-lg);
+    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+    padding-bottom: var(--spacing-lg);
+    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
   }
   body.mobile-touch .header-menu-container {
     display: none;
@@ -5685,7 +5697,16 @@
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
-      padding: var(--spacing-sm) var(--spacing-md);
+      padding-top: calc(var(--spacing-sm) + env(safe-area-inset-top));
+      padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+      padding-bottom: var(--spacing-sm);
+      padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+    }
+    #homepage-views-container {
+      padding-top: var(--spacing-lg);
+      padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+      padding-bottom: var(--spacing-lg);
+      padding-left: max(var(--spacing-md), env(safe-area-inset-left));
     }
     .header-menu-container {
       display: none;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -142,6 +142,9 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.game-active {\n    overflow: hidden;\n    touch-action: none;');
     expect(html).toContain('-webkit-overflow-scrolling: touch;');
     expect(html).toContain('body.mobile-touch .homepage-header {\n    display: flex;\n    position: sticky;\n    top: 0;\n    z-index: 120;');
+    expect(html).toContain('padding-top: calc(var(--spacing-sm) + env(safe-area-inset-top));');
+    expect(html).toContain('padding-right: max(var(--spacing-md), env(safe-area-inset-right));');
+    expect(html).toContain('body.mobile-touch #homepage-views-container {\n    padding-top: var(--spacing-lg);\n    padding-right: max(var(--spacing-md), env(safe-area-inset-right));');
     expect(html).not.toContain('body.mobile-touch .homepage-header {\n    display: flex;\n    position: relative;');
     expect(mainTs).not.toContain("visualViewport?.addEventListener('scroll', syncAppViewport)");
   });
@@ -193,8 +196,10 @@ describe('client HTML shell', () => {
     expect(html).toContain('id="btn-offline"');
     expect(html).not.toContain('class="mode-card');
     expect(html).not.toContain('.mode-row {');
+    expect(html).toContain('body.mobile-touch #mode-select {\n    width: 100%;\n    max-width: min(440px, calc(100vw - 32px - env(safe-area-inset-left) - env(safe-area-inset-right)));\n    margin-inline: auto;');
     // Landscape compacts the single play console instead of splitting two cards.
     expect(html).toContain('@media (orientation: landscape) {\n    body.mobile-touch .play-console {');
+    expect(html).toContain('@media (orientation: landscape) {\n    body.mobile-touch .play-console {\n      width: 100%;\n      max-width: 460px;');
   });
 
   it('ships a looping cinematic backdrop with a poster fallback', () => {


### PR DESCRIPTION
## Summary

Fixes the mobile homepage layout in fullscreen/PWA contexts:

1. Adds safe-area-aware top padding to the mobile homepage navbar so iOS standalone status bars do not cover it.
2. Centers the main Play card on mobile portrait and gives the card safe-area-aware side gutters so landscape does not clip against the right edge.
3. Keeps the changes scoped to homepage/menu CSS and shell coverage; in-game HUD rules are untouched.

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/client_shell.test.ts` -> 24 passed.
- Local Chrome mobile layout check at iPhone 12 Pro dimensions:
  - Portrait 390x844: Play card measured 16px left / 16px right gap.
  - Landscape 844x390: Play card measured equal left / right gaps.

---

## Checklist

- [x] Tests pass for the focused mobile shell coverage.
- [x] No secrets / `.env`; `ALLOW_DEV_COMMANDS` not enabled anywhere.
- [x] No generated files were hand-edited.