### PR TITLE
feat(content): zone3 mob-affix pack (16 on-hit affixes across Thornpeak/Stormcrag)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/enervate_visual.mjs
+++ b/scripts/enervate_visual.mjs
@@ -1,0 +1,116 @@
+// Screenshots for the "Soul Siphon" enervate affix (Boneclad Revenant).
+// A landed hit drains the victim's Stamina, shrinking their max-HP pool, and
+// shows a red debuff on the buff bar. Runs the offline flow (no server). Needs
+// `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Brann', n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate(() => document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click());
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+// Level the warrior to 20 so a L18 Revenant's swing never one-shots it.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  p.hp = p.maxHp;
+});
+await wait(400);
+
+// Retemplate the nearest mob into a Boneclad Revenant, stage it in front of the
+// player, then force swings until the Soul Siphon drain lands.
+const result = await page.evaluate(async () => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let mob = null, best = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < best) { best = d; mob = e; }
+  }
+  if (!mob) return { ok: false, why: 'no mob nearby' };
+  mob.templateId = 'boneclad_revenant';
+  mob.name = 'Boneclad Revenant';
+  mob.hostile = true;
+  mob.level = 18;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z; mob.pos.y = p.pos.y;
+  const staBefore = p.stats.sta, maxHpBefore = p.maxHp;
+  let drained = false;
+  for (let i = 0; i < 400 && !drained; i++) {
+    p.hp = p.maxHp; // never let the swing kill us
+    sim.mobSwing(mob, p);
+    drained = p.auras.some((a) => a.kind === 'buff_sta' && a.value < 0);
+  }
+  // Set HP to ~70% of the (now-smaller) pool so the red HP bar reads clearly.
+  p.hp = Math.round(p.maxHp * 0.7);
+  return {
+    ok: drained, staBefore, staAfter: p.stats.sta,
+    maxHpBefore, maxHpAfter: p.maxHp,
+    aura: p.auras.find((a) => a.kind === 'buff_sta' && a.value < 0)?.name ?? null,
+  };
+});
+
+// Teleport the player away so combat ends and the 12s drain rides along, then
+// screenshot quickly before regen/recalc churn.
+await page.evaluate(() => {
+  const sim = window.__game.sim, p = sim.player;
+  p.pos.x -= 80;
+  p.prevPos = { ...p.pos };
+});
+await wait(160);
+await page.screenshot({ path: 'tmp/enervate-hud.png' });
+
+// Crop the buff bar (top-right, left of the minimap) for a legible debuff icon.
+try {
+  const clip = await page.evaluate(() => {
+    const el = document.querySelector('#buff-bar');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: Math.max(0, r.x - 12), y: Math.max(0, r.y - 8), width: Math.min(360, r.width + 24), height: Math.min(120, r.height + 50) };
+  });
+  if (clip && clip.width > 4) await page.screenshot({ path: 'tmp/enervate-buffbar.png', clip });
+} catch (e) { errors.push('buffbar crop: ' + e.message); }
+
+// Hover the debuff icon to surface its tooltip, then crop the top-right region.
+try {
+  await page.evaluate(() => {
+    const icon = document.querySelector('#buff-bar .buff.debuff') || document.querySelector('#buff-bar .buff');
+    if (!icon) return;
+    const r = icon.getBoundingClientRect();
+    const opts = { bubbles: false, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2 };
+    icon.dispatchEvent(new MouseEvent('mouseenter', opts));
+    icon.dispatchEvent(new MouseEvent('mousemove', { ...opts, bubbles: true }));
+  });
+  await wait(250);
+  await page.screenshot({ path: 'tmp/enervate-tooltip.png', clip: { x: 900, y: 0, width: 380, height: 230 } });
+} catch (e) { errors.push('tooltip: ' + e.message); }
+
+console.log('RESULT', JSON.stringify(result));
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/scripts/shot_bleed.mjs
+++ b/scripts/shot_bleed.mjs
@@ -1,0 +1,97 @@
+// Screenshot the on-hit Bleed affix (Rending Claws) in the offline client.
+// Boots the game, repurposes a nearby mob as a Ridge Stalker, drives its
+// raking swipes onto the player until the physical bleed DoT lands, and
+// captures the resulting debuff on the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Ridge Stalker and drive its bleed onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the bleeding predator and stand it next to us.
+  mob.templateId = 'ridge_stalker';
+  mob.name = 'Ridge Stalker';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Swing until the bleed rolls (chance is 0.25 per landed hit), keeping the
+  // player topped up so swing damage never masks the DoT.
+  let bleed = null;
+  for (let i = 0; i < 200 && !bleed; i++) {
+    p.hp = p.maxHp;
+    sim.mobSwing(mob, p);
+    bleed = p.auras.find((a) => a.id === 'bleed_ridge_stalker');
+  }
+  return { hasBleed: !!bleed, name: bleed?.name, school: bleed?.school, value: bleed?.value, remaining: bleed?.remaining };
+});
+console.log('bleed result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/bleed_full.png' });
+
+// Crop tightly around the player buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/bleed_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+  // Hover the debuff icon to surface its tooltip.
+  await page.mouse.move(box.x + box.w / 2, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 500));
+  await page.screenshot({
+    path: 'tmp/bleed_tooltip_crop.png',
+    clip: {
+      x: Math.max(0, box.x - 300), y: Math.max(0, box.y - 10),
+      width: 300 + box.w + 20, height: 140,
+    },
+  });
+}
+
+console.log('saved tmp/bleed_full.png, bleed_frame.png, bleed_tooltip_crop.png');
+await browser.close();

--- a/scripts/shot_cinder.mjs
+++ b/scripts/shot_cinder.mjs
@@ -1,0 +1,85 @@
+// Screenshot the Cinderburn affix (on-hit fire DoT) in the offline client.
+// Boots the game, repurposes a nearby mob as an Ironvein Sapper, forces its
+// on-hit cinder onto the player, and captures the resulting fire DoT debuff
+// on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as an Ironvein Sapper and drive its cinder onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live loop (applyAura re-derives maxHp from stamina, wiping a
+  // raw hp override) and the cinder roll fires independently of damage landing.
+  p.gm = true;
+  sim.rng.chance = () => true;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the demolitionist kobold and stand it next to us.
+  mob.templateId = 'ironvein_sapper';
+  mob.name = 'Ironvein Sapper';
+  mob.level = 16;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const cinder = p.auras.find((a) => a.id === 'cinder_ironvein_sapper');
+  return { hasCinder: !!cinder, name: cinder?.name, school: cinder?.school, value: cinder?.value, remaining: cinder?.remaining };
+});
+console.log('cinder result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/cinder_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right) to show the icon.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/cinder_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/cinder_scene.png, cinder_debuff.png');
+await browser.close();

--- a/scripts/shot_disarm.mjs
+++ b/scripts/shot_disarm.mjs
@@ -1,0 +1,87 @@
+// Screenshot harness for the Thornpeak Crusher "Disarming Smash" disarm affix.
+// Runs the offline client (no server/Postgres), forces the on-hit disarm proc, and
+// captures the debuff on the player frame + proves auto-attack is suppressed while
+// the weapon is knocked away. Needs `npm run dev` running. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 800 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Disarmed'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap('#offline-select .mini-class[data-class="warrior"]');
+await tap('#btn-start-offline');
+await wait(3000);
+
+// God-mode the player and force the disarm proc from a repurposed nearby mob.
+const info = await page.evaluate(() => {
+  const game = window.__game;
+  const sim = game.sim;
+  const p = sim.player;
+  p.maxHp = 99999; p.hp = 99999;
+  // Repurpose the nearest living mob as a Thornpeak Crusher carrying the affix.
+  let best = null, bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.id === p.id) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < bestD) { bestD = d; best = e; }
+  }
+  if (!best) return { ok: false, reason: 'no mob nearby' };
+  best.templateId = 'ogre_crusher';
+  best.hostile = true;
+  // Swing repeatedly until the 25% disarm proc lands (misses/dodges possible).
+  for (let i = 0; i < 200 && !p.auras.some((a) => a.kind === 'disarm'); i++) {
+    p.hp = 99999; // stay alive through every landed swing
+    sim.mobSwing(best, p);
+  }
+  const disarm = p.auras.find((a) => a.kind === 'disarm');
+  return {
+    ok: !!disarm,
+    auraName: disarm?.name ?? null,
+    remaining: disarm?.remaining ?? null,
+    autoAttackSuppressed: disarm ? (sim.isDisarmed ? sim.isDisarmed(p) : true) : null,
+  };
+});
+
+await wait(400);
+await page.screenshot({ path: 'tmp/disarm_world.png' });
+
+// Crop the player unit frame + buff/debuff bar if present.
+const frame = await page.evaluate(() => {
+  const el = document.querySelector('#buff-bar') || document.querySelector('#player-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: Math.max(0, r.x - 8), y: Math.max(0, r.y - 8), width: r.width + 16, height: r.height + 16 };
+});
+if (frame && frame.width > 4 && frame.height > 4) {
+  await page.screenshot({ path: 'tmp/disarm_debuff_crop.png', clip: frame });
+}
+
+console.log('disarm result:', JSON.stringify(info));
+if (errors.length) console.log('PAGE ERRORS:\n' + errors.join('\n'));
+console.log('wrote tmp/disarm_world.png' + (frame ? ', tmp/disarm_debuff_crop.png' : ''));
+await browser.close();
+process.exit(info.ok ? 0 : 1);

--- a/scripts/shot_expose.mjs
+++ b/scripts/shot_expose.mjs
@@ -1,0 +1,106 @@
+// Screenshot script for the Expose affix (Cracked Guard).
+// Boots the offline client, parks a warrior next to a Varkas Boneguard, forces
+// its on-hit Expose proc, and captures the red Cracked Guard debuff on the
+// player frame plus a cropped close-up. Needs `npm run dev` on :5173.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.click('#btn-offline');
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Highwatch');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 1500));
+
+// Level up so the lvl18-19 Boneguard isn't trivially out of band, god-mode the
+// player so they survive the swings, and force the Expose proc to 100%.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  sim.setPlayerLevel(20);
+  const p = sim.player;
+  p.maxHp = 1e5; p.hp = 1e5;
+
+  // Varkas Boneguards only exist as Marrowlord Varkas's summoned adds, so find
+  // the Marrowlord (a rare in a static camp) and call up a real Boneguard.
+  let boss = null;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'marrowlord_varkas' && !e.dead) { boss = e; break; }
+  }
+  if (!boss) return { found: false };
+  // teleport beside the Marrowlord, then summon one authentic Boneguard
+  p.pos.x = boss.pos.x + 8; p.pos.z = boss.pos.z; p.pos.y = boss.pos.y;
+  boss.aggroTargetId = p.id;
+  sim.spawnBossAdds(boss, 'varkas_boneguard', 1);
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.templateId === 'varkas_boneguard' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - boss.pos.x, e.pos.z - boss.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  if (!mob) return { found: false };
+  // hide the boss so only the Boneguard frames in the shot, park the player ~6yd off
+  boss.pos.x = boss.pos.x - 40;
+  p.pos.x = mob.pos.x + 6; p.pos.z = mob.pos.z + 2; p.pos.y = mob.pos.y;
+  return { found: true, mobId: mob.id };
+});
+
+if (!setup.found) {
+  console.log('could not summon a varkas_boneguard from Marrowlord Varkas — FAIL');
+  await browser.close();
+  process.exit(1);
+}
+
+// Drive swings until Cracked Guard lands. The affix is a real 25% proc shipped
+// on the Boneguard, so ~120 swings makes it virtually certain — no need to mutate
+// the live template (which the sim closes over privately).
+const applied = await page.evaluate(async (mobId) => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  const mob = sim.entities.get(mobId);
+  let ok = false;
+  for (let i = 0; i < 120 && !ok; i++) {
+    sim.mobSwing(mob, p);
+    ok = p.auras.some((a) => a.kind === 'expose');
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  // pin the Boneguard a few yards directly in front of the player and stop it
+  // wandering, then aim the third-person camera down that line.
+  mob.pos.x = p.pos.x; mob.pos.z = p.pos.z + 5; mob.pos.y = p.pos.y;
+  mob.aiState = 'idle'; mob.aggroTargetId = null;
+  if (mob.vel) { mob.vel.x = 0; mob.vel.z = 0; }
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  g.input.camDist = 8;
+  if ('camPitch' in g.input) g.input.camPitch = 0.18;
+  sim.targetEntity(mob.id);
+  return ok;
+}, setup.mobId);
+
+await new Promise((r) => setTimeout(r, 800));
+console.log('Cracked Guard applied to player:', applied ? 'OK' : 'FAIL');
+
+await page.screenshot({ path: 'tmp/expose_full.png' });
+// close-up of the player's buff bar (top-right) where Cracked Guard shows as a
+// red-bordered debuff with its countdown.
+await page.screenshot({ path: 'tmp/expose_debuff.png', clip: { x: 1330, y: 2, width: 270, height: 96 } });
+
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 10).join('\n') : 'no page errors');
+await browser.close();

--- a/scripts/shot_frostbite.mjs
+++ b/scripts/shot_frostbite.mjs
@@ -1,0 +1,84 @@
+// Screenshot the Frostbite affix in the offline client. Boots the game,
+// repurposes a nearby mob as Shardlord Kazzix, forces its on-hit frost DoT onto
+// the player, and captures the resulting frost debuff on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Shardlord Kazzix and drive its frost burn onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp bump is wiped by recalcPlayerStats);
+  // applyAura still lands, so the debuff renders.
+  p.gm = true;
+  // Force the on-hit roll so the frost DoT lands deterministically.
+  sim.rng.chance = () => true;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the rare ice elemental and stand it next to us.
+  mob.templateId = 'shardlord_kazzix';
+  mob.name = 'Shardlord Kazzix';
+  mob.level = 18;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const frost = p.auras.find((a) => a.id === 'frostbite_shardlord_kazzix');
+  return { hasFrostbite: !!frost, name: frost?.name, value: frost?.value, school: frost?.school, remaining: frost?.remaining };
+});
+console.log('frostbite result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/frostbite_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box && box.w > 0) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/frostbite_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+await browser.close();

--- a/scripts/shot_knockback.mjs
+++ b/scripts/shot_knockback.mjs
@@ -1,0 +1,82 @@
+// Screenshot the Knockback affix (Crushing Sweep) in the offline client.
+// Boots the game, repurposes the nearest mob as Marrowlord Varkas, captures the
+// player standing toe-to-toe with it, forces the on-hit shove, then captures the
+// player hurled back with the "unleashes Crushing Sweep!" line in the combat log.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Stand the Marrowlord toe-to-toe with us, look at it. (before the shove)
+await page.evaluate(() => {
+  const g = window.__game, sim = g.sim, p = sim.player;
+  p.gm = true; // an L19 elite shouldn't kill us mid-demo
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'marrowlord_varkas';
+  mob.name = 'Marrowlord Varkas';
+  mob.level = 19; mob.hostile = true; mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2.5; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing; g.input.camDist = 9;
+  window.__mobId = mob.id;
+});
+await new Promise((r) => setTimeout(r, 800));
+await page.screenshot({ path: 'tmp/knockback_before.png' });
+
+// Force the on-hit shove and confirm the displacement via the real swing path.
+const result = await page.evaluate(() => {
+  const g = window.__game, sim = g.sim, p = sim.player;
+  const mob = sim.entities.get(window.__mobId);
+  const before = Math.hypot(p.pos.x - mob.pos.x, p.pos.z - mob.pos.z);
+  // drive real swings until we're flung; guarantee the demo lands if RNG is shy
+  let moved = false;
+  for (let i = 0; i < 60 && !moved; i++) {
+    sim.mobSwing(mob, p);
+    moved = Math.hypot(p.pos.x - mob.pos.x, p.pos.z - mob.pos.z) > before + 1;
+  }
+  if (!moved) sim.applyKnockback(mob, p, 6);
+  const after = Math.hypot(p.pos.x - mob.pos.x, p.pos.z - mob.pos.z);
+  // keep facing the (now distant) Marrowlord
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  return { before, after };
+});
+console.log('knockback gap before/after:', JSON.stringify(result));
+
+// Surface the combat log so the "unleashes Crushing Sweep!" line shows.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]') ||
+              document.querySelector('[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/knockback_after.png' });
+
+console.log('saved tmp/knockback_before.png, knockback_after.png');
+await browser.close();

--- a/scripts/shot_lockout.mjs
+++ b/scripts/shot_lockout.mjs
@@ -1,0 +1,85 @@
+// Screenshot the school-lockout affix (Wyrmward Sigil) in the offline client.
+// Boots the game, repurposes a nearby mob as a Wyrmcult Zealot, forces its
+// on-hit lockout onto the player, and captures the resulting red fire-lockout
+// debuff icon in the top-right buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 400)); // panel reveal + auto-select warrior
+await page.type('#char-name', 'Brannok');
+await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override gets wiped by
+  // recalcPlayerStats); applyAura still lands so the debuff shows.
+  p.gm = true;
+  sim.rng.chance = () => true; // force the lockout proc deterministically
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as a Wyrmcult Zealot and stand it next to us.
+  mob.templateId = 'wyrmcult_zealot';
+  mob.name = 'Wyrmcult Zealot';
+  mob.level = 18;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 3.5; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input.camDist !== undefined) g.input.camDist = 10;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const sigil = p.auras.find((a) => a.kind === 'lockout');
+  // hold the aura open so the live tick doesn't expire it before capture
+  if (sigil) { sigil.remaining = 30; sigil.duration = 30; }
+  return { hasSigil: !!sigil, name: sigil?.name, school: sigil?.school, remaining: sigil?.remaining };
+});
+console.log('lockout result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/lockout_scene.png' });
+
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box && box.w > 0) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/lockout_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+await browser.close();
+console.log('done');

--- a/scripts/shot_rally.mjs
+++ b/scripts/shot_rally.mjs
@@ -1,0 +1,115 @@
+// Screenshot the Rally commander affix (Rallying Banner) in the offline client.
+// Boots the game, repurposes nearby mobs as an Ironvein Foreman and his sapper
+// crew, fires the periodic rally, and captures the boss in-world + target frame
+// + the combat log line. A mob ally-buff has no player-facing debuff icon
+// (mirrors the Rampage shot, PR #540), so the proof is the world scene, the
+// elite target frame, and the empowered allies' attack power in the console.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // survive the live hostile loop; aura application still works
+
+  // Collect the three nearest mobs: one becomes the Foreman, two his sappers.
+  const mobs = [...sim.entities.values()]
+    .filter((e) => e.kind === 'mob' && !e.dead)
+    .sort((a, b) => Math.hypot(a.pos.x - p.pos.x, a.pos.z - p.pos.z) - Math.hypot(b.pos.x - p.pos.x, b.pos.z - p.pos.z));
+
+  const foreman = mobs[0];
+  foreman.templateId = 'ironvein_foreman';
+  foreman.name = 'Ironvein Foreman';
+  foreman.level = 16;
+  foreman.hostile = true;
+  foreman.inCombat = true;
+  foreman.aggroTargetId = p.id;
+  foreman.pos.x = p.pos.x + 4; foreman.pos.z = p.pos.z + 5;
+
+  const sappers = mobs.slice(1, 3);
+  sappers.forEach((s, i) => {
+    s.templateId = 'ironvein_sapper';
+    s.name = 'Ironvein Sapper';
+    s.level = 16;
+    s.hostile = true;
+    s.inCombat = true;
+    s.pos.x = p.pos.x + (i === 0 ? 2 : 6); s.pos.z = p.pos.z + 6;
+  });
+
+  // Aim the camera at the Foreman so the elite target frame is shown.
+  sim.targetEntity(foreman.id);
+  p.facing = Math.atan2(foreman.pos.x - p.pos.x, foreman.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input.camDist !== undefined) g.input.camDist = 12;
+
+  const apBefore = sappers.map((s) => sim.effectiveAttackPower(s));
+  // Fire the rally immediately rather than waiting the 12s telegraph.
+  foreman.rallyTimer = 0.001;
+  sim.updateBossMechanics(foreman);
+  const apAfter = sappers.map((s) => sim.effectiveAttackPower(s));
+  const banner = sappers[0]?.auras.find((a) => a.name === 'Rallying Banner');
+
+  return {
+    apBefore, apAfter,
+    hasBanner: !!banner, bannerValue: banner?.value, bannerRemaining: banner?.remaining,
+    foremanBuffed: foreman.auras.some((a) => a.name === 'Rallying Banner'),
+  };
+});
+console.log('rally result:', JSON.stringify(result));
+
+// Open the combat-log tab to surface the "unleashes Rallying Banner!" line.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/rally_scene.png' });
+
+// Crop the boss/elite target frame (top-left of the HUD).
+const tf = await page.evaluate(() => {
+  const el = document.querySelector('#target-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (tf && tf.w > 0) {
+  const pad = 14;
+  await page.screenshot({
+    path: 'tmp/rally_frame.png',
+    clip: {
+      x: Math.max(0, tf.x - pad), y: Math.max(0, tf.y - pad),
+      width: tf.w + pad * 2, height: tf.h + pad * 2,
+    },
+  });
+}
+
+// Crop the combat log (bottom-left chat region).
+await page.screenshot({
+  path: 'tmp/rally_log.png',
+  clip: { x: 0, y: 640, width: 560, height: 240 },
+});
+
+console.log('saved tmp/rally_scene.png, rally_frame.png, rally_log.png');
+await browser.close();

--- a/scripts/shot_rampage.mjs
+++ b/scripts/shot_rampage.mjs
@@ -1,0 +1,89 @@
+// Screenshot the Battle Fury (Rampage) affix carrier — Warlord Drogmar — in the
+// offline client. Boots the game, repurposes a nearby mob as the warlord, stands
+// it in front of a god-moded player, drives a string of landed swings so the
+// self-stacking buff_ap aura builds, and captures the boss in-world (nameplate +
+// target frame). The fury is a self-BUFF on the mob (it has no enemy-debuff UI),
+// so the meaningful visual is the warlord himself; the ramp is asserted in
+// tests/mob_rampage.test.ts and reported on the console here.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Warlord Drogmar, stand it in front of us, and
+// drive a run of landed swings so Battle Fury stacks up to its cap.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+  p.dodgeChance = 0;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'warlord_drogmar';
+  mob.name = 'Warlord Drogmar';
+  mob.level = 17;
+  mob.scale = 1.5;
+  mob.hostile = true;
+  mob.maxHp = 800; mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const apBefore = sim.effectiveAttackPower(mob);
+  for (let i = 0; i < 12; i++) { p.hp = p.maxHp; sim.mobSwing(mob, p); }
+  const fury = mob.auras.find((a) => a.name === 'Battle Fury');
+  const apAfter = sim.effectiveAttackPower(mob);
+  return { apBefore, apAfter, hasFury: !!fury, stacks: fury?.stacks, furyValue: fury?.value };
+});
+console.log('rampage result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 700));
+await page.screenshot({ path: 'tmp/rampage_full.png' });
+
+// Crop around the target frame (top-center boss frame) for a tight portrait.
+const box = await page.evaluate(() => {
+  const tf = document.querySelector('#target-frame');
+  if (!tf) return null;
+  const r = tf.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 24;
+  await page.screenshot({
+    path: 'tmp/rampage_target.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/rampage_full.png, rampage_target.png');
+await browser.close();

--- a/scripts/shot_smolder.mjs
+++ b/scripts/shot_smolder.mjs
@@ -1,0 +1,87 @@
+// Screenshot the Smoldering Fuse affix (on-hit fire DoT) in the offline client.
+// Boots the game, repurposes a nearby mob as an Ironvein Sapper, forces its
+// burning fuse onto the player, and captures the resulting fire DoT debuff on
+// the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as an Ironvein Sapper and drive its fuse onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (raw maxHp gets re-derived from stamina each
+  // tick by recalcPlayerStats); applyAura still lands on a gm player.
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+  sim.rng.chance = () => true; // guarantee the on-hit proc fires
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the smoldering sapper and stand it next to us (offset on +x/+z
+  // so the third-person camera frames it close).
+  mob.templateId = 'ironvein_sapper';
+  mob.name = 'Ironvein Sapper';
+  mob.level = 16;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 4; mob.pos.z = p.pos.z + 4;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input) g.input.camDist = 10;
+
+  for (let i = 0; i < 6; i++) sim.mobSwing(mob, p);
+  const fuse = p.auras.find((a) => a.name === 'Smoldering Fuse');
+  return { hasFuse: !!fuse, school: fuse?.school, value: fuse?.value, remaining: fuse?.remaining };
+});
+console.log('smolder result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/smolder_scene.png' });
+
+// Crop tightly around the top-right buff/debuff bar where the fire DoT renders.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box && box.w > 0) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/smolder_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/smolder_scene.png, tmp/smolder_debuff.png');
+await browser.close();

--- a/scripts/shot_spell_reflect.mjs
+++ b/scripts/shot_spell_reflect.mjs
@@ -1,0 +1,108 @@
+// Screenshot the Spectral Ward affix (mob spell reflect) in the offline client.
+// Boots the game as a mage, reskins a nearby mob as a Wyrmcult Necromancer,
+// stands it in front, and repeatedly lands spell hits on it so its ward lashes
+// flat shadow damage back at the caster — captured as the floating combat text
+// over the player and the "Spectral Ward hits you" combat-log lines.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Aevera');
+await page.click('#offline-select .mini-class[data-class="mage"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Reskin the nearest mob as the warded necromancer and plant it in front of us.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000; // survive the bout; gm would block the reflect
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'wyrmcult_necromancer';
+  mob.name = 'Wyrmcult Necromancer';
+  mob.level = 19; // match its real Thornpeak spawn level for the label
+  mob.hostile = true;
+  mob.maxHp = 100000; mob.hp = 100000;
+  mob.pos.x = p.pos.x + 6; mob.pos.z = p.pos.z + 6;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  if (g.input) g.input.camDist = 10;
+  return { mobId: mob.id, ward: sim.constructor && null, name: mob.name };
+});
+console.log('spell-reflect setup:', JSON.stringify(setup));
+
+// Fire a burst of spell hits so the ward reflects repeatedly; capture mid-burst
+// while the floating "-9" combat text is still rising over the player.
+for (let i = 0; i < 10; i++) {
+  await page.evaluate(({ mobId, crit }) => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    const mob = sim.entities.get(mobId);
+    if (mob && !mob.dead) sim.dealDamage(p, mob, 45, crit, 'fire', 'Fireball', 'hit');
+  }, { mobId: setup.mobId, crit: i % 3 === 0 });
+  await new Promise((r) => setTimeout(r, 120));
+}
+
+await new Promise((r) => setTimeout(r, 250));
+await page.screenshot({ path: 'tmp/spell_reflect_full.png' });
+
+// One more burst, then immediately grab the scene to catch fresh FCT, and crop
+// the combat log (persistent) which lists the "Spectral Ward hits you" lines.
+const verdict = await page.evaluate(({ mobId }) => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const mob = sim.entities.get(mobId);
+  const before = p.hp;
+  for (let i = 0; i < 4; i++) sim.dealDamage(p, mob, 45, false, 'frost', 'Frostbolt', 'hit');
+  return { reflectedTotal: before - p.hp, mob: mob.name };
+}, { mobId: setup.mobId });
+console.log('spell-reflect verdict:', JSON.stringify(verdict));
+await new Promise((r) => setTimeout(r, 60));
+await page.screenshot({ path: 'tmp/spell_reflect_fct.png' });
+
+// Crop the combat log (bottom-left) showing the named reflect lines, and read
+// back its text so we can confirm the wording is "Spectral Ward hits you".
+const logBox = await page.evaluate(() => {
+  const el = document.querySelector('#combatlog');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height, text: el.innerText };
+});
+console.log('combat-log text:', logBox && JSON.stringify(logBox.text));
+// Switch to the Combat Log tab so the reflect lines are visible, then crop the
+// known bottom-left region directly (the panel measures 0-width via the DOM).
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 200));
+await page.screenshot({ path: 'tmp/spell_reflect_log.png', clip: { x: 6, y: 600, width: 440, height: 160 } });
+// Player-centred crop to frame the reflected damage text over the caster.
+await page.screenshot({ path: 'tmp/spell_reflect_scene.png', clip: { x: 430, y: 150, width: 740, height: 480 } });
+console.log('crops written');
+
+await browser.close();

--- a/scripts/shot_spellvuln.mjs
+++ b/scripts/shot_spellvuln.mjs
@@ -1,0 +1,104 @@
+// Screenshot the Spell Vulnerability affix (Static Charge) in the offline client.
+// Boots the game, repurposes a nearby mob as a Stormcrag Elemental, suppresses
+// its unrelated chill so the capture is clean, forces its on-hit Static Charge
+// onto the player, then lands a magic vs a physical hit to show the amplified
+// (yellow) spell damage next to the unaffected physical hit in the floating
+// combat text.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // GM = invulnerable: recalcPlayerStats re-derives maxHp from stamina every
+  // tick (so a raw maxHp override gets wiped and the live elemental can grind
+  // the warrior down). gm keeps the player alive so the debuff stays on-frame.
+  p.gm = true; p.hp = p.maxHp;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Stormcrag Elemental and stand it next to us.
+  mob.templateId = 'stormcrag_elemental';
+  mob.name = 'Stormcrag Elemental';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Apply Static Charge directly (the on-hit proc is verified in the unit test;
+  // here we just need the debuff present on the frame for the capture, without
+  // the swing loop slowly grinding the player down).
+  p.auras = p.auras.filter((a) => a.kind !== 'spellvuln' && a.name !== 'Numbing Chill');
+  sim.applyAura(p, {
+    id: 'spellvuln_stormcrag_elemental', name: 'Static Charge', kind: 'spellvuln',
+    remaining: 10, duration: 10, value: 0.18, sourceId: mob.id, school: 'nature',
+  });
+  const charge = p.auras.find((a) => a.kind === 'spellvuln');
+  return {
+    hasCharge: !!charge, name: charge?.name, amp: charge?.value, remaining: charge?.remaining,
+  };
+});
+console.log('spellvuln result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 500));
+await page.screenshot({ path: 'tmp/spellvuln_full.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/spellvuln_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+  // Hover the debuff icon to surface its tooltip.
+  await page.mouse.move(box.x + box.w / 2, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 500));
+  await page.screenshot({
+    path: 'tmp/spellvuln_tooltip.png',
+    clip: {
+      x: Math.max(0, box.x - 320), y: Math.max(0, box.y - 10),
+      width: 320 + box.w + 20, height: 160,
+    },
+  });
+}
+
+console.log('saved tmp/spellvuln_full.png, spellvuln_frame.png, spellvuln_tooltip.png');
+await browser.close();

--- a/scripts/shot_stagger.mjs
+++ b/scripts/shot_stagger.mjs
@@ -1,0 +1,87 @@
+// Screenshot the Stagger affix (Off-Balance) in the offline client.
+// Boots the game, repurposes a nearby mob as a Deeprock Tunneler, forces its
+// on-hit Jarring Swing onto the player, and captures the resulting dodge-cut
+// debuff on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Deeprock Tunneler and drive its stagger onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // invulnerable through the live tick; applyAura still fires
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the staggering kobold and stand it next to us.
+  mob.templateId = 'deeprock_kobold';
+  mob.name = 'Deeprock Tunneler';
+  mob.level = 15;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const dodgeBefore = p.dodgeChance;
+  // Force a landed hit + a proc so the debuff appears for the capture.
+  sim.rng.next = () => 0.99;
+  sim.rng.chance = () => true;
+  sim.mobSwing(mob, p);
+  const dodgeAfter = p.dodgeChance;
+  const aura = p.auras.find((a) => a.name === 'Off-Balance');
+  return { dodgeBefore, dodgeAfter, hasAura: !!aura, value: aura?.value, remaining: aura?.remaining };
+});
+console.log('stagger result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/stagger_full.png' });
+
+// Crop tightly around the buff/debuff bar where Off-Balance shows.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/stagger_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/stagger_full.png, stagger_debuff.png');
+await browser.close();

--- a/scripts/shot_stoneskin.mjs
+++ b/scripts/shot_stoneskin.mjs
@@ -1,0 +1,112 @@
+// Screenshot the Stoneskin affix (Bone Carapace) in the offline client.
+// Boots the game, repurposes a nearby mob as Marrowlord Varkas, fires its
+// periodic self-shield through the real mob-AI path, and captures the boss
+// in-world (with the barrier nova), its target frame, and the combat-log line.
+// A mob self-buff has no player-debuff icon, so the proof is the log + the
+// console soak math (shield drains, HP spared).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live boss loop; applyAura/updateMob still work, and the
+  // barrier sits on the mob anyway so player invulnerability doesn't confound it.
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Marrowlord and stand it in front of us at its real level.
+  mob.templateId = 'marrowlord_varkas';
+  mob.name = 'Marrowlord Varkas';
+  mob.level = 19;
+  mob.hostile = true;
+  mob.maxHp = 4000; mob.hp = 4000;
+  mob.scale = 1.25;
+  // Must sit inside MELEE_RANGE or the mob-AI attack case breaks to 'chase'
+  // before the periodic self-shield block runs.
+  mob.pos.x = p.pos.x + 3.5; mob.pos.z = p.pos.z;
+  mob.spawnPos = { x: mob.pos.x, y: mob.pos.y, z: mob.pos.z };
+  mob.aiState = 'attack'; mob.aggroTargetId = p.id; mob.inCombat = true;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+  g.input.camDist = 11;
+
+  // Fire the barrier through the real periodic path (emits the nova + log line).
+  mob.stoneskinTimer = 0.001;
+  sim.updateMob(mob);
+  const ward = mob.auras.find((a) => a.id === 'stoneskin_marrowlord_varkas');
+
+  // Prove the soak: a 100-damage hit is fully absorbed; HP is untouched.
+  const shieldBefore = ward?.value;
+  const hpBefore = mob.hp;
+  sim.dealDamage(p, mob, 100, false, 'physical', null, 'hit');
+  const shieldAfter = mob.auras.find((a) => a.id === 'stoneskin_marrowlord_varkas')?.value;
+
+  return {
+    hasWard: !!ward, name: ward?.name, kind: ward?.kind,
+    shieldBefore, shieldAfter, soaked: shieldBefore - shieldAfter,
+    hpBefore, hpAfter: mob.hp, hpSpared: hpBefore === mob.hp,
+  };
+});
+console.log('stoneskin result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 500));
+await page.screenshot({ path: 'tmp/stoneskin_scene.png' });
+
+// Crop the boss target frame (top-left): name + boss portrait.
+const tf = await page.evaluate(() => {
+  const el = document.querySelector('#target-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (tf && tf.w > 0) {
+  const pad = 14;
+  await page.screenshot({
+    path: 'tmp/stoneskin_targetframe.png',
+    clip: { x: Math.max(0, tf.x - pad), y: Math.max(0, tf.y - pad), width: tf.w + pad * 2, height: tf.h + pad * 2 },
+  });
+}
+
+// Switch to the combat log tab and crop it to show the "unleashes Bone Carapace!" line.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]') || document.querySelector('.chat-tab');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 400));
+await page.screenshot({
+  path: 'tmp/stoneskin_log.png',
+  clip: { x: 0, y: 620, width: 560, height: 280 },
+});
+
+console.log('saved tmp/stoneskin_scene.png, stoneskin_targetframe.png, stoneskin_log.png');
+await browser.close();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -241,7 +241,7 @@ function blankEntity(id: number): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,7 +225,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, rallyTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -65,6 +65,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'tallow_candle', chance: 0.4 },
     ],
     scale: 0.85, color: 0x9c7a3c,
+    // Jarring Swing: a heavy mining-pick blow knocks the victim off-balance,
+    // cutting their dodge for 8s so the tunneler's strikes land more reliably.
+    staggerHit: { chance: 0.3, dodgeReduction: 0.05, duration: 8, name: 'Off-Balance' },
   },
   ironvein_foreman: {
     id: 'ironvein_foreman', name: 'Ironvein Foreman', minLevel: 16, maxLevel: 16, family: 'kobold', rare: true,

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -49,6 +49,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ridge_stalker', name: 'Ridge Stalker', minLevel: 13, maxLevel: 14, family: 'beast',
     hpBase: 58, hpPerLevel: 21, dmgBase: 10, dmgPerLevel: 2.5, attackSpeed: 1.9,
     armorPerLevel: 14, moveSpeed: 8, aggroRadius: 11,
+    // Rending Claws: the stalker's raking swipes can open a bleeding wound — a
+    // refreshing physical DoT (~5 every 3s for 9s). Distinct from poison: it is
+    // physical-school, so it bypasses poison cleanses and ignores nature resist.
+    bleed: { chance: 0.25, perTick: 5, interval: 3, duration: 9, name: 'Rending Claws', school: 'physical' },
     loot: [
       { copper: 60, chance: 1 },
       { itemId: 'ridge_stalker_pelt', chance: 0.6, questId: 'q_stalker_pelts' },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -193,6 +193,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 44, moveSpeed: 6.5, aggroRadius: 13,
     aoePulse: { min: 30, max: 42, radius: 11, every: 9, name: 'Marrow Rot', school: 'shadow' },
     summonAdds: { mobId: 'varkas_boneguard', count: 2, atHpPct: [0.66, 0.33] },
+    stoneskin: { amount: 260, every: 14, duration: 8, name: 'Bone Carapace', school: 'shadow' },
     loot: [
       { copper: 650, chance: 1 },
       { itemId: 'bone_fragments', chance: 1 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -73,6 +73,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 38, moveSpeed: 7, aggroRadius: 12,
     aoePulse: { min: 28, max: 38, radius: 8, every: 10, name: 'Powder Keg', school: 'fire' },
     summonAdds: { mobId: 'ironvein_sapper', count: 2, atHpPct: [0.50] },
+    rally: { radius: 14, every: 12, ap: 40, duration: 10, name: 'Rallying Banner' },
     enrage: { belowHpPct: 0.30, dmgMult: 1.45, hasteMult: 1.3 },
     loot: [
       { copper: 420, chance: 1 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -95,6 +95,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'thornpeak_ogre', name: 'Thornpeak Ogre', minLevel: 15, maxLevel: 16, family: 'ogre',
     hpBase: 66, hpPerLevel: 23, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.6,
     armorPerLevel: 22, moveSpeed: 7, aggroRadius: 11,
+    concuss: { chance: 0.2, duration: 2, name: 'Concussive Blow' },
     loot: [
       { copper: 75, chance: 1 },
       { itemId: 'ogre_toe_ring', chance: 0.35 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -148,6 +148,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'kazzix_heartshard', chance: 1, questId: 'q_kazzix' },
       { itemId: 'inert_storm_shard', chance: 1 },
     ],
+    // The Shardlord's rimebound core sheathes its blows in killing cold, leaving
+    // a frost burn that gnaws at the victim long after the strike lands.
+    frostbite: { chance: 0.3, perTick: 6, interval: 3, duration: 12, name: 'Frostbite', school: 'frost' },
     scale: 1.3, color: 0xaed6f1,
   },
   wyrmcult_zealot: {

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -174,6 +174,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.3 },
     ],
     manaBurn: { chance: 0.3, amount: 80, name: 'Mana Sear', school: 'shadow' },
+    // Spectral Ward: a shroud of dark wards that lashes back at any caster whose
+    // spell strikes the necromancer — the magic-school twin of melee thorns.
+    spellReflect: { value: 9, name: 'Spectral Ward', school: 'shadow' },
     scale: 1.0, color: 0x533566,
   },
   boneclad_revenant: {

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -88,6 +88,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ironvein_sapper', name: 'Ironvein Sapper', minLevel: 15, maxLevel: 16, family: 'kobold',
     hpBase: 58, hpPerLevel: 20, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.0,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 12,
+    smolder: { chance: 0.25, perTick: 5, interval: 3, duration: 12, name: 'Smoldering Fuse' },
     loot: [],
     scale: 0.85, color: 0x8f6b34,
   },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -88,6 +88,8 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ironvein_sapper', name: 'Ironvein Sapper', minLevel: 15, maxLevel: 16, family: 'kobold',
     hpBase: 58, hpPerLevel: 20, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.0,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 12,
+    // The sapper's blasting powder clings and smolders: a struck foe catches fire.
+    cinder: { chance: 0.3, perTick: 5, interval: 3, duration: 12, name: 'Cinderburn', school: 'fire' },
     loot: [],
     scale: 0.85, color: 0x8f6b34,
   },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -117,6 +117,11 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     hpBase: 200, hpPerLevel: 30, dmgBase: 12, dmgPerLevel: 2.7, attackSpeed: 2.6,
     armorPerLevel: 28, moveSpeed: 7, aggroRadius: 14,
     aoePulse: { min: 22, max: 30, radius: 10, every: 12, name: 'Ground Slam' },
+    // The longer the warlord is left to swing, the harder he hits: every landed
+    // blow stokes his Battle Fury, stacking attack power up to a hard cap. A
+    // drawn-out fight snowballs, so burn him down or kite him off you to bleed
+    // the stacks back off.
+    rampage: { ap: 20, maxStacks: 5, duration: 10, name: 'Battle Fury', school: 'physical' },
     loot: [
       { copper: 2000, chance: 1 },
       { itemId: 'drogmar_warboots', chance: 0.3 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -162,6 +162,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     // The zealot's fevered chanting claws at a caster's mind, draining Intellect
     // and shrinking their mana pool for a while.
     enfeeble: { chance: 0.3, int: 12, duration: 12, name: 'Maddening Whisper', school: 'shadow' },
+    // The Wyrmcult hoards their master's flame: a branding strike seals away the
+    // victim's fire magic so it can never rival the wyrm's, while leaving every
+    // other school free (a single-school counterspell, distinct from a full silence).
+    lockout: { chance: 0.25, duration: 6, name: 'Wyrmward Sigil', school: 'fire' },
     scale: 1.0, color: 0x76448a,
   },
   wyrmcult_necromancer: {

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -138,6 +138,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     // A touch of the storm's cold numbs the limbs: each landed swing has a
     // chance to slow the victim to half speed for a few seconds.
     chillOnHit: { chance: 0.35, mult: 0.5, duration: 6, name: 'Numbing Chill' },
+    // Static Charge: the elemental's storm clings to whatever it strikes, leaving
+    // the victim conductive so every spell that lands on them bites deeper —
+    // +18% magic damage taken from all attackers for a while.
+    spellVuln: { chance: 0.3, amp: 0.18, duration: 10, name: 'Static Charge', school: 'nature' },
   },
   shardlord_kazzix: {
     id: 'shardlord_kazzix', name: 'Shardlord Kazzix', minLevel: 18, maxLevel: 18, family: 'elemental', rare: true,

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -180,6 +180,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'boneclad_revenant', name: 'Boneclad Revenant', minLevel: 18, maxLevel: 19, family: 'undead',
     hpBase: 66, hpPerLevel: 23, dmgBase: 12, dmgPerLevel: 2.7, attackSpeed: 2.3,
     armorPerLevel: 18, moveSpeed: 6.5, aggroRadius: 11,
+    enervate: { chance: 0.3, sta: 14, duration: 12, name: 'Soul Siphon', school: 'shadow' },
     loot: [
       { copper: 100, chance: 1 },
       { itemId: 'bone_fragments', chance: 0.6 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -205,6 +205,9 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'varkas_boneguard', name: 'Varkas Boneguard', minLevel: 18, maxLevel: 19, family: 'undead',
     hpBase: 64, hpPerLevel: 22, dmgBase: 12, dmgPerLevel: 2.8, attackSpeed: 2.3,
     armorPerLevel: 20, moveSpeed: 6.5, aggroRadius: 12,
+    // Shattering Maul: a landed hit can crack the victim's guard, leaving them
+    // taking +18% physical damage from every attacker for 8s.
+    expose: { chance: 0.25, dmgIncrease: 0.18, duration: 8, name: 'Cracked Guard' },
     loot: [],
     scale: 1.0, color: 0xc9c2b5,
   },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -105,6 +105,10 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     id: 'ogre_crusher', name: 'Thornpeak Crusher', minLevel: 16, maxLevel: 17, family: 'ogre', elite: true,
     hpBase: 64, hpPerLevel: 23, dmgBase: 11, dmgPerLevel: 2.6, attackSpeed: 2.6,
     armorPerLevel: 24, moveSpeed: 7, aggroRadius: 12,
+    // Disarming Smash: a war-camp crusher's two-handed blow can batter the weapon
+    // from your grip, cutting off auto-attack for a few seconds — a real threat to
+    // a tank holding the pack. The inverse of the Summoner's Silencing Shriek.
+    disarm: { chance: 0.25, duration: 6, name: 'Disarming Smash', school: 'physical' },
     loot: [
       { copper: 200, chance: 1 },
       { itemId: 'ogre_toe_ring', chance: 0.5 },

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -193,6 +193,7 @@ export const ZONE3_MOBS: Record<string, MobTemplate> = {
     armorPerLevel: 44, moveSpeed: 6.5, aggroRadius: 13,
     aoePulse: { min: 30, max: 42, radius: 11, every: 9, name: 'Marrow Rot', school: 'shadow' },
     summonAdds: { mobId: 'varkas_boneguard', count: 2, atHpPct: [0.66, 0.33] },
+    knockback: { chance: 0.25, distance: 6, name: 'Crushing Sweep' },
     loot: [
       { copper: 650, chance: 1 },
       { itemId: 'bone_fragments', chance: 1 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, rallyTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first Rally the same way: one full interval after engage.
+  if (template.rally) e.rallyTimer = template.rally.every;
   return e;
 }
 

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -132,7 +132,8 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
   e.rangedPower = cls === 'hunter' ? Math.round((s.agi * 2 + bonusAp) * (1 + (mods?.stats.apPct ?? 0))) : 0;
   // Crit: ~1% per 20 agi at low level
   e.critChance = 0.05 + s.agi * 0.0005 + (mods?.stats.crit ?? 0);
-  e.dodgeChance = 0.05 + s.agi * 0.0005 + bonusDodge;
+  // Floored at 0: an off-balance debuff (negative buff_dodge) can drive dodge to nothing.
+  e.dodgeChance = Math.max(0, 0.05 + s.agi * 0.0005 + bonusDodge);
 
   const hpFrac = e.maxHp > 0 ? e.hp / e.maxHp : 1;
   e.maxHp = def.baseHp + def.hpPerLevel * (lvl - 1) + hpFromStamina(s.sta);

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first Stoneskin: one full interval after engage.
+  if (template.stoneskin) e.stoneskinTimer = template.stoneskin.every;
   return e;
 }
 

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -46,7 +46,10 @@ export type PlayerEquipment = Partial<Record<EquipSlot, string>>;
 // Vanilla rules: first 20 stamina gives 1 hp each, the rest 10 hp each.
 // First 20 intellect gives 1 mana each, the rest 15 mana each.
 function hpFromStamina(sta: number): number {
-  return Math.min(sta, 20) + Math.max(0, sta - 20) * 10;
+  // Floor at 0 so a Stamina-draining debuff (negative buff_sta) can never push
+  // the HP pool below its level-based base into negative territory.
+  const s = Math.max(0, sta);
+  return Math.min(s, 20) + Math.max(0, s - 20) * 10;
 }
 function manaFromIntellect(int: number): number {
   // Floor at 0 so an Intellect-draining debuff (negative buff_int) can never push

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,19 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // frostbite: a landed swing may sear the victim with a refreshing frost DoT
+    // (the frost twin of venom — chilling elementals). Hostile mobs only, never a
+    // friendly pet (mobSwing is also the pet attack path).
+    const frostbite = MOBS[mob.templateId]?.frostbite;
+    if (frostbite && mob.hostile && !target.dead && this.rng.chance(frostbite.chance)) {
+      this.applyAura(target, {
+        id: 'frostbite_' + mob.templateId, name: frostbite.name, kind: 'dot',
+        remaining: frostbite.duration, duration: frostbite.duration,
+        value: Math.max(1, Math.round(frostbite.perTick)),
+        tickInterval: frostbite.interval, tickTimer: frostbite.interval,
+        sourceId: mob.id, school: (frostbite.school as Aura['school']) ?? 'frost',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4192,6 +4192,25 @@ export class Sim {
         school: (ms.school as Aura['school']) ?? 'physical',
       });
     }
+    // Staggering blow: a landed hit may knock the victim off-balance, cutting their
+    // dodge for a short while so attacks land more reliably. Hostile mobs only (a
+    // friendly pet shares this swing path) and only players have a meaningful dodge
+    // chance. Rides buff_dodge with a NEGATIVE value — recalcPlayerStats already
+    // folds buff_dodge into e.dodgeChance and it recalcs on expiry (buff* kind), so
+    // no new aura kind is needed.
+    const stagger = MOBS[mob.templateId]?.staggerHit;
+    if (stagger && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(stagger.chance)) {
+      this.applyAura(target, {
+        id: `stagger_${mob.templateId}`,
+        name: stagger.name,
+        kind: 'buff_dodge',
+        remaining: stagger.duration,
+        duration: stagger.duration,
+        value: -stagger.dodgeReduction,
+        sourceId: mob.id,
+        school: 'physical',
+      });
+    }
     // Ensnare: a landed hit may web the victim in place (root). Hostile mobs only
     // (a friendly pet shares this swing path) and only roots players — `applyRootAura`
     // applies crowd-control DR so repeated webs from the same mob shrink and break.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,20 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // bleed ("Rend"): a landed swing may open a refreshing PHYSICAL DoT wound.
+    // Same on-hit DoT seam as venom, but physical-school — the predator/beast
+    // flavour (raking claws, gore). Hostile mobs only (mobSwing is also the pet
+    // attack path, so a friendly pet must never bleed the party).
+    const bleed = MOBS[mob.templateId]?.bleed;
+    if (bleed && mob.hostile && !target.dead && this.rng.chance(bleed.chance)) {
+      this.applyAura(target, {
+        id: 'bleed_' + mob.templateId, name: bleed.name, kind: 'dot',
+        remaining: bleed.duration, duration: bleed.duration,
+        value: Math.max(1, Math.round(bleed.perTick)),
+        tickInterval: bleed.interval, tickTimer: bleed.interval,
+        sourceId: mob.id, school: (bleed.school as Aura['school']) ?? 'physical',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3977,6 +3977,25 @@ export class Sim {
             }
           }
         }
+        // Stoneskin: a periodic self-absorb barrier. Telegraphed via createMob,
+        // which seeds stoneskinTimer to one full interval so the first barrier
+        // never snaps up the instant combat opens. Reuses the `absorb` aura,
+        // which dealDamage already soaks before any health is lost.
+        const stoneskin = MOBS[mob.templateId]?.stoneskin;
+        if (stoneskin) {
+          mob.stoneskinTimer -= DT;
+          if (mob.stoneskinTimer <= 0) {
+            mob.stoneskinTimer = stoneskin.every;
+            const school = (stoneskin.school ?? 'physical') as Aura['school'];
+            this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+            this.emit({ type: 'log', text: `${mob.name} unleashes ${stoneskin.name}!`, color: '#c9c2b5', entityId: mob.id });
+            this.applyAura(mob, {
+              id: `stoneskin_${mob.templateId}`, name: stoneskin.name, kind: 'absorb',
+              remaining: stoneskin.duration, duration: stoneskin.duration, value: stoneskin.amount,
+              sourceId: mob.id, school,
+            });
+          }
+        }
         break;
       }
       case 'flee': {
@@ -4052,6 +4071,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.stoneskinTimer = MOBS[mob.templateId]?.stoneskin?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4539,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.stoneskinTimer = MOBS[mob.templateId]?.stoneskin?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4052,6 +4052,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.rallyTimer = MOBS[mob.templateId]?.rally?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4520,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.rallyTimer = MOBS[mob.templateId]?.rally?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4612,7 +4614,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly && !tmpl.rally)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4658,6 +4660,40 @@ export class Sim {
           for (const ally of wounded) {
             const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
             this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
+      }
+    }
+    // Commander "Rally": periodically empower every friendly mob in range
+    // (including the caster) with a refreshing attack-power buff. The offensive
+    // twin of mendAlly — same telegraphed timer, same same-faction ally scan —
+    // but it grants buff_ap (folded by effectiveAttackPower) instead of healing.
+    if (tmpl.rally) {
+      mob.rallyTimer -= DT;
+      if (mob.rallyTimer <= 0) {
+        mob.rallyTimer = tmpl.rally.every;
+        const allies: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile) continue; // only same-faction mobs
+          if (dist2d(ally.pos, mob.pos) > tmpl.rally.radius) continue;
+          allies.push(ally);
+        }
+        if (allies.length > 0) {
+          const school = tmpl.rally.school ?? 'physical';
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} unleashes ${tmpl.rally.name}!`, color: '#ffcc33', entityId: mob.id });
+          for (const ally of allies) {
+            this.applyAura(ally, {
+              id: `rally_${mob.templateId}`,
+              name: tmpl.rally.name,
+              kind: 'buff_ap',
+              remaining: tmpl.rally.duration,
+              duration: tmpl.rally.duration,
+              value: tmpl.rally.ap,
+              sourceId: mob.id,
+              school,
+            });
           }
         }
       }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4126,6 +4126,27 @@ export class Sim {
         this.emit({ type: 'heal', targetId: mob.id, amount: heal });
       }
     }
+    // Battle Fury (Rampage): a landed swing whips this attacker into an escalating
+    // frenzy — a self-applied, stacking buff_ap aura (up to `maxStacks`) that grows
+    // its attack power, and thus its melee damage, the longer the fight drags on.
+    // Rides the existing buff_ap aura that effectiveAttackPower already folds into
+    // mob swing damage, so there is no new combat math. Hostile mobs only, so a
+    // friendly pet (mobSwing's other caller) never self-buffs off the party's kills;
+    // skip if the mob died to the defender's thorns/reflect earlier this swing. The
+    // single shared aura slot is bumped and refreshed each hit; left alone it falls
+    // off after `duration`s, so burning the mob down or kiting it out of melee both
+    // reset the ramp.
+    const rampage = MOBS[mob.templateId]?.rampage;
+    if (rampage && mob.hostile && !mob.dead) {
+      const existing = mob.auras.find((a) => a.id === `rampage_${mob.templateId}` && a.sourceId === mob.id);
+      const stacks = Math.min(rampage.maxStacks, (existing?.stacks ?? 0) + 1);
+      this.applyAura(mob, {
+        id: `rampage_${mob.templateId}`, name: rampage.name, kind: 'buff_ap',
+        remaining: rampage.duration, duration: rampage.duration,
+        value: rampage.ap * stacks, stacks,
+        sourceId: mob.id, school: rampage.school ?? 'physical',
+      });
+    }
     // Cleave: the swing splashes onto other players standing near the primary
     // target, each taking the hit reduced by their own armor. Hostile mobs only,
     // so a friendly pet swinging through mobSwing never cleaves its owner's party.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,18 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // smoldering fuse: a landed swing may ignite a refreshing fire DoT — the
+    // fire-school sibling of venom (same guards: hostile mobs only, never a pet).
+    const smolder = MOBS[mob.templateId]?.smolder;
+    if (smolder && mob.hostile && !target.dead && this.rng.chance(smolder.chance)) {
+      this.applyAura(target, {
+        id: 'smolder_' + mob.templateId, name: smolder.name, kind: 'dot',
+        remaining: smolder.duration, duration: smolder.duration,
+        value: Math.max(1, Math.round(smolder.perTick)),
+        tickInterval: smolder.interval, tickTimer: smolder.interval,
+        sourceId: mob.id, school: (smolder.school as Aura['school']) ?? 'fire',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3379,9 +3379,25 @@ export class Sim {
       }
     }
 
+    this.reflectSpellWard(source, target, amount, kind, school);
+
     if (target.hp <= 0) {
       this.handleDeath(target, source);
     }
+  }
+
+  /**
+   * Innate "warded" mobs reflect flat damage onto a caster whose SPELL connects
+   * — the magic-school twin of melee thorns (which only punishes melee swings).
+   * Fires for any non-physical hit the mob survives; the reflected blow is
+   * mob-sourced, so it can never re-trigger a reflect (players carry no template).
+   */
+  private reflectSpellWard(source: Entity | null, target: Entity, amount: number, kind: 'hit' | 'miss' | 'dodge', school: string): void {
+    if (!source || source.kind !== 'player' || source.id === target.id) return;
+    if (target.kind !== 'mob' || target.hp <= 0 || kind !== 'hit' || amount <= 0 || school === 'physical') return;
+    const ward = MOBS[target.templateId]?.spellReflect;
+    if (!ward) return;
+    this.dealDamage(target, source, ward.value, false, ward.school ?? 'shadow', ward.name ?? 'Spell Reflection', 'hit', true);
   }
 
   private enterCombat(a: Entity, b: Entity): void {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1333,6 +1333,11 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+  // A school lockout denies casts of one specific school only (a counterspell),
+  // leaving every other school — and physical abilities — untouched.
+  private isLockedOut(e: Entity, school: Aura['school']): boolean {
+    return e.auras.some((a) => a.kind === 'lockout' && a.school === school);
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -1799,6 +1804,11 @@ export class Sim {
       const cast = this.resolvedAbility(p.castingAbility, p.id);
       if (cast && cast.def.school !== 'physical') { this.cancelCast(p); return; }
     }
+    // a school lockout breaks an in-progress spell only when it matches the locked school.
+    if (p.castingAbility !== FISHING_CAST_ID) {
+      const cast = this.resolvedAbility(p.castingAbility, p.id);
+      if (cast && cast.def.school !== 'physical' && this.isLockedOut(p, cast.def.school)) { this.cancelCast(p); return; }
+    }
     p.castRemaining -= DT;
 
     if (p.channeling) {
@@ -1879,6 +1889,7 @@ export class Sim {
     const ability = res.def;
     if (this.isStunned(p)) { this.error(p.id, 'You are stunned!'); return; }
     if (ability.school !== 'physical' && this.isSilenced(p)) { this.error(p.id, 'You are silenced!'); return; }
+    if (ability.school !== 'physical' && this.isLockedOut(p, ability.school)) { this.error(p.id, 'You are silenced!'); return; }
     if (p.castingAbility) { this.error(p.id, 'You are busy.'); return; }
     if (!ability.offGcd && p.gcdRemaining > 0) return; // silent, classic spams this
     const togglingOff = isToggleBuff(ability) && p.auras.some((a) => a.id === ability.id);
@@ -4167,6 +4178,16 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // school lockout: a counterspell-on-hit that seals a single spell school. Same
+    // hostile + alive guard as silence so a friendly pet never locks out the party.
+    const lockout = MOBS[mob.templateId]?.lockout;
+    if (lockout && mob.hostile && !target.dead && this.rng.chance(lockout.chance)) {
+      this.applyAura(target, {
+        id: `lockout_${mob.templateId}`, name: lockout.name, kind: 'lockout',
+        remaining: lockout.duration, duration: lockout.duration, value: 0,
+        sourceId: mob.id, school: lockout.school,
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4286,6 +4286,22 @@ export class Sim {
         });
       }
     }
+    // Concussive Blow: a landed hit can briefly STUN the victim (single-target,
+    // distinct from War Stomp's AoE slam). Hostile mobs only so a friendly pet
+    // never stuns an ally; CC DR is PvP-only so a mob source always lands full.
+    const concuss = MOBS[mob.templateId]?.concuss;
+    if (concuss && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(concuss.chance)) {
+      this.applyAura(target, {
+        id: `concuss_${mob.templateId}`,
+        name: concuss.name,
+        kind: 'stun',
+        remaining: concuss.duration,
+        duration: concuss.duration,
+        value: 0,
+        sourceId: mob.id,
+        school: concuss.school ?? 'physical',
+      });
+    }
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,19 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // cinder: the fire-school twin of venom — a landed swing may set a refreshing
+    // burning DoT (hostile mobs only, never a friendly pet — mobSwing is also the
+    // pet attack path). Reuses the same dot aura seam; school defaults 'fire'.
+    const cinder = MOBS[mob.templateId]?.cinder;
+    if (cinder && mob.hostile && !target.dead && this.rng.chance(cinder.chance)) {
+      this.applyAura(target, {
+        id: 'cinder_' + mob.templateId, name: cinder.name, kind: 'dot',
+        remaining: cinder.duration, duration: cinder.duration,
+        value: Math.max(1, Math.round(cinder.perTick)),
+        tickInterval: cinder.interval, tickTimer: cinder.interval,
+        sourceId: mob.id, school: (cinder.school as Aura['school']) ?? 'fire',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'spellvuln',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'spellvuln',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -3271,6 +3271,18 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Spell Vulnerability: a `spellvuln` debuff amplifies all NON-physical (magic)
+    // damage the victim takes from every attacker. Holy is excluded so healing-
+    // school spells are untouched. Stacks additively across active debuffs and
+    // lands before absorb shields, so a soaked hit still soaks the amplified total.
+    if (amount > 0 && school !== 'physical' && school !== 'holy') {
+      let amp = 0;
+      for (const a of target.auras) {
+        if (a.kind === 'spellvuln') amp += a.value;
+      }
+      if (amp > 0) amount = Math.round(amount * (1 + amp));
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4190,6 +4202,23 @@ export class Sim {
         value: ms.healReduction,
         sourceId: mob.id,
         school: (ms.school as Aura['school']) ?? 'physical',
+      });
+    }
+    // Spell Vulnerability: a landed hit may curse the victim so they take more
+    // magic damage from everyone (the arcane twin of corrode's armor shred).
+    // Hostile mobs only, so a friendly pet (mobSwing's other caller) never curses
+    // the party. A single refreshing slot keyed by template, like mortal_wound.
+    const sv = MOBS[mob.templateId]?.spellVuln;
+    if (sv && mob.hostile && !target.dead && this.rng.chance(sv.chance)) {
+      this.applyAura(target, {
+        id: `spellvuln_${mob.templateId}`,
+        name: sv.name,
+        kind: 'spellvuln',
+        remaining: sv.duration,
+        duration: sv.duration,
+        value: sv.amp,
+        sourceId: mob.id,
+        school: (sv.school as Aura['school']) ?? 'arcane',
       });
     }
     // Ensnare: a landed hit may web the victim in place (root). Hostile mobs only

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3271,6 +3271,15 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Expose: a cracked-guard debuff amplifies the physical damage the victim
+    // takes (from any attacker) until it expires. Armor is already applied at the
+    // swing site, so this rides on top of the post-mitigation amount.
+    if (school === 'physical' && amount > 0) {
+      let exposeMult = 1;
+      for (const a of target.auras) if (a.kind === 'expose') exposeMult += a.value;
+      if (exposeMult !== 1) amount = Math.round(amount * exposeMult);
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4285,6 +4294,22 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+    // Expose: a landed hit can crack the victim's guard, raising the physical
+    // damage they take for a duration. Guarded on `hostile` so a friendly pet
+    // (mobSwing's other caller) never debuffs the party.
+    const expose = MOBS[mob.templateId]?.expose;
+    if (expose && mob.hostile && !target.dead && this.rng.chance(expose.chance)) {
+      this.applyAura(target, {
+        id: `expose_${mob.templateId}`,
+        name: expose.name,
+        kind: 'expose',
+        remaining: expose.duration,
+        duration: expose.duration,
+        value: expose.dmgIncrease,
+        sourceId: mob.id,
+        school: (expose.school as Aura['school']) ?? 'physical',
+      });
     }
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2606,6 +2606,43 @@ export class Sim {
     });
   }
 
+  // On-hit knockback: hurl `target` up to `distance` yards straight away from
+  // `source`. Instantaneous displacement (no aura) walked in small steps so it can
+  // be terrain-clamped exactly like a warrior charge — the shove stops at the last
+  // safe footing before deep water or a cliff rather than stranding the victim off
+  // the world. Returns the yards actually moved (0 if blocked immediately).
+  private applyKnockback(source: Entity, target: Entity, distance: number): number {
+    let dx = target.pos.x - source.pos.x;
+    let dz = target.pos.z - source.pos.z;
+    let len = Math.hypot(dx, dz);
+    if (len < 1e-4) {
+      // exactly overlapping: shove along the mob's facing so the direction is stable
+      dx = Math.sin(source.facing); dz = Math.cos(source.facing); len = 1;
+    }
+    const ux = dx / len, uz = dz / len;
+    const STEP = 0.5;
+    let moved = 0;
+    let cx = target.pos.x, cz = target.pos.z;
+    while (moved < distance) {
+      const adv = Math.min(STEP, distance - moved);
+      const nx = cx + ux * adv, nz = cz + uz * adv;
+      const h0 = groundHeight(cx, cz, this.cfg.seed);
+      const h1 = groundHeight(nx, nz, this.cfg.seed);
+      if (h1 < WATER_LEVEL - SWIM_DEPTH) break;                // would land in deep water
+      if (h1 > h0 && (h1 - h0) / adv > MAX_CLIMB_SLOPE) break; // would slam into a cliff
+      cx = nx; cz = nz; moved += adv;
+    }
+    if (moved <= 0) return 0;
+    const resolved = resolvePosition(this.cfg.seed, cx, cz, BODY_RADIUS);
+    target.pos.x = resolved.x;
+    target.pos.z = resolved.z;
+    target.pos.y = groundHeight(resolved.x, resolved.z, this.cfg.seed);
+    target.vy = 0;
+    target.onGround = true;
+    target.fallStartY = target.pos.y;
+    return moved;
+  }
+
   private diminishedCrowdControlDuration(
     source: Entity,
     target: Entity,
@@ -4198,6 +4235,19 @@ export class Sim {
     const ensnare = MOBS[mob.templateId]?.ensnare;
     if (ensnare && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(ensnare.chance)) {
       this.applyRootAura(mob, target, ensnare.name, `ensnare_${mob.templateId}`, ensnare.duration, ensnare.school ?? 'nature');
+    }
+    // Knockback: a landed hit can physically hurl the player victim straight back.
+    // Hostile mobs only (a friendly pet shares this swing path) and players only —
+    // shoving a fellow mob is meaningless. Pure positional displacement (no aura),
+    // terrain-clamped so it never strands the victim off the world; surfaced via a
+    // spellfx nova + the same "unleashes" log line War Stomp uses.
+    const knockback = MOBS[mob.templateId]?.knockback;
+    if (knockback && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(knockback.chance)) {
+      if (this.applyKnockback(mob, target, knockback.distance) > 0) {
+        const school = (knockback.school ?? 'physical') as Aura['school'];
+        this.emit({ type: 'spellfx', sourceId: mob.id, targetId: target.id, school, fx: 'nova' });
+        this.emit({ type: 'log', text: `${mob.name} unleashes ${knockback.name}!`, color: '#ff9933', entityId: mob.id });
+      }
     }
     // slowStrike: a landed hit may mire the victim, slowing their attack speed.
     // Rides the existing `attackspeed` aura (swingIntervalMult: value > 1 = slower);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4209,6 +4209,24 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Vitality drain: a landed hit can siphon the victim's Stamina, shrinking
+    // their maximum-HP pool. Hits every class (all players have Stamina), unlike
+    // the mana-only enfeeble. Hostile mobs only, so a friendly pet (mobSwing's
+    // other caller) never drains the party. Rides buff_sta with a negative value,
+    // so recalcPlayerStats folds it through to maxHp with no new HP math.
+    const enervate = MOBS[mob.templateId]?.enervate;
+    if (enervate && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(enervate.chance)) {
+      this.applyAura(target, {
+        id: `enervate_${mob.templateId}`,
+        name: enervate.name,
+        kind: 'buff_sta',
+        remaining: enervate.duration,
+        duration: enervate.duration,
+        value: -Math.abs(enervate.sta),
+        sourceId: mob.id,
+        school: enervate.school ?? 'shadow',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1333,6 +1333,11 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+  // Disarm suppresses weapon swings (auto-attack, melee and ranged) but leaves
+  // movement, spells and instant abilities untouched — the inverse of silence.
+  private isDisarmed(e: Entity): boolean {
+    return e.auras.some((a) => a.kind === 'disarm');
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -3127,6 +3132,7 @@ export class Sim {
     if (!t || t.dead || !this.isHostileTo(p, t)) { p.autoAttack = false; return; }
     if (p.swingTimer > 0) return;
     if (this.isStunned(p)) return;
+    if (this.isDisarmed(p)) return; // weapon knocked away: no auto-attack swings
     const d = dist2d(p.pos, t.pos);
     const facingDiff = Math.abs(normAngle(angleTo(p.pos, t.pos) - p.facing));
     if (facingDiff > MELEE_ARC) return;
@@ -4167,6 +4173,18 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // disarm: a brutal swing can knock the weapon from a player's grip, suppressing
+    // their auto-attack for a duration. Players only (only they run the primary-target
+    // auto-attack path) and hostile only, so a friendly pet (mobSwing's other caller)
+    // never disarms the party. Refreshes by id; never stacks.
+    const disarm = MOBS[mob.templateId]?.disarm;
+    if (disarm && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(disarm.chance)) {
+      this.applyAura(target, {
+        id: `disarm_${mob.templateId}`, name: disarm.name, kind: 'disarm',
+        remaining: disarm.duration, duration: disarm.duration, value: 0,
+        sourceId: mob.id, school: (disarm.school ?? 'physical') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -191,6 +191,14 @@ export interface MobTemplate {
   // opens. Resets on evade/respawn. Routes through the normal heal path, so it
   // shows green floating text and grants no threat to the menders themselves.
   mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
+  // Commander mechanic ("Rallying Banner"): periodically empowers every friendly
+  // mob in range (including the caster) with a refreshing `buff_ap` aura worth
+  // `ap` attack power for `duration`s — the support twin of mendAlly, granting
+  // offense instead of healing. Rides the existing buff_ap aura that
+  // effectiveAttackPower already folds for mobs, so no new aura kind or combat
+  // math. Telegraphed like stomp/mendAlly: the first rally only lands one full
+  // interval after combat opens.
+  rally?: { radius: number; every: number; ap: number; duration: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -582,6 +590,7 @@ export interface Entity {
   stompTimer: number; // boss War Stomp stun-pulse countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
+  rallyTimer: number; // rally commander-buff cast countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -195,6 +195,10 @@ export interface MobTemplate {
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
   stomp?: { radius: number; every: number; duration: number; min?: number; max?: number; name: string; school?: string };
+  // Periodic self-shield: the mob wraps itself in a damage-absorbing barrier
+  // every `every` seconds, soaking up to `amount` damage for `duration` seconds.
+  // Reuses the existing `absorb` aura (soaked first in dealDamage) — no new combat math.
+  stoneskin?: { amount: number; every: number; duration: number; name: string; school?: string };
   // Melee mechanic: each landed swing also splashes onto other players near the
   // primary target for `mult` of the (pre-armor) hit. Classic-WoW Cleave.
   cleave?: { radius: number; mult: number; name?: string };
@@ -580,6 +584,7 @@ export interface Entity {
   petTauntTimer: number; // controlled pet Growl cooldown
   pulseTimer: number; // boss aoe pulse countdown
   stompTimer: number; // boss War Stomp stun-pulse countdown
+  stoneskinTimer: number; // periodic self-absorb barrier countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
   firedSummons: number; // summonAdds thresholds already triggered

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,11 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit bleed: a landed melee swing has `chance` to open a refreshing PHYSICAL
+  // damage-over-time wound on the victim ("Rend"). Distinct from `venom` (a
+  // nature/poison DoT) — bleeds are physical-school, the predator/beast flavour
+  // of the same on-hit DoT seam. Refreshes (never stacks) like venom.
+  bleed?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: Aura['school'] };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -223,6 +223,11 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // Melee mechanic: a landed swing has `chance` to knock the victim off-balance,
+  // cutting their dodge chance by `dodgeReduction` (a flat fraction, e.g. 0.05)
+  // for `duration` seconds — so the attacker (and everyone else) lands more hits.
+  // Rides the existing buff_dodge aura with a NEGATIVE value; no new aura kind.
+  staggerHit?: { chance: number; dodgeReduction: number; duration: number; name: string };
   // On-hit web mechanic: a landed melee swing has `chance` to ensnare the struck
   // player in place — a `root` aura for `duration`s (naga/spider snares). Rides the
   // existing root aura + crowd-control DR; no new aura kind. Players only; rooting a

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,9 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // damage-over-time frost burn on the struck target — the frost twin of venom
+  // (chilling/elemental creatures). Reuses the 'dot' aura; school defaults to 'frost'.
+  frostbite?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,9 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // Burning fuse: a landed swing may set a refreshing fire DoT (the fire-school
+  // sibling of venom; sappers, ember-touched creatures). Defaults to the 'fire' school.
+  smolder?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'lockout';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +256,10 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit mechanic: chance to lock out a SINGLE spell school (a school-specific
+  // counterspell) for a duration. Unlike `silence` (which blocks all non-physical
+  // casts), only casts whose `ability.school` matches `school` are denied/broken.
+  lockout?: { chance: number; duration: number; name: string; school: Aura['school'] };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -185,6 +185,17 @@ export interface MobTemplate {
   // Mob mechanic: a one-time desperation self-heal the first time hp drops
   // below the threshold (healPct is a fraction of maxHp). Resets on evade/respawn.
   desperateHeal?: { belowHpPct: number; healPct: number };
+  // Self-buff affix ("Battle Fury" / Rampage): every landed melee swing whips the
+  // attacker into an escalating frenzy — a self-applied, stacking buff_ap aura (up
+  // to `maxStacks`) that grows its attack power, and thus its melee damage, the
+  // longer the fight drags on. Rides the existing buff_ap aura that
+  // effectiveAttackPower already folds into mob swing damage, so there is no new
+  // combat math. Unlike `enrage` (a one-shot threshold burst) or `packFrenzy` (a
+  // haste pulse on an ally's death), this ramps continuously while the mob keeps
+  // connecting. The single shared aura slot is refreshed each hit; left alone it
+  // falls off after `duration`s, undoing the ramp — so burning the mob down or
+  // kiting it out of melee both reset its fury.
+  rampage?: { ap: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
   // Support mechanic ("Mend"): while in combat, periodically heal every wounded
   // living friendly mob within `radius` (incl. itself) for `healMin..healMax`.
   // Telegraphed: the first cast lands one full `every` interval after combat

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -268,6 +268,10 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // Innate "warded" trait: casters take flat damage back on every connecting
+  // SPELL hit — the magic-school twin of `thorns` (which only punishes melee).
+  // Reflects on any non-physical damage instance the mob survives.
+  spellReflect?: { value: number; school?: Aura['school']; name?: string };
 }
 
 export type AbilityEffect =

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -218,6 +218,10 @@ export interface MobTemplate {
   // other on-hit affixes it sustains the attacker instead of debuffing the
   // victim. Optional `chance` gates the proc (defaults to every landed hit).
   lifeleech?: { healFrac: number; chance?: number; name?: string };
+  // Melee mechanic: a landed swing has `chance` to land a concussive blow that
+  // STUNS the victim for `duration`s (can't move, cast, or act). The single-target
+  // cousin of War Stomp's AoE slam — rides the existing `stun` aura, no new kind.
+  concuss?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to corrode the victim's
   // armor: a stacking `sunder` debuff (up to `maxStacks`) so the victim takes
   // more physical damage from everyone until it expires. Rides the existing

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,10 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit debuff: the fire-school twin of `venom` — a chance per landed melee
+  // swing to set a stacking-refresh burning damage-over-time (cinder/ember mobs,
+  // demolitionists carrying blasting powder). Same DoT seam, school defaults 'fire'.
+  cinder?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,8 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence'
+  | 'spellvuln';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -223,6 +224,13 @@ export interface MobTemplate {
   // more physical damage from everyone until it expires. Rides the existing
   // sunder aura; no new aura kind.
   corrode?: { chance: number; armor: number; maxStacks: number; duration: number; name: string; school?: Aura['school'] };
+  // Combat mechanic: a landed melee hit has `chance` to curse the victim with a
+  // spell-vulnerability debuff (`spellvuln`) that amplifies all NON-physical
+  // (magic) damage they take by `amp` (e.g. 0.15 = +15%) from every attacker for
+  // `duration`. The arcane twin of `corrode` — corrode shreds armor (physical
+  // mitigation); this raises magic damage taken. Holy is excluded so healing-
+  // school spells stay unaffected.
+  spellVuln?: { chance: number; amp: number; duration: number; name: string; school?: Aura['school'] };
   // On-hit web mechanic: a landed melee swing has `chance` to ensnare the struck
   // player in place — a `root` aura for `duration`s (naga/spider snares). Rides the
   // existing root aura + crowd-control DR; no new aura kind. Players only; rooting a

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'expose';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -218,6 +218,10 @@ export interface MobTemplate {
   // other on-hit affixes it sustains the attacker instead of debuffing the
   // victim. Optional `chance` gates the proc (defaults to every landed hit).
   lifeleech?: { healFrac: number; chance?: number; name?: string };
+  // Melee mechanic: a landed swing has `chance` to crack the victim's guard with
+  // an Expose debuff that raises the physical damage they take by `dmgIncrease`
+  // (e.g. 0.15 = +15%) for `duration` seconds. Stacks multiplicatively with armor.
+  expose?: { chance: number; dmgIncrease: number; duration: number; name: string; school?: string };
   // Combat mechanic: a landed melee hit has `chance` to corrode the victim's
   // armor: a stacking `sunder` debuff (up to `maxStacks`) so the victim takes
   // more physical damage from everyone until it expires. Rides the existing

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -235,6 +235,13 @@ export interface MobTemplate {
   // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
   // resource math. Only meaningful on mana users — applied to them alone.
   enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to drain `sta` Stamina from
+  // the victim for `duration`s, shrinking their maximum-HP pool (recalcPlayerStats
+  // re-derives maxHp from Stamina and scales current HP down with the smaller
+  // ceiling, clamped to a 1-HP floor — it never kills outright). Rides the
+  // existing buff_sta aura with a NEGATIVE value, so there is no new HP math.
+  // Affects every class (all players have Stamina), unlike enfeeble (mana only).
+  enervate?: { chance: number; sta: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to terrify the victim — a
   // fear that sends the struck player fleeing for `duration`s. Rides the existing
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'disarm';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +256,13 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit mechanic ("Disarm"): a landed melee swing has `chance` to knock the
+  // victim's weapon from their grip — a `disarm` aura that suppresses their
+  // auto-attack (melee and ranged) for `duration` seconds. The inverse of silence:
+  // silence locks out spells, disarm locks out weapon swings; movement and
+  // instant abilities are untouched. Players only (only they auto-attack at the
+  // primary-target swing path). Refreshes by id; never stacks.
+  disarm?: { chance: number; duration: number; name: string; school?: Aura['school'] };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -233,6 +233,13 @@ export interface MobTemplate {
   // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new
   // combat math. Distinct from a movement snare (`slow`) or an AP cut (`debuff_ap`).
   slowStrike?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit knockback: a landed melee swing has `chance` to physically hurl the
+  // struck player `distance` yards straight away from the mob — an instantaneous
+  // positional shove, not an aura. The displacement is terrain-clamped (it stops
+  // before deep water and cliffs, reusing the charge-movement safety checks), so a
+  // knockback can never strand the victim off the world. Players only; shoving a
+  // fellow mob is meaningless and a friendly pet shares this swing path.
+  knockback?: { chance: number; distance: number; name: string; school?: Aura['school'] };
   // On-hit mechanic ("Mana Burn"): a landed melee swing has `chance` to drain a
   // flat `amount` of mana from a mana-using victim (casters). Rage/energy users
   // are unaffected. Drains only what mana the victim still has; no overkill.

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1842,7 +1842,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'lockout'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'spellvuln'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'expose'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/tests/mob_bleed.test.ts
+++ b/tests/mob_bleed.test.ts
@@ -1,0 +1,111 @@
+// Predators (e.g. the Ridge Stalker's "Rending Claws") can open a bleeding wound
+// on a landed melee swing: a refreshing PHYSICAL damage-over-time. Bleed shares
+// the on-hit DoT seam with venom, but is physical-school (not nature/poison), so
+// it bypasses poison cleanses and ignores nature resistance.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn a Ridge Stalker adjacent to the player and hand it back.
+function spawnStalker(sim: Sim, id = 980001, level = 13) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ridge_stalker, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the bleed aura (the chance is 1 in these tests).
+function swingUntilBleed(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'bleed_ridge_stalker')) return true;
+  }
+  return false;
+}
+
+describe('mob bleed (on-hit physical DoT)', () => {
+  it('the Ridge Stalker carries bleed data tuned to a physical DoT', () => {
+    const b = MOBS.ridge_stalker.bleed!;
+    expect(b).toBeDefined();
+    expect(b.school).toBe('physical');
+    expect(b.chance).toBeGreaterThan(0);
+    expect(b.perTick).toBeGreaterThan(0);
+    expect(b.interval).toBeGreaterThan(0);
+    expect(b.duration).toBeGreaterThan(b.interval);
+  });
+
+  it('a landed swing opens a physical-school bleed DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnStalker(sim);
+    const orig = MOBS.ridge_stalker.bleed!.chance;
+    MOBS.ridge_stalker.bleed!.chance = 1;
+    try {
+      expect(swingUntilBleed(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ridge_stalker.bleed!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'bleed_ridge_stalker')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('physical');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.ridge_stalker.bleed!.duration);
+  });
+
+  it('the bleed DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnStalker(sim);
+    const orig = MOBS.ridge_stalker.bleed!.chance;
+    MOBS.ridge_stalker.bleed!.chance = 1;
+    try {
+      expect(swingUntilBleed(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ridge_stalker.bleed!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 4; i++) sim.tick(); // 4s — at least one tick interval
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-bleeding mob (forest wolf) opens no bleed aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === 'bleed_ridge_stalker')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated swipes from the same stalker', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnStalker(sim);
+    const orig = MOBS.ridge_stalker.bleed!.chance;
+    MOBS.ridge_stalker.bleed!.chance = 1;
+    try {
+      swingUntilBleed(sim, mob, player);
+      swingUntilBleed(sim, mob, player);
+      swingUntilBleed(sim, mob, player);
+    } finally {
+      MOBS.ridge_stalker.bleed!.chance = orig;
+    }
+    const bleedAuras = player.auras.filter((a) => a.id === 'bleed_ridge_stalker');
+    expect(bleedAuras.length).toBe(1);
+  });
+});

--- a/tests/mob_cinder.test.ts
+++ b/tests/mob_cinder.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn an Ironvein Sapper adjacent to the player and hand it back.
+function spawnSapper(sim: Sim, id = 980001, level = 16) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ironvein_sapper, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the cinder aura (the chance is 1 in these tests).
+function swingUntilCinder(sim: Sim, mob: any, target: any, tries = 60): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'cinder_ironvein_sapper')) return true;
+  }
+  return false;
+}
+
+describe('mob cinder (on-hit fire DoT)', () => {
+  it('the Ironvein Sapper carries cinder data tuned to a fire DoT', () => {
+    const c = MOBS.ironvein_sapper.cinder!;
+    expect(c).toBeDefined();
+    expect(c.school).toBe('fire');
+    expect(c.chance).toBeGreaterThan(0);
+    expect(c.perTick).toBeGreaterThan(0);
+    expect(c.interval).toBeGreaterThan(0);
+    expect(c.duration).toBeGreaterThan(c.interval);
+  });
+
+  it('a landed swing sets a burning DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.cinder!.chance;
+    MOBS.ironvein_sapper.cinder!.chance = 1;
+    try {
+      expect(swingUntilCinder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.cinder!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'cinder_ironvein_sapper')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('fire');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.ironvein_sapper.cinder!.duration);
+  });
+
+  it('the burning DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.cinder!.chance;
+    MOBS.ironvein_sapper.cinder!.chance = 1;
+    try {
+      expect(swingUntilCinder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.cinder!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 4; i++) sim.tick(); // 4s — past one tick interval, beats regen
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-cinder mob (forest wolf) sets no burning aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 16, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 60; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === 'cinder_forest_wolf')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated hits from the same sapper', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    // The sapper hits hard at L16, and applyAura re-derives maxHp from stamina
+    // (wiping any raw hp override), so a plain pool gets ground down across the
+    // ~180 swings below. gm keeps the player invulnerable; the cinder roll fires
+    // independently of damage landing, so the aura still applies.
+    player.gm = true;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.cinder!.chance;
+    MOBS.ironvein_sapper.cinder!.chance = 1;
+    try {
+      swingUntilCinder(sim, mob, player);
+      swingUntilCinder(sim, mob, player);
+      swingUntilCinder(sim, mob, player);
+    } finally {
+      MOBS.ironvein_sapper.cinder!.chance = orig;
+    }
+    const cinderAuras = player.auras.filter((a) => a.id === 'cinder_ironvein_sapper');
+    expect(cinderAuras.length).toBe(1);
+  });
+});

--- a/tests/mob_concuss.test.ts
+++ b/tests/mob_concuss.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+describe('Concussive Blow stun-on-hit affix', () => {
+  it('a landed thornpeak_ogre swing can stun the victim', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the stun
+    const tmpl = MOBS.thornpeak_ogre;
+    const saved = tmpl.concuss!.chance;
+    tmpl.concuss!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900600, tmpl, 16, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        p.auras.length = 0; // a fresh swing each loop; isolate the stun aura
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'stun');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'stun')!;
+      expect(a.name).toBe('Concussive Blow');
+      expect(a.duration).toBe(2);
+      expect((sim as any).isStunned(p)).toBe(true);
+    } finally {
+      tmpl.concuss!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never stuns', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.thornpeak_ogre;
+    const saved = tmpl.concuss!.chance;
+    tmpl.concuss!.chance = 1;
+    try {
+      const pet = createMob(900601, tmpl, 16, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) {
+        p.hp = p.maxHp;
+        (sim as any).mobSwing(pet, p);
+      }
+      expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+    } finally {
+      tmpl.concuss!.chance = saved;
+    }
+  });
+
+  it('a mob without the concuss affix applies no stun', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900602, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'stun')).toBe(false);
+  });
+
+  it('the refreshing stun never stacks into multiple auras', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.thornpeak_ogre;
+    const saved = tmpl.concuss!.chance;
+    tmpl.concuss!.chance = 1;
+    try {
+      const mob = createMob(900603, tmpl, 16, { x: 0, y: 0, z: 0 });
+      for (let i = 0; i < 30; i++) {
+        p.hp = p.maxHp; // a fatal swing would clear auras; keep the victim alive
+        (sim as any).mobSwing(mob, p);
+      }
+      expect(p.auras.filter((a) => a.kind === 'stun').length).toBeLessThanOrEqual(1);
+    } finally {
+      tmpl.concuss!.chance = saved;
+    }
+  });
+});

--- a/tests/mob_disarm.test.ts
+++ b/tests/mob_disarm.test.ts
@@ -1,0 +1,91 @@
+// Brutal melee mobs (e.g. the Thornpeak Crusher's "Disarming Smash") can knock a
+// victim's weapon from their grip on a landed hit. Disarm is the inverse of silence:
+// it suppresses weapon swings (auto-attack, melee and ranged) for a duration but
+// leaves movement, spells and instant abilities untouched.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 11, playerClass, autoEquip: true });
+}
+
+// Spawn a Thornpeak Crusher adjacent to the player, engaged and ready to swing.
+function spawnCrusher(sim: Sim, target: Entity): Entity {
+  const template = MOBS['ogre_crusher'];
+  const mob = createMob((sim as any).nextId++, template, 17, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (disarm chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob disarm ("Disarming Smash")', () => {
+  it('seeds the disarm mechanic on the Thornpeak Crusher', () => {
+    expect(MOBS['ogre_crusher'].disarm).toEqual({
+      chance: 0.25, duration: 6, name: 'Disarming Smash', school: 'physical',
+    });
+  });
+
+  it('applies a disarm aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCrusher(sim, p);
+    MOBS['ogre_crusher'].disarm!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['ogre_crusher'].disarm!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'disarm');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Disarming Smash');
+    expect(aura!.remaining).toBe(6);
+  });
+
+  it('suppresses auto-attack while disarmed, then resumes once it falls off', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    const meta = (sim as any).players.get(p.id);
+    // A defenseless dummy directly in front of the player, inside melee range.
+    const dummy = createMob((sim as any).nextId++, MOBS['ogre_crusher'], 1, { x: p.pos.x + 1, y: p.pos.y, z: p.pos.z });
+    dummy.hostile = true; dummy.maxHp = 100000; dummy.hp = 100000;
+    (sim as any).addEntity(dummy);
+    p.targetId = dummy.id;
+    p.autoAttack = true;
+    p.facing = Math.atan2(dummy.pos.x - p.pos.x, dummy.pos.z - p.pos.z);
+
+    // Disarmed: a ready swing must NOT land.
+    p.auras.push({
+      id: 'disarm_x', name: 'Disarming Smash', kind: 'disarm',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'physical',
+    });
+    p.swingTimer = 0;
+    const before = dummy.hp;
+    (sim as any).updatePlayerAutoAttack(p, meta);
+    expect(dummy.hp).toBe(before); // no swing while disarmed
+
+    // Weapon recovered: the same ready swing now lands.
+    p.auras = p.auras.filter((a) => a.kind !== 'disarm');
+    p.swingTimer = 0;
+    (sim as any).updatePlayerAutoAttack(p, meta);
+    expect(dummy.hp).toBeLessThan(before);
+  });
+
+  it('a friendly pet swing never disarms its target', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnCrusher(sim, p);
+    pet.hostile = false; // a friendly shape sharing the mobSwing path
+    pet.ownerId = p.id;
+    MOBS['ogre_crusher'].disarm!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['ogre_crusher'].disarm!.chance = 0.25;
+    expect(p.auras.some((a) => a.kind === 'disarm')).toBe(false);
+  });
+});

--- a/tests/mob_enervate.test.ts
+++ b/tests/mob_enervate.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// Level the victim to 20 so a L18 Boneclad Revenant's swing never one-shots it
+// (death would clear the aura before we can read it).
+const makeSim = (cls: PlayerClass = 'warrior') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+const spawnRevenant = (sim: Sim) => {
+  const mob = createMob(990800, MOBS.boneclad_revenant, 18, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Swing until the Soul Siphon buff_sta debuff lands (a swing can miss/dodge).
+const swingUntilDrained = (sim: Sim, mob: any, target: any, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_sta' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob vitality drain (Soul Siphon)', () => {
+  it('Boneclad Revenant template carries the enervate mechanic', () => {
+    expect(MOBS.boneclad_revenant.enervate).toBeDefined();
+    expect(MOBS.boneclad_revenant.enervate!.name).toBe('Soul Siphon');
+  });
+
+  it('a landed hit applies a negative buff_sta aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      expect(swingUntilDrained(sim, mob, player)).toBe(true);
+    } finally {
+      enervate.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_sta');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Soul Siphon');
+    expect(aura!.value).toBe(-enervate.sta); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('shadow');
+  });
+
+  it('the drain lowers the victim Stamina and shrinks their max-HP pool', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const staBefore = player.stats.sta;
+    const maxHpBefore = player.maxHp;
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      swingUntilDrained(sim, mob, player);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.stats.sta).toBe(staBefore - enervate.sta);
+    expect(player.maxHp).toBeLessThan(maxHpBefore);
+  });
+
+  it('hits every class, not just mana users (warrior gets drained)', () => {
+    const sim = makeSim('warrior');
+    const player = sim.player;
+    expect(player.resourceType).not.toBe('mana');
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      expect(swingUntilDrained(sim, mob, player)).toBe(true);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_sta' && a.value < 0)).toBe(true);
+  });
+
+  it('never drops the victim below 1 HP (drain cannot kill outright)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      swingUntilDrained(sim, mob, player);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.hp).toBeGreaterThanOrEqual(1);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilDrained(sim, mob, player);
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_sta' && a.value < 0).length).toBe(1);
+  });
+
+  it('a friendly pet never drains its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnRevenant(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const enervate = MOBS.boneclad_revenant.enervate!;
+    const old = enervate.chance;
+    enervate.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      enervate.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_sta' && a.value < 0)).toBe(false);
+  });
+});

--- a/tests/mob_expose.test.ts
+++ b/tests/mob_expose.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+function exposeAura(value: number, remaining = 8): Aura {
+  return {
+    id: 'expose_test', name: 'Cracked Guard', kind: 'expose',
+    remaining, duration: 8, value, sourceId: -1, school: 'physical',
+  };
+}
+
+describe('Expose physical-vulnerability debuff', () => {
+  it('amplifies physical damage taken by the debuff fraction', () => {
+    const sim = makeSim();
+    const src = createMob(900600, MOBS.varkas_boneguard, 18, { x: 0, y: 0, z: 0 });
+
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    (sim as any).dealDamage(src, p, 100, false, 'physical', null, 'hit');
+    const baseline = 1_000_000 - p.hp;
+    expect(baseline).toBe(100);
+
+    p.auras.length = 0;
+    p.hp = 1_000_000;
+    p.auras.push(exposeAura(0.18));
+    (sim as any).dealDamage(src, p, 100, false, 'physical', null, 'hit');
+    const amplified = 1_000_000 - p.hp;
+    expect(amplified).toBe(118);
+  });
+
+  it('only amplifies physical damage, not spell schools', () => {
+    const sim = makeSim();
+    const src = createMob(900601, MOBS.varkas_boneguard, 18, { x: 0, y: 0, z: 0 });
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    p.auras.push(exposeAura(0.18));
+    (sim as any).dealDamage(src, p, 100, false, 'shadow', null, 'hit');
+    expect(1_000_000 - p.hp).toBe(100);
+  });
+
+  it('stacks additively across multiple Expose auras', () => {
+    const sim = makeSim();
+    const src = createMob(900602, MOBS.varkas_boneguard, 18, { x: 0, y: 0, z: 0 });
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    p.auras.push({ ...exposeAura(0.18), id: 'a', sourceId: 1 });
+    p.auras.push({ ...exposeAura(0.18), id: 'b', sourceId: 2 });
+    (sim as any).dealDamage(src, p, 100, false, 'physical', null, 'hit');
+    // 1 + 0.18 + 0.18 = 1.36
+    expect(1_000_000 - p.hp).toBe(136);
+  });
+
+  it('a landed Varkas Boneguard swing can inflict Cracked Guard', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.varkas_boneguard;
+    const saved = tmpl.expose!.chance;
+    tmpl.expose!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900610, tmpl, 18, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'expose');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'expose')!;
+      expect(a.name).toBe('Cracked Guard');
+      expect(a.value).toBe(0.18);
+    } finally {
+      tmpl.expose!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts Expose', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    const tmpl = MOBS.varkas_boneguard;
+    const saved = tmpl.expose!.chance;
+    tmpl.expose!.chance = 1;
+    try {
+      const pet = createMob(900611, tmpl, 18, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'expose')).toBe(false);
+    } finally {
+      tmpl.expose!.chance = saved;
+    }
+  });
+
+  it('a mob without the expose affix applies no debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 1_000_000; p.hp = 1_000_000;
+    const mob = createMob(900612, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'expose')).toBe(false);
+  });
+});

--- a/tests/mob_frostbite.test.ts
+++ b/tests/mob_frostbite.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn a Shardlord adjacent to the player and hand it back.
+function spawnShardlord(sim: Sim, id = 970601, level = 18) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.shardlord_kazzix, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the frostbite aura (the chance is 1 in these tests).
+function swingUntilFrostbite(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'frostbite_shardlord_kazzix')) return true;
+  }
+  return false;
+}
+
+describe('mob frostbite (on-hit frost DoT)', () => {
+  it('Shardlord Kazzix carries frostbite data tuned to a frost DoT', () => {
+    const f = MOBS.shardlord_kazzix.frostbite!;
+    expect(f).toBeDefined();
+    expect(f.school).toBe('frost');
+    expect(f.chance).toBeGreaterThan(0);
+    expect(f.perTick).toBeGreaterThan(0);
+    expect(f.interval).toBeGreaterThan(0);
+    expect(f.duration).toBeGreaterThan(f.interval);
+  });
+
+  it('a landed frostbitten swing inflicts a frost DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnShardlord(sim);
+    const orig = MOBS.shardlord_kazzix.frostbite!.chance;
+    MOBS.shardlord_kazzix.frostbite!.chance = 1;
+    try {
+      expect(swingUntilFrostbite(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.shardlord_kazzix.frostbite!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'frostbite_shardlord_kazzix')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('frost');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.shardlord_kazzix.frostbite!.duration);
+  });
+
+  it('the frost DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnShardlord(sim);
+    const orig = MOBS.shardlord_kazzix.frostbite!.chance;
+    MOBS.shardlord_kazzix.frostbite!.chance = 1;
+    try {
+      expect(swingUntilFrostbite(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.shardlord_kazzix.frostbite!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    // interval is 3s; tick well past it (8s) so the DoT outpaces out-of-combat regen.
+    for (let i = 0; i < 20 * 8; i++) sim.tick();
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-frostbitten mob (forest wolf) applies no frost DoT aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(970650, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === 'frostbite_forest_wolf')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated strikes from the same Shardlord', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    // Shardlord Kazzix is a level-18 elite; god-mode the dummy so the barrage of forced
+    // swings can't kill it (death clears all auras). A raw maxHp bump won't do — the tick's
+    // recalcPlayerStats re-derives maxHp from stamina and wipes it; gm survives + still takes auras.
+    (player as any).gm = true;
+    const mob = spawnShardlord(sim);
+    const orig = MOBS.shardlord_kazzix.frostbite!.chance;
+    MOBS.shardlord_kazzix.frostbite!.chance = 1;
+    try {
+      swingUntilFrostbite(sim, mob, player);
+      swingUntilFrostbite(sim, mob, player);
+      swingUntilFrostbite(sim, mob, player);
+    } finally {
+      MOBS.shardlord_kazzix.frostbite!.chance = orig;
+    }
+    const frostAuras = player.auras.filter((a) => a.id === 'frostbite_shardlord_kazzix');
+    expect(frostAuras.length).toBe(1);
+  });
+});

--- a/tests/mob_knockback.test.ts
+++ b/tests/mob_knockback.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+const dist2d = (a: { x: number; z: number }, b: { x: number; z: number }) =>
+  Math.hypot(a.x - b.x, a.z - b.z);
+
+describe('Knockback on-hit affix (Crushing Sweep)', () => {
+  it('a landed marrowlord_varkas swing hurls the player straight away from the mob', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; // an L19 elite would otherwise grind the warrior down mid-loop
+    // flat starting ground (Eastbrook town) so the shove isn't terrain-clamped
+    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const tmpl = MOBS.marrowlord_varkas;
+    const saved = tmpl.knockback!.chance;
+    tmpl.knockback!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      // spawn at the player's level for an even hit table, on top of the player
+      const mob = createMob(900700, tmpl, p.level, { x: 0, y: 0, z: 0 });
+      const startGap = dist2d(p.pos, mob.pos);
+      let moved = false;
+      for (let i = 0; i < 80 && !moved; i++) {
+        (sim as any).mobSwing(mob, p);
+        moved = dist2d(p.pos, mob.pos) > startGap + 1;
+      }
+      expect(moved).toBe(true);
+      // pushed outward along the +x line it started on (away, not toward, the mob)
+      expect(p.pos.x).toBeGreaterThan(2);
+      expect(dist2d(p.pos, mob.pos)).toBeGreaterThan(startGap + 3);
+    } finally {
+      tmpl.knockback!.chance = saved;
+    }
+  });
+
+  it('applyKnockback shoves the exact distance over open ground and reports it', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const mob = createMob(900701, MOBS.marrowlord_varkas, p.level, { x: 0, y: 0, z: 0 });
+    const moved = (sim as any).applyKnockback(mob, p, 6);
+    expect(moved).toBeGreaterThan(0);
+    expect(moved).toBeLessThanOrEqual(6);
+    expect(p.pos.x).toBeGreaterThan(2); // displaced along the mob→player axis
+  });
+
+  it('a friendly pet swing (hostile=false) never knocks its target back', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const tmpl = MOBS.marrowlord_varkas;
+    const saved = tmpl.knockback!.chance;
+    tmpl.knockback!.chance = 1;
+    try {
+      const pet = createMob(900702, tmpl, p.level, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      const startGap = dist2d(p.pos, pet.pos);
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(dist2d(p.pos, pet.pos)).toBeLessThan(startGap + 1);
+    } finally {
+      tmpl.knockback!.chance = saved;
+    }
+  });
+
+  it('a mob without knockback never displaces the player', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    const mob = createMob(900703, MOBS.forest_wolf, p.level, { x: 0, y: 0, z: 0 });
+    const startGap = dist2d(p.pos, mob.pos);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(dist2d(p.pos, mob.pos)).toBeLessThan(startGap + 1);
+  });
+});

--- a/tests/mob_lockout.test.ts
+++ b/tests/mob_lockout.test.ts
@@ -1,0 +1,122 @@
+// The Wyrmcult Zealot's "Wyrmward Sigil" is a school-specific counterspell: a
+// landed melee hit can lock the victim out of ONE spell school (fire) for a few
+// seconds. Unlike a full silence, every other school — and physical abilities —
+// stays usable, and an in-progress cast only breaks if it matches the locked school.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Wyrmcult Zealot adjacent to the player, at the player's level for an
+// even hit table, engaged and ready to swing.
+function spawnZealot(sim: Sim, target: Entity): Entity {
+  const template = MOBS['wyrmcult_zealot'];
+  const mob = createMob((sim as any).nextId++, template, target.level, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (lockout chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob school lockout ("Wyrmward Sigil")', () => {
+  it('seeds the lockout mechanic on the Wyrmcult Zealot', () => {
+    expect(MOBS['wyrmcult_zealot'].lockout).toEqual({
+      chance: 0.25, duration: 6, name: 'Wyrmward Sigil', school: 'fire',
+    });
+  });
+
+  it('applies a fire-school lockout aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnZealot(sim, p);
+    MOBS['wyrmcult_zealot'].lockout!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['wyrmcult_zealot'].lockout!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'lockout');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Wyrmward Sigil');
+    expect(aura!.remaining).toBe(6);
+    expect(aura!.school).toBe('fire');
+  });
+
+  it('blocks a fire cast while locked out but leaves other schools free', () => {
+    const sim = makeSim('mage');
+    sim.setPlayerLevel(10); // so the mage knows both Fireball (fire) and Frostbolt (frost)
+    const p = sim.player;
+    p.auras.push({
+      id: 'lockout_wyrmcult_zealot', name: 'Wyrmward Sigil', kind: 'lockout',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'fire',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    // Fireball is fire — locked out, rejected with the silence message.
+    sim.castAbility('fireball', p.id);
+    expect(errs).toContain('You are silenced!');
+    // Frostbolt is frost — a fire lockout must NOT block it.
+    errs.length = 0;
+    sim.castAbility('frostbolt', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('breaks an in-progress fire cast on the next tick but spares other schools', () => {
+    const sim = makeSim('mage');
+    sim.setPlayerLevel(10);
+    const p = sim.player;
+    p.auras.push({
+      id: 'lockout_x', name: 'Wyrmward Sigil', kind: 'lockout',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'fire',
+    });
+    // A fireball mid-cast is the locked school → broken next tick.
+    p.castingAbility = 'fireball';
+    p.castRemaining = 2;
+    p.channeling = false;
+    sim.tick();
+    expect(p.castingAbility).toBeNull();
+    // A frostbolt mid-cast is a different school → survives.
+    p.castingAbility = 'frostbolt';
+    p.castRemaining = 2;
+    p.channeling = false;
+    sim.tick();
+    expect(p.castingAbility).toBe('frostbolt');
+  });
+
+  it('does not block a physical ability while locked out', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    p.resource = 100;
+    p.auras.push({
+      id: 'lockout_x', name: 'Wyrmward Sigil', kind: 'lockout',
+      remaining: 6, duration: 6, value: 0, sourceId: 999, school: 'fire',
+    });
+    const errs: string[] = [];
+    const orig = (sim as any).error.bind(sim);
+    (sim as any).error = (pid: number, msg: string) => { errs.push(msg); orig(pid, msg); };
+    // Heroic Strike is physical — a lockout must never be the reason it's blocked.
+    sim.castAbility('heroic_strike', p.id);
+    expect(errs).not.toContain('You are silenced!');
+  });
+
+  it('a friendly pet swing never locks out its target', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnZealot(sim, p);
+    pet.hostile = false; // a tamed/friendly shape
+    pet.ownerId = p.id;
+    MOBS['wyrmcult_zealot'].lockout!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['wyrmcult_zealot'].lockout!.chance = 0.25;
+    expect(p.auras.some((a) => a.kind === 'lockout')).toBe(false);
+  });
+});

--- a/tests/mob_rally.test.ts
+++ b/tests/mob_rally.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Ironvein Foreman is the seeded carrier of the rally commander mechanic.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+  effectiveAttackPower(e: Entity): number;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string]) {
+  const mob = createMob(id, tmpl, 16, { x: 0, y: 0, z: 0 });
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+function buffAp(e: Entity): number {
+  return e.auras.filter((a) => a.kind === 'buff_ap').reduce((s, a) => s + a.value, 0);
+}
+
+describe('mob commander buff (rally)', () => {
+  it('seeds the mechanic on the Ironvein Foreman', () => {
+    expect(MOBS.ironvein_foreman.rally).toEqual({
+      radius: 14, every: 12, ap: 40, duration: 10, name: 'Rallying Banner',
+    });
+  });
+
+  it('empowers a nearby ally once the cast timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9001, MOBS.ironvein_foreman);
+    const ally = spawn(sim, 9002, MOBS.ironvein_sapper);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    const before = inner(sim).effectiveAttackPower(ally);
+    // Telegraphed: createMob seeds rallyTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first rally.
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(ally)).toBe(40);
+    expect(inner(sim).effectiveAttackPower(ally)).toBe(before + 40);
+  });
+
+  it('does not rally before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9011, MOBS.ironvein_foreman);
+    const ally = spawn(sim, 9012, MOBS.ironvein_sapper);
+    for (let i = 0; i < 20 * 11; i++) inner(sim).updateBossMechanics(foreman); // 11s < 12s
+    expect(buffAp(ally)).toBe(0);
+  });
+
+  it('empowers every ally in range plus the caster (AoE)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9021, MOBS.ironvein_foreman);
+    const a = spawn(sim, 9022, MOBS.ironvein_sapper);
+    const b = spawn(sim, 9023, MOBS.ironvein_sapper);
+    b.pos = { x: 8, y: 0, z: 0 };
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(a)).toBe(40);
+    expect(buffAp(b)).toBe(40);
+    expect(buffAp(foreman)).toBe(40); // the commander rallies itself too
+  });
+
+  it('ignores allies outside the rally radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9031, MOBS.ironvein_foreman);
+    const far = spawn(sim, 9032, MOBS.ironvein_sapper);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 14
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(far)).toBe(0);
+  });
+
+  it('does not empower opposing-faction mobs (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9041, MOBS.ironvein_foreman);
+    const enemyMob = spawn(sim, 9042, MOBS.ironvein_sapper);
+    enemyMob.hostile = false; // flip faction
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(foreman);
+    expect(buffAp(enemyMob)).toBe(0);
+  });
+
+  it('refreshes rather than stacks on repeated casts', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9051, MOBS.ironvein_foreman);
+    const ally = spawn(sim, 9052, MOBS.ironvein_sapper);
+    for (let i = 0; i < 20 * 12 * 2 + 2; i++) inner(sim).updateBossMechanics(foreman);
+    expect(ally.auras.filter((a) => a.kind === 'buff_ap').length).toBe(1);
+    expect(buffAp(ally)).toBe(40);
+  });
+
+  it('re-arms the telegraph after the foreman evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const foreman = spawn(sim, 9061, MOBS.ironvein_foreman);
+    inner(sim).resetEvadingMob(foreman);
+    expect(foreman.rallyTimer).toBe(MOBS.ironvein_foreman.rally!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const sapper = spawn(sim, 9071, MOBS.ironvein_sapper);
+    const ally = spawn(sim, 9072, MOBS.ironvein_sapper);
+    for (let i = 0; i < 20 * 12 + 1; i++) inner(sim).updateBossMechanics(sapper);
+    expect(buffAp(ally)).toBe(0);
+  });
+});

--- a/tests/mob_rampage.test.ts
+++ b/tests/mob_rampage.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 42;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior', autoEquip: true });
+
+// Spawn Warlord Drogmar next to a beefy player so the fury can ramp over many
+// landed swings without the target ever dropping.
+const setup = () => {
+  const sim = makeSim();
+  const player = sim.player;
+  player.maxHp = 100000;
+  player.hp = player.maxHp;
+  player.dodgeChance = 0; // never dodge: every swing lands and stokes the fury
+  const mob = createMob(990700, MOBS.warlord_drogmar, 17, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return { sim, player, mob };
+};
+
+const rampageStacks = (mob: any) =>
+  mob.auras.find((a: any) => a.id === `rampage_${mob.templateId}`)?.stacks ?? 0;
+
+// Swing repeatedly, keeping the target topped off so no swing kills it.
+const swingTimes = (sim: Sim, mob: any, target: any, n: number) => {
+  for (let i = 0; i < n; i++) {
+    target.hp = target.maxHp;
+    (sim as any).mobSwing(mob, target);
+  }
+};
+
+describe('mob Battle Fury (Rampage)', () => {
+  it('Warlord Drogmar carries the rampage mechanic', () => {
+    const r = MOBS.warlord_drogmar.rampage;
+    expect(r).toBeDefined();
+    expect(r!.name).toBe('Battle Fury');
+    expect(r!.ap).toBeGreaterThan(0);
+    expect(r!.maxStacks).toBeGreaterThan(1);
+  });
+
+  it('a landed hit applies a self buff_ap aura that grows the mob attack power', () => {
+    const { sim, player, mob } = setup();
+    const baseAp = (sim as any).effectiveAttackPower(mob);
+    swingTimes(sim, mob, player, 1);
+    expect(rampageStacks(mob)).toBe(1);
+    // one stack of +ap is now folded into the mob's effective attack power
+    expect((sim as any).effectiveAttackPower(mob)).toBe(baseAp + MOBS.warlord_drogmar.rampage!.ap);
+  });
+
+  it('stacks build with each landed swing up to the cap, and no further', () => {
+    const { sim, player, mob } = setup();
+    const { maxStacks, ap } = MOBS.warlord_drogmar.rampage!;
+    const baseAp = (sim as any).effectiveAttackPower(mob);
+    swingTimes(sim, mob, player, maxStacks + 10);
+    expect(rampageStacks(mob)).toBe(maxStacks);
+    // the single shared aura is valued at ap * maxStacks — never beyond the cap
+    expect((sim as any).effectiveAttackPower(mob)).toBe(baseAp + ap * maxStacks);
+    expect(mob.auras.filter((a: any) => a.id === `rampage_${mob.templateId}`).length).toBe(1);
+  });
+
+  it('a friendly pet never self-buffs (hostile guard)', () => {
+    const { sim, player, mob } = setup();
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    swingTimes(sim, mob, player, 5);
+    expect(rampageStacks(mob)).toBe(0);
+  });
+
+  it('the fury falls off after its duration, undoing the ramp', () => {
+    const { sim, player, mob } = setup();
+    swingTimes(sim, mob, player, 3);
+    expect(rampageStacks(mob)).toBeGreaterThan(0);
+    const baseAp = mob.attackPower;
+    // drop the player so the warlord stops swinging — otherwise it keeps landing
+    // hits during tick() and refreshes the fury forever. Now let it time out.
+    player.dead = true;
+    player.hp = 0;
+    for (let i = 0; i < 20 * (MOBS.warlord_drogmar.rampage!.duration + 2); i++) sim.tick();
+    expect(rampageStacks(mob)).toBe(0);
+    expect((sim as any).effectiveAttackPower(mob)).toBe(baseAp);
+  });
+});

--- a/tests/mob_smolder.test.ts
+++ b/tests/mob_smolder.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn an Ironvein Sapper adjacent to the player and hand it back. Spawned near
+// the player's level so the hit table lands reliably (a big level gap inflates miss).
+function spawnSapper(sim: Sim, id = 980001, level = 5) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ironvein_sapper, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the smolder aura (the chance is forced to 1 here).
+function swingUntilSmolder(sim: Sim, mob: any, target: any, tries = 40): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'smolder_ironvein_sapper')) return true;
+  }
+  return false;
+}
+
+describe('mob smolder (on-hit fire DoT)', () => {
+  it('the Ironvein Sapper carries smolder data tuned to a fire DoT', () => {
+    const s = MOBS.ironvein_sapper.smolder!;
+    expect(s).toBeDefined();
+    expect(s.name).toBe('Smoldering Fuse');
+    expect(s.chance).toBeGreaterThan(0);
+    expect(s.perTick).toBeGreaterThan(0);
+    expect(s.interval).toBeGreaterThan(0);
+    expect(s.duration).toBeGreaterThan(s.interval);
+  });
+
+  it('a landed swing ignites a fire DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.smolder!.chance;
+    MOBS.ironvein_sapper.smolder!.chance = 1;
+    try {
+      expect(swingUntilSmolder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.smolder!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'smolder_ironvein_sapper')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('fire');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.ironvein_sapper.smolder!.duration);
+  });
+
+  it('the fire DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.smolder!.chance;
+    MOBS.ironvein_sapper.smolder!.chance = 1;
+    try {
+      expect(swingUntilSmolder(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.ironvein_sapper.smolder!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    // interval = 3s; run ~7s so the DoT outpaces any out-of-combat regen.
+    for (let i = 0; i < 20 * 7; i++) sim.tick();
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-smoldering mob (forest wolf) applies no fire DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 5, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated hits from the same sapper', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnSapper(sim);
+    const orig = MOBS.ironvein_sapper.smolder!.chance;
+    MOBS.ironvein_sapper.smolder!.chance = 1;
+    try {
+      swingUntilSmolder(sim, mob, player);
+      swingUntilSmolder(sim, mob, player);
+      swingUntilSmolder(sim, mob, player);
+    } finally {
+      MOBS.ironvein_sapper.smolder!.chance = orig;
+    }
+    const auras = player.auras.filter((a) => a.id === 'smolder_ironvein_sapper');
+    expect(auras.length).toBe(1);
+  });
+});

--- a/tests/mob_spell_reflect.test.ts
+++ b/tests/mob_spell_reflect.test.ts
@@ -1,0 +1,93 @@
+// Innate "warded" mobs (Wyrmcult Necromancers) reflect flat damage onto any
+// caster whose SPELL connects — the magic-school twin of melee thorns. The
+// reflect lives in dealDamage, the single funnel every damage instance passes
+// through, so driving dealDamage directly exercises the exact production path.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'mage', autoEquip: true });
+}
+
+function spawnMob(sim: Sim, templateId: string, level: number): Entity {
+  const tpl = MOBS[templateId];
+  const id = (sim as any).nextId++;
+  const mob = createMob(id, tpl, level, { x: 1, y: 0, z: 0 });
+  mob.maxHp = 100000; // survive the scripted hits (death wipes state / suppresses the ward)
+  mob.hp = mob.maxHp;
+  sim.entities.set(id, mob);
+  return mob;
+}
+
+// drive the production damage funnel exactly as a landed spell would
+function spellHit(sim: Sim, caster: Entity, target: Entity, amount: number, school = 'fire') {
+  (sim as any).dealDamage(caster, target, amount, false, school, 'Fireball', 'hit');
+}
+
+describe('mob spell reflect (Spectral Ward)', () => {
+  it('reflects flat shadow damage onto a mage whose spell strikes the necromancer', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const necro = spawnMob(sim, 'wyrmcult_necromancer', 19);
+
+    const ward = MOBS['wyrmcult_necromancer'].spellReflect!;
+    const before = player.hp;
+    spellHit(sim, player, necro, 50);
+
+    // the caster eats exactly one ward reflect per connecting spell
+    expect(before - player.hp).toBe(ward.value);
+  });
+
+  it('does not reflect a physical (melee) hit — that is the thorns domain', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const necro = spawnMob(sim, 'wyrmcult_necromancer', 19);
+
+    const before = player.hp;
+    spellHit(sim, player, necro, 50, 'physical');
+
+    expect(player.hp).toBe(before);
+  });
+
+  it('a mob without the ward reflects nothing on a spell hit', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const plain = spawnMob(sim, 'boneclad_revenant', 19);
+    expect(MOBS['boneclad_revenant'].spellReflect).toBeUndefined();
+
+    const before = player.hp;
+    spellHit(sim, player, plain, 50);
+
+    expect(player.hp).toBe(before);
+  });
+
+  it('does not reflect when the killing blow drops the mob (no burst from a corpse)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    player.maxHp = 100000;
+    player.hp = player.maxHp;
+    const necro = spawnMob(sim, 'wyrmcult_necromancer', 19);
+    necro.hp = 5; // the incoming nuke is lethal
+
+    const before = player.hp;
+    spellHit(sim, player, necro, 50);
+
+    expect(necro.hp).toBe(0);
+    expect(player.hp).toBe(before);
+  });
+
+  it('the necromancer template carries a positive-value Spectral Ward', () => {
+    const ward = MOBS['wyrmcult_necromancer'].spellReflect;
+    expect(ward).toBeDefined();
+    expect(ward!.value).toBeGreaterThan(0);
+  });
+});

--- a/tests/mob_spellvuln.test.ts
+++ b/tests/mob_spellvuln.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+function spellVulnAura(value: number, remaining = 10): Aura {
+  return {
+    id: 'spellvuln_test', name: 'Static Charge', kind: 'spellvuln',
+    remaining, duration: 10, value, sourceId: -1, school: 'nature',
+  };
+}
+
+// Drive a single damage application and report how much HP it removed. The mob
+// `src` carries no stance/affix, so dealDamage applies only the spell-vuln math.
+function dmgTaken(sim: Sim, school: string, base = 100): number {
+  const p = sim.entities.get(sim.playerId)!;
+  const src = createMob(900600, MOBS.forest_wolf, 5, { x: 50, y: 0, z: 50 });
+  p.hp = 100000;
+  (sim as any).dealDamage(src, p, base, false, school, null, 'hit', true);
+  return 100000 - p.hp;
+}
+
+describe('Spell Vulnerability (spellvuln) debuff', () => {
+  it('amplifies non-physical damage by the debuff fraction', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+    expect(dmgTaken(sim, 'fire')).toBe(100); // baseline, no debuff
+
+    p.auras.push(spellVulnAura(0.18));
+    expect(dmgTaken(sim, 'fire')).toBe(118); // +18%
+    expect(dmgTaken(sim, 'shadow')).toBe(118); // any magic school
+  });
+
+  it('does not amplify physical or holy (healing-school) damage', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+    p.auras.push(spellVulnAura(0.18));
+    expect(dmgTaken(sim, 'physical')).toBe(100); // armor-school, untouched
+    expect(dmgTaken(sim, 'holy')).toBe(100); // healing-school, excluded
+  });
+
+  it('stacks additively across multiple spellvuln auras', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000;
+    p.auras.push({ ...spellVulnAura(0.18), id: 'a', sourceId: 1 });
+    p.auras.push({ ...spellVulnAura(0.18), id: 'b', sourceId: 2 });
+    expect(dmgTaken(sim, 'frost')).toBe(136); // 100 * (1 + 0.18 + 0.18)
+  });
+
+  it('a landed stormcrag_elemental swing can inflict Static Charge', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.stormcrag_elemental;
+    const saved = tmpl.spellVuln!.chance;
+    tmpl.spellVuln!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(900601, tmpl, 18, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'spellvuln');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'spellvuln')!;
+      expect(a.name).toBe('Static Charge');
+      expect(a.value).toBeCloseTo(0.18, 6);
+    } finally {
+      tmpl.spellVuln!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts Static Charge', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.stormcrag_elemental;
+    const saved = tmpl.spellVuln!.chance;
+    tmpl.spellVuln!.chance = 1;
+    try {
+      const pet = createMob(900602, tmpl, 18, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'spellvuln')).toBe(false);
+    } finally {
+      tmpl.spellVuln!.chance = saved;
+    }
+  });
+
+  it('a mob without spellVuln applies no debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(900603, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'spellvuln')).toBe(false);
+  });
+});

--- a/tests/mob_stagger.test.ts
+++ b/tests/mob_stagger.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { createMob } from '../src/sim/entity';
+import { MOBS } from '../src/sim/data';
+
+// Staggering mobs knock a player victim off-balance on a landed hit, cutting
+// their dodge chance for the duration so the attacker (and its pack) land more
+// of their swings. It rides the existing buff_dodge aura with a NEGATIVE value,
+// so recalcPlayerStats folds it straight into the victim's dodgeChance.
+describe('mob stagger-on-hit', () => {
+  it('the Deeprock Tunneler template carries a Jarring Swing proc', () => {
+    expect(MOBS.deeprock_kobold.staggerHit).toMatchObject({
+      chance: 0.3, dodgeReduction: 0.05, duration: 8, name: 'Off-Balance',
+    });
+  });
+
+  it('a landed swing cuts the victim dodge via a negative buff_dodge aura', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Staggered');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+    victim.gm = true; // invulnerable for the test; applyAura still fires
+
+    const baseDodge = victim.dodgeChance;
+    expect(baseDodge).toBeGreaterThan(0.05);
+
+    const kobold = createMob((sim as any).nextId++, MOBS.deeprock_kobold, 15, { x: 0, y: 0, z: 0 });
+    kobold.hostile = true;
+    kobold.hp = kobold.maxHp;
+    (sim as any).addEntity(kobold);
+
+    // Force a landed hit (high roll clears miss+dodge) and a proc, so the test
+    // asserts the mechanic, not the RNG.
+    (sim as any).rng.next = () => 0.99;
+    (sim as any).rng.chance = () => true;
+    (sim as any).mobSwing(kobold, victim);
+
+    const aura = victim.auras.find((a) => a.name === 'Off-Balance');
+    expect(aura).toBeTruthy();
+    expect(aura!.kind).toBe('buff_dodge');
+    expect(aura!.value).toBe(-0.05);
+    expect(aura!.duration).toBe(8);
+    // recalcPlayerStats already folded the negative buff_dodge into dodgeChance.
+    expect(victim.dodgeChance).toBeCloseTo(Math.max(0, baseDodge - 0.05), 6);
+  });
+
+  it('re-applies (refreshes) rather than stacking on repeated hits', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Hounded');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+    victim.gm = true; // invulnerable for the test; applyAura still fires
+
+    const kobold = createMob((sim as any).nextId++, MOBS.deeprock_kobold, 15, { x: 0, y: 0, z: 0 });
+    kobold.hostile = true;
+    kobold.hp = kobold.maxHp;
+    (sim as any).addEntity(kobold);
+
+    (sim as any).rng.next = () => 0.99;
+    (sim as any).rng.chance = () => true;
+    for (let i = 0; i < 10; i++) (sim as any).mobSwing(kobold, victim);
+
+    const staggers = victim.auras.filter((a) => a.name === 'Off-Balance');
+    expect(staggers.length).toBe(1);
+    expect(staggers[0].value).toBe(-0.05);
+  });
+
+  it('the dodge floor keeps dodgeChance from going negative', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Floored');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+
+    // A reduction larger than the victim's whole dodge clamps to exactly 0.
+    (sim as any).applyAura(victim, {
+      id: 'stagger_test', name: 'Off-Balance', kind: 'buff_dodge',
+      remaining: 8, duration: 8, value: -1, sourceId: victim.id, school: 'physical',
+    });
+    expect(victim.dodgeChance).toBe(0);
+  });
+
+  it('an ordinary mob with no staggerHit field never applies the debuff', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Safe');
+    sim.setPlayerLevel(15);
+    const victim = sim.entities.get(pid)!;
+    victim.pos = { x: 1, y: 0, z: 0 };
+    victim.maxHp = 100000;
+    victim.hp = 100000;
+    victim.gm = true; // invulnerable for the test; applyAura still fires
+
+    const wolf = createMob((sim as any).nextId++, MOBS.forest_wolf, 2, { x: 0, y: 0, z: 0 });
+    wolf.hostile = true;
+    wolf.hp = wolf.maxHp;
+    (sim as any).addEntity(wolf);
+
+    // Even with every swing landing and every proc roll true, a mob without the
+    // staggerHit field can never inflict Off-Balance.
+    (sim as any).rng.next = () => 0.99;
+    (sim as any).rng.chance = () => true;
+    for (let i = 0; i < 50; i++) (sim as any).mobSwing(wolf, victim);
+    expect(victim.auras.some((a) => a.name === 'Off-Balance')).toBe(false);
+  });
+});

--- a/tests/mob_stoneskin.test.ts
+++ b/tests/mob_stoneskin.test.ts
@@ -1,0 +1,107 @@
+// "Stoneskin" boss mechanic: a mob with a `stoneskin` template field
+// periodically wraps itself in a damage-absorbing barrier while in melee
+// combat. It is telegraphed — the first barrier only snaps up one full
+// interval after the fight begins — resets on evade/respawn, and reuses the
+// existing `absorb` aura, which dealDamage already soaks before any HP is lost.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim() {
+  return new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+}
+
+// Spawn a stoneskin boss locked in melee on the player and return it.
+function engagedWard(sim: Sim): Entity {
+  const mob = createMob(900200, MOBS.marrowlord_varkas, 19, { ...sim.player.pos });
+  mob.spawnPos = { ...sim.player.pos }; // sit on the player: in melee, no leash
+  mob.aiState = 'attack';
+  mob.aggroTargetId = sim.playerId;
+  mob.inCombat = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+const wardAura = (e: Entity) => e.auras.find((a) => a.id === 'stoneskin_marrowlord_varkas');
+
+describe('Stoneskin boss mechanic', () => {
+  it('Marrowlord Varkas carries a Bone Carapace', () => {
+    expect(MOBS.marrowlord_varkas.stoneskin?.name).toBe('Bone Carapace');
+    expect(MOBS.marrowlord_varkas.stoneskin?.amount).toBeGreaterThan(0);
+  });
+
+  it('is telegraphed: a freshly spawned warden waits one interval before its first barrier', () => {
+    const mob = createMob(900201, MOBS.marrowlord_varkas, 19, { x: 0, y: 0, z: 0 });
+    expect(mob.stoneskinTimer).toBe(MOBS.marrowlord_varkas.stoneskin!.every);
+  });
+
+  it('raises an absorb barrier on itself when the timer elapses and resets the timer', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    mob.stoneskinTimer = 0.001; // due now
+    (sim as any).updateMob(mob);
+
+    const aura = wardAura(mob);
+    expect(aura?.kind).toBe('absorb');
+    expect(aura?.name).toBe('Bone Carapace');
+    expect(aura?.value).toBe(MOBS.marrowlord_varkas.stoneskin!.amount);
+    expect(mob.stoneskinTimer).toBeCloseTo(MOBS.marrowlord_varkas.stoneskin!.every, 5);
+  });
+
+  it('soaks incoming damage: HP is spared while the barrier holds, then drains', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    // The boss sits on the player and swings during updateMob; keep the player
+    // alive (a dead attacker's blow won't land) so it can test-fire into the shield.
+    sim.player.gm = true;
+    mob.stoneskinTimer = 0.001;
+    (sim as any).updateMob(mob);
+
+    const amount = MOBS.marrowlord_varkas.stoneskin!.amount;
+    const hpBefore = mob.hp;
+
+    // A hit smaller than the shield: no HP lost, shield drains by that much.
+    (sim as any).dealDamage(sim.player, mob, 100, false, 'physical', null, 'hit');
+    expect(mob.hp).toBe(hpBefore);
+    expect(wardAura(mob)?.value).toBe(amount - 100);
+
+    // A hit that overruns the remaining shield: shield pops, overflow hits HP.
+    (sim as any).dealDamage(sim.player, mob, amount, false, 'physical', null, 'hit');
+    expect(wardAura(mob)).toBeUndefined();
+    expect(mob.hp).toBeLessThan(hpBefore);
+  });
+
+  it('does not raise a barrier before the timer elapses', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    mob.stoneskinTimer = 5; // not due yet
+    (sim as any).updateMob(mob);
+
+    expect(wardAura(mob)).toBeUndefined();
+    expect(mob.stoneskinTimer).toBeLessThan(5);
+  });
+
+  it('re-arms the telegraph delay when the mob evades home', () => {
+    const sim = makeSim();
+    const mob = engagedWard(sim);
+    mob.stoneskinTimer = 0;
+    (sim as any).resetEvadingMob(mob);
+    expect(mob.stoneskinTimer).toBe(MOBS.marrowlord_varkas.stoneskin!.every);
+  });
+
+  it('a normal mob without a stoneskin template never gains the barrier', () => {
+    const sim = makeSim();
+    const wolf = createMob(900202, MOBS.forest_wolf, 5, { ...sim.player.pos });
+    wolf.spawnPos = { ...sim.player.pos };
+    wolf.aiState = 'attack';
+    wolf.aggroTargetId = sim.playerId;
+    wolf.inCombat = true;
+    (sim as any).addEntity(wolf);
+    wolf.stoneskinTimer = 0.001;
+    (sim as any).updateMob(wolf);
+
+    expect(wolf.auras.some((a) => a.kind === 'absorb')).toBe(false);
+  });
+});


### PR DESCRIPTION
Consolidates sixteen independent zone3 (Thornpeak Heights / Stormcrag) mob-affix PRs into one branch to cut merge-conflict churn on the shared `src/sim/sim.ts`, `src/sim/types.ts`, `src/ui/hud.ts` and i18n files. All conflicts were additive (the `AuraKind` union, the `isDebuff` array, separate `MobTemplate` fields and on-hit blocks) — resolved by union, never dropping a feature. No new `tsc` errors; full test suite green (1617 passed). Two mobs intentionally carry two affixes each (Marrowlord Varkas: stoneskin+knockback; Ironvein Sappers: cinder+smolder).

Folds in:
- #495 Soul Siphon · #497 Concussive Blow (stun) · #510 Disarming Smash · #512 Rending Claws (bleed)
- #519 Cracked Guard · #522 Static Charge (spell-vuln) · #524 Spectral Ward (spell reflect) · #528 Jarring Swing (stagger)
- #532 Frostbite (frost DoT) · #533 Smoldering Fuse · #534 Cinderburn · #540 Battle Fury (rampage)
- #547 Crushing Sweep (knockback) · #548 Bone Carapace (stoneskin) · #550 Rallying Banner · #552 Wyrmward Sigil (spell lockout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)