### PR TITLE
feat(ui): add resizable bags window (desktop only)

### DIFF
--- a/index.html
+++ b/index.html
@@ -950,22 +950,48 @@
   .vendor-empty { padding: 5px; font-size: 11px; color: #887c5c; }
   .vendor-hint { font-size: 11px; color: #c8b888; margin-top: 8px; border-top: 1px solid #463a1c; padding-top: 6px; }
 
-  /* bags — centred in the bottom gap between the action cluster and micro-menu */
+  /* bags: center-right by default, then freely draggable and resizable */
   #bags {
-    --bags-bar-half: 306px;
-    --bags-gap: 12px;
-    --bags-micro-r: calc(16px + 34px + var(--bags-gap));
-    --bags-slot-w: max(180px, calc(100vw - 50% - var(--bags-bar-half) - var(--bags-gap) - var(--bags-micro-r)));
-    left: calc((100% + 50% + var(--bags-bar-half) + var(--bags-gap) - var(--bags-micro-r)) / 2);
+    left: 72%;
     right: auto;
-    bottom: 6px;
-    top: auto;
-    width: min(310px, var(--bags-slot-w));
-    transform: translateX(-50%);
-    max-height: calc(100vh - 18px);
+    top: 50%;
+    bottom: auto;
+    width: min(310px, calc(100vw - 32px));
+    height: min(300px, calc(100vh - 32px));
+    min-height: min(220px, calc(100vh - 32px));
+    transform: translate(-50%, -50%);
+    max-height: calc(100vh - 32px);
     overflow: hidden;
     flex-direction: column;
   }
+  #bags.bag-user-sized {
+    height: min(var(--bags-user-height), calc(100vh - 16px));
+    min-height: min(112px, calc(100vh - 16px));
+  }
+  #bags.bag-resizing { cursor: ns-resize; }
+  #bags .bag-resize-handle {
+    position: absolute;
+    left: 50%;
+    top: 0;
+    width: 48px;
+    height: 12px;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #9a8250;
+    cursor: ns-resize;
+    touch-action: none;
+    z-index: 2;
+  }
+  #bags .bag-resize-handle::before {
+    content: "";
+    width: 26px;
+    height: 3px;
+    border-top: 1px solid currentColor;
+    border-bottom: 1px solid currentColor;
+  }
+  #bags .bag-resize-handle:hover { color: var(--gold); }
   #bags .panel-title { flex: none; }
   #bags .bag-grid { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
   #bags .money { flex: none; }
@@ -4420,6 +4446,8 @@
     bottom: calc(72px + env(safe-area-inset-bottom));
     width: auto;
     transform: none;
+    height: auto;
+    min-height: 0;
     max-height: none;
     box-sizing: border-box;
     overflow: hidden;
@@ -4427,6 +4455,9 @@
   }
   body.mobile-touch #bags .bag-grid {
     min-height: 150px;
+  }
+  body.mobile-touch #bags .bag-resize-handle {
+    display: none;
   }
   body.mobile-touch .vendor-item,
   body.mobile-touch .bag-item,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -163,6 +163,9 @@ const DEFAULT_EMOTE_WHEEL: OverheadEmoteId[] = ['wave', 'laugh', 'question', 'ch
 // yards past a zone boundary before the crossing banner/welcome commits
 const ZONE_BANNER_DEADBAND = 5;
 const IGNORED_CHAT_NAMES_KEY = 'woc_ignored_chat_names';
+const BAGS_HEIGHT_KEY = 'woc_bags_height';
+const BAGS_MIN_HEIGHT = 112;
+const BAGS_VIEWPORT_MARGIN = 8;
 const BIND_CATEGORY_LABEL_KEYS: Partial<Record<string, TranslationKey>> = {
   Movement: 'hud.keybinds.categories.movement',
   Targeting: 'hud.keybinds.categories.targeting',
@@ -358,6 +361,7 @@ export class Hud {
     this.meters = new Meters(sim);
     this.bindLogTabs();
     this.initWindowManagement();
+    this.restoreBagHeight();
     this.emoteWheelSlots = this.loadEmoteWheelSlots();
     this.loadSlotMap();
     this.buildActionBar();
@@ -679,6 +683,76 @@ export class Hud {
     el.style.right = 'auto';
     el.style.bottom = 'auto';
     el.style.transform = 'none';
+  }
+
+  private restoreBagHeight(): void {
+    let stored: number | null = null;
+    try {
+      const raw = localStorage.getItem(BAGS_HEIGHT_KEY);
+      if (raw !== null) stored = Number(raw);
+    } catch { /* storage unavailable */ }
+    if (stored === null || !Number.isFinite(stored) || stored <= 0) return;
+    this.applyBagHeight($('#bags'), stored);
+  }
+
+  private bagHeightBounds(el: HTMLElement): { min: number; max: number } {
+    const rect = el.getBoundingClientRect();
+    const bottom = rect.height > 0
+      ? Math.min(window.innerHeight - BAGS_VIEWPORT_MARGIN, rect.bottom)
+      : window.innerHeight - BAGS_VIEWPORT_MARGIN;
+    const max = Math.max(1, Math.round(bottom - BAGS_VIEWPORT_MARGIN));
+    return { min: Math.min(BAGS_MIN_HEIGHT, max), max };
+  }
+
+  private applyBagHeight(el: HTMLElement, height: number, persist = false): void {
+    const { min, max } = this.bagHeightBounds(el);
+    const clamped = Math.round(Math.max(min, Math.min(max, height)));
+    el.style.setProperty('--bags-user-height', `${clamped}px`);
+    el.classList.add('bag-user-sized');
+    if (persist) {
+      try { localStorage.setItem(BAGS_HEIGHT_KEY, String(clamped)); } catch { /* storage unavailable */ }
+    }
+  }
+
+  private bindBagResizeHandle(el: HTMLElement): void {
+    const handle = el.querySelector<HTMLElement>('.bag-resize-handle');
+    if (!handle) return;
+
+    let resize: { pointerId: number; startY: number; startHeight: number } | null = null;
+    const anchorBottom = () => {
+      const rect = el.getBoundingClientRect();
+      el.style.top = 'auto';
+      el.style.bottom = `${Math.max(BAGS_VIEWPORT_MARGIN, window.innerHeight - rect.bottom)}px`;
+      return rect;
+    };
+    const finishResize = (ev: PointerEvent) => {
+      if (!resize || resize.pointerId !== ev.pointerId) return;
+      resize = null;
+      el.classList.remove('bag-resizing');
+      try { handle.releasePointerCapture(ev.pointerId); } catch { /* capture already released */ }
+      const height = el.getBoundingClientRect().height;
+      this.applyBagHeight(el, height, true);
+    };
+
+    handle.addEventListener('pointerdown', (ev) => {
+      if (ev.button !== 0 || document.body.classList.contains('mobile-touch')) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      this.hideTooltip();
+      this.bringWindowToFront(el);
+      const rect = anchorBottom();
+      resize = { pointerId: ev.pointerId, startY: ev.clientY, startHeight: rect.height };
+      el.classList.add('bag-resizing');
+      handle.setPointerCapture(ev.pointerId);
+    });
+    handle.addEventListener('pointermove', (ev) => {
+      if (!resize || resize.pointerId !== ev.pointerId) return;
+      ev.preventDefault();
+      this.applyBagHeight(el, resize.startHeight - (ev.clientY - resize.startY));
+    });
+    handle.addEventListener('pointerup', finishResize);
+    handle.addEventListener('pointercancel', finishResize);
+    handle.addEventListener('lostpointercapture', finishResize);
   }
 
   private topmostOpenWindow(): HTMLElement | null {
@@ -3952,7 +4026,7 @@ export class Hud {
 
   toggleBags(): void {
     const el = $('#bags');
-    if (el.style.display !== 'none') { el.style.display = 'none'; this.hideTooltip(); audio.bagClose(); this.cancelPetFeed(); return; }
+    if (this.isWindowVisible(el)) { el.style.display = 'none'; this.hideTooltip(); audio.bagClose(); this.cancelPetFeed(); return; }
     this.closeOtherWindows('#bags');
     this.renderBags();
     el.style.display = 'flex';
@@ -3974,7 +4048,14 @@ export class Hud {
   renderBags(): void {
     const el = $('#bags');
     const sim = this.sim;
-    el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.bags.title'))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.bags.close'))}">${svgIcon('close')}</button></div>`;
+    const previousGrid = el.querySelector<HTMLElement>('.bag-grid');
+    const previousScrollRange = previousGrid
+      ? Math.max(0, previousGrid.scrollHeight - previousGrid.clientHeight)
+      : 0;
+    const previousScrollProgress = previousGrid && previousScrollRange > 0
+      ? Math.min(1, Math.max(0, previousGrid.scrollTop / previousScrollRange))
+      : 0;
+    el.innerHTML = `<div class="bag-resize-handle" aria-hidden="true"></div><div class="panel-title"><span>${esc(t('itemUi.bags.title'))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.bags.close'))}">${svgIcon('close')}</button></div>`;
     const grid = document.createElement('div');
     grid.className = 'bag-grid';
     if (sim.inventory.length === 0) {
@@ -4054,6 +4135,9 @@ export class Hud {
     money.className = 'money';
     money.innerHTML = this.moneyHtml(sim.copper);
     el.appendChild(money);
+    const nextScrollRange = Math.max(0, grid.scrollHeight - grid.clientHeight);
+    grid.scrollTop = previousScrollProgress * nextScrollRange;
+    this.bindBagResizeHandle(el);
     el.querySelector('[data-close]')?.addEventListener('click', () => {
       if (this.vendorOpen && document.body.classList.contains('mobile-touch')) {
         this.closeVendor();

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -71,6 +71,12 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch.game-active *::-webkit-scrollbar:horizontal {\n    height: 0;\n    display: none;');
   });
 
+  it('preserves bag scroll progress when inventory updates redraw the list', () => {
+    expect(hudTs).toContain("const previousGrid = el.querySelector<HTMLElement>('.bag-grid');");
+    expect(hudTs).toContain('previousGrid.scrollTop / previousScrollRange');
+    expect(hudTs).toContain('grid.scrollTop = previousScrollProgress * nextScrollRange;');
+  });
+
   it('suppresses mobile in-game text selection and touch callouts without blocking inputs', () => {
     expect(html).toContain('body.mobile-touch.game-active #mobile-controls *,\n  body.mobile-touch.game-active #bottom-bar,');
     expect(html).toContain('body.mobile-touch.game-active .mobile-btn {\n    user-select: none;\n    -webkit-user-select: none;\n    -webkit-touch-callout: none;');
@@ -293,6 +299,13 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch #bags .bag-grid {\n    min-height: 150px;');
     expect(html).not.toContain('body.mobile-touch #bags {\n    position: fixed;\n    left: 10px;\n    right: 10px;\n    bottom: 10px;');
     expect(html).not.toContain('max-height: calc(38vh - 20px);');
+  });
+
+  it('opens desktop Bags at a useful center-right size', () => {
+    expect(html).toContain('left: 72%;\n    right: auto;\n    top: 50%;\n    bottom: auto;');
+    expect(html).toContain('height: min(300px, calc(100vh - 32px));');
+    expect(html).toContain('min-height: min(220px, calc(100vh - 32px));');
+    expect(html).toContain('transform: translate(-50%, -50%);');
   });
 
   it('combines Trader and Bags into a mobile split-pane modal', () => {


### PR DESCRIPTION
```markdown
## Summary

Adds desktop-only resizing and internal scrolling to the bag window.

- Adds a mouse/pointer resize handle at the top of the bag window.
- Keeps the title and money display fixed while bag contents scroll.
- Persists the selected height in local storage.
- Clamps the height within the viewport.
- Preserves the existing mobile/touch bag layout.
- Cleans up the resizing state if pointer capture is interrupted.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npm test`: 1,487 passed, 7 skipped
  - `npx tsc --noEmit`: passed
  - `npm run build`: passed

- Manual steps:
  - Opened the Bags window in the local offline client.
  - Resized it by dragging the handle with the pointer.
  - Verified the minimum and maximum viewport bounds.
  - Verified bag contents use internal vertical scrolling.

## Screenshots / recordings

Desktop screenshot attached.

<img width="1913" height="1029" alt="image" src="https://github.com/user-attachments/assets/5b6a9365-ac57-43c8-87fc-73d38c78872e" />


The mobile layout is intentionally unchanged and does not expose bag resizing.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. No simulation or server behavior was changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` passes. Server and headless builds are not applicable.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Desktop behavior was manually verified. Phone-sized portrait and landscape testing should be completed before merge.
- [ ] **Accessible.** The resize interaction is intentionally pointer-only and hidden from the accessibility tree.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` files were committed, and `ALLOW_DEV_COMMANDS` was not enabled.
- [x] Generated localization files were regenerated using the project scripts rather than edited manually.
```