### PR TITLE
fix(ui): improve mobile menu panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -4455,6 +4455,46 @@
     max-height: calc(100vh - 92px);
     transform: translateX(-50%);
   }
+  body.mobile-touch.vendor-open #vendor-window,
+  body.mobile-touch.vendor-open #bags {
+    position: fixed;
+    top: max(10px, env(safe-area-inset-top));
+    bottom: calc(72px + env(safe-area-inset-bottom));
+    width: auto;
+    max-width: none;
+    max-height: none;
+    transform: none;
+    box-sizing: border-box;
+    z-index: 95;
+  }
+  body.mobile-touch.vendor-open #vendor-window {
+    left: max(10px, env(safe-area-inset-left));
+    right: 50vw;
+    display: block;
+    overflow-y: auto;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right-width: 1px;
+  }
+  body.mobile-touch.vendor-open #bags {
+    left: 50vw;
+    right: max(10px, env(safe-area-inset-right));
+    overflow: hidden;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 0;
+  }
+  body.mobile-touch.vendor-open #vendor-window .panel-title,
+  body.mobile-touch.vendor-open #bags .panel-title {
+    height: 47px;
+    min-height: 47px;
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+    box-sizing: border-box;
+  }
+  body.mobile-touch.vendor-open #vendor-window .panel-title .x-btn {
+    display: none;
+  }
   body.mobile-touch #spellbook,
   body.mobile-touch #options-menu {
     left: 50%;
@@ -5122,6 +5162,7 @@
     margin: 0;
     overflow: visible;
   }
+  body.mobile-touch #charselect-panel #charselect-class-details,
   body.mobile-touch #charselect-panel #online-class-details {
     flex: 1 1 auto;
     width: 100%;
@@ -5131,10 +5172,12 @@
     margin-bottom: 0;
     overflow: visible;
   }
+  body.mobile-touch #charselect-panel #charselect-class-details .class-details-content,
   body.mobile-touch #charselect-panel #online-class-details .class-details-content {
     min-height: 100%;
     height: auto;
   }
+  body.mobile-touch #charselect-panel #charselect-class-details .class-details-grid,
   body.mobile-touch #charselect-panel #online-class-details .class-details-grid {
     display: flex;
     flex-direction: column;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -699,7 +699,10 @@ export class Hud {
       case 'vendor-window': this.closeVendor(); break;
       case 'loot-window': this.closeLoot(); break;
       case 'quest-dialog': this.closeQuestDialog(); break;
-      case 'bags': el.style.display = 'none'; this.hideTooltip(); this.cancelPetFeed(); break;
+      case 'bags':
+        if (this.vendorOpen && document.body.classList.contains('mobile-touch')) this.closeVendor();
+        else { el.style.display = 'none'; this.hideTooltip(); this.cancelPetFeed(); }
+        break;
       case 'talents-window': el.style.display = 'none'; this.talentStage = null; this.hideTooltip(); break;
       case 'emote-editor': this.closeEmoteEditor(); break;
       default: el.style.display = 'none'; this.hideTooltip(); break;
@@ -3610,7 +3613,7 @@ export class Hud {
       row.innerHTML = `${this.itemIcon(item)}<span class="vi-name">${esc(itemName)}${s.count > 1 ? ` x${s.count}` : ''}</span><span class="vi-price">${this.moneyHtml(item.sellValue)}</span>`;
       row.addEventListener('click', () => {
         this.sim.buyBackItem(s.itemId);
-        if ($('#bags').style.display === 'block') this.renderBags();
+        if ($('#bags').style.display !== 'none') this.renderBags();
         this.renderVendor();
       });
       this.attachTooltip(row, () => this.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuyback'))}</div>`);
@@ -3626,11 +3629,17 @@ export class Hud {
   }
 
   closeVendor(): void {
+    const closeMobileBags = document.body.classList.contains('mobile-touch') && $('#bags').style.display !== 'none';
     $('#vendor-window').style.display = 'none';
     this.openVendorNpcId = null;
     document.body.classList.remove('vendor-open'); // bags (if still open) re-centres
     this.hideTooltip();
-    if ($('#bags').style.display !== 'none') this.renderBags();
+    if (closeMobileBags) {
+      $('#bags').style.display = 'none';
+      this.cancelPetFeed();
+    } else if ($('#bags').style.display !== 'none') {
+      this.renderBags();
+    }
   }
 
   get vendorOpen(): boolean {
@@ -3990,7 +3999,15 @@ export class Hud {
     money.className = 'money';
     money.innerHTML = this.moneyHtml(sim.copper);
     el.appendChild(money);
-    el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); this.cancelPetFeed(); });
+    el.querySelector('[data-close]')?.addEventListener('click', () => {
+      if (this.vendorOpen && document.body.classList.contains('mobile-touch')) {
+        this.closeVendor();
+        return;
+      }
+      el.style.display = 'none';
+      this.hideTooltip();
+      this.cancelPetFeed();
+    });
   }
 
   private sellBagItem(slot: InvSlot, ev: MouseEvent): void {

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -149,6 +149,11 @@ describe('client HTML shell', () => {
     expect(mainTs).not.toContain("visualViewport?.addEventListener('scroll', syncAppViewport)");
   });
 
+  it('stacks selected character details on mobile', () => {
+    expect(html).toContain('id="charselect-class-details"');
+    expect(html).toContain('body.mobile-touch #charselect-panel #charselect-class-details .class-details-grid,\n  body.mobile-touch #charselect-panel #online-class-details .class-details-grid {\n    display: flex;\n    flex-direction: column;');
+  });
+
   it('lays out mobile More tray buttons horizontally', () => {
     expect(html).toContain('<div id="mobile-extra-controls" class="window panel" role="dialog" aria-modal="true" aria-labelledby="mobile-more-title">');
     expect(html).toContain('<div class="panel-title">');
@@ -282,6 +287,16 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch #bags .bag-grid {\n    min-height: 150px;');
     expect(html).not.toContain('body.mobile-touch #bags {\n    position: fixed;\n    left: 10px;\n    right: 10px;\n    bottom: 10px;');
     expect(html).not.toContain('max-height: calc(38vh - 20px);');
+  });
+
+  it('combines Trader and Bags into a mobile split-pane modal', () => {
+    expect(html).toContain('body.mobile-touch.vendor-open #vendor-window,\n  body.mobile-touch.vendor-open #bags {\n    position: fixed;\n    top: max(10px, env(safe-area-inset-top));\n    bottom: calc(72px + env(safe-area-inset-bottom));');
+    expect(html).toContain('body.mobile-touch.vendor-open #vendor-window {\n    left: max(10px, env(safe-area-inset-left));\n    right: 50vw;');
+    expect(html).toContain('body.mobile-touch.vendor-open #bags {\n    left: 50vw;\n    right: max(10px, env(safe-area-inset-right));');
+    expect(html).toContain('body.mobile-touch.vendor-open #vendor-window .panel-title,\n  body.mobile-touch.vendor-open #bags .panel-title {\n    height: 47px;\n    min-height: 47px;');
+    expect(html).toContain('body.mobile-touch.vendor-open #vendor-window .panel-title .x-btn {\n    display: none;');
+    expect(hudTs).toContain("if (this.vendorOpen && document.body.classList.contains('mobile-touch')) this.closeVendor();");
+    expect(hudTs).toContain("const closeMobileBags = document.body.classList.contains('mobile-touch') && $('#bags').style.display !== 'none';");
   });
 
   it('keeps the expanded mobile More tray inside the viewport', () => {


### PR DESCRIPTION
## Summary

Mobile UI fixes for the homepage menu and in-game trader flow:

1. Fixes the selected-character details regression on mobile by stacking Starting Stats and Equipment vertically against the current `#charselect-class-details` panel.
2. Combines the mobile Trader and Bags windows into a single split-pane modal while a vendor is open: Trader on the left, Bags on the right.
3. Uses one close button on the Bags pane for the combined mobile trader modal and aligns both pane heading bars so their dividers line up.
4. Keeps desktop vendor and bag behavior unchanged.

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/client_shell.test.ts` -> 26 passed.
- `npx tsc --noEmit` -> clean.
- Local Chrome mobile layout checks:
  - Selected character details compute to a vertical column on mobile portrait.
  - Trader/Bags split pane has no overlap or overflow in mobile portrait or landscape.
  - Trader/Bags title bars both measure 47px; only the Bags close button is visible.

---

## Checklist

- [x] Tests pass for the focused mobile shell coverage.
- [x] Typecheck passes.
- [x] No secrets / `.env`; `ALLOW_DEV_COMMANDS` not enabled anywhere.
- [x] No generated files were hand-edited.