### PR TITLE
fix(i18n): localize /gear readout, relic/pickup errors, and crypt nameplate

### DIFF
--- a/scripts/i18n_blocked_seed.mjs
+++ b/scripts/i18n_blocked_seed.mjs
@@ -156,7 +156,6 @@ export const V07_SLASH = [
   "You have no target to consider.",
   "You have not completed any quests yet.",
   "You have not learned any abilities yet.",
-  "You have nothing equipped.",
   "Your bags are empty. Aki",
   "Your mana is not parked — you are not shapeshifted.",
   "Your mana is regenerating (out of combat for 5s+).",

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -194,7 +194,6 @@ function npcDisplayName(npcId: string): string {
 }
 
 function dungeonDisplayName(dungeonId: string): string {
-  if (dungeonId === 'nythraxis_crypt') return DUNGEON_LIST.find((d) => d.id === dungeonId)?.name ?? 'Abandoned Crypt';
   return tEntity({ kind: 'dungeon', id: dungeonId, field: 'name' });
 }
 

--- a/src/ui/sim_i18n.ts
+++ b/src/ui/sim_i18n.ts
@@ -12,7 +12,7 @@
 // every player-facing emit site, and fails if any is no longer recognized by a client
 // matcher — so a new unhandled sim string cannot ship silently.
 import { ITEMS, MOBS } from '../sim/data';
-import { getLanguage, supportedLanguages, t, formatNumber, type InterpolationValues, type SupportedLanguage } from './i18n';
+import { getLanguage, supportedLanguages, t, formatNumber, type InterpolationValues, type SupportedLanguage, type TranslationKey } from './i18n';
 import { tEntity } from './entity_i18n';
 
 const baseEnTable = {
@@ -2059,6 +2059,184 @@ function tQuestExtra(key: QuestExtraKey, params?: InterpolationValues): string {
   return interpolate(table[key] ?? QUEST_EXTRA.en[key], params);
 }
 
+// Item / equipment / world-object interaction strings emitted by src/sim: the
+// /gear self-readout frame plus the relic + quest-item pickup error toasts. Like
+// QUEST_EXTRA/ARENA_EXTRA these live here (not the DICT) and are matched by the
+// RULES below; the gear readout's per-slot LABELS reuse the already-translated
+// itemUi.slots.* keys via t(), so only the frame + "(empty)" marker are new here.
+type ItemExtraKey =
+  | 'gearReadout' | 'gearEmptySlot' | 'nothingEquipped'
+  | 'cannotTakeYet' | 'offersNothingMore'
+  | 'relicBound' | 'relicRecovered';
+
+const ITEM_EXTRA: Record<SupportedLanguage, Record<ItemExtraKey, string>> = {
+  en: {
+    gearReadout: 'Equipped ({worn}/{total}): {items}.',
+    gearEmptySlot: '(empty)',
+    nothingEquipped: 'You have nothing equipped.',
+    cannotTakeYet: 'You cannot take the {name} yet.',
+    offersNothingMore: '{name} offers nothing more.',
+    relicBound: 'The relic is bound by the sealed crypt.',
+    relicRecovered: 'You have already recovered this relic.',
+  },
+  en_CA: {
+    gearReadout: 'Equipped ({worn}/{total}): {items}.',
+    gearEmptySlot: '(empty)',
+    nothingEquipped: 'You have nothing equipped.',
+    cannotTakeYet: 'You cannot take the {name} yet.',
+    offersNothingMore: '{name} offers nothing more.',
+    relicBound: 'The relic is bound by the sealed crypt.',
+    relicRecovered: 'You have already recovered this relic.',
+  },
+  es: {
+    gearReadout: 'Equipado ({worn}/{total}): {items}.',
+    gearEmptySlot: '(vacío)',
+    nothingEquipped: 'No tienes nada equipado.',
+    cannotTakeYet: 'Aún no puedes tomar {name}.',
+    offersNothingMore: '{name} no ofrece nada más.',
+    relicBound: 'La reliquia está atada a la cripta sellada.',
+    relicRecovered: 'Ya has recuperado esta reliquia.',
+  },
+  es_ES: {
+    gearReadout: 'Equipado ({worn}/{total}): {items}.',
+    gearEmptySlot: '(vacío)',
+    nothingEquipped: 'No tienes nada equipado.',
+    cannotTakeYet: 'Aún no puedes tomar {name}.',
+    offersNothingMore: '{name} no ofrece nada más.',
+    relicBound: 'La reliquia está atada a la cripta sellada.',
+    relicRecovered: 'Ya has recuperado esta reliquia.',
+  },
+  fr_FR: {
+    gearReadout: 'Équipé ({worn}/{total}): {items}.',
+    gearEmptySlot: '(vide)',
+    nothingEquipped: "Vous n'avez rien d'équipé.",
+    cannotTakeYet: 'Vous ne pouvez pas encore prendre {name}.',
+    offersNothingMore: "{name} n'offre rien de plus.",
+    relicBound: 'La relique est liée à la crypte scellée.',
+    relicRecovered: 'Vous avez déjà récupéré cette relique.',
+  },
+  fr_CA: {
+    gearReadout: 'Équipé ({worn}/{total}): {items}.',
+    gearEmptySlot: '(vide)',
+    nothingEquipped: "Vous n'avez rien d'équipé.",
+    cannotTakeYet: 'Vous ne pouvez pas encore prendre {name}.',
+    offersNothingMore: "{name} n'offre rien de plus.",
+    relicBound: 'La relique est liée à la crypte scellée.',
+    relicRecovered: 'Vous avez déjà récupéré cette relique.',
+  },
+  it_IT: {
+    gearReadout: 'Equipaggiato ({worn}/{total}): {items}.',
+    gearEmptySlot: '(vuoto)',
+    nothingEquipped: 'Non hai nulla equipaggiato.',
+    cannotTakeYet: 'Non puoi ancora prendere {name}.',
+    offersNothingMore: "{name} non offre nient'altro.",
+    relicBound: 'La reliquia è vincolata alla cripta sigillata.',
+    relicRecovered: 'Hai già recuperato questa reliquia.',
+  },
+  de_DE: {
+    gearReadout: 'Ausgerüstet ({worn}/{total}): {items}.',
+    gearEmptySlot: '(leer)',
+    nothingEquipped: 'Ihr habt nichts ausgerüstet.',
+    cannotTakeYet: 'Ihr könnt {name} noch nicht nehmen.',
+    offersNothingMore: '{name} bietet nichts weiter.',
+    relicBound: 'Das Relikt ist an die versiegelte Krypta gebunden.',
+    relicRecovered: 'Ihr habt dieses Relikt bereits geborgen.',
+  },
+  zh_CN: {
+    gearReadout: '已装备（{worn}/{total}）：{items}。',
+    gearEmptySlot: '（空）',
+    nothingEquipped: '你没有装备任何物品。',
+    cannotTakeYet: '你还不能拿取{name}。',
+    offersNothingMore: '{name}没有更多可提供的了。',
+    relicBound: '圣物被封印的墓穴束缚着。',
+    relicRecovered: '你已经找回了这件圣物。',
+  },
+  zh_TW: {
+    gearReadout: '已裝備（{worn}/{total}）：{items}。',
+    gearEmptySlot: '（空）',
+    nothingEquipped: '你沒有裝備任何物品。',
+    cannotTakeYet: '你還不能拿取{name}。',
+    offersNothingMore: '{name}沒有更多可提供的了。',
+    relicBound: '聖物被封印的墓穴束縛著。',
+    relicRecovered: '你已經找回了這件聖物。',
+  },
+  ko_KR: {
+    gearReadout: '착용 중 ({worn}/{total}): {items}.',
+    gearEmptySlot: '(없음)',
+    nothingEquipped: '착용한 장비가 없습니다.',
+    cannotTakeYet: '아직 {name}을(를) 가져갈 수 없습니다.',
+    offersNothingMore: '{name}에게서 더 얻을 것이 없습니다.',
+    relicBound: '유물이 봉인된 묘실에 묶여 있습니다.',
+    relicRecovered: '이미 이 유물을 되찾았습니다.',
+  },
+  ja_JP: {
+    gearReadout: '装備中（{worn}/{total}）：{items}。',
+    gearEmptySlot: '（なし）',
+    nothingEquipped: '何も装備していません。',
+    cannotTakeYet: 'まだ{name}を取ることはできません。',
+    offersNothingMore: '{name}からはもう何も得られません。',
+    relicBound: '聖遺物は封印された墓所に縛られています。',
+    relicRecovered: 'この聖遺物はすでに回収しています。',
+  },
+  pt_BR: {
+    gearReadout: 'Equipado ({worn}/{total}): {items}.',
+    gearEmptySlot: '(vazio)',
+    nothingEquipped: 'Você não tem nada equipado.',
+    cannotTakeYet: 'Você ainda não pode pegar {name}.',
+    offersNothingMore: '{name} não oferece mais nada.',
+    relicBound: 'A relíquia está presa à cripta selada.',
+    relicRecovered: 'Você já recuperou esta relíquia.',
+  },
+  ru_RU: {
+    gearReadout: 'Экипировано ({worn}/{total}): {items}.',
+    gearEmptySlot: '(пусто)',
+    nothingEquipped: 'У вас ничего не экипировано.',
+    cannotTakeYet: 'Вы пока не можете взять {name}.',
+    offersNothingMore: '{name} больше ничего не предлагает.',
+    relicBound: 'Реликвия привязана к запечатанной крипте.',
+    relicRecovered: 'Вы уже нашли эту реликвию.',
+  },
+};
+
+function tItemExtra(key: ItemExtraKey, params?: InterpolationValues): string {
+  const table = ITEM_EXTRA[getLanguage()] ?? ITEM_EXTRA.en;
+  return interpolate(table[key] ?? ITEM_EXTRA.en[key], params);
+}
+
+// The /gear readout's English slot labels -> the already-translated itemUi.slots.*
+// keys the character-window paperdoll renders. Keep in sync with gearReadout() in
+// src/sim/sim.ts (the slot order/labels it emits).
+const GEAR_SLOT_KEYS: Record<string, TranslationKey> = {
+  'Main Hand': 'itemUi.slots.mainhand',
+  'Helmet': 'itemUi.slots.helmet',
+  'Shoulder': 'itemUi.slots.shoulder',
+  'Chest': 'itemUi.slots.chest',
+  'Waist': 'itemUi.slots.waist',
+  'Legs': 'itemUi.slots.legs',
+  'Gloves': 'itemUi.slots.gloves',
+  'Feet': 'itemUi.slots.feet',
+};
+
+// Rebuild the /gear readout in the active locale: localize each "Slot: value"
+// segment (slot label via itemUi.slots.*, item name via the entity dict, the
+// "(empty)" marker via ITEM_EXTRA) then re-frame via the gearReadout template.
+function locGearReadout(worn: string, total: string, body: string): string {
+  const items = body
+    .split(', ')
+    .map((seg) => {
+      const sep = seg.indexOf(': ');
+      if (sep < 0) return seg;
+      const label = seg.slice(0, sep);
+      const value = seg.slice(sep + 2);
+      const slotKey = GEAR_SLOT_KEYS[label];
+      const locLabel = slotKey ? t(slotKey) : label;
+      const locValue = value === '(empty)' ? tItemExtra('gearEmptySlot') : locItem(value);
+      return `${locLabel}: ${locValue}`;
+    })
+    .join(', ');
+  return tItemExtra('gearReadout', { worn, total, items });
+}
+
 // EXACT (no-placeholder) sim messages: English -> key (auto-built; throws on collision).
 const EXACT: Record<string, SimMessageKey> = {};
 for (const key of Object.keys(enTable) as SimMessageKey[]) {
@@ -2129,7 +2307,18 @@ const RULES: Rule[] = [
   { re: /^(.+) begins to swell — get clear!$/, build: (m) => tSim('log.deathThroesArm', { name: locMob(m[1]) }) },
   { re: /^(.+) bursts in a cloud of (.+)!$/, build: (m) => tSim('log.deathThroesBurst', { name: locMob(m[1]), effect: localizeSimAuraName(m[2]) ?? m[2] }) },
   { re: /^Discarded (.+?)( x\d+)?\.$/, build: (m) => tSim('log.discarded', { item: locItemStack(m[1], m[2]) }) },
-  { re: /^Equipped (.+)\.$/, build: (m) => tSim('log.equipped', { item: locItem(m[1]) }) },
+  // /gear self-readout (must precede the single-item Equipped rule below, which is
+  // anchored with (?!\() so it can never swallow this compound readout).
+  { re: /^Equipped \(([^/]+)\/([^)]+)\): (.+)\.$/, build: (m) => locGearReadout(m[1], m[2], m[3]) },
+  { re: /^You have nothing equipped\.$/, build: () => tItemExtra('nothingEquipped') },
+  // Quest-item + relic pickup error toasts (src/sim emits these as `?? 'English'`
+  // fallbacks, so the S3 drift guard's this.error regex cannot see them — covered
+  // explicitly by tests/sim_item_i18n.test.ts instead).
+  { re: /^You cannot take the (.+) yet\.$/, build: (m) => tItemExtra('cannotTakeYet', { name: locItem(m[1]) }) },
+  { re: /^(.+) offers nothing more\.$/, build: (m) => tItemExtra('offersNothingMore', { name: locItem(m[1]) }) },
+  { re: /^The relic is bound by the sealed crypt\.$/, build: () => tItemExtra('relicBound') },
+  { re: /^You have already recovered this relic\.$/, build: () => tItemExtra('relicRecovered') },
+  { re: /^Equipped (?!\()(.+)\.$/, build: (m) => tSim('log.equipped', { item: locItem(m[1]) }) },
   { re: /^You quaff (.+)\.$/, build: (m) => tSim('log.quaff', { item: locItem(m[1]) }) },
   { re: /^(.+) wins (.+) \((\d+)\)$/, build: (m) => tSim('loot.rollWin', { winner: m[1], item: locItem(m[2]), roll: m[3] }) },
   { re: /^(.+) leaves the party\.$/, build: (m) => tSim('log.partyLeaves', { name: m[1] }) },

--- a/tests/sim_item_i18n.test.ts
+++ b/tests/sim_item_i18n.test.ts
@@ -1,0 +1,104 @@
+// Coverage for sim-emitted item / equipment / world-object interaction strings that
+// the S3 drift guard (tests/localization_fixes.test.ts) cannot see: the relic + quest-
+// item pickup error toasts are emitted as `this.error(id, def?.pickup* ?? 'English')`,
+// and the guard's this.error regex only captures a literal that immediately follows the
+// comma — so a `?? 'literal'` fallback slips past it. The /gear readout slot labels also
+// regressed (the over-broad Equipped rule mangled the worn case). This file pins all of
+// them: every string must localize (non-null) in every locale and not stay English.
+import { describe, it, expect } from "vitest";
+import { localizeSimText } from "../src/ui/sim_i18n";
+import { setLanguage, supportedLanguages, t } from "../src/ui/i18n";
+import { tEntity } from "../src/ui/entity_i18n";
+
+const translatedLocales = supportedLanguages.filter((l) => l !== "en" && l !== "en_CA");
+
+describe("sim /gear readout is fully localized in every locale", () => {
+  // Mirrors gearReadout() in src/sim/sim.ts: one filled slot + empty slots, fixed order.
+  const worn =
+    "Equipped (1/8): Main Hand: Iron Sword, Helmet: (empty), Shoulder: (empty), " +
+    "Chest: (empty), Waist: (empty), Legs: (empty), Gloves: (empty), Feet: (empty).";
+  const empty = "You have nothing equipped.";
+
+  it("recognizes the worn and empty readouts in every locale (non-null)", () => {
+    for (const lang of supportedLanguages) {
+      setLanguage(lang);
+      expect(localizeSimText(worn), `${lang}: worn /gear not recognized`).not.toBeNull();
+      expect(localizeSimText(empty), `${lang}: empty /gear not recognized`).not.toBeNull();
+    }
+    setLanguage("en");
+  });
+
+  it("does not leave the readout in English for any translated locale", () => {
+    for (const lang of translatedLocales) {
+      setLanguage(lang);
+      expect(localizeSimText(worn), `${lang}: worn /gear stayed English`).not.toBe(worn);
+      expect(localizeSimText(empty), `${lang}: empty /gear stayed English`).not.toBe(empty);
+    }
+    setLanguage("en");
+  });
+
+  it("translates the slot labels and the (empty) marker (no raw English labels leak)", () => {
+    for (const lang of translatedLocales) {
+      setLanguage(lang);
+      const out = localizeSimText(worn)!;
+      // The slot label must be the localized itemUi.slots.* value, never raw English.
+      const helmet = t("itemUi.slots.helmet");
+      if (helmet !== "Helmet") {
+        expect(out, `${lang}: readout shows the localized Helmet label`).toContain(helmet);
+        expect(out, `${lang}: raw English 'Helmet:' leaked into readout`).not.toContain("Helmet:");
+      }
+      // The "(empty)" marker must be localized too.
+      expect(out, `${lang}: raw English '(empty)' leaked into readout`).not.toContain("(empty)");
+    }
+    setLanguage("en");
+  });
+});
+
+describe("sim relic + pickup error toasts localize in every locale", () => {
+  // The exact `?? 'English'` fallbacks emitted by sim.ts (activateNythraxisRelic /
+  // pickUpObject). {name} stands in for a quest-item name spliced in by the sim.
+  const strings = [
+    "The relic is bound by the sealed crypt.",
+    "You have already recovered this relic.",
+    "You cannot take the Captain's Crest yet.",
+    "Captain's Crest offers nothing more.",
+  ];
+
+  it("recognizes every string in every locale (non-null)", () => {
+    for (const lang of supportedLanguages) {
+      setLanguage(lang);
+      for (const s of strings) {
+        expect(localizeSimText(s), `${lang}: "${s}" not recognized (would leak English)`).not.toBeNull();
+      }
+    }
+    setLanguage("en");
+  });
+
+  it("does not stay English in any translated locale", () => {
+    for (const lang of translatedLocales) {
+      setLanguage(lang);
+      for (const s of strings) {
+        expect(localizeSimText(s), `${lang}: "${s}" stayed English`).not.toBe(s);
+      }
+    }
+    setLanguage("en");
+  });
+});
+
+describe("nythraxis_crypt dungeon name resolves through the entity dictionary", () => {
+  // renderer.ts dungeonDisplayName no longer special-cases this id to the raw English
+  // content-def name; it must localize like every other dungeon nameplate.
+  it("is translated (not raw English) in every translated locale", () => {
+    const en = ((): string => {
+      setLanguage("en");
+      return tEntity({ kind: "dungeon", id: "nythraxis_crypt", field: "name" });
+    })();
+    expect(en.length, "english crypt name resolves").toBeGreaterThan(0);
+    for (const lang of translatedLocales) {
+      setLanguage(lang);
+      const out = tEntity({ kind: "dungeon", id: "nythraxis_crypt", field: "name" });
+      expect(out, `${lang}: crypt name resolves`).toBeTruthy();
+    }
+    setLanguage("en");
+  });
+});


### PR DESCRIPTION
## What

Localizes player-visible English introduced by recent commits that the
compiler and the i18n status registry cannot catch (unkeyed literals and
unregistered `sim/` emits). Found by auditing the diffs of the commits since
the last full fill; the registered-key side was already complete (`pending=0`).

## Fixes

- **Crypt nameplate** (`renderer.ts`): `dungeonDisplayName` special-cased
  `nythraxis_crypt` to a hardcoded English name, bypassing `tEntity` and
  dropping the existing translation on the door/exit nameplate in every locale.
  Removed the special case so it localizes like every other dungeon.
- **`/gear` readout** (`sim_i18n.ts`): commit `3bd9a36` added 4 equip slots; the
  slot labels shipped English and the worn case was actively *garbled* by the
  over-broad `Equipped` matcher rule (e.g. German rendered
  `"(2/8): Main Hand: ... ausgerüstet."`). Now fully localized, reusing the
  already-translated `itemUi.slots.*` keys. Tightened the single-item `Equipped`
  rule so it can never swallow a readout again. `"You have nothing equipped."`
  removed from the `V07_SLASH` English backstop (blockedSource 105 -> 104).
- **Relic + quest-item pickup error toasts** (`sim_i18n.ts`): the four
  `this.error(id, def?.pickup* ?? 'English')` fallbacks from the Nythraxis chain
  (`2cb11e4`) were registered in neither matcher. Added rules. The S3 drift
  guard's `this.error([^,]+, <lit>)` regex cannot see a `?? 'literal'` fallback,
  which is why these shipped CI-green.

## Notes

- New sim strings live in a new `ITEM_EXTRA` table in `sim_i18n.ts`, inline
  across all 14 locales (same pattern as `QUEST_EXTRA`/`ARENA_EXTRA`), so they
  are not registry keys and add no `pending` rows. German uses the project's
  formal `Ihr` register; accents/umlauts match `BASE_DICT`.
- The rest of the v0.7 slash-command surface (`/pet`, `/quest`, `/bags`,
  `/arena`, ...) stays English by the documented `V07_SLASH` policy. `/gear` is
  the deliberate exception here.

## Testing

- New `tests/sim_item_i18n.test.ts` pins every string in every locale (the S3
  guard structurally can't, given the `??`-fallback shape).
- `I18N_RELEASE_TIER=1 npm test`: 154 files, 1574 passed. `tsc --noEmit` clean.
  Registry reproducible, `pending=0`.

## Follow-ups (not in this PR)

- Harden the S3 guard extractor to also see `?? 'literal'` fallbacks so this
  class is caught automatically.
- Spellbook hotbar toggle aria-label conveys add/remove via a bare `+`/`-`
  symbol with no localized verb (minor a11y).
- Dead key `questUi.dialog.nythraxisDeathlessKingWarning` (translated but
  unreferenced; likely a cut-quest leftover).
