### PR TITLE
fix(css): default --app-vw/--app-vh to 100% (mobile right-shift)

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,8 +137,9 @@
     --scrollbar-track: rgba(10, 10, 15, 0.7);
     --scrollbar-thumb-hover: #7c6233;
     --scrollbar-border: #7c6233;
-    --app-vw: 100vw;
-    --app-vh: 100vh;
+    /* Default 100% (not 100vw): first paint before JS viewport sync must not overflow right on mobile, where 100vw excludes scrollbar/safe-area. Overwritten with exact px once main.ts boots. */
+    --app-vw: 100%;
+    --app-vh: 100%;
     /* Shared with src/game/cursors.ts — keep hotspots in sync. */
     --cursor-hand: url('./ui/cursors/hand-default.png') 12 2, default;
     --cursor-sword: url('./ui/cursors/attack-sword.png') 4 4, pointer;


### PR DESCRIPTION
## Summary

`--app-vw` / `--app-vh` default to `100vw` / `100vh`. On mobile, `100vw` excludes the scrollbar / safe-area inset and is wider than the visual viewport, so any first paint *before* the JS viewport sync (`syncAppViewport`) runs can overflow to the right (content visibly shifted right + horizontal scroll).

Defaulting to `100%` removes that latent footgun. The app still overwrites both with exact pixels on boot via `syncAppViewport()`, so behaviour after load is identical — this only hardens the pre-sync first paint.

## Test plan
- [ ] Load on a mobile viewport; confirm no right-shift / horizontal scroll on first paint
- [ ] Confirm post-load layout is unchanged on desktop and mobile
- [ ] Confirm `syncAppViewport()` still sets exact px after boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)