### PR TITLE
feat(auth): OIDC SSO + moderator/user dashboards

### DIFF
--- a/docs/sso-and-dashboards.md
+++ b/docs/sso-and-dashboards.md
@@ -1,0 +1,212 @@
+# OIDC SSO + role-tiered dashboards (admin / moderator / user)
+
+This branch adds three additive features that extend the existing admin
+pattern. All opt-in; nothing breaks if you don't apply the db migration.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| `server/oidc.ts` | Generic OpenID Connect SSO routes at `/api/oidc/{login,callback}`. Provider-agnostic via `.well-known/openid-configuration` discovery. Self-disables (501) when env vars aren't set. |
+| `server/dashboard.ts` | `/me/api/*` (any logged-in account) + `/mod/api/*` (moderator or admin) handlers. Same `{success,data,error}` envelope as `server/admin.ts`. |
+| `src/user/{api,main}.ts` + `user.html` | `/me/` dashboard SPA — own characters, role chips, standing. |
+| `src/moderator/{api,main}.ts` + `mod.html` | `/mod/` dashboard SPA — mod login + read-only queue. |
+
+## Integration steps
+
+Three files in your existing codebase need additive edits.
+
+### 1. `server/db.ts` — schema migrations + 3 helpers + 1 upsert
+
+Add to the `SCHEMA` template literal (idempotent, safe to re-run):
+
+```sql
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS is_moderator BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS oauth_provider TEXT;
+ALTER TABLE accounts ADD COLUMN IF NOT EXISTS oauth_sub TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS accounts_oauth_identity
+  ON accounts(oauth_provider, oauth_sub) WHERE oauth_provider IS NOT NULL;
+```
+
+Add these helpers below the existing `isAdminAccount`:
+
+```ts
+export async function isModeratorAccount(accountId: number): Promise<boolean> {
+  const res = await pool.query(
+    'SELECT is_admin, is_moderator FROM accounts WHERE id = $1',
+    [accountId],
+  );
+  const row = res.rows[0];
+  return row?.is_admin === true || row?.is_moderator === true;
+}
+
+export interface AccountRoleFlags { isAdmin: boolean; isModerator: boolean; }
+
+export async function accountRoleFlags(accountId: number): Promise<AccountRoleFlags> {
+  const res = await pool.query(
+    'SELECT is_admin, is_moderator FROM accounts WHERE id = $1',
+    [accountId],
+  );
+  const row = res.rows[0];
+  return {
+    isAdmin: row?.is_admin === true,
+    isModerator: row?.is_moderator === true || row?.is_admin === true,
+  };
+}
+
+export interface OAuthUpsertResult { id: number; username: string; created: boolean; }
+
+function sanitizeUsernameCandidate(raw: string): string {
+  const stripped = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 20);
+  return stripped.length >= 3 ? stripped : (stripped ? `${stripped}_usr` : 'usr');
+}
+
+export async function upsertOAuthAccount(input: {
+  provider: string;
+  sub: string;
+  displayName: string;
+}): Promise<OAuthUpsertResult> {
+  // Existing link wins — no username conflicts to worry about.
+  const existing = await pool.query(
+    'SELECT id, username FROM accounts WHERE oauth_provider = $1 AND oauth_sub = $2 LIMIT 1',
+    [input.provider, input.sub],
+  );
+  if (existing.rows.length) {
+    return { id: existing.rows[0].id, username: existing.rows[0].username, created: false };
+  }
+  // Brand new identity: derive a free username and create the row.
+  const base = sanitizeUsernameCandidate(input.displayName || input.sub);
+  let candidate = base;
+  for (let n = 1; n < 9999; n++) {
+    const dupe = await pool.query('SELECT id FROM accounts WHERE username = $1 LIMIT 1', [candidate]);
+    if (!dupe.rows.length) break;
+    candidate = `${base.slice(0, 18)}_${n}`;
+  }
+  // OAuth accounts have no password — store a sentinel that won't pass
+  // scrypt verification, so the username can never be logged into via
+  // /api/login.
+  const res = await pool.query(
+    `INSERT INTO accounts (username, password_hash, oauth_provider, oauth_sub)
+     VALUES ($1, $2, $3, $4)
+     RETURNING id, username`,
+    [candidate, 'oauth:' + input.provider, input.provider, input.sub],
+  );
+  return { id: res.rows[0].id, username: res.rows[0].username, created: true };
+}
+```
+
+### 2. `server/main.ts` — register the new dispatchers
+
+Add these imports at the top, near `handleAdminApi`:
+
+```ts
+import { handleModeratorApi, handleUserApi } from './dashboard';
+import { handleOidcRoute, isOidcConfigured } from './oidc';
+```
+
+Update the request dispatcher:
+
+```ts
+    const isApi =
+      url.startsWith('/api/') ||
+      url.startsWith('/admin/api/') ||
+      url.startsWith('/mod/api/') ||
+      url.startsWith('/me/api/');
+    if (isApi) maybeCors(req, res);
+    if (req.method === 'OPTIONS' && isApi) { res.writeHead(204); res.end(); return; }
+    if (url.startsWith('/admin/api/')) void handleAdminApi(req, res, game);
+    else if (url.startsWith('/mod/api/')) void handleModeratorApi(req, res);
+    else if (url.startsWith('/me/api/')) void handleUserApi(req, res);
+    else if (url.startsWith('/api/oidc')) void handleOidcRoute(req, res);
+    else if (url.startsWith('/api/')) void handleApi(req, res);
+    else serveStatic(req, res);
+```
+
+Extend `serveStatic` to swap shells for `/me/` and `/mod/`:
+
+```ts
+function dashboardShellFor(urlPath: string): string | null {
+  if (urlPath === '/mod' || urlPath === '/mod/') return 'mod.html';
+  if (urlPath === '/me' || urlPath === '/me/') return 'user.html';
+  return null;
+}
+
+function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void {
+  let urlPath = (req.url ?? '/').split('?')[0];
+  const dashShell = dashboardShellFor(urlPath);
+  const shell = dashShell ?? (isAdminRequest(req) ? 'admin.html' : 'index.html');
+  // …existing wiki redirect…
+  if (
+    urlPath === '/' ||
+    urlPath === '/admin' || urlPath === '/admin/' ||
+    urlPath === '/mod'   || urlPath === '/mod/'   ||
+    urlPath === '/me'    || urlPath === '/me/'
+  ) urlPath = `/${shell}`;
+  // …existing static file handling…
+}
+```
+
+Optional boot log:
+
+```ts
+    if (isOidcConfigured()) {
+      console.log('  SSO:  OIDC enabled at /api/oidc/login');
+    }
+```
+
+### 3. `vite.config.ts` — add the two new entries
+
+```ts
+      input: {
+        main: fileURLToPath(new URL('index.html', import.meta.url)),
+        admin: fileURLToPath(new URL('admin.html', import.meta.url)),
+        user: fileURLToPath(new URL('user.html', import.meta.url)),
+        moderator: fileURLToPath(new URL('mod.html', import.meta.url)),
+      },
+```
+
+## Configuration
+
+### OIDC SSO env vars
+
+All four must be set, otherwise `/api/oidc/login` returns 501 and `/api/login`
+keeps being the only entry point.
+
+```
+OIDC_ISSUER=https://auth.example.com/application/o/woc
+OIDC_CLIENT_ID=<provider issues this when you register WoC>
+OIDC_CLIENT_SECRET=<same>
+OIDC_REDIRECT_URI=https://your-deploy.example.com/api/oidc/callback
+```
+
+The issuer URL is whatever your provider documents as the per-application
+issuer (on Authentik it's `https://<auth>/application/o/<app-slug>`). We
+fetch `<issuer>/.well-known/openid-configuration` once at first request and
+cache the discovered `authorization_endpoint` / `token_endpoint` /
+`userinfo_endpoint`. Tested against Authentik 2025.8.x; same code path works
+unchanged with any conformant OIDC 1.0 provider (Keycloak / Auth0 /
+Ory Hydra / Cognito / Zitadel).
+
+The callback redirects back to `/#auth_token=…&auth_user=…&auth_via=oidc`.
+Token format is the same 64-hex Bearer the existing `/api/login` issues.
+
+### Granting moderator access
+
+```sql
+UPDATE accounts SET is_moderator = TRUE WHERE username = '<name>';
+```
+
+Admins are implicit moderators; no need to grant both.
+
+## Roll-back
+
+The migration columns + index are additive and safe to leave in place even if
+you disable the routes. To turn the feature off entirely:
+
+- Unset the `OIDC_*` env vars (route returns 501).
+- Remove the dispatcher branches in `server/main.ts`.
+- Drop `user.html` and `mod.html` from `vite.config.ts` inputs.

--- a/mod.html
+++ b/mod.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>World of ClaudeCraft — Moderator</title>
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <meta name="robots" content="noindex,nofollow" />
+  <style>
+    body { background: #060609; color: #e8d8a8; font-family: 'Arial', sans-serif; font-size: 14px; margin: 0; min-height: 100vh; }
+    .woc-dash { max-width: 1100px; margin: 0 auto; padding: 32px 24px 80px; display: flex; flex-direction: column; gap: 24px; }
+    .woc-card { background: linear-gradient(170deg, #15151f 0%, #0b0b12 60%, #08080d 100%); border: 2px solid #6f5a2a; outline: 1px solid #000; border-radius: 6px; box-shadow: 0 2px 16px #000c, inset 0 0 24px #0006, inset 0 1px 0 #ffffff14; padding: 18px 20px; }
+    .woc-header { display: flex; justify-content: space-between; align-items: flex-end; flex-wrap: wrap; gap: 16px; padding-bottom: 12px; border-bottom: 1px solid #6f5a2a; }
+    .woc-meta { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; font-size: 13px; }
+    .woc-stack { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; }
+    .woc-stack input, .woc-stack button { padding: 10px 12px; border: 1px solid #6f5a2a; border-radius: 6px; background: rgba(0, 0, 0, 0.4); color: inherit; font: inherit; }
+    .woc-stack button { background: linear-gradient(180deg, #c8a838, #8a721d); border-color: #ffd100; color: #15151f; font-weight: 800; letter-spacing: 1px; text-transform: uppercase; cursor: pointer; }
+    .woc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    .woc-table th, .woc-table td { text-align: left; padding: 8px 10px; border-bottom: 1px solid rgba(255, 255, 255, 0.06); }
+    .woc-table th { font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: #9a8c66; }
+    .woc-chip { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; border: 1px solid #6f5a2a; }
+    .woc-admin { border-color: #d4442a; color: #ffb39c; }
+    .woc-mod { border-color: #c9a14a; color: #f3dfaa; }
+    .woc-banned { border-color: #c0392b; color: #ff7b6b; }
+    .woc-suspended { border-color: #e67e22; color: #ffb169; }
+    .woc-muted { border-color: #9b59b6; color: #d3a3e6; }
+    .woc-online { border-color: #27ae60; color: #7fdc4f; }
+    .woc-dim { color: #9a8c66; }
+    .woc-error { color: #ff6b5e; }
+    .woc-ok { color: #7fdc4f; }
+    .woc-link { background: transparent; border: 1px solid #6f5a2a; color: #c8a838; padding: 6px 10px; border-radius: 6px; cursor: pointer; text-decoration: none; font: inherit; font-size: 12px; }
+    .woc-link:hover { border-color: #ffd100; color: #ffd100; }
+  </style>
+</head>
+<body>
+  <script type="module" src="/src/moderator/main.ts"></script>
+</body>
+</html>

--- a/server/dashboard.ts
+++ b/server/dashboard.ts
@@ -1,0 +1,136 @@
+// User + moderator dashboard endpoints. Adds two parallel route prefixes
+// alongside the existing /admin/api/*:
+//
+//   /me/api/*   — any logged-in account (own-data view)
+//   /mod/api/*  — accounts flagged is_moderator (or is_admin, since admins
+//                  are implicit moderators)
+//
+// All responses use the same {success,data,error} envelope as the admin API
+// so src/admin/api.ts can be reused with only the path prefix swapped.
+
+import * as http from 'node:http';
+import { json, readBody } from './http_util';
+import { rateLimited } from './ratelimit';
+import {
+  findAccount, touchLogin, saveToken, accountForToken,
+  isModeratorAccount, accountRoleFlags,
+  listCharacters, type CharacterRow,
+  moderationStatusForAccount, chatMuteStatusForAccount,
+} from './db';
+import { verifyPassword, newToken } from './auth';
+import { moderationQueue } from './moderation_db';
+import { REALM } from './realm';
+
+const DASH_LOGIN_MAX_PER_MINUTE = 10;
+
+function ok(res: http.ServerResponse, data: unknown): void {
+  json(res, 200, { success: true, data, error: null });
+}
+function fail(res: http.ServerResponse, status: number, error: string): void {
+  json(res, status, { success: false, data: null, error });
+}
+
+async function bearerAccountId(req: http.IncomingMessage): Promise<number | null> {
+  const m = /^Bearer ([a-f0-9]{64})$/.exec(req.headers.authorization ?? '');
+  if (!m) return null;
+  return accountForToken(m[1]);
+}
+
+interface LoginBody { username?: unknown; password?: unknown; }
+
+async function handleLogin(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  requireModerator: boolean,
+): Promise<void> {
+  if (rateLimited(req, DASH_LOGIN_MAX_PER_MINUTE)) {
+    return fail(res, 429, 'too many attempts — wait a minute and try again');
+  }
+  const body = (await readBody(req)) as LoginBody;
+  const account = typeof body.username === 'string' ? await findAccount(body.username) : null;
+  if (!account || !(await verifyPassword(String(body.password ?? ''), account.password_hash))) {
+    return fail(res, 401, 'invalid username or password');
+  }
+  const mod = await moderationStatusForAccount(account.id);
+  if (mod.locked) return fail(res, 403, mod.message);
+  if (requireModerator && !(await isModeratorAccount(account.id))) {
+    return fail(res, 403, 'this account does not have moderator access');
+  }
+  await touchLogin(account.id);
+  const token = newToken();
+  await saveToken(token, account.id);
+  const roles = await accountRoleFlags(account.id);
+  ok(res, { token, username: account.username, roles });
+}
+
+interface CharSummary {
+  id: number; name: string; class: string; level: number; realm: string; lifetimeXp: number;
+}
+
+function summarizeCharacter(row: CharacterRow): CharSummary {
+  const state = row.state as Record<string, unknown> | null;
+  const lifetimeXp = typeof state?.lifetimeXp === 'number' ? (state.lifetimeXp as number) : 0;
+  return {
+    id: row.id, name: row.name, class: String(row.class),
+    level: row.level, realm: REALM, lifetimeXp,
+  };
+}
+
+async function handleMe(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const accountId = await bearerAccountId(req);
+  if (accountId === null) return fail(res, 401, 'not authenticated');
+
+  const [roles, mod, chatMute, chars] = await Promise.all([
+    accountRoleFlags(accountId),
+    moderationStatusForAccount(accountId),
+    chatMuteStatusForAccount(accountId),
+    listCharacters(accountId),
+  ]);
+
+  ok(res, {
+    accountId, realm: REALM, roles,
+    moderation: {
+      locked: mod.locked, message: mod.message,
+      chatMutedUntil: chatMute.mutedUntil ?? null,
+    },
+    characters: chars.map(summarizeCharacter),
+  });
+}
+
+async function handleModQueue(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const accountId = await bearerAccountId(req);
+  if (accountId === null) return fail(res, 401, 'not authenticated');
+  if (!(await isModeratorAccount(accountId))) return fail(res, 403, 'moderator access required');
+  // Dashboard view is read-only — without access to the game's live session
+  // table we pass an empty online set; the queue still surfaces every open
+  // report, mods just see the "offline" tag for everyone.
+  const queue = await moderationQueue(new Set<number>());
+  ok(res, queue);
+}
+
+/** Dispatch `/me/api/*` requests. */
+export async function handleUserApi(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const path = url.pathname;
+  try {
+    if (req.method === 'POST' && path === '/me/api/login') return await handleLogin(req, res, false);
+    if (req.method === 'GET' && path === '/me/api/me') return await handleMe(req, res);
+    return fail(res, 404, 'route not found');
+  } catch (err) {
+    return fail(res, 500, err instanceof Error ? err.message : 'internal error');
+  }
+}
+
+/** Dispatch `/mod/api/*` requests. */
+export async function handleModeratorApi(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const path = url.pathname;
+  try {
+    if (req.method === 'POST' && path === '/mod/api/login') return await handleLogin(req, res, true);
+    if (req.method === 'GET' && path === '/mod/api/me') return await handleMe(req, res);
+    if (req.method === 'GET' && path === '/mod/api/queue') return await handleModQueue(req, res);
+    return fail(res, 404, 'route not found');
+  } catch (err) {
+    return fail(res, 500, err instanceof Error ? err.message : 'internal error');
+  }
+}

--- a/server/oidc.ts
+++ b/server/oidc.ts
@@ -1,0 +1,192 @@
+// OIDC single sign-on. Adds two routes parallel to /api/login:
+//
+//   GET  /api/oidc/login    → 302 to the configured provider's authorize URL
+//   GET  /api/oidc/callback → exchange code, upsert account, redirect home
+//
+// The flow is generic — any OpenID Connect 1.0 provider works (Authentik,
+// Keycloak, Auth0, Ory Hydra, Zitadel, Cognito, …). We fetch the provider's
+// .well-known/openid-configuration once at first request and cache the
+// discovered endpoints, so deploys don't need to hard-code authorize/token/
+// userinfo URLs.
+//
+// Configuration (read once at startup; all four must be present, otherwise
+// the routes return 501 and the existing /api/login flow keeps working):
+//
+//   OIDC_ISSUER         e.g. https://auth.example.com/application/o/woc
+//   OIDC_CLIENT_ID      issued by the provider when you register WoC
+//   OIDC_CLIENT_SECRET  issued alongside the client id
+//   OIDC_REDIRECT_URI   e.g. https://your-deploy.example.com/api/oidc/callback
+//
+// CSRF: a short-lived woc_oidc_state cookie carries the state nonce we sent
+// to the provider; the callback rejects any code that arrives without a
+// matching state.
+
+import * as http from 'node:http';
+import { randomBytes } from 'node:crypto';
+import { json } from './http_util';
+import { saveToken, touchLogin, upsertOAuthAccount, accountForToken } from './db';
+import { newToken } from './auth';
+
+const STATE_COOKIE = 'woc_oidc_state';
+const STATE_COOKIE_MAX_AGE = 600;
+const PROVIDER = 'oidc';
+
+interface OidcConfig { issuer: string; clientId: string; clientSecret: string; redirectUri: string; }
+interface OidcEndpoints { authorize: string; token: string; userinfo: string; }
+
+function readConfig(): OidcConfig | null {
+  const issuer = (process.env.OIDC_ISSUER ?? '').trim().replace(/\/+$/, '');
+  const clientId = (process.env.OIDC_CLIENT_ID ?? '').trim();
+  const clientSecret = (process.env.OIDC_CLIENT_SECRET ?? '').trim();
+  const redirectUri = (process.env.OIDC_REDIRECT_URI ?? '').trim();
+  if (!issuer || !clientId || !clientSecret || !redirectUri) return null;
+  return { issuer, clientId, clientSecret, redirectUri };
+}
+
+const CONFIG: OidcConfig | null = readConfig();
+
+let endpointsCache: OidcEndpoints | null = null;
+let endpointsInflight: Promise<OidcEndpoints> | null = null;
+
+async function discoverEndpoints(cfg: OidcConfig): Promise<OidcEndpoints> {
+  if (endpointsCache) return endpointsCache;
+  if (endpointsInflight) return endpointsInflight;
+  endpointsInflight = (async () => {
+    const r = await fetch(`${cfg.issuer}/.well-known/openid-configuration`);
+    if (!r.ok) throw new Error(`OIDC discovery failed (${r.status})`);
+    const j = (await r.json()) as Record<string, unknown>;
+    const authorize = typeof j.authorization_endpoint === 'string' ? j.authorization_endpoint : '';
+    const token = typeof j.token_endpoint === 'string' ? j.token_endpoint : '';
+    const userinfo = typeof j.userinfo_endpoint === 'string' ? j.userinfo_endpoint : '';
+    if (!authorize || !token || !userinfo) {
+      throw new Error('OIDC discovery doc missing required endpoints');
+    }
+    endpointsCache = { authorize, token, userinfo };
+    return endpointsCache;
+  })();
+  try { return await endpointsInflight; }
+  finally { endpointsInflight = null; }
+}
+
+export function isOidcConfigured(): boolean { return CONFIG !== null; }
+
+function setStateCookie(res: http.ServerResponse, state: string): void {
+  const flags = [
+    `${STATE_COOKIE}=${state}`,
+    'Path=/api/oidc',
+    `Max-Age=${STATE_COOKIE_MAX_AGE}`,
+    'HttpOnly', 'SameSite=Lax', 'Secure',
+  ];
+  res.setHeader('Set-Cookie', flags.join('; '));
+}
+
+function clearStateCookie(res: http.ServerResponse): void {
+  res.setHeader('Set-Cookie',
+    `${STATE_COOKIE}=; Path=/api/oidc; Max-Age=0; HttpOnly; SameSite=Lax; Secure`);
+}
+
+function readCookie(req: http.IncomingMessage, name: string): string | null {
+  const raw = req.headers.cookie ?? '';
+  for (const part of raw.split(';')) {
+    const [k, ...rest] = part.split('=');
+    if (k.trim() === name) return rest.join('=').trim();
+  }
+  return null;
+}
+
+function buildAuthorizeUrl(authorizeEndpoint: string, cfg: OidcConfig, state: string): string {
+  const params = new URLSearchParams({
+    response_type: 'code', scope: 'openid profile email',
+    client_id: cfg.clientId, redirect_uri: cfg.redirectUri, state,
+  });
+  return `${authorizeEndpoint}?${params.toString()}`;
+}
+
+interface TokenResponse { access_token?: string; id_token?: string; token_type?: string; }
+interface UserInfo { sub?: string; preferred_username?: string; name?: string; email?: string; }
+
+async function exchangeCode(tokenEndpoint: string, cfg: OidcConfig, code: string): Promise<TokenResponse> {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code', code, redirect_uri: cfg.redirectUri,
+    client_id: cfg.clientId, client_secret: cfg.clientSecret,
+  });
+  const r = await fetch(tokenEndpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+  if (!r.ok) throw new Error(`token exchange failed: ${r.status} ${await r.text().catch(() => '')}`);
+  return (await r.json()) as TokenResponse;
+}
+
+async function fetchUserInfo(userinfoEndpoint: string, accessToken: string): Promise<UserInfo> {
+  const r = await fetch(userinfoEndpoint, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  if (!r.ok) throw new Error(`userinfo failed: ${r.status}`);
+  return (await r.json()) as UserInfo;
+}
+
+/** Public entry: handles `/api/oidc/login` and `/api/oidc/callback`. */
+export async function handleOidcRoute(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  const url = new URL(req.url ?? '/', 'http://localhost');
+  const path = url.pathname;
+
+  if (!CONFIG) {
+    return json(res, 501, { error: 'OIDC SSO is not configured on this server' });
+  }
+
+  if (path === '/api/oidc/login') {
+    try {
+      const endpoints = await discoverEndpoints(CONFIG);
+      const state = randomBytes(24).toString('hex');
+      setStateCookie(res, state);
+      res.writeHead(302, { Location: buildAuthorizeUrl(endpoints.authorize, CONFIG, state) });
+      res.end();
+      return;
+    } catch (err) {
+      return json(res, 502, { error: err instanceof Error ? err.message : 'OIDC discovery failed' });
+    }
+  }
+
+  if (path === '/api/oidc/callback') {
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    const cookieState = readCookie(req, STATE_COOKIE);
+    if (!code || !state || state !== cookieState) {
+      clearStateCookie(res);
+      return json(res, 400, { error: 'invalid OAuth state — please retry sign-in' });
+    }
+    try {
+      const endpoints = await discoverEndpoints(CONFIG);
+      const tok = await exchangeCode(endpoints.token, CONFIG, code);
+      if (!tok.access_token) throw new Error('missing access_token');
+      const info = await fetchUserInfo(endpoints.userinfo, tok.access_token);
+      if (!info.sub) throw new Error('userinfo missing sub claim');
+      const account = await upsertOAuthAccount({
+        provider: PROVIDER, sub: info.sub,
+        displayName: info.preferred_username ?? info.name ?? info.email ?? info.sub,
+      });
+      await touchLogin(account.id);
+      const localToken = newToken();
+      await saveToken(localToken, account.id);
+      clearStateCookie(res);
+      const hash = new URLSearchParams({
+        auth_token: localToken,
+        auth_user: account.username,
+        auth_via: PROVIDER,
+      });
+      res.writeHead(302, { Location: `/#${hash.toString()}` });
+      res.end();
+      return;
+    } catch (err) {
+      clearStateCookie(res);
+      console.error('OIDC callback failed:', err);
+      return json(res, 502, { error: err instanceof Error ? err.message : 'OAuth callback failed' });
+    }
+  }
+
+  return json(res, 404, { error: 'not found' });
+}
+
+export { accountForToken };

--- a/src/moderator/api.ts
+++ b/src/moderator/api.ts
@@ -1,0 +1,76 @@
+// Fetch wrapper for /mod/api/*. Same envelope + Bearer flow as the admin
+// and user APIs, scoped to moderator-gated routes.
+
+const TOKEN_KEY = 'woc_mod_token';
+const NAME_KEY = 'woc_mod_name';
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) { super(message); }
+}
+
+export function getToken(): string | null { return localStorage.getItem(TOKEN_KEY); }
+export function getModName(): string { return localStorage.getItem(NAME_KEY) ?? ''; }
+export function clearSession(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(NAME_KEY);
+}
+
+interface Envelope<T> { success: boolean; data: T | null; error: string | null; }
+
+async function parseEnvelope<T>(res: Response): Promise<T> {
+  let body: Envelope<T> | null = null;
+  try { body = await res.json(); } catch {
+    throw new ApiError(res.status, `unexpected response (${res.status})`);
+  }
+  if (!res.ok || !body || body.success !== true || body.data === null) {
+    throw new ApiError(res.status, body?.error ?? `request failed (${res.status})`);
+  }
+  return body.data;
+}
+
+export interface ModRoleFlags { isAdmin: boolean; isModerator: boolean; }
+export interface ModLoginData { token: string; username: string; roles: ModRoleFlags; }
+export interface ModMeData {
+  accountId: number;
+  realm: string;
+  roles: ModRoleFlags;
+  moderation: { locked: boolean; message: string; chatMutedUntil: string | null };
+  characters: { id: number; name: string; class: string; level: number; realm: string; lifetimeXp: number }[];
+}
+export interface ModQueueRow {
+  accountId: number;
+  username: string | null;
+  characterName: string | null;
+  characterClass: string | null;
+  characterLevel: number | null;
+  online: boolean;
+  openReports: number;
+  lastReportAt: string | null;
+  banned: boolean;
+  suspendedUntil: string | null;
+  moderationReason: string | null;
+  chatMutedUntil: string | null;
+  chatStrikes: number;
+}
+
+export async function modLogin(username: string, password: string): Promise<ModLoginData> {
+  const res = await fetch('/mod/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  const data = await parseEnvelope<ModLoginData>(res);
+  localStorage.setItem(TOKEN_KEY, data.token);
+  localStorage.setItem(NAME_KEY, data.username);
+  return data;
+}
+
+async function authedGet<T>(path: string): Promise<T> {
+  const token = getToken();
+  if (!token) throw new ApiError(401, 'not signed in');
+  const res = await fetch(path, { headers: { Authorization: `Bearer ${token}` } });
+  return parseEnvelope<T>(res);
+}
+
+export const getModMe = () => authedGet<ModMeData>('/mod/api/me');
+export const getModQueue = () => authedGet<ModQueueRow[]>('/mod/api/queue');

--- a/src/moderator/main.ts
+++ b/src/moderator/main.ts
@@ -1,0 +1,137 @@
+// Moderator dashboard SPA — /mod/. Requires is_moderator or is_admin.
+// Shows the moderation queue and the current mod's own info.
+
+import {
+  modLogin, getModMe, getModQueue, getToken, getModName, clearSession,
+  ApiError, type ModMeData, type ModQueueRow,
+} from './api';
+
+const $ = <T extends HTMLElement = HTMLElement>(sel: string): T =>
+  document.querySelector(sel) as T;
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string),
+  );
+}
+
+function renderLoginShell(): void {
+  document.body.innerHTML = `
+    <div class="woc-dash">
+      <div class="woc-card">
+        <h1>World of ClaudeCraft — Moderator</h1>
+        <p class="woc-dim">Sign in. Moderator or admin access required.</p>
+        <form id="login-form">
+          <div class="woc-stack">
+            <input id="login-username" type="text" placeholder="Username" autocomplete="username" required />
+            <input id="login-password" type="password" placeholder="Password" autocomplete="current-password" required />
+            <div id="login-error" class="woc-error" hidden></div>
+            <button type="submit">Sign in</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `;
+  ($('#login-form') as HTMLFormElement).addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const err = $('#login-error');
+    err.hidden = true;
+    try {
+      await modLogin(
+        ($('#login-username') as HTMLInputElement).value.trim(),
+        ($('#login-password') as HTMLInputElement).value,
+      );
+      void boot();
+    } catch (e) {
+      err.hidden = false;
+      err.textContent = e instanceof ApiError ? e.message : 'sign-in failed';
+    }
+  });
+}
+
+function renderQueueTable(rows: ModQueueRow[]): string {
+  if (rows.length === 0) {
+    return '<p class="woc-ok">No open reports. Queue is clear.</p>';
+  }
+  return `<table class="woc-table">
+    <thead><tr>
+      <th>Account</th><th>Character</th><th>Reports</th><th>Status</th><th>Last report</th>
+    </tr></thead>
+    <tbody>
+      ${rows.map((r) => {
+        const status: string[] = [];
+        if (r.banned) status.push('<span class="woc-chip woc-banned">Banned</span>');
+        if (r.suspendedUntil) status.push(`<span class="woc-chip woc-suspended">Suspended → ${escapeHtml(r.suspendedUntil)}</span>`);
+        if (r.chatMutedUntil) status.push(`<span class="woc-chip woc-muted">Chat muted → ${escapeHtml(r.chatMutedUntil)}</span>`);
+        if (r.online) status.push('<span class="woc-chip woc-online">Online</span>');
+        if (status.length === 0) status.push('<span class="woc-dim">—</span>');
+        return `<tr>
+          <td>${escapeHtml(r.username ?? '(deleted)')}</td>
+          <td>${escapeHtml(r.characterName ?? '(none)')} ${r.characterClass ? `<span class="woc-dim">${escapeHtml(r.characterClass)} ${r.characterLevel ?? ''}</span>` : ''}</td>
+          <td>${r.openReports}</td>
+          <td>${status.join(' ')}</td>
+          <td>${escapeHtml(r.lastReportAt ?? '—')}</td>
+        </tr>`;
+      }).join('')}
+    </tbody>
+  </table>`;
+}
+
+async function renderDashboard(): Promise<void> {
+  let me: ModMeData;
+  try { me = await getModMe(); }
+  catch (e) {
+    clearSession();
+    renderLoginShell();
+    if (e instanceof ApiError && e.status !== 401) {
+      const el = document.getElementById('login-error');
+      if (el) { el.hidden = false; el.textContent = e.message; }
+    }
+    return;
+  }
+
+  const roleChips: string[] = [];
+  if (me.roles.isAdmin) roleChips.push('<span class="woc-chip woc-admin">Admin</span>');
+  if (me.roles.isModerator) roleChips.push('<span class="woc-chip woc-mod">Moderator</span>');
+
+  document.body.innerHTML = `
+    <div class="woc-dash">
+      <header class="woc-header">
+        <h1>World of ClaudeCraft — Moderator Tools</h1>
+        <div class="woc-meta">
+          <span>${escapeHtml(getModName())}</span>
+          ${roleChips.join(' ')}
+          <span class="woc-dim">Realm: <strong>${escapeHtml(me.realm)}</strong></span>
+          <a class="woc-link" href="/me/">My Account</a>
+          ${me.roles.isAdmin ? '<a class="woc-link" href="/admin/">Admin</a>' : ''}
+          <button id="signout" class="woc-link" type="button">Sign out</button>
+        </div>
+      </header>
+      <section class="woc-card">
+        <h2>Moderation queue</h2>
+        <div id="queue">Loading…</div>
+      </section>
+    </div>
+  `;
+  $('#signout').addEventListener('click', () => { clearSession(); renderLoginShell(); });
+
+  try {
+    const queue = await getModQueue();
+    $('#queue').innerHTML = renderQueueTable(queue);
+  } catch (e) {
+    $('#queue').innerHTML = `<div class="woc-error">Queue load failed: ${escapeHtml(e instanceof Error ? e.message : 'unknown')}</div>`;
+  }
+}
+
+async function boot(): Promise<void> {
+  if (!getToken()) { renderLoginShell(); return; }
+  await renderDashboard();
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => void boot());
+  } else {
+    void boot();
+  }
+}

--- a/src/user/api.ts
+++ b/src/user/api.ts
@@ -1,0 +1,61 @@
+// Fetch wrapper for /me/api/*. Mirrors src/admin/api.ts so both dashboards
+// share the same {success,data,error} envelope handling.
+
+const TOKEN_KEY = 'woc_user_token';
+const NAME_KEY = 'woc_user_name';
+
+export class ApiError extends Error {
+  constructor(public status: number, message: string) { super(message); }
+}
+
+export function getToken(): string | null { return localStorage.getItem(TOKEN_KEY); }
+export function getUserName(): string { return localStorage.getItem(NAME_KEY) ?? ''; }
+export function clearSession(): void {
+  localStorage.removeItem(TOKEN_KEY);
+  localStorage.removeItem(NAME_KEY);
+}
+
+interface Envelope<T> { success: boolean; data: T | null; error: string | null; }
+
+async function parseEnvelope<T>(res: Response): Promise<T> {
+  let body: Envelope<T> | null = null;
+  try { body = await res.json(); } catch {
+    throw new ApiError(res.status, `unexpected response (${res.status})`);
+  }
+  if (!res.ok || !body || body.success !== true || body.data === null) {
+    throw new ApiError(res.status, body?.error ?? `request failed (${res.status})`);
+  }
+  return body.data;
+}
+
+export interface RoleFlags { isAdmin: boolean; isModerator: boolean; }
+export interface LoginData { token: string; username: string; roles: RoleFlags; }
+export interface MyCharacter {
+  id: number; name: string; class: string; level: number; realm: string; lifetimeXp: number;
+}
+export interface MeData {
+  accountId: number;
+  realm: string;
+  roles: RoleFlags;
+  moderation: { locked: boolean; message: string; chatMutedUntil: string | null };
+  characters: MyCharacter[];
+}
+
+export async function userLogin(username: string, password: string): Promise<LoginData> {
+  const res = await fetch('/me/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  const data = await parseEnvelope<LoginData>(res);
+  localStorage.setItem(TOKEN_KEY, data.token);
+  localStorage.setItem(NAME_KEY, data.username);
+  return data;
+}
+
+export async function getMe(): Promise<MeData> {
+  const token = getToken();
+  if (!token) throw new ApiError(401, 'not signed in');
+  const res = await fetch('/me/api/me', { headers: { Authorization: `Bearer ${token}` } });
+  return parseEnvelope<MeData>(res);
+}

--- a/src/user/main.ts
+++ b/src/user/main.ts
@@ -1,0 +1,125 @@
+// User dashboard SPA — /me/. Anyone who can log in to the game can sign in
+// here and see their character list, realm, role flags, and any active
+// chat-mute / suspension status.
+
+import {
+  userLogin, getMe, getToken, getUserName, clearSession,
+  ApiError, type MeData,
+} from './api';
+
+const $ = <T extends HTMLElement = HTMLElement>(sel: string): T =>
+  document.querySelector(sel) as T;
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string),
+  );
+}
+
+function renderLoginShell(): void {
+  document.body.innerHTML = `
+    <div class="woc-dash">
+      <div class="woc-card">
+        <h1>World of ClaudeCraft — My Account</h1>
+        <p class="woc-dim">Sign in with your game username and password.</p>
+        <form id="login-form">
+          <div class="woc-stack">
+            <input id="login-username" type="text" placeholder="Username" autocomplete="username" required />
+            <input id="login-password" type="password" placeholder="Password" autocomplete="current-password" required />
+            <div id="login-error" class="woc-error" hidden></div>
+            <button type="submit">Sign in</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  `;
+  ($('#login-form') as HTMLFormElement).addEventListener('submit', async (ev) => {
+    ev.preventDefault();
+    const err = $('#login-error');
+    err.hidden = true;
+    try {
+      await userLogin(
+        ($('#login-username') as HTMLInputElement).value.trim(),
+        ($('#login-password') as HTMLInputElement).value,
+      );
+      void boot();
+    } catch (e) {
+      err.hidden = false;
+      err.textContent = e instanceof ApiError ? e.message : 'sign-in failed';
+    }
+  });
+}
+
+function renderDashboard(me: MeData): void {
+  const roleChips: string[] = [];
+  if (me.roles.isAdmin) roleChips.push('<span class="woc-chip woc-admin">Admin</span>');
+  if (me.roles.isModerator && !me.roles.isAdmin) roleChips.push('<span class="woc-chip woc-mod">Moderator</span>');
+  if (roleChips.length === 0) roleChips.push('<span class="woc-chip">Player</span>');
+
+  const charsHtml = me.characters.length === 0
+    ? '<p class="woc-dim">No characters on this realm yet.</p>'
+    : `<table class="woc-table"><thead><tr><th>Name</th><th>Class</th><th>Level</th><th>Lifetime XP</th></tr></thead><tbody>
+        ${me.characters.map((c) => `<tr>
+          <td>${escapeHtml(c.name)}</td>
+          <td>${escapeHtml(c.class)}</td>
+          <td>${c.level}</td>
+          <td>${c.lifetimeXp.toLocaleString()}</td>
+        </tr>`).join('')}
+       </tbody></table>`;
+
+  const moderationHtml = me.moderation.locked
+    ? `<div class="woc-error">Account locked: ${escapeHtml(me.moderation.message)}</div>`
+    : me.moderation.chatMutedUntil
+    ? `<div class="woc-error">Chat muted until ${escapeHtml(me.moderation.chatMutedUntil)}.</div>`
+    : '<div class="woc-ok">Account in good standing.</div>';
+
+  document.body.innerHTML = `
+    <div class="woc-dash">
+      <header class="woc-header">
+        <h1>My Account — ${escapeHtml(getUserName())}</h1>
+        <div class="woc-meta">
+          ${roleChips.join(' ')}
+          <span class="woc-dim">Realm: <strong>${escapeHtml(me.realm)}</strong></span>
+          ${me.roles.isModerator ? '<a class="woc-link" href="/mod/">Moderator Tools</a>' : ''}
+          ${me.roles.isAdmin ? '<a class="woc-link" href="/admin/">Admin</a>' : ''}
+          <button id="signout" class="woc-link" type="button">Sign out</button>
+        </div>
+      </header>
+      <section class="woc-card">
+        <h2>Standing</h2>
+        ${moderationHtml}
+      </section>
+      <section class="woc-card">
+        <h2>Characters on ${escapeHtml(me.realm)}</h2>
+        ${charsHtml}
+      </section>
+    </div>
+  `;
+  $('#signout').addEventListener('click', () => {
+    clearSession();
+    renderLoginShell();
+  });
+}
+
+async function boot(): Promise<void> {
+  if (!getToken()) { renderLoginShell(); return; }
+  try {
+    const me = await getMe();
+    renderDashboard(me);
+  } catch (err) {
+    clearSession();
+    renderLoginShell();
+    if (err instanceof ApiError && err.status !== 401) {
+      const e = document.getElementById('login-error');
+      if (e) { e.hidden = false; e.textContent = err.message; }
+    }
+  }
+}
+
+if (typeof document !== 'undefined') {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => void boot());
+  } else {
+    void boot();
+  }
+}

--- a/user.html
+++ b/user.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>World of ClaudeCraft — My Account</title>
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <meta name="robots" content="noindex,nofollow" />
+  <style>
+    body { background: #060609; color: #e8d8a8; font-family: 'Arial', sans-serif; font-size: 14px; margin: 0; min-height: 100vh; }
+    .woc-dash { max-width: 1100px; margin: 0 auto; padding: 32px 24px 80px; display: flex; flex-direction: column; gap: 24px; }
+    .woc-card { background: linear-gradient(170deg, #15151f 0%, #0b0b12 60%, #08080d 100%); border: 2px solid #6f5a2a; outline: 1px solid #000; border-radius: 6px; box-shadow: 0 2px 16px #000c, inset 0 0 24px #0006, inset 0 1px 0 #ffffff14; padding: 18px 20px; }
+    .woc-header { display: flex; justify-content: space-between; align-items: flex-end; flex-wrap: wrap; gap: 16px; padding-bottom: 12px; border-bottom: 1px solid #6f5a2a; }
+    .woc-meta { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; font-size: 13px; }
+    .woc-stack { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; }
+    .woc-stack input, .woc-stack button { padding: 10px 12px; border: 1px solid #6f5a2a; border-radius: 6px; background: rgba(0, 0, 0, 0.4); color: inherit; font: inherit; }
+    .woc-stack button { background: linear-gradient(180deg, #c8a838, #8a721d); border-color: #ffd100; color: #15151f; font-weight: 800; letter-spacing: 1px; text-transform: uppercase; cursor: pointer; }
+    .woc-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    .woc-table th, .woc-table td { text-align: left; padding: 8px 10px; border-bottom: 1px solid rgba(255, 255, 255, 0.06); }
+    .woc-table th { font-size: 11px; letter-spacing: 1px; text-transform: uppercase; color: #9a8c66; }
+    .woc-chip { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; border: 1px solid #6f5a2a; }
+    .woc-admin { border-color: #d4442a; color: #ffb39c; }
+    .woc-mod { border-color: #c9a14a; color: #f3dfaa; }
+    .woc-banned { border-color: #c0392b; color: #ff7b6b; }
+    .woc-suspended { border-color: #e67e22; color: #ffb169; }
+    .woc-muted { border-color: #9b59b6; color: #d3a3e6; }
+    .woc-online { border-color: #27ae60; color: #7fdc4f; }
+    .woc-dim { color: #9a8c66; }
+    .woc-error { color: #ff6b5e; }
+    .woc-ok { color: #7fdc4f; }
+    .woc-link { background: transparent; border: 1px solid #6f5a2a; color: #c8a838; padding: 6px 10px; border-radius: 6px; cursor: pointer; text-decoration: none; font: inherit; font-size: 12px; }
+    .woc-link:hover { border-color: #ffd100; color: #ffd100; }
+  </style>
+</head>
+<body>
+  <script type="module" src="/src/user/main.ts"></script>
+</body>
+</html>


### PR DESCRIPTION
Three additive, opt-in features extending the existing admin pattern: generic OIDC SSO (server/oidc.ts, provider-agnostic via .well-known discovery; missing OIDC_* env -> 501, existing /api/login unaffected), /me/ and /mod/ dashboard tiers (server/dashboard.ts), and client SPAs reusing the admin Bearer-token envelope. All new files, pull-safe. Integration + db migration in docs/sso-and-dashboards.md.