### PR TITLE
fix(render): stop online walk clip resetting from self predictor

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -1219,10 +1219,19 @@ export class Renderer {
       v.visual.setFar(v.isFar && active === v.visual);
 
       // animation state machine inputs, derived from render-space motion with
-      // hysteresis so a one-frame speed dip can't reset the walk clip
-      const vx = x - v.lastX, vz = z - v.lastZ;
-      v.lastX = x;
-      v.lastZ = z;
+      // hysteresis so a one-frame speed dip can't reset the walk clip.
+      // For the local player online, sample the *plain* interpolated sim motion
+      // (ax/ay/az), never the smoothed/predicted self render position (selfPos):
+      // the online self predictor freezes-then-jumps within each snapshot
+      // interval, and feeding that jitter to the cadence/airborne logic
+      // intermittently flips the base state and resets the walk clip. The
+      // predictor moves only the mesh. Offline, ax==x so this is a no-op.
+      const ax = isSelf ? e.prevPos.x + (e.pos.x - e.prevPos.x) * alpha : x;
+      const ay = isSelf ? e.prevPos.y + (e.pos.y - e.prevPos.y) * alpha : y;
+      const az = isSelf ? e.prevPos.z + (e.pos.z - e.prevPos.z) * alpha : z;
+      const vx = ax - v.lastX, vz = az - v.lastZ;
+      v.lastX = ax;
+      v.lastZ = az;
       const loco = updateLocomotion(v.loco, vx, vz, facing, dt);
       const moving = loco.moving;
       const visuallyDead = isVisuallyDead(e);
@@ -1234,7 +1243,7 @@ export class Renderer {
       const airborne = !visuallyDead && !swimming && (
         !e.onGround
         || (e.kind === 'player'
-          && y - groundHeight(x, z, this.sim.cfg.seed) > AIRBORNE_EPS));
+          && ay - groundHeight(ax, az, this.sim.cfg.seed) > AIRBORNE_EPS));
       const st: AnimState = {
         speed: loco.speed,
         moving,


### PR DESCRIPTION
## Problem
On `release/v0.9` (not on `main`), the local player's **walk animation resets randomly while walking** — only online. Reported on dev; prod (on `main`) is unaffected.

## Root cause
Commit `797e6e9` ("Movement fixes") added an online-only local-player render predictor (`updateSelfRenderPosition` / `selfPos`, driven by `ONLINE_SELF_RENDER_ALPHA_LEAD = 0.65`). Because `selfSnapshotAlpha` clamps at `1.25`, the predicted target **freezes for part of each snapshot interval then jumps** when the next snapshot arrives; exponential smoothing and the `>6u` snap distort the per-frame motion further.

The animation state machine derived its inputs — locomotion speed (`vx = x - v.lastX`), backpedal, and the airborne check (`y - groundHeight(x,z) > AIRBORNE_EPS`) — from that jittery `selfPos`. The resulting oscillation intermittently flipped the base state (`walk`⇄`idle`/`run`/`jump`), and `visual.ts` `fadeTo()` calls `next.reset()` on every base-state change → the walk clip snaps back to frame 0.

## Fix
Derive the animation inputs from the **plain interpolated sim motion** (`ax/ay/az`, using the unled `alpha`), never the smoothed/predicted `selfPos`. The predictor now moves **only the mesh**, keeping the responsive online feel. Offline, `ax == x`, so single-player is byte-for-byte unchanged.

## Verification
- `tsc --noEmit` clean
- 28 tests green: `locomotion`, `visual_anim_state`, `click_move`, `move_input`
- Manually confirmed in the local online stack (Vite client → local authoritative server) — walk cycle stays smooth across snapshot boundaries and uneven terrain.

## Notes
- No new player-visible strings (no i18n impact).
- I deliberately skipped a new unit test: the regression lives in WebGL renderer wiring and its faithful triggers (airborne flip from a lagging smoothed `y`, run-spike from the snap) aren't isolated in a pure function, so any pure test would be contrived rather than a true guard. Happy to add a puppeteer visual/E2E check instead if wanted.