### PR TITLE
fix(audio): battle music replaces zone music instead of layering over it

### DIFF
--- a/src/game/music.ts
+++ b/src/game/music.ts
@@ -1128,8 +1128,9 @@ export class MusicDirector {
     const now = this.ctx.currentTime;
     for (const [name, layer] of Object.entries(this.layers)) {
       if (name === 'combat') continue;
-      // the zone theme keeps playing (quieter) under the combat layer
-      const target = name === zone ? (inCombat ? 0.45 : 1) : 0;
+      // combat music replaces the zone theme rather than layering over it: the
+      // zone is silenced for the duration of combat and fades back in when it ends
+      const target = name === zone ? (inCombat ? 0 : 1) : 0;
       if (layer.target !== target) {
         layer.target = target;
         // fade out faster than fade in so instance music doesn't bleed into the world

--- a/tests/music.test.ts
+++ b/tests/music.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MusicDirector } from '../src/game/music';
+
+// MusicDirector is WebAudio; jsdom has no AudioContext, so we stub the minimal
+// surface init() touches. We only assert layer gain *targets* (the mix logic),
+// not actual audio output.
+class FakeParam {
+  value = 0;
+  setTargetAtTime = vi.fn();
+}
+class FakeGain {
+  gain = new FakeParam();
+  connect = vi.fn();
+}
+class FakeAudioContext {
+  currentTime = 0;
+  sampleRate = 44100;
+  destination = {};
+  createGain(): FakeGain { return new FakeGain(); }
+  createDynamicsCompressor() {
+    return {
+      threshold: new FakeParam(), knee: new FakeParam(), ratio: new FakeParam(),
+      attack: new FakeParam(), release: new FakeParam(), connect: vi.fn(),
+    };
+  }
+  createConvolver() { return { buffer: null, connect: vi.fn() }; }
+  createBuffer(_ch: number, len: number) { return { getChannelData: () => new Float32Array(len) }; }
+  resume() { return Promise.resolve(); }
+}
+
+describe('MusicDirector — combat / background mix', () => {
+  let director: MusicDirector;
+
+  beforeEach(() => {
+    const g = globalThis as unknown as { AudioContext: unknown; window: unknown };
+    g.AudioContext = FakeAudioContext;
+    // init() schedules via window.setInterval; tests run in node, so stub it to a
+    // no-op (we drive update() synchronously and never need the scheduler to fire)
+    g.window = { setInterval: () => 0 };
+    director = new MusicDirector();
+    director.init();
+  });
+
+  afterEach(() => {
+    // init() registers a scheduler interval; stop it so it can't leak across tests
+    clearInterval((director as unknown as { timer: number }).timer);
+  });
+
+  const layers = () => (director as unknown as {
+    layers: Record<string, { target: number }>;
+  }).layers;
+
+  it('plays the zone theme and no combat layer when out of combat', () => {
+    director.update('vale', false);
+    expect(layers().vale.target).toBe(1);
+    expect(layers().combat.target).toBe(0);
+  });
+
+  it('silences the zone theme so ONLY combat music plays in combat (no layering)', () => {
+    director.update('vale', false);
+    director.update('vale', true);
+    // the bug was a 0.45 duck here — the zone must be fully silenced now
+    expect(layers().vale.target).toBe(0);
+    expect(layers().combat.target).toBe(1);
+  });
+
+  it('restores the background theme and drops combat when combat ends', () => {
+    director.update('vale', true);
+    director.update('vale', false);
+    expect(layers().vale.target).toBe(1);
+    expect(layers().combat.target).toBe(0);
+  });
+
+  it('never runs the zone and combat layers at non-zero gain simultaneously', () => {
+    for (const inCombat of [false, true, false, true]) {
+      director.update('vale', inCombat);
+      const zone = layers().vale.target;
+      const combat = layers().combat.target;
+      expect(Math.min(zone, combat)).toBe(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

**Bug fix.** Battle music played *on top of* the zone/background music instead of replacing it. Entering combat ducked the zone theme to `0.45` gain and faded the combat layer in over it, so both tracks played at once and muddied the mix.

Now combat music **replaces** the background: the zone theme is silenced for the duration of combat (only the battle music plays), then fades back in when combat ends. A clean crossfade with mutual exclusion.

## Root cause

`src/game/music.ts` → `MusicDirector.update()`: the per-frame mix set the active zone layer's gain target to `0.45` while in combat (`name === zone ? (inCombat ? 0.45 : 1) : 0`) and brought the combat layer to `1.0` on top. The architecture already has independent gain nodes per layer; only the target logic was layering them.

## Fix

One-line change to the zone target: `inCombat ? 0 : 1` — silence the zone in combat, restore it when combat ends. The existing fade timing already gives a smooth out (0.35s) / in (~0.73s) crossfade, and the scheduler stops pumping notes for a silenced layer.

## Testing

- New `tests/music.test.ts` (mock `AudioContext`) asserts the mix logic:
  - out of combat → zone gain target `1`, combat `0`
  - **in combat → zone `0`, combat `1` (only battle music plays)**
  - background restored after combat ends
  - invariant: zone and combat layers never both play at non-zero gain
- `npx tsc --noEmit` clean · full suite green · `npm run build` OK.

Procedural WebAudio, client-only — no wire/server changes.
