### PR TITLE
Add adaptive graphics budgets and client movement prediction

### DIFF
--- a/scripts/analyze_prediction_trace.mjs
+++ b/scripts/analyze_prediction_trace.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node scripts/analyze_prediction_trace.mjs <trace.json>');
+  process.exit(1);
+}
+
+const trace = JSON.parse(fs.readFileSync(file, 'utf8'));
+const events = Array.isArray(trace.events) ? trace.events : [];
+const data = (event) => event?.data ?? {};
+const finite = (value) => typeof value === 'number' && Number.isFinite(value);
+const values = (type, key) => events
+  .filter((event) => event.type === type)
+  .map((event) => data(event)[key])
+  .filter(finite);
+
+function pct(sorted, p) {
+  if (sorted.length === 0) return 0;
+  return sorted[Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1))];
+}
+
+function round(value) {
+  return Math.round(value * 1000) / 1000;
+}
+
+function stats(list) {
+  if (list.length === 0) return { count: 0, avg: 0, p50: 0, p95: 0, p99: 0, max: 0 };
+  const sorted = [...list].sort((a, b) => a - b);
+  const total = list.reduce((sum, value) => sum + value, 0);
+  return {
+    count: list.length,
+    avg: round(total / list.length),
+    p50: round(pct(sorted, 0.5)),
+    p95: round(pct(sorted, 0.95)),
+    p99: round(pct(sorted, 0.99)),
+    max: round(sorted[sorted.length - 1]),
+  };
+}
+
+function gaps(type) {
+  const matching = events.filter((event) => event.type === type);
+  const out = [];
+  for (let i = 1; i < matching.length; i++) out.push(matching[i].at - matching[i - 1].at);
+  return out;
+}
+
+function nearestBefore(type, at) {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.at <= at && event.type === type) return event;
+  }
+  return null;
+}
+
+function activeMovement(event) {
+  const d = data(event);
+  return !!(d.moveForward || d.moveBack || d.strafeLeft || d.strafeRight);
+}
+
+function movingStepBuckets(list) {
+  const buckets = { zero: 0, lt005: 0, lt015: 0, lt025: 0, tickish025To05: 0, gt05: 0 };
+  for (const event of list) {
+    const step = data(event).displayStep;
+    if (!finite(step)) continue;
+    if (step < 0.001) buckets.zero++;
+    else if (step < 0.05) buckets.lt005++;
+    else if (step < 0.15) buckets.lt015++;
+    else if (step < 0.25) buckets.lt025++;
+    else if (step < 0.5) buckets.tickish025To05++;
+    else buckets.gt05++;
+  }
+  return buckets;
+}
+
+function correctionByAnchor() {
+  const groups = new Map();
+  for (const event of events) {
+    if (event.type !== 'snapshot-reconcile') continue;
+    const anchor = String(data(event).anchorMode ?? 'unknown');
+    const value = data(event).renderCorrectionDist;
+    if (!finite(value)) continue;
+    const list = groups.get(anchor) ?? [];
+    list.push(value);
+    groups.set(anchor, list);
+  }
+  return Object.fromEntries([...groups.entries()].map(([anchor, list]) => [anchor, stats(list)]));
+}
+
+function predictionsBetween(afterAt, beforeOrAt) {
+  return events.filter((event) => event.type === 'input-predict' && event.at > afterAt && event.at <= beforeOrAt);
+}
+
+const frames = events.filter((event) => event.type === 'frame');
+const frameDt = values('frame', 'frameDtMs').filter((value) => value >= 0);
+const displayStep = values('frame', 'displayStep');
+const jumps = frames.filter((event) => finite(data(event).displayStep) && data(event).displayStep > 0.75);
+const jumpsOnNormalFrames = jumps.filter((event) => !finite(data(event).frameDtMs) || data(event).frameDtMs <= 50);
+const movingFrames = frames.filter(activeMovement);
+const largestDisplaySteps = [...frames]
+  .filter((event) => finite(data(event).displayStep))
+  .sort((a, b) => data(b).displayStep - data(a).displayStep)
+  .slice(0, 10)
+  .map((event) => {
+    const previousFrame = frames[frames.indexOf(event) - 1] ?? null;
+    const preds = predictionsBetween(previousFrame?.at ?? -Infinity, event.at);
+    const rec = nearestBefore('snapshot-reconcile', event.at);
+    return {
+      at: round(event.at),
+      frameDtMs: data(event).frameDtMs,
+      displayStep: data(event).displayStep,
+      camYawStep: data(event).camYawStep,
+      input: {
+        f: data(event).moveForward ?? 0,
+        b: data(event).moveBack ?? 0,
+        sl: data(event).strafeLeft ?? 0,
+        sr: data(event).strafeRight ?? 0,
+      },
+      predictionsSincePreviousFrame: preds.length,
+      predictedDistSincePreviousFrame: round(preds.reduce((sum, pred) => sum + (finite(data(pred).predictedDist) ? data(pred).predictedDist : 0), 0)),
+      msSinceReconcile: rec ? round(event.at - rec.at) : null,
+      lastCorrection: rec && finite(data(rec).renderCorrectionDist) ? data(rec).renderCorrectionDist : null,
+      mainRendererP95: data(event).mainRendererP95,
+      mainHudP95: data(event).mainHudP95,
+      rphTotalP95: data(event).rphTotalP95,
+      longTaskCount: data(event).longTaskCount,
+      longTaskMax: data(event).longTaskMax,
+    };
+  });
+
+let jumpsAfterPrediction = 0;
+let jumpsAfterReconcile = 0;
+for (const jump of jumps) {
+  const pred = nearestBefore('input-predict', jump.at);
+  const rec = nearestBefore('snapshot-reconcile', jump.at);
+  if (pred && jump.at - pred.at <= 50) jumpsAfterPrediction++;
+  if (rec && jump.at - rec.at <= 50) jumpsAfterReconcile++;
+}
+
+const firstAt = events[0]?.at ?? 0;
+const lastAt = events.at(-1)?.at ?? firstAt;
+const seconds = Math.max(0, (lastAt - firstAt) / 1000);
+const count = (type) => events.filter((event) => event.type === type).length;
+
+const report = {
+  file,
+  url: trace.url ?? null,
+  seconds: round(seconds),
+  frameRate: seconds > 0 ? round(frames.length / seconds) : 0,
+  frameDt: stats(frameDt),
+  longFrames: {
+    gt33: frameDt.filter((value) => value > 33).length,
+    gt50: frameDt.filter((value) => value > 50).length,
+    gt100: frameDt.filter((value) => value > 100).length,
+  },
+  displayStep: stats(displayStep),
+  displayStepBuckets: {
+    gt05: displayStep.filter((value) => value > 0.5).length,
+    gt075: displayStep.filter((value) => value > 0.75).length,
+    gt1: displayStep.filter((value) => value > 1).length,
+  },
+  movingFrames: {
+    count: movingFrames.length,
+    displayStep: stats(movingFrames.map((event) => data(event).displayStep).filter(finite)),
+    buckets: movingStepBuckets(movingFrames),
+  },
+  jumps: {
+    gt075: jumps.length,
+    gt075OnFramesAtOrBelow50ms: jumpsOnNormalFrames.length,
+    within50msAfterPrediction: jumpsAfterPrediction,
+    within50msAfterReconcile: jumpsAfterReconcile,
+  },
+  prediction: {
+    count: count('input-predict'),
+    predictedDist: stats(values('input-predict', 'predictedDist')),
+  },
+  snapshots: {
+    queued: count('snapshot-queued'),
+    reconciled: count('snapshot-reconcile'),
+    queuedGapMs: stats(gaps('snapshot-queued')),
+    reconcileGapMs: stats(gaps('snapshot-reconcile')),
+    renderCorrectionDist: stats(values('snapshot-reconcile', 'renderCorrectionDist')),
+    ackLag: stats(values('snapshot-reconcile', 'ackLag')),
+    pendingAfter: stats(values('snapshot-reconcile', 'pendingAfter')),
+    correctionByAnchor: correctionByAnchor(),
+  },
+  longFrameContext: {
+    mainRendererP95: stats(values('frame', 'mainRendererP95')),
+    mainHudP95: stats(values('frame', 'mainHudP95')),
+    rphTotalP95: stats(values('frame', 'rphTotalP95')),
+    rphEntitiesP95: stats(values('frame', 'rphEntitiesP95')),
+    rphWorldP95: stats(values('frame', 'rphWorldP95')),
+    rphNameplatesP95: stats(values('frame', 'rphNameplatesP95')),
+    rphSubmitP95: stats(values('frame', 'rphSubmitP95')),
+    longTaskMax: stats(values('frame', 'longTaskMax')),
+  },
+  largestDisplaySteps,
+};
+
+console.log(JSON.stringify(report, null, 2));

--- a/scripts/arena_visual.mjs
+++ b/scripts/arena_visual.mjs
@@ -40,7 +40,7 @@ async function login(page, charName, cls) {
   await sleep(700);
   await page.evaluate((name) => {
     const rows = [...document.querySelectorAll('.char-row')];
-    rows.find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('button')?.click();
+    rows.find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('.enter-world-btn')?.click();
   }, charName);
   await page.waitForFunction(() => window.__game?.world?.entities?.size > 5, { timeout: 20000, polling: 500 });
 }

--- a/scripts/market_mp_e2e.mjs
+++ b/scripts/market_mp_e2e.mjs
@@ -47,7 +47,7 @@ async function enter(page, charName, cls, mode) {
     await sleep(700);
   }
   await page.evaluate((name) => {
-    [...document.querySelectorAll('.char-row')].find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('button')?.click();
+    [...document.querySelectorAll('.char-row')].find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('.enter-world-btn')?.click();
   }, charName);
   await page.waitForFunction(() => window.__game?.world?.entities?.size > 5, { timeout: 20000, polling: 500 });
   await sleep(500);

--- a/scripts/mp_browser.mjs
+++ b/scripts/mp_browser.mjs
@@ -54,7 +54,7 @@ async function loginAndEnter(page, username, password, charName, cls, fresh) {
     const rows = [...document.querySelectorAll('.char-row')];
     const row = rows.find((r) => r.querySelector('.char-name')?.textContent === name);
     if (!row) return false;
-    row.querySelector('button').click();
+    row.querySelector('.enter-world-btn').click();
     return true;
   }, charName);
   if (!entered) throw new Error(`could not enter world as ${charName}`);

--- a/scripts/mp_combat_visibility.mjs
+++ b/scripts/mp_combat_visibility.mjs
@@ -38,7 +38,7 @@ async function enter(page, charName, cls, fresh) {
   await page.evaluate((name) => {
     const rows = [...document.querySelectorAll('.char-row')];
     const row = rows.find((r) => r.querySelector('.char-name').textContent === name);
-    row.querySelector('button').click();
+    row.querySelector('.enter-world-btn').click();
   }, charName);
   await page.waitForFunction(() => window.__game?.online?.connected, { timeout: 15000 });
   await page.bringToFront();

--- a/scripts/perf_tour.mjs
+++ b/scripts/perf_tour.mjs
@@ -35,6 +35,12 @@ const THRESHOLDS = {
   maxViews: numberEnv('PERF_MAX_VIEWS'),
   maxInputIntentToFrameP95: numberEnv('PERF_MAX_INPUT_FRAME_P95'),
   maxInputIntentToVisibleP95: numberEnv('PERF_MAX_INPUT_VISIBLE_P95'),
+  maxPrewarmMs: numberEnv('PERF_MAX_PREWARM_MS'),
+  maxPrewarmBudgetRatio: numberEnv('PERF_MAX_PREWARM_BUDGET_RATIO'),
+  maxPrewarmTimedOut: numberEnv('PERF_MAX_PREWARM_TIMED_OUT'),
+  maxPrewarmFailed: numberEnv('PERF_MAX_PREWARM_FAILED'),
+  minPrewarmCompleted: numberEnv('PERF_MIN_PREWARM_COMPLETED'),
+  minPrewarmEntries: numberEnv('PERF_MIN_PREWARM_ENTRIES'),
 };
 
 const VIEWPORTS = {
@@ -242,6 +248,8 @@ function summarizeResult(result) {
   const gltf = lastAssets.byType?.gltf;
   const texture = lastAssets.byType?.texture;
   const renderer = lastReport.renderer;
+  const prewarm = renderer?.prewarm;
+  const foliage = renderer?.foliage;
   const hud = lastReport.hud;
   const longTasks = lastReport.browser?.longTasks;
   const bootByType = bootBytesByType(lastReport);
@@ -277,6 +285,36 @@ function summarizeResult(result) {
     maxSampleTriangles: maxOf(result.samples, (s) => s.report?.renderer?.triangles),
     views: renderer?.views ?? 0,
     maxViews: maxOf(result.samples, (s) => s.report?.renderer?.views),
+    foliageModelQuality: foliage?.modelQuality ?? 0,
+    foliageModelVisibleBuckets: foliage?.modelVisibleBuckets ?? 0,
+    foliageModelVisibleDraws: foliage?.modelVisibleDraws ?? 0,
+    foliageModelVisibleTriangles: foliage?.modelVisibleTriangles ?? 0,
+    foliageModelVisibleByLod: foliage?.modelVisibleByLod ?? {},
+    foliageModelVisibleDrawsByLod: foliage?.modelVisibleDrawsByLod ?? {},
+    foliageModelVisibleTrianglesByLod: foliage?.modelVisibleTrianglesByLod ?? {},
+    foliageGrassVisibleTufts: foliage?.grassVisibleTufts ?? 0,
+    prewarmElapsedMs: prewarm?.elapsedMs ?? 0,
+    prewarmMaxMs: prewarm?.maxMs ?? 0,
+    prewarmRemainingMs: prewarm?.remainingMs ?? 0,
+    prewarmBudgetUsedRatio: prewarm?.budgetUsedRatio ?? 0,
+    prewarmTimedOut: prewarm?.timedOut ?? false,
+    prewarmCompleted: prewarm?.manifestCompleted ?? 0,
+    prewarmPlanned: prewarm?.manifestPlanned ?? 0,
+    prewarmTimedOutEntries: prewarm?.manifestTimedOut ?? 0,
+    prewarmFailedEntries: prewarm?.manifestFailed ?? 0,
+    prewarmTimedOutEntryIds: prewarm?.timedOutEntryIds ?? [],
+    prewarmFailedEntryIds: prewarm?.failedEntryIds ?? [],
+    prewarmEntries: prewarm?.manifestEntries?.map((entry) => ({
+      id: entry.id,
+      category: entry.category,
+      required: entry.required,
+      status: entry.status,
+      elapsedMs: entry.elapsedMs,
+      remainingMsAfter: entry.remainingMsAfter,
+      programDelta: entry.programDelta,
+      textureDelta: entry.textureDelta,
+      detail: entry.detail,
+    })) ?? [],
     contextLost: renderer?.contextLost ?? 0,
     hudHotDomWrites: hud?.hotDomWrites ?? 0,
     hudHotDomSkippedWrites: hud?.hotDomSkippedWrites ?? 0,
@@ -305,6 +343,10 @@ function budgetFailures(summary) {
     ['max sample draw calls', summary.maxSampleCalls, THRESHOLDS.maxSampleCalls, ''],
     ['max sample triangles', summary.maxSampleTriangles, THRESHOLDS.maxSampleTriangles, ''],
     ['renderer views', summary.maxViews, THRESHOLDS.maxViews, ''],
+    ['prewarm elapsed', summary.prewarmElapsedMs, THRESHOLDS.maxPrewarmMs, 'ms'],
+    ['prewarm budget ratio', summary.prewarmBudgetUsedRatio, THRESHOLDS.maxPrewarmBudgetRatio, ''],
+    ['prewarm timed-out entries', summary.prewarmTimedOutEntries, THRESHOLDS.maxPrewarmTimedOut, ''],
+    ['prewarm failed entries', summary.prewarmFailedEntries, THRESHOLDS.maxPrewarmFailed, ''],
     ['input intent->frame p95', summary.inputIntentToFrameP95, THRESHOLDS.maxInputIntentToFrameP95, 'ms'],
     ['input intent->visible p95', summary.inputIntentToVisibleP95, THRESHOLDS.maxInputIntentToVisibleP95, 'ms'],
   ];
@@ -312,6 +354,14 @@ function budgetFailures(summary) {
   for (const [label, actual, max, unit] of checks) {
     if (max !== null && actual > max) failures.push(`${label} ${actual}${unit} > ${max}${unit}`);
   }
+  const minChecks = [
+    ['prewarm completed entries', summary.prewarmCompleted, THRESHOLDS.minPrewarmCompleted],
+    ['prewarm entries', summary.prewarmEntries.length, THRESHOLDS.minPrewarmEntries],
+  ];
+  for (const [label, actual, min] of minChecks) {
+    if (min !== null && actual < min) failures.push(`${label} ${actual} < ${min}`);
+  }
+  if (summary.prewarmTimedOut) failures.push('prewarm exceeded startup budget');
   if (summary.contextLost > 0) failures.push(`context lost ${summary.contextLost} > 0`);
   return failures;
 }
@@ -415,7 +465,7 @@ fs.writeFileSync(OUTPUT, `${JSON.stringify(artifact, null, 2)}\n`);
 console.log(`wrote ${OUTPUT}`);
 for (const r of results) {
   const s = r.summary;
-  console.log(`${r.viewport}: fps ${s.fps} (10s ${s.fps10s}) p95 ${s.frameP95}ms maxP95 ${s.maxFrameP95}ms longtask ${s.longTasks}/${s.longTaskP95}ms tasks ${s.preloadTasks} gltf ${s.gltfCount} tex ${s.textureCount} boot ${s.bootMib}MiB calls ${s.calls}/${s.maxSampleCalls} tris ${s.triangles}/${s.maxSampleTriangles} views ${s.views}/${s.maxViews} input ${s.inputIntentToVisibleP95}ms tier ${s.rendererTier} hudSkip ${Math.round(s.hudHotDomSkipRate * 100)}%`);
+  console.log(`${r.viewport}: fps ${s.fps} (10s ${s.fps10s}) p95 ${s.frameP95}ms maxP95 ${s.maxFrameP95}ms longtask ${s.longTasks}/${s.longTaskP95}ms tasks ${s.preloadTasks} gltf ${s.gltfCount} tex ${s.textureCount} boot ${s.bootMib}MiB calls ${s.calls}/${s.maxSampleCalls} tris ${s.triangles}/${s.maxSampleTriangles} views ${s.views}/${s.maxViews} foliage q${s.foliageModelQuality} buckets ${s.foliageModelVisibleBuckets} draws ${s.foliageModelVisibleDraws} tris ${s.foliageModelVisibleTriangles} prewarm ${s.prewarmElapsedMs}/${s.prewarmMaxMs}ms ${s.prewarmCompleted}/${s.prewarmPlanned} fail ${s.prewarmFailedEntries} timeout ${s.prewarmTimedOutEntries} input ${s.inputIntentToVisibleP95}ms tier ${s.rendererTier} hudSkip ${Math.round(s.hudHotDomSkipRate * 100)}%`);
 }
 
 const hardErrors = results.flatMap((r) => [

--- a/scripts/perf_tour.mjs
+++ b/scripts/perf_tour.mjs
@@ -8,9 +8,11 @@ import { BROWSER_PATH } from './browser_path.mjs';
 
 const BASE_URL = process.env.GAME_URL ?? 'http://localhost:5173';
 const VIEWPORT_MODE = process.env.PERF_VIEWPORT ?? 'both';
+const PERF_SCENARIO = process.env.PERF_SCENARIO ?? 'bench_perf_tour';
 const STEP_MS = Number(process.env.PERF_STEP_MS ?? 2500);
 const SETTLE_MS = Number(process.env.PERF_SETTLE_MS ?? 600);
 const BOOT_TIMEOUT_MS = Number(process.env.PERF_BOOT_TIMEOUT_MS ?? 120000);
+const NAV_TIMEOUT_MS = Number(process.env.PERF_NAV_TIMEOUT_MS ?? 30000);
 const OUTPUT = process.env.PERF_OUT ?? path.join('tmp', `perf-tour-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
 
 const THRESHOLDS = {
@@ -68,6 +70,7 @@ function numberEnv(name) {
 function perfUrl() {
   const url = new URL(BASE_URL);
   url.searchParams.set('perf', '');
+  url.searchParams.set('perfScenario', PERF_SCENARIO);
   return url.toString();
 }
 
@@ -84,7 +87,7 @@ function isIgnorableConsoleError(text) {
 
 async function bootOffline(page, viewport) {
   await page.setViewport(viewport);
-  await page.goto(perfUrl(), { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.goto(perfUrl(), { waitUntil: 'domcontentloaded', timeout: NAV_TIMEOUT_MS });
   await page.waitForSelector('#btn-offline', { timeout: 30000 });
   await page.$eval('#btn-offline', (el) => el.click());
   await page.waitForSelector('#char-name', { timeout: 30000 });
@@ -398,9 +401,11 @@ const artifact = {
   generatedAt: startedAt,
   baseUrl: BASE_URL,
   url: perfUrl(),
+  scenario: PERF_SCENARIO,
   stepMs: STEP_MS,
   settleMs: SETTLE_MS,
   bootTimeoutMs: BOOT_TIMEOUT_MS,
+  navTimeoutMs: NAV_TIMEOUT_MS,
   browserPath: BROWSER_PATH,
   thresholds: THRESHOLDS,
   summary: Object.fromEntries(results.map((r) => [r.viewport, r.summary])),

--- a/scripts/social_visual.mjs
+++ b/scripts/social_visual.mjs
@@ -37,7 +37,7 @@ async function login(page, charName, cls, fresh) {
   await sleep(700);
   await page.evaluate((name) => {
     const rows = [...document.querySelectorAll('.char-row')];
-    rows.find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('button')?.click();
+    rows.find((r) => r.querySelector('.char-name')?.textContent === name)?.querySelector('.enter-world-btn')?.click();
   }, charName);
   await page.waitForFunction(() => window.__game?.world?.entities?.size > 5, { timeout: 20000, polling: 500 });
 }

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -5,7 +5,7 @@ import { findAccount, touchLogin, saveToken, accountForToken, isAdminAccount } f
 import { verifyPassword, newToken } from './auth';
 import {
   overviewCounts, registrationsByDay, sessionsByDay, classDistribution, levelDistribution,
-  listAccounts, listCharacters, accountDetail,
+  listAccounts, listCharacters, accountDetail, clientPerfSummary, clientPerfRaw,
 } from './admin_db';
 import {
   forceCharacterRename, ignoreReport, moderateAccount, muteAccountChat, moderationQueue, moderationReportsForAccount,
@@ -229,6 +229,15 @@ export async function handleAdminApi(
         levelDistribution(),
       ]);
       return ok(res, { days: ACTIVITY_WINDOW_DAYS, registrations, sessions, classes, levels });
+    }
+    if (path === '/admin/api/perf/summary') {
+      const hours = Number(url.searchParams.get('hours') ?? '24');
+      return ok(res, await clientPerfSummary(hours));
+    }
+    if (path === '/admin/api/perf/raw') {
+      const hours = Number(url.searchParams.get('hours') ?? '24');
+      const limit = Number(url.searchParams.get('limit') ?? '100');
+      return ok(res, { rows: await clientPerfRaw(hours, limit) });
     }
     if (path === '/admin/api/accounts') {
       const { page, limit } = parsePageParams(url.searchParams);

--- a/server/admin.ts
+++ b/server/admin.ts
@@ -237,7 +237,14 @@ export async function handleAdminApi(
     if (path === '/admin/api/perf/raw') {
       const hours = Number(url.searchParams.get('hours') ?? '24');
       const limit = Number(url.searchParams.get('limit') ?? '100');
-      return ok(res, { rows: await clientPerfRaw(hours, limit) });
+      const beforeIdParam = url.searchParams.get('beforeId');
+      const beforeId = beforeIdParam === null ? undefined : Number(beforeIdParam);
+      const rows = await clientPerfRaw(hours, limit, beforeId);
+      return ok(res, {
+        rows,
+        nextBeforeId: rows.length > 0 ? rows[rows.length - 1].id : null,
+        hasMore: rows.length >= Math.min(1000, Math.max(1, Math.floor(Number.isFinite(limit) ? limit : 100))),
+      });
     }
     if (path === '/admin/api/accounts') {
       const { page, limit } = parsePageParams(url.searchParams);

--- a/server/admin_db.ts
+++ b/server/admin_db.ts
@@ -95,6 +95,218 @@ export async function levelDistribution(): Promise<BucketCount[]> {
   return res.rows;
 }
 
+export interface PerfAggregate {
+  sampleCount: number;
+  medianFps: number;
+  p95FrameMs: number;
+  p99FrameMs: number;
+  contextLossCount: number;
+  avgRenderScale: number;
+  avgEffectiveRenderScale: number;
+}
+
+export interface PerfBucket extends PerfAggregate {
+  key: string;
+}
+
+export interface PerfSummary {
+  hours: number;
+  generatedAt: string;
+  totals: PerfAggregate;
+  byPreset: PerfBucket[];
+  byGpu: PerfBucket[];
+  byBrowser: PerfBucket[];
+  byOs: PerfBucket[];
+  byScenario: PerfBucket[];
+  worstGpuBuckets: PerfBucket[];
+}
+
+export interface PerfRawRow {
+  id: number;
+  createdAt: string;
+  releaseVersion: string;
+  buildId: string;
+  sessionId: string;
+  accountId: number | null;
+  characterId: number | null;
+  realm: string;
+  graphicsPreset: string;
+  gfxTier: string;
+  autoGovernor: boolean;
+  targetFps: number;
+  renderScale: number;
+  effectiveRenderScale: number;
+  fpsAvg: number;
+  frameP95Ms: number;
+  frameP99Ms: number;
+  longFrameCount: number;
+  rendererCalls: number;
+  rendererTriangles: number;
+  rendererTextures: number;
+  rendererPrograms: number;
+  contextLostCount: number;
+  longTaskCount: number;
+  longTaskP95Ms: number;
+  memoryUsedMb: number | null;
+  memoryLimitMb: number | null;
+  dpr: number;
+  viewportBucket: string;
+  deviceMemory: number | null;
+  hardwareConcurrency: number;
+  mobileTouch: boolean;
+  browserFamily: string;
+  osFamily: string;
+  glVendor: string;
+  glRendererBucket: string;
+  zoneOrScenario: string;
+  source: string;
+  rawSummary: unknown;
+}
+
+function cleanHours(hours: number): number {
+  return Number.isFinite(hours) ? Math.min(168, Math.max(1, Math.floor(hours))) : 24;
+}
+
+function cleanPerfLimit(limit: number): number {
+  return Number.isFinite(limit) ? Math.min(500, Math.max(1, Math.floor(limit))) : 100;
+}
+
+function perfAggregateFromRow(r: Record<string, unknown>): PerfAggregate {
+  return {
+    sampleCount: Number(r.sample_count ?? 0),
+    medianFps: Number(r.median_fps ?? 0),
+    p95FrameMs: Number(r.p95_frame_ms ?? 0),
+    p99FrameMs: Number(r.p99_frame_ms ?? 0),
+    contextLossCount: Number(r.context_loss_count ?? 0),
+    avgRenderScale: Number(r.avg_render_scale ?? 0),
+    avgEffectiveRenderScale: Number(r.avg_effective_render_scale ?? 0),
+  };
+}
+
+async function perfAggregate(hours: number): Promise<PerfAggregate> {
+  const res = await pool.query(
+    `SELECT
+       count(*)::int AS sample_count,
+       COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY fps_avg), 0)::real AS median_fps,
+       COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY frame_p95_ms), 0)::real AS p95_frame_ms,
+       COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY frame_p95_ms), 0)::real AS p99_frame_ms,
+       COALESCE(sum(context_lost_count), 0)::int AS context_loss_count,
+       COALESCE(avg(render_scale), 0)::real AS avg_render_scale,
+       COALESCE(avg(effective_render_scale), 0)::real AS avg_effective_render_scale
+     FROM client_perf_reports
+     WHERE created_at > now() - ($1 || ' hours')::interval`,
+    [String(hours)],
+  );
+  return perfAggregateFromRow(res.rows[0] ?? {});
+}
+
+async function perfBuckets(column: string, hours: number, limit: number, worstFirst = false): Promise<PerfBucket[]> {
+  const order = worstFirst ? 'p95_frame_ms DESC, sample_count DESC' : 'sample_count DESC, key ASC';
+  const res = await pool.query(
+    `SELECT
+       ${column} AS key,
+       count(*)::int AS sample_count,
+       COALESCE(percentile_cont(0.5) WITHIN GROUP (ORDER BY fps_avg), 0)::real AS median_fps,
+       COALESCE(percentile_cont(0.95) WITHIN GROUP (ORDER BY frame_p95_ms), 0)::real AS p95_frame_ms,
+       COALESCE(percentile_cont(0.99) WITHIN GROUP (ORDER BY frame_p95_ms), 0)::real AS p99_frame_ms,
+       COALESCE(sum(context_lost_count), 0)::int AS context_loss_count,
+       COALESCE(avg(render_scale), 0)::real AS avg_render_scale,
+       COALESCE(avg(effective_render_scale), 0)::real AS avg_effective_render_scale
+     FROM client_perf_reports
+     WHERE created_at > now() - ($1 || ' hours')::interval
+     GROUP BY ${column}
+     ORDER BY ${order}
+     LIMIT $2`,
+    [String(hours), limit],
+  );
+  return res.rows.map((r) => ({ key: String(r.key ?? ''), ...perfAggregateFromRow(r) }));
+}
+
+export async function clientPerfSummary(hoursInput = 24): Promise<PerfSummary> {
+  const hours = cleanHours(hoursInput);
+  const [totals, byPreset, byGpu, byBrowser, byOs, byScenario, worstGpuBuckets] = await Promise.all([
+    perfAggregate(hours),
+    perfBuckets('graphics_preset', hours, 20),
+    perfBuckets('gl_renderer_bucket', hours, 50),
+    perfBuckets('browser_family', hours, 20),
+    perfBuckets('os_family', hours, 20),
+    perfBuckets('zone_or_scenario', hours, 30),
+    perfBuckets('gl_renderer_bucket', hours, 20, true),
+  ]);
+  return {
+    hours,
+    generatedAt: new Date().toISOString(),
+    totals,
+    byPreset,
+    byGpu,
+    byBrowser,
+    byOs,
+    byScenario,
+    worstGpuBuckets,
+  };
+}
+
+export async function clientPerfRaw(hoursInput = 24, limitInput = 100): Promise<PerfRawRow[]> {
+  const hours = cleanHours(hoursInput);
+  const limit = cleanPerfLimit(limitInput);
+  const res = await pool.query(
+    `SELECT
+       id, created_at, release_version, build_id, session_id, account_id, character_id, realm,
+       graphics_preset, gfx_tier, auto_governor, target_fps, render_scale, effective_render_scale,
+       fps_avg, frame_p95_ms, frame_p99_ms, long_frame_count,
+       renderer_calls, renderer_triangles, renderer_textures, renderer_programs, context_lost_count,
+       long_task_count, long_task_p95_ms, memory_used_mb, memory_limit_mb,
+       dpr, viewport_bucket, device_memory, hardware_concurrency, mobile_touch,
+       browser_family, os_family, gl_vendor, gl_renderer_bucket, zone_or_scenario, source, raw_summary
+     FROM client_perf_reports
+     WHERE created_at > now() - ($1 || ' hours')::interval
+     ORDER BY created_at DESC
+     LIMIT $2`,
+    [String(hours), limit],
+  );
+  return res.rows.map((r) => ({
+    id: r.id,
+    createdAt: r.created_at,
+    releaseVersion: r.release_version,
+    buildId: r.build_id,
+    sessionId: r.session_id,
+    accountId: r.account_id,
+    characterId: r.character_id,
+    realm: r.realm,
+    graphicsPreset: r.graphics_preset,
+    gfxTier: r.gfx_tier,
+    autoGovernor: r.auto_governor,
+    targetFps: r.target_fps,
+    renderScale: r.render_scale,
+    effectiveRenderScale: r.effective_render_scale,
+    fpsAvg: r.fps_avg,
+    frameP95Ms: r.frame_p95_ms,
+    frameP99Ms: r.frame_p99_ms,
+    longFrameCount: r.long_frame_count,
+    rendererCalls: r.renderer_calls,
+    rendererTriangles: r.renderer_triangles,
+    rendererTextures: r.renderer_textures,
+    rendererPrograms: r.renderer_programs,
+    contextLostCount: r.context_lost_count,
+    longTaskCount: r.long_task_count,
+    longTaskP95Ms: r.long_task_p95_ms,
+    memoryUsedMb: r.memory_used_mb,
+    memoryLimitMb: r.memory_limit_mb,
+    dpr: r.dpr,
+    viewportBucket: r.viewport_bucket,
+    deviceMemory: r.device_memory,
+    hardwareConcurrency: r.hardware_concurrency,
+    mobileTouch: r.mobile_touch,
+    browserFamily: r.browser_family,
+    osFamily: r.os_family,
+    glVendor: r.gl_vendor,
+    glRendererBucket: r.gl_renderer_bucket,
+    zoneOrScenario: r.zone_or_scenario,
+    source: r.source,
+    rawSummary: r.raw_summary,
+  }));
+}
+
 // Escape LIKE wildcards in user-supplied search text so "%" matches a literal
 // percent sign instead of everything.
 export function escapeLike(input: string): string {

--- a/server/admin_db.ts
+++ b/server/admin_db.ts
@@ -168,7 +168,13 @@ function cleanHours(hours: number): number {
 }
 
 function cleanPerfLimit(limit: number): number {
-  return Number.isFinite(limit) ? Math.min(500, Math.max(1, Math.floor(limit))) : 100;
+  return Number.isFinite(limit) ? Math.min(1000, Math.max(1, Math.floor(limit))) : 100;
+}
+
+function cleanBeforeId(id: number | undefined): number | null {
+  if (id === undefined || !Number.isFinite(id)) return null;
+  const n = Math.floor(id);
+  return n > 0 ? n : null;
 }
 
 function perfAggregateFromRow(r: Record<string, unknown>): PerfAggregate {
@@ -246,9 +252,10 @@ export async function clientPerfSummary(hoursInput = 24): Promise<PerfSummary> {
   };
 }
 
-export async function clientPerfRaw(hoursInput = 24, limitInput = 100): Promise<PerfRawRow[]> {
+export async function clientPerfRaw(hoursInput = 24, limitInput = 100, beforeIdInput?: number): Promise<PerfRawRow[]> {
   const hours = cleanHours(hoursInput);
   const limit = cleanPerfLimit(limitInput);
+  const beforeId = cleanBeforeId(beforeIdInput);
   const res = await pool.query(
     `SELECT
        id, created_at, release_version, build_id, session_id, account_id, character_id, realm,
@@ -260,9 +267,10 @@ export async function clientPerfRaw(hoursInput = 24, limitInput = 100): Promise<
        browser_family, os_family, gl_vendor, gl_renderer_bucket, zone_or_scenario, source, raw_summary
      FROM client_perf_reports
      WHERE created_at > now() - ($1 || ' hours')::interval
-     ORDER BY created_at DESC
+       AND ($3::bigint IS NULL OR id < $3)
+     ORDER BY id DESC
      LIMIT $2`,
-    [String(hours), limit],
+    [String(hours), limit, beforeId],
   );
   return res.rows.map((r) => ({
     id: r.id,

--- a/server/db.ts
+++ b/server/db.ts
@@ -162,6 +162,51 @@ CREATE TABLE IF NOT EXISTS chat_violations (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS chat_violations_account ON chat_violations(account_id, created_at DESC);
+CREATE TABLE IF NOT EXISTS client_perf_reports (
+  id BIGSERIAL PRIMARY KEY,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  schema_version INT NOT NULL DEFAULT 1,
+  release_version TEXT NOT NULL DEFAULT '',
+  build_id TEXT NOT NULL DEFAULT '',
+  session_id TEXT NOT NULL DEFAULT '',
+  account_id INT REFERENCES accounts(id) ON DELETE SET NULL,
+  character_id INT REFERENCES characters(id) ON DELETE SET NULL,
+  realm TEXT NOT NULL DEFAULT '${REALM_SQL_DEFAULT}',
+  graphics_preset TEXT NOT NULL DEFAULT '',
+  gfx_tier TEXT NOT NULL DEFAULT '',
+  auto_governor BOOLEAN NOT NULL DEFAULT FALSE,
+  target_fps INT NOT NULL DEFAULT 0,
+  render_scale REAL NOT NULL DEFAULT 1,
+  effective_render_scale REAL NOT NULL DEFAULT 1,
+  fps_avg REAL NOT NULL DEFAULT 0,
+  frame_p95_ms REAL NOT NULL DEFAULT 0,
+  frame_p99_ms REAL NOT NULL DEFAULT 0,
+  long_frame_count INT NOT NULL DEFAULT 0,
+  renderer_calls INT NOT NULL DEFAULT 0,
+  renderer_triangles INT NOT NULL DEFAULT 0,
+  renderer_textures INT NOT NULL DEFAULT 0,
+  renderer_programs INT NOT NULL DEFAULT 0,
+  context_lost_count INT NOT NULL DEFAULT 0,
+  long_task_count INT NOT NULL DEFAULT 0,
+  long_task_p95_ms REAL NOT NULL DEFAULT 0,
+  memory_used_mb REAL,
+  memory_limit_mb REAL,
+  dpr REAL NOT NULL DEFAULT 1,
+  viewport_bucket TEXT NOT NULL DEFAULT '',
+  device_memory REAL,
+  hardware_concurrency INT NOT NULL DEFAULT 0,
+  mobile_touch BOOLEAN NOT NULL DEFAULT FALSE,
+  browser_family TEXT NOT NULL DEFAULT '',
+  os_family TEXT NOT NULL DEFAULT '',
+  gl_vendor TEXT NOT NULL DEFAULT '',
+  gl_renderer_bucket TEXT NOT NULL DEFAULT '',
+  zone_or_scenario TEXT NOT NULL DEFAULT '',
+  source TEXT NOT NULL DEFAULT 'gameplay',
+  raw_summary JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS client_perf_reports_created ON client_perf_reports(created_at DESC);
+CREATE INDEX IF NOT EXISTS client_perf_reports_release_created ON client_perf_reports(release_version, created_at DESC);
+CREATE INDEX IF NOT EXISTS client_perf_reports_gpu_created ON client_perf_reports(gl_renderer_bucket, created_at DESC);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -560,6 +605,85 @@ export async function topLifetimeXp(limit = 100, opts: { global?: boolean } = {}
     name: r.name, class: r.class, level: r.level, realm: r.realm,
     lifetimeXp: Number(r.lifetime_xp), prestigeRank: Number(r.prestige_rank),
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Client performance telemetry: small, sanitized summaries from the browser.
+// Kept separate from play sessions because reports can come from offline
+// benchmark runs with no account, and one session may emit several samples.
+// ---------------------------------------------------------------------------
+
+export interface ClientPerfReportInsert {
+  schemaVersion: number;
+  releaseVersion: string;
+  buildId: string;
+  sessionId: string;
+  accountId: number | null;
+  characterId: number | null;
+  realm: string;
+  graphicsPreset: string;
+  gfxTier: string;
+  autoGovernor: boolean;
+  targetFps: number;
+  renderScale: number;
+  effectiveRenderScale: number;
+  fpsAvg: number;
+  frameP95Ms: number;
+  frameP99Ms: number;
+  longFrameCount: number;
+  rendererCalls: number;
+  rendererTriangles: number;
+  rendererTextures: number;
+  rendererPrograms: number;
+  contextLostCount: number;
+  longTaskCount: number;
+  longTaskP95Ms: number;
+  memoryUsedMb: number | null;
+  memoryLimitMb: number | null;
+  dpr: number;
+  viewportBucket: string;
+  deviceMemory: number | null;
+  hardwareConcurrency: number;
+  mobileTouch: boolean;
+  browserFamily: string;
+  osFamily: string;
+  glVendor: string;
+  glRendererBucket: string;
+  zoneOrScenario: string;
+  source: string;
+  rawSummary: Record<string, unknown>;
+}
+
+export async function insertClientPerfReport(row: ClientPerfReportInsert): Promise<void> {
+  await pool.query(
+    `INSERT INTO client_perf_reports (
+       schema_version, release_version, build_id, session_id, account_id, character_id, realm,
+       graphics_preset, gfx_tier, auto_governor, target_fps, render_scale, effective_render_scale,
+       fps_avg, frame_p95_ms, frame_p99_ms, long_frame_count,
+       renderer_calls, renderer_triangles, renderer_textures, renderer_programs, context_lost_count,
+       long_task_count, long_task_p95_ms, memory_used_mb, memory_limit_mb,
+       dpr, viewport_bucket, device_memory, hardware_concurrency, mobile_touch,
+       browser_family, os_family, gl_vendor, gl_renderer_bucket, zone_or_scenario, source, raw_summary
+     ) VALUES (
+       $1, $2, $3, $4, $5, $6, $7,
+       $8, $9, $10, $11, $12, $13,
+       $14, $15, $16, $17,
+       $18, $19, $20, $21, $22,
+       $23, $24, $25, $26,
+       $27, $28, $29, $30, $31,
+       $32, $33, $34, $35, $36, $37, $38
+     )`,
+    [
+      row.schemaVersion, row.releaseVersion, row.buildId, row.sessionId, row.accountId, row.characterId, row.realm,
+      row.graphicsPreset, row.gfxTier, row.autoGovernor, row.targetFps, row.renderScale, row.effectiveRenderScale,
+      row.fpsAvg, row.frameP95Ms, row.frameP99Ms, row.longFrameCount,
+      row.rendererCalls, row.rendererTriangles, row.rendererTextures, row.rendererPrograms, row.contextLostCount,
+      row.longTaskCount, row.longTaskP95Ms, row.memoryUsedMb, row.memoryLimitMb,
+      row.dpr, row.viewportBucket, row.deviceMemory, row.hardwareConcurrency, row.mobileTouch,
+      row.browserFamily, row.osFamily, row.glVendor, row.glRendererBucket, row.zoneOrScenario, row.source,
+      JSON.stringify(row.rawSummary),
+    ],
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/server/db.ts
+++ b/server/db.ts
@@ -207,6 +207,7 @@ CREATE TABLE IF NOT EXISTS client_perf_reports (
 CREATE INDEX IF NOT EXISTS client_perf_reports_created ON client_perf_reports(created_at DESC);
 CREATE INDEX IF NOT EXISTS client_perf_reports_release_created ON client_perf_reports(release_version, created_at DESC);
 CREATE INDEX IF NOT EXISTS client_perf_reports_gpu_created ON client_perf_reports(gl_renderer_bucket, created_at DESC);
+CREATE INDEX IF NOT EXISTS client_perf_reports_session_created ON client_perf_reports(session_id, created_at DESC);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -684,6 +685,19 @@ export async function insertClientPerfReport(row: ClientPerfReportInsert): Promi
       JSON.stringify(row.rawSummary),
     ],
   );
+}
+
+// Keeps production telemetry bounded. PERF_REPORT_RETENTION_DAYS=0 disables
+// pruning for a short manual capture window.
+export async function pruneClientPerfReports(retentionDays: number): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return 0;
+  const days = Math.max(1, Math.floor(retentionDays));
+  const res = await pool.query(
+    `DELETE FROM client_perf_reports
+      WHERE created_at < now() - ($1 || ' days')::interval`,
+    [String(days)],
+  );
+  return res.rowCount ?? 0;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/game.ts
+++ b/server/game.ts
@@ -69,6 +69,7 @@ const ANTIBOT_ENFORCE = process.env.ANTIBOT_ENFORCE === '1';
 // the last packet held a key down, stop applying it instead of turning/running
 // forever. 750ms leaves room for normal jitter and short browser stalls.
 const STALE_INPUT_SECONDS = 0.75;
+const MAX_PENDING_MOVE_INPUT_RUNS = 80;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
 
@@ -101,10 +102,10 @@ export interface ClientSession {
   lastWhisperFrom: string | null;
   // last explicit channel this player sent to; plain text follows it.
   rememberedChat: RememberedChat;
-  // last client input sequence received by the socket
+  // last contiguous client input sequence accepted by the socket
   lastInputSeq: number;
-  // last input sequence reflected by a completed sim tick; echoed in snapshots
-  // for prediction reconciliation and latency telemetry
+  // last input sequence reflected by completed server authority; echoed in
+  // snapshots for prediction reconciliation and latency telemetry
   appliedInputSeq: number;
   pendingMoveInputs: QueuedMoveInput[];
   // sim time of the last movement input frame, used to clear stale held input
@@ -126,7 +127,8 @@ export interface ClientSession {
 }
 
 interface QueuedMoveInput {
-  seq: number;
+  fromSeq: number;
+  toSeq: number;
   moveInput: MoveInput;
   facing: number | null;
 }
@@ -296,6 +298,16 @@ interface EntityWireCache {
 
 function round2(v: number): number {
   return Math.round(v * 100) / 100;
+}
+
+function sameMoveInput(a: MoveInput, b: MoveInput): boolean {
+  return a.forward === b.forward
+    && a.back === b.back
+    && a.turnLeft === b.turnLeft
+    && a.turnRight === b.turnRight
+    && a.strafeLeft === b.strafeLeft
+    && a.strafeRight === b.strafeRight
+    && a.jump === b.jump;
 }
 
 function logSocialErr(err: unknown): void {
@@ -536,8 +548,13 @@ export class GameServer {
 
   private clearStaleInputs(): void {
     for (const session of this.clients.values()) {
-      if (session.pendingMoveInputs.length > 0) continue;
       if (this.sim.time - session.lastInputAt <= STALE_INPUT_SECONDS) continue;
+      if (session.pendingMoveInputs.length > 0) {
+        // Timed-out commands are authoritatively expired, not simulated. Ack them
+        // so the client drops matching predictions and reanchors to the stopped pose.
+        session.pendingMoveInputs.length = 0;
+        session.appliedInputSeq = Math.max(session.appliedInputSeq, session.lastInputSeq);
+      }
       const meta = this.sim.meta(session.pid);
       if (!meta) continue;
       const mi = meta.moveInput;
@@ -548,15 +565,32 @@ export class GameServer {
 
   private markInputSeqsApplied(): void {
     for (const session of this.clients.values()) {
-      const next = session.pendingMoveInputs.shift();
+      const next = session.pendingMoveInputs[0];
       if (!next) continue;
       const meta = this.sim.meta(session.pid);
       const e = this.sim.entities.get(session.pid);
       if (!meta || !e) continue;
       Object.assign(meta.moveInput, next.moveInput);
       if (next.facing !== null && !e.dead) e.facing = next.facing;
-      session.appliedInputSeq = next.seq;
+      session.appliedInputSeq = next.fromSeq;
+      if (next.fromSeq >= next.toSeq) {
+        session.pendingMoveInputs.shift();
+      } else {
+        next.fromSeq++;
+      }
     }
+  }
+
+  private enqueueMoveInput(session: ClientSession, seq: number, moveInput: MoveInput, facing: number | null): boolean {
+    const pending = session.pendingMoveInputs;
+    const last = pending[pending.length - 1];
+    if (last && last.toSeq + 1 === seq && last.facing === facing && sameMoveInput(last.moveInput, moveInput)) {
+      last.toSeq = seq;
+      return true;
+    }
+    if (pending.length >= MAX_PENDING_MOVE_INPUT_RUNS) return false;
+    pending.push({ fromSeq: seq, toSeq: seq, moveInput, facing });
+    return true;
   }
 
   // -------------------------------------------------------------------------
@@ -940,15 +974,16 @@ export class GameServer {
       const e = sim.entities.get(pid);
       if (!meta || !e) return;
       const { moveInput, facing } = parseMoveInputFrame(msg);
-      session.lastInputAt = sim.time;
       if (typeof msg.seq === 'number' && Number.isFinite(msg.seq) && msg.seq > 0) {
         const seq = Math.floor(msg.seq);
-        if (seq > session.lastInputSeq) {
-          session.lastInputSeq = seq;
-          session.pendingMoveInputs.push({ seq, moveInput, facing });
-          if (session.pendingMoveInputs.length > 80) {
-            session.pendingMoveInputs.splice(0, session.pendingMoveInputs.length - 80);
+        if (seq === session.lastInputSeq + 1) {
+          if (!this.enqueueMoveInput(session, seq, moveInput, facing)) {
+            try { session.ws.close(); } catch { /* already closing */ }
+            void this.leave(session, 'movement input queue overflow');
+            return;
           }
+          session.lastInputSeq = seq;
+          session.lastInputAt = sim.time;
         }
       }
       return;

--- a/server/game.ts
+++ b/server/game.ts
@@ -70,6 +70,8 @@ const ANTIBOT_ENFORCE = process.env.ANTIBOT_ENFORCE === '1';
 // forever. 750ms leaves room for normal jitter and short browser stalls.
 const STALE_INPUT_SECONDS = 0.75;
 const MAX_PENDING_MOVE_INPUT_RUNS = 80;
+const MAX_HELD_INPUT_COVERAGE_TICKS = Math.ceil(STALE_INPUT_SECONDS / DT) + 1;
+const MAX_REORDERED_MOVE_INPUTS = 64;
 // Exponential moving average weight for the per-tick duration stat.
 const TICK_EMA_ALPHA = 0.05;
 
@@ -104,10 +106,16 @@ export interface ClientSession {
   rememberedChat: RememberedChat;
   // last contiguous client input sequence accepted by the socket
   lastInputSeq: number;
-  // last input sequence reflected by completed server authority; echoed in
-  // snapshots for prediction reconciliation and latency telemetry
+  // last input sequence directly consumed or otherwise covered by completed
+  // server authority; echoed in snapshots for prediction reconciliation and latency telemetry.
   appliedInputSeq: number;
   pendingMoveInputs: QueuedMoveInput[];
+  bufferedMoveInputs: Map<number, BufferedMoveInput>;
+  // When no fresh input arrives, the server keeps simulating the last held input
+  // for a short stale window. These ticks are movement coverage after `ack` for
+  // matching future client commands, so the client must not replay them twice.
+  heldInputTicks: number;
+  activeMoveFacing: number | null;
   // sim time of the last movement input frame, used to clear stale held input
   lastInputAt: number;
   // serialized form of each delta self field as last sent to this client;
@@ -133,9 +141,21 @@ interface QueuedMoveInput {
   facing: number | null;
 }
 
+interface BufferedMoveInput {
+  moveInput: MoveInput;
+  facing: number | null;
+}
+
+interface AppliedMoveInput {
+  seq: number;
+  moveInput: MoveInput;
+  facing: number | null;
+}
+
 interface SentEntityVersions {
   idVer: number;
   dynVer: number;
+  urgentVer: number;
   // sim tick of the last full/lite record, so distance-tiered rates hold
   // even when one broadcast covers several catch-up sim ticks
   sentAtTick: number;
@@ -253,6 +273,39 @@ function dynamicFields(e: Entity): Record<string, unknown> {
   return out;
 }
 
+function urgentDynamicFields(e: Entity): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    hp: e.hp,
+    mhp: e.maxHp,
+  };
+  if (e.dead) out.dead = 1;
+  if (e.lootable) out.loot = 1;
+  if (e.hostile) out.h = 1;
+  if (e.castingAbility) {
+    out.cast = e.castingAbility;
+    out.castRem = round2(e.castRemaining);
+    out.castTot = round2(e.castTotal);
+    if (e.channeling) out.chan = 1;
+  }
+  if (e.sitting || e.eating || e.drinking) out.sit = 1;
+  if (e.aggroTargetId !== null) out.aggro = e.aggroTargetId;
+  if (e.tappedById !== null) out.tap = e.tappedById;
+  if (e.ownerId !== null) {
+    out.own = e.ownerId;
+    out.pm = e.petMode;
+    out.pt = round2(e.petTauntTimer);
+  }
+  if (e.auras.length > 0) {
+    out.auras = e.auras.map((a): WireAura => ({
+      id: a.id, name: a.name, kind: a.kind, rem: round2(a.remaining), dur: a.duration, v: round2(a.value),
+    }));
+  }
+  if (e.kind === 'mob' && e.lootable && e.loot) {
+    out.lootList = { copper: e.loot.copper, items: e.loot.items };
+  }
+  return out;
+}
+
 export function wireEntity(e: Entity): Record<string, unknown> {
   return { id: e.id, ...identityFields(e), ...dynamicFields(e) };
 }
@@ -290,8 +343,10 @@ interface EntityWireCache {
   tick: number;
   idJson: string;
   dynJson: string;
+  urgentJson: string;
   idVer: number;
   dynVer: number;
+  urgentVer: number;
   fullJson: string;
   liteJson: string;
 }
@@ -308,6 +363,30 @@ function sameMoveInput(a: MoveInput, b: MoveInput): boolean {
     && a.strafeLeft === b.strafeLeft
     && a.strafeRight === b.strafeRight
     && a.jump === b.jump;
+}
+
+function sameMoveFacing(a: number | null, b: number | null): boolean {
+  if (a === null || b === null) return a === b;
+  return Math.abs(a - b) <= 1e-6;
+}
+
+function moveInputWire(mi: MoveInput): Record<string, 0 | 1> {
+  return {
+    f: mi.forward ? 1 : 0,
+    b: mi.back ? 1 : 0,
+    tl: mi.turnLeft ? 1 : 0,
+    tr: mi.turnRight ? 1 : 0,
+    sl: mi.strafeLeft ? 1 : 0,
+    sr: mi.strafeRight ? 1 : 0,
+    j: mi.jump ? 1 : 0,
+  };
+}
+
+function predictionMovementMode(p: Entity): 'charge' | 'follow' | 'fear' | undefined {
+  if (p.chargeTargetId !== null) return 'charge';
+  if (p.followTargetId !== null) return 'follow';
+  if (p.auras.some((a) => a.id === 'fear_incap' && a.kind === 'incapacitate')) return 'fear';
+  return undefined;
 }
 
 function logSocialErr(err: unknown): void {
@@ -555,6 +634,8 @@ export class GameServer {
         session.pendingMoveInputs.length = 0;
         session.appliedInputSeq = Math.max(session.appliedInputSeq, session.lastInputSeq);
       }
+      session.heldInputTicks = 0;
+      session.activeMoveFacing = null;
       const meta = this.sim.meta(session.pid);
       if (!meta) continue;
       const mi = meta.moveInput;
@@ -565,32 +646,79 @@ export class GameServer {
 
   private markInputSeqsApplied(): void {
     for (const session of this.clients.values()) {
-      const next = session.pendingMoveInputs[0];
-      if (!next) continue;
       const meta = this.sim.meta(session.pid);
       const e = this.sim.entities.get(session.pid);
       if (!meta || !e) continue;
-      Object.assign(meta.moveInput, next.moveInput);
-      if (next.facing !== null && !e.dead) e.facing = next.facing;
-      session.appliedInputSeq = next.fromSeq;
-      if (next.fromSeq >= next.toSeq) {
-        session.pendingMoveInputs.shift();
-      } else {
-        next.fromSeq++;
+
+      this.drainHeldCoveredInputs(session, meta.moveInput);
+      const next = this.consumeMoveInput(session);
+      if (next) {
+        Object.assign(meta.moveInput, next.moveInput);
+        session.activeMoveFacing = next.facing;
+        if (next.facing !== null && !e.dead) e.facing = next.facing;
+        session.appliedInputSeq = next.seq;
+        session.heldInputTicks = 0;
+        continue;
+      }
+
+      if (this.sim.time - session.lastInputAt <= STALE_INPUT_SECONDS) {
+        session.heldInputTicks = Math.min(MAX_HELD_INPUT_COVERAGE_TICKS, session.heldInputTicks + 1);
       }
     }
+  }
+
+  private drainHeldCoveredInputs(session: ClientSession, heldInput: MoveInput): void {
+    while (session.heldInputTicks > 0) {
+      const next = session.pendingMoveInputs[0];
+      if (!next) return;
+      if (!sameMoveInput(next.moveInput, heldInput) || !sameMoveFacing(next.facing, session.activeMoveFacing)) return;
+      const covered = this.consumeMoveInput(session);
+      if (!covered) return;
+      session.appliedInputSeq = covered.seq;
+      session.heldInputTicks--;
+    }
+  }
+
+  private consumeMoveInput(session: ClientSession): AppliedMoveInput | null {
+    const next = session.pendingMoveInputs[0];
+    if (!next) return null;
+    const seq = next.fromSeq;
+    const out = { seq, moveInput: next.moveInput, facing: next.facing };
+    if (next.fromSeq >= next.toSeq) {
+      session.pendingMoveInputs.shift();
+    } else {
+      next.fromSeq++;
+    }
+    return out;
   }
 
   private enqueueMoveInput(session: ClientSession, seq: number, moveInput: MoveInput, facing: number | null): boolean {
     const pending = session.pendingMoveInputs;
     const last = pending[pending.length - 1];
-    if (last && last.toSeq + 1 === seq && last.facing === facing && sameMoveInput(last.moveInput, moveInput)) {
+    if (last && last.toSeq + 1 === seq && sameMoveInput(last.moveInput, moveInput) && sameMoveFacing(last.facing, facing)) {
       last.toSeq = seq;
       return true;
     }
     if (pending.length >= MAX_PENDING_MOVE_INPUT_RUNS) return false;
     pending.push({ fromSeq: seq, toSeq: seq, moveInput, facing });
     return true;
+  }
+
+  private appendMoveInput(session: ClientSession, seq: number, moveInput: MoveInput, facing: number | null): boolean {
+    if (!this.enqueueMoveInput(session, seq, moveInput, facing)) return false;
+    session.lastInputSeq = seq;
+    session.lastInputAt = this.sim.time;
+    return true;
+  }
+
+  private drainBufferedMoveInputs(session: ClientSession): boolean {
+    while (true) {
+      const seq = session.lastInputSeq + 1;
+      const buffered = session.bufferedMoveInputs.get(seq);
+      if (!buffered) return true;
+      session.bufferedMoveInputs.delete(seq);
+      if (!this.appendMoveInput(session, seq, buffered.moveInput, buffered.facing)) return false;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -642,6 +770,9 @@ export class GameServer {
       lastInputSeq: 0,
       appliedInputSeq: 0,
       pendingMoveInputs: [],
+      bufferedMoveInputs: new Map(),
+      heldInputTicks: 0,
+      activeMoveFacing: null,
       lastInputAt: this.sim.time,
       lastSent: {},
       sentEnts: new Map(),
@@ -977,13 +1108,15 @@ export class GameServer {
       if (typeof msg.seq === 'number' && Number.isFinite(msg.seq) && msg.seq > 0) {
         const seq = Math.floor(msg.seq);
         if (seq === session.lastInputSeq + 1) {
-          if (!this.enqueueMoveInput(session, seq, moveInput, facing)) {
+          if (!this.appendMoveInput(session, seq, moveInput, facing) || !this.drainBufferedMoveInputs(session)) {
             try { session.ws.close(); } catch { /* already closing */ }
             void this.leave(session, 'movement input queue overflow');
             return;
           }
-          session.lastInputSeq = seq;
-          session.lastInputAt = sim.time;
+        } else if (seq > session.lastInputSeq + 1
+          && seq <= session.lastInputSeq + MAX_REORDERED_MOVE_INPUTS
+          && session.bufferedMoveInputs.size < MAX_REORDERED_MOVE_INPUTS) {
+          session.bufferedMoveInputs.set(seq, { moveInput, facing });
         }
       }
       return;
@@ -1252,18 +1385,26 @@ export class GameServer {
           // first sight carries the at-rest state exactly, so no settle
           // record is owed until it moves again
           ents.push(cache.fullJson);
-          session.sentEnts.set(e.id, { idVer: cache.idVer, dynVer: cache.dynVer, sentAtTick: tick, settled: true });
+          session.sentEnts.set(e.id, {
+            idVer: cache.idVer,
+            dynVer: cache.dynVer,
+            urgentVer: cache.urgentVer,
+            sentAtTick: tick,
+            settled: true,
+          });
           return;
         }
         if (known.idVer !== cache.idVer) {
           ents.push(cache.fullJson);
           known.idVer = cache.idVer;
           known.dynVer = cache.dynVer;
+          known.urgentVer = cache.urgentVer;
           known.sentAtTick = tick;
           known.settled = false;
           return;
         }
-        if (!isUpdateDue(tick, e, d2, p, known.sentAtTick) || (known.dynVer === cache.dynVer && known.settled)) {
+        const urgentChanged = known.urgentVer !== cache.urgentVer;
+        if (!urgentChanged && (!isUpdateDue(tick, e, d2, p, known.sentAtTick) || (known.dynVer === cache.dynVer && known.settled))) {
           // not due at this distance tier yet, or unchanged and already
           // settled: a bare id keeps it alive on the client
           keep.push(e.id);
@@ -1272,6 +1413,7 @@ export class GameServer {
         // due, and either changed or owing its one settle record
         known.settled = known.dynVer === cache.dynVer;
         known.dynVer = cache.dynVer;
+        known.urgentVer = cache.urgentVer;
         known.sentAtTick = tick;
         ents.push(cache.liteJson);
       });
@@ -1306,13 +1448,14 @@ export class GameServer {
   private wireCacheFor(e: Entity): EntityWireCache {
     let cache = this.wireCache.get(e.id);
     if (!cache) {
-      cache = { tick: -1, idJson: '', dynJson: '', idVer: 0, dynVer: 0, fullJson: '', liteJson: '' };
+      cache = { tick: -1, idJson: '', dynJson: '', urgentJson: '', idVer: 0, dynVer: 0, urgentVer: 0, fullJson: '', liteJson: '' };
       this.wireCache.set(e.id, cache);
     }
     if (cache.tick === this.sim.tickCount) return cache;
     cache.tick = this.sim.tickCount;
     const idJson = JSON.stringify(identityFields(e));
     const dynJson = JSON.stringify(dynamicFields(e));
+    const urgentJson = JSON.stringify(urgentDynamicFields(e));
     let changed = false;
     if (idJson !== cache.idJson) {
       cache.idJson = idJson;
@@ -1323,6 +1466,10 @@ export class GameServer {
       cache.dynJson = dynJson;
       cache.dynVer++;
       changed = true;
+    }
+    if (urgentJson !== cache.urgentJson) {
+      cache.urgentJson = urgentJson;
+      cache.urgentVer++;
     }
     if (changed) {
       cache.fullJson = `{"id":${e.id},${idJson.slice(1, -1)},${dynJson.slice(1, -1)}}`;
@@ -1365,6 +1512,10 @@ export class GameServer {
       og: p.onGround ? 1 : 0,
       fy: round2(p.fallStartY),
       ack: session.appliedInputSeq,
+      pmv: predictionMovementMode(p),
+      ackh: session.heldInputTicks > 0 ? session.heldInputTicks : undefined,
+      ackmi: session.heldInputTicks > 0 ? moveInputWire(meta.moveInput) : undefined,
+      ackf: session.heldInputTicks > 0 ? session.activeMoveFacing : undefined,
     });
     const json = JSON.stringify(self);
     // heavy, rarely-changing fields ride along only when their serialized

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,7 +1,7 @@
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
-import { DT, Entity, SimEvent, dist2d, emptyMoveInput } from '../src/sim/types';
+import { DT, Entity, SimEvent, dist2d, emptyMoveInput, type MoveInput } from '../src/sim/types';
 import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
@@ -101,8 +101,12 @@ export interface ClientSession {
   lastWhisperFrom: string | null;
   // last explicit channel this player sent to; plain text follows it.
   rememberedChat: RememberedChat;
-  // last client input sequence processed; echoed in snapshots for latency telemetry
+  // last client input sequence received by the socket
   lastInputSeq: number;
+  // last input sequence reflected by a completed sim tick; echoed in snapshots
+  // for prediction reconciliation and latency telemetry
+  appliedInputSeq: number;
+  pendingMoveInputs: QueuedMoveInput[];
   // sim time of the last movement input frame, used to clear stale held input
   lastInputAt: number;
   // serialized form of each delta self field as last sent to this client;
@@ -119,6 +123,12 @@ export interface ClientSession {
   ip: string;
   // Behavioral bot-detection state. Ephemeral — reset on every join.
   bot: BotTracker;
+}
+
+interface QueuedMoveInput {
+  seq: number;
+  moveInput: MoveInput;
+  facing: number | null;
 }
 
 interface SentEntityVersions {
@@ -172,6 +182,7 @@ interface WireAura {
   kind: string;
   rem: number;
   dur: number;
+  v: number;
 }
 
 interface WhoRosterRow {
@@ -230,7 +241,9 @@ function dynamicFields(e: Entity): Record<string, unknown> {
   // top hate-table entries so the party threat meter shows real numbers
   if (e.kind === 'mob' && !e.dead && e.threat.size > 0) out.thr = threatEntries(e, 8);
   if (e.auras.length > 0) {
-    out.auras = e.auras.map((a): WireAura => ({ id: a.id, name: a.name, kind: a.kind, rem: round2(a.remaining), dur: a.duration }));
+    out.auras = e.auras.map((a): WireAura => ({
+      id: a.id, name: a.name, kind: a.kind, rem: round2(a.remaining), dur: a.duration, v: round2(a.value),
+    }));
   }
   if (e.kind === 'mob' && e.lootable && e.loot) {
     out.lootList = { copper: e.loot.copper, items: e.loot.items };
@@ -479,6 +492,7 @@ export class GameServer {
       acc += dt;
       while (acc >= DT) {
         this.clearStaleInputs();
+        this.markInputSeqsApplied();
         const events = this.sim.tick();
         this.routeEvents(events);
         this.runAntibotTick();
@@ -522,12 +536,26 @@ export class GameServer {
 
   private clearStaleInputs(): void {
     for (const session of this.clients.values()) {
+      if (session.pendingMoveInputs.length > 0) continue;
       if (this.sim.time - session.lastInputAt <= STALE_INPUT_SECONDS) continue;
       const meta = this.sim.meta(session.pid);
       if (!meta) continue;
       const mi = meta.moveInput;
       if (!(mi.forward || mi.back || mi.turnLeft || mi.turnRight || mi.strafeLeft || mi.strafeRight || mi.jump)) continue;
       Object.assign(meta.moveInput, emptyMoveInput());
+    }
+  }
+
+  private markInputSeqsApplied(): void {
+    for (const session of this.clients.values()) {
+      const next = session.pendingMoveInputs.shift();
+      if (!next) continue;
+      const meta = this.sim.meta(session.pid);
+      const e = this.sim.entities.get(session.pid);
+      if (!meta || !e) continue;
+      Object.assign(meta.moveInput, next.moveInput);
+      if (next.facing !== null && !e.dead) e.facing = next.facing;
+      session.appliedInputSeq = next.seq;
     }
   }
 
@@ -578,6 +606,8 @@ export class GameServer {
       lastWhisperFrom: null,
       rememberedChat: { channel: 'say' },
       lastInputSeq: 0,
+      appliedInputSeq: 0,
+      pendingMoveInputs: [],
       lastInputAt: this.sim.time,
       lastSent: {},
       sentEnts: new Map(),
@@ -910,13 +940,16 @@ export class GameServer {
       const e = sim.entities.get(pid);
       if (!meta || !e) return;
       const { moveInput, facing } = parseMoveInputFrame(msg);
-      Object.assign(meta.moveInput, moveInput);
       session.lastInputAt = sim.time;
       if (typeof msg.seq === 'number' && Number.isFinite(msg.seq) && msg.seq > 0) {
-        session.lastInputSeq = Math.max(session.lastInputSeq, Math.floor(msg.seq));
-      }
-      if (facing !== null && !e.dead) {
-        e.facing = facing;
+        const seq = Math.floor(msg.seq);
+        if (seq > session.lastInputSeq) {
+          session.lastInputSeq = seq;
+          session.pendingMoveInputs.push({ seq, moveInput, facing });
+          if (session.pendingMoveInputs.length > 80) {
+            session.pendingMoveInputs.splice(0, session.pendingMoveInputs.length - 80);
+          }
+        }
       }
       return;
     }
@@ -1291,7 +1324,12 @@ export class GameServer {
       eat: p.eating ? { remaining: round2(p.eating.remaining) } : null,
       drk: p.drinking ? { remaining: round2(p.drinking.remaining) } : null,
       opUntil: p.overpowerUntil > this.sim.time ? 1 : 0,
-      ack: session.lastInputSeq,
+      vx: round2(p.vx),
+      vz: round2(p.vz),
+      vy: round2(p.vy),
+      og: p.onGround ? 1 : 0,
+      fy: round2(p.fallStartY),
+      ack: session.appliedInputSeq,
     });
     const json = JSON.stringify(self);
     // heavy, rarely-changing fields ride along only when their serialized

--- a/server/http_util.ts
+++ b/server/http_util.ts
@@ -16,14 +16,16 @@ export function isUniqueViolation(err: unknown): boolean {
   return e?.code === '23505' || (typeof e?.message === 'string' && e.message.includes('unique'));
 }
 
-export function readBody(req: http.IncomingMessage): Promise<any> {
+export function readBody(req: http.IncomingMessage, maxBytes = 64 * 1024): Promise<any> {
   return new Promise((resolve, reject) => {
     let data = '';
+    let bytes = 0;
     let aborted = false;
-    req.on('data', (c) => {
+    req.on('data', (c: Buffer | string) => {
       if (aborted) return;
+      bytes += typeof c === 'string' ? Buffer.byteLength(c) : c.byteLength;
       data += c;
-      if (data.length > 64 * 1024) {
+      if (bytes > maxBytes) {
         // Rejecting the promise does not pause the socket, so without
         // destroying the request a client could keep streaming unbounded
         // data into `data`. Stop reading and ignore any further chunks.

--- a/server/main.ts
+++ b/server/main.ts
@@ -23,6 +23,7 @@ import { requestIp, rateLimited, authThrottled, recordAuthFailure, clearAuthFail
 import { verifyTurnstile } from './turnstile';
 import { handleAdminApi } from './admin';
 import { handleInternalApi } from './internal';
+import { handlePerfReport } from './perf_report';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
 import { webLoginEnforced, isWebClientRequest } from './web_login_guard';
@@ -480,6 +481,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       } catch (err) {
         return json(res, 400, { error: err instanceof Error ? err.message : 'could not submit report' });
       }
+    }
+    if (req.method === 'POST' && url === '/api/perf-report') {
+      return await handlePerfReport(req, res);
     }
     if (req.method === 'GET' && url === '/api/project-stats') {
       const accountsCount = await getAccountsCount();

--- a/server/main.ts
+++ b/server/main.ts
@@ -5,7 +5,7 @@ import { WebSocketServer, WebSocket } from 'ws';
 import {
   ensureSchema, pool, createAccount, findAccount, getAccountsCount, touchLogin, saveToken, accountForToken,
   listCharacters, getCharacter, createCharacterCapped, deleteCharacter, closeOrphanSessions,
-  pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
+  pruneChatLogs, pruneClientPerfReports, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
   findCharacterReportTargetByName, topArenaRatings, topLifetimeXp, chatMuteStatusForAccount,
 } from './db';
 import { virtualLevel } from '../src/sim/types';
@@ -38,6 +38,9 @@ const LINKS_ALIASES = new Set([
 ]);
 // How long chat logs are kept (0 = forever); pruned at boot and daily.
 const CHAT_LOG_RETENTION_DAYS = Number(process.env.CHAT_LOG_RETENTION_DAYS ?? 90);
+// Client performance reports are operational telemetry, not permanent records.
+// Keep enough history for tuning runs while bounding table growth.
+const PERF_REPORT_RETENTION_DAYS = Number(process.env.PERF_REPORT_RETENTION_DAYS ?? 14);
 // Cloudflare Turnstile secret. When unset (local dev / tests) registration and
 // login skip human verification entirely — see requireTurnstile below.
 const TURNSTILE_SECRET = process.env.TURNSTILE_SECRET ?? '';
@@ -556,10 +559,13 @@ async function main(): Promise<void> {
   if (orphans > 0) console.log(`closed ${orphans} orphaned play session(s) from a previous run`);
   const pruned = await pruneChatLogs(CHAT_LOG_RETENTION_DAYS);
   if (pruned > 0) console.log(`pruned ${pruned} chat log row(s) older than ${CHAT_LOG_RETENTION_DAYS} days`);
+  const prunedPerfReports = await pruneClientPerfReports(PERF_REPORT_RETENTION_DAYS);
+  if (prunedPerfReports > 0) console.log(`pruned ${prunedPerfReports} client perf report row(s) older than ${PERF_REPORT_RETENTION_DAYS} days`);
   await game.loadMarket();
   await game.loadChatFilter();
   setInterval(() => {
     void pruneChatLogs(CHAT_LOG_RETENTION_DAYS).catch((err) => console.error('chat log prune failed:', err));
+    void pruneClientPerfReports(PERF_REPORT_RETENTION_DAYS).catch((err) => console.error('perf report prune failed:', err));
   }, 24 * 3600 * 1000).unref();
   // keep both leaderboard caches warm so the first viewer never waits on the
   // query and it never recomputes per request (PR-3)

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -8,7 +8,7 @@ const PERF_REPORT_SCHEMA_VERSION = 1;
 const PERF_REPORT_MAX_PER_MINUTE = 30;
 const PERF_REPORT_WINDOW_MS = 60_000;
 const PERF_REPORT_MAX_TRACKED_IPS = 5000;
-const RAW_SUMMARY_MAX_BYTES = 8192;
+const RAW_SUMMARY_MAX_BYTES = 16 * 1024;
 const RAW_SUMMARY_DEV_TRACE_MAX_BYTES = 512 * 1024;
 const PERF_REPORT_MAX_BODY_BYTES = 64 * 1024;
 const PERF_REPORT_DEV_TRACE_MAX_BODY_BYTES = 768 * 1024;
@@ -120,6 +120,75 @@ function allowDevTrace(req: http.IncomingMessage): boolean {
   return process.env.NODE_ENV !== 'production' && isLoopbackIp(requestIp(req));
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function compactPrewarmSummary(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const out: Record<string, unknown> = {};
+  const scalarKeys = [
+    'elapsedMs',
+    'maxMs',
+    'remainingMs',
+    'budgetUsedRatio',
+    'timedOut',
+    'createdViews',
+    'candidateViews',
+    'renderPasses',
+    'programsDelta',
+    'texturesDelta',
+    'compileMode',
+    'compileMs',
+    'compileTimedOut',
+    'manifestPlanned',
+    'manifestCompleted',
+    'manifestTimedOut',
+    'manifestFailed',
+    'timedOutEntryIds',
+    'failedEntryIds',
+  ];
+  for (const key of scalarKeys) {
+    if (value[key] !== undefined) out[key] = value[key];
+  }
+  const entries = Array.isArray(value.entries) ? value.entries : Array.isArray(value.manifestEntries) ? value.manifestEntries : [];
+  out.entries = entries.slice(0, 24).filter(isRecord).map((entry) => ({
+    id: textIn(entry.id, 80),
+    category: textIn(entry.category, 24),
+    required: Boolean(entry.required),
+    status: textIn(entry.status, 16),
+    elapsedMs: nullableNumberIn(entry.elapsedMs, 0, 60_000),
+    remainingMsAfter: nullableNumberIn(entry.remainingMsAfter, 0, 60_000),
+    programDelta: nullableNumberIn(entry.programDelta, -10_000, 10_000),
+    textureDelta: nullableNumberIn(entry.textureDelta, -10_000, 10_000),
+    detail: textIn(entry.detail, 160),
+  }));
+  return out;
+}
+
+function compactRawSummary(value: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = { truncated: true };
+  for (const key of [
+    'graphicsConfigVersion',
+    'seconds',
+    'frames',
+    'windows',
+    'mainMs',
+    'rendererPhaseMs',
+    'rendererFoliage',
+    'rendererBudget',
+    'rendererQualityBuckets',
+    'network',
+    'input',
+    'hud',
+  ]) {
+    if (value[key] !== undefined) out[key] = value[key];
+  }
+  const prewarm = compactPrewarmSummary(value.rendererPrewarmSummary ?? value.rendererPrewarm);
+  if (prewarm) out.rendererPrewarmSummary = prewarm;
+  return out;
+}
+
 function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
   try {
@@ -128,7 +197,10 @@ function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unk
     if (!devTraceAllowed) delete parsed.devTrace;
     const boundedText = JSON.stringify(parsed);
     const maxBytes = devTraceAllowed ? RAW_SUMMARY_DEV_TRACE_MAX_BYTES : RAW_SUMMARY_MAX_BYTES;
-    if (Buffer.byteLength(boundedText) > maxBytes) return { truncated: true };
+    if (Buffer.byteLength(boundedText) > maxBytes) {
+      const compact = compactRawSummary(parsed);
+      return Buffer.byteLength(JSON.stringify(compact)) > maxBytes ? { truncated: true } : compact;
+    }
     return JSON.parse(boundedText) as Record<string, unknown>;
   } catch {
     return {};

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -1,0 +1,199 @@
+import * as http from 'node:http';
+import { accountForToken, getCharacter, insertClientPerfReport, type ClientPerfReportInsert } from './db';
+import { json, readBody } from './http_util';
+import { requestIp } from './ratelimit';
+import { REALM } from './realm';
+
+const PERF_REPORT_SCHEMA_VERSION = 1;
+const PERF_REPORT_MAX_PER_MINUTE = 30;
+const PERF_REPORT_WINDOW_MS = 60_000;
+const PERF_REPORT_MAX_TRACKED_IPS = 5000;
+const RAW_SUMMARY_MAX_BYTES = 8192;
+
+const perfReportAttempts = new Map<string, number[]>();
+
+function rateLimitedPerfReport(req: http.IncomingMessage): boolean {
+  const ip = requestIp(req);
+  const now = Date.now();
+  const windowStart = now - PERF_REPORT_WINDOW_MS;
+  const updated = (perfReportAttempts.get(ip) ?? []).filter((t) => t > windowStart);
+  updated.push(now);
+  perfReportAttempts.set(ip, updated);
+
+  if (perfReportAttempts.size > PERF_REPORT_MAX_TRACKED_IPS) {
+    for (const [key, times] of perfReportAttempts) {
+      if (times.length === 0 || times[times.length - 1] <= windowStart) perfReportAttempts.delete(key);
+      if (perfReportAttempts.size <= PERF_REPORT_MAX_TRACKED_IPS) break;
+    }
+  }
+
+  return updated.length > PERF_REPORT_MAX_PER_MINUTE;
+}
+
+function numberIn(value: unknown, min: number, max: number, fallback: number): number {
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(max, Math.max(min, n));
+}
+
+function intIn(value: unknown, min: number, max: number, fallback: number): number {
+  return Math.floor(numberIn(value, min, max, fallback));
+}
+
+function nullableNumberIn(value: unknown, min: number, max: number): number | null {
+  if (value === null || value === undefined || value === '') return null;
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Math.min(max, Math.max(min, n));
+}
+
+function textIn(value: unknown, max: number, fallback = ''): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  return (text || fallback).slice(0, max);
+}
+
+function choiceIn(value: unknown, choices: readonly string[], fallback: string): string {
+  const text = textIn(value, 64);
+  return choices.includes(text) ? text : fallback;
+}
+
+function browserFamily(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes('edg/')) return 'edge';
+  if (ua.includes('firefox/')) return 'firefox';
+  if (ua.includes('chrome/') || ua.includes('crios/')) return 'chrome';
+  if (ua.includes('safari/')) return 'safari';
+  return 'other';
+}
+
+function osFamily(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes('windows')) return 'windows';
+  if (ua.includes('iphone') || ua.includes('ipad') || ua.includes('ios')) return 'ios';
+  if (ua.includes('mac os') || ua.includes('macintosh')) return 'macos';
+  if (ua.includes('android')) return 'android';
+  if (ua.includes('linux')) return 'linux';
+  return 'other';
+}
+
+function bucketGpu(renderer: string): string {
+  const r = renderer.toLowerCase();
+  if (!r) return 'unknown';
+  if (/swiftshader|llvmpipe|software/.test(r)) return 'software';
+  if (/apple/.test(r)) {
+    const chip = /(m[1-9][a-z0-9 ]*)/i.exec(renderer)?.[1]?.toLowerCase().replace(/\s+/g, '-');
+    return chip ? `apple-${chip}` : 'apple';
+  }
+  if (/intel/.test(r)) {
+    if (/iris/.test(r)) return 'intel-iris';
+    if (/uhd|hd graphics/.test(r)) return 'intel-uhd';
+    return 'intel';
+  }
+  if (/nvidia|geforce|rtx|gtx/.test(r)) return 'nvidia';
+  if (/amd|radeon/.test(r)) return 'amd';
+  return renderer.slice(0, 48).replace(/[^\w.-]+/g, '-').toLowerCase() || 'other';
+}
+
+function viewportBucket(body: Record<string, unknown>): string {
+  const supplied = textIn(body.viewportBucket, 32);
+  if (/^(small|medium|large|wide|mobile|unknown)(-\d+x\d+)?$/.test(supplied)) return supplied;
+  const w = intIn(body.viewportWidth, 0, 10000, 0);
+  const h = intIn(body.viewportHeight, 0, 10000, 0);
+  if (w <= 0 || h <= 0) return 'unknown';
+  const short = Math.min(w, h);
+  const long = Math.max(w, h);
+  if (short <= 480) return `mobile-${w}x${h}`;
+  if (long >= 1800) return `wide-${w}x${h}`;
+  if (long >= 1200) return `large-${w}x${h}`;
+  return `medium-${w}x${h}`;
+}
+
+function rawSummary(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+  try {
+    const text = JSON.stringify(value);
+    if (Buffer.byteLength(text) > RAW_SUMMARY_MAX_BYTES) return { truncated: true };
+    return JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function authenticatedAccountId(req: http.IncomingMessage): Promise<number | null> {
+  const m = /^Bearer ([a-f0-9]{64})$/.exec(req.headers.authorization ?? '');
+  if (!m) return null;
+  return accountForToken(m[1]);
+}
+
+async function authenticatedCharacterId(accountId: number | null, value: unknown): Promise<number | null> {
+  if (accountId === null) return null;
+  const id = intIn(value, 1, Number.MAX_SAFE_INTEGER, 0);
+  if (id <= 0) return null;
+  const character = await getCharacter(accountId, id);
+  return character ? id : null;
+}
+
+export async function handlePerfReport(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  if (req.method !== 'POST') return json(res, 405, { ok: false });
+  if (rateLimitedPerfReport(req)) return json(res, 200, { ok: true });
+
+  const body = await readBody(req) as Record<string, unknown>;
+  const accountId = await authenticatedAccountId(req);
+  const userAgent = String(req.headers['user-agent'] ?? '');
+  const glRenderer = textIn(body.glRenderer, 160);
+  const releaseVersion = textIn(body.releaseVersion, 40);
+  const buildId = textIn(body.buildId, 40);
+  const source = choiceIn(body.source, ['gameplay', 'benchmark'], 'gameplay');
+
+  const row: ClientPerfReportInsert = {
+    schemaVersion: intIn(body.schemaVersion, 1, PERF_REPORT_SCHEMA_VERSION, PERF_REPORT_SCHEMA_VERSION),
+    releaseVersion,
+    buildId,
+    sessionId: textIn(body.sessionId, 64),
+    accountId,
+    characterId: await authenticatedCharacterId(accountId, body.characterId),
+    realm: REALM,
+    graphicsPreset: choiceIn(body.graphicsPreset, ['auto', 'low', 'medium', 'high', 'ultra', 'advanced'], 'auto'),
+    gfxTier: choiceIn(body.gfxTier, ['low', 'medium', 'high', 'ultra'], 'low'),
+    autoGovernor: Boolean(body.autoGovernor),
+    targetFps: intIn(body.targetFps, 0, 240, 0),
+    renderScale: numberIn(body.renderScale, 0.3, 1.5, 1),
+    effectiveRenderScale: numberIn(body.effectiveRenderScale, 0.3, 1.5, 1),
+    fpsAvg: numberIn(body.fpsAvg, 0, 300, 0),
+    frameP95Ms: numberIn(body.frameP95Ms, 0, 1000, 0),
+    frameP99Ms: numberIn(body.frameP99Ms, 0, 1000, 0),
+    longFrameCount: intIn(body.longFrameCount, 0, 1_000_000, 0),
+    rendererCalls: intIn(body.rendererCalls, 0, 1_000_000, 0),
+    rendererTriangles: intIn(body.rendererTriangles, 0, 100_000_000, 0),
+    rendererTextures: intIn(body.rendererTextures, 0, 100_000, 0),
+    rendererPrograms: intIn(body.rendererPrograms, 0, 100_000, 0),
+    contextLostCount: intIn(body.contextLostCount, 0, 1000, 0),
+    longTaskCount: intIn(body.longTaskCount, 0, 1_000_000, 0),
+    longTaskP95Ms: numberIn(body.longTaskP95Ms, 0, 1000, 0),
+    memoryUsedMb: nullableNumberIn(body.memoryUsedMb, 0, 1_000_000),
+    memoryLimitMb: nullableNumberIn(body.memoryLimitMb, 0, 1_000_000),
+    dpr: numberIn(body.dpr, 0.1, 8, 1),
+    viewportBucket: viewportBucket(body),
+    deviceMemory: nullableNumberIn(body.deviceMemory, 0, 1024),
+    hardwareConcurrency: intIn(body.hardwareConcurrency, 0, 1024, 0),
+    mobileTouch: Boolean(body.mobileTouch),
+    browserFamily: choiceIn(body.browserFamily, ['chrome', 'safari', 'firefox', 'edge', 'other'], browserFamily(userAgent)),
+    osFamily: choiceIn(body.osFamily, ['macos', 'windows', 'ios', 'android', 'linux', 'other'], osFamily(userAgent)),
+    glVendor: textIn(body.glVendor, 80),
+    glRendererBucket: bucketGpu(glRenderer || textIn(body.glRendererBucket, 80)),
+    zoneOrScenario: textIn(body.zoneOrScenario, 80, source === 'benchmark' ? 'benchmark' : 'gameplay'),
+    source,
+    rawSummary: rawSummary(body.rawSummary),
+  };
+
+  await insertClientPerfReport(row);
+  return json(res, 200, { ok: true });
+}
+
+export const perfReportInternalsForTest = {
+  bucketGpu,
+  browserFamily,
+  osFamily,
+  viewportBucket,
+  rawSummary,
+};

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -9,6 +9,9 @@ const PERF_REPORT_MAX_PER_MINUTE = 30;
 const PERF_REPORT_WINDOW_MS = 60_000;
 const PERF_REPORT_MAX_TRACKED_IPS = 5000;
 const RAW_SUMMARY_MAX_BYTES = 8192;
+const RAW_SUMMARY_DEV_TRACE_MAX_BYTES = 512 * 1024;
+const PERF_REPORT_MAX_BODY_BYTES = 64 * 1024;
+const PERF_REPORT_DEV_TRACE_MAX_BODY_BYTES = 768 * 1024;
 
 const perfReportAttempts = new Map<string, number[]>();
 
@@ -108,12 +111,25 @@ function viewportBucket(body: Record<string, unknown>): string {
   return `medium-${w}x${h}`;
 }
 
-function rawSummary(value: unknown): Record<string, unknown> {
+function isLoopbackIp(ip: string): boolean {
+  const normalized = ip.startsWith('::ffff:') ? ip.slice('::ffff:'.length) : ip;
+  return normalized === '::1' || normalized === '127.0.0.1' || normalized.startsWith('127.');
+}
+
+function allowDevTrace(req: http.IncomingMessage): boolean {
+  return process.env.NODE_ENV !== 'production' && isLoopbackIp(requestIp(req));
+}
+
+function rawSummary(value: unknown, devTraceAllowed = false): Record<string, unknown> {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
   try {
     const text = JSON.stringify(value);
-    if (Buffer.byteLength(text) > RAW_SUMMARY_MAX_BYTES) return { truncated: true };
-    return JSON.parse(text) as Record<string, unknown>;
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    if (!devTraceAllowed) delete parsed.devTrace;
+    const boundedText = JSON.stringify(parsed);
+    const maxBytes = devTraceAllowed ? RAW_SUMMARY_DEV_TRACE_MAX_BYTES : RAW_SUMMARY_MAX_BYTES;
+    if (Buffer.byteLength(boundedText) > maxBytes) return { truncated: true };
+    return JSON.parse(boundedText) as Record<string, unknown>;
   } catch {
     return {};
   }
@@ -137,7 +153,8 @@ export async function handlePerfReport(req: http.IncomingMessage, res: http.Serv
   if (req.method !== 'POST') return json(res, 405, { ok: false });
   if (rateLimitedPerfReport(req)) return json(res, 200, { ok: true });
 
-  const body = await readBody(req) as Record<string, unknown>;
+  const devTraceAllowed = allowDevTrace(req);
+  const body = await readBody(req, devTraceAllowed ? PERF_REPORT_DEV_TRACE_MAX_BODY_BYTES : PERF_REPORT_MAX_BODY_BYTES) as Record<string, unknown>;
   const accountId = await authenticatedAccountId(req);
   const userAgent = String(req.headers['user-agent'] ?? '');
   const glRenderer = textIn(body.glRenderer, 160);
@@ -183,7 +200,7 @@ export async function handlePerfReport(req: http.IncomingMessage, res: http.Serv
     glRendererBucket: bucketGpu(glRenderer || textIn(body.glRendererBucket, 80)),
     zoneOrScenario: textIn(body.zoneOrScenario, 80, source === 'benchmark' ? 'benchmark' : 'gameplay'),
     source,
-    rawSummary: rawSummary(body.rawSummary),
+    rawSummary: rawSummary(body.rawSummary, devTraceAllowed),
   };
 
   await insertClientPerfReport(row);
@@ -195,5 +212,6 @@ export const perfReportInternalsForTest = {
   browserFamily,
   osFamily,
   viewportBucket,
+  allowDevTrace,
   rawSummary,
 };

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -13,7 +13,19 @@ const RAW_SUMMARY_DEV_TRACE_MAX_BYTES = 512 * 1024;
 const PERF_REPORT_MAX_BODY_BYTES = 64 * 1024;
 const PERF_REPORT_DEV_TRACE_MAX_BODY_BYTES = 768 * 1024;
 
+function envNumber(name: string, fallback: number): number {
+  const n = Number(process.env[name] ?? fallback);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+const PERF_REPORT_MIN_INSERT_INTERVAL_MS = Math.max(
+  10_000,
+  Math.min(10 * 60_000, envNumber('PERF_REPORT_MIN_INSERT_INTERVAL_MS', 45_000)),
+);
+const PERF_REPORT_MAX_TRACKED_SESSIONS = 20_000;
+
 const perfReportAttempts = new Map<string, number[]>();
+const perfReportLastInsertBySession = new Map<string, number>();
 
 function rateLimitedPerfReport(req: http.IncomingMessage): boolean {
   const ip = requestIp(req);
@@ -31,6 +43,26 @@ function rateLimitedPerfReport(req: http.IncomingMessage): boolean {
   }
 
   return updated.length > PERF_REPORT_MAX_PER_MINUTE;
+}
+
+function throttleKey(req: http.IncomingMessage, sessionId: string): string {
+  const session = sessionId || 'anonymous';
+  return `${requestIp(req)}:${session}`;
+}
+
+function shouldStorePerfReport(req: http.IncomingMessage, sessionId: string, now = Date.now()): boolean {
+  const key = throttleKey(req, sessionId);
+  const previous = perfReportLastInsertBySession.get(key);
+  perfReportLastInsertBySession.delete(key);
+  perfReportLastInsertBySession.set(key, now);
+
+  while (perfReportLastInsertBySession.size > PERF_REPORT_MAX_TRACKED_SESSIONS) {
+    const oldest = perfReportLastInsertBySession.keys().next().value as string | undefined;
+    if (!oldest) break;
+    perfReportLastInsertBySession.delete(oldest);
+  }
+
+  return previous === undefined || now - previous >= PERF_REPORT_MIN_INSERT_INTERVAL_MS;
 }
 
 function numberIn(value: unknown, min: number, max: number, fallback: number): number {
@@ -227,6 +259,9 @@ export async function handlePerfReport(req: http.IncomingMessage, res: http.Serv
 
   const devTraceAllowed = allowDevTrace(req);
   const body = await readBody(req, devTraceAllowed ? PERF_REPORT_DEV_TRACE_MAX_BODY_BYTES : PERF_REPORT_MAX_BODY_BYTES) as Record<string, unknown>;
+  const sessionId = textIn(body.sessionId, 64);
+  if (!shouldStorePerfReport(req, sessionId)) return json(res, 200, { ok: true });
+
   const accountId = await authenticatedAccountId(req);
   const userAgent = String(req.headers['user-agent'] ?? '');
   const glRenderer = textIn(body.glRenderer, 160);
@@ -238,7 +273,7 @@ export async function handlePerfReport(req: http.IncomingMessage, res: http.Serv
     schemaVersion: intIn(body.schemaVersion, 1, PERF_REPORT_SCHEMA_VERSION, PERF_REPORT_SCHEMA_VERSION),
     releaseVersion,
     buildId,
-    sessionId: textIn(body.sessionId, 64),
+    sessionId,
     accountId,
     characterId: await authenticatedCharacterId(accountId, body.characterId),
     realm: REALM,
@@ -286,4 +321,5 @@ export const perfReportInternalsForTest = {
   viewportBucket,
   allowDevTrace,
   rawSummary,
+  shouldStorePerfReport,
 };

--- a/server/perf_report.ts
+++ b/server/perf_report.ts
@@ -22,6 +22,10 @@ const PERF_REPORT_MIN_INSERT_INTERVAL_MS = Math.max(
   10_000,
   Math.min(10 * 60_000, envNumber('PERF_REPORT_MIN_INSERT_INTERVAL_MS', 45_000)),
 );
+const PERF_REPORT_DEV_TRACE_MIN_INSERT_INTERVAL_MS = Math.max(
+  2_000,
+  Math.min(PERF_REPORT_MIN_INSERT_INTERVAL_MS, envNumber('PERF_REPORT_DEV_TRACE_MIN_INSERT_INTERVAL_MS', 10_000)),
+);
 const PERF_REPORT_MAX_TRACKED_SESSIONS = 20_000;
 
 const perfReportAttempts = new Map<string, number[]>();
@@ -50,7 +54,12 @@ function throttleKey(req: http.IncomingMessage, sessionId: string): string {
   return `${requestIp(req)}:${session}`;
 }
 
-function shouldStorePerfReport(req: http.IncomingMessage, sessionId: string, now = Date.now()): boolean {
+function shouldStorePerfReport(
+  req: http.IncomingMessage,
+  sessionId: string,
+  now = Date.now(),
+  minInsertIntervalMs = PERF_REPORT_MIN_INSERT_INTERVAL_MS,
+): boolean {
   const key = throttleKey(req, sessionId);
   const previous = perfReportLastInsertBySession.get(key);
   perfReportLastInsertBySession.delete(key);
@@ -62,7 +71,7 @@ function shouldStorePerfReport(req: http.IncomingMessage, sessionId: string, now
     perfReportLastInsertBySession.delete(oldest);
   }
 
-  return previous === undefined || now - previous >= PERF_REPORT_MIN_INSERT_INTERVAL_MS;
+  return previous === undefined || now - previous >= minInsertIntervalMs;
 }
 
 function numberIn(value: unknown, min: number, max: number, fallback: number): number {
@@ -211,6 +220,7 @@ function compactRawSummary(value: Record<string, unknown>): Record<string, unkno
     'rendererBudget',
     'rendererQualityBuckets',
     'network',
+    'predictionTrace',
     'input',
     'hud',
   ]) {
@@ -260,7 +270,10 @@ export async function handlePerfReport(req: http.IncomingMessage, res: http.Serv
   const devTraceAllowed = allowDevTrace(req);
   const body = await readBody(req, devTraceAllowed ? PERF_REPORT_DEV_TRACE_MAX_BODY_BYTES : PERF_REPORT_MAX_BODY_BYTES) as Record<string, unknown>;
   const sessionId = textIn(body.sessionId, 64);
-  if (!shouldStorePerfReport(req, sessionId)) return json(res, 200, { ok: true });
+  const minInsertIntervalMs = devTraceAllowed
+    ? PERF_REPORT_DEV_TRACE_MIN_INSERT_INTERVAL_MS
+    : PERF_REPORT_MIN_INSERT_INTERVAL_MS;
+  if (!shouldStorePerfReport(req, sessionId, Date.now(), minInsertIntervalMs)) return json(res, 200, { ok: true });
 
   const accountId = await authenticatedAccountId(req);
   const userAgent = String(req.headers['user-agent'] ?? '');

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -49,6 +49,29 @@ export interface TouchMoveInput {
   strafeRight: boolean;
 }
 
+export interface InputDebugState {
+  suspendMovement: boolean;
+  attackMoveEnabled: boolean;
+  mouseCameraEnabled: boolean;
+  activeElementTag: string;
+  keyCount: number;
+  keys: string[];
+  movementHeld: {
+    forward: boolean;
+    back: boolean;
+    turnLeft: boolean;
+    turnRight: boolean;
+    strafeLeft: boolean;
+    strafeRight: boolean;
+    jump: boolean;
+  };
+  leftDown: boolean;
+  rightDown: boolean;
+  cameraDragActive: boolean;
+  pointerLocked: boolean;
+  hoverActive: boolean;
+}
+
 export class Input {
   keys = new Set<string>();
   leftDown = false;
@@ -75,8 +98,9 @@ export class Input {
   // True while the current click-to-move was issued as an attack-move (walk to
   // the point and auto-attack enemies). Set by setClickMoveTarget, cleared on stop.
   clickMoveAttack = false;
-  // When on (the Attack Move setting), WASD/keyboard steering is disabled and the
-  // Attack Move key issues attack-moves toward the cursor instead of turning.
+  // When on (the Attack Move setting), only the attack-move key itself is
+  // reserved. Other movement keys still work so enabling Attack Move cannot
+  // make WASD appear dead.
   private attackMoveEnabled = false;
   /** Latest pointer position while over the canvas (for hover pick). */
   hoverX = 0;
@@ -217,6 +241,31 @@ export class Input {
 
   setAttackMoveEnabled(on: boolean): void {
     this.attackMoveEnabled = on;
+  }
+
+  debugState(): InputDebugState {
+    return {
+      suspendMovement: this.suspendMovement,
+      attackMoveEnabled: this.attackMoveEnabled,
+      mouseCameraEnabled: this.mouseCameraEnabled,
+      activeElementTag: (document.activeElement?.tagName ?? '').toLowerCase(),
+      keyCount: this.keys.size,
+      keys: [...this.keys].sort(),
+      movementHeld: {
+        forward: this.heldAction('forward'),
+        back: this.heldAction('back'),
+        turnLeft: this.heldAction('turnLeft'),
+        turnRight: this.heldAction('turnRight'),
+        strafeLeft: this.heldAction('strafeLeft'),
+        strafeRight: this.heldAction('strafeRight'),
+        jump: this.keybinds.codesForAction('jump').some((c) => this.keys.has(c)),
+      },
+      leftDown: this.leftDown,
+      rightDown: this.rightDown,
+      cameraDragActive: this.cameraDragActive,
+      pointerLocked: document.pointerLockElement === this.canvas,
+      hoverActive: this.hoverActive,
+    };
   }
 
   setMouseCameraEnabled(on: boolean): void {
@@ -553,22 +602,25 @@ export class Input {
     this.cb.onInputIntent?.(kind);
   }
 
+  private isAttackMoveReservedCode(code: string): boolean {
+    return this.attackMoveEnabled && this.keybinds.codesForAction('attackMove').includes(code);
+  }
+
+  private heldAction(id: string): boolean {
+    return this.keybinds.codesForAction(id).some((c) => this.keys.has(c) && !this.isAttackMoveReservedCode(c));
+  }
+
   readMoveInput(): MoveInput {
     if (this.suspendMovement) {
       return { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
     }
     if (this.controllerMoveInput) return { ...this.controllerMoveInput };
-    const k = this.keys;
-    // Attack Move mode replaces keyboard steering with click/key-driven movement,
-    // so WASD (and Q/E strafe / arrow turn) are ignored; the mouse-run, autorun
-    // and touch joystick still work.
-    const held = (id: string) => !this.attackMoveEnabled
-      && this.keybinds.codesForAction(id).some((c) => k.has(c));
+    const held = (id: string) => this.heldAction(id);
     const bothButtons = this.leftDown && this.rightDown;
     const forward = held('forward') || bothButtons || this.autorun || this.touchMove.forward;
     const back = held('back') || this.touchMove.back;
     // Jump is not a WASD key, so it keeps working in Attack Move mode.
-    const jump = this.keybinds.codesForAction('jump').some((c) => k.has(c)) || performance.now() <= this.touchJumpUntil;
+    const jump = this.keybinds.codesForAction('jump').some((c) => this.keys.has(c)) || performance.now() <= this.touchJumpUntil;
 
     if (this.mouseCameraEnabled) {
       return {

--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -20,9 +20,9 @@ export interface BindAction {
   defaults: string[]; // 1 or 2 codes; index 0 = primary, 1 = secondary
   // When true this action is exempt from the WoW-style "one code per action"
   // uniqueness sweep: its code may deliberately overlap another action's. Used
-  // by Attack Move, whose default (A) intentionally shadows Turn Left — the two
-  // are mutually exclusive (Attack Move mode disables WASD), so they can share a
-  // key without either stealing it from the other on save/load.
+  // by Attack Move, whose default (A) intentionally shadows Turn Left while the
+  // setting is on, so they can share a key without either stealing it from the
+  // other on save/load.
   allowShared?: boolean;
 }
 
@@ -46,8 +46,8 @@ export const BIND_ACTIONS: BindAction[] = [
   { id: 'targetFriendly', label: 'Target Nearest Friendly', category: 'Targeting', kind: 'edge', defaults: ['KeyH'] },
   { id: 'targetFriendlyNext', label: 'Cycle Friendly Target', category: 'Targeting', kind: 'edge', defaults: ['KeyJ'] },
   { id: 'interact', label: 'Interact / Loot', category: 'Targeting', kind: 'edge', defaults: ['KeyF'] },
-  // Only acts while the Attack Move setting is on (then WASD is disabled); shares
-  // its default key with Turn Left intentionally — see allowShared.
+  // Only acts while the Attack Move setting is on; shares its default key with
+  // Turn Left intentionally, and only that key is reserved while active.
   { id: 'attackMove', label: 'Attack Move', category: 'Targeting', kind: 'edge', defaults: ['KeyA'], allowShared: true },
   // Interface windows
   { id: 'char', label: 'Character', category: 'Interface', kind: 'edge', defaults: ['KeyC'] },

--- a/src/game/perf.ts
+++ b/src/game/perf.ts
@@ -1,6 +1,5 @@
 import type { Renderer } from '../render/renderer';
 import { assetTimingSnapshot, type AssetTimingSnapshot } from '../render/assets/stats';
-import { analyzePerfSuggestions, type PerfSuggestion } from './perf_doctor';
 
 export interface PerfSnapshot {
   seconds: number;
@@ -24,6 +23,7 @@ export interface PerfSnapshot {
     intentToSend: { count: number; avg: number; p95: number; max: number };
     sendToEcho: { count: number; avg: number; p95: number; max: number };
     intentToVisible: { count: number; avg: number; p95: number; max: number };
+    debug?: PerfInputDebugState | null;
   };
   browser: {
     longTasks: { count: number; totalMs: number; avg: number; p95: number; max: number; lastAge: number };
@@ -42,6 +42,8 @@ export interface PerfSnapshot {
   devTrace?: DevPerfTrace;
 }
 
+export type PerfInputDebugState = Record<string, unknown>;
+
 type TimedBucket = 'renderer' | 'hud' | 'events' | 'sim';
 const MAX_SAMPLES = 7200; // ~2 minutes at 60fps; enough for stable p95/p99 without unbounded growth.
 const MAX_WINDOW_MS = 30_000;
@@ -49,6 +51,9 @@ const DEV_TRACE_WORST_FRAME_LIMIT = 40;
 const DEV_TRACE_LONG_TASK_LIMIT = 80;
 const DEV_TRACE_ATTRIBUTION_LIMIT = 4;
 const DEV_TRACE_MIN_FRAME_MS = 33;
+const DEV_TRACE_STALL_ATTRIBUTION_MS = 80;
+const DEV_TRACE_STALL_CATEGORY_LIMIT = 8;
+const DEV_TRACE_STALL_SAMPLE_LIMIT = 12;
 const DEV_TRACE_SPAN_LIMIT = 120;
 const DEV_TRACE_SPAN_MIN_MS = 8;
 const DEV_TRACE_DETAIL_LIMIT = 16;
@@ -56,6 +61,51 @@ const DEV_TRACE_DETAIL_LIMIT = 16;
 type RendererStats = NonNullable<ReturnType<Renderer['perfStats']>>;
 type DevRendererFrame = Omit<NonNullable<RendererStats['lastFrame']>, 'renderDiagnostics'>;
 type DevTraceDetail = Record<string, string | number | boolean | null>;
+
+interface DevRenderStallCategory {
+  name: string;
+  objects: number;
+  draws: number;
+  triangles: number;
+  points: number;
+  materials: number;
+  materialSamples: string[];
+}
+
+interface DevRenderStallAttribution {
+  submitMs: number;
+  totalMs: number;
+  calls: number;
+  triangles: number;
+  programs: number;
+  textures: number;
+  programDelta: number;
+  textureDelta: number;
+  cameraPosition: { x: number; y: number; z: number };
+  playerPosition: { x: number; y: number; z: number };
+  biome: string;
+  createdViews: number;
+  removedViews: number;
+  candidateViews: number;
+  activeViews: number;
+  visibleViews: number;
+  createdViewTypes: string[];
+  lastQualityChange: DevRendererFrame['lastQualityChange'];
+  renderBudget: RendererStats['renderBudget'];
+  qualityLevels: RendererStats['qualityBuckets']['levels'];
+  qualityFeatures: RendererStats['qualityBuckets']['features'];
+  foliage: RendererStats['foliage'];
+  diagnostics: {
+    enabled: boolean;
+    totalObjects: number;
+    estimatedDraws: number;
+    estimatedTriangles: number;
+    estimatedPoints: number;
+    newMaterials: string[];
+    firstVisibleObjects: string[];
+    topCategories: DevRenderStallCategory[];
+  };
+}
 
 interface DevPerfTraceFrame {
   atMs: number;
@@ -72,6 +122,7 @@ interface DevPerfTraceFrame {
     renderScale: number;
     effectiveRenderScale: number;
     renderBudget: RendererStats['renderBudget'];
+    qualityBuckets: RendererStats['qualityBuckets'];
     pixelRatio: number;
     width: number;
     height: number;
@@ -85,6 +136,7 @@ interface DevPerfTraceFrame {
     memoryUsedMb: number | null;
   };
   network: PerfSnapshot['network'];
+  stallAttribution?: DevRenderStallAttribution;
 }
 
 interface DevPerfTraceSpan {
@@ -170,6 +222,64 @@ function pushSample(values: number[], sample: number): void {
   if (values.length > MAX_SAMPLES) values.splice(0, values.length - MAX_SAMPLES);
 }
 
+function renderStallCategories(rendererFrame: NonNullable<RendererStats['lastFrame']>): DevRenderStallCategory[] {
+  const categories = rendererFrame.renderDiagnostics.categories;
+  return Object.entries(categories)
+    .map(([name, stat]) => ({
+      name: name.slice(0, 80),
+      objects: stat.objects,
+      draws: stat.draws,
+      triangles: stat.triangles,
+      points: stat.points,
+      materials: stat.materials,
+      materialSamples: stat.materialSamples.slice(0, 4),
+    }))
+    .sort((a, b) => (b.triangles - a.triangles) || (b.draws - a.draws) || a.name.localeCompare(b.name))
+    .slice(0, DEV_TRACE_STALL_CATEGORY_LIMIT);
+}
+
+function renderStallAttribution(
+  renderer: RendererStats,
+  rendererFrame: NonNullable<RendererStats['lastFrame']>,
+): DevRenderStallAttribution | undefined {
+  if (rendererFrame.phaseMs.submit < DEV_TRACE_STALL_ATTRIBUTION_MS) return undefined;
+  const diagnostics = rendererFrame.renderDiagnostics;
+  return {
+    submitMs: rendererFrame.phaseMs.submit,
+    totalMs: rendererFrame.phaseMs.total,
+    calls: renderer.calls,
+    triangles: renderer.triangles,
+    programs: renderer.programs,
+    textures: renderer.textures,
+    programDelta: diagnostics.programDelta,
+    textureDelta: diagnostics.textureDelta,
+    cameraPosition: rendererFrame.cameraPosition,
+    playerPosition: rendererFrame.playerPosition,
+    biome: rendererFrame.biome,
+    createdViews: rendererFrame.createdViews,
+    removedViews: rendererFrame.removedViews,
+    candidateViews: rendererFrame.candidateViews,
+    activeViews: rendererFrame.activeViews,
+    visibleViews: rendererFrame.visibleViews,
+    createdViewTypes: rendererFrame.createdViewTypes.slice(0, DEV_TRACE_STALL_SAMPLE_LIMIT),
+    lastQualityChange: rendererFrame.lastQualityChange,
+    renderBudget: renderer.renderBudget,
+    qualityLevels: renderer.qualityBuckets.levels,
+    qualityFeatures: renderer.qualityBuckets.features,
+    foliage: renderer.foliage,
+    diagnostics: {
+      enabled: diagnostics.enabled,
+      totalObjects: diagnostics.totalObjects,
+      estimatedDraws: diagnostics.estimatedDraws,
+      estimatedTriangles: diagnostics.estimatedTriangles,
+      estimatedPoints: diagnostics.estimatedPoints,
+      newMaterials: diagnostics.newMaterials.slice(0, DEV_TRACE_STALL_SAMPLE_LIMIT),
+      firstVisibleObjects: diagnostics.firstVisibleObjects.slice(0, DEV_TRACE_STALL_SAMPLE_LIMIT),
+      topCategories: renderStallCategories(rendererFrame),
+    },
+  };
+}
+
 function sanitizeTraceDetail(detail?: Record<string, unknown>): DevTraceDetail | undefined {
   if (!detail) return undefined;
   const out: DevTraceDetail = {};
@@ -208,11 +318,6 @@ export function localDevPerfTraceEnabled(): boolean {
 export class PerfMonitor {
   readonly enabled: boolean;
   private overlay: HTMLDivElement | null = null;
-  private doctor: HTMLDivElement | null = null;
-  private doctorList: HTMLDivElement | null = null;
-  private doctorDismissed = false;
-  private lastDoctorAt = 0;
-  private lastDoctorIds = '';
   private startedAt = performance.now();
   private lastOverlayAt = 0;
   private frames = 0;
@@ -238,6 +343,7 @@ export class PerfMonitor {
   private lastLongTaskAt = 0;
   private longTaskObserver: PerformanceObserver | null = null;
   private readonly traceEnabled: boolean;
+  private inputDebugProvider: (() => PerfInputDebugState | null) | null = null;
   private devTraceFrames: DevPerfTraceFrame[] = [];
   private devTraceSpans: DevPerfTraceSpan[] = [];
   private devLongTasks: DevLongTaskRecord[] = [];
@@ -258,6 +364,10 @@ export class PerfMonitor {
 
   setHud(hud: { perfStats(): PerfSnapshot['hud'] }): void {
     this.hud = hud;
+  }
+
+  setInputDebugProvider(provider: () => PerfInputDebugState | null): void {
+    this.inputDebugProvider = provider;
   }
 
   frame(dt: number, now = performance.now()): void {
@@ -496,6 +606,9 @@ export class PerfMonitor {
         return frame;
       })()
       : null;
+    const stallAttribution = renderer && rendererFrame
+      ? renderStallAttribution(renderer, rendererFrame)
+      : undefined;
     const frame: DevPerfTraceFrame = {
       atMs: round(now - this.startedAt),
       frameMs: round(this.lastFrameMs),
@@ -511,6 +624,7 @@ export class PerfMonitor {
         renderScale: renderer.renderScale,
         effectiveRenderScale: renderer.effectiveRenderScale,
         renderBudget: renderer.renderBudget,
+        qualityBuckets: renderer.qualityBuckets,
         pixelRatio: renderer.pixelRatio,
         width: renderer.width,
         height: renderer.height,
@@ -524,6 +638,7 @@ export class PerfMonitor {
         memoryUsedMb: memory?.usedMB ?? null,
       },
       network: this.network,
+      ...(stallAttribution ? { stallAttribution } : {}),
     };
     this.devTraceFrames.push(frame);
     this.devTraceFrames.sort((a, b) => b.scoreMs - a.scoreMs || b.frameMs - a.frameMs || a.atMs - b.atMs);
@@ -539,7 +654,6 @@ export class PerfMonitor {
     this.lastSnapshot = this.snapshot(now);
     if (!this.enabled) return;
     this.renderOverlay(this.lastSnapshot);
-    this.renderDoctor(this.lastSnapshot, now);
   }
 
   snapshot(now = performance.now()): PerfSnapshot {
@@ -559,6 +673,7 @@ export class PerfMonitor {
         frameMs: summarizeFrames(samples.map((s) => s.ms)),
       };
     };
+    const inputDebug = this.readInputDebug();
     const snapshot: PerfSnapshot = {
       seconds: round(seconds),
       frames: this.frames,
@@ -581,6 +696,7 @@ export class PerfMonitor {
         intentToSend: summarize(this.inputToSendMs),
         sendToEcho: summarize(this.inputToEchoMs),
         intentToVisible: summarize(this.inputToVisibleMs),
+        ...(inputDebug ? { debug: inputDebug } : {}),
       },
       browser: {
         longTasks: {
@@ -612,6 +728,15 @@ export class PerfMonitor {
       };
     }
     return snapshot;
+  }
+
+  private readInputDebug(): PerfInputDebugState | null {
+    if (!this.inputDebugProvider) return null;
+    try {
+      return this.inputDebugProvider();
+    } catch {
+      return null;
+    }
   }
 
   report(): PerfSnapshot {
@@ -675,93 +800,6 @@ export class PerfMonitor {
     this.overlay.textContent = 'perf: collecting...';
     this.overlay.addEventListener('click', () => this.copyReport());
     document.body.appendChild(this.overlay);
-  }
-
-  private mountDoctor(): void {
-    this.doctor = document.createElement('div');
-    this.doctor.style.cssText = [
-      'position:fixed',
-      'right:14px',
-      'bottom:14px',
-      'z-index:2147483600',
-      'width:min(360px,calc(100vw - 28px))',
-      'font:13px/1.35 system-ui,-apple-system,Segoe UI,sans-serif',
-      'color:#e5edf8',
-      'background:rgba(8,13,22,0.94)',
-      'border:1px solid rgba(250,204,21,0.42)',
-      'border-radius:8px',
-      'box-shadow:0 12px 36px rgba(0,0,0,0.45)',
-      'padding:11px',
-      'pointer-events:auto',
-    ].join(';');
-    const head = document.createElement('div');
-    head.style.cssText = 'display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:7px';
-    const title = document.createElement('div');
-    title.textContent = 'Performance suggestions';
-    title.style.cssText = 'font-weight:700;color:#fde68a;letter-spacing:0';
-    const close = document.createElement('button');
-    close.type = 'button';
-    close.textContent = 'x';
-    close.setAttribute('aria-label', 'Dismiss performance suggestions');
-    close.style.cssText = [
-      'width:28px',
-      'height:28px',
-      'border:1px solid rgba(255,255,255,0.18)',
-      'border-radius:6px',
-      'background:rgba(255,255,255,0.08)',
-      'color:#e5edf8',
-      'font:20px/1 system-ui,sans-serif',
-      'cursor:pointer',
-    ].join(';');
-    close.addEventListener('click', () => {
-      this.doctorDismissed = true;
-      this.doctor?.remove();
-      this.doctor = null;
-      this.doctorList = null;
-    });
-    head.append(title, close);
-    this.doctorList = document.createElement('div');
-    this.doctor.append(head, this.doctorList);
-    document.body.appendChild(this.doctor);
-  }
-
-  private renderDoctor(s: PerfSnapshot, now: number): void {
-    if (this.doctorDismissed || now - this.startedAt < 12_000 || now - this.lastDoctorAt < 5_000) return;
-    this.lastDoctorAt = now;
-    const suggestions = analyzePerfSuggestions(s, location.search);
-    if (!suggestions.length) {
-      this.doctor?.remove();
-      this.doctor = null;
-      this.doctorList = null;
-      this.lastDoctorIds = '';
-      return;
-    }
-    const ids = suggestions.map((x) => x.id).join('|');
-    if (ids === this.lastDoctorIds && this.doctor) return;
-    this.lastDoctorIds = ids;
-    if (!this.doctor) this.mountDoctor();
-    if (!this.doctorList) return;
-    this.doctorList.replaceChildren(...suggestions.map((suggestion) => this.doctorItem(suggestion)));
-  }
-
-  private doctorItem(suggestion: PerfSuggestion): HTMLElement {
-    const item = document.createElement('div');
-    item.style.cssText = 'padding:8px 0;border-top:1px solid rgba(255,255,255,0.08)';
-    const title = document.createElement('div');
-    title.textContent = suggestion.title;
-    title.style.cssText = `font-weight:700;color:${suggestion.severity === 'critical' ? '#fecaca' : '#dbeafe'};margin-bottom:3px`;
-    const body = document.createElement('div');
-    body.textContent = suggestion.body;
-    body.style.cssText = 'color:#b8c4d6';
-    item.append(title, body);
-    if (suggestion.action) {
-      const action = document.createElement('a');
-      action.textContent = suggestion.action.label;
-      action.href = suggestion.action.href;
-      action.style.cssText = 'display:inline-block;margin-top:7px;color:#93c5fd;text-decoration:underline;font-weight:700';
-      item.append(action);
-    }
-    return item;
   }
 
   private renderOverlay(s: PerfSnapshot): void {

--- a/src/game/perf.ts
+++ b/src/game/perf.ts
@@ -39,11 +39,96 @@ export interface PerfSnapshot {
     deviceMemory: number | null;
     maxTouchPoints: number;
   };
+  devTrace?: DevPerfTrace;
 }
 
 type TimedBucket = 'renderer' | 'hud' | 'events' | 'sim';
 const MAX_SAMPLES = 7200; // ~2 minutes at 60fps; enough for stable p95/p99 without unbounded growth.
 const MAX_WINDOW_MS = 30_000;
+const DEV_TRACE_WORST_FRAME_LIMIT = 40;
+const DEV_TRACE_LONG_TASK_LIMIT = 80;
+const DEV_TRACE_ATTRIBUTION_LIMIT = 4;
+const DEV_TRACE_MIN_FRAME_MS = 33;
+const DEV_TRACE_SPAN_LIMIT = 120;
+const DEV_TRACE_SPAN_MIN_MS = 8;
+const DEV_TRACE_DETAIL_LIMIT = 16;
+
+type RendererStats = NonNullable<ReturnType<Renderer['perfStats']>>;
+type DevRendererFrame = Omit<NonNullable<RendererStats['lastFrame']>, 'renderDiagnostics'>;
+type DevTraceDetail = Record<string, string | number | boolean | null>;
+
+interface DevPerfTraceFrame {
+  atMs: number;
+  frameMs: number;
+  scoreMs: number;
+  reasons: string[];
+  mainMs: Record<TimedBucket, number>;
+  renderer: {
+    calls: number;
+    triangles: number;
+    textures: number;
+    programs: number;
+    views: number;
+    renderScale: number;
+    effectiveRenderScale: number;
+    renderBudget: RendererStats['renderBudget'];
+    pixelRatio: number;
+    width: number;
+    height: number;
+    foliage: RendererStats['foliage'];
+    lastFrame: DevRendererFrame | null;
+  } | null;
+  browser: {
+    longTaskCount: number;
+    longTaskTotalMs: number;
+    longTaskLastAgeMs: number;
+    memoryUsedMb: number | null;
+  };
+  network: PerfSnapshot['network'];
+}
+
+interface DevPerfTraceSpan {
+  atMs: number;
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  name: string;
+  kind: 'bucket' | 'scope' | 'external';
+  detail?: DevTraceDetail;
+}
+
+interface DevLongTaskAttribution {
+  name: string;
+  entryType: string;
+  containerType: string;
+  containerName: string;
+  containerId: string;
+  containerSrc: string;
+}
+
+interface DevLongTaskRecord {
+  startMs: number;
+  endMs: number;
+  durationMs: number;
+  name: string;
+  entryType: string;
+  attribution: DevLongTaskAttribution[];
+  nearestFrameAtMs?: number;
+  nearestFrameMs?: number;
+  nearestFrameDeltaMs?: number;
+  nearestSpanName?: string;
+  nearestSpanMs?: number;
+  nearestSpanDeltaMs?: number;
+}
+
+export interface DevPerfTrace {
+  enabled: true;
+  worstFrameLimit: number;
+  minFrameMs: number;
+  frames: DevPerfTraceFrame[];
+  spans: DevPerfTraceSpan[];
+  longTasks: DevLongTaskRecord[];
+}
 
 interface FrameSample {
   at: number;
@@ -85,6 +170,41 @@ function pushSample(values: number[], sample: number): void {
   if (values.length > MAX_SAMPLES) values.splice(0, values.length - MAX_SAMPLES);
 }
 
+function sanitizeTraceDetail(detail?: Record<string, unknown>): DevTraceDetail | undefined {
+  if (!detail) return undefined;
+  const out: DevTraceDetail = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(detail)) {
+    if (count >= DEV_TRACE_DETAIL_LIMIT) break;
+    const cleanKey = key.slice(0, 40);
+    if (typeof value === 'string') {
+      out[cleanKey] = value.slice(0, 120);
+    } else if (typeof value === 'number') {
+      out[cleanKey] = Number.isFinite(value) ? round(value) : null;
+    } else if (typeof value === 'boolean' || value === null) {
+      out[cleanKey] = value;
+    } else if (Array.isArray(value)) {
+      out[cleanKey] = value.slice(0, 8).map((v) => String(v).slice(0, 40)).join(',');
+    } else if (value !== undefined) {
+      out[cleanKey] = String(value).slice(0, 120);
+    }
+    count++;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+export function localDevPerfTraceEnabled(): boolean {
+  if (!import.meta.env.DEV) return false;
+  if (typeof location === 'undefined') return false;
+  const params = new URLSearchParams(location.search);
+  if (params.get('perfTrace') !== '1' && params.get('perf_trace') !== '1') return false;
+  return isLoopbackHostname(location.hostname);
+}
+
 export class PerfMonitor {
   readonly enabled: boolean;
   private overlay: HTMLDivElement | null = null;
@@ -97,8 +217,10 @@ export class PerfMonitor {
   private lastOverlayAt = 0;
   private frames = 0;
   private frameMs: number[] = [];
+  private lastFrameMs = 0;
   private frameWindow: FrameSample[] = [];
   private buckets: Record<TimedBucket, number[]> = { renderer: [], hud: [], events: [], sim: [] };
+  private lastBucketMs: Record<TimedBucket, number> = { renderer: 0, hud: 0, events: 0, sim: 0 };
   private lastSnapshot: PerfSnapshot | null = null;
   private network: PerfSnapshot['network'] = null;
   private inputIntents = 0;
@@ -115,10 +237,15 @@ export class PerfMonitor {
   private longTaskTotalMs = 0;
   private lastLongTaskAt = 0;
   private longTaskObserver: PerformanceObserver | null = null;
+  private readonly traceEnabled: boolean;
+  private devTraceFrames: DevPerfTraceFrame[] = [];
+  private devTraceSpans: DevPerfTraceSpan[] = [];
+  private devLongTasks: DevLongTaskRecord[] = [];
 
   constructor(private renderer: Renderer | null, private hud: { perfStats(): PerfSnapshot['hud'] } | null = null) {
     const params = new URLSearchParams(location.search);
-    this.enabled = params.has('perf') || localStorage.getItem('woc_perf') === '1';
+    this.traceEnabled = localDevPerfTraceEnabled();
+    this.enabled = this.traceEnabled || params.has('perf') || localStorage.getItem('woc_perf') === '1';
     if (this.enabled) {
       this.mountOverlay();
     }
@@ -136,6 +263,7 @@ export class PerfMonitor {
   frame(dt: number, now = performance.now()): void {
     this.frames++;
     const ms = Math.min(250, Math.max(0, dt * 1000));
+    this.lastFrameMs = ms;
     pushSample(this.frameMs, ms);
     this.frameWindow.push({ at: now, ms });
     while (this.frameWindow.length && now - this.frameWindow[0].at > MAX_WINDOW_MS) this.frameWindow.shift();
@@ -180,13 +308,56 @@ export class PerfMonitor {
     try {
       return fn();
     } finally {
-      pushSample(this.buckets[bucket], performance.now() - start);
+      const ms = performance.now() - start;
+      this.lastBucketMs[bucket] = round(ms);
+      pushSample(this.buckets[bucket], ms);
+      this.recordDevTraceSpan(bucket, start, ms, 'bucket');
     }
+  }
+
+  trace<T>(name: string, fn: () => T, detail?: Record<string, unknown>): T {
+    if (!this.traceEnabled) return fn();
+    const start = performance.now();
+    try {
+      return fn();
+    } finally {
+      this.recordDevTraceSpan(name, start, performance.now() - start, 'scope', detail);
+    }
+  }
+
+  markTraceSpan(name: string, startMs: number, durationMs: number, detail?: Record<string, unknown>): void {
+    this.recordDevTraceSpan(name, startMs, durationMs, 'external', detail);
   }
 
   setNetwork(stats: PerfSnapshot['network']): void {
     if (!this.enabled) return;
     this.network = stats;
+  }
+
+  private recordDevTraceSpan(
+    name: string,
+    startMs: number,
+    durationMs: number,
+    kind: DevPerfTraceSpan['kind'],
+    detail?: Record<string, unknown>,
+  ): void {
+    if (!this.traceEnabled || !Number.isFinite(durationMs) || durationMs < DEV_TRACE_SPAN_MIN_MS) return;
+    const startRel = Math.max(0, startMs - this.startedAt);
+    const span: DevPerfTraceSpan = {
+      atMs: round(startRel + durationMs),
+      startMs: round(startRel),
+      endMs: round(startRel + durationMs),
+      durationMs: round(durationMs),
+      name: name.slice(0, 80),
+      kind,
+    };
+    const cleanDetail = sanitizeTraceDetail(detail);
+    if (cleanDetail) span.detail = cleanDetail;
+    this.devTraceSpans.push(span);
+    this.devTraceSpans.sort((a, b) => b.durationMs - a.durationMs || a.startMs - b.startMs);
+    if (this.devTraceSpans.length > DEV_TRACE_SPAN_LIMIT) {
+      this.devTraceSpans.length = DEV_TRACE_SPAN_LIMIT;
+    }
   }
 
   private observeLongTasks(): void {
@@ -201,6 +372,7 @@ export class PerfMonitor {
           pushSample(this.longTaskMs, duration);
           this.longTaskTotalMs += duration;
           this.lastLongTaskAt = entry.startTime + duration;
+          if (this.traceEnabled) this.recordDevLongTask(entry);
         }
       });
       this.longTaskObserver.observe({ entryTypes: ['longtask'] });
@@ -224,7 +396,144 @@ export class PerfMonitor {
     };
   }
 
+  private recordDevLongTask(entry: PerformanceEntry): void {
+    const withAttribution = entry as PerformanceEntry & {
+      attribution?: Array<Partial<DevLongTaskAttribution>>;
+    };
+    const attribution = (withAttribution.attribution ?? []).slice(0, DEV_TRACE_ATTRIBUTION_LIMIT).map((a) => ({
+      name: String(a.name ?? '').slice(0, 80),
+      entryType: String(a.entryType ?? '').slice(0, 40),
+      containerType: String(a.containerType ?? '').slice(0, 40),
+      containerName: String(a.containerName ?? '').slice(0, 80),
+      containerId: String(a.containerId ?? '').slice(0, 80),
+      containerSrc: String(a.containerSrc ?? '').slice(0, 160),
+    }));
+    const startMs = Math.max(0, entry.startTime - this.startedAt);
+    this.devLongTasks.push({
+      startMs: round(startMs),
+      endMs: round(startMs + entry.duration),
+      durationMs: round(entry.duration),
+      name: String(entry.name ?? '').slice(0, 80),
+      entryType: String(entry.entryType ?? '').slice(0, 40),
+      attribution,
+    });
+    if (this.devLongTasks.length > DEV_TRACE_LONG_TASK_LIMIT) {
+      this.devLongTasks.splice(0, this.devLongTasks.length - DEV_TRACE_LONG_TASK_LIMIT);
+    }
+  }
+
+  private devTraceLongTasks(): DevLongTaskRecord[] {
+    return this.devLongTasks.map((task) => {
+      let nearest: DevPerfTraceFrame | null = null;
+      let nearestDelta = Infinity;
+      let nearestSpan: DevPerfTraceSpan | null = null;
+      let nearestSpanDelta = Infinity;
+      const taskMid = (task.startMs + task.endMs) / 2;
+      for (const frame of this.devTraceFrames) {
+        const delta = Math.abs(frame.atMs - taskMid);
+        if (delta < nearestDelta) {
+          nearest = frame;
+          nearestDelta = delta;
+        }
+      }
+      for (const span of this.devTraceSpans) {
+        const delta = taskMid >= span.startMs && taskMid <= span.endMs
+          ? 0
+          : Math.min(Math.abs(taskMid - span.startMs), Math.abs(taskMid - span.endMs));
+        if (delta < nearestSpanDelta) {
+          nearestSpan = span;
+          nearestSpanDelta = delta;
+        }
+      }
+      return nearest
+        ? {
+          ...task,
+          nearestFrameAtMs: nearest.atMs,
+          nearestFrameMs: nearest.frameMs,
+          nearestFrameDeltaMs: round(nearestDelta),
+          ...(nearestSpan
+            ? {
+              nearestSpanName: nearestSpan.name,
+              nearestSpanMs: nearestSpan.durationMs,
+              nearestSpanDeltaMs: round(nearestSpanDelta),
+            }
+            : {}),
+        }
+        : {
+          ...task,
+          ...(nearestSpan
+            ? {
+              nearestSpanName: nearestSpan.name,
+              nearestSpanMs: nearestSpan.durationMs,
+              nearestSpanDeltaMs: round(nearestSpanDelta),
+            }
+            : {}),
+        };
+    });
+  }
+
+  private recordDevTraceFrame(now: number): void {
+    const renderer = this.renderer?.perfStats() ?? null;
+    const rendererFrame = renderer?.lastFrame ?? null;
+    const bucketMax = Math.max(...Object.values(this.lastBucketMs));
+    const rendererTotal = rendererFrame?.phaseMs.total ?? 0;
+    const rendererSubmit = rendererFrame?.phaseMs.submit ?? 0;
+    const rendererWorld = rendererFrame?.phaseMs.world ?? 0;
+    const rendererEntities = rendererFrame?.phaseMs.entities ?? 0;
+    const scoreMs = Math.max(this.lastFrameMs, bucketMax, rendererTotal, rendererSubmit, rendererWorld, rendererEntities);
+    const reasons: string[] = [];
+    if (this.lastFrameMs >= DEV_TRACE_MIN_FRAME_MS) reasons.push('frame-gap');
+    if (bucketMax >= DEV_TRACE_MIN_FRAME_MS) reasons.push('main-bucket');
+    if (rendererTotal >= DEV_TRACE_MIN_FRAME_MS) reasons.push('renderer-total');
+    if (rendererSubmit >= DEV_TRACE_MIN_FRAME_MS) reasons.push('renderer-submit');
+    if (rendererWorld >= DEV_TRACE_MIN_FRAME_MS) reasons.push('renderer-world');
+    if (rendererEntities >= DEV_TRACE_MIN_FRAME_MS) reasons.push('renderer-entities');
+    if (reasons.length === 0) return;
+    const memory = this.memorySnapshot();
+    const devRendererFrame = rendererFrame
+      ? (() => {
+        const { renderDiagnostics: _renderDiagnostics, ...frame } = rendererFrame;
+        return frame;
+      })()
+      : null;
+    const frame: DevPerfTraceFrame = {
+      atMs: round(now - this.startedAt),
+      frameMs: round(this.lastFrameMs),
+      scoreMs: round(scoreMs),
+      reasons,
+      mainMs: { ...this.lastBucketMs },
+      renderer: renderer ? {
+        calls: renderer.calls,
+        triangles: renderer.triangles,
+        textures: renderer.textures,
+        programs: renderer.programs,
+        views: renderer.views,
+        renderScale: renderer.renderScale,
+        effectiveRenderScale: renderer.effectiveRenderScale,
+        renderBudget: renderer.renderBudget,
+        pixelRatio: renderer.pixelRatio,
+        width: renderer.width,
+        height: renderer.height,
+        foliage: renderer.foliage,
+        lastFrame: devRendererFrame,
+      } : null,
+      browser: {
+        longTaskCount: this.longTaskMs.length,
+        longTaskTotalMs: round(this.longTaskTotalMs),
+        longTaskLastAgeMs: this.lastLongTaskAt > 0 ? round(now - this.lastLongTaskAt) : -1,
+        memoryUsedMb: memory?.usedMB ?? null,
+      },
+      network: this.network,
+    };
+    this.devTraceFrames.push(frame);
+    this.devTraceFrames.sort((a, b) => b.scoreMs - a.scoreMs || b.frameMs - a.frameMs || a.atMs - b.atMs);
+    if (this.devTraceFrames.length > DEV_TRACE_WORST_FRAME_LIMIT) {
+      this.devTraceFrames.length = DEV_TRACE_WORST_FRAME_LIMIT;
+    }
+  }
+
   tick(now = performance.now()): void {
+    if (this.traceEnabled) this.recordDevTraceFrame(now);
     if (now - this.lastOverlayAt < 1000) return;
     this.lastOverlayAt = now;
     this.lastSnapshot = this.snapshot(now);
@@ -250,7 +559,7 @@ export class PerfMonitor {
         frameMs: summarizeFrames(samples.map((s) => s.ms)),
       };
     };
-    return {
+    const snapshot: PerfSnapshot = {
       seconds: round(seconds),
       frames: this.frames,
       fps: round(this.frames / seconds),
@@ -292,6 +601,17 @@ export class PerfMonitor {
         maxTouchPoints: navigator.maxTouchPoints || 0,
       },
     };
+    if (this.traceEnabled) {
+      snapshot.devTrace = {
+        enabled: true,
+        worstFrameLimit: DEV_TRACE_WORST_FRAME_LIMIT,
+        minFrameMs: DEV_TRACE_MIN_FRAME_MS,
+        frames: this.devTraceFrames,
+        spans: this.devTraceSpans,
+        longTasks: this.devTraceLongTasks(),
+      };
+    }
+    return snapshot;
   }
 
   report(): PerfSnapshot {
@@ -326,6 +646,11 @@ export class PerfMonitor {
     this.longTaskMs = [];
     this.longTaskTotalMs = 0;
     this.lastLongTaskAt = 0;
+    this.lastFrameMs = 0;
+    this.lastBucketMs = { renderer: 0, hud: 0, events: 0, sim: 0 };
+    this.devTraceFrames = [];
+    this.devTraceSpans = [];
+    this.devLongTasks = [];
   }
 
   private mountOverlay(): void {

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -166,6 +166,44 @@ function scenarioFromUrl(): { source: 'gameplay' | 'benchmark'; zoneOrScenario: 
   return { source: 'gameplay', zoneOrScenario: 'gameplay' };
 }
 
+type RendererPrewarmSnapshot = NonNullable<NonNullable<PerfSnapshot['renderer']>['prewarm']>;
+
+function rendererPrewarmSummary(prewarm: RendererPrewarmSnapshot | null): Record<string, unknown> | null {
+  if (!prewarm) return null;
+  return {
+    elapsedMs: prewarm.elapsedMs,
+    maxMs: prewarm.maxMs,
+    remainingMs: prewarm.remainingMs,
+    budgetUsedRatio: prewarm.budgetUsedRatio,
+    timedOut: prewarm.timedOut,
+    createdViews: prewarm.createdViews,
+    candidateViews: prewarm.candidateViews,
+    renderPasses: prewarm.renderPasses,
+    programsDelta: prewarm.programsAfter - prewarm.programsBefore,
+    texturesDelta: prewarm.texturesAfter - prewarm.texturesBefore,
+    compileMode: prewarm.compileMode,
+    compileMs: prewarm.compileMs,
+    compileTimedOut: prewarm.compileTimedOut,
+    manifestPlanned: prewarm.manifestPlanned,
+    manifestCompleted: prewarm.manifestCompleted,
+    manifestTimedOut: prewarm.manifestTimedOut,
+    manifestFailed: prewarm.manifestFailed,
+    timedOutEntryIds: prewarm.timedOutEntryIds,
+    failedEntryIds: prewarm.failedEntryIds,
+    entries: prewarm.manifestEntries.map((entry) => ({
+      id: entry.id,
+      category: entry.category,
+      required: entry.required,
+      status: entry.status,
+      elapsedMs: entry.elapsedMs,
+      remainingMsAfter: entry.remainingMsAfter,
+      programDelta: entry.programDelta,
+      textureDelta: entry.textureDelta,
+      detail: entry.detail,
+    })),
+  };
+}
+
 function payloadFromSnapshot(
   snapshot: PerfSnapshot,
   settings: Settings,
@@ -187,6 +225,7 @@ function payloadFromSnapshot(
     sessionId,
     characterId,
     graphicsPreset: graphicsPresetLabel(settings.get('graphicsPreset')),
+    graphicsConfigVersion: renderer.graphicsConfigVersion,
     gfxTier: renderer.tier,
     autoGovernor: renderer.autoGovernor,
     targetFps: renderer.budget.targetFps,
@@ -220,6 +259,7 @@ function payloadFromSnapshot(
     source: scenario.source,
     zoneOrScenario: scenario.zoneOrScenario,
     rawSummary: {
+      graphicsConfigVersion: renderer.graphicsConfigVersion,
       seconds: snapshot.seconds,
       frames: snapshot.frames,
       windows: snapshot.windows,
@@ -227,7 +267,9 @@ function payloadFromSnapshot(
       rendererPhaseMs: renderer.phaseMs,
       rendererFoliage: renderer.foliage,
       rendererBudget: renderer.renderBudget,
+      rendererQualityBuckets: renderer.qualityBuckets,
       rendererDiagnostics: renderer.renderDiagnostics,
+      rendererPrewarmSummary: rendererPrewarmSummary(renderer.prewarm),
       rendererPrewarm: renderer.prewarm,
       assets: {
         preload: snapshot.assets.preload,

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -1,5 +1,5 @@
 import { graphicsPresetLabel } from '../render/gfx';
-import type { PerfMonitor, PerfSnapshot } from './perf';
+import { localDevPerfTraceEnabled, type PerfMonitor, type PerfSnapshot } from './perf';
 import type { Settings } from './settings';
 
 declare const __APP_VERSION__: string;
@@ -7,8 +7,12 @@ declare const __APP_BUILD_ID__: string;
 
 const FIRST_REPORT_MS = 75_000;
 const REPEAT_REPORT_MS = 5 * 60_000;
+const DEV_TRACE_FIRST_REPORT_MS = 10_000;
+const DEV_TRACE_REPEAT_REPORT_MS = 15_000;
 const MIN_REPORT_SECONDS = 20;
+const MIN_DEV_TRACE_REPORT_SECONDS = 5;
 const MIN_REPORT_FRAMES = 30;
+const FETCH_KEEPALIVE_MAX_BYTES = 60 * 1024;
 const SESSION_KEY = 'woc_perf_session_id';
 
 export interface PerfReporterOptions {
@@ -16,6 +20,83 @@ export interface PerfReporterOptions {
   settings: Settings;
   tokenProvider: () => string | null;
   characterIdProvider: () => number | null;
+}
+
+export type PerfReporterSkipReason = 'disabled' | 'hidden' | 'not-ready' | 'no-renderer';
+
+export interface PerfReporterStatus {
+  enabled: boolean;
+  devTrace: boolean;
+  sessionId: string;
+  startedAt: number;
+  nextSendAt: number | null;
+  lastAttemptAt: number | null;
+  lastSuccessAt: number | null;
+  lastHttpStatus: number | null;
+  lastError: string | null;
+  lastSkipReason: PerfReporterSkipReason | null;
+  lastSnapshotSeconds: number;
+  lastSnapshotFrames: number;
+  lastBodyBytes: number;
+  sendCount: number;
+  successCount: number;
+  failCount: number;
+}
+
+interface PerfReporterDebug {
+  status: PerfReporterStatus;
+  sendNow: () => void;
+  stop: () => void;
+}
+
+declare global {
+  interface Window {
+    __wocPerfReporter?: PerfReporterDebug;
+  }
+}
+
+function makeStatus(enabled: boolean, devTrace: boolean, sessionId: string): PerfReporterStatus {
+  return {
+    enabled,
+    devTrace,
+    sessionId,
+    startedAt: Date.now(),
+    nextSendAt: null,
+    lastAttemptAt: null,
+    lastSuccessAt: null,
+    lastHttpStatus: null,
+    lastError: null,
+    lastSkipReason: enabled ? null : 'disabled',
+    lastSnapshotSeconds: 0,
+    lastSnapshotFrames: 0,
+    lastBodyBytes: 0,
+    sendCount: 0,
+    successCount: 0,
+    failCount: 0,
+  };
+}
+
+function exposeDebug(status: PerfReporterStatus, sendNow: () => void, stop: () => void): () => void {
+  if (!status.devTrace || typeof window === 'undefined') return () => {};
+  const debug: PerfReporterDebug = { status, sendNow, stop };
+  window.__wocPerfReporter = debug;
+  return () => {
+    if (window.__wocPerfReporter === debug) delete window.__wocPerfReporter;
+  };
+}
+
+function textBytes(text: string): number {
+  if (typeof TextEncoder !== 'undefined') return new TextEncoder().encode(text).byteLength;
+  return text.length;
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function devTraceLog(status: PerfReporterStatus, level: 'debug' | 'warn', message: string): void {
+  if (!status.devTrace) return;
+  console[level](`[perf-report] ${message}`);
 }
 
 function storedSessionId(): string {
@@ -144,6 +225,10 @@ function payloadFromSnapshot(
       windows: snapshot.windows,
       mainMs: snapshot.mainMs,
       rendererPhaseMs: renderer.phaseMs,
+      rendererFoliage: renderer.foliage,
+      rendererBudget: renderer.renderBudget,
+      rendererDiagnostics: renderer.renderDiagnostics,
+      rendererPrewarm: renderer.prewarm,
       assets: {
         preload: snapshot.assets.preload,
         byType: snapshot.assets.byType,
@@ -151,58 +236,136 @@ function payloadFromSnapshot(
       network: snapshot.network,
       input: snapshot.input,
       hud: snapshot.hud,
+      ...(snapshot.devTrace ? { devTrace: snapshot.devTrace } : {}),
     },
   };
 }
 
 export function startPerfReporter(options: PerfReporterOptions): () => void {
   const params = new URLSearchParams(location.search);
-  if (params.get('perfReport') === '0' || params.get('perf_report') === '0') return () => {};
+  const devTrace = localDevPerfTraceEnabled();
+  if (params.get('perfReport') === '0' || params.get('perf_report') === '0') {
+    const status = makeStatus(false, devTrace, '');
+    const cleanupDebug = exposeDebug(status, () => {}, () => {});
+    devTraceLog(status, 'debug', 'disabled by URL parameter');
+    return cleanupDebug;
+  }
 
   const sessionId = storedSessionId();
+  const status = makeStatus(true, devTrace, sessionId);
   let stopped = false;
   let timer: number | null = null;
+  let lastFinalFlushAt = 0;
+  let cleanupDebug = (): void => {};
 
   const schedule = (delay: number): void => {
     if (stopped) return;
-    timer = window.setTimeout(send, delay);
+    status.nextSendAt = Date.now() + delay;
+    timer = window.setTimeout(() => send(), delay);
   };
 
-  const send = (): void => {
+  function skip(reason: PerfReporterSkipReason, delay: number | null): void {
+    status.lastSkipReason = reason;
+    status.nextSendAt = null;
+    devTraceLog(status, 'debug', `skipped: ${reason}`);
+    if (delay !== null) schedule(delay);
+  }
+
+  function send(sendOptions: { allowHidden?: boolean; final?: boolean } = {}): void {
     timer = null;
     if (stopped) return;
-    if (document.visibilityState !== 'visible') {
-      schedule(REPEAT_REPORT_MS);
+    if (!sendOptions.allowHidden && document.visibilityState !== 'visible') {
+      skip('hidden', REPEAT_REPORT_MS);
       return;
     }
     const snapshot = options.perf.report();
-    if (snapshot.seconds < MIN_REPORT_SECONDS || snapshot.frames < MIN_REPORT_FRAMES) {
-      schedule(15_000);
+    status.lastSnapshotSeconds = snapshot.seconds;
+    status.lastSnapshotFrames = snapshot.frames;
+    const minSeconds = devTrace ? MIN_DEV_TRACE_REPORT_SECONDS : MIN_REPORT_SECONDS;
+    if (snapshot.seconds < minSeconds || snapshot.frames < MIN_REPORT_FRAMES) {
+      skip('not-ready', sendOptions.final ? null : 15_000);
       return;
     }
     const body = payloadFromSnapshot(snapshot, options.settings, sessionId, options.characterIdProvider());
     if (!body) {
-      schedule(REPEAT_REPORT_MS);
+      skip('no-renderer', sendOptions.final ? null : REPEAT_REPORT_MS);
       return;
     }
     const token = options.tokenProvider();
+    const bodyText = JSON.stringify(body);
+    status.lastAttemptAt = Date.now();
+    status.lastSkipReason = null;
+    status.lastError = null;
+    status.lastHttpStatus = null;
+    status.lastBodyBytes = textBytes(bodyText);
+    status.sendCount++;
+    const useKeepalive = Boolean(sendOptions.final && status.lastBodyBytes <= FETCH_KEEPALIVE_MAX_BYTES);
+    if (sendOptions.final && !useKeepalive) {
+      devTraceLog(status, 'debug', `final post too large for keepalive: ${status.lastBodyBytes} bytes`);
+    }
     void fetch('/api/perf-report', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
-      body: JSON.stringify(body),
-      keepalive: true,
-    }).catch(() => {});
-    schedule(REPEAT_REPORT_MS);
-  };
+      body: bodyText,
+      keepalive: useKeepalive,
+    }).then(async (res) => {
+      status.lastHttpStatus = res.status;
+      if (!res.ok) {
+        const responseText = (await res.text().catch(() => '')).slice(0, 160);
+        status.failCount++;
+        status.lastError = responseText ? `HTTP ${res.status}: ${responseText}` : `HTTP ${res.status}`;
+        devTraceLog(status, 'warn', `post failed: ${status.lastError}`);
+        return;
+      }
+      status.successCount++;
+      status.lastSuccessAt = Date.now();
+      status.lastError = null;
+      devTraceLog(status, 'debug', `posted ${status.lastBodyBytes} bytes`);
+    }).catch((err: unknown) => {
+      status.failCount++;
+      status.lastError = errorText(err);
+      devTraceLog(status, 'warn', `post failed: ${status.lastError}`);
+    });
+    if (!sendOptions.final) schedule(devTrace ? DEV_TRACE_REPEAT_REPORT_MS : REPEAT_REPORT_MS);
+  }
 
-  schedule(FIRST_REPORT_MS);
-  return () => {
+  function sendNow(): void {
+    if (timer !== null) {
+      window.clearTimeout(timer);
+      timer = null;
+    }
+    send();
+  }
+
+  function flushFinal(): void {
+    const now = Date.now();
+    if (now - lastFinalFlushAt < 2000) return;
+    lastFinalFlushAt = now;
+    send({ allowHidden: true, final: true });
+  }
+
+  function handleVisibilityChange(): void {
+    if (document.visibilityState === 'hidden') flushFinal();
+  }
+
+  function stop(): void {
     stopped = true;
+    status.enabled = false;
+    status.nextSendAt = null;
     if (timer !== null) window.clearTimeout(timer);
-  };
+    window.removeEventListener('pagehide', flushFinal);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    cleanupDebug();
+  }
+
+  cleanupDebug = exposeDebug(status, sendNow, stop);
+  window.addEventListener('pagehide', flushFinal);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+  schedule(devTrace ? DEV_TRACE_FIRST_REPORT_MS : FIRST_REPORT_MS);
+  return stop;
 }
 
 export const perfReporterInternalsForTest = {

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -1,0 +1,214 @@
+import { graphicsPresetLabel } from '../render/gfx';
+import type { PerfMonitor, PerfSnapshot } from './perf';
+import type { Settings } from './settings';
+
+declare const __APP_VERSION__: string;
+declare const __APP_BUILD_ID__: string;
+
+const FIRST_REPORT_MS = 75_000;
+const REPEAT_REPORT_MS = 5 * 60_000;
+const MIN_REPORT_SECONDS = 20;
+const MIN_REPORT_FRAMES = 30;
+const SESSION_KEY = 'woc_perf_session_id';
+
+export interface PerfReporterOptions {
+  perf: PerfMonitor;
+  settings: Settings;
+  tokenProvider: () => string | null;
+  characterIdProvider: () => number | null;
+}
+
+function storedSessionId(): string {
+  try {
+    const existing = sessionStorage.getItem(SESSION_KEY);
+    if (existing) return existing;
+    const id = typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+    sessionStorage.setItem(SESSION_KEY, id);
+    return id;
+  } catch {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  }
+}
+
+function browserFamily(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes('edg/')) return 'edge';
+  if (ua.includes('firefox/')) return 'firefox';
+  if (ua.includes('chrome/') || ua.includes('crios/')) return 'chrome';
+  if (ua.includes('safari/')) return 'safari';
+  return 'other';
+}
+
+function osFamily(userAgent: string): string {
+  const ua = userAgent.toLowerCase();
+  if (ua.includes('windows')) return 'windows';
+  if (ua.includes('iphone') || ua.includes('ipad') || ua.includes('ios')) return 'ios';
+  if (ua.includes('mac os') || ua.includes('macintosh')) return 'macos';
+  if (ua.includes('android')) return 'android';
+  if (ua.includes('linux')) return 'linux';
+  return 'other';
+}
+
+function gpuBucket(renderer: string): string {
+  const r = renderer.toLowerCase();
+  if (!r) return 'unknown';
+  if (/swiftshader|llvmpipe|software/.test(r)) return 'software';
+  if (/apple/.test(r)) {
+    const chip = /(m[1-9][a-z0-9 ]*)/i.exec(renderer)?.[1]?.toLowerCase().replace(/\s+/g, '-');
+    return chip ? `apple-${chip}` : 'apple';
+  }
+  if (/intel/.test(r)) {
+    if (/iris/.test(r)) return 'intel-iris';
+    if (/uhd|hd graphics/.test(r)) return 'intel-uhd';
+    return 'intel';
+  }
+  if (/nvidia|geforce|rtx|gtx/.test(r)) return 'nvidia';
+  if (/amd|radeon/.test(r)) return 'amd';
+  return renderer.slice(0, 48).replace(/[^\w.-]+/g, '-').toLowerCase() || 'other';
+}
+
+function viewportBucket(width: number, height: number): string {
+  const short = Math.min(width, height);
+  const long = Math.max(width, height);
+  if (short <= 480) return `mobile-${width}x${height}`;
+  if (long >= 1800) return `wide-${width}x${height}`;
+  if (long >= 1200) return `large-${width}x${height}`;
+  return `medium-${width}x${height}`;
+}
+
+function scenarioFromUrl(): { source: 'gameplay' | 'benchmark'; zoneOrScenario: string } {
+  const params = new URLSearchParams(location.search);
+  const scenario = (params.get('perfScenario') ?? params.get('perf_scenario') ?? '').trim().slice(0, 80);
+  if (scenario) return { source: 'benchmark', zoneOrScenario: scenario };
+  return { source: 'gameplay', zoneOrScenario: 'gameplay' };
+}
+
+function payloadFromSnapshot(
+  snapshot: PerfSnapshot,
+  settings: Settings,
+  sessionId: string,
+  characterId: number | null,
+): Record<string, unknown> | null {
+  const renderer = snapshot.renderer;
+  if (!renderer) return null;
+  const memory = snapshot.browser.memory;
+  const longTasks = snapshot.browser.longTasks;
+  const device = snapshot.device;
+  const viewportWidth = Math.max(1, Math.round(window.innerWidth));
+  const viewportHeight = Math.max(1, Math.round(window.innerHeight));
+  const scenario = scenarioFromUrl();
+  return {
+    schemaVersion: 1,
+    releaseVersion: __APP_VERSION__,
+    buildId: __APP_BUILD_ID__,
+    sessionId,
+    characterId,
+    graphicsPreset: graphicsPresetLabel(settings.get('graphicsPreset')),
+    gfxTier: renderer.tier,
+    autoGovernor: renderer.autoGovernor,
+    targetFps: renderer.budget.targetFps,
+    renderScale: renderer.renderScale,
+    effectiveRenderScale: renderer.effectiveRenderScale,
+    fpsAvg: snapshot.fps,
+    frameP95Ms: snapshot.frameMs.p95,
+    frameP99Ms: snapshot.frameMs.p99,
+    longFrameCount: snapshot.frameMs.long50,
+    rendererCalls: renderer.calls,
+    rendererTriangles: renderer.triangles,
+    rendererTextures: renderer.textures,
+    rendererPrograms: renderer.programs,
+    contextLostCount: renderer.contextLost,
+    longTaskCount: longTasks.count,
+    longTaskP95Ms: longTasks.p95,
+    memoryUsedMb: memory?.usedMB ?? null,
+    memoryLimitMb: memory?.limitMB ?? null,
+    dpr: device.dpr,
+    viewportWidth,
+    viewportHeight,
+    viewportBucket: viewportBucket(viewportWidth, viewportHeight),
+    deviceMemory: device.deviceMemory,
+    hardwareConcurrency: device.hardwareConcurrency,
+    mobileTouch: device.mobileTouch,
+    browserFamily: browserFamily(device.userAgent),
+    osFamily: osFamily(device.userAgent),
+    glVendor: renderer.glVendor,
+    glRenderer: renderer.glRenderer,
+    glRendererBucket: gpuBucket(renderer.glRenderer),
+    source: scenario.source,
+    zoneOrScenario: scenario.zoneOrScenario,
+    rawSummary: {
+      seconds: snapshot.seconds,
+      frames: snapshot.frames,
+      windows: snapshot.windows,
+      mainMs: snapshot.mainMs,
+      rendererPhaseMs: renderer.phaseMs,
+      assets: {
+        preload: snapshot.assets.preload,
+        byType: snapshot.assets.byType,
+      },
+      network: snapshot.network,
+      input: snapshot.input,
+      hud: snapshot.hud,
+    },
+  };
+}
+
+export function startPerfReporter(options: PerfReporterOptions): () => void {
+  const params = new URLSearchParams(location.search);
+  if (params.get('perfReport') === '0' || params.get('perf_report') === '0') return () => {};
+
+  const sessionId = storedSessionId();
+  let stopped = false;
+  let timer: number | null = null;
+
+  const schedule = (delay: number): void => {
+    if (stopped) return;
+    timer = window.setTimeout(send, delay);
+  };
+
+  const send = (): void => {
+    timer = null;
+    if (stopped) return;
+    if (document.visibilityState !== 'visible') {
+      schedule(REPEAT_REPORT_MS);
+      return;
+    }
+    const snapshot = options.perf.report();
+    if (snapshot.seconds < MIN_REPORT_SECONDS || snapshot.frames < MIN_REPORT_FRAMES) {
+      schedule(15_000);
+      return;
+    }
+    const body = payloadFromSnapshot(snapshot, options.settings, sessionId, options.characterIdProvider());
+    if (!body) {
+      schedule(REPEAT_REPORT_MS);
+      return;
+    }
+    const token = options.tokenProvider();
+    void fetch('/api/perf-report', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+      keepalive: true,
+    }).catch(() => {});
+    schedule(REPEAT_REPORT_MS);
+  };
+
+  schedule(FIRST_REPORT_MS);
+  return () => {
+    stopped = true;
+    if (timer !== null) window.clearTimeout(timer);
+  };
+}
+
+export const perfReporterInternalsForTest = {
+  browserFamily,
+  osFamily,
+  gpuBucket,
+  viewportBucket,
+  payloadFromSnapshot,
+};

--- a/src/game/perf_reporter.ts
+++ b/src/game/perf_reporter.ts
@@ -1,5 +1,6 @@
 import { graphicsPresetLabel } from '../render/gfx';
 import { localDevPerfTraceEnabled, type PerfMonitor, type PerfSnapshot } from './perf';
+import { predictionTrace, type PredictionTraceTelemetry } from './prediction_trace';
 import type { Settings } from './settings';
 
 declare const __APP_VERSION__: string;
@@ -209,6 +210,7 @@ function payloadFromSnapshot(
   settings: Settings,
   sessionId: string,
   characterId: number | null,
+  predictionTelemetry: PredictionTraceTelemetry | null = null,
 ): Record<string, unknown> | null {
   const renderer = snapshot.renderer;
   if (!renderer) return null;
@@ -276,6 +278,7 @@ function payloadFromSnapshot(
         byType: snapshot.assets.byType,
       },
       network: snapshot.network,
+      ...(predictionTelemetry ? { predictionTrace: predictionTelemetry } : {}),
       input: snapshot.input,
       hud: snapshot.hud,
       ...(snapshot.devTrace ? { devTrace: snapshot.devTrace } : {}),
@@ -328,7 +331,13 @@ export function startPerfReporter(options: PerfReporterOptions): () => void {
       skip('not-ready', sendOptions.final ? null : 15_000);
       return;
     }
-    const body = payloadFromSnapshot(snapshot, options.settings, sessionId, options.characterIdProvider());
+    const body = payloadFromSnapshot(
+      snapshot,
+      options.settings,
+      sessionId,
+      options.characterIdProvider(),
+      predictionTrace.telemetry(devTrace),
+    );
     if (!body) {
       skip('no-renderer', sendOptions.final ? null : REPEAT_REPORT_MS);
       return;

--- a/src/game/prediction_trace.ts
+++ b/src/game/prediction_trace.ts
@@ -1,0 +1,257 @@
+type TraceData = Record<string, unknown>;
+
+export interface PredictionTraceEvent {
+  at: number;
+  type: string;
+  data: TraceData;
+}
+
+interface NumericSummary {
+  count: number;
+  avg: number;
+  p95: number;
+  max: number;
+}
+
+interface FrameState {
+  x: number;
+  y: number;
+  z: number;
+  camYaw: number;
+}
+
+const MAX_EVENTS = 20_000;
+const OVERLAY_INTERVAL_MS = 500;
+
+function browserNow(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function round(v: number): number {
+  return Math.round(v * 1000) / 1000;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * p) - 1));
+  return sorted[idx];
+}
+
+function summarize(values: number[]): NumericSummary {
+  if (values.length === 0) return { count: 0, avg: 0, p95: 0, max: 0 };
+  const sorted = [...values].sort((a, b) => a - b);
+  const total = values.reduce((a, b) => a + b, 0);
+  return {
+    count: values.length,
+    avg: round(total / values.length),
+    p95: round(percentile(sorted, 0.95)),
+    max: round(sorted[sorted.length - 1]),
+  };
+}
+
+function numericEvents(events: PredictionTraceEvent[], type: string, key: string): number[] {
+  const out: number[] = [];
+  for (const event of events) {
+    if (event.type !== type) continue;
+    const value = event.data[key];
+    if (typeof value === 'number' && Number.isFinite(value)) out.push(value);
+  }
+  return out;
+}
+
+function angleDelta(a: number, b: number): number {
+  let d = a - b;
+  while (d > Math.PI) d -= Math.PI * 2;
+  while (d < -Math.PI) d += Math.PI * 2;
+  return d;
+}
+
+function queryParams(): Record<string, string> {
+  if (typeof location === 'undefined') return {};
+  return Object.fromEntries(new URLSearchParams(location.search));
+}
+
+function localStorageGet(key: string): string | null {
+  try {
+    return typeof localStorage === 'undefined' ? null : localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function traceEnabled(): boolean {
+  if (typeof location === 'undefined') return false;
+  const params = new URLSearchParams(location.search);
+  return params.has('predictTrace')
+    || params.has('predictionTrace')
+    || params.has('tracePrediction')
+    || localStorageGet('woc_prediction_trace') === '1';
+}
+
+export class PredictionTrace {
+  readonly enabled = traceEnabled();
+  private startedAt = browserNow();
+  private events: PredictionTraceEvent[] = [];
+  private overlay: HTMLDivElement | null = null;
+  private lastOverlayAt = 0;
+  private lastFrame: FrameState | null = null;
+
+  constructor() {
+    if (typeof window !== 'undefined') {
+      window.wocPredictionTrace = this;
+    }
+    if (this.enabled && typeof document !== 'undefined') {
+      if (document.body) this.mountOverlay();
+      else document.addEventListener('DOMContentLoaded', () => this.mountOverlay(), { once: true });
+    }
+  }
+
+  reset(): void {
+    this.startedAt = browserNow();
+    this.events = [];
+    this.lastFrame = null;
+    this.renderOverlay(true);
+  }
+
+  record(type: string, data: TraceData = {}): void {
+    if (!this.enabled) return;
+    this.push({ at: round(browserNow() - this.startedAt), type, data });
+  }
+
+  recordFrame(data: TraceData & { displayX: number; displayY: number; displayZ: number; camYaw: number }): void {
+    if (!this.enabled) return;
+    const frame: FrameState = { x: data.displayX, y: data.displayY, z: data.displayZ, camYaw: data.camYaw };
+    const displayStep = this.lastFrame
+      ? Math.hypot(frame.x - this.lastFrame.x, frame.y - this.lastFrame.y, frame.z - this.lastFrame.z)
+      : 0;
+    const camYawStep = this.lastFrame ? Math.abs(angleDelta(frame.camYaw, this.lastFrame.camYaw)) : 0;
+    this.lastFrame = frame;
+    this.push({ at: round(browserNow() - this.startedAt), type: 'frame', data: { ...data, displayStep: round(displayStep), camYawStep: round(camYawStep) } });
+  }
+
+  summary(): TraceData {
+    const snapshots = this.events.filter((event) => event.type === 'snapshot-reconcile');
+    const worstCorrections = [...snapshots]
+      .sort((a, b) => Number(b.data.renderCorrectionDist ?? 0) - Number(a.data.renderCorrectionDist ?? 0))
+      .slice(0, 12)
+      .map((event) => ({
+        at: event.at,
+        tick: event.data.tick,
+        ack: event.data.ack,
+        ackLag: event.data.ackLag,
+        pendingAfter: event.data.pendingAfter,
+        replayed: event.data.replayed,
+        renderCorrectionDist: event.data.renderCorrectionDist,
+        serverDeltaDist: event.data.serverDeltaDist,
+        replayDeltaDist: event.data.replayDeltaDist,
+        anchorMode: event.data.anchorMode,
+      }));
+    return {
+      seconds: round((browserNow() - this.startedAt) / 1000),
+      events: this.events.length,
+      params: queryParams(),
+      upstreamDelay: summarize(numericEvents(this.events, 'socket-send-scheduled', 'delayMs')),
+      downstreamDelay: summarize(numericEvents(this.events, 'socket-receive-scheduled', 'delayMs')),
+      predictedDist: summarize(numericEvents(this.events, 'input-predict', 'predictedDist')),
+      renderCorrectionDist: summarize(numericEvents(this.events, 'snapshot-reconcile', 'renderCorrectionDist')),
+      serverDeltaDist: summarize(numericEvents(this.events, 'snapshot-reconcile', 'serverDeltaDist')),
+      replayDeltaDist: summarize(numericEvents(this.events, 'snapshot-reconcile', 'replayDeltaDist')),
+      ackLag: summarize(numericEvents(this.events, 'snapshot-reconcile', 'ackLag')),
+      pendingAfter: summarize(numericEvents(this.events, 'snapshot-reconcile', 'pendingAfter')),
+      displayStep: summarize(numericEvents(this.events, 'frame', 'displayStep')),
+      camYawStep: summarize(numericEvents(this.events, 'frame', 'camYawStep')),
+      alpha: summarize(numericEvents(this.events, 'frame', 'alpha')),
+      worstCorrections,
+    };
+  }
+
+  report(): { createdAt: string; url: string | null; summary: TraceData; events: PredictionTraceEvent[] } {
+    return {
+      createdAt: new Date().toISOString(),
+      url: typeof location === 'undefined' ? null : location.href,
+      summary: this.summary(),
+      events: [...this.events],
+    };
+  }
+
+  copy(): void {
+    const text = JSON.stringify(this.report(), null, 2);
+    void navigator.clipboard?.writeText(text).catch(() => {
+      console.info('World of ClaudeCraft prediction trace:', text);
+    });
+  }
+
+  download(filename = 'woc-prediction-trace.json'): void {
+    if (typeof document === 'undefined' || typeof URL === 'undefined' || typeof Blob === 'undefined') {
+      console.info('World of ClaudeCraft prediction trace:', this.report());
+      return;
+    }
+    const blob = new Blob([JSON.stringify(this.report(), null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  }
+
+  private push(event: PredictionTraceEvent): void {
+    this.events.push(event);
+    if (this.events.length > MAX_EVENTS) this.events.splice(0, this.events.length - MAX_EVENTS);
+    this.renderOverlay();
+  }
+
+  private mountOverlay(): void {
+    if (this.overlay || typeof document === 'undefined' || !document.body) return;
+    this.overlay = document.createElement('div');
+    this.overlay.style.cssText = [
+      'position:fixed',
+      'left:8px',
+      'bottom:8px',
+      'z-index:2147483647',
+      'min-width:260px',
+      'font:12px/1.35 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace',
+      'color:#e0f2fe',
+      'background:rgba(2,8,18,0.86)',
+      'border:1px solid rgba(56,189,248,0.45)',
+      'border-radius:6px',
+      'padding:8px',
+      'white-space:pre',
+      'cursor:pointer',
+      'box-shadow:0 8px 28px rgba(0,0,0,0.35)',
+    ].join(';');
+    this.overlay.title = 'Click to download prediction trace JSON';
+    this.overlay.addEventListener('click', () => this.download());
+    document.body.appendChild(this.overlay);
+    this.renderOverlay(true);
+  }
+
+  private renderOverlay(force = false): void {
+    if (!this.overlay) return;
+    const now = browserNow();
+    if (!force && now - this.lastOverlayAt < OVERLAY_INTERVAL_MS) return;
+    this.lastOverlayAt = now;
+    const summary = this.summary();
+    const correction = summary.renderCorrectionDist as NumericSummary;
+    const displayStep = summary.displayStep as NumericSummary;
+    const camStep = summary.camYawStep as NumericSummary;
+    const ackLag = summary.ackLag as NumericSummary;
+    const pending = summary.pendingAfter as NumericSummary;
+    this.overlay.textContent = [
+      `prediction trace ${summary.seconds}s  events ${summary.events}`,
+      `corr p95 ${correction.p95} max ${correction.max}`,
+      `frame step p95 ${displayStep.p95} max ${displayStep.max}`,
+      `cam step p95 ${camStep.p95} max ${camStep.max}`,
+      `ack lag p95 ${ackLag.p95} max ${ackLag.max}  pending max ${pending.max}`,
+      'click: download json',
+    ].join('\n');
+  }
+}
+
+declare global {
+  interface Window {
+    wocPredictionTrace?: PredictionTrace;
+  }
+}
+
+export const predictionTrace = new PredictionTrace();

--- a/src/game/prediction_trace.ts
+++ b/src/game/prediction_trace.ts
@@ -20,6 +20,17 @@ interface FrameState {
   camYaw: number;
 }
 
+export interface PredictionTraceTelemetry {
+  enabled: true;
+  seconds: number;
+  events: number;
+  params: Record<string, string>;
+  eventCounts: Record<string, number>;
+  summary: TraceData;
+  largestDisplaySteps: Array<Record<string, unknown>>;
+  recentEvents?: PredictionTraceEvent[];
+}
+
 const MAX_EVENTS = 20_000;
 const OVERLAY_INTERVAL_MS = 500;
 
@@ -59,6 +70,70 @@ function numericEvents(events: PredictionTraceEvent[], type: string, key: string
   return out;
 }
 
+function eventCounts(events: PredictionTraceEvent[]): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const event of events) counts[event.type] = (counts[event.type] ?? 0) + 1;
+  return counts;
+}
+
+function valueCounts(events: PredictionTraceEvent[], type: string, key: string): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const event of events) {
+    if (event.type !== type) continue;
+    const value = event.data[key];
+    if (typeof value !== 'string' || value === '') continue;
+    counts[value] = (counts[value] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function finiteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function numericValue(data: TraceData, key: string): number {
+  const value = data[key];
+  return finiteNumber(value) ? value : 0;
+}
+
+function classifyFrameStall(data: TraceData): string | null {
+  const frameDtMs = numericValue(data, 'frameDtMs');
+  if (frameDtMs < 33) return null;
+  const longTaskMax = numericValue(data, 'longTaskMax');
+  const renderMain = Math.max(
+    numericValue(data, 'mainRendererP95'),
+    numericValue(data, 'rphTotalP95'),
+    numericValue(data, 'rphSubmitP95'),
+  );
+  const ackLag = numericValue(data, 'ackLag');
+  const pendingInputs = numericValue(data, 'pendingInputs');
+  const lastSnapAge = numericValue(data, 'lastSnapAge');
+  if (longTaskMax >= 50 || longTaskMax >= frameDtMs * 0.65) return 'browser-long-task';
+  if (renderMain >= 18 || renderMain >= frameDtMs * 0.5) return 'render-main';
+  if (ackLag >= 8 || pendingInputs >= 8) return 'prediction-backlog';
+  if (lastSnapAge >= 180) return 'snapshot-gap';
+  return 'frame-budget';
+}
+
+function nearestBefore(events: PredictionTraceEvent[], type: string, at: number): PredictionTraceEvent | null {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.at <= at && event.type === type) return event;
+  }
+  return null;
+}
+
+function importantEvent(event: PredictionTraceEvent): boolean {
+  if (event.type !== 'frame') return true;
+  const frameMs = event.data.frameDtMs;
+  const step = event.data.displayStep;
+  const camStep = event.data.camYawStep;
+  return (typeof event.data.stallKind === 'string')
+    || (finiteNumber(frameMs) && frameMs >= 33)
+    || (finiteNumber(step) && step >= 0.35)
+    || (finiteNumber(camStep) && camStep >= 0.35);
+}
+
 function angleDelta(a: number, b: number): number {
   let d = a - b;
   while (d > Math.PI) d -= Math.PI * 2;
@@ -77,6 +152,29 @@ function localStorageGet(key: string): string | null {
   } catch {
     return null;
   }
+}
+
+function compactTraceData(data: TraceData): TraceData {
+  const out: TraceData = {};
+  let count = 0;
+  for (const [key, value] of Object.entries(data)) {
+    if (count >= 48) break;
+    if (typeof value === 'number') out[key] = Number.isFinite(value) ? round(value) : null;
+    else if (typeof value === 'string') out[key] = value.slice(0, 120);
+    else if (typeof value === 'boolean' || value === null) out[key] = value;
+    else if (Array.isArray(value)) out[key] = value.slice(0, 12);
+    else if (value && typeof value === 'object') out[key] = value;
+    count++;
+  }
+  return out;
+}
+
+function compactEvent(event: PredictionTraceEvent): PredictionTraceEvent {
+  return {
+    at: event.at,
+    type: event.type,
+    data: compactTraceData(event.data),
+  };
 }
 
 function traceEnabled(): boolean {
@@ -126,7 +224,10 @@ export class PredictionTrace {
       : 0;
     const camYawStep = this.lastFrame ? Math.abs(angleDelta(frame.camYaw, this.lastFrame.camYaw)) : 0;
     this.lastFrame = frame;
-    this.push({ at: round(browserNow() - this.startedAt), type: 'frame', data: { ...data, displayStep: round(displayStep), camYawStep: round(camYawStep) } });
+    const frameData: TraceData = { ...data, displayStep: round(displayStep), camYawStep: round(camYawStep) };
+    const stallKind = classifyFrameStall(frameData);
+    if (stallKind) frameData.stallKind = stallKind;
+    this.push({ at: round(browserNow() - this.startedAt), type: 'frame', data: frameData });
   }
 
   summary(): TraceData {
@@ -161,6 +262,7 @@ export class PredictionTrace {
       displayStep: summarize(numericEvents(this.events, 'frame', 'displayStep')),
       camYawStep: summarize(numericEvents(this.events, 'frame', 'camYawStep')),
       alpha: summarize(numericEvents(this.events, 'frame', 'alpha')),
+      frameStalls: valueCounts(this.events, 'frame', 'stallKind'),
       worstCorrections,
     };
   }
@@ -172,6 +274,55 @@ export class PredictionTrace {
       summary: this.summary(),
       events: [...this.events],
     };
+  }
+
+  telemetry(includeRecentEvents = false): PredictionTraceTelemetry | null {
+    if (!this.enabled || this.events.length === 0) return null;
+    const frames = this.events.filter((event) => event.type === 'frame');
+    const largestDisplaySteps = [...frames]
+      .filter((event) => finiteNumber(event.data.displayStep))
+      .sort((a, b) => Number(b.data.displayStep) - Number(a.data.displayStep))
+      .slice(0, 12)
+      .map((event) => {
+        const rec = nearestBefore(this.events, 'snapshot-reconcile', event.at);
+        return {
+          at: event.at,
+          frameDtMs: event.data.frameDtMs,
+          stallKind: event.data.stallKind ?? null,
+          displayStep: event.data.displayStep,
+          camYawStep: event.data.camYawStep,
+          alpha: event.data.alpha,
+          lastSnapAge: event.data.lastSnapAge,
+          input: {
+            f: event.data.moveForward ?? 0,
+            b: event.data.moveBack ?? 0,
+            sl: event.data.strafeLeft ?? 0,
+            sr: event.data.strafeRight ?? 0,
+          },
+          display: { x: event.data.displayX, y: event.data.displayY, z: event.data.displayZ },
+          entity: { x: event.data.entityX, y: event.data.entityY, z: event.data.entityZ },
+          msSinceReconcile: rec ? round(event.at - rec.at) : null,
+          lastCorrection: rec?.data.renderCorrectionDist ?? null,
+          lastAckLag: rec?.data.ackLag ?? null,
+          lastPredictionMode: rec?.data.predictionMode ?? null,
+        };
+      });
+    const telemetry: PredictionTraceTelemetry = {
+      enabled: true,
+      seconds: round((browserNow() - this.startedAt) / 1000),
+      events: this.events.length,
+      params: queryParams(),
+      eventCounts: eventCounts(this.events),
+      summary: this.summary(),
+      largestDisplaySteps,
+    };
+    if (includeRecentEvents) {
+      telemetry.recentEvents = this.events
+        .filter(importantEvent)
+        .slice(-240)
+        .map(compactEvent);
+    }
+    return telemetry;
   }
 
   copy(): void {

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -49,10 +49,10 @@ export const BOOL_SETTINGS = {
   // local display choice; the server sends raw text and each client decides.
   // (Slurs are blocked server-side regardless and never reach here.)
   filterProfanity: { def: true },
-  // off by default: MOBA-style "attack move". When on, the WASD movement keys are
-  // disabled and a single rebindable Attack Move key (default A) walks the player
-  // toward the cursor, auto-attacking the enemy under it or the nearest one met
-  // along the way. Opt-in because it replaces the classic keyboard control scheme.
+  // off by default: MOBA-style "attack move". When on, one rebindable Attack
+  // Move key (default A) walks the player toward the cursor, auto-attacking the
+  // enemy under it or the nearest one met along the way. Other movement keys
+  // keep working; only the attack-move key itself is reserved while active.
   attackMove: { def: false },
 } as const;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ import { hydrateIcons } from './ui/ui_icons';
 import { portraitChipHtml, hydratePortraits } from './ui/portrait_chip';
 import { playerPortraitDataUrl } from './render/characters/portrait';
 import { createPerfMonitor } from './game/perf';
+import { startPerfReporter } from './game/perf_reporter';
 import { updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
 
 
@@ -733,6 +734,12 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       submitByName: (targetName, reason, details) => api.reportPlayerByName(online.characterId, targetName, reason, details),
     });
   }
+  startPerfReporter({
+    perf,
+    settings,
+    tokenProvider: () => api.token,
+    characterIdProvider: () => online?.characterId ?? null,
+  });
 
   function interactKey(): void {
     const p = world.player;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1244,6 +1244,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     const tracePhases = traceRenderer?.phaseMs;
     const traceLongTasks = tracePerf?.browser.longTasks;
     const traceMemory = tracePerf?.browser.memory;
+    const tracePredictionState = predictionTrace.enabled ? net.predictionTraceState() : null;
     perf.trace('camera.follow', () => updateCamera(Math.min(frameDt, 1 / 30), interpFacing), {
       mode: 'online',
       alpha,
@@ -1283,6 +1284,11 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       moveBack: resolved.mi.back ? 1 : 0,
       strafeLeft: resolved.mi.strafeLeft ? 1 : 0,
       strafeRight: resolved.mi.strafeRight ? 1 : 0,
+      inputSeq: tracePredictionState?.inputSeq,
+      ackedInputSeq: tracePredictionState?.ackedInputSeq,
+      ackLag: tracePredictionState?.ackLag,
+      pendingInputs: tracePredictionState?.pendingInputs,
+      predictionMode: tracePredictionState?.predictionMode,
       mainRendererP95: tracePerf?.mainMs.renderer.p95,
       mainHudP95: tracePerf?.mainMs.hud.p95,
       mainEventsP95: tracePerf?.mainMs.events.p95,

--- a/src/main.ts
+++ b/src/main.ts
@@ -559,6 +559,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   let renderer!: Renderer;
   let hud!: Hud;
   const perf = createPerfMonitor(null);
+  online?.setTraceSink((name, startMs, durationMs, detail) => perf.markTraceSpan(name, startMs, durationMs, detail));
   try {
     renderer = new Renderer(world, canvas, nameplates);
     perf.setRenderer(renderer);
@@ -734,13 +735,6 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       submitByName: (targetName, reason, details) => api.reportPlayerByName(online.characterId, targetName, reason, details),
     });
   }
-  startPerfReporter({
-    perf,
-    settings,
-    tokenProvider: () => api.token,
-    characterIdProvider: () => online?.characterId ?? null,
-  });
-
   function interactKey(): void {
     const p = world.player;
     let bestCorpse: number | null = null, bestCorpseD = INTERACT_RANGE;
@@ -961,6 +955,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   let last = performance.now();
   let acc = 0;
   let onlineInputEchoMs = 0;
+  let gameInputReady = false;
 
   // Camera follow state: keyboard turning advances facing in 20Hz sim steps,
   // so the camera tracks the player's render-interpolated facing per frame
@@ -1142,9 +1137,9 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
 
     // freeze movement while the game menu is up so WASD doesn't walk the
     // character behind it (other windows stay non-modal, as before)
-    input.suspendMovement = hud.isModalOpen();
-    input.updateTouchLook(frameDt);
-    updateHoverCursor();
+    input.suspendMovement = !gameInputReady || hud.isModalOpen();
+    perf.trace('input.updateTouchLook', () => input.updateTouchLook(frameDt), { frameDtMs: frameDt * 1000 });
+    perf.trace('input.hoverCursor', () => updateHoverCursor(), { active: input.hoverActive });
     perf.markInputFrame(performance.now());
 
     const mouselook = input.isMouselookActive() && !world.player.dead;
@@ -1160,20 +1155,30 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         const stepFacing = movementFacing ?? facing;
         if (stepFacing !== null) offlineSim.player.facing = stepFacing;
         perf.markInputSent(performance.now());
-        const events = perf.time('sim', () => offlineSim.tick());
-        perf.time('events', () => hud.handleEvents(events));
+        const events = perf.time('sim', () => perf.trace('sim.tick', () => offlineSim.tick(), { mode: 'offline' }));
+        perf.time('events', () => perf.trace('hud.handleEvents', () => hud.handleEvents(events), {
+          mode: 'offline',
+          events: events.length,
+        }));
         acc -= DT;
       }
       const pp = offlineSim.player;
-      updateCamera(frameDt, pp.prevFacing + wrapAngle(pp.facing - pp.prevFacing) * (acc / DT));
+      perf.trace('camera.follow', () => updateCamera(frameDt, pp.prevFacing + wrapAngle(pp.facing - pp.prevFacing) * (acc / DT)), {
+        mode: 'offline',
+        frameDtMs: frameDt * 1000,
+      });
       renderer.camYaw = input.camYaw;
       renderer.camPitch = input.camPitch;
       renderer.camDist = input.camDist;
       perf.setNetwork(null);
-      perf.time('renderer', () => renderer.sync(acc / DT, frameDt, movementFacing));
-      updateClickMoveMarker();
+      perf.time('renderer', () => perf.trace('renderer.sync', () => renderer.sync(acc / DT, frameDt, movementFacing), {
+        mode: 'offline',
+        views: renderer.views.size,
+        alpha: acc / DT,
+      }));
+      perf.trace('ui.clickMoveMarker', () => updateClickMoveMarker());
       perf.markInputVisible(performance.now());
-      perf.time('hud', () => hud.update());
+      perf.time('hud', () => perf.trace('hud.update', () => hud.update(), { mode: 'offline' }));
       perf.tick(now);
       return;
     }
@@ -1184,17 +1189,26 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     const netFacing = movementFacing ?? resolved.facing;
     Object.assign(net.moveInput, resolved.mi);
     net.setMouselookFacing(netFacing);
-    if (net.flushInput()) perf.markInputSent(performance.now());
-    for (const sample of net.consumeInputEchoSamples()) {
+    if (perf.trace('net.flushInput', () => net.flushInput(), { connected: net.connected })) perf.markInputSent(performance.now());
+    const echoSamples = perf.trace('net.consumeInputEcho', () => net.consumeInputEchoSamples());
+    for (const sample of echoSamples) {
       if (Number.isFinite(sample) && sample >= 0) {
         onlineInputEchoMs = onlineInputEchoMs === 0 ? sample : onlineInputEchoMs + 0.2 * (sample - onlineInputEchoMs);
       }
       perf.markInputEcho(sample);
     }
     net.pendingFacingDelta = 0; // superseded by the interpolated follow below
-    perf.time('events', () => hud.handleEvents(net.drainEvents()));
-    if (net.consumeProfanityChanged()) hud.setProfanityWords(net.profanityWords);
-    if (net.consumeInventoryChanged()) hud.onInventoryChanged();
+    const drainedEvents = perf.trace('net.drainEvents', () => net.drainEvents());
+    perf.time('events', () => perf.trace('hud.handleEvents', () => hud.handleEvents(drainedEvents), {
+      mode: 'online',
+      events: drainedEvents.length,
+    }));
+    if (net.consumeProfanityChanged()) {
+      perf.trace('hud.setProfanityWords', () => hud.setProfanityWords(net.profanityWords), { words: net.profanityWords.length });
+    }
+    if (net.consumeInventoryChanged()) {
+      perf.trace('hud.onInventoryChanged', () => hud.onInventoryChanged());
+    }
     const alpha = net.lastSnapAt > 0
       ? Math.min(1.25, (performance.now() - net.lastSnapAt) / Math.max(20, net.snapInterval))
       : 1;
@@ -1206,23 +1220,27 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     });
     const pe = world.player;
     // facing interp capped at 1 - extrapolating angles past the snapshot oscillates
-    updateCamera(frameDt, pe.prevFacing + wrapAngle(pe.facing - pe.prevFacing) * Math.min(1, alpha));
+    perf.trace('camera.follow', () => updateCamera(frameDt, pe.prevFacing + wrapAngle(pe.facing - pe.prevFacing) * Math.min(1, alpha)), {
+      mode: 'online',
+      alpha,
+      frameDtMs: frameDt * 1000,
+      lastSnapAge: net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1,
+    });
     renderer.camYaw = input.camYaw;
     renderer.camPitch = input.camPitch;
     renderer.camDist = input.camDist;
-    perf.time('renderer', () => renderer.sync(alpha, frameDt, movementFacing, ONLINE_SELF_RENDER_ALPHA_LEAD));
-    updateClickMoveMarker();
+    perf.time('renderer', () => perf.trace('renderer.sync', () => renderer.sync(alpha, frameDt, movementFacing, ONLINE_SELF_RENDER_ALPHA_LEAD), {
+      mode: 'online',
+      views: renderer.views.size,
+      alpha,
+      frameDtMs: frameDt * 1000,
+    }));
+    perf.trace('ui.clickMoveMarker', () => updateClickMoveMarker());
     maybeShowImmobileNote(now);
     perf.markInputVisible(performance.now());
-    perf.time('hud', () => hud.update());
+    perf.time('hud', () => perf.trace('hud.update', () => hud.update(), { mode: 'online' }));
     perf.tick(now);
   }
-  requestAnimationFrame(frame);
-  // cut to the game only once the first frame is actually on screen
-  requestAnimationFrame(() => requestAnimationFrame(() => hideLoadingScreen()));
-  // Now in-game: fade the home-page theme out (it kept playing through loading).
-  fadeOutHomepageMusic();
-
   const controller = {
     move(moveInput: unknown, facing?: unknown) {
       if (arguments.length > 1) input.setControllerMoveInput(moveInput, facing);
@@ -1231,7 +1249,33 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     face(facing: unknown) { input.setControllerFacing(facing); },
     stop() { input.clearControllerMoveInput(); },
   };
-  (window as any).__game = { sim: world, world, renderer, input, hud, online, controller, perf };
+  input.suspendMovement = true;
+  await nextPaint();
+  try {
+    await renderer.prewarmInitialScene();
+  } catch (err) {
+    console.warn('Renderer prewarm failed', err);
+  }
+  await nextPaint();
+  last = performance.now();
+  requestAnimationFrame(frame);
+  // cut to the game only once the first frame is actually on screen
+  requestAnimationFrame(() => requestAnimationFrame(() => {
+    hideLoadingScreen();
+    window.setTimeout(() => {
+      gameInputReady = true;
+      perf.reset();
+      startPerfReporter({
+        perf,
+        settings,
+        tokenProvider: () => api.token,
+        characterIdProvider: () => online?.characterId ?? null,
+      });
+      (window as any).__game = { sim: world, world, renderer, input, hud, online, controller, perf };
+    }, LOADING_FADE_MS);
+  }));
+  // Now in-game: fade the home-page theme out (it kept playing through loading).
+  fadeOutHomepageMusic();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ import { portraitChipHtml, hydratePortraits } from './ui/portrait_chip';
 import { playerPortraitDataUrl } from './render/characters/portrait';
 import { createPerfMonitor } from './game/perf';
 import { startPerfReporter } from './game/perf_reporter';
+import { predictionTrace } from './game/prediction_trace';
 import { updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
 
 
@@ -1163,7 +1164,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
         acc -= DT;
       }
       const pp = offlineSim.player;
-      perf.trace('camera.follow', () => updateCamera(frameDt, pp.prevFacing + wrapAngle(pp.facing - pp.prevFacing) * (acc / DT)), {
+      perf.trace('camera.follow', () => updateCamera(Math.min(frameDt, 1 / 30), pp.prevFacing + wrapAngle(pp.facing - pp.prevFacing) * (acc / DT)), {
         mode: 'offline',
         frameDtMs: frameDt * 1000,
       });
@@ -1189,7 +1190,9 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     const netFacing = movementFacing ?? resolved.facing;
     Object.assign(net.moveInput, resolved.mi);
     net.setMouselookFacing(netFacing);
-    if (perf.trace('net.flushInput', () => net.flushInput(), { connected: net.connected })) perf.markInputSent(performance.now());
+    const predictionSent = perf.trace('net.stepPrediction', () => net.stepPrediction(frameDt), { connected: net.connected });
+    if (predictionSent) perf.markInputSent(performance.now());
+    perf.trace('net.flushQueuedSnapshot', () => net.flushQueuedSnapshot());
     const echoSamples = perf.trace('net.consumeInputEcho', () => net.consumeInputEchoSamples());
     for (const sample of echoSamples) {
       if (Number.isFinite(sample) && sample >= 0) {
@@ -1209,22 +1212,36 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     if (net.consumeInventoryChanged()) {
       perf.trace('hud.onInventoryChanged', () => hud.onInventoryChanged());
     }
+    const frameNow = performance.now();
     const alpha = net.lastSnapAt > 0
-      ? Math.min(1.25, (performance.now() - net.lastSnapAt) / Math.max(20, net.snapInterval))
+      ? Math.min(1.25, (frameNow - net.lastSnapAt) / Math.max(20, net.snapInterval))
       : 1;
+    const lastSnapAge = net.lastSnapAt > 0 ? Math.round(frameNow - net.lastSnapAt) : -1;
     perf.setNetwork({
       connected: net.connected,
       snapInterval: Math.round(net.snapInterval),
-      lastSnapAge: net.lastSnapAt > 0 ? Math.round(performance.now() - net.lastSnapAt) : -1,
+      lastSnapAge,
       alpha: Math.round(alpha * 100) / 100,
     });
     const pe = world.player;
+    const renderPose = world.renderPoseFor?.(pe.id, alpha, frameNow) ?? null;
     // facing interp capped at 1 - extrapolating angles past the snapshot oscillates
-    perf.trace('camera.follow', () => updateCamera(frameDt, pe.prevFacing + wrapAngle(pe.facing - pe.prevFacing) * Math.min(1, alpha)), {
+    const interpFacing = renderPose
+      ? renderPose.facing
+      : pe.prevFacing + wrapAngle(pe.facing - pe.prevFacing) * Math.min(1, alpha);
+    const displayX = renderPose ? renderPose.pos.x : pe.prevPos.x + (pe.pos.x - pe.prevPos.x) * alpha;
+    const displayY = renderPose ? renderPose.pos.y : pe.prevPos.y + (pe.pos.y - pe.prevPos.y) * alpha;
+    const displayZ = renderPose ? renderPose.pos.z : pe.prevPos.z + (pe.pos.z - pe.prevPos.z) * alpha;
+    const tracePerf = predictionTrace.enabled && frameDt * 1000 >= 33 ? perf.snapshot(frameNow) : null;
+    const traceRenderer = tracePerf?.renderer;
+    const tracePhases = traceRenderer?.phaseMs;
+    const traceLongTasks = tracePerf?.browser.longTasks;
+    const traceMemory = tracePerf?.browser.memory;
+    perf.trace('camera.follow', () => updateCamera(Math.min(frameDt, 1 / 30), interpFacing), {
       mode: 'online',
       alpha,
       frameDtMs: frameDt * 1000,
-      lastSnapAge: net.lastSnapAt > 0 ? performance.now() - net.lastSnapAt : -1,
+      lastSnapAge,
     });
     renderer.camYaw = input.camYaw;
     renderer.camPitch = input.camPitch;
@@ -1235,6 +1252,47 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
       alpha,
       frameDtMs: frameDt * 1000,
     }));
+    predictionTrace.recordFrame({
+      frameDtMs: Math.round(frameDt * 100_000) / 100,
+      alpha: Math.round(alpha * 1000) / 1000,
+      snapInterval: Math.round(net.snapInterval),
+      lastSnapAge,
+      displayX: Math.round(displayX * 1000) / 1000,
+      displayY: Math.round(displayY * 1000) / 1000,
+      displayZ: Math.round(displayZ * 1000) / 1000,
+      entityX: Math.round(pe.pos.x * 1000) / 1000,
+      entityY: Math.round(pe.pos.y * 1000) / 1000,
+      entityZ: Math.round(pe.pos.z * 1000) / 1000,
+      prevX: Math.round(pe.prevPos.x * 1000) / 1000,
+      prevY: Math.round(pe.prevPos.y * 1000) / 1000,
+      prevZ: Math.round(pe.prevPos.z * 1000) / 1000,
+      interpFacing: Math.round(interpFacing * 1000) / 1000,
+      playerFacing: Math.round(pe.facing * 1000) / 1000,
+      prevFacing: Math.round(pe.prevFacing * 1000) / 1000,
+      camYaw: Math.round(input.camYaw * 1000) / 1000,
+      renderFacing: movementFacing === null ? null : Math.round(movementFacing * 1000) / 1000,
+      mouselook,
+      moveForward: resolved.mi.forward ? 1 : 0,
+      moveBack: resolved.mi.back ? 1 : 0,
+      strafeLeft: resolved.mi.strafeLeft ? 1 : 0,
+      strafeRight: resolved.mi.strafeRight ? 1 : 0,
+      mainRendererP95: tracePerf?.mainMs.renderer.p95,
+      mainHudP95: tracePerf?.mainMs.hud.p95,
+      mainEventsP95: tracePerf?.mainMs.events.p95,
+      rendererCalls: traceRenderer?.calls,
+      rendererTriangles: traceRenderer?.triangles,
+      rendererViews: traceRenderer?.views,
+      renderScale: traceRenderer?.effectiveRenderScale,
+      rphEntitiesP95: tracePhases?.entities.p95,
+      rphWorldP95: tracePhases?.world.p95,
+      rphNameplatesP95: tracePhases?.nameplates.p95,
+      rphSubmitP95: tracePhases?.submit.p95,
+      rphTotalP95: tracePhases?.total.p95,
+      longTaskCount: traceLongTasks?.count,
+      longTaskP95: traceLongTasks?.p95,
+      longTaskMax: traceLongTasks?.max,
+      heapUsedMB: traceMemory?.usedMB,
+    });
     perf.trace('ui.clickMoveMarker', () => updateClickMoveMarker());
     maybeShowImmobileNote(now);
     perf.markInputVisible(performance.now());
@@ -1980,6 +2038,7 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
   // wait for hello + first snapshot so the world starts populated
   const waitStart = Date.now();
   const poll = setInterval(() => {
+    world.flushQueuedSnapshot();
     if (world.connected && world.entities.has(world.playerId)) {
       clearInterval(poll);
       void startGame(world, null, world);

--- a/src/main.ts
+++ b/src/main.ts
@@ -642,6 +642,13 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     canUseGameKeys: () => !hud.isModalOpen() && chatInput.style.display !== 'block',
   }, keybinds);
   input.camYaw = world.player.facing;
+  perf.setInputDebugProvider(() => ({
+    ...input.debugState(),
+    canUseGameKeys: !hud.isModalOpen() && chatInput.style.display !== 'block',
+    modalOpen: hud.isModalOpen(),
+    chatOpen: chatInput.style.display === 'block',
+    gameInputReady,
+  }));
 
   const mobileControls = new MobileControls(input, {
     onAttackNearest: () => attackNearest(),

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -11,7 +11,7 @@ import {
   emptyMoveInput,
 } from '../sim/types';
 import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
-import { LocalPredictionController, type MoveCommand } from './prediction';
+import { LocalPredictionController, type MoveCommand, type PredictionAckCoverage } from './prediction';
 import { predictionTrace } from '../game/prediction_trace';
 import { isOverheadEmoteId, type ArenaInfo, type CharacterSearchResult, type DuelInfo, type FriendInfo, type IWorld, type LeaderboardEntry, type MarketInfo, type OverheadEmoteId, type PartyInfo, type PresenceStatus, type RenderPose, type SocialInfo, type TradeInfo } from '../world_api';
 
@@ -265,6 +265,16 @@ function traceWirePose(w: any): Record<string, unknown> | null {
   };
 }
 
+function traceRenderPose(p: RenderPose | null): Record<string, unknown> | null {
+  if (!p) return null;
+  return {
+    x: traceRound(p.pos.x),
+    y: traceRound(p.pos.y),
+    z: traceRound(p.pos.z),
+    f: traceRound(p.facing),
+  };
+}
+
 function tracePoseDist(a: Record<string, unknown> | null, b: Record<string, unknown> | null): number {
   if (!a || !b) return 0;
   const ax = Number(a.x), ay = Number(a.y), az = Number(a.z);
@@ -295,6 +305,13 @@ function tracePayload(payload: string): Record<string, unknown> {
       seq: typeof msg.seq === 'number' ? msg.seq : null,
       tick: typeof msg.tick === 'number' ? Math.floor(msg.tick) : null,
       ack: typeof msg.self?.ack === 'number' ? Math.floor(msg.self.ack) : null,
+      ackh: typeof msg.self?.ackh === 'number' ? Math.floor(msg.self.ackh) : null,
+      pmv: typeof msg.self?.pmv === 'string' ? msg.self.pmv : null,
+      selfX: typeof msg.self?.x === 'number' ? traceRound(msg.self.x) : null,
+      selfY: typeof msg.self?.y === 'number' ? traceRound(msg.self.y) : null,
+      selfZ: typeof msg.self?.z === 'number' ? traceRound(msg.self.z) : null,
+      ents: Array.isArray(msg.ents) ? msg.ents.length : null,
+      keep: Array.isArray(msg.keep) ? msg.keep.length : null,
     };
   } catch {
     return {};
@@ -325,16 +342,58 @@ function withPreviousWireIdentity(previousFull: Record<string, unknown>, current
 interface PredictionReplayResult {
   pendingBefore: number;
   dropped: number;
+  heldCovered: number;
   replayed: number;
   pendingAfter: number;
+  effectiveAck: number;
+  capped: number;
   renderCorrectionDist: number;
   replayDeltaDist: number;
   anchorMode: 'dead' | 'none' | 'snap' | 'blend';
+  correctionSmoothMs: number;
+  inputMode: PredictionInputMode;
+  leadTicks: number;
+}
+
+type PredictionMovementMode = 'normal' | 'server';
+type PredictionInputMode = 'moving' | 'idle';
+type TransportLane = 'movement' | 'action' | 'social' | 'system';
+
+const MAX_LOCAL_PREDICTION_LEAD_TICKS = 8;
+const IDLE_STOP_RESEND_MS = 90;
+
+const ACTION_COMMANDS = new Set([
+  'cast', 'castSlot', 'target', 'tab', 'targetNearestFriendly', 'tabFriendly',
+  'attack', 'stopattack', 'interact', 'loot', 'pickup', 'release',
+  'pet_attack', 'pet_taunt', 'pet_revive', 'pet_abandon', 'pet_rename',
+]);
+
+const SOCIAL_COMMANDS = new Set([
+  'chat', 'emote', 'party_invite', 'party_accept', 'party_leave', 'guild_invite',
+  'guild_accept', 'guild_leave', 'trade_request', 'trade_accept', 'trade_cancel',
+  'duel_request', 'duel_accept', 'duel_forfeit',
+]);
+
+function predictionAckCoverageFromWire(s: any): PredictionAckCoverage | undefined {
+  if (typeof s?.ackh !== 'number' || !Number.isFinite(s.ackh) || s.ackh <= 0) return undefined;
+  const heldTicks = Math.floor(s.ackh);
+  if (heldTicks <= 0) return undefined;
+  const heldFacing = typeof s.ackf === 'number' && Number.isFinite(s.ackf) ? s.ackf : null;
+  return {
+    heldTicks,
+    heldInput: sanitizeMoveInput(s.ackmi),
+    heldFacing,
+  };
+}
+
+function predictionMovementModeFromWire(raw: unknown): PredictionMovementMode {
+  return raw === 'charge' || raw === 'follow' || raw === 'fear' ? 'server' : 'normal';
 }
 
 interface LaggedSocketFrame {
   payload: string;
   deliveryAt: number;
+  lane?: TransportLane;
 }
 
 interface NetLagConfig {
@@ -373,6 +432,23 @@ function lagDelayMs(baseMs: number, jitterMs: number): number {
 
 function nowMs(): number {
   return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function isIdleMoveInput(input: MoveInput): boolean {
+  return !input.forward
+    && !input.back
+    && !input.turnLeft
+    && !input.turnRight
+    && !input.strafeLeft
+    && !input.strafeRight
+    && !input.jump;
+}
+
+function transportLaneForCommand(payload: Record<string, unknown>): TransportLane {
+  const cmd = typeof payload.cmd === 'string' ? payload.cmd : '';
+  if (ACTION_COMMANDS.has(cmd)) return 'action';
+  if (SOCIAL_COMMANDS.has(cmd)) return 'social';
+  return 'system';
 }
 
 function orderedLagDelayMs(baseMs: number, jitterMs: number, nextDeliveryAt: number): { delayMs: number; deliveryAt: number } {
@@ -471,6 +547,7 @@ export class ClientWorld implements IWorld {
   private mouselookFacing: number | null = null;
   private sendTimer: number | undefined;
   private lastInputSentAt = 0;
+  private lastIdleStopSentAt = 0;
   private lastInputSig = '';
   private inputSeq = 0;
   private pendingInputSeqSentAt = new Map<number, number>();
@@ -480,7 +557,9 @@ export class ClientWorld implements IWorld {
   private pendingPredictions: MoveCommand[] = [];
   private predictionController: LocalPredictionController | null = null;
   private predictionAccumulator = 0;
+  private predictionMovementMode: PredictionMovementMode = 'normal';
   private localPredictionTick = 0;
+  private optimisticCommandSeq = 0;
   private lastSnapshotTick = -1;
   private queuedSnapshot: any | null = null;
   private netLag: NetLagConfig = NO_NET_LAG;
@@ -518,7 +597,7 @@ export class ClientWorld implements IWorld {
     // The normal 20Hz movement stream is sent by stepPrediction().
     this.sendTimer = window.setInterval(() => {
       const now = performance.now();
-      if (now - this.lastInputSentAt > 250) this.sendInput(now);
+      if (now - this.lastInputSentAt > 250) this.predictLocalTick(now);
     }, 250);
   }
 
@@ -564,7 +643,10 @@ export class ClientWorld implements IWorld {
   }
 
   flushInput(now = performance.now()): boolean {
-    return this.sendInput(now, true);
+    const sig = this.inputSignature();
+    if (sig === this.lastInputSig) return false;
+    if (now - this.lastInputSentAt < 16) return false;
+    return this.predictLocalTick(now);
   }
 
   consumeInputEchoSamples(): number[] {
@@ -586,22 +668,23 @@ export class ClientWorld implements IWorld {
     this.downstreamQueue = [];
   }
 
-  private sendSocketPayload(payload: string): void {
+  private sendSocketPayload(payload: string, lane: TransportLane = 'system'): void {
     const lag = this.netLag ?? NO_NET_LAG;
     const { delayMs, deliveryAt } = orderedLagDelayMs(lag.upstreamMs, lag.jitterMs, this.nextUpstreamDeliveryAt ?? 0);
     this.nextUpstreamDeliveryAt = deliveryAt;
     predictionTrace.record('socket-send-scheduled', {
       ...tracePayload(payload),
+      lane,
       delayMs: traceRound(delayMs),
       upstreamMs: lag.upstreamMs,
       jitterMs: lag.jitterMs,
     });
-    if (delayMs <= 0) {
-      predictionTrace.record('socket-send-delivered', tracePayload(payload));
+    if (delayMs <= 0 && this.upstreamQueue.length === 0) {
+      predictionTrace.record('socket-send-delivered', { ...tracePayload(payload), lane });
       this.ws.send(payload);
       return;
     }
-    this.upstreamQueue.push({ payload, deliveryAt });
+    this.upstreamQueue.push({ payload, deliveryAt, lane });
     this.scheduleLagDelivery('up');
   }
 
@@ -615,7 +698,7 @@ export class ClientWorld implements IWorld {
       downstreamMs: lag.downstreamMs,
       jitterMs: lag.jitterMs,
     });
-    if (delayMs <= 0) {
+    if (delayMs <= 0 && this.downstreamQueue.length === 0) {
       predictionTrace.record('socket-receive-delivered', tracePayload(raw));
       this.onMessage(raw);
       return;
@@ -647,7 +730,7 @@ export class ClientWorld implements IWorld {
       const frame = queue.shift()!;
       if (direction === 'up') {
         if (this.ws.readyState === WebSocket.OPEN) {
-          predictionTrace.record('socket-send-delivered', tracePayload(frame.payload));
+          predictionTrace.record('socket-send-delivered', { ...tracePayload(frame.payload), lane: frame.lane ?? 'system' });
           this.ws.send(frame.payload);
         }
       } else {
@@ -669,45 +752,6 @@ export class ClientWorld implements IWorld {
     ].join(',');
   }
 
-  private sendInput(now = performance.now(), changedOnly = false): boolean {
-    if (!this.connected || this.ws.readyState !== WebSocket.OPEN) return false;
-    const sig = this.inputSignature();
-    if (changedOnly) {
-      if (sig === this.lastInputSig) return false;
-      if (now - this.lastInputSentAt < 16) return false;
-    }
-    const mi = this.moveInput;
-    const seq = ++this.inputSeq;
-    const facing = this.mouselookFacing;
-    const msg: Record<string, unknown> = {
-      t: 'input',
-      seq,
-      mi: {
-        f: mi.forward ? 1 : 0, b: mi.back ? 1 : 0,
-        tl: mi.turnLeft ? 1 : 0, tr: mi.turnRight ? 1 : 0,
-        sl: mi.strafeLeft ? 1 : 0, sr: mi.strafeRight ? 1 : 0,
-        j: mi.jump ? 1 : 0,
-      },
-    };
-    if (facing !== null) msg.facing = facing;
-    predictionTrace.record('input-send', {
-      seq,
-      input: traceInput(mi),
-      facing: facing === null ? null : traceRound(facing),
-    });
-    this.sendSocketPayload(JSON.stringify(msg));
-    this.lastInputSentAt = now;
-    this.lastInputSig = sig;
-    this.pendingInputSeqSentAt.set(seq, now);
-    if (this.pendingInputSeqSentAt.size > 120) {
-      const stale = seq - 120;
-      for (const seq of this.pendingInputSeqSentAt.keys()) {
-        if (seq <= stale) this.pendingInputSeqSentAt.delete(seq);
-      }
-    }
-    return true;
-  }
-
   private sendMoveCommand(command: MoveCommand, sig = this.inputSignature()): void {
     const mi = command.moveInput;
     const msg: Record<string, unknown> = {
@@ -726,7 +770,7 @@ export class ClientWorld implements IWorld {
       input: traceInput(mi),
       facing: command.facing === null ? null : traceRound(command.facing),
     });
-    this.sendSocketPayload(JSON.stringify(msg));
+    this.sendSocketPayload(JSON.stringify(msg), 'movement');
     this.lastInputSentAt = command.sentAt;
     this.lastInputSig = sig;
     this.pendingInputSeqSentAt.set(command.seq, command.sentAt);
@@ -772,12 +816,66 @@ export class ClientWorld implements IWorld {
 
   private cmd(payload: Record<string, unknown>): void {
     if (!this.canSendCommand()) return;
-    this.sendSocketPayload(JSON.stringify({ t: 'cmd', ...payload }));
+    const lane = transportLaneForCommand(payload);
+    this.applyOptimisticCommand(payload, lane);
+    this.sendSocketPayload(JSON.stringify({ t: 'cmd', ...payload }), lane);
   }
 
   /** Raw WS command — used by dev scripts and browser console when online. */
   devCmd(payload: Record<string, unknown>): void {
     this.cmd(payload);
+  }
+
+  predictionTraceState(): Record<string, unknown> {
+    const ackLag = Math.max(0, (this.inputSeq ?? 0) - (this.ackedInputSeq ?? 0));
+    return {
+      inputSeq: this.inputSeq ?? 0,
+      ackedInputSeq: this.ackedInputSeq ?? 0,
+      ackLag,
+      pendingInputs: (this.pendingPredictions ?? []).length,
+      predictionMode: this.predictionMovementMode,
+    };
+  }
+
+  private currentPredictionInputMode(): PredictionInputMode {
+    return isIdleMoveInput(this.moveInput) && this.mouselookFacing === null ? 'idle' : 'moving';
+  }
+
+  private applyOptimisticCommand(payload: Record<string, unknown>, lane: TransportLane): void {
+    if (lane !== 'action') return;
+    const command = typeof payload.cmd === 'string' ? payload.cmd : '';
+    const optimisticId = ++this.optimisticCommandSeq;
+    const player = this.entities.get(this.playerId);
+    let applied: string | null = null;
+
+    if (player && command === 'attack') {
+      const target = player.targetId === null ? null : this.entities.get(player.targetId);
+      if (target && !target.dead) {
+        player.autoAttack = true;
+        applied = 'autoAttack';
+      }
+    } else if (player && command === 'stopattack') {
+      player.autoAttack = false;
+      player.queuedOnSwing = null;
+      applied = 'stopAutoAttack';
+    } else if (player && command === 'cast' && typeof payload.ability === 'string') {
+      const ability = this.known.find((known) => known.def.id === payload.ability);
+      if (ability?.def.onNextSwing) {
+        player.queuedOnSwing = player.queuedOnSwing === payload.ability ? null : payload.ability;
+        const target = player.targetId === null ? null : this.entities.get(player.targetId);
+        if (target && !target.dead) player.autoAttack = true;
+        applied = 'queuedOnSwing';
+      }
+    }
+
+    predictionTrace.record('optimistic-command', {
+      id: optimisticId,
+      lane,
+      command,
+      applied,
+      ability: typeof payload.ability === 'string' ? payload.ability : null,
+      targetId: player?.targetId ?? null,
+    });
   }
 
   private markTrace(name: string, startMs: number, detail?: Record<string, unknown>): void {
@@ -811,26 +909,107 @@ export class ClientWorld implements IWorld {
     return this.prediction().applyCommand(e, frame, now).predictedDist;
   }
 
-  private predictLocalTick(now: number): boolean {
+  private recordInputSkip(reason: string, now: number, detail: Record<string, unknown> = {}): void {
     const e = this.entities.get(this.playerId);
-    if (!e || e.dead) return false;
+    predictionTrace.record('input-skip', {
+      reason,
+      predictionMode: this.predictionMovementMode,
+      connected: this.connected,
+      readyState: this.ws?.readyState ?? null,
+      inputSeq: this.inputSeq ?? 0,
+      ackedInputSeq: this.ackedInputSeq ?? 0,
+      pending: (this.pendingPredictions ?? []).length,
+      lastInputAgeMs: traceRound(now - (this.lastInputSentAt ?? now)),
+      input: traceInput(this.moveInput),
+      facing: this.mouselookFacing === null ? null : traceRound(this.mouselookFacing),
+      player: tracePose(e),
+      ...detail,
+    });
+  }
+
+  private predictLocalTick(now: number): boolean {
+    if (!this.connected || this.ws.readyState !== WebSocket.OPEN) {
+      this.recordInputSkip('socket-not-open', now);
+      return false;
+    }
+    const e = this.entities.get(this.playerId);
+    if (!e) {
+      this.recordInputSkip('missing-player', now);
+      return false;
+    }
+    if (e.dead) {
+      this.recordInputSkip('dead-player', now);
+      return false;
+    }
     const mi = this.moveInput;
     const facing = this.mouselookFacing;
     const sig = this.inputSignature();
     const inputChanged = sig !== this.lastInputSig;
-    if (!this.hasPredictableMovement(mi, e) && facing === null && !inputChanged) return false;
+    const hasPredictableMovement = this.hasPredictableMovement(mi, e);
+    const inputMode = this.currentPredictionInputMode();
+    const leadTicks = Math.max(0, (this.inputSeq ?? 0) - (this.ackedInputSeq ?? 0));
+    if (!hasPredictableMovement && facing === null && !inputChanged) {
+      if ((this.pendingPredictions ?? []).length > 0) {
+        if (now - (this.lastIdleStopSentAt ?? 0) >= IDLE_STOP_RESEND_MS) {
+          const frame = this.prediction().makeCommand(++this.inputSeq, ++this.localPredictionTick, mi, facing, now);
+          this.lastIdleStopSentAt = now;
+          this.sendMoveCommand(frame, sig);
+          predictionTrace.record('input-predict', {
+            seq: frame.seq,
+            localTick: frame.localTick,
+            predictionMode: 'idle-stop',
+            inputMode,
+            leadTicks,
+            leadCapped: leadTicks >= MAX_LOCAL_PREDICTION_LEAD_TICKS,
+            input: traceInput(mi),
+            facing: null,
+            inputChanged,
+            hasPredictableMovement,
+            ackedInputSeq: this.ackedInputSeq ?? 0,
+            pendingBefore: (this.pendingPredictions ?? []).length,
+            pending: (this.pendingPredictions ?? []).length,
+            predictedDist: 0,
+            accumulator: traceRound(this.predictionAccumulator),
+            before: tracePose(e),
+            after: tracePose(e),
+            now: traceRound(now),
+          });
+          return true;
+        }
+        this.recordInputSkip('idle-with-pending', now, { inputChanged, hasPredictableMovement, inputMode, leadTicks });
+      }
+      return false;
+    }
     const prediction = this.prediction();
     const frame = prediction.makeCommand(++this.inputSeq, ++this.localPredictionTick, mi, facing, now);
     const beforePrediction = tracePose(e);
-    prediction.push(frame);
-    const predictedDist = this.predictTick(frame, now);
+    const serverDrivenMovement = this.predictionMovementMode === 'server';
+    const leadAfterSend = Math.max(0, frame.seq - (this.ackedInputSeq ?? 0));
+    const leadCapped = !serverDrivenMovement && leadTicks >= MAX_LOCAL_PREDICTION_LEAD_TICKS;
+    const pendingBefore = (this.pendingPredictions ?? []).length;
+    let predictedDist = 0;
+    if (!serverDrivenMovement) {
+      prediction.push(frame);
+    }
+    if (!serverDrivenMovement && !leadCapped) {
+      predictedDist = this.predictTick(frame, now);
+    }
     this.sendMoveCommand(frame, sig);
+    if (inputMode === 'idle') this.lastIdleStopSentAt = now;
     const afterPrediction = tracePose(e);
     predictionTrace.record('input-predict', {
       seq: frame.seq,
       localTick: frame.localTick,
+      predictionMode: serverDrivenMovement ? 'server' : (leadCapped ? 'lead-capped' : 'client'),
+      inputMode,
+      leadTicks: leadAfterSend,
+      leadCapped,
       input: traceInput(mi),
       facing: facing === null ? null : traceRound(facing),
+      inputChanged,
+      hasPredictableMovement,
+      ackedInputSeq: this.ackedInputSeq ?? 0,
+      pendingBefore,
       pending: (this.pendingPredictions ?? []).length,
       predictedDist: traceRound(predictedDist),
       accumulator: traceRound(this.predictionAccumulator),
@@ -841,18 +1020,62 @@ export class ClientWorld implements IWorld {
     return true;
   }
 
-  private replayPendingInputs(e: Entity, ack: number, renderedBefore: RenderPose | null, preReplayPose: Record<string, unknown> | null, now: number): PredictionReplayResult {
-    const replay = this.prediction().replayFromAck(e, ack);
+  private replayPendingInputs(
+    e: Entity,
+    ack: number,
+    coverage: PredictionAckCoverage | undefined,
+    renderedBefore: RenderPose | null,
+    preReplayPose: Record<string, unknown> | null,
+    now: number,
+  ): PredictionReplayResult {
+    const replay = this.prediction().replayFromAck(e, ack, coverage, MAX_LOCAL_PREDICTION_LEAD_TICKS);
     const afterReplayPose = tracePose(e);
-    const correction = this.prediction().reconcilePresentation(e, renderedBefore, now);
+    const inputMode = this.currentPredictionInputMode();
+    const leadTicks = Math.max(0, (this.inputSeq ?? 0) - replay.effectiveAck);
+    const correction = this.prediction().reconcilePresentation(e, renderedBefore, now, { inputMode, leadTicks });
     return {
       pendingBefore: replay.pendingBefore,
       dropped: replay.dropped,
+      heldCovered: replay.heldCovered,
       replayed: replay.replayed,
       pendingAfter: replay.pendingAfter,
+      effectiveAck: replay.effectiveAck,
+      capped: replay.capped,
       renderCorrectionDist: traceRound(correction.renderCorrectionDist),
       replayDeltaDist: tracePoseDist(preReplayPose, afterReplayPose),
       anchorMode: correction.anchorMode,
+      correctionSmoothMs: correction.correctionSmoothMs,
+      inputMode,
+      leadTicks,
+    };
+  }
+
+  private acceptServerDrivenMovement(
+    e: Entity,
+    ack: number,
+    renderedBefore: RenderPose | null,
+    preReplayPose: Record<string, unknown> | null,
+    now: number,
+  ): PredictionReplayResult {
+    const pendingBefore = this.pendingPredictions.length;
+    this.pendingPredictions.length = 0;
+    const afterReplayPose = tracePose(e);
+    const renderCorrectionDist = tracePoseDist(traceRenderPose(renderedBefore), afterReplayPose);
+    this.prediction().snapPresentationTo(e, now);
+    return {
+      pendingBefore,
+      dropped: pendingBefore,
+      heldCovered: 0,
+      replayed: 0,
+      pendingAfter: 0,
+      effectiveAck: ack,
+      capped: 0,
+      renderCorrectionDist,
+      replayDeltaDist: tracePoseDist(preReplayPose, afterReplayPose),
+      anchorMode: renderedBefore ? 'snap' : 'none',
+      correctionSmoothMs: 0,
+      inputMode: 'moving',
+      leadTicks: Math.max(0, (this.inputSeq ?? 0) - ack),
     };
   }
 
@@ -1119,6 +1342,8 @@ export class ClientWorld implements IWorld {
       // it appears exactly where the server placed it.
       const teleDx = w.x - e.pos.x, teleDz = w.z - e.pos.z;
       const wasDead = e.dead;
+      const wasLootable = e.lootable;
+      const previousHp = e.hp;
       const nowDead = !!w.dead;
       if ((wasDead && !nowDead) || teleDx * teleDx + teleDz * teleDz > TELEPORT_SNAP_DIST_SQ) {
         e.prevPos = { x: w.x, y: w.y, z: w.z };
@@ -1158,6 +1383,23 @@ export class ClientWorld implements IWorld {
         value: typeof a.v === 'number' ? a.v : 0, sourceId: 0, school: 'physical' as const,
       }));
       e.loot = w.lootList ?? null;
+      if (wasDead !== e.dead || wasLootable !== e.lootable || (previousHp > 0 && e.hp <= 0)) {
+        predictionTrace.record('entity-state', {
+          id: e.id,
+          kind: e.kind,
+          templateId: e.templateId,
+          wasDead,
+          dead: e.dead,
+          previousHp,
+          hp: e.hp,
+          maxHp: e.maxHp,
+          wasLootable,
+          lootable: e.lootable,
+          x: traceRound(e.pos.x),
+          y: traceRound(e.pos.y),
+          z: traceRound(e.pos.z),
+        });
+      }
       return e;
     };
 
@@ -1188,22 +1430,24 @@ export class ClientWorld implements IWorld {
     const e = s ? applyWire(s) : null;
     if (s && e) {
       seen.add(s.id);
-      let ackForReplay = this.ackedInputSeq ?? 0;
       const previousAck = this.ackedInputSeq ?? 0;
+      let ackForReplay = previousAck;
       const snapshotAck = typeof s.ack === 'number' && Number.isFinite(s.ack) ? Math.floor(s.ack) : null;
-      if (typeof s.ack === 'number' && s.ack > previousAck) {
-        const sentAtBySeq = (this.pendingInputSeqSentAt ??= new Map());
-        const echoSamples = (this.inputEchoSamples ??= []);
-        for (let seq = previousAck + 1; seq <= s.ack; seq++) {
-          const sentAt = sentAtBySeq.get(seq);
-          if (sentAt !== undefined) {
-            echoSamples.push(now - sentAt);
-            sentAtBySeq.delete(seq);
+      const rawAckCoverage = snapshotAck !== null ? predictionAckCoverageFromWire(s) : undefined;
+      let ackCoverage: PredictionAckCoverage | undefined;
+      if (snapshotAck !== null) {
+        const coveredThrough = snapshotAck + (rawAckCoverage?.heldTicks ?? 0);
+        if (coveredThrough >= previousAck) {
+          ackForReplay = Math.max(snapshotAck, previousAck);
+          if (rawAckCoverage && coveredThrough > ackForReplay) {
+            ackCoverage = {
+              ...rawAckCoverage,
+              heldTicks: coveredThrough - ackForReplay,
+            };
           }
         }
-        this.ackedInputSeq = s.ack;
-        ackForReplay = s.ack;
       }
+      this.predictionMovementMode = predictionMovementModeFromWire(s.pmv);
       e.resource = s.res;
       e.maxResource = s.mres;
       e.resourceType = s.rtype;
@@ -1262,24 +1506,48 @@ export class ClientWorld implements IWorld {
       if (s.duel !== undefined) this.duelInfo = s.duel;
       if (s.arena !== undefined) this.arenaInfo = s.arena;
       if (s.market !== undefined) this.marketInfo = s.market;
-      const replay = this.replayPendingInputs(e, ackForReplay, renderedSelfBefore, preReplayPose, now);
+      const replay = this.predictionMovementMode === 'server'
+        ? this.acceptServerDrivenMovement(e, ackForReplay, renderedSelfBefore, preReplayPose, now)
+        : this.replayPendingInputs(e, ackForReplay, ackCoverage, renderedSelfBefore, preReplayPose, now);
+      if (replay.effectiveAck > previousAck) {
+        const sentAtBySeq = (this.pendingInputSeqSentAt ??= new Map());
+        const echoSamples = (this.inputEchoSamples ??= []);
+        for (let seq = previousAck + 1; seq <= replay.effectiveAck; seq++) {
+          const sentAt = sentAtBySeq.get(seq);
+          if (sentAt !== undefined) {
+            echoSamples.push(now - sentAt);
+            sentAtBySeq.delete(seq);
+          }
+        }
+        this.ackedInputSeq = replay.effectiveAck;
+      }
       const afterReplayPose = tracePose(e);
       predictionTrace.record('snapshot-reconcile', {
         tick: typeof snap.tick === 'number' ? Math.floor(snap.tick) : null,
         time: typeof snap.time === 'number' ? traceRound(snap.time) : null,
         ack: snapshotAck,
         ackForReplay,
+        effectiveAck: replay.effectiveAck,
+        ackHeldTicks: rawAckCoverage?.heldTicks ?? 0,
+        residualHeldTicks: ackCoverage?.heldTicks ?? 0,
+        heldCovered: replay.heldCovered,
+        predictionMode: this.predictionMovementMode,
         previousAck,
-        ackAdvanced: ackForReplay - previousAck,
-        ackLag: Math.max(0, (this.inputSeq ?? 0) - ackForReplay),
+        ackAdvanced: replay.effectiveAck - previousAck,
+        ackLag: Math.max(0, (this.inputSeq ?? 0) - replay.effectiveAck),
         inputSeq: this.inputSeq ?? 0,
         snapInterval: traceRound(this.snapInterval),
         contAlpha: traceRound(contAlpha),
         pendingBefore: replay.pendingBefore,
         dropped: replay.dropped,
         replayed: replay.replayed,
+        capped: replay.capped,
         pendingAfter: replay.pendingAfter,
         anchorMode: replay.anchorMode,
+        inputMode: replay.inputMode,
+        leadTicks: replay.leadTicks,
+        leadCapped: replay.leadTicks >= MAX_LOCAL_PREDICTION_LEAD_TICKS,
+        correctionSmoothMs: replay.correctionSmoothMs,
         renderCorrectionDist: replay.renderCorrectionDist,
         serverDeltaDist: tracePoseDist(selfBeforeSnapshot, serverPose),
         replayDeltaDist: replay.replayDeltaDist,
@@ -1309,8 +1577,20 @@ export class ClientWorld implements IWorld {
     // prune entities that left our interest area
     phaseStart = performance.now();
     let removedEntities = 0;
-    for (const [id] of this.entities) {
+    for (const [id, entity] of this.entities) {
       if (!seen.has(id)) {
+        predictionTrace.record('entity-remove', {
+          id,
+          kind: entity.kind,
+          templateId: entity.templateId,
+          dead: entity.dead,
+          lootable: entity.lootable,
+          hp: entity.hp,
+          maxHp: entity.maxHp,
+          x: traceRound(entity.pos.x),
+          y: traceRound(entity.pos.y),
+          z: traceRound(entity.pos.z),
+        });
         this.entities.delete(id);
         removedEntities++;
       }

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -7,11 +7,13 @@ import {
   type TalentAllocation, type SavedLoadout, type Role,
 } from '../sim/content/talents';
 import {
-  Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
+  DT, Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
 } from '../sim/types';
 import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
-import { isOverheadEmoteId, type ArenaInfo, type CharacterSearchResult, type DuelInfo, type FriendInfo, type IWorld, type LeaderboardEntry, type MarketInfo, type OverheadEmoteId, type PartyInfo, type PresenceStatus, type SocialInfo, type TradeInfo } from '../world_api';
+import { LocalPredictionController, type MoveCommand } from './prediction';
+import { predictionTrace } from '../game/prediction_trace';
+import { isOverheadEmoteId, type ArenaInfo, type CharacterSearchResult, type DuelInfo, type FriendInfo, type IWorld, type LeaderboardEntry, type MarketInfo, type OverheadEmoteId, type PartyInfo, type PresenceStatus, type RenderPose, type SocialInfo, type TradeInfo } from '../world_api';
 
 // ---------------------------------------------------------------------------
 // REST
@@ -225,6 +227,160 @@ function copyPos(dst: { x: number; y: number; z: number }, src: { x: number; y: 
   dst.z = src.z;
 }
 
+function traceRound(v: number): number {
+  return Math.round(v * 1000) / 1000;
+}
+
+function tracePose(e: Entity | null | undefined): Record<string, unknown> | null {
+  if (!e) return null;
+  return {
+    x: traceRound(e.pos.x),
+    y: traceRound(e.pos.y),
+    z: traceRound(e.pos.z),
+    f: traceRound(e.facing),
+    prevX: traceRound(e.prevPos.x),
+    prevY: traceRound(e.prevPos.y),
+    prevZ: traceRound(e.prevPos.z),
+    prevF: traceRound(e.prevFacing),
+    vx: traceRound(e.vx),
+    vy: traceRound(e.vy),
+    vz: traceRound(e.vz),
+    onGround: e.onGround,
+    fallStartY: traceRound(e.fallStartY),
+  };
+}
+
+function traceWirePose(w: any): Record<string, unknown> | null {
+  if (!w) return null;
+  return {
+    x: traceRound(Number(w.x ?? 0)),
+    y: traceRound(Number(w.y ?? 0)),
+    z: traceRound(Number(w.z ?? 0)),
+    f: traceRound(Number(w.f ?? 0)),
+    vx: typeof w.vx === 'number' ? traceRound(w.vx) : null,
+    vy: typeof w.vy === 'number' ? traceRound(w.vy) : null,
+    vz: typeof w.vz === 'number' ? traceRound(w.vz) : null,
+    onGround: w.og === undefined ? null : !!w.og,
+    fallStartY: typeof w.fy === 'number' ? traceRound(w.fy) : null,
+  };
+}
+
+function tracePoseDist(a: Record<string, unknown> | null, b: Record<string, unknown> | null): number {
+  if (!a || !b) return 0;
+  const ax = Number(a.x), ay = Number(a.y), az = Number(a.z);
+  const bx = Number(b.x), by = Number(b.y), bz = Number(b.z);
+  if (![ax, ay, az, bx, by, bz].every(Number.isFinite)) return 0;
+  return traceRound(Math.hypot(ax - bx, ay - by, az - bz));
+}
+
+function traceInput(input: MoveInput): Record<string, number> {
+  return {
+    f: input.forward ? 1 : 0,
+    b: input.back ? 1 : 0,
+    tl: input.turnLeft ? 1 : 0,
+    tr: input.turnRight ? 1 : 0,
+    sl: input.strafeLeft ? 1 : 0,
+    sr: input.strafeRight ? 1 : 0,
+    j: input.jump ? 1 : 0,
+  };
+}
+
+function tracePayload(payload: string): Record<string, unknown> {
+  try {
+    const msg = JSON.parse(payload);
+    if (typeof msg !== 'object' || msg === null) return {};
+    return {
+      t: typeof msg.t === 'string' ? msg.t : null,
+      cmd: typeof msg.cmd === 'string' ? msg.cmd : null,
+      seq: typeof msg.seq === 'number' ? msg.seq : null,
+      tick: typeof msg.tick === 'number' ? Math.floor(msg.tick) : null,
+      ack: typeof msg.self?.ack === 'number' ? Math.floor(msg.self.ack) : null,
+    };
+  } catch {
+    return {};
+  }
+}
+
+const ENTITY_IDENTITY_KEYS = ['k', 'tid', 'nm', 'lv', 'sk', 'dgn', 'sc', 'c'] as const;
+
+function wireId(w: unknown): number | null {
+  if (typeof w !== 'object' || w === null) return null;
+  const id = (w as { id?: unknown }).id;
+  return typeof id === 'number' && Number.isFinite(id) ? id : null;
+}
+
+function hasWireIdentity(w: unknown): boolean {
+  return typeof w === 'object' && w !== null && (w as { k?: unknown }).k !== undefined;
+}
+
+function withPreviousWireIdentity(previousFull: Record<string, unknown>, currentLite: Record<string, unknown>): Record<string, unknown> {
+  const merged: Record<string, unknown> = {};
+  for (const key of ENTITY_IDENTITY_KEYS) {
+    if (previousFull[key] !== undefined) merged[key] = previousFull[key];
+  }
+  for (const [key, value] of Object.entries(currentLite)) merged[key] = value;
+  return merged;
+}
+
+interface PredictionReplayResult {
+  pendingBefore: number;
+  dropped: number;
+  replayed: number;
+  pendingAfter: number;
+  renderCorrectionDist: number;
+  replayDeltaDist: number;
+  anchorMode: 'dead' | 'none' | 'snap' | 'blend';
+}
+
+interface LaggedSocketFrame {
+  payload: string;
+  deliveryAt: number;
+}
+
+interface NetLagConfig {
+  upstreamMs: number;
+  downstreamMs: number;
+  jitterMs: number;
+}
+
+const NO_NET_LAG: NetLagConfig = { upstreamMs: 0, downstreamMs: 0, jitterMs: 0 };
+
+function numberParam(params: URLSearchParams, keys: string[]): number | null {
+  for (const key of keys) {
+    const raw = params.get(key);
+    if (raw === null || raw.trim() === '') continue;
+    const n = Number(raw);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function readNetLagConfig(): NetLagConfig {
+  if (typeof location === 'undefined') return NO_NET_LAG;
+  const params = new URLSearchParams(location.search);
+  const rtt = Math.max(0, numberParam(params, ['netRtt', 'netLag']) ?? 0);
+  const upstreamMs = Math.max(0, numberParam(params, ['netUp', 'netUpstream']) ?? rtt / 2);
+  const downstreamMs = Math.max(0, numberParam(params, ['netDown', 'netDownstream']) ?? rtt / 2);
+  const jitterMs = Math.max(0, numberParam(params, ['netJitter']) ?? 0);
+  return { upstreamMs, downstreamMs, jitterMs };
+}
+
+function lagDelayMs(baseMs: number, jitterMs: number): number {
+  if (baseMs <= 0 && jitterMs <= 0) return 0;
+  const jitter = jitterMs > 0 ? (Math.random() * 2 - 1) * jitterMs : 0;
+  return Math.max(0, baseMs + jitter);
+}
+
+function nowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+function orderedLagDelayMs(baseMs: number, jitterMs: number, nextDeliveryAt: number): { delayMs: number; deliveryAt: number } {
+  const now = nowMs();
+  const deliveryAt = Math.max(now + lagDelayMs(baseMs, jitterMs), nextDeliveryAt);
+  return { delayMs: Math.max(0, deliveryAt - now), deliveryAt };
+}
+
 // A single position update never moves an entity more than a few yards by
 // walking; anything past this is a teleport (arena pit, dungeon portal,
 // graveyard release). Those are snapped, not interpolated — see applyWire.
@@ -321,6 +477,20 @@ export class ClientWorld implements IWorld {
   private ackedInputSeq = 0;
   private inputEchoSamples: number[] = [];
   private traceSink: ClientTraceSink | null = null;
+  private pendingPredictions: MoveCommand[] = [];
+  private predictionController: LocalPredictionController | null = null;
+  private predictionAccumulator = 0;
+  private localPredictionTick = 0;
+  private lastSnapshotTick = -1;
+  private queuedSnapshot: any | null = null;
+  private netLag: NetLagConfig = NO_NET_LAG;
+  private lagTimers = new Set<ReturnType<typeof setTimeout>>();
+  private upstreamQueue: LaggedSocketFrame[] = [];
+  private downstreamQueue: LaggedSocketFrame[] = [];
+  private upstreamTimer: ReturnType<typeof setTimeout> | null = null;
+  private downstreamTimer: ReturnType<typeof setTimeout> | null = null;
+  private nextUpstreamDeliveryAt = 0;
+  private nextDownstreamDeliveryAt = 0;
 
   constructor(token: string, characterId: number, cls: PlayerClass, base = '') {
     this.characterId = characterId;
@@ -336,18 +506,25 @@ export class ClientWorld implements IWorld {
     this.ws.onopen = () => {
       this.ws.send(JSON.stringify(buildWebSocketAuthMessage(token, characterId)));
     };
-    this.ws.onmessage = (ev) => this.onMessage(String(ev.data));
+    this.netLag = readNetLagConfig();
+    this.ws.onmessage = (ev) => this.receiveSocketMessage(String(ev.data));
     this.ws.onclose = () => {
       this.connected = false;
       clearInterval(this.sendTimer);
+      this.clearLagTimers();
       this.onDisconnect?.('Connection to the server was lost.');
     };
-    // input stream at sim rate
-    this.sendTimer = window.setInterval(() => this.sendInput(), 50);
+    // Fallback keepalive so held input cannot go stale if rendering is paused.
+    // The normal 20Hz movement stream is sent by stepPrediction().
+    this.sendTimer = window.setInterval(() => {
+      const now = performance.now();
+      if (now - this.lastInputSentAt > 250) this.sendInput(now);
+    }, 250);
   }
 
   close(): void {
     clearInterval(this.sendTimer);
+    this.clearLagTimers();
     this.ws.onclose = null;
     this.ws.close();
   }
@@ -358,6 +535,13 @@ export class ClientWorld implements IWorld {
 
   get player(): Entity {
     return this.entities.get(this.playerId) ?? blankEntity(-1);
+  }
+
+  renderPoseFor(entityId: number, _alpha: number, now: number): RenderPose | null {
+    if (entityId !== this.playerId) return null;
+    const e = this.entities.get(this.playerId);
+    if (!e) return null;
+    return this.prediction().renderPose(e, now);
   }
 
   drainEvents(): SimEvent[] {
@@ -375,12 +559,16 @@ export class ClientWorld implements IWorld {
     this.mouselookFacing = normalizeMoveFacing(facing);
   }
 
+  private prediction(): LocalPredictionController {
+    return this.predictionController ??= new LocalPredictionController(this.cfg.seed, this.pendingPredictions);
+  }
+
   flushInput(now = performance.now()): boolean {
     return this.sendInput(now, true);
   }
 
   consumeInputEchoSamples(): number[] {
-    const samples = this.inputEchoSamples;
+    const samples = this.inputEchoSamples ?? [];
     this.inputEchoSamples = [];
     return samples;
   }
@@ -388,6 +576,87 @@ export class ClientWorld implements IWorld {
   // -----------------------------------------------------------------------
   // Socket
   // -----------------------------------------------------------------------
+
+  private clearLagTimers(): void {
+    for (const timer of this.lagTimers ?? []) clearTimeout(timer);
+    this.lagTimers?.clear();
+    this.upstreamTimer = null;
+    this.downstreamTimer = null;
+    this.upstreamQueue = [];
+    this.downstreamQueue = [];
+  }
+
+  private sendSocketPayload(payload: string): void {
+    const lag = this.netLag ?? NO_NET_LAG;
+    const { delayMs, deliveryAt } = orderedLagDelayMs(lag.upstreamMs, lag.jitterMs, this.nextUpstreamDeliveryAt ?? 0);
+    this.nextUpstreamDeliveryAt = deliveryAt;
+    predictionTrace.record('socket-send-scheduled', {
+      ...tracePayload(payload),
+      delayMs: traceRound(delayMs),
+      upstreamMs: lag.upstreamMs,
+      jitterMs: lag.jitterMs,
+    });
+    if (delayMs <= 0) {
+      predictionTrace.record('socket-send-delivered', tracePayload(payload));
+      this.ws.send(payload);
+      return;
+    }
+    this.upstreamQueue.push({ payload, deliveryAt });
+    this.scheduleLagDelivery('up');
+  }
+
+  private receiveSocketMessage(raw: string): void {
+    const lag = this.netLag ?? NO_NET_LAG;
+    const { delayMs, deliveryAt } = orderedLagDelayMs(lag.downstreamMs, lag.jitterMs, this.nextDownstreamDeliveryAt ?? 0);
+    this.nextDownstreamDeliveryAt = deliveryAt;
+    predictionTrace.record('socket-receive-scheduled', {
+      ...tracePayload(raw),
+      delayMs: traceRound(delayMs),
+      downstreamMs: lag.downstreamMs,
+      jitterMs: lag.jitterMs,
+    });
+    if (delayMs <= 0) {
+      predictionTrace.record('socket-receive-delivered', tracePayload(raw));
+      this.onMessage(raw);
+      return;
+    }
+    this.downstreamQueue.push({ payload: raw, deliveryAt });
+    this.scheduleLagDelivery('down');
+  }
+
+  private scheduleLagDelivery(direction: 'up' | 'down'): void {
+    const queue = direction === 'up' ? this.upstreamQueue : this.downstreamQueue;
+    if (queue.length === 0) return;
+    if (direction === 'up' ? this.upstreamTimer : this.downstreamTimer) return;
+    const delay = Math.max(0, queue[0].deliveryAt - nowMs());
+    const timer = setTimeout(() => {
+      this.lagTimers?.delete(timer);
+      if (direction === 'up') this.upstreamTimer = null;
+      else this.downstreamTimer = null;
+      this.deliverLagQueue(direction);
+    }, delay);
+    if (direction === 'up') this.upstreamTimer = timer;
+    else this.downstreamTimer = timer;
+    (this.lagTimers ??= new Set()).add(timer);
+  }
+
+  private deliverLagQueue(direction: 'up' | 'down'): void {
+    const queue = direction === 'up' ? this.upstreamQueue : this.downstreamQueue;
+    const now = nowMs() + 0.5;
+    while (queue.length > 0 && queue[0].deliveryAt <= now) {
+      const frame = queue.shift()!;
+      if (direction === 'up') {
+        if (this.ws.readyState === WebSocket.OPEN) {
+          predictionTrace.record('socket-send-delivered', tracePayload(frame.payload));
+          this.ws.send(frame.payload);
+        }
+      } else {
+        predictionTrace.record('socket-receive-delivered', tracePayload(frame.payload));
+        this.onMessage(frame.payload);
+      }
+    }
+    this.scheduleLagDelivery(direction);
+  }
 
   private inputSignature(): string {
     const mi = this.moveInput;
@@ -408,9 +677,11 @@ export class ClientWorld implements IWorld {
       if (now - this.lastInputSentAt < 16) return false;
     }
     const mi = this.moveInput;
+    const seq = ++this.inputSeq;
+    const facing = this.mouselookFacing;
     const msg: Record<string, unknown> = {
       t: 'input',
-      seq: ++this.inputSeq,
+      seq,
       mi: {
         f: mi.forward ? 1 : 0, b: mi.back ? 1 : 0,
         tl: mi.turnLeft ? 1 : 0, tr: mi.turnRight ? 1 : 0,
@@ -418,18 +689,81 @@ export class ClientWorld implements IWorld {
         j: mi.jump ? 1 : 0,
       },
     };
-    if (this.mouselookFacing !== null) msg.facing = this.mouselookFacing;
-    this.ws.send(JSON.stringify(msg));
+    if (facing !== null) msg.facing = facing;
+    predictionTrace.record('input-send', {
+      seq,
+      input: traceInput(mi),
+      facing: facing === null ? null : traceRound(facing),
+    });
+    this.sendSocketPayload(JSON.stringify(msg));
     this.lastInputSentAt = now;
     this.lastInputSig = sig;
-    this.pendingInputSeqSentAt.set(this.inputSeq, now);
+    this.pendingInputSeqSentAt.set(seq, now);
     if (this.pendingInputSeqSentAt.size > 120) {
-      const stale = this.inputSeq - 120;
+      const stale = seq - 120;
       for (const seq of this.pendingInputSeqSentAt.keys()) {
         if (seq <= stale) this.pendingInputSeqSentAt.delete(seq);
       }
     }
     return true;
+  }
+
+  private sendMoveCommand(command: MoveCommand, sig = this.inputSignature()): void {
+    const mi = command.moveInput;
+    const msg: Record<string, unknown> = {
+      t: 'input',
+      seq: command.seq,
+      mi: {
+        f: mi.forward ? 1 : 0, b: mi.back ? 1 : 0,
+        tl: mi.turnLeft ? 1 : 0, tr: mi.turnRight ? 1 : 0,
+        sl: mi.strafeLeft ? 1 : 0, sr: mi.strafeRight ? 1 : 0,
+        j: mi.jump ? 1 : 0,
+      },
+    };
+    if (command.facing !== null) msg.facing = command.facing;
+    predictionTrace.record('input-send', {
+      seq: command.seq,
+      input: traceInput(mi),
+      facing: command.facing === null ? null : traceRound(command.facing),
+    });
+    this.sendSocketPayload(JSON.stringify(msg));
+    this.lastInputSentAt = command.sentAt;
+    this.lastInputSig = sig;
+    this.pendingInputSeqSentAt.set(command.seq, command.sentAt);
+    if (this.pendingInputSeqSentAt.size > 120) {
+      const stale = command.seq - 120;
+      for (const seq of this.pendingInputSeqSentAt.keys()) {
+        if (seq <= stale) this.pendingInputSeqSentAt.delete(seq);
+      }
+    }
+  }
+
+  flushQueuedSnapshot(): boolean {
+    const snap = this.queuedSnapshot;
+    this.queuedSnapshot = null;
+    if (!snap) return false;
+    const start = performance.now();
+    this.applySnapshot(snap);
+    this.markTrace('net.applySnapshot', start, {
+      ents: Array.isArray(snap.ents) ? snap.ents.length : 0,
+      keep: Array.isArray(snap.keep) ? snap.keep.length : 0,
+      hasSelf: !!snap.self,
+      entities: this.entities.size,
+      snapInterval: this.snapInterval,
+    });
+    return true;
+  }
+
+  stepPrediction(frameDt: number, now = performance.now()): boolean {
+    if (!this.connected || this.ws.readyState !== WebSocket.OPEN) return false;
+    const dt = Math.max(0, Math.min(0.25, frameDt));
+    this.predictionAccumulator += dt;
+    let predicted = false;
+    while (this.predictionAccumulator >= DT) {
+      predicted = this.predictLocalTick(now) || predicted;
+      this.predictionAccumulator -= DT;
+    }
+    return predicted;
   }
 
   private canSendCommand(): boolean {
@@ -438,7 +772,7 @@ export class ClientWorld implements IWorld {
 
   private cmd(payload: Record<string, unknown>): void {
     if (!this.canSendCommand()) return;
-    this.ws.send(JSON.stringify({ t: 'cmd', ...payload }));
+    this.sendSocketPayload(JSON.stringify({ t: 'cmd', ...payload }));
   }
 
   /** Raw WS command — used by dev scripts and browser console when online. */
@@ -448,6 +782,78 @@ export class ClientWorld implements IWorld {
 
   private markTrace(name: string, startMs: number, detail?: Record<string, unknown>): void {
     this.traceSink?.(name, startMs, performance.now() - startMs, detail);
+  }
+
+  private renderedPose(e: Entity, alpha: number): RenderPose {
+    const a = Math.max(0, alpha);
+    const facingAlpha = Math.min(1, a);
+    return {
+      pos: {
+        x: e.prevPos.x + (e.pos.x - e.prevPos.x) * a,
+        y: e.prevPos.y + (e.pos.y - e.prevPos.y) * a,
+        z: e.prevPos.z + (e.pos.z - e.prevPos.z) * a,
+      },
+      facing: e.prevFacing + wrapAngle(e.facing - e.prevFacing) * facingAlpha,
+    };
+  }
+
+  private hasPredictableMovement(input: MoveInput, e: Entity): boolean {
+    return !!(input.forward || input.back || input.turnLeft || input.turnRight || input.strafeLeft || input.strafeRight || input.jump)
+      || !e.onGround
+      || e.vx !== 0
+      || e.vz !== 0
+      || e.vy !== 0;
+  }
+
+  private predictTick(frame: MoveCommand, now: number): number {
+    const e = this.entities.get(this.playerId);
+    if (!e || e.dead) return 0;
+    return this.prediction().applyCommand(e, frame, now).predictedDist;
+  }
+
+  private predictLocalTick(now: number): boolean {
+    const e = this.entities.get(this.playerId);
+    if (!e || e.dead) return false;
+    const mi = this.moveInput;
+    const facing = this.mouselookFacing;
+    const sig = this.inputSignature();
+    const inputChanged = sig !== this.lastInputSig;
+    if (!this.hasPredictableMovement(mi, e) && facing === null && !inputChanged) return false;
+    const prediction = this.prediction();
+    const frame = prediction.makeCommand(++this.inputSeq, ++this.localPredictionTick, mi, facing, now);
+    const beforePrediction = tracePose(e);
+    prediction.push(frame);
+    const predictedDist = this.predictTick(frame, now);
+    this.sendMoveCommand(frame, sig);
+    const afterPrediction = tracePose(e);
+    predictionTrace.record('input-predict', {
+      seq: frame.seq,
+      localTick: frame.localTick,
+      input: traceInput(mi),
+      facing: facing === null ? null : traceRound(facing),
+      pending: (this.pendingPredictions ?? []).length,
+      predictedDist: traceRound(predictedDist),
+      accumulator: traceRound(this.predictionAccumulator),
+      before: beforePrediction,
+      after: afterPrediction,
+      now: traceRound(now),
+    });
+    return true;
+  }
+
+  private replayPendingInputs(e: Entity, ack: number, renderedBefore: RenderPose | null, preReplayPose: Record<string, unknown> | null, now: number): PredictionReplayResult {
+    const replay = this.prediction().replayFromAck(e, ack);
+    const afterReplayPose = tracePose(e);
+    const correction = this.prediction().reconcilePresentation(e, renderedBefore, now);
+    return {
+      pendingBefore: replay.pendingBefore,
+      dropped: replay.dropped,
+      replayed: replay.replayed,
+      pendingAfter: replay.pendingAfter,
+      renderCorrectionDist: traceRound(correction.renderCorrectionDist),
+      replayDeltaDist: tracePoseDist(preReplayPose, afterReplayPose),
+      anchorMode: correction.anchorMode,
+    };
   }
 
   private onMessage(raw: string): void {
@@ -525,17 +931,68 @@ export class ClientWorld implements IWorld {
       return;
     }
     if (msg.t === 'snap') {
-      const start = performance.now();
-      this.applySnapshot(msg);
-      this.markTrace('net.applySnapshot', start, {
-        bytes: raw.length,
-        ents: Array.isArray(msg.ents) ? msg.ents.length : 0,
-        keep: Array.isArray(msg.keep) ? msg.keep.length : 0,
-        hasSelf: !!msg.self,
-        entities: this.entities.size,
-        snapInterval: this.snapInterval,
-      });
+      this.queueSnapshot(msg);
     }
+  }
+
+  private queueSnapshot(snap: any): void {
+    const tick = typeof snap.tick === 'number' && Number.isFinite(snap.tick) ? Math.floor(snap.tick) : null;
+    const queuedTick = typeof this.queuedSnapshot?.tick === 'number' && Number.isFinite(this.queuedSnapshot.tick)
+      ? Math.floor(this.queuedSnapshot.tick)
+      : null;
+    if (tick !== null && queuedTick !== null && tick < queuedTick) {
+      predictionTrace.record('snapshot-drop', { tick, queuedTick });
+      return;
+    }
+    this.queuedSnapshot = this.queuedSnapshot ? this.mergeQueuedSnapshot(this.queuedSnapshot, snap) : snap;
+    predictionTrace.record('snapshot-queued', {
+      tick,
+      queuedTick,
+      ack: typeof snap.self?.ack === 'number' ? Math.floor(snap.self.ack) : null,
+    });
+  }
+
+  private mergeQueuedSnapshot(previous: any, next: any): any {
+    const merged = {
+      ...next,
+      self: previous.self && next.self ? { ...previous.self, ...next.self } : (next.self ?? previous.self),
+    };
+    const previousFull = new Map<number, Record<string, unknown>>();
+    for (const w of Array.isArray(previous.ents) ? previous.ents : []) {
+      const id = wireId(w);
+      if (id !== null && hasWireIdentity(w)) previousFull.set(id, w as Record<string, unknown>);
+    }
+
+    const ents: unknown[] = [];
+    const included = new Set<number>();
+    for (const w of Array.isArray(next.ents) ? next.ents : []) {
+      const id = wireId(w);
+      if (id === null) {
+        ents.push(w);
+        continue;
+      }
+      const prev = previousFull.get(id);
+      ents.push(prev && !hasWireIdentity(w)
+        ? withPreviousWireIdentity(prev, w as Record<string, unknown>)
+        : w);
+      included.add(id);
+    }
+
+    const keep: number[] = [];
+    for (const id of Array.isArray(next.keep) ? next.keep : []) {
+      if (typeof id !== 'number' || included.has(id)) continue;
+      const prev = previousFull.get(id);
+      if (prev) {
+        ents.push(prev);
+        included.add(id);
+      } else {
+        keep.push(id);
+      }
+    }
+    merged.ents = ents;
+    if (keep.length > 0) merged.keep = keep;
+    else delete merged.keep;
+    return merged;
   }
 
   consumeSocialChanged(): boolean {
@@ -551,6 +1008,14 @@ export class ClientWorld implements IWorld {
   }
 
   private applySnapshot(snap: any): void {
+    if (typeof snap.tick === 'number' && Number.isFinite(snap.tick)) {
+      const tick = Math.floor(snap.tick);
+      if (tick < (this.lastSnapshotTick ?? -1)) {
+        predictionTrace.record('snapshot-drop', { tick, lastSnapshotTick: this.lastSnapshotTick ?? -1 });
+        return;
+      }
+      this.lastSnapshotTick = tick;
+    }
     const now = performance.now();
     // the interpolation alpha the render loop reached on its last frame
     // (same formula and caps as main.ts); used below to re-anchor the new
@@ -558,6 +1023,17 @@ export class ClientWorld implements IWorld {
     const contAlpha = this.lastSnapAt > 0
       ? Math.min(1.25, (now - this.lastSnapAt) / Math.max(20, this.snapInterval))
       : 1;
+    const prevSelf = this.entities.get(this.playerId);
+    const renderedSelfBefore = prevSelf
+      ? (this.predictionController ? this.prediction().renderPose(prevSelf, now) : this.renderedPose(prevSelf, contAlpha))
+      : null;
+    const selfBeforeSnapshot = tracePose(prevSelf);
+    const renderedSelfTrace = renderedSelfBefore ? {
+      x: traceRound(renderedSelfBefore.pos.x),
+      y: traceRound(renderedSelfBefore.pos.y),
+      z: traceRound(renderedSelfBefore.pos.z),
+      f: traceRound(renderedSelfBefore.facing),
+    } : null;
     if (this.lastSnapAt > 0) {
       const gap = now - this.lastSnapAt;
       if (gap > 5 && gap < 500) this.snapInterval = this.snapInterval * 0.9 + gap * 0.1;
@@ -565,7 +1041,6 @@ export class ClientWorld implements IWorld {
     this.lastSnapAt = now;
 
     const seen = new Set<number>();
-    const prevSelf = this.entities.get(this.playerId);
     const prevSelfFacing = prevSelf?.facing;
     let addedEntities = 0;
     let fullRecords = 0;
@@ -680,7 +1155,7 @@ export class ClientWorld implements IWorld {
       e.threat = new Map(w.thr ?? []);
       e.auras = (w.auras ?? []).map((a: any) => ({
         id: a.id, name: a.name, kind: a.kind, remaining: a.rem, duration: a.dur,
-        value: 0, sourceId: 0, school: 'physical' as const,
+        value: typeof a.v === 'number' ? a.v : 0, sourceId: 0, school: 'physical' as const,
       }));
       e.loot = w.lootList ?? null;
       return e;
@@ -713,19 +1188,32 @@ export class ClientWorld implements IWorld {
     const e = s ? applyWire(s) : null;
     if (s && e) {
       seen.add(s.id);
-      if (typeof s.ack === 'number' && s.ack > this.ackedInputSeq) {
-        for (let seq = this.ackedInputSeq + 1; seq <= s.ack; seq++) {
-          const sentAt = this.pendingInputSeqSentAt.get(seq);
+      let ackForReplay = this.ackedInputSeq ?? 0;
+      const previousAck = this.ackedInputSeq ?? 0;
+      const snapshotAck = typeof s.ack === 'number' && Number.isFinite(s.ack) ? Math.floor(s.ack) : null;
+      if (typeof s.ack === 'number' && s.ack > previousAck) {
+        const sentAtBySeq = (this.pendingInputSeqSentAt ??= new Map());
+        const echoSamples = (this.inputEchoSamples ??= []);
+        for (let seq = previousAck + 1; seq <= s.ack; seq++) {
+          const sentAt = sentAtBySeq.get(seq);
           if (sentAt !== undefined) {
-            this.inputEchoSamples.push(now - sentAt);
-            this.pendingInputSeqSentAt.delete(seq);
+            echoSamples.push(now - sentAt);
+            sentAtBySeq.delete(seq);
           }
         }
         this.ackedInputSeq = s.ack;
+        ackForReplay = s.ack;
       }
       e.resource = s.res;
       e.maxResource = s.mres;
       e.resourceType = s.rtype;
+      if (typeof s.vx === 'number') e.vx = s.vx;
+      if (typeof s.vz === 'number') e.vz = s.vz;
+      if (typeof s.vy === 'number') e.vy = s.vy;
+      if (s.og !== undefined) e.onGround = !!s.og;
+      if (typeof s.fy === 'number') e.fallStartY = s.fy;
+      const serverPose = traceWirePose(s);
+      const preReplayPose = tracePose(e);
       // delta fields: the server omits them while unchanged, so only the
       // snapshots that carry them rebuild the local structures
       if (s.cds !== undefined) e.cooldowns = new Map(Object.entries(s.cds).map(([k, v]) => [k, Number(v)]));
@@ -774,6 +1262,33 @@ export class ClientWorld implements IWorld {
       if (s.duel !== undefined) this.duelInfo = s.duel;
       if (s.arena !== undefined) this.arenaInfo = s.arena;
       if (s.market !== undefined) this.marketInfo = s.market;
+      const replay = this.replayPendingInputs(e, ackForReplay, renderedSelfBefore, preReplayPose, now);
+      const afterReplayPose = tracePose(e);
+      predictionTrace.record('snapshot-reconcile', {
+        tick: typeof snap.tick === 'number' ? Math.floor(snap.tick) : null,
+        time: typeof snap.time === 'number' ? traceRound(snap.time) : null,
+        ack: snapshotAck,
+        ackForReplay,
+        previousAck,
+        ackAdvanced: ackForReplay - previousAck,
+        ackLag: Math.max(0, (this.inputSeq ?? 0) - ackForReplay),
+        inputSeq: this.inputSeq ?? 0,
+        snapInterval: traceRound(this.snapInterval),
+        contAlpha: traceRound(contAlpha),
+        pendingBefore: replay.pendingBefore,
+        dropped: replay.dropped,
+        replayed: replay.replayed,
+        pendingAfter: replay.pendingAfter,
+        anchorMode: replay.anchorMode,
+        renderCorrectionDist: replay.renderCorrectionDist,
+        serverDeltaDist: tracePoseDist(selfBeforeSnapshot, serverPose),
+        replayDeltaDist: replay.replayDeltaDist,
+        renderedBefore: renderedSelfTrace,
+        before: selfBeforeSnapshot,
+        server: serverPose,
+        preReplay: preReplayPose,
+        after: afterReplayPose,
+      });
       // camera follows server-side facing changes when not mouselooking
       if (prevSelfFacing !== undefined && this.mouselookFacing === null) {
         let d = e.facing - prevSelfFacing;

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -36,6 +36,13 @@ export function buildWebSocketAuthMessage(token: string, characterId: number): {
   return { t: 'auth', token, character: characterId };
 }
 
+type ClientTraceSink = (
+  name: string,
+  startMs: number,
+  durationMs: number,
+  detail?: Record<string, unknown>,
+) => void;
+
 export type RealmType = 'Normal' | 'PvP' | 'RP' | 'RP-PvP';
 
 export interface RealmEntry {
@@ -313,6 +320,7 @@ export class ClientWorld implements IWorld {
   private pendingInputSeqSentAt = new Map<number, number>();
   private ackedInputSeq = 0;
   private inputEchoSamples: number[] = [];
+  private traceSink: ClientTraceSink | null = null;
 
   constructor(token: string, characterId: number, cls: PlayerClass, base = '') {
     this.characterId = characterId;
@@ -342,6 +350,10 @@ export class ClientWorld implements IWorld {
     clearInterval(this.sendTimer);
     this.ws.onclose = null;
     this.ws.close();
+  }
+
+  setTraceSink(sink: ClientTraceSink | null): void {
+    this.traceSink = sink;
   }
 
   get player(): Entity {
@@ -434,14 +446,22 @@ export class ClientWorld implements IWorld {
     this.cmd(payload);
   }
 
+  private markTrace(name: string, startMs: number, detail?: Record<string, unknown>): void {
+    this.traceSink?.(name, startMs, performance.now() - startMs, detail);
+  }
+
   private onMessage(raw: string): void {
+    const parseStart = performance.now();
     let msg: any;
     try {
       msg = JSON.parse(raw);
     } catch {
+      this.markTrace('net.ws.parse', parseStart, { bytes: raw.length, ok: false });
       return;
     }
+    this.markTrace('net.ws.parse', parseStart, { bytes: raw.length, type: typeof msg.t === 'string' ? msg.t : 'unknown' });
     if (msg.t === 'hello') {
+      const start = performance.now();
       this.playerId = msg.pid;
       this.cfg.seed = msg.seed;
       if (typeof msg.realm === 'string') this.realm = msg.realm;
@@ -450,14 +470,17 @@ export class ClientWorld implements IWorld {
         this.profanityDirty = true;
       }
       this.connected = true;
+      this.markTrace('net.hello', start, { softWords: this.profanityWords.length, realm: this.realm });
       return;
     }
     if (msg.t === 'censor') {
+      const start = performance.now();
       // live word-list update pushed after an admin edits the filter
       this.profanityWords = Array.isArray(msg.words)
         ? msg.words.filter((w: unknown): w is string => typeof w === 'string')
         : [];
       this.profanityDirty = true;
+      this.markTrace('net.censor', start, { words: this.profanityWords.length });
       return;
     }
     if (msg.t === 'error') {
@@ -466,15 +489,24 @@ export class ClientWorld implements IWorld {
       return;
     }
     if (msg.t === 'events') {
+      const start = performance.now();
       for (const ev of msg.list) this.eventQueue.push(ev as SimEvent);
+      this.markTrace('net.events.enqueue', start, { events: Array.isArray(msg.list) ? msg.list.length : 0 });
       return;
     }
     if (msg.t === 'social') {
+      const start = performance.now();
       this.socialInfo = { friends: msg.friends ?? [], blocks: msg.blocks ?? [], guild: msg.guild ?? null };
       this.socialDirty = true;
+      this.markTrace('net.social', start, {
+        friends: Array.isArray(msg.friends) ? msg.friends.length : 0,
+        blocks: Array.isArray(msg.blocks) ? msg.blocks.length : 0,
+        guildMembers: Array.isArray(msg.guild?.members) ? msg.guild.members.length : 0,
+      });
       return;
     }
     if (msg.t === 'socialpos') {
+      const start = performance.now();
       // live position refresh for friends/guildmates (drives the world map);
       // merge into the existing roster in place — snapshots own online/offline.
       if (this.socialInfo && Array.isArray(msg.list)) {
@@ -489,10 +521,20 @@ export class ClientWorld implements IWorld {
         apply(this.socialInfo.friends);
         if (this.socialInfo.guild) apply(this.socialInfo.guild.members);
       }
+      this.markTrace('net.socialpos', start, { rows: Array.isArray(msg.list) ? msg.list.length : 0 });
       return;
     }
     if (msg.t === 'snap') {
+      const start = performance.now();
       this.applySnapshot(msg);
+      this.markTrace('net.applySnapshot', start, {
+        bytes: raw.length,
+        ents: Array.isArray(msg.ents) ? msg.ents.length : 0,
+        keep: Array.isArray(msg.keep) ? msg.keep.length : 0,
+        hasSelf: !!msg.self,
+        entities: this.entities.size,
+        snapInterval: this.snapInterval,
+      });
     }
   }
 
@@ -525,21 +567,32 @@ export class ClientWorld implements IWorld {
     const seen = new Set<number>();
     const prevSelf = this.entities.get(this.playerId);
     const prevSelfFacing = prevSelf?.facing;
+    let addedEntities = 0;
+    let fullRecords = 0;
+    let liteRecords = 0;
+    let skippedLiteRecords = 0;
+    let teleportSnaps = 0;
 
     const applyWire = (w: any): Entity | null => {
       let e = this.entities.get(w.id);
       // identity fields ride only in "full" records: first sight and changes
       const hasIdentity = w.k !== undefined;
+      if (hasIdentity) fullRecords++;
+      else liteRecords++;
       if (!e) {
         // a lite record for an entity we never met would render as a
         // half-initialized ghost; skip it (the server sends identity first)
-        if (!hasIdentity) return null;
+        if (!hasIdentity) {
+          skippedLiteRecords++;
+          return null;
+        }
         e = blankEntity(w.id);
         e.pos = { x: w.x, y: w.y, z: w.z };
         copyPos(e.prevPos, e.pos);
         e.facing = w.f;
         e.prevFacing = w.f;
         this.entities.set(w.id, e);
+        addedEntities++;
       }
       if (hasIdentity) {
         e.kind = w.k;
@@ -595,6 +648,7 @@ export class ClientWorld implements IWorld {
       if ((wasDead && !nowDead) || teleDx * teleDx + teleDz * teleDz > TELEPORT_SNAP_DIST_SQ) {
         e.prevPos = { x: w.x, y: w.y, z: w.z };
         e.prevFacing = w.f;
+        teleportSnaps++;
       } else {
         e.prevPos = {
           x: e.prevPos.x + (e.pos.x - e.prevPos.x) * entAlpha,
@@ -632,16 +686,29 @@ export class ClientWorld implements IWorld {
       return e;
     };
 
+    let phaseStart = performance.now();
     for (const w of snap.ents) {
       if (applyWire(w) !== null) seen.add(w.id);
     }
+    this.markTrace('net.snapshot.entities', phaseStart, {
+      ents: Array.isArray(snap.ents) ? snap.ents.length : 0,
+      seen: seen.size,
+      added: addedEntities,
+      full: fullRecords,
+      lite: liteRecords,
+      skippedLite: skippedLiteRecords,
+      teleports: teleportSnaps,
+    });
     // entities listed in keep are alive but unchanged (or not due an update
     // at their distance tier this snapshot) — just protect them from pruning
+    phaseStart = performance.now();
     for (const id of snap.keep ?? []) {
       seen.add(id);
     }
+    this.markTrace('net.snapshot.keep', phaseStart, { keep: Array.isArray(snap.keep) ? snap.keep.length : 0, seen: seen.size });
 
     // self with extended state (always a full record)
+    phaseStart = performance.now();
     const s = snap.self;
     const e = s ? applyWire(s) : null;
     if (s && e) {
@@ -715,11 +782,25 @@ export class ClientWorld implements IWorld {
         this.pendingFacingDelta += d;
       }
     }
+    this.markTrace('net.snapshot.self', phaseStart, {
+      hasSelf: !!s,
+      inventory: s?.inv !== undefined,
+      quests: s?.qlog !== undefined || s?.qdone !== undefined,
+      talents: s?.tal !== undefined,
+      party: s?.party !== undefined,
+      socialEntities: seen.size,
+    });
 
     // prune entities that left our interest area
-    for (const [id, e] of this.entities) {
-      if (!seen.has(id)) this.entities.delete(id);
+    phaseStart = performance.now();
+    let removedEntities = 0;
+    for (const [id] of this.entities) {
+      if (!seen.has(id)) {
+        this.entities.delete(id);
+        removedEntities++;
+      }
     }
+    this.markTrace('net.snapshot.prune', phaseStart, { removed: removedEntities, entities: this.entities.size });
   }
 
   // -----------------------------------------------------------------------

--- a/src/net/prediction.ts
+++ b/src/net/prediction.ts
@@ -2,7 +2,9 @@ import { applyPlayerInputMovement } from '../sim/player_movement';
 import { DT, type Entity, type MoveInput } from '../sim/types';
 import type { RenderPose } from '../world_api';
 
-const CORRECTION_SMOOTH_SECONDS = 0.16;
+const CORRECTION_MOVING_SMOOTH_SECONDS = 0.16;
+const CORRECTION_HIGH_LEAD_SMOOTH_SECONDS = 0.08;
+const CORRECTION_IDLE_SMOOTH_SECONDS = 0.055;
 const CORRECTION_MAX_DECAY_DT_SECONDS = 1 / 30;
 const PREDICTION_SEGMENT_MS = DT * 1000;
 const MAX_PREDICTION_SEGMENT_MS = 250;
@@ -27,13 +29,28 @@ export interface PredictionStepResult {
 export interface PredictionReplayResult {
   pendingBefore: number;
   dropped: number;
+  heldCovered: number;
   replayed: number;
   pendingAfter: number;
+  effectiveAck: number;
+  capped: number;
 }
 
 export interface PresentationCorrectionResult {
   renderCorrectionDist: number;
   anchorMode: 'dead' | 'none' | 'snap' | 'blend';
+  correctionSmoothMs: number;
+}
+
+export interface PresentationCorrectionOptions {
+  inputMode?: 'moving' | 'idle';
+  leadTicks?: number;
+}
+
+export interface PredictionAckCoverage {
+  heldTicks: number;
+  heldInput: MoveInput;
+  heldFacing: number | null;
 }
 
 interface PresentationSegment {
@@ -98,6 +115,21 @@ function poseDist(a: RenderPose | null, b: RenderPose): number {
   return Math.hypot(a.pos.x - b.pos.x, a.pos.y - b.pos.y, a.pos.z - b.pos.z);
 }
 
+function sameMoveInput(a: MoveInput, b: MoveInput): boolean {
+  return a.forward === b.forward
+    && a.back === b.back
+    && a.turnLeft === b.turnLeft
+    && a.turnRight === b.turnRight
+    && a.strafeLeft === b.strafeLeft
+    && a.strafeRight === b.strafeRight
+    && a.jump === b.jump;
+}
+
+function sameMoveFacing(a: number | null, b: number | null): boolean {
+  if (a === null || b === null) return a === b;
+  return Math.abs(a - b) <= 1e-6;
+}
+
 export class LocalPredictionController {
   private offsetX = 0;
   private offsetY = 0;
@@ -106,6 +138,7 @@ export class LocalPredictionController {
   private lastPresentationAt = 0;
   private presentationInitialized = false;
   private predictionSegment: PresentationSegment | null = null;
+  private correctionSmoothSeconds = CORRECTION_MOVING_SMOOTH_SECONDS;
 
   constructor(private readonly seed: number, private readonly pendingCommands: MoveCommand[] = []) {}
 
@@ -150,7 +183,12 @@ export class LocalPredictionController {
     };
   }
 
-  replayFromAck(e: Entity, ack: number): PredictionReplayResult {
+  replayFromAck(
+    e: Entity,
+    ack: number,
+    coverage?: PredictionAckCoverage,
+    maxReplayCommands = Number.POSITIVE_INFINITY,
+  ): PredictionReplayResult {
     const pendingBefore = this.pendingCommands.length;
     let write = 0;
     for (let read = 0; read < this.pendingCommands.length; read++) {
@@ -158,17 +196,31 @@ export class LocalPredictionController {
       if (command.seq > ack) this.pendingCommands[write++] = command;
     }
     this.pendingCommands.length = write;
+    let effectiveAck = ack;
+    let heldCovered = 0;
+    if (coverage && coverage.heldTicks > 0) {
+      while (heldCovered < coverage.heldTicks && heldCovered < this.pendingCommands.length) {
+        const command = this.pendingCommands[heldCovered];
+        if (command.seq !== effectiveAck + 1) break;
+        if (!sameMoveInput(command.moveInput, coverage.heldInput)) break;
+        if (!sameMoveFacing(command.facing, coverage.heldFacing)) break;
+        effectiveAck = command.seq;
+        heldCovered++;
+      }
+      if (heldCovered > 0) this.pendingCommands.splice(0, heldCovered);
+    }
     const pendingAfter = this.pendingCommands.length;
     const dropped = pendingBefore - pendingAfter;
 
     if (e.dead) {
       this.pendingCommands.length = 0;
       this.snapPresentationTo(e);
-      return { pendingBefore, dropped, replayed: 0, pendingAfter: 0 };
+      return { pendingBefore, dropped, heldCovered, replayed: 0, pendingAfter: 0, effectiveAck, capped: 0 };
     }
 
-    for (const command of this.pendingCommands) this.applyCommand(e, command);
-    return { pendingBefore, dropped, replayed: pendingAfter, pendingAfter };
+    const replayed = Math.min(pendingAfter, Math.max(0, Math.floor(maxReplayCommands)));
+    for (let i = 0; i < replayed; i++) this.applyCommand(e, this.pendingCommands[i]);
+    return { pendingBefore, dropped, heldCovered, replayed, pendingAfter, effectiveAck, capped: pendingAfter - replayed };
   }
 
   renderPose(e: Entity, now: number): RenderPose {
@@ -193,10 +245,23 @@ export class LocalPredictionController {
     };
   }
 
-  reconcilePresentation(e: Entity, displayedBefore: RenderPose | null, now: number): PresentationCorrectionResult {
+  reconcilePresentation(
+    e: Entity,
+    displayedBefore: RenderPose | null,
+    now: number,
+    options: PresentationCorrectionOptions = {},
+  ): PresentationCorrectionResult {
+    const correctionSmoothSeconds = options.inputMode === 'idle'
+      ? CORRECTION_IDLE_SMOOTH_SECONDS
+      : (options.leadTicks ?? 0) >= 6
+        ? CORRECTION_HIGH_LEAD_SMOOTH_SECONDS
+        : CORRECTION_MOVING_SMOOTH_SECONDS;
+    this.correctionSmoothSeconds = correctionSmoothSeconds;
+    const correctionSmoothMs = Math.round(correctionSmoothSeconds * 1000);
+
     if (e.dead) {
       this.snapPresentationTo(e, now);
-      return { renderCorrectionDist: 0, anchorMode: 'dead' };
+      return { renderCorrectionDist: 0, anchorMode: 'dead', correctionSmoothMs };
     }
 
     const predicted = poseOf(e);
@@ -204,7 +269,7 @@ export class LocalPredictionController {
     const renderCorrectionDist = poseDist(displayedBefore, predicted);
     if (!displayedBefore) {
       this.snapPresentationTo(e, now);
-      return { renderCorrectionDist, anchorMode: 'snap' };
+      return { renderCorrectionDist, anchorMode: 'snap', correctionSmoothMs };
     }
 
     const dx = displayedBefore.pos.x - predicted.pos.x;
@@ -213,11 +278,11 @@ export class LocalPredictionController {
     const distSq = dx * dx + dy * dy + dz * dz;
     if (distSq <= PRESENTATION_IGNORE_DIST_SQ) {
       this.snapPresentationTo(e, now);
-      return { renderCorrectionDist, anchorMode: 'none' };
+      return { renderCorrectionDist, anchorMode: 'none', correctionSmoothMs };
     }
     if (distSq >= PRESENTATION_TELEPORT_DIST_SQ) {
       this.snapPresentationTo(e, now);
-      return { renderCorrectionDist, anchorMode: 'snap' };
+      return { renderCorrectionDist, anchorMode: 'snap', correctionSmoothMs };
     }
 
     this.presentationInitialized = true;
@@ -226,7 +291,7 @@ export class LocalPredictionController {
     this.offsetY = dy;
     this.offsetZ = dz;
     this.offsetFacing = wrapAngle(displayedBefore.facing - predicted.facing);
-    return { renderCorrectionDist, anchorMode: 'blend' };
+    return { renderCorrectionDist, anchorMode: 'blend', correctionSmoothMs };
   }
 
   snapPresentationTo(e: Entity, now = this.lastPresentationAt): void {
@@ -274,7 +339,7 @@ export class LocalPredictionController {
     this.lastPresentationAt = now;
     if (dt <= 0) return;
     const decayDt = Math.min(dt, CORRECTION_MAX_DECAY_DT_SECONDS);
-    const keep = Math.exp(-decayDt / CORRECTION_SMOOTH_SECONDS);
+    const keep = Math.exp(-decayDt / this.correctionSmoothSeconds);
     this.offsetX *= keep;
     this.offsetY *= keep;
     this.offsetZ *= keep;

--- a/src/net/prediction.ts
+++ b/src/net/prediction.ts
@@ -1,0 +1,287 @@
+import { applyPlayerInputMovement } from '../sim/player_movement';
+import { DT, type Entity, type MoveInput } from '../sim/types';
+import type { RenderPose } from '../world_api';
+
+const CORRECTION_SMOOTH_SECONDS = 0.16;
+const CORRECTION_MAX_DECAY_DT_SECONDS = 1 / 30;
+const PREDICTION_SEGMENT_MS = DT * 1000;
+const MAX_PREDICTION_SEGMENT_MS = 250;
+const PRESENTATION_IGNORE_DIST_SQ = 0.03 * 0.03;
+const PRESENTATION_TELEPORT_DIST_SQ = 40 * 40;
+const MAX_PENDING_COMMANDS = 80;
+
+export interface MoveCommand {
+  seq: number;
+  localTick: number;
+  moveInput: MoveInput;
+  facing: number | null;
+  sentAt: number;
+}
+
+export interface PredictionStepResult {
+  before: RenderPose;
+  after: RenderPose;
+  predictedDist: number;
+}
+
+export interface PredictionReplayResult {
+  pendingBefore: number;
+  dropped: number;
+  replayed: number;
+  pendingAfter: number;
+}
+
+export interface PresentationCorrectionResult {
+  renderCorrectionDist: number;
+  anchorMode: 'dead' | 'none' | 'snap' | 'blend';
+}
+
+interface PresentationSegment {
+  from: RenderPose;
+  to: RenderPose;
+  startedAt: number;
+  durationMs: number;
+}
+
+function copyPos(dst: { x: number; y: number; z: number }, src: { x: number; y: number; z: number }): void {
+  dst.x = src.x;
+  dst.y = src.y;
+  dst.z = src.z;
+}
+
+function cloneMoveInput(input: MoveInput): MoveInput {
+  return {
+    forward: input.forward,
+    back: input.back,
+    turnLeft: input.turnLeft,
+    turnRight: input.turnRight,
+    strafeLeft: input.strafeLeft,
+    strafeRight: input.strafeRight,
+    jump: input.jump,
+  };
+}
+
+function wrapAngle(d: number): number {
+  while (d > Math.PI) d -= 2 * Math.PI;
+  while (d < -Math.PI) d += 2 * Math.PI;
+  return d;
+}
+
+function poseOf(e: Entity): RenderPose {
+  return {
+    pos: { x: e.pos.x, y: e.pos.y, z: e.pos.z },
+    facing: e.facing,
+  };
+}
+
+function clonePose(pose: RenderPose): RenderPose {
+  return {
+    pos: { x: pose.pos.x, y: pose.pos.y, z: pose.pos.z },
+    facing: pose.facing,
+  };
+}
+
+function interpolatePose(a: RenderPose, b: RenderPose, t: number): RenderPose {
+  const alpha = Math.max(0, Math.min(1, t));
+  return {
+    pos: {
+      x: a.pos.x + (b.pos.x - a.pos.x) * alpha,
+      y: a.pos.y + (b.pos.y - a.pos.y) * alpha,
+      z: a.pos.z + (b.pos.z - a.pos.z) * alpha,
+    },
+    facing: a.facing + wrapAngle(b.facing - a.facing) * alpha,
+  };
+}
+
+function poseDist(a: RenderPose | null, b: RenderPose): number {
+  if (!a) return 0;
+  return Math.hypot(a.pos.x - b.pos.x, a.pos.y - b.pos.y, a.pos.z - b.pos.z);
+}
+
+export class LocalPredictionController {
+  private offsetX = 0;
+  private offsetY = 0;
+  private offsetZ = 0;
+  private offsetFacing = 0;
+  private lastPresentationAt = 0;
+  private presentationInitialized = false;
+  private predictionSegment: PresentationSegment | null = null;
+
+  constructor(private readonly seed: number, private readonly pendingCommands: MoveCommand[] = []) {}
+
+  get pendingCount(): number {
+    return this.pendingCommands.length;
+  }
+
+  pendingSnapshot(): readonly MoveCommand[] {
+    return this.pendingCommands;
+  }
+
+  makeCommand(seq: number, localTick: number, input: MoveInput, facing: number | null, sentAt: number): MoveCommand {
+    return {
+      seq,
+      localTick,
+      moveInput: cloneMoveInput(input),
+      facing,
+      sentAt,
+    };
+  }
+
+  push(command: MoveCommand): void {
+    this.pendingCommands.push(command);
+    if (this.pendingCommands.length > MAX_PENDING_COMMANDS) {
+      this.pendingCommands.splice(0, this.pendingCommands.length - MAX_PENDING_COMMANDS);
+    }
+  }
+
+  applyCommand(e: Entity, command: MoveCommand, presentationAt?: number): PredictionStepResult {
+    const before = poseOf(e);
+    const segmentFrom = presentationAt === undefined ? null : this.basePose(e, presentationAt);
+    copyPos(e.prevPos, e.pos);
+    e.prevFacing = e.facing;
+    if (command.facing !== null) e.facing = command.facing;
+    applyPlayerInputMovement(e, command.moveInput, this.seed);
+    const after = poseOf(e);
+    if (presentationAt !== undefined && segmentFrom) this.extendPredictionSegment(segmentFrom, after, presentationAt);
+    return {
+      before,
+      after,
+      predictedDist: poseDist(before, after),
+    };
+  }
+
+  replayFromAck(e: Entity, ack: number): PredictionReplayResult {
+    const pendingBefore = this.pendingCommands.length;
+    let write = 0;
+    for (let read = 0; read < this.pendingCommands.length; read++) {
+      const command = this.pendingCommands[read];
+      if (command.seq > ack) this.pendingCommands[write++] = command;
+    }
+    this.pendingCommands.length = write;
+    const pendingAfter = this.pendingCommands.length;
+    const dropped = pendingBefore - pendingAfter;
+
+    if (e.dead) {
+      this.pendingCommands.length = 0;
+      this.snapPresentationTo(e);
+      return { pendingBefore, dropped, replayed: 0, pendingAfter: 0 };
+    }
+
+    for (const command of this.pendingCommands) this.applyCommand(e, command);
+    return { pendingBefore, dropped, replayed: pendingAfter, pendingAfter };
+  }
+
+  renderPose(e: Entity, now: number): RenderPose {
+    if (!this.presentationInitialized) {
+      this.presentationInitialized = true;
+      this.lastPresentationAt = now;
+      this.offsetX = 0;
+      this.offsetY = 0;
+      this.offsetZ = 0;
+      this.offsetFacing = 0;
+    } else {
+      this.decay(now);
+    }
+    const base = this.basePose(e, now);
+    return {
+      pos: {
+        x: base.pos.x + this.offsetX,
+        y: base.pos.y + this.offsetY,
+        z: base.pos.z + this.offsetZ,
+      },
+      facing: base.facing + this.offsetFacing,
+    };
+  }
+
+  reconcilePresentation(e: Entity, displayedBefore: RenderPose | null, now: number): PresentationCorrectionResult {
+    if (e.dead) {
+      this.snapPresentationTo(e, now);
+      return { renderCorrectionDist: 0, anchorMode: 'dead' };
+    }
+
+    const predicted = poseOf(e);
+    this.snapPredictionSegmentTo(predicted);
+    const renderCorrectionDist = poseDist(displayedBefore, predicted);
+    if (!displayedBefore) {
+      this.snapPresentationTo(e, now);
+      return { renderCorrectionDist, anchorMode: 'snap' };
+    }
+
+    const dx = displayedBefore.pos.x - predicted.pos.x;
+    const dy = displayedBefore.pos.y - predicted.pos.y;
+    const dz = displayedBefore.pos.z - predicted.pos.z;
+    const distSq = dx * dx + dy * dy + dz * dz;
+    if (distSq <= PRESENTATION_IGNORE_DIST_SQ) {
+      this.snapPresentationTo(e, now);
+      return { renderCorrectionDist, anchorMode: 'none' };
+    }
+    if (distSq >= PRESENTATION_TELEPORT_DIST_SQ) {
+      this.snapPresentationTo(e, now);
+      return { renderCorrectionDist, anchorMode: 'snap' };
+    }
+
+    this.presentationInitialized = true;
+    this.lastPresentationAt = now;
+    this.offsetX = dx;
+    this.offsetY = dy;
+    this.offsetZ = dz;
+    this.offsetFacing = wrapAngle(displayedBefore.facing - predicted.facing);
+    return { renderCorrectionDist, anchorMode: 'blend' };
+  }
+
+  snapPresentationTo(e: Entity, now = this.lastPresentationAt): void {
+    this.presentationInitialized = true;
+    this.lastPresentationAt = now;
+    this.offsetX = 0;
+    this.offsetY = 0;
+    this.offsetZ = 0;
+    this.offsetFacing = 0;
+    this.snapPredictionSegmentTo(poseOf(e));
+  }
+
+  private basePose(e: Entity, now: number): RenderPose {
+    const segment = this.predictionSegment;
+    if (!segment) return poseOf(e);
+    if (segment.durationMs <= 0) return clonePose(segment.to);
+    const alpha = (now - segment.startedAt) / segment.durationMs;
+    if (alpha >= 1) return clonePose(segment.to);
+    if (alpha <= 0) return clonePose(segment.from);
+    return interpolatePose(segment.from, segment.to, alpha);
+  }
+
+  private extendPredictionSegment(from: RenderPose, to: RenderPose, now: number): void {
+    const active = this.predictionSegment;
+    const remaining = active ? Math.max(0, active.startedAt + active.durationMs - now) : 0;
+    this.predictionSegment = {
+      from: clonePose(from),
+      to: clonePose(to),
+      startedAt: now,
+      durationMs: Math.min(MAX_PREDICTION_SEGMENT_MS, Math.max(PREDICTION_SEGMENT_MS, remaining + PREDICTION_SEGMENT_MS)),
+    };
+  }
+
+  private snapPredictionSegmentTo(pose: RenderPose): void {
+    this.predictionSegment = {
+      from: clonePose(pose),
+      to: clonePose(pose),
+      startedAt: this.lastPresentationAt,
+      durationMs: PREDICTION_SEGMENT_MS,
+    };
+  }
+
+  private decay(now: number): void {
+    const dt = Math.max(0, Math.min(0.25, (now - this.lastPresentationAt) / 1000));
+    this.lastPresentationAt = now;
+    if (dt <= 0) return;
+    const decayDt = Math.min(dt, CORRECTION_MAX_DECAY_DT_SECONDS);
+    const keep = Math.exp(-decayDt / CORRECTION_SMOOTH_SECONDS);
+    this.offsetX *= keep;
+    this.offsetY *= keep;
+    this.offsetZ *= keep;
+    this.offsetFacing *= keep;
+    if (Math.abs(this.offsetX) < 0.0005) this.offsetX = 0;
+    if (Math.abs(this.offsetY) < 0.0005) this.offsetY = 0;
+    if (Math.abs(this.offsetZ) < 0.0005) this.offsetZ = 0;
+    if (Math.abs(this.offsetFacing) < 0.0005) this.offsetFacing = 0;
+  }
+}

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -143,6 +143,7 @@ function flattenWeaponScene(src: THREE.Object3D): THREE.Object3D {
 
 function attachProp(root: THREE.Object3D, bone: THREE.Object3D, att: AttachDef): void {
   const payload = flattenWeaponScene(cloneSkinned(resolvedGltf(att.url).scene));
+  payload.traverse((o) => { if ((o as THREE.Mesh).isMesh) o.userData.weaponMesh = true; });
   if (att.position || att.rotationY !== undefined) {
     if (att.position) payload.position.set(...att.position);
     if (att.rotationY !== undefined) payload.rotation.y = att.rotationY;
@@ -172,21 +173,19 @@ for (const url of preloadUrls) {
 }
 
 // Skin textures: player alternate body atlases, loaded sRGB + flipY=false so
-// they line up with the glTF-embedded UVs. Standard tier only — low tier aliases
-// character models and keeps the default look.
+// they line up with the glTF-embedded UVs. Low may alias a few character GLBs,
+// but player-selected skins still need to load and apply on every tier.
 const skinTexByUrl = new Map<string, THREE.Texture>();
-if (GFX.standardMaterials) {
-  for (const url of [...new Set(Object.values(SKINS).flat().filter((u): u is string => !!u))]) {
-    registerPreload(loadTexture(url, { srgb: true }).then((t) => {
-      t.flipY = false;
-      t.needsUpdate = true;
-      skinTexByUrl.set(url, t);
-    }));
-  }
+for (const url of [...new Set(Object.values(SKINS).flat().filter((u): u is string => !!u))]) {
+  registerPreload(loadTexture(url, { srgb: true }).then((t) => {
+    t.flipY = false;
+    t.needsUpdate = true;
+    skinTexByUrl.set(url, t);
+  }));
 }
 
 /** Resolved skin texture for a visual key + skin index, or null for the model's
- *  embedded default (index 0, unknown key, or low tier). */
+ *  embedded default (index 0 or unknown key). */
 export function skinTexture(key: string, skinIndex: number): THREE.Texture | null {
   const url = SKINS[key]?.[skinIndex] ?? null;
   return url ? skinTexByUrl.get(url) ?? null : null;
@@ -311,9 +310,38 @@ export function assembleModel(def: VisualDef): THREE.Object3D {
 
 const matCache = new Map<string, THREE.Material>();
 const tintScratch = new THREE.Color();
+const lowReadabilityWhite = new THREE.Color(0xffffff);
+const weaponHighlight = new THREE.Color(0xfff0c2);
+type MaterialRole = 'body' | 'weapon';
 
-export function tintedMaterial(src: THREE.Material, tint: number | null, strength: number, skinTex: THREE.Texture | null = null): THREE.Material {
-  const key = `${src.uuid}|${tint ?? 'n'}|${tint === null ? 0 : strength}|${GFX.standardMaterials ? 's' : 'l'}|${skinTex ? skinTex.uuid : 'n'}`;
+function applyLowReadabilityLift(mat: THREE.MeshStandardMaterial | THREE.MeshLambertMaterial | THREE.MeshBasicMaterial, role: MaterialRole): void {
+  const lift = role === 'weapon' ? 0.14 : 0.075;
+  const emissive = role === 'weapon' ? 0.075 : 0.045;
+  mat.color.lerp(role === 'weapon' ? weaponHighlight : lowReadabilityWhite, lift);
+  if ((mat as THREE.MeshLambertMaterial).isMeshLambertMaterial) {
+    const lambert = mat as THREE.MeshLambertMaterial;
+    lambert.emissive = mat.color.clone().multiplyScalar(emissive);
+  }
+}
+
+function applyWeaponMaterialPolish(mat: THREE.MeshStandardMaterial | THREE.MeshLambertMaterial | THREE.MeshBasicMaterial): void {
+  mat.color.lerp(weaponHighlight, 0.08);
+  const std = mat as THREE.MeshStandardMaterial;
+  if (std.isMeshStandardMaterial) {
+    std.roughness = Math.min(std.roughness, 0.55);
+    std.metalness = Math.max(std.metalness, 0.12);
+    std.emissive.copy(mat.color).multiplyScalar(0.025);
+  }
+}
+
+export function tintedMaterial(
+  src: THREE.Material,
+  tint: number | null,
+  strength: number,
+  skinTex: THREE.Texture | null = null,
+  role: MaterialRole = 'body',
+): THREE.Material {
+  const key = `${src.uuid}|${tint ?? 'n'}|${tint === null ? 0 : strength}|${GFX.standardMaterials ? 's' : 'l'}|${skinTex ? skinTex.uuid : 'n'}|${role}`;
   const cached = matCache.get(key);
   if (cached) return cached;
 
@@ -342,6 +370,8 @@ export function tintedMaterial(src: THREE.Material, tint: number | null, strengt
     mat.color.lerp(tintScratch.set(tint), strength);
   }
   if (skinTex) mat.map = skinTex; // alternate body atlas, same UVs as the default
+  if (role === 'weapon') applyWeaponMaterialPolish(mat);
+  if (!GFX.standardMaterials) applyLowReadabilityLift(mat, role);
   matCache.set(key, mat);
   return mat;
 }
@@ -359,12 +389,14 @@ export function applyMaterials(root: THREE.Object3D, def: VisualDef, entityColor
   root.traverse((o) => {
     const mesh = o as THREE.Mesh;
     if (!mesh.isMesh) return;
+    const role: MaterialRole = mesh.userData.weaponMesh ? 'weapon' : 'body';
+    const materialTint = role === 'weapon' ? null : tint;
     // skin override only touches the character's own atlas meshes, not weapons
     const sk = skinTex && mesh.userData.bodyMesh ? skinTex : null;
     if (Array.isArray(mesh.material)) {
-      mesh.material = mesh.material.map((m) => tintedMaterial(m, tint, strength, sk));
+      mesh.material = mesh.material.map((m) => tintedMaterial(m, materialTint, strength, sk, role));
     } else {
-      mesh.material = tintedMaterial(mesh.material, tint, strength, sk);
+      mesh.material = tintedMaterial(mesh.material, materialTint, strength, sk, role);
     }
   });
 }

--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -13,13 +13,17 @@ import type { GLTF } from 'three/addons/loaders/GLTFLoader.js';
 import { loadGltf, loadTexture } from '../assets/loader';
 import { registerPreload } from '../assets/preload';
 import { GFX, addRimGlow } from '../gfx';
-import { manifestUrls, SKINS, VISUALS, VisualDef, type AttachDef } from './manifest';
+import {
+  manifestUrlsForGraphics,
+  SKINS,
+  visibleAttachmentsForGraphics,
+  VISUALS,
+  VisualDef,
+  visualAssetUrlForGraphics,
+  type AttachDef,
+} from './manifest';
 
 const DEFAULT_TINT_STRENGTH = 0.4;
-
-const LOW_URL_ALIAS: Record<string, string> = {
-  'models/chars/players/rogue_hooded.glb': 'models/chars/players/rogue.glb',
-};
 
 type HandGrip = {
   position: [number, number, number];
@@ -158,14 +162,10 @@ function attachProp(root: THREE.Object3D, bone: THREE.Object3D, att: AttachDef):
 const gltfByUrl = new Map<string, GLTF>();
 
 function assetUrl(url: string): string {
-  return GFX.standardMaterials ? url : (LOW_URL_ALIAS[url] ?? url);
+  return visualAssetUrlForGraphics(url, GFX.standardMaterials);
 }
 
-const preloadUrls = GFX.standardMaterials
-  ? manifestUrls()
-  : [...new Set(manifestUrls()
-    .filter((url) => !url.startsWith('models/weapons/'))
-    .map(assetUrl))];
+const preloadUrls = manifestUrlsForGraphics(GFX.standardMaterials);
 
 for (const url of preloadUrls) {
   registerPreload(loadGltf(url).then((g) => { gltfByUrl.set(url, g); }));
@@ -291,7 +291,9 @@ export function assembleModel(def: VisualDef): THREE.Object3D {
       }
     });
   }
-  const attachments = GFX.standardMaterials ? (def.attach ?? []) : [];
+  // Weapons and held props are gameplay-readable silhouettes, not decoration.
+  // Low tier still downgrades body/material cost, but keeps attachments visible.
+  const attachments = visibleAttachmentsForGraphics(def);
   for (const att of attachments) {
     // GLTFLoader sanitizes node names (PropertyBinding strips [].:/ chars),
     // so the authored "handslot.r" arrives as "handslotr" — try both

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -168,6 +168,10 @@ const ENEMIES = 'models/chars/enemies';
 const CREATURES = 'models/creatures';
 const WEAPONS = 'models/weapons';
 
+const LOW_URL_ALIAS: Record<string, string> = {
+  'models/chars/players/rogue_hooded.glb': 'models/chars/players/rogue.glb',
+};
+
 const HUMANOID_H = 2.6;
 
 const SKINS_DIR = 'textures/skins';
@@ -559,4 +563,16 @@ export function manifestUrls(): string[] {
     for (const a of def.attach ?? []) urls.add(a.url);
   }
   return [...urls];
+}
+
+export function visualAssetUrlForGraphics(url: string, standardMaterials: boolean): string {
+  return standardMaterials ? url : (LOW_URL_ALIAS[url] ?? url);
+}
+
+export function manifestUrlsForGraphics(standardMaterials: boolean): string[] {
+  return [...new Set(manifestUrls().map((url) => visualAssetUrlForGraphics(url, standardMaterials)))];
+}
+
+export function visibleAttachmentsForGraphics(def: Pick<VisualDef, 'attach'>): readonly AttachDef[] {
+  return def.attach ?? [];
 }

--- a/src/render/dungeon.ts
+++ b/src/render/dungeon.ts
@@ -382,7 +382,7 @@ export class DungeonInteriors {
     const variant = this.variantFor(interior, ox);
     const group = new THREE.Group();
     const p = new Placements();
-    const arenaWalls = variant === 'arena' ? this.pendingArenaWalls(layout, ox, oz) : null;
+    const arenaWalls = variant === 'arena' ? this.pendingArenaWalls(layout, ox, oz) : undefined;
 
     this.placeFloor(p, layout, variant);
     this.placeWalls(p, layout, variant, arenaWalls);

--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -77,10 +77,10 @@ const FOLIAGE_MODEL_URLS_LOW = {
   twisted: [1].map((i) => `${MODEL_DIR}twisted_${i}.glb`),
   dead: [1].map((i) => `${MODEL_DIR}dead_${i}.glb`),
   rock: [1].map((i) => `${MODEL_DIR}rock_${i}.glb`),
-  bush: [],
-  bushFlowers: [],
-  fern: [],
-  mushroom: [],
+  bush: [`${MODEL_DIR}bush.glb`],
+  bushFlowers: [`${MODEL_DIR}bush_flowers.glb`],
+  fern: [`${MODEL_DIR}fern.glb`],
+  mushroom: [`${MODEL_DIR}mushroom.glb`],
 };
 const MODEL_URLS = GFX.standardMaterials ? FOLIAGE_MODEL_URLS_HIGH : FOLIAGE_MODEL_URLS_LOW;
 
@@ -126,10 +126,24 @@ export interface FoliageView {
     fogFar: number,
   ): void;
   setGrassQuality(level: number): void;
+  setModelQuality(level: number): void;
   perfStats(): FoliagePerfStats;
 }
 
 export interface FoliagePerfStats {
+  modelQuality: number;
+  modelBuckets: number;
+  modelVisibleBuckets: number;
+  modelBucketsByLod: Record<string, number>;
+  modelVisibleByLod: Record<string, number>;
+  modelDraws: number;
+  modelVisibleDraws: number;
+  modelDrawsByLod: Record<string, number>;
+  modelVisibleDrawsByLod: Record<string, number>;
+  modelTriangles: number;
+  modelVisibleTriangles: number;
+  modelTrianglesByLod: Record<string, number>;
+  modelVisibleTrianglesByLod: Record<string, number>;
   grassEnabled: boolean;
   grassQuality: number;
   grassActiveRadius: number;
@@ -161,6 +175,27 @@ interface BucketMesh {
   radius: number;
   minDist?: number;
   maxDist?: number;
+  lod: 'core' | 'near-fill' | 'shadow' | 'proxy' | 'impostor' | 'rock' | 'dressing';
+  draws: number;
+  triangles: number;
+}
+
+function drawCountFor(material: THREE.Material | THREE.Material[], geometry?: THREE.BufferGeometry): number {
+  if (Array.isArray(material)) return Math.max(1, geometry?.groups.length ? geometry.groups.length : material.length);
+  return Math.max(1, geometry?.groups.length && geometry.groups.length > 0 ? geometry.groups.length : 1);
+}
+
+function triangleCountFor(geometry?: THREE.BufferGeometry): number {
+  if (!geometry) return 0;
+  const drawCount = geometry.index?.count ?? geometry.getAttribute('position')?.count ?? 0;
+  return Math.max(0, Math.floor(drawCount / 3));
+}
+
+function bucketMeshCost(mesh: THREE.InstancedMesh): Pick<BucketMesh, 'draws' | 'triangles'> {
+  return {
+    draws: drawCountFor(mesh.material, mesh.geometry),
+    triangles: triangleCountFor(mesh.geometry) * Math.max(0, mesh.count),
+  };
 }
 
 interface TreeHidePart {
@@ -187,14 +222,16 @@ interface TreeHideable {
 // has no shadows or fog-flattering post, and raw triangle rate is its limit.
 interface LodDists {
   barkFar: number;
+  treeDetailFar: number;
   dressFar: number;
   rockFar: number;
+  treeFillFar: number;
 }
-const LOD_HIGH: LodDists = { barkFar: 330, dressFar: 200, rockFar: 360 };
+const LOD_HIGH: LodDists = { barkFar: 330, treeDetailFar: 300, dressFar: 200, rockFar: 360, treeFillFar: 310 };
 // low caps must clear the worst camera-to-bucket-CENTRE distance (~158u for a
 // 2-column x 240u-band bucket) or nearby dressing vanishes and trunks pop at
 // bucket boundaries — the windows test bucket centres, not instances
-const LOD_LOW: LodDists = { barkFar: 120, dressFar: 0, rockFar: 150 };
+const LOD_LOW: LodDists = { barkFar: 170, treeDetailFar: 250, dressFar: 185, rockFar: 190, treeFillFar: 245 };
 function lodDists(): LodDists {
   return GFX.standardMaterials ? LOD_HIGH : LOD_LOW;
 }
@@ -379,10 +416,64 @@ interface SpeciesSpec {
   sink: number; // x instance scale, beyond the model's own below-ground roots
   leafTint: Record<BiomeId, number> | number;
   castBarkShadow: boolean;
+  proxyShape: 'pine' | 'round' | 'twisted' | 'dead';
   /** hide the heavy bark mesh beyond BARK_FAR (needs a canopy that covers) */
   cullBarkFar?: boolean;
   /** beyond BARK_FAR swap the bark for a cheap cylinder (straight trunks) */
   farTrunkProxy?: boolean;
+}
+
+const farTreeProxyGeoCache = new Map<SpeciesSpec['proxyShape'], THREE.BufferGeometry>();
+const farTreeProxyMatCache = new Map<string, THREE.Material>();
+
+function withWhiteVertexColors(geo: THREE.BufferGeometry): THREE.BufferGeometry {
+  const count = geo.getAttribute('position')?.count ?? 0;
+  geo.setAttribute('color', new THREE.BufferAttribute(new Float32Array(count * 3).fill(1), 3));
+  return geo;
+}
+
+function farTreeProxyGeo(shape: SpeciesSpec['proxyShape']): THREE.BufferGeometry {
+  const cached = farTreeProxyGeoCache.get(shape);
+  if (cached) return cached;
+  let geo: THREE.BufferGeometry;
+  if (shape === 'pine') {
+    geo = new THREE.ConeGeometry(2.2, 7.2, 7, 2);
+    geo.translate(0, 3.6, 0);
+  } else if (shape === 'dead') {
+    geo = new THREE.CylinderGeometry(0.18, 0.42, 6.4, 7, 2, true);
+    geo.translate(0, 3.2, 0);
+  } else if (shape === 'twisted') {
+    geo = new THREE.ConeGeometry(2.6, 5.6, 8, 2);
+    geo.scale(1.15, 1, 0.75);
+    geo.translate(0, 2.8, 0);
+  } else {
+    geo = new THREE.SphereGeometry(2.35, 8, 5);
+    geo.scale(1.15, 0.9, 1.15);
+    geo.translate(0, 4.4, 0);
+  }
+  geo = withWhiteVertexColors(geo);
+  farTreeProxyGeoCache.set(shape, geo);
+  return geo;
+}
+
+function farTreeProxyMaterial(shape: SpeciesSpec['proxyShape']): THREE.Material {
+  const cached = farTreeProxyMatCache.get(shape);
+  if (cached) return cached;
+  const fallback = shape === 'dead'
+    ? 0xbca784
+    : shape === 'pine'
+      ? 0xb8d7a5
+      : shape === 'twisted'
+        ? 0xb7cda0
+        : 0xc0d8a8;
+  const mat = new THREE.MeshLambertMaterial({
+    color: fallback,
+    vertexColors: true,
+    fog: true,
+  });
+  mat.name = `foliage:far-${shape}`;
+  farTreeProxyMatCache.set(shape, mat);
+  return mat;
 }
 
 // far-LOD stand-in for a straight trunk: an open tapered cylinder sized from
@@ -450,7 +541,7 @@ function makeShadowOnlyMaterial(src: THREE.Material): THREE.Material {
 
 function placeSpecies(
   parent: THREE.Group, seed: number, bucket: Bucket, items: Decoration[],
-  spec: SpeciesSpec, register: (mesh: THREE.InstancedMesh, minDist?: number, maxDist?: number) => void,
+  spec: SpeciesSpec, register: (mesh: THREE.InstancedMesh, lod: BucketMesh['lod'], minDist?: number, maxDist?: number) => void,
   hideRegistry: TreeHideable[],
 ): void {
   if (items.length === 0) return;
@@ -462,63 +553,111 @@ function placeSpecies(
   }
   groups.forEach((list, gi) => {
     if (list.length === 0) return;
-    const handles: TreeHideable[] = list.map((d) => ({
-      x: d.x,
-      z: d.z,
-      r: 0.55 * d.scale,
-      topY: terrainHeight(d.x, d.z, seed) + 7.5 * d.scale,
-      hidden: false,
-      parts: [],
-    }));
-    hideRegistry.push(...handles);
-    for (const part of spec.sets[subset[gi]]) {
-      const im = new THREE.InstancedMesh(part.geometry, part.material, list.length);
-      list.forEach((d, i) => {
-        const y = terrainHeight(d.x, d.z, seed);
-        const s = d.scale * spec.baseScale;
-        const heightJitter = 1 + (hashAt(d.x, d.z, 31) - 0.5) * 0.18;
-        q.setFromAxisAngle(up, d.variant * 2.1 + hashAt(d.x, d.z, 11) * Math.PI * 2);
-        m.compose(v.set(d.x, y - spec.sink * s, d.z), q, sv.set(s, s * heightJitter, s));
-        im.setMatrixAt(i, m);
-        const visibleMatrix = new THREE.Matrix4().copy(m);
-        const hiddenMatrix = new THREE.Matrix4().copy(m).scale(zeroScale);
-        handles[i].parts.push({ mesh: im, index: i, visibleMatrix, hiddenMatrix });
-        if (part.isLeaf) {
-          const hex = typeof spec.leafTint === 'number' ? spec.leafTint : spec.leafTint[d.biome];
-          im.setColorAt(i, softTint(d.x, d.z, hex, c, LEAF_TINT_SOFTEN));
-        } else {
-          im.setColorAt(i, softTint(d.x, d.z, TRUNK_TINT[d.biome], c, BARK_TINT_SOFTEN, 0.5));
-        }
-      });
-      // canopy owns the tree shadow; bark casts only when there is no canopy
-      const castsShadow = part.isLeaf || spec.castBarkShadow;
-      im.castShadow = false;
-      im.receiveShadow = true;
-      parent.add(im);
-      const { barkFar } = lodDists();
-      const cullBark = !part.isLeaf && (spec.cullBarkFar || spec.farTrunkProxy);
-      register(im, undefined, cullBark ? barkFar : undefined);
-      if (castsShadow) {
-        const shadow = cloneInstancedTo(im, part.geometry, makeShadowOnlyMaterial(part.material));
-        shadow.castShadow = true;
-        shadow.receiveShadow = false;
-        parent.add(shadow);
-        register(shadow, undefined, cullBark ? barkFar : undefined);
-      }
-      if (!part.isLeaf && spec.farTrunkProxy) {
-        const proxy = cloneInstancedTo(im, farTrunkGeo(part.geometry), part.material);
+    const { treeDetailFar, treeFillFar } = lodDists();
+    const coreItems: Decoration[] = [];
+    const nearFillItems: Decoration[] = [];
+    const coreRatio = GFX.standardMaterials ? 0.5 : 0.42;
+    for (const d of list) {
+      if (list.length < 4 || hashAt(d.x, d.z, spec.salt + 91) < coreRatio) coreItems.push(d);
+      else nearFillItems.push(d);
+    }
+    const lodGroups = [
+      { lod: 'core' as const, items: coreItems, maxDist: undefined },
+      { lod: 'near-fill' as const, items: nearFillItems, maxDist: treeFillFar },
+    ].filter((g) => g.items.length > 0);
+    const handlesByLod = lodGroups.map((g) => {
+      const handles: TreeHideable[] = g.items.map((d) => ({
+        x: d.x,
+        z: d.z,
+        r: 0.55 * d.scale,
+        topY: terrainHeight(d.x, d.z, seed) + 7.5 * d.scale,
+        hidden: false,
+        parts: [],
+      }));
+      hideRegistry.push(...handles);
+      return { ...g, handles };
+    });
+    if (GFX.standardMaterials) {
+      for (const group of handlesByLod) {
+        if (group.maxDist !== undefined && group.maxDist <= treeDetailFar) continue;
+        const proxy = new THREE.InstancedMesh(
+          farTreeProxyGeo(spec.proxyShape),
+          farTreeProxyMaterial(spec.proxyShape),
+          group.items.length,
+        );
+        group.items.forEach((d, i) => {
+          const y = terrainHeight(d.x, d.z, seed);
+          const s = d.scale * spec.baseScale;
+          q.setFromAxisAngle(up, d.variant * 2.1 + hashAt(d.x, d.z, 11) * Math.PI * 2);
+          m.compose(v.set(d.x, y - spec.sink * s, d.z), q, sv.set(s, s, s));
+          proxy.setMatrixAt(i, m);
+          const tintHex = spec.proxyShape === 'dead'
+            ? TRUNK_TINT[d.biome]
+            : typeof spec.leafTint === 'number' ? spec.leafTint : spec.leafTint[d.biome];
+          proxy.setColorAt(i, softTint(d.x, d.z, tintHex, c, spec.proxyShape === 'dead' ? BARK_TINT_SOFTEN : LEAF_TINT_SOFTEN));
+        });
+        if (proxy.instanceColor) proxy.instanceColor.needsUpdate = true;
         proxy.receiveShadow = true;
-        for (let i = 0; i < list.length; i++) {
-          const source = handles[i].parts[handles[i].parts.length - 1];
-          handles[i].parts.push({
-            mesh: proxy,
-            index: i,
-            visibleMatrix: source.visibleMatrix,
-            hiddenMatrix: source.hiddenMatrix,
-          });
-        }
         parent.add(proxy);
-        register(proxy, barkFar, undefined);
+        register(proxy, 'impostor', treeDetailFar, group.maxDist);
+      }
+    }
+    for (const part of spec.sets[subset[gi]]) {
+      const { barkFar } = lodDists();
+      for (const group of handlesByLod) {
+        const im = new THREE.InstancedMesh(part.geometry, part.material, group.items.length);
+        group.items.forEach((d, i) => {
+          const y = terrainHeight(d.x, d.z, seed);
+          const s = d.scale * spec.baseScale;
+          const heightJitter = 1 + (hashAt(d.x, d.z, 31) - 0.5) * 0.18;
+          q.setFromAxisAngle(up, d.variant * 2.1 + hashAt(d.x, d.z, 11) * Math.PI * 2);
+          m.compose(v.set(d.x, y - spec.sink * s, d.z), q, sv.set(s, s * heightJitter, s));
+          im.setMatrixAt(i, m);
+          const visibleMatrix = new THREE.Matrix4().copy(m);
+          const hiddenMatrix = new THREE.Matrix4().copy(m).scale(zeroScale);
+          group.handles[i].parts.push({ mesh: im, index: i, visibleMatrix, hiddenMatrix });
+          if (part.isLeaf) {
+            const hex = typeof spec.leafTint === 'number' ? spec.leafTint : spec.leafTint[d.biome];
+            im.setColorAt(i, softTint(d.x, d.z, hex, c, LEAF_TINT_SOFTEN));
+          } else {
+            im.setColorAt(i, softTint(d.x, d.z, TRUNK_TINT[d.biome], c, BARK_TINT_SOFTEN, 0.5));
+          }
+        });
+        // canopy owns the tree shadow; bark casts only when there is no canopy
+        const castsShadow = part.isLeaf || spec.castBarkShadow;
+        im.castShadow = false;
+        im.receiveShadow = true;
+        parent.add(im);
+        const cullBark = GFX.standardMaterials && !part.isLeaf && (spec.cullBarkFar || spec.farTrunkProxy);
+        const detailMaxDist = group.maxDist === undefined
+          ? treeDetailFar
+          : Math.min(group.maxDist, treeDetailFar);
+        const maxDist = cullBark
+          ? Math.min(detailMaxDist, barkFar)
+          : detailMaxDist;
+        register(im, group.lod, undefined, maxDist === Infinity ? undefined : maxDist);
+        if (GFX.standardMaterials && castsShadow) {
+          const shadow = cloneInstancedTo(im, part.geometry, makeShadowOnlyMaterial(part.material));
+          shadow.castShadow = true;
+          shadow.receiveShadow = false;
+          parent.add(shadow);
+          register(shadow, 'shadow', undefined, maxDist === Infinity ? undefined : maxDist);
+        }
+        if (GFX.standardMaterials && !part.isLeaf && spec.farTrunkProxy && detailMaxDist > barkFar) {
+          const proxy = cloneInstancedTo(im, farTrunkGeo(part.geometry), part.material);
+          proxy.receiveShadow = true;
+          for (let i = 0; i < group.items.length; i++) {
+            const source = group.handles[i].parts[group.handles[i].parts.length - 1];
+            group.handles[i].parts.push({
+              mesh: proxy,
+              index: i,
+              visibleMatrix: source.visibleMatrix,
+              hiddenMatrix: source.hiddenMatrix,
+            });
+          }
+          parent.add(proxy);
+          register(proxy, 'proxy', barkFar, detailMaxDist);
+        }
       }
     }
   });
@@ -529,7 +668,7 @@ function buildTrees(parent: THREE.Group, seed: number, registry: BucketMesh[], h
   const sourceDecos = GFX.standardMaterials
     ? decos
     : decos.filter((d) => {
-      const keep = d.kind === 'rock' ? 0.42 : 0.34;
+      const keep = d.kind === 'rock' ? 0.55 : 0.46;
       return hashAt(d.x, d.z, 83) < keep;
     });
   const buckets = new Map<string, Bucket>();
@@ -552,12 +691,14 @@ function buildTrees(parent: THREE.Group, seed: number, registry: BucketMesh[], h
     sets: MODEL_URLS.pine.map(extractParts),
     perBucket: treeVariants, salt: 51, baseScale: 1.1, sink: 0.05,
     leafTint: PINE_TINT, castBarkShadow: false,
+    proxyShape: 'pine',
     cullBarkFar: true, // pine canopies start ~2u up: no proxy needed in fog
   };
   const oakSpec: SpeciesSpec = {
     sets: MODEL_URLS.oak.map(extractParts),
     perBucket: treeVariants, salt: 54, baseScale: 1.15, sink: 0.05,
     leafTint: OAK_TINT, castBarkShadow: false,
+    proxyShape: 'round',
     farTrunkProxy: true, // oak crowns float without a trunk stand-in
   };
   const twistedSpec: SpeciesSpec = {
@@ -565,12 +706,14 @@ function buildTrees(parent: THREE.Group, seed: number, registry: BucketMesh[], h
     perBucket: treeVariants, salt: 57, baseScale: 0.5, sink: 0.05,
     // twisted trunks sprawl sideways — no cheap proxy fits, keep them whole
     leafTint: SWAMP_CANOPY_TINT, castBarkShadow: false,
+    proxyShape: 'twisted',
   };
   const deadSpec: SpeciesSpec = {
     sets: MODEL_URLS.dead.map(extractParts),
     perBucket: 1, salt: 60, baseScale: 0.7, sink: 0.05,
     // dead trees have no canopy — the bark must cast or they go shadowless
     leafTint: TRUNK_TINT.marsh, castBarkShadow: true,
+    proxyShape: 'dead',
   };
 
   // rocks: 3 single variants + a merged 3-boulder cluster, each in a mossy-top
@@ -617,8 +760,13 @@ function buildTrees(parent: THREE.Group, seed: number, registry: BucketMesh[], h
     }
     const bx = (minX + maxX) / 2, bz = (minZ + maxZ) / 2;
     const bRadius = Math.hypot(maxX - minX, maxZ - minZ) / 2 + 18; // canopy margin
-    const register = (mesh: THREE.InstancedMesh, minDist?: number, maxDist?: number): void => {
-      registry.push({ mesh, x: bx, z: bz, radius: bRadius, minDist, maxDist });
+    const register = (
+      mesh: THREE.InstancedMesh,
+      lod: BucketMesh['lod'],
+      minDist?: number,
+      maxDist?: number,
+    ): void => {
+      registry.push({ mesh, x: bx, z: bz, radius: bRadius, minDist, maxDist, lod, ...bucketMeshCost(mesh) });
     };
 
     placeSpecies(parent, seed, bucket, pines, pineSpec, register, hideRegistry);
@@ -668,7 +816,7 @@ function buildTrees(parent: THREE.Group, seed: number, registry: BucketMesh[], h
         // no rock shadows cast: sub-pixel at typical camera range, real draw cost
         rockMesh.receiveShadow = true;
         parent.add(rockMesh);
-        register(rockMesh, undefined, lodDists().rockFar);
+        register(rockMesh, 'rock', undefined, lodDists().rockFar);
       }
     }
   }
@@ -687,8 +835,16 @@ interface DressingSpot {
   scale: number;
 }
 
-const DRESS_STEP = 12;
+const DRESS_STEP_HIGH = 12;
+const DRESS_STEP_LOW = 10;
 const DRESS_DENSITY: Record<BiomeId, number> = { vale: 0.26, marsh: 0.26, peaks: 0.15 };
+const DRESS_DENSITY_LOW_SCALE = 1.24;
+const DRESS_LOW_SCALE_BOOST = 1.08;
+const DRESS_TINT_SOFTEN_LOW = 0.56;
+
+function dressStep(): number {
+  return GFX.standardMaterials ? DRESS_STEP_HIGH : DRESS_STEP_LOW;
+}
 
 function dressKindFor(biome: BiomeId, r: number): DressKind {
   if (biome === 'vale') {
@@ -718,13 +874,16 @@ function tooSteep(x: number, z: number, seed: number): boolean {
 function generateDressing(seed: number): DressingSpot[] {
   const out: DressingSpot[] = [];
   const xHalf = WORLD_MAX_X - 16;
-  for (let gx = -xHalf; gx < xHalf; gx += DRESS_STEP) {
-    for (let gz = WORLD_MIN_Z + 16; gz < WORLD_MAX_Z - 16; gz += DRESS_STEP) {
+  const step = dressStep();
+  const scaleBoost = GFX.standardMaterials ? 1 : DRESS_LOW_SCALE_BOOST;
+  for (let gx = -xHalf; gx < xHalf; gx += step) {
+    for (let gz = WORLD_MIN_Z + 16; gz < WORLD_MAX_Z - 16; gz += step) {
       const r = hashAt(gx, gz, 41);
       const biome = zoneBiomeAt(gz);
-      if (r > DRESS_DENSITY[biome]) continue;
-      const x = gx + (hashAt(gx, gz, 42) - 0.5) * DRESS_STEP;
-      const z = gz + (hashAt(gx, gz, 43) - 0.5) * DRESS_STEP;
+      const density = DRESS_DENSITY[biome] * (GFX.standardMaterials ? 1 : DRESS_DENSITY_LOW_SCALE);
+      if (r > density) continue;
+      const x = gx + (hashAt(gx, gz, 42) - 0.5) * step;
+      const z = gz + (hashAt(gx, gz, 43) - 0.5) * step;
       let blocked = false;
       for (const zone of ZONES) {
         if (Math.hypot(x - zone.hub.x, z - zone.hub.z) < zone.hub.radius + 4) { blocked = true; break; }
@@ -739,7 +898,7 @@ function generateDressing(seed: number): DressingSpot[] {
       if (tooSteep(x, z, seed)) continue;
       const kind = dressKindFor(biome, hashAt(gx, gz, 44));
       const [sMin, sRange] = DRESS_SCALE[kind];
-      out.push({ x, z, kind, scale: sMin + hashAt(gx, gz, 45) * sRange });
+      out.push({ x, z, kind, scale: (sMin + hashAt(gx, gz, 45) * sRange) * scaleBoost });
     }
   }
   return out;
@@ -777,11 +936,13 @@ function buildDressing(parent: THREE.Group, seed: number, registry: BucketMesh[]
       if (list) list.push(s);
       else byKind.set(s.kind, [s]);
     }
-    // cap kinds per bucket: dropping a bucket's rarest dressing kind is
-    // invisible, the draw call is not
+    // Keep all four low-cost dressing kinds. Recent low-tier telemetry has
+    // dressing well below both call and triangle budgets, so variety here is
+    // higher ROI than adding more far canopy or post-processing work.
+    const maxKinds = 4;
     const kept = [...byKind.entries()]
       .sort((a, b) => b[1].length - a[1].length)
-      .slice(0, 3);
+      .slice(0, maxKinds);
     for (const [kind, list] of kept) {
       for (const part of kindParts[kind]) {
         const im = new THREE.InstancedMesh(part.geometry, part.material, list.length);
@@ -794,12 +955,18 @@ function buildDressing(parent: THREE.Group, seed: number, registry: BucketMesh[]
             // mushrooms keep their painted cap colors — brightness jitter only
             im.setColorAt(i, c.setScalar(0.85 + hashAt(s.x, s.z, 47) * 0.3));
           } else {
-            im.setColorAt(i, softTint(s.x, s.z, DRESS_TINT[zoneBiomeAt(s.z)], c, DRESS_TINT_SOFTEN));
+            im.setColorAt(i, softTint(
+              s.x,
+              s.z,
+              DRESS_TINT[zoneBiomeAt(s.z)],
+              c,
+              GFX.standardMaterials ? DRESS_TINT_SOFTEN : DRESS_TINT_SOFTEN_LOW,
+            ));
           }
         });
         im.receiveShadow = true; // dressing casts nothing: too small to matter
         parent.add(im);
-        registry.push({ mesh: im, x: bx, z: bz, radius: bRadius, maxDist: lodDists().dressFar });
+        registry.push({ mesh: im, x: bx, z: bz, radius: bRadius, maxDist: lodDists().dressFar, lod: 'dressing', ...bucketMeshCost(im) });
       }
     }
   }
@@ -883,6 +1050,19 @@ function localGrassDisabled(): boolean {
 
 function emptyGrassStats(enabled: boolean, cacheLimit = 0): FoliagePerfStats {
   return {
+    modelQuality: 1,
+    modelBuckets: 0,
+    modelVisibleBuckets: 0,
+    modelBucketsByLod: {},
+    modelVisibleByLod: {},
+    modelDraws: 0,
+    modelVisibleDraws: 0,
+    modelDrawsByLod: {},
+    modelVisibleDrawsByLod: {},
+    modelTriangles: 0,
+    modelVisibleTriangles: 0,
+    modelTrianglesByLod: {},
+    modelVisibleTrianglesByLod: {},
     grassEnabled: enabled,
     grassQuality: enabled ? 1 : 0,
     grassActiveRadius: 0,
@@ -1195,8 +1375,27 @@ export function buildFoliage(seed: number): FoliageView {
   group.name = 'foliage';
   const bucketMeshes: BucketMesh[] = [];
   const treeHideables: TreeHideable[] = [];
+  let modelQuality = GFX.bucketBaselines.foliage;
+  let modelVisibleBuckets = 0;
+  let modelVisibleDraws = 0;
+  let modelVisibleTriangles = 0;
+  const modelBucketsByLod: Record<string, number> = {};
+  const modelDrawsByLod: Record<string, number> = {};
+  const modelTrianglesByLod: Record<string, number> = {};
+  let modelVisibleByLod: Record<string, number> = {};
+  let modelVisibleDrawsByLod: Record<string, number> = {};
+  let modelVisibleTrianglesByLod: Record<string, number> = {};
+  let modelDraws = 0;
+  let modelTriangles = 0;
   buildTrees(group, seed, bucketMeshes, treeHideables);
-  if (GFX.standardMaterials) buildDressing(group, seed, bucketMeshes);
+  buildDressing(group, seed, bucketMeshes);
+  for (const b of bucketMeshes) {
+    modelBucketsByLod[b.lod] = (modelBucketsByLod[b.lod] ?? 0) + 1;
+    modelDraws += b.draws;
+    modelTriangles += b.triangles;
+    modelDrawsByLod[b.lod] = (modelDrawsByLod[b.lod] ?? 0) + b.draws;
+    modelTrianglesByLod[b.lod] = (modelTrianglesByLod[b.lod] ?? 0) + b.triangles;
+  }
   const grass = localGrassDisabled()
     ? {
       update(): void {},
@@ -1209,6 +1408,9 @@ export function buildFoliage(seed: number): FoliageView {
     setGrassQuality(level: number): void {
       grass.setQuality(level);
     },
+    setModelQuality(level: number): void {
+      modelQuality = Math.min(1, Math.max(0, Number.isFinite(level) ? level : 1));
+    },
     update(
       px: number, pz: number,
       camX: number, camY: number, camZ: number,
@@ -1220,14 +1422,51 @@ export function buildFoliage(seed: number): FoliageView {
       // buckets fully behind the fog wall are pure overdraw; the optional
       // [minDist, maxDist) window uses the bucket-CENTER distance so a bark
       // mesh and its far-trunk proxy are never drawn together
+      const distanceScale = GFX.standardMaterials
+        ? 0.72 + 0.28 * modelQuality
+        : 0.56 + 0.44 * modelQuality;
+      const fogLimit = fogFar * (0.78 + 0.22 * modelQuality);
+      modelVisibleBuckets = 0;
+      modelVisibleDraws = 0;
+      modelVisibleTriangles = 0;
+      modelVisibleByLod = {};
+      modelVisibleDrawsByLod = {};
+      modelVisibleTrianglesByLod = {};
       for (const b of bucketMeshes) {
         const d = Math.hypot(b.x - camX, b.z - camZ);
-        b.mesh.visible = d >= (b.minDist ?? 0) && d < (b.maxDist ?? Infinity)
-          && d - b.radius < fogFar;
+        const minDist = (b.minDist ?? 0) * distanceScale;
+        const revealScale = !GFX.standardMaterials && (b.lod === 'core' || b.lod === 'near-fill')
+          ? 0.94 + hashAt(b.x, b.z, 109) * 0.06
+          : 1;
+        const maxDist = b.maxDist === undefined ? Infinity : b.maxDist * distanceScale * revealScale;
+        b.mesh.visible = d >= minDist && d < maxDist
+          && d - b.radius < fogLimit;
+        if (b.mesh.visible) {
+          modelVisibleBuckets++;
+          modelVisibleDraws += b.draws;
+          modelVisibleTriangles += b.triangles;
+          modelVisibleByLod[b.lod] = (modelVisibleByLod[b.lod] ?? 0) + 1;
+          modelVisibleDrawsByLod[b.lod] = (modelVisibleDrawsByLod[b.lod] ?? 0) + b.draws;
+          modelVisibleTrianglesByLod[b.lod] = (modelVisibleTrianglesByLod[b.lod] ?? 0) + b.triangles;
+        }
       }
     },
     perfStats(): FoliagePerfStats {
-      return grass.perfStats();
+      const stats = grass.perfStats();
+      stats.modelQuality = Math.round(modelQuality * 100) / 100;
+      stats.modelBuckets = bucketMeshes.length;
+      stats.modelVisibleBuckets = modelVisibleBuckets;
+      stats.modelBucketsByLod = { ...modelBucketsByLod };
+      stats.modelVisibleByLod = { ...modelVisibleByLod };
+      stats.modelDraws = modelDraws;
+      stats.modelVisibleDraws = modelVisibleDraws;
+      stats.modelDrawsByLod = { ...modelDrawsByLod };
+      stats.modelVisibleDrawsByLod = { ...modelVisibleDrawsByLod };
+      stats.modelTriangles = modelTriangles;
+      stats.modelVisibleTriangles = modelVisibleTriangles;
+      stats.modelTrianglesByLod = { ...modelTrianglesByLod };
+      stats.modelVisibleTrianglesByLod = { ...modelVisibleTrianglesByLod };
+      return stats;
     },
   };
 }

--- a/src/render/foliage.ts
+++ b/src/render/foliage.ts
@@ -9,7 +9,7 @@ import {
   generateDecorations, roadDistance, terrainHeight, zoneBiomeAt, WATER_LEVEL,
 } from '../sim/world';
 import type { Decoration } from '../sim/world';
-import { GFX, sharedUniforms } from './gfx';
+import { configureMaskedDoubleSidedVegetationMaterial, GFX, sharedUniforms } from './gfx';
 import { grassTuftTexture } from './textures';
 import { loadGltf } from './assets/loader';
 import { registerPreload } from './assets/preload';
@@ -42,10 +42,16 @@ import { registerPreload } from './assets/preload';
 //   canopy, so their bark casts instead.
 // - Ground dressing (bushes/ferns/mushrooms) is a new deterministic hash-grid
 //   scatter, walk-through by design (no colliders, like grass).
-// - Grass is a player-centered ring (O(radius^2), not O(world^2)) rebuilt
-//   when the player moves >12u, unchanged from the previous pass.
+// - Grass is streamed in deterministic chunks around the player. The old
+//   player-centered ring rebuilt O(radius^2) instances in one frame whenever
+//   the player moved far enough; chunking keeps both CPU generation and GPU
+//   instance-buffer uploads bounded.
 
-const GRASS_REBUILD_DIST = 12;
+const GRASS_CHUNK_SIZE = 48;
+const GRASS_CHUNK_BUILD_BUDGET_MS = 2.2;
+const GRASS_CHUNK_MAX_BUILDS_PER_FRAME = 1;
+const GRASS_CHUNK_CACHE_LIMIT_LOW = 96;
+const GRASS_CHUNK_CACHE_LIMIT_HIGH = 128;
 const TREE_WIND_STRENGTH = 0.06;
 const GRASS_WIND_STRENGTH = 0.08;
 // two x-halves x 240u z-bands: bucket count x variants-per-bucket is the
@@ -119,6 +125,25 @@ export interface FoliageView {
     eyeX: number, eyeY: number, eyeZ: number,
     fogFar: number,
   ): void;
+  setGrassQuality(level: number): void;
+  perfStats(): FoliagePerfStats;
+}
+
+export interface FoliagePerfStats {
+  grassEnabled: boolean;
+  grassQuality: number;
+  grassActiveRadius: number;
+  grassChunks: number;
+  grassReadyChunks: number;
+  grassVisibleChunks: number;
+  grassQueuedChunks: number;
+  grassTufts: number;
+  grassVisibleTufts: number;
+  grassBuiltChunks: number;
+  grassDisposedChunks: number;
+  grassLastBuildMs: number;
+  grassBuildMs: number;
+  grassCacheLimit: number;
 }
 
 // deterministic 0..1 hash on integer grid cells / world coords
@@ -786,10 +811,26 @@ function buildDressing(parent: THREE.Group, seed: number, registry: BucketMesh[]
 
 interface GrassRing {
   update(px: number, pz: number): void;
+  setQuality(level: number): void;
+  perfStats(): FoliagePerfStats;
 }
 
-// wind sway + edge fade for the grass tufts; the fade keys off the tuft's
-// instance origin so whole tufts dissolve cleanly against alphaTest
+interface GrassChunk {
+  key: string;
+  cx: number;
+  cz: number;
+  centerX: number;
+  centerZ: number;
+  ready: boolean;
+  queued: boolean;
+  lastSeen: number;
+  lastUsed: number;
+  prioritySq: number;
+  mesh?: THREE.InstancedMesh;
+}
+
+// wind sway + masked edge fade for the grass tufts; the fade keys off the
+// tuft's instance origin so alphaTest thins whole tufts without blending
 function applyGrassShader(
   mat: THREE.Material,
   uniforms: { uPlayerPos: { value: THREE.Vector2 }; uFadeFar: { value: number } },
@@ -828,11 +869,45 @@ function applyGrassShader(
   };
 }
 
+function loopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+function localGrassDisabled(): boolean {
+  if (!import.meta.env.DEV) return false;
+  if (typeof location === 'undefined') return false;
+  if (!loopbackHostname(location.hostname)) return false;
+  const params = new URLSearchParams(location.search);
+  return params.get('grass') === '0' || params.get('grass') === 'off' || params.get('noGrass') === '1';
+}
+
+function emptyGrassStats(enabled: boolean, cacheLimit = 0): FoliagePerfStats {
+  return {
+    grassEnabled: enabled,
+    grassQuality: enabled ? 1 : 0,
+    grassActiveRadius: 0,
+    grassChunks: 0,
+    grassReadyChunks: 0,
+    grassVisibleChunks: 0,
+    grassQueuedChunks: 0,
+    grassTufts: 0,
+    grassVisibleTufts: 0,
+    grassBuiltChunks: 0,
+    grassDisposedChunks: 0,
+    grassLastBuildMs: 0,
+    grassBuildMs: 0,
+    grassCacheLimit: cacheLimit,
+  };
+}
+
 function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
-  const radius = GFX.grassRadius;
+  const baseRadius = GFX.grassRadius;
   const step = GFX.grassStep;
-  const cells = Math.ceil((radius * 2) / step) + 2;
-  const maxCount = Math.ceil(cells * cells * 0.5);
+  const chunkCells = Math.ceil(GRASS_CHUNK_SIZE / step) + 3;
+  const maxChunkCount = Math.ceil(chunkCells * chunkCells * 0.5);
+  const chunkHalfDiag = Math.SQRT2 * GRASS_CHUNK_SIZE * 0.5;
+  const buildBudgetMs = GRASS_CHUNK_BUILD_BUDGET_MS;
+  const cacheLimit = GFX.standardMaterials ? GRASS_CHUNK_CACHE_LIMIT_HIGH : GRASS_CHUNK_CACHE_LIMIT_LOW;
 
   // high tier reads as a lush meadow: wider tufts with more blades; low keeps
   // the legacy sprite size
@@ -843,39 +918,78 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
   const geo = mergeGeometries([quad, quad2]);
 
   const tuftTex = grassTuftTexture(lush ? 30 : 18);
-  const uniforms = { uPlayerPos: { value: new THREE.Vector2(1e6, 1e6) }, uFadeFar: { value: radius } };
-  const mat = lush
+  let quality = 1;
+  const minRadiusScale = lush ? 0.58 : 0.48;
+  const activeRadius = (): number => Math.round(baseRadius * Math.max(minRadiusScale, quality) * 10) / 10;
+  const uniforms = { uPlayerPos: { value: new THREE.Vector2(1e6, 1e6) }, uFadeFar: { value: activeRadius() } };
+  const mat = configureMaskedDoubleSidedVegetationMaterial(lush
     ? new THREE.MeshStandardMaterial({
-      map: tuftTex, transparent: true, alphaTest: 0.3, side: THREE.DoubleSide, roughness: 0.9,
+      map: tuftTex, alphaTest: 0.3, roughness: 0.9,
     })
     : new THREE.MeshLambertMaterial({
-      map: tuftTex, transparent: true, alphaTest: 0.35, side: THREE.DoubleSide,
-    });
+      map: tuftTex, alphaTest: 0.35,
+    }));
   applyGrassShader(mat, uniforms);
 
-  const im = new THREE.InstancedMesh(geo, mat, maxCount);
-  im.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
-  im.frustumCulled = false; // ring is centered on the player; bounds churn isn't worth it
-  im.receiveShadow = true; // tufts must darken inside canopy shade, not glow through it
-  im.count = 0;
-  parent.add(im);
+  const chunks = new Map<string, GrassChunk>();
+  const buildQueue: GrassChunk[] = [];
+  let generation = 0;
+  let builtChunks = 0;
+  let disposedChunks = 0;
+  let buildMs = 0;
+  let lastBuildMs = 0;
 
-  let lastX = Infinity;
-  let lastZ = Infinity;
+  const chunkKey = (cx: number, cz: number): string => `${cx}:${cz}`;
+  const chunkCenter = (cidx: number): number => (cidx + 0.5) * GRASS_CHUNK_SIZE;
 
-  const rebuild = (px: number, pz: number): void => {
+  const createChunk = (cx: number, cz: number): GrassChunk => {
+    const chunk: GrassChunk = {
+      key: chunkKey(cx, cz),
+      cx,
+      cz,
+      centerX: chunkCenter(cx),
+      centerZ: chunkCenter(cz),
+      ready: false,
+      queued: false,
+      lastSeen: -1,
+      lastUsed: -1,
+      prioritySq: Infinity,
+    };
+    chunks.set(chunk.key, chunk);
+    return chunk;
+  };
+
+  const queueChunk = (chunk: GrassChunk): void => {
+    if (chunk.ready || chunk.queued) return;
+    chunk.queued = true;
+    buildQueue.push(chunk);
+  };
+
+  const buildChunk = (chunk: GrassChunk): void => {
+    const started = performance.now();
     let n = 0;
-    const i0 = Math.floor((px - radius) / step), i1 = Math.ceil((px + radius) / step);
-    const j0 = Math.floor((pz - radius) / step), j1 = Math.ceil((pz + radius) / step);
-    const r2 = radius * radius;
-    for (let i = i0; i <= i1 && n < maxCount; i++) {
-      for (let j = j0; j <= j1 && n < maxCount; j++) {
+    const im = new THREE.InstancedMesh(geo, mat, maxChunkCount);
+    im.userData.renderCategory = 'grass';
+    im.frustumCulled = true;
+    im.receiveShadow = true; // tufts must darken inside canopy shade, not glow through it
+    im.count = 0;
+
+    const minX = chunk.cx * GRASS_CHUNK_SIZE;
+    const maxX = minX + GRASS_CHUNK_SIZE;
+    const minZ = chunk.cz * GRASS_CHUNK_SIZE;
+    const maxZ = minZ + GRASS_CHUNK_SIZE;
+    const i0 = Math.floor(minX / step) - 1;
+    const i1 = Math.ceil(maxX / step) + 1;
+    const j0 = Math.floor(minZ / step) - 1;
+    const j1 = Math.ceil(maxZ / step) + 1;
+
+    for (let i = i0; i <= i1 && n < maxChunkCount; i++) {
+      for (let j = j0; j <= j1 && n < maxChunkCount; j++) {
         const r = hashAt(i, j, 0);
         if (r > 0.5) continue; // ~half the cells grow a tuft
         const x = i * step + (hashAt(i, j, 1) - 0.5) * step * 1.4;
         const z = j * step + (hashAt(i, j, 2) - 0.5) * step * 1.4;
-        const dx = x - px, dz = z - pz;
-        if (dx * dx + dz * dz > r2) continue;
+        if (x < minX || x >= maxX || z < minZ || z >= maxZ) continue;
         if (Math.abs(x) > WORLD_MAX_X - 16 || z < WORLD_MIN_Z + 16 || z > WORLD_MAX_Z - 16) continue;
         const h = terrainHeight(x, z, seed);
         if (h < WATER_LEVEL + 1.6) continue;
@@ -901,25 +1015,122 @@ function buildGrassRing(parent: THREE.Group, seed: number): GrassRing {
         n++;
       }
     }
-    im.count = n;
-    im.instanceMatrix.needsUpdate = true;
-    if (im.instanceColor) im.instanceColor.needsUpdate = true;
+    if (n > 0) {
+      im.count = n;
+      im.instanceMatrix.needsUpdate = true;
+      if (im.instanceColor) im.instanceColor.needsUpdate = true;
+      im.computeBoundingSphere();
+      im.visible = chunk.lastSeen === generation;
+      chunk.mesh = im;
+      parent.add(im);
+    }
+    chunk.ready = true;
+    builtChunks++;
+    lastBuildMs = Math.round((performance.now() - started) * 100) / 100;
+    buildMs = Math.round((buildMs + lastBuildMs) * 100) / 100;
+  };
+
+  const disposeChunk = (chunk: GrassChunk): void => {
+    if (chunk.mesh) {
+      parent.remove(chunk.mesh);
+      chunk.mesh.dispose();
+    }
+    disposedChunks++;
+    chunks.delete(chunk.key);
+  };
+
+  const retireStaleChunks = (): void => {
+    if (chunks.size <= cacheLimit) return;
+    const stale = [...chunks.values()]
+      .filter((chunk) => chunk.lastSeen !== generation)
+      .sort((a, b) => a.lastUsed - b.lastUsed);
+    for (const chunk of stale) {
+      if (chunks.size <= cacheLimit) break;
+      disposeChunk(chunk);
+    }
+  };
+
+  const buildQueuedChunks = (): void => {
+    if (buildQueue.length === 0) return;
+    buildQueue.sort((a, b) => a.prioritySq - b.prioritySq || a.key.localeCompare(b.key));
+    const deadline = performance.now() + buildBudgetMs;
+    let built = 0;
+    while (buildQueue.length > 0 && built < GRASS_CHUNK_MAX_BUILDS_PER_FRAME) {
+      const chunk = buildQueue.shift()!;
+      chunk.queued = false;
+      if (chunks.get(chunk.key) !== chunk || chunk.ready || chunk.lastSeen !== generation) continue;
+      buildChunk(chunk);
+      built++;
+      if (performance.now() >= deadline) break;
+    }
   };
 
   return {
+    setQuality(level: number): void {
+      quality = Math.min(1, Math.max(0, Number.isFinite(level) ? level : 1));
+      uniforms.uFadeFar.value = activeRadius();
+    },
     update(px: number, pz: number): void {
       uniforms.uPlayerPos.value.set(px, pz);
+      uniforms.uFadeFar.value = activeRadius();
       if (px > DUNGEON_X_THRESHOLD) {
         // dungeon instances live far outside the strip — no meadow indoors
-        if (im.count !== 0) im.count = 0;
-        lastX = Infinity;
+        if (parent.visible) parent.visible = false;
         return;
       }
-      if (Math.hypot(px - lastX, pz - lastZ) > GRASS_REBUILD_DIST) {
-        lastX = px;
-        lastZ = pz;
-        rebuild(px, pz);
+      if (!parent.visible) parent.visible = true;
+
+      generation++;
+      const coverRadius = activeRadius() + chunkHalfDiag;
+      const c0 = Math.floor((px - coverRadius) / GRASS_CHUNK_SIZE);
+      const c1 = Math.floor((px + coverRadius) / GRASS_CHUNK_SIZE);
+      const z0 = Math.floor((pz - coverRadius) / GRASS_CHUNK_SIZE);
+      const z1 = Math.floor((pz + coverRadius) / GRASS_CHUNK_SIZE);
+      for (let cx = c0; cx <= c1; cx++) {
+        for (let cz = z0; cz <= z1; cz++) {
+          const centerX = chunkCenter(cx);
+          const centerZ = chunkCenter(cz);
+          const dx = centerX - px;
+          const dz = centerZ - pz;
+          const prioritySq = dx * dx + dz * dz;
+          if (prioritySq > coverRadius * coverRadius) continue;
+          const key = chunkKey(cx, cz);
+          const chunk = chunks.get(key) ?? createChunk(cx, cz);
+          chunk.lastSeen = generation;
+          chunk.lastUsed = generation;
+          chunk.prioritySq = prioritySq;
+          if (chunk.mesh) chunk.mesh.visible = true;
+          queueChunk(chunk);
+        }
       }
+
+      for (const chunk of chunks.values()) {
+        if (chunk.lastSeen === generation) continue;
+        if (chunk.mesh?.visible) chunk.mesh.visible = false;
+      }
+      buildQueuedChunks();
+      retireStaleChunks();
+    },
+    perfStats(): FoliagePerfStats {
+      const stats = emptyGrassStats(true, cacheLimit);
+      stats.grassQuality = Math.round(quality * 100) / 100;
+      stats.grassActiveRadius = activeRadius();
+      stats.grassChunks = chunks.size;
+      stats.grassQueuedChunks = buildQueue.length;
+      stats.grassBuiltChunks = builtChunks;
+      stats.grassDisposedChunks = disposedChunks;
+      stats.grassLastBuildMs = lastBuildMs;
+      stats.grassBuildMs = buildMs;
+      for (const chunk of chunks.values()) {
+        if (chunk.ready) stats.grassReadyChunks++;
+        const tuftCount = chunk.mesh?.count ?? 0;
+        stats.grassTufts += tuftCount;
+        if (chunk.mesh?.visible) {
+          stats.grassVisibleChunks++;
+          stats.grassVisibleTufts += tuftCount;
+        }
+      }
+      return stats;
     },
   };
 }
@@ -986,9 +1197,18 @@ export function buildFoliage(seed: number): FoliageView {
   const treeHideables: TreeHideable[] = [];
   buildTrees(group, seed, bucketMeshes, treeHideables);
   if (GFX.standardMaterials) buildDressing(group, seed, bucketMeshes);
-  const grass = buildGrassRing(group, seed);
+  const grass = localGrassDisabled()
+    ? {
+      update(): void {},
+      setQuality(): void {},
+      perfStats(): FoliagePerfStats { return emptyGrassStats(false); },
+    }
+    : buildGrassRing(group, seed);
   return {
     group,
+    setGrassQuality(level: number): void {
+      grass.setQuality(level);
+    },
     update(
       px: number, pz: number,
       camX: number, camY: number, camZ: number,
@@ -1005,6 +1225,9 @@ export function buildFoliage(seed: number): FoliageView {
         b.mesh.visible = d >= (b.minDist ?? 0) && d < (b.maxDist ?? Infinity)
           && d - b.radius < fogFar;
       }
+    },
+    perfStats(): FoliagePerfStats {
+      return grass.perfStats();
     },
   };
 }

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -11,6 +11,37 @@ import * as THREE from 'three';
 //   4. otherwise: software GL (SwiftShader/llvmpipe) -> low, real GPUs -> high
 
 export type GfxTier = 'low' | 'medium' | 'high' | 'ultra';
+export const GFX_CONFIG_VERSION = 11;
+
+export const GFX_BUCKET_IDS = [
+  'resolution',
+  'grass',
+  'foliage',
+  'props',
+  'lighting',
+  'materials',
+  'waterSky',
+  'vfx',
+  'characters',
+  'weapons',
+  'worldStreaming',
+  'ui',
+] as const;
+
+export type GfxBucketId = typeof GFX_BUCKET_IDS[number];
+export type GfxBucketCost = 'gpu' | 'cpu' | 'mixed';
+
+export interface GfxBucketBand {
+  readonly min: number;
+  readonly baseline: number;
+  readonly max: number;
+  readonly roi: number;
+  readonly cost: GfxBucketCost;
+  readonly governable: boolean;
+}
+
+export type GfxBucketBands = Record<GfxBucketId, GfxBucketBand>;
+export type GfxBucketLevels = Record<GfxBucketId, number>;
 
 export interface GfxRuntimeHints {
   search: string;
@@ -27,7 +58,10 @@ export interface GfxRuntimeHints {
 }
 
 export interface GfxSettings {
+  readonly graphicsConfigVersion: number;
   readonly tier: GfxTier;
+  readonly bucketBands: GfxBucketBands;
+  readonly bucketBaselines: GfxBucketLevels;
   readonly budget: GfxRuntimeBudget;
   readonly autoGovernor: boolean;
   /** post-processing chain (N8AO + bloom + grade) */
@@ -72,21 +106,21 @@ const PRESET_ADVANCED = 5;
 
 export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
   low: {
-    targetFps: 30,
+    targetFps: 60,
     minRenderScaleDesktop: 0.65,
     minRenderScaleMobile: 0.55,
     maxRenderScale: 1,
-    dropFrameMs: 28,
-    urgentFrameMs: 38,
-    recoverFrameMs: 22,
-    dropStep: 0.1,
-    urgentDropStep: 0.15,
-    recoverStep: 0.05,
-    recoverStableSeconds: 8,
-    cooldownSeconds: 1.5,
+    dropFrameMs: 22,
+    urgentFrameMs: 34,
+    recoverFrameMs: 17.5,
+    dropStep: 0.08,
+    urgentDropStep: 0.12,
+    recoverStep: 0.06,
+    recoverStableSeconds: 6,
+    cooldownSeconds: 1.1,
   },
   medium: {
-    targetFps: 45,
+    targetFps: 60,
     minRenderScaleDesktop: 0.72,
     minRenderScaleMobile: 0.55,
     maxRenderScale: 1,
@@ -129,6 +163,82 @@ export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
   },
 };
 
+export const GFX_BUCKET_BANDS: Record<GfxTier, GfxBucketBands> = {
+  low: {
+    resolution: { min: 0.55, baseline: 1.0, max: 1.0, roi: 0.88, cost: 'gpu', governable: true },
+    grass: { min: 0.62, baseline: 0.9, max: 1.0, roi: 0.9, cost: 'gpu', governable: true },
+    foliage: { min: 0.68, baseline: 0.9, max: 1.0, roi: 0.84, cost: 'gpu', governable: true },
+    props: { min: 0.35, baseline: 0.5, max: 0.62, roi: 0.58, cost: 'mixed', governable: false },
+    lighting: { min: 0.78, baseline: 1.0, max: 1.0, roi: 0.72, cost: 'gpu', governable: true },
+    materials: { min: 0.3, baseline: 0.45, max: 0.58, roi: 0.78, cost: 'gpu', governable: false },
+    waterSky: { min: 0.35, baseline: 0.7, max: 0.8, roi: 0.82, cost: 'gpu', governable: false },
+    vfx: { min: 0.84, baseline: 1.0, max: 1.0, roi: 0.9, cost: 'mixed', governable: true },
+    characters: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    worldStreaming: { min: 0.25, baseline: 0.5, max: 0.68, roi: 0.62, cost: 'cpu', governable: true },
+    ui: { min: 0.75, baseline: 0.9, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
+  },
+  medium: {
+    resolution: { min: 0.55, baseline: 1.0, max: 1.0, roi: 0.88, cost: 'gpu', governable: true },
+    grass: { min: 0.5, baseline: 0.78, max: 0.9, roi: 0.86, cost: 'gpu', governable: true },
+    foliage: { min: 0.5, baseline: 0.74, max: 0.86, roi: 0.64, cost: 'gpu', governable: true },
+    props: { min: 0.55, baseline: 0.7, max: 0.82, roi: 0.58, cost: 'mixed', governable: false },
+    lighting: { min: 0.45, baseline: 0.72, max: 0.82, roi: 0.7, cost: 'gpu', governable: true },
+    materials: { min: 0.62, baseline: 0.78, max: 0.9, roi: 0.78, cost: 'gpu', governable: false },
+    waterSky: { min: 0.55, baseline: 0.78, max: 0.9, roi: 0.82, cost: 'gpu', governable: false },
+    vfx: { min: 0.58, baseline: 0.8, max: 0.9, roi: 0.7, cost: 'mixed', governable: true },
+    characters: { min: 0.86, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    worldStreaming: { min: 0.42, baseline: 0.7, max: 0.82, roi: 0.62, cost: 'cpu', governable: true },
+    ui: { min: 0.82, baseline: 1.0, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
+  },
+  high: {
+    resolution: { min: 0.6, baseline: 1.0, max: 1.0, roi: 0.88, cost: 'gpu', governable: true },
+    grass: { min: 0.6, baseline: 0.88, max: 1.0, roi: 0.86, cost: 'gpu', governable: true },
+    foliage: { min: 0.6, baseline: 0.9, max: 1.0, roi: 0.72, cost: 'gpu', governable: true },
+    props: { min: 0.7, baseline: 0.88, max: 1.0, roi: 0.58, cost: 'mixed', governable: false },
+    lighting: { min: 0.62, baseline: 0.9, max: 1.0, roi: 0.7, cost: 'gpu', governable: true },
+    materials: { min: 0.75, baseline: 0.92, max: 1.0, roi: 0.78, cost: 'gpu', governable: false },
+    waterSky: { min: 0.72, baseline: 0.92, max: 1.0, roi: 0.82, cost: 'gpu', governable: false },
+    vfx: { min: 0.68, baseline: 0.92, max: 1.0, roi: 0.7, cost: 'mixed', governable: true },
+    characters: { min: 0.9, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    worldStreaming: { min: 0.55, baseline: 0.88, max: 1.0, roi: 0.62, cost: 'cpu', governable: true },
+    ui: { min: 0.86, baseline: 1.0, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
+  },
+  ultra: {
+    resolution: { min: 0.68, baseline: 1.0, max: 1.0, roi: 0.88, cost: 'gpu', governable: true },
+    grass: { min: 0.78, baseline: 1.0, max: 1.0, roi: 0.86, cost: 'gpu', governable: true },
+    foliage: { min: 0.78, baseline: 1.0, max: 1.0, roi: 0.72, cost: 'gpu', governable: true },
+    props: { min: 0.86, baseline: 1.0, max: 1.0, roi: 0.58, cost: 'mixed', governable: false },
+    lighting: { min: 0.78, baseline: 1.0, max: 1.0, roi: 0.7, cost: 'gpu', governable: true },
+    materials: { min: 0.86, baseline: 1.0, max: 1.0, roi: 0.78, cost: 'gpu', governable: false },
+    waterSky: { min: 0.86, baseline: 1.0, max: 1.0, roi: 0.82, cost: 'gpu', governable: false },
+    vfx: { min: 0.86, baseline: 1.0, max: 1.0, roi: 0.7, cost: 'mixed', governable: true },
+    characters: { min: 0.94, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
+    worldStreaming: { min: 0.7, baseline: 1.0, max: 1.0, roi: 0.62, cost: 'cpu', governable: true },
+    ui: { min: 0.9, baseline: 1.0, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
+  },
+};
+
+function bucketBaselines(bands: GfxBucketBands): GfxBucketLevels {
+  return {
+    resolution: bands.resolution.baseline,
+    grass: bands.grass.baseline,
+    foliage: bands.foliage.baseline,
+    props: bands.props.baseline,
+    lighting: bands.lighting.baseline,
+    materials: bands.materials.baseline,
+    waterSky: bands.waterSky.baseline,
+    vfx: bands.vfx.baseline,
+    characters: bands.characters.baseline,
+    weapons: bands.weapons.baseline,
+    worldStreaming: bands.worldStreaming.baseline,
+    ui: bands.ui.baseline,
+  };
+}
+
 export function graphicsPresetLabel(value: number | undefined): 'auto' | 'low' | 'medium' | 'high' | 'ultra' | 'advanced' {
   switch (Math.round(value ?? PRESET_AUTO)) {
     case PRESET_LOW: return 'low';
@@ -163,8 +273,12 @@ function settingsFor(
   tier: GfxTier,
   hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset' | 'terrainDetail' | 'foliageDensity' | 'effectsQuality' | 'shadowQuality'>,
 ): GfxSettings {
+  const bucketBands = GFX_BUCKET_BANDS[tier];
   let settings: GfxSettings = {
+    graphicsConfigVersion: GFX_CONFIG_VERSION,
     tier,
+    bucketBands,
+    bucketBaselines: bucketBaselines(bucketBands),
     budget: GFX_BUDGETS[tier],
     autoGovernor: shouldUseAutoGovernor(hints),
     composer: tier === 'high' || tier === 'ultra',
@@ -175,11 +289,11 @@ function settingsFor(
     pixelRatioCap: tier === 'low' ? 1.48 : tier === 'medium' ? 1.48 : tier === 'high' ? 1.75 : 2.5,
     shadowMap: tier === 'low' ? 2048 : tier === 'medium' ? 2560 : 4096,
     standardMaterials: tier === 'medium' || tier === 'high' || tier === 'ultra',
-    grassRadius: tier === 'low' ? 70 : tier === 'medium' ? 70 : 82, // low/mobile prioritizes fill/alpha cost over meadow density
-    grassStep: tier === 'low' ? 2.15 : tier === 'medium' ? 2.15 : 1.8,
+    grassRadius: tier === 'low' ? 86 : tier === 'medium' ? 76 : 82, // low spends spare budget on nearby meadow density
+    grassStep: tier === 'low' ? 1.85 : tier === 'medium' ? 2.0 : 1.8,
     terrainSplat: tier === 'medium' || tier === 'high' || tier === 'ultra',
-    windSway: tier === 'medium' || tier === 'high' || tier === 'ultra',
-    maxPointLights: tier === 'low' ? 5 : 6,
+    windSway: true,
+    maxPointLights: 6,
   };
   if (hints?.graphicsPreset === PRESET_ADVANCED) {
     if ((hints.terrainDetail ?? 1) < 0.5) settings = { ...settings, terrainSplat: false };
@@ -300,6 +414,10 @@ export function initGfxTier(webgl: THREE.WebGLRenderer): GfxTier {
   GFX = settingsFor(tier, hints);
   return tier;
 }
+
+export const gfxInternalsForTest = {
+  settingsFor,
+};
 
 // One clock uniform shared by every onBeforeCompile shader (wind, water,
 // grade grain). The renderer ticks it once per frame in sync(). uRimBoost

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -144,8 +144,8 @@ export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
     dropStep: 0.1,
     urgentDropStep: 0.15,
     recoverStep: 0.05,
-    recoverStableSeconds: 7,
-    cooldownSeconds: 1.35,
+    recoverStableSeconds: 3,
+    cooldownSeconds: 0.85,
   },
   ultra: {
     targetFps: 60,
@@ -158,8 +158,8 @@ export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
     dropStep: 0.08,
     urgentDropStep: 0.12,
     recoverStep: 0.04,
-    recoverStableSeconds: 9,
-    cooldownSeconds: 1.5,
+    recoverStableSeconds: 3,
+    cooldownSeconds: 0.85,
   },
 };
 
@@ -256,6 +256,7 @@ export function shouldUseAutoGovernor(hints?: Pick<GfxRuntimeHints, 'search' | '
   const override = params.get('governor') ?? params.get('autoGovernor');
   if (override === '1' || override === 'true' || override === 'on') return true;
   if (override === '0' || override === 'false' || override === 'off') return false;
+  if (forcedTierFromSearch(hints.search) === 'ultra') return false;
   return graphicsPresetLabel(hints.graphicsPreset) !== 'ultra';
 }
 

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -73,7 +73,7 @@ const PRESET_ADVANCED = 5;
 export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
   low: {
     targetFps: 30,
-    minRenderScaleDesktop: 0.82,
+    minRenderScaleDesktop: 0.65,
     minRenderScaleMobile: 0.55,
     maxRenderScale: 1,
     dropFrameMs: 28,
@@ -142,8 +142,21 @@ export function graphicsPresetLabel(value: number | undefined): 'auto' | 'low' |
 
 export function shouldUseAutoGovernor(hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset'>): boolean {
   if (!hints) return false;
-  if (forcedTierFromSearch(hints.search)) return false;
-  return graphicsPresetLabel(hints.graphicsPreset) === 'auto';
+  const params = new URLSearchParams(hints.search);
+  const override = params.get('governor') ?? params.get('autoGovernor');
+  if (override === '1' || override === 'true' || override === 'on') return true;
+  if (override === '0' || override === 'false' || override === 'off') return false;
+  return graphicsPresetLabel(hints.graphicsPreset) !== 'ultra';
+}
+
+export function configureMaskedDoubleSidedVegetationMaterial<T extends THREE.Material>(mat: T): T {
+  mat.side = THREE.DoubleSide;
+  mat.transparent = false;
+  mat.alphaHash = false;
+  mat.forceSinglePass = true;
+  mat.depthTest = true;
+  mat.depthWrite = true;
+  return mat;
 }
 
 function settingsFor(

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -28,6 +28,8 @@ export interface GfxRuntimeHints {
 
 export interface GfxSettings {
   readonly tier: GfxTier;
+  readonly budget: GfxRuntimeBudget;
+  readonly autoGovernor: boolean;
   /** post-processing chain (N8AO + bloom + grade) */
   readonly composer: boolean;
   /** N8AO screen-space ambient occlusion pass */
@@ -46,6 +48,21 @@ export interface GfxSettings {
   readonly maxPointLights: number;
 }
 
+export interface GfxRuntimeBudget {
+  readonly targetFps: number;
+  readonly minRenderScaleDesktop: number;
+  readonly minRenderScaleMobile: number;
+  readonly maxRenderScale: number;
+  readonly dropFrameMs: number;
+  readonly urgentFrameMs: number;
+  readonly recoverFrameMs: number;
+  readonly dropStep: number;
+  readonly urgentDropStep: number;
+  readonly recoverStep: number;
+  readonly recoverStableSeconds: number;
+  readonly cooldownSeconds: number;
+}
+
 const PRESET_AUTO = 0;
 const PRESET_LOW = 1;
 const PRESET_MEDIUM = 2;
@@ -53,12 +70,90 @@ const PRESET_HIGH = 3;
 const PRESET_ULTRA = 4;
 const PRESET_ADVANCED = 5;
 
+export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
+  low: {
+    targetFps: 30,
+    minRenderScaleDesktop: 0.82,
+    minRenderScaleMobile: 0.55,
+    maxRenderScale: 1,
+    dropFrameMs: 28,
+    urgentFrameMs: 38,
+    recoverFrameMs: 22,
+    dropStep: 0.1,
+    urgentDropStep: 0.15,
+    recoverStep: 0.05,
+    recoverStableSeconds: 8,
+    cooldownSeconds: 1.5,
+  },
+  medium: {
+    targetFps: 45,
+    minRenderScaleDesktop: 0.72,
+    minRenderScaleMobile: 0.55,
+    maxRenderScale: 1,
+    dropFrameMs: 24,
+    urgentFrameMs: 34,
+    recoverFrameMs: 17,
+    dropStep: 0.1,
+    urgentDropStep: 0.15,
+    recoverStep: 0.05,
+    recoverStableSeconds: 7,
+    cooldownSeconds: 1.35,
+  },
+  high: {
+    targetFps: 60,
+    minRenderScaleDesktop: 0.7,
+    minRenderScaleMobile: 0.6,
+    maxRenderScale: 1,
+    dropFrameMs: 22,
+    urgentFrameMs: 32,
+    recoverFrameMs: 15,
+    dropStep: 0.1,
+    urgentDropStep: 0.15,
+    recoverStep: 0.05,
+    recoverStableSeconds: 7,
+    cooldownSeconds: 1.35,
+  },
+  ultra: {
+    targetFps: 60,
+    minRenderScaleDesktop: 0.78,
+    minRenderScaleMobile: 0.68,
+    maxRenderScale: 1,
+    dropFrameMs: 24,
+    urgentFrameMs: 34,
+    recoverFrameMs: 15,
+    dropStep: 0.08,
+    urgentDropStep: 0.12,
+    recoverStep: 0.04,
+    recoverStableSeconds: 9,
+    cooldownSeconds: 1.5,
+  },
+};
+
+export function graphicsPresetLabel(value: number | undefined): 'auto' | 'low' | 'medium' | 'high' | 'ultra' | 'advanced' {
+  switch (Math.round(value ?? PRESET_AUTO)) {
+    case PRESET_LOW: return 'low';
+    case PRESET_MEDIUM: return 'medium';
+    case PRESET_HIGH: return 'high';
+    case PRESET_ULTRA: return 'ultra';
+    case PRESET_ADVANCED: return 'advanced';
+    default: return 'auto';
+  }
+}
+
+export function shouldUseAutoGovernor(hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset'>): boolean {
+  if (!hints) return false;
+  if (forcedTierFromSearch(hints.search)) return false;
+  return graphicsPresetLabel(hints.graphicsPreset) === 'auto';
+}
+
 function settingsFor(
   tier: GfxTier,
-  hints?: Pick<GfxRuntimeHints, 'graphicsPreset' | 'terrainDetail' | 'foliageDensity' | 'effectsQuality' | 'shadowQuality'>,
+  hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset' | 'terrainDetail' | 'foliageDensity' | 'effectsQuality' | 'shadowQuality'>,
 ): GfxSettings {
   let settings: GfxSettings = {
     tier,
+    budget: GFX_BUDGETS[tier],
+    autoGovernor: shouldUseAutoGovernor(hints),
     composer: tier === 'high' || tier === 'ultra',
     // N8AO runs on both composer tiers: half-res + Low quality on high keeps
     // it ~1ms-class on real GPUs; ultra gets full-res Medium

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -255,6 +255,45 @@ function propAsset(key: PropKey): PropAsset {
   return asset;
 }
 
+export function buildPropMaterialPrewarmGroup(): THREE.Group {
+  const group = new THREE.Group();
+  group.name = 'prop-material-prewarm';
+  group.visible = true;
+  group.userData.renderCategory = 'prewarm';
+  const seen = new Set<string>();
+  let idx = 0;
+  const instanceMatrix = new THREE.Matrix4();
+  const place = (obj: THREE.Object3D): void => {
+    const col = idx % 10;
+    const row = Math.floor(idx / 10) % 8;
+    const layer = Math.floor(idx / 80);
+    obj.position.set((col - 4.5) * 1.2, row * 0.85, -8 - layer * 1.5);
+    obj.scale.setScalar(0.08);
+    obj.frustumCulled = false;
+    group.add(obj);
+    idx++;
+  };
+  for (const key of ACTIVE_PROP_KEYS) {
+    const asset = propAsset(key);
+    for (const part of asset.parts) {
+      const matKey = `${part.mat.uuid}:${part.geo.getAttribute('color') ? 'color' : 'plain'}`;
+      if (seen.has(matKey)) continue;
+      seen.add(matKey);
+      const mesh = new THREE.Mesh(part.geo, part.mat);
+      mesh.castShadow = false;
+      mesh.receiveShadow = false;
+      place(mesh);
+      const instanced = new THREE.InstancedMesh(part.geo, part.mat, 1);
+      instanced.setMatrixAt(0, instanceMatrix.identity());
+      instanced.instanceMatrix.needsUpdate = true;
+      instanced.castShadow = false;
+      instanced.receiveShadow = false;
+      place(instanced);
+    }
+  }
+  return group;
+}
+
 // ---------------------------------------------------------------------------
 // deterministic per-prop rand streams (no native random — placement is shared
 // with colliders/tests via the world seed)
@@ -299,6 +338,7 @@ export function buildProps(seed: number): PropsResult {
       const mesh = o as THREE.Mesh;
       if (!mesh.isMesh) return;
       keepFromMerge.add(mesh);
+      if (lowProps) return;
       const src = mesh.material as THREE.Material;
       let tm = matMap.get(src);
       if (!tm) {
@@ -771,10 +811,15 @@ export function buildProps(seed: number): PropsResult {
           h.group.visible = false; // fully fogged: drop it (shadow is out of range too)
           continue;
         }
-        h.group.visible = true;
         // Hide from the camera while still casting a shadow: disable colour +
         // depth writes, not the object.
         const hide = cameraSegmentHitsFootprint(h, eyeX, eyeY, eyeZ, camX, camY, camZ);
+        if (h.mats.length === 0) {
+          h.hidden = hide;
+          h.group.visible = !hide;
+          continue;
+        }
+        h.group.visible = true;
         if (hide !== h.hidden) {
           h.hidden = hide;
           for (const m of h.mats) {

--- a/src/render/render_budget.ts
+++ b/src/render/render_budget.ts
@@ -1,11 +1,13 @@
-import type { GfxRuntimeBudget, GfxTier } from './gfx';
+import { GFX_BUCKET_BANDS, type GfxBucketBands, type GfxRuntimeBudget, type GfxTier } from './gfx';
 
 export type RenderBudgetMode = 'disabled' | 'stable' | 'degrading' | 'recovering';
-export type RenderBudgetReason = 'disabled' | 'startup' | 'stable' | 'frame' | 'submit' | 'draw' | 'grass' | 'recover';
+export type RenderBudgetReason = 'disabled' | 'startup' | 'stable' | 'frame' | 'submit' | 'submit-stall' | 'draw' | 'grass' | 'recover';
 
 export interface RenderBudgetLevels {
   grass: number;
+  foliage: number;
   vfx: number;
+  lighting: number;
   resolution: number;
 }
 
@@ -17,7 +19,9 @@ export interface RenderBudgetCaps {
   targetGrassTufts: number;
   urgentGrassTufts: number;
   minGrassLevel: number;
+  minFoliageLevel: number;
   minVfxLevel: number;
+  minLightingLevel: number;
 }
 
 export interface RenderBudgetState {
@@ -27,6 +31,10 @@ export interface RenderBudgetState {
   pressure: number;
   frameMsEma: number;
   submitMsEma: number;
+  stallPressure: number;
+  recentSubmitStalls: number;
+  lastSubmitStallMs: number;
+  stallHoldSeconds: number;
   stableSeconds: number;
   cooldownSeconds: number;
   levels: RenderBudgetLevels;
@@ -56,14 +64,16 @@ export interface RenderBudgetGovernorOptions {
 
 const CAPS_BY_TIER: Record<GfxTier, RenderBudgetCaps> = {
   low: {
-    targetCalls: 220,
-    urgentCalls: 340,
-    targetTriangles: 650_000,
-    urgentTriangles: 1_100_000,
-    targetGrassTufts: 1_450,
-    urgentGrassTufts: 2_350,
-    minGrassLevel: 0.42,
-    minVfxLevel: 0.5,
+    targetCalls: 560,
+    urgentCalls: 760,
+    targetTriangles: 2_200_000,
+    urgentTriangles: 3_000_000,
+    targetGrassTufts: 5_600,
+    urgentGrassTufts: 7_600,
+    minGrassLevel: 0.62,
+    minFoliageLevel: 0.68,
+    minVfxLevel: 0.84,
+    minLightingLevel: 0.78,
   },
   medium: {
     targetCalls: 260,
@@ -73,7 +83,9 @@ const CAPS_BY_TIER: Record<GfxTier, RenderBudgetCaps> = {
     targetGrassTufts: 2_000,
     urgentGrassTufts: 3_200,
     minGrassLevel: 0.5,
+    minFoliageLevel: 0.5,
     minVfxLevel: 0.58,
+    minLightingLevel: 0.45,
   },
   high: {
     targetCalls: 330,
@@ -83,7 +95,9 @@ const CAPS_BY_TIER: Record<GfxTier, RenderBudgetCaps> = {
     targetGrassTufts: 2_850,
     urgentGrassTufts: 4_500,
     minGrassLevel: 0.6,
+    minFoliageLevel: 0.6,
     minVfxLevel: 0.68,
+    minLightingLevel: 0.62,
   },
   ultra: {
     targetCalls: 460,
@@ -93,7 +107,9 @@ const CAPS_BY_TIER: Record<GfxTier, RenderBudgetCaps> = {
     targetGrassTufts: 4_500,
     urgentGrassTufts: 6_800,
     minGrassLevel: 0.78,
+    minFoliageLevel: 0.78,
     minVfxLevel: 0.86,
+    minLightingLevel: 0.78,
   },
 };
 
@@ -109,7 +125,9 @@ function positiveRatio(value: number, target: number): number {
 function copyLevels(levels: RenderBudgetLevels): RenderBudgetLevels {
   return {
     grass: round2(levels.grass),
+    foliage: round2(levels.foliage),
     vfx: round2(levels.vfx),
+    lighting: round2(levels.lighting),
     resolution: round2(levels.resolution),
   };
 }
@@ -118,32 +136,56 @@ function copyCaps(caps: RenderBudgetCaps): RenderBudgetCaps {
   return { ...caps };
 }
 
+const SUBMIT_STALL_MS = 120;
+const SUBMIT_STALL_URGENT_MS = 250;
+const SUBMIT_STALL_HOLD_SECONDS = 18;
+const SUBMIT_STALL_URGENT_HOLD_SECONDS = 30;
+const SUBMIT_STALL_RECOVERY_CEILING_MS = 42;
+
 export class RenderBudgetGovernor {
   private readonly budget: GfxRuntimeBudget;
   private readonly enabled: boolean;
   private readonly caps: RenderBudgetCaps;
+  private readonly bands: GfxBucketBands;
   private mode: RenderBudgetMode;
   private reason: RenderBudgetReason;
   private pressure = 0;
   private frameMsEma = 16.7;
   private submitMsEma = 0;
+  private stallPressure = 0;
+  private recentSubmitStalls = 0;
+  private lastSubmitStallMs = 0;
+  private stallHoldSeconds = 0;
   private stableSeconds = 0;
   private cooldownSeconds = 0;
-  private levels: RenderBudgetLevels = { grass: 1, vfx: 1, resolution: 1 };
+  private levels: RenderBudgetLevels = { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 1 };
 
   constructor(options: RenderBudgetGovernorOptions) {
     this.budget = options.budget;
     this.enabled = options.enabled;
     this.caps = CAPS_BY_TIER[options.tier];
+    this.bands = GFX_BUCKET_BANDS[options.tier];
     this.mode = options.enabled ? 'stable' : 'disabled';
     this.reason = options.enabled ? 'startup' : 'disabled';
   }
 
   reset(renderScale: number, minRenderScale: number, maxRenderScale: number): RenderBudgetState {
     const scale = Math.min(Math.max(renderScale, minRenderScale), maxRenderScale);
-    this.levels = { grass: 1, vfx: 1, resolution: round2(scale) };
+    this.levels = this.enabled
+      ? {
+        grass: this.bands.grass.baseline,
+        foliage: this.bands.foliage.baseline,
+        vfx: this.bands.vfx.baseline,
+        lighting: this.bands.lighting.baseline,
+        resolution: round2(scale),
+      }
+      : { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: round2(scale) };
     this.frameMsEma = 16.7;
     this.submitMsEma = 0;
+    this.stallPressure = 0;
+    this.recentSubmitStalls = 0;
+    this.lastSubmitStallMs = 0;
+    this.stallHoldSeconds = 0;
     this.stableSeconds = 0;
     this.cooldownSeconds = this.enabled ? 0.5 : 0;
     this.pressure = 0;
@@ -160,6 +202,10 @@ export class RenderBudgetGovernor {
       pressure: round2(this.pressure),
       frameMsEma: round2(this.frameMsEma),
       submitMsEma: round2(this.submitMsEma),
+      stallPressure: round2(this.stallPressure),
+      recentSubmitStalls: round2(this.recentSubmitStalls),
+      lastSubmitStallMs: round2(this.lastSubmitStallMs),
+      stallHoldSeconds: round2(this.stallHoldSeconds),
       stableSeconds: round2(this.stableSeconds),
       cooldownSeconds: round2(this.cooldownSeconds),
       levels: copyLevels(this.levels),
@@ -171,10 +217,12 @@ export class RenderBudgetGovernor {
     if (!Number.isFinite(sample.dt) || sample.dt <= 0) return this.state();
     const frameMs = Math.min(250, Math.max(0, sample.frameMs));
     const totalMs = Math.min(250, Math.max(0, sample.totalMs));
-    const submitMs = Math.min(250, Math.max(0, sample.submitMs));
+    const rawSubmitMs = Math.max(0, sample.submitMs);
+    const submitMs = Math.min(250, rawSubmitMs);
     const frameCost = Math.max(frameMs, totalMs);
     this.frameMsEma += (frameCost - this.frameMsEma) * 0.08;
     this.submitMsEma += (submitMs - this.submitMsEma) * 0.12;
+    this.stallPressure = Math.max(this.stallPressure * Math.exp(-sample.dt / 12), positiveRatio(rawSubmitMs, SUBMIT_STALL_MS));
 
     if (!this.enabled) {
       this.mode = 'disabled';
@@ -190,6 +238,9 @@ export class RenderBudgetGovernor {
     if (this.cooldownSeconds > 0) {
       this.cooldownSeconds = Math.max(0, this.cooldownSeconds - sample.dt);
     }
+    if (this.stallHoldSeconds > 0) {
+      this.stallHoldSeconds = Math.max(0, this.stallHoldSeconds - sample.dt);
+    }
 
     const framePressure = Math.max(
       positiveRatio(this.frameMsEma, this.budget.dropFrameMs),
@@ -204,9 +255,22 @@ export class RenderBudgetGovernor {
       positiveRatio(sample.triangles, this.caps.targetTriangles),
     );
     const grassPressure = positiveRatio(sample.grassVisibleTufts, this.caps.targetGrassTufts);
-    this.pressure = Math.max(framePressure, submitPressure, drawPressure, grassPressure);
+    this.pressure = Math.max(framePressure, submitPressure, drawPressure, grassPressure, this.stallPressure);
 
-    const urgent = frameMs >= this.budget.urgentFrameMs
+    const submitStall = rawSubmitMs >= SUBMIT_STALL_MS;
+    if (submitStall) {
+      this.recentSubmitStalls = Math.min(99, this.recentSubmitStalls + 1);
+      this.lastSubmitStallMs = rawSubmitMs;
+      this.stallHoldSeconds = Math.max(
+        this.stallHoldSeconds,
+        rawSubmitMs >= SUBMIT_STALL_URGENT_MS ? SUBMIT_STALL_URGENT_HOLD_SECONDS : SUBMIT_STALL_HOLD_SECONDS,
+      );
+    } else if (this.stallHoldSeconds <= 0 && this.recentSubmitStalls > 0) {
+      this.recentSubmitStalls = Math.max(0, this.recentSubmitStalls - sample.dt / 12);
+    }
+
+    const urgent = submitStall
+      || frameMs >= this.budget.urgentFrameMs
       || totalMs >= this.budget.urgentFrameMs
       || submitMs >= Math.max(12, this.budget.urgentFrameMs * 0.58)
       || sample.calls >= this.caps.urgentCalls
@@ -217,26 +281,44 @@ export class RenderBudgetGovernor {
       || totalMs >= this.budget.dropFrameMs
       || submitMs >= Math.max(8, this.budget.dropFrameMs * 0.58);
 
-    if (overBudget && this.cooldownSeconds <= 0) {
-      const changed = this.degrade(urgent, minRenderScale);
+    if ((submitStall || overBudget) && (submitStall || this.cooldownSeconds <= 0)) {
+      const changed = this.degrade(urgent, minRenderScale, {
+        frame: framePressure,
+        submit: submitStall ? Math.max(submitPressure, this.stallPressure) : submitPressure,
+        draw: drawPressure,
+        grass: grassPressure,
+      });
       if (changed) {
         this.stableSeconds = 0;
         this.mode = 'degrading';
-        this.reason = sample.grassVisibleTufts >= this.caps.targetGrassTufts
+        this.reason = submitStall
+          ? 'submit-stall'
+          : sample.grassVisibleTufts >= this.caps.targetGrassTufts
           ? 'grass'
           : submitPressure >= framePressure && submitPressure >= drawPressure
             ? 'submit'
             : drawPressure >= framePressure
               ? 'draw'
               : 'frame';
-        this.cooldownSeconds = urgent ? this.budget.cooldownSeconds * 0.55 : this.budget.cooldownSeconds;
+        this.cooldownSeconds = submitStall
+          ? Math.max(this.cooldownSeconds, this.budget.cooldownSeconds * (rawSubmitMs >= SUBMIT_STALL_URGENT_MS ? 4 : 2.5))
+          : urgent ? this.budget.cooldownSeconds * 0.55 : this.budget.cooldownSeconds;
         return this.state();
       }
+    }
+
+    if (this.stallHoldSeconds > 0) {
+      this.stableSeconds = 0;
+      this.mode = 'degrading';
+      this.reason = 'submit-stall';
+      return this.state();
     }
 
     const canRecover = this.frameMsEma <= this.budget.recoverFrameMs
       && totalMs <= this.budget.recoverFrameMs
       && submitMs <= Math.max(8, this.budget.recoverFrameMs * 0.7)
+      && rawSubmitMs <= SUBMIT_STALL_RECOVERY_CEILING_MS
+      && this.stallPressure < 0.5
       && sample.calls <= this.caps.targetCalls * 0.9
       && sample.triangles <= this.caps.targetTriangles * 0.9
       && sample.grassVisibleTufts <= this.caps.targetGrassTufts * 0.9;
@@ -262,43 +344,69 @@ export class RenderBudgetGovernor {
     return this.state();
   }
 
-  private degrade(urgent: boolean, minRenderScale: number): boolean {
+  private reduceLevel(key: keyof RenderBudgetLevels, floor: number, step: number): boolean {
+    if (this.levels[key] <= floor + 0.001) return false;
+    this.levels[key] = Math.max(floor, round2(this.levels[key] - step));
+    return true;
+  }
+
+  private raiseLevel(key: keyof RenderBudgetLevels, ceiling: number, step: number): boolean {
+    if (this.levels[key] >= ceiling - 0.001) return false;
+    this.levels[key] = Math.min(ceiling, round2(this.levels[key] + step));
+    return true;
+  }
+
+  private degrade(
+    urgent: boolean,
+    minRenderScale: number,
+    pressure: { frame: number; submit: number; draw: number; grass: number },
+  ): boolean {
     let changed = false;
-    const grassStep = urgent ? 0.16 : 0.1;
-    if (this.levels.grass > this.caps.minGrassLevel) {
-      this.levels.grass = Math.max(this.caps.minGrassLevel, round2(this.levels.grass - grassStep));
+
+    const drawDominant = pressure.draw >= pressure.frame && pressure.draw >= pressure.submit;
+    const foliageStep = urgent ? 0.14 : 0.08;
+    if ((urgent || drawDominant || pressure.draw >= 1.08)
+      && this.reduceLevel('foliage', this.caps.minFoliageLevel, foliageStep)) {
       changed = true;
     }
 
-    const vfxStep = urgent ? 0.12 : 0.07;
-    const grassDone = this.levels.grass <= this.caps.minGrassLevel + 0.001;
-    if ((urgent || grassDone) && this.levels.vfx > this.caps.minVfxLevel) {
-      this.levels.vfx = Math.max(this.caps.minVfxLevel, round2(this.levels.vfx - vfxStep));
+    const grassStep = urgent ? 0.14 : 0.08;
+    if ((urgent || pressure.grass >= 1 || (drawDominant && this.levels.foliage <= this.caps.minFoliageLevel + 0.001))
+      && this.reduceLevel('grass', this.caps.minGrassLevel, grassStep)) {
+      changed = true;
+    }
+
+    const lightingStep = urgent ? 0.12 : 0.07;
+    const environmentFloored = this.levels.foliage <= this.caps.minFoliageLevel + 0.001
+      && this.levels.grass <= this.caps.minGrassLevel + 0.001;
+    if ((urgent || pressure.submit >= 1 || environmentFloored)
+      && this.reduceLevel('lighting', this.caps.minLightingLevel, lightingStep)) {
+      changed = true;
+    }
+
+    const vfxStep = urgent ? 0.08 : 0.05;
+    const lightingDone = this.levels.lighting <= this.caps.minLightingLevel + 0.001;
+    const severeFramePressure = pressure.frame >= 1.25 || pressure.submit >= 1.25;
+    if ((severeFramePressure || (!urgent && environmentFloored && lightingDone && (pressure.frame >= 1 || pressure.submit >= 1)))
+      && this.reduceLevel('vfx', this.caps.minVfxLevel, vfxStep)) {
       changed = true;
     }
 
     const resolutionStep = urgent ? this.budget.urgentDropStep : this.budget.dropStep;
     const vfxDone = this.levels.vfx <= this.caps.minVfxLevel + 0.001;
-    if ((urgent || (grassDone && vfxDone)) && this.levels.resolution > minRenderScale) {
-      this.levels.resolution = Math.max(minRenderScale, round2(this.levels.resolution - resolutionStep));
+    if ((severeFramePressure || (environmentFloored && lightingDone && vfxDone))
+      && this.reduceLevel('resolution', minRenderScale, resolutionStep)) {
       changed = true;
     }
     return changed;
   }
 
   private recover(maxRenderScale: number): boolean {
-    if (this.levels.resolution < maxRenderScale) {
-      this.levels.resolution = Math.min(maxRenderScale, round2(this.levels.resolution + this.budget.recoverStep));
-      return true;
-    }
-    if (this.levels.vfx < 1) {
-      this.levels.vfx = Math.min(1, round2(this.levels.vfx + 0.05));
-      return true;
-    }
-    if (this.levels.grass < 1) {
-      this.levels.grass = Math.min(1, round2(this.levels.grass + 0.05));
-      return true;
-    }
+    if (this.raiseLevel('foliage', this.bands.foliage.max, 0.08)) return true;
+    if (this.raiseLevel('vfx', this.bands.vfx.max, 0.08)) return true;
+    if (this.raiseLevel('grass', this.bands.grass.max, 0.06)) return true;
+    if (this.raiseLevel('lighting', this.bands.lighting.max, 0.05)) return true;
+    if (this.raiseLevel('resolution', maxRenderScale, this.budget.recoverStep)) return true;
     return false;
   }
 }

--- a/src/render/render_budget.ts
+++ b/src/render/render_budget.ts
@@ -1,0 +1,304 @@
+import type { GfxRuntimeBudget, GfxTier } from './gfx';
+
+export type RenderBudgetMode = 'disabled' | 'stable' | 'degrading' | 'recovering';
+export type RenderBudgetReason = 'disabled' | 'startup' | 'stable' | 'frame' | 'submit' | 'draw' | 'grass' | 'recover';
+
+export interface RenderBudgetLevels {
+  grass: number;
+  vfx: number;
+  resolution: number;
+}
+
+export interface RenderBudgetCaps {
+  targetCalls: number;
+  urgentCalls: number;
+  targetTriangles: number;
+  urgentTriangles: number;
+  targetGrassTufts: number;
+  urgentGrassTufts: number;
+  minGrassLevel: number;
+  minVfxLevel: number;
+}
+
+export interface RenderBudgetState {
+  enabled: boolean;
+  mode: RenderBudgetMode;
+  reason: RenderBudgetReason;
+  pressure: number;
+  frameMsEma: number;
+  submitMsEma: number;
+  stableSeconds: number;
+  cooldownSeconds: number;
+  levels: RenderBudgetLevels;
+  caps: RenderBudgetCaps;
+}
+
+export interface RenderBudgetSample {
+  dt: number;
+  frameMs: number;
+  totalMs: number;
+  submitMs: number;
+  calls: number;
+  triangles: number;
+  grassVisibleTufts: number;
+  grassVisibleChunks: number;
+  activeViews: number;
+  createdViews: number;
+  minRenderScale: number;
+  maxRenderScale: number;
+}
+
+export interface RenderBudgetGovernorOptions {
+  tier: GfxTier;
+  budget: GfxRuntimeBudget;
+  enabled: boolean;
+}
+
+const CAPS_BY_TIER: Record<GfxTier, RenderBudgetCaps> = {
+  low: {
+    targetCalls: 220,
+    urgentCalls: 340,
+    targetTriangles: 650_000,
+    urgentTriangles: 1_100_000,
+    targetGrassTufts: 1_450,
+    urgentGrassTufts: 2_350,
+    minGrassLevel: 0.42,
+    minVfxLevel: 0.5,
+  },
+  medium: {
+    targetCalls: 260,
+    urgentCalls: 400,
+    targetTriangles: 850_000,
+    urgentTriangles: 1_350_000,
+    targetGrassTufts: 2_000,
+    urgentGrassTufts: 3_200,
+    minGrassLevel: 0.5,
+    minVfxLevel: 0.58,
+  },
+  high: {
+    targetCalls: 330,
+    urgentCalls: 500,
+    targetTriangles: 1_100_000,
+    urgentTriangles: 1_750_000,
+    targetGrassTufts: 2_850,
+    urgentGrassTufts: 4_500,
+    minGrassLevel: 0.6,
+    minVfxLevel: 0.68,
+  },
+  ultra: {
+    targetCalls: 460,
+    urgentCalls: 680,
+    targetTriangles: 1_800_000,
+    urgentTriangles: 2_700_000,
+    targetGrassTufts: 4_500,
+    urgentGrassTufts: 6_800,
+    minGrassLevel: 0.78,
+    minVfxLevel: 0.86,
+  },
+};
+
+function round2(v: number): number {
+  return Math.round(v * 100) / 100;
+}
+
+function positiveRatio(value: number, target: number): number {
+  if (!Number.isFinite(value) || value <= 0 || target <= 0) return 0;
+  return value / target;
+}
+
+function copyLevels(levels: RenderBudgetLevels): RenderBudgetLevels {
+  return {
+    grass: round2(levels.grass),
+    vfx: round2(levels.vfx),
+    resolution: round2(levels.resolution),
+  };
+}
+
+function copyCaps(caps: RenderBudgetCaps): RenderBudgetCaps {
+  return { ...caps };
+}
+
+export class RenderBudgetGovernor {
+  private readonly budget: GfxRuntimeBudget;
+  private readonly enabled: boolean;
+  private readonly caps: RenderBudgetCaps;
+  private mode: RenderBudgetMode;
+  private reason: RenderBudgetReason;
+  private pressure = 0;
+  private frameMsEma = 16.7;
+  private submitMsEma = 0;
+  private stableSeconds = 0;
+  private cooldownSeconds = 0;
+  private levels: RenderBudgetLevels = { grass: 1, vfx: 1, resolution: 1 };
+
+  constructor(options: RenderBudgetGovernorOptions) {
+    this.budget = options.budget;
+    this.enabled = options.enabled;
+    this.caps = CAPS_BY_TIER[options.tier];
+    this.mode = options.enabled ? 'stable' : 'disabled';
+    this.reason = options.enabled ? 'startup' : 'disabled';
+  }
+
+  reset(renderScale: number, minRenderScale: number, maxRenderScale: number): RenderBudgetState {
+    const scale = Math.min(Math.max(renderScale, minRenderScale), maxRenderScale);
+    this.levels = { grass: 1, vfx: 1, resolution: round2(scale) };
+    this.frameMsEma = 16.7;
+    this.submitMsEma = 0;
+    this.stableSeconds = 0;
+    this.cooldownSeconds = this.enabled ? 0.5 : 0;
+    this.pressure = 0;
+    this.mode = this.enabled ? 'stable' : 'disabled';
+    this.reason = this.enabled ? 'startup' : 'disabled';
+    return this.state();
+  }
+
+  state(): RenderBudgetState {
+    return {
+      enabled: this.enabled,
+      mode: this.mode,
+      reason: this.reason,
+      pressure: round2(this.pressure),
+      frameMsEma: round2(this.frameMsEma),
+      submitMsEma: round2(this.submitMsEma),
+      stableSeconds: round2(this.stableSeconds),
+      cooldownSeconds: round2(this.cooldownSeconds),
+      levels: copyLevels(this.levels),
+      caps: copyCaps(this.caps),
+    };
+  }
+
+  update(sample: RenderBudgetSample): RenderBudgetState {
+    if (!Number.isFinite(sample.dt) || sample.dt <= 0) return this.state();
+    const frameMs = Math.min(250, Math.max(0, sample.frameMs));
+    const totalMs = Math.min(250, Math.max(0, sample.totalMs));
+    const submitMs = Math.min(250, Math.max(0, sample.submitMs));
+    const frameCost = Math.max(frameMs, totalMs);
+    this.frameMsEma += (frameCost - this.frameMsEma) * 0.08;
+    this.submitMsEma += (submitMs - this.submitMsEma) * 0.12;
+
+    if (!this.enabled) {
+      this.mode = 'disabled';
+      this.reason = 'disabled';
+      this.pressure = 0;
+      return this.state();
+    }
+
+    const minRenderScale = Math.min(sample.maxRenderScale, Math.max(0.5, sample.minRenderScale));
+    const maxRenderScale = Math.max(minRenderScale, Math.min(1, sample.maxRenderScale));
+    this.levels.resolution = Math.min(maxRenderScale, Math.max(minRenderScale, this.levels.resolution));
+
+    if (this.cooldownSeconds > 0) {
+      this.cooldownSeconds = Math.max(0, this.cooldownSeconds - sample.dt);
+    }
+
+    const framePressure = Math.max(
+      positiveRatio(this.frameMsEma, this.budget.dropFrameMs),
+      positiveRatio(totalMs, this.budget.dropFrameMs),
+    );
+    const submitPressure = Math.max(
+      positiveRatio(this.submitMsEma, Math.max(8, this.budget.dropFrameMs * 0.58)),
+      positiveRatio(submitMs, Math.max(8, this.budget.dropFrameMs * 0.58)),
+    );
+    const drawPressure = Math.max(
+      positiveRatio(sample.calls, this.caps.targetCalls),
+      positiveRatio(sample.triangles, this.caps.targetTriangles),
+    );
+    const grassPressure = positiveRatio(sample.grassVisibleTufts, this.caps.targetGrassTufts);
+    this.pressure = Math.max(framePressure, submitPressure, drawPressure, grassPressure);
+
+    const urgent = frameMs >= this.budget.urgentFrameMs
+      || totalMs >= this.budget.urgentFrameMs
+      || submitMs >= Math.max(12, this.budget.urgentFrameMs * 0.58)
+      || sample.calls >= this.caps.urgentCalls
+      || sample.triangles >= this.caps.urgentTriangles
+      || sample.grassVisibleTufts >= this.caps.urgentGrassTufts;
+    const overBudget = this.pressure >= 1
+      || this.frameMsEma >= this.budget.dropFrameMs
+      || totalMs >= this.budget.dropFrameMs
+      || submitMs >= Math.max(8, this.budget.dropFrameMs * 0.58);
+
+    if (overBudget && this.cooldownSeconds <= 0) {
+      const changed = this.degrade(urgent, minRenderScale);
+      if (changed) {
+        this.stableSeconds = 0;
+        this.mode = 'degrading';
+        this.reason = sample.grassVisibleTufts >= this.caps.targetGrassTufts
+          ? 'grass'
+          : submitPressure >= framePressure && submitPressure >= drawPressure
+            ? 'submit'
+            : drawPressure >= framePressure
+              ? 'draw'
+              : 'frame';
+        this.cooldownSeconds = urgent ? this.budget.cooldownSeconds * 0.55 : this.budget.cooldownSeconds;
+        return this.state();
+      }
+    }
+
+    const canRecover = this.frameMsEma <= this.budget.recoverFrameMs
+      && totalMs <= this.budget.recoverFrameMs
+      && submitMs <= Math.max(8, this.budget.recoverFrameMs * 0.7)
+      && sample.calls <= this.caps.targetCalls * 0.9
+      && sample.triangles <= this.caps.targetTriangles * 0.9
+      && sample.grassVisibleTufts <= this.caps.targetGrassTufts * 0.9;
+
+    if (canRecover) {
+      this.stableSeconds += sample.dt;
+      if (this.stableSeconds >= this.budget.recoverStableSeconds && this.cooldownSeconds <= 0) {
+        const changed = this.recover(maxRenderScale);
+        if (changed) {
+          this.mode = 'recovering';
+          this.reason = 'recover';
+          this.stableSeconds = 0;
+          this.cooldownSeconds = this.budget.cooldownSeconds * 1.5;
+          return this.state();
+        }
+      }
+    } else {
+      this.stableSeconds = 0;
+    }
+
+    this.mode = 'stable';
+    this.reason = 'stable';
+    return this.state();
+  }
+
+  private degrade(urgent: boolean, minRenderScale: number): boolean {
+    let changed = false;
+    const grassStep = urgent ? 0.16 : 0.1;
+    if (this.levels.grass > this.caps.minGrassLevel) {
+      this.levels.grass = Math.max(this.caps.minGrassLevel, round2(this.levels.grass - grassStep));
+      changed = true;
+    }
+
+    const vfxStep = urgent ? 0.12 : 0.07;
+    const grassDone = this.levels.grass <= this.caps.minGrassLevel + 0.001;
+    if ((urgent || grassDone) && this.levels.vfx > this.caps.minVfxLevel) {
+      this.levels.vfx = Math.max(this.caps.minVfxLevel, round2(this.levels.vfx - vfxStep));
+      changed = true;
+    }
+
+    const resolutionStep = urgent ? this.budget.urgentDropStep : this.budget.dropStep;
+    const vfxDone = this.levels.vfx <= this.caps.minVfxLevel + 0.001;
+    if ((urgent || (grassDone && vfxDone)) && this.levels.resolution > minRenderScale) {
+      this.levels.resolution = Math.max(minRenderScale, round2(this.levels.resolution - resolutionStep));
+      changed = true;
+    }
+    return changed;
+  }
+
+  private recover(maxRenderScale: number): boolean {
+    if (this.levels.resolution < maxRenderScale) {
+      this.levels.resolution = Math.min(maxRenderScale, round2(this.levels.resolution + this.budget.recoverStep));
+      return true;
+    }
+    if (this.levels.vfx < 1) {
+      this.levels.vfx = Math.min(1, round2(this.levels.vfx + 0.05));
+      return true;
+    }
+    if (this.levels.grass < 1) {
+      this.levels.grass = Math.min(1, round2(this.levels.grass + 0.05));
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/render/render_budget.ts
+++ b/src/render/render_budget.ts
@@ -76,36 +76,36 @@ const CAPS_BY_TIER: Record<GfxTier, RenderBudgetCaps> = {
     minLightingLevel: 0.78,
   },
   medium: {
-    targetCalls: 260,
-    urgentCalls: 400,
-    targetTriangles: 850_000,
-    urgentTriangles: 1_350_000,
-    targetGrassTufts: 2_000,
-    urgentGrassTufts: 3_200,
+    targetCalls: 420,
+    urgentCalls: 620,
+    targetTriangles: 1_800_000,
+    urgentTriangles: 2_600_000,
+    targetGrassTufts: 3_800,
+    urgentGrassTufts: 5_500,
     minGrassLevel: 0.5,
     minFoliageLevel: 0.5,
     minVfxLevel: 0.58,
     minLightingLevel: 0.45,
   },
   high: {
-    targetCalls: 330,
-    urgentCalls: 500,
-    targetTriangles: 1_100_000,
-    urgentTriangles: 1_750_000,
-    targetGrassTufts: 2_850,
-    urgentGrassTufts: 4_500,
+    targetCalls: 620,
+    urgentCalls: 860,
+    targetTriangles: 4_500_000,
+    urgentTriangles: 6_500_000,
+    targetGrassTufts: 6_000,
+    urgentGrassTufts: 8_500,
     minGrassLevel: 0.6,
     minFoliageLevel: 0.6,
     minVfxLevel: 0.68,
     minLightingLevel: 0.62,
   },
   ultra: {
-    targetCalls: 460,
-    urgentCalls: 680,
-    targetTriangles: 1_800_000,
-    urgentTriangles: 2_700_000,
-    targetGrassTufts: 4_500,
-    urgentGrassTufts: 6_800,
+    targetCalls: 820,
+    urgentCalls: 1_100,
+    targetTriangles: 6_500_000,
+    urgentTriangles: 9_000_000,
+    targetGrassTufts: 8_000,
+    urgentGrassTufts: 11_000,
     minGrassLevel: 0.78,
     minFoliageLevel: 0.78,
     minVfxLevel: 0.86,
@@ -138,11 +138,12 @@ function copyCaps(caps: RenderBudgetCaps): RenderBudgetCaps {
 
 const SUBMIT_STALL_MS = 120;
 const SUBMIT_STALL_URGENT_MS = 250;
-const SUBMIT_STALL_HOLD_SECONDS = 18;
-const SUBMIT_STALL_URGENT_HOLD_SECONDS = 30;
+const SUBMIT_STALL_HOLD_SECONDS: Record<GfxTier, number> = { low: 18, medium: 14, high: 8, ultra: 6 };
+const SUBMIT_STALL_URGENT_HOLD_SECONDS: Record<GfxTier, number> = { low: 30, medium: 24, high: 14, ultra: 12 };
 const SUBMIT_STALL_RECOVERY_CEILING_MS = 42;
 
 export class RenderBudgetGovernor {
+  private readonly tier: GfxTier;
   private readonly budget: GfxRuntimeBudget;
   private readonly enabled: boolean;
   private readonly caps: RenderBudgetCaps;
@@ -161,6 +162,7 @@ export class RenderBudgetGovernor {
   private levels: RenderBudgetLevels = { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 1 };
 
   constructor(options: RenderBudgetGovernorOptions) {
+    this.tier = options.tier;
     this.budget = options.budget;
     this.enabled = options.enabled;
     this.caps = CAPS_BY_TIER[options.tier];
@@ -263,7 +265,9 @@ export class RenderBudgetGovernor {
       this.lastSubmitStallMs = rawSubmitMs;
       this.stallHoldSeconds = Math.max(
         this.stallHoldSeconds,
-        rawSubmitMs >= SUBMIT_STALL_URGENT_MS ? SUBMIT_STALL_URGENT_HOLD_SECONDS : SUBMIT_STALL_HOLD_SECONDS,
+        rawSubmitMs >= SUBMIT_STALL_URGENT_MS
+          ? SUBMIT_STALL_URGENT_HOLD_SECONDS[this.tier]
+          : SUBMIT_STALL_HOLD_SECONDS[this.tier],
       );
     } else if (this.stallHoldSeconds <= 0 && this.recentSubmitStalls > 0) {
       this.recentSubmitStalls = Math.max(0, this.recentSubmitStalls - sample.dt / 12);
@@ -402,6 +406,10 @@ export class RenderBudgetGovernor {
   }
 
   private recover(maxRenderScale: number): boolean {
+    if (this.raiseLevel('grass', this.bands.grass.baseline, 0.08)) return true;
+    if (this.raiseLevel('lighting', this.bands.lighting.baseline, 0.08)) return true;
+    if (this.raiseLevel('vfx', this.bands.vfx.baseline, 0.08)) return true;
+    if (this.raiseLevel('foliage', this.bands.foliage.baseline, 0.08)) return true;
     if (this.raiseLevel('foliage', this.bands.foliage.max, 0.08)) return true;
     if (this.raiseLevel('vfx', this.bands.vfx.max, 0.08)) return true;
     if (this.raiseLevel('grass', this.bands.grass.max, 0.06)) return true;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -563,6 +563,8 @@ export class Renderer {
 
   perfStats(): {
     tier: string;
+    autoGovernor: boolean;
+    budget: typeof GFX.budget;
     renderScale: number;
     effectiveRenderScale: number;
     pixelRatio: number;
@@ -582,6 +584,8 @@ export class Renderer {
     const info = this.webgl.info;
     return {
       tier: GFX.tier,
+      autoGovernor: GFX.autoGovernor,
+      budget: GFX.budget,
       renderScale: this.renderScale,
       effectiveRenderScale: this.effectiveRenderScale,
       pixelRatio: this.webgl.getPixelRatio(),
@@ -620,6 +624,7 @@ export class Renderer {
 
   private updateAdaptiveResolution(dt: number): void {
     if (!Number.isFinite(dt) || dt <= 0) return;
+    if (!GFX.autoGovernor) return;
     const frameMs = Math.min(250, dt * 1000);
     this.frameMsEma += (frameMs - this.frameMsEma) * 0.08;
     if (this.adaptiveGrace > 0) {
@@ -631,27 +636,26 @@ export class Renderer {
       return;
     }
 
+    const budget = GFX.budget;
     const mobile = this.isMobileRuntime();
-    const minScale = mobile ? 0.55 : (GFX.tier === 'low' ? 0.9 : 0.7);
-    const dropThreshold = mobile ? 20 : 24; // ~50fps mobile, ~42fps desktop
-    const urgentThreshold = mobile ? 28 : 34;
-    const recoverThreshold = mobile ? 15.5 : 14.5;
+    const minScale = mobile ? budget.minRenderScaleMobile : budget.minRenderScaleDesktop;
+    const maxScale = Math.min(this.renderScale, budget.maxRenderScale);
 
-    if (this.frameMsEma >= dropThreshold && this.effectiveRenderScale > minScale) {
-      const step = this.frameMsEma >= urgentThreshold ? 0.15 : 0.1;
+    if (this.frameMsEma >= budget.dropFrameMs && this.effectiveRenderScale > minScale) {
+      const step = this.frameMsEma >= budget.urgentFrameMs ? budget.urgentDropStep : budget.dropStep;
       this.effectiveRenderScale = Math.max(minScale, Math.round((this.effectiveRenderScale - step) * 100) / 100);
       this.stableFrameTime = 0;
-      this.adaptiveCooldown = 1.25;
+      this.adaptiveCooldown = budget.cooldownSeconds;
       this.applyResolution();
       return;
     }
 
-    if (this.frameMsEma <= recoverThreshold && this.effectiveRenderScale < this.renderScale) {
+    if (this.frameMsEma <= budget.recoverFrameMs && this.effectiveRenderScale < maxScale) {
       this.stableFrameTime += dt;
-      if (this.stableFrameTime >= 6) {
-        this.effectiveRenderScale = Math.min(this.renderScale, Math.round((this.effectiveRenderScale + 0.05) * 100) / 100);
+      if (this.stableFrameTime >= budget.recoverStableSeconds) {
+        this.effectiveRenderScale = Math.min(maxScale, Math.round((this.effectiveRenderScale + budget.recoverStep) * 100) / 100);
         this.stableFrameTime = 0;
-        this.adaptiveCooldown = 2.0;
+        this.adaptiveCooldown = budget.cooldownSeconds * 1.5;
         this.applyResolution();
       }
     } else {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1,23 +1,26 @@
 import * as THREE from 'three';
-import { Entity, SimEvent } from '../sim/types';
+import { ALL_CLASSES, type Entity, type SimEvent } from '../sim/types';
 import { OVERHEAD_EMOTES, type IWorld } from '../world_api';
 import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import {
-  MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
+  CLASSES, MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
   instanceOrigin, INSTANCE_SLOT_COUNT, ARENA_SLOT_COUNT, arenaOrigin, isArenaPos, dungeonAt,
+  WORLD_MAX_Z, WORLD_MIN_Z, ZONES,
 } from '../sim/data';
 import { cameraOcclusion } from '../sim/colliders';
 import type { BiomeId } from '../sim/types';
 import { AnimState, CharacterVisual, createCharacterVisual } from './characters';
+import { skinCount } from './characters/manifest';
 import { isVisuallyDead } from './anim_state';
 import { LocoTrack, newLocoTrack, updateLocomotion } from './locomotion';
-import { buildProps } from './props';
+import { buildPropMaterialPrewarmGroup, buildProps } from './props';
 import { plankTexture, sparkleTexture } from './textures';
 import { DungeonInteriors, ensureDungeonAssets } from './dungeon';
 import { buildGroundQuestObject } from './quest_objects';
 import { Vfx } from './vfx';
 import {
   GFX, initGfxTier, sharedUniforms, SUN_ANCHOR, SUN_DIR, surfaceMat, urlForcedTier,
+  type GfxBucketBands, type GfxBucketLevels,
 } from './gfx';
 import { buildComposer, PostPipeline } from './post';
 import { buildTerrain, TerrainView } from './terrain';
@@ -61,9 +64,10 @@ const ENTITY_SHADOW_RANGE_SQ = 25 * 25;
 const ENTITY_PROXY_SHADOW_RANGE_SQ = 62 * 62;
 // loot sparkles further than this are hidden (sub-pixel, real draw cost)
 const SPARKLE_DRAW_RANGE_SQ = 40 * 40;
-// beyond this, the articulated rig swaps for its single-draw merged far LOD
-// (just inside the nameplate range; rigs out there are ~30px tall)
-const ENTITY_LOD_RANGE_SQ = 50 * 50;
+// beyond this, the articulated rig swaps for its single-draw merged far LOD.
+// Keep the full rig just past nameplate range so nearby characters and held
+// weapons stay readable on low while the 80u draw cap still bounds total cost.
+const ENTITY_LOD_RANGE_SQ = 58 * 58;
 // Feet-above-terrain margin that counts as "airborne" for the jump pose. Mirrors
 // the sim's own 0.4u grounded tolerance (sim.ts), so walking slopes doesn't trip
 // it but a jump (apex ~1.1u) does. Needed because online snapshots don't carry
@@ -107,12 +111,26 @@ const DUNGEON_RIM_BOOST = 2.4;
 const RENDERER_PHASE_SAMPLE_LIMIT = 720;
 const RENDER_DIAGNOSTICS_SAMPLE_MS = 2000;
 const RENDER_DIAGNOSTICS_IDLE_TIMEOUT_MS = 1000;
+const RENDER_STALL_ATTRIBUTION_MS = 80;
 const PREWARM_MOB_TEMPLATE_IDS = [
   'forest_wolf',
+  'wild_boar',
+  'webwood_spider',
   'mudfin_murloc',
+  'tunnel_rat',
+  'vale_bandit',
   'restless_bones',
   'old_greyjaw',
   'mogger',
+  'mire_widow',
+  'fen_troll',
+  'gravecaller_cultist',
+  'stormcrag_elemental',
+  'thornpeak_ogre',
+  'glimmermere_wader',
+  'sethrael_palecoil',
+  'warlock_imp',
+  'warlock_voidwalker',
 ] as const;
 const PREWARM_OBJECT_ITEM_IDS = [
   'supply_crate',
@@ -120,9 +138,20 @@ const PREWARM_OBJECT_ITEM_IDS = [
   'morthen_grimoire',
   'gravecaller_sigil',
   'weathered_ledger_page',
+  'fen_muster_order',
+  'rusted_censer',
+  'bastion_ward_stone',
+  'ogre_war_totem',
+  'sanctum_key_shard',
+  'gravewyrm_sigil',
+  'crypt_ritual_circle',
 ] as const;
 const PREWARM_MOB_POOL_COPIES = 3;
 const PREWARM_OBJECT_POOL_COPIES = 2;
+
+function prewarmPlayerSkinVariantCount(): number {
+  return ALL_CLASSES.reduce((sum, cls) => sum + skinCount(`player_${cls}`), 0);
+}
 
 type RendererPhase = 'setup' | 'entities' | 'world' | 'nameplates' | 'submit' | 'total';
 type RendererWorldPhase =
@@ -156,6 +185,23 @@ type RenderableDiagnosticObject = THREE.Object3D & {
   material?: THREE.Material | THREE.Material[];
   count?: number;
 };
+
+type TextureBackedMaterial = THREE.Material & {
+  map?: THREE.Texture | null;
+  alphaMap?: THREE.Texture | null;
+  aoMap?: THREE.Texture | null;
+  bumpMap?: THREE.Texture | null;
+  displacementMap?: THREE.Texture | null;
+  emissiveMap?: THREE.Texture | null;
+  envMap?: THREE.Texture | null;
+  lightMap?: THREE.Texture | null;
+  metalnessMap?: THREE.Texture | null;
+  normalMap?: THREE.Texture | null;
+  roughnessMap?: THREE.Texture | null;
+  specularMap?: THREE.Texture | null;
+  gradientMap?: THREE.Texture | null;
+};
+type TextureMaterialKey = keyof Omit<TextureBackedMaterial, keyof THREE.Material>;
 interface ViewCandidate {
   e: Entity;
   d2: number;
@@ -191,6 +237,10 @@ interface RendererFrameStats {
   worldPhaseMs: RendererWorldPhaseMs;
   foliage: FoliagePerfStats;
   renderDiagnostics: RenderDiagnosticsSnapshot;
+  cameraPosition: { x: number; y: number; z: number };
+  playerPosition: { x: number; y: number; z: number };
+  biome: BiomeId;
+  lastQualityChange: RendererQualityChangeStats | null;
   createdViews: number;
   createdViewTypes: string[];
   removedViews: number;
@@ -199,17 +249,70 @@ interface RendererFrameStats {
   visibleViews: number;
 }
 
+interface RendererQualityChangeStats {
+  atMs: number;
+  ageMs: number;
+  mode: RenderBudgetState['mode'];
+  reason: RenderBudgetState['reason'];
+  previousLevels: RenderBudgetState['levels'];
+  levels: RenderBudgetState['levels'];
+}
+
+type RendererPrewarmCategory = 'views' | 'world' | 'sky' | 'props' | 'entities' | 'objects' | 'vfx' | 'post' | 'diagnostics';
+
+interface RendererPrewarmManifestEntryStats {
+  id: string;
+  category: RendererPrewarmCategory;
+  priority: number;
+  required: boolean;
+  status: 'completed' | 'skipped' | 'timed-out' | 'failed';
+  elapsedMs: number;
+  remainingMsAfter: number;
+  passes: number;
+  programsBefore: number;
+  programsAfter: number;
+  programDelta: number;
+  texturesBefore: number;
+  texturesAfter: number;
+  textureDelta: number;
+  detail?: string;
+}
+
+interface RendererPrewarmDiagnosticsBaselineStats {
+  programs: number;
+  textures: number;
+  totalObjects: number;
+  estimatedDraws: number;
+  estimatedTriangles: number;
+  categories: Record<string, { draws: number; triangles: number; materials: number }>;
+}
+
 export interface RendererPrewarmStats {
   elapsedMs: number;
   maxMs: number;
   createdViews: number;
   candidateViews: number;
   renderPasses: number;
+  programsBefore: number;
+  programsAfter: number;
+  texturesBefore: number;
+  texturesAfter: number;
   compileMode: 'async' | 'sync' | 'none';
   compileMs: number;
   compileTimedOut: boolean;
   timedOut: boolean;
+  remainingMs: number;
+  budgetUsedRatio: number;
   createdViewTypes: string[];
+  manifestPlanned: number;
+  manifestEntries: RendererPrewarmManifestEntryStats[];
+  manifestCompleted: number;
+  manifestSkipped: number;
+  manifestTimedOut: number;
+  manifestFailed: number;
+  timedOutEntryIds: string[];
+  failedEntryIds: string[];
+  diagnosticsBaseline: RendererPrewarmDiagnosticsBaselineStats | null;
 }
 
 interface PooledObjectView {
@@ -320,6 +423,19 @@ function emptyWorldPhaseMs(): RendererWorldPhaseMs {
 
 function emptyFoliagePerfStats(): FoliagePerfStats {
   return {
+    modelQuality: 1,
+    modelBuckets: 0,
+    modelVisibleBuckets: 0,
+    modelBucketsByLod: {},
+    modelVisibleByLod: {},
+    modelDraws: 0,
+    modelVisibleDraws: 0,
+    modelDrawsByLod: {},
+    modelVisibleDrawsByLod: {},
+    modelTriangles: 0,
+    modelVisibleTriangles: 0,
+    modelTrianglesByLod: {},
+    modelVisibleTrianglesByLod: {},
     grassEnabled: false,
     grassQuality: 0,
     grassActiveRadius: 0,
@@ -470,6 +586,7 @@ export class Renderer {
   private fogScratch = new THREE.Color();
   private flames: THREE.Mesh[];
   private fireLights: THREE.PointLight[];
+  private effectivePointLights = 0;
   private propsView!: {
     update(
       camX: number, camY: number, camZ: number,
@@ -510,6 +627,10 @@ export class Renderer {
     worldPhaseMs: emptyWorldPhaseMs(),
     foliage: emptyFoliagePerfStats(),
     renderDiagnostics: emptyRenderDiagnosticsSnapshot(),
+    cameraPosition: { x: 0, y: 0, z: 0 },
+    playerPosition: { x: 0, y: 0, z: 0 },
+    biome: 'vale',
+    lastQualityChange: null,
     createdViews: 0,
     createdViewTypes: [],
     removedViews: 0,
@@ -526,6 +647,8 @@ export class Renderer {
   private renderDiagnosticsKnownVisibleObjects = new Set<string>();
   private renderDiagnosticsLastPrograms = 0;
   private renderDiagnosticsLastTextures = 0;
+  private appliedBudgetLevels: RenderBudgetState['levels'] | null = null;
+  private lastQualityChange: Omit<RendererQualityChangeStats, 'ageMs'> | null = null;
   private visualPool = new Map<string, CharacterVisual[]>();
   private objectPool = new Map<string, PooledObjectView[]>();
 
@@ -594,10 +717,10 @@ export class Renderer {
       pmrem.dispose(); // prefiltered envRTs stay alive for the session
     }
 
-    const hemi = new THREE.HemisphereLight(0xd8ecff, 0x405a35, LOW_GFX ? 0.9 : HEMI_INTENSITY);
+    const hemi = new THREE.HemisphereLight(0xdcefff, 0x465f39, LOW_GFX ? 0.98 : HEMI_INTENSITY);
     this.scene.add(hemi);
     this.hemi = hemi;
-    const sun = new THREE.DirectionalLight(LOW_GFX ? 0xfff2d6 : 0xffedd0, LOW_GFX ? 2.45 : SUN_INTENSITY);
+    const sun = new THREE.DirectionalLight(LOW_GFX ? 0xfff0d0 : 0xffedd0, LOW_GFX ? 2.65 : SUN_INTENSITY);
     sun.position.copy(SUN_ANCHOR);
     sun.castShadow = !LOW_GFX;
     sun.shadow.mapSize.set(GFX.shadowMap, GFX.shadowMap);
@@ -837,14 +960,62 @@ export class Renderer {
 
   private applyRenderBudgetState(state: RenderBudgetState): void {
     const previousScale = this.effectiveRenderScale;
+    const previousLevels = this.appliedBudgetLevels;
+    const levelsChanged = previousLevels
+      ? Object.entries(state.levels).some(([key, value]) => Math.abs(value - previousLevels[key as keyof RenderBudgetState['levels']]) >= 0.001)
+      : true;
+    if (levelsChanged) {
+      this.lastQualityChange = {
+        atMs: performance.now(),
+        mode: state.mode,
+        reason: state.reason,
+        previousLevels: previousLevels ?? state.levels,
+        levels: state.levels,
+      };
+      this.appliedBudgetLevels = { ...state.levels };
+    }
     this.effectiveRenderScale = Math.min(this.renderBudgetMaxScale(), Math.max(this.renderBudgetMinScale(), state.levels.resolution));
     this.foliage.setGrassQuality(state.levels.grass);
+    this.foliage.setModelQuality(state.levels.foliage);
     this.vfx.setQuality(state.levels.vfx);
+    this.effectivePointLights = Math.max(1, Math.round(GFX.maxPointLights * state.levels.lighting));
     if (Math.abs(previousScale - this.effectiveRenderScale) >= 0.001) this.applyResolution();
   }
 
+  private graphicsBucketLevels(state = this.renderBudgetGovernor.state()): GfxBucketLevels {
+    return {
+      ...GFX.bucketBaselines,
+      resolution: Math.round(this.effectiveRenderScale * 100) / 100,
+      grass: state.levels.grass,
+      foliage: state.levels.foliage,
+      vfx: state.levels.vfx,
+      lighting: state.levels.lighting,
+      characters: 1,
+      weapons: 1,
+      worldStreaming: this.lowGfx ? GFX.bucketBaselines.worldStreaming : 1,
+      ui: this.isMobileRuntime() ? Math.min(GFX.bucketBaselines.ui, 0.9) : GFX.bucketBaselines.ui,
+    };
+  }
+
   perfStats(): {
+    graphicsConfigVersion: number;
     tier: string;
+    qualityBuckets: {
+      version: number;
+      bands: GfxBucketBands;
+      baseline: GfxBucketLevels;
+      levels: GfxBucketLevels;
+      features: {
+        composer: boolean;
+        ao: boolean;
+        standardMaterials: boolean;
+        terrainSplat: boolean;
+        windSway: boolean;
+        maxPointLights: number;
+        activePointLights: number;
+        shadowMap: number;
+      };
+    };
     autoGovernor: boolean;
     budget: typeof GFX.budget;
     renderScale: number;
@@ -869,13 +1040,31 @@ export class Renderer {
     prewarm: RendererPrewarmStats | null;
   } {
     const info = this.webgl.info;
+    const renderBudget = this.renderBudgetGovernor.state();
     return {
+      graphicsConfigVersion: GFX.graphicsConfigVersion,
       tier: GFX.tier,
+      qualityBuckets: {
+        version: GFX.graphicsConfigVersion,
+        bands: GFX.bucketBands,
+        baseline: GFX.bucketBaselines,
+        levels: this.graphicsBucketLevels(renderBudget),
+        features: {
+          composer: GFX.composer,
+          ao: GFX.ao,
+          standardMaterials: GFX.standardMaterials,
+          terrainSplat: GFX.terrainSplat,
+          windSway: GFX.windSway,
+          maxPointLights: GFX.maxPointLights,
+          activePointLights: this.effectivePointLights || GFX.maxPointLights,
+          shadowMap: GFX.shadowMap,
+        },
+      },
       autoGovernor: GFX.autoGovernor,
       budget: GFX.budget,
       renderScale: this.renderScale,
       effectiveRenderScale: this.effectiveRenderScale,
-      renderBudget: this.renderBudgetGovernor.state(),
+      renderBudget,
       pixelRatio: this.webgl.getPixelRatio(),
       width: this.viewport.width,
       height: this.viewport.height,
@@ -1047,8 +1236,13 @@ export class Renderer {
     };
   }
 
-  private renderDiagnosticsForFrame(now: number): RenderDiagnosticsSnapshot {
+  private renderDiagnosticsForFrame(now: number, force = false): RenderDiagnosticsSnapshot {
     if (!this.renderDiagnosticsEnabled) return emptyRenderDiagnosticsSnapshot();
+    if (force) {
+      this.renderDiagnosticsSnapshot = this.collectRenderDiagnostics();
+      this.renderDiagnosticsNextSampleAt = now + RENDER_DIAGNOSTICS_SAMPLE_MS;
+      return this.renderDiagnosticsSnapshot;
+    }
     if (!this.renderDiagnosticsSamplePending && now >= this.renderDiagnosticsNextSampleAt) {
       this.renderDiagnosticsSamplePending = true;
       this.renderDiagnosticsNextSampleAt = now + RENDER_DIAGNOSTICS_SAMPLE_MS;
@@ -1241,11 +1435,11 @@ export class Renderer {
     this.updateChatBubbles();
   }
 
-  private prewarmEntity(kind: 'player' | 'mob', templateId: string, color: number, scale: number): Entity {
+  private prewarmEntity(kind: 'player' | 'mob', templateId: string, color: number, scale: number, skin = 0, id = -10_000): Entity {
     const p = this.sim.player;
     return {
       ...p,
-      id: -10_000,
+      id,
       kind,
       templateId,
       name: templateId,
@@ -1259,7 +1453,7 @@ export class Renderer {
       hostile: kind === 'mob',
       color,
       scale,
-      skin: 0,
+      skin,
       dead: false,
       castingAbility: null,
       overheadEmoteId: null,
@@ -1336,7 +1530,7 @@ export class Renderer {
     pool.push(object);
   }
 
-  private buildArchetypePrewarmGroup(): THREE.Group {
+  private buildEntityPrewarmGroup(): THREE.Group {
     const group = new THREE.Group();
     const p = this.sim.player;
     group.position.set(p.pos.x, p.pos.y, p.pos.z - 14);
@@ -1359,6 +1553,45 @@ export class Renderer {
         place(visual.root);
       }
     }
+    return group;
+  }
+
+  private buildPlayerPrewarmGroup(deadline: number): { group: THREE.Group; visualCount: number } {
+    const group = new THREE.Group();
+    const p = this.sim.player;
+    group.position.set(p.pos.x, p.pos.y, p.pos.z - 21);
+    setRenderCategory(group, 'prewarm');
+    let idx = 0;
+    const place = (obj: THREE.Object3D): void => {
+      obj.position.set(((idx % 8) - 3.5) * 2.8, 0, Math.floor(idx / 8) * 2.8);
+      group.add(obj);
+      idx++;
+    };
+    for (const cls of ALL_CLASSES) {
+      const variants = skinCount(`player_${cls}`);
+      for (let skin = 0; skin < variants; skin++) {
+        if (performance.now() >= deadline) return { group, visualCount: idx };
+        const color = CLASSES[cls]?.color ?? 0xffffff;
+        const entity = this.prewarmEntity('player', cls, color, 1, skin, -11_000 - idx);
+        const visual = createCharacterVisual(entity);
+        visual.root.visible = true;
+        place(visual.root);
+      }
+    }
+    return { group, visualCount: idx };
+  }
+
+  private buildObjectPrewarmGroup(): THREE.Group {
+    const group = new THREE.Group();
+    const p = this.sim.player;
+    group.position.set(p.pos.x, p.pos.y, p.pos.z - 17);
+    setRenderCategory(group, 'prewarm');
+    let idx = 0;
+    const place = (obj: THREE.Object3D): void => {
+      obj.position.set(((idx % 6) - 2.5) * 3.2, 0, Math.floor(idx / 6) * 3.2);
+      group.add(obj);
+      idx++;
+    };
     for (const itemId of PREWARM_OBJECT_ITEM_IDS) {
       const key = `object:${itemId}`;
       for (let i = 0; i < PREWARM_OBJECT_POOL_COPIES; i++) {
@@ -1371,30 +1604,296 @@ export class Renderer {
     return group;
   }
 
+  private prewarmCounts(): { programs: number; textures: number } {
+    return {
+      programs: this.webgl.info.programs?.length ?? 0,
+      textures: this.webgl.info.memory.textures,
+    };
+  }
+
+  private prewarmTexture(texture: THREE.Texture | null | undefined): void {
+    if (!texture) return;
+    this.webgl.initTexture(texture);
+  }
+
+  private prewarmMaterialTextures(material: THREE.Material | THREE.Material[] | undefined): void {
+    const mats = Array.isArray(material) ? material : material ? [material] : [];
+    const textureKeys: TextureMaterialKey[] = [
+      'map',
+      'alphaMap',
+      'aoMap',
+      'bumpMap',
+      'displacementMap',
+      'emissiveMap',
+      'envMap',
+      'lightMap',
+      'metalnessMap',
+      'normalMap',
+      'roughnessMap',
+      'specularMap',
+      'gradientMap',
+    ];
+    for (const mat of mats) {
+      const textureMat = mat as TextureBackedMaterial;
+      for (const key of textureKeys) this.prewarmTexture(textureMat[key]);
+    }
+  }
+
+  private prewarmObjectTextures(obj: THREE.Object3D): number {
+    let count = 0;
+    obj.traverse((child) => {
+      const renderable = child as RenderableDiagnosticObject;
+      if (!renderable.material) return;
+      const before = this.webgl.info.memory.textures;
+      this.prewarmMaterialTextures(renderable.material);
+      count += Math.max(0, this.webgl.info.memory.textures - before);
+    });
+    return count;
+  }
+
+  private renderPrewarmPass(dt: number): void {
+    this.prewarmWorldFrame(dt);
+    if (this.post) this.post.render();
+    else this.webgl.render(this.scene, this.camera);
+  }
+
+  private diagnosticsBaselineForPrewarm(): RendererPrewarmDiagnosticsBaselineStats | null {
+    if (!this.renderDiagnosticsEnabled) return null;
+    this.renderDiagnosticsSnapshot = this.collectRenderDiagnostics();
+    const categories: RendererPrewarmDiagnosticsBaselineStats['categories'] = {};
+    for (const [name, stat] of Object.entries(this.renderDiagnosticsSnapshot.categories)) {
+      categories[name] = {
+        draws: stat.draws,
+        triangles: stat.triangles,
+        materials: stat.materials,
+      };
+    }
+    return {
+      programs: this.renderDiagnosticsSnapshot.programs,
+      textures: this.renderDiagnosticsSnapshot.textures,
+      totalObjects: this.renderDiagnosticsSnapshot.totalObjects,
+      estimatedDraws: this.renderDiagnosticsSnapshot.estimatedDraws,
+      estimatedTriangles: this.renderDiagnosticsSnapshot.estimatedTriangles,
+      categories,
+    };
+  }
+
   async prewarmInitialScene(options: { maxMs?: number } = {}): Promise<RendererPrewarmStats> {
     const maxMs = Math.max(0, options.maxMs ?? VIEW_PREWARM_MAX_MS);
     const started = performance.now();
     const deadline = started + maxMs;
+    const manifestEntries: RendererPrewarmManifestEntryStats[] = [];
+    const startCounts = this.prewarmCounts();
     const createdViewTypes: string[] = [];
     const p = this.sim.player;
-    let createdViews = this.createRequiredViews(p, createdViewTypes);
-    createdViews += this.createPersistentPortalViews(createdViewTypes, deadline);
-    this.collectMissingViewCandidates(p, VIEW_PREWARM_RANGE_SQ, false);
-    const candidateViews = this.viewCandidates.length;
-    const maxViews = this.lowGfx ? VIEW_PREWARM_MAX_VIEWS_LOW : VIEW_PREWARM_MAX_VIEWS_HIGH;
-    createdViews += this.createCandidateViews(Math.max(0, maxViews - createdViews), createdViewTypes, deadline);
-    const doorPrewarmGroup = this.buildDoorPrewarmGroup();
-    const archetypePrewarmGroup = this.buildArchetypePrewarmGroup();
-    this.scene.add(doorPrewarmGroup);
-    this.scene.add(archetypePrewarmGroup);
+    let createdViews = 0;
+    let candidateViews = 0;
+    let doorPrewarmGroup: THREE.Group | null = null;
+    let entityPrewarmGroup: THREE.Group | null = null;
+    let playerPrewarmGroup: THREE.Group | null = null;
+    let objectPrewarmGroup: THREE.Group | null = null;
+    let propMaterialPrewarmGroup: THREE.Group | null = null;
 
     let renderPasses = 0;
+    let playerPrewarmVisuals = 0;
+    let vfxPrewarmBursts = 0;
     let compileMode: RendererPrewarmStats['compileMode'] = 'none';
     let compileMs = 0;
     let compileTimedOut = false;
-    try {
-      if (performance.now() < deadline) {
-        this.prewarmWorldFrame(1 / 60);
+    let textureUploads = 0;
+    let diagnosticsBaseline: RendererPrewarmDiagnosticsBaselineStats | null = null;
+
+    type PrewarmManifestEntry = {
+      id: string;
+      category: RendererPrewarmCategory;
+      priority: number;
+      required: boolean;
+      run: () => void | Promise<void>;
+      detail?: () => string;
+    };
+
+    const runEntry = async (
+      entry: PrewarmManifestEntry,
+    ): Promise<void> => {
+      const before = this.prewarmCounts();
+      const entryStarted = performance.now();
+      if (entryStarted >= deadline) {
+        manifestEntries.push({
+          id: entry.id,
+          category: entry.category,
+          priority: entry.priority,
+          required: entry.required,
+          status: 'timed-out',
+          elapsedMs: 0,
+          remainingMsAfter: 0,
+          passes: renderPasses,
+          programsBefore: before.programs,
+          programsAfter: before.programs,
+          programDelta: 0,
+          texturesBefore: before.textures,
+          texturesAfter: before.textures,
+          textureDelta: 0,
+          detail: entry.detail?.(),
+        });
+        return;
+      }
+      let status: RendererPrewarmManifestEntryStats['status'] = 'completed';
+      try {
+        await entry.run();
+      } catch (err) {
+        status = 'failed';
+        console.warn(`Renderer prewarm entry failed: ${entry.id}`, err);
+      }
+      const after = this.prewarmCounts();
+      const entryEnded = performance.now();
+      manifestEntries.push({
+        id: entry.id,
+        category: entry.category,
+        priority: entry.priority,
+        required: entry.required,
+        status,
+        elapsedMs: roundMs(entryEnded - entryStarted),
+        remainingMsAfter: roundMs(Math.max(0, deadline - entryEnded)),
+        passes: renderPasses,
+        programsBefore: before.programs,
+        programsAfter: after.programs,
+        programDelta: after.programs - before.programs,
+        texturesBefore: before.textures,
+        texturesAfter: after.textures,
+        textureDelta: after.textures - before.textures,
+        detail: entry.detail?.(),
+      });
+    };
+
+    const manifest: PrewarmManifestEntry[] = [
+      {
+        id: 'views.required',
+        category: 'views',
+        priority: 10,
+        required: true,
+        run: () => {
+        createdViews += this.createRequiredViews(p, createdViewTypes);
+        createdViews += this.createPersistentPortalViews(createdViewTypes, deadline);
+        },
+        detail: () => `created=${createdViews}`,
+      },
+      {
+        id: 'views.nearby',
+        category: 'views',
+        priority: 20,
+        required: true,
+        run: () => {
+        this.collectMissingViewCandidates(p, VIEW_PREWARM_RANGE_SQ, false);
+        candidateViews = this.viewCandidates.length;
+        const maxViews = this.lowGfx ? VIEW_PREWARM_MAX_VIEWS_LOW : VIEW_PREWARM_MAX_VIEWS_HIGH;
+        createdViews += this.createCandidateViews(Math.max(0, maxViews - createdViews), createdViewTypes, deadline);
+        },
+        detail: () => `created=${createdViews};candidates=${candidateViews}`,
+      },
+      {
+        id: 'props.dungeon-doors',
+        category: 'objects',
+        priority: 30,
+        required: true,
+        run: () => {
+        doorPrewarmGroup = this.buildDoorPrewarmGroup();
+          this.scene.add(doorPrewarmGroup);
+        },
+      },
+      {
+        id: 'entities.mob-archetypes',
+        category: 'entities',
+        priority: 35,
+        required: true,
+        run: () => {
+          entityPrewarmGroup = this.buildEntityPrewarmGroup();
+          this.scene.add(entityPrewarmGroup);
+        },
+        detail: () => `templates=${PREWARM_MOB_TEMPLATE_IDS.length};copies=${PREWARM_MOB_POOL_COPIES}`,
+      },
+      {
+        id: 'entities.player-archetypes',
+        category: 'entities',
+        priority: 37,
+        required: true,
+        run: () => {
+          const built = this.buildPlayerPrewarmGroup(deadline);
+          playerPrewarmGroup = built.group;
+          playerPrewarmVisuals = built.visualCount;
+          this.scene.add(playerPrewarmGroup);
+        },
+        detail: () => `classes=${ALL_CLASSES.length};skins=${prewarmPlayerSkinVariantCount()};visuals=${playerPrewarmVisuals}`,
+      },
+      {
+        id: 'objects.quest-archetypes',
+        category: 'objects',
+        priority: 40,
+        required: true,
+        run: () => {
+          objectPrewarmGroup = this.buildObjectPrewarmGroup();
+          this.scene.add(objectPrewarmGroup);
+        },
+        detail: () => `items=${PREWARM_OBJECT_ITEM_IDS.length};copies=${PREWARM_OBJECT_POOL_COPIES}`,
+      },
+      {
+        id: 'props.material-variants',
+        category: 'props',
+        priority: 45,
+        required: true,
+        run: () => {
+        propMaterialPrewarmGroup = buildPropMaterialPrewarmGroup();
+        propMaterialPrewarmGroup.position.set(p.pos.x, p.pos.y, p.pos.z - 18);
+        setRenderCategory(propMaterialPrewarmGroup, 'prewarm');
+        this.scene.add(propMaterialPrewarmGroup);
+        },
+        detail: () => `objects=${propMaterialPrewarmGroup?.children.length ?? 0}`,
+      },
+      {
+        id: 'textures.scene',
+        category: 'world',
+        priority: 50,
+        required: true,
+        run: () => {
+        textureUploads = this.prewarmObjectTextures(this.scene);
+        },
+        detail: () => `uploaded=${textureUploads}`,
+      },
+      {
+        id: 'vfx.atlas',
+        category: 'vfx',
+        priority: 60,
+        required: false,
+        run: () => {
+        const offsets = [
+          [0, -4],
+          [-3, -5],
+          [3, -5],
+          [0, -7],
+        ] as const;
+        for (const [dx, dz] of offsets) {
+          if (performance.now() >= deadline) break;
+          this.vfx.prewarm(new THREE.Vector3(p.pos.x + dx, p.pos.y + 1, p.pos.z + dz));
+          vfxPrewarmBursts++;
+        }
+        },
+        detail: () => `bursts=${vfxPrewarmBursts}`,
+      },
+      {
+        id: 'world.initial-frame',
+        category: 'world',
+        priority: 70,
+        required: true,
+        run: () => {
+        this.renderPrewarmPass(1 / 60);
+        renderPasses++;
+        },
+      },
+      {
+        id: 'programs.compile',
+        category: 'world',
+        priority: 80,
+        required: true,
+        run: async () => {
         const compileStart = performance.now();
         const compileBudgetMs = Math.max(0, deadline - compileStart);
         if (compileBudgetMs > 0 && this.webgl.compileAsync) {
@@ -1414,29 +1913,94 @@ export class Renderer {
           this.webgl.compile(this.scene, this.camera);
           compileMs = roundMs(performance.now() - compileStart);
         }
-        while (renderPasses < 2 && performance.now() < deadline) {
-          if (this.post) this.post.render();
-          else this.webgl.render(this.scene, this.camera);
+        },
+        detail: () => `mode=${compileMode};timedOut=${compileTimedOut}`,
+      },
+      {
+        id: 'sky.biome-variants',
+        category: 'sky',
+        priority: 90,
+        required: false,
+        run: () => {
+        const zs = [p.pos.z, ...ZONES.map((z) => z.zMax - 8), ...ZONES.map((z) => z.zMax + 8)]
+          .filter((z) => Number.isFinite(z) && z > WORLD_MIN_Z && z < WORLD_MAX_Z)
+          .slice(0, this.lowGfx ? 3 : 8);
+        for (const z of zs) {
+          if (performance.now() >= deadline) break;
+          this.skyView.setCameraZ(z, 1 / 20);
+          this.renderPrewarmPass(1 / 60);
           renderPasses++;
         }
+        },
+      },
+      {
+        id: 'render.settle-passes',
+        category: this.post ? 'post' : 'world',
+        priority: 100,
+        required: false,
+        run: () => {
+        const minPasses = this.lowGfx ? 8 : 10;
+        while (renderPasses < minPasses && performance.now() < deadline) {
+          this.renderPrewarmPass(1 / 60);
+          renderPasses++;
+        }
+        },
+        detail: () => `passes=${renderPasses}`,
+      },
+      {
+        id: 'diagnostics.baseline',
+        category: 'diagnostics',
+        priority: 110,
+        required: false,
+        run: () => {
+        diagnosticsBaseline = this.diagnosticsBaselineForPrewarm();
+        },
+      },
+    ];
+
+    try {
+      for (const entry of manifest) {
+        await runEntry(entry);
       }
     } finally {
-      this.scene.remove(doorPrewarmGroup);
-      this.scene.remove(archetypePrewarmGroup);
+      this.vfx.clear();
+      if (doorPrewarmGroup) this.scene.remove(doorPrewarmGroup);
+      if (entityPrewarmGroup) this.scene.remove(entityPrewarmGroup);
+      if (playerPrewarmGroup) this.scene.remove(playerPrewarmGroup);
+      if (objectPrewarmGroup) this.scene.remove(objectPrewarmGroup);
+      if (propMaterialPrewarmGroup) this.scene.remove(propMaterialPrewarmGroup);
     }
 
     const elapsed = performance.now() - started;
+    const finalCounts = this.prewarmCounts();
+    const manifestTimedOut = manifestEntries.filter((entry) => entry.status === 'timed-out');
+    const manifestFailed = manifestEntries.filter((entry) => entry.status === 'failed');
     const stats: RendererPrewarmStats = {
       elapsedMs: roundMs(elapsed),
       maxMs: roundMs(maxMs),
       createdViews,
       candidateViews,
       renderPasses,
+      programsBefore: startCounts.programs,
+      programsAfter: finalCounts.programs,
+      texturesBefore: startCounts.textures,
+      texturesAfter: finalCounts.textures,
       compileMode,
       compileMs,
       compileTimedOut,
       timedOut: elapsed >= maxMs,
+      remainingMs: roundMs(Math.max(0, deadline - performance.now())),
+      budgetUsedRatio: maxMs > 0 ? roundMs(elapsed / maxMs) : 1,
       createdViewTypes,
+      manifestPlanned: manifest.length,
+      manifestEntries,
+      manifestCompleted: manifestEntries.filter((entry) => entry.status === 'completed').length,
+      manifestSkipped: manifestEntries.filter((entry) => entry.status === 'skipped').length,
+      manifestTimedOut: manifestTimedOut.length,
+      manifestFailed: manifestFailed.length,
+      timedOutEntryIds: manifestTimedOut.map((entry) => entry.id),
+      failedEntryIds: manifestFailed.map((entry) => entry.id),
+      diagnosticsBaseline,
     };
     this.lastPrewarmStats = stats;
     return stats;
@@ -2277,12 +2841,34 @@ export class Renderer {
     for (const v of this.views.values()) {
       if (v.group.visible) visibleViews++;
     }
-    const renderDiagnostics = this.renderDiagnosticsForFrame(performance.now());
+    const afterSubmit = performance.now();
+    const renderDiagnostics = this.renderDiagnosticsForFrame(
+      afterSubmit,
+      framePhaseMs.submit >= RENDER_STALL_ATTRIBUTION_MS,
+    );
+    const qualityChange = this.lastQualityChange
+      ? {
+        ...this.lastQualityChange,
+        ageMs: roundMs(afterSubmit - this.lastQualityChange.atMs),
+      }
+      : null;
     this.lastFrameStats = {
       phaseMs: framePhaseMs,
       worldPhaseMs,
       foliage: this.foliage.perfStats(),
       renderDiagnostics,
+      cameraPosition: {
+        x: roundMs(this.camera.position.x),
+        y: roundMs(this.camera.position.y),
+        z: roundMs(this.camera.position.z),
+      },
+      playerPosition: {
+        x: roundMs(p.pos.x),
+        y: roundMs(p.pos.y),
+        z: roundMs(p.pos.z),
+      },
+      biome: zoneBiomeAt(p.pos.z),
+      lastQualityChange: qualityChange,
       createdViews,
       createdViewTypes,
       removedViews,
@@ -2307,9 +2893,10 @@ export class Renderer {
       const dx = entry.worldPos.x - px, dz = entry.worldPos.z - pz;
       entry.d2 = dx * dx + dz * dz;
     }
-    if (ranked.length > GFX.maxPointLights) ranked.sort((a, b) => a.d2 - b.d2);
+    const lightBudget = this.effectivePointLights || GFX.maxPointLights;
+    if (ranked.length > lightBudget) ranked.sort((a, b) => a.d2 - b.d2);
     for (let i = 0; i < ranked.length; i++) {
-      ranked[i].light.visible = i < GFX.maxPointLights && ranked[i].d2 < LIGHT_BUDGET_RANGE_SQ;
+      ranked[i].light.visible = i < lightBudget && ranked[i].d2 < LIGHT_BUDGET_RANGE_SQ;
     }
   }
 

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -3020,11 +3020,12 @@ export class Renderer {
       const urgent = id === p.targetId || d2 < 14 * 14 || e.castingAbility !== null;
       const isSelf = id === p.id;
       const hasOverheadEmote = !!(e.kind === 'player' && e.overheadEmoteId && !e.dead);
+      const deadForNameplate = isVisuallyDead(e);
       const isDoor = e.templateId === 'dungeon_door' || e.templateId === 'dungeon_exit';
       const hidden = (isSelf && !hasOverheadEmote) || d2 > NAMEPLATE_RANGE_SQ
-        || (e.dead && !e.lootable && e.kind === 'mob')
+        || (deadForNameplate && !e.lootable && e.kind === 'mob')
         || (e.kind === 'object' && !isDoor)
-        || (!this.showNameplates && e.kind === 'mob' && !e.dead);
+        || (!this.showNameplates && e.kind === 'mob' && !deadForNameplate);
       if (hidden) {
         if (v.nameplateDisplay !== 'none') {
           v.nameplate.style.display = 'none';
@@ -3119,11 +3120,11 @@ export class Renderer {
         const diff = e.level - p.level;
         const template = MOBS[e.templateId];
         const elite = !!template?.elite;
-        const color = e.dead ? '#999' : diff >= 3 ? '#ff4444' : diff >= 1 ? '#ffaa33' : diff >= -2 ? '#ffe97a' : diff >= -5 ? '#7fdc4f' : '#9d9d9d';
+        const color = deadForNameplate ? '#999' : diff >= 3 ? '#ff4444' : diff >= 1 ? '#ffaa33' : diff >= -2 ? '#ffe97a' : diff >= -5 ? '#7fdc4f' : '#9d9d9d';
         const mobName = e.ownerId !== null ? e.name : mobDisplayName(e.templateId);
-        const name = e.dead ? t('worldContent.corpseName', { name: mobName }) : `[${e.level}${elite ? '+' : ''}] ${mobName}`;
-        const hpDisplay = e.dead ? 'none' : '';
-        const marker = e.lootable ? '$' : elite && !e.dead ? '◆' : '';
+        const name = deadForNameplate ? t('worldContent.corpseName', { name: mobName }) : `[${e.level}${elite ? '+' : ''}] ${mobName}`;
+        const hpDisplay = deadForNameplate ? 'none' : '';
+        const marker = e.lootable ? '$' : elite && !deadForNameplate ? '◆' : '';
         this.setNameplateStatic(v, `mob|${name}|${color}|${hpDisplay}|${marker}`, name, color, hpDisplay, marker, 'np-marker loot', '1');
         this.setNameplateHp(v, e);
       }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1196,14 +1196,28 @@ export class Renderer {
     const p = this.sim.player;
     this.time += dt;
     sharedUniforms.uTime.value = this.time;
-    this.updateCamera(1, dt);
+    const selfPos = this.updateSelfRenderPosition(1, dt, 0);
+    this.updateCamera(selfPos, dt);
     this.updateAmbience(p.pos.x, this.camera.position.y, dt);
     this.budgetFireLights(p.pos.x, p.pos.z);
     this.waterView.update(this.time);
     const fogFar = (this.scene.fog as THREE.Fog).far;
     this.terrainView.update(this.camera.position.x, this.camera.position.z, fogFar);
-    this.propsView.update(this.camera.position.x, this.camera.position.y, this.camera.position.z, fogFar);
-    this.foliage.update(p.pos.x, p.pos.z, this.camera.position.x, this.camera.position.z, fogFar);
+    this.propsView.update(
+      this.camera.position.x, this.camera.position.y, this.camera.position.z,
+      this.cameraLookAt.x, this.cameraLookAt.y, this.cameraLookAt.z,
+      fogFar,
+    );
+    this.dungeons?.update(
+      this.camera.position.x, this.camera.position.y, this.camera.position.z,
+      this.cameraLookAt.x, this.cameraLookAt.y, this.cameraLookAt.z,
+    );
+    this.foliage.update(
+      p.pos.x, p.pos.z,
+      this.camera.position.x, this.camera.position.y, this.camera.position.z,
+      this.cameraLookAt.x, this.cameraLookAt.y, this.cameraLookAt.z,
+      fogFar,
+    );
     this.fish.update(p.pos.x, p.pos.z, dt);
     this.vfx.update(dt);
     const pv = this.views.get(p.id);
@@ -2010,11 +2024,12 @@ export class Renderer {
       const ea = e.id !== p.id && e.netUpdatedAt !== undefined && e.netInterval !== undefined
         ? Math.min(1.25, (now - e.netUpdatedAt) / Math.max(20, e.netInterval))
         : isSelf ? selfSnapshotAlpha(alpha, selfAlphaLead) : alpha;
-      const x = isSelf ? selfPos.x : e.prevPos.x + (e.pos.x - e.prevPos.x) * ea;
-      const y = isSelf ? selfPos.y : e.prevPos.y + (e.pos.y - e.prevPos.y) * ea;
-      const z = isSelf ? selfPos.z : e.prevPos.z + (e.pos.z - e.prevPos.z) * ea;
+      const renderPose = sim.renderPoseFor?.(e.id, ea, now) ?? null;
+      const x = renderPose ? renderPose.pos.x : isSelf ? selfPos.x : e.prevPos.x + (e.pos.x - e.prevPos.x) * ea;
+      const y = renderPose ? renderPose.pos.y : isSelf ? selfPos.y : e.prevPos.y + (e.pos.y - e.prevPos.y) * ea;
+      const z = renderPose ? renderPose.pos.z : isSelf ? selfPos.z : e.prevPos.z + (e.pos.z - e.prevPos.z) * ea;
       v.group.position.set(x, y, z);
-      let facing = e.prevFacing + shortestAngle(e.prevFacing, e.facing) * ea;
+      let facing = renderPose ? renderPose.facing : e.prevFacing + shortestAngle(e.prevFacing, e.facing) * ea;
       if (id === p.id && renderFacingOverride !== null) facing = renderFacingOverride;
       v.group.rotation.y = facing;
 
@@ -2192,7 +2207,7 @@ export class Renderer {
     this.vfx.update(dt);
     worldStart = markWorldPhase('vfx', worldStart);
 
-    this.updateCamera(selfPos, dt);
+    this.updateCamera(selfPos, dt, now);
     worldStart = markWorldPhase('camera', worldStart);
     // Fully-fogged terrain chunks / tree buckets are dropped before the
     // frustum; camera-ghost props hide against the current eye-to-camera ray.
@@ -2351,12 +2366,13 @@ export class Renderer {
     return this.selfRenderPosition;
   }
 
-  private updateCamera(selfPos: THREE.Vector3, dt: number): void {
+  private updateCamera(selfPos: THREE.Vector3, dt: number, now = performance.now()): void {
     const p = this.sim.player;
     const seed = this.sim.cfg.seed;
-    const px = selfPos.x;
-    const py = selfPos.y;
-    const pz = selfPos.z;
+    const renderPose = this.sim.renderPoseFor?.(p.id, 1, now) ?? null;
+    const px = renderPose ? renderPose.pos.x : selfPos.x;
+    const py = renderPose ? renderPose.pos.y : selfPos.y;
+    const pz = renderPose ? renderPose.pos.z : selfPos.z;
     const eyeY = py + 2.0;
     let cx = px - Math.sin(this.camYaw) * Math.cos(this.camPitch) * this.camDist;
     let cy = eyeY + Math.sin(this.camPitch) * this.camDist;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -23,9 +23,10 @@ import { buildComposer, PostPipeline } from './post';
 import { buildTerrain, TerrainView } from './terrain';
 import { buildWater, WaterView } from './water';
 import { buildClouds, buildSky, SkyView } from './sky';
-import { buildFoliage, FoliageView } from './foliage';
+import { buildFoliage, type FoliagePerfStats, type FoliageView } from './foliage';
 import { buildFish, FishView } from './fish';
 import { shouldRenderStealthGhost } from './stealth';
+import { RenderBudgetGovernor, type RenderBudgetState } from './render_budget';
 import { t } from '../ui/i18n';
 import { tEntity } from '../ui/entity_i18n';
 import { raidMarkerDataUrl } from '../ui/icons';
@@ -41,8 +42,17 @@ const emoteIconUrl = (id: string): string => `/ui/emotes/emote-${id}.png`;
 const ENTITY_DRAW_RANGE = 80;
 const ENTITY_VIEW_CREATE_RANGE_SQ = ENTITY_DRAW_RANGE * ENTITY_DRAW_RANGE;
 const ENTITY_VIEW_DESTROY_RANGE_SQ = 96 * 96;
-const VIEW_CREATE_BUDGET_LOW = 4;
-const VIEW_CREATE_BUDGET_HIGH = 16;
+const VIEW_CREATE_BUDGET_LOW = 2;
+const VIEW_CREATE_BUDGET_HIGH = 8;
+const VIEW_CREATE_SLOW_FRAME_MS = 33;
+const VIEW_CREATE_HITCH_FRAME_MS = 50;
+const VIEW_CREATE_BACKOFF_SECONDS = 0.75;
+const VIEW_PREWARM_RANGE_SQ = ENTITY_VIEW_CREATE_RANGE_SQ;
+const VIEW_PREWARM_MAX_MS = 5000;
+const VIEW_PREWARM_MAX_VIEWS_LOW = 48;
+const VIEW_PREWARM_MAX_VIEWS_HIGH = 72;
+const VIEW_CREATED_TYPE_SAMPLE_LIMIT = 24;
+const PERSISTENT_PORTAL_VIEW_PREWARM_LIMIT = 16;
 // rigs further than this stop casting articulated shadows (~7 draws each) and
 // hand off to a single-draw static-pose shadow proxy (the merged far-LOD mesh
 // with a colorWrite-off material) so mid-ground NPCs keep their grounding for
@@ -95,9 +105,117 @@ const DUNGEON_HEMI_INTENSITY = 0.22; // floor of readability — bosses crushed 
 // character rim glow scales up underground so silhouettes split from the murk
 const DUNGEON_RIM_BOOST = 2.4;
 const RENDERER_PHASE_SAMPLE_LIMIT = 720;
+const RENDER_DIAGNOSTICS_SAMPLE_MS = 2000;
+const RENDER_DIAGNOSTICS_IDLE_TIMEOUT_MS = 1000;
+const PREWARM_MOB_TEMPLATE_IDS = [
+  'forest_wolf',
+  'mudfin_murloc',
+  'restless_bones',
+  'old_greyjaw',
+  'mogger',
+] as const;
+const PREWARM_OBJECT_ITEM_IDS = [
+  'supply_crate',
+  'lost_caravan_goods',
+  'morthen_grimoire',
+  'gravecaller_sigil',
+  'weathered_ledger_page',
+] as const;
+const PREWARM_MOB_POOL_COPIES = 3;
+const PREWARM_OBJECT_POOL_COPIES = 2;
 
 type RendererPhase = 'setup' | 'entities' | 'world' | 'nameplates' | 'submit' | 'total';
+type RendererWorldPhase =
+  | 'lights'
+  | 'clouds'
+  | 'water'
+  | 'terrain'
+  | 'props'
+  | 'foliage'
+  | 'fish'
+  | 'vfx'
+  | 'camera'
+  | 'ambience'
+  | 'shadows'
+  | 'sky'
+  | 'sunSprites'
+  | 'godRays';
 type RendererPhaseStats = Record<RendererPhase, { count: number; avg: number; p95: number; max: number }>;
+type RendererFramePhaseMs = Record<RendererPhase, number>;
+type RendererWorldPhaseMs = Record<RendererWorldPhase, number>;
+type RenderDiagnosticsCategory = string;
+type RenderableDiagnosticObject = THREE.Object3D & {
+  isMesh?: boolean;
+  isInstancedMesh?: boolean;
+  isSkinnedMesh?: boolean;
+  isPoints?: boolean;
+  isSprite?: boolean;
+  isLine?: boolean;
+  isLineSegments?: boolean;
+  geometry?: THREE.BufferGeometry;
+  material?: THREE.Material | THREE.Material[];
+  count?: number;
+};
+interface ViewCandidate {
+  e: Entity;
+  d2: number;
+  priority: number;
+}
+
+export interface RenderDiagnosticsCategoryStats {
+  objects: number;
+  draws: number;
+  triangles: number;
+  points: number;
+  materials: number;
+  materialSamples: string[];
+}
+
+export interface RenderDiagnosticsSnapshot {
+  enabled: boolean;
+  totalObjects: number;
+  estimatedDraws: number;
+  estimatedTriangles: number;
+  estimatedPoints: number;
+  programs: number;
+  programDelta: number;
+  textures: number;
+  textureDelta: number;
+  newMaterials: string[];
+  firstVisibleObjects: string[];
+  categories: Record<RenderDiagnosticsCategory, RenderDiagnosticsCategoryStats>;
+}
+
+interface RendererFrameStats {
+  phaseMs: RendererFramePhaseMs;
+  worldPhaseMs: RendererWorldPhaseMs;
+  foliage: FoliagePerfStats;
+  renderDiagnostics: RenderDiagnosticsSnapshot;
+  createdViews: number;
+  createdViewTypes: string[];
+  removedViews: number;
+  candidateViews: number;
+  activeViews: number;
+  visibleViews: number;
+}
+
+export interface RendererPrewarmStats {
+  elapsedMs: number;
+  maxMs: number;
+  createdViews: number;
+  candidateViews: number;
+  renderPasses: number;
+  compileMode: 'async' | 'sync' | 'none';
+  compileMs: number;
+  compileTimedOut: boolean;
+  timedOut: boolean;
+  createdViewTypes: string[];
+}
+
+interface PooledObjectView {
+  group: THREE.Group;
+  height: number;
+}
 
 function selfSnapshotAlpha(alpha: number, lead: number): number {
   return Math.min(1.25, alpha + Math.max(0, lead));
@@ -107,6 +225,7 @@ interface EntityView {
   group: THREE.Group;
   /** rigged glTF visual for characters; null for object views (doors/crates) */
   visual: CharacterVisual | null;
+  visualPoolKey: string | null;
   sheepVisual: CharacterVisual | null; // polymorph form, built lazily
   bearVisual: CharacterVisual | null; // druid bear form, built lazily
   catVisual: CharacterVisual | null; // druid cat form, built lazily
@@ -133,6 +252,7 @@ interface EntityView {
   comboSig: string; // cheap-diff for the combo pip row
   sparkle?: THREE.Sprite; // ground objects
   objectMesh?: THREE.Object3D;
+  objectPoolKey: string | null;
   portal?: THREE.Mesh; // dungeon door swirl
   objectCasters: THREE.Object3D[]; // object-view shadow meshes, distance-gated
   shadowOn: boolean;
@@ -173,6 +293,107 @@ function summarizeMs(values: number[]): { count: number; avg: number; p95: numbe
     p95: roundMs(sorted[p95Idx]),
     max: roundMs(sorted[sorted.length - 1]),
   };
+}
+
+function emptyFramePhaseMs(): RendererFramePhaseMs {
+  return { setup: 0, entities: 0, world: 0, nameplates: 0, submit: 0, total: 0 };
+}
+
+function emptyWorldPhaseMs(): RendererWorldPhaseMs {
+  return {
+    lights: 0,
+    clouds: 0,
+    water: 0,
+    terrain: 0,
+    props: 0,
+    foliage: 0,
+    fish: 0,
+    vfx: 0,
+    camera: 0,
+    ambience: 0,
+    shadows: 0,
+    sky: 0,
+    sunSprites: 0,
+    godRays: 0,
+  };
+}
+
+function emptyFoliagePerfStats(): FoliagePerfStats {
+  return {
+    grassEnabled: false,
+    grassQuality: 0,
+    grassActiveRadius: 0,
+    grassChunks: 0,
+    grassReadyChunks: 0,
+    grassVisibleChunks: 0,
+    grassQueuedChunks: 0,
+    grassTufts: 0,
+    grassVisibleTufts: 0,
+    grassBuiltChunks: 0,
+    grassDisposedChunks: 0,
+    grassLastBuildMs: 0,
+    grassBuildMs: 0,
+    grassCacheLimit: 0,
+  };
+}
+
+function emptyRenderDiagnosticsSnapshot(): RenderDiagnosticsSnapshot {
+  return {
+    enabled: false,
+    totalObjects: 0,
+    estimatedDraws: 0,
+    estimatedTriangles: 0,
+    estimatedPoints: 0,
+    programs: 0,
+    programDelta: 0,
+    textures: 0,
+    textureDelta: 0,
+    newMaterials: [],
+    firstVisibleObjects: [],
+    categories: {},
+  };
+}
+
+function loopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1' || hostname === '[::1]';
+}
+
+function localRenderDiagnosticsEnabled(): boolean {
+  if (!import.meta.env.DEV) return false;
+  if (typeof location === 'undefined') return false;
+  if (!loopbackHostname(location.hostname)) return false;
+  const params = new URLSearchParams(location.search);
+  return params.get('perfTrace') === '1' || params.get('perf_trace') === '1' || params.get('renderTrace') === '1';
+}
+
+function setRenderCategory(obj: THREE.Object3D, category: RenderDiagnosticsCategory): void {
+  obj.userData.renderCategory = category;
+}
+
+function isPersistentPortalObject(e: Entity): boolean {
+  return e.kind === 'object' && (e.templateId === 'dungeon_door' || e.templateId === 'dungeon_exit');
+}
+
+function markSharedGeometry<T extends THREE.BufferGeometry>(geometry: T): T {
+  geometry.userData.sharedRendererResource = true;
+  return geometry;
+}
+
+function markSharedMaterial<T extends THREE.Material>(material: T): T {
+  material.userData.sharedRendererResource = true;
+  return material;
+}
+
+function isSharedGeometry(geometry: THREE.BufferGeometry): boolean {
+  return geometry.userData.sharedRendererResource === true;
+}
+
+function isSharedMaterial(material: THREE.Material): boolean {
+  return material.userData.sharedRendererResource === true;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, Math.max(0, ms)));
 }
 
 function mobDisplayName(mobId: string): string {
@@ -222,10 +443,12 @@ export class Renderer {
   private frameMsEma = 16.7;
   private adaptiveGrace = 2.0;
   private adaptiveCooldown = 0;
+  private viewCreateBackoff = 0;
   private stableFrameTime = 0;
+  private renderBudgetGovernor!: RenderBudgetGovernor;
   private baseExposure = 1.12; // tone-mapping exposure at brightness 1.0
   private tmpV = new THREE.Vector3();
-  private viewCandidates: { e: Entity; d2: number }[] = [];
+  private viewCandidates: ViewCandidate[] = [];
   private tmpV2 = new THREE.Vector3();
   private selfRenderPosition = new THREE.Vector3();
   private selfRenderPositionReady = false;
@@ -282,6 +505,29 @@ export class Renderer {
     submit: [],
     total: [],
   };
+  private lastFrameStats: RendererFrameStats = {
+    phaseMs: emptyFramePhaseMs(),
+    worldPhaseMs: emptyWorldPhaseMs(),
+    foliage: emptyFoliagePerfStats(),
+    renderDiagnostics: emptyRenderDiagnosticsSnapshot(),
+    createdViews: 0,
+    createdViewTypes: [],
+    removedViews: 0,
+    candidateViews: 0,
+    activeViews: 0,
+    visibleViews: 0,
+  };
+  private lastPrewarmStats: RendererPrewarmStats | null = null;
+  private readonly renderDiagnosticsEnabled = localRenderDiagnosticsEnabled();
+  private renderDiagnosticsSnapshot = emptyRenderDiagnosticsSnapshot();
+  private renderDiagnosticsNextSampleAt = 0;
+  private renderDiagnosticsSamplePending = false;
+  private renderDiagnosticsKnownMaterials = new Set<string>();
+  private renderDiagnosticsKnownVisibleObjects = new Set<string>();
+  private renderDiagnosticsLastPrograms = 0;
+  private renderDiagnosticsLastTextures = 0;
+  private visualPool = new Map<string, CharacterVisual[]>();
+  private objectPool = new Map<string, PooledObjectView[]>();
 
   constructor(private sim: IWorld, canvas: HTMLCanvasElement, nameplateLayer: HTMLDivElement) {
     this.nameplateLayer = nameplateLayer;
@@ -300,6 +546,8 @@ export class Renderer {
     // The lightweight material path does not preload HDR sky/water assets.
     // Keep the renderer's HDR/IBL branch aligned with that preload decision.
     this.lowGfx = !GFX.standardMaterials;
+    this.renderBudgetGovernor = new RenderBudgetGovernor({ tier: GFX.tier, budget: GFX.budget, enabled: GFX.autoGovernor });
+    this.renderBudgetGovernor.reset(this.effectiveRenderScale, this.renderBudgetMinScale(), this.renderBudgetMaxScale());
     const LOW_GFX = this.lowGfx;
     this.viewport = this.measureViewport();
     this.webgl.setPixelRatio(Math.min(window.devicePixelRatio, GFX.pixelRatioCap));
@@ -317,6 +565,7 @@ export class Renderer {
     // low keeps the legacy canvas-gradient dome.
     this.skyView = buildSky(LOW_GFX, SUN_ANCHOR);
     this.sky = this.skyView.dome;
+    setRenderCategory(this.sky, 'sky');
     this.scene.add(this.sky);
 
     // IBL: prefilter the real per-biome HDRI equirects so PBR materials get
@@ -395,6 +644,7 @@ export class Renderer {
         // would double up and wash out the sky
         opacity: scale === 190 && !LOW_GFX ? SUN_HALO_OPACITY : 1,
       }));
+      setRenderCategory(sp, 'sky');
       sp.scale.set(scale, scale, 1);
       sp.renderOrder = -9;
       this.sunSprites.push(sp);
@@ -429,6 +679,7 @@ export class Renderer {
           depthWrite: false, depthTest: false, blending: THREE.AdditiveBlending,
           rotation: 0.42 + i * 0.13,
         }));
+        setRenderCategory(sp, 'sky');
         sp.scale.set(26 + i * 16, 150 + i * 35, 1);
         sp.renderOrder = -8;
         this.godRays.push(sp);
@@ -439,20 +690,28 @@ export class Renderer {
     // clouds, spread over the whole zone strip (3 sprite variants + a faint
     // high cirrus layer on the full pipeline)
     for (const cl of buildClouds(LOW_GFX).sprites) {
+      setRenderCategory(cl, 'sky');
       this.clouds.push(cl);
       this.scene.add(cl);
     }
 
     this.terrainView = buildTerrain(this.sim.cfg.seed);
+    setRenderCategory(this.terrainView.group, 'terrain');
     this.scene.add(this.terrainView.group);
     this.waterView = buildWater(this.sim.cfg.seed);
-    for (const mesh of this.waterView.meshes) this.scene.add(mesh);
+    for (const mesh of this.waterView.meshes) {
+      setRenderCategory(mesh, 'water');
+      this.scene.add(mesh);
+    }
 
     this.foliage = buildFoliage(this.sim.cfg.seed);
+    setRenderCategory(this.foliage.group, 'foliage');
     this.scene.add(this.foliage.group);
     this.fish = buildFish(this.sim.cfg.seed);
+    setRenderCategory(this.fish.group, 'fish');
     this.scene.add(this.fish.group);
     const props = buildProps(this.sim.cfg.seed);
+    setRenderCategory(props.group, 'props');
     this.scene.add(props.group);
     this.flames = props.flames;
     this.fireLights = props.fireLights;
@@ -465,6 +724,7 @@ export class Renderer {
       ringGeo,
       new THREE.MeshBasicMaterial({ color: 0xd4af37, transparent: true, opacity: 0.9, depthWrite: false }),
     );
+    setRenderCategory(this.selectionRing, 'ui3d');
     this.selectionRing.visible = false;
     this.scene.add(this.selectionRing);
 
@@ -548,6 +808,11 @@ export class Renderer {
     this.adaptiveGrace = 1.0;
     this.adaptiveCooldown = 0.5;
     this.stableFrameTime = 0;
+    this.applyRenderBudgetState(this.renderBudgetGovernor.reset(
+      this.effectiveRenderScale,
+      this.renderBudgetMinScale(),
+      this.renderBudgetMaxScale(),
+    ));
     this.applyResolution();
   }
 
@@ -561,12 +826,30 @@ export class Renderer {
     return scale;
   }
 
+  private renderBudgetMinScale(): number {
+    const budget = GFX.budget;
+    return this.isMobileRuntime() ? budget.minRenderScaleMobile : budget.minRenderScaleDesktop;
+  }
+
+  private renderBudgetMaxScale(): number {
+    return Math.min(this.renderScale, GFX.budget.maxRenderScale);
+  }
+
+  private applyRenderBudgetState(state: RenderBudgetState): void {
+    const previousScale = this.effectiveRenderScale;
+    this.effectiveRenderScale = Math.min(this.renderBudgetMaxScale(), Math.max(this.renderBudgetMinScale(), state.levels.resolution));
+    this.foliage.setGrassQuality(state.levels.grass);
+    this.vfx.setQuality(state.levels.vfx);
+    if (Math.abs(previousScale - this.effectiveRenderScale) >= 0.001) this.applyResolution();
+  }
+
   perfStats(): {
     tier: string;
     autoGovernor: boolean;
     budget: typeof GFX.budget;
     renderScale: number;
     effectiveRenderScale: number;
+    renderBudget: RenderBudgetState;
     pixelRatio: number;
     width: number;
     height: number;
@@ -575,11 +858,15 @@ export class Renderer {
     textures: number;
     programs: number;
     views: number;
+    foliage: FoliagePerfStats;
     glVendor: string;
     glRenderer: string;
     contextLost: number;
     contextRestored: number;
     phaseMs: RendererPhaseStats;
+    renderDiagnostics: RenderDiagnosticsSnapshot;
+    lastFrame?: RendererFrameStats;
+    prewarm: RendererPrewarmStats | null;
   } {
     const info = this.webgl.info;
     return {
@@ -588,6 +875,7 @@ export class Renderer {
       budget: GFX.budget,
       renderScale: this.renderScale,
       effectiveRenderScale: this.effectiveRenderScale,
+      renderBudget: this.renderBudgetGovernor.state(),
       pixelRatio: this.webgl.getPixelRatio(),
       width: this.viewport.width,
       height: this.viewport.height,
@@ -596,11 +884,15 @@ export class Renderer {
       textures: info.memory.textures,
       programs: info.programs?.length ?? 0,
       views: this.views.size,
+      foliage: this.foliage.perfStats(),
       glVendor: this.glVendor,
       glRenderer: this.glRenderer,
       contextLost: this.contextLostCount,
       contextRestored: this.contextRestoredCount,
       phaseMs: this.rendererPhaseStats(),
+      renderDiagnostics: this.lastFrameStats.renderDiagnostics,
+      lastFrame: this.lastFrameStats,
+      prewarm: this.lastPrewarmStats,
     };
   }
 
@@ -622,45 +914,518 @@ export class Renderer {
     };
   }
 
+  private materialLabels(material: THREE.Material | THREE.Material[] | undefined): string[] {
+    const mats = Array.isArray(material) ? material : material ? [material] : [];
+    return mats.map((mat) => `${mat.name || mat.type}:${mat.uuid.slice(0, 8)}`);
+  }
+
+  private drawCountFor(material: THREE.Material | THREE.Material[] | undefined, geometry?: THREE.BufferGeometry): number {
+    if (!material) return 1;
+    if (Array.isArray(material)) return Math.max(1, geometry?.groups.length || material.length);
+    return Math.max(1, geometry?.groups.length && geometry.groups.length > 0 ? geometry.groups.length : 1);
+  }
+
+  private triangleCountFor(geometry?: THREE.BufferGeometry): number {
+    if (!geometry) return 0;
+    const drawCount = geometry.index?.count ?? geometry.getAttribute('position')?.count ?? 0;
+    return Math.max(0, Math.floor(drawCount / 3));
+  }
+
+  private objectDiagnosticLabel(obj: THREE.Object3D, category: string, materialLabels: string[]): string {
+    const name = obj.name || obj.type;
+    const material = materialLabels[0] ?? 'no-material';
+    return `${category}:${name}:${material}`.slice(0, 140);
+  }
+
+  private collectRenderDiagnostics(): RenderDiagnosticsSnapshot {
+    if (!this.renderDiagnosticsEnabled) return emptyRenderDiagnosticsSnapshot();
+    const info = this.webgl.info;
+    const programs = info.programs?.length ?? 0;
+    const textures = info.memory.textures;
+    const programDelta = programs - this.renderDiagnosticsLastPrograms;
+    const textureDelta = textures - this.renderDiagnosticsLastTextures;
+    this.renderDiagnosticsLastPrograms = programs;
+    this.renderDiagnosticsLastTextures = textures;
+
+    type MutableCategoryStats = RenderDiagnosticsCategoryStats & { materialKeys: Set<string> };
+    const categories: Record<string, MutableCategoryStats> = {};
+    const totals = { objects: 0, draws: 0, triangles: 0, points: 0 };
+    const newMaterials: string[] = [];
+    const firstVisibleObjects: string[] = [];
+    const categoryStats = (category: string): MutableCategoryStats => {
+      categories[category] ??= {
+        objects: 0,
+        draws: 0,
+        triangles: 0,
+        points: 0,
+        materials: 0,
+        materialSamples: [],
+        materialKeys: new Set<string>(),
+      };
+      return categories[category];
+    };
+    const visit = (obj: THREE.Object3D, inheritedCategory: string, inheritedVisible: boolean): void => {
+      const visible = inheritedVisible && obj.visible;
+      const category = typeof obj.userData.renderCategory === 'string'
+        ? obj.userData.renderCategory as string
+        : inheritedCategory;
+      if (visible) {
+        const renderable = obj as RenderableDiagnosticObject;
+        const hasMesh = Boolean(renderable.isMesh || renderable.isInstancedMesh || renderable.isSkinnedMesh);
+        const hasPoints = Boolean(renderable.isPoints);
+        const hasSprite = Boolean(renderable.isSprite);
+        const hasLine = Boolean(renderable.isLine || renderable.isLineSegments);
+        if (hasMesh || hasPoints || hasSprite || hasLine) {
+          const geometry = renderable.geometry;
+          const material = renderable.material;
+          const stat = categoryStats(category);
+          const labels = this.materialLabels(material);
+          const draws = this.drawCountFor(material, geometry);
+          let triangles = 0;
+          let pointCount = 0;
+          if (hasMesh) {
+            const instanceCount = renderable.isInstancedMesh ? Math.max(0, renderable.count ?? 0) : 1;
+            triangles = this.triangleCountFor(geometry) * instanceCount;
+          } else if (hasSprite) {
+            triangles = 2;
+          } else if (hasPoints) {
+            pointCount = geometry?.getAttribute('position')?.count ?? 0;
+          }
+          stat.objects++;
+          stat.draws += draws;
+          stat.triangles += triangles;
+          stat.points += pointCount;
+          totals.objects++;
+          totals.draws += draws;
+          totals.triangles += triangles;
+          totals.points += pointCount;
+          for (const label of labels) {
+            if (!stat.materialKeys.has(label)) {
+              stat.materialKeys.add(label);
+              if (stat.materialSamples.length < 8) stat.materialSamples.push(label);
+            }
+            if (!this.renderDiagnosticsKnownMaterials.has(label)) {
+              this.renderDiagnosticsKnownMaterials.add(label);
+              if (newMaterials.length < 16) newMaterials.push(label);
+            }
+          }
+          const visibleKey = `${category}|${obj.uuid}|${geometry?.uuid ?? ''}|${labels.join('|')}`;
+          if (!this.renderDiagnosticsKnownVisibleObjects.has(visibleKey)) {
+            this.renderDiagnosticsKnownVisibleObjects.add(visibleKey);
+            if (firstVisibleObjects.length < 16) firstVisibleObjects.push(this.objectDiagnosticLabel(obj, category, labels));
+          }
+        }
+      }
+      for (const child of obj.children) visit(child, category, visible);
+    };
+    visit(this.scene, 'unknown', true);
+
+    const outCategories: Record<string, RenderDiagnosticsCategoryStats> = {};
+    for (const [category, stat] of Object.entries(categories)) {
+      outCategories[category] = {
+        objects: stat.objects,
+        draws: stat.draws,
+        triangles: stat.triangles,
+        points: stat.points,
+        materials: stat.materialKeys.size,
+        materialSamples: stat.materialSamples,
+      };
+    }
+    return {
+      enabled: true,
+      totalObjects: totals.objects,
+      estimatedDraws: totals.draws,
+      estimatedTriangles: totals.triangles,
+      estimatedPoints: totals.points,
+      programs,
+      programDelta,
+      textures,
+      textureDelta,
+      newMaterials,
+      firstVisibleObjects,
+      categories: outCategories,
+    };
+  }
+
+  private renderDiagnosticsForFrame(now: number): RenderDiagnosticsSnapshot {
+    if (!this.renderDiagnosticsEnabled) return emptyRenderDiagnosticsSnapshot();
+    if (!this.renderDiagnosticsSamplePending && now >= this.renderDiagnosticsNextSampleAt) {
+      this.renderDiagnosticsSamplePending = true;
+      this.renderDiagnosticsNextSampleAt = now + RENDER_DIAGNOSTICS_SAMPLE_MS;
+      const run = (): void => {
+        try {
+          this.renderDiagnosticsSnapshot = this.collectRenderDiagnostics();
+        } finally {
+          this.renderDiagnosticsSamplePending = false;
+        }
+      };
+      const win = window as Window & {
+        requestIdleCallback?: (callback: () => void, options?: { timeout?: number }) => number;
+      };
+      if (win.requestIdleCallback) win.requestIdleCallback(run, { timeout: RENDER_DIAGNOSTICS_IDLE_TIMEOUT_MS });
+      else window.setTimeout(run, 100);
+    }
+    return this.renderDiagnosticsSnapshot;
+  }
+
   private updateAdaptiveResolution(dt: number): void {
     if (!Number.isFinite(dt) || dt <= 0) return;
-    if (!GFX.autoGovernor) return;
     const frameMs = Math.min(250, dt * 1000);
-    this.frameMsEma += (frameMs - this.frameMsEma) * 0.08;
-    if (this.adaptiveGrace > 0) {
-      this.adaptiveGrace -= dt;
-      return;
-    }
-    if (this.adaptiveCooldown > 0) {
-      this.adaptiveCooldown -= dt;
-      return;
-    }
+    const previousSubmitMs = this.lastFrameStats.phaseMs.submit;
+    const previousTotalMs = this.lastFrameStats.phaseMs.total;
+    const info = this.webgl.info;
+    // Do not let the live governor resize the drawing buffers during play.
+    // Three/WebGL can turn setSize/setPixelRatio into a large synchronous
+    // allocation on weak GPUs/software GL, which is worse than the pressure
+    // signal it is trying to fix. Manual render-scale changes still apply via
+    // setRenderScale(); the automatic governor keeps to grass/VFX budgets here.
+    const lockedRenderScale = this.effectiveRenderScale;
+    const state = this.renderBudgetGovernor.update({
+      dt,
+      frameMs,
+      totalMs: previousTotalMs,
+      submitMs: previousSubmitMs,
+      calls: info.render.calls,
+      triangles: info.render.triangles,
+      grassVisibleTufts: this.lastFrameStats.foliage.grassVisibleTufts,
+      grassVisibleChunks: this.lastFrameStats.foliage.grassVisibleChunks,
+      activeViews: this.lastFrameStats.activeViews,
+      createdViews: this.lastFrameStats.createdViews,
+      minRenderScale: lockedRenderScale,
+      maxRenderScale: lockedRenderScale,
+    });
+    this.frameMsEma = state.frameMsEma;
+    this.adaptiveCooldown = state.cooldownSeconds;
+    this.stableFrameTime = state.stableSeconds;
+    if (this.adaptiveGrace > 0) this.adaptiveGrace = Math.max(0, this.adaptiveGrace - dt);
+    this.applyRenderBudgetState(state);
+  }
 
-    const budget = GFX.budget;
-    const mobile = this.isMobileRuntime();
-    const minScale = mobile ? budget.minRenderScaleMobile : budget.minRenderScaleDesktop;
-    const maxScale = Math.min(this.renderScale, budget.maxRenderScale);
-
-    if (this.frameMsEma >= budget.dropFrameMs && this.effectiveRenderScale > minScale) {
-      const step = this.frameMsEma >= budget.urgentFrameMs ? budget.urgentDropStep : budget.dropStep;
-      this.effectiveRenderScale = Math.max(minScale, Math.round((this.effectiveRenderScale - step) * 100) / 100);
-      this.stableFrameTime = 0;
-      this.adaptiveCooldown = budget.cooldownSeconds;
-      this.applyResolution();
-      return;
+  private runtimeViewCreateBudget(dt: number): number {
+    const base = this.lowGfx ? VIEW_CREATE_BUDGET_LOW : VIEW_CREATE_BUDGET_HIGH;
+    if (!Number.isFinite(dt) || dt <= 0) return base;
+    const frameMs = Math.min(250, dt * 1000);
+    if (frameMs >= VIEW_CREATE_HITCH_FRAME_MS) this.viewCreateBackoff = VIEW_CREATE_BACKOFF_SECONDS;
+    if (this.viewCreateBackoff > 0) {
+      this.viewCreateBackoff = Math.max(0, this.viewCreateBackoff - dt);
+      return 1;
     }
+    if (frameMs >= VIEW_CREATE_SLOW_FRAME_MS || this.frameMsEma >= GFX.budget.dropFrameMs) {
+      return Math.max(1, Math.ceil(base / 2));
+    }
+    return base;
+  }
 
-    if (this.frameMsEma <= budget.recoverFrameMs && this.effectiveRenderScale < maxScale) {
-      this.stableFrameTime += dt;
-      if (this.stableFrameTime >= budget.recoverStableSeconds) {
-        this.effectiveRenderScale = Math.min(maxScale, Math.round((this.effectiveRenderScale + budget.recoverStep) * 100) / 100);
-        this.stableFrameTime = 0;
-        this.adaptiveCooldown = budget.cooldownSeconds * 1.5;
-        this.applyResolution();
+  private viewCandidatePriority(e: Entity, p: Entity, d2: number): number {
+    if (e.id === p.id) return -100;
+    if (e.id === p.targetId) return -90;
+    if (e.kind === 'mob' && e.hostile && d2 <= 35 * 35) return 0;
+    if (e.kind === 'npc' && d2 <= 45 * 45) return 1;
+    if (e.kind === 'object' && (e.lootable || isPersistentPortalObject(e))) return 2;
+    if (e.kind === 'player') return 3;
+    if (e.kind === 'mob' && e.hostile) return 4;
+    if (e.kind === 'mob') return 5;
+    if (e.kind === 'npc') return 6;
+    if (e.kind === 'object') return 7;
+    return 9;
+  }
+
+  private collectMissingViewCandidates(center: Entity, rangeSq: number, includeRequired: boolean): void {
+    this.viewCandidates.length = 0;
+    for (const e of this.sim.entities.values()) {
+      if (this.views.has(e.id)) continue;
+      const required = e.id === center.id || e.id === center.targetId;
+      if (required && !includeRequired) continue;
+      const d2 = distSqXZ(e, center);
+      if (!required && d2 > rangeSq) continue;
+      this.viewCandidates.push({ e, d2, priority: this.viewCandidatePriority(e, center, d2) });
+    }
+    if (this.viewCandidates.length > 1) {
+      this.viewCandidates.sort((a, b) => a.priority - b.priority || a.d2 - b.d2 || a.e.id - b.e.id);
+    }
+  }
+
+  private createdViewType(e: Entity): string {
+    const id = e.templateId || e.kind;
+    return `${e.kind}:${id}`.slice(0, 64);
+  }
+
+  private sampleCreatedViewType(into: string[], e: Entity): void {
+    if (into.length < VIEW_CREATED_TYPE_SAMPLE_LIMIT) into.push(this.createdViewType(e));
+  }
+
+  private createRequiredViews(player: Entity, createdViewTypes: string[]): number {
+    let created = 0;
+    const requiredIds = [player.id, player.targetId].filter((id): id is number => id !== null);
+    for (const id of requiredIds) {
+      const e = this.sim.entities.get(id);
+      if (!e || this.views.has(e.id)) continue;
+      this.createView(e);
+      this.sampleCreatedViewType(createdViewTypes, e);
+      created++;
+    }
+    return created;
+  }
+
+  private createPersistentPortalViews(createdViewTypes: string[], deadlineMs: number): number {
+    let created = 0;
+    for (const e of this.sim.entities.values()) {
+      if (created >= PERSISTENT_PORTAL_VIEW_PREWARM_LIMIT || performance.now() >= deadlineMs) break;
+      if (!isPersistentPortalObject(e) || this.views.has(e.id)) continue;
+      this.createView(e);
+      this.sampleCreatedViewType(createdViewTypes, e);
+      created++;
+    }
+    return created;
+  }
+
+  private createCandidateViews(limit: number, createdViewTypes: string[], deadlineMs = Infinity): number {
+    const max = Math.max(0, Math.floor(limit));
+    let created = 0;
+    for (const candidate of this.viewCandidates) {
+      if (created >= max || performance.now() >= deadlineMs) break;
+      if (this.views.has(candidate.e.id)) continue;
+      this.createView(candidate.e);
+      this.sampleCreatedViewType(createdViewTypes, candidate.e);
+      created++;
+    }
+    return created;
+  }
+
+  private prewarmWorldFrame(dt: number): void {
+    const p = this.sim.player;
+    this.time += dt;
+    sharedUniforms.uTime.value = this.time;
+    this.updateCamera(1, dt);
+    this.updateAmbience(p.pos.x, this.camera.position.y, dt);
+    this.budgetFireLights(p.pos.x, p.pos.z);
+    this.waterView.update(this.time);
+    const fogFar = (this.scene.fog as THREE.Fog).far;
+    this.terrainView.update(this.camera.position.x, this.camera.position.z, fogFar);
+    this.propsView.update(this.camera.position.x, this.camera.position.y, this.camera.position.z, fogFar);
+    this.foliage.update(p.pos.x, p.pos.z, this.camera.position.x, this.camera.position.z, fogFar);
+    this.fish.update(p.pos.x, p.pos.z, dt);
+    this.vfx.update(dt);
+    const pv = this.views.get(p.id);
+    if (pv) {
+      const pp = pv.group.position;
+      this.sun.position.set(pp.x + SUN_ANCHOR.x, pp.y + SUN_ANCHOR.y, pp.z + SUN_ANCHOR.z);
+      this.sun.target.position.set(pp.x, pp.y, pp.z);
+    }
+    this.sky.position.set(this.camera.position.x, 0, this.camera.position.z);
+    this.sky.visible = this.fogState === 'outdoor';
+    if (this.sky.visible) {
+      this.skyView.setCameraZ(this.camera.position.z, dt);
+      this.updateEnvBiome(dt);
+    }
+    for (const sp of this.sunSprites) {
+      sp.position.copy(this.camera.position).addScaledVector(this.sunDir, 760);
+      sp.visible = this.fogState === 'outdoor';
+    }
+    this.updateGodRays();
+    this.updateNameplates(true);
+    this.updateChatBubbles();
+  }
+
+  private prewarmEntity(kind: 'player' | 'mob', templateId: string, color: number, scale: number): Entity {
+    const p = this.sim.player;
+    return {
+      ...p,
+      id: -10_000,
+      kind,
+      templateId,
+      name: templateId,
+      level: 1,
+      pos: { ...p.pos },
+      prevPos: { ...p.pos },
+      facing: 0,
+      prevFacing: 0,
+      targetId: null,
+      auras: [],
+      hostile: kind === 'mob',
+      color,
+      scale,
+      skin: 0,
+      dead: false,
+      castingAbility: null,
+      overheadEmoteId: null,
+      overheadEmoteUntil: 0,
+      objectItemId: null,
+      lootable: false,
+      dungeonId: null,
+      ownerId: null,
+    };
+  }
+
+  private visualPoolKeyFor(e: Entity): string | null {
+    if (e.kind !== 'mob') return null;
+    return `mob:${e.templateId}:${e.color}:${e.scale}`;
+  }
+
+  private takePooledVisual(key: string): CharacterVisual | null {
+    const pool = this.visualPool.get(key);
+    const visual = pool?.pop() ?? null;
+    if (!visual) return null;
+    visual.root.removeFromParent();
+    visual.root.visible = true;
+    visual.root.position.set(0, 0, 0);
+    visual.root.rotation.set(0, 0, 0);
+    visual.root.scale.set(1, 1, 1);
+    visual.setFar(false);
+    visual.setGhost(false);
+    return visual;
+  }
+
+  private storePooledVisual(key: string, visual: CharacterVisual): void {
+    visual.root.removeFromParent();
+    visual.root.visible = false;
+    visual.root.position.set(0, 0, 0);
+    visual.root.rotation.set(0, 0, 0);
+    visual.root.scale.set(1, 1, 1);
+    let pool = this.visualPool.get(key);
+    if (!pool) {
+      pool = [];
+      this.visualPool.set(key, pool);
+    }
+    pool.push(visual);
+  }
+
+  private objectPoolKeyFor(e: Entity): string | null {
+    if (e.kind !== 'object' || !e.objectItemId) return null;
+    if (e.templateId === 'dungeon_door' || e.templateId === 'dungeon_exit') return null;
+    return `object:${e.objectItemId}`;
+  }
+
+  private takePooledObject(key: string): PooledObjectView | null {
+    const pool = this.objectPool.get(key);
+    const object = pool?.pop() ?? null;
+    if (!object) return null;
+    object.group.removeFromParent();
+    object.group.visible = true;
+    object.group.position.set(0, 0, 0);
+    object.group.rotation.set(0, 0, 0);
+    object.group.scale.set(1, 1, 1);
+    return object;
+  }
+
+  private storePooledObject(key: string, object: PooledObjectView): void {
+    object.group.removeFromParent();
+    object.group.visible = false;
+    object.group.position.set(0, 0, 0);
+    object.group.rotation.set(0, 0, 0);
+    object.group.scale.set(1, 1, 1);
+    let pool = this.objectPool.get(key);
+    if (!pool) {
+      pool = [];
+      this.objectPool.set(key, pool);
+    }
+    pool.push(object);
+  }
+
+  private buildArchetypePrewarmGroup(): THREE.Group {
+    const group = new THREE.Group();
+    const p = this.sim.player;
+    group.position.set(p.pos.x, p.pos.y, p.pos.z - 14);
+    setRenderCategory(group, 'prewarm');
+    let idx = 0;
+    const place = (obj: THREE.Object3D): void => {
+      obj.position.set(((idx % 6) - 2.5) * 3.2, 0, Math.floor(idx / 6) * 3.2);
+      group.add(obj);
+      idx++;
+    };
+    for (const templateId of PREWARM_MOB_TEMPLATE_IDS) {
+      const template = MOBS[templateId];
+      if (!template) continue;
+      for (let i = 0; i < PREWARM_MOB_POOL_COPIES; i++) {
+        const entity = this.prewarmEntity('mob', template.id, template.color, template.scale);
+        const visual = createCharacterVisual(entity);
+        const key = this.visualPoolKeyFor(entity);
+        if (key) this.storePooledVisual(key, visual);
+        visual.root.visible = true;
+        place(visual.root);
       }
-    } else {
-      this.stableFrameTime = 0;
     }
+    for (const itemId of PREWARM_OBJECT_ITEM_IDS) {
+      const key = `object:${itemId}`;
+      for (let i = 0; i < PREWARM_OBJECT_POOL_COPIES; i++) {
+        const built = buildGroundQuestObject(itemId, -20_000 - idx);
+        this.storePooledObject(key, built);
+        built.group.visible = true;
+        place(built.group);
+      }
+    }
+    return group;
+  }
+
+  async prewarmInitialScene(options: { maxMs?: number } = {}): Promise<RendererPrewarmStats> {
+    const maxMs = Math.max(0, options.maxMs ?? VIEW_PREWARM_MAX_MS);
+    const started = performance.now();
+    const deadline = started + maxMs;
+    const createdViewTypes: string[] = [];
+    const p = this.sim.player;
+    let createdViews = this.createRequiredViews(p, createdViewTypes);
+    createdViews += this.createPersistentPortalViews(createdViewTypes, deadline);
+    this.collectMissingViewCandidates(p, VIEW_PREWARM_RANGE_SQ, false);
+    const candidateViews = this.viewCandidates.length;
+    const maxViews = this.lowGfx ? VIEW_PREWARM_MAX_VIEWS_LOW : VIEW_PREWARM_MAX_VIEWS_HIGH;
+    createdViews += this.createCandidateViews(Math.max(0, maxViews - createdViews), createdViewTypes, deadline);
+    const doorPrewarmGroup = this.buildDoorPrewarmGroup();
+    const archetypePrewarmGroup = this.buildArchetypePrewarmGroup();
+    this.scene.add(doorPrewarmGroup);
+    this.scene.add(archetypePrewarmGroup);
+
+    let renderPasses = 0;
+    let compileMode: RendererPrewarmStats['compileMode'] = 'none';
+    let compileMs = 0;
+    let compileTimedOut = false;
+    try {
+      if (performance.now() < deadline) {
+        this.prewarmWorldFrame(1 / 60);
+        const compileStart = performance.now();
+        const compileBudgetMs = Math.max(0, deadline - compileStart);
+        if (compileBudgetMs > 0 && this.webgl.compileAsync) {
+          compileMode = 'async';
+          let settled = false;
+          const compilePromise = this.webgl.compileAsync(this.scene, this.camera)
+            .then(() => { settled = true; })
+            .catch((err: unknown) => {
+              settled = true;
+              console.warn('Renderer async prewarm compile failed', err);
+            });
+          await Promise.race([compilePromise, sleep(compileBudgetMs)]);
+          compileTimedOut = !settled;
+          compileMs = roundMs(performance.now() - compileStart);
+        } else if (compileBudgetMs > 0) {
+          compileMode = 'sync';
+          this.webgl.compile(this.scene, this.camera);
+          compileMs = roundMs(performance.now() - compileStart);
+        }
+        while (renderPasses < 2 && performance.now() < deadline) {
+          if (this.post) this.post.render();
+          else this.webgl.render(this.scene, this.camera);
+          renderPasses++;
+        }
+      }
+    } finally {
+      this.scene.remove(doorPrewarmGroup);
+      this.scene.remove(archetypePrewarmGroup);
+    }
+
+    const elapsed = performance.now() - started;
+    const stats: RendererPrewarmStats = {
+      elapsedMs: roundMs(elapsed),
+      maxMs: roundMs(maxMs),
+      createdViews,
+      candidateViews,
+      renderPasses,
+      compileMode,
+      compileMs,
+      compileTimedOut,
+      timedOut: elapsed >= maxMs,
+      createdViewTypes,
+    };
+    this.lastPrewarmStats = stats;
+    return stats;
   }
 
   // Visual reactions to sim events (called by the HUD for every event,
@@ -702,90 +1467,165 @@ export class Renderer {
   // Shared object-view resources: views must not own materials/textures, or
   // interest churn leaks them (removeView only disposes per-view geometry).
   private doorStoneMat: THREE.Material | null = null;
-  private doorMineRockMat: THREE.Material | null = null;
-  private doorMineWoodMat: THREE.Material | null = null;
-  private doorMineDarkMat: THREE.Material | null = null;
-  private doorLanternMat: THREE.Material | null = null;
+  private doorArchGeo: THREE.BufferGeometry | null = null;
+  private doorKeystoneGeo: THREE.BufferGeometry | null = null;
+  private doorPlinthGeo: THREE.BufferGeometry | null = null;
+  private doorPortalGeo: THREE.BufferGeometry | null = null;
+  private doorNythraxisClickGeo: THREE.BufferGeometry | null = null;
+  private doorNythraxisClickMat: THREE.MeshBasicMaterial | null = null;
+  private doorEntrancePortalMat: THREE.MeshBasicMaterial | null = null;
+  private doorExitPortalMat: THREE.MeshBasicMaterial | null = null;
   private sparkleMat: THREE.SpriteMaterial | null = null;
+
+  private doorStoneMaterial(): THREE.Material {
+    this.doorStoneMat ??= markSharedMaterial(new THREE.MeshLambertMaterial({ color: 0x6a6a72 }));
+    return this.doorStoneMat;
+  }
+
+  private doorArchGeometry(): THREE.BufferGeometry {
+    if (!this.doorArchGeo) {
+      const outer = new THREE.Shape();
+      outer.moveTo(-2.1, 0);
+      outer.lineTo(-2.1, 3.1);
+      outer.quadraticCurveTo(-2.1, 4.85, 0, 5.05);
+      outer.quadraticCurveTo(2.1, 4.85, 2.1, 3.1);
+      outer.lineTo(2.1, 0);
+      outer.closePath();
+      const inner = new THREE.Path();
+      inner.moveTo(-1.3, -0.5);
+      inner.lineTo(-1.3, 2.9);
+      inner.quadraticCurveTo(-1.3, 4.05, 0, 4.22);
+      inner.quadraticCurveTo(1.3, 4.05, 1.3, 2.9);
+      inner.lineTo(1.3, -0.5);
+      inner.closePath();
+      outer.holes.push(inner);
+      const archGeo = new THREE.ExtrudeGeometry(outer, {
+        depth: 0.7, bevelEnabled: true, bevelThickness: 0.07, bevelSize: 0.07, bevelSegments: 1,
+      });
+      archGeo.translate(0, 0, -0.35);
+      this.doorArchGeo = markSharedGeometry(archGeo);
+    }
+    return this.doorArchGeo;
+  }
+
+  private doorKeystoneGeometry(): THREE.BufferGeometry {
+    this.doorKeystoneGeo ??= markSharedGeometry(new THREE.BoxGeometry(0.7, 1.0, 0.95));
+    return this.doorKeystoneGeo;
+  }
+
+  private doorPlinthGeometry(): THREE.BufferGeometry {
+    this.doorPlinthGeo ??= markSharedGeometry(new THREE.BoxGeometry(1.15, 0.7, 1.15));
+    return this.doorPlinthGeo;
+  }
+
+  private doorPortalGeometry(): THREE.BufferGeometry {
+    this.doorPortalGeo ??= markSharedGeometry(new THREE.CircleGeometry(1.55, 24));
+    return this.doorPortalGeo;
+  }
+
+  private doorNythraxisClickGeometry(): THREE.BufferGeometry {
+    this.doorNythraxisClickGeo ??= markSharedGeometry(new THREE.BoxGeometry(4.6, 4.2, 2.4));
+    return this.doorNythraxisClickGeo;
+  }
+
+  private doorNythraxisClickMaterial(): THREE.MeshBasicMaterial {
+    this.doorNythraxisClickMat ??= markSharedMaterial(new THREE.MeshBasicMaterial({
+      color: 0x000000, transparent: true, opacity: 0.001, depthWrite: false,
+    }));
+    return this.doorNythraxisClickMat;
+  }
+
+  private doorPortalMaterial(entering: boolean): THREE.MeshBasicMaterial {
+    const tint = entering ? 0x9a5df0 : 0x6ab8ff;
+    const existing = entering ? this.doorEntrancePortalMat : this.doorExitPortalMat;
+    if (existing) return existing;
+    const material = markSharedMaterial(new THREE.MeshBasicMaterial({
+      color: tint, transparent: true, opacity: 0.55, side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending, depthWrite: false,
+    }));
+    if (!this.lowGfx) material.color.multiplyScalar(PORTAL_BOOST);
+    if (entering) this.doorEntrancePortalMat = material;
+    else this.doorExitPortalMat = material;
+    return material;
+  }
+
+  private buildDoorBody(entering: boolean, dungeonId?: string | null): { body: THREE.Group; portal?: THREE.Mesh } {
+    const body = new THREE.Group();
+    if (entering && dungeonId === 'nythraxis_crypt') {
+      const clickBox = new THREE.Mesh(this.doorNythraxisClickGeometry(), this.doorNythraxisClickMaterial());
+      clickBox.position.y = 2.1;
+      body.add(clickBox);
+      return { body };
+    }
+
+    const stone = this.doorStoneMaterial();
+    const arch = new THREE.Mesh(this.doorArchGeometry(), stone);
+    arch.castShadow = true;
+    body.add(arch);
+    const keystone = new THREE.Mesh(this.doorKeystoneGeometry(), stone);
+    keystone.position.set(0, 4.75, 0);
+    keystone.castShadow = true;
+    body.add(keystone);
+    for (const sx of [-1.7, 1.7]) {
+      const plinth = new THREE.Mesh(this.doorPlinthGeometry(), stone);
+      plinth.position.set(sx, 0.35, 0);
+      plinth.castShadow = true;
+      body.add(plinth);
+    }
+    const portal = new THREE.Mesh(this.doorPortalGeometry(), this.doorPortalMaterial(entering));
+    portal.position.y = 2.15;
+    portal.scale.set(1, 1.35, 1);
+    body.add(portal);
+    return { body, portal };
+  }
+
+  private buildDoorPrewarmGroup(): THREE.Group {
+    const group = new THREE.Group();
+    const entrance = this.buildDoorBody(true).body;
+    entrance.position.x = -3;
+    group.add(entrance);
+    const exit = this.buildDoorBody(false).body;
+    exit.position.x = 3;
+    group.add(exit);
+    const p = this.sim.player;
+    group.position.set(p.pos.x, p.pos.y, p.pos.z - 8);
+    setRenderCategory(group, 'entity:object');
+    return group;
+  }
 
   private createView(e: Entity): void {
     const group = new THREE.Group();
+    setRenderCategory(group, `entity:${e.kind}`);
     let visual: CharacterVisual | null = null;
     let body: THREE.Group | null = null; // object views build meshes into this
     let height = 1.2;
     let sparkle: THREE.Sprite | undefined;
     let objectMesh: THREE.Object3D | undefined;
+    let visualPoolKey: string | null = null;
+    let objectPoolKey: string | null = null;
     const isQuestVision = e.kind === 'mob' && e.templateId.startsWith('vision_');
 
     let portal: THREE.Mesh | undefined;
     if (e.kind === 'object' && (e.templateId === 'dungeon_door' || e.templateId === 'dungeon_exit')) {
-      // dungeon doorway: stone arch with a swirling portal
       const entering = e.templateId === 'dungeon_door';
-      const tint = entering ? 0x9a5df0 : 0x6ab8ff;
-      body = new THREE.Group();
+      const built = this.buildDoorBody(entering, e.dungeonId);
+      body = built.body;
+      portal = built.portal;
       height = 4.6;
-      this.doorStoneMat ??= new THREE.MeshLambertMaterial({ color: 0x6a6a72 });
-      const stone = this.doorStoneMat;
-      if (entering && e.dungeonId === 'nythraxis_crypt') {
-        const clickMat = new THREE.MeshBasicMaterial({
-          color: 0x000000, transparent: true, opacity: 0.001, depthWrite: false,
-        });
-        const clickBox = new THREE.Mesh(new THREE.BoxGeometry(4.6, 4.2, 2.4), clickMat);
-        clickBox.position.y = 2.1;
-        body!.add(clickBox);
-      } else {
-        // carved stone arch: pointed outer/inner outline + keystone + plinths
-        // (no raw pillar-and-lintel boxes)
-        const outer = new THREE.Shape();
-        outer.moveTo(-2.1, 0);
-        outer.lineTo(-2.1, 3.1);
-        outer.quadraticCurveTo(-2.1, 4.85, 0, 5.05);
-        outer.quadraticCurveTo(2.1, 4.85, 2.1, 3.1);
-        outer.lineTo(2.1, 0);
-        outer.closePath();
-        const inner = new THREE.Path();
-        inner.moveTo(-1.3, -0.5);
-        inner.lineTo(-1.3, 2.9);
-        inner.quadraticCurveTo(-1.3, 4.05, 0, 4.22);
-        inner.quadraticCurveTo(1.3, 4.05, 1.3, 2.9);
-        inner.lineTo(1.3, -0.5);
-        inner.closePath();
-        outer.holes.push(inner);
-        const archGeo = new THREE.ExtrudeGeometry(outer, {
-          depth: 0.7, bevelEnabled: true, bevelThickness: 0.07, bevelSize: 0.07, bevelSegments: 1,
-        });
-        archGeo.translate(0, 0, -0.35);
-        const arch = new THREE.Mesh(archGeo, stone);
-        arch.castShadow = true;
-        body!.add(arch);
-        const keystone = new THREE.Mesh(new THREE.BoxGeometry(0.7, 1.0, 0.95), stone);
-        keystone.position.set(0, 4.75, 0);
-        keystone.castShadow = true;
-        body!.add(keystone);
-        for (const sx of [-1.7, 1.7]) {
-          const plinth = new THREE.Mesh(new THREE.BoxGeometry(1.15, 0.7, 1.15), stone);
-          plinth.position.set(sx, 0.35, 0);
-          plinth.castShadow = true;
-          body!.add(plinth);
-        }
-        const portalMat = new THREE.MeshBasicMaterial({
-          color: tint, transparent: true, opacity: 0.55, side: THREE.DoubleSide,
-          blending: THREE.AdditiveBlending, depthWrite: false,
-        });
-        if (!this.lowGfx) portalMat.color.multiplyScalar(PORTAL_BOOST); // HDR swirl -> bloom
-        portal = new THREE.Mesh(new THREE.CircleGeometry(1.55, 24), portalMat);
-        portal.position.y = 2.15;
-        portal.scale.set(1, 1.35, 1);
-        body!.add(portal);
-        const glow = new THREE.PointLight(tint, 9, 15, 2);
-        glow.position.y = 2.4;
-        body!.add(glow);
-      }
       objectMesh = body!;
     } else if (e.kind === 'object') {
-      const built = buildGroundQuestObject(e.objectItemId ?? '', e.id);
-      body = built.group;
-      height = built.height;
+      objectPoolKey = this.objectPoolKeyFor(e);
+      const pooled = objectPoolKey ? this.takePooledObject(objectPoolKey) : null;
+      if (pooled) {
+        body = pooled.group;
+        height = pooled.height;
+        body.rotation.y = (e.id % 7) * 0.45;
+      } else {
+        const built = buildGroundQuestObject(e.objectItemId ?? '', e.id);
+        body = built.group;
+        height = built.height;
+        objectPoolKey = null;
+      }
       objectMesh = body!;
       if (!this.sparkleMat) {
         this.sparkleMat = new THREE.SpriteMaterial({ map: sparkleTexture(), transparent: true, depthWrite: false });
@@ -796,7 +1636,12 @@ export class Renderer {
       sparkle.position.y = 1.35;
       group.add(sparkle);
     } else {
-      visual = createCharacterVisual(e);
+      visualPoolKey = this.visualPoolKeyFor(e);
+      visual = visualPoolKey ? this.takePooledVisual(visualPoolKey) : null;
+      if (!visual) {
+        visual = createCharacterVisual(e);
+        visualPoolKey = null;
+      }
       visual.root.scale.multiplyScalar(e.scale);
       group.add(visual.root);
       height = visual.height;
@@ -864,8 +1709,8 @@ export class Renderer {
     const objectCasters: THREE.Object3D[] = [];
     if (!visual) collectCasters(group, objectCasters);
     this.views.set(e.id, {
-      group, visual, sheepVisual: null, bearVisual: null, catVisual: null, height, clickTarget,
-      nameplate: np, nameEl, hpBar, hpFill, emoteEl, emoteIconEl, emoteLabelEl, markerEl: marker, raidMarkEl: raidMark, comboRow, comboPips, sparkle, objectMesh, portal,
+      group, visual, visualPoolKey, sheepVisual: null, bearVisual: null, catVisual: null, height, clickTarget,
+      nameplate: np, nameEl, hpBar, hpFill, emoteEl, emoteIconEl, emoteLabelEl, markerEl: marker, raidMarkEl: raidMark, comboRow, comboPips, sparkle, objectMesh, objectPoolKey, portal,
       nameplateDisplay: 'none', nameplateTransform: '', nameplateSig: '', nameplateHpWidth: '', comboSig: '',
       objectCasters, shadowOn: true, isFar: false, lastOverheadEmoteKey: null,
       lastX: e.pos.x, lastZ: e.pos.z, skin: e.skin,
@@ -1038,19 +1883,23 @@ export class Renderer {
     if (v.visual) {
       // Character geometry/materials are shared per-asset caches and must
       // survive interest churn — dispose only per-instance mixer bindings.
-      v.visual.dispose();
+      if (v.visualPoolKey) this.storePooledVisual(v.visualPoolKey, v.visual);
+      else v.visual.dispose();
       v.sheepVisual?.dispose();
       v.bearVisual?.dispose();
       v.catVisual?.dispose();
     } else {
-      // Object views (door arch, loot crates) own their geometries; their
-      // materials are shared caches (door stone / crate planks / sparkle) and
-      // must survive. The per-view portal swirl material is owned here.
-      v.group.traverse((o) => {
-        const mesh = o as THREE.Mesh;
-        if (mesh.isMesh) mesh.geometry.dispose();
-      });
-      if (v.portal) (v.portal.material as THREE.Material).dispose();
+      if (v.objectPoolKey && v.objectMesh instanceof THREE.Group) {
+        this.storePooledObject(v.objectPoolKey, { group: v.objectMesh, height: v.height });
+      } else {
+        // Object views usually own their geometries. Door portal resources are
+        // shared and prewarmed, so they must survive interest churn.
+        v.group.traverse((o) => {
+          const mesh = o as THREE.Mesh;
+          if (mesh.isMesh && !isSharedGeometry(mesh.geometry)) mesh.geometry.dispose();
+        });
+        if (v.portal && !isSharedMaterial(v.portal.material as THREE.Material)) (v.portal.material as THREE.Material).dispose();
+      }
     }
     this.views.delete(id);
   }
@@ -1058,10 +1907,22 @@ export class Renderer {
   sync(alpha: number, dt: number, renderFacingOverride: number | null, selfAlphaLead = 0): void {
     const totalStart = performance.now();
     let phaseStart = totalStart;
+    const framePhaseMs = emptyFramePhaseMs();
+    const worldPhaseMs = emptyWorldPhaseMs();
+    let createdViews = 0;
+    let removedViews = 0;
+    const createdViewTypes: string[] = [];
     const markPhase = (phase: RendererPhase): void => {
       const t = performance.now();
-      this.recordRendererPhase(phase, t - phaseStart);
+      const ms = t - phaseStart;
+      framePhaseMs[phase] = roundMs(ms);
+      this.recordRendererPhase(phase, ms);
       phaseStart = t;
+    };
+    const markWorldPhase = (phase: RendererWorldPhase, start: number): number => {
+      const t = performance.now();
+      worldPhaseMs[phase] += roundMs(t - start);
+      return t;
     };
 
     this.updateAdaptiveResolution(dt);
@@ -1084,30 +1945,20 @@ export class Renderer {
     // dynamic worlds: create nearby views lazily and drop views for leavers or
     // entities that moved well outside the draw band. This avoids building
     // rig/nameplate DOM for the whole sim on the first rendered frame.
-    let createBudget = this.lowGfx ? VIEW_CREATE_BUDGET_LOW : VIEW_CREATE_BUDGET_HIGH;
-    this.viewCandidates.length = 0;
-    for (const e of sim.entities.values()) {
-      if (this.views.has(e.id)) continue;
-      const required = e.id === p.id || e.id === p.targetId;
-      if (required) {
-        this.createView(e);
-      } else {
-        const d2 = distSqXZ(e, p);
-        if (d2 <= ENTITY_VIEW_CREATE_RANGE_SQ) this.viewCandidates.push({ e, d2 });
-      }
-    }
-    if (this.viewCandidates.length > 1) this.viewCandidates.sort((a, b) => a.d2 - b.d2);
-    for (let i = 0; i < this.viewCandidates.length && createBudget > 0; i++, createBudget--) {
-      this.createView(this.viewCandidates[i].e);
-    }
+    createdViews += this.createRequiredViews(p, createdViewTypes);
+    this.collectMissingViewCandidates(p, ENTITY_VIEW_CREATE_RANGE_SQ, false);
+    createdViews += this.createCandidateViews(this.runtimeViewCreateBudget(dt), createdViewTypes);
     this.doomedIds.length = 0;
     for (const id of this.views.keys()) {
       const e = sim.entities.get(id);
-      if (!e || (id !== p.id && id !== p.targetId && distSqXZ(e, p) > ENTITY_VIEW_DESTROY_RANGE_SQ)) {
+      if (!e || (!isPersistentPortalObject(e) && id !== p.id && id !== p.targetId && distSqXZ(e, p) > ENTITY_VIEW_DESTROY_RANGE_SQ)) {
         this.doomedIds.push(id);
       }
     }
-    for (const id of this.doomedIds) this.removeView(id);
+    for (const id of this.doomedIds) {
+      this.removeView(id);
+      removedViews++;
+    }
 
     // frame parity for distance-tiered mixer throttling
     this.frameIdx = (this.frameIdx + 1) & 0xffff;
@@ -1168,7 +2019,8 @@ export class Renderer {
       v.group.rotation.y = facing;
 
       if (e.kind === 'object') {
-        const vis = e.lootable;
+        const isPortalObject = isPersistentPortalObject(e);
+        const vis = e.lootable && (!isPortalObject || d2 <= ENTITY_VIEW_CREATE_RANGE_SQ);
         v.group.visible = vis;
         if (v.sparkle && vis) {
           // sub-pixel beyond ~45u but still a full transparent draw each
@@ -1297,6 +2149,8 @@ export class Renderer {
     }
     markPhase('entities');
 
+    let worldStart = performance.now();
+
     // fire flicker + rising embers
     for (let i = 0; i < this.flames.length; i++) {
       const f = this.flames[i];
@@ -1314,6 +2168,7 @@ export class Renderer {
       light.intensity = base + Math.sin(this.time * 11 + i * 1.7) * 2.5 * (base / 11);
     }
     this.budgetFireLights(p.pos.x, p.pos.z);
+    worldStart = markWorldPhase('lights', worldStart);
 
     // clouds drift (the high cirrus layer crawls slower); on the lit tiers
     // they tint warm sunward / cool anti-sun to anchor the key light's azimuth
@@ -1329,16 +2184,21 @@ export class Renderer {
         );
       }
     }
+    worldStart = markWorldPhase('clouds', worldStart);
 
     // water shimmer (low-tier texture scroll; shader water rides uTime)
     this.waterView.update(this.time);
+    worldStart = markWorldPhase('water', worldStart);
     this.vfx.update(dt);
+    worldStart = markWorldPhase('vfx', worldStart);
 
     this.updateCamera(selfPos, dt);
+    worldStart = markWorldPhase('camera', worldStart);
     // Fully-fogged terrain chunks / tree buckets are dropped before the
     // frustum; camera-ghost props hide against the current eye-to-camera ray.
     const fogFar = (this.scene.fog as THREE.Fog).far;
     this.terrainView.update(this.camera.position.x, this.camera.position.z, fogFar);
+    worldStart = markWorldPhase('terrain', worldStart);
     this.propsView.update(
       this.camera.position.x, this.camera.position.y, this.camera.position.z,
       this.cameraLookAt.x, this.cameraLookAt.y, this.cameraLookAt.z,
@@ -1348,15 +2208,18 @@ export class Renderer {
       this.camera.position.x, this.camera.position.y, this.camera.position.z,
       this.cameraLookAt.x, this.cameraLookAt.y, this.cameraLookAt.z,
     );
+    worldStart = markWorldPhase('props', worldStart);
     this.foliage.update(
       p.pos.x, p.pos.z,
       this.camera.position.x, this.camera.position.y, this.camera.position.z,
       this.cameraLookAt.x, this.cameraLookAt.y, this.cameraLookAt.z,
       fogFar,
     );
+    worldStart = markWorldPhase('foliage', worldStart);
     this.fish.update(p.pos.x, p.pos.z, dt);
-
+    worldStart = markWorldPhase('fish', worldStart);
     this.updateAmbience(p.pos.x, this.camera.position.y, dt);
+    worldStart = markWorldPhase('ambience', worldStart);
     // shadow frustum follows the player
     const pv = this.views.get(p.id);
     if (pv) {
@@ -1364,6 +2227,7 @@ export class Renderer {
       this.sun.position.set(pp.x + SUN_ANCHOR.x, pp.y + SUN_ANCHOR.y, pp.z + SUN_ANCHOR.z);
       this.sun.target.position.set(pp.x, pp.y, pp.z);
     }
+    worldStart = markWorldPhase('shadows', worldStart);
     // sky dome + sun disc ride along with the camera
     this.sky.position.set(this.camera.position.x, 0, this.camera.position.z);
     this.sky.visible = this.fogState === 'outdoor';
@@ -1371,11 +2235,14 @@ export class Renderer {
       this.skyView.setCameraZ(this.camera.position.z, dt);
       this.updateEnvBiome(dt);
     }
+    worldStart = markWorldPhase('sky', worldStart);
     for (const sp of this.sunSprites) {
       sp.position.copy(this.camera.position).addScaledVector(this.sunDir, 760);
       sp.visible = this.fogState === 'outdoor';
     }
+    worldStart = markWorldPhase('sunSprites', worldStart);
     this.updateGodRays();
+    worldStart = markWorldPhase('godRays', worldStart);
     markPhase('world');
 
     this.nameplateTimer += dt;
@@ -1388,7 +2255,26 @@ export class Renderer {
     if (this.post) this.post.render();
     else this.webgl.render(this.scene, this.camera);
     markPhase('submit');
-    this.recordRendererPhase('total', performance.now() - totalStart);
+    const totalMs = performance.now() - totalStart;
+    framePhaseMs.total = roundMs(totalMs);
+    this.recordRendererPhase('total', totalMs);
+    let visibleViews = 0;
+    for (const v of this.views.values()) {
+      if (v.group.visible) visibleViews++;
+    }
+    const renderDiagnostics = this.renderDiagnosticsForFrame(performance.now());
+    this.lastFrameStats = {
+      phaseMs: framePhaseMs,
+      worldPhaseMs,
+      foliage: this.foliage.perfStats(),
+      renderDiagnostics,
+      createdViews,
+      createdViewTypes,
+      removedViews,
+      candidateViews: this.viewCandidates.length,
+      activeViews: this.views.size,
+      visibleViews,
+    };
   }
 
   // Forward-renderer point-light budget: every campfire/torch light exists,

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -227,6 +227,34 @@ export class Vfx {
     this.quality = Math.min(1, Math.max(0, Number.isFinite(level) ? level : 1));
   }
 
+  prewarm(at: THREE.Vector3): void {
+    const sprites = Object.values(SPR);
+    for (let i = 0; i < sprites.length; i++) {
+      const a = (i / sprites.length) * Math.PI * 2;
+      this.spawn(
+        at.x + Math.sin(a) * 1.2, at.y + 0.6 + (i % 4) * 0.25, at.z + Math.cos(a) * 1.2,
+        0, 0, 0,
+        i % 3 === 0 ? 0xffd28a : i % 3 === 1 ? 0x8ed2ff : 0xd98aff,
+        0.35 + (i % 4) * 0.08,
+        1.0,
+        0,
+        sprites[i],
+        0,
+      );
+    }
+    this.update(0);
+  }
+
+  clear(): void {
+    this.projectiles.length = 0;
+    this.life.fill(0);
+    this.size.fill(0);
+    this.alphaAttr.fill(0);
+    const geo = this.points.geometry;
+    (geo.attributes.aSize as THREE.BufferAttribute).needsUpdate = true;
+    (geo.attributes.aAlpha as THREE.BufferAttribute).needsUpdate = true;
+  }
+
   private scaledCount(count: number): number {
     if (count <= 1) return count;
     const scale = 0.45 + 0.55 * this.quality;

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -135,6 +135,7 @@ export class Vfx {
   private head = 0;
   private projectiles: Projectile[] = [];
   private tmpColor = new THREE.Color();
+  private quality = 1;
 
   constructor(scene: THREE.Scene, private anchor: EntityAnchor) {
     this.pos = new Float32Array(CAPACITY * 3);
@@ -211,6 +212,7 @@ export class Vfx {
       `,
     });
     this.points = new THREE.Points(geo, mat);
+    this.points.userData.renderCategory = 'vfx';
     this.points.frustumCulled = false;
     this.points.renderOrder = 5;
     scene.add(this.points);
@@ -219,6 +221,20 @@ export class Vfx {
   setViewportScale(heightPx: number, fovDeg: number): void {
     const mat = this.points.material as THREE.ShaderMaterial;
     mat.uniforms.uScale.value = heightPx / (2 * Math.tan((fovDeg * Math.PI) / 360));
+  }
+
+  setQuality(level: number): void {
+    this.quality = Math.min(1, Math.max(0, Number.isFinite(level) ? level : 1));
+  }
+
+  private scaledCount(count: number): number {
+    if (count <= 1) return count;
+    const scale = 0.45 + 0.55 * this.quality;
+    return Math.max(1, Math.min(count, Math.round(count * scale)));
+  }
+
+  private emitChance(ratePerSecond: number, dt: number): boolean {
+    return Math.random() <= dt * ratePerSecond * (0.35 + 0.65 * this.quality);
   }
 
   private spawn(
@@ -267,7 +283,8 @@ export class Vfx {
   burst(at: THREE.Vector3, school: string, count = 18, power = 1): void {
     const c = new THREE.Color(SCHOOL_COLORS[school] ?? 0xffffff).multiplyScalar(hdr(1.6));
     const isFire = school === 'fire';
-    for (let i = 0; i < count; i++) {
+    const scaledCount = this.scaledCount(count);
+    for (let i = 0; i < scaledCount; i++) {
       const a = Math.random() * Math.PI * 2;
       const up = Math.random() * 0.9 + 0.1;
       const sp = (2 + Math.random() * 4.5) * power;
@@ -295,8 +312,9 @@ export class Vfx {
     const c = new THREE.Color(SCHOOL_COLORS[school] ?? 0xffffff).multiplyScalar(hdr(1.6));
     // one expanding rune ring at the centre sells the shockwave
     this.spawn(at.x, at.y + 0.3, at.z, 0, 0.3, 0, c, 1.5, 0.4, 0, SPR.ring, 0);
-    for (let i = 0; i < 34; i++) {
-      const a = (i / 34) * Math.PI * 2;
+    const count = this.scaledCount(34);
+    for (let i = 0; i < count; i++) {
+      const a = (i / count) * Math.PI * 2;
       const sp = 11 + Math.random() * 3;
       this.spawn(
         at.x, at.y + 0.25, at.z, Math.sin(a) * sp, 1.2, Math.cos(a) * sp, c, 0.5, 0.55, 6,
@@ -310,7 +328,7 @@ export class Vfx {
     if (!at) return;
     const green = new THREE.Color(0xbaf7a0).multiplyScalar(hdr(1.8));
     const gold = new THREE.Color(0xffe9a0).multiplyScalar(hdr(1.8));
-    for (let i = 0; i < 22; i++) {
+    for (let i = 0; i < this.scaledCount(22); i++) {
       const a = Math.random() * Math.PI * 2;
       const r = 0.4 + Math.random() * 0.7;
       this.spawn(
@@ -325,8 +343,9 @@ export class Vfx {
   buffSwirl(targetId: number, color = 0xffe9a0): void {
     const at = this.anchor(targetId, 0.2);
     if (!at) return;
-    for (let i = 0; i < 14; i++) {
-      const a = (i / 14) * Math.PI * 2;
+    const count = this.scaledCount(14);
+    for (let i = 0; i < count; i++) {
+      const a = (i / count) * Math.PI * 2;
       this.spawn(
         at.x + Math.sin(a) * 0.85, at.y + 0.2, at.z + Math.cos(a) * 0.85,
         -Math.cos(a) * 1.6, 2.1, Math.sin(a) * 1.6,
@@ -350,7 +369,7 @@ export class Vfx {
     if (!at) return;
     const white = new THREE.Color(0xfff8e0).multiplyScalar(hdr(1.8));
     const gold = new THREE.Color(0xffd14d).multiplyScalar(hdr(1.8));
-    for (let i = 0; i < 46; i++) {
+    for (let i = 0; i < this.scaledCount(46); i++) {
       const a = Math.random() * Math.PI * 2;
       const r = 0.3 + Math.random() * 0.9;
       this.spawn(
@@ -364,7 +383,7 @@ export class Vfx {
 
   // continuous emitters (called per frame)
   castSparkle(entityId: number, school: string, dt: number): void {
-    if (Math.random() > dt * 30) return;
+    if (!this.emitChance(30, dt)) return;
     const at = this.anchor(entityId, 0.66);
     if (!at) return;
     const c = SCHOOL_COLORS[school] ?? 0xffffff;
@@ -378,7 +397,7 @@ export class Vfx {
   }
 
   swimRipple(at: THREE.Vector3, dt: number): void {
-    if (Math.random() > dt * 9) return;
+    if (!this.emitChance(9, dt)) return;
     const a = Math.random() * Math.PI * 2;
     this.spawn(
       at.x + Math.sin(a) * 0.5, at.y + 0.55, at.z + Math.cos(a) * 0.5,
@@ -388,7 +407,7 @@ export class Vfx {
   }
 
   campfireEmber(at: THREE.Vector3, dt: number): void {
-    if (Math.random() > dt * 6) return;
+    if (!this.emitChance(6, dt)) return;
     if (Math.random() < 0.3) {
       // faint additive smoke puff drifting off the flame tip
       this.spawn(
@@ -426,7 +445,7 @@ export class Vfx {
         // impact: school-tinted cross-flash + burst that survives a 30fps frame
         this.tmpColor.copy(pr.color).multiplyScalar(hdr(1.6));
         this.spawn(target.x, target.y, target.z, 0, 0.5, 0, this.tmpColor, 1.1, 0.22, 0, SPR.flash);
-        for (let k = 0; k < 22; k++) {
+        for (let k = 0; k < this.scaledCount(22); k++) {
           const a = Math.random() * Math.PI * 2;
           const sp = 2.5 + Math.random() * 4;
           this.spawn(
@@ -443,11 +462,13 @@ export class Vfx {
       pr.pos.add(dir);
       // bright HDR core (blooms into a comet) + sparkling trail
       this.spawn(pr.pos.x, pr.pos.y, pr.pos.z, 0, 0, 0, pr.coreColor, 1.0, 0.12, 0, pr.coreSprite);
-      this.spawn(
-        pr.pos.x + (Math.random() - 0.5) * 0.25, pr.pos.y + (Math.random() - 0.5) * 0.25, pr.pos.z + (Math.random() - 0.5) * 0.25,
-        (Math.random() - 0.5) * 0.8, 0.4, (Math.random() - 0.5) * 0.8,
-        pr.trailColor, 0.32, 0.6, 1.5, pr.trailSprite,
-      );
+      if (Math.random() < 0.35 + 0.65 * this.quality) {
+        this.spawn(
+          pr.pos.x + (Math.random() - 0.5) * 0.25, pr.pos.y + (Math.random() - 0.5) * 0.25, pr.pos.z + (Math.random() - 0.5) * 0.25,
+          (Math.random() - 0.5) * 0.8, 0.4, (Math.random() - 0.5) * 0.8,
+          pr.trailColor, 0.32, 0.6, 1.5, pr.trailSprite,
+        );
+      }
     }
 
     // advance the pool

--- a/src/sim/player_movement.ts
+++ b/src/sim/player_movement.ts
@@ -1,0 +1,206 @@
+import { resolveMovement } from './colliders';
+import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE, PLAYER_SWIM_DEPTH } from './pathfind';
+import { DT, Entity, MoveInput, RUN_SPEED, TURN_SPEED, normAngle } from './types';
+import { groundHeight, WATER_LEVEL } from './world';
+
+export const BACKPEDAL_MULT = 0.65;
+export const GRAVITY = 16;
+export const JUMP_VELOCITY = 6; // apex = v^2/2g ~= 1.125 yd
+export const FALL_SAFE_DISTANCE = 12;
+export const MAX_CLIMB_SLOPE = PLAYER_MAX_CLIMB_SLOPE;
+export const SWIM_SURFACE_Y = WATER_LEVEL - 0.75;
+export const SWIM_DEPTH = PLAYER_SWIM_DEPTH;
+export const SWIM_SPEED_MULT = 0.65;
+export const BODY_RADIUS = PLAYER_BODY_RADIUS;
+
+export interface PlayerMovementHooks {
+  standUp?(): void;
+  cancelCast?(): void;
+  fallDamage?(amount: number): void;
+}
+
+export interface PlayerMovementResult {
+  wantsMove: boolean;
+  moved: boolean;
+  fallDamage: number;
+}
+
+export function playerIsStunned(e: Entity): boolean {
+  return e.auras.some((a) => a.kind === 'stun' || a.kind === 'incapacitate' || a.kind === 'polymorph');
+}
+
+export function playerIsRooted(e: Entity): boolean {
+  return playerIsStunned(e) || e.auras.some((a) => a.kind === 'root');
+}
+
+export function playerMoveSpeedMult(e: Entity): number {
+  let slow = 1, speed = 1;
+  for (const a of e.auras) {
+    if (a.kind === 'slow' || a.kind === 'stealth') slow = Math.min(slow, a.value);
+    if (a.kind === 'buff_speed') speed = Math.max(speed, a.value);
+  }
+  return slow * speed;
+}
+
+export function playerIsSwimming(e: Entity, seed: number): boolean {
+  return groundHeight(e.pos.x, e.pos.z, seed) < WATER_LEVEL - SWIM_DEPTH
+    && e.pos.y <= SWIM_SURFACE_Y + 0.15;
+}
+
+export function applyPlayerInputMovement(
+  p: Entity,
+  inp: MoveInput,
+  seed: number,
+  hooks: PlayerMovementHooks = {},
+): PlayerMovementResult {
+  let moved = false;
+  let fallDamage = 0;
+
+  // Convention: facing f points along (sin f, cos f); the camera sits behind
+  // the player, so screen-right is the world vector (-cos f, sin f).
+  // Turning right therefore decreases facing.
+  if (!playerIsStunned(p)) {
+    const before = p.facing;
+    if (inp.turnLeft) p.facing = normAngle(p.facing + TURN_SPEED * DT);
+    if (inp.turnRight) p.facing = normAngle(p.facing - TURN_SPEED * DT);
+    moved = moved || before !== p.facing;
+  }
+
+  let mx = 0, mz = 0; // local: z forward, x strafe-right
+  if (inp.forward) mz += 1;
+  if (inp.back) mz -= 1;
+  if (inp.strafeLeft) mx -= 1;
+  if (inp.strafeRight) mx += 1;
+
+  const wantsMove = mx !== 0 || mz !== 0 || inp.jump;
+  if (wantsMove && p.sitting) hooks.standUp?.();
+
+  const rooted = playerIsRooted(p);
+  const hasMoveInput = mx !== 0 || mz !== 0;
+  const moving = hasMoveInput && !rooted;
+  const swimming = playerIsSwimming(p, seed);
+  let wishX = 0, wishZ = 0, wishSpeed = 0;
+  if (moving) {
+    if (p.castingAbility) hooks.cancelCast?.();
+    const len = Math.hypot(mx, mz);
+    mx /= len; mz /= len;
+    let speed = RUN_SPEED * playerMoveSpeedMult(p);
+    if (mz < 0) speed *= BACKPEDAL_MULT;
+    if (swimming) speed *= SWIM_SPEED_MULT;
+    // world = forward * mz + right * mx, with right = (-cos f, sin f)
+    const sin = Math.sin(p.facing), cos = Math.cos(p.facing);
+    const wx = mz * sin - mx * cos;
+    const wz = mz * cos + mx * sin;
+    wishX = wx;
+    wishZ = wz;
+    wishSpeed = speed;
+  }
+
+  const movingOnGround = moving && (p.onGround || swimming);
+  if (movingOnGround || (!p.onGround && (p.vx !== 0 || p.vz !== 0))) {
+    const stepX = movingOnGround ? wishX * wishSpeed : p.vx;
+    const stepZ = movingOnGround ? wishZ * wishSpeed : p.vz;
+    let nx = p.pos.x + stepX * DT;
+    let nz = p.pos.z + stepZ * DT;
+    // cliffs and the world rim are walls, not ramps
+    if (p.onGround && !swimming) {
+      const h0 = groundHeight(p.pos.x, p.pos.z, seed);
+      const h1 = groundHeight(nx, nz, seed);
+      const run = Math.hypot(nx - p.pos.x, nz - p.pos.z);
+      if (h1 > h0 && run > 1e-5 && (h1 - h0) / run > MAX_CLIMB_SLOPE) {
+        nx = p.pos.x;
+        nz = p.pos.z;
+        if (!p.onGround) { p.vx = 0; p.vz = 0; }
+      }
+    }
+    // While airborne from a jump, pass through fences for the whole arc.
+    // Walking off a ledge still collides with fences.
+    const clearFences = !p.onGround && p.jumping;
+    const beforeX = p.pos.x, beforeZ = p.pos.z;
+    const resolved = resolveMovement(seed, p.pos.x, p.pos.z, nx, nz, BODY_RADIUS, clearFences);
+    p.pos.x = resolved.x;
+    p.pos.z = resolved.z;
+    moved = moved || beforeX !== p.pos.x || beforeZ !== p.pos.z;
+    if (!p.onGround && (resolved.x !== nx || resolved.z !== nz)) {
+      p.vx = (resolved.x - p.prevPos.x) / DT;
+      p.vz = (resolved.z - p.prevPos.z) / DT;
+    }
+  }
+
+  // Vertical: jumping, gravity, swimming, fall damage
+  const ground = groundHeight(p.pos.x, p.pos.z, seed);
+  const deepWater = ground < WATER_LEVEL - SWIM_DEPTH;
+  if (deepWater && p.pos.y <= SWIM_SURFACE_Y + 0.05) {
+    const beforeY = p.pos.y;
+    p.pos.y = SWIM_SURFACE_Y;
+    p.vy = 0;
+    p.vx = 0;
+    p.vz = 0;
+    p.onGround = true;
+    p.jumping = false;
+    p.fallStartY = p.pos.y;
+    moved = moved || beforeY !== p.pos.y;
+    if (inp.jump && !rooted) {
+      // small hop to climb onto shores and docks
+      p.vy = JUMP_VELOCITY * 0.7;
+      p.vx = wishX * wishSpeed;
+      p.vz = wishZ * wishSpeed;
+      p.onGround = false;
+      p.jumping = true;
+    }
+    return { wantsMove, moved, fallDamage };
+  }
+  if (inp.jump && p.onGround && !rooted) {
+    p.vy = JUMP_VELOCITY;
+    p.vx = wishX * wishSpeed;
+    p.vz = wishZ * wishSpeed;
+    p.onGround = false;
+    p.jumping = true;
+    p.fallStartY = p.pos.y;
+  }
+  if (!p.onGround) {
+    const beforeY = p.pos.y;
+    p.vy -= GRAVITY * DT;
+    p.pos.y += p.vy * DT;
+    moved = moved || beforeY !== p.pos.y;
+    p.fallStartY = Math.max(p.fallStartY, p.pos.y);
+    if (deepWater && p.pos.y <= SWIM_SURFACE_Y) {
+      p.pos.y = SWIM_SURFACE_Y;
+      p.vy = 0;
+      p.vx = 0;
+      p.vz = 0;
+      p.onGround = true;
+      p.jumping = false;
+      p.fallStartY = p.pos.y;
+      return { wantsMove, moved, fallDamage };
+    }
+    if (p.pos.y <= ground) {
+      p.pos.y = ground;
+      p.vy = 0;
+      p.vx = 0;
+      p.vz = 0;
+      p.onGround = true;
+      p.jumping = false;
+      const drop = p.fallStartY - ground;
+      if (drop > FALL_SAFE_DISTANCE) {
+        fallDamage = Math.round(p.maxHp * (drop - FALL_SAFE_DISTANCE) * 0.07);
+        if (fallDamage > 0) hooks.fallDamage?.(fallDamage);
+      }
+      p.fallStartY = ground;
+    }
+  } else if (ground < p.pos.y - 0.4) {
+    p.onGround = false;
+    p.jumping = false;
+    p.vx = 0;
+    p.vz = 0;
+    p.vy = 0;
+    p.fallStartY = p.pos.y;
+  } else {
+    const beforeY = p.pos.y;
+    p.pos.y = ground;
+    p.fallStartY = ground;
+    moved = moved || beforeY !== p.pos.y;
+  }
+
+  return { wantsMove, moved, fallDamage };
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7,7 +7,12 @@ import {
 } from './data';
 import { ARENA_SPAWN_A, ARENA_SPAWN_B, ARENA_SPAWNS_A_2v2, ARENA_SPAWNS_B_2v2 } from './dungeon_layout';
 import { lineOfSightClear, resolveMovement, resolvePosition } from './colliders';
-import { PLAYER_BODY_RADIUS, PLAYER_MAX_CLIMB_SLOPE, PLAYER_SWIM_DEPTH, findPlayerPath } from './pathfind';
+import {
+  applyPlayerInputMovement, BODY_RADIUS, FALL_SAFE_DISTANCE, MAX_CLIMB_SLOPE,
+  SWIM_DEPTH, SWIM_SPEED_MULT, SWIM_SURFACE_Y, playerIsRooted, playerIsStunned,
+  playerIsSwimming, playerMoveSpeedMult,
+} from './player_movement';
+import { findPlayerPath } from './pathfind';
 import { createGroundObject, createMob, createNpc, createPlayer, recalcPlayerStats, PlayerEquipment } from './entity';
 import {
   computeTalentModifiers, emptyAllocation, emptyModifiers, talentsFor, talentPointsAtLevel,
@@ -27,7 +32,7 @@ import {
   DEFAULT_PARTY_LOOT_STRATEGIES,
   CONSUME_TICKS, CrowdControlDrCategory, DT, Entity, EquipSlot, FISHING_CAST_ID, FISHING_CAST_TIME, GCD,
   CurrencyLootStrategy, INTERACT_RANGE, InvSlot, ItemLootStrategy, LootEntry, LootSlot, LootStrategies, MELEE_RANGE, MAX_LEVEL, MobFamily, MobTemplate,
-  MoveInput, OverheadEmoteId, PetMode, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, TURN_SPEED, Vec3,
+  MoveInput, OverheadEmoteId, PetMode, PlayerClass, QuestProgress, QuestState, RUN_SPEED, SimConfig, SimEvent, Vec3,
   angleTo, armorReduction, dist2d, emptyMoveInput, isConsuming, meleeMissChance, mobXpValue, normAngle,
   rageFromDealing, rageFromTaking, spellHitChance, xpForLevel,
   MILESTONES, virtualLevel, xpToReachLevel, canPrestige,
@@ -51,7 +56,6 @@ const EVADE_STALL_TIMEOUT = 3;
 // can slide around a prop instead of pinning on it. Desired heading (0) first;
 // only evaluated past the first entry when that straight step is obstructed.
 const MOVE_SLIDE_FAN = [0, 0.5, -0.5, 1.0, -1.0, 1.6, -1.6];
-const BACKPEDAL_MULT = 0.65;
 // Low-HP flee ("fear"): a cowardly mob at or below this HP fraction panics, turns
 // and runs from its attacker for FLEE_DURATION seconds at FLEE_SPEED_MULT speed,
 // calling same-family allies within FLEE_HELP_RADIUS to assist. It flees only once
@@ -63,10 +67,7 @@ const FLEE_HELP_RADIUS = 8;
 // Only sentient, cowardly families flee; beasts/undead/elementals/dragonkin fight
 // to the death. Elites, rares, and bosses never flee regardless of family.
 const FLEEING_FAMILIES: ReadonlySet<MobFamily> = new Set(['humanoid', 'kobold', 'murloc', 'troll']);
-const GRAVITY = 16;
-const JUMP_VELOCITY = 6; // apex = v^2/2g ≈ 1.125 yd
 const MELEE_ARC = 2.2; // radians half-arc within which melee swings connect
-const FALL_SAFE_DISTANCE = 12; // yards of free fall before damage
 const OBJECT_RESPAWN = 30;
 const NYTHRAXIS_RELIC_SUMMONS: Record<string, string> = {
   captains_crest: 'fallen_captain_aldren',
@@ -157,8 +158,6 @@ const MARKET_LISTING_DURATION = 48 * 3600; // sim-seconds an unsold listing ling
 const MARKET_WIRE_LIMIT = 120; // most listings shipped to one client at a time
 const VENDOR_BUYBACK_LIMIT = 12;
 const INSTANCE_EMPTY_TIMEOUT = 300; // seconds before an empty instance resets
-const MAX_CLIMB_SLOPE = PLAYER_MAX_CLIMB_SLOPE; // rise/run above which a ground move is blocked (cliffs, world rim)
-
 // How far a mob pulls same-family neighbours into a fight ("social aggro").
 // Murlocs (the clustered water mobs players call "frogs") used to pull too much,
 // chain-aggroing the whole pond and making solo pulls impossible (#102). Tune
@@ -169,15 +168,11 @@ const SOCIAL_PULL_RADIUS: Partial<Record<MobFamily, number>> = {
   murloc: 8,
 };
 const PACK_FRENZY_AURA_ID = 'pack_frenzy'; // attack-speed buff granted to surviving packmates
-const SWIM_SURFACE_Y = WATER_LEVEL - 0.75; // body bobs just below the water line
-const SWIM_DEPTH = PLAYER_SWIM_DEPTH; // ground this far under the water line = deep water
-const SWIM_SPEED_MULT = 0.65;
 const FISHING_SAMPLE_DISTANCES = [4, 8, 12, 16, 20, 24];
 const DEEPFEN_FISHING_SHORE_MARGIN = 10;
 const THE_CODFATHER_ITEM_ID = 'the_codfather';
 const THE_CODFATHER_QUEST_ID = 'q_the_codfather';
 const DOOR_TRIGGER_RADIUS = 2.0; // walking this close to a dungeon door teleports you
-const BODY_RADIUS = PLAYER_BODY_RADIUS;
 const CHARGE_SPEED_MULT = 3; // warrior charge runs at 3x normal speed
 const CHARGE_MAX_DURATION = 3; // seconds before a blocked charge gives up
 const CHARGE_ARRIVE_RANGE = MELEE_RANGE - 1; // stop inside melee range
@@ -1363,10 +1358,10 @@ export class Sim {
   // -------------------------------------------------------------------------
 
   private isStunned(e: Entity): boolean {
-    return e.auras.some((a) => a.kind === 'stun' || a.kind === 'incapacitate' || a.kind === 'polymorph');
+    return playerIsStunned(e);
   }
   private isRooted(e: Entity): boolean {
-    return this.isStunned(e) || e.auras.some((a) => a.kind === 'root');
+    return playerIsRooted(e);
   }
   private fearAura(e: Entity): Aura | undefined {
     return e.auras.find((a) => a.id === 'fear_incap' && a.kind === 'incapacitate');
@@ -1419,12 +1414,7 @@ export class Sim {
     return q === 'poor' || q === 'common' ? strategies.commonItems : strategies.premiumItems;
   }
   private moveSpeedMult(e: Entity): number {
-    let slow = 1, speed = 1;
-    for (const a of e.auras) {
-      if (a.kind === 'slow' || a.kind === 'stealth') slow = Math.min(slow, a.value);
-      if (a.kind === 'buff_speed') speed = Math.max(speed, a.value);
-    }
-    return slow * speed;
+    return playerMoveSpeedMult(e);
   }
 
   // Sunder Armor stacks shave flat armor off the defender for physical hits.
@@ -1508,8 +1498,7 @@ export class Sim {
   }
 
   isSwimming(e: Entity): boolean {
-    return groundHeight(e.pos.x, e.pos.z, this.cfg.seed) < WATER_LEVEL - SWIM_DEPTH
-      && e.pos.y <= SWIM_SURFACE_Y + 0.15;
+    return playerIsSwimming(e, this.cfg.seed);
   }
 
   private findChargePath(p: Entity, target: Entity): Vec3[] {
@@ -1610,148 +1599,11 @@ export class Sim {
     if (this.updateChargeMovement(p)) return;
     if (this.updateFollowMovement(p, meta)) return;
     if (this.updateFearMovement(p)) return;
-    const inp = meta.moveInput;
-    // Convention: facing f points along (sin f, cos f); the camera sits behind
-    // the player, so screen-right is the world vector (-cos f, sin f).
-    // Turning right therefore DECREASES facing.
-    if (!this.isStunned(p)) {
-      if (inp.turnLeft) p.facing = normAngle(p.facing + TURN_SPEED * DT);
-      if (inp.turnRight) p.facing = normAngle(p.facing - TURN_SPEED * DT);
-    }
-
-    let mx = 0, mz = 0; // local: z forward, x strafe-right
-    if (inp.forward) mz += 1;
-    if (inp.back) mz -= 1;
-    if (inp.strafeLeft) mx -= 1;
-    if (inp.strafeRight) mx += 1;
-
-    const wantsMove = mx !== 0 || mz !== 0 || inp.jump;
-    if (wantsMove && p.sitting) this.standUp(p);
-
-    const hasMoveInput = mx !== 0 || mz !== 0;
-    const moving = hasMoveInput && !this.isRooted(p);
-    const swimming = this.isSwimming(p);
-    let wishX = 0, wishZ = 0, wishSpeed = 0;
-    if (moving) {
-      if (p.castingAbility) this.cancelCast(p);
-      const len = Math.hypot(mx, mz);
-      mx /= len; mz /= len;
-      let speed = RUN_SPEED * this.moveSpeedMult(p);
-      if (mz < 0) speed *= BACKPEDAL_MULT;
-      if (swimming) speed *= SWIM_SPEED_MULT;
-      // world = forward * mz + right * mx, with right = (-cos f, sin f)
-      const sin = Math.sin(p.facing), cos = Math.cos(p.facing);
-      const wx = mz * sin - mx * cos;
-      const wz = mz * cos + mx * sin;
-      wishX = wx;
-      wishZ = wz;
-      wishSpeed = speed;
-    }
-
-    const movingOnGround = moving && (p.onGround || swimming);
-    if (movingOnGround || (!p.onGround && (p.vx !== 0 || p.vz !== 0))) {
-      const stepX = movingOnGround ? wishX * wishSpeed : p.vx;
-      const stepZ = movingOnGround ? wishZ * wishSpeed : p.vz;
-      let nx = p.pos.x + stepX * DT;
-      let nz = p.pos.z + stepZ * DT;
-      // cliffs and the world rim are walls, not ramps
-      if (p.onGround && !swimming) {
-        const h0 = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
-        const h1 = groundHeight(nx, nz, this.cfg.seed);
-        const run = Math.hypot(nx - p.pos.x, nz - p.pos.z);
-        if (h1 > h0 && run > 1e-5 && (h1 - h0) / run > MAX_CLIMB_SLOPE) {
-          nx = p.pos.x;
-          nz = p.pos.z;
-          if (!p.onGround) { p.vx = 0; p.vz = 0; }
-        }
-      }
-      // Slide along buildings, trees, crypt walls — but while airborne from a
-      // jump, pass through fences for the whole arc. Keying off the jump itself
-      // (not a height threshold) makes this independent of slope: an uphill
-      // approach no longer flickers the clearance off right at the rail.
-      const clearFences = !p.onGround && p.jumping;
-      const resolved = resolveMovement(this.cfg.seed, p.pos.x, p.pos.z, nx, nz, BODY_RADIUS, clearFences);
-      p.pos.x = resolved.x;
-      p.pos.z = resolved.z;
-      if (!p.onGround && (resolved.x !== nx || resolved.z !== nz)) {
-        p.vx = (resolved.x - p.prevPos.x) / DT;
-        p.vz = (resolved.z - p.prevPos.z) / DT;
-      }
-    }
-
-    // Vertical: jumping, gravity, swimming, fall damage
-    const ground = groundHeight(p.pos.x, p.pos.z, this.cfg.seed);
-    const deepWater = ground < WATER_LEVEL - SWIM_DEPTH;
-    if (deepWater && p.pos.y <= SWIM_SURFACE_Y + 0.05) {
-      // treading water at the surface
-      p.pos.y = SWIM_SURFACE_Y;
-      p.vy = 0;
-      p.vx = 0;
-      p.vz = 0;
-      p.onGround = true;
-      p.jumping = false;
-      p.fallStartY = p.pos.y;
-      if (inp.jump && !this.isRooted(p)) {
-        // small hop to climb onto shores and docks
-        p.vy = JUMP_VELOCITY * 0.7;
-        p.vx = wishX * wishSpeed;
-        p.vz = wishZ * wishSpeed;
-        p.onGround = false;
-        p.jumping = true;
-      }
-      return;
-    }
-    if (inp.jump && p.onGround && !this.isRooted(p)) {
-      p.vy = JUMP_VELOCITY;
-      p.vx = wishX * wishSpeed;
-      p.vz = wishZ * wishSpeed;
-      p.onGround = false;
-      p.jumping = true;
-      p.fallStartY = p.pos.y;
-    }
-    if (!p.onGround) {
-      p.vy -= GRAVITY * DT;
-      p.pos.y += p.vy * DT;
-      p.fallStartY = Math.max(p.fallStartY, p.pos.y);
-      if (deepWater && p.pos.y <= SWIM_SURFACE_Y) {
-        // splashing into deep water breaks the fall
-        p.pos.y = SWIM_SURFACE_Y;
-        p.vy = 0;
-        p.vx = 0;
-        p.vz = 0;
-        p.onGround = true;
-        p.jumping = false;
-        p.fallStartY = p.pos.y;
-        return;
-      }
-      if (p.pos.y <= ground) {
-        p.pos.y = ground;
-        p.vy = 0;
-        p.vx = 0;
-        p.vz = 0;
-        p.onGround = true;
-        p.jumping = false;
-        const drop = p.fallStartY - ground;
-        if (drop > FALL_SAFE_DISTANCE) {
-          const dmg = Math.round(p.maxHp * (drop - FALL_SAFE_DISTANCE) * 0.07);
-          if (dmg > 0) this.dealDamage(null, p, dmg, false, 'physical', 'Falling', 'hit', true);
-        }
-        p.fallStartY = ground;
-      }
-    } else {
-      if (ground < p.pos.y - 0.4) {
-        // walked off a ledge — not a jump, so fences still block
-        p.onGround = false;
-        p.jumping = false;
-        p.vx = 0;
-        p.vz = 0;
-        p.vy = 0;
-        p.fallStartY = p.pos.y;
-      } else {
-        p.pos.y = ground;
-        p.fallStartY = ground;
-      }
-    }
+    applyPlayerInputMovement(p, meta.moveInput, this.cfg.seed, {
+      standUp: () => this.standUp(p),
+      cancelCast: () => this.cancelCast(p),
+      fallDamage: (dmg) => this.dealDamage(null, p, dmg, false, 'physical', 'Falling', 'hit', true),
+    });
   }
 
   private standUp(p: Entity): void {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -183,6 +183,11 @@ export interface MarketInfo {
   myListingCount: number; // how many active listings the viewer already has
 }
 
+export interface RenderPose {
+  pos: { x: number; y: number; z: number };
+  facing: number;
+}
+
 // The surface the renderer + HUD need from a game world. The offline `Sim`
 // satisfies this structurally; the online `ClientWorld` implements it by
 // mirroring server snapshots and sending commands over the socket.
@@ -191,6 +196,7 @@ export interface IWorld {
   entities: Map<number, Entity>;
   playerId: number;
   player: Entity;
+  renderPoseFor?(entityId: number, alpha: number, now: number): RenderPose | null;
   moveInput: MoveInput;
   inventory: InvSlot[];
   vendorBuyback: InvSlot[];

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -22,6 +22,8 @@ vi.mock('../server/admin_db', async () => {
     listAccounts: vi.fn(),
     listCharacters: vi.fn(),
     accountDetail: vi.fn(),
+    clientPerfSummary: vi.fn(),
+    clientPerfRaw: vi.fn(),
   };
 });
 vi.mock('../server/moderation_db', () => ({
@@ -46,7 +48,7 @@ vi.mock('../server/chat_filter_db', () => ({
 
 import { handleAdminApi, parsePageParams } from '../server/admin';
 import { accountForToken, isAdminAccount, findAccount } from '../server/db';
-import { overviewCounts, listAccounts, accountDetail, escapeLike } from '../server/admin_db';
+import { overviewCounts, listAccounts, accountDetail, escapeLike, clientPerfSummary, clientPerfRaw } from '../server/admin_db';
 import { forceCharacterRename, ignoreReport, moderateAccount, moderationQueue, moderationReportsForAccount, muteAccountChat } from '../server/moderation_db';
 import {
   addFilterWord, chatModerationForAccount, getFilterConfig, liftChatMute, listFilterWords,
@@ -212,6 +214,35 @@ describe('admin api auth', () => {
     expect(res.statusCode).toBe(200);
     expect(moderationQueue).toHaveBeenCalledWith(new Set([9]));
     expect(res.body.data.rows[0].openReports).toBe(4);
+  });
+
+  it('serves perf summaries and raw rows through existing admin auth', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(7);
+    vi.mocked(isAdminAccount).mockResolvedValue(true);
+    vi.mocked(clientPerfSummary).mockResolvedValue({
+      hours: 24,
+      generatedAt: 'now',
+      totals: { sampleCount: 1, medianFps: 60, p95FrameMs: 18, p99FrameMs: 22, contextLossCount: 0, avgRenderScale: 1, avgEffectiveRenderScale: 0.9 },
+      byPreset: [],
+      byGpu: [],
+      byBrowser: [],
+      byOs: [],
+      byScenario: [],
+      worstGpuBuckets: [],
+    });
+    vi.mocked(clientPerfRaw).mockResolvedValue([]);
+
+    const summaryRes = fakeRes();
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/perf/summary?hours=24' }), summaryRes, fakeGame);
+    expect(summaryRes.statusCode).toBe(200);
+    expect(clientPerfSummary).toHaveBeenCalledWith(24);
+    expect(summaryRes.body.data.totals.sampleCount).toBe(1);
+
+    const rawRes = fakeRes();
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/perf/raw?hours=24&limit=10' }), rawRes, fakeGame);
+    expect(rawRes.statusCode).toBe(200);
+    expect(clientPerfRaw).toHaveBeenCalledWith(24, 10);
+    expect(rawRes.body.data.rows).toEqual([]);
   });
 
   it('loads moderation account detail with open reports', async () => {

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -230,7 +230,7 @@ describe('admin api auth', () => {
       byScenario: [],
       worstGpuBuckets: [],
     });
-    vi.mocked(clientPerfRaw).mockResolvedValue([]);
+    vi.mocked(clientPerfRaw).mockResolvedValue([{ id: 123 } as any, { id: 100 } as any]);
 
     const summaryRes = fakeRes();
     await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/perf/summary?hours=24' }), summaryRes, fakeGame);
@@ -239,10 +239,12 @@ describe('admin api auth', () => {
     expect(summaryRes.body.data.totals.sampleCount).toBe(1);
 
     const rawRes = fakeRes();
-    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/perf/raw?hours=24&limit=10' }), rawRes, fakeGame);
+    await handleAdminApi(fakeReq({ token: VALID_TOKEN, url: '/admin/api/perf/raw?hours=24&limit=10&beforeId=500' }), rawRes, fakeGame);
     expect(rawRes.statusCode).toBe(200);
-    expect(clientPerfRaw).toHaveBeenCalledWith(24, 10);
-    expect(rawRes.body.data.rows).toEqual([]);
+    expect(clientPerfRaw).toHaveBeenCalledWith(24, 10, 500);
+    expect(rawRes.body.data.rows).toHaveLength(2);
+    expect(rawRes.body.data.nextBeforeId).toBe(100);
+    expect(rawRes.body.data.hasMore).toBe(false);
   });
 
   it('loads moderation account detail with open reports', async () => {

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -4,6 +4,7 @@ import {
   configureMaskedDoubleSidedVegetationMaterial,
   forcedTierFromSearch, graphicsPresetLabel, isConstrainedBrowser, isWeakIntegratedGpu,
   shouldUseAutoGovernor, tierFromHints, GFX_BUDGETS, type GfxRuntimeHints,
+  GFX_BUCKET_BANDS, gfxInternalsForTest,
 } from '../src/render/gfx';
 
 const desktop: GfxRuntimeHints = {
@@ -70,7 +71,7 @@ describe('graphics tier resolution', () => {
 
   it('keeps every quality tier bounded by explicit runtime budgets', () => {
     for (const [tier, budget] of Object.entries(GFX_BUDGETS)) {
-      expect(budget.targetFps).toBeGreaterThanOrEqual(30);
+      expect(budget.targetFps).toBe(60);
       expect(budget.maxRenderScale).toBeLessThanOrEqual(1);
       expect(budget.minRenderScaleDesktop).toBeGreaterThanOrEqual(0.5);
       expect(budget.minRenderScaleMobile).toBeGreaterThanOrEqual(0.5);
@@ -78,6 +79,70 @@ describe('graphics tier resolution', () => {
       expect(budget.recoverFrameMs).toBeLessThan(budget.dropFrameMs);
       expect(tier).toMatch(/^(low|medium|high|ultra)$/);
     }
+  });
+
+  it('defines tunable bucket bands for every quality tier', () => {
+    for (const [tier, bands] of Object.entries(GFX_BUCKET_BANDS)) {
+      expect(Object.keys(bands).sort()).toEqual([
+        'characters',
+        'foliage',
+        'grass',
+        'lighting',
+        'materials',
+        'props',
+        'resolution',
+        'ui',
+        'vfx',
+        'waterSky',
+        'weapons',
+        'worldStreaming',
+      ].sort());
+      for (const band of Object.values(bands)) {
+        expect(band.min).toBeGreaterThanOrEqual(0);
+        expect(band.max).toBeLessThanOrEqual(1);
+        expect(band.min).toBeLessThanOrEqual(band.baseline);
+        expect(band.baseline).toBeLessThanOrEqual(band.max);
+      }
+      expect(tier).toMatch(/^(low|medium|high|ultra)$/);
+    }
+    expect(GFX_BUCKET_BANDS.low.grass.baseline).toBeGreaterThan(GFX_BUCKET_BANDS.low.grass.min);
+    expect(GFX_BUCKET_BANDS.low.foliage.baseline).toBeGreaterThan(GFX_BUCKET_BANDS.low.foliage.min);
+    expect(GFX_BUCKET_BANDS.low.characters.baseline).toBe(1);
+    expect(GFX_BUCKET_BANDS.low.weapons.baseline).toBe(1);
+  });
+
+  it('keeps medium as a middle tier while high and ultra retain the premium pipeline', () => {
+    const low = gfxInternalsForTest.settingsFor('low');
+    const medium = gfxInternalsForTest.settingsFor('medium');
+    const high = gfxInternalsForTest.settingsFor('high');
+    const ultra = gfxInternalsForTest.settingsFor('ultra');
+
+    expect(low.standardMaterials).toBe(false);
+    expect(low.composer).toBe(false);
+    expect(low.ao).toBe(false);
+
+    expect(medium.standardMaterials).toBe(true);
+    expect(medium.terrainSplat).toBe(true);
+    expect(medium.composer).toBe(false);
+    expect(medium.ao).toBe(false);
+    expect(medium.shadowMap).toBeGreaterThan(low.shadowMap);
+    expect(medium.shadowMap).toBeLessThan(high.shadowMap);
+    expect(medium.pixelRatioCap).toBeLessThan(high.pixelRatioCap);
+
+    expect(high.standardMaterials).toBe(true);
+    expect(high.composer).toBe(true);
+    expect(high.ao).toBe(true);
+    expect(high.msaaSamples).toBe(4);
+    expect(high.shadowMap).toBe(4096);
+
+    expect(ultra.standardMaterials).toBe(true);
+    expect(ultra.composer).toBe(true);
+    expect(ultra.ao).toBe(true);
+    expect(ultra.msaaSamples).toBe(4);
+    expect(ultra.shadowMap).toBe(high.shadowMap);
+    expect(ultra.pixelRatioCap).toBeGreaterThan(high.pixelRatioCap);
+    expect(GFX_BUCKET_BANDS.ultra.grass.baseline).toBeGreaterThan(GFX_BUCKET_BANDS.high.grass.baseline);
+    expect(GFX_BUCKET_BANDS.ultra.foliage.baseline).toBeGreaterThan(GFX_BUCKET_BANDS.high.foliage.baseline);
   });
 
   it('treats older Intel integrated GPUs as constrained in auto mode', () => {

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -65,8 +65,10 @@ describe('graphics tier resolution', () => {
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 5 })).toBe(true);
     expect(shouldUseAutoGovernor({ search: '?gfx=low', graphicsPreset: 0 })).toBe(true);
     expect(shouldUseAutoGovernor({ search: '?gfx=high', graphicsPreset: 0 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '?gfx=ultra', graphicsPreset: 0 })).toBe(false);
     expect(shouldUseAutoGovernor({ search: '?gfx=ultra', graphicsPreset: 4 })).toBe(false);
     expect(shouldUseAutoGovernor({ search: '?governor=0', graphicsPreset: 1 })).toBe(false);
+    expect(shouldUseAutoGovernor({ search: '?gfx=ultra&governor=1', graphicsPreset: 0 })).toBe(true);
   });
 
   it('keeps every quality tier bounded by explicit runtime budgets', () => {

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
 import {
+  configureMaskedDoubleSidedVegetationMaterial,
   forcedTierFromSearch, graphicsPresetLabel, isConstrainedBrowser, isWeakIntegratedGpu,
   shouldUseAutoGovernor, tierFromHints, GFX_BUDGETS, type GfxRuntimeHints,
 } from '../src/render/gfx';
@@ -46,7 +48,7 @@ describe('graphics tier resolution', () => {
     expect(tierFromHints({ ...desktop, search: '?gfx=low', graphicsPreset: 3 }, false)).toBe('low');
   });
 
-  it('labels presets and only enables the runtime governor for unforced Auto', () => {
+  it('labels presets and runs the budget governor unless Ultra or URL-forced', () => {
     expect(graphicsPresetLabel(undefined)).toBe('auto');
     expect(graphicsPresetLabel(1)).toBe('low');
     expect(graphicsPresetLabel(2)).toBe('medium');
@@ -55,8 +57,15 @@ describe('graphics tier resolution', () => {
     expect(graphicsPresetLabel(5)).toBe('advanced');
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 0 })).toBe(true);
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: undefined })).toBe(true);
-    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 3 })).toBe(false);
-    expect(shouldUseAutoGovernor({ search: '?gfx=high', graphicsPreset: 0 })).toBe(false);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 1 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 2 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 3 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 4 })).toBe(false);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 5 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '?gfx=low', graphicsPreset: 0 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '?gfx=high', graphicsPreset: 0 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '?gfx=ultra', graphicsPreset: 4 })).toBe(false);
+    expect(shouldUseAutoGovernor({ search: '?governor=0', graphicsPreset: 1 })).toBe(false);
   });
 
   it('keeps every quality tier bounded by explicit runtime budgets', () => {
@@ -75,5 +84,19 @@ describe('graphics tier resolution', () => {
     expect(isWeakIntegratedGpu('ANGLE (Intel, ANGLE Metal Renderer: Intel(R) Iris(TM) Plus Graphics 655)')).toBe(true);
     expect(isWeakIntegratedGpu('ANGLE (Apple, ANGLE Metal Renderer: Apple M2)')).toBe(false);
     expect(tierFromHints({ ...desktop, gpuRenderer: 'ANGLE (Intel, Intel(R) Iris(TM) Plus Graphics 655)' }, false)).toBe('low');
+  });
+
+  it('keeps masked double-sided vegetation off the transparent blended path', () => {
+    const mat = configureMaskedDoubleSidedVegetationMaterial(new THREE.MeshBasicMaterial({
+      alphaTest: 0.3,
+      transparent: true,
+    }));
+
+    expect(mat.alphaTest).toBe(0.3);
+    expect(mat.side).toBe(THREE.DoubleSide);
+    expect(mat.transparent).toBe(false);
+    expect(mat.forceSinglePass).toBe(true);
+    expect(mat.depthTest).toBe(true);
+    expect(mat.depthWrite).toBe(true);
   });
 });

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { forcedTierFromSearch, isConstrainedBrowser, isWeakIntegratedGpu, tierFromHints, type GfxRuntimeHints } from '../src/render/gfx';
+import {
+  forcedTierFromSearch, graphicsPresetLabel, isConstrainedBrowser, isWeakIntegratedGpu,
+  shouldUseAutoGovernor, tierFromHints, GFX_BUDGETS, type GfxRuntimeHints,
+} from '../src/render/gfx';
 
 const desktop: GfxRuntimeHints = {
   search: '',
@@ -41,6 +44,31 @@ describe('graphics tier resolution', () => {
     expect(tierFromHints({ ...desktop, graphicsPreset: 4 }, false)).toBe('ultra');
     expect(tierFromHints({ ...desktop, graphicsPreset: 5 }, false)).toBe('high');
     expect(tierFromHints({ ...desktop, search: '?gfx=low', graphicsPreset: 3 }, false)).toBe('low');
+  });
+
+  it('labels presets and only enables the runtime governor for unforced Auto', () => {
+    expect(graphicsPresetLabel(undefined)).toBe('auto');
+    expect(graphicsPresetLabel(1)).toBe('low');
+    expect(graphicsPresetLabel(2)).toBe('medium');
+    expect(graphicsPresetLabel(3)).toBe('high');
+    expect(graphicsPresetLabel(4)).toBe('ultra');
+    expect(graphicsPresetLabel(5)).toBe('advanced');
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 0 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: undefined })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 3 })).toBe(false);
+    expect(shouldUseAutoGovernor({ search: '?gfx=high', graphicsPreset: 0 })).toBe(false);
+  });
+
+  it('keeps every quality tier bounded by explicit runtime budgets', () => {
+    for (const [tier, budget] of Object.entries(GFX_BUDGETS)) {
+      expect(budget.targetFps).toBeGreaterThanOrEqual(30);
+      expect(budget.maxRenderScale).toBeLessThanOrEqual(1);
+      expect(budget.minRenderScaleDesktop).toBeGreaterThanOrEqual(0.5);
+      expect(budget.minRenderScaleMobile).toBeGreaterThanOrEqual(0.5);
+      expect(budget.dropFrameMs).toBeLessThan(budget.urgentFrameMs);
+      expect(budget.recoverFrameMs).toBeLessThan(budget.dropFrameMs);
+      expect(tier).toMatch(/^(low|medium|high|ultra)$/);
+    }
   });
 
   it('treats older Intel integrated GPUs as constrained in auto mode', () => {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -56,6 +56,7 @@ function makeInput() {
     onUiKey: vi.fn(),
     onEmoteWheel: vi.fn(),
     onClickPick: vi.fn(),
+    onAttackMove: vi.fn(),
   };
   const input = new Input(canvas as any, cb, new Keybinds());
   return {
@@ -411,6 +412,26 @@ describe('Input Space handling', () => {
 
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(input.readMoveInput().jump).toBe(true);
+  });
+});
+
+describe('Input attack move', () => {
+  it('reserves only the attack-move key and keeps other movement keys working', () => {
+    const { input, cb, windowListeners, canvasListeners } = makeInput();
+    input.setAttackMoveEnabled(true);
+    canvasListeners.get('mouseenter')!({});
+
+    windowListeners.get('keydown')!({ code: 'KeyW', repeat: false });
+    windowListeners.get('keydown')!({ code: 'KeyD', repeat: false });
+    expect(input.readMoveInput().forward).toBe(true);
+    expect(input.readMoveInput().turnRight).toBe(true);
+
+    const preventDefault = vi.fn();
+    windowListeners.get('keydown')!({ code: 'KeyA', repeat: false, preventDefault });
+
+    expect(cb.onAttackMove).toHaveBeenCalledTimes(1);
+    expect(input.readMoveInput().turnLeft).toBe(false);
+    expect(input.readMoveInput().forward).toBe(true);
   });
 });
 

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -153,7 +153,7 @@ describe('activePvpOpponentIds', () => {
     const ids = activePvpOpponentIds({
       playerId: 1,
       player,
-      duelInfo: { otherPid: 2, otherName: 'Duelist', state: 'pending' },
+      duelInfo: { otherPid: 2, otherName: 'Duelist', state: 'countdown' },
       arenaInfo: {
         queued: false,
         queueSize: 0,

--- a/tests/interest.test.ts
+++ b/tests/interest.test.ts
@@ -241,6 +241,26 @@ describe('crowd interest management', () => {
     expect(lite).toBe(2);
   });
 
+  it('sends urgent death state immediately even when far updates are throttled', () => {
+    placeSubjectAt(85);
+    broadcast(server);
+
+    const e = server.sim.entities.get(subject.pid)!;
+    e.hp = 0;
+    e.dead = true;
+
+    viewerFc.sent.length = 0;
+    server.sim.tickCount++;
+    broadcast(server);
+
+    const snap = lastSnap(viewerFc.sent);
+    const rec = entRecord(snap, subject.pid);
+    expect(rec).not.toBeNull();
+    expect(rec.hp).toBe(0);
+    expect(rec.dead).toBe(1);
+    expect(inKeep(snap, subject.pid)).toBe(false);
+  });
+
   it("always updates the viewer's target at full rate", () => {
     placeSubjectAt(70);
     broadcast(server);

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -84,7 +84,7 @@ describe('perf report ingestion', () => {
       glRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M2)',
       source: 'benchmark',
       zoneOrScenario: 'bench_town',
-      rawSummary: { large: 'x'.repeat(9000) },
+      rawSummary: { large: 'x'.repeat(18_000) },
     }, { token: VALID_TOKEN }), res);
 
     expect(res.statusCode).toBe(200);
@@ -120,6 +120,58 @@ describe('perf report ingestion', () => {
     expect(res.statusCode).toBe(200);
     expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
       rawSummary: { seconds: 30 },
+    }));
+  });
+
+  it('preserves compact prewarm data when public raw summaries are truncated', async () => {
+    const res = fakeRes();
+
+    await handlePerfReport(fakeReq({
+      sessionId: 'public-large',
+      rawSummary: {
+        seconds: 30,
+        rendererPrewarmSummary: {
+          elapsedMs: 3200,
+          maxMs: 5000,
+          manifestPlanned: 14,
+          manifestCompleted: 11,
+          manifestTimedOut: 1,
+          timedOutEntryIds: ['diagnostics.baseline'],
+          entries: [
+            {
+              id: 'textures.scene',
+              category: 'world',
+              required: true,
+              status: 'completed',
+              elapsedMs: 120,
+              remainingMsAfter: 4200,
+              programDelta: 0,
+              textureDelta: 12,
+              detail: 'uploaded=12',
+            },
+          ],
+        },
+        oversized: 'x'.repeat(40_000),
+      },
+    }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
+      rawSummary: expect.objectContaining({
+        truncated: true,
+        seconds: 30,
+        rendererPrewarmSummary: expect.objectContaining({
+          elapsedMs: 3200,
+          manifestPlanned: 14,
+          manifestTimedOut: 1,
+          entries: [
+            expect.objectContaining({
+              id: 'textures.scene',
+              textureDelta: 12,
+            }),
+          ],
+        }),
+      }),
     }));
   });
 

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -12,7 +12,7 @@ import { accountForToken, getCharacter, insertClientPerfReport } from '../server
 
 const VALID_TOKEN = 'b'.repeat(64);
 
-function fakeReq(body: unknown, opts: { token?: string; method?: string } = {}) {
+function fakeReq(body: unknown, opts: { token?: string; method?: string; remoteAddress?: string } = {}) {
   const req: any = new EventEmitter();
   req.method = opts.method ?? 'POST';
   req.url = '/api/perf-report';
@@ -20,7 +20,8 @@ function fakeReq(body: unknown, opts: { token?: string; method?: string } = {}) 
     'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15',
     ...(opts.token ? { authorization: `Bearer ${opts.token}` } : {}),
   };
-  req.socket = { remoteAddress: '203.0.113.10' };
+  req.socket = { remoteAddress: opts.remoteAddress ?? '203.0.113.10' };
+  req.destroy = vi.fn();
   setImmediate(() => {
     req.emit('data', JSON.stringify(body));
     req.emit('end');
@@ -106,5 +107,103 @@ describe('perf report ingestion', () => {
     expect(perfReportInternalsForTest.bucketGpu('Google SwiftShader')).toBe('software');
     expect(perfReportInternalsForTest.bucketGpu('ANGLE (Intel, Intel(R) Iris(TM) Plus Graphics 655)')).toBe('intel-iris');
     expect(perfReportInternalsForTest.bucketGpu('ANGLE (AMD Radeon Pro)')).toBe('amd');
+  });
+
+  it('strips development trace data from public reports', async () => {
+    const res = fakeRes();
+
+    await handlePerfReport(fakeReq({
+      sessionId: 'public',
+      rawSummary: { seconds: 30, devTrace: { frames: [{ frameMs: 200 }] } },
+    }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
+      rawSummary: { seconds: 30 },
+    }));
+  });
+
+  it('strips development trace data in production even on loopback', async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    try {
+      const res = fakeRes();
+
+      await handlePerfReport(fakeReq({
+        sessionId: 'prod-loopback',
+        rawSummary: { seconds: 30, devTrace: { frames: [{ frameMs: 200 }] } },
+      }, { remoteAddress: '127.0.0.1' }), res);
+
+      expect(res.statusCode).toBe(200);
+      expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
+        rawSummary: { seconds: 30 },
+      }));
+    } finally {
+      if (previous === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previous;
+    }
+  });
+
+  it('allows larger development trace summaries from local non-production requests', async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    try {
+      const res = fakeRes();
+
+      await handlePerfReport(fakeReq({
+        sessionId: 'local-dev',
+        rawSummary: {
+          seconds: 30,
+          devTrace: {
+            frames: [{ frameMs: 200, detail: 'x'.repeat(9000) }],
+          },
+        },
+      }, { remoteAddress: '127.0.0.1' }), res);
+
+      expect(res.statusCode).toBe(200);
+      expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
+        rawSummary: {
+          seconds: 30,
+          devTrace: {
+            frames: [{ frameMs: 200, detail: 'x'.repeat(9000) }],
+          },
+        },
+      }));
+    } finally {
+      if (previous === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previous;
+    }
+  });
+
+  it('accepts local development trace request bodies above the normal route limit', async () => {
+    const previous = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+    try {
+      const res = fakeRes();
+      const detail = 'x'.repeat(260_000);
+
+      await handlePerfReport(fakeReq({
+        sessionId: 'local-large-dev',
+        rawSummary: {
+          seconds: 30,
+          devTrace: {
+            frames: [{ frameMs: 200, detail }],
+          },
+        },
+      }, { remoteAddress: '127.0.0.1' }), res);
+
+      expect(res.statusCode).toBe(200);
+      expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
+        rawSummary: {
+          seconds: 30,
+          devTrace: {
+            frames: [{ frameMs: 200, detail }],
+          },
+        },
+      }));
+    } finally {
+      if (previous === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = previous;
+    }
   });
 });

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -1,0 +1,110 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../server/db', () => ({
+  accountForToken: vi.fn(),
+  getCharacter: vi.fn(),
+  insertClientPerfReport: vi.fn(async () => {}),
+}));
+
+import { handlePerfReport, perfReportInternalsForTest } from '../server/perf_report';
+import { accountForToken, getCharacter, insertClientPerfReport } from '../server/db';
+
+const VALID_TOKEN = 'b'.repeat(64);
+
+function fakeReq(body: unknown, opts: { token?: string; method?: string } = {}) {
+  const req: any = new EventEmitter();
+  req.method = opts.method ?? 'POST';
+  req.url = '/api/perf-report';
+  req.headers = {
+    'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15',
+    ...(opts.token ? { authorization: `Bearer ${opts.token}` } : {}),
+  };
+  req.socket = { remoteAddress: '203.0.113.10' };
+  setImmediate(() => {
+    req.emit('data', JSON.stringify(body));
+    req.emit('end');
+  });
+  return req;
+}
+
+function fakeRes() {
+  const res: any = {
+    statusCode: 0,
+    body: null as any,
+    writeHead(status: number) { this.statusCode = status; },
+    end(data?: string) { this.body = data ? JSON.parse(data) : null; },
+  };
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('perf report ingestion', () => {
+  it('sanitizes and stores a bounded report with authenticated account context', async () => {
+    vi.mocked(accountForToken).mockResolvedValue(10);
+    vi.mocked(getCharacter).mockResolvedValue({ id: 55 } as any);
+    const res = fakeRes();
+
+    await handlePerfReport(fakeReq({
+      schemaVersion: 99,
+      releaseVersion: '0.9.0',
+      buildId: 'abcdef123456',
+      sessionId: 'sess',
+      characterId: 55,
+      graphicsPreset: 'ultra',
+      gfxTier: 'ultra',
+      autoGovernor: false,
+      targetFps: 60,
+      renderScale: 1,
+      effectiveRenderScale: 0.95,
+      fpsAvg: 58,
+      frameP95Ms: 22,
+      frameP99Ms: 38,
+      longFrameCount: 2,
+      rendererCalls: 600,
+      rendererTriangles: 400000,
+      rendererTextures: 90,
+      rendererPrograms: 40,
+      contextLostCount: 0,
+      longTaskCount: 1,
+      longTaskP95Ms: 70,
+      memoryUsedMb: 120,
+      memoryLimitMb: 4096,
+      dpr: 2,
+      viewportWidth: 1440,
+      viewportHeight: 900,
+      deviceMemory: 8,
+      hardwareConcurrency: 12,
+      mobileTouch: false,
+      glVendor: 'Apple',
+      glRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M2)',
+      source: 'benchmark',
+      zoneOrScenario: 'bench_town',
+      rawSummary: { large: 'x'.repeat(9000) },
+    }, { token: VALID_TOKEN }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledTimes(1);
+    expect(insertClientPerfReport).toHaveBeenCalledWith(expect.objectContaining({
+      schemaVersion: 1,
+      accountId: 10,
+      characterId: 55,
+      graphicsPreset: 'ultra',
+      gfxTier: 'ultra',
+      glRendererBucket: 'apple-m2',
+      browserFamily: 'safari',
+      osFamily: 'macos',
+      viewportBucket: 'large-1440x900',
+      rawSummary: { truncated: true },
+    }));
+  });
+
+  it('keeps GPU bucketing coarse', () => {
+    expect(perfReportInternalsForTest.bucketGpu('Google SwiftShader')).toBe('software');
+    expect(perfReportInternalsForTest.bucketGpu('ANGLE (Intel, Intel(R) Iris(TM) Plus Graphics 655)')).toBe('intel-iris');
+    expect(perfReportInternalsForTest.bucketGpu('ANGLE (AMD Radeon Pro)')).toBe('amd');
+  });
+});

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -109,6 +109,20 @@ describe('perf report ingestion', () => {
     expect(perfReportInternalsForTest.bucketGpu('ANGLE (AMD Radeon Pro)')).toBe('amd');
   });
 
+  it('drops duplicate inserts from the same session inside the server throttle window', async () => {
+    const first = fakeRes();
+    const second = fakeRes();
+    const remoteAddress = '203.0.113.210';
+    const sessionId = 'dupe-throttle';
+
+    await handlePerfReport(fakeReq({ sessionId, rawSummary: { seconds: 30 } }, { remoteAddress }), first);
+    await handlePerfReport(fakeReq({ sessionId, rawSummary: { seconds: 35 } }, { remoteAddress }), second);
+
+    expect(first.statusCode).toBe(200);
+    expect(second.statusCode).toBe(200);
+    expect(insertClientPerfReport).toHaveBeenCalledTimes(1);
+  });
+
   it('strips development trace data from public reports', async () => {
     const res = fakeRes();
 

--- a/tests/perf_report.test.ts
+++ b/tests/perf_report.test.ts
@@ -165,6 +165,14 @@ describe('perf report ingestion', () => {
             },
           ],
         },
+        predictionTrace: {
+          enabled: true,
+          seconds: 12,
+          events: 50,
+          eventCounts: { 'input-predict': 10, 'snapshot-reconcile': 9 },
+          summary: { ackLag: { p95: 4, max: 5 } },
+          largestDisplaySteps: [{ at: 1200, displayStep: 0.8 }],
+        },
         oversized: 'x'.repeat(40_000),
       },
     }), res);
@@ -184,6 +192,10 @@ describe('perf report ingestion', () => {
               textureDelta: 12,
             }),
           ],
+        }),
+        predictionTrace: expect.objectContaining({
+          events: 50,
+          eventCounts: { 'input-predict': 10, 'snapshot-reconcile': 9 },
         }),
       }),
     }));

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -17,6 +17,23 @@ function installBrowserGlobals(): void {
   (globalThis as any).window = { innerWidth: 1440, innerHeight: 900 };
 }
 
+function renderDiagnostics() {
+  return {
+    enabled: false,
+    totalObjects: 0,
+    estimatedDraws: 0,
+    estimatedTriangles: 0,
+    estimatedPoints: 0,
+    programs: 0,
+    programDelta: 0,
+    textures: 0,
+    textureDelta: 0,
+    newMaterials: [],
+    firstVisibleObjects: [],
+    categories: {},
+  };
+}
+
 function snapshot(): PerfSnapshot {
   return {
     seconds: 80,
@@ -47,6 +64,27 @@ function snapshot(): PerfSnapshot {
       },
       renderScale: 1,
       effectiveRenderScale: 0.9,
+      renderBudget: {
+        enabled: true,
+        mode: 'stable',
+        reason: 'stable',
+        pressure: 0.4,
+        frameMsEma: 16.7,
+        submitMsEma: 1,
+        stableSeconds: 0,
+        cooldownSeconds: 0,
+        levels: { grass: 1, vfx: 1, resolution: 0.9 },
+        caps: {
+          targetCalls: 330,
+          urgentCalls: 500,
+          targetTriangles: 1100000,
+          urgentTriangles: 1750000,
+          targetGrassTufts: 2850,
+          urgentGrassTufts: 4500,
+          minGrassLevel: 0.6,
+          minVfxLevel: 0.68,
+        },
+      },
       pixelRatio: 1.5,
       width: 1440,
       height: 900,
@@ -55,6 +93,22 @@ function snapshot(): PerfSnapshot {
       textures: 80,
       programs: 30,
       views: 40,
+      foliage: {
+        grassEnabled: true,
+        grassQuality: 1,
+        grassActiveRadius: 82,
+        grassChunks: 48,
+        grassReadyChunks: 48,
+        grassVisibleChunks: 42,
+        grassQueuedChunks: 0,
+        grassTufts: 12000,
+        grassVisibleTufts: 9800,
+        grassBuiltChunks: 52,
+        grassDisposedChunks: 4,
+        grassLastBuildMs: 1.2,
+        grassBuildMs: 55,
+        grassCacheLimit: 96,
+      },
       glVendor: 'Apple',
       glRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M3 Pro)',
       contextLost: 0,
@@ -67,6 +121,7 @@ function snapshot(): PerfSnapshot {
         submit: { count: 1, avg: 1, p95: 1, max: 1 },
         total: { count: 1, avg: 5, p95: 5, max: 5 },
       },
+      renderDiagnostics: renderDiagnostics(),
     },
     hud: null,
     assets: { preload: { tasks: 0, waitMs: 0, complete: true }, byType: {}, files: [] },
@@ -116,5 +171,114 @@ describe('perf reporter payload', () => {
     expect(body.source).toBe('benchmark');
     expect(body.zoneOrScenario).toBe('bench_dense_foliage');
     expect(JSON.stringify(body.rawSummary)).not.toContain('Safari/605');
+  });
+
+  it('keeps local dev trace frames and long-task correlation in raw summary', () => {
+    const settings = new Settings();
+    const snap = snapshot();
+    snap.devTrace = {
+      enabled: true,
+      worstFrameLimit: 40,
+      minFrameMs: 33,
+      frames: [{
+        atMs: 1200,
+        frameMs: 80,
+        scoreMs: 80,
+        reasons: ['frame-gap'],
+        mainMs: { renderer: 20, hud: 2, events: 0, sim: 0 },
+        renderer: {
+          calls: 200,
+          triangles: 300000,
+          textures: 80,
+          programs: 30,
+          views: 40,
+          renderScale: 1,
+          effectiveRenderScale: 0.9,
+          renderBudget: {
+            enabled: true,
+            mode: 'stable',
+            reason: 'stable',
+            pressure: 0.4,
+            frameMsEma: 16.7,
+            submitMsEma: 1,
+            stableSeconds: 0,
+            cooldownSeconds: 0,
+            levels: { grass: 1, vfx: 1, resolution: 0.9 },
+            caps: {
+              targetCalls: 330,
+              urgentCalls: 500,
+              targetTriangles: 1100000,
+              urgentTriangles: 1750000,
+              targetGrassTufts: 2850,
+              urgentGrassTufts: 4500,
+              minGrassLevel: 0.6,
+              minVfxLevel: 0.68,
+            },
+          },
+          pixelRatio: 1.5,
+          width: 1440,
+          height: 900,
+          foliage: {
+            grassEnabled: true,
+            grassQuality: 1,
+            grassActiveRadius: 82,
+            grassChunks: 48,
+            grassReadyChunks: 48,
+            grassVisibleChunks: 42,
+            grassQueuedChunks: 0,
+            grassTufts: 12000,
+            grassVisibleTufts: 9800,
+            grassBuiltChunks: 52,
+            grassDisposedChunks: 4,
+            grassLastBuildMs: 1.2,
+            grassBuildMs: 55,
+            grassCacheLimit: 96,
+          },
+          lastFrame: null,
+        },
+        browser: { longTaskCount: 1, longTaskTotalMs: 70, longTaskLastAgeMs: 15, memoryUsedMb: 100 },
+        network: null,
+      }],
+      spans: [{
+        atMs: 1190,
+        startMs: 1110,
+        endMs: 1190,
+        durationMs: 80,
+        name: 'net.applySnapshot',
+        kind: 'external',
+        detail: { ents: 42 },
+      }],
+      longTasks: [{
+        startMs: 1100,
+        endMs: 1170,
+        durationMs: 70,
+        name: 'self',
+        entryType: 'longtask',
+        attribution: [],
+        nearestFrameAtMs: 1200,
+        nearestFrameMs: 80,
+        nearestFrameDeltaMs: 65,
+        nearestSpanName: 'net.applySnapshot',
+        nearestSpanMs: 80,
+        nearestSpanDeltaMs: 0,
+      }],
+    };
+
+    const body = perfReporterInternalsForTest.payloadFromSnapshot(snap, settings, 'sess1', 42)!;
+
+    const rawSummary = body.rawSummary as {
+      devTrace: {
+        frames: Array<{ renderer: { calls: number } }>;
+        spans: Array<{ name: string; detail?: { ents?: number } }>;
+        longTasks: Array<{ nearestFrameMs?: number }>;
+      };
+    };
+    expect(rawSummary.devTrace.frames[0].renderer.calls).toBe(200);
+    expect(rawSummary.devTrace.spans[0].name).toBe('net.applySnapshot');
+    expect(rawSummary.devTrace.spans[0].detail?.ents).toBe(42);
+    expect(rawSummary.devTrace.longTasks[0].nearestFrameMs).toBe(80);
+    expect((body.rawSummary as { rendererFoliage?: { grassVisibleChunks?: number } }).rendererFoliage?.grassVisibleChunks).toBe(42);
+    expect((body.rawSummary as { rendererBudget?: { levels?: { grass?: number } } }).rendererBudget?.levels?.grass).toBe(1);
+    expect((body.rawSummary as { rendererDiagnostics?: { enabled?: boolean } }).rendererDiagnostics?.enabled).toBe(false);
   });
 });

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Settings } from '../src/game/settings';
+import type { PerfSnapshot } from '../src/game/perf';
+import { perfReporterInternalsForTest } from '../src/game/perf_reporter';
+
+function installBrowserGlobals(): void {
+  const map = new Map<string, string>();
+  (globalThis as any).__APP_VERSION__ = '0.9.0';
+  (globalThis as any).__APP_BUILD_ID__ = 'testbuild';
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => { map.set(k, v); },
+    removeItem: (k: string) => { map.delete(k); },
+    clear: () => map.clear(),
+  };
+  (globalThis as any).location = { search: '?perfScenario=bench_dense_foliage' };
+  (globalThis as any).window = { innerWidth: 1440, innerHeight: 900 };
+}
+
+function snapshot(): PerfSnapshot {
+  return {
+    seconds: 80,
+    frames: 4800,
+    fps: 60,
+    frameMs: { avg: 16.6, p50: 16, p95: 19, p99: 28, max: 52, long50: 1 },
+    windows: {
+      last10s: { seconds: 10, frames: 600, fps: 60, frameMs: { avg: 16.6, p50: 16, p95: 18, p99: 24, max: 40, long50: 0 } },
+      last30s: { seconds: 30, frames: 1800, fps: 60, frameMs: { avg: 16.6, p50: 16, p95: 19, p99: 28, max: 52, long50: 1 } },
+    },
+    mainMs: { renderer: { count: 1, avg: 5, p95: 5, max: 5 } },
+    renderer: {
+      tier: 'high',
+      autoGovernor: true,
+      budget: {
+        targetFps: 60,
+        minRenderScaleDesktop: 0.7,
+        minRenderScaleMobile: 0.6,
+        maxRenderScale: 1,
+        dropFrameMs: 22,
+        urgentFrameMs: 32,
+        recoverFrameMs: 15,
+        dropStep: 0.1,
+        urgentDropStep: 0.15,
+        recoverStep: 0.05,
+        recoverStableSeconds: 7,
+        cooldownSeconds: 1.35,
+      },
+      renderScale: 1,
+      effectiveRenderScale: 0.9,
+      pixelRatio: 1.5,
+      width: 1440,
+      height: 900,
+      calls: 500,
+      triangles: 300000,
+      textures: 80,
+      programs: 30,
+      views: 40,
+      glVendor: 'Apple',
+      glRenderer: 'ANGLE (Apple, ANGLE Metal Renderer: Apple M3 Pro)',
+      contextLost: 0,
+      contextRestored: 0,
+      phaseMs: {
+        setup: { count: 1, avg: 1, p95: 1, max: 1 },
+        entities: { count: 1, avg: 1, p95: 1, max: 1 },
+        world: { count: 1, avg: 1, p95: 1, max: 1 },
+        nameplates: { count: 1, avg: 1, p95: 1, max: 1 },
+        submit: { count: 1, avg: 1, p95: 1, max: 1 },
+        total: { count: 1, avg: 5, p95: 5, max: 5 },
+      },
+    },
+    hud: null,
+    assets: { preload: { tasks: 0, waitMs: 0, complete: true }, byType: {}, files: [] },
+    network: null,
+    input: {
+      intents: 0,
+      lastKind: '',
+      lastIntentAge: -1,
+      intentToFrame: { count: 0, avg: 0, p95: 0, max: 0 },
+      intentToSend: { count: 0, avg: 0, p95: 0, max: 0 },
+      sendToEcho: { count: 0, avg: 0, p95: 0, max: 0 },
+      intentToVisible: { count: 0, avg: 0, p95: 0, max: 0 },
+    },
+    browser: {
+      longTasks: { count: 2, totalMs: 120, avg: 60, p95: 80, max: 80, lastAge: 1000 },
+      memory: { usedJSHeapSize: 1, totalJSHeapSize: 2, jsHeapSizeLimit: 3, usedMB: 100, limitMB: 4096 },
+      visibilityState: 'visible',
+    },
+    device: {
+      dpr: 2,
+      viewport: '1440x900',
+      mobileTouch: false,
+      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15',
+      hardwareConcurrency: 12,
+      deviceMemory: 8,
+      maxTouchPoints: 0,
+    },
+  };
+}
+
+beforeEach(() => installBrowserGlobals());
+
+describe('perf reporter payload', () => {
+  it('summarizes renderer performance without copying the full user agent', () => {
+    const settings = new Settings();
+    const body = perfReporterInternalsForTest.payloadFromSnapshot(snapshot(), settings, 'sess1', 42)!;
+
+    expect(body.releaseVersion).toBe('0.9.0');
+    expect(body.buildId).toBe('testbuild');
+    expect(body.graphicsPreset).toBe('auto');
+    expect(body.gfxTier).toBe('high');
+    expect(body.autoGovernor).toBe(true);
+    expect(body.effectiveRenderScale).toBe(0.9);
+    expect(body.browserFamily).toBe('safari');
+    expect(body.osFamily).toBe('macos');
+    expect(body.glRendererBucket).toBe('apple-m3-pro');
+    expect(body.source).toBe('benchmark');
+    expect(body.zoneOrScenario).toBe('bench_dense_foliage');
+    expect(JSON.stringify(body.rawSummary)).not.toContain('Safari/605');
+  });
+});

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -318,7 +318,16 @@ beforeEach(() => installBrowserGlobals());
 describe('perf reporter payload', () => {
   it('summarizes renderer performance without copying the full user agent', () => {
     const settings = new Settings();
-    const body = perfReporterInternalsForTest.payloadFromSnapshot(snapshot(), settings, 'sess1', 42)!;
+    const predictionTrace = {
+      enabled: true as const,
+      seconds: 12,
+      events: 50,
+      params: { netRtt: '200', netJitter: '150', predictTrace: '1' },
+      eventCounts: { 'input-predict': 10, 'snapshot-reconcile': 9 },
+      summary: { ackLag: { count: 9, avg: 2, p95: 4, max: 5 } },
+      largestDisplaySteps: [{ at: 1200, displayStep: 0.8, lastAckLag: 4 }],
+    };
+    const body = perfReporterInternalsForTest.payloadFromSnapshot(snapshot(), settings, 'sess1', 42, predictionTrace)!;
 
     expect(body.releaseVersion).toBe('0.9.0');
     expect(body.buildId).toBe('testbuild');
@@ -340,6 +349,8 @@ describe('perf reporter payload', () => {
     expect((body.rawSummary as { rendererPrewarmSummary?: { entries?: unknown[] } }).rendererPrewarmSummary?.entries).toHaveLength(2);
     expect((body.rawSummary as { rendererPrewarm?: { manifestEntries?: unknown[] } }).rendererPrewarm?.manifestEntries).toHaveLength(2);
     expect((body.rawSummary as { rendererFoliage?: { modelVisibleTrianglesByLod?: { core?: number } } }).rendererFoliage?.modelVisibleTrianglesByLod?.core).toBe(420_000);
+    expect((body.rawSummary as { predictionTrace?: { params?: { netRtt?: string }; events?: number } }).predictionTrace?.params?.netRtt).toBe('200');
+    expect((body.rawSummary as { predictionTrace?: { events?: number } }).predictionTrace?.events).toBe(50);
   });
 
   it('keeps local dev trace frames and long-task correlation in raw summary', () => {

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -122,6 +122,7 @@ function snapshot(): PerfSnapshot {
         total: { count: 1, avg: 5, p95: 5, max: 5 },
       },
       renderDiagnostics: renderDiagnostics(),
+      prewarm: null,
     },
     hud: null,
     assets: { preload: { tasks: 0, waitMs: 0, complete: true }, byType: {}, files: [] },

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -34,6 +34,152 @@ function renderDiagnostics() {
   };
 }
 
+function qualityBuckets(): NonNullable<PerfSnapshot['renderer']>['qualityBuckets'] {
+  return {
+    version: 11,
+    bands: {
+      resolution: { min: 0.6, baseline: 1, max: 1, roi: 0.88, cost: 'gpu', governable: true },
+      grass: { min: 0.6, baseline: 0.88, max: 1, roi: 0.86, cost: 'gpu', governable: true },
+      foliage: { min: 0.6, baseline: 0.9, max: 1, roi: 0.72, cost: 'gpu', governable: true },
+      props: { min: 0.7, baseline: 0.88, max: 1, roi: 0.58, cost: 'mixed', governable: false },
+      lighting: { min: 0.62, baseline: 0.9, max: 1, roi: 0.7, cost: 'gpu', governable: true },
+      materials: { min: 0.75, baseline: 0.92, max: 1, roi: 0.78, cost: 'gpu', governable: false },
+      waterSky: { min: 0.72, baseline: 0.92, max: 1, roi: 0.82, cost: 'gpu', governable: false },
+      vfx: { min: 0.68, baseline: 0.92, max: 1, roi: 0.7, cost: 'mixed', governable: true },
+      characters: { min: 0.9, baseline: 1, max: 1, roi: 1, cost: 'mixed', governable: false },
+      weapons: { min: 1, baseline: 1, max: 1, roi: 1, cost: 'mixed', governable: false },
+      worldStreaming: { min: 0.55, baseline: 0.88, max: 1, roi: 0.62, cost: 'cpu', governable: true },
+      ui: { min: 0.86, baseline: 1, max: 1, roi: 0.86, cost: 'cpu', governable: false },
+    },
+    baseline: {
+      resolution: 1,
+      grass: 0.88,
+      foliage: 0.9,
+      props: 0.88,
+      lighting: 0.9,
+      materials: 0.92,
+      waterSky: 0.92,
+      vfx: 0.92,
+      characters: 1,
+      weapons: 1,
+      worldStreaming: 0.88,
+      ui: 1,
+    },
+    levels: {
+      resolution: 0.9,
+      grass: 1,
+      foliage: 1,
+      props: 0.88,
+      lighting: 1,
+      materials: 0.92,
+      waterSky: 0.92,
+      vfx: 1,
+      characters: 1,
+      weapons: 1,
+      worldStreaming: 0.88,
+      ui: 1,
+    },
+    features: {
+      composer: true,
+      ao: true,
+      standardMaterials: true,
+      terrainSplat: true,
+      windSway: true,
+      maxPointLights: 6,
+      activePointLights: 6,
+      shadowMap: 4096,
+    },
+  };
+}
+
+function prewarmStats(): NonNullable<NonNullable<PerfSnapshot['renderer']>['prewarm']> {
+  return {
+    elapsedMs: 3200,
+    maxMs: 5000,
+    createdViews: 36,
+    candidateViews: 80,
+    renderPasses: 10,
+    programsBefore: 10,
+    programsAfter: 18,
+    texturesBefore: 40,
+    texturesAfter: 52,
+    compileMode: 'async',
+    compileMs: 480,
+    compileTimedOut: false,
+    timedOut: false,
+    remainingMs: 1800,
+    budgetUsedRatio: 0.64,
+    createdViewTypes: ['player:player', 'mob:forest_wolf'],
+    manifestPlanned: 14,
+    manifestEntries: [
+      {
+        id: 'views.required',
+        category: 'views',
+        priority: 10,
+        required: true,
+        status: 'completed',
+        elapsedMs: 25,
+        remainingMsAfter: 4975,
+        passes: 0,
+        programsBefore: 10,
+        programsAfter: 10,
+        programDelta: 0,
+        texturesBefore: 40,
+        texturesAfter: 40,
+        textureDelta: 0,
+        detail: 'created=12',
+      },
+      {
+        id: 'textures.scene',
+        category: 'world',
+        priority: 50,
+        required: true,
+        status: 'completed',
+        elapsedMs: 120,
+        remainingMsAfter: 4200,
+        passes: 0,
+        programsBefore: 10,
+        programsAfter: 10,
+        programDelta: 0,
+        texturesBefore: 40,
+        texturesAfter: 52,
+        textureDelta: 12,
+        detail: 'uploaded=12',
+      },
+    ],
+    manifestCompleted: 12,
+    manifestSkipped: 0,
+    manifestTimedOut: 0,
+    manifestFailed: 0,
+    timedOutEntryIds: [],
+    failedEntryIds: [],
+    diagnosticsBaseline: null,
+  };
+}
+
+function foliageCostStats(): Pick<
+  NonNullable<PerfSnapshot['renderer']>['foliage'],
+  | 'modelDraws'
+  | 'modelVisibleDraws'
+  | 'modelDrawsByLod'
+  | 'modelVisibleDrawsByLod'
+  | 'modelTriangles'
+  | 'modelVisibleTriangles'
+  | 'modelTrianglesByLod'
+  | 'modelVisibleTrianglesByLod'
+> {
+  return {
+    modelDraws: 96,
+    modelVisibleDraws: 48,
+    modelDrawsByLod: { core: 32, impostor: 12, dressing: 20 },
+    modelVisibleDrawsByLod: { core: 24, impostor: 8, dressing: 16 },
+    modelTriangles: 1_200_000,
+    modelVisibleTriangles: 540_000,
+    modelTrianglesByLod: { core: 900_000, impostor: 24_000, dressing: 80_000 },
+    modelVisibleTrianglesByLod: { core: 420_000, impostor: 16_000, dressing: 64_000 },
+  };
+}
+
 function snapshot(): PerfSnapshot {
   return {
     seconds: 80,
@@ -46,7 +192,9 @@ function snapshot(): PerfSnapshot {
     },
     mainMs: { renderer: { count: 1, avg: 5, p95: 5, max: 5 } },
     renderer: {
+      graphicsConfigVersion: 11,
       tier: 'high',
+      qualityBuckets: qualityBuckets(),
       autoGovernor: true,
       budget: {
         targetFps: 60,
@@ -71,9 +219,13 @@ function snapshot(): PerfSnapshot {
         pressure: 0.4,
         frameMsEma: 16.7,
         submitMsEma: 1,
+        stallPressure: 0,
+        recentSubmitStalls: 0,
+        lastSubmitStallMs: 0,
+        stallHoldSeconds: 0,
         stableSeconds: 0,
         cooldownSeconds: 0,
-        levels: { grass: 1, vfx: 1, resolution: 0.9 },
+        levels: { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 0.9 },
         caps: {
           targetCalls: 330,
           urgentCalls: 500,
@@ -82,7 +234,9 @@ function snapshot(): PerfSnapshot {
           targetGrassTufts: 2850,
           urgentGrassTufts: 4500,
           minGrassLevel: 0.6,
+          minFoliageLevel: 0.6,
           minVfxLevel: 0.68,
+          minLightingLevel: 0.62,
         },
       },
       pixelRatio: 1.5,
@@ -94,6 +248,12 @@ function snapshot(): PerfSnapshot {
       programs: 30,
       views: 40,
       foliage: {
+        modelQuality: 1,
+        modelBuckets: 64,
+        modelVisibleBuckets: 48,
+        modelBucketsByLod: { core: 32, impostor: 12, dressing: 20 },
+        modelVisibleByLod: { core: 24, impostor: 8, dressing: 16 },
+        ...foliageCostStats(),
         grassEnabled: true,
         grassQuality: 1,
         grassActiveRadius: 82,
@@ -122,7 +282,7 @@ function snapshot(): PerfSnapshot {
         total: { count: 1, avg: 5, p95: 5, max: 5 },
       },
       renderDiagnostics: renderDiagnostics(),
-      prewarm: null,
+      prewarm: prewarmStats(),
     },
     hud: null,
     assets: { preload: { tasks: 0, waitMs: 0, complete: true }, byType: {}, files: [] },
@@ -163,6 +323,7 @@ describe('perf reporter payload', () => {
     expect(body.releaseVersion).toBe('0.9.0');
     expect(body.buildId).toBe('testbuild');
     expect(body.graphicsPreset).toBe('auto');
+    expect(body.graphicsConfigVersion).toBe(11);
     expect(body.gfxTier).toBe('high');
     expect(body.autoGovernor).toBe(true);
     expect(body.effectiveRenderScale).toBe(0.9);
@@ -172,6 +333,13 @@ describe('perf reporter payload', () => {
     expect(body.source).toBe('benchmark');
     expect(body.zoneOrScenario).toBe('bench_dense_foliage');
     expect(JSON.stringify(body.rawSummary)).not.toContain('Safari/605');
+    expect((body.rawSummary as { graphicsConfigVersion?: number }).graphicsConfigVersion).toBe(11);
+    expect((body.rawSummary as { rendererQualityBuckets?: { levels?: { foliage?: number } } }).rendererQualityBuckets?.levels?.foliage).toBe(1);
+    expect((body.rawSummary as { rendererQualityBuckets?: { levels?: { weapons?: number } } }).rendererQualityBuckets?.levels?.weapons).toBe(1);
+    expect((body.rawSummary as { rendererPrewarmSummary?: { manifestPlanned?: number } }).rendererPrewarmSummary?.manifestPlanned).toBe(14);
+    expect((body.rawSummary as { rendererPrewarmSummary?: { entries?: unknown[] } }).rendererPrewarmSummary?.entries).toHaveLength(2);
+    expect((body.rawSummary as { rendererPrewarm?: { manifestEntries?: unknown[] } }).rendererPrewarm?.manifestEntries).toHaveLength(2);
+    expect((body.rawSummary as { rendererFoliage?: { modelVisibleTrianglesByLod?: { core?: number } } }).rendererFoliage?.modelVisibleTrianglesByLod?.core).toBe(420_000);
   });
 
   it('keeps local dev trace frames and long-task correlation in raw summary', () => {
@@ -202,9 +370,13 @@ describe('perf reporter payload', () => {
             pressure: 0.4,
             frameMsEma: 16.7,
             submitMsEma: 1,
+            stallPressure: 0,
+            recentSubmitStalls: 0,
+            lastSubmitStallMs: 0,
+            stallHoldSeconds: 0,
             stableSeconds: 0,
             cooldownSeconds: 0,
-            levels: { grass: 1, vfx: 1, resolution: 0.9 },
+            levels: { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 0.9 },
             caps: {
               targetCalls: 330,
               urgentCalls: 500,
@@ -213,13 +385,22 @@ describe('perf reporter payload', () => {
               targetGrassTufts: 2850,
               urgentGrassTufts: 4500,
               minGrassLevel: 0.6,
+              minFoliageLevel: 0.6,
               minVfxLevel: 0.68,
+              minLightingLevel: 0.62,
             },
           },
+          qualityBuckets: qualityBuckets(),
           pixelRatio: 1.5,
           width: 1440,
           height: 900,
           foliage: {
+            modelQuality: 1,
+            modelBuckets: 64,
+            modelVisibleBuckets: 48,
+            modelBucketsByLod: { core: 32, impostor: 12, dressing: 20 },
+            modelVisibleByLod: { core: 24, impostor: 8, dressing: 16 },
+            ...foliageCostStats(),
             grassEnabled: true,
             grassQuality: 1,
             grassActiveRadius: 82,
@@ -280,6 +461,7 @@ describe('perf reporter payload', () => {
     expect(rawSummary.devTrace.longTasks[0].nearestFrameMs).toBe(80);
     expect((body.rawSummary as { rendererFoliage?: { grassVisibleChunks?: number } }).rendererFoliage?.grassVisibleChunks).toBe(42);
     expect((body.rawSummary as { rendererBudget?: { levels?: { grass?: number } } }).rendererBudget?.levels?.grass).toBe(1);
+    expect((body.rawSummary as { rendererQualityBuckets?: { features?: { windSway?: boolean } } }).rendererQualityBuckets?.features?.windSway).toBe(true);
     expect((body.rawSummary as { rendererDiagnostics?: { enabled?: boolean } }).rendererDiagnostics?.enabled).toBe(false);
   });
 });

--- a/tests/render_budget.test.ts
+++ b/tests/render_budget.test.ts
@@ -35,10 +35,32 @@ describe('render budget governor', () => {
     }));
 
     expect(state.mode).toBe('disabled');
-    expect(state.levels).toEqual({ grass: 1, vfx: 1, resolution: 1 });
+    expect(state.levels).toEqual({ grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 1 });
   });
 
-  it('reduces grass first for non-urgent foliage pressure', () => {
+  it('reduces model foliage before grass for non-urgent draw pressure', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(1, 0.65, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    const state = governor.update(sample({
+      frameMs: 20,
+      totalMs: 20,
+      submitMs: 8,
+      calls: 610,
+      triangles: 2_350_000,
+      grassVisibleTufts: 2_000,
+    }));
+
+    expect(state.mode).toBe('degrading');
+    expect(state.reason).toBe('draw');
+    expect(state.levels.foliage).toBeLessThan(0.9);
+    expect(state.levels.grass).toBe(0.9);
+    expect(state.levels.vfx).toBe(1);
+    expect(state.levels.resolution).toBe(1);
+  });
+
+  it('reduces grass when grass density alone is over budget', () => {
     const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
     governor.reset(1, 0.65, 1);
     governor.update(sample({ dt: 0.6 }));
@@ -47,14 +69,15 @@ describe('render budget governor', () => {
       frameMs: 24,
       totalMs: 24,
       submitMs: 8,
-      calls: 260,
+      calls: 180,
       triangles: 500_000,
-      grassVisibleTufts: 2_000,
+      grassVisibleTufts: 5_900,
     }));
 
     expect(state.mode).toBe('degrading');
     expect(state.reason).toBe('grass');
-    expect(state.levels.grass).toBeLessThan(1);
+    expect(state.levels.foliage).toBe(0.9);
+    expect(state.levels.grass).toBeLessThan(0.9);
     expect(state.levels.vfx).toBe(1);
     expect(state.levels.resolution).toBe(1);
   });
@@ -74,9 +97,67 @@ describe('render budget governor', () => {
     }));
 
     expect(state.mode).toBe('degrading');
-    expect(state.levels.grass).toBeLessThan(1);
+    expect(state.levels.foliage).toBeLessThan(0.9);
+    expect(state.levels.grass).toBeLessThan(0.9);
+    expect(state.levels.lighting).toBeLessThan(1);
     expect(state.levels.vfx).toBeLessThan(1);
     expect(state.levels.resolution).toBeLessThan(1);
+  });
+
+  it('treats 60fps-class low frames as stable headroom', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(1, 0.65, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    const state = governor.update(sample({
+      frameMs: 18,
+      totalMs: 18,
+      submitMs: 7,
+      calls: 260,
+      triangles: 950_000,
+      grassVisibleTufts: 3_300,
+    }));
+
+    expect(state.mode).toBe('stable');
+    expect(state.levels).toEqual({ grass: 0.9, foliage: 0.9, vfx: 1, lighting: 1, resolution: 1 });
+  });
+
+  it('holds a separate submit-stall budget even when steady draw pressure is low', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(1, 0.65, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    let state = governor.update(sample({
+      frameMs: 16,
+      totalMs: 16,
+      submitMs: 180,
+      calls: 120,
+      triangles: 180_000,
+      grassVisibleTufts: 800,
+    }));
+
+    expect(state.mode).toBe('degrading');
+    expect(state.reason).toBe('submit-stall');
+    expect(state.stallPressure).toBeGreaterThan(1);
+    expect(state.recentSubmitStalls).toBe(1);
+    expect(state.lastSubmitStallMs).toBe(180);
+    expect(state.stallHoldSeconds).toBeGreaterThan(10);
+    expect(state.levels.foliage).toBeLessThan(0.9);
+    expect(state.levels.grass).toBeLessThan(0.9);
+
+    state = governor.update(sample({
+      dt: 1,
+      frameMs: 13,
+      totalMs: 13,
+      submitMs: 4,
+      calls: 100,
+      triangles: 150_000,
+      grassVisibleTufts: 500,
+    }));
+
+    expect(state.mode).toBe('degrading');
+    expect(state.reason).toBe('submit-stall');
+    expect(state.stableSeconds).toBe(0);
   });
 
   it('does not reduce resolution below the runtime floor', () => {

--- a/tests/render_budget.test.ts
+++ b/tests/render_budget.test.ts
@@ -122,6 +122,59 @@ describe('render budget governor', () => {
     expect(state.levels).toEqual({ grass: 0.9, foliage: 0.9, vfx: 1, lighting: 1, resolution: 1 });
   });
 
+  it('keeps high quality stable when fast frames carry premium foliage density', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'high', budget: GFX_BUDGETS.high, enabled: true });
+    governor.reset(1, 0.7, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    const state = governor.update(sample({
+      frameMs: 8.4,
+      totalMs: 8.4,
+      submitMs: 2.8,
+      calls: 215,
+      triangles: 3_950_000,
+      grassVisibleTufts: 2_200,
+    }));
+
+    expect(state.mode).toBe('stable');
+    expect(state.levels).toEqual({ grass: 0.88, foliage: 0.9, vfx: 0.92, lighting: 0.9, resolution: 1 });
+  });
+
+  it('recovers high buckets toward their baselines before overfilling one bucket', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'high', budget: GFX_BUDGETS.high, enabled: true });
+    governor.reset(1, 0.7, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    let state = governor.update(sample({
+      frameMs: 16,
+      totalMs: 16,
+      submitMs: 145,
+      calls: 215,
+      triangles: 3_950_000,
+      grassVisibleTufts: 2_200,
+    }));
+
+    expect(state.reason).toBe('submit-stall');
+    expect(state.levels.grass).toBeLessThan(0.88);
+
+    for (let i = 0; i < 40; i++) {
+      state = governor.update(sample({
+        dt: 1,
+        frameMs: 8.4,
+        totalMs: 8.4,
+        submitMs: 2.8,
+        calls: 215,
+        triangles: 3_950_000,
+        grassVisibleTufts: 2_200,
+      }));
+    }
+
+    expect(state.levels.grass).toBeGreaterThanOrEqual(0.88);
+    expect(state.levels.vfx).toBeGreaterThanOrEqual(0.92);
+    expect(state.levels.lighting).toBeGreaterThanOrEqual(0.9);
+    expect(state.levels.foliage).toBeGreaterThanOrEqual(0.9);
+  });
+
   it('holds a separate submit-stall budget even when steady draw pressure is low', () => {
     const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
     governor.reset(1, 0.65, 1);

--- a/tests/render_budget.test.ts
+++ b/tests/render_budget.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+import { GFX_BUDGETS } from '../src/render/gfx';
+import { RenderBudgetGovernor, type RenderBudgetSample } from '../src/render/render_budget';
+
+function sample(overrides: Partial<RenderBudgetSample> = {}): RenderBudgetSample {
+  return {
+    dt: 1,
+    frameMs: 16,
+    totalMs: 16,
+    submitMs: 5,
+    calls: 150,
+    triangles: 250000,
+    grassVisibleTufts: 900,
+    grassVisibleChunks: 8,
+    activeViews: 25,
+    createdViews: 0,
+    minRenderScale: 0.65,
+    maxRenderScale: 1,
+    ...overrides,
+  };
+}
+
+describe('render budget governor', () => {
+  it('leaves all scalers at full quality when disabled', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: false });
+    governor.reset(1, 0.65, 1);
+
+    const state = governor.update(sample({
+      frameMs: 80,
+      totalMs: 80,
+      submitMs: 60,
+      calls: 900,
+      triangles: 2_000_000,
+      grassVisibleTufts: 6_000,
+    }));
+
+    expect(state.mode).toBe('disabled');
+    expect(state.levels).toEqual({ grass: 1, vfx: 1, resolution: 1 });
+  });
+
+  it('reduces grass first for non-urgent foliage pressure', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(1, 0.65, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    const state = governor.update(sample({
+      frameMs: 24,
+      totalMs: 24,
+      submitMs: 8,
+      calls: 260,
+      triangles: 500_000,
+      grassVisibleTufts: 2_000,
+    }));
+
+    expect(state.mode).toBe('degrading');
+    expect(state.reason).toBe('grass');
+    expect(state.levels.grass).toBeLessThan(1);
+    expect(state.levels.vfx).toBe(1);
+    expect(state.levels.resolution).toBe(1);
+  });
+
+  it('drops resolution on urgent submit pressure', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(1, 0.65, 1);
+    governor.update(sample({ dt: 0.6 }));
+
+    const state = governor.update(sample({
+      frameMs: 72,
+      totalMs: 72,
+      submitMs: 55,
+      calls: 500,
+      triangles: 1_400_000,
+      grassVisibleTufts: 3_000,
+    }));
+
+    expect(state.mode).toBe('degrading');
+    expect(state.levels.grass).toBeLessThan(1);
+    expect(state.levels.vfx).toBeLessThan(1);
+    expect(state.levels.resolution).toBeLessThan(1);
+  });
+
+  it('does not reduce resolution below the runtime floor', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(0.7, 0.65, 1);
+
+    let state = governor.update(sample({ dt: 0.6 }));
+    for (let i = 0; i < 12; i++) {
+      state = governor.update(sample({
+        dt: 2,
+        frameMs: 90,
+        totalMs: 90,
+        submitMs: 65,
+        calls: 900,
+        triangles: 2_200_000,
+        grassVisibleTufts: 6_500,
+      }));
+    }
+
+    expect(state.levels.resolution).toBeGreaterThanOrEqual(0.65);
+  });
+
+  it('recovers slowly after sustained stable frames', () => {
+    const governor = new RenderBudgetGovernor({ tier: 'low', budget: GFX_BUDGETS.low, enabled: true });
+    governor.reset(1, 0.65, 1);
+    governor.update(sample({ dt: 0.6 }));
+    let state = governor.update(sample({
+      frameMs: 80,
+      totalMs: 80,
+      submitMs: 55,
+      calls: 600,
+      triangles: 1_500_000,
+      grassVisibleTufts: 4_000,
+    }));
+    const degradedResolution = state.levels.resolution;
+
+    for (let i = 0; i < 12; i++) {
+      state = governor.update(sample({
+        dt: 1,
+        frameMs: 13,
+        totalMs: 13,
+        submitMs: 4,
+        calls: 100,
+        triangles: 150_000,
+        grassVisibleTufts: 500,
+      }));
+    }
+
+    expect(state.levels.resolution).toBeGreaterThanOrEqual(degradedResolution);
+    expect(state.levels.grass).toBeLessThanOrEqual(1);
+  });
+});

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -174,7 +174,7 @@ describe('delta snapshots', () => {
   });
 
   it('echoes the last input sequence applied by a sim tick in self snapshots', () => {
-    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 7, mi: { f: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1, mi: { f: 1 } }));
     broadcast(server);
     const snap = lastSnap(fc.sent);
     expect(snap.self.ack).toBe(0);
@@ -183,14 +183,14 @@ describe('delta snapshots', () => {
     server.sim.tick();
     fc.sent.length = 0;
     broadcast(server);
-    expect(lastSnap(fc.sent).self.ack).toBe(7);
+    expect(lastSnap(fc.sent).self.ack).toBe(1);
 
-    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 6, mi: { f: 0 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1, mi: { f: 0 } }));
     (server as any).markInputSeqsApplied();
     server.sim.tick();
     fc.sent.length = 0;
     broadcast(server);
-    expect(lastSnap(fc.sent).self.ack).toBe(7);
+    expect(lastSnap(fc.sent).self.ack).toBe(1);
   });
 
   it('acks queued movement inputs only as server ticks consume them', () => {
@@ -218,6 +218,52 @@ describe('delta snapshots', () => {
     fc.sent.length = 0;
     broadcast(server);
     expect(lastSnap(fc.sent).self.ack).toBe(3);
+  });
+
+  it('compresses repeated held input without acking unsimulated sequence numbers', () => {
+    for (let seq = 1; seq <= 100; seq++) {
+      server.handleMessage(session, JSON.stringify({ t: 'input', seq, mi: { f: 1 } }));
+    }
+
+    expect(session.lastInputSeq).toBe(100);
+    expect(session.pendingMoveInputs).toHaveLength(1);
+
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(1);
+    expect(session.pendingMoveInputs).toHaveLength(1);
+
+    for (let i = 0; i < 9; i++) {
+      (server as any).markInputSeqsApplied();
+      server.sim.tick();
+    }
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(10);
+    expect(session.pendingMoveInputs).toHaveLength(1);
+  });
+
+  it('rejects sequence gaps without wedging later contiguous input', () => {
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1, mi: { f: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1_000_000, mi: { b: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 2, mi: { f: 0, b: 1 } }));
+
+    expect(session.lastInputSeq).toBe(2);
+    expect(session.pendingMoveInputs).toHaveLength(2);
+
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(1);
+
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(2);
   });
 
   it('turns echoed input acks into client latency samples', () => {
@@ -783,6 +829,35 @@ describe('online movement input lifetime', () => {
     for (let i = 0; i < Math.ceil(0.35 / DT); i++) server.sim.tick();
     (server as any).clearStaleInputs();
     expect(meta.moveInput.turnLeft).toBe(false);
+  });
+
+  it('expires queued movement when the websocket input stream goes quiet', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = joinServer(server, fc, 1, 'Backlog');
+
+    server.handleMessage(session, JSON.stringify({
+      t: 'input',
+      seq: 1,
+      mi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 },
+    }));
+    server.handleMessage(session, JSON.stringify({
+      t: 'input',
+      seq: 2,
+      mi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 },
+    }));
+    const meta = server.sim.meta(session.pid)!;
+    (server as any).markInputSeqsApplied();
+    expect(meta.moveInput.forward).toBe(true);
+    expect(session.appliedInputSeq).toBe(1);
+    expect(session.pendingMoveInputs).toHaveLength(1);
+
+    for (let i = 0; i < Math.ceil(0.8 / DT); i++) server.sim.tick();
+    (server as any).clearStaleInputs();
+
+    expect(meta.moveInput.forward).toBe(false);
+    expect(session.pendingMoveInputs).toHaveLength(0);
+    expect(session.appliedInputSeq).toBe(2);
   });
 });
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -78,6 +78,7 @@ function bareClient(pid: number): ClientWorld {
   c.eventQueue = [];
   c.mouselookFacing = null;
   c.lastInputSentAt = 0;
+  c.lastIdleStopSentAt = 0;
   c.lastInputSig = '';
   c.inputSeq = 0;
   c.pendingInputSeqSentAt = new Map();
@@ -85,6 +86,8 @@ function bareClient(pid: number): ClientWorld {
   c.inputEchoSamples = [];
   c.pendingPredictions = [];
   c.predictionAccumulator = 0;
+  c.predictionMovementMode = 'normal';
+  c.optimisticCommandSeq = 0;
   c.localPredictionTick = 0;
   c.lastSnapshotTick = -1;
   c.queuedSnapshot = null;
@@ -266,6 +269,66 @@ describe('delta snapshots', () => {
     expect(lastSnap(fc.sent).self.ack).toBe(2);
   });
 
+  it('buffers small out-of-order movement inputs instead of wedging the sequence stream', () => {
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1, mi: { f: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 3, mi: { sr: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 2, mi: { b: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 4, mi: { sl: 1 } }));
+
+    expect(session.lastInputSeq).toBe(4);
+    expect([...session.bufferedMoveInputs.keys()]).toEqual([]);
+
+    for (let i = 0; i < 4; i++) {
+      (server as any).markInputSeqsApplied();
+      server.sim.tick();
+    }
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(4);
+  });
+
+  it('reports held-input coverage and accounts later identical queued input against it', () => {
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1, mi: { f: 1 } }));
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+
+    for (let i = 0; i < 3; i++) {
+      (server as any).markInputSeqsApplied();
+      server.sim.tick();
+    }
+    fc.sent.length = 0;
+    broadcast(server);
+    const heldSnap = lastSnap(fc.sent);
+    expect(heldSnap.self.ack).toBe(1);
+    expect(heldSnap.self.ackh).toBe(3);
+    expect(heldSnap.self.ackmi).toEqual({ f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 });
+
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 2, mi: { f: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 3, mi: { f: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 4, mi: { f: 1 } }));
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    const caughtUpSnap = lastSnap(fc.sent);
+    expect(caughtUpSnap.self.ack).toBe(4);
+    expect(caughtUpSnap.self.ackh).toBe(1);
+  });
+
+  it('marks server-driven movement modes in self snapshots', () => {
+    const p = server.sim.entities.get(session.pid)!;
+    p.chargeTargetId = 999;
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.pmv).toBe('charge');
+
+    p.chargeTargetId = null;
+    p.followTargetId = 999;
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.pmv).toBe('follow');
+  });
+
   it('turns echoed input acks into client latency samples', () => {
     const client = bareClient(1);
     const first = { id: 1, k: 'player', tid: 'player', nm: 'Testa', lv: 1, x: 0, y: 0, z: 0, f: 0, hp: 100, mhp: 100 };
@@ -322,6 +385,173 @@ describe('delta snapshots', () => {
       (client as any).applySnapshot({ t: 'snap', tick: 3, time: DT * 2, ents: [], self: self(predictedZ, 1) });
       expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
       expect((client as any).pendingPredictions).toHaveLength(0);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('uses held-input coverage to avoid replaying movement already represented in the server pose', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = (z: number, extra: Record<string, unknown> = {}) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+      ...extra,
+    });
+
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self: self(z0) });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+      for (let i = 0; i < 5; i++) expect((client as any).stepPrediction(DT, 100 + i * 50)).toBe(true);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 5, 5);
+      expect((client as any).pendingPredictions).toHaveLength(5);
+
+      (client as any).applySnapshot({
+        t: 'snap',
+        tick: 4,
+        time: DT * 3,
+        ents: [],
+        self: self(z0 + RUN_SPEED * DT * 3, {
+          ack: 0,
+          ackh: 3,
+          ackmi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 },
+        }),
+      });
+
+      expect((client as any).ackedInputSeq).toBe(3);
+      expect((client as any).pendingPredictions.map((cmd: any) => cmd.seq)).toEqual([4, 5]);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 5, 5);
+
+      (client as any).applySnapshot({
+        t: 'snap',
+        tick: 5,
+        time: DT * 5,
+        ents: [],
+        self: self(z0 + RUN_SPEED * DT * 5, {
+          ack: 0,
+          ackh: 5,
+          ackmi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 },
+        }),
+      });
+
+      expect((client as any).ackedInputSeq).toBe(5);
+      expect((client as any).pendingPredictions).toHaveLength(0);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 5, 5);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('does not apply held-input coverage across a local input change', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = (z: number, extra: Record<string, unknown> = {}) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+      ...extra,
+    });
+
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self: self(z0) });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+      expect((client as any).stepPrediction(DT, 100)).toBe(true);
+      Object.assign(client.moveInput, { forward: false, back: true });
+      expect((client as any).stepPrediction(DT, 150)).toBe(true);
+
+      (client as any).applySnapshot({
+        t: 'snap',
+        tick: 3,
+        time: DT * 2,
+        ents: [],
+        self: self(z0 + RUN_SPEED * DT * 2, {
+          ack: 0,
+          ackh: 2,
+          ackmi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 },
+        }),
+      });
+
+      expect((client as any).ackedInputSeq).toBe(1);
+      expect((client as any).pendingPredictions.map((cmd: any) => cmd.seq)).toEqual([2]);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('does not replay normal predicted movement over server-driven movement snapshots', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = (z: number, extra: Record<string, unknown> = {}) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+      ...extra,
+    });
+
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self: self(z0) });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+      expect((client as any).stepPrediction(DT, 100)).toBe(true);
+      expect((client as any).pendingPredictions).toHaveLength(1);
+
+      (client as any).applySnapshot({
+        t: 'snap',
+        tick: 2,
+        time: DT,
+        ents: [],
+        self: self(z0 + RUN_SPEED * DT * 3, { ack: 0, pmv: 'charge' }),
+      });
+
+      expect((client as any).pendingPredictions).toHaveLength(0);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 3, 5);
+      expect(client.renderPoseFor(client.playerId, 0.5, performance.now())!.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 3, 5);
+      expect((client as any).stepPrediction(DT, 150)).toBe(true);
+      expect((client as any).pendingPredictions).toHaveLength(0);
+      expect(sent.at(-1)).toEqual({ t: 'input', seq: 2, mi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 } });
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 3, 5);
     } finally {
       (globalThis as any).WebSocket = oldWebSocket;
     }
@@ -465,7 +695,7 @@ describe('delta snapshots', () => {
     }
   });
 
-  it('predicts local movement at sim tick rate instead of per input packet', () => {
+  it('flushes changed local movement through the prediction ring', () => {
     const client = bareClient(1);
     const sent: any[] = [];
     (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
@@ -493,15 +723,15 @@ describe('delta snapshots', () => {
       });
 
       expect(client.flushInput(100)).toBe(true);
-      expect(client.player.pos.z).toBeCloseTo(z0, 5);
-      expect((client as any).pendingPredictions).toHaveLength(0);
-
-      expect((client as any).stepPrediction(DT / 2, 125)).toBe(false);
-      expect(client.player.pos.z).toBeCloseTo(z0, 5);
-
-      expect((client as any).stepPrediction(DT / 2, 150)).toBe(true);
       expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT, 5);
       expect((client as any).pendingPredictions).toHaveLength(1);
+
+      expect((client as any).stepPrediction(DT / 2, 125)).toBe(false);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT, 5);
+
+      expect((client as any).stepPrediction(DT / 2, 150)).toBe(true);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT * 2, 5);
+      expect((client as any).pendingPredictions).toHaveLength(2);
       expect(sent.map((msg) => msg.seq)).toEqual([1, 2]);
     } finally {
       (globalThis as any).WebSocket = oldWebSocket;
@@ -858,6 +1088,7 @@ describe('online movement input lifetime', () => {
     expect(meta.moveInput.forward).toBe(false);
     expect(session.pendingMoveInputs).toHaveLength(0);
     expect(session.appliedInputSeq).toBe(2);
+    expect(session.heldInputTicks).toBe(0);
   });
 });
 
@@ -1116,10 +1347,25 @@ describe('client-side delta merge', () => {
     (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
     const oldWebSocket = (globalThis as any).WebSocket;
     (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z: z0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
     try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self });
       Object.assign(client.moveInput, { forward: true, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false });
       expect(client.flushInput(100)).toBe(true);
       expect(sent).toEqual([{ t: 'input', seq: 1, mi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 } }]);
+      expect((client as any).pendingPredictions.map((cmd: any) => cmd.seq)).toEqual([1]);
 
       expect(client.flushInput(105)).toBe(false);
       expect(sent).toHaveLength(1);
@@ -1130,7 +1376,152 @@ describe('client-side delta merge', () => {
 
       expect(client.flushInput(120)).toBe(true);
       expect(sent.at(-1)).toEqual({ t: 'input', seq: 2, mi: { f: 0, b: 0, tl: 0, tr: 0, sl: 0, sr: 1, j: 0 } });
+      expect((client as any).pendingPredictions.map((cmd: any) => cmd.seq)).toEqual([1, 2]);
     } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('caps local movement prediction lead while continuing to stream inputs', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z: z0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self });
+      Object.assign(client.moveInput, { forward: true, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false });
+      for (let i = 0; i < 12; i++) {
+        expect((client as any).predictLocalTick(100 + i * 50)).toBe(true);
+      }
+
+      expect(sent.map((msg) => msg.seq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      expect((client as any).pendingPredictions.map((cmd: any) => cmd.seq)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      const p = client.player;
+      const localLeadDist = Math.hypot(p.pos.x - x, p.pos.z - z0);
+      expect(localLeadDist).toBeLessThanOrEqual(RUN_SPEED * DT * 8 + 0.001);
+
+      (client as any).applySnapshot({ t: 'snap', tick: 2, time: DT, ents: [], self: { ...self, ack: 2 } });
+      expect((client as any).pendingPredictions.map((cmd: any) => cmd.seq)).toEqual([3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      const replayLeadDist = Math.hypot(client.player.pos.x - x, client.player.pos.z - z0);
+      expect(replayLeadDist).toBeLessThanOrEqual(RUN_SPEED * DT * 8 + 0.001);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('resends idle stop frames while pending input remains, but rate limits them', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z: z0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self });
+      Object.assign(client.moveInput, { forward: true, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false });
+      expect((client as any).predictLocalTick(100)).toBe(true);
+
+      Object.assign(client.moveInput, { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false });
+      expect((client as any).predictLocalTick(150)).toBe(true);
+      expect(sent.at(-1)).toEqual({ t: 'input', seq: 2, mi: { f: 0, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 } });
+
+      expect((client as any).predictLocalTick(200)).toBe(false);
+      expect(sent).toHaveLength(2);
+
+      expect((client as any).predictLocalTick(245)).toBe(true);
+      expect(sent.at(-1)).toEqual({ t: 'input', seq: 3, mi: { f: 0, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 } });
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('applies only local presentation optimism for combat intent', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const y = groundHeight(12, 20, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x: 12, y, z: 20, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: 2, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+    const mob = {
+      id: 2, k: 'mob', tid: 'wolf', nm: 'Wolf', lv: 1,
+      x: 13, y, z: 20, f: 0, hp: 30, mhp: 30,
+    };
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [mob], self });
+      client.startAutoAttack();
+      expect(client.player.autoAttack).toBe(true);
+      expect(sent.at(-1)).toEqual({ t: 'cmd', cmd: 'attack' });
+
+      client.stopAutoAttack();
+      expect(client.player.autoAttack).toBe(false);
+      expect(client.player.queuedOnSwing).toBeNull();
+
+      (client as any).known = [{ def: { id: 'heroic_strike', onNextSwing: true } }];
+      client.castAbility('heroic_strike');
+      expect(client.player.queuedOnSwing).toBe('heroic_strike');
+      expect(sent.at(-1)).toEqual({ t: 'cmd', cmd: 'cast', ability: 'heroic_strike' });
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('keeps overdue lagged socket sends in FIFO order', () => {
+    vi.useFakeTimers();
+    const client = bareClient(1);
+    const sent: any[] = [];
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    (client as any).netLag = { upstreamMs: 0, downstreamMs: 0, jitterMs: 0 };
+    (client as any).upstreamQueue.push({ payload: JSON.stringify({ t: 'input', seq: 1 }), deliveryAt: 0 });
+
+    try {
+      (client as any).sendSocketPayload(JSON.stringify({ t: 'input', seq: 2 }));
+
+      expect(sent).toEqual([]);
+      expect((client as any).upstreamQueue.map((frame: any) => JSON.parse(frame.payload).seq)).toEqual([1, 2]);
+
+      (client as any).deliverLagQueue('up');
+      expect(sent.map((msg) => msg.seq)).toEqual([1, 2]);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
       (globalThis as any).WebSocket = oldWebSocket;
     }
   });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -12,7 +12,8 @@ vi.mock('../server/db', () => ({
 import { GameServer, ClientSession } from '../server/game';
 import { saveCharacterState } from '../server/db';
 import { ClientWorld } from '../src/net/online';
-import { DT, type PlayerClass } from '../src/sim/types';
+import { DT, RUN_SPEED, TURN_SPEED, type PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
 
 const DELTA_KEYS = ['inv', 'buyback', 'equip', 'qlog', 'qdone', 'cds', 'stats', 'weapon', 'party', 'trade', 'duel'];
 
@@ -82,6 +83,19 @@ function bareClient(pid: number): ClientWorld {
   c.pendingInputSeqSentAt = new Map();
   c.ackedInputSeq = 0;
   c.inputEchoSamples = [];
+  c.pendingPredictions = [];
+  c.predictionAccumulator = 0;
+  c.localPredictionTick = 0;
+  c.lastSnapshotTick = -1;
+  c.queuedSnapshot = null;
+  c.netLag = { upstreamMs: 0, downstreamMs: 0, jitterMs: 0 };
+  c.lagTimers = new Set();
+  c.upstreamQueue = [];
+  c.downstreamQueue = [];
+  c.upstreamTimer = null;
+  c.downstreamTimer = null;
+  c.nextUpstreamDeliveryAt = 0;
+  c.nextDownstreamDeliveryAt = 0;
   return c;
 }
 
@@ -159,16 +173,51 @@ describe('delta snapshots', () => {
     expect(snap.self.qlog).toEqual([{ questId: 'q_widows', counts: [10, 4], state: 'active' }]);
   });
 
-  it('echoes the last processed input sequence in self snapshots', () => {
+  it('echoes the last input sequence applied by a sim tick in self snapshots', () => {
     server.handleMessage(session, JSON.stringify({ t: 'input', seq: 7, mi: { f: 1 } }));
     broadcast(server);
     const snap = lastSnap(fc.sent);
-    expect(snap.self.ack).toBe(7);
+    expect(snap.self.ack).toBe(0);
 
-    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 6, mi: { f: 0 } }));
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
     fc.sent.length = 0;
     broadcast(server);
     expect(lastSnap(fc.sent).self.ack).toBe(7);
+
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 6, mi: { f: 0 } }));
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(7);
+  });
+
+  it('acks queued movement inputs only as server ticks consume them', () => {
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1, mi: { f: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 2, mi: { f: 0, b: 1 } }));
+    server.handleMessage(session, JSON.stringify({ t: 'input', seq: 3, mi: { f: 0, b: 0, sr: 1 } }));
+
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(0);
+
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(1);
+
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(2);
+
+    (server as any).markInputSeqsApplied();
+    server.sim.tick();
+    fc.sent.length = 0;
+    broadcast(server);
+    expect(lastSnap(fc.sent).self.ack).toBe(3);
   });
 
   it('turns echoed input acks into client latency samples', () => {
@@ -187,6 +236,345 @@ describe('delta snapshots', () => {
 
     expect(client.consumeInputEchoSamples()).toEqual([100, 60]);
     expect(client.consumeInputEchoSamples()).toEqual([]);
+  });
+
+  it('replays unacked local movement over stale authoritative snapshots', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = (z: number, ack: number) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    });
+
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self: self(z0, 0) });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+      expect((client as any).stepPrediction(DT, 100)).toBe(true);
+      expect(sent).toEqual([{ t: 'input', seq: 1, mi: { f: 1, b: 0, tl: 0, tr: 0, sl: 0, sr: 0, j: 0 } }]);
+      const predictedZ = z0 + RUN_SPEED * DT;
+      expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
+
+      (client as any).applySnapshot({ t: 'snap', tick: 2, time: DT, ents: [], self: self(z0, 0) });
+      expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
+      expect((client as any).pendingPredictions).toHaveLength(1);
+
+      (client as any).applySnapshot({ t: 'snap', tick: 3, time: DT * 2, ents: [], self: self(predictedZ, 1) });
+      expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
+      expect((client as any).pendingPredictions).toHaveLength(0);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('keeps the reconcile blend anchor when snapshots apply after same-frame prediction', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    const oldPerf = (globalThis as any).performance;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = (z: number, ack: number) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    });
+
+    let now = 1000;
+    (globalThis as any).performance = { now: () => now };
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self: self(z0, 0) });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+
+      now = 1025;
+      expect((client as any).stepPrediction(DT * 2, now)).toBe(true);
+      const predictedZ = z0 + RUN_SPEED * DT * 2;
+      expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
+      const renderedBeforeZ = client.renderPoseFor(client.playerId, 0.5, now)!.pos.z;
+
+      (client as any).applySnapshot({ t: 'snap', tick: 2, time: DT, ents: [], self: self(z0, 0) });
+
+      expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
+      expect(client.renderPoseFor(client.playerId, 0.5, now)!.pos.z).toBeCloseTo(renderedBeforeZ, 5);
+      expect(client.player.prevPos.z).not.toBeCloseTo(renderedBeforeZ, 5);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+      (globalThis as any).performance = oldPerf;
+    }
+  });
+
+  it('interpolates predicted local movement between render frames', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    const oldPerf = (globalThis as any).performance;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z: z0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+
+    let now = 900;
+    (globalThis as any).performance = { now: () => now };
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+
+      now = 1000;
+      expect((client as any).stepPrediction(DT, now)).toBe(true);
+      const predictedZ = z0 + RUN_SPEED * DT;
+      expect(client.player.pos.z).toBeCloseTo(predictedZ, 5);
+      expect(client.renderPoseFor(client.playerId, 0.5, now)!.pos.z).toBeCloseTo(z0, 5);
+
+      now += DT * 500;
+      expect(client.renderPoseFor(client.playerId, 0.5, now)!.pos.z).toBeCloseTo(z0 + (predictedZ - z0) * 0.5, 5);
+
+      now += DT * 500;
+      expect(client.renderPoseFor(client.playerId, 0.5, now)!.pos.z).toBeCloseTo(predictedZ, 5);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+      (globalThis as any).performance = oldPerf;
+    }
+  });
+
+  it('does not spend a full reconcile correction during one long frame', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    const oldPerf = (globalThis as any).performance;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = (z: number, ack: number) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    });
+
+    let now = 1000;
+    (globalThis as any).performance = { now: () => now };
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self: self(z0, 0) });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+
+      now = 1050;
+      expect((client as any).stepPrediction(DT * 2, now)).toBe(true);
+      const displayedBeforeZ = client.renderPoseFor(client.playerId, 0.5, now)!.pos.z;
+      (client as any).applySnapshot({ t: 'snap', tick: 2, time: DT, ents: [], self: self(z0, 0) });
+      expect(client.renderPoseFor(client.playerId, 0.5, now)!.pos.z).toBeCloseTo(displayedBeforeZ, 5);
+
+      now += 200;
+      expect(client.renderPoseFor(client.playerId, 0.5, now)!.pos.z - displayedBeforeZ).toBeLessThan(0.25);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+      (globalThis as any).performance = oldPerf;
+    }
+  });
+
+  it('predicts local movement at sim tick rate instead of per input packet', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z: z0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self });
+      Object.assign(client.moveInput, {
+        forward: true, back: false, turnLeft: false, turnRight: false,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+
+      expect(client.flushInput(100)).toBe(true);
+      expect(client.player.pos.z).toBeCloseTo(z0, 5);
+      expect((client as any).pendingPredictions).toHaveLength(0);
+
+      expect((client as any).stepPrediction(DT / 2, 125)).toBe(false);
+      expect(client.player.pos.z).toBeCloseTo(z0, 5);
+
+      expect((client as any).stepPrediction(DT / 2, 150)).toBe(true);
+      expect(client.player.pos.z).toBeCloseTo(z0 + RUN_SPEED * DT, 5);
+      expect((client as any).pendingPredictions).toHaveLength(1);
+      expect(sent.map((msg) => msg.seq)).toEqual([1, 2]);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('predicts held keyboard turning at sim tick rate', () => {
+    const client = bareClient(1);
+    const sent: any[] = [];
+    (client as any).ws = { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) };
+    const oldWebSocket = (globalThis as any).WebSocket;
+    (globalThis as any).WebSocket = { OPEN: 1 };
+    const x = 12;
+    const z0 = 20;
+    const y = groundHeight(x, z0, client.cfg.seed);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z: z0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+
+    try {
+      (client as any).applySnapshot({ t: 'snap', tick: 1, time: 0, ents: [], self });
+      Object.assign(client.moveInput, {
+        forward: false, back: false, turnLeft: false, turnRight: true,
+        strafeLeft: false, strafeRight: false, jump: false,
+      });
+
+      expect((client as any).stepPrediction(DT, 100)).toBe(true);
+      expect((client as any).stepPrediction(DT, 150)).toBe(true);
+      expect(client.player.facing).toBeCloseTo(-TURN_SPEED * DT * 2, 5);
+      expect(sent.map((msg) => msg.seq)).toEqual([1, 2]);
+      expect(sent.every((msg) => msg.mi.tr === 1)).toBe(true);
+    } finally {
+      (globalThis as any).WebSocket = oldWebSocket;
+    }
+  });
+
+  it('coalesces queued snapshots once per frame while preserving self deltas', () => {
+    const client = bareClient(1);
+    const x = 12;
+    const y = groundHeight(x, 20, client.cfg.seed);
+    const self = (z: number, extra: Record<string, unknown> = {}) => ({
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x, y, z, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: y, ack: 0,
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+      ...extra,
+    });
+
+    (client as any).queueSnapshot({
+      t: 'snap',
+      tick: 1,
+      time: 0,
+      ents: [],
+      self: self(20, { inv: [], buyback: [{ itemId: 'apprentice_staff', count: 1 }], equip: {}, qlog: [], qdone: [], cds: {} }),
+    });
+    (client as any).queueSnapshot({
+      t: 'snap',
+      tick: 2,
+      time: DT,
+      ents: [],
+      self: self(21),
+    });
+
+    expect(client.entities.has(1)).toBe(false);
+    expect((client as any).flushQueuedSnapshot()).toBe(true);
+    expect(client.player.pos.z).toBeCloseTo(21, 5);
+    expect(client.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
+    expect((client as any).flushQueuedSnapshot()).toBe(false);
+  });
+
+  it('coalesces queued snapshots without dropping first-sight entity identity', () => {
+    const client = bareClient(1);
+    const self = {
+      id: 1, k: 'player', tid: 'warrior', nm: 'Testa', lv: 1,
+      x: 0, y: 0, z: 0, f: 0, hp: 100, mhp: 100,
+      res: 0, mres: 100, rtype: 'rage', xp: 0, copper: 0, gcd: 0,
+      target: null, auto: false, queued: null,
+      vx: 0, vz: 0, vy: 0, og: 1, fy: 0, ack: 0,
+      inv: [], equip: {}, qlog: [], qdone: [], cds: {},
+      stats: { str: 1, agi: 1, sta: 1, int: 1, spi: 1, armor: 0 },
+      weapon: { min: 1, max: 2, speed: 2 },
+    };
+    const liteMob = { id: 99, x: 8, y: 0, z: 9, f: 0.5, hp: 45, mhp: 45, h: 1 };
+
+    (client as any).queueSnapshot({
+      t: 'snap',
+      tick: 1,
+      time: 0,
+      self,
+      ents: [
+        { id: 99, k: 'mob', tid: 'forest_wolf', nm: 'Forest Wolf', lv: 1, x: 5, y: 0, z: 6, f: 0, hp: 45, mhp: 45, h: 1 },
+        { id: 100, k: 'npc', tid: 'marshal_redbrook', nm: 'Marshal Redbrook', lv: 1, x: 2, y: 0, z: 3, f: 0, hp: 100, mhp: 100 },
+      ],
+    });
+    (client as any).queueSnapshot({
+      t: 'snap',
+      tick: 2,
+      time: DT,
+      self: { ...self, z: 1 },
+      ents: [liteMob],
+      keep: [100],
+    });
+
+    expect((client as any).flushQueuedSnapshot()).toBe(true);
+    const mob = client.entities.get(99)!;
+    const npc = client.entities.get(100)!;
+    expect(mob).toMatchObject({ kind: 'mob', templateId: 'forest_wolf', name: 'Forest Wolf' });
+    expect(mob.pos).toMatchObject({ x: 8, y: 0, z: 9 });
+    expect(npc).toMatchObject({ kind: 'npc', templateId: 'marshal_redbrook', name: 'Marshal Redbrook' });
   });
 
   it('snaps a dead mob to its respawn pose instead of interpolating from the corpse', () => {
@@ -384,6 +772,8 @@ describe('online movement input lifetime', () => {
       mi: { f: 0, b: 0, tl: 1, tr: 0, sl: 0, sr: 0, j: 0 },
     }));
     const meta = server.sim.meta(session.pid)!;
+    expect(meta.moveInput.turnLeft).toBe(false);
+    (server as any).markInputSeqsApplied();
     expect(meta.moveInput.turnLeft).toBe(true);
 
     for (let i = 0; i < Math.floor(0.5 / DT); i++) server.sim.tick();

--- a/tests/visual_manifest.test.ts
+++ b/tests/visual_manifest.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { VISUALS } from '../src/render/characters/manifest';
+import {
+  manifestUrls,
+  manifestUrlsForGraphics,
+  visibleAttachmentsForGraphics,
+  VISUALS,
+} from '../src/render/characters/manifest';
 
 describe('character visual manifest', () => {
   it('uses the custom boar death clip without relying on a speed override', () => {
     expect(VISUALS.mob_boar.clips.death).toBe('Dying');
     expect(VISUALS.mob_boar.deathTimeScale).toBeUndefined();
+  });
+
+  it('keeps held weapons and props available on low graphics', () => {
+    const allWeaponUrls = manifestUrls().filter((url) => url.startsWith('models/weapons/'));
+    expect(allWeaponUrls.length).toBeGreaterThan(0);
+    expect(manifestUrlsForGraphics(false)).toEqual(expect.arrayContaining(allWeaponUrls));
+    expect(visibleAttachmentsForGraphics(VISUALS.player_warrior).map((a) => a.url))
+      .toContain('models/weapons/sword_1handed.glb');
+    expect(visibleAttachmentsForGraphics(VISUALS.player_rogue).map((a) => a.url))
+      .toEqual(['models/weapons/dagger.glb', 'models/weapons/dagger.glb']);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,6 +38,9 @@ const appBuildId = env([
   'VERCEL_GIT_COMMIT_SHA',
   'CF_PAGES_COMMIT_SHA',
 ]) ?? gitSha() ?? appBuildDate.replace(/[-:TZ.]/g, '').slice(0, 12);
+const devServerPort = Number(env(['DEV_SERVER_PORT', 'VITE_DEV_SERVER_PORT']) ?? '5173');
+const devApiOrigin = env(['DEV_API_ORIGIN', 'VITE_DEV_API_ORIGIN']) ?? 'http://127.0.0.1:8787';
+const devWsOrigin = env(['DEV_WS_ORIGIN', 'VITE_DEV_WS_ORIGIN']) ?? devApiOrigin.replace(/^http/, 'ws');
 
 // Pretty-URL aliases for the standalone official-channels page (public/links.html).
 // Mirrors the production server's rewrite in server/main.ts (LINKS_ALIASES) so the
@@ -72,11 +75,11 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5173,
+    port: devServerPort,
     proxy: {
-      '/api': { target: 'http://127.0.0.1:8787', changeOrigin: true },
-      '/admin/api': { target: 'http://127.0.0.1:8787', changeOrigin: true },
-      '/ws': { target: 'ws://127.0.0.1:8787', ws: true },
+      '/api': { target: devApiOrigin, changeOrigin: true },
+      '/admin/api': { target: devApiOrigin, changeOrigin: true },
+      '/ws': { target: devWsOrigin, ws: true },
       // MediaWiki community wiki runs as its own container on :8080. Proxy /wiki*
       // to it so the in-app "Browse the Wiki" link resolves in dev too — mirrors
       // the prod reverse-proxy route (nginx /wiki -> :8080). Needs the container


### PR DESCRIPTION
## Summary

This PR combines the 0.9 performance work with the client movement prediction work, rebased on the latest `release/v0.9`.

### Graphics performance and telemetry
- Adds adaptive render budgets and an auto-governor for graphics quality.
- Adds local and production performance telemetry paths for renderer, frame timing, long tasks, foliage, render budget state, and graphics diagnostics.
- Preserves the low/medium/high/ultra preset model while allowing runtime budget adjustments inside those bands.
- Adds renderer warmup/prewarm reporting and keeps weapons/important gameplay visuals visible on low settings.

### Client movement prediction
- Queues movement inputs on the server and ACKs only the sequence applied by a completed sim tick.
- Extracts deterministic player movement into `src/sim/player_movement.ts` so server sim and client prediction share the same movement logic.
- Adds local client prediction, replay from authoritative ACKs, and presentation reconciliation to reduce visible input latency/rubber-banding.
- Adds `renderPoseFor` so rendering/camera can use the predicted local pose while preserving existing interpolation for other entities.
- Adds local-only prediction trace tooling and an analyzer script for diagnosing correction spikes and packet delay behavior.

### Merge notes
- Fetched `origin` and rebased onto `origin/release/v0.9`; the branch was already up to date with the latest release head (`a5c51c7`).
- Resolved prior prediction/performance conflicts by keeping the 0.9 renderer/perf work and layering prediction hooks into it.
- Updated the existing remote feature branch with `--force-with-lease`; no push was made to `release/v0.9`.

## Validation

- `npx tsc --noEmit`
- `npm run build`
- `npx vitest run --testTimeout 20000`

Build notes: Vite still emits the existing cursor asset runtime-resolution warnings and large chunk warning.
