### PR TITLE
fix(input): make mobile jump taps reliable

### DIFF
--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -13,6 +13,7 @@ import type { MoveInput } from '../sim/types';
 const BASE_LOOK_SENS = 0.0045;
 const TOUCH_LOOK_YAW_RATE = 3.2;
 const TOUCH_LOOK_PITCH_RATE = 2.2;
+const TOUCH_JUMP_LATCH_MS = 220;
 const CAMERA_DRAG_START_DISTANCE = 18;
 const CAMERA_DRAG_START_MS = 140;
 
@@ -101,7 +102,7 @@ export class Input {
   // was BASE_LOOK_SENS — setCameraSpeed scales it from the settings menu
   private lookSensitivity = BASE_LOOK_SENS;
   private touchMove: TouchMoveInput = { forward: false, back: false, strafeLeft: false, strafeRight: false };
-  private touchJump = false;
+  private touchJumpUntil = 0;
   private touchLookActive = false;
   private touchLookVector = { x: 0, y: 0 };
   // multiplier on the touch look (camera joystick) rate; setTouchLookSpeed
@@ -252,11 +253,11 @@ export class Input {
     if (changed) this.noteIntent('move');
   }
 
-  // A touch jump is momentary: the on-screen button arms this flag and the next
-  // readMoveInput() poll consumes it, yielding a single frame of jump=true (the
-  // sim only launches when grounded, so one frame is enough — same as a Space tap).
+  // A touch jump is momentary, but readMoveInput() is also used by camera/HUD
+  // helpers between sim ticks. Latch the tap briefly so those reads cannot eat
+  // the jump before the grounded movement tick sees it.
   triggerTouchJump(): void {
-    this.touchJump = true;
+    this.touchJumpUntil = Math.max(this.touchJumpUntil, performance.now() + TOUCH_JUMP_LATCH_MS);
   }
 
   // Touch-reachable autorun toggle (the keyboard path is the 'autorun' edge action).
@@ -567,8 +568,7 @@ export class Input {
     const forward = held('forward') || bothButtons || this.autorun || this.touchMove.forward;
     const back = held('back') || this.touchMove.back;
     // Jump is not a WASD key, so it keeps working in Attack Move mode.
-    const jump = this.keybinds.codesForAction('jump').some((c) => k.has(c)) || this.touchJump;
-    this.touchJump = false;
+    const jump = this.keybinds.codesForAction('jump').some((c) => k.has(c)) || performance.now() <= this.touchJumpUntil;
 
     if (this.mouseCameraEnabled) {
       return {

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -209,7 +209,7 @@ export class MobileControls {
     });
 
     this.bindButton('mobile-attack-nearest', () => this.callbacks.onAttackNearest());
-    this.bindButton('mobile-jump', () => this.callbacks.onJump());
+    this.bindButton('mobile-jump', () => this.callbacks.onJump(), { pressFirst: true });
     this.bindButton('mobile-target', () => this.callbacks.onTarget());
     this.bindButton('mobile-interact', () => this.callbacks.onInteract());
     this.bindButton('mobile-chat', () => this.toggleChat());
@@ -270,9 +270,10 @@ export class MobileControls {
     }
   }
 
-  private bindButton(id: string, cb: () => void): void {
+  private bindButton(id: string, cb: () => void, opts: { pressFirst?: boolean } = {}): void {
     const button = document.getElementById(id);
-    button?.addEventListener('click', (e) => {
+    if (!button) return;
+    const run = (e: Event) => {
       if (!this.active) return;
       e.preventDefault();
       triggerHaptic(HAPTIC_TAP, this.hapticsOn);
@@ -280,7 +281,25 @@ export class MobileControls {
         this.closeMoreModal();
       }
       cb();
-    });
+    };
+    if (opts.pressFirst) {
+      let suppressNextClick = false;
+      button.addEventListener('pointerdown', (e) => {
+        suppressNextClick = true;
+        globalThis.setTimeout(() => { suppressNextClick = false; }, 700);
+        run(e);
+      });
+      button.addEventListener('click', (e) => {
+        if (suppressNextClick) {
+          suppressNextClick = false;
+          e.preventDefault();
+          return;
+        }
+        run(e);
+      });
+      return;
+    }
+    button.addEventListener('click', run);
   }
 
   private closeMoreModal(): void {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -454,12 +454,18 @@ describe('touch jump', () => {
     expect(input.readMoveInput().jump).toBe(false);
   });
 
-  it('triggerTouchJump yields exactly one frame of jump', () => {
+  it('triggerTouchJump latches briefly so non-sim movement reads cannot consume it', () => {
     const { input } = makeInput();
+    const now = vi.spyOn(performance, 'now');
+    now.mockReturnValue(1000);
     input.triggerTouchJump();
     expect(input.readMoveInput().jump).toBe(true);
-    // momentary: a single poll consumes it so it cannot stick on like a held key
+    expect(input.readMoveInput().jump).toBe(true);
+    now.mockReturnValue(1219);
+    expect(input.readMoveInput().jump).toBe(true);
+    now.mockReturnValue(1221);
     expect(input.readMoveInput().jump).toBe(false);
+    now.mockRestore();
   });
 });
 

--- a/tests/mobile_controls.test.ts
+++ b/tests/mobile_controls.test.ts
@@ -221,6 +221,7 @@ function installMobileControlDom(): {
   moveZone: FakeElement;
   moveJoystick: FakeElement;
   cameraJoystick: FakeElement;
+  jumpButton: FakeElement;
   emoteButton: FakeElement;
   windowTarget: EventTarget;
 } {
@@ -232,6 +233,7 @@ function installMobileControlDom(): {
     ['mobile-move-stick', new FakeElement()],
     ['mobile-camera-joystick', new FakeElement()],
     ['mobile-camera-stick', new FakeElement()],
+    ['mobile-jump', new FakeElement()],
     ['mobile-emote', new FakeElement()],
   ]);
   const body = new FakeElement();
@@ -256,6 +258,7 @@ function installMobileControlDom(): {
     moveZone: elements.get('mobile-move-zone')!,
     moveJoystick: elements.get('mobile-move-joystick')!,
     cameraJoystick: elements.get('mobile-camera-joystick')!,
+    jumpButton: elements.get('mobile-jump')!,
     emoteButton: elements.get('mobile-emote')!,
     windowTarget,
   };
@@ -363,6 +366,26 @@ describe('MobileControls pointer lifecycle', () => {
     emoteButton.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
 
     expect(emotes).toBe(1);
+  });
+
+  it('fires the Jump callback immediately on pointerdown without double-firing the generated click', () => {
+    const { jumpButton } = installMobileControlDom();
+    const input = {
+      setTouchMove: () => {},
+      clearTouchMove: () => {},
+      setTouchLook: () => {},
+      setTouchLookVector: () => {},
+    } as unknown as Input;
+
+    let jumps = 0;
+    const callbacks = { ...mobileCallbacks(), onJump: () => { jumps += 1; } };
+    new MobileControls(input, callbacks).start();
+
+    jumpButton.dispatchEvent(pointerEvent('pointerdown', { pointerId: 30, pointerType: 'touch' }));
+    expect(jumps).toBe(1);
+
+    jumpButton.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
+    expect(jumps).toBe(1);
   });
 
   it('rotates the camera from a single-finger swipe on the game canvas', () => {


### PR DESCRIPTION
## Summary

Fixes unreliable mobile Jump button taps:

1. Fires the mobile Jump action on `pointerdown` instead of waiting for the synthesized click.
2. Suppresses the follow-up generated click so a single tap does not double-fire.
3. Latches touch jump input for a short 220ms window so camera/HUD movement reads cannot consume the tap before the grounded sim tick sees it.
4. Keeps desktop Space behavior unchanged.

## Type of change

- [x] Bug fix

## How was this tested?

- `npx vitest run tests/mobile_controls.test.ts tests/input.test.ts` -> 56 passed.
- `npx tsc --noEmit` -> clean.
- Mobile-emulated Chrome, iPhone 12 Pro landscape dimensions, offline game session:
  - Reproduced the failure first: 5 mobile Jump taps produced 0 jumps before the latch fix.
  - After the fix, 5 consecutive Jump taps all succeeded; each raised the player from `y=1.5` to about `y=2.48`.

---

## Checklist

- [x] Tests pass for focused input/mobile controls coverage.
- [x] Typecheck passes.
- [x] No secrets / `.env`; `ALLOW_DEV_COMMANDS` not enabled anywhere.
- [x] No generated files were hand-edited.