### PR TITLE
feat(woc): shareable player card + share-to-X + OG unfurl + referral capture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,3 +77,20 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # DANGER: enables the level/teleport/item cheat commands used by the test
 # bots (scripts/crypt_raid.mjs etc). Never set this on a public server.
 #ALLOW_DEV_COMMANDS=1
+
+# Reown (WalletConnect) project id for the non-custodial Solana wallet-link
+# feature. This is a PUBLIC client identifier (safe to ship), read by the Vite
+# client at build/dev time, so it must be prefixed VITE_. Get one free at
+# https://dashboard.reown.com. Without it the "Connect Wallet" button renders
+# but the modal cannot reach the relay. For local dev put it in .env.local
+# (Vite auto-loads VITE_* there); it is NOT used by the game server.
+#VITE_REOWN_PROJECT_ID=your_reown_project_id
+
+# The $WOC SPL token mint, used to read a connected wallet's balance. Defaults
+# to the published contract address; override only if the canonical mint changes.
+#VITE_WOC_MINT=3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth
+
+# Solana RPC endpoint for reading $WOC balances (mainnet). The public default is
+# heavily rate-limited; set a dedicated endpoint (Helius/QuickNode/Triton) for
+# anything beyond local testing.
+#VITE_SOLANA_RPC_URL=https://api.mainnet-beta.solana.com

--- a/docs/prd/woc/wallet-link.md
+++ b/docs/prd/woc/wallet-link.md
@@ -1,0 +1,34 @@
+# Feature Stub — Non-custodial wallet link
+
+> 🚧 **STATUS: STUB — opening discussion.** This is a *feature stub*, not an implementation. It exists to open a focused discussion thread around the **Non-custodial wallet link** `$WOC` flywheel mechanic before any code is written.
+
+| | |
+|---|---|
+| **Tier** | 0 · Foundations |
+| **Ease** | 3/5 |
+| **Flywheel** | — |
+| **Sustainability** | Infra |
+| **Reg risk** | Low |
+
+## What
+Let a player link a Solana wallet to their account by signing a message — no funds custody. The server stores the account↔wallet mapping and reads on-chain state (balances / ownership) read-only.
+
+## Why it's a flywheel
+Foundational rather than a flywheel itself: every other $WOC mechanic needs a verified wallet link before it can work.
+
+## Proposed approach (for discussion)
+- Sign-to-link flow in `src/net/` + a server endpoint; persist `account ↔ wallet` in Postgres.
+- The server only *reads* chain state — it never holds keys or funds.
+- Linking is opt-in; the game is fully playable without ever connecting a wallet.
+
+## Constraints (non-negotiable)
+- **Cosmetic-only / no pay-to-win** — token utility is appearance, convenience, access, or realm-operation; never power.
+- **Non-custodial** — the chain owns assets; `src/sim/` stays pure (no network / wallet deps).
+
+## Open questions
+- Which wallet adapters do we support?
+- One wallet per account, or many?
+- How do we handle wallet rotation / unlink?
+
+## Out of scope
+This PR adds **no implementation** — it is a stub to anchor discussion. Part of the proposed `$WOC` GameFi roadmap.

--- a/index.html
+++ b/index.html
@@ -1461,6 +1461,64 @@
   }
   .donate-cta svg { width: 16px; height: 16px; display: block; }
 
+  /* Connect-wallet CTA — outlined gold to sit beside (not compete with) the
+     filled Donate button. Turns blue when a wallet is connected and green once
+     the wallet is verified-linked to the account. */
+  .wallet-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 7px 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--gold-dim);
+    background: rgba(11, 11, 18, 0.55);
+    color: var(--gold);
+    font-family: var(--font-heading);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                color var(--transition-speed) var(--transition-ease);
+  }
+  .wallet-cta:hover,
+  .wallet-cta:focus-visible {
+    border-color: var(--gold);
+    box-shadow: 0 0 12px var(--color-primary-glow);
+    outline: none;
+  }
+  .wallet-cta svg { width: 16px; height: 16px; display: block; }
+  .wallet-cta.is-connected { color: var(--color-text-light); border-color: var(--color-mana); }
+  .wallet-cta.is-linked { color: var(--color-text-success); border-color: var(--color-text-success); }
+  .wallet-cta.is-connected #wallet-label,
+  .wallet-cta.is-linked #wallet-label {
+    font-family: 'SFMono-Regular', ui-monospace, 'Courier New', monospace;
+    font-size: 12px;
+    letter-spacing: 0;
+  }
+  .wallet-cta.busy { opacity: 0.6; pointer-events: none; }
+
+  /* Wallet row inside the (logged-in) character-select panel — the account
+     context where linking actually belongs. */
+  .cs-wallet {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(199, 148, 26, 0.18);
+  }
+  .cs-wallet-label {
+    font-family: var(--font-heading);
+    color: var(--gold-dim);
+    font-size: 13px;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+  }
+
   /* Footer donate link keeps the social-link shape but warms up on hover. */
   .footer-lang-row { display: flex; justify-content: center; }
   .social-link.donate:hover,
@@ -4625,6 +4683,13 @@
           <h2 class="auth-title"><span data-i18n="auth.characters">Characters:</span> <span id="charselect-user" class="gold"></span></h2>
           <div class="cs-realm" id="charselect-realm"></div>
           <button type="button" class="btn btn-secondary btn-small" id="btn-change-realm" data-i18n="auth.changeRealm">Change Realm</button>
+          <div class="cs-wallet">
+            <span class="cs-wallet-label">$WOC Wallet</span>
+            <button type="button" class="wallet-cta" id="btn-wallet" title="Link your Solana wallet" aria-label="Connect your Solana wallet">
+              <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h13a1 1 0 0 1 1 1v2"></path><path d="M3 7v10a2 2 0 0 0 2 2h14a1 1 0 0 0 1-1v-3"></path><path d="M21 11h-4a2 2 0 0 0 0 4h4a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1Z"></path></svg>
+              <span id="wallet-label">Connect Wallet</span>
+            </button>
+          </div>
           <div class="mobile-char-tabs" role="tablist" data-i18n-aria="a11y.characterActions" aria-label="Character actions">
             <button type="button" class="mobile-char-tab active" data-char-tab="characters" role="tab" aria-selected="true" data-i18n="character.tabCharacters">Characters</button>
             <button type="button" class="mobile-char-tab" data-char-tab="create" role="tab" aria-selected="false" data-i18n="character.tabCreate">Create</button>

--- a/index.html
+++ b/index.html
@@ -926,7 +926,11 @@
   }
   #bags .panel-title { flex: none; }
   #bags .bag-grid { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
-  #bags .money { flex: none; }
+  #bags .money { flex: none; display: flex; align-items: center; gap: 10px; }
+  /* coins stay right-aligned whether or not the $WOC chip is present */
+  #bags .money .money-inline { margin-left: auto; }
+  .woc-balance { display: inline-flex; align-items: center; gap: 5px; color: var(--gold-dim); font-weight: 600; white-space: nowrap; }
+  .woc-coin { display: inline-block; width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, #c9a3ff, #6b3fa0); box-shadow: 0 0 4px rgba(150, 90, 230, 0.5); }
   .bag-grid { display: flex; flex-direction: column; gap: 2px; }
   .bag-item { display: flex; gap: 8px; align-items: center; width: 100%; font-size: 12px; padding: 3px 4px; border: 0; border-radius: 3px; cursor: pointer; background: transparent; color: inherit; font-family: var(--ui-font); text-align: left; }
   .bag-item:hover { background: #ffffff12; }

--- a/index.html
+++ b/index.html
@@ -1518,6 +1518,31 @@
     letter-spacing: 0.4px;
     white-space: nowrap;
   }
+  .cs-wallet-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+  /* Secondary wallet controls (Switch / Sign out) — only shown when connected. */
+  .wallet-mini {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border-default);
+    background: rgba(11, 11, 18, 0.55);
+    color: var(--color-text-muted);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: color var(--transition-speed) var(--transition-ease),
+                border-color var(--transition-speed) var(--transition-ease);
+  }
+  .wallet-mini svg { width: 14px; height: 14px; display: block; }
+  .wallet-mini:hover,
+  .wallet-mini:focus-visible { color: var(--color-text-light); border-color: var(--gold-dim); outline: none; }
+  #btn-wallet-signout:hover,
+  #btn-wallet-signout:focus-visible { color: var(--color-text-error); border-color: var(--color-text-error); }
+  .wallet-mini[hidden] { display: none; }
 
   /* Footer donate link keeps the social-link shape but warms up on hover. */
   .footer-lang-row { display: flex; justify-content: center; }
@@ -4685,10 +4710,20 @@
           <button type="button" class="btn btn-secondary btn-small" id="btn-change-realm" data-i18n="auth.changeRealm">Change Realm</button>
           <div class="cs-wallet">
             <span class="cs-wallet-label">$WOC Wallet</span>
-            <button type="button" class="wallet-cta" id="btn-wallet" title="Link your Solana wallet" aria-label="Connect your Solana wallet">
-              <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h13a1 1 0 0 1 1 1v2"></path><path d="M3 7v10a2 2 0 0 0 2 2h14a1 1 0 0 0 1-1v-3"></path><path d="M21 11h-4a2 2 0 0 0 0 4h4a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1Z"></path></svg>
-              <span id="wallet-label">Connect Wallet</span>
-            </button>
+            <div class="cs-wallet-actions">
+              <button type="button" class="wallet-cta" id="btn-wallet" title="Link your Solana wallet" aria-label="Connect your Solana wallet">
+                <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h13a1 1 0 0 1 1 1v2"></path><path d="M3 7v10a2 2 0 0 0 2 2h14a1 1 0 0 0 1-1v-3"></path><path d="M21 11h-4a2 2 0 0 0 0 4h4a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1Z"></path></svg>
+                <span id="wallet-label">Connect Wallet</span>
+              </button>
+              <button type="button" class="wallet-mini" id="btn-wallet-switch" title="Connect a different wallet" hidden>
+                <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><polyline points="7 23 3 19 7 15"></polyline><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
+                <span>Switch</span>
+              </button>
+              <button type="button" class="wallet-mini" id="btn-wallet-signout" title="Disconnect this wallet" hidden>
+                <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>
+                <span>Sign out</span>
+              </button>
+            </div>
           </div>
           <div class="mobile-char-tabs" role="tablist" data-i18n-aria="a11y.characterActions" aria-label="Character actions">
             <button type="button" class="mobile-char-tab active" data-char-tab="characters" role="tab" aria-selected="true" data-i18n="character.tabCharacters">Characters</button>

--- a/index.html
+++ b/index.html
@@ -898,6 +898,29 @@
   #confirm-dialog .cd-actions { display: flex; justify-content: flex-end; gap: 8px; }
   #confirm-dialog .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }
 
+  /* player card: char-window entry button + share modal */
+  .pc-share-row { margin-top: 10px; display: flex; justify-content: center; }
+  .pc-share-btn { display: inline-flex; align-items: center; gap: 7px; }
+  .pc-share-ico { flex: none; }
+  #player-card-modal { z-index: 320; }
+  #player-card-modal .pc-modal { width: min(680px, 96vw); max-height: calc(100vh - 32px);
+    padding: 16px; display: flex; flex-direction: column; }
+  #player-card-modal .pc-preview { margin: 12px 0; min-height: 200px; display: flex;
+    align-items: center; justify-content: center; overflow: auto; }
+  #player-card-modal .pc-preview.pc-loading { color: #c8b888; font-size: 13px; font-style: italic; }
+  #player-card-modal .pc-card-canvas { width: 100%; height: auto; display: block; border-radius: 8px;
+    box-shadow: 0 8px 28px rgba(0,0,0,.55); }
+  #player-card-modal .pc-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
+  #player-card-modal .pc-actions .btn { min-width: 110px; }
+  #player-card-modal .pc-actions .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }
+  #player-card-modal .pc-link { margin-top: 12px; }
+  #player-card-modal .pc-link[hidden] { display: none; }
+  #player-card-modal .pc-link-label { display: block; font-size: 11.5px; color: #c8b888; margin-bottom: 4px; }
+  #player-card-modal .pc-link-input { width: 100%; box-sizing: border-box; padding: 8px 10px; font-size: 12.5px;
+    color: var(--gold); background: #120d07; border: 1px solid #463a1c; border-radius: 5px; font-family: var(--ui-font); }
+  #player-card-modal .pc-status { margin-top: 10px; min-height: 16px; font-size: 12px;
+    color: #c8b888; text-align: center; }
+
   /* vendor */
   #vendor-window { width: 400px; }
   .vendor-item { display: flex; gap: 8px; align-items: center; width: 100%; padding: 5px; border: 0; border-radius: 4px; cursor: pointer; background: transparent; color: inherit; font-family: var(--ui-font); text-align: left; }

--- a/index.html
+++ b/index.html
@@ -910,6 +910,9 @@
   #player-card-modal .pc-preview.pc-loading { color: #c8b888; font-size: 13px; font-style: italic; }
   #player-card-modal .pc-card-canvas { width: 100%; height: auto; display: block; border-radius: 8px;
     box-shadow: 0 8px 28px rgba(0,0,0,.55); }
+  #player-card-modal .pc-poses { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; margin-bottom: 10px; }
+  #player-card-modal .pc-pose { min-width: 84px; padding: 5px 12px; font-size: 12px; opacity: 0.72; }
+  #player-card-modal .pc-pose.sel { opacity: 1; border-color: var(--gold); color: var(--gold); }
   #player-card-modal .pc-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
   #player-card-modal .pc-actions .btn { min-width: 110px; }
   #player-card-modal .pc-actions .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,20 @@
 {
   "name": "world-of-claudecraft",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-of-claudecraft",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "@reown/appkit": "^1.8.21",
+        "@reown/appkit-adapter-solana": "^1.8.21",
+        "@solana/web3.js": "^1.98.4",
+        "bs58": "^6.0.0",
+        "buffer": "^6.0.3",
         "n8ao": "^1.10.1",
         "obscenity": "^0.4.6",
         "pg": "^8.21.0",
@@ -28,6 +34,117 @@
         "vite": "^8.0.16",
         "vitest": "^4.1.8"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@base-org/account": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.4.0.tgz",
+      "integrity": "sha512-A4Umpi8B9/pqR78D1Yoze4xHyQaujioVRqqO3d6xuDFw9VRtjg6tK3bPlwE0aW+nVH/ntllCpPa2PbI8Rnjcug==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@coinbase/cdp-sdk": "^1.0.0",
+        "@noble/hashes": "1.4.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.31.7",
+        "zustand": "5.0.3"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@coinbase/cdp-sdk": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.51.0.tgz",
+      "integrity": "sha512-XK8+OXDER1jirYpuiOct4ij65ODQ31LsmyRrZi/J7zF4GB89qxWZ0KPfAdsqJMP7VvE4no+Q++MKkQtAJUBoyg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana-program/system": "^0.10.0",
+        "@solana-program/token": "^0.9.0",
+        "@solana/kit": "^5.5.1",
+        "abitype": "1.0.6",
+        "axios": "1.16.0",
+        "axios-retry": "^4.5.0",
+        "bs58": "^6.0.0",
+        "jose": "^6.2.0",
+        "md5": "^2.3.0",
+        "uncrypto": "^0.1.3",
+        "viem": "^2.47.0",
+        "zod": "^3.25.76"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
+      "integrity": "sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.27.2",
+        "zustand": "5.0.3"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1337,6 +1454,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
+      "integrity": "sha512-VHb0ALPMTlgKjM6yIxxoQNnpKyUKLD04VzeQdsiXkMqkvYlAHxq9glGLmgbb889/1GsohSOAjvQYoiBppXFqrQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
+      }
+    },
+    "node_modules/@msgpack/msgpack": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-3.1.3.tgz",
+      "integrity": "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -1356,6 +1507,45 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
@@ -1364,6 +1554,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@phosphor-icons/webcomponents": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@phosphor-icons/webcomponents/-/webcomponents-2.1.5.tgz",
+      "integrity": "sha512-JcvQkZxvcX2jK+QCclm8+e8HXqtdFW9xV4/kk2aL9Y3dJA2oQVt+pzbv1orkumz3rfx4K9mn9fDoMr1He1yr7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lit": "^3"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1400,6 +1599,195 @@
         "proxy-agent": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@reown/appkit": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.21.tgz",
+      "integrity": "sha512-+6IRUBc9cgXKhNHzxlzxEp7nL1Jx/lcYgHdqwD10O7MPzU2/Ao5/epwt5vqn1nUlwyI6Awm/YCUWIa0Zg5RVEA==",
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-pay": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@reown/appkit-scaffold-ui": "1.8.21",
+        "@reown/appkit-ui": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@walletconnect/universal-provider": "2.23.7",
+        "bs58": "6.0.0",
+        "semver": "7.7.2",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@lit/react": "1.0.8"
+      }
+    },
+    "node_modules/@reown/appkit-adapter-solana": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-solana/-/appkit-adapter-solana-1.8.21.tgz",
+      "integrity": "sha512-VjdD9K+N8fg0VdX+iVgrfWhzhwKeqEgcgoLNgauBNXIlqXg2Q9LnJUqNGiKPgr7M9ym42X46ccZJZBs0OyADLA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit": "1.8.21",
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@solana/spl-token": "0.4.14",
+        "@solana/wallet-adapter-base": "0.9.27",
+        "@solana/wallet-standard-features": "1.3.0",
+        "@solana/wallet-standard-util": "1.1.2",
+        "@solana/web3.js": "1.98.4",
+        "@wallet-standard/app": "1.1.0",
+        "@wallet-standard/base": "1.1.0",
+        "@wallet-standard/features": "1.1.0",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7"
+      },
+      "optionalDependencies": {
+        "borsh": "0.7.0",
+        "bs58": "6.0.0"
+      }
+    },
+    "node_modules/@reown/appkit-common": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.21.tgz",
+      "integrity": "sha512-FigrZbke9dHVdc4GjG4JNqClIN58gOhREugLx2oEBUFD2e3oQNvX2gcjoUDM2yP0ZAaIEYJOXwjw4sbBU4gzLQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-controllers": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.21.tgz",
+      "integrity": "sha512-2xh64lhPb+p0pwKQDQXpokUGqklB+xWD0JpfBvMVEZxeYzKXyJ7piRBB45TH01Etyitkh5Fh4pzBYz4gbIZSog==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-pay": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.21.tgz",
+      "integrity": "sha512-Tsio2tVcJgBa3WGhDty3Wy9XevTkZISrDsEpR8iaOnaPHdJrKXt7lbFrTEfptKjSgdnKcjhQXqzOdgiF9ljfnA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-ui": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "lit": "3.3.0",
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.21.tgz",
+      "integrity": "sha512-EurjE4G6M27yf77GPSuOu1gjUvpRKS3NC5FJgFMzZxmkF5/Dm9kQdokvzK1rdmtQ8JKe+XHmQ75NbmCFt1/7FQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.21.tgz",
+      "integrity": "sha512-bJxHdZmjwwAd1fIQmMgr0jjvyT1EI0KetFP+7UlTs51SxOflXzZ+rz9ZcWKNSLFtSQOro1+Xu6aPRO+5OapmhA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-pay": "1.8.21",
+        "@reown/appkit-ui": "1.8.21",
+        "@reown/appkit-utils": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "lit": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-ui": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.21.tgz",
+      "integrity": "sha512-1AthTwGq1/gR1Xjib1kkt7unz0Hgh7wbdm1LvOA+Tfp79W8gM1BI/ELP/D8VwTOtaTgHCWERmlnps65p8MHi5Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit-utils": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.21.tgz",
+      "integrity": "sha512-WzEYji9oQIh9P8WkqXiqrLyx/ZYy+svpwT4u2ZC8n7sMSl0j+AzRqMaVrblyFEYAFkW/BtxVqJEqstDZ8f0FYw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-controllers": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@reown/appkit-wallet": "1.8.21",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
+        "@coinbase/wallet-sdk": "4.3.6",
+        "@safe-global/safe-apps-provider": "0.18.6",
+        "@safe-global/safe-apps-sdk": "9.1.0"
+      },
+      "peerDependencies": {
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-wallet": {
+      "version": "1.8.21",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.21.tgz",
+      "integrity": "sha512-4Y0W8QUdnXpy/KA9Lg1ESZN6VQurBIX3BhLQYIGwQ2/D3CuFe3xCbQDQOuDdgeAr0cMjgnFOvpGy0iOBH9Aivg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.21",
+        "@reown/appkit-polyfills": "1.8.21",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit-wallet/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1677,6 +2065,75 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@safe-global/safe-apps-provider": {
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.6.tgz",
+      "integrity": "sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@safe-global/safe-apps-sdk": "^9.1.0",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@safe-global/safe-apps-sdk": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
+      "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
+        "viem": "^2.1.1"
+      }
+    },
+    "node_modules/@safe-global/safe-gateway-typescript-sdk": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.23.1.tgz",
+      "integrity": "sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@so-ric/colorspace": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
@@ -1688,12 +2145,1516 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@solana-program/system": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.10.0.tgz",
+      "integrity": "sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.9.0.tgz",
+      "integrity": "sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peerDependencies": {
+        "@solana/kit": "^5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
+      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
+      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/buffer-layout": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "~6.0.3"
+      },
+      "engines": {
+        "node": ">=5.10"
+      }
+    },
+    "node_modules/@solana/buffer-layout-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
+      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/web3.js": "^1.32.0",
+        "bigint-buffer": "^1.1.5",
+        "bignumber.js": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
+      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
+      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
+      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
+      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
+      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chalk": "5.6.2",
+        "commander": "14.0.2"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
+      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
+      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
+      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
+      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-core": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/programs": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/promises": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
+        "ws": "^8.19.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
+      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/spl-token": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
+      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.7",
+        "@solana/spl-token-metadata": "^0.1.6",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+      }
+    },
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
+      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/spl-token-group/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
+      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/codecs": "2.0.0-rc.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.3"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
+      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/options": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-core": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
+      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
+      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
+      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
+      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/errors": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
+      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/@solana/options": {
+      "version": "2.0.0-rc.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
+      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-rc.1",
+        "@solana/codecs-data-structures": "2.0.0-rc.1",
+        "@solana/codecs-numbers": "2.0.0-rc.1",
+        "@solana/codecs-strings": "2.0.0-rc.1",
+        "@solana/errors": "2.0.0-rc.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/spl-token-metadata/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/errors": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
+      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
+      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/wallet-adapter-base": {
+      "version": "0.9.27",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.27.tgz",
+      "integrity": "sha512-kXjeNfNFVs/NE9GPmysBRKQ/nf+foSaq3kfVSeMcO/iVgigyRmB551OjU3WyAolLG/1jeEfKLqF9fKwMCRkUqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@solana/wallet-standard-features": "^1.3.0",
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0",
+        "eventemitter3": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.98.0"
+      }
+    },
+    "node_modules/@solana/wallet-standard-chains": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.1.tgz",
+      "integrity": "sha512-Us3TgL4eMVoVWhuC4UrePlYnpWN+lwteCBlhZDUhFZBJ5UMGh94mYPXno3Ho7+iHPYRtuCi/ePvPcYBqCGuBOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@solana/wallet-standard-features": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.3.0.tgz",
+      "integrity": "sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0",
+        "@wallet-standard/features": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@solana/wallet-standard-util": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-util/-/wallet-standard-util-1.1.2.tgz",
+      "integrity": "sha512-rUXFNP4OY81Ddq7qOjQV4Kmkozx4wjYAxljvyrqPx8Ycz0FYChG/hQVWqvgpK3sPsEaO/7ABG1NOACsyAKWNOA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.8.0",
+        "@solana/wallet-standard-chains": "^1.1.1",
+        "@solana/wallet-standard-features": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@solana/web3.js": {
+      "version": "1.98.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
+      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "@noble/curves": "^1.4.2",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "@solana/codecs-numbers": "^2.1.0",
+        "agentkeepalive": "^4.5.0",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^2.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
+      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
+      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "2.3.0",
+        "@solana/errors": "2.3.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
+      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^14.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.3.3"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
@@ -1729,6 +3690,15 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1798,7 +3768,6 @@
       "version": "25.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -1836,6 +3805,17 @@
       "dependencies": {
         "@types/node": "*",
         "kleur": "^3.0.3"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/stats.js": {
@@ -1880,6 +3860,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/webxr": {
       "version": "0.5.24",
       "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
@@ -1898,7 +3890,6 @@
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -2017,6 +4008,542 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wallet-standard/app": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/app/-/app-1.1.0.tgz",
+      "integrity": "sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.1.0.tgz",
+      "integrity": "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/features": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.1.0.tgz",
+      "integrity": "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@wallet-standard/wallet": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wallet-standard/wallet/-/wallet-1.1.0.tgz",
+      "integrity": "sha512-Gt8TnSlDZpAl+RWOOAB/kuvC7RpcdWAlFbHNoi4gsXsfaWa1QCT6LBcfIYTPdOZC9OVZUDwqGuGAcqZejDmHjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@wallet-standard/base": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@walletconnect/core": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
+      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0",
+        "uint8arrays": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.8"
+      }
+    },
+    "node_modules/@walletconnect/environment": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/environment/-/environment-1.0.1.tgz",
+      "integrity": "sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/environment/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/events": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/events/-/events-1.0.1.tgz",
+      "integrity": "sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "keyvaluestorage-interface": "^1.0.0",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/events/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/heartbeat": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/heartbeat/-/heartbeat-1.2.2.tgz",
+      "integrity": "sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/events": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-http-connection": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.8.tgz",
+      "integrity": "sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.1",
+        "cross-fetch": "^3.1.4",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-provider": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.14.tgz",
+      "integrity": "sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-types": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.4.tgz",
+      "integrity": "sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0",
+        "keyvaluestorage-interface": "^1.0.0"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/environment": "^1.0.1",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-utils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-ws-connection/-/jsonrpc-ws-connection-1.0.16.tgz",
+      "integrity": "sha512-G81JmsMqh5nJheE1mPst1W0WfVv0SG3N7JggwLLGnI7iuDZJq8cRJvQwLGKHn5H1WTW7DEPCo00zz5w62AbL3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-utils": "^1.0.6",
+        "@walletconnect/safe-json": "^1.0.2",
+        "events": "^3.3.0",
+        "ws": "^7.5.1"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/keyvaluestorage": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/keyvaluestorage/-/keyvaluestorage-1.1.1.tgz",
+      "integrity": "sha512-V7ZQq2+mSxAq7MrRqDxanTzu2RcElfK1PfNYiaVnJgJ7Q7G7hTVwF8voIBx92qsRyGHZihrwNPHuZd1aKkd0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.1",
+        "idb-keyval": "^6.2.1",
+        "unstorage": "^1.9.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "1.x"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-3.0.2.tgz",
+      "integrity": "sha512-7wR3wAwJTOmX4gbcUZcFMov8fjftY05+5cO/d4cpDD8wDzJ+cIlKdYOXaXfxHLSYeDazMXIsxMYjHYVDfkx+nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/safe-json": "^1.0.2",
+        "pino": "10.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-api": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
+      "integrity": "sha512-tLPErkze/HmC9aCmdZOhtVmYZq1wKfWTJtygQHoWtgg722Jd4homo54Cs4ak2RUFUZIGO2RsOpIcWipaua5D5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/jsonrpc-types": "^1.0.2"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/relay-auth/-/relay-auth-1.1.0.tgz",
+      "integrity": "sha512-qFw+a9uRz26jRCDgL7Q5TA9qYIgcNY8jpJzI1zAWNZ8i7mQjaijRnWFKsCHAU9CyGjvt6RKrRXyFtFOpWTVmCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.0",
+        "@noble/hashes": "1.7.0",
+        "@walletconnect/safe-json": "^1.0.1",
+        "@walletconnect/time": "^1.0.2",
+        "uint8arrays": "^3.0.0"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/curves": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.0.tgz",
+      "integrity": "sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/relay-auth/node_modules/@noble/hashes": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.0.tgz",
+      "integrity": "sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/safe-json": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/safe-json/-/safe-json-1.0.2.tgz",
+      "integrity": "sha512-Ogb7I27kZ3LPC3ibn8ldyUr5544t3/STow9+lzz7Sfo808YD7SBWk7SAsdBFlYgP2zDRy2hS3sKRcuSRM0OTmA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/safe-json/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/sign-client": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
+      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/core": "2.23.7",
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/time/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/types": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
+      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/heartbeat": "1.2.2",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/universal-provider": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.23.7.tgz",
+      "integrity": "sha512-6UicU/Mhr/1bh7MNoajypz7BhigORbHpP1LFTf8FYLQGDqzmqHMqmMH2GDAImtaY2sFTi2jBvc22tLl8VMze/A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@walletconnect/events": "1.0.1",
+        "@walletconnect/jsonrpc-http-connection": "1.0.8",
+        "@walletconnect/jsonrpc-provider": "1.0.14",
+        "@walletconnect/jsonrpc-types": "1.0.4",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/sign-client": "2.23.7",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/utils": "2.23.7",
+        "es-toolkit": "1.44.0",
+        "events": "3.3.0"
+      }
+    },
+    "node_modules/@walletconnect/utils": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
+      "integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@msgpack/msgpack": "3.1.3",
+        "@noble/ciphers": "1.3.0",
+        "@noble/curves": "1.9.7",
+        "@noble/hashes": "1.8.0",
+        "@scure/base": "1.2.6",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
+        "@walletconnect/keyvaluestorage": "1.1.1",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/relay-api": "1.0.11",
+        "@walletconnect/relay-auth": "1.1.0",
+        "@walletconnect/safe-json": "1.0.2",
+        "@walletconnect/time": "1.0.2",
+        "@walletconnect/types": "2.23.7",
+        "@walletconnect/window-getters": "1.0.1",
+        "@walletconnect/window-metadata": "1.0.1",
+        "blakejs": "1.2.1",
+        "detect-browser": "5.3.0",
+        "ox": "0.9.3",
+        "uint8arrays": "3.1.1"
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/abitype": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.4.tgz",
+      "integrity": "sha512-dpKH+N27vRjarMVTFFkeY445VTKftzGWpL0FiT7xmVmzQRKazZexzC5uHG0f6XKsVLAuUlndnbGau6lRejClxg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.3.tgz",
+      "integrity": "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.0.9",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/utils/node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@walletconnect/window-getters": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-getters/-/window-getters-1.0.1.tgz",
+      "integrity": "sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-getters/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/@walletconnect/window-metadata": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/window-metadata/-/window-metadata-1.0.1.tgz",
+      "integrity": "sha512-9koTqyGrM2cqFRW517BPY/iEtUDx2r1+Pwwu5m7sJ7ka79wi3EyqhqcICk/yDmv6jAS1rjKgTKXlEhanYjijcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@walletconnect/window-getters": "^1.0.1",
+        "tslib": "1.14.1"
+      }
+    },
+    "node_modules/@walletconnect/window-metadata/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
+    "node_modules/abitype": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2054,10 +4581,37 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/assertion-error": {
@@ -2091,8 +4645,42 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -2100,6 +4688,117 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/big.js": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
+    "node_modules/bigint-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
+      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bindings": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+      "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
+      "license": "MIT"
+    },
+    "node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/borsh/node_modules/base-x": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/borsh/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "2.1.1",
@@ -2124,11 +4823,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2136,6 +4882,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/chai": {
@@ -2162,20 +4917,29 @@
         "node": ">=8"
       }
     },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">= 20.19.0"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chromium-bidi": {
@@ -2313,6 +5077,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -2331,7 +5105,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2344,7 +5117,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -2404,7 +5176,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2413,12 +5185,56 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.2.tgz",
+      "integrity": "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie-es": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
+      "license": "MIT"
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2434,6 +5250,33 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -2462,15 +5305,60 @@
         "node": ">= 12"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/defu": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
+      "license": "MIT"
+    },
+    "node_modules/delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
+    },
+    "node_modules/destr": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+      "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+      "license": "MIT"
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2489,6 +5377,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/draco3dgltf": {
       "version": "1.5.7",
       "resolved": "https://registry.npmjs.org/draco3dgltf/-/draco3dgltf-1.5.7.tgz",
@@ -2500,7 +5394,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2522,7 +5416,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/enabled": {
@@ -2530,6 +5423,12 @@
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encode-utf8": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/encode-utf8/-/encode-utf8-1.0.3.tgz",
+      "integrity": "sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==",
       "license": "MIT"
     },
     "node_modules/environment": {
@@ -2549,7 +5448,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2559,7 +5458,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2576,7 +5475,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
       "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2589,7 +5488,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2599,6 +5498,31 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.44.0.tgz",
+      "integrity": "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
+    "node_modules/es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es6-promise": "^4.0.3"
       }
     },
     "node_modules/esbuild": {
@@ -2667,8 +5591,16 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -2678,6 +5610,14 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "engines": {
+        "node": "> 0.1.90"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2693,6 +5633,19 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-stable-stringify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
+      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
+      "license": "MIT"
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "license": "CC0-1.0",
+      "peer": true
     },
     "node_modules/fecha": {
       "version": "4.2.3",
@@ -2732,6 +5685,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2745,12 +5704,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -2773,7 +5766,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
       "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2818,7 +5811,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2828,7 +5821,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -2851,7 +5843,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2876,7 +5868,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2919,13 +5911,30 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/h3": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie-es": "^1.2.3",
+        "crossws": "^0.3.5",
+        "defu": "^6.1.6",
+        "destr": "^2.0.5",
+        "iron-webcrypto": "^1.2.1",
+        "node-mock-http": "^1.0.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.6.3",
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/has-flag": {
@@ -2942,7 +5951,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2955,7 +5964,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -2971,7 +5980,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2979,6 +5988,41 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -2994,18 +6038,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/iron-webcrypto": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/brc-dd"
+      }
+    },
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3021,12 +6073,49 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
@@ -3044,6 +6133,99 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jayson": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
+      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "^3.4.33",
+        "@types/node": "^12.12.54",
+        "@types/ws": "^7.4.4",
+        "commander": "^2.20.3",
+        "delay": "^5.0.0",
+        "es6-promisify": "^5.0.0",
+        "eyes": "^0.1.8",
+        "isomorphic-ws": "^4.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "stream-json": "^1.9.1",
+        "uuid": "^8.3.2",
+        "ws": "^7.5.10"
+      },
+      "bin": {
+        "jayson": "bin/jayson.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jayson/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/jayson/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/jayson/node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -3051,12 +6233,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/keyframe-resample": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/keyframe-resample/-/keyframe-resample-0.1.0.tgz",
       "integrity": "sha512-z1au6Q6qCWP734q44t/5SyGwNydC7MvOWo2ZETAz7ZqAgtcyb5EGO7jwgk3DEH7CaDtb0DkGec9iwVpeDWX5dA==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/keyvaluestorage-interface": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/keyvaluestorage-interface/-/keyvaluestorage-interface-1.0.0.tgz",
+      "integrity": "sha512-8t6Q3TclQ4uZynJY9IGr2+SsIGwK9JHcO6ootkHCGA0CrQCRy+VkouYNO2xicET6b9al7QKzpebNow+gkpCL8g==",
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "3.0.3",
@@ -3466,6 +6660,49 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lit": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.3.tgz",
+      "integrity": "sha512-el8M6jK2o3RXBnrSHX3ZKrsN8zEV63pSExTO1wYJz7QndGYZ8353e2a5PPX+qHe2aGayfnchQmkAojaWAREOIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -3660,10 +6897,22 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/meshoptimizer": {
@@ -3698,7 +6947,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3708,7 +6957,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3777,8 +7026,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
+      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/n8ao": {
       "version": "1.10.1",
@@ -3894,6 +7148,39 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-fetch-native": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+      "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-mock-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/obscenity": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/obscenity/-/obscenity-0.4.6.tgz",
@@ -3917,6 +7204,26 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/ofetch": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.5.1.tgz",
+      "integrity": "sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==",
+      "license": "MIT",
+      "dependencies": {
+        "destr": "^2.0.5",
+        "node-fetch-native": "^1.6.7",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/one-time": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -3927,12 +7234,94 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -4068,13 +7457,58 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -4154,6 +7588,33 @@
         "three": ">= 0.157.0 < 0.168.0"
       }
     },
+    "node_modules/preact": {
+      "version": "10.24.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
+      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -4174,6 +7635,22 @@
       "integrity": "sha512-AvPcP7XECNWy4LGmFQ77k7un4lSKM4eS29PTvW4ck95uYeLxXPWJM7hLuBqK91FaHqCcgJvIUCuNJjjxKE7VKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/proxy-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
+      "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4203,6 +7680,102 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/radix3": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
+      "license": "MIT"
+    },
     "node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -4218,15 +7791,42 @@
         "node": ">= 6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
@@ -4302,11 +7902,46 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/rpc-websockets": {
+      "version": "9.3.9",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.9.tgz",
+      "integrity": "sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==",
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/uuid": "^10.0.0",
+        "@types/ws": "^8.2.2",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "uuid": "^14.0.0",
+        "ws": "^8.5.0"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/kozjak"
+      },
+      "optionalDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^6.0.0"
+      }
+    },
+    "node_modules/rpc-websockets/node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4327,7 +7962,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4345,6 +7979,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -4484,6 +8124,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/slow-redact": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.2.tgz",
+      "integrity": "sha512-MseHyi2+E/hBRqdOi5COy6wZ7j7DxXRz9NkseavNYSvvWC06D8a5cidVZX3tcG5eCW3NIyVU4zT63hw0Q486jw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4527,6 +8182,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stream-chain": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
+      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/stream-json": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
+      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "stream-chain": "^2.2.5"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -4541,7 +8211,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -4572,7 +8241,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4593,6 +8261,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/superstruct": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
+      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -4724,12 +8401,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/text-encoding-utf-8": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
+      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/three": {
       "version": "0.165.0",
@@ -4835,6 +8526,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/triple-beam": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
@@ -4849,9 +8546,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/typed-query-selector": {
       "version": "2.12.2",
@@ -4864,7 +8559,6 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4874,11 +8568,31 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "license": "MIT"
+    },
+    "node_modules/uint8arrays": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
+      "integrity": "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg==",
+      "license": "MIT",
+      "dependencies": {
+        "multiformats": "^9.4.2"
+      }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uniq": {
@@ -4887,6 +8601,111 @@
       "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unstorage": {
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "^3.1.3",
+        "chokidar": "^5.0.0",
+        "destr": "^2.0.5",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
+        "node-fetch-native": "^1.6.7",
+        "ofetch": "^1.5.1",
+        "ufo": "^1.6.3"
+      },
+      "peerDependencies": {
+        "@azure/app-configuration": "^1.8.0",
+        "@azure/cosmos": "^4.2.0",
+        "@azure/data-tables": "^13.3.0",
+        "@azure/identity": "^4.6.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.26.0",
+        "@capacitor/preferences": "^6 || ^7 || ^8",
+        "@deno/kv": ">=0.9.0",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
+        "@vercel/blob": ">=0.27.1",
+        "@vercel/functions": "^2.2.12 || ^3.0.0",
+        "@vercel/kv": "^1 || ^2 || ^3",
+        "aws4fetch": "^1.0.20",
+        "db0": ">=0.2.1",
+        "idb-keyval": "^6.2.1",
+        "ioredis": "^5.4.2",
+        "uploadthing": "^7.4.4"
+      },
+      "peerDependenciesMeta": {
+        "@azure/app-configuration": {
+          "optional": true
+        },
+        "@azure/cosmos": {
+          "optional": true
+        },
+        "@azure/data-tables": {
+          "optional": true
+        },
+        "@azure/identity": {
+          "optional": true
+        },
+        "@azure/keyvault-secrets": {
+          "optional": true
+        },
+        "@azure/storage-blob": {
+          "optional": true
+        },
+        "@capacitor/preferences": {
+          "optional": true
+        },
+        "@deno/kv": {
+          "optional": true
+        },
+        "@netlify/blobs": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/blob": {
+          "optional": true
+        },
+        "@vercel/functions": {
+          "optional": true
+        },
+        "@vercel/kv": {
+          "optional": true
+        },
+        "aws4fetch": {
+          "optional": true
+        },
+        "db0": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "uploadthing": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4898,12 +8717,183 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valtio": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
+      "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
+      "license": "MIT",
+      "dependencies": {
+        "proxy-compare": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.52.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
+      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.29",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.14.29",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.29.tgz",
+      "integrity": "sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vite": {
       "version": "8.0.16",
@@ -5123,6 +9113,22 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5138,6 +9144,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
     },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
@@ -5244,38 +9256,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -5349,10 +9329,40 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
     "wiki:seed": "node scripts/mediawiki/build_seed.mjs"
   },
   "dependencies": {
+    "@noble/curves": "^1.9.7",
+    "@reown/appkit": "^1.8.21",
+    "@reown/appkit-adapter-solana": "^1.8.21",
+    "@solana/web3.js": "^1.98.4",
+    "bs58": "^6.0.0",
+    "buffer": "^6.0.3",
     "n8ao": "^1.10.1",
     "obscenity": "^0.4.6",
     "pg": "^8.21.0",

--- a/scripts/player_card_e2e.mjs
+++ b/scripts/player_card_e2e.mjs
@@ -1,0 +1,97 @@
+// End-to-end check for the shareable player-card + referral feature against a
+// REAL running server + Postgres (no mocks). Live counterpart to the CI unit
+// tests in tests/player_card_server.test.ts (which mock pg).
+//
+// Usage:
+//   npm run db:up          # Postgres on :5433
+//   npm run server         # game server on :8787 (reads .env / DATABASE_URL)
+//   node scripts/player_card_e2e.mjs
+//   WOC_E2E_BASE=https://realm.example node scripts/player_card_e2e.mjs
+//
+// Exercises: publish a card → OG page + card.png → auth gate → register via
+// ?ref → referral count reflects it. Exits non-zero on any failure.
+const BASE = process.env.WOC_E2E_BASE ?? 'http://127.0.0.1:8787';
+const checks = [];
+const check = (name, cond) => { checks.push({ name, ok: !!cond }); console.log(`${cond ? '✅' : '❌'} ${name}`); };
+
+async function api(path, { method = 'GET', token, body } = {}) {
+  const res = await fetch(BASE + path, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: res.status, data: await res.json().catch(() => ({})) };
+}
+
+const register = async (u, ref) =>
+  (await api('/api/register', { method: 'POST', body: { username: u, password: 'test1234', ref } })).data.token;
+
+// A unique letters-only character name (server rule: ^[A-Za-z][A-Za-z' -]{1,15}$).
+function randomName() {
+  const letters = 'abcdefghijklmnopqrstuvwxyz';
+  let s = 'C';
+  for (let i = 0; i < 9; i++) s += letters[Math.floor(Math.random() * letters.length)];
+  return s;
+}
+
+// A tiny but signature-valid PNG (8-byte magic + filler). The server validates
+// the magic, then stores/serves the bytes verbatim.
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+async function uploadCard(token, characterId, bytes = PNG) {
+  const res = await fetch(`${BASE}/api/card?character=${characterId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'image/png', Authorization: `Bearer ${token}` },
+    body: bytes,
+  });
+  return { status: res.status, data: await res.json().catch(() => ({})) };
+}
+
+const stamp = Date.now();
+const tokenA = await register('cardA' + stamp);
+const name = randomName();
+const created = await api('/api/characters', { method: 'POST', token: tokenA, body: { name, class: 'paladin', skin: 0 } });
+check('create character -> 200', created.status === 200);
+const characterId = created.data.id;
+const slug = name.toLowerCase();
+
+check('unauthenticated card upload -> 401', (await fetch(`${BASE}/api/card?character=${characterId}`, { method: 'POST', headers: { 'Content-Type': 'image/png' }, body: PNG })).status === 401);
+
+const up = await uploadCard(tokenA, characterId);
+check('publish card -> 200 + name slug', up.status === 200 && up.data.url === `/p/${slug}` && up.data.ref === slug);
+
+check('reject non-PNG body -> 400', (await uploadCard(tokenA, characterId, new Uint8Array([1, 2, 3, 4]))).status === 400);
+check('upload for a foreign character -> 404', (await uploadCard(tokenA, 999999999)).status === 404);
+
+const pageRes = await fetch(`${BASE}/p/${slug}`);
+const pageHtml = await pageRes.text();
+check('GET /p/<slug> -> 200 html', pageRes.status === 200 && pageRes.headers.get('content-type')?.includes('text/html'));
+check('OG page references the card image', pageHtml.includes(`/p/${slug}/card.png`) && pageHtml.includes('twitter:card'));
+check('OG page CTA carries the referral', pageHtml.includes(`/?ref=${slug}`));
+
+const imgRes = await fetch(`${BASE}/p/${slug}/card.png`);
+const imgBytes = new Uint8Array(await imgRes.arrayBuffer());
+check('GET /p/<slug>/card.png -> 200 image/png', imgRes.status === 200 && imgRes.headers.get('content-type') === 'image/png');
+check('card.png round-trips the stored bytes', imgBytes.length === PNG.length && imgBytes[0] === 0x89 && imgBytes[1] === 0x50);
+
+check('GET /p/<unknown> -> 404', (await fetch(`${BASE}/p/this-card-does-not-exist`)).status === 404);
+check('GET /p/<invalid slug> -> 404', (await fetch(`${BASE}/p/..%2f..%2fetc`)).status === 404);
+
+// Referral capture: a brand-new account that registers via ?ref=<slug>.
+const before = await api('/api/referrals', { token: tokenA });
+check('referrals start at zero', before.status === 200 && before.data.count === 0 && before.data.slug === slug);
+await register('cardB' + stamp, slug);
+const after = await api('/api/referrals', { token: tokenA });
+check('referral is captured for the card owner', after.data.count === 1 && after.data.slug === slug);
+
+// A self-referral must not inflate the count.
+const selfBefore = (await api('/api/referrals', { token: tokenA })).data.count;
+// (the owner can't re-register, but an unknown ref or self-ref is silently ignored server-side)
+await register('cardC' + stamp, 'totally-unknown-slug');
+const selfAfter = (await api('/api/referrals', { token: tokenA })).data.count;
+check('unknown ref does not credit anyone', selfAfter === selfBefore);
+
+const passed = checks.filter((c) => c.ok).length;
+console.log(`\n${passed}/${checks.length} checks passed`);
+if (passed !== checks.length) process.exit(1);
+console.log('✅ player-card e2e passed against', BASE);

--- a/scripts/wallet_e2e.mjs
+++ b/scripts/wallet_e2e.mjs
@@ -1,0 +1,68 @@
+// End-to-end check for the non-custodial wallet-link feature against a REAL
+// running server + Postgres (no mocks). This is the live counterpart to the
+// CI unit tests in tests/wallet_server.test.ts (which mock pg).
+//
+// Usage:
+//   npm run db:up          # Postgres on :5433
+//   npm run server         # game server on :8787 (reads .env / DATABASE_URL)
+//   node scripts/wallet_e2e.mjs            # against http://127.0.0.1:8787
+//   WOC_E2E_BASE=https://realm.example node scripts/wallet_e2e.mjs
+//
+// A throwaway ed25519 keypair stands in for a Solana wallet (signMessage is
+// exactly ed25519 over the UTF-8 message bytes). Exits non-zero on any failure.
+import bs58 from 'bs58';
+import { ed25519 } from '@noble/curves/ed25519';
+
+const BASE = process.env.WOC_E2E_BASE ?? 'http://127.0.0.1:8787';
+const checks = [];
+const check = (name, cond) => { checks.push({ name, ok: !!cond }); console.log(`${cond ? '✅' : '❌'} ${name}`); };
+
+async function api(path, { method = 'GET', token, body } = {}) {
+  const res = await fetch(BASE + path, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  return { status: res.status, data: await res.json().catch(() => ({})) };
+}
+const register = async (u) => (await api('/api/register', { method: 'POST', body: { username: u, password: 'test1234' } })).data.token;
+function newWallet() {
+  const priv = ed25519.utils.randomPrivateKey();
+  return { priv, address: bs58.encode(ed25519.getPublicKey(priv)) };
+}
+async function link(token, wallet, { tamper = false } = {}) {
+  const ch = await api('/api/wallet/link/challenge', { method: 'POST', token, body: { address: wallet.address } });
+  const msg = tamper ? ch.data.message + ' tampered' : ch.data.message;
+  const signature = bs58.encode(ed25519.sign(new TextEncoder().encode(msg), wallet.priv));
+  return api('/api/wallet/link', { method: 'POST', token, body: { address: wallet.address, signature, nonce: ch.data.nonce } });
+}
+
+const stamp = Date.now();
+const tokenA = await register('e2eA' + stamp);
+const tokenB = await register('e2eB' + stamp);
+const wallet = newWallet();
+
+check('unauthenticated GET /api/wallet -> 401', (await api('/api/wallet')).status === 401);
+check('no wallet linked initially', (await api('/api/wallet', { token: tokenA })).data.wallet === null);
+
+const linked = await link(tokenA, wallet);
+check('valid sign-to-link -> 200 + linked', linked.status === 200 && linked.data.linked === true);
+check('GET reflects the linked wallet', (await api('/api/wallet', { token: tokenA })).data.wallet?.pubkey === wallet.address);
+
+// replay: the same challenge nonce was consumed, so re-submitting must fail
+const ch = await api('/api/wallet/link/challenge', { method: 'POST', token: tokenA, body: { address: wallet.address } });
+const sig = bs58.encode(ed25519.sign(new TextEncoder().encode(ch.data.message), wallet.priv));
+await api('/api/wallet/link', { method: 'POST', token: tokenA, body: { address: wallet.address, signature: sig, nonce: ch.data.nonce } });
+const replay = await api('/api/wallet/link', { method: 'POST', token: tokenA, body: { address: wallet.address, signature: sig, nonce: ch.data.nonce } });
+check('challenge replay -> 400', replay.status === 400);
+
+check('forged signature -> 401', (await link(tokenA, wallet, { tamper: true })).status === 401);
+check('linking the same wallet to another account -> 409', (await link(tokenB, wallet)).status === 409);
+check('unlink -> 200', (await api('/api/wallet/link', { method: 'DELETE', token: tokenA })).status === 200);
+check('wallet is null after unlink', (await api('/api/wallet', { token: tokenA })).data.wallet === null);
+check('freed wallet can now link to the other account', (await link(tokenB, wallet)).status === 200);
+
+const passed = checks.filter((c) => c.ok).length;
+console.log(`\n${passed}/${checks.length} checks passed`);
+if (passed !== checks.length) process.exit(1);
+console.log('✅ wallet-link e2e passed against', BASE);

--- a/server/db.ts
+++ b/server/db.ts
@@ -183,6 +183,32 @@ CREATE TABLE IF NOT EXISTS wallet_link_challenges (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS wallet_link_challenges_account ON wallet_link_challenges(account_id);
+-- Shareable player cards (docs/prd/woc/player-card.md). One card per character;
+-- the PNG is composited client-side and stored here as bytes so any realm
+-- process (all share this database) can serve /p/<slug> and the OG image. slug
+-- is globally unique and is the public, referral-friendly handle.
+CREATE TABLE IF NOT EXISTS player_cards (
+  character_id INT PRIMARY KEY REFERENCES characters(id) ON DELETE CASCADE,
+  account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL UNIQUE,
+  png BYTEA NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  description TEXT NOT NULL DEFAULT '',
+  realm TEXT NOT NULL DEFAULT '${REALM_SQL_DEFAULT}',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS player_cards_account ON player_cards(account_id);
+-- Referral capture: when a new account registers via someone's card link
+-- (?ref=<slug>) we record who referred whom, once per referee. Reward payout is
+-- intentionally out of scope here — this just captures the relationship so it
+-- can be synced to rewards later.
+CREATE TABLE IF NOT EXISTS referrals (
+  referee_account_id INT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  referrer_account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  slug TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS referrals_referrer ON referrals(referrer_account_id);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -359,6 +385,96 @@ export async function linkWalletToAccount(accountId: number, pubkey: string): Pr
 
 export async function unlinkWallet(accountId: number): Promise<void> {
   await pool.query('DELETE FROM wallet_links WHERE account_id = $1', [accountId]);
+}
+
+// ── Shareable player cards + referrals ─────────────────────────────────────
+
+export interface PlayerCardRow {
+  characterId: number;
+  accountId: number;
+  png: Buffer;
+  title: string;
+  description: string;
+}
+
+// True when `slug` is free, or already owned by `exceptCharacterId` (so a
+// character can re-publish under its own existing slug). Lets the handler pick a
+// collision-free slug before the upsert.
+export async function slugAvailable(slug: string, exceptCharacterId: number): Promise<boolean> {
+  const res = await pool.query('SELECT character_id FROM player_cards WHERE slug = $1', [slug]);
+  const owner = res.rows[0]?.character_id;
+  return owner === undefined || owner === exceptCharacterId;
+}
+
+export async function upsertPlayerCard(card: {
+  characterId: number;
+  accountId: number;
+  slug: string;
+  png: Buffer;
+  title: string;
+  description: string;
+}): Promise<void> {
+  await pool.query(
+    `INSERT INTO player_cards (character_id, account_id, slug, png, title, description, realm, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+     ON CONFLICT (character_id)
+     DO UPDATE SET slug = EXCLUDED.slug, png = EXCLUDED.png, title = EXCLUDED.title,
+                   description = EXCLUDED.description, updated_at = now()`,
+    [card.characterId, card.accountId, card.slug, card.png, card.title, card.description, REALM],
+  );
+}
+
+export async function getPlayerCardBySlug(slug: string): Promise<PlayerCardRow | null> {
+  const res = await pool.query(
+    'SELECT character_id, account_id, png, title, description FROM player_cards WHERE slug = $1',
+    [slug],
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  return {
+    characterId: Number(row.character_id),
+    accountId: Number(row.account_id),
+    png: row.png as Buffer,
+    title: row.title ?? '',
+    description: row.description ?? '',
+  };
+}
+
+// The account that owns a card slug — i.e. the referrer credited when someone
+// signs up through their link.
+export async function accountForSlug(slug: string): Promise<number | null> {
+  const res = await pool.query('SELECT account_id FROM player_cards WHERE slug = $1', [slug]);
+  return res.rows[0]?.account_id ?? null;
+}
+
+// Record that `referee` joined via `referrer`'s `slug`. Idempotent: only the
+// first referral for a given referee is kept (PK on referee_account_id).
+export async function recordReferral(refereeAccountId: number, referrerAccountId: number, slug: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO referrals (referee_account_id, referrer_account_id, slug)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (referee_account_id) DO NOTHING`,
+    [refereeAccountId, referrerAccountId, slug],
+  );
+}
+
+export async function referralCountForAccount(accountId: number): Promise<number> {
+  const res = await pool.query(
+    'SELECT count(*)::int AS n FROM referrals WHERE referrer_account_id = $1',
+    [accountId],
+  );
+  return res.rows[0]?.n ?? 0;
+}
+
+// This account's published-card slug, if any (one slug per card; an account can
+// have several characters, so return the most recently updated card's slug for
+// referral display).
+export async function primarySlugForAccount(accountId: number): Promise<string | null> {
+  const res = await pool.query(
+    'SELECT slug FROM player_cards WHERE account_id = $1 ORDER BY updated_at DESC LIMIT 1',
+    [accountId],
+  );
+  return res.rows[0]?.slug ?? null;
 }
 
 export async function moderationStatusForAccount(accountId: number): Promise<AccountModerationStatus> {

--- a/server/db.ts
+++ b/server/db.ts
@@ -162,6 +162,27 @@ CREATE TABLE IF NOT EXISTS chat_violations (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 CREATE INDEX IF NOT EXISTS chat_violations_account ON chat_violations(account_id, created_at DESC);
+-- Non-custodial Solana wallet links (PRD: docs/prd/woc/wallet-link.md). One
+-- wallet per account (account_id is the PK) and one account per wallet (pubkey
+-- is UNIQUE). The server never holds keys; ownership is proven by a signed
+-- challenge (see wallet_link_challenges) and this table is just the mirror.
+CREATE TABLE IF NOT EXISTS wallet_links (
+  account_id INT PRIMARY KEY REFERENCES accounts(id) ON DELETE CASCADE,
+  pubkey TEXT NOT NULL UNIQUE,
+  linked_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- Single-use, short-lived sign-to-link challenges. The full message the wallet
+-- must sign is stored server-side so the client cannot choose what gets signed;
+-- consuming a challenge deletes it (replay protection).
+CREATE TABLE IF NOT EXISTS wallet_link_challenges (
+  nonce TEXT PRIMARY KEY,
+  account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  address TEXT NOT NULL,
+  message TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS wallet_link_challenges_account ON wallet_link_challenges(account_id);
 `;
 
 export async function ensureSchema(): Promise<void> {
@@ -265,6 +286,79 @@ export async function accountForToken(token: string): Promise<number | null> {
     [token],
   );
   return res.rows[0]?.account_id ?? null;
+}
+
+// ── Non-custodial Solana wallet links ──────────────────────────────────────
+
+export interface WalletLinkRow {
+  account_id: number;
+  pubkey: string;
+  linked_at: string;
+}
+
+export async function createWalletChallenge(
+  nonce: string,
+  accountId: number,
+  address: string,
+  message: string,
+  ttlMinutes = 10,
+): Promise<void> {
+  await pool.query(
+    `INSERT INTO wallet_link_challenges (nonce, account_id, address, message, expires_at)
+     VALUES ($1, $2, $3, $4, now() + ($5 || ' minutes')::interval)`,
+    [nonce, accountId, address, message, String(ttlMinutes)],
+  );
+}
+
+// Atomically consume a challenge: returns the stored address+message if the
+// nonce belongs to this account and is unexpired, deleting the row so a
+// signature can never be replayed against it twice.
+export async function consumeWalletChallenge(
+  nonce: string,
+  accountId: number,
+): Promise<{ address: string; message: string } | null> {
+  const res = await pool.query(
+    `DELETE FROM wallet_link_challenges
+     WHERE nonce = $1 AND account_id = $2 AND expires_at > now()
+     RETURNING address, message`,
+    [nonce, accountId],
+  );
+  return res.rows[0] ?? null;
+}
+
+export async function pruneWalletChallenges(): Promise<void> {
+  await pool.query('DELETE FROM wallet_link_challenges WHERE expires_at <= now()');
+}
+
+export async function walletForAccount(accountId: number): Promise<WalletLinkRow | null> {
+  const res = await pool.query(
+    'SELECT account_id, pubkey, linked_at FROM wallet_links WHERE account_id = $1',
+    [accountId],
+  );
+  return res.rows[0] ?? null;
+}
+
+export async function accountForWallet(pubkey: string): Promise<number | null> {
+  const res = await pool.query('SELECT account_id FROM wallet_links WHERE pubkey = $1', [pubkey]);
+  return res.rows[0]?.account_id ?? null;
+}
+
+// One wallet per account (account_id PK) and one account per wallet (pubkey
+// UNIQUE). Upserts the caller's link; returns false when the wallet is already
+// owned by a different account so the handler can surface a 409.
+export async function linkWalletToAccount(accountId: number, pubkey: string): Promise<boolean> {
+  const owner = await accountForWallet(pubkey);
+  if (owner !== null && owner !== accountId) return false;
+  await pool.query(
+    `INSERT INTO wallet_links (account_id, pubkey) VALUES ($1, $2)
+     ON CONFLICT (account_id) DO UPDATE SET pubkey = EXCLUDED.pubkey, linked_at = now()`,
+    [accountId, pubkey],
+  );
+  return true;
+}
+
+export async function unlinkWallet(accountId: number): Promise<void> {
+  await pool.query('DELETE FROM wallet_links WHERE account_id = $1', [accountId]);
 }
 
 export async function moderationStatusForAccount(accountId: number): Promise<AccountModerationStatus> {

--- a/server/db.ts
+++ b/server/db.ts
@@ -477,6 +477,32 @@ export async function primarySlugForAccount(accountId: number): Promise<string |
   return res.rows[0]?.slug ?? null;
 }
 
+// Where a character ranks among all characters on its realm by lifetime XP (the
+// canonical progression metric — encodes level plus post-cap overflow), for the
+// player card's "Top N%" flex. Ownership + realm are enforced via the caller's
+// account; returns null when the character isn't the caller's. rank is 1-based
+// (1 = highest lifetime XP on the realm); total is the realm population.
+export async function lifetimeXpStanding(
+  accountId: number,
+  characterId: number,
+): Promise<{ rank: number; total: number } | null> {
+  const own = await pool.query(
+    `SELECT COALESCE((state->>'lifetimeXp')::bigint, 0)::text AS xp
+       FROM characters WHERE id = $1 AND account_id = $2 AND realm = $3`,
+    [characterId, accountId, REALM],
+  );
+  if ((own.rowCount ?? 0) === 0) return null;
+  const xp = own.rows[0].xp as string;
+  const res = await pool.query(
+    `SELECT
+       (SELECT count(*) FROM characters
+         WHERE realm = $1 AND COALESCE((state->>'lifetimeXp')::bigint, 0) > $2::bigint)::int AS ahead,
+       (SELECT count(*) FROM characters WHERE realm = $1)::int AS total`,
+    [REALM, xp],
+  );
+  return { rank: (res.rows[0]?.ahead ?? 0) + 1, total: res.rows[0]?.total ?? 0 };
+}
+
 export async function moderationStatusForAccount(accountId: number): Promise<AccountModerationStatus> {
   const res = await pool.query(
     `SELECT banned_at, suspended_until, moderation_reason, chat_muted_until, chat_strikes

--- a/server/http_util.ts
+++ b/server/http_util.ts
@@ -43,3 +43,39 @@ export function readBody(req: http.IncomingMessage): Promise<any> {
     req.on('error', reject);
   });
 }
+
+// Read a raw binary request body into a Buffer, capped at `maxBytes`. JSON
+// bodies go through readBody (64 KB); this exists for the player-card PNG
+// upload, which is far larger than that cap but still bounded. As with
+// readBody, exceeding the cap destroys the socket so a client can't stream
+// unbounded data into memory.
+export function readBinaryBody(req: http.IncomingMessage, maxBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let size = 0;
+    let aborted = false;
+    req.on('data', (c: Buffer) => {
+      if (aborted) return;
+      size += c.length;
+      if (size > maxBytes) {
+        aborted = true;
+        req.destroy();
+        reject(new Error('body too large'));
+        return;
+      }
+      chunks.push(c);
+    });
+    req.on('end', () => {
+      if (aborted) return;
+      resolve(Buffer.concat(chunks));
+    });
+    req.on('error', reject);
+  });
+}
+
+// The 8-byte PNG signature. Card uploads must be real PNGs (the card page sets
+// Content-Type: image/png), so reject anything else before it is stored.
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+export function isPng(buf: Buffer): boolean {
+  return buf.length > PNG_MAGIC.length && buf.subarray(0, 8).equals(PNG_MAGIC);
+}

--- a/server/main.ts
+++ b/server/main.ts
@@ -21,6 +21,7 @@ import {
 import { json, readBody, isUniqueViolation } from './http_util';
 import { requestIp, rateLimited, authThrottled, recordAuthFailure, clearAuthFailures } from './ratelimit';
 import { verifyTurnstile } from './turnstile';
+import { handleWalletChallenge, handleWalletLink, handleWalletGet, handleWalletUnlink } from './wallet';
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
@@ -427,6 +428,27 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const limit = Math.max(1, Math.min(LEADERBOARD_SIZE, Number(params.get('limit')) || LEADERBOARD_SIZE));
       const entries = await getLeaderboard(scope);
       return json(res, 200, { realm: REALM, scope, metric: 'lifetimeXp', leaders: entries.slice(0, limit) });
+    }
+    // Non-custodial Solana wallet linking — all account-scoped.
+    if (req.method === 'POST' && url === '/api/wallet/link/challenge') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      return handleWalletChallenge(req, res, accountId);
+    }
+    if (req.method === 'POST' && url === '/api/wallet/link') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      return handleWalletLink(req, res, accountId);
+    }
+    if (req.method === 'DELETE' && url === '/api/wallet/link') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      return handleWalletUnlink(req, res, accountId);
+    }
+    if (req.method === 'GET' && url === '/api/wallet') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      return handleWalletGet(req, res, accountId);
     }
     json(res, 404, { error: 'unknown endpoint' });
   } catch (err: any) {

--- a/server/main.ts
+++ b/server/main.ts
@@ -7,6 +7,7 @@ import {
   listCharacters, getCharacter, createCharacterCapped, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
   findCharacterReportTargetByName, topArenaRatings, topLifetimeXp, chatMuteStatusForAccount,
+  referralCountForAccount, primarySlugForAccount,
 } from './db';
 import { virtualLevel } from '../src/sim/types';
 import { Sim } from '../src/sim/sim';
@@ -22,6 +23,7 @@ import { json, readBody, isUniqueViolation } from './http_util';
 import { requestIp, rateLimited, authThrottled, recordAuthFailure, clearAuthFailures } from './ratelimit';
 import { verifyTurnstile } from './turnstile';
 import { handleWalletChallenge, handleWalletLink, handleWalletGet, handleWalletUnlink } from './wallet';
+import { handleCardUpload, handleCardRoutes, captureReferral } from './player_card';
 import { handleAdminApi } from './admin';
 import { GameServer } from './game';
 import { REALM, REALM_DIRECTORY, REALM_ORIGINS } from './realm';
@@ -252,6 +254,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
         username: account.username,
         ...requestMetadata(req),
       }).catch((err) => console.error('suspicious registration report failed:', err));
+      // Capture the referral when this account signed up via a card link
+      // (?ref=<slug>). Best-effort: never block or fail registration on it.
+      void captureReferral(account.id, body.ref).catch((err) => console.error('referral capture failed:', err));
       return json(res, 200, { token, username: account.username });
     }
     if (req.method === 'POST' && url === '/api/login') {
@@ -450,6 +455,21 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       if (accountId === null) return;
       return handleWalletGet(req, res, accountId);
     }
+    // Shareable player card: publish (PNG body) + referral stats for the card.
+    if (req.method === 'POST' && url === '/api/card') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      return handleCardUpload(req, res, accountId);
+    }
+    if (req.method === 'GET' && url === '/api/referrals') {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      const [count, slug] = await Promise.all([
+        referralCountForAccount(accountId),
+        primarySlugForAccount(accountId),
+      ]);
+      return json(res, 200, { count, slug });
+    }
     json(res, 404, { error: 'unknown endpoint' });
   } catch (err: any) {
     console.error('api error:', err);
@@ -500,6 +520,7 @@ async function main(): Promise<void> {
     if (req.method === 'OPTIONS' && isApi) { res.writeHead(204); res.end(); return; }
     if (url.startsWith('/admin/api/')) void handleAdminApi(req, res, game);
     else if (url.startsWith('/api/')) void handleApi(req, res);
+    else if (req.method === 'GET' && url.startsWith('/p/')) void handleCardRoutes(req, res);
     else serveStatic(req, res);
   });
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -7,7 +7,7 @@ import {
   listCharacters, getCharacter, createCharacterCapped, deleteCharacter, closeOrphanSessions,
   pruneChatLogs, searchCharacters, characterCountsByRealm, moderationStatusForAccount, renameCharacter,
   findCharacterReportTargetByName, topArenaRatings, topLifetimeXp, chatMuteStatusForAccount,
-  referralCountForAccount, primarySlugForAccount,
+  referralCountForAccount, primarySlugForAccount, lifetimeXpStanding,
 } from './db';
 import { virtualLevel } from '../src/sim/types';
 import { Sim } from '../src/sim/sim';
@@ -316,6 +316,14 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
     }
     const delMatch = /^\/api\/characters\/(\d+)$/.exec(url);
     const renameMatch = /^\/api\/characters\/(\d+)\/rename$/.exec(url);
+    const standingMatch = /^\/api\/characters\/(\d+)\/standing$/.exec(url);
+    if (req.method === 'GET' && standingMatch) {
+      const accountId = await bearerActiveAccount(req, res);
+      if (accountId === null) return;
+      const standing = await lifetimeXpStanding(accountId, Number(standingMatch[1]));
+      if (!standing) return json(res, 404, { error: 'character not found' });
+      return json(res, 200, standing);
+    }
     if (req.method === 'POST' && renameMatch) {
       const accountId = await bearerActiveAccount(req, res);
       if (accountId === null) return;

--- a/server/player_card.ts
+++ b/server/player_card.ts
@@ -1,0 +1,244 @@
+// Shareable player cards + referral capture (server side).
+//
+// Three public surfaces:
+//   POST /api/card?character=<id>   (authed) — store/replace this character's
+//                                    client-composited PNG, return its slug+URL.
+//   GET  /p/<slug>                  — an Open-Graph HTML page that unfurls on X /
+//                                    Discord and links into the game with ?ref.
+//   GET  /p/<slug>/card.png         — the stored PNG (the og:image).
+//
+// Cards are stored as bytes in Postgres (shared by every realm process), so a
+// shared link resolves no matter which realm serves the request. Referral
+// capture only records the relationship; reward payout is out of scope.
+import type http from 'node:http';
+import { json, readBinaryBody, isPng, isUniqueViolation } from './http_util';
+import {
+  getCharacter,
+  slugAvailable,
+  upsertPlayerCard,
+  getPlayerCardBySlug,
+  accountForSlug,
+  recordReferral,
+} from './db';
+
+// A composited card is ~1200×630 @2× PNG — comfortably under this bound, which
+// is generous enough to never reject a legitimate upload yet caps memory.
+const MAX_CARD_BYTES = 4 * 1024 * 1024;
+
+const CLASS_DISPLAY: Record<string, string> = {
+  warrior: 'Warrior', paladin: 'Paladin', hunter: 'Hunter', rogue: 'Rogue',
+  priest: 'Priest', mage: 'Mage', warlock: 'Warlock', druid: 'Druid', shaman: 'Shaman',
+};
+
+function classDisplay(cls: string): string {
+  return CLASS_DISPLAY[cls] ?? (cls ? cls[0].toUpperCase() + cls.slice(1) : 'Adventurer');
+}
+
+// Build a URL/file-safe slug from a character name. Lowercased, non-alphanumerics
+// collapsed to single hyphens, trimmed, capped. May be empty (e.g. an all-symbol
+// name) — callers fall back to a character-id slug.
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+// Validate a slug arriving from an untrusted URL before it is used in a query.
+// Slugs are only ever used as SQL parameters (never file paths), but this keeps
+// lookups bounded and 404s clean.
+export function isValidSlug(slug: string): boolean {
+  return /^[a-z0-9][a-z0-9-]{0,63}$/.test(slug);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function requestOrigin(req: http.IncomingMessage): string {
+  const fwd = String(req.headers['x-forwarded-proto'] ?? '').split(',')[0].trim();
+  const proto = fwd || ((req.socket as { encrypted?: boolean }).encrypted ? 'https' : 'http');
+  const host = req.headers.host ?? 'localhost';
+  return `${proto}://${host}`;
+}
+
+// POST /api/card?character=<id>  (body: image/png)  → { url, ref }
+export async function handleCardUpload(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  accountId: number,
+): Promise<void> {
+  const params = new URLSearchParams((req.url ?? '').split('?')[1] ?? '');
+  const characterId = Number(params.get('character'));
+  if (!Number.isInteger(characterId) || characterId <= 0) {
+    return json(res, 400, { error: 'character id is required' });
+  }
+  const character = await getCharacter(accountId, characterId);
+  if (!character) return json(res, 404, { error: 'character not found' });
+
+  let png: Buffer;
+  try {
+    png = await readBinaryBody(req, MAX_CARD_BYTES);
+  } catch (err) {
+    const tooLarge = err instanceof Error && err.message === 'body too large';
+    return json(res, tooLarge ? 413 : 400, { error: tooLarge ? 'image too large' : 'could not read image' });
+  }
+  if (!isPng(png)) return json(res, 400, { error: 'expected a PNG image' });
+
+  const base = slugify(character.name) || `player-${characterId}`;
+  const title = `${character.name} — Level ${character.level} ${classDisplay(character.class)}`;
+  const description = `${character.name} is forging a legend in World of Claudecraft. Join the realm.`;
+
+  // Prefer the clean name slug; fall back to a character-id-suffixed slug when
+  // the name slug is taken by a different character. Retry once under a unique
+  // violation in case the slug is claimed between the check and the upsert.
+  let slug = (await slugAvailable(base, characterId)) ? base : `${base}-${characterId}`.slice(0, 64);
+  try {
+    await upsertPlayerCard({ characterId, accountId, slug, png, title, description });
+  } catch (err) {
+    if (!isUniqueViolation(err)) throw err;
+    slug = `${base}-${characterId}`.slice(0, 64);
+    await upsertPlayerCard({ characterId, accountId, slug, png, title, description });
+  }
+  return json(res, 200, { url: `/p/${slug}`, ref: slug });
+}
+
+// GET /p/<slug>  and  GET /p/<slug>/card.png
+export async function handleCardRoutes(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
+  try {
+    const path = (req.url ?? '').split('?')[0];
+    const m = /^\/p\/([^/]+)(\/card\.png)?\/?$/.exec(path);
+    const slug = m ? decodeURIComponent(m[1]).toLowerCase() : '';
+    if (!m || !isValidSlug(slug)) {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('not found');
+      return;
+    }
+    if (m[2]) return await serveCardImage(res, slug);
+    return await serveCardPage(req, res, slug);
+  } catch (err) {
+    console.error('player-card route error:', err);
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('internal error');
+  }
+}
+
+async function serveCardImage(res: http.ServerResponse, slug: string): Promise<void> {
+  const card = await getPlayerCardBySlug(slug);
+  if (!card) {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('not found');
+    return;
+  }
+  res.writeHead(200, {
+    'Content-Type': 'image/png',
+    'Content-Length': card.png.length,
+    // Cards can be re-published, so revalidate fairly often rather than caching
+    // immutably like content-hashed build assets.
+    'Cache-Control': 'public, max-age=300',
+  });
+  res.end(card.png);
+}
+
+async function serveCardPage(req: http.IncomingMessage, res: http.ServerResponse, slug: string): Promise<void> {
+  const card = await getPlayerCardBySlug(slug);
+  const origin = requestOrigin(req);
+  if (!card) {
+    res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.end(missingCardHtml(origin));
+    return;
+  }
+  res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=120' });
+  res.end(cardPageHtml({ slug, title: card.title, description: card.description, origin }));
+}
+
+function cardPageHtml(opts: { slug: string; title: string; description: string; origin: string }): string {
+  const { slug, title, description, origin } = opts;
+  const pageUrl = `${origin}/p/${slug}`;
+  const imageUrl = `${pageUrl}/card.png`;
+  const playUrl = `${origin}/?ref=${encodeURIComponent(slug)}`;
+  const t = escapeHtml(title);
+  const d = escapeHtml(description);
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${t} · World of Claudecraft</title>
+<meta name="description" content="${d}">
+<meta property="og:type" content="website">
+<meta property="og:title" content="${t}">
+<meta property="og:description" content="${d}">
+<meta property="og:image" content="${escapeHtml(imageUrl)}">
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="630">
+<meta property="og:url" content="${escapeHtml(pageUrl)}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="${t}">
+<meta name="twitter:description" content="${d}">
+<meta name="twitter:image" content="${escapeHtml(imageUrl)}">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700&family=Alegreya+Sans:wght@400;700&display=swap" rel="stylesheet">
+<style>
+  :root { --gold: #ffd100; }
+  * { box-sizing: border-box; }
+  body { margin: 0; min-height: 100vh; display: flex; flex-direction: column; align-items: center;
+    justify-content: center; gap: 22px; padding: 32px 16px;
+    background: radial-gradient(circle at 50% 18%, #241910, #0a0805 70%);
+    color: #ece2c4; font-family: 'Alegreya Sans', system-ui, sans-serif; text-align: center; }
+  h1 { font-family: 'Cinzel', Georgia, serif; color: var(--gold); font-size: clamp(22px, 4vw, 34px);
+    margin: 0; text-shadow: 0 2px 10px rgba(0,0,0,.6); }
+  p { margin: 0; color: #c9bb92; max-width: 640px; line-height: 1.5; }
+  img.card { width: min(720px, 96vw); height: auto; border-radius: 12px;
+    box-shadow: 0 12px 48px rgba(0,0,0,.6); border: 1px solid #4a3a18; }
+  a.cta { display: inline-block; margin-top: 6px; padding: 13px 30px; border-radius: 8px;
+    font-family: 'Cinzel', serif; font-weight: 700; font-size: 17px; text-decoration: none;
+    color: #2a1d05; background: linear-gradient(#ffe27a, #e0a52a); box-shadow: 0 4px 18px rgba(224,165,42,.4); }
+  a.cta:hover { filter: brightness(1.08); }
+  footer { color: #7c6f4e; font-size: 13px; }
+</style>
+</head>
+<body>
+  <h1>${t}</h1>
+  <img class="card" src="${escapeHtml(imageUrl)}" alt="${t}" width="1200" height="630">
+  <p>${d}</p>
+  <a class="cta" href="${escapeHtml(playUrl)}">Forge your legend →</a>
+  <footer>World of Claudecraft</footer>
+</body>
+</html>`;
+}
+
+function missingCardHtml(origin: string): string {
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Card not found · World of Claudecraft</title>
+<style>
+  body { margin: 0; min-height: 100vh; display: flex; flex-direction: column; align-items: center;
+    justify-content: center; gap: 16px; background: radial-gradient(circle at 50% 18%, #241910, #0a0805 70%);
+    color: #ece2c4; font-family: system-ui, sans-serif; text-align: center; padding: 24px; }
+  a { color: #ffd100; }
+</style></head>
+<body><h1>This card has wandered off.</h1>
+<p>It may have been retired or never existed.</p>
+<p><a href="${escapeHtml(origin)}/">Enter World of Claudecraft →</a></p>
+</body></html>`;
+}
+
+// Record a referral when a brand-new account registered via ?ref=<slug>. Safe to
+// call with any untrusted `ref`: invalid slugs, unknown slugs, and self-referrals
+// are silently ignored.
+export async function captureReferral(refereeAccountId: number, ref: unknown): Promise<void> {
+  const slug = typeof ref === 'string' ? ref.trim().toLowerCase() : '';
+  if (!isValidSlug(slug)) return;
+  const referrer = await accountForSlug(slug);
+  if (referrer === null || referrer === refereeAccountId) return;
+  await recordReferral(refereeAccountId, referrer, slug);
+}

--- a/server/wallet.ts
+++ b/server/wallet.ts
@@ -1,0 +1,90 @@
+// Non-custodial Solana wallet linking.
+//
+// The chain is the source of truth for wallet ownership; this server only
+// *observes* it. To link a wallet to a World of ClaudeCraft account we issue a
+// short-lived, single-use challenge message, the player signs it with their
+// wallet (Solana = ed25519 over the raw UTF-8 bytes), and we verify the
+// signature here. No private keys, seeds, or funds ever touch the server.
+import type http from 'node:http';
+import { randomBytes } from 'node:crypto';
+import { json, readBody } from './http_util';
+import { isSolanaAddress, verifySolanaSignature, buildLinkMessage } from './wallet_link';
+import {
+  createWalletChallenge,
+  consumeWalletChallenge,
+  pruneWalletChallenges,
+  linkWalletToAccount,
+  walletForAccount,
+  unlinkWallet,
+} from './db';
+
+const CHALLENGE_TTL_MINUTES = 10;
+
+function requestDomain(req: http.IncomingMessage): string {
+  const host = (req.headers.host ?? '').split(':')[0];
+  return host || 'world-of-claudecraft';
+}
+
+// POST /api/wallet/link/challenge  { address }  → { nonce, message }
+export async function handleWalletChallenge(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  accountId: number,
+): Promise<void> {
+  const body = await readBody(req);
+  const address = typeof body.address === 'string' ? body.address.trim() : '';
+  if (!isSolanaAddress(address)) return json(res, 400, { error: 'invalid Solana wallet address' });
+
+  await pruneWalletChallenges();
+  const nonce = randomBytes(16).toString('hex');
+  const issuedAt = new Date().toISOString();
+  const message = buildLinkMessage({ domain: requestDomain(req), accountId, address, nonce, issuedAt });
+  await createWalletChallenge(nonce, accountId, address, message, CHALLENGE_TTL_MINUTES);
+  return json(res, 200, { nonce, message });
+}
+
+// POST /api/wallet/link  { address, signature, nonce }  → { pubkey, linked }
+export async function handleWalletLink(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  accountId: number,
+): Promise<void> {
+  const body = await readBody(req);
+  const address = typeof body.address === 'string' ? body.address.trim() : '';
+  const signature = typeof body.signature === 'string' ? body.signature.trim() : '';
+  const nonce = typeof body.nonce === 'string' ? body.nonce.trim() : '';
+  if (!isSolanaAddress(address) || !signature || !nonce) {
+    return json(res, 400, { error: 'address, signature, and nonce are required' });
+  }
+
+  const challenge = await consumeWalletChallenge(nonce, accountId);
+  if (!challenge) return json(res, 400, { error: 'challenge expired or already used — request a new one' });
+  if (challenge.address !== address) return json(res, 400, { error: 'wallet address does not match the challenge' });
+  if (!verifySolanaSignature(challenge.message, signature, address)) {
+    return json(res, 401, { error: 'signature verification failed' });
+  }
+
+  const linked = await linkWalletToAccount(accountId, address);
+  if (!linked) return json(res, 409, { error: 'this wallet is already linked to another account' });
+  return json(res, 200, { pubkey: address, linked: true });
+}
+
+// GET /api/wallet  → { wallet: { pubkey, linkedAt } | null }
+export async function handleWalletGet(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse,
+  accountId: number,
+): Promise<void> {
+  const row = await walletForAccount(accountId);
+  return json(res, 200, { wallet: row ? { pubkey: row.pubkey, linkedAt: row.linked_at } : null });
+}
+
+// DELETE /api/wallet/link  → { unlinked: true }
+export async function handleWalletUnlink(
+  _req: http.IncomingMessage,
+  res: http.ServerResponse,
+  accountId: number,
+): Promise<void> {
+  await unlinkWallet(accountId);
+  return json(res, 200, { unlinked: true });
+}

--- a/server/wallet_link.ts
+++ b/server/wallet_link.ts
@@ -1,0 +1,60 @@
+// Pure (IO-free) helpers for non-custodial Solana wallet linking: address
+// validation, the challenge-message format, and ed25519 signature verification.
+// Kept separate from server/wallet.ts (which does DB + HTTP) so it can be unit
+// tested without a database.
+import bs58 from 'bs58';
+import { ed25519 } from '@noble/curves/ed25519';
+
+// Base58 alphabet (Bitcoin/Solana). Testing the charset first guarantees the
+// decode below never throws, so no input-shape guard is needed around it.
+const BASE58 = /^[1-9A-HJ-NP-Za-km-z]+$/;
+
+export function decodeBase58(s: string): Uint8Array | null {
+  if (!BASE58.test(s)) return null;
+  return bs58.decode(s);
+}
+
+/** A Solana address is a 32-byte ed25519 public key, base58-encoded. */
+export function isSolanaAddress(s: unknown): s is string {
+  if (typeof s !== 'string') return false;
+  const bytes = decodeBase58(s);
+  return bytes !== null && bytes.length === 32;
+}
+
+/**
+ * Verify that `signatureB58` is a valid ed25519 signature of `message` by the
+ * wallet `addressB58`. The verify call is wrapped because the inputs are
+ * attacker-controlled and `@noble/curves` throws on malformed points — a forged
+ * or garbage signature must read as `false`, never crash the request.
+ */
+export function verifySolanaSignature(message: string, signatureB58: string, addressB58: string): boolean {
+  const sig = decodeBase58(signatureB58);
+  const pub = decodeBase58(addressB58);
+  if (sig === null || pub === null || sig.length !== 64 || pub.length !== 32) return false;
+  const msg = new TextEncoder().encode(message);
+  try {
+    return ed25519.verify(sig, msg, pub);
+  } catch {
+    return false;
+  }
+}
+
+/** The exact human-readable text the wallet is asked to sign. */
+export function buildLinkMessage(opts: {
+  domain: string;
+  accountId: number;
+  address: string;
+  nonce: string;
+  issuedAt: string;
+}): string {
+  return [
+    `${opts.domain} wants you to link this Solana wallet to your World of ClaudeCraft account.`,
+    '',
+    `Account: #${opts.accountId}`,
+    `Wallet: ${opts.address}`,
+    `Nonce: ${opts.nonce}`,
+    `Issued At: ${opts.issuedAt}`,
+    '',
+    'Signing is free, proves you control this wallet, and authorizes no transaction.',
+  ].join('\n');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { music } from './game/music';
 import { handlePickedEntity, hoverCursorKind } from './game/interactions';
 import { clickMoveShouldCancel, clickMoveStep, stepAngleToward } from './game/click_move';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
-import { initWallet, openWalletModal, signMessageBase58, currentWallet, onWalletChange, walletConfigured, fetchWocBalance } from './net/wallet';
+import { initWallet, openWalletModal, signMessageBase58, currentWallet, onWalletChange, walletConfigured, fetchWocBalance, disconnectWallet } from './net/wallet';
 import type { IWorld, LeaderboardEntry } from './world_api';
 import { formatXp } from './ui/xp_bar';
 import { assetsReady } from './render/assets/preload';
@@ -2095,8 +2095,14 @@ function updateWalletButton(): void {
   const label = document.getElementById('wallet-label');
   if (!btn || !label) return;
   const { address, isConnected } = currentWallet();
+  const connected = isConnected && !!address;
+  // Switch / Sign out are only meaningful once a wallet is connected.
+  const switchBtn = document.getElementById('btn-wallet-switch');
+  const signoutBtn = document.getElementById('btn-wallet-signout');
+  if (switchBtn) switchBtn.hidden = !connected;
+  if (signoutBtn) signoutBtn.hidden = !connected;
   btn.classList.remove('is-connected', 'is-linked');
-  if (!isConnected || !address) {
+  if (!connected) {
     label.textContent = 'Connect Wallet';
     btn.title = 'Connect your Solana wallet';
     return;
@@ -2197,10 +2203,24 @@ async function onWalletButtonClick(): Promise<void> {
   await openWalletModal(); // connected but logged out → manage; link happens after login
 }
 
+// Sign out: disconnect the wallet connection. The account↔wallet link persists
+// server-side, so reconnecting the same wallet re-shows the ✓ linked state.
+async function signOutWallet(): Promise<void> {
+  await disconnectWallet();
+}
+
+// Switch: disconnect, then reopen the picker to connect a different wallet.
+async function switchWallet(): Promise<void> {
+  await disconnectWallet();
+  await openWalletModal();
+}
+
 function wireWallet(): void {
   const btn = document.getElementById('btn-wallet');
   if (!btn) return;
   btn.addEventListener('click', () => { void onWalletButtonClick(); });
+  document.getElementById('btn-wallet-switch')?.addEventListener('click', () => { void switchWallet(); });
+  document.getElementById('btn-wallet-signout')?.addEventListener('click', () => { void signOutWallet(); });
   onWalletChange((state) => {
     if (state.address) void refreshWocBalance(state.address);
     else connectedWocBalance = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import { handlePickedEntity, hoverCursorKind } from './game/interactions';
 import { clickMoveShouldCancel, clickMoveStep, stepAngleToward } from './game/click_move';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
 import { setWocBalance, setWalletUiEnabled } from './ui/wallet_balance';
-import { setCardUploader, setReferralProvider } from './ui/player_card_share';
+import { setCardUploader, setReferralProvider, setStandingProvider } from './ui/player_card_share';
 // The wallet module (Reown AppKit + @solana/web3.js, ~1MB) is loaded lazily via
 // dynamic import() in the wallet controller below, so it stays out of the main
 // entry chunk and only loads when the feature is enabled + used.
@@ -1560,6 +1560,7 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     return { url: new URL(r.url, api.base || location.origin).href, ref: r.ref };
   });
   setReferralProvider(() => api.referralStats());
+  setStandingProvider(() => api.characterStanding(c.id));
   // wait for hello + first snapshot so the world starts populated
   const waitStart = Date.now();
   const poll = setInterval(() => {
@@ -1578,6 +1579,7 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     clearInterval(poll);
     setCardUploader(null);
     setReferralProvider(null);
+    setStandingProvider(null);
     fatalOverlay(userFacingApiError(reason));
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { music } from './game/music';
 import { handlePickedEntity, hoverCursorKind } from './game/interactions';
 import { clickMoveShouldCancel, clickMoveStep, stepAngleToward } from './game/click_move';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
+import { initWallet, openWalletModal, signMessageBase58, currentWallet, onWalletChange, walletConfigured, fetchWocBalance } from './net/wallet';
 import type { IWorld, LeaderboardEntry } from './world_api';
 import { formatXp } from './ui/xp_bar';
 import { assetsReady } from './render/assets/preload';
@@ -2078,10 +2079,144 @@ async function loadHighscores(): Promise<void> {
   host.innerHTML = head + body;
 }
 
+// ── Non-custodial Solana wallet linking (Reown) ─────────────────────────────
+// The header button connects a wallet (AppKit) and, once the player is logged
+// in, binds it to their account by signing a server-issued challenge. Wallet
+// connection persists in the browser (AppKit/localStorage); the account↔wallet
+// link is the durable, server-verified artifact.
+let linkedWalletPubkey: string | null = null;
+let connectedWocBalance: number | null = null;
+
+const shortenAddress = (a: string): string => `${a.slice(0, 4)}…${a.slice(-4)}`;
+const formatWoc = (n: number): string => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+
+function updateWalletButton(): void {
+  const btn = document.getElementById('btn-wallet');
+  const label = document.getElementById('wallet-label');
+  if (!btn || !label) return;
+  const { address, isConnected } = currentWallet();
+  btn.classList.remove('is-connected', 'is-linked');
+  if (!isConnected || !address) {
+    label.textContent = 'Connect Wallet';
+    btn.title = 'Connect your Solana wallet';
+    return;
+  }
+  // $WOC balance sits to the left of the address once it has loaded.
+  const balance = connectedWocBalance !== null ? `${formatWoc(connectedWocBalance)} $WOC · ` : '';
+  const short = shortenAddress(address);
+  if (linkedWalletPubkey && linkedWalletPubkey === address) {
+    btn.classList.add('is-linked');
+    label.textContent = `${balance}${short} ✓`;
+    btn.title = 'Wallet linked to your account — click to manage';
+  } else if (api.token) {
+    btn.classList.add('is-connected');
+    label.textContent = `${balance}${short}`;
+    btn.title = 'Click to sign and link this wallet to your account';
+  } else {
+    btn.classList.add('is-connected');
+    label.textContent = `${balance}${short}`;
+    btn.title = 'Connected — log in to link this wallet to your account';
+  }
+}
+
+// Read the connected wallet's $WOC balance and re-render. Ignores a stale
+// response if the connected wallet changed while the RPC call was in flight.
+async function refreshWocBalance(address: string): Promise<void> {
+  connectedWocBalance = null;
+  updateWalletButton();
+  const balance = await fetchWocBalance(address);
+  if (currentWallet().address === address) {
+    connectedWocBalance = balance;
+    updateWalletButton();
+  }
+}
+
+function flashWalletError(message: string): void {
+  const btn = document.getElementById('btn-wallet');
+  const label = document.getElementById('wallet-label');
+  if (!btn || !label) return;
+  const previous = label.textContent;
+  label.textContent = message;
+  btn.title = message;
+  window.setTimeout(() => {
+    if (label.textContent === message) label.textContent = previous;
+    updateWalletButton();
+  }, 4000);
+}
+
+// Refreshed after login: ask the server which wallet (if any) this account has
+// linked, so the button can show the verified ✓ state.
+async function refreshWalletLinkStatus(): Promise<void> {
+  if (!api.token) {
+    linkedWalletPubkey = null;
+    updateWalletButton();
+    return;
+  }
+  try {
+    const wallet = await api.linkedWallet();
+    linkedWalletPubkey = wallet?.pubkey ?? null;
+  } catch (err) {
+    console.error('[wallet] could not load link status', err);
+    linkedWalletPubkey = null;
+  }
+  updateWalletButton();
+}
+
+// challenge → sign → link, with a verified mirror written server-side.
+async function runWalletLink(address: string): Promise<void> {
+  const btn = document.getElementById('btn-wallet');
+  btn?.classList.add('busy');
+  try {
+    const { message, nonce } = await api.walletLinkChallenge(address);
+    const signature = await signMessageBase58(message);
+    const result = await api.linkWallet(address, signature, nonce);
+    linkedWalletPubkey = result.pubkey;
+    updateWalletButton();
+  } catch (err: any) {
+    console.error('[wallet] link failed', err);
+    flashWalletError(err?.message ? `Link failed: ${err.message}`.slice(0, 48) : 'Link failed');
+  } finally {
+    btn?.classList.remove('busy');
+  }
+}
+
+async function onWalletButtonClick(): Promise<void> {
+  const { address, isConnected } = currentWallet();
+  if (!isConnected || !address) {
+    await openWalletModal(); // connect
+    return;
+  }
+  if (linkedWalletPubkey === address) {
+    await openWalletModal(); // already linked → manage / disconnect
+    return;
+  }
+  if (api.token) {
+    await runWalletLink(address); // connected + logged in + unlinked → sign-to-link
+    return;
+  }
+  await openWalletModal(); // connected but logged out → manage; link happens after login
+}
+
+function wireWallet(): void {
+  const btn = document.getElementById('btn-wallet');
+  if (!btn) return;
+  btn.addEventListener('click', () => { void onWalletButtonClick(); });
+  onWalletChange((state) => {
+    if (state.address) void refreshWocBalance(state.address);
+    else connectedWocBalance = null;
+    updateWalletButton();
+  });
+  // With a real project id, init eagerly so a persisted connection shows on
+  // load; otherwise stay lazy (first click) to avoid relay noise in dev.
+  if (walletConfigured()) initWallet();
+  updateWalletButton();
+}
+
 function wireStartScreens(): void {
   // Initial page translation and stats load
   translatePage();
   void loadProjectStats();
+  wireWallet();
 
   // mode select
   const onlineBtn = $('#btn-online');
@@ -2281,6 +2416,9 @@ function wireStartScreens(): void {
     // so don't reset the widget or let the user re-submit the (now duplicate) auth.
     try {
       $('#charselect-user').textContent = api.username ?? '';
+      // bind-on-login: surface the account's linked wallet (and flip a
+      // connected-but-unlinked button into a "Link" call-to-action).
+      void refreshWalletLinkStatus();
       await enterRealmFlow();
     } catch (err) {
       loginError(userFacingApiError(err));

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { music } from './game/music';
 import { handlePickedEntity, hoverCursorKind } from './game/interactions';
 import { clickMoveShouldCancel, clickMoveStep, stepAngleToward } from './game/click_move';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
+import { setWocBalance, setWalletUiEnabled } from './ui/wallet_balance';
 // The wallet module (Reown AppKit + @solana/web3.js, ~1MB) is loaded lazily via
 // dynamic import() in the wallet controller below, so it stays out of the main
 // entry chunk and only loads when the feature is enabled + used.
@@ -2104,6 +2105,8 @@ const shortenAddress = (a: string): string => `${a.slice(0, 4)}…${a.slice(-4)}
 const formatWoc = (n: number): string => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
 
 function updateWalletButton(): void {
+  // mirror the balance into the HUD store so the bag footer stays in sync
+  setWocBalance(connectedWocBalance);
   const btn = document.getElementById('btn-wallet');
   const label = document.getElementById('wallet-label');
   if (!btn || !label) return;
@@ -2235,6 +2238,7 @@ async function switchWallet(): Promise<void> {
 }
 
 function wireWallet(): void {
+  setWalletUiEnabled(WALLET_ENABLED);
   const btn = document.getElementById('btn-wallet');
   if (!btn) return;
   // Feature-gate: with no project id configured, remove the wallet row entirely

--- a/src/main.ts
+++ b/src/main.ts
@@ -2218,9 +2218,12 @@ async function switchWallet(): Promise<void> {
 function wireWallet(): void {
   const btn = document.getElementById('btn-wallet');
   if (!btn) return;
-  btn.addEventListener('click', () => { void onWalletButtonClick(); });
-  document.getElementById('btn-wallet-switch')?.addEventListener('click', () => { void switchWallet(); });
-  document.getElementById('btn-wallet-signout')?.addEventListener('click', () => { void signOutWallet(); });
+  // These async actions are fire-and-forget from the click, so attach a .catch:
+  // an AppKit open/disconnect rejection must surface, not vanish silently.
+  const onErr = (what: string) => (e: unknown) => console.error(`[wallet] ${what} failed`, e);
+  btn.addEventListener('click', () => { onWalletButtonClick().catch(onErr('action')); });
+  document.getElementById('btn-wallet-switch')?.addEventListener('click', () => { switchWallet().catch(onErr('switch')); });
+  document.getElementById('btn-wallet-signout')?.addEventListener('click', () => { signOutWallet().catch(onErr('sign out')); });
   onWalletChange((state) => {
     if (state.address) void refreshWocBalance(state.address);
     else connectedWocBalance = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ import { handlePickedEntity, hoverCursorKind } from './game/interactions';
 import { clickMoveShouldCancel, clickMoveStep, stepAngleToward } from './game/click_move';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
 import { setWocBalance, setWalletUiEnabled } from './ui/wallet_balance';
+import { setCardUploader, setReferralProvider } from './ui/player_card_share';
 // The wallet module (Reown AppKit + @solana/web3.js, ~1MB) is loaded lazily via
 // dynamic import() in the wallet controller below, so it stays out of the main
 // entry chunk and only loads when the feature is enabled + used.
@@ -987,6 +988,15 @@ async function startOffline(playerClass: PlayerClass, name: string, skin = 0): P
 
 const api = new Api();
 
+// Referral capture: a visitor who arrives from a shared player card link
+// (?ref=<slug>) carries the referrer's slug into registration. Read it once at
+// load and sanitise it to the server's slug shape so a junk param is dropped.
+const REFERRAL_SLUG = (() => {
+  const raw = new URLSearchParams(location.search).get('ref') ?? '';
+  const slug = raw.trim().toLowerCase();
+  return /^[a-z0-9][a-z0-9-]{0,63}$/.test(slug) ? slug : '';
+})();
+
 let activeTransitionTimeout: number | null = null;
 let activeTransitionCleanup: (() => void) | null = null;
 let characterPreview: CharacterPreview | null = null;
@@ -1542,6 +1552,14 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
     }
   }
   const world = new ClientWorld(api.token!, c.id, c.class, api.base);
+  // Wire shareable player cards for this online session: publishing uploads the
+  // composited PNG to this realm and returns an absolute public page URL, and
+  // the referral provider feeds the card footer. Both are cleared on disconnect.
+  setCardUploader(async (png) => {
+    const r = await api.uploadCard(c.id, png);
+    return { url: new URL(r.url, api.base || location.origin).href, ref: r.ref };
+  });
+  setReferralProvider(() => api.referralStats());
   // wait for hello + first snapshot so the world starts populated
   const waitStart = Date.now();
   const poll = setInterval(() => {
@@ -1558,6 +1576,8 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
   // mask the real reason (e.g. "character already in world")
   world.onDisconnect = (reason) => {
     clearInterval(poll);
+    setCardUploader(null);
+    setReferralProvider(null);
     fatalOverlay(userFacingApiError(reason));
   };
 }
@@ -2459,7 +2479,7 @@ function wireStartScreens(): void {
     }
     try {
       if (mode === 'login') await api.login(username, password, token);
-      else await api.register(username, password, token);
+      else await api.register(username, password, token, REFERRAL_SLUG);
     } catch (err) {
       // Auth itself failed (bad credentials, taken username, Turnstile reject…).
       // The token is single-use, so refresh the widget for the next attempt.

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,9 @@ import { music } from './game/music';
 import { handlePickedEntity, hoverCursorKind } from './game/interactions';
 import { clickMoveShouldCancel, clickMoveStep, stepAngleToward } from './game/click_move';
 import { Api, ClientWorld, CharacterSummary } from './net/online';
-import { initWallet, openWalletModal, signMessageBase58, currentWallet, onWalletChange, walletConfigured, fetchWocBalance, disconnectWallet } from './net/wallet';
+// The wallet module (Reown AppKit + @solana/web3.js, ~1MB) is loaded lazily via
+// dynamic import() in the wallet controller below, so it stays out of the main
+// entry chunk and only loads when the feature is enabled + used.
 import type { IWorld, LeaderboardEntry } from './world_api';
 import { formatXp } from './ui/xp_bar';
 import { assetsReady } from './render/assets/preload';
@@ -2087,6 +2089,17 @@ async function loadHighscores(): Promise<void> {
 let linkedWalletPubkey: string | null = null;
 let connectedWocBalance: number | null = null;
 
+// Feature flag: the wallet UI is shown only when a Reown project id is set.
+// Read straight from env here (no module load) so an unconfigured deploy never
+// shows a dead button and never downloads the wallet chunk.
+const WALLET_ENABLED = String(import.meta.env.VITE_REOWN_PROJECT_ID ?? '').trim().length > 0;
+
+// Lazily load the heavy wallet module the first time it's needed, then cache it.
+let walletMod: typeof import('./net/wallet') | null = null;
+function loadWallet(): Promise<typeof import('./net/wallet')> {
+  return walletMod ? Promise.resolve(walletMod) : import('./net/wallet').then((m) => (walletMod = m));
+}
+
 const shortenAddress = (a: string): string => `${a.slice(0, 4)}…${a.slice(-4)}`;
 const formatWoc = (n: number): string => n.toLocaleString(undefined, { maximumFractionDigits: 2 });
 
@@ -2094,7 +2107,8 @@ function updateWalletButton(): void {
   const btn = document.getElementById('btn-wallet');
   const label = document.getElementById('wallet-label');
   if (!btn || !label) return;
-  const { address, isConnected } = currentWallet();
+  // currentWallet is sync; before the module loads, treat as disconnected.
+  const { address, isConnected } = walletMod ? walletMod.currentWallet() : { address: null, isConnected: false };
   const connected = isConnected && !!address;
   // Switch / Sign out are only meaningful once a wallet is connected.
   const switchBtn = document.getElementById('btn-wallet-switch');
@@ -2130,8 +2144,9 @@ function updateWalletButton(): void {
 async function refreshWocBalance(address: string): Promise<void> {
   connectedWocBalance = null;
   updateWalletButton();
-  const balance = await fetchWocBalance(address);
-  if (currentWallet().address === address) {
+  const wallet = await loadWallet();
+  const balance = await wallet.fetchWocBalance(address);
+  if (wallet.currentWallet().address === address) {
     connectedWocBalance = balance;
     updateWalletButton();
   }
@@ -2173,8 +2188,9 @@ async function runWalletLink(address: string): Promise<void> {
   const btn = document.getElementById('btn-wallet');
   btn?.classList.add('busy');
   try {
+    const wallet = await loadWallet();
     const { message, nonce } = await api.walletLinkChallenge(address);
-    const signature = await signMessageBase58(message);
+    const signature = await wallet.signMessageBase58(message);
     const result = await api.linkWallet(address, signature, nonce);
     linkedWalletPubkey = result.pubkey;
     updateWalletButton();
@@ -2187,51 +2203,63 @@ async function runWalletLink(address: string): Promise<void> {
 }
 
 async function onWalletButtonClick(): Promise<void> {
-  const { address, isConnected } = currentWallet();
+  const wallet = await loadWallet();
+  const { address, isConnected } = wallet.currentWallet();
   if (!isConnected || !address) {
-    await openWalletModal(); // connect
+    await wallet.openWalletModal(); // connect
     return;
   }
   if (linkedWalletPubkey === address) {
-    await openWalletModal(); // already linked → manage / disconnect
+    await wallet.openWalletModal(); // already linked → manage / disconnect
     return;
   }
   if (api.token) {
     await runWalletLink(address); // connected + logged in + unlinked → sign-to-link
     return;
   }
-  await openWalletModal(); // connected but logged out → manage; link happens after login
+  await wallet.openWalletModal(); // connected but logged out → manage; link happens after login
 }
 
 // Sign out: disconnect the wallet connection. The account↔wallet link persists
 // server-side, so reconnecting the same wallet re-shows the ✓ linked state.
 async function signOutWallet(): Promise<void> {
-  await disconnectWallet();
+  const wallet = await loadWallet();
+  await wallet.disconnectWallet();
 }
 
 // Switch: disconnect, then reopen the picker to connect a different wallet.
 async function switchWallet(): Promise<void> {
-  await disconnectWallet();
-  await openWalletModal();
+  const wallet = await loadWallet();
+  await wallet.disconnectWallet();
+  await wallet.openWalletModal();
 }
 
 function wireWallet(): void {
   const btn = document.getElementById('btn-wallet');
   if (!btn) return;
+  // Feature-gate: with no project id configured, remove the wallet row entirely
+  // (no dead button) and never download the wallet chunk.
+  if (!WALLET_ENABLED) {
+    document.querySelector('.cs-wallet')?.remove();
+    return;
+  }
   // These async actions are fire-and-forget from the click, so attach a .catch:
   // an AppKit open/disconnect rejection must surface, not vanish silently.
   const onErr = (what: string) => (e: unknown) => console.error(`[wallet] ${what} failed`, e);
   btn.addEventListener('click', () => { onWalletButtonClick().catch(onErr('action')); });
   document.getElementById('btn-wallet-switch')?.addEventListener('click', () => { switchWallet().catch(onErr('switch')); });
   document.getElementById('btn-wallet-signout')?.addEventListener('click', () => { signOutWallet().catch(onErr('sign out')); });
-  onWalletChange((state) => {
-    if (state.address) void refreshWocBalance(state.address);
-    else connectedWocBalance = null;
+  // Load the wallet chunk (separate async bundle), then subscribe to changes and
+  // init so a persisted connection is reflected on the character screen.
+  loadWallet().then((wallet) => {
+    wallet.onWalletChange((state) => {
+      if (state.address) void refreshWocBalance(state.address);
+      else connectedWocBalance = null;
+      updateWalletButton();
+    });
+    wallet.initWallet();
     updateWalletButton();
-  });
-  // With a real project id, init eagerly so a persisted connection shows on
-  // load; otherwise stay lazy (first click) to avoid relay noise in dev.
-  if (walletConfigured()) initWallet();
+  }).catch((e) => console.error('[wallet] load failed', e));
   updateWalletButton();
 }
 

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -225,6 +225,18 @@ export class Api {
       return { count: 0, slug: null };
     }
   }
+
+  // A character's realm standing by lifetime XP (rank 1 = highest), for the
+  // card's "Top N%" flex. Best-effort: null on error so the card still renders.
+  async characterStanding(characterId: number): Promise<{ rank: number; total: number } | null> {
+    try {
+      const data = await this.get(`/api/characters/${characterId}/standing`);
+      if (typeof data.rank === 'number' && typeof data.total === 'number') return { rank: data.rank, total: data.total };
+      return null;
+    } catch {
+      return null;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -175,6 +175,27 @@ export class Api {
       return [];
     }
   }
+
+  // ── Non-custodial wallet linking (Reown / Solana) ──────────────────────────
+  // Step 1: ask the server for the exact message to sign for this address.
+  async walletLinkChallenge(address: string): Promise<{ nonce: string; message: string }> {
+    return this.post('/api/wallet/link/challenge', { address });
+  }
+
+  // Step 2: submit the wallet's signature; server verifies + persists the link.
+  async linkWallet(address: string, signature: string, nonce: string): Promise<{ pubkey: string }> {
+    return this.post('/api/wallet/link', { address, signature, nonce });
+  }
+
+  // Current account's linked wallet (null when none).
+  async linkedWallet(): Promise<{ pubkey: string; linkedAt: string } | null> {
+    const data = await this.get('/api/wallet');
+    return data.wallet ?? null;
+  }
+
+  async unlinkWallet(): Promise<void> {
+    await this.delete('/api/wallet/link', {});
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -124,8 +124,8 @@ export class Api {
     return data;
   }
 
-  async register(username: string, password: string, turnstileToken = ''): Promise<void> {
-    const data = await this.post('/api/register', { username, password, turnstileToken });
+  async register(username: string, password: string, turnstileToken = '', ref = ''): Promise<void> {
+    const data = await this.post('/api/register', { username, password, turnstileToken, ref });
     this.token = data.token;
     this.username = data.username;
   }
@@ -195,6 +195,35 @@ export class Api {
 
   async unlinkWallet(): Promise<void> {
     await this.delete('/api/wallet/link', {});
+  }
+
+  // ── Shareable player card + referrals ──────────────────────────────────────
+  // Publish (or replace) this character's card PNG; returns the public page path
+  // and the referral slug. The body is the raw PNG, so this bypasses the JSON
+  // `post` helper.
+  async uploadCard(characterId: number, png: Blob): Promise<{ url: string; ref: string }> {
+    const res = await fetch(`${this.base}/api/card?character=${characterId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'image/png',
+        ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+      },
+      body: png,
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error ?? `card upload failed (${res.status})`);
+    return { url: data.url, ref: data.ref };
+  }
+
+  // The account's referral count + published-card slug (null before first
+  // publish). Best-effort: returns zeros rather than throwing on error.
+  async referralStats(): Promise<{ count: number; slug: string | null }> {
+    try {
+      const data = await this.get('/api/referrals');
+      return { count: data.count ?? 0, slug: data.slug ?? null };
+    } catch {
+      return { count: 0, slug: null };
+    }
   }
 }
 

--- a/src/net/wallet-polyfill.ts
+++ b/src/net/wallet-polyfill.ts
@@ -1,0 +1,9 @@
+// Solana / Reown libraries assume a Node-ish global environment (`Buffer`,
+// `global`). Vite targets the browser, so shim them before any wallet code
+// loads. wallet.ts imports this module FIRST so it evaluates ahead of the
+// @reown / @solana modules in the import graph.
+import { Buffer } from 'buffer';
+
+const g = globalThis as unknown as { Buffer?: typeof Buffer; global?: typeof globalThis };
+if (!g.Buffer) g.Buffer = Buffer;
+if (!g.global) g.global = globalThis;

--- a/src/net/wallet.ts
+++ b/src/net/wallet.ts
@@ -1,0 +1,125 @@
+// Non-custodial Solana wallet connection via Reown AppKit (formerly
+// WalletConnect). This module owns the AppKit instance and the browser-side
+// connection; the account↔wallet *link* is performed by the server after the
+// wallet signs a challenge (see src/net/online.ts + server/wallet.ts).
+//
+// Lives in src/net/ and is never imported by src/sim/ — the deterministic core
+// stays free of network/wallet dependencies.
+import './wallet-polyfill';
+import { createAppKit } from '@reown/appkit';
+import { solana, solanaDevnet } from '@reown/appkit/networks';
+import { SolanaAdapter } from '@reown/appkit-adapter-solana';
+import { Connection, PublicKey } from '@solana/web3.js';
+import bs58 from 'bs58';
+
+export interface WalletState {
+  address: string | null;
+  isConnected: boolean;
+}
+
+// The Solana provider AppKit hands back exposes raw message signing.
+interface SolanaSignProvider {
+  signMessage(message: Uint8Array): Promise<Uint8Array>;
+}
+
+const PROJECT_ID = String(import.meta.env.VITE_REOWN_PROJECT_ID ?? '').trim();
+
+type AppKitInstance = ReturnType<typeof createAppKit>;
+let appkit: AppKitInstance | null = null;
+const listeners = new Set<(state: WalletState) => void>();
+
+/** Whether a Reown project id is configured (set VITE_REOWN_PROJECT_ID). */
+export function walletConfigured(): boolean {
+  return PROJECT_ID.length > 0;
+}
+
+export function initWallet(): AppKitInstance {
+  if (appkit) return appkit;
+  if (!PROJECT_ID) {
+    console.warn('[wallet] VITE_REOWN_PROJECT_ID is not set — add it to .env.local to enable wallet connect.');
+  }
+  appkit = createAppKit({
+    adapters: [new SolanaAdapter()],
+    networks: [solana, solanaDevnet],
+    projectId: PROJECT_ID || 'MISSING_VITE_REOWN_PROJECT_ID',
+    metadata: {
+      name: 'World of ClaudeCraft',
+      description: 'Link your Solana wallet to your World of ClaudeCraft account.',
+      url: window.location.origin,
+      icons: [`${window.location.origin}/worldofclaudecraft-logo.png`],
+    },
+    features: { analytics: false, email: false, socials: false },
+  });
+  appkit.subscribeAccount((acct) => {
+    const address = acct.address ?? null;
+    for (const cb of listeners) cb({ address, isConnected: address !== null });
+  }, 'solana');
+  return appkit;
+}
+
+/** Subscribe to connection changes. Fires on connect/disconnect/account switch. */
+export function onWalletChange(cb: (state: WalletState) => void): void {
+  listeners.add(cb);
+}
+
+export function currentWallet(): WalletState {
+  if (!appkit) return { address: null, isConnected: false };
+  const address = appkit.getAddress('solana') ?? null;
+  return { address, isConnected: address !== null };
+}
+
+/** Open the Reown modal (connect, or the account view when already connected). */
+export async function openWalletModal(): Promise<void> {
+  await initWallet().open();
+}
+
+export async function disconnectWallet(): Promise<void> {
+  if (appkit) await appkit.disconnect('solana');
+}
+
+/**
+ * Ask the connected wallet to sign `message` and return the signature
+ * base58-encoded (the encoding the server's verifier expects).
+ */
+export async function signMessageBase58(message: string): Promise<string> {
+  const provider = initWallet().getProvider<SolanaSignProvider>('solana');
+  if (!provider) throw new Error('connect a wallet first');
+  const signature = await provider.signMessage(new TextEncoder().encode(message));
+  return bs58.encode(signature);
+}
+
+// ── $WOC balance ────────────────────────────────────────────────────────────
+// The $WOC SPL mint and the RPC endpoint used to read balances. $WOC lives on
+// mainnet, so balances are read there regardless of which network the wallet is
+// on. Both overridable via env; the mint defaults to the published contract.
+const WOC_MINT = String(import.meta.env.VITE_WOC_MINT ?? '3WjLscH2JsXLEFJZRA9z8ti8yRGxWGKbqymPd7UicRth').trim();
+const SOLANA_RPC = String(import.meta.env.VITE_SOLANA_RPC_URL ?? 'https://api.mainnet-beta.solana.com').trim();
+
+let connection: Connection | null = null;
+function getConnection(): Connection {
+  if (!connection) connection = new Connection(SOLANA_RPC, 'confirmed');
+  return connection;
+}
+
+/**
+ * Read the connected wallet's $WOC balance (uiAmount, summed across token
+ * accounts for the mint). Returns 0 when the wallet holds none, or null if the
+ * RPC read fails (network/rate-limit) so the UI can simply omit the balance.
+ */
+export async function fetchWocBalance(owner: string): Promise<number | null> {
+  try {
+    const res = await getConnection().getParsedTokenAccountsByOwner(
+      new PublicKey(owner),
+      { mint: new PublicKey(WOC_MINT) },
+    );
+    let total = 0;
+    for (const { account } of res.value) {
+      const amount = account.data.parsed?.info?.tokenAmount?.uiAmount;
+      if (typeof amount === 'number') total += amount;
+    }
+    return total;
+  } catch (err) {
+    console.error('[wallet] $WOC balance read failed', err);
+    return null;
+  }
+}

--- a/src/render/characters/preview.ts
+++ b/src/render/characters/preview.ts
@@ -227,7 +227,9 @@ export class CharacterPreview {
    * untouched. Because nothing awaits between the off-pose render and the
    * restore, the browser never paints the intermediate frame.
    */
-  captureCloseup(opts: { width?: number; height?: number; angle?: number } = {}): string {
+  captureCloseup(
+    opts: { width?: number; height?: number; angle?: number; poseClips?: readonly string[]; poseFraction?: number } = {},
+  ): string {
     const width = Math.max(1, Math.round(opts.width ?? 540));
     const height = Math.max(1, Math.round(opts.height ?? 720));
     const angle = opts.angle ?? -0.42; // gentle 3/4 turn for a heroic stance
@@ -238,6 +240,12 @@ export class CharacterPreview {
     const prevAspect = this.camera.aspect;
     const prevPos = this.camera.position.clone();
     const prevRotY = this.characterGroup.rotation.y;
+
+    // Optionally lock a deliberate pose for the shot (e.g. a hero/cast/cheer
+    // stance) instead of whatever idle frame is up. Restored via clearPose below.
+    const posed = opts.poseClips && opts.poseClips.length > 0
+      ? this.currentVisual?.poseFreeze(opts.poseClips, opts.poseFraction ?? 0.5) ?? null
+      : null;
 
     // Pixel-exact buffer (ratio 1 → drawingBuffer is exactly width×height).
     this.renderer.setPixelRatio(1);
@@ -250,7 +258,8 @@ export class CharacterPreview {
     this.renderer.render(this.scene, this.camera);
     const url = this.canvas.toDataURL('image/png');
 
-    // Restore the live preview exactly as it was.
+    // Restore the live preview exactly as it was (camera + idle animation).
+    if (posed) this.currentVisual?.clearPose();
     this.renderer.setPixelRatio(prevPixelRatio);
     this.renderer.setSize(prevSize.x, prevSize.y, false);
     this.camera.aspect = prevAspect;

--- a/src/render/characters/preview.ts
+++ b/src/render/characters/preview.ts
@@ -215,6 +215,53 @@ export class CharacterPreview {
     this.renderer.render(this.scene, this.camera);
   };
 
+  /**
+   * Render a single crisp, deterministic close-up of the current character and
+   * return it as a PNG data URL. Used to stamp the player's avatar onto the
+   * shareable player card.
+   *
+   * The live preview canvas is borrowed for one synchronous render: we save the
+   * renderer size, camera, and group rotation; frame a tighter portrait at the
+   * requested pixel size; read the pixels (preserveDrawingBuffer makes this
+   * reliable); then restore everything and re-render so the visible preview is
+   * untouched. Because nothing awaits between the off-pose render and the
+   * restore, the browser never paints the intermediate frame.
+   */
+  captureCloseup(opts: { width?: number; height?: number; angle?: number } = {}): string {
+    const width = Math.max(1, Math.round(opts.width ?? 540));
+    const height = Math.max(1, Math.round(opts.height ?? 720));
+    const angle = opts.angle ?? -0.42; // gentle 3/4 turn for a heroic stance
+
+    const prevSize = new THREE.Vector2();
+    this.renderer.getSize(prevSize);
+    const prevPixelRatio = this.renderer.getPixelRatio();
+    const prevAspect = this.camera.aspect;
+    const prevPos = this.camera.position.clone();
+    const prevRotY = this.characterGroup.rotation.y;
+
+    // Pixel-exact buffer (ratio 1 → drawingBuffer is exactly width×height).
+    this.renderer.setPixelRatio(1);
+    this.renderer.setSize(width, height, false);
+    this.camera.aspect = width / height;
+    this.camera.position.set(-0.1, 1.32, 3.15);
+    this.camera.lookAt(new THREE.Vector3(-0.1, 1.12, 0));
+    this.camera.updateProjectionMatrix();
+    this.characterGroup.rotation.y = angle;
+    this.renderer.render(this.scene, this.camera);
+    const url = this.canvas.toDataURL('image/png');
+
+    // Restore the live preview exactly as it was.
+    this.renderer.setPixelRatio(prevPixelRatio);
+    this.renderer.setSize(prevSize.x, prevSize.y, false);
+    this.camera.aspect = prevAspect;
+    this.camera.position.copy(prevPos);
+    this.camera.lookAt(new THREE.Vector3(-0.15, 1.3, 0));
+    this.camera.updateProjectionMatrix();
+    this.characterGroup.rotation.y = prevRotY;
+    this.renderer.render(this.scene, this.camera);
+    return url;
+  }
+
   /** Cleanup resources */
   destroy(): void {
     if (this.animationFrameId !== null) {

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -267,6 +267,64 @@ export class CharacterVisual {
   }
 
   // -------------------------------------------------------------------------
+  // Static posing (player-card capture). poseFreeze() locks the rig on a chosen
+  // clip's frame so an offscreen render captures a deliberate pose instead of
+  // whatever idle frame happens to be up; clearPose() resumes the idle loop.
+  // -------------------------------------------------------------------------
+
+  /**
+   * Pose the rig on the first available clip from `candidates`, frozen at
+   * `fraction` (0..1) of that clip's duration, and hold it paused. Returns the
+   * chosen clip name, or null if none of the candidates exist on this model.
+   * Only contributes the chosen action (others are stopped) so the frame is
+   * clean. Pair with clearPose() to return to the idle loop.
+   */
+  poseFreeze(candidates: readonly string[], fraction: number): string | null {
+    let chosen: THREE.AnimationAction | null = null;
+    let name: string | null = null;
+    for (const c of candidates) {
+      const a = this.action(c);
+      if (a) { chosen = a; name = c; break; }
+    }
+    if (!chosen) return null;
+    for (const a of this.actions.values()) if (a !== chosen) a.stop();
+    chosen.stop();
+    chosen.reset();
+    chosen.setLoop(THREE.LoopOnce, 1);
+    chosen.clampWhenFinished = true;
+    chosen.timeScale = 1;
+    chosen.setEffectiveWeight(1);
+    chosen.play();
+    const dur = chosen.getClip().duration;
+    chosen.time = dur > 0 ? Math.max(0, Math.min(dur - 1e-3, dur * fraction)) : 0;
+    chosen.paused = true; // hold the frame
+    this.current = chosen;
+    this.currentIsOneShot = true;
+    this.currentOneShotIsEmote = false;
+    this.mixer.update(0);
+    return name;
+  }
+
+  /** Resume the looping idle after poseFreeze() so the live preview isn't stuck. */
+  clearPose(): void {
+    this.currentIsOneShot = false;
+    this.currentOneShotIsEmote = false;
+    this.baseState = 'idle';
+    const idle = this.action(this.def.clips.idle);
+    if (!idle) return;
+    for (const a of this.actions.values()) if (a !== idle) a.stop();
+    idle.reset();
+    idle.setLoop(THREE.LoopRepeat, Infinity);
+    idle.clampWhenFinished = false;
+    idle.timeScale = 1;
+    idle.paused = false;
+    idle.setEffectiveWeight(1);
+    idle.play();
+    this.current = idle;
+    this.mixer.update(0);
+  }
+
+  // -------------------------------------------------------------------------
   // LOD / shadow plumbing (memoized — called every frame by the renderer)
   // -------------------------------------------------------------------------
 

--- a/src/ui/holder_tier.ts
+++ b/src/ui/holder_tier.ts
@@ -1,0 +1,143 @@
+// $WOC holder-tier "flexonomics" ladder.
+//
+// A purely cosmetic honor badge derived from how much $WOC a connected wallet
+// holds. It grants NO gameplay power (the vanilla-formula invariant forbids
+// pay-to-win) — it is flair for the player card and, later, nameplate cosmetics.
+//
+// This module is intentionally free of DOM, Three.js, and network imports: it is
+// plain data + a lookup, so it can be unit-tested in Node and reused anywhere.
+// The SVG glyphs are placeholder vector art; a PR note tracks reskinning them
+// with proper assets once the feature is proven (see PR discussion).
+
+/** $WOC max supply (1,000,000,000). Percentages on the ladder are relative to this. */
+export const WOC_MAX_SUPPLY = 1_000_000_000;
+
+export interface HolderTier {
+  /** 1-based rung (1 = Ember … 10 = Sovereign). */
+  index: number;
+  /** Stable machine key (used for CSS hooks / analytics). */
+  key: string;
+  /** Display name of the rung. */
+  name: string;
+  /** Minimum whole-$WOC balance to reach this rung. */
+  threshold: number;
+  /** Short hype line shown on the card. */
+  flavor: string;
+  /** Primary ring/accent colour (hex). */
+  ring: string;
+  /** Outer glow colour (hex). */
+  glow: string;
+  /** Inner SVG markup for the rung's glyph, drawn centred in a 0 0 64 64 box. */
+  glyph: string;
+}
+
+// Glyphs are filled with the cream tone below so they read on the dark card and
+// against any ring colour.
+const GLYPH_FILL = '#fff6df';
+
+// The ten rungs. Thresholds climb by 10× per rung so the ladder spans a single
+// $WOC up to the entire supply. Rungs 6-10 also call out their share of supply.
+export const HOLDER_TIERS: readonly HolderTier[] = [
+  {
+    index: 1, key: 'ember', name: 'Ember', threshold: 1,
+    flavor: 'The spark is lit.',
+    ring: '#ff8a4c', glow: '#ff5e1f',
+    glyph: `<path d="M32 7c5 9 15 15 12 27-2 9-8 16-12 22-4-6-10-13-12-22C17 22 27 16 32 7Z" fill="${GLYPH_FILL}"/><path d="M32 26c3 5 7 8 5 14-1 4-3 7-5 9-2-2-4-5-5-9-2-6 2-9 5-14Z" fill="#ff7a3c"/>`,
+  },
+  {
+    index: 2, key: 'coinbearer', name: 'Coinbearer', threshold: 10,
+    flavor: 'First coin in the war chest.',
+    ring: '#d79a4e', glow: '#b9792e',
+    glyph: `<circle cx="32" cy="32" r="17" fill="none" stroke="${GLYPH_FILL}" stroke-width="4"/><path d="M32 21v22M26 26h9a4 4 0 0 1 0 8h-7m0 0h8a4 4 0 0 1 0 8h-9" fill="none" stroke="${GLYPH_FILL}" stroke-width="3.4" stroke-linecap="round"/>`,
+  },
+  {
+    index: 3, key: 'coppercrest', name: 'Coppercrest', threshold: 100,
+    flavor: 'Coppers stacked, your name spoken.',
+    ring: '#d27d45', glow: '#a8551f',
+    glyph: `<path d="M32 8l20 7v15c0 12-9 21-20 26-11-5-20-14-20-26V15l20-7Z" fill="none" stroke="${GLYPH_FILL}" stroke-width="4" stroke-linejoin="round"/><circle cx="32" cy="29" r="6.5" fill="${GLYPH_FILL}"/>`,
+  },
+  {
+    index: 4, key: 'silverbound', name: 'Silverbound', threshold: 1_000,
+    flavor: 'Bound in silver, building the bag.',
+    ring: '#cbd6e2', glow: '#9fb2c9',
+    glyph: `<g fill="none" stroke="${GLYPH_FILL}" stroke-width="3.4"><ellipse cx="32" cy="44" rx="16" ry="6"/><ellipse cx="32" cy="34" rx="16" ry="6"/><ellipse cx="32" cy="24" rx="16" ry="6"/></g>`,
+  },
+  {
+    index: 5, key: 'gilded', name: 'Gilded', threshold: 10_000,
+    flavor: 'Gilded and grinning.',
+    ring: '#ffd24a', glow: '#e0a52a',
+    glyph: `<path d="M32 8l6.6 13.8L54 24l-11 10.8L45.8 50 32 42.6 18.2 50 21 34.8 10 24l15.4-2.2Z" fill="${GLYPH_FILL}"/>`,
+  },
+  {
+    index: 6, key: 'vaultwarden', name: 'Vaultwarden', threshold: 100_000,
+    flavor: 'Guarding a real vault now — 0.01% of all $WOC.',
+    ring: '#57e0b9', glow: '#1fae86',
+    glyph: `<rect x="12" y="16" width="40" height="32" rx="4" fill="none" stroke="${GLYPH_FILL}" stroke-width="4"/><circle cx="32" cy="32" r="7" fill="none" stroke="${GLYPH_FILL}" stroke-width="3.4"/><path d="M32 25v-3M32 39v3M25 32h-3M39 32h3" stroke="${GLYPH_FILL}" stroke-width="3.2" stroke-linecap="round"/>`,
+  },
+  {
+    index: 7, key: 'whale', name: 'Whale', threshold: 1_000_000,
+    flavor: 'The deep parts when you swim — 0.1% of supply.',
+    ring: '#4ea8ff', glow: '#1f6fe0',
+    glyph: `<path d="M10 30c10-10 30-12 40-2 3 3 5 3 8 1-1 7-7 11-14 11 1 4-1 8-5 9l2-7c-9 3-21 1-27-6-3-3-5-4-7-3 0-2 1-3 3-4Z" fill="${GLYPH_FILL}"/><circle cx="22" cy="30" r="2.2" fill="${'#1f6fe0'}"/>`,
+  },
+  {
+    index: 8, key: 'leviathan', name: 'Leviathan', threshold: 10_000_000,
+    flavor: 'Markets feel you move — 1% of supply.',
+    ring: '#9b6cff', glow: '#6a37e0',
+    glyph: `<path d="M8 40c4 0 6-6 10-6s6 6 10 6 6-9 10-9 6 9 10 9 5-4 8-4" fill="none" stroke="${GLYPH_FILL}" stroke-width="4" stroke-linecap="round"/><path d="M48 30c3-4 9-4 9-4s-2 6-6 7" fill="none" stroke="${GLYPH_FILL}" stroke-width="3.4" stroke-linecap="round"/><circle cx="51" cy="26" r="2" fill="${GLYPH_FILL}"/>`,
+  },
+  {
+    index: 9, key: 'worldbearer', name: 'Worldbearer', threshold: 100_000_000,
+    flavor: 'You carry a piece of the world — 10% of supply.',
+    ring: '#ff5c8a', glow: '#e02a5c',
+    glyph: `<circle cx="32" cy="32" r="18" fill="none" stroke="${GLYPH_FILL}" stroke-width="4"/><ellipse cx="32" cy="32" rx="8" ry="18" fill="none" stroke="${GLYPH_FILL}" stroke-width="3"/><path d="M14 32h36M17 22h30M17 42h30" stroke="${GLYPH_FILL}" stroke-width="3"/>`,
+  },
+  {
+    index: 10, key: 'sovereign', name: 'Sovereign', threshold: 1_000_000_000,
+    flavor: 'The realm bends the knee — the entire supply.',
+    ring: '#ffe27a', glow: '#ffaa00',
+    glyph: `<path d="M12 22l8 12 12-18 12 18 8-12v24H12V22Z" fill="${GLYPH_FILL}"/><circle cx="12" cy="20" r="3.4" fill="${GLYPH_FILL}"/><circle cx="32" cy="14" r="3.4" fill="${GLYPH_FILL}"/><circle cx="52" cy="20" r="3.4" fill="${GLYPH_FILL}"/><rect x="14" y="48" width="36" height="5" fill="${GLYPH_FILL}"/>`,
+  },
+] as const;
+
+/**
+ * The highest rung a balance qualifies for, or null when there is no connected
+ * wallet (balance === null) or the balance is below the first rung (< 1 $WOC).
+ */
+export function holderTierForBalance(balance: number | null): HolderTier | null {
+  if (balance === null || !Number.isFinite(balance) || balance < HOLDER_TIERS[0].threshold) return null;
+  let tier: HolderTier | null = null;
+  for (const t of HOLDER_TIERS) {
+    if (balance >= t.threshold) tier = t;
+    else break;
+  }
+  return tier;
+}
+
+/** This rung's share of max supply, as a fraction in [0, 1]. */
+export function tierSupplyShare(tier: HolderTier): number {
+  return tier.threshold / WOC_MAX_SUPPLY;
+}
+
+/**
+ * A standalone SVG data URL for the rung's badge: a glowing ring filled with a
+ * ring→glow radial, the glyph centred on top. Suitable for an <img> src or for
+ * drawing onto a canvas. `px` sets the rasterised pixel box (the viewBox is
+ * always 0 0 64 64, so the glyph scales crisply).
+ */
+export function holderTierBadgeDataUrl(tier: HolderTier, px = 128): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${px}" height="${px}" viewBox="0 0 64 64">` +
+    `<defs>` +
+    `<radialGradient id="g" cx="38%" cy="32%" r="72%">` +
+    `<stop offset="0%" stop-color="${tier.ring}"/>` +
+    `<stop offset="100%" stop-color="${tier.glow}"/>` +
+    `</radialGradient>` +
+    `</defs>` +
+    `<circle cx="32" cy="32" r="30" fill="url(#g)"/>` +
+    `<circle cx="32" cy="32" r="30" fill="none" stroke="#1c140a" stroke-width="2"/>` +
+    `<circle cx="32" cy="32" r="26" fill="none" stroke="#fff6df" stroke-opacity="0.35" stroke-width="1.5"/>` +
+    tier.glyph +
+    `</svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -24,7 +24,7 @@ import { music, musicZoneForLocation } from '../game/music';
 import { iconDataUrl, iconCanvas, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_NAMES } from './icons';
 import { svgIcon } from './ui_icons';
 import { walletUiEnabled, wocBalance, onWalletUiChange } from './wallet_balance';
-import { renderPlayerCardCanvas, cardCanvasToBlob, type PlayerCardData, type PlayerCardStat } from './player_card';
+import { renderPlayerCardCanvas, cardCanvasToBlob, CARD_POSES, type PlayerCardData, type PlayerCardStat } from './player_card';
 import { cardHostingAvailable, publishCard, fetchReferralInfo, type PublishedCard } from './player_card_share';
 import { holderTierForBalance } from './holder_tier';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
@@ -3798,15 +3798,17 @@ export class Hud {
     if (!this.charPreview) this.renderCharPreview();
     const preview = this.charPreview;
     if (!preview) return;
-    const characterImage = preview.captureCloseup();
 
     this.cardModalEl?.remove();
     const back = document.createElement('div');
     back.className = 'modal-backdrop';
     back.id = 'player-card-modal';
+    const poseBtns = CARD_POSES.map((p, i) =>
+      `<button type="button" class="btn pc-pose${i === 0 ? ' sel' : ''}" data-pose="${i}">${esc(p.label)}</button>`).join('');
     back.innerHTML = `<div class="window panel pc-modal">`
       + `<div class="panel-title"><span>Player Card</span><span class="x-btn" data-close>${svgIcon('close')}</span></div>`
       + `<div class="pc-preview pc-loading">Forging your card…</div>`
+      + `<div class="pc-poses" role="group" aria-label="Pose">${poseBtns}</div>`
       + `<div class="pc-actions"></div>`
       + `<div class="pc-link" hidden><span class="pc-link-label">Your referral link — anyone who joins through it is credited to you:</span>`
       + `<input class="pc-link-input" type="text" readonly aria-label="Your referral link"></div>`
@@ -3818,35 +3820,61 @@ export class Hud {
     back.addEventListener('click', (e) => { if (e.target === back) close(); });
     back.querySelector('[data-close]')?.addEventListener('click', () => { audio.click(); close(); });
 
+    const previewBox = back.querySelector('.pc-preview') as HTMLElement;
     const status = back.querySelector('.pc-status') as HTMLElement;
+    const linkRow = back.querySelector('.pc-link') as HTMLElement;
     const setStatus = (msg: string) => { status.textContent = msg; };
 
-    // Referral info is online-only (null offline); it enriches the footer.
+    // Referral info is online-only (null offline); it enriches the footer. Fetch
+    // once and reuse across pose re-renders.
     const referral = await fetchReferralInfo();
     if (this.cardModalEl !== back) return; // modal closed while awaiting
-    const data = this.buildPlayerCardData(characterImage, referral);
-    const canvas = await renderPlayerCardCanvas(data);
+
+    // Current card state, shared with the action handlers by reference so a pose
+    // change (which re-captures + re-composites) also invalidates any publish.
+    const state: { canvas: HTMLCanvasElement | null; data: PlayerCardData | null; published: PublishedCard | null } =
+      { canvas: null, data: null, published: null };
+
+    const poseButtons = Array.from(back.querySelectorAll<HTMLButtonElement>('.pc-pose'));
+    const compose = async (poseIndex: number): Promise<void> => {
+      const pose = CARD_POSES[poseIndex];
+      poseButtons.forEach((b, i) => b.classList.toggle('sel', i === poseIndex));
+      const characterImage = preview.captureCloseup({ poseClips: pose.clips, poseFraction: pose.fraction });
+      const data = this.buildPlayerCardData(characterImage, referral);
+      const canvas = await renderPlayerCardCanvas(data);
+      if (this.cardModalEl !== back) return; // modal closed mid-render
+      canvas.classList.add('pc-card-canvas');
+      previewBox.classList.remove('pc-loading');
+      previewBox.innerHTML = '';
+      previewBox.appendChild(canvas);
+      // A new pose is a different image, so any prior publish is stale.
+      state.canvas = canvas;
+      state.data = data;
+      state.published = null;
+      linkRow.hidden = true;
+      setStatus('');
+    };
+
+    poseButtons.forEach((b, i) => b.addEventListener('click', () => {
+      if (b.classList.contains('sel')) return;
+      audio.click();
+      void compose(i);
+    }));
+
+    await compose(0);
     if (this.cardModalEl !== back) return;
-
-    const previewBox = back.querySelector('.pc-preview') as HTMLElement;
-    previewBox.classList.remove('pc-loading');
-    previewBox.innerHTML = '';
-    canvas.classList.add('pc-card-canvas');
-    previewBox.appendChild(canvas);
-
-    this.wireCardActions(back, canvas, data, setStatus);
+    this.wireCardActions(back, state, setStatus);
   }
 
   private wireCardActions(
     back: HTMLElement,
-    canvas: HTMLCanvasElement,
-    data: PlayerCardData,
+    state: { canvas: HTMLCanvasElement | null; data: PlayerCardData | null; published: PublishedCard | null },
     setStatus: (msg: string) => void,
   ): void {
     const actions = back.querySelector('.pc-actions') as HTMLElement;
     const linkRow = back.querySelector('.pc-link') as HTMLElement;
     const linkInput = back.querySelector('.pc-link-input') as HTMLInputElement;
-    const fileName = `${(data.referralHandle || 'player').replace(/[^a-z0-9-]/g, '')}-woc-card.png`;
+    const fileName = () => `${(state.data?.referralHandle || 'player').replace(/[^a-z0-9-]/g, '')}-woc-card.png`;
     const mkBtn = (label: string, cls = ''): HTMLButtonElement => {
       const b = document.createElement('button');
       b.type = 'button';
@@ -3857,18 +3885,19 @@ export class Hud {
     };
     const errMsg = (err: unknown) => (err instanceof Error ? err.message : 'Something went wrong.');
 
-    // Publish-once: hosting a public card is needed for X / copy-link; cache the
-    // result so repeated actions don't re-upload. On success the player's
-    // referral link is revealed so it's tangible (and selectable as a fallback).
-    let published: PublishedCard | null = null;
+    // Publish-once per pose: hosting a public card is needed for X / copy-link.
+    // The result is cached on `state` and cleared whenever the pose changes, so
+    // switching pose after publishing re-uploads the new image on next share.
     const publishOnce = async (): Promise<PublishedCard> => {
-      if (published) return published;
+      if (state.published) return state.published;
+      if (!state.canvas) throw new Error('card is still rendering');
       setStatus('Publishing card…');
-      published = await publishCard(await cardCanvasToBlob(canvas));
-      linkInput.value = published.url;
+      const pub = await publishCard(await cardCanvasToBlob(state.canvas));
+      state.published = pub;
+      linkInput.value = pub.url;
       linkRow.hidden = false;
       setStatus('Card published — share your referral link below.');
-      return published;
+      return pub;
     };
 
     if (cardHostingAvailable()) {
@@ -3878,7 +3907,8 @@ export class Hud {
         xb.disabled = true;
         try {
           const pub = await publishOnce();
-          const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(this.cardShareText(data))}&url=${encodeURIComponent(pub.url)}`;
+          const text = state.data ? this.cardShareText(state.data) : 'World of Claudecraft';
+          const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(pub.url)}`;
           window.open(intent, '_blank', 'noopener,noreferrer');
         } catch (err) {
           setStatus(errMsg(err));
@@ -3907,11 +3937,12 @@ export class Hud {
     const dl = mkBtn('Download');
     dl.addEventListener('click', async () => {
       audio.click();
-      const blob = await cardCanvasToBlob(canvas);
+      if (!state.canvas) return;
+      const blob = await cardCanvasToBlob(state.canvas);
       const href = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = href;
-      a.download = fileName;
+      a.download = fileName();
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -3926,10 +3957,11 @@ export class Hud {
       const sb = mkBtn('Share…');
       sb.addEventListener('click', async () => {
         audio.click();
+        if (!state.canvas) return;
         sb.disabled = true;
         try {
-          const file = new File([await cardCanvasToBlob(canvas)], fileName, { type: 'image/png' });
-          const payload: ShareData = { files: [file], title: 'World of Claudecraft', text: this.cardShareText(data) };
+          const file = new File([await cardCanvasToBlob(state.canvas)], fileName(), { type: 'image/png' });
+          const payload: ShareData = { files: [file], title: 'World of Claudecraft', text: state.data ? this.cardShareText(state.data) : 'World of Claudecraft' };
           // Attach the hosted link when hosting is available; if publishing
           // fails, fall back to sharing just the image file.
           if (cardHostingAvailable()) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -24,6 +24,9 @@ import { music, musicZoneForLocation } from '../game/music';
 import { iconDataUrl, iconCanvas, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_NAMES } from './icons';
 import { svgIcon } from './ui_icons';
 import { walletUiEnabled, wocBalance, onWalletUiChange } from './wallet_balance';
+import { renderPlayerCardCanvas, cardCanvasToBlob, type PlayerCardData, type PlayerCardStat } from './player_card';
+import { cardHostingAvailable, publishCard, fetchReferralInfo, type PublishedCard } from './player_card_share';
+import { holderTierForBalance } from './holder_tier';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES, clickMoveButtonLabel, normalizeClickMoveButton } from '../game/settings';
 import { isPhoneTouchDevice } from '../game/mobile_controls';
@@ -321,6 +324,7 @@ export class Hud {
   private lastHudSlowAt = 0;
   private charPreview: CharacterPreview | null = null;
   private charPreviewCanvas: HTMLCanvasElement | null = null;
+  private cardModalEl: HTMLElement | null = null;
   // current typeahead state: which input, its results, and the keyboard-
   // highlighted row (-1 = none), so Enter/Arrow keys can pick a suggestion
   private socialSuggest: { field: string; items: { name: string; cls: string; level: number }[]; index: number } = { field: '', items: [], index: -1 };
@@ -3712,8 +3716,11 @@ export class Hud {
     </div>`;
     html += this.talentSummaryHtml();
     html += this.progressionHtml(p.level);
+    const shareGlyph = `<svg class="pc-share-ico" viewBox="0 0 24 24" width="15" height="15" aria-hidden="true"><path fill="currentColor" d="M18 16.1a3 3 0 0 0-2.3 1.1l-6.7-3.9a3 3 0 0 0 0-2.6l6.7-3.9A3 3 0 1 0 15 4l-6.7 3.9a3 3 0 1 0 0 8.2L15 20a3 3 0 1 0 3-3.9z"/></svg>`;
+    html += `<div class="pc-share-row"><button type="button" class="btn pc-share-btn" data-act="share-card">${shareGlyph}<span>Share Player Card</span></button></div>`;
     el.innerHTML = html;
     el.querySelector('[data-act="prestige"]')?.addEventListener('click', () => this.openPrestigeDialog());
+    el.querySelector('[data-act="share-card"]')?.addEventListener('click', () => { audio.click(); void this.openPlayerCard(); });
     const col = el.querySelector('#equip-col')!;
     const slots: { key: EquipSlot; name: string }[] = [
       { key: 'mainhand', name: itemSlotName('mainhand') },
@@ -3775,6 +3782,245 @@ export class Hud {
       });
       row.appendChild(b);
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Shareable player card. Captures a crisp close-up of the character from the
+  // character-window preview, composites it with the player's stats, gear, and
+  // $WOC holder badge, and offers share/download/publish actions. Hosting a
+  // public card link is online-only (requires the injected uploader); offline
+  // play still gets download + native share.
+  // -------------------------------------------------------------------------
+
+  private async openPlayerCard(): Promise<void> {
+    // The button lives in the character window, so the preview already exists;
+    // create it defensively in case that ever changes.
+    if (!this.charPreview) this.renderCharPreview();
+    const preview = this.charPreview;
+    if (!preview) return;
+    const characterImage = preview.captureCloseup();
+
+    this.cardModalEl?.remove();
+    const back = document.createElement('div');
+    back.className = 'modal-backdrop';
+    back.id = 'player-card-modal';
+    back.innerHTML = `<div class="window panel pc-modal">`
+      + `<div class="panel-title"><span>Player Card</span><span class="x-btn" data-close>${svgIcon('close')}</span></div>`
+      + `<div class="pc-preview pc-loading">Forging your card…</div>`
+      + `<div class="pc-actions"></div>`
+      + `<div class="pc-link" hidden><span class="pc-link-label">Your referral link — anyone who joins through it is credited to you:</span>`
+      + `<input class="pc-link-input" type="text" readonly aria-label="Your referral link"></div>`
+      + `<div class="pc-status" aria-live="polite"></div>`
+      + `</div>`;
+    document.body.appendChild(back);
+    this.cardModalEl = back;
+    const close = () => { back.remove(); if (this.cardModalEl === back) this.cardModalEl = null; };
+    back.addEventListener('click', (e) => { if (e.target === back) close(); });
+    back.querySelector('[data-close]')?.addEventListener('click', () => { audio.click(); close(); });
+
+    const status = back.querySelector('.pc-status') as HTMLElement;
+    const setStatus = (msg: string) => { status.textContent = msg; };
+
+    // Referral info is online-only (null offline); it enriches the footer.
+    const referral = await fetchReferralInfo();
+    if (this.cardModalEl !== back) return; // modal closed while awaiting
+    const data = this.buildPlayerCardData(characterImage, referral);
+    const canvas = await renderPlayerCardCanvas(data);
+    if (this.cardModalEl !== back) return;
+
+    const previewBox = back.querySelector('.pc-preview') as HTMLElement;
+    previewBox.classList.remove('pc-loading');
+    previewBox.innerHTML = '';
+    canvas.classList.add('pc-card-canvas');
+    previewBox.appendChild(canvas);
+
+    this.wireCardActions(back, canvas, data, setStatus);
+  }
+
+  private wireCardActions(
+    back: HTMLElement,
+    canvas: HTMLCanvasElement,
+    data: PlayerCardData,
+    setStatus: (msg: string) => void,
+  ): void {
+    const actions = back.querySelector('.pc-actions') as HTMLElement;
+    const linkRow = back.querySelector('.pc-link') as HTMLElement;
+    const linkInput = back.querySelector('.pc-link-input') as HTMLInputElement;
+    const fileName = `${(data.referralHandle || 'player').replace(/[^a-z0-9-]/g, '')}-woc-card.png`;
+    const mkBtn = (label: string, cls = ''): HTMLButtonElement => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.className = 'btn' + (cls ? ` ${cls}` : '');
+      b.textContent = label;
+      actions.appendChild(b);
+      return b;
+    };
+    const errMsg = (err: unknown) => (err instanceof Error ? err.message : 'Something went wrong.');
+
+    // Publish-once: hosting a public card is needed for X / copy-link; cache the
+    // result so repeated actions don't re-upload. On success the player's
+    // referral link is revealed so it's tangible (and selectable as a fallback).
+    let published: PublishedCard | null = null;
+    const publishOnce = async (): Promise<PublishedCard> => {
+      if (published) return published;
+      setStatus('Publishing card…');
+      published = await publishCard(await cardCanvasToBlob(canvas));
+      linkInput.value = published.url;
+      linkRow.hidden = false;
+      setStatus('Card published — share your referral link below.');
+      return published;
+    };
+
+    if (cardHostingAvailable()) {
+      const xb = mkBtn('Share to X', 'cd-ok');
+      xb.addEventListener('click', async () => {
+        audio.click();
+        xb.disabled = true;
+        try {
+          const pub = await publishOnce();
+          const intent = `https://twitter.com/intent/tweet?text=${encodeURIComponent(this.cardShareText(data))}&url=${encodeURIComponent(pub.url)}`;
+          window.open(intent, '_blank', 'noopener,noreferrer');
+        } catch (err) {
+          setStatus(errMsg(err));
+        } finally {
+          xb.disabled = false;
+        }
+      });
+
+      const cb = mkBtn('Copy Referral Link');
+      cb.addEventListener('click', async () => {
+        audio.click();
+        cb.disabled = true;
+        try {
+          const pub = await publishOnce();
+          await navigator.clipboard.writeText(pub.url);
+          linkInput.select();
+          setStatus('Referral link copied — share it anywhere.');
+        } catch (err) {
+          setStatus(errMsg(err));
+        } finally {
+          cb.disabled = false;
+        }
+      });
+    }
+
+    const dl = mkBtn('Download');
+    dl.addEventListener('click', async () => {
+      audio.click();
+      const blob = await cardCanvasToBlob(canvas);
+      const href = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = href;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(href), 4000);
+      setStatus('Card downloaded.');
+    });
+
+    // Native share (mobile): share the PNG file, plus the hosted link when one
+    // is available. navigator.canShare with files is the capability gate.
+    const nav = navigator as Navigator & { canShare?: (d?: ShareData) => boolean };
+    if (typeof nav.canShare === 'function') {
+      const sb = mkBtn('Share…');
+      sb.addEventListener('click', async () => {
+        audio.click();
+        sb.disabled = true;
+        try {
+          const file = new File([await cardCanvasToBlob(canvas)], fileName, { type: 'image/png' });
+          const payload: ShareData = { files: [file], title: 'World of Claudecraft', text: this.cardShareText(data) };
+          // Attach the hosted link when hosting is available; if publishing
+          // fails, fall back to sharing just the image file.
+          if (cardHostingAvailable()) {
+            try { payload.url = (await publishOnce()).url; } catch { /* share file-only */ }
+          }
+          if (nav.canShare!(payload)) await nav.share!(payload);
+          else if (nav.canShare!({ files: [file] })) await nav.share!({ files: [file] });
+          else setStatus('Sharing is not supported on this device.');
+        } catch (err) {
+          if (!(err instanceof Error && err.name === 'AbortError')) setStatus(errMsg(err));
+        } finally {
+          sb.disabled = false;
+        }
+      });
+    }
+  }
+
+  private cardShareText(data: PlayerCardData): string {
+    const tier = holderTierForBalance(data.balance);
+    const tierBit = tier ? `, ${tier.name}-rank $WOC holder` : '';
+    // The URL X appends to this text is the player's card page — it unfurls the
+    // card image and credits the referral when a recruit joins through it.
+    return `I'm forging my legend in World of Claudecraft — Level ${data.level} ${data.className}${tierBit}. Join my realm:`;
+  }
+
+  private buildPlayerCardData(characterImage: string, referral: { count: number; slug: string | null } | null): PlayerCardData {
+    const sim = this.sim;
+    const p = sim.player;
+    const cls = sim.cfg.playerClass;
+    const classColor = '#' + (p.color & 0xffffff).toString(16).padStart(6, '0');
+    const num = (n: number) => formatNumber(n, { maximumFractionDigits: 0 });
+    const pct = (n: number) => `${formatNumber(n * 100, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`;
+
+    const wpn = sim.equipment.mainhand ? ITEMS[sim.equipment.mainhand] : null;
+    const dps = wpn?.weapon
+      ? ((wpn.weapon.min + wpn.weapon.max) / 2 + (p.attackPower / 14) * wpn.weapon.speed) / wpn.weapon.speed
+      : 0;
+
+    const primaryStats: PlayerCardStat[] = [
+      { label: t('itemUi.stats.str'), value: num(p.stats.str) },
+      { label: t('itemUi.stats.agi'), value: num(p.stats.agi) },
+      { label: t('itemUi.stats.sta'), value: num(p.stats.sta) },
+      { label: t('itemUi.stats.int'), value: num(p.stats.int) },
+      { label: t('itemUi.stats.spi'), value: num(p.stats.spi) },
+      { label: t('itemUi.stats.armor'), value: num(p.stats.armor) },
+    ];
+    const combatStats: PlayerCardStat[] = [
+      { label: t('itemUi.stats.attackPower'), value: num(p.attackPower) },
+      { label: t('itemUi.stats.dps'), value: formatNumber(dps, { minimumFractionDigits: 1, maximumFractionDigits: 1 }) },
+      { label: t('itemUi.stats.critChance'), value: pct(p.critChance) },
+      { label: t('itemUi.stats.dodge'), value: pct(p.dodgeChance) },
+    ];
+    const rating = sim.arenaInfo?.rating ?? null;
+    if (rating !== null) combatStats.push({ label: 'Arena', value: num(rating) });
+    if (sim.prestigeRank > 0) combatStats.push({ label: 'Prestige', value: num(sim.prestigeRank) });
+
+    const slots: EquipSlot[] = ['mainhand', 'chest', 'legs', 'feet'];
+    const gear = slots.map((slot) => {
+      const id = sim.equipment[slot];
+      const item = id ? ITEMS[id] : null;
+      return {
+        slot: itemSlotName(slot),
+        name: item ? itemDisplayName(item) : t('itemUi.equipment.empty'),
+        color: item ? (QUALITY_COLOR[item.quality ?? 'common'] ?? '#cfc3a0') : '#7c7058',
+      };
+    });
+
+    return {
+      name: p.name,
+      className: classDisplayName(cls),
+      classColor,
+      level: p.level,
+      realm: sim.realm,
+      characterImage,
+      primaryStats,
+      combatStats,
+      gear,
+      arenaRating: rating,
+      virtualLevel: null,
+      prestigeRank: sim.prestigeRank,
+      balance: wocBalance(),
+      referralHandle: referral?.slug ?? this.cardSlug(p.name),
+      referralCount: referral?.count ?? null,
+      siteUrl: location.host,
+    };
+  }
+
+  // Client-side mirror of the server's slugify (server/player_card.ts) — used
+  // only for the footer handle preview before the card is published.
+  private cardSlug(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40);
   }
 
   // -------------------------------------------------------------------------

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -25,7 +25,7 @@ import { iconDataUrl, iconCanvas, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_
 import { svgIcon } from './ui_icons';
 import { walletUiEnabled, wocBalance, onWalletUiChange } from './wallet_balance';
 import { renderPlayerCardCanvas, cardCanvasToBlob, CARD_POSES, type PlayerCardData, type PlayerCardStat } from './player_card';
-import { cardHostingAvailable, publishCard, fetchReferralInfo, type PublishedCard } from './player_card_share';
+import { cardHostingAvailable, publishCard, fetchReferralInfo, fetchStanding, type PublishedCard, type CharacterStanding } from './player_card_share';
 import { holderTierForBalance } from './holder_tier';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES, clickMoveButtonLabel, normalizeClickMoveButton } from '../game/settings';
@@ -3825,9 +3825,9 @@ export class Hud {
     const linkRow = back.querySelector('.pc-link') as HTMLElement;
     const setStatus = (msg: string) => { status.textContent = msg; };
 
-    // Referral info is online-only (null offline); it enriches the footer. Fetch
-    // once and reuse across pose re-renders.
-    const referral = await fetchReferralInfo();
+    // Referral info + realm standing are online-only (null offline). Fetch once
+    // and reuse across pose re-renders.
+    const [referral, standing] = await Promise.all([fetchReferralInfo(), fetchStanding()]);
     if (this.cardModalEl !== back) return; // modal closed while awaiting
 
     // Current card state, shared with the action handlers by reference so a pose
@@ -3840,7 +3840,7 @@ export class Hud {
       const pose = CARD_POSES[poseIndex];
       poseButtons.forEach((b, i) => b.classList.toggle('sel', i === poseIndex));
       const characterImage = preview.captureCloseup({ poseClips: pose.clips, poseFraction: pose.fraction });
-      const data = this.buildPlayerCardData(characterImage, referral);
+      const data = this.buildPlayerCardData(characterImage, referral, standing);
       const canvas = await renderPlayerCardCanvas(data);
       if (this.cardModalEl !== back) return; // modal closed mid-render
       canvas.classList.add('pc-card-canvas');
@@ -3987,13 +3987,26 @@ export class Hud {
     return `I'm forging my legend in World of Claudecraft — Level ${data.level} ${data.className}${tierBit}. Join my realm:`;
   }
 
-  private buildPlayerCardData(characterImage: string, referral: { count: number; slug: string | null } | null): PlayerCardData {
+  private buildPlayerCardData(
+    characterImage: string,
+    referral: { count: number; slug: string | null } | null,
+    standing: CharacterStanding | null,
+  ): PlayerCardData {
     const sim = this.sim;
     const p = sim.player;
     const cls = sim.cfg.playerClass;
     const classColor = '#' + (p.color & 0xffffff).toString(16).padStart(6, '0');
     const num = (n: number) => formatNumber(n, { maximumFractionDigits: 0 });
     const pct = (n: number) => `${formatNumber(n * 100, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}%`;
+
+    // Realm percentile by lifetime XP. Only surfaced as a flex when the realm is
+    // populated enough to be meaningful and the character is in the top half —
+    // no one wants to broadcast "Top 90%".
+    let topPercent: number | null = null;
+    if (standing && standing.total >= 10 && standing.rank >= 1) {
+      const p100 = (standing.rank / standing.total) * 100;
+      if (p100 <= 50) topPercent = p100;
+    }
 
     const wpn = sim.equipment.mainhand ? ITEMS[sim.equipment.mainhand] : null;
     const dps = wpn?.weapon
@@ -4042,10 +4055,11 @@ export class Hud {
       arenaRating: rating,
       virtualLevel: null,
       prestigeRank: sim.prestigeRank,
+      topPercent,
       balance: wocBalance(),
       referralHandle: referral?.slug ?? this.cardSlug(p.name),
       referralCount: referral?.count ?? null,
-      siteUrl: location.host,
+      siteUrl: 'worldofclaudecraft.com',
     };
   }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -23,6 +23,7 @@ import { audio } from '../game/audio';
 import { music, musicZoneForLocation } from '../game/music';
 import { iconDataUrl, iconCanvas, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_NAMES } from './icons';
 import { svgIcon } from './ui_icons';
+import { walletUiEnabled, wocBalance, onWalletUiChange } from './wallet_balance';
 import { Keybinds, BIND_ACTIONS, BIND_CATEGORIES, isReservedCode, keyLabel } from '../game/keybinds';
 import { Settings, GameSettings, BoolSettingKey, NumericSettingKey, SETTING_RANGES, clickMoveButtonLabel, normalizeClickMoveButton } from '../game/settings';
 import { isPhoneTouchDevice } from '../game/mobile_controls';
@@ -343,6 +344,8 @@ export class Hud {
     this.refreshKeybindLabels();
     this.buildXpTicks();
     document.addEventListener('woc:languagechange', () => this.refreshLocalizedDynamicUi());
+    // re-render the bag footer when the connected wallet's $WOC balance changes
+    onWalletUiChange(() => { if ($('#bags').style.display === 'block') this.renderBags(); });
     $('#pf-name').textContent = sim.player.name;
     this.drawPortrait($('#pf-portrait') as unknown as HTMLCanvasElement, `class_${sim.cfg.playerClass}`);
     const mm = $('#minimap') as unknown as HTMLCanvasElement;
@@ -920,6 +923,16 @@ export class Hud {
     if (parts.silver > 0 || parts.gold > 0) html += coin(parts.silver, 's', 'itemUi.money.silver');
     html += coin(parts.copper, 'c', 'itemUi.money.copper');
     return `<span class="money-inline" aria-label="${esc(formatLocalizedMoney(copper, 'long'))}">${html}</span>`;
+  }
+
+  // The connected wallet's $WOC balance, shown left of the coins in the bag.
+  // Empty unless the feature is enabled AND a wallet is connected (balance set).
+  private wocBalanceHtml(): string {
+    if (!walletUiEnabled()) return '';
+    const bal = wocBalance();
+    if (bal === null) return '';
+    const amount = formatNumber(bal, { maximumFractionDigits: 2 });
+    return `<span class="woc-balance" title="Linked Solana wallet $WOC balance"><span class="woc-coin" aria-hidden="true"></span>${esc(amount)} $WOC</span>`;
   }
 
   attachTooltip(el: HTMLElement, html: () => string): void {
@@ -3561,7 +3574,7 @@ export class Hud {
     el.appendChild(grid);
     const money = document.createElement('div');
     money.className = 'money';
-    money.innerHTML = this.moneyHtml(sim.copper);
+    money.innerHTML = `${this.wocBalanceHtml()}${this.moneyHtml(sim.copper)}`;
     el.appendChild(money);
     el.querySelector('[data-close]')?.addEventListener('click', () => { el.style.display = 'none'; this.hideTooltip(); });
   }

--- a/src/ui/player_card.ts
+++ b/src/ui/player_card.ts
@@ -40,6 +40,8 @@ export interface PlayerCardData {
   /** Post-cap virtual level (null below cap). */
   virtualLevel: number | null;
   prestigeRank: number;
+  /** Realm percentile by lifetime XP (e.g. 3 = top 3%), or null to hide it. */
+  topPercent: number | null;
   /** Connected wallet's $WOC balance (null when no wallet). Drives the badge. */
   balance: number | null;
   /** Handle shown in the footer referral line (the card slug, or the name). */
@@ -125,6 +127,16 @@ function fillTextClamped(ctx: CanvasRenderingContext2D, text: string, x: number,
 const TITLE_FONT = 'Cinzel, Georgia, serif';
 const BODY_FONT = '"Alegreya Sans", "Segoe UI", system-ui, sans-serif';
 
+// The brand logo lockup (served from /public). Same-origin, so drawing it does
+// not taint the canvas. Loaded best-effort: if it's missing the footer falls
+// back to a text wordmark rather than failing the whole card.
+const LOGO_URL = '/worldofclaudecraft-logo.png';
+
+/** Format a realm percentile as a card chip label, e.g. 3 → "TOP 3%". */
+function formatTopPercent(pct: number): string {
+  return pct < 1 ? `TOP ${pct.toFixed(1)}%` : `TOP ${Math.ceil(pct)}%`;
+}
+
 /**
  * Composite the player card and return the canvas (2400×1260). The caller can
  * scale it for preview or export it to a PNG blob. Fonts are awaited so the
@@ -142,9 +154,10 @@ export async function renderPlayerCardCanvas(data: PlayerCardData): Promise<HTML
   }
 
   const tier = holderTierForBalance(data.balance);
-  const [charImg, badgeImg] = await Promise.all([
+  const [charImg, badgeImg, logoImg] = await Promise.all([
     loadImage(data.characterImage),
     tier ? loadImage(holderTierBadgeDataUrl(tier, 256)) : Promise.resolve(null),
+    loadImage(LOGO_URL).catch(() => null), // best-effort brand mark
   ]);
 
   const canvas = document.createElement('canvas');
@@ -160,7 +173,7 @@ export async function renderPlayerCardCanvas(data: PlayerCardData): Promise<HTML
   if (tier && badgeImg) drawBadge(ctx, tier, badgeImg, data.balance);
   drawStats(ctx, data);
   drawGear(ctx, data);
-  drawFooter(ctx, data);
+  drawFooter(ctx, data, logoImg);
   drawFrame(ctx, data.classColor);
 
   return canvas;
@@ -217,6 +230,23 @@ function drawHeader(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
   ctx.font = `600 24px ${BODY_FONT}`;
   const sub = `Level ${data.level} · ${data.className}`;
   ctx.fillText(sub, x, 130);
+  const subW = ctx.measureText(sub).width;
+
+  // A "TOP N%" flex chip beside the subtitle (only shown when it's a flex).
+  if (data.topPercent !== null) {
+    const label = formatTopPercent(data.topPercent);
+    ctx.font = `700 16px ${BODY_FONT}`;
+    const tw = ctx.measureText(label).width;
+    const padX = 12;
+    const chipX = x + subW + 16;
+    const chipY = 109;
+    const chipH = 26;
+    ctx.fillStyle = COL.gold;
+    roundRect(ctx, chipX, chipY, tw + padX * 2, chipH, 13);
+    ctx.fill();
+    ctx.fillStyle = '#1c1407';
+    ctx.fillText(label, chipX + padX, chipY + 18);
+  }
 
   ctx.fillStyle = COL.muted;
   ctx.font = `400 19px ${BODY_FONT}`;
@@ -316,11 +346,18 @@ function drawGear(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
   }
 }
 
-function drawFooter(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
+function drawFooter(ctx: CanvasRenderingContext2D, data: PlayerCardData, logo: HTMLImageElement | null): void {
   const y = CARD_H - 26;
-  ctx.fillStyle = COL.gold;
-  ctx.font = `700 24px ${TITLE_FONT}`;
-  ctx.fillText('WORLD OF CLAUDECRAFT', 478, y);
+  // Brand mark: the real logo lockup when available, else a text wordmark.
+  if (logo && logo.width > 0) {
+    const h = 52;
+    const w = (logo.width / logo.height) * h;
+    ctx.drawImage(logo, 478, CARD_H - 30 - h, w, h);
+  } else {
+    ctx.fillStyle = COL.gold;
+    ctx.font = `700 24px ${TITLE_FONT}`;
+    ctx.fillText('WORLD OF CLAUDECRAFT', 478, y);
+  }
 
   ctx.textAlign = 'right';
   ctx.fillStyle = COL.cream;

--- a/src/ui/player_card.ts
+++ b/src/ui/player_card.ts
@@ -67,6 +67,30 @@ const COL = {
   panelEdge: 'rgba(255,209,0,0.14)',
 };
 
+/** A selectable pose for the card avatar. `clips` is tried in order against the
+ *  model (first present wins; Idle is the universal fallback); `fraction` is the
+ *  point in the clip (0..1) to freeze. Verified to read well across all classes. */
+export interface CardPose {
+  id: string;
+  label: string;
+  clips: readonly string[];
+  fraction: number;
+}
+
+export const CARD_POSES: readonly CardPose[] = [
+  // Heroic raised weapon — epic across warrior/mage/hunter/etc. The default.
+  { id: 'hero', label: 'Hero', clips: ['Spellcast_Raise', 'Spellcasting', 'Idle'], fraction: 0.5 },
+  // Class-appropriate combat action (melee swing / drawn bow / cast).
+  { id: 'battle', label: 'Battle', clips: ['2H_Melee_Attack_Chop', '1H_Melee_Attack_Chop', '1H_Melee_Attack_Slice_Diagonal', 'Dualwield_Melee_Attack_Chop', '2H_Ranged_Shoot', 'Spellcast_Shoot', 'Idle'], fraction: 0.4 },
+  // Arm-up celebration.
+  { id: 'victory', label: 'Victory', clips: ['Cheer', 'Jump_Idle', 'Idle'], fraction: 0.5 },
+];
+
+/** Human-readable $WOC amount: whole tokens with thousands separators. */
+function formatWoc(n: number): string {
+  return (n >= 1 ? Math.round(n) : n).toLocaleString('en-US', { maximumFractionDigits: n >= 1 ? 0 : 2 });
+}
+
 function loadImage(src: string): Promise<HTMLImageElement> {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -133,7 +157,7 @@ export async function renderPlayerCardCanvas(data: PlayerCardData): Promise<HTML
   drawBackdrop(ctx, data.classColor);
   drawCharacter(ctx, charImg);
   drawHeader(ctx, data);
-  if (tier && badgeImg) drawBadge(ctx, tier, badgeImg);
+  if (tier && badgeImg) drawBadge(ctx, tier, badgeImg, data.balance);
   drawStats(ctx, data);
   drawGear(ctx, data);
   drawFooter(ctx, data);
@@ -199,9 +223,9 @@ function drawHeader(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
   ctx.fillText(data.realm ? `${data.realm} Realm` : 'World of Claudecraft', x, 158);
 }
 
-function drawBadge(ctx: CanvasRenderingContext2D, tier: HolderTier, badge: HTMLImageElement): void {
+function drawBadge(ctx: CanvasRenderingContext2D, tier: HolderTier, badge: HTMLImageElement, balance: number | null): void {
   const cx = 1108;
-  const cy = 92;
+  const cy = 96;
   const r = 52;
   ctx.save();
   ctx.shadowColor = hexWithAlpha(tier.glow, 0.9);
@@ -209,13 +233,22 @@ function drawBadge(ctx: CanvasRenderingContext2D, tier: HolderTier, badge: HTMLI
   ctx.drawImage(badge, cx - r, cy - r, r * 2, r * 2);
   ctx.restore();
 
+  const right = cx - r - 14;
   ctx.textAlign = 'right';
+  // Tier name.
   ctx.fillStyle = tier.ring;
   ctx.font = `700 22px ${TITLE_FONT}`;
-  ctx.fillText(tier.name.toUpperCase(), cx - r - 14, cy - 4);
+  ctx.fillText(tier.name.toUpperCase(), right, cy - 22);
+  // The actual on-chain bag — the flex.
+  if (balance !== null) {
+    ctx.fillStyle = COL.gold;
+    ctx.font = `700 24px ${BODY_FONT}`;
+    fillTextClamped(ctx, `${formatWoc(balance)} $WOC`, right, cy + 4, 380);
+  }
+  // Flavour line.
   ctx.fillStyle = COL.muted;
-  ctx.font = `400 15px ${BODY_FONT}`;
-  fillTextClamped(ctx, tier.flavor, cx - r - 14, cy + 20, 360);
+  ctx.font = `400 14px ${BODY_FONT}`;
+  fillTextClamped(ctx, tier.flavor, right, cy + 26, 400);
   ctx.textAlign = 'left';
 }
 

--- a/src/ui/player_card.ts
+++ b/src/ui/player_card.ts
@@ -1,0 +1,336 @@
+// Player card compositor.
+//
+// Paints a shareable 1200×630 (Open-Graph aspect) card from the player's live
+// stats, equipped gear, a captured close-up of their character, and — when a
+// wallet is connected — their $WOC holder-tier badge. Pure Canvas-2D + the
+// holder-tier data; no network, no game state beyond what the caller passes in.
+//
+// The caller (the HUD) assembles PlayerCardData from IWorld; this module only
+// knows how to draw it.
+import { holderTierForBalance, holderTierBadgeDataUrl, type HolderTier } from './holder_tier';
+
+export interface PlayerCardStat {
+  label: string;
+  value: string;
+}
+
+export interface PlayerCardGear {
+  slot: string;
+  name: string;
+  /** Quality colour (hex) for the item name; empty slots use a muted tone. */
+  color: string;
+}
+
+export interface PlayerCardData {
+  name: string;
+  className: string;
+  /** Class accent colour (hex), used for the name + frame highlights. */
+  classColor: string;
+  level: number;
+  /** Realm name, or '' in offline play (then a generic subtitle is used). */
+  realm: string;
+  /** PNG data URL of the character close-up (transparent background). */
+  characterImage: string;
+  /** STR / AGI / STA / INT / SPI / Armor. */
+  primaryStats: PlayerCardStat[];
+  /** Attack power, DPS, crit, dodge, etc. */
+  combatStats: PlayerCardStat[];
+  gear: PlayerCardGear[];
+  arenaRating: number | null;
+  /** Post-cap virtual level (null below cap). */
+  virtualLevel: number | null;
+  prestigeRank: number;
+  /** Connected wallet's $WOC balance (null when no wallet). Drives the badge. */
+  balance: number | null;
+  /** Handle shown in the footer referral line (the card slug, or the name). */
+  referralHandle: string;
+  /** Recruited-friends count, when known. */
+  referralCount: number | null;
+  /** Play URL printed on the card footer. */
+  siteUrl: string;
+}
+
+export const CARD_W = 1200;
+export const CARD_H = 630;
+const SCALE = 2; // render at 2× for crisp text, then the canvas is 2400×1260
+
+const COL = {
+  bgTop: '#1d1409',
+  bgBottom: '#0a0805',
+  frame: '#b8902f',
+  frameInner: '#3a2d12',
+  gold: '#ffd100',
+  goldDim: '#caa64a',
+  cream: '#ece2c4',
+  muted: '#9b8b62',
+  panel: 'rgba(0,0,0,0.34)',
+  panelEdge: 'rgba(255,209,0,0.14)',
+};
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('player-card: image failed to load'));
+    img.src = src;
+  });
+}
+
+function roundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+  const rr = Math.min(r, w / 2, h / 2);
+  ctx.beginPath();
+  ctx.moveTo(x + rr, y);
+  ctx.arcTo(x + w, y, x + w, y + h, rr);
+  ctx.arcTo(x + w, y + h, x, y + h, rr);
+  ctx.arcTo(x, y + h, x, y, rr);
+  ctx.arcTo(x, y, x + w, y, rr);
+  ctx.closePath();
+}
+
+/** Draw `text` truncated with an ellipsis if it would exceed `maxW`. */
+function fillTextClamped(ctx: CanvasRenderingContext2D, text: string, x: number, y: number, maxW: number): void {
+  if (ctx.measureText(text).width <= maxW) {
+    ctx.fillText(text, x, y);
+    return;
+  }
+  let s = text;
+  while (s.length > 1 && ctx.measureText(s + '…').width > maxW) s = s.slice(0, -1);
+  ctx.fillText(s + '…', x, y);
+}
+
+const TITLE_FONT = 'Cinzel, Georgia, serif';
+const BODY_FONT = '"Alegreya Sans", "Segoe UI", system-ui, sans-serif';
+
+/**
+ * Composite the player card and return the canvas (2400×1260). The caller can
+ * scale it for preview or export it to a PNG blob. Fonts are awaited so the
+ * brand typefaces are used rather than a fallback.
+ */
+export async function renderPlayerCardCanvas(data: PlayerCardData): Promise<HTMLCanvasElement> {
+  // Make sure the brand fonts are rasterisable before we measure/draw text.
+  if (document.fonts?.ready) {
+    await document.fonts.ready;
+    await Promise.all([
+      document.fonts.load('700 64px Cinzel').catch(() => undefined),
+      document.fonts.load('700 26px "Alegreya Sans"').catch(() => undefined),
+      document.fonts.load('400 22px "Alegreya Sans"').catch(() => undefined),
+    ]);
+  }
+
+  const tier = holderTierForBalance(data.balance);
+  const [charImg, badgeImg] = await Promise.all([
+    loadImage(data.characterImage),
+    tier ? loadImage(holderTierBadgeDataUrl(tier, 256)) : Promise.resolve(null),
+  ]);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = CARD_W * SCALE;
+  canvas.height = CARD_H * SCALE;
+  const ctx = canvas.getContext('2d')!;
+  ctx.scale(SCALE, SCALE);
+  ctx.textBaseline = 'alphabetic';
+
+  drawBackdrop(ctx, data.classColor);
+  drawCharacter(ctx, charImg);
+  drawHeader(ctx, data);
+  if (tier && badgeImg) drawBadge(ctx, tier, badgeImg);
+  drawStats(ctx, data);
+  drawGear(ctx, data);
+  drawFooter(ctx, data);
+  drawFrame(ctx, data.classColor);
+
+  return canvas;
+}
+
+function drawBackdrop(ctx: CanvasRenderingContext2D, accent: string): void {
+  const g = ctx.createLinearGradient(0, 0, CARD_W, CARD_H);
+  g.addColorStop(0, COL.bgTop);
+  g.addColorStop(1, COL.bgBottom);
+  ctx.fillStyle = g;
+  ctx.fillRect(0, 0, CARD_W, CARD_H);
+
+  // Soft accent wash behind the character (class-coloured).
+  const halo = ctx.createRadialGradient(230, 330, 40, 230, 330, 360);
+  halo.addColorStop(0, hexWithAlpha(accent, 0.34));
+  halo.addColorStop(1, hexWithAlpha(accent, 0));
+  ctx.fillStyle = halo;
+  ctx.fillRect(0, 0, CARD_W, CARD_H);
+
+  // Vignette.
+  const vig = ctx.createRadialGradient(CARD_W / 2, CARD_H / 2, 200, CARD_W / 2, CARD_H / 2, 720);
+  vig.addColorStop(0, 'rgba(0,0,0,0)');
+  vig.addColorStop(1, 'rgba(0,0,0,0.5)');
+  ctx.fillStyle = vig;
+  ctx.fillRect(0, 0, CARD_W, CARD_H);
+}
+
+function drawCharacter(ctx: CanvasRenderingContext2D, img: HTMLImageElement): void {
+  // Fit the portrait into the left third, anchored to the bottom so feet sit on
+  // the frame. The capture is transparent, so it composites over the backdrop.
+  const boxX = 24;
+  const boxY = 40;
+  const boxW = 430;
+  const boxH = CARD_H - boxY - 40;
+  const scale = Math.min(boxW / img.width, boxH / img.height);
+  const w = img.width * scale;
+  const h = img.height * scale;
+  const x = boxX + (boxW - w) / 2;
+  const y = boxY + (boxH - h);
+  ctx.drawImage(img, x, y, w, h);
+}
+
+function drawHeader(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
+  const x = 478;
+  ctx.save();
+  ctx.shadowColor = 'rgba(0,0,0,0.6)';
+  ctx.shadowBlur = 8;
+  ctx.fillStyle = COL.gold;
+  ctx.font = `700 58px ${TITLE_FONT}`;
+  fillTextClamped(ctx, data.name, x, 96, 540);
+  ctx.restore();
+
+  ctx.fillStyle = COL.cream;
+  ctx.font = `600 24px ${BODY_FONT}`;
+  const sub = `Level ${data.level} · ${data.className}`;
+  ctx.fillText(sub, x, 130);
+
+  ctx.fillStyle = COL.muted;
+  ctx.font = `400 19px ${BODY_FONT}`;
+  ctx.fillText(data.realm ? `${data.realm} Realm` : 'World of Claudecraft', x, 158);
+}
+
+function drawBadge(ctx: CanvasRenderingContext2D, tier: HolderTier, badge: HTMLImageElement): void {
+  const cx = 1108;
+  const cy = 92;
+  const r = 52;
+  ctx.save();
+  ctx.shadowColor = hexWithAlpha(tier.glow, 0.9);
+  ctx.shadowBlur = 22;
+  ctx.drawImage(badge, cx - r, cy - r, r * 2, r * 2);
+  ctx.restore();
+
+  ctx.textAlign = 'right';
+  ctx.fillStyle = tier.ring;
+  ctx.font = `700 22px ${TITLE_FONT}`;
+  ctx.fillText(tier.name.toUpperCase(), cx - r - 14, cy - 4);
+  ctx.fillStyle = COL.muted;
+  ctx.font = `400 15px ${BODY_FONT}`;
+  fillTextClamped(ctx, tier.flavor, cx - r - 14, cy + 20, 360);
+  ctx.textAlign = 'left';
+}
+
+function drawStats(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
+  const x = 478;
+  const y = 196;
+  const w = 690;
+  const h = 196;
+  ctx.fillStyle = COL.panel;
+  roundRect(ctx, x, y, w, h, 12);
+  ctx.fill();
+  ctx.strokeStyle = COL.panelEdge;
+  ctx.lineWidth = 1.5;
+  roundRect(ctx, x, y, w, h, 12);
+  ctx.stroke();
+
+  // Two stat blocks side by side: attributes (left) and combat (right).
+  const padX = 26;
+  const colW = (w - padX * 2) / 2;
+  drawStatColumn(ctx, data.primaryStats, x + padX, y + 22, colW - 20);
+  drawStatColumn(ctx, data.combatStats, x + padX + colW + 8, y + 22, colW - 20);
+}
+
+function drawStatColumn(ctx: CanvasRenderingContext2D, stats: PlayerCardStat[], x: number, y: number, w: number): void {
+  const rowH = 27;
+  ctx.font = `600 20px ${BODY_FONT}`;
+  for (let i = 0; i < stats.length; i++) {
+    const ry = y + i * rowH + 18;
+    ctx.fillStyle = COL.muted;
+    ctx.textAlign = 'left';
+    ctx.fillText(stats[i].label, x, ry);
+    ctx.fillStyle = COL.cream;
+    ctx.textAlign = 'right';
+    ctx.fillText(stats[i].value, x + w, ry);
+  }
+  ctx.textAlign = 'left';
+}
+
+function drawGear(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
+  const x = 478;
+  const y = 412;
+  const w = 690;
+  const h = 118;
+  ctx.fillStyle = COL.panel;
+  roundRect(ctx, x, y, w, h, 12);
+  ctx.fill();
+  ctx.strokeStyle = COL.panelEdge;
+  ctx.lineWidth = 1.5;
+  roundRect(ctx, x, y, w, h, 12);
+  ctx.stroke();
+
+  const padX = 26;
+  const colW = (w - padX * 2) / 2;
+  for (let i = 0; i < data.gear.length; i++) {
+    const col = i % 2;
+    const rowIdx = Math.floor(i / 2);
+    const gx = x + padX + col * colW;
+    const gy = y + 20 + rowIdx * 44;
+    ctx.fillStyle = COL.muted;
+    ctx.font = `600 15px ${BODY_FONT}`;
+    ctx.fillText(data.gear[i].slot.toUpperCase(), gx, gy);
+    ctx.fillStyle = data.gear[i].color;
+    ctx.font = `600 20px ${BODY_FONT}`;
+    fillTextClamped(ctx, data.gear[i].name, gx, gy + 22, colW - 24);
+  }
+}
+
+function drawFooter(ctx: CanvasRenderingContext2D, data: PlayerCardData): void {
+  const y = CARD_H - 26;
+  ctx.fillStyle = COL.gold;
+  ctx.font = `700 24px ${TITLE_FONT}`;
+  ctx.fillText('WORLD OF CLAUDECRAFT', 478, y);
+
+  ctx.textAlign = 'right';
+  ctx.fillStyle = COL.cream;
+  ctx.font = `600 19px ${BODY_FONT}`;
+  const recruited = data.referralCount && data.referralCount > 0 ? `  ·  ${data.referralCount} recruited` : '';
+  ctx.fillText(`@${data.referralHandle}${recruited}`, 1168, y - 22);
+  ctx.fillStyle = COL.goldDim;
+  ctx.font = `400 16px ${BODY_FONT}`;
+  fillTextClamped(ctx, `Forge your legend → ${data.siteUrl}`, 1168, y, 480);
+  ctx.textAlign = 'left';
+}
+
+function drawFrame(ctx: CanvasRenderingContext2D, accent: string): void {
+  // Outer gold frame with a class-accent inner hairline.
+  ctx.strokeStyle = COL.frameInner;
+  ctx.lineWidth = 10;
+  ctx.strokeRect(5, 5, CARD_W - 10, CARD_H - 10);
+  const grad = ctx.createLinearGradient(0, 0, CARD_W, CARD_H);
+  grad.addColorStop(0, COL.frame);
+  grad.addColorStop(0.5, COL.gold);
+  grad.addColorStop(1, COL.frame);
+  ctx.strokeStyle = grad;
+  ctx.lineWidth = 3;
+  ctx.strokeRect(10, 10, CARD_W - 20, CARD_H - 20);
+  ctx.strokeStyle = hexWithAlpha(accent, 0.5);
+  ctx.lineWidth = 1.5;
+  ctx.strokeRect(15, 15, CARD_W - 30, CARD_H - 30);
+}
+
+/** Convert a #rrggbb hex to an rgba() string at the given alpha. */
+function hexWithAlpha(hex: string, alpha: number): string {
+  const m = /^#?([0-9a-fA-F]{6})$/.exec(hex.trim());
+  if (!m) return `rgba(255,209,0,${alpha})`;
+  const n = parseInt(m[1], 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+}
+
+/** Export a composited card canvas to a PNG blob. */
+export function cardCanvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('player-card: canvas.toBlob returned null'));
+    }, 'image/png');
+  });
+}

--- a/src/ui/player_card_share.ts
+++ b/src/ui/player_card_share.ts
@@ -24,8 +24,16 @@ export interface ReferralInfo {
 }
 export type ReferralProvider = () => Promise<ReferralInfo>;
 
+/** A character's realm standing by lifetime XP (rank 1 = highest of `total`). */
+export interface CharacterStanding {
+  rank: number;
+  total: number;
+}
+export type StandingProvider = () => Promise<CharacterStanding | null>;
+
 let uploader: CardUploader | null = null;
 let referralProvider: ReferralProvider | null = null;
+let standingProvider: StandingProvider | null = null;
 
 /** main.ts injects the authenticated uploader on world entry (null to clear). */
 export function setCardUploader(fn: CardUploader | null): void {
@@ -35,6 +43,11 @@ export function setCardUploader(fn: CardUploader | null): void {
 /** main.ts injects a referral-stats fetcher on world entry (null to clear). */
 export function setReferralProvider(fn: ReferralProvider | null): void {
   referralProvider = fn;
+}
+
+/** main.ts injects a character-standing fetcher on world entry (null to clear). */
+export function setStandingProvider(fn: StandingProvider | null): void {
+  standingProvider = fn;
 }
 
 /** True when the current session can host a card (online play). */
@@ -51,4 +64,9 @@ export function publishCard(png: Blob): Promise<PublishedCard> {
 /** Referral stats for the card footer, or null when unavailable (offline). */
 export function fetchReferralInfo(): Promise<ReferralInfo | null> {
   return referralProvider ? referralProvider() : Promise.resolve(null);
+}
+
+/** Character standing for the card's "Top N%", or null when unavailable. */
+export function fetchStanding(): Promise<CharacterStanding | null> {
+  return standingProvider ? standingProvider() : Promise.resolve(null);
 }

--- a/src/ui/player_card_share.ts
+++ b/src/ui/player_card_share.ts
@@ -1,0 +1,54 @@
+// Bridge for hosting a shared player card.
+//
+// Publishing a card requires the network layer (an authenticated upload to the
+// current realm), but src/ui must not import src/net. So — exactly like
+// wallet_balance.ts — main.ts (the one layer that knows both) injects an
+// uploader here, and the HUD reads it out. When no uploader is set (offline
+// play, or before world entry) the HUD falls back to download / native share
+// only, with no hosted link.
+
+/** Result of publishing a card: an absolute page URL and the referral slug. */
+export interface PublishedCard {
+  /** Absolute URL of the public card page (carries no ?ref itself). */
+  url: string;
+  /** The player's referral slug, appended as ?ref=<slug> to invite links. */
+  ref: string;
+}
+
+export type CardUploader = (png: Blob) => Promise<PublishedCard>;
+
+/** Referral count + the player's published-card slug (null before first publish). */
+export interface ReferralInfo {
+  count: number;
+  slug: string | null;
+}
+export type ReferralProvider = () => Promise<ReferralInfo>;
+
+let uploader: CardUploader | null = null;
+let referralProvider: ReferralProvider | null = null;
+
+/** main.ts injects the authenticated uploader on world entry (null to clear). */
+export function setCardUploader(fn: CardUploader | null): void {
+  uploader = fn;
+}
+
+/** main.ts injects a referral-stats fetcher on world entry (null to clear). */
+export function setReferralProvider(fn: ReferralProvider | null): void {
+  referralProvider = fn;
+}
+
+/** True when the current session can host a card (online play). */
+export function cardHostingAvailable(): boolean {
+  return uploader !== null;
+}
+
+/** Publish the card PNG; resolves to its hosted URL + referral slug. */
+export function publishCard(png: Blob): Promise<PublishedCard> {
+  if (!uploader) throw new Error('card hosting is unavailable in this session');
+  return uploader(png);
+}
+
+/** Referral stats for the card footer, or null when unavailable (offline). */
+export function fetchReferralInfo(): Promise<ReferralInfo | null> {
+  return referralProvider ? referralProvider() : Promise.resolve(null);
+}

--- a/src/ui/wallet_balance.ts
+++ b/src/ui/wallet_balance.ts
@@ -1,0 +1,37 @@
+// Client-side wallet balance surfaced in the HUD (the bag footer).
+//
+// The connected wallet's $WOC balance is external (read from a Solana RPC by
+// src/net/wallet) and is NOT world state, so it doesn't belong on IWorld. To
+// keep src/ui free of any src/net import, main.ts — the one layer that knows
+// both — pushes the value in here, and the HUD reads it out. A single listener
+// lets the bag re-render when the value changes.
+let enabled = false;
+let balance: number | null = null;
+let listener: (() => void) | null = null;
+
+/** Whether the wallet feature is configured (VITE_REOWN_PROJECT_ID set). */
+export function walletUiEnabled(): boolean {
+  return enabled;
+}
+
+/** The connected wallet's $WOC balance, or null when no wallet is connected. */
+export function wocBalance(): number | null {
+  return balance;
+}
+
+export function setWalletUiEnabled(value: boolean): void {
+  if (enabled === value) return;
+  enabled = value;
+  listener?.();
+}
+
+export function setWocBalance(value: number | null): void {
+  if (balance === value) return;
+  balance = value;
+  listener?.();
+}
+
+/** Register the HUD's re-render hook (one consumer: the bag). */
+export function onWalletUiChange(cb: () => void): void {
+  listener = cb;
+}

--- a/tests/holder_tier.test.ts
+++ b/tests/holder_tier.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  HOLDER_TIERS, WOC_MAX_SUPPLY, holderTierForBalance, tierSupplyShare, holderTierBadgeDataUrl,
+} from '../src/ui/holder_tier';
+
+describe('holder-tier ladder', () => {
+  it('has ten rungs with strictly increasing 10× thresholds and 1-based indexes', () => {
+    expect(HOLDER_TIERS.length).toBe(10);
+    expect(WOC_MAX_SUPPLY).toBe(1_000_000_000);
+    for (let i = 0; i < HOLDER_TIERS.length; i++) {
+      expect(HOLDER_TIERS[i].index).toBe(i + 1);
+      if (i > 0) expect(HOLDER_TIERS[i].threshold).toBeGreaterThan(HOLDER_TIERS[i - 1].threshold);
+    }
+    expect(HOLDER_TIERS[0].threshold).toBe(1);
+    expect(HOLDER_TIERS[9].threshold).toBe(WOC_MAX_SUPPLY);
+  });
+
+  it('returns null with no wallet or a sub-threshold balance', () => {
+    expect(holderTierForBalance(null)).toBeNull();
+    expect(holderTierForBalance(0)).toBeNull();
+    expect(holderTierForBalance(0.99)).toBeNull();
+    expect(holderTierForBalance(Number.NaN)).toBeNull();
+  });
+
+  it('maps balances to the highest qualifying rung', () => {
+    expect(holderTierForBalance(1)!.name).toBe('Ember');
+    expect(holderTierForBalance(9)!.name).toBe('Ember');
+    expect(holderTierForBalance(10)!.name).toBe('Coinbearer');
+    expect(holderTierForBalance(100)!.name).toBe('Coppercrest');
+    expect(holderTierForBalance(1_000)!.name).toBe('Silverbound');
+    expect(holderTierForBalance(10_000)!.name).toBe('Gilded');
+    expect(holderTierForBalance(100_000)!.name).toBe('Vaultwarden');
+    expect(holderTierForBalance(1_000_000)!.name).toBe('Whale');
+    expect(holderTierForBalance(10_000_000)!.name).toBe('Leviathan');
+    expect(holderTierForBalance(100_000_000)!.name).toBe('Worldbearer');
+    expect(holderTierForBalance(1_000_000_000)!.name).toBe('Sovereign');
+  });
+
+  it('clamps balances above max supply to the top rung', () => {
+    expect(holderTierForBalance(5_000_000_000)!.name).toBe('Sovereign');
+  });
+
+  it('reports supply share', () => {
+    const sovereign = HOLDER_TIERS[9];
+    const vaultwarden = HOLDER_TIERS[5];
+    expect(tierSupplyShare(sovereign)).toBe(1);
+    expect(tierSupplyShare(vaultwarden)).toBeCloseTo(0.0001, 10);
+  });
+
+  it('builds an SVG data URL embedding the rung ring colour', () => {
+    const ember = HOLDER_TIERS[0];
+    const url = holderTierBadgeDataUrl(ember);
+    expect(url.startsWith('data:image/svg+xml,')).toBe(true);
+    expect(decodeURIComponent(url)).toContain(ember.ring);
+    expect(decodeURIComponent(url)).toContain('<svg');
+  });
+});

--- a/tests/player_card_server.test.ts
+++ b/tests/player_card_server.test.ts
@@ -15,6 +15,7 @@ vi.mock('pg', () => ({
 import {
   handleCardUpload, handleCardRoutes, captureReferral, slugify, isValidSlug,
 } from '../server/player_card';
+import { lifetimeXpStanding } from '../server/db';
 
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 const fakePng = Buffer.concat([PNG_MAGIC, Buffer.from('IDATfake-pixels')]);
@@ -51,12 +52,17 @@ let slugRows: any[] = [];          // SELECT character_id FROM player_cards WHER
 let cardRows: any[] = [];          // getPlayerCardBySlug
 let accountForSlugRows: any[] = [];
 let upsertThrows: Error | null = null;
+let standingXpRows: any[] = [];    // lifetimeXpStanding ownership/xp lookup
+let standingCountRows: any[] = []; // lifetimeXpStanding ahead/total
 
 beforeEach(() => {
   characterRows = []; slugRows = []; cardRows = []; accountForSlugRows = []; upsertThrows = null;
+  standingXpRows = []; standingCountRows = [];
   dbMock.query.mockReset();
   dbMock.query.mockImplementation((sql: string) => {
     const s = String(sql).replace(/\s+/g, ' ').trim();
+    if (s.includes('::text AS xp')) return Promise.resolve({ rows: standingXpRows, rowCount: standingXpRows.length });
+    if (s.includes('AS ahead')) return Promise.resolve({ rows: standingCountRows });
     if (s.includes('SELECT id, account_id, name, class, level, state')) return Promise.resolve({ rows: characterRows });
     if (s.includes('SELECT character_id FROM player_cards WHERE slug')) return Promise.resolve({ rows: slugRows });
     if (s.includes('INSERT INTO player_cards')) {
@@ -202,6 +208,26 @@ describe('GET /p/<slug>', () => {
     await handleCardRoutes(makeGetReq('/p/..%2f..%2fetc'), res);
     expect(res.statusCode).toBe(404);
     expect(dbMock.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('lifetimeXpStanding', () => {
+  it('returns 1-based rank + realm total for an owned character', async () => {
+    standingXpRows = [{ xp: '12345' }];
+    standingCountRows = [{ ahead: 9, total: 500 }];
+    const s = await lifetimeXpStanding(1, 42);
+    expect(s).toEqual({ rank: 10, total: 500 }); // 9 ahead → rank 10
+  });
+
+  it('returns null when the character is not the caller’s', async () => {
+    standingXpRows = []; // ownership/realm lookup found nothing
+    expect(await lifetimeXpStanding(1, 999)).toBeNull();
+  });
+
+  it('ranks a brand-new character (0 ahead) as rank 1', async () => {
+    standingXpRows = [{ xp: '0' }];
+    standingCountRows = [{ ahead: 0, total: 3 }];
+    expect(await lifetimeXpStanding(1, 5)).toEqual({ rank: 1, total: 3 });
   });
 });
 

--- a/tests/player_card_server.test.ts
+++ b/tests/player_card_server.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Readable } from 'node:stream';
+
+// Same DB-test pattern as wallet_server.test.ts: stub DATABASE_URL + mock pg so
+// db.ts loads and every pool.query is a spy we route by SQL. Drives the REAL
+// card/referral handlers through every branch with no live database.
+const dbMock = vi.hoisted(() => {
+  process.env.DATABASE_URL ??= 'postgres://test/test';
+  return { query: vi.fn() };
+});
+vi.mock('pg', () => ({
+  Pool: vi.fn(function Pool() { return { query: dbMock.query }; }),
+}));
+
+import {
+  handleCardUpload, handleCardRoutes, captureReferral, slugify, isValidSlug,
+} from '../server/player_card';
+
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const fakePng = Buffer.concat([PNG_MAGIC, Buffer.from('IDATfake-pixels')]);
+
+// ── http fakes ──────────────────────────────────────────────────────────────
+function makeBinaryReq(url: string, body: Buffer): any {
+  const req: any = Readable.from([body]);
+  req.url = url;
+  req.headers = { host: 'realm.example' };
+  req.socket = {};
+  return req;
+}
+function makeGetReq(url: string): any {
+  const req: any = Readable.from([]);
+  req.method = 'GET';
+  req.url = url;
+  req.headers = { host: 'realm.example' };
+  req.socket = {};
+  return req;
+}
+function makeRes(): any {
+  return {
+    statusCode: 0,
+    headers: {} as Record<string, unknown>,
+    body: '' as string | Buffer,
+    writeHead(status: number, headers?: Record<string, unknown>) { this.statusCode = status; if (headers) this.headers = headers; return this; },
+    end(data?: string | Buffer) { this.body = data ?? ''; return this; },
+  };
+}
+
+// per-test DB state, routed by SQL
+let characterRows: any[] = [];
+let slugRows: any[] = [];          // SELECT character_id FROM player_cards WHERE slug
+let cardRows: any[] = [];          // getPlayerCardBySlug
+let accountForSlugRows: any[] = [];
+let upsertThrows: Error | null = null;
+
+beforeEach(() => {
+  characterRows = []; slugRows = []; cardRows = []; accountForSlugRows = []; upsertThrows = null;
+  dbMock.query.mockReset();
+  dbMock.query.mockImplementation((sql: string) => {
+    const s = String(sql).replace(/\s+/g, ' ').trim();
+    if (s.includes('SELECT id, account_id, name, class, level, state')) return Promise.resolve({ rows: characterRows });
+    if (s.includes('SELECT character_id FROM player_cards WHERE slug')) return Promise.resolve({ rows: slugRows });
+    if (s.includes('INSERT INTO player_cards')) {
+      if (upsertThrows) return Promise.reject(upsertThrows);
+      return Promise.resolve({ rows: [] });
+    }
+    if (s.includes('SELECT character_id, account_id, png, title, description FROM player_cards')) return Promise.resolve({ rows: cardRows });
+    if (s.includes('SELECT account_id FROM player_cards WHERE slug')) return Promise.resolve({ rows: accountForSlugRows });
+    if (s.includes('INSERT INTO referrals')) return Promise.resolve({ rows: [] });
+    return Promise.resolve({ rows: [] });
+  });
+});
+
+async function callUpload(url: string, body: Buffer, accountId = 1) {
+  const res = makeRes();
+  await handleCardUpload(makeBinaryReq(url, body), res, accountId);
+  return { status: res.statusCode, data: res.body ? JSON.parse(String(res.body)) : {} };
+}
+
+describe('slugify / isValidSlug', () => {
+  it('builds url-safe slugs from names', () => {
+    expect(slugify('Sir Test')).toBe('sir-test');
+    expect(slugify("D'Argath the Bold!!")).toBe('d-argath-the-bold');
+    expect(slugify('  Mixed__Case  ')).toBe('mixed-case');
+    expect(slugify('日本語')).toBe(''); // non-latin collapses to empty → caller falls back
+    expect(slugify('a'.repeat(80)).length).toBe(40);
+  });
+  it('validates incoming slugs and rejects traversal / junk', () => {
+    expect(isValidSlug('sir-test')).toBe(true);
+    expect(isValidSlug('player-42')).toBe(true);
+    expect(isValidSlug('')).toBe(false);
+    expect(isValidSlug('-leading')).toBe(false);
+    expect(isValidSlug('../etc/passwd')).toBe(false);
+    expect(isValidSlug('has space')).toBe(false);
+    expect(isValidSlug('UPPER')).toBe(false);
+    expect(isValidSlug('a'.repeat(65))).toBe(false);
+  });
+});
+
+describe('POST /api/card', () => {
+  it('stores the PNG and returns the name slug + url', async () => {
+    characterRows = [{ id: 5, account_id: 1, name: 'Sir Test', class: 'paladin', level: 12 }];
+    slugRows = []; // slug free
+    const { status, data } = await callUpload('/api/card?character=5', fakePng);
+    expect(status).toBe(200);
+    expect(data).toEqual({ url: '/p/sir-test', ref: 'sir-test' });
+    const insert = dbMock.query.mock.calls.find((c) => String(c[0]).includes('INSERT INTO player_cards'));
+    expect(insert?.[1][0]).toBe(5);        // character_id
+    expect(insert?.[1][2]).toBe('sir-test'); // slug
+    expect(Buffer.isBuffer(insert?.[1][3])).toBe(true); // png bytes
+    expect(insert?.[1][4]).toBe('Sir Test — Level 12 Paladin'); // title
+  });
+
+  it('falls back to a character-id-suffixed slug when the name slug is taken', async () => {
+    characterRows = [{ id: 5, account_id: 1, name: 'Sir Test', class: 'paladin', level: 12 }];
+    slugRows = [{ character_id: 999 }]; // taken by a different character
+    const { status, data } = await callUpload('/api/card?character=5', fakePng);
+    expect(status).toBe(200);
+    expect(data.ref).toBe('sir-test-5');
+  });
+
+  it('retries with a suffixed slug on a unique violation', async () => {
+    characterRows = [{ id: 5, account_id: 1, name: 'Sir Test', class: 'paladin', level: 12 }];
+    slugRows = []; // appears free, but the insert races a 23505
+    let first = true;
+    dbMock.query.mockImplementation((sql: string) => {
+      const s = String(sql).replace(/\s+/g, ' ').trim();
+      if (s.includes('SELECT id, account_id, name, class, level, state')) return Promise.resolve({ rows: characterRows });
+      if (s.includes('SELECT character_id FROM player_cards WHERE slug')) return Promise.resolve({ rows: [] });
+      if (s.includes('INSERT INTO player_cards')) {
+        if (first) { first = false; return Promise.reject(Object.assign(new Error('dup'), { code: '23505' })); }
+        return Promise.resolve({ rows: [] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const { status, data } = await callUpload('/api/card?character=5', fakePng);
+    expect(status).toBe(200);
+    expect(data.ref).toBe('sir-test-5');
+  });
+
+  it('uses a player-<id> slug for an all-symbol name', async () => {
+    characterRows = [{ id: 7, account_id: 1, name: '✦✦✦', class: 'mage', level: 3 }];
+    slugRows = [];
+    const { data } = await callUpload('/api/card?character=7', fakePng);
+    expect(data.ref).toBe('player-7');
+  });
+
+  it('rejects a missing character id with 400', async () => {
+    const { status } = await callUpload('/api/card', fakePng);
+    expect(status).toBe(400);
+  });
+
+  it('returns 404 when the character is not the caller’s', async () => {
+    characterRows = []; // getCharacter finds nothing
+    const { status } = await callUpload('/api/card?character=5', fakePng);
+    expect(status).toBe(404);
+  });
+
+  it('rejects a non-PNG body with 400', async () => {
+    characterRows = [{ id: 5, account_id: 1, name: 'Sir Test', class: 'paladin', level: 12 }];
+    const { status } = await callUpload('/api/card?character=5', Buffer.from('not a png'));
+    expect(status).toBe(400);
+    expect(dbMock.query.mock.calls.some((c) => String(c[0]).includes('INSERT INTO player_cards'))).toBe(false);
+  });
+});
+
+describe('GET /p/<slug>', () => {
+  it('serves an OG page with escaped meta + the og:image', async () => {
+    cardRows = [{ character_id: 5, account_id: 1, png: fakePng, title: 'A "Quote" <b>', description: 'desc & more' }];
+    const res = makeRes();
+    await handleCardRoutes(makeGetReq('/p/sir-test'), res);
+    expect(res.statusCode).toBe(200);
+    expect(String(res.headers['Content-Type'])).toContain('text/html');
+    const html = String(res.body);
+    expect(html).toContain('property="og:image" content="http://realm.example/p/sir-test/card.png"');
+    expect(html).toContain('name="twitter:card" content="summary_large_image"');
+    expect(html).toContain('href="http://realm.example/?ref=sir-test"');
+    // title/description are HTML-escaped
+    expect(html).toContain('A &quot;Quote&quot; &lt;b&gt;');
+    expect(html).toContain('desc &amp; more');
+    expect(html).not.toContain('<b>A "Quote"');
+  });
+
+  it('serves the PNG bytes with image/png', async () => {
+    cardRows = [{ character_id: 5, account_id: 1, png: fakePng, title: 't', description: 'd' }];
+    const res = makeRes();
+    await handleCardRoutes(makeGetReq('/p/sir-test/card.png'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['Content-Type']).toBe('image/png');
+    expect(Buffer.isBuffer(res.body)).toBe(true);
+    expect((res.body as Buffer).equals(fakePng)).toBe(true);
+  });
+
+  it('404s an unknown slug', async () => {
+    cardRows = [];
+    const res = makeRes();
+    await handleCardRoutes(makeGetReq('/p/nope'), res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('404s an invalid slug without touching the database', async () => {
+    const res = makeRes();
+    await handleCardRoutes(makeGetReq('/p/..%2f..%2fetc'), res);
+    expect(res.statusCode).toBe(404);
+    expect(dbMock.query).not.toHaveBeenCalled();
+  });
+});
+
+describe('captureReferral', () => {
+  it('records a referral for a known slug owned by another account', async () => {
+    accountForSlugRows = [{ account_id: 10 }];
+    await captureReferral(42, 'sir-test');
+    const ins = dbMock.query.mock.calls.find((c) => String(c[0]).includes('INSERT INTO referrals'));
+    expect(ins?.[1]).toEqual([42, 10, 'sir-test']);
+  });
+
+  it('ignores a self-referral', async () => {
+    accountForSlugRows = [{ account_id: 42 }];
+    await captureReferral(42, 'sir-test');
+    expect(dbMock.query.mock.calls.some((c) => String(c[0]).includes('INSERT INTO referrals'))).toBe(false);
+  });
+
+  it('ignores an unknown slug', async () => {
+    accountForSlugRows = [];
+    await captureReferral(42, 'ghost');
+    expect(dbMock.query.mock.calls.some((c) => String(c[0]).includes('INSERT INTO referrals'))).toBe(false);
+  });
+
+  it('ignores an invalid/empty ref without querying', async () => {
+    await captureReferral(42, '../evil');
+    await captureReferral(42, '');
+    await captureReferral(42, undefined);
+    expect(dbMock.query).not.toHaveBeenCalled();
+  });
+});

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import bs58 from 'bs58';
+import { ed25519 } from '@noble/curves/ed25519';
+import { isSolanaAddress, verifySolanaSignature, buildLinkMessage } from '../server/wallet_link';
+
+// A Solana wallet signMessage() is exactly ed25519 over the raw UTF-8 bytes, so
+// a @noble/curves keypair is an accurate stand-in for a real wallet here.
+function makeWallet(): { priv: Uint8Array; address: string } {
+  const priv = ed25519.utils.randomPrivateKey();
+  const pub = ed25519.getPublicKey(priv);
+  return { priv, address: bs58.encode(pub) };
+}
+
+function sign(message: string, priv: Uint8Array): string {
+  return bs58.encode(ed25519.sign(new TextEncoder().encode(message), priv));
+}
+
+describe('wallet link signature verification', () => {
+  const wallet = makeWallet();
+  const message = buildLinkMessage({
+    domain: 'localhost',
+    accountId: 42,
+    address: wallet.address,
+    nonce: 'abc123def456',
+    issuedAt: '2026-06-16T00:00:00.000Z',
+  });
+
+  it('accepts a valid signature from the signing wallet', () => {
+    expect(verifySolanaSignature(message, sign(message, wallet.priv), wallet.address)).toBe(true);
+  });
+
+  it('rejects a tampered message', () => {
+    const signature = sign(message, wallet.priv);
+    expect(verifySolanaSignature(message + ' ', signature, wallet.address)).toBe(false);
+  });
+
+  it('rejects a signature produced by a different wallet', () => {
+    const other = makeWallet();
+    expect(verifySolanaSignature(message, sign(message, other.priv), wallet.address)).toBe(false);
+  });
+
+  it('rejects a valid signature presented under a different address', () => {
+    const other = makeWallet();
+    expect(verifySolanaSignature(message, sign(message, wallet.priv), other.address)).toBe(false);
+  });
+
+  it('rejects garbage / malformed input without throwing', () => {
+    expect(verifySolanaSignature(message, 'not-a-signature', wallet.address)).toBe(false);
+    expect(verifySolanaSignature(message, bs58.encode(new Uint8Array(10)), wallet.address)).toBe(false);
+    expect(verifySolanaSignature(message, sign(message, wallet.priv), 'has0OIlchars')).toBe(false);
+  });
+});
+
+describe('isSolanaAddress', () => {
+  it('accepts a real 32-byte base58 pubkey', () => {
+    expect(isSolanaAddress(makeWallet().address)).toBe(true);
+  });
+
+  it('rejects non-strings, wrong byte length, and non-base58', () => {
+    expect(isSolanaAddress(123)).toBe(false);
+    expect(isSolanaAddress('')).toBe(false);
+    expect(isSolanaAddress(bs58.encode(new Uint8Array(31)))).toBe(false);
+    expect(isSolanaAddress('not valid base58 +/=')).toBe(false);
+  });
+});
+
+describe('buildLinkMessage', () => {
+  it('embeds account, wallet, nonce, and domain so the signed text is unambiguous', () => {
+    const m = buildLinkMessage({ domain: 'play.woc', accountId: 7, address: 'WALLET123', nonce: 'N1', issuedAt: 'T' });
+    expect(m).toContain('Account: #7');
+    expect(m).toContain('Wallet: WALLET123');
+    expect(m).toContain('Nonce: N1');
+    expect(m).toContain('play.woc');
+  });
+});

--- a/tests/wallet_server.test.ts
+++ b/tests/wallet_server.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Readable } from 'node:stream';
+import bs58 from 'bs58';
+import { ed25519 } from '@noble/curves/ed25519';
+
+// Follow the repo's DB-test pattern: stub DATABASE_URL + mock the pg Pool so
+// db.ts loads and every pool.query is a spy we control. This lets us drive the
+// REAL handlers through every branch with REAL signatures and no live database.
+const dbMock = vi.hoisted(() => {
+  process.env.DATABASE_URL ??= 'postgres://test/test';
+  return { query: vi.fn() };
+});
+vi.mock('pg', () => ({
+  Pool: vi.fn(function Pool() { return { query: dbMock.query }; }),
+}));
+
+import { handleWalletChallenge, handleWalletLink, handleWalletGet, handleWalletUnlink } from '../server/wallet';
+
+// ── fakes for http.IncomingMessage / ServerResponse ─────────────────────────
+function makeReq(body: unknown): any {
+  const req: any = Readable.from([Buffer.from(JSON.stringify(body))]);
+  req.headers = { host: 'localhost:8787' };
+  return req;
+}
+function makeRes(): any {
+  return {
+    statusCode: 0,
+    body: '',
+    writeHead(status: number) { this.statusCode = status; return this; },
+    end(data: string) { this.body = data ?? ''; return this; },
+  };
+}
+async function call(handler: any, body: unknown, accountId = 1) {
+  const res = makeRes();
+  await handler(makeReq(body), res, accountId);
+  return { status: res.statusCode, data: res.body ? JSON.parse(res.body) : {} };
+}
+
+// ── a real Solana-style wallet (ed25519) ────────────────────────────────────
+function makeWallet() {
+  const priv = ed25519.utils.randomPrivateKey();
+  return { priv, address: bs58.encode(ed25519.getPublicKey(priv)) };
+}
+const sign = (message: string, priv: Uint8Array) =>
+  bs58.encode(ed25519.sign(new TextEncoder().encode(message), priv));
+
+// per-test control over what the mocked DB returns, routed by SQL
+let challengeRows: any[] = [];
+let ownerRows: any[] = [];
+let walletRows: any[] = [];
+
+beforeEach(() => {
+  challengeRows = []; ownerRows = []; walletRows = [];
+  dbMock.query.mockReset();
+  dbMock.query.mockImplementation((sql: string) => {
+    // The real queries are multi-line; collapse whitespace so routing is robust.
+    const s = String(sql).replace(/\s+/g, ' ').trim();
+    if (s.includes('DELETE FROM wallet_link_challenges WHERE nonce')) return Promise.resolve({ rows: challengeRows });
+    if (s.includes('DELETE FROM wallet_link_challenges WHERE expires_at')) return Promise.resolve({ rows: [] }); // prune
+    if (s.includes('INSERT INTO wallet_link_challenges')) return Promise.resolve({ rows: [] });
+    if (s.includes('SELECT account_id FROM wallet_links WHERE pubkey')) return Promise.resolve({ rows: ownerRows });
+    if (s.includes('INSERT INTO wallet_links')) return Promise.resolve({ rows: [] });
+    if (s.includes('SELECT account_id, pubkey, linked_at FROM wallet_links')) return Promise.resolve({ rows: walletRows });
+    if (s.includes('DELETE FROM wallet_links WHERE account_id')) return Promise.resolve({ rows: [] }); // unlink
+    return Promise.resolve({ rows: [] });
+  });
+});
+
+describe('POST /api/wallet/link/challenge', () => {
+  it('issues a nonce + message that binds the wallet address', async () => {
+    const w = makeWallet();
+    const { status, data } = await call(handleWalletChallenge, { address: w.address });
+    expect(status).toBe(200);
+    expect(data.nonce).toMatch(/^[a-f0-9]{32}$/);
+    expect(data.message).toContain(w.address);
+    expect(data.message).toContain('World of ClaudeCraft');
+    // the challenge is persisted with the account + address it was issued for
+    const insert = dbMock.query.mock.calls.find((c) => String(c[0]).includes('INSERT INTO wallet_link_challenges'));
+    expect(insert?.[1]).toEqual([data.nonce, 1, w.address, data.message, expect.any(String)]);
+  });
+
+  it('rejects a non-Solana address', async () => {
+    const { status } = await call(handleWalletChallenge, { address: 'not-a-real-address' });
+    expect(status).toBe(400);
+  });
+});
+
+describe('POST /api/wallet/link', () => {
+  it('links a wallet when the signature over the stored challenge is valid', async () => {
+    const w = makeWallet();
+    const message = 'link challenge message';
+    challengeRows = [{ address: w.address, message }];
+    ownerRows = []; // wallet not yet owned by anyone
+    const { status, data } = await call(handleWalletLink, { address: w.address, signature: sign(message, w.priv), nonce: 'n1' });
+    expect(status).toBe(200);
+    expect(data).toEqual({ pubkey: w.address, linked: true });
+    const insert = dbMock.query.mock.calls.find((c) => String(c[0]).includes('INSERT INTO wallet_links'));
+    expect(insert?.[1]).toEqual([1, w.address]);
+  });
+
+  it('rejects an expired / already-used challenge with 400', async () => {
+    const w = makeWallet();
+    challengeRows = []; // consume returns nothing
+    const { status } = await call(handleWalletLink, { address: w.address, signature: sign('x', w.priv), nonce: 'n1' });
+    expect(status).toBe(400);
+  });
+
+  it('rejects when the submitted address does not match the challenge with 400', async () => {
+    const w = makeWallet();
+    const other = makeWallet();
+    const message = 'm';
+    challengeRows = [{ address: other.address, message }]; // challenge was for a different wallet
+    const { status } = await call(handleWalletLink, { address: w.address, signature: sign(message, w.priv), nonce: 'n1' });
+    expect(status).toBe(400);
+  });
+
+  it('rejects a forged signature with 401', async () => {
+    const w = makeWallet();
+    const message = 'the real message';
+    challengeRows = [{ address: w.address, message }];
+    const forged = sign('a different message', w.priv); // valid sig, wrong payload
+    const { status } = await call(handleWalletLink, { address: w.address, signature: forged, nonce: 'n1' });
+    expect(status).toBe(401);
+  });
+
+  it('returns 409 when the wallet is already linked to another account', async () => {
+    const w = makeWallet();
+    const message = 'm';
+    challengeRows = [{ address: w.address, message }];
+    ownerRows = [{ account_id: 999 }]; // owned by a different account
+    const { status, data } = await call(handleWalletLink, { address: w.address, signature: sign(message, w.priv), nonce: 'n1' }, 1);
+    expect(status).toBe(409);
+    expect(data.error).toMatch(/another account/i);
+    // must NOT have attempted the upsert
+    expect(dbMock.query.mock.calls.some((c) => String(c[0]).includes('INSERT INTO wallet_links'))).toBe(false);
+  });
+
+  it('rejects missing fields with 400', async () => {
+    const { status } = await call(handleWalletLink, { address: '', signature: '', nonce: '' });
+    expect(status).toBe(400);
+  });
+});
+
+describe('GET /api/wallet', () => {
+  it('returns the linked wallet', async () => {
+    walletRows = [{ account_id: 1, pubkey: 'PUBKEY', linked_at: '2026-06-16T00:00:00.000Z' }];
+    const { status, data } = await call(handleWalletGet, {});
+    expect(status).toBe(200);
+    expect(data.wallet).toEqual({ pubkey: 'PUBKEY', linkedAt: '2026-06-16T00:00:00.000Z' });
+  });
+
+  it('returns null when no wallet is linked', async () => {
+    walletRows = [];
+    const { status, data } = await call(handleWalletGet, {});
+    expect(status).toBe(200);
+    expect(data.wallet).toBeNull();
+  });
+});
+
+describe('DELETE /api/wallet/link', () => {
+  it('unlinks the account wallet', async () => {
+    const { status, data } = await call(handleWalletUnlink, {});
+    expect(status).toBe(200);
+    expect(data).toEqual({ unlinked: true });
+    const del = dbMock.query.mock.calls.find((c) => String(c[0]).includes('DELETE FROM wallet_links WHERE account_id'));
+    expect(del?.[1]).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## What this adds

A **shareable player card** players can post to X / Discord to flex and recruit:

- A crisp close-up of their **real 3D character** (captured from the character-sheet preview).
- Their **stats, equipped gear** (quality-coloured), arena rating, prestige.
- A **$WOC holder-tier badge** — a 10-rung cosmetic "flexonomics" ladder (Ember → Sovereign, 1 $WOC → the full 1B supply) derived from the connected wallet's balance. Cosmetic only; no gameplay power (keeps the vanilla-formula / no-pay-to-win invariant).
- A **referral link**: sharing publishes the card to the realm and produces a public `/p/<slug>` page that **unfurls the card image** on X (server-side Open-Graph) and links new players into the game with `?ref=<slug>`. Sign-ups through it are credited to the sharer (relationship captured now; reward payout intentionally out of scope, to be synced later).

Stacks on #465 (reuses the wallet balance surfaced there). The diff narrows to just the card work once #465 merges.

## How it works

```
Char sheet → "Share Player Card" → modal composites the card (Canvas-2D)
  ├─ Download / native Share (works offline)
  └─ Share to X / Copy Referral Link (online)
        → POST /api/card (PNG stored as BYTEA in Postgres, one per character)
        → tweet attaches  /p/<slug>   (prerendered OG page, unfurls og:image)
        → recruit clicks "Forge your legend" → /?ref=<slug>
        → register sends ref → server records referrer→referee (once)
```

PNGs are stored in Postgres (not local fs) so a shared link resolves from **any** realm process. Cards composite client-side and upload as raw PNG via a dedicated 4 MB binary body reader (the 64 KB JSON reader is untouched). The server never holds keys/funds.

## Verification (evidence)

- **`npx tsc --noEmit`** (src + server + tests): clean.
- **`npx vitest run`**: **1279 passed** (+23 new). New: `tests/holder_tier.test.ts` (ladder boundaries, clamp, badge data URL) and `tests/player_card_server.test.ts` (22 cases: upload happy/collision/unique-retry/symbol-name/404/non-PNG, OG page meta + HTML-escaping, card.png bytes, invalid-slug 404 with no DB hit, referral record/self/unknown/invalid).
- **`scripts/player_card_e2e.mjs`** vs a REAL server + Postgres: **15/15** — publish → OG page → card.png round-trip → auth gate → referral captured → unknown ref ignored.
- **`npm run build` + `npm run build:server`**: both succeed.
- **Manual, real components**: rendered the actual paladin model into the card, published it, and confirmed the live `/p/<slug>` page unfurls the real card image with the working "Forge your legend → /?ref=<slug>" CTA.

## Production-Readiness Validation

| Check | Status |
|---|---|
| **Tests real, not mocked** | Unit tests drive the *real* handlers (only `pg` is mocked, per repo convention); a live e2e exercises the real server + DB end-to-end. |
| **Error handling + logging** | Route handler wrapped in try/catch → 500 + `console.error`; upload validates character ownership (404), body size (413), PNG magic (400); referral capture is best-effort and never blocks signup; client share actions surface failures in the modal status (AbortError on user-cancel is ignored). |
| **Config externalized / no secrets** | No new secrets. No new env required (cards live in the existing Postgres). |
| **Perf / load** | Card image cached `max-age=300`, OG page `max-age=120`; upload bounded at 4 MB; slug lookups hit the UNIQUE index; no per-request heavy work. |
| **Deps** | Zero new dependencies. |
| **Rollback** | Additive: new tables + routes + UI. Dropping `player_cards`/`referrals` and reverting the commits fully removes it; no destructive migrations. |
| **Monitoring** | Errors logged server-side; referral count queryable via `GET /api/referrals`. |

## Security

- Slugs from untrusted URLs are validated (`^[a-z0-9][a-z0-9-]{0,63}$`) and only ever used as **SQL parameters** (never filesystem paths) — no path traversal.
- OG title/description are **HTML-escaped** (tested).
- `?ref` is sanitised client- and server-side; self-referrals and unknown slugs are ignored.
- Non-custodial unchanged: the server stores no keys/funds; tier is read-only flair.

## Follow-ups
- **Badge glyphs are placeholder vector art** — a gfx artist should reskin the 10 tier badges (and broader $WOC flair) with proper assets once the feature is approved.
- The card modal / share chrome uses literal English strings (not i18n keys) to keep the feature self-contained; localisation is a follow-up.
- `VITE_SOLANA_RPC_URL` (balance reads, from #465) should move behind a server-side proxy for production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
