### PR TITLE
feat(realms): realm-overlay framework (registry, rarity, pickit)

### DIFF
--- a/docs/realm-overlays.md
+++ b/docs/realm-overlays.md
@@ -1,0 +1,31 @@
+# Realm overlays
+
+A display-only overlay system: run multiple "realms" (themed presentations)
+on top of the same base sim without forking it. Each realm supplies strings,
+colors, class skins, and item-rarity flavor; none of it mutates Sim state, so
+the base game can change freely and realm packs keep working.
+
+## Files (`src/realms/`)
+
+- `types.ts` — `RealmContent` / `RealmBranding` / `RealmClassSkin`. `RealmId`
+  is a free-form string so you can register any realms.
+- `registry.ts` — `createRealmRegistry(realms)` returns helpers
+  (`getActiveRealm`, `resolveActiveRealmId` from `?realm=`/localStorage,
+  `HOME_REALM_LIST`, cross-realm hub support, etc.).
+- `rarity.ts` — item rarity tiers + affix rolling (`generateRealmItem`).
+- `pickit.ts` — a pickit-style item filter (`parsePickitFilter`, `evaluateItem`).
+- `example.realm.ts` — a neutral reference realm.
+
+## Usage
+
+```ts
+import { createRealmRegistry } from './realms/registry';
+import { EXAMPLE_REALM } from './realms/example.realm';
+
+const realms = createRealmRegistry([EXAMPLE_REALM /*, ...your realms */]);
+const active = realms.getActiveRealm();
+// feed active.name / branding / classes into your renderer + login UI
+```
+
+Additive and standalone — nothing in the base game depends on it until you
+wire `getActiveRealm()` into the UI.

--- a/src/realms/example.realm.ts
+++ b/src/realms/example.realm.ts
@@ -1,0 +1,26 @@
+// Example realm overlay — a neutral reference showing the RealmContent shape.
+// Copy this to build your own realms; none of the base game depends on it.
+import type { RealmContent } from './types';
+
+export const EXAMPLE_REALM: RealmContent = {
+  id: 'example',
+  name: 'Example Realm',
+  tagline: 'A reference realm overlay',
+  description: 'Demonstrates the realm-overlay shape: branding, classes, and rarity flavor layered on the base sim.',
+  mood: 'Neutral · Reference',
+  accentHex: '#4a9eff',
+  bgGradient: 'linear-gradient(135deg, #10131a 0%, #080a0f 100%)',
+  previewColors: { primary: '#4a9eff', secondary: '#ffd166', bg: '#10131a' },
+  isDefault: true,
+  classes: [
+    {
+      id: 'guardian', name: 'Guardian', role: 'Tank', icon: '🛡', color: '#f1c40f',
+      lore: 'A frontline protector.',
+      baseStats: { maxHp: 190, maxMp: 80, str: 28, dex: 10, vit: 34, nrg: 12, dmg: 20, def: 34, spd: 1.0 },
+      skills: [
+        { name: 'Shield Bash', icon: '🛡', mp: 18, type: 'Melee', dmg: 200, range: 3, desc: 'Strike and stun briefly', color: '#f1c40f' },
+      ],
+      skillTrees: ['Defense', 'Valor'],
+    },
+  ],
+};

--- a/src/realms/pickit.ts
+++ b/src/realms/pickit.ts
@@ -1,0 +1,131 @@
+// Pickit loot filter — Diablo / PoE / D2 style "SHOW item if rarity>=rare"
+//
+// This filter never decides what drops (the upstream Sim does); it only
+// decides which ground items the realm UI should highlight, hide, or color.
+// Players opt into a filter per-realm; the default is to show everything.
+
+import { RARITY_ORDER, type RarityId, type RealmItemSlot, type RealmItem } from './rarity';
+
+export type PickitOp = '>=' | '<=' | '=' | '*=';
+
+export interface PickitCondition {
+  /** 'rarity' | 'slot' | 'level' | 'name' | 'stat:<statName>' */
+  key: string;
+  op: PickitOp;
+  value: string;
+}
+
+export interface PickitRule {
+  action: 'show' | 'hide';
+  conditions: PickitCondition[];
+  /** Optional CSS hex color override for the highlighted label. */
+  color: string | null;
+  /** True when the rule was tagged HIGHLIGHT (extra outline + ground beam). */
+  highlight: boolean;
+  /** 1-based source line for debugging. */
+  line: number;
+}
+
+export interface PickitResult {
+  show: boolean;
+  highlight: boolean;
+  color: string | null;
+  matchedRule: PickitRule | null;
+}
+
+function parseCondition(token: string): PickitCondition | null {
+  let op: PickitOp;
+  let parts: string[];
+  if (token.includes('>=')) { op = '>='; parts = token.split('>='); }
+  else if (token.includes('<=')) { op = '<='; parts = token.split('<='); }
+  else if (token.includes('*=')) { op = '*='; parts = token.split('*='); }
+  else if (token.includes('=')) { op = '=';  parts = token.split('='); }
+  else return null;
+  const [key, value] = parts;
+  if (!key || value === undefined) return null;
+  return { key: key.trim(), op, value: value.trim() };
+}
+
+export function parsePickitFilter(text: string): PickitRule[] {
+  const rules: PickitRule[] = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line || line.startsWith('#') || line.startsWith('//')) continue;
+
+    const upper = line.toUpperCase();
+    const action: 'show' | 'hide' = upper.startsWith('HIDE') ? 'hide' : 'show';
+    const rest = line.replace(/^(SHOW|HIDE)\s+/i, '').trim();
+
+    const rule: PickitRule = {
+      action, conditions: [], color: null, highlight: false, line: i + 1,
+    };
+    for (const token of rest.split(/\s+/)) {
+      const up = token.toUpperCase();
+      if (up === 'HIGHLIGHT') { rule.highlight = true; continue; }
+      if (up.startsWith('COLOR:')) { rule.color = token.split(':')[1] ?? null; continue; }
+      const cond = parseCondition(token);
+      if (cond) rule.conditions.push(cond);
+    }
+    rules.push(rule);
+  }
+  return rules;
+}
+
+function rarityRank(r: string): number {
+  return RARITY_ORDER.indexOf(r as RarityId);
+}
+
+function evaluateCondition(cond: PickitCondition, item: RealmItem): boolean {
+  const { key, op, value } = cond;
+  if (key === 'rarity') {
+    const itemRank = rarityRank(item.rarity);
+    const valRank = rarityRank(value);
+    if (valRank < 0) return false;
+    if (op === '>=') return itemRank >= valRank;
+    if (op === '<=') return itemRank <= valRank;
+    if (op === '=')  return item.rarity === value;
+  }
+  if (key === 'slot') {
+    return item.slot === (value as RealmItemSlot);
+  }
+  if (key === 'level') {
+    const ilvl = item.itemLevel ?? 1;
+    const v = parseInt(value, 10);
+    if (Number.isNaN(v)) return false;
+    if (op === '>=') return ilvl >= v;
+    if (op === '<=') return ilvl <= v;
+    if (op === '=')  return ilvl === v;
+  }
+  if (key === 'name' && op === '*=') {
+    return (item.name ?? '').toLowerCase().includes(value.toLowerCase());
+  }
+  if (key.startsWith('stat:')) {
+    const statName = key.slice(5);
+    const affix = item.affixes.find((a) => a.stat === statName);
+    if (!affix) return false;
+    const v = parseFloat(value);
+    if (Number.isNaN(v)) return false;
+    if (op === '>=') return affix.value >= v;
+    if (op === '<=') return affix.value <= v;
+    if (op === '=')  return affix.value === v;
+  }
+  return false;
+}
+
+/** First matching rule wins. Items with no rule match show by default. */
+export function evaluateItem(item: RealmItem, rules: PickitRule[]): PickitResult {
+  for (const rule of rules) {
+    const matches = rule.conditions.length > 0
+      && rule.conditions.every((c) => evaluateCondition(c, item));
+    if (matches) {
+      return {
+        show: rule.action === 'show',
+        highlight: rule.highlight,
+        color: rule.color,
+        matchedRule: rule,
+      };
+    }
+  }
+  return { show: true, highlight: false, color: null, matchedRule: null };
+}

--- a/src/realms/rarity.ts
+++ b/src/realms/rarity.ts
@@ -1,0 +1,191 @@
+// Item rarity + affix model for realm overlays.
+//
+// Lives next to the realm registry because it's a realm-overlay concept
+// (Diablo-style item tiers) layered on top of the upstream ItemDef. The
+// upstream sim still owns the loot table; this module only describes how a
+// realm-themed item should be tagged, colored, glowed, and named.
+
+import { Rng } from '../sim/rng';
+
+export type RarityId = 'common' | 'magic' | 'rare' | 'legendary' | 'mythic' | 'unique';
+
+export interface RarityDef {
+  id: RarityId;
+  name: string;
+  /** CSS hex for item name tint. */
+  color: string;
+  /** CSS box-shadow / outline string used by tooltip + ground item beam. */
+  glow: string;
+  /** Number of random affixes rolled (unique uses fixed list, ignores this). */
+  affixCount: number;
+  /** Drop weight for the weighted random roll. */
+  weight: number;
+}
+
+export const RARITY: Record<RarityId, RarityDef> = {
+  common:    { id: 'common',    name: 'Common',    color: '#9e9e9e', glow: 'none',                                            affixCount: 0, weight: 50 },
+  magic:     { id: 'magic',     name: 'Magic',     color: '#4a9eff', glow: '0 0 8px #4a9eff55',                               affixCount: 2, weight: 30 },
+  rare:      { id: 'rare',      name: 'Rare',      color: '#ffd700', glow: '0 0 12px #ffd70055',                              affixCount: 4, weight: 12 },
+  legendary: { id: 'legendary', name: 'Legendary', color: '#ff8c00', glow: '0 0 16px #ff8c0066',                              affixCount: 5, weight: 5 },
+  mythic:    { id: 'mythic',    name: 'Mythic',    color: '#ff1493', glow: '0 0 20px #ff149388',                              affixCount: 6, weight: 2 },
+  unique:    { id: 'unique',    name: 'Unique',    color: '#a855f7', glow: '0 0 24px #a855f799, inset 0 0 8px #a855f744',     affixCount: 0, weight: 1 },
+};
+
+export const RARITY_ORDER: readonly RarityId[] = [
+  'common', 'magic', 'rare', 'legendary', 'mythic', 'unique',
+];
+
+export type RealmItemSlot = 'weapon' | 'helmet' | 'armor' | 'gloves' | 'boots' | 'ring' | 'amulet' | 'belt';
+
+export interface RealmItemSlotDef {
+  id: RealmItemSlot;
+  name: string;
+  icon: string;
+}
+
+export const ITEM_SLOTS: Record<RealmItemSlot, RealmItemSlotDef> = {
+  weapon: { id: 'weapon', name: 'Weapon', icon: '⚔' },
+  helmet: { id: 'helmet', name: 'Helmet', icon: '\u{1FA96}' },
+  armor:  { id: 'armor',  name: 'Armor',  icon: '\u{1F6E1}' },
+  gloves: { id: 'gloves', name: 'Gloves', icon: '\u{1F9E4}' },
+  boots:  { id: 'boots',  name: 'Boots',  icon: '\u{1F462}' },
+  ring:   { id: 'ring',   name: 'Ring',   icon: '\u{1F48D}' },
+  amulet: { id: 'amulet', name: 'Amulet', icon: '\u{1F4FF}' },
+  belt:   { id: 'belt',   name: 'Belt',   icon: '\u{1F517}' },
+};
+
+export interface AffixDef {
+  name: string;
+  /** Stat key the affix grants. */
+  stat: string;
+  /** Inclusive min / max roll range. */
+  min: number;
+  max: number;
+}
+
+export interface AffixPool {
+  prefixes: AffixDef[];
+  suffixes: AffixDef[];
+}
+
+export const AFFIX_POOL: AffixPool = {
+  prefixes: [
+    { name: 'Sharp',       stat: 'dmg',       min: 3,    max: 12 },
+    { name: 'Cruel',       stat: 'dmg',       min: 8,    max: 25 },
+    { name: 'Sturdy',      stat: 'def',       min: 5,    max: 20 },
+    { name: 'Arcane',      stat: 'maxMp',     min: 10,   max: 40 },
+    { name: 'Vital',       stat: 'maxHp',     min: 15,   max: 60 },
+    { name: 'Swift',       stat: 'spd',       min: 0.1,  max: 0.4 },
+    { name: "Berserker's", stat: 'str',       min: 3,    max: 12 },
+    { name: "Viper's",     stat: 'dex',       min: 3,    max: 12 },
+    { name: "Scholar's",   stat: 'nrg',       min: 3,    max: 12 },
+    { name: 'Vampiric',    stat: 'lifeLeech', min: 1,    max: 8 },
+    { name: 'Fiery',       stat: 'fireDmg',   min: 5,    max: 30 },
+    { name: 'Frozen',      stat: 'coldDmg',   min: 5,    max: 30 },
+    { name: 'Charged',     stat: 'ltngDmg',   min: 5,    max: 30 },
+  ],
+  suffixes: [
+    { name: 'of the Bear',   stat: 'str',       min: 2,   max: 10 },
+    { name: 'of the Hawk',   stat: 'dex',       min: 2,   max: 10 },
+    { name: 'of the Whale',  stat: 'maxHp',     min: 10,  max: 50 },
+    { name: 'of the Fox',    stat: 'nrg',       min: 2,   max: 10 },
+    { name: 'of Warding',    stat: 'def',       min: 3,   max: 15 },
+    { name: 'of Speed',      stat: 'spd',       min: 0.1, max: 0.3 },
+    { name: 'of Absorption', stat: 'dmgReduce', min: 1,   max: 8 },
+    { name: 'of the Leech',  stat: 'manaLeech', min: 1,   max: 6 },
+    { name: 'of Flames',     stat: 'fireRes',   min: 5,   max: 25 },
+    { name: 'of Frost',      stat: 'coldRes',   min: 5,   max: 25 },
+    { name: 'of Thunder',    stat: 'ltngRes',   min: 5,   max: 25 },
+    { name: 'of Blight',     stat: 'poisDmg',   min: 5,   max: 20 },
+  ],
+};
+
+export function rarityRank(r: RarityId): number {
+  return RARITY_ORDER.indexOf(r);
+}
+
+/** Roll a weighted random rarity. magicFind biases away from common. */
+export function rollRarity(rng: Rng, magicFind = 0): RarityId {
+  const weights = RARITY_ORDER.map((r) => {
+    const base = RARITY[r].weight;
+    if (r === 'common') return Math.max(5, base - magicFind * 0.5);
+    return base + magicFind * (r === 'unique' ? 0.3 : r === 'mythic' ? 0.5 : 1);
+  });
+  const total = weights.reduce((a, b) => a + b, 0);
+  let roll = rng.next() * total;
+  for (let i = 0; i < RARITY_ORDER.length; i++) {
+    roll -= weights[i];
+    if (roll <= 0) return RARITY_ORDER[i];
+  }
+  return 'common';
+}
+
+export interface RealmItem {
+  id: string;
+  slot: RealmItemSlot;
+  rarity: RarityId;
+  itemLevel: number;
+  color: string;
+  glow: string;
+  name?: string;
+  affixes: RealmAffixRoll[];
+}
+
+export interface RealmAffixRoll {
+  name: string;
+  stat: string;
+  value: number;
+}
+
+const SLOT_NAMES: Record<RealmItemSlot, string> = {
+  weapon: 'Blade',
+  helmet: 'Helm',
+  armor: 'Plate',
+  gloves: 'Grips',
+  boots: 'Treads',
+  ring: 'Band',
+  amulet: 'Pendant',
+  belt: 'Sash',
+};
+
+function shuffle<T>(rng: Rng, arr: T[]): T[] {
+  const out = arr.slice();
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng.next() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+function rollAffix(rng: Rng, def: AffixDef): RealmAffixRoll {
+  const value = def.min + rng.next() * (def.max - def.min);
+  return { name: def.name, stat: def.stat, value: Math.round(value * 100) / 100 };
+}
+
+export function generateRealmItem(
+  rng: Rng,
+  slot: RealmItemSlot,
+  rarity: RarityId,
+  itemLevel = 1,
+): RealmItem {
+  const r = RARITY[rarity];
+  const id = `item_${itemLevel}_${rng.int(0, 0xffffff).toString(16)}`;
+  const base: RealmItem = {
+    id, slot, rarity, itemLevel,
+    color: r.color, glow: r.glow,
+    affixes: [],
+  };
+  if (rarity === 'unique') {
+    // Unique names are realm-specific and live in the realm content packs.
+    return base;
+  }
+  const prefixCount = Math.ceil(r.affixCount / 2);
+  const suffixCount = Math.floor(r.affixCount / 2);
+  const prefixes = shuffle(rng, AFFIX_POOL.prefixes).slice(0, prefixCount).map((p) => rollAffix(rng, p));
+  const suffixes = shuffle(rng, AFFIX_POOL.suffixes).slice(0, suffixCount).map((s) => rollAffix(rng, s));
+  base.affixes = [...prefixes, ...suffixes];
+  const prefixName = prefixes[0]?.name ?? '';
+  const suffixName = suffixes[0]?.name ?? '';
+  base.name = [prefixName, SLOT_NAMES[slot], suffixName].filter(Boolean).join(' ').trim();
+  return base;
+}

--- a/src/realms/registry.ts
+++ b/src/realms/registry.ts
@@ -1,0 +1,55 @@
+// Realm registry — register any set of realm overlays and resolve the active
+// one. The active realm is resolved from ?realm=<id>, then localStorage, then
+// the default. Provide your realms via createRealmRegistry().
+
+import type { RealmContent, RealmId } from './types';
+
+const STORE_KEY = 'active_realm';
+
+export interface RealmRegistry {
+  REALMS: Record<RealmId, RealmContent>;
+  REALM_LIST: readonly RealmContent[];
+  HOME_REALM_LIST: readonly RealmContent[];
+  DEFAULT_REALM: RealmId;
+  getRealm(id: RealmId): RealmContent;
+  isRealmId(s: string | null | undefined): s is RealmId;
+  isCrossRealm(id: RealmId): boolean;
+  resolveActiveRealmId(): RealmId;
+  persistActiveRealm(id: RealmId): void;
+  getActiveRealm(): RealmContent;
+}
+
+export function createRealmRegistry(realms: readonly RealmContent[]): RealmRegistry {
+  if (realms.length === 0) throw new Error('createRealmRegistry: at least one realm required');
+  const REALMS: Record<RealmId, RealmContent> = {};
+  for (const r of realms) REALMS[r.id] = r;
+  const REALM_LIST = realms;
+  const HOME_REALM_LIST = realms.filter((r) => !r.crossRealm);
+  const DEFAULT_REALM = (realms.find((r) => r.isDefault) ?? realms[0]).id;
+
+  const isRealmId = (s: string | null | undefined): s is RealmId => s != null && s in REALMS;
+  const getRealm = (id: RealmId): RealmContent => REALMS[id] ?? REALMS[DEFAULT_REALM];
+  const isCrossRealm = (id: RealmId): boolean => REALMS[id]?.crossRealm === true;
+
+  const resolveActiveRealmId = (): RealmId => {
+    try {
+      if (typeof window !== 'undefined') {
+        const q = new URLSearchParams(window.location.search).get('realm');
+        if (isRealmId(q)) return q;
+        const ls = window.localStorage?.getItem(STORE_KEY);
+        if (isRealmId(ls)) return ls;
+      }
+    } catch { /* SSR / sandboxed */ }
+    return DEFAULT_REALM;
+  };
+  const persistActiveRealm = (id: RealmId): void => {
+    try { window.localStorage?.setItem(STORE_KEY, id); } catch { /* unavailable */ }
+  };
+  const getActiveRealm = (): RealmContent => getRealm(resolveActiveRealmId());
+
+  return {
+    REALMS, REALM_LIST, HOME_REALM_LIST, DEFAULT_REALM,
+    getRealm, isRealmId, isCrossRealm,
+    resolveActiveRealmId, persistActiveRealm, getActiveRealm,
+  };
+}

--- a/src/realms/types.ts
+++ b/src/realms/types.ts
@@ -1,0 +1,73 @@
+// Realm-overlay types — display metadata that overlays the base sim without
+// mutating it. A "realm" describes how the same underlying world should look
+// and read (strings, colors, class skins, item-rarity flavor). It never
+// touches Sim state, so the base game can be rebalanced or restructured and
+// realm packs keep working.
+
+/** Stable realm identifier (e.g. 'classic', 'hardcore'). Free-form string so
+ *  consumers can register any set of realms. */
+export type RealmId = string;
+
+export type RealmRole = 'Tank' | 'DPS' | 'Healer' | 'Support' | 'Assassin' | 'Summoner';
+
+/** A class skin: how a realm presents one of the underlying base classes. */
+export interface RealmClassSkin {
+  id: string;
+  name: string;
+  role: RealmRole;
+  icon: string;
+  color: string;
+  lore: string;
+  baseStats: RealmClassStats;
+  skills: RealmClassSkill[];
+  skillTrees: string[];
+}
+
+export interface RealmClassStats {
+  maxHp: number; maxMp: number; str: number; dex: number; vit: number;
+  nrg: number; dmg: number; def: number; spd: number;
+}
+
+export interface RealmClassSkill {
+  name: string; icon: string; mp: number; type: string;
+  dmg: number; range: number; desc: string; color: string;
+}
+
+/** Per-realm branding & UX overrides. Every field optional — unset fields keep
+ *  the base value, so a realm can re-skin without forking index.html. */
+export interface RealmBranding {
+  /** Square logo path. Falls back to the base logo when undefined. */
+  logoSrc?: string;
+  /** Brand text shown in the header / SEO title. */
+  brandText?: string;
+  /** Loading-screen background image. */
+  loadingScreenSrc?: string;
+  /** Community Discord invite URL. */
+  discordUrl?: string;
+  /** Source repo URL. */
+  githubUrl?: string;
+  /** Show the Donate button. Defaults to false. */
+  showDonate?: boolean;
+  /** Show an optional SSO sign-in button on the login panel. */
+  showSsoButton?: boolean;
+}
+
+export interface RealmContent {
+  id: RealmId;
+  name: string;
+  tagline: string;
+  description: string;
+  mood: string;
+  accentHex: string;
+  bgGradient: string;
+  previewColors: { primary: string; secondary: string; bg: string };
+  classes: RealmClassSkin[];
+  branding?: RealmBranding;
+  /** Auto-load this realm when no preference exists. */
+  isDefault?: boolean;
+  /** Cross-realm hub: characters from any realm are admitted but combat /
+   *  questing are disabled (e.g. a trade hub). */
+  crossRealm?: boolean;
+  /** First-person-only realm: lock the camera to first-person. */
+  fpsOnly?: boolean;
+}


### PR DESCRIPTION
## Summary

A display-only overlay system to run multiple themed "realms" on top of the same base sim without forking it. Each realm supplies strings, colors, class skins, and item-rarity flavor; it never mutates Sim state, so the base game can change freely and realm packs keep working.

`src/realms/`:
- **types.ts** — `RealmContent` / `RealmBranding` / `RealmClassSkin`. `RealmId` is a free-form string so you can register any realms.
- **registry.ts** — `createRealmRegistry(realms)` → `getActiveRealm`, `resolveActiveRealmId` (from `?realm=` / localStorage), `HOME_REALM_LIST`, cross-realm hub support.
- **rarity.ts** — item rarity tiers + affix rolling (`generateRealmItem`), seeded by the existing `src/sim/rng`.
- **pickit.ts** — a pickit-style item filter (`parsePickitFilter`, `evaluateItem`).
- **example.realm.ts** — a neutral reference realm.

Additive and standalone — nothing in the base game depends on it until you wire `getActiveRealm()` into the UI. Docs in `docs/realm-overlays.md`.

## Test plan
- [ ] `createRealmRegistry([EXAMPLE_REALM])` resolves `getActiveRealm()` to the example
- [ ] `?realm=example` and localStorage override the default
- [ ] `generateRealmItem` produces deterministic items for a fixed rng seed
- [ ] `parsePickitFilter` + `evaluateItem` match/reject as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)