### PR TITLE
feat(content): zone2 mob-affix pack (14 on-hit affixes across Mirefen/Gravecaller/Nhalia)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/jegoh/Documents/repo/world-of-claudecraft/node_modules

--- a/scripts/curse_visual.mjs
+++ b/scripts/curse_visual.mjs
@@ -1,0 +1,112 @@
+// Screenshots for the "Curse of Frailty" vulnerability affix (Gravecaller Cultist).
+// A landed hit curses the victim so they take more damage from every source, shown
+// as a red debuff on the buff bar. Runs the offline flow (no server). Needs
+// `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 720 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Garrosh'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.evaluate(() => document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click());
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await wait(3000);
+
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  sim.setPlayerLevel(20);
+});
+await wait(400);
+
+// Retemplate the nearest mob into a Gravecaller Cultist, stage it in front of the
+// player at level+3 (a lower-level attacker mostly MISSES a higher-level player —
+// #443 miss scaling — so bump its level to make forced swings reliably connect),
+// then force swings until the Curse of Frailty lands. Also measure the damage
+// amplification on a fixed test hit for the PR write-up.
+const result = await page.evaluate(async () => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  let mob = null, best = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead) continue;
+    const dx = e.pos.x - p.pos.x, dz = e.pos.z - p.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < best) { best = d; mob = e; }
+  }
+  if (!mob) return { ok: false, why: 'no mob nearby' };
+  mob.templateId = 'gravecaller_cultist';
+  mob.name = 'Gravecaller Cultist';
+  mob.hostile = true;
+  mob.level = p.level + 3;
+  mob.pos.x = p.pos.x + 3; mob.pos.z = p.pos.z; mob.pos.y = p.pos.y;
+
+  p.maxHp = 100000;
+  let cursed = false;
+  for (let i = 0; i < 600 && !cursed; i++) {
+    p.hp = p.maxHp; // never let the swing kill us
+    sim.mobSwing(mob, p);
+    cursed = p.auras.some((a) => a.kind === 'vulnerability');
+  }
+  const aura = p.auras.find((a) => a.kind === 'vulnerability');
+  return { ok: cursed, amp: aura?.value ?? null, aura: aura?.name ?? null };
+});
+
+// Teleport the player away so combat ends and the 10s curse rides along, then
+// screenshot quickly before it expires.
+await page.evaluate(() => {
+  const sim = window.__game.sim, p = sim.player;
+  p.pos.x -= 80;
+  p.prevPos = { ...p.pos };
+});
+await wait(160);
+await page.screenshot({ path: 'tmp/curse-hud.png' });
+
+// Crop the buff bar (top-right, left of the minimap) for a legible debuff icon.
+try {
+  const clip = await page.evaluate(() => {
+    const el = document.querySelector('#buff-bar');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { x: Math.max(0, r.x - 12), y: Math.max(0, r.y - 8), width: Math.min(360, r.width + 24), height: Math.min(120, r.height + 50) };
+  });
+  if (clip && clip.width > 4) await page.screenshot({ path: 'tmp/curse-buffbar.png', clip });
+} catch (e) { errors.push('buffbar crop: ' + e.message); }
+
+// Hover the debuff icon to surface its tooltip, then crop the top-right region.
+try {
+  await page.evaluate(() => {
+    const icon = document.querySelector('#buff-bar .buff.debuff') || document.querySelector('#buff-bar .buff');
+    if (!icon) return;
+    const r = icon.getBoundingClientRect();
+    const opts = { bubbles: false, clientX: r.x + r.width / 2, clientY: r.y + r.height / 2 };
+    icon.dispatchEvent(new MouseEvent('mouseenter', opts));
+    icon.dispatchEvent(new MouseEvent('mousemove', { ...opts, bubbles: true }));
+  });
+  await wait(250);
+  await page.screenshot({ path: 'tmp/curse-tooltip.png', clip: { x: 900, y: 0, width: 380, height: 230 } });
+} catch (e) { errors.push('tooltip: ' + e.message); }
+
+console.log('RESULT', JSON.stringify(result));
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'OK: no page errors');
+await browser.close();

--- a/scripts/shot_arcane_rot.mjs
+++ b/scripts/shot_arcane_rot.mjs
@@ -1,0 +1,85 @@
+// Screenshot the Arcane Rot affix (Profane Rune) in the offline client.
+// Boots the game, repurposes a nearby mob as Deacon Voss, forces its on-hit
+// arcane brand onto the player, and captures the resulting DoT debuff icon on
+// the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Deacon Voss and drive his arcane brand onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz boss loop (a raw maxHp override gets re-derived
+  // from stamina by recalcPlayerStats each tick); applyAura still lands.
+  p.gm = true;
+  sim.rng.chance = () => true; // force the on-hit proc deterministically
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the corrupt deacon and stand it next to us.
+  mob.templateId = 'deacon_voss';
+  mob.name = 'Deacon Voss';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const rune = p.auras.find((a) => a.name === 'Profane Rune');
+  return { hasRune: !!rune, school: rune?.school, kind: rune?.kind, value: rune?.value, remaining: rune?.remaining };
+});
+console.log('arcane rot result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/arcane_rot_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/arcane_rot_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/arcane_rot_scene.png, arcane_rot_debuff.png');
+await browser.close();

--- a/scripts/shot_critvuln.mjs
+++ b/scripts/shot_critvuln.mjs
@@ -1,0 +1,83 @@
+// Screenshot the Find Weakness affix (Exposed Wound) in the offline client.
+// Boots the game, repurposes a nearby mob as a Mirefen Widow, forces its
+// on-hit bite onto the player, and captures the resulting crit-vulnerability
+// debuff on the player buff/debuff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm survives the live 20Hz loop (a raw maxHp override is wiped by recalc);
+  // applyAura still lands, so the debuff icon shows. Force the proc deterministically.
+  p.gm = true; p.maxHp = 100000; p.hp = 100000;
+  sim.rng.chance = () => true;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'mire_widow';
+  mob.name = 'Mirefen Widow';
+  mob.level = 10;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const cv = p.auras.find((a) => a.name === 'Exposed Wound');
+  return { hasDebuff: !!cv, value: cv?.value, remaining: cv?.remaining };
+});
+console.log('critvuln result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/critvuln_scene.png' });
+
+// Crop tightly around the buff/debuff bar (top-right) where the debuff shows.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/critvuln_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/critvuln_scene.png, critvuln_debuff.png');
+await browser.close();

--- a/scripts/shot_heal_absorb.mjs
+++ b/scripts/shot_heal_absorb.mjs
@@ -1,0 +1,95 @@
+// Screenshot the Heal-Absorb affix (Grave Blight) in the offline client.
+// Boots the game, repurposes a nearby mob as a Gravecaller Summoner, forces
+// its on-hit blight onto the player, and captures the resulting heal-absorb
+// debuff on the player buff bar — plus a console proof that a follow-up heal
+// is devoured by the shield.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm keeps the player alive through the live 20Hz loop without maxHp being
+  // wiped by recalcPlayerStats; applyAura/applyHeal still resolve normally.
+  p.gm = true;
+  p.maxHp = 100000; p.hp = 60000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Gravecaller Summoner and stand it next to us.
+  mob.templateId = 'gravecaller_summoner';
+  mob.name = 'Gravecaller Summoner';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the blight to land, then prove a heal is devoured by the shield.
+  sim.entities; // touch
+  const MOBS = mob; // not used; the affix reads its own template
+  for (let i = 0; i < 10; i++) sim.mobSwing(mob, p);
+  const blight = p.auras.find((a) => a.kind === 'heal_absorb');
+  const before = blight?.value;
+  const hpBefore = p.hp;
+  sim.applyHeal(p, p, 80, 'Test Heal');
+  const after = (p.auras.find((a) => a.kind === 'heal_absorb') || {}).value;
+  const hpAfter = p.hp;
+  return {
+    hasBlight: !!blight, name: blight?.name, shieldBefore: before, shieldAfter: after,
+    healedHp: hpAfter - hpBefore, remaining: blight?.remaining,
+  };
+});
+console.log('heal_absorb result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/heal_absorb_scene.png' });
+
+// Crop tightly around the player buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/heal_absorb_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+console.log('saved tmp/heal_absorb_scene.png, heal_absorb_debuff.png');
+await browser.close();

--- a/scripts/shot_hex.mjs
+++ b/scripts/shot_hex.mjs
@@ -1,0 +1,104 @@
+// Screenshot the Weakening Hex affix in the offline client. Boots the game,
+// repurposes a nearby mob as a Gravecaller Cultist, forces its on-hit hex onto
+// the player, and captures the resulting debuff on the player unit frame. Logs
+// the measured damage/healing reduction the hex applies.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Gravecaller Cultist and drive its hex onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the hexing cultist and stand it next to us.
+  mob.templateId = 'gravecaller_cultist';
+  mob.name = 'Gravecaller Cultist';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Force the hex, then measure the output reduction on a fresh dummy target.
+  for (let i = 0; i < 8 && !p.auras.some((a) => a.kind === 'hex'); i++) sim.mobSwing(mob, p);
+  const hex = p.auras.find((a) => a.kind === 'hex');
+  const dummyHp = 1e9;
+  mob.hp = dummyHp;
+  sim.dealDamage(p, mob, 1000, false, 'shadow', null, 'hit', true);
+  const hexedHit = dummyHp - mob.hp;
+  mob.hp = mob.maxHp;
+  return {
+    hasHex: !!hex, hexName: hex?.name, reduction: hex?.value, remaining: hex?.remaining,
+    fullHit: 1000, hexedHit,
+  };
+});
+console.log('hex result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/hex_full.png' });
+
+// Crop tightly around the player unit frame + buff/debuff bar.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/hex_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+// Hover the debuff icon to surface its tooltip, then capture it.
+if (box) {
+  // The hex is the rightmost icon in the bar; hover its centre to surface the tooltip.
+  await page.mouse.move(box.x + box.w - 14, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 600));
+  await page.screenshot({
+    path: 'tmp/hex_tooltip_crop.png',
+    clip: {
+      x: Math.max(0, box.x - 360), y: Math.max(0, box.y - 10),
+      width: 360 + box.w + 30, height: 170,
+    },
+  });
+}
+
+console.log('saved tmp/hex_full.png, hex_frame.png, hex_tooltip_crop.png');
+await browser.close();

--- a/scripts/shot_purge.mjs
+++ b/scripts/shot_purge.mjs
@@ -1,0 +1,101 @@
+// Screenshot the Devour Magic affix in the offline client. Boots the game,
+// repurposes a nearby mob as Grubjaw the Glutton, grants the player a couple of
+// real enhancement buffs, captures the buff bar, then drives Grubjaw's on-hit
+// purge to devour a buff and captures the bar again (one fewer buff = proof).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5174';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const bufBox = () => page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+const cropBar = async (file) => {
+  const box = await bufBox();
+  if (!box) return;
+  const pad = 18;
+  await page.screenshot({ path: file, clip: {
+    x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+    width: box.w + pad * 2, height: box.h + pad * 2,
+  } });
+};
+
+// Reskin nearest mob as Grubjaw, give the player two enhancement buffs.
+const setup = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // survive the live loop without wiping pushed auras via recalc
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'grubjaw';
+  mob.name = 'Grubjaw the Glutton';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const buff = (id, name, kind, value) => p.auras.push({
+    id, name, kind, remaining: 300, duration: 300, value, sourceId: p.id, school: 'arcane',
+  });
+  p.auras = p.auras.filter((a) => a.kind.startsWith('buff_') === false || a.value < 0);
+  buff('pwf', 'Power Word: Fortitude', 'buff_sta', 18);
+  buff('bshout', 'Battle Shout', 'buff_ap', 40);
+  return { buffNames: p.auras.filter((a) => a.kind.startsWith('buff_')).map((a) => a.name) };
+});
+console.log('before:', JSON.stringify(setup));
+await new Promise((r) => setTimeout(r, 500));
+await page.screenshot({ path: 'tmp/devour_scene.png' });
+await cropBar('tmp/devour_before.png');
+
+// Force the purge to land and devour one buff.
+const result = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const p = sim.player;
+  const mob = sim.getEntity ? sim.getEntity(p.targetId) : [...sim.entities.values()].find((e) => e.id === p.targetId);
+  sim.rng.chance = () => true;
+  const before = p.auras.filter((a) => a.kind.startsWith('buff_') && a.value > 0).length;
+  // Swing until exactly one buff has been devoured, then stop.
+  for (let i = 0; i < 30; i++) {
+    sim.mobSwing(mob, p);
+    if (p.auras.filter((a) => a.kind.startsWith('buff_') && a.value > 0).length < before) break;
+  }
+  return { remaining: p.auras.filter((a) => a.kind.startsWith('buff_') && a.value > 0).map((a) => a.name) };
+});
+console.log('after :', JSON.stringify(result));
+await new Promise((r) => setTimeout(r, 400));
+await cropBar('tmp/devour_after.png');
+
+console.log('saved tmp/devour_scene.png, devour_before.png, devour_after.png');
+await browser.close();

--- a/scripts/shot_sap_vigor.mjs
+++ b/scripts/shot_sap_vigor.mjs
@@ -1,0 +1,105 @@
+// Screenshot the Sap Vigor affix (Sapping Bite) in the offline client.
+// Boots a rogue, repurposes a nearby mob as Mirejaw the Ravenous, forces its
+// on-hit Sapping Bite onto the player, and captures the drained energy bar on
+// the player unit frame plus the combat log line (the affix has no debuff icon
+// — the proof is the resource bar dropping).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 400));
+await page.type('#char-name', 'Skezzik');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Mirejaw the Ravenous and drain our energy.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+  p.resource = p.maxResource; // full energy bar
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  mob.templateId = 'mirejaw_the_ravenous';
+  mob.name = 'Mirejaw the Ravenous';
+  mob.level = 10;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  sim.rng.chance = () => true; // force the Sapping Bite proc
+  const before = p.resource;
+  for (let i = 0; i < 10 && p.resource >= before; i++) { p.hp = 100000; sim.mobSwing(mob, p); }
+  return { resourceType: p.resourceType, before, after: p.resource, maxResource: p.maxResource };
+});
+console.log('sap vigor result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/sap_vigor_scene.png' });
+
+// Crop the player unit frame — the energy bar shows the drain.
+const box = await page.evaluate(() => {
+  const el = document.querySelector('#player-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/sap_vigor_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+// Open the combat log to surface the "Sapping Bite" line.
+await page.evaluate(() => {
+  const tab = document.querySelector('.chat-tab[data-log-tab="combat"]');
+  if (tab) tab.click();
+});
+await new Promise((r) => setTimeout(r, 400));
+const logBox = await page.evaluate(() => {
+  const el = document.querySelector('#combatlog');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: Math.max(r.width, 380), h: Math.max(r.height, 160) };
+});
+if (logBox) {
+  await page.screenshot({
+    path: 'tmp/sap_vigor_log.png',
+    clip: {
+      x: Math.max(0, logBox.x), y: Math.max(0, logBox.y - 10),
+      width: logBox.w, height: logBox.h + 20,
+    },
+  });
+}
+
+console.log('saved tmp/sap_vigor_scene.png, sap_vigor_frame.png, sap_vigor_log.png');
+await browser.close();

--- a/scripts/shot_siphon_spirit.mjs
+++ b/scripts/shot_siphon_spirit.mjs
@@ -1,0 +1,87 @@
+// Screenshot the Spirit Siphon affix in the offline client. Boots the game as a
+// mage (a mana user, so the Spirit drain applies), repurposes a nearby mob as
+// Sister Nhalia, forces her on-hit siphon onto the player, and captures the
+// resulting Spirit debuff (negative buff_spi) on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Aelwyn');
+await page.click('#offline-select .mini-class[data-class="mage"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as Sister Nhalia and drive her siphon onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  // gm keeps us alive through the live boss loop; applyAura still lands. (A raw
+  // maxHp override would be wiped by recalcPlayerStats re-deriving HP each tick.)
+  p.gm = true;
+  sim.rng.chance = () => true; // force the proc deterministically for the capture
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the shadow priestess and stand it next to us.
+  mob.templateId = 'sister_nhalia';
+  mob.name = 'Sister Nhalia';
+  mob.level = 12;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const spiBefore = p.stats.spi;
+  for (let i = 0; i < 5; i++) sim.mobSwing(mob, p);
+  const siphon = p.auras.find((a) => a.name === 'Spirit Siphon');
+  return { spiBefore, spiAfter: p.stats.spi, hasSiphon: !!siphon, value: siphon?.value, remaining: siphon?.remaining };
+});
+console.log('siphon result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/siphon_spirit_scene.png' });
+
+// Crop tightly around the buff/debuff bar (top-right) where the red-bordered
+// Spirit Siphon debuff icon renders.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/siphon_spirit_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/siphon_spirit_scene.png, siphon_spirit_debuff.png');
+await browser.close();

--- a/scripts/shot_stackpoison.mjs
+++ b/scripts/shot_stackpoison.mjs
@@ -1,0 +1,94 @@
+// Screenshot the stacking-poison affix (Brood Venom) in the offline client.
+// Boots the game, repurposes a nearby mob as the Broodmother, forces its
+// on-hit poison onto the player repeatedly, and captures the ramped 5-stack
+// debuff (Brood Venom x5) on the player buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 400)); // panel reveal auto-selects warrior
+await page.type('#char-name', 'Brannok');
+try { await page.click('#offline-select .mini-class[data-class="warrior"]'); } catch {}
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.gm = true; // survive the L10 boss; applyAura still lands
+  sim.rng.chance = () => true; // force every on-hit roll to proc
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the Broodmother and stand it next to us.
+  mob.templateId = 'mirefen_broodmother';
+  mob.name = 'The Broodmother';
+  mob.level = 10;
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  // Bite repeatedly to ramp the stacks to the cap (maxStacks = 5).
+  for (let i = 0; i < 16; i++) sim.mobSwing(mob, p);
+  const venom = p.auras.find((a) => a.name === 'Brood Venom');
+  return { hasVenom: !!venom, stacks: venom?.stacks, value: venom?.value, remaining: venom?.remaining };
+});
+console.log('stackPoison result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/stackpoison_scene.png' });
+
+// Crop tightly around the (top-right) buff/debuff bar showing Brood Venom x5.
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/stackpoison_debuff.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+// Hover the debuff icon to surface its tooltip (shows "Brood Venom x5").
+if (box) {
+  await page.mouse.move(box.x + box.w / 2, box.y + box.h / 2);
+  await new Promise((r) => setTimeout(r, 500));
+  await page.screenshot({
+    path: 'tmp/stackpoison_tooltip.png',
+    clip: {
+      x: Math.max(0, box.x - 320), y: Math.max(0, box.y - 10),
+      width: 320 + box.w + 20, height: 170,
+    },
+  });
+}
+console.log('saved tmp/stackpoison_scene.png, stackpoison_debuff.png, stackpoison_tooltip.png');
+await browser.close();

--- a/scripts/shot_warcry.mjs
+++ b/scripts/shot_warcry.mjs
@@ -1,0 +1,112 @@
+// Screenshot for the Deepfen Snapper ally-haste mechanic (warcry / Tide Cadence).
+// Drives the offline world, repurposes three nearby mobs into a murloc school in
+// front of the player, forces the Tide Cadence pulse, and captures the buffed
+// pack, the combat log, and a snapper's target frame carrying the haste buff.
+// Requires `npm run dev` (pass GAME_URL if it landed off :5173).
+//
+// Usage: node scripts/shot_warcry.mjs
+import { mkdirSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL || 'http://localhost:5173/';
+const OUT = 'tmp/shots';
+mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+
+try {
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1280, height: 800 });
+  await page.goto(URL, { waitUntil: 'networkidle2' });
+
+  // Offline flow: Play Offline (auto-selects warrior) → name → Start.
+  await page.waitForSelector('#btn-offline', { timeout: 15000 });
+  await page.evaluate(() => document.querySelector('#btn-offline').click());
+  await page.waitForSelector('#char-name', { visible: true });
+  await new Promise((r) => setTimeout(r, 400));
+  await page.evaluate(() => {
+    const n = document.querySelector('#char-name');
+    n.value = 'Tidewatch';
+    n.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+  await new Promise((r) => setTimeout(r, 3000));
+
+  // Stage the scene: god-mode the player, repurpose three mobs into a Deepfen
+  // murloc school clustered a few yards in front of the camera.
+  await page.evaluate(() => {
+    const sim = window.__game.sim;
+    const p = sim.player;
+    p.gm = true;
+    p.hp = p.maxHp;
+    const mobs = [...sim.entities.values()].filter((e) => e.kind === 'mob' && !e.dead);
+    const fx = p.pos.x + Math.sin(p.facing) * 7;
+    const fz = p.pos.z + Math.cos(p.facing) * 7;
+    const ground = (x, z) => sim.groundPos(x, z);
+    const offsets = [[-2.5, 0], [2.5, 0.5], [0, 2.5]];
+    window.__school = [];
+    for (let i = 0; i < 3 && i < mobs.length; i++) {
+      const m = mobs[i];
+      m.templateId = 'deepfen_murloc';
+      m.name = 'Deepfen Snapper';
+      m.level = 9;
+      Object.assign(m.pos, ground(fx + offsets[i][0], fz + offsets[i][1]));
+      m.prevPos = { ...m.pos };
+      m.hostile = true;
+      m.inCombat = true;
+      m.combatTimer = 0;
+      window.__school.push(m.id);
+    }
+    // Target the lead snapper so its target frame (and buff) is on screen.
+    p.targetId = window.__school[0];
+    if (window.__game.input) window.__game.input.targetId = window.__school[0];
+  });
+
+  // Drive several Tide Cadence pulses so the whole school carries the haste buff.
+  for (let i = 0; i < 6; i++) {
+    await page.evaluate(() => {
+      const sim = window.__game.sim;
+      for (const id of window.__school) {
+        const m = sim.entities.get(id);
+        if (!m) continue;
+        m.inCombat = true;
+        m.warcryTimer = 0; // fire the pulse now
+        sim.updateBossMechanics?.(m) ?? sim['updateBossMechanics'](m);
+      }
+    });
+    await new Promise((r) => setTimeout(r, 160));
+  }
+
+  // Report the applied auras as proof.
+  const proof = await page.evaluate(() => {
+    const sim = window.__game.sim;
+    return window.__school.map((id) => {
+      const m = sim.entities.get(id);
+      const a = m?.auras.find((x) => x.id === 'warcry_deepfen_murloc');
+      return { name: m?.name, haste: a ? a.value : null, remaining: a ? Math.round(a.remaining * 10) / 10 : null };
+    });
+  });
+  console.log('Tide Cadence auras:', JSON.stringify(proof));
+
+  await new Promise((r) => setTimeout(r, 120));
+  await page.screenshot({ path: `${OUT}/warcry-scene.png` });
+  console.log('saved warcry-scene.png (full scene — the buffed murloc school)');
+
+  await page.screenshot({ path: `${OUT}/warcry-actors.png`, clip: { x: 420, y: 90, width: 470, height: 360 } });
+  console.log('saved warcry-actors.png (close-up on the school)');
+
+  // Combat log showing the repeated "channels Tide Cadence" lines.
+  await page.screenshot({ path: `${OUT}/warcry-log.png`, clip: { x: 8, y: 470, width: 560, height: 250 } });
+  console.log('saved warcry-log.png (combat log)');
+
+  // Target frame of the lead snapper (top-left), which carries the haste buff.
+  await page.screenshot({ path: `${OUT}/warcry-targetframe.png`, clip: { x: 0, y: 0, width: 420, height: 150 } });
+  console.log('saved warcry-targetframe.png (target frame)');
+} finally {
+  await browser.close();
+}

--- a/scripts/shot_wither.mjs
+++ b/scripts/shot_wither.mjs
@@ -1,0 +1,85 @@
+// Screenshot the Withering Rot affix in the offline client. Boots the game,
+// repurposes a nearby mob as a Mirefen Troll, forces its on-hit wither onto the
+// player, and captures the resulting Agility-draining debuff on the buff bar.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// Repurpose the nearest mob as a Mirefen Troll and drive its wither onto us.
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  let mob = null, d = 1e9;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead) {
+      const dd = Math.hypot(e.pos.x - p.pos.x, e.pos.z - p.pos.z);
+      if (dd < d) { d = dd; mob = e; }
+    }
+  }
+  // Reskin it as the withering troll and stand it next to us.
+  mob.templateId = 'fen_troll';
+  mob.name = 'Mirefen Troll';
+  mob.hostile = true;
+  mob.hp = mob.maxHp;
+  mob.pos.x = p.pos.x + 2; mob.pos.z = p.pos.z;
+  sim.targetEntity(mob.id);
+  p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  const agiBefore = p.stats.agi;
+  const armorBefore = p.stats.armor;
+  for (let i = 0; i < 8; i++) sim.mobSwing(mob, p);
+  const rot = p.auras.find((a) => a.name === 'Withering Rot');
+  return {
+    agiBefore, agiAfter: p.stats.agi, armorBefore, armorAfter: p.stats.armor,
+    hasRot: !!rot, rotValue: rot?.value, rotRemaining: rot?.remaining,
+  };
+});
+console.log('wither result:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 600));
+await page.screenshot({ path: 'tmp/wither_full.png' });
+
+// Crop tightly around the buff/debuff bar (top-right).
+const box = await page.evaluate(() => {
+  const bar = document.querySelector('#buff-bar');
+  if (!bar) return null;
+  const r = bar.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 16;
+  await page.screenshot({
+    path: 'tmp/wither_frame.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/wither_full.png, wither_frame.png');
+await browser.close();

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,7 +225,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 
 function blankEntity(id: number): Entity {
   return {
-    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0,
+    id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, warcryTimer: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -229,6 +229,8 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 200, hpPerLevel: 30, dmgBase: 11, dmgPerLevel: 2.5, attackSpeed: 2.4,
     armorPerLevel: 26, moveSpeed: 7, aggroRadius: 14, boss: true,
     aoePulse: { min: 10, max: 14, radius: 10, every: 12, name: 'Drowning Hymn' },
+    // The deacon brands the faithless with a searing arcane rune that festers.
+    arcaneRot: { chance: 0.3, perTick: 7, interval: 3, duration: 12, name: 'Profane Rune', school: 'arcane' },
     loot: [
       { copper: 600, chance: 1 },
       { itemId: 'tallow_candle', chance: 1 },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -181,6 +181,11 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     // Low dread proc so this mob doesn't routinely stack two panic effects
     // (silence + fear) on one victim — keeps the encounter from feeling like a lockout.
     dread: { chance: 0.12, duration: 4, name: 'Wail of the Grave', school: 'shadow' },
+    // Grave Blight: a landed hit can sear undeath into the wound, devouring the
+    // next 120 healing the victim receives before it fades. A sustain-denial axis
+    // that complements (not compounds) the summoner's silence/fear lockout —
+    // healers must out-pace the blight or top off after it lapses.
+    healAbsorb: { chance: 0.25, amount: 120, duration: 10, name: 'Grave Blight', school: 'shadow' },
     loot: [
       { copper: 60, chance: 1 },
       { itemId: 'cult_cipher', chance: 0.6, questId: 'q_summoners' },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -79,6 +79,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     scale: 0.85, color: 0x45b39d,
     // Acid Spit: a snapper's bite corrodes armor, stacking so a swarm shreds you fast.
     corrode: { chance: 0.35, armor: 20, maxStacks: 5, duration: 15, name: 'Acid Spit', school: 'nature' },
+    // Tide Cadence: a snapper drums up the school, quickening the whole pack's
+    // bites — the swarm's signature pressure when you pull more than one.
+    warcry: { radius: 12, every: 10, hasteMult: 1.25, duration: 6, name: 'Tide Cadence', school: 'frost' },
   },
   mirejaw_the_ravenous: {
     id: 'mirejaw_the_ravenous', name: 'Mirejaw the Ravenous', minLevel: 10, maxLevel: 10, family: 'murloc', rare: true,

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -166,6 +166,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'gravecaller_cultist', name: 'Gravecaller Cultist', minLevel: 10, maxLevel: 12, family: 'humanoid',
     hpBase: 50, hpPerLevel: 20, dmgBase: 9, dmgPerLevel: 2.4, attackSpeed: 2.0,
     armorPerLevel: 20, moveSpeed: 7, aggroRadius: 11,
+    // The cultist's hex leaves the victim taking more damage from everyone —
+    // a soft-up that rewards a group focusing the cursed player's target down.
+    vulnerability: { chance: 0.2, amp: 0.15, duration: 10, name: 'Curse of Frailty', school: 'shadow' },
     loot: [
       { copper: 55, chance: 1 },
       { itemId: 'linen_scrap', chance: 0.3 },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -132,6 +132,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 52, hpPerLevel: 20, dmgBase: 8, dmgPerLevel: 2.3, attackSpeed: 2.3,
     armorPerLevel: 14, moveSpeed: 6.5, aggroRadius: 11,
     lifeleech: { healFrac: 0.5, chance: 0.35, name: 'Drowning Grasp' },
+    // A clammy, fevered touch that rots the living from within, wasting away
+    // their constitution (Stamina) and shrinking their health pool.
+    plague: { chance: 0.3, sta: 12, duration: 12, name: 'Bog Rot' },
     loot: [
       { copper: 42, chance: 1 },
       { itemId: 'bone_fragments', chance: 0.5 },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -86,6 +86,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 320, hpPerLevel: 58, dmgBase: 15, dmgPerLevel: 3.7, attackSpeed: 1.8,
     armorPerLevel: 26, moveSpeed: 8.2, aggroRadius: 14,
     aoePulse: { min: 18, max: 26, radius: 10, every: 9, name: 'Ravenous Frenzy', school: 'nature' },
+    sapVigor: { chance: 0.3, amount: 25, name: 'Sapping Bite' },
     summonAdds: { mobId: 'mirejaw_frenzy', count: 2, atHpPct: [0.55] },
     loot: [
       { copper: 260, chance: 1 },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -160,6 +160,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'grubjaw_tusk', chance: 1, questId: 'q_grubjaw' },
       { itemId: 'chipped_tusk', chance: 1 },
     ],
+    purgeOnHit: { chance: 0.3, name: 'Devour Magic' },
     scale: 1.3, color: 0x145a32,
   },
   gravecaller_cultist: {

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -195,6 +195,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     // wounds shut on a slow cadence. Pull it away from the camp — or drop it
     // first — or the fight never ends.
     mendAlly: { healMin: 26, healMax: 38, radius: 14, every: 6, name: 'Grave Mending', school: 'shadow' },
+    // Draining Litany: the mender siphons the victim's vigour to fuel its grave
+    // prayers, inflating every ability the victim uses by 40% for 8s on a hit.
+    costTax: { chance: 0.3, pct: 0.4, duration: 8, name: 'Draining Litany', school: 'shadow' },
     loot: [
       { copper: 58, chance: 1 },
       { itemId: 'cult_cipher', chance: 0.4, questId: 'q_summoners' },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -208,6 +208,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     hpBase: 330, hpPerLevel: 60, dmgBase: 16, dmgPerLevel: 3.8, attackSpeed: 2.0,
     armorPerLevel: 30, moveSpeed: 7, aggroRadius: 13,
     aoePulse: { min: 18, max: 26, radius: 11, every: 9, name: 'Dirge of Nhalia', school: 'shadow' },
+    // Spirit Siphon: the priestess's touch drains a caster's Spirit, choking
+    // their out-of-combat mana regen for the duration (see siphonSpirit affix).
+    siphonSpirit: { chance: 0.3, spi: 14, duration: 10, name: 'Spirit Siphon', school: 'shadow' },
     summonAdds: { mobId: 'nhalia_mourner', count: 2, atHpPct: [0.65, 0.35] },
     loot: [
       { copper: 350, chance: 1 },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -171,6 +171,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
       { itemId: 'linen_scrap', chance: 0.3 },
       { itemId: 'tallow_candle', chance: 0.3 },
     ],
+    // The cultist's muttered curse weakens its prey: a hexed victim deals less
+    // damage and heals for less until the hex fades.
+    hex: { chance: 0.3, reductionPct: 0.2, duration: 10, name: 'Weakening Hex', school: 'shadow' },
     scale: 1.0, color: 0x6c3483,
   },
   gravecaller_summoner: {

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -108,6 +108,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'mire_widow', name: 'Mirefen Widow', minLevel: 8, maxLevel: 10, family: 'spider',
     hpBase: 48, hpPerLevel: 19, dmgBase: 8, dmgPerLevel: 2.2, attackSpeed: 1.8,
     armorPerLevel: 10, moveSpeed: 8, aggroRadius: 10,
+    // Find Weakness: the widow's bite leaves the flesh raw, so critical blows
+    // against the victim bite 50% deeper for a few seconds.
+    critVuln: { chance: 0.3, critDamage: 0.5, duration: 8, name: 'Exposed Wound' },
     loot: [
       { copper: 38, chance: 1 },
       { itemId: 'widow_venom_sac', chance: 0.65, questId: 'q_widows' },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -221,6 +221,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'nhalia_mourner', name: 'Nhalia Mourner', minLevel: 11, maxLevel: 12, family: 'humanoid',
     hpBase: 46, hpPerLevel: 17, dmgBase: 8, dmgPerLevel: 2.3, attackSpeed: 2.0,
     armorPerLevel: 14, moveSpeed: 7, aggroRadius: 12,
+    // Curse of Tongues: the mourners' dirge garbles a caster's incantations, slowing
+    // their spell cast times by 30% for 10s on a landed hit (30% chance).
+    tongues: { chance: 0.3, mult: 1.3, duration: 10, name: 'Dirge of Tongues', school: 'shadow' },
     loot: [],
     scale: 0.95, color: 0x332044,
   },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -143,6 +143,9 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'fen_troll', name: 'Mirefen Troll', minLevel: 10, maxLevel: 12, family: 'troll',
     hpBase: 56, hpPerLevel: 21, dmgBase: 9, dmgPerLevel: 2.4, attackSpeed: 2.2,
     armorPerLevel: 18, moveSpeed: 7.5, aggroRadius: 11,
+    // Withering Rot: the troll's fetid claws rot a struck victim's sinews, draining
+    // Agility (thinning their armor and dodge) for a few seconds.
+    wither: { chance: 0.3, agi: 18, duration: 8, name: 'Withering Rot', school: 'nature' },
     loot: [
       { copper: 50, chance: 1 },
       { itemId: 'troll_fetish', chance: 0.6, questId: 'q_troll_fetishes' },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -119,6 +119,7 @@ export const ZONE2_MOBS: Record<string, MobTemplate> = {
     id: 'mirefen_broodmother', name: 'The Broodmother', minLevel: 10, maxLevel: 10, family: 'spider',
     hpBase: 150, hpPerLevel: 26, dmgBase: 9, dmgPerLevel: 2.4, attackSpeed: 1.8,
     armorPerLevel: 16, moveSpeed: 8, aggroRadius: 14, boss: true,
+    stackPoison: { chance: 0.35, perTick: 3, interval: 2, duration: 12, maxStacks: 5, name: 'Brood Venom', school: 'nature' },
     loot: [
       { copper: 300, chance: 1 },
       { itemId: 'marshstrider_boots', chance: 0.4 },

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -20,7 +20,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     comboPoints: 0, comboTargetId: null, overpowerUntil: -1, potionCooldownUntil: -1, savedMana: 0,
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
-    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
+    aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, detonateTimer: Infinity, mendTimer: 0, warcryTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
@@ -189,6 +189,8 @@ export function createMob(id: number, template: MobTemplate, level: number, pos:
   if (template.stomp) e.stompTimer = template.stomp.every;
   // Telegraph the first Mend the same way: one full interval after engage.
   if (template.mendAlly) e.mendTimer = template.mendAlly.every;
+  // Telegraph the first War Cadence the same way: one full interval after engage.
+  if (template.warcry) e.warcryTimer = template.warcry.every;
   return e;
 }
 

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -90,6 +90,7 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     if (a.kind === 'buff_ap') bonusAp += a.value;
     else if (a.kind === 'buff_armor') s.armor += a.value;
     else if (a.kind === 'buff_int') s.int += a.value;
+    else if (a.kind === 'buff_agi') s.agi += a.value;
     else if (a.kind === 'buff_sta') s.sta += a.value;
     else if (a.kind === 'buff_allstats') {
       s.str += a.value; s.agi += a.value; s.sta += a.value; s.int += a.value; s.spi += a.value;
@@ -107,6 +108,9 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     bonusDodge += m.dodge;
     if (m.staPct) s.sta = Math.round(s.sta * (1 + m.staPct));
   }
+  // Floor Agility at 0 so a draining debuff (negative buff_agi) can never push the
+  // derived armor/dodge below what zero Agility would give.
+  s.agi = Math.max(0, s.agi);
   s.armor += s.agi * 2;
   if (bearForm) {
     s.armor = Math.round(s.armor * 1.65);

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -90,6 +90,7 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     if (a.kind === 'buff_ap') bonusAp += a.value;
     else if (a.kind === 'buff_armor') s.armor += a.value;
     else if (a.kind === 'buff_int') s.int += a.value;
+    else if (a.kind === 'buff_spi') s.spi += a.value;
     else if (a.kind === 'buff_sta') s.sta += a.value;
     else if (a.kind === 'buff_allstats') {
       s.str += a.value; s.agi += a.value; s.sta += a.value; s.int += a.value; s.spi += a.value;
@@ -117,6 +118,9 @@ export function recalcPlayerStats(e: Entity, cls: PlayerClass, equipment: Player
     s.agi += Math.max(2, Math.floor(lvl / 2));
   }
   if (mods?.stats.armorPct) s.armor = Math.round(s.armor * (1 + mods.stats.armorPct));
+  // Floor Spirit at 0 so a Spirit-siphoning debuff (negative buff_spi) can never
+  // drive out-of-combat regen (updateRegen reads stats.spi) below zero.
+  s.spi = Math.max(0, s.spi);
 
   e.stats = s;
   const weapon = (equipment.mainhand && ITEMS[equipment.mainhand]?.weapon) || { min: 1, max: 2, speed: 2 };

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4052,6 +4052,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.warcryTimer = MOBS[mob.templateId]?.warcry?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
   }
 
@@ -4519,6 +4520,7 @@ export class Sim {
     mob.healedThisPull = false;
     mob.stompTimer = MOBS[mob.templateId]?.stomp?.every ?? 0;
     mob.mendTimer = MOBS[mob.templateId]?.mendAlly?.every ?? 0;
+    mob.warcryTimer = MOBS[mob.templateId]?.warcry?.every ?? 0;
     mob.wanderTimer = this.rng.range(2, 8);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
@@ -4612,7 +4614,7 @@ export class Sim {
   // and reset on evade/respawn.
   private updateBossMechanics(mob: Entity): void {
     const tmpl = MOBS[mob.templateId];
-    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly)) return;
+    if (!tmpl || (!tmpl.summonAdds && !tmpl.enrage && !tmpl.desperateHeal && !tmpl.mendAlly && !tmpl.warcry)) return;
     const hpFrac = mob.hp / Math.max(1, mob.maxHp);
     if (tmpl.summonAdds) {
       const thresholds = tmpl.summonAdds.atHpPct;
@@ -4658,6 +4660,46 @@ export class Sim {
           for (const ally of wounded) {
             const amount = Math.round(this.rng.range(tmpl.mendAlly.healMin, tmpl.mendAlly.healMax));
             this.applyHeal(mob, ally, amount, tmpl.mendAlly.name);
+          }
+        }
+      }
+    }
+    // Support "War Cadence": periodically quicken every nearby friendly mob's
+    // swings (including the caster) by re-applying a refreshing buff_haste aura.
+    // Same telegraph as Mend; rides swingIntervalMult's existing buff_haste fold.
+    if (tmpl.warcry) {
+      mob.warcryTimer -= DT;
+      if (mob.warcryTimer <= 0) {
+        mob.warcryTimer = tmpl.warcry.every;
+        const allies: Entity[] = [];
+        for (const ally of this.entities.values()) {
+          if (ally.kind !== 'mob' || ally.dead || ally.ownerId !== null) continue; // skip players, pets, corpses
+          if (ally.hostile !== mob.hostile) continue; // same-faction only
+          if (dist2d(ally.pos, mob.pos) > tmpl.warcry.radius) continue;
+          allies.push(ally);
+        }
+        if (allies.length > 0) {
+          const school = tmpl.warcry.school ?? 'physical';
+          const auraId = `warcry_${mob.templateId}`;
+          this.emit({ type: 'spellfx', sourceId: mob.id, targetId: mob.id, school, fx: 'nova' });
+          this.emit({ type: 'log', text: `${mob.name} channels ${tmpl.warcry.name}.`, color: '#ffd27f', entityId: mob.id });
+          for (const ally of allies) {
+            const existing = ally.auras.find((a) => a.id === auraId);
+            if (existing) {
+              existing.remaining = tmpl.warcry.duration; // refresh on each pulse; never stack
+              continue;
+            }
+            ally.auras.push({
+              id: auraId,
+              name: tmpl.warcry.name,
+              kind: 'buff_haste',
+              remaining: tmpl.warcry.duration,
+              duration: tmpl.warcry.duration,
+              value: tmpl.warcry.hasteMult,
+              sourceId: mob.id,
+              school,
+            });
+            this.emit({ type: 'aura', targetId: ally.id, name: tmpl.warcry.name, gained: true });
           }
         }
       }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2103,10 +2103,31 @@ export class Sim {
     return mult < 0 ? 0 : mult;
   }
 
+  // Consume the victim's Heal-Absorb shields (classic necrotic blight): each such
+  // aura holds a remaining budget of healing it devours. Drains `healed` against
+  // every active shield, decrementing their stored budget and dropping any that
+  // run dry. Returns the healing that survives (>= 0). A no-op when none are set.
+  private consumeHealAbsorb(target: Entity, healed: number): number {
+    if (healed <= 0) return healed;
+    let remaining = healed;
+    let depleted = false;
+    for (const a of target.auras) {
+      if (a.kind !== 'heal_absorb' || a.value <= 0) continue;
+      const eaten = Math.min(remaining, a.value);
+      a.value -= eaten;
+      remaining -= eaten;
+      if (a.value <= 0) depleted = true;
+      if (remaining <= 0) break;
+    }
+    if (depleted) target.auras = target.auras.filter((a) => !(a.kind === 'heal_absorb' && a.value <= 0));
+    return remaining;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
     let healed = Math.round(amount * (crit ? 1.5 : 1) * this.healingTakenMult(target));
+    healed = this.consumeHealAbsorb(target, healed);
     healed = Math.min(healed, target.maxHp - target.hp);
     target.hp += healed;
     this.emit({ type: 'heal2', sourceId: source.id, targetId: target.id, amount: healed, crit, ability });
@@ -4190,6 +4211,24 @@ export class Sim {
         value: ms.healReduction,
         sourceId: mob.id,
         school: (ms.school as Aura['school']) ?? 'physical',
+      });
+    }
+    // Heal-Absorb: a landed hit can brand the victim with a necrotic blight that
+    // devours the next chunk of incoming healing. The sibling of Mortal Strike —
+    // where Mortal Strike scales every heal down, this eats a fixed pool then
+    // fades. Guarded on `hostile` so a friendly pet (mobSwing's other caller)
+    // never blights an ally.
+    const ha = MOBS[mob.templateId]?.healAbsorb;
+    if (ha && mob.hostile && !target.dead && this.rng.chance(ha.chance)) {
+      this.applyAura(target, {
+        id: `heal_absorb_${mob.templateId}`,
+        name: ha.name,
+        kind: 'heal_absorb',
+        remaining: ha.duration,
+        duration: ha.duration,
+        value: ha.amount,
+        sourceId: mob.id,
+        school: (ha.school as Aura['school']) ?? 'shadow',
       });
     }
     // Ensnare: a landed hit may web the victim in place (root). Hostile mobs only

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,20 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // arcane rot: a landed swing may brand the victim with a searing arcane rune
+    // that festers as a refreshing DoT. The arcane-school twin of venom; reuses
+    // the `dot` aura. Guarded on hostile + alive so a friendly pet (the other
+    // mobSwing caller) never debuffs an ally.
+    const arcaneRot = MOBS[mob.templateId]?.arcaneRot;
+    if (arcaneRot && mob.hostile && !target.dead && this.rng.chance(arcaneRot.chance)) {
+      this.applyAura(target, {
+        id: 'arcaneRot_' + mob.templateId, name: arcaneRot.name, kind: 'dot',
+        remaining: arcaneRot.duration, duration: arcaneRot.duration,
+        value: Math.max(1, Math.round(arcaneRot.perTick)),
+        tickInterval: arcaneRot.interval, tickTimer: arcaneRot.interval,
+        sourceId: mob.id, school: (arcaneRot.school as Aura['school']) ?? 'arcane',
+      });
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2194,7 +2194,6 @@ export class Sim {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
     let healed = Math.round(amount * (crit ? 1.5 : 1) * this.hexOutputMult(source) * this.healingTakenMult(target));
-    let healed = Math.round(amount * (crit ? 1.5 : 1) * this.healingTakenMult(target));
     healed = this.consumeHealAbsorb(target, healed);
     healed = Math.min(healed, target.maxHp - target.hp);
     target.hp += healed;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -123,7 +123,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'vulnerability',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -185,7 +185,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'vulnerability',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -3242,6 +3242,15 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Curse of frailty: a cursed victim takes more damage from every source. The
+    // offensive mirror of Defensive Stance's cut above. Multiple curses stack
+    // additively (sum of amps) so layered curses can't multiply out of control.
+    if (amount > 0) {
+      let vuln = 0;
+      for (const a of target.auras) if (a.kind === 'vulnerability') vuln += a.value;
+      if (vuln > 0) amount = Math.round(amount * (1 + vuln));
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4251,6 +4260,23 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+    // Curse of frailty: a landed hit may curse the victim so they take more
+    // damage from every source (a `vulnerability` aura read in dealDamage).
+    // Players only, hostile mobs only, so a friendly pet (mobSwing's other
+    // caller) never softens an ally. Refreshes by id, never stacks past one.
+    const vuln = MOBS[mob.templateId]?.vulnerability;
+    if (vuln && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(vuln.chance)) {
+      this.applyAura(target, {
+        id: `vulnerability_${mob.templateId}`,
+        name: vuln.name,
+        kind: 'vulnerability',
+        remaining: vuln.duration,
+        duration: vuln.duration,
+        value: vuln.amp,
+        sourceId: mob.id,
+        school: vuln.school ?? 'shadow',
+      });
     }
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -130,6 +130,15 @@ const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
 function isHarmfulAura(kind: AuraKind): boolean {
   return HARMFUL_AURA_KINDS.has(kind);
 }
+// A "Devour Magic"-strippable beneficial enhancement: a positive buff_* stat
+// buff, a heal-over-time, an absorb shield, or a weapon imbue. Stances, forms,
+// stealth, righteous fury, thorns and every debuff (incl. negative buff_* drains
+// like enfeeble/wither) are deliberately left alone — only an active "magic"
+// enhancement is eaten. Mirrors the inverse of the HUD's debuff test.
+function isDevourableAura(a: Aura): boolean {
+  return (a.kind.startsWith('buff_') && a.value > 0)
+    || a.kind === 'hot' || a.kind === 'absorb' || a.kind === 'imbue';
+}
 const NEARBY_RANGE = 40; // /nearby scan radius — wider than say, tighter than yell
 const NEARBY_MAX = 10; // cap the /nearby list so a crowded camp can't spam chat
 const CHAT_BURST = 8; // messages a player may send back-to-back...
@@ -4286,6 +4295,30 @@ export class Sim {
         });
       }
     }
+    // Devour Magic: a landed hit can strip one beneficial enhancement buff off
+    // the player victim (classic warlock/demon Devour Magic). Hostile mobs only
+    // (a friendly pet — mobSwing's other caller — must never purge its owner's
+    // party) and players only. No-op when the victim carries no devourable buff.
+    const purge = MOBS[mob.templateId]?.purgeOnHit;
+    if (purge && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(purge.chance)) {
+      this.devourBeneficialAura(target, purge.name);
+    }
+  }
+
+  // Strip one beneficial enhancement aura from a player victim. Removes the
+  // first devourable buff (auras are in application order, so this is
+  // deterministic), recalcs the player's derived stats so a stripped
+  // buff_armor/buff_ap/buff_int actually un-folds, and surfaces the proc via the
+  // standard `aura` event (the full aura array on the next snapshot reflects the
+  // removal to online clients). Returns whether anything was devoured.
+  private devourBeneficialAura(target: Entity, name: string): boolean {
+    const idx = target.auras.findIndex(isDevourableAura);
+    if (idx < 0) return false;
+    target.auras.splice(idx, 1);
+    const meta = this.players.get(target.id);
+    if (meta) recalcPlayerStats(target, meta.cls, meta.equipment, meta.talentMods);
+    this.emit({ type: 'aura', targetId: target.id, name, gained: true });
+    return true;
   }
 
   // Apply (or refresh + stack) a corrosive armor-shred debuff on the victim.

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4225,6 +4225,17 @@ export class Sim {
       target.resource = Math.max(0, target.resource - burn.amount);
       this.emit({ type: 'aura', targetId: target.id, name: burn.name, gained: true });
     }
+    // Sap Vigor: the melee-resource twin of manaBurn. A landed hit can drain a
+    // flat amount of rage or energy from a melee victim, starving their ability
+    // use. Mana users are unaffected (it does nothing to casters); hostile mobs
+    // only, so a friendly pet (mobSwing's other caller) never saps an ally. The
+    // resource bar visibly drops and the affix is surfaced via an `aura` log line.
+    const sap = MOBS[mob.templateId]?.sapVigor;
+    if (sap && mob.hostile && !target.dead && (target.resourceType === 'rage' || target.resourceType === 'energy')
+        && target.resource > 0 && this.rng.chance(sap.chance)) {
+      target.resource = Math.max(0, target.resource - sap.amount);
+      this.emit({ type: 'aura', targetId: target.id, name: sap.name, gained: true });
+    }
     // Maddening curse: a landed hit can fog a caster's mind, draining Intellect
     // and thus shrinking their mana pool. Mana users only (it does nothing to
     // rage/energy users); hostile mobs only, so a friendly pet (mobSwing's other

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4243,6 +4243,25 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Spirit Siphon: a landed hit can drain a caster's Spirit, slowing their
+    // out-of-combat mana/health regen (updateRegen reads stats.spi). Mana users
+    // only (it does nothing to rage/energy users); hostile mobs only, so a
+    // friendly pet (mobSwing's other caller) never debuffs the party. Rides
+    // buff_spi with a negative value, so recalcPlayerStats folds it through with
+    // no new regen math; it expires like any buff* aura.
+    const siphon = MOBS[mob.templateId]?.siphonSpirit;
+    if (siphon && mob.hostile && !target.dead && target.resourceType === 'mana' && this.rng.chance(siphon.chance)) {
+      this.applyAura(target, {
+        id: `siphon_spirit_${mob.templateId}`,
+        name: siphon.name,
+        kind: 'buff_spi',
+        remaining: siphon.duration,
+        duration: siphon.duration,
+        value: -Math.abs(siphon.spi),
+        sourceId: mob.id,
+        school: siphon.school ?? 'shadow',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'cost_tax',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'cost_tax',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -1213,7 +1213,23 @@ export class Sim {
   resolvedAbility(abilityId: string, pid?: number): ResolvedAbility | null {
     const r = this.resolve(pid);
     if (!r) return null;
-    return r.meta.known.find((k) => k.def.id === abilityId) ?? null;
+    const found = r.meta.known.find((k) => k.def.id === abilityId) ?? null;
+    if (!found) return null;
+    // A "draining curse" (cost_tax aura) inflates the resource cost of every
+    // ability the victim uses. Resolve it here, the single choke point all cost
+    // checks/spends read, so the affordability check and the spend stay in
+    // lockstep. Return a shallow copy so the cached known-list entry is never
+    // mutated.
+    const tax = this.costTaxMult(r.e);
+    if (tax > 1 && found.cost > 0) return { ...found, cost: Math.ceil(found.cost * tax) };
+    return found;
+  }
+
+  // Highest active cost_tax aura, expressed as a cost multiplier (1 = no tax).
+  private costTaxMult(e: Entity): number {
+    let pct = 0;
+    for (const a of e.auras) if (a.kind === 'cost_tax' && a.value > pct) pct = a.value;
+    return 1 + pct;
   }
 
   // -------------------------------------------------------------------------
@@ -4167,6 +4183,17 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // draining curse: a landed hit can leave a cost-tax debuff that inflates the
+    // victim's ability costs. Guarded on hostile + alive so a friendly pet (the
+    // other mobSwing caller) never debuffs the party.
+    const costTax = MOBS[mob.templateId]?.costTax;
+    if (costTax && mob.hostile && !target.dead && this.rng.chance(costTax.chance)) {
+      this.applyAura(target, {
+        id: `cost_tax_${mob.templateId}`, name: costTax.name, kind: 'cost_tax',
+        remaining: costTax.duration, duration: costTax.duration, value: costTax.pct,
+        sourceId: mob.id, school: (costTax.school ?? 'shadow') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'critvuln',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'critvuln',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -2103,6 +2103,16 @@ export class Sim {
     return mult < 0 ? 0 : mult;
   }
 
+  // "Find Weakness" vulnerability: the largest active critvuln aura adds its
+  // fraction to the damage of CRITICAL hits the target takes (read in dealDamage).
+  private critVulnBonus(target: Entity): number {
+    let bonus = 0;
+    for (const a of target.auras) {
+      if (a.kind === 'critvuln' && a.value > bonus) bonus = a.value;
+    }
+    return bonus;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
@@ -3271,6 +3281,14 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // "Find Weakness": a critvuln debuff makes the target's exposed flesh take
+    // extra damage from CRITICAL hits only (any attacker, any school). Applied
+    // after the defensive-stance reduction, before absorb shields soak it.
+    if (crit && amount > 0 && source && source.id !== target.id) {
+      const bonus = this.critVulnBonus(target);
+      if (bonus > 0) amount = Math.round(amount * (1 + bonus));
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4167,6 +4185,18 @@ export class Sim {
         id: `silence_${mob.templateId}`, name: silence.name, kind: 'silence',
         remaining: silence.duration, duration: silence.duration, value: 0,
         sourceId: mob.id, school: (silence.school ?? 'shadow') as Aura['school'],
+      });
+    }
+    // Find Weakness: a landed hit can leave the victim's flesh exposed, so the
+    // next critical hits against them bite deeper. Hostile + player-only, like the
+    // other on-hit debuffs, so a friendly pet (mobSwing's other caller) never marks
+    // the party.
+    const cv = MOBS[mob.templateId]?.critVuln;
+    if (cv && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(cv.chance)) {
+      this.applyAura(target, {
+        id: `critvuln_${mob.templateId}`, name: cv.name, kind: 'critvuln',
+        remaining: cv.duration, duration: cv.duration, value: cv.critDamage,
+        sourceId: mob.id, school: (cv.school ?? 'physical') as Aura['school'],
       });
     }
     // thorns / lightning shield on the defender

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4209,6 +4209,25 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Plague: a landed hit can rot the victim's vitality, draining Stamina and
+    // thus shrinking their health pool (recalcPlayerStats folds the smaller
+    // Stamina through to a smaller maxHp; current HP scales down with it).
+    // Players only; hostile mobs only, so a friendly pet (mobSwing's other
+    // caller) never debuffs the party. Rides buff_sta with a negative value, so
+    // there is no new HP math. Refreshes by id and never stacks.
+    const plague = MOBS[mob.templateId]?.plague;
+    if (plague && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(plague.chance)) {
+      this.applyAura(target, {
+        id: `plague_${mob.templateId}`,
+        name: plague.name,
+        kind: 'buff_sta',
+        remaining: plague.duration,
+        duration: plague.duration,
+        value: -Math.abs(plague.sta),
+        sourceId: mob.id,
+        school: plague.school ?? 'nature',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2103,10 +2103,22 @@ export class Sim {
     return mult < 0 ? 0 : mult;
   }
 
+  // Weakening Hex: while a `hex` aura rides the source, the damage AND healing it
+  // deals are scaled by (1 - value). Read by dealDamage (outgoing damage) and
+  // applyHeal (outgoing healing) so a hexed player's whole output is throttled.
+  private hexOutputMult(source: Entity | null): number {
+    if (!source) return 1;
+    let mult = 1;
+    for (const a of source.auras) {
+      if (a.kind === 'hex') mult *= 1 - a.value;
+    }
+    return mult < 0 ? 0 : mult;
+  }
+
   private applyHeal(source: Entity, target: Entity, amount: number, ability: string): void {
     if (target.dead) return;
     const crit = this.rng.chance(this.spellCrit(source));
-    let healed = Math.round(amount * (crit ? 1.5 : 1) * this.healingTakenMult(target));
+    let healed = Math.round(amount * (crit ? 1.5 : 1) * this.hexOutputMult(source) * this.healingTakenMult(target));
     healed = Math.min(healed, target.maxHp - target.hp);
     target.hp += healed;
     this.emit({ type: 'heal2', sourceId: source.id, targetId: target.id, amount: healed, crit, ability });
@@ -3271,6 +3283,13 @@ export class Sim {
       amount = Math.round(amount * 0.9);
     }
 
+    // Weakening Hex: a hexed source deals less damage (mirrors the healing cut in
+    // applyHeal). Self-damage paths (source === target) are left untouched.
+    if (source && source.id !== target.id) {
+      const hexMult = this.hexOutputMult(source);
+      if (hexMult !== 1) amount = Math.round(amount * hexMult);
+    }
+
     // absorb shields soak damage first
     if (amount > 0) {
       for (let i = target.auras.length - 1; i >= 0 && amount > 0; i--) {
@@ -4285,6 +4304,23 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+    // Weakening Hex: a landed hit can curse the player victim, scaling the damage
+    // AND healing they deal by (1 - reductionPct) for a while. Guarded on
+    // `hostile` so a friendly pet (mobSwing's other caller) never hexes the party,
+    // and on a player target. Rides a dedicated `hex` aura read by hexOutputMult.
+    const hex = MOBS[mob.templateId]?.hex;
+    if (hex && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(hex.chance)) {
+      this.applyAura(target, {
+        id: `hex_${mob.templateId}`,
+        name: hex.name,
+        kind: 'hex',
+        remaining: hex.duration,
+        duration: hex.duration,
+        value: hex.reductionPct,
+        sourceId: mob.id,
+        school: hex.school ?? 'shadow',
+      });
     }
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -124,7 +124,7 @@ const EMOTE_ALIASES: Record<string, string> = {
 // (buff_*, hot, absorb, imbue, stances, forms, stealth, thorns, attackspeed
 // haste) is treated as helpful/neutral. Used by /targetbuffs to tag each aura.
 const HARMFUL_AURA_KINDS: ReadonlySet<AuraKind> = new Set<AuraKind>([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'sunder', 'tongues',
 ]);
 
 function isHarmfulAura(kind: AuraKind): boolean {
@@ -186,7 +186,7 @@ const DEMON_HEAL_DURATION = 5;
 const DEMON_HEAL_TICK = 1;
 const TAMED_TARGET_RESPAWN_SECONDS = 60;
 const FRIENDLY_NPC_REJECTED_AURA_KINDS: ReadonlySet<AuraKind> = new Set([
-  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder',
+  'dot', 'slow', 'stun', 'root', 'incapacitate', 'polymorph', 'attackspeed', 'sunder', 'tongues',
 ]);
 
 function isRejectedFriendlyNpcAura(aura: Aura): boolean {
@@ -1333,6 +1333,14 @@ export class Sim {
   private isSilenced(e: Entity): boolean {
     return e.auras.some((a) => a.kind === 'silence');
   }
+  // Curse of Tongues: returns the spell cast-time multiplier (>=1) imposed by any
+  // active `tongues` aura, or 1 when unafflicted. Non-stacking across sources — the
+  // strongest curse wins (refresh-by-id keeps a single source from compounding).
+  private tonguesMult(e: Entity): number {
+    let m = 1;
+    for (const a of e.auras) if (a.kind === 'tongues') m = Math.max(m, a.value);
+    return m;
+  }
   private mobCanSwim(template: { family?: string; canSwim?: boolean } | undefined): boolean {
     return !!template;
   }
@@ -2006,11 +2014,13 @@ export class Sim {
     }
 
     if (res.castTime > 0 && !togglingOff) {
+      // Curse of Tongues stretches the resolved (already haste-adjusted) cast time.
+      const castTime = res.castTime * this.tonguesMult(p);
       p.castingAbility = ability.id;
-      p.castTotal = res.castTime;
-      p.castRemaining = res.castTime;
+      p.castTotal = castTime;
+      p.castRemaining = castTime;
       p.gcdRemaining = Math.max(p.gcdRemaining, gcd);
-      this.emit({ type: 'castStart', entityId: p.id, ability: ability.id, time: res.castTime });
+      this.emit({ type: 'castStart', entityId: p.id, ability: ability.id, time: castTime });
       return;
     }
 
@@ -4214,6 +4224,23 @@ export class Sim {
         value: slowStrike.mult,
         sourceId: mob.id,
         school: (slowStrike.school as Aura['school']) ?? 'physical',
+      });
+    }
+    // Curse of Tongues: a landed hit may garble the victim's incantations, stretching
+    // their spell cast times (`tonguesMult` reads this at cast-start). Refreshes by id
+    // and never stacks. Guarded on `hostile` so a friendly pet (mobSwing's other
+    // caller) never curses an ally; players only, since only players hard-cast here.
+    const tongues = MOBS[mob.templateId]?.tongues;
+    if (tongues && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(tongues.chance)) {
+      this.applyAura(target, {
+        id: `tongues_${mob.templateId}`,
+        name: tongues.name,
+        kind: 'tongues',
+        remaining: tongues.duration,
+        duration: tongues.duration,
+        value: tongues.mult,
+        sourceId: mob.id,
+        school: (tongues.school as Aura['school']) ?? 'shadow',
       });
     }
     // Mana Burn: a landed hit may sap a flat amount of mana from a mana-using

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4152,6 +4152,13 @@ export class Sim {
         sourceId: mob.id, school: (venom.school as Aura['school']) ?? 'nature',
       });
     }
+    // deadly poison: a landed swing may apply (or add a stack to) a ramping DoT.
+    // Guarded on hostile so a friendly pet (the other mobSwing caller) never
+    // poisons an ally. Per-tick damage scales with the stack count.
+    const stackPoison = MOBS[mob.templateId]?.stackPoison;
+    if (stackPoison && mob.hostile && !target.dead && this.rng.chance(stackPoison.chance)) {
+      this.applyStackPoison(mob, target, stackPoison);
+    }
     // corrosive bite: a landed hit may shred the victim's armor (stacking sunder).
     // Guarded on hostile so a friendly pet (the other mobSwing caller) never debuffs an ally.
     const corrode = MOBS[mob.templateId]?.corrode;
@@ -4285,6 +4292,30 @@ export class Sim {
           sourceId: mob.id, school: dread.school ?? 'shadow', breaksOnDamage: true,
         });
       }
+    }
+  }
+
+  // Apply (or add a stack to) a ramping poison DoT on the victim. One shared
+  // `dot` slot found by id, its per-tick `value` recomputed as perTick*stacks
+  // (bumped up to `maxStacks`) and its timer fully refreshed each application —
+  // so the per-tick damage climbs the longer the creature keeps biting. The dot
+  // tick reads `value` directly, so storing perTick*stacks is what makes it ramp.
+  private applyStackPoison(mob: Entity, target: Entity, sp: NonNullable<MobTemplate['stackPoison']>): void {
+    const id = 'stackpoison_' + mob.templateId;
+    const existing = target.auras.find((a) => a.id === id && a.kind === 'dot');
+    if (existing) {
+      existing.stacks = Math.min(sp.maxStacks, (existing.stacks ?? 1) + 1);
+      existing.value = Math.max(1, Math.round(sp.perTick * existing.stacks));
+      existing.remaining = existing.duration;
+      this.emit({ type: 'aura', targetId: target.id, name: sp.name, gained: true });
+    } else {
+      this.applyAura(target, {
+        id, name: sp.name, kind: 'dot',
+        remaining: sp.duration, duration: sp.duration,
+        value: Math.max(1, Math.round(sp.perTick)),
+        tickInterval: sp.interval, tickTimer: sp.interval, stacks: 1,
+        sourceId: mob.id, school: (sp.school as Aura['school']) ?? 'nature',
+      });
     }
   }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4243,6 +4243,24 @@ export class Sim {
         school: enfeeble.school ?? 'shadow',
       });
     }
+    // Withering curse: a landed hit can rot the victim's sinews, draining Agility
+    // and so thinning their armor (agi*2) and dodge at once. Hostile mobs only, so a
+    // friendly pet (mobSwing's other caller) never debuffs the party; player targets
+    // only (mobs derive no stats from auras). Rides buff_agi with a negative value, so
+    // recalcPlayerStats folds it through with no new stat math.
+    const wither = MOBS[mob.templateId]?.wither;
+    if (wither && mob.hostile && target.kind === 'player' && !target.dead && this.rng.chance(wither.chance)) {
+      this.applyAura(target, {
+        id: `wither_${mob.templateId}`,
+        name: wither.name,
+        kind: 'buff_agi',
+        remaining: wither.duration,
+        duration: wither.duration,
+        value: -Math.abs(wither.agi),
+        sourceId: mob.id,
+        school: wither.school ?? 'nature',
+      });
+    }
     // On-hit chill: frost-touched mobs numb the victim, slowing their movement.
     const chill = MOBS[mob.templateId]?.chillOnHit;
     if (chill && !mob.dead && !target.dead && this.rng.chance(chill.chance)) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,12 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit arcane DoT: the arcane-school sibling of venom (nature) / bleed
+  // (physical) / soulrot (shadow) / frostbite (frost) / cinder (fire). A landed
+  // swing may brand the victim with a searing arcane rune that festers as a
+  // refreshing damage-over-time. Reuses the `dot` aura; only the default school
+  // differs. Carried by corrupt spellcasters that channel raw arcane energy.
+  arcaneRot?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'heal_absorb';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -213,6 +213,11 @@ export interface MobTemplate {
   // Melee mechanic: a landed swing has `chance` to inflict a Mortal Wound debuff
   // that reduces all healing the victim receives by `healReduction` for `duration`.
   mortalStrike?: { chance: number; healReduction: number; duration: number; name: string; school?: string };
+  // Heal-absorb mechanic: a landed swing has `chance` to brand the victim with a
+  // necrotic blight that devours the next `amount` points of incoming healing
+  // (a consumable shield, not a percentage) before fading after `duration`.
+  // Distinct from mortalStrike, which scales every heal down for its whole life.
+  healAbsorb?: { chance: number; amount: number; duration: number; name: string; school?: string };
   // On-hit lifesteal: a landed melee swing heals the mob for `healFrac` of the
   // damage it just dealt (drowned undead, leeches, vampiric beasts). Unlike the
   // other on-hit affixes it sustains the attacker instead of debuffing the

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -39,7 +39,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'vulnerability';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -240,6 +240,13 @@ export interface MobTemplate {
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`
   // drives the panicked run with no new aura kind or movement hook.
   dread?: { chance: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to lay a curse of frailty on
+  // the victim, raising all damage they take by `amp` (e.g. 0.15 = +15%) from
+  // every source for `duration`s. Introduces the `vulnerability` aura kind, read
+  // once in dealDamage as a damage multiplier (the offensive mirror of Defensive
+  // Stance's 10% cut). Players only — amplifying a fellow mob would let a friendly
+  // pet soften enemies for its owner.
+  vulnerability?: { chance: number; amp: number; duration: number; name: string; school?: Aura['school'] };
   // Pet mechanic: this creature is a ranged caster (warlock Imp) — instead of
   // closing to melee, it stays at `range` and hurls bolts of `school` damage.
   // updatePet reads this; the bolt damage comes from the mob's weapon range.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -191,6 +191,12 @@ export interface MobTemplate {
   // opens. Resets on evade/respawn. Routes through the normal heal path, so it
   // shows green floating text and grants no threat to the menders themselves.
   mendAlly?: { healMin: number; healMax: number; radius: number; every: number; name: string; school?: Aura['school'] };
+  // Support "War Cadence": periodically quicken the swing speed of every nearby
+  // friendly mob (including the caster) by `hasteMult` for `duration`s. Rides the
+  // existing buff_haste primitive (the same aura packFrenzy uses, already folded
+  // into swingIntervalMult), so it needs no new combat math. Telegraphed and
+  // reset on evade/respawn exactly like mendAlly.
+  warcry?: { radius: number; every: number; hasteMult: number; duration: number; name: string; school?: Aura['school'] };
   // Boss mechanic ("War Stomp"): periodic ground slam that stuns nearby players
   // for `duration`s (and optionally deals min..max damage). Telegraphed: the
   // first slam only lands one full `every` interval after combat starts.
@@ -582,6 +588,7 @@ export interface Entity {
   stompTimer: number; // boss War Stomp stun-pulse countdown
   detonateTimer: number; // Death Throes fuse on a volatile corpse; Infinity = no pending detonation
   mendTimer: number; // mendAlly support-heal cast countdown
+  warcryTimer: number; // warcry ally-haste pulse countdown
   firedSummons: number; // summonAdds thresholds already triggered
   summonedIds: number[]; // live adds this boss summoned; despawned on reset
   enraged: boolean; // enrage mechanic active

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,8 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence'
+  | 'cost_tax';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -256,6 +257,10 @@ export interface MobTemplate {
   petSpell?: { name: string; school: 'physical' | 'fire' | 'frost' | 'arcane' | 'shadow' | 'holy' | 'nature'; min: number; max: number; range: number; every: number };
   // On-hit mechanic: chance to silence the victim, locking out spell (non-physical) casts for a duration.
   silence?: { chance: number; duration: number; name: string; school?: string };
+  // On-hit "draining curse": a landed swing has `chance` to inflate every
+  // ability the victim uses by `pct` (e.g. 0.4 = +40% resource cost) for
+  // `duration` seconds — taxes mana/rage/energy alike, not a stat drain.
+  costTax?: { chance: number; pct: number; duration: number; name: string; school?: string };
   // On-hit chill: a landed melee swing has `chance` to slow the victim's
   // movement to `mult` of normal for `duration` seconds (frost school). Reuses
   // the standard `slow` aura, so it rides the same movement path as Frostbolt.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -268,6 +268,14 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // On-hit purge ("Devour Magic"): a landed melee swing has `chance` to strip
+  // one beneficial enhancement aura off the player victim — a positive buff_*
+  // stat buff, a heal-over-time, an absorb shield, or a weapon imbue. Forms,
+  // stances, stealth, and every debuff are left untouched. Removes nothing if
+  // the victim carries no such buff. Players only; offensive against a fellow
+  // mob is meaningless and a friendly pet (mobSwing's other caller) must never
+  // strip its owner's party. Rides the existing aura system — no new aura kind.
+  purgeOnHit?: { chance: number; name: string };
 }
 
 export type AbilityEffect =

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -46,7 +46,7 @@ export type AiState = 'idle' | 'chase' | 'attack' | 'flee' | 'evade' | 'dead';
 export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
-  | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
+  | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_spi' | 'buff_allstats' | 'thorns' | 'form_bear'
   | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
 
 export interface Aura {
@@ -265,6 +265,15 @@ export interface MobTemplate {
   // the damage *they* deal weaker. `ap` is the attack-power reduction (applied
   // as a negative buff_ap aura); `chance` defaults to 1 (every hit, refreshing).
   demoralize?: { ap: number; duration: number; chance?: number; name?: string };
+  // On-hit curse: a landed melee swing has `chance` to siphon the victim's
+  // Spirit for `duration`, slowing their out-of-combat mana/health regen
+  // (updateRegen reads `stats.spi`). Rides a `buff_spi` aura with a NEGATIVE
+  // value — recalcPlayerStats folds it and floors Spirit at 0, so there is no
+  // new regen math. Distinct from manaBurn (one-shot mana drain) and enfeeble
+  // (Intellect → mana-pool size): this attacks the REGEN axis. Only meaningful
+  // on mana users; applied to them alone. Hostile mobs only (a friendly pet,
+  // mobSwing's other caller, never debuffs the party).
+  siphonSpirit?: { chance: number; spi: number; duration: number; name: string; school?: Aura['school'] };
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -237,6 +237,11 @@ export interface MobTemplate {
   // flat `amount` of mana from a mana-using victim (casters). Rage/energy users
   // are unaffected. Drains only what mana the victim still has; no overkill.
   manaBurn?: { chance: number; amount: number; name: string; school?: Aura['school'] };
+  // On-hit mechanic ("Sap Vigor"): the melee-resource twin of manaBurn. A landed
+  // swing has `chance` to drain a flat `amount` of rage or energy from a melee
+  // victim (warriors, rogues, feral druids), starving their ability use. Mana
+  // users are unaffected. Drains only what the victim still has; no overkill.
+  sapVigor?: { chance: number; amount: number; name: string; school?: Aura['school'] };
   // On-hit curse: a landed melee swing has `chance` to fog the victim's mind,
   // draining `int` Intellect for `duration` and thus shrinking a caster's mana
   // pool (recalcPlayerStats clamps current mana down with the smaller ceiling).

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'critvuln';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -268,6 +268,12 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // On-hit affix ("Find Weakness"): a landed melee swing has `chance` to leave the
+  // victim's flesh exposed, so CRITICAL hits against them (from anyone, any school)
+  // deal an extra `critDamage` fraction for `duration`s. Read once in the dealDamage
+  // funnel (crit-only). Distinct from a flat-damage vuln (expose/spellvuln) — this
+  // sharpens only the rare crits, the way a predator's bite finds the soft spot.
+  critVuln?: { chance: number; critDamage: number; duration: number; name: string; school?: Aura['school'] };
 }
 
 export type AbilityEffect =

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -235,6 +235,13 @@ export interface MobTemplate {
   // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
   // resource math. Only meaningful on mana users — applied to them alone.
   enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit disease ("plague"): a landed melee swing has `chance` to rot the
+  // victim's vitality, draining `sta` Stamina for `duration`. recalcPlayerStats
+  // folds the smaller Stamina through to a smaller maxHp (and current HP scales
+  // down with the shrunken pool), so there is no new HP math. Rides the existing
+  // buff_sta aura with a NEGATIVE value. Unlike enfeeble (casters only) it
+  // afflicts everyone, since Stamina matters to every class.
+  plague?: { chance: number; sta: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to terrify the victim — a
   // fear that sends the struck player fleeing for `duration`s. Rides the existing
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'hex';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -268,6 +268,14 @@ export interface MobTemplate {
   // Innate "spiked hide" trait: melee attackers take flat damage back on every
   // connecting swing — the mob-side equivalent of the druid Thorns aura.
   thorns?: { value: number; school?: Aura['school']; name?: string };
+  // On-hit affix ("Weakening Hex"): a landed melee swing has `chance` to curse
+  // the player victim, scaling BOTH the damage and the healing *they* deal by
+  // (1 - reductionPct) for `duration` seconds. Distinct from `demoralize` (flat
+  // attack-power cut, physical only) and `mortal_wound` (healing *received*):
+  // this throttles the victim's whole offensive/support output — classic witch-
+  // doctor / curse-of-weakness flavour. Rides a dedicated `hex` aura kind read in
+  // dealDamage (outgoing) and applyHeal (outgoing).
+  hex?: { chance: number; reductionPct: number; duration: number; name: string; school?: Aura['school'] };
 }
 
 export type AbilityEffect =

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -47,7 +47,7 @@ export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
   | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
-  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
+  | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence' | 'tongues';
 
 export interface Aura {
   id: string; // ability id that applied it
@@ -233,6 +233,13 @@ export interface MobTemplate {
   // interval) for `duration`s. Rides the existing swingIntervalMult hook — no new
   // combat math. Distinct from a movement snare (`slow`) or an AP cut (`debuff_ap`).
   slowStrike?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse ("Curse of Tongues"): a landed melee swing has `chance` to garble
+  // the victim's incantations, stretching their SPELL CAST TIMES by `mult` (>1 =
+  // slower) for `duration`s. Read at cast-start so it composes with the already
+  // haste-resolved cast time — no new combat math. Distinct from `slowStrike` (melee
+  // swing speed) and `silence` (a full spell lockout): a casting victim still casts,
+  // just slower. Inert against rage/energy melee classes that never hard-cast.
+  tongues?: { chance: number; mult: number; duration: number; name: string; school?: Aura['school'] };
   // On-hit mechanic ("Mana Burn"): a landed melee swing has `chance` to drain a
   // flat `amount` of mana from a mana-using victim (casters). Rage/energy users
   // are unaffected. Drains only what mana the victim still has; no overkill.

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -201,6 +201,12 @@ export interface MobTemplate {
   // On-hit debuff: a chance per landed melee swing to inflict a stacking-refresh
   // damage-over-time poison on the struck target (spiders, serpents, scorpions).
   venom?: { chance: number; perTick: number; interval: number; duration: number; name: string; school?: string };
+  // On-hit debuff: a *stacking* poison DoT. Unlike `venom` (a single fixed-value
+  // DoT that merely refreshes), each landed swing adds a stack — the per-tick
+  // damage is `perTick * stacks`, ramping up to `maxStacks` — so the longer the
+  // creature stays on its target the worse the venom bites (classic "Deadly
+  // Poison"). Reuses the `dot` aura kind; the shared slot carries the stack count.
+  stackPoison?: { chance: number; perTick: number; interval: number; duration: number; maxStacks: number; name: string; school?: string };
   // On-death mechanic ("Death Throes"): a volatile creature does not detonate
   // the instant it dies. Its corpse destabilizes for `delay` seconds (a
   // telegraph players can run from), then bursts for min..max `school` damage

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -45,7 +45,7 @@ export type AiState = 'idle' | 'chase' | 'attack' | 'flee' | 'evade' | 'dead';
 
 export type AuraKind =
   | 'dot' | 'slow' | 'stun' | 'root' | 'incapacitate' | 'polymorph'
-  | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
+  | 'attackspeed' | 'debuff_ap' | 'buff_ap' | 'buff_armor' | 'buff_int' | 'buff_agi' | 'buff_dodge' | 'buff_speed' | 'buff_haste'
   | 'hot' | 'absorb' | 'imbue' | 'buff_sta' | 'buff_allstats' | 'thorns' | 'form_bear'
   | 'form_cat' | 'stealth' | 'defensive_stance' | 'righteous_fury' | 'sunder' | 'mortal_wound' | 'silence';
 
@@ -243,6 +243,12 @@ export interface MobTemplate {
   // Rides the existing buff_int aura with a NEGATIVE value, so there is no new
   // resource math. Only meaningful on mana users — applied to them alone.
   enfeeble?: { chance: number; int: number; duration: number; name: string; school?: Aura['school'] };
+  // On-hit curse: a landed melee swing has `chance` to wither the victim's sinews,
+  // draining `agi` Agility for `duration`. Agility is a derived-stat hub — it feeds
+  // armor (agi*2), dodge and crit — so a single drain shreds both the victim's
+  // physical mitigation and their avoidance at once. Rides a `buff_agi` aura with a
+  // NEGATIVE value (recalcPlayerStats folds it through), so there is no new stat math.
+  wither?: { chance: number; agi: number; duration: number; name: string; school?: Aura['school'] };
   // Combat mechanic: a landed melee hit has `chance` to terrify the victim — a
   // fear that sends the struck player fleeing for `duration`s. Rides the existing
   // `fear_incap` incapacitate aura the player-cast Fear uses, so `updateFearMovement`

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1789,7 +1789,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'vulnerability'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2068,10 +2068,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'vulnerability', 'hex', 'tongues'].includes(a.kind)
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'cost_tax'].includes(a.kind)
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'heal_absorb'].includes(a.kind)
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'critvuln'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'vulnerability', 'hex', 'tongues', 'cost_tax', 'heal_absorb', 'critvuln'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'heal_absorb'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'cost_tax'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1842,7 +1842,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'critvuln'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'hex'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1843,7 +1843,7 @@ export class Hud {
     for (const a of e.auras) {
       // A negative-value stat aura (e.g. a mob's Withering Wail sapping attack
       // power, or an Intellect-draining curse) is a debuff even though it reuses a buff_* kind.
-      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap'].includes(a.kind)
+      const isDebuff = ['dot', 'slow', 'root', 'stun', 'incapacitate', 'polymorph', 'attackspeed', 'debuff_ap', 'tongues'].includes(a.kind)
         || (a.kind.startsWith('buff_') && a.value < 0);
       if (mode === 'debuffs' && !isDebuff) continue;
       const d = document.createElement('div');

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1094,6 +1094,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_imbue: r('holy', 'holyGold', ['sword', { p: 'sunburst', ...TL }]),
   aura_buff_allstats: r('arcane', 'arcanePink', ['gem']),
   aura_thorns: r('nature', 'leafGreen', ['leaf', { p: 'claw_slash', ...BR }]),
+  aura_heal_absorb: r('shadow', 'shadowPurple', ['heart'], ['drips']),
   aura_form_bear: r('earth', 'earthBrown', ['paw']),
 };
 

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1094,6 +1094,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_imbue: r('holy', 'holyGold', ['sword', { p: 'sunburst', ...TL }]),
   aura_buff_allstats: r('arcane', 'arcanePink', ['gem']),
   aura_thorns: r('nature', 'leafGreen', ['leaf', { p: 'claw_slash', ...BR }]),
+  aura_cost_tax: r('shadow', 'shadowPurple', ['gem', { p: 'droplet', ...BR }], ['drips']),
   aura_form_bear: r('earth', 'earthBrown', ['paw']),
 };
 

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1083,6 +1083,7 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_incapacitate: r('storm', 'sky', ['eye']),
   aura_polymorph: r('arcane', 'pink', ['sheep_head']),
   aura_attackspeed: r('storm', 'ice', ['axe', { p: 'snowflake', ...BR }]),
+  aura_tongues: r('shadow', 'shadowPurple', ['skull'], ['motion']),
   aura_buff_sta: r('blood', 'blood', ['heart']),
   aura_buff_ap: r('fury', 'gold', ['fist']),
   aura_buff_armor: r('steel', 'steel', ['shield']),

--- a/tests/mob_arcane_rot.test.ts
+++ b/tests/mob_arcane_rot.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = (cls: 'warrior' | 'mage' = 'warrior') => new Sim({ seed: SEED, playerClass: cls });
+
+// Spawn Deacon Voss adjacent to the player and hand it back.
+function spawnDeacon(sim: Sim, id = 980001, level = 12) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.deacon_voss, level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing in a
+// loop until the target carries the arcane-rot aura (the chance is 1 in tests).
+function swingUntilRot(sim: Sim, mob: any, target: any, tries = 60): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.id === 'arcaneRot_deacon_voss')) return true;
+  }
+  return false;
+}
+
+describe('mob arcane rot (on-hit arcane DoT)', () => {
+  it('Deacon Voss carries arcaneRot data tuned to an arcane DoT', () => {
+    const v = MOBS.deacon_voss.arcaneRot!;
+    expect(v).toBeDefined();
+    expect(v.school).toBe('arcane');
+    expect(v.chance).toBeGreaterThan(0);
+    expect(v.perTick).toBeGreaterThan(0);
+    expect(v.interval).toBeGreaterThan(0);
+    expect(v.duration).toBeGreaterThan(v.interval);
+  });
+
+  it('a landed swing brands the struck player with an arcane DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnDeacon(sim);
+    const orig = MOBS.deacon_voss.arcaneRot!.chance;
+    MOBS.deacon_voss.arcaneRot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.deacon_voss.arcaneRot!.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === 'arcaneRot_deacon_voss')!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('arcane');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.remaining).toBeCloseTo(MOBS.deacon_voss.arcaneRot!.duration);
+  });
+
+  it('the arcane DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnDeacon(sim);
+    const orig = MOBS.deacon_voss.arcaneRot!.chance;
+    MOBS.deacon_voss.arcaneRot!.chance = 1;
+    try {
+      expect(swingUntilRot(sim, mob, player)).toBe(true);
+    } finally {
+      MOBS.deacon_voss.arcaneRot!.chance = orig;
+    }
+    // Park the mob out of melee so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    // interval=3, so a ~7s window outpaces out-of-combat regen on a boundary tick.
+    for (let i = 0; i < 20 * 7; i++) sim.tick();
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a mob without arcaneRot (forest wolf) applies no arcane DoT', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const wolf = createMob(980050, MOBS.forest_wolf, 4, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.kind === 'dot')).toBe(false);
+  });
+
+  it('refreshes (does not infinitely stack) on repeated brands from the same deacon', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const mob = spawnDeacon(sim);
+    const orig = MOBS.deacon_voss.arcaneRot!.chance;
+    MOBS.deacon_voss.arcaneRot!.chance = 1;
+    try {
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+      swingUntilRot(sim, mob, player);
+    } finally {
+      MOBS.deacon_voss.arcaneRot!.chance = orig;
+    }
+    const rotAuras = player.auras.filter((a) => a.id === 'arcaneRot_deacon_voss');
+    expect(rotAuras.length).toBe(1);
+  });
+});

--- a/tests/mob_cost_tax.test.ts
+++ b/tests/mob_cost_tax.test.ts
@@ -1,0 +1,88 @@
+// The Gravecaller Mender's "Draining Litany" is a cost-tax curse: a landed hit
+// can leave the victim's abilities more expensive (mana/rage/energy alike) for a
+// few seconds. Unlike a silence (full lockout) or a stat drain, it inflates the
+// resolved resource cost — resolved at the single resolvedAbility() choke point,
+// so the affordability check and the actual spend always agree.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Mender adjacent to the player, engaged and ready to swing.
+function spawnMender(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_mender'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (the cost-tax chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+const taxAura = (sourceId: number, pct = 0.4) => ({
+  id: 'cost_tax_gravecaller_mender', name: 'Draining Litany', kind: 'cost_tax' as const,
+  remaining: 8, duration: 8, value: pct, sourceId, school: 'shadow' as const,
+});
+
+describe('mob cost-tax ("Draining Litany")', () => {
+  it('seeds the cost-tax mechanic on the Gravecaller Mender', () => {
+    expect(MOBS['gravecaller_mender'].costTax).toEqual({
+      chance: 0.3, pct: 0.4, duration: 8, name: 'Draining Litany', school: 'shadow',
+    });
+  });
+
+  it('applies a cost_tax aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnMender(sim, p);
+    MOBS['gravecaller_mender'].costTax!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_mender'].costTax!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'cost_tax');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Draining Litany');
+    expect(aura!.remaining).toBe(8);
+    expect(aura!.value).toBe(0.4);
+  });
+
+  it('inflates the resolved resource cost of an ability while taxed', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const base = sim.resolvedAbility('fireball', p.id)!.cost;
+    expect(base).toBeGreaterThan(0);
+    p.auras.push(taxAura(999));
+    expect(sim.resolvedAbility('fireball', p.id)!.cost).toBe(Math.ceil(base * 1.4));
+  });
+
+  it('takes the strongest tax when more than one is active and leaves cost intact with none', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const base = sim.resolvedAbility('fireball', p.id)!.cost;
+    expect(sim.resolvedAbility('fireball', p.id)!.cost).toBe(base); // no aura → untouched
+    p.auras.push(taxAura(999, 0.2));
+    p.auras.push(taxAura(998, 0.5));
+    expect(sim.resolvedAbility('fireball', p.id)!.cost).toBe(Math.ceil(base * 1.5));
+  });
+
+  it('a friendly pet swing never taxes its target', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnMender(sim, p);
+    pet.hostile = false; // a tamed/friendly mender shape
+    pet.ownerId = p.id;
+    MOBS['gravecaller_mender'].costTax!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['gravecaller_mender'].costTax!.chance = 0.3;
+    expect(p.auras.some((a) => a.kind === 'cost_tax')).toBe(false);
+  });
+});

--- a/tests/mob_critvuln.test.ts
+++ b/tests/mob_critvuln.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Aura } from '../src/sim/types';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+function critVulnAura(value: number, remaining = 8): Aura {
+  return {
+    id: 'critvuln_test', name: 'Exposed Wound', kind: 'critvuln',
+    remaining, duration: 8, value, sourceId: -1, school: 'physical',
+  };
+}
+
+describe('Find Weakness crit-vulnerability debuff', () => {
+  it('critVulnBonus reports the largest active critvuln aura', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    expect((sim as any).critVulnBonus(p)).toBe(0);
+    p.auras.push({ ...critVulnAura(0.3), id: 'a', sourceId: 1 });
+    p.auras.push({ ...critVulnAura(0.5), id: 'b', sourceId: 2 });
+    expect((sim as any).critVulnBonus(p)).toBe(0.5);
+  });
+
+  it('amplifies CRITICAL hits by the debuff fraction but leaves normal hits alone', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(910000, MOBS.mire_widow, 10, { x: 0, y: 0, z: 0 });
+
+    // normal hit — no amplification even with the debuff up
+    p.auras.length = 0;
+    p.auras.push(critVulnAura(0.5));
+    p.hp = 100000;
+    (sim as any).dealDamage(mob, p, 100, false, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(100);
+
+    // critical hit — amplified by +50%
+    p.auras.length = 0;
+    p.auras.push(critVulnAura(0.5));
+    p.hp = 100000;
+    (sim as any).dealDamage(mob, p, 100, true, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(150);
+
+    // critical hit without the debuff — unmodified
+    p.auras.length = 0;
+    p.hp = 100000;
+    (sim as any).dealDamage(mob, p, 100, true, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(100);
+  });
+
+  it('amplifies crits of any school (not just physical)', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(910001, MOBS.mire_widow, 10, { x: 0, y: 0, z: 0 });
+    p.auras.push(critVulnAura(0.5));
+    (sim as any).dealDamage(mob, p, 100, true, 'shadow', null, 'hit');
+    expect(100000 - p.hp).toBe(150);
+  });
+
+  it('a self-inflicted crit is never amplified', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    p.auras.push(critVulnAura(0.5));
+    (sim as any).dealDamage(p, p, 100, true, 'physical', null, 'hit');
+    expect(100000 - p.hp).toBe(100);
+  });
+
+  it('a landed Mirefen Widow swing can inflict the Exposed Wound', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000; // survive every swing so we observe the debuff
+    const tmpl = MOBS.mire_widow;
+    const saved = tmpl.critVuln!.chance;
+    tmpl.critVuln!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const mob = createMob(910002, tmpl, 10, { x: 0, y: 0, z: 0 });
+      let applied = false;
+      for (let i = 0; i < 60 && !applied; i++) {
+        (sim as any).mobSwing(mob, p);
+        applied = p.auras.some((a) => a.kind === 'critvuln');
+      }
+      expect(applied).toBe(true);
+      const a = p.auras.find((x) => x.kind === 'critvuln')!;
+      expect(a.name).toBe('Exposed Wound');
+      expect(a.value).toBe(0.5);
+    } finally {
+      tmpl.critVuln!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never inflicts the debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const tmpl = MOBS.mire_widow;
+    const saved = tmpl.critVuln!.chance;
+    tmpl.critVuln!.chance = 1;
+    try {
+      const pet = createMob(910003, tmpl, 10, { x: 0, y: 0, z: 0 });
+      pet.hostile = false;
+      for (let i = 0; i < 60; i++) (sim as any).mobSwing(pet, p);
+      expect(p.auras.some((a) => a.kind === 'critvuln')).toBe(false);
+    } finally {
+      tmpl.critVuln!.chance = saved;
+    }
+  });
+
+  it('a mob without critVuln applies no debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = createMob(910004, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);
+    expect(p.auras.some((a) => a.kind === 'critvuln')).toBe(false);
+  });
+});

--- a/tests/mob_heal_absorb.test.ts
+++ b/tests/mob_heal_absorb.test.ts
@@ -1,0 +1,82 @@
+// Necrotic mobs (e.g. the Gravecaller Summoner's "Grave Blight") can brand a
+// victim on a melee hit with a heal-absorb shield: the next chunk of incoming
+// healing is devoured before any of it lands. This is the sibling of Mortal
+// Strike — where Mortal Strike scales every heal down for its whole duration,
+// Grave Blight eats a FIXED pool of healing once, then fades.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Summoner adjacent to the player, engaged and ready to swing.
+function spawnSummoner(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_summoner'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob heal-absorb ("Grave Blight")', () => {
+  it('seeds the heal-absorb mechanic on the Gravecaller Summoner', () => {
+    expect(MOBS['gravecaller_summoner'].healAbsorb).toEqual({
+      chance: 0.25, amount: 120, duration: 10, name: 'Grave Blight', school: 'shadow',
+    });
+  });
+
+  it('applies a heal_absorb aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnSummoner(sim, p);
+    MOBS['gravecaller_summoner'].healAbsorb!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_summoner'].healAbsorb!.chance = 0.25;
+    const aura = p.auras.find((a) => a.kind === 'heal_absorb');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Grave Blight');
+    expect(aura!.value).toBe(120);
+    expect(aura!.remaining).toBe(10);
+  });
+
+  it('devours healing up to its budget, then leaves the rest, depleting the shield', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.auras.push({
+      id: 'heal_absorb_test', name: 'Grave Blight', kind: 'heal_absorb',
+      remaining: 10, duration: 10, value: 120, sourceId: 999, school: 'shadow',
+    });
+    // A 50-point heal is fully eaten; the shield drains to 70 and remains.
+    expect((sim as any).consumeHealAbsorb(p, 50)).toBe(0);
+    expect(p.auras.find((a) => a.kind === 'heal_absorb')!.value).toBe(70);
+    // A 200-point heal eats the remaining 70 and 130 survives; the shield drops.
+    expect((sim as any).consumeHealAbsorb(p, 200)).toBe(130);
+    expect(p.auras.some((a) => a.kind === 'heal_absorb')).toBe(false);
+  });
+
+  it('blocks real healing while a shield is active, then heals normally after it lapses', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 1000; p.hp = 500;
+    // A shield larger than any heal (crit included) absorbs the whole heal.
+    p.auras.push({
+      id: 'heal_absorb_test', name: 'Grave Blight', kind: 'heal_absorb',
+      remaining: 10, duration: 10, value: 100000, sourceId: 999, school: 'shadow',
+    });
+    (sim as any).applyHeal(p, p, 200, 'Test Heal');
+    expect(p.hp).toBe(500); // fully absorbed
+    // Drop the shield and the same heal now lands (>= base, crit may add more).
+    p.auras = p.auras.filter((a) => a.kind !== 'heal_absorb');
+    (sim as any).applyHeal(p, p, 200, 'Test Heal');
+    expect(p.hp).toBeGreaterThanOrEqual(700);
+  });
+});

--- a/tests/mob_hex.test.ts
+++ b/tests/mob_hex.test.ts
@@ -1,0 +1,110 @@
+// Witch-doctor mobs (e.g. the Gravecaller Cultist's "Weakening Hex") can curse a
+// victim on a melee hit, scaling BOTH the damage and the healing *they* deal by
+// (1 - reductionPct) for a while. The hex is distinct from `demoralize` (a flat
+// attack-power cut, physical only) and `mortal_wound` (healing *received*): it
+// throttles the hexed player's whole offensive/support output.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'priest' = 'priest') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Cultist adjacent to the player, hostile and ready to swing.
+function spawnCultist(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_cultist'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (hex chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+const HEX_AURA = {
+  id: 'hex_gravecaller_cultist', name: 'Weakening Hex', kind: 'hex' as const,
+  remaining: 10, duration: 10, value: 0.2, sourceId: 999, school: 'shadow' as const,
+};
+
+describe('mob hex ("Weakening Hex")', () => {
+  it('seeds the hex mechanic on the Gravecaller Cultist', () => {
+    expect(MOBS['gravecaller_cultist'].hex).toEqual({
+      chance: 0.3, reductionPct: 0.2, duration: 10, name: 'Weakening Hex', school: 'shadow',
+    });
+  });
+
+  it('applies a hex aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    MOBS['gravecaller_cultist'].hex!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['gravecaller_cultist'].hex!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'hex');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Weakening Hex');
+    expect(aura!.value).toBe(0.2);
+    expect(aura!.remaining).toBe(10);
+  });
+
+  it('hexOutputMult scales by (1 - reductionPct) per hex aura', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    expect((sim as any).hexOutputMult(p)).toBe(1);
+    p.auras.push({ ...HEX_AURA });
+    expect((sim as any).hexOutputMult(p)).toBeCloseTo(0.8, 6);
+    expect((sim as any).hexOutputMult(null)).toBe(1);
+  });
+
+  it('reduces the damage a hexed source deals', () => {
+    const sim = makeSim('warrior');
+    const p = sim.player;
+    const dummy = spawnCultist(sim, p);
+    dummy.maxHp = 100000; dummy.hp = 100000;
+    // Baseline hit (unhexed).
+    (sim as any).dealDamage(p, dummy, 1000, false, 'shadow', null, 'hit', true);
+    const plain = 100000 - dummy.hp;
+    dummy.hp = 100000;
+    // Same hit while hexed.
+    p.auras.push({ ...HEX_AURA });
+    (sim as any).dealDamage(p, dummy, 1000, false, 'shadow', null, 'hit', true);
+    const hexed = 100000 - dummy.hp;
+    expect(hexed).toBeLessThan(plain);
+    expect(hexed).toBeCloseTo(plain * 0.8, 0);
+  });
+
+  it('reduces the healing a hexed source does', () => {
+    const sim = makeSim('priest');
+    const p = sim.player;
+    (sim as any).spellCrit = () => 0; // remove crit RNG so the ratio is exact
+    p.maxHp = 100000; p.hp = 1; // huge deficit so nothing is capped by overheal
+    (sim as any).applyHeal(p, p, 1000, 'Test Heal');
+    const plain = p.hp - 1;
+    p.hp = 1;
+    p.auras.push({ ...HEX_AURA });
+    (sim as any).applyHeal(p, p, 1000, 'Test Heal');
+    const hexed = p.hp - 1;
+    expect(hexed).toBeLessThan(plain);
+    expect(hexed).toBeCloseTo(plain * 0.8, 0);
+  });
+
+  it('a friendly pet swing never hexes its target', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const pet = spawnCultist(sim, p);
+    pet.hostile = false; // a tamed/friendly cultist shape
+    pet.ownerId = p.id;
+    MOBS['gravecaller_cultist'].hex!.chance = 1;
+    swing(sim, pet, p);
+    MOBS['gravecaller_cultist'].hex!.chance = 0.3;
+    expect(p.auras.some((a) => a.kind === 'hex')).toBe(false);
+  });
+});

--- a/tests/mob_plague.test.ts
+++ b/tests/mob_plague.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 5150;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+
+// Force a drowned_dead swing to land its plague, returning the applied aura (or
+// undefined). Resets the player's HP each iteration so a connecting swing never
+// kills before the disease is observed.
+function forcePlague(sim: Sim, p: any, mob: any): any {
+  for (let i = 0; i < 80; i++) {
+    p.maxHp = 100000; p.hp = 100000;
+    (sim as any).mobSwing(mob, p);
+    const a = p.auras.find((x: any) => x.id === 'plague_drowned_dead');
+    if (a) return a;
+  }
+  return undefined;
+}
+
+describe('Plague Stamina-drain affix (Bog Rot)', () => {
+  it('a landed drowned_dead swing drains the victim Stamina and shrinks max HP', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    // A disease-free twin in an identical sim — same seed/class/level, so its
+    // recalculated maxHp is exactly what ours would be without the plague.
+    const cleanMaxHp = makeSim().entities.get(sim.playerId)!.maxHp;
+    const baseSta = p.stats.sta;
+    const tmpl = MOBS.drowned_dead;
+    const saved = tmpl.plague!.chance;
+    tmpl.plague!.chance = 1; // force the proc; misses/dodges still possible
+    try {
+      const a = forcePlague(sim, p, createMob(910700, tmpl, 10, { x: 0, y: 0, z: 0 }));
+      expect(a).toBeDefined();
+      expect(a.kind).toBe('buff_sta');
+      expect(a.name).toBe('Bog Rot');
+      expect(a.value).toBe(-12);
+      expect(a.school).toBe('nature');
+      // Stamina and the health pool both shrank under the disease.
+      expect(p.stats.sta).toBe(baseSta - 12);
+      expect(p.maxHp).toBeLessThan(cleanMaxHp);
+    } finally {
+      tmpl.plague!.chance = saved;
+    }
+  });
+
+  it('the drained Stamina is restored when the disease expires', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const baseSta = p.stats.sta;
+    const tmpl = MOBS.drowned_dead;
+    const saved = tmpl.plague!.chance;
+    tmpl.plague!.chance = 1;
+    try {
+      const a = forcePlague(sim, p, createMob(910701, tmpl, 10, { x: 0, y: 0, z: 0 }));
+      expect(a).toBeDefined();
+      expect(p.stats.sta).toBe(baseSta - 12);
+      a.remaining = 0; // let this tick expire it
+      sim.tick();
+      expect(p.auras.some((x) => x.id === 'plague_drowned_dead')).toBe(false);
+      expect(p.stats.sta).toBe(baseSta); // Stamina fully restored
+    } finally {
+      tmpl.plague!.chance = saved;
+    }
+  });
+
+  it('a friendly pet swing (hostile=false) never plagues its target', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const tmpl = MOBS.drowned_dead;
+    const saved = tmpl.plague!.chance;
+    tmpl.plague!.chance = 1;
+    try {
+      const pet = createMob(910702, tmpl, 10, { x: 0, y: 0, z: 0 });
+      pet.hostile = false; // pets call mobSwing too
+      for (let i = 0; i < 80; i++) { p.maxHp = 100000; p.hp = 100000; (sim as any).mobSwing(pet, p); }
+      expect(p.auras.some((a) => a.id === 'plague_drowned_dead')).toBe(false);
+    } finally {
+      tmpl.plague!.chance = saved;
+    }
+  });
+
+  it('a mob without the plague affix applies no Stamina debuff', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const mob = createMob(910703, MOBS.forest_wolf, 5, { x: 0, y: 0, z: 0 });
+    for (let i = 0; i < 60; i++) { p.maxHp = 100000; p.hp = 100000; (sim as any).mobSwing(mob, p); }
+    expect(p.auras.some((a) => a.kind === 'buff_sta' && a.value < 0)).toBe(false);
+  });
+});

--- a/tests/mob_purge.test.ts
+++ b/tests/mob_purge.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob, recalcPlayerStats } from '../src/sim/entity';
+import type { Aura, PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+
+const makeSim = (cls: PlayerClass = 'warrior') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+// Grubjaw at the player's level so its swings land on an even hit table.
+const spawnGrubjaw = (sim: Sim) => {
+  const mob = createMob(990700, MOBS.grubjaw, 20, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+const pushBuff = (target: any, kind: Aura['kind'], value: number, id = `test_${kind}`) => {
+  const aura: Aura = {
+    id, name: 'Test Buff', kind,
+    remaining: 300, duration: 300, value,
+    sourceId: target.id, school: 'arcane',
+  };
+  target.auras.push(aura);
+  return aura;
+};
+
+// Force-swing until the named beneficial buff is gone (a swing can miss/dodge).
+const swingUntilDevoured = (sim: Sim, mob: any, target: any, auraId: string, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp;
+    (sim as any).mobSwing(mob, target);
+    if (!target.auras.some((a: any) => a.id === auraId)) return true;
+  }
+  return false;
+};
+
+describe('mob purge affix (Devour Magic)', () => {
+  it('Grubjaw the Glutton carries the purge mechanic', () => {
+    expect(MOBS.grubjaw.purgeOnHit).toBeDefined();
+    expect(MOBS.grubjaw.purgeOnHit!.name).toBe('Devour Magic');
+  });
+
+  it('strips one beneficial buff on a landed hit and recalcs derived stats', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnGrubjaw(sim);
+    const armorBefore = player.stats.armor;
+    pushBuff(player, 'buff_armor', 80, 'test_buff_armor');
+    // recalc so the pushed buff folds into derived armor (mirrors applyAura).
+    const meta = (sim as any).players.get(player.id);
+    recalcPlayerStats(player, meta.cls, meta.equipment, meta.talentMods);
+    expect(player.stats.armor).toBe(armorBefore + 80);
+
+    const purge = MOBS.grubjaw.purgeOnHit!;
+    const old = purge.chance;
+    purge.chance = 1;
+    try {
+      expect(swingUntilDevoured(sim, mob, player, 'test_buff_armor')).toBe(true);
+    } finally {
+      purge.chance = old;
+    }
+    expect(player.auras.some((a) => a.id === 'test_buff_armor')).toBe(false);
+    expect(player.stats.armor).toBe(armorBefore); // un-folded after the strip
+  });
+
+  it('devours only one buff per proc, beneficial buffs only', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    spawnGrubjaw(sim);
+    player.auras = [];
+    pushBuff(player, 'buff_armor', 80, 'b1');
+    pushBuff(player, 'buff_ap', 40, 'b2');
+    const removed = (sim as any).devourBeneficialAura(player, 'Devour Magic');
+    expect(removed).toBe(true);
+    expect(player.auras.length).toBe(1); // exactly one eaten
+  });
+
+  it('never strips a debuff or a negative buff_* drain', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    spawnGrubjaw(sim);
+    player.auras = [];
+    pushBuff(player, 'dot', 5, 'd1'); // harmful DoT
+    pushBuff(player, 'buff_int', -18, 'd2'); // enfeeble-style stat drain
+    const removed = (sim as any).devourBeneficialAura(player, 'Devour Magic');
+    expect(removed).toBe(false);
+    expect(player.auras.length).toBe(2); // both left untouched
+  });
+
+  it('is a harmless no-op when the victim carries no beneficial buff', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnGrubjaw(sim);
+    player.auras = [];
+    const purge = MOBS.grubjaw.purgeOnHit!;
+    const old = purge.chance;
+    purge.chance = 1;
+    try {
+      for (let i = 0; i < 40; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      purge.chance = old;
+    }
+    expect(player.dead).toBe(false);
+  });
+
+  it('a friendly pet never purges its owner (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnGrubjaw(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    player.auras = [];
+    pushBuff(player, 'buff_armor', 80, 'pet_buff');
+    const purge = MOBS.grubjaw.purgeOnHit!;
+    const old = purge.chance;
+    purge.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      purge.chance = old;
+    }
+    expect(player.auras.some((a) => a.id === 'pet_buff')).toBe(true);
+  });
+});

--- a/tests/mob_sap_vigor.test.ts
+++ b/tests/mob_sap_vigor.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+const makeSim = (cls: PlayerClass) => new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+
+// Spawn Mirejaw the Ravenous next to the player (at the player's level for an
+// even hit table) and swing until a hit connects — a swing can miss/dodge.
+const setup = (cls: PlayerClass) => {
+  const sim = makeSim(cls);
+  const player = sim.player;
+  const mob = createMob(990700, MOBS.mirejaw_the_ravenous, player.level, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return { sim, player, mob };
+};
+
+const KEEP_ALIVE = 1e7; // an elite one-shots a low-level victim; keep it alive so
+// the post-hit drain (guarded on `!target.dead`) can fire.
+const swingUntilDrain = (sim: Sim, mob: any, target: any, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.maxHp = KEEP_ALIVE;
+    target.hp = KEEP_ALIVE; // top up so a hit never kills (death would reset state)
+    const before = target.resource;
+    (sim as any).mobSwing(mob, target);
+    if (target.resource < before) return true;
+  }
+  return false;
+};
+
+describe('mob sap vigor (Sapping Bite)', () => {
+  it('Mirejaw the Ravenous template carries the sapVigor mechanic', () => {
+    expect(MOBS.mirejaw_the_ravenous.sapVigor).toBeDefined();
+    expect(MOBS.mirejaw_the_ravenous.sapVigor!.name).toBe('Sapping Bite');
+  });
+
+  it('a landed hit drains the template amount of energy from an energy user', () => {
+    const { sim, player, mob } = setup('rogue');
+    expect(player.resourceType).toBe('energy');
+    const sap = MOBS.mirejaw_the_ravenous.sapVigor!;
+    player.resource = player.maxResource;
+    const old = sap.chance;
+    sap.chance = 1;
+    try {
+      const start = player.resource;
+      expect(swingUntilDrain(sim, mob, player)).toBe(true);
+      expect(player.resource).toBe(start - sap.amount);
+    } finally {
+      sap.chance = old;
+    }
+  });
+
+  it('drain clamps at zero — it never pushes the resource negative', () => {
+    const { sim, player, mob } = setup('rogue');
+    const sap = MOBS.mirejaw_the_ravenous.sapVigor!;
+    player.resource = 10; // less than sap.amount (25)
+    const old = sap.chance;
+    sap.chance = 1;
+    try {
+      expect(swingUntilDrain(sim, mob, player)).toBe(true);
+      expect(player.resource).toBe(0);
+    } finally {
+      sap.chance = old;
+    }
+  });
+
+  it('a mana user is unaffected (melee-resource only)', () => {
+    const { sim, player, mob } = setup('mage');
+    expect(player.resourceType).toBe('mana');
+    const sap = MOBS.mirejaw_the_ravenous.sapVigor!;
+    const old = sap.chance;
+    sap.chance = 1;
+    player.resource = player.maxResource;
+    try {
+      for (let i = 0; i < 50; i++) { player.maxHp = KEEP_ALIVE; player.hp = KEEP_ALIVE; (sim as any).mobSwing(mob, player); }
+    } finally {
+      sap.chance = old;
+    }
+    // a caster's mana is never touched by Sapping Bite.
+    expect(player.resource).toBe(player.maxResource);
+  });
+
+  it('a friendly pet never drains its target (hostile guard)', () => {
+    const { sim, player, mob } = setup('rogue');
+    mob.hostile = false; // emulate a tamed pet swinging
+    player.resource = player.maxResource;
+    const sap = MOBS.mirejaw_the_ravenous.sapVigor!;
+    const old = sap.chance;
+    sap.chance = 1;
+    try {
+      for (let i = 0; i < 50; i++) { player.maxHp = KEEP_ALIVE; player.hp = KEEP_ALIVE; (sim as any).mobSwing(mob, player); }
+    } finally {
+      sap.chance = old;
+    }
+    expect(player.resource).toBe(player.maxResource);
+  });
+});

--- a/tests/mob_siphon_spirit.test.ts
+++ b/tests/mob_siphon_spirit.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// A mage so the victim is a mana user; level it up so Sister Nhalia's L12 elite
+// swing never one-shots it (death would clear the aura before we can read it).
+const makeSim = (cls: PlayerClass = 'mage') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(20);
+  return sim;
+};
+
+// Spawn Nhalia at the player's level so the hit table is even — an L12 elite
+// swinging at an L20 mage misses almost every time, and the on-hit affix only
+// fires on a connecting hit. The victim is set gm in the swing loops so her
+// elite swing can't kill it mid-test (death clears auras).
+const spawnNhalia = (sim: Sim) => {
+  const mob = createMob(990700, MOBS.sister_nhalia, sim.player.level, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Spirit regen tick mirror (updateRegen): mana recovers by spi/3 + 4 + lvl/5.
+const spiritRegen = (p: any) => Math.round(p.stats.spi / 3 + 4 + Math.floor(p.level / 5));
+
+// Swing until the Spirit Siphon (negative buff_spi) debuff lands (a swing can miss/dodge).
+const swingUntilSiphoned = (sim: Sim, mob: any, target: any, max = 300) => {
+  target.gm = true; // invulnerable so an elite swing can't kill it (applyAura still lands)
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_spi' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob Spirit Siphon (Sister Nhalia)', () => {
+  it('Sister Nhalia template carries the siphonSpirit mechanic', () => {
+    expect(MOBS.sister_nhalia.siphonSpirit).toBeDefined();
+    expect(MOBS.sister_nhalia.siphonSpirit!.name).toBe('Spirit Siphon');
+  });
+
+  it('a landed hit applies a negative buff_spi aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      expect(swingUntilSiphoned(sim, mob, player)).toBe(true);
+    } finally {
+      siphon.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_spi');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Spirit Siphon');
+    expect(aura!.value).toBe(-siphon.spi); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('shadow');
+  });
+
+  it('the siphon lowers Spirit and thus the out-of-combat mana regen rate', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const spiBefore = player.stats.spi;
+    const regenBefore = spiritRegen(player);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      swingUntilSiphoned(sim, mob, player);
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.stats.spi).toBe(spiBefore - siphon.spi);
+    expect(spiritRegen(player)).toBeLessThan(regenBefore);
+  });
+
+  it('Spirit is floored at 0 even if the drain exceeds the victim pool', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const oldChance = siphon.chance;
+    const oldSpi = siphon.spi;
+    siphon.chance = 1;
+    siphon.spi = 100000; // absurd drain
+    try {
+      swingUntilSiphoned(sim, mob, player);
+    } finally {
+      siphon.chance = oldChance;
+      siphon.spi = oldSpi;
+    }
+    expect(player.stats.spi).toBe(0);
+    expect(player.stats.spi).toBeGreaterThanOrEqual(0);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilSiphoned(sim, mob, player);
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_spi' && a.value < 0).length).toBe(1);
+  });
+
+  it('never siphons a non-mana victim (warrior uses rage)', () => {
+    const sim = makeSim('warrior');
+    const player = sim.player;
+    expect(player.resourceType).not.toBe('mana');
+    const mob = spawnNhalia(sim);
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_spi')).toBe(false);
+  });
+
+  it('a friendly pet never siphons its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnNhalia(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const siphon = MOBS.sister_nhalia.siphonSpirit!;
+    const old = siphon.chance;
+    siphon.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      siphon.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_spi' && a.value < 0)).toBe(false);
+  });
+});

--- a/tests/mob_stack_poison.test.ts
+++ b/tests/mob_stack_poison.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
+const AURA_ID = 'stackpoison_mirefen_broodmother';
+
+// Spawn the Broodmother adjacent to the player, level-matched so the hit table
+// is even (a big level gap would inflate her miss/dodge and starve the on-hit
+// roll). gm keeps the player alive through the swing loop; applyAura still lands.
+function spawnBroodmother(sim: Sim, id = 980001) {
+  const p = sim.entities.get(sim.playerId)!;
+  p.gm = true;
+  const mob = createMob(id, MOBS.mirefen_broodmother, p.level, { x: p.pos.x, y: p.pos.y, z: p.pos.z });
+  sim.entities.set(mob.id, mob);
+  return mob;
+}
+
+// mobSwing rolls the hit table, so a single swing may miss/dodge. Swing until
+// the poison reaches at least `stacks` applications (chance is forced to 1).
+function swingToStacks(sim: Sim, mob: any, target: any, stacks: number, tries = 200): boolean {
+  for (let i = 0; i < tries; i++) {
+    (sim as any).mobSwing(mob, target);
+    const a = target.auras.find((x: any) => x.id === AURA_ID);
+    if (a && (a.stacks ?? 1) >= stacks) return true;
+  }
+  return false;
+}
+
+describe('mob stacking poison (ramping on-hit DoT)', () => {
+  it('the Broodmother carries stackPoison data tuned to a capped nature DoT', () => {
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    expect(sp).toBeDefined();
+    expect(sp.school).toBe('nature');
+    expect(sp.chance).toBeGreaterThan(0);
+    expect(sp.perTick).toBeGreaterThan(0);
+    expect(sp.interval).toBeGreaterThan(0);
+    expect(sp.duration).toBeGreaterThan(sp.interval);
+    expect(sp.maxStacks).toBeGreaterThan(1);
+  });
+
+  it('a landed bite applies a one-stack poison DoT on the struck player', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    const mob = spawnBroodmother(sim);
+    const orig = sp.chance;
+    sp.chance = 1;
+    try {
+      expect(swingToStacks(sim, mob, player, 1)).toBe(true);
+    } finally {
+      sp.chance = orig;
+    }
+    const aura = player.auras.find((a) => a.id === AURA_ID)!;
+    expect(aura.kind).toBe('dot');
+    expect(aura.school).toBe('nature');
+    expect(aura.sourceId).toBe(mob.id);
+    expect(aura.stacks).toBe(1);
+    expect(aura.value).toBe(Math.round(sp.perTick));
+    expect(aura.remaining).toBeCloseTo(sp.duration);
+  });
+
+  it('repeated bites ramp the per-tick damage with the stack count, capped at maxStacks', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    const mob = spawnBroodmother(sim);
+    const orig = sp.chance;
+    sp.chance = 1;
+    try {
+      expect(swingToStacks(sim, mob, player, sp.maxStacks)).toBe(true);
+      // Keep biting past the cap — the stack count must not exceed maxStacks.
+      for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, player);
+    } finally {
+      sp.chance = orig;
+    }
+    const auras = player.auras.filter((a) => a.id === AURA_ID);
+    expect(auras.length).toBe(1); // one shared slot, never duplicated
+    const aura = auras[0];
+    expect(aura.stacks).toBe(sp.maxStacks);
+    expect(aura.value).toBe(Math.round(sp.perTick * sp.maxStacks));
+  });
+
+  it('the poison DoT ticks damage to the player over time', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    const sp = MOBS.mirefen_broodmother.stackPoison!;
+    const mob = spawnBroodmother(sim);
+    player.gm = false; // gm gates dealDamage, which the DoT tick routes through
+    player.maxHp = 5000;
+    player.hp = 5000;
+    const orig = sp.chance;
+    sp.chance = 1;
+    try {
+      expect(swingToStacks(sim, mob, player, 1)).toBe(true);
+    } finally {
+      sp.chance = orig;
+    }
+    // Park the mob far away so only the DoT (not swings) chips the player.
+    mob.pos = { x: player.pos.x + 500, y: player.pos.y, z: player.pos.z };
+    const before = player.hp;
+    for (let i = 0; i < 20 * 3; i++) sim.tick(); // 3s — at least one tick interval
+    expect(player.hp).toBeLessThan(before);
+  });
+
+  it('a non-poisonous mob (forest wolf) applies no stacking-poison aura', () => {
+    const sim = makeSim();
+    const player = sim.entities.get(sim.playerId)!;
+    player.gm = true;
+    const wolf = createMob(980050, MOBS.forest_wolf, player.level, { x: player.pos.x, y: player.pos.y, z: player.pos.z });
+    sim.entities.set(wolf.id, wolf);
+    for (let i = 0; i < 40; i++) (sim as any).mobSwing(wolf, player);
+    expect(player.auras.some((a) => a.id === AURA_ID)).toBe(false);
+  });
+});

--- a/tests/mob_tongues.test.ts
+++ b/tests/mob_tongues.test.ts
@@ -1,0 +1,108 @@
+// The Nhalia Mourners' funeral dirge ("Dirge of Tongues") can curse a caster on a
+// melee hit, stretching their spell cast times. Curse of Tongues is distinct from a
+// silence (a full spell lockout) and from slowStrike (melee swing speed): a cursed
+// victim still casts, just slower. It is read at cast-start, so it composes with the
+// already haste-resolved cast time.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'mage') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Nhalia Mourner adjacent to the player, hostile and ready to swing.
+function spawnMourner(sim: Sim, target: Entity): Entity {
+  const template = MOBS['nhalia_mourner'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+// Force a single landed swing (the curse chance is rolled per landed hit).
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob curse of tongues ("Dirge of Tongues")', () => {
+  it('seeds the tongues mechanic on the Nhalia Mourner', () => {
+    expect(MOBS['nhalia_mourner'].tongues).toEqual({
+      chance: 0.3, mult: 1.3, duration: 10, name: 'Dirge of Tongues', school: 'shadow',
+    });
+  });
+
+  it('applies a tongues aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnMourner(sim, p);
+    MOBS['nhalia_mourner'].tongues!.chance = 1; // deterministic for the test
+    swing(sim, mob, p);
+    MOBS['nhalia_mourner'].tongues!.chance = 0.3;
+    const aura = p.auras.find((a) => a.kind === 'tongues');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Dirge of Tongues');
+    expect(aura!.remaining).toBe(10);
+    expect(aura!.value).toBe(1.3);
+  });
+
+  // Point the player at a hostile, in-range, in-arc dummy so a hostile spell can begin.
+  function aimAt(sim: Sim, p: Entity): Entity {
+    const mob = spawnMourner(sim, { ...p, pos: { x: p.pos.x + 3, y: p.pos.y, z: p.pos.z } } as Entity);
+    mob.pos = { x: p.pos.x + 3, y: p.pos.y, z: p.pos.z };
+    mob.maxHp = 100000; mob.hp = 100000;
+    p.targetId = mob.id;
+    p.facing = Math.atan2(mob.pos.x - p.pos.x, mob.pos.z - p.pos.z);
+    return mob;
+  }
+
+  it('stretches a spell cast time while cursed', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    p.resource = p.maxResource;
+    aimAt(sim, p);
+    // Baseline cast time with no curse.
+    sim.castAbility('fireball', p.id);
+    const baseCast = p.castTotal;
+    expect(baseCast).toBeGreaterThan(0);
+    (sim as any).cancelCast(p);
+
+    // Apply the curse and recast — the cast time should be 30% longer.
+    p.auras.push({
+      id: 'tongues_nhalia_mourner', name: 'Dirge of Tongues', kind: 'tongues',
+      remaining: 10, duration: 10, value: 1.3, sourceId: 999, school: 'shadow',
+    });
+    p.gcdRemaining = 0;
+    sim.castAbility('fireball', p.id);
+    expect(p.castTotal).toBeCloseTo(baseCast * 1.3, 5);
+  });
+
+  it('does not block the cast outright (distinct from silence)', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    p.resource = p.maxResource;
+    aimAt(sim, p);
+    p.auras.push({
+      id: 'tongues_x', name: 'Dirge of Tongues', kind: 'tongues',
+      remaining: 10, duration: 10, value: 1.3, sourceId: 999, school: 'shadow',
+    });
+    sim.castAbility('fireball', p.id);
+    expect(p.castingAbility).toBe('fireball');
+  });
+
+  it('a friendly pet swing never curses an ally', () => {
+    const sim = makeSim('mage');
+    const p = sim.player;
+    const mob = spawnMourner(sim, p);
+    mob.hostile = false; // friendly (mobSwing's other caller)
+    MOBS['nhalia_mourner'].tongues!.chance = 1;
+    swing(sim, mob, p);
+    MOBS['nhalia_mourner'].tongues!.chance = 0.3;
+    expect(p.auras.find((a) => a.kind === 'tongues')).toBeUndefined();
+  });
+});

--- a/tests/mob_vulnerability.test.ts
+++ b/tests/mob_vulnerability.test.ts
@@ -1,0 +1,97 @@
+// Cursing mobs (e.g. the Gravecaller Cultist's "Curse of Frailty") can lay a
+// vulnerability hex on a melee hit: while it lingers the victim takes more
+// damage from EVERY source. It is the offensive mirror of Defensive Stance's
+// damage cut — a single multiplier read in dealDamage, no new resource math.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+function makeSim(playerClass: 'warrior' | 'mage' = 'warrior') {
+  return new Sim({ seed: 7, playerClass, autoEquip: true });
+}
+
+// Spawn a Gravecaller Cultist adjacent to the player, hostile and ready to swing.
+function spawnCultist(sim: Sim, target: Entity): Entity {
+  const template = MOBS['gravecaller_cultist'];
+  const mob = createMob((sim as any).nextId++, template, 12, { x: target.pos.x, y: target.pos.y, z: target.pos.z });
+  mob.hostile = true;
+  (sim as any).addEntity(mob);
+  return mob;
+}
+
+function swing(sim: Sim, mob: Entity, target: Entity) {
+  (sim as any).mobSwing(mob, target);
+}
+
+describe('mob vulnerability ("Curse of Frailty")', () => {
+  it('seeds the curse mechanic on the Gravecaller Cultist', () => {
+    expect(MOBS['gravecaller_cultist'].vulnerability).toEqual({
+      chance: 0.2, amp: 0.15, duration: 10, name: 'Curse of Frailty', school: 'shadow',
+    });
+  });
+
+  it('applies a vulnerability aura on a landed hit when it rolls', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 1; // deterministic
+    swing(sim, mob, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 0.2;
+    const aura = p.auras.find((a) => a.kind === 'vulnerability');
+    expect(aura).toBeTruthy();
+    expect(aura!.name).toBe('Curse of Frailty');
+    expect(aura!.remaining).toBe(10);
+    expect(aura!.value).toBe(0.15);
+  });
+
+  it('makes the cursed victim take more damage from any source', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000;
+
+    // Baseline: an uncursed 1000-damage hit removes exactly 1000.
+    p.hp = 100000;
+    (sim as any).dealDamage(null, p, 1000, false, 'physical', 'Test', 'hit', true);
+    expect(p.hp).toBe(99000);
+
+    // Cursed: the same hit is amplified by amp (0.15) → 1150 removed.
+    p.hp = 100000;
+    p.auras.push({
+      id: 'vulnerability_gravecaller_cultist', name: 'Curse of Frailty', kind: 'vulnerability',
+      remaining: 10, duration: 10, value: 0.15, sourceId: 999, school: 'shadow',
+    });
+    (sim as any).dealDamage(null, p, 1000, false, 'physical', 'Test', 'hit', true);
+    expect(p.hp).toBe(98850);
+  });
+
+  it('a friendly pet swinging never curses its ally', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    mob.hostile = false; // friendly pets route through mobSwing too
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 1;
+    swing(sim, mob, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 0.2;
+    expect(p.auras.find((a) => a.kind === 'vulnerability')).toBeUndefined();
+  });
+
+  it('refreshes rather than stacks a second curse from the same mob', () => {
+    const sim = makeSim();
+    const p = sim.player;
+    p.maxHp = 100000; p.hp = 100000;
+    const mob = spawnCultist(sim, p);
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 1;
+    swing(sim, mob, p);
+    const aura = p.auras.find((a) => a.kind === 'vulnerability')!;
+    aura.remaining = 3; // let it tick down
+    swing(sim, mob, p); // a second landed hit
+    MOBS['gravecaller_cultist'].vulnerability!.chance = 0.2;
+    const curses = p.auras.filter((a) => a.kind === 'vulnerability');
+    expect(curses).toHaveLength(1);
+    expect(curses[0].remaining).toBe(10); // timer fully refreshed, not doubled
+  });
+});

--- a/tests/mob_warcry.test.ts
+++ b/tests/mob_warcry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { Entity } from '../src/sim/types';
+
+const SEED = 41099;
+
+// Deepfen Snapper is the seeded carrier of the warcry (ally-haste) mechanic.
+const inner = (sim: Sim) => sim as unknown as {
+  addEntity(e: Entity): void;
+  updateBossMechanics(m: Entity): void;
+  resetEvadingMob(m: Entity): void;
+};
+
+function spawn(sim: Sim, id: number, tmpl: typeof MOBS[string]) {
+  const mob = createMob(id, tmpl, 9, { x: 0, y: 0, z: 0 });
+  mob.inCombat = true;
+  inner(sim).addEntity(mob);
+  return mob;
+}
+
+const HASTE = (e: Entity) => e.auras.find((a) => a.id === 'warcry_deepfen_murloc');
+
+describe('mob ally-haste (warcry)', () => {
+  it('seeds the mechanic on the Deepfen Snapper', () => {
+    expect(MOBS.deepfen_murloc.warcry).toEqual({
+      radius: 12, every: 10, hasteMult: 1.25, duration: 6, name: 'Tide Cadence', school: 'frost',
+    });
+  });
+
+  it('hastens a nearby ally once the pulse timer elapses', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9001, MOBS.deepfen_murloc);
+    const ally = spawn(sim, 9002, MOBS.deepfen_murloc);
+    ally.pos = { x: 5, y: 0, z: 0 };
+    // Telegraphed: createMob seeds warcryTimer to a full interval, so it takes
+    // `every` seconds (20 ticks/s) of in-combat updates before the first pulse.
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    const aura = HASTE(ally);
+    expect(aura).toBeDefined();
+    expect(aura!.kind).toBe('buff_haste');
+    expect(aura!.value).toBe(1.25);
+  });
+
+  it('does not pulse before the telegraphed first interval', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9011, MOBS.deepfen_murloc);
+    const ally = spawn(sim, 9012, MOBS.deepfen_murloc);
+    for (let i = 0; i < 20 * 9; i++) inner(sim).updateBossMechanics(caller); // 9s < 10s
+    expect(HASTE(ally)).toBeUndefined();
+  });
+
+  it('hastens every ally in range plus the caster (AoE), without stacking', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9021, MOBS.deepfen_murloc);
+    const a = spawn(sim, 9022, MOBS.deepfen_murloc);
+    a.pos = { x: 4, y: 0, z: 0 };
+    const b = spawn(sim, 9023, MOBS.deepfen_murloc);
+    b.pos = { x: 0, y: 0, z: 6 };
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(HASTE(a)).toBeDefined();
+    expect(HASTE(b)).toBeDefined();
+    expect(HASTE(caller)).toBeDefined(); // the caller drums up itself too
+    // a second pulse only refreshes the single aura — never a second copy
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(a.auras.filter((x) => x.id === 'warcry_deepfen_murloc')).toHaveLength(1);
+  });
+
+  it('ignores allies outside the radius', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9031, MOBS.deepfen_murloc);
+    const far = spawn(sim, 9032, MOBS.deepfen_murloc);
+    far.pos = { x: 100, y: 0, z: 0 }; // well beyond radius 12
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(HASTE(far)).toBeUndefined();
+  });
+
+  it('does not buff mobs of the opposing faction (players/pets excluded by faction)', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9041, MOBS.deepfen_murloc);
+    const friendlyMob = spawn(sim, 9042, MOBS.deepfen_murloc);
+    friendlyMob.hostile = false; // flip faction
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(caller);
+    expect(HASTE(friendlyMob)).toBeUndefined();
+  });
+
+  it('re-arms the telegraph after the caller evades and resets', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const caller = spawn(sim, 9051, MOBS.deepfen_murloc);
+    inner(sim).resetEvadingMob(caller);
+    expect(caller.warcryTimer).toBe(MOBS.deepfen_murloc.warcry!.every);
+  });
+
+  it('leaves mobs without the mechanic untouched', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior', noPlayer: true });
+    const cultist = spawn(sim, 9061, MOBS.gravecaller_cultist);
+    const ally = spawn(sim, 9062, MOBS.deepfen_murloc);
+    for (let i = 0; i < 20 * 10 + 1; i++) inner(sim).updateBossMechanics(cultist);
+    expect(ally.auras.some((a) => a.kind === 'buff_haste')).toBe(false);
+  });
+});

--- a/tests/mob_wither.test.ts
+++ b/tests/mob_wither.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import type { PlayerClass } from '../src/sim/types';
+
+const SEED = 42;
+// A mage victim at the troll's own level: low melee avoidance and no level gap, so
+// the troll's swings land reliably (a big level gap would inflate miss/dodge and the
+// on-hit roll would rarely fire). We top hp up each swing so a hit never kills.
+const makeSim = (cls: PlayerClass = 'mage') => {
+  const sim = new Sim({ seed: SEED, playerClass: cls, autoEquip: true });
+  sim.setPlayerLevel(12);
+  return sim;
+};
+
+const spawnTroll = (sim: Sim) => {
+  const mob = createMob(990700, MOBS.fen_troll, 12, { x: 0, y: 0, z: 0 });
+  sim.entities.set(mob.id, mob);
+  return mob;
+};
+
+// Swing until the Withering Rot buff_agi debuff lands (a swing can miss/dodge).
+const swingUntilWithered = (sim: Sim, mob: any, target: any, max = 300) => {
+  for (let i = 0; i < max; i++) {
+    target.hp = target.maxHp; // top up so a hit never kills (death clears auras)
+    (sim as any).mobSwing(mob, target);
+    if (target.auras.some((a: any) => a.kind === 'buff_agi' && a.value < 0)) return true;
+  }
+  return false;
+};
+
+describe('mob withering curse (Withering Rot)', () => {
+  it('Mirefen Troll template carries the wither mechanic', () => {
+    expect(MOBS.fen_troll.wither).toBeDefined();
+    expect(MOBS.fen_troll.wither!.name).toBe('Withering Rot');
+  });
+
+  it('a landed hit applies a negative buff_agi aura with the template values', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    const wither = MOBS.fen_troll.wither!;
+    const old = wither.chance;
+    wither.chance = 1;
+    try {
+      expect(swingUntilWithered(sim, mob, player)).toBe(true);
+    } finally {
+      wither.chance = old;
+    }
+    const aura = player.auras.find((a) => a.kind === 'buff_agi');
+    expect(aura).toBeDefined();
+    expect(aura!.name).toBe('Withering Rot');
+    expect(aura!.value).toBe(-wither.agi); // stored negative
+    expect(aura!.sourceId).toBe(mob.id);
+    expect(aura!.school).toBe('nature');
+  });
+
+  it('the curse lowers the victim Agility and thins their armor', () => {
+    // A rogue has ample base Agility, so the drain lands without flooring at 0.
+    // Apply the aura through the normal path (recalcPlayerStats runs on apply).
+    const sim = makeSim('rogue');
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    const agiBefore = player.stats.agi;
+    const armorBefore = player.stats.armor;
+    const wither = MOBS.fen_troll.wither!;
+    expect(agiBefore).toBeGreaterThan(wither.agi); // precondition: no floor
+    (sim as any).applyAura(player, {
+      id: `wither_${mob.templateId}`, name: wither.name, kind: 'buff_agi',
+      remaining: wither.duration, duration: wither.duration,
+      value: -wither.agi, sourceId: mob.id, school: 'nature',
+    });
+    expect(player.stats.agi).toBe(agiBefore - wither.agi);
+    // Agility feeds armor at 2 per point, so the drain shaves it too.
+    expect(player.stats.armor).toBe(armorBefore - wither.agi * 2);
+  });
+
+  it('refreshes a single shared slot instead of stacking', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    const wither = MOBS.fen_troll.wither!;
+    const old = wither.chance;
+    wither.chance = 1;
+    try {
+      for (let i = 0; i < 5; i++) swingUntilWithered(sim, mob, player);
+    } finally {
+      wither.chance = old;
+    }
+    expect(player.auras.filter((a) => a.kind === 'buff_agi' && a.value < 0).length).toBe(1);
+  });
+
+  it('a friendly pet never curses its target (hostile guard)', () => {
+    const sim = makeSim();
+    const player = sim.player;
+    const mob = spawnTroll(sim);
+    mob.hostile = false; // emulate a tamed pet swinging through mobSwing
+    const wither = MOBS.fen_troll.wither!;
+    const old = wither.chance;
+    wither.chance = 1;
+    try {
+      for (let i = 0; i < 80; i++) { player.hp = player.maxHp; (sim as any).mobSwing(mob, player); }
+    } finally {
+      wither.chance = old;
+    }
+    expect(player.auras.some((a) => a.kind === 'buff_agi' && a.value < 0)).toBe(false);
+  });
+});


### PR DESCRIPTION
Consolidates fourteen independent zone2 (Mirefen Marsh / Gravecaller / Nhalia) mob-affix PRs into one branch to cut merge-conflict churn on the shared `src/sim/sim.ts`, `src/sim/types.ts`, `src/ui/hud.ts`, `src/ui/icons.ts` and i18n files. All conflicts were additive (the `AuraKind` union, `MobTemplate` fields, the `isDebuff` list, on-hit blocks) — resolved by union, never dropping a feature. No new `tsc` errors; 77 affix tests + sim/localization guards all green.

Folds in:
- #503 Bog Rot · #504 Curse of Frailty · #515 Weakening Hex · #517 Curse of Tongues
- #523 Withering Rot · #525 Draining Litany · #527 Grave Blight (heal-absorb) · #541 Profane Rune (arcane DoT)
- #543 Find Weakness (crit-vuln) · #544 Spirit Siphon · #549 Devour Magic · #555 Brood Venom (stacking)
- #561 Tide Cadence (ally haste) · #562 Sapping Bite

🤖 Generated with [Claude Code](https://claude.com/claude-code)