### PR TITLE
feat(render): SMAA edge AA, explicit output color space, clamped anisotropy

### DIFF
--- a/src/render/CLAUDE.md
+++ b/src/render/CLAUDE.md
@@ -60,11 +60,12 @@ collision/movement.
 
 ## Performance discipline — this runs at frame rate
 - Three.js is **pinned at r0.165**; post uses `three/examples/jsm/postprocessing/*`
-  (EffectComposer→RenderPass/N8AO→UnrealBloom→OutputPass→Grade) plus the `n8ao`
-  package (SSAO). The `postprocessing` dep in `package.json` is n8ao's peer
-  dependency — not imported directly, so don't remove it as "unused." Don't bump
-  Three or swap the chain casually — shaders here patch r165 chunks via
-  `onBeforeCompile`.
+  (EffectComposer→RenderPass/N8AO→UnrealBloom→OutputPass→SMAA→Grade) plus the
+  `n8ao` package (SSAO). SMAA runs only on the AO path (which carries no MSAA)
+  and sits before Grade so film grain lands after AA. The `postprocessing` dep in
+  `package.json` is n8ao's peer dependency — not imported directly, so don't
+  remove it as "unused." Don't bump Three or swap the chain casually — shaders
+  here patch r165 chunks via `onBeforeCompile`.
 - Reuse, don't allocate: instancing for repeats, merge one-offs per
   (material × z-band), share materials via `surfaceMat`, distance-cull/LOD in
   `sync` (see the `*_RANGE_SQ` constants). No per-frame `new THREE.*` in hot paths

--- a/src/render/assets/loader.ts
+++ b/src/render/assets/loader.ts
@@ -7,6 +7,7 @@ import { RGBELoader } from 'three/addons/loaders/RGBELoader.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import { assetUrl } from './media';
 import { assetLoadStarted, recordAssetLoad } from './stats';
+import { anisotropic } from '../gfx';
 
 let gltfLoader: GLTFLoader | null = null;
 const gltfCache = new Map<string, Promise<GLTF>>();
@@ -111,10 +112,18 @@ export function loadHdr(url: string): Promise<THREE.DataTexture> {
   return p;
 }
 
-/** Plain image texture (terrain splats, water normals, VFX sprites). */
-export function loadTexture(url: string, opts: { srgb?: boolean; repeat?: boolean } = {}): Promise<THREE.Texture> {
+/** Plain image texture (terrain splats, water normals, VFX sprites).
+ *  `aniso` requests capability-clamped anisotropic filtering (defaults to 8 for
+ *  repeat-wrapped surfaces — they alias worst at grazing angles; 1 otherwise).
+ *  Pass aniso: 1 explicitly for mip-less sprite atlases that don't want it. */
+export function loadTexture(
+  url: string,
+  opts: { srgb?: boolean; repeat?: boolean; aniso?: number } = {},
+): Promise<THREE.Texture> {
   const resolved = assetUrl(url);
-  const key = `${resolved}|${opts.srgb ? 's' : 'l'}|${opts.repeat ? 'r' : 'c'}`;
+  // one source for both the cache key and the applied value — must not desync
+  const aniso = opts.aniso ?? (opts.repeat ? 8 : 1);
+  const key = `${resolved}|${opts.srgb ? 's' : 'l'}|${opts.repeat ? 'r' : 'c'}|a${aniso}`;
   let p = texCache.get(key);
   if (!p) {
     const startedAt = assetLoadStarted();
@@ -122,6 +131,7 @@ export function loadTexture(url: string, opts: { srgb?: boolean; repeat?: boolea
       new THREE.TextureLoader().load(resolved, (tex) => {
         if (opts.srgb) tex.colorSpace = THREE.SRGBColorSpace;
         if (opts.repeat) tex.wrapS = tex.wrapT = THREE.RepeatWrapping;
+        anisotropic(tex, aniso);
         recordAssetLoad('texture', resolved, startedAt);
         resolve(tex);
       }, undefined, () => {

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -186,11 +186,44 @@ export function isWeakIntegratedGpu(name: string | undefined): boolean {
 // building any scene content.
 export let GFX: GfxSettings = settingsFor(tierFromHints(runtimeHints(), false), runtimeHints());
 
+// Device max anisotropic-filtering samples, resolved once the GL context exists
+// (initGfxTier). 0 = not yet resolved: boot-time texture preloads (terrain/water)
+// run BEFORE the Renderer is constructed, so anisotropic() must NOT clamp against
+// a stale value then — it falls back to the requested level, which GL itself
+// clamps to the hardware max on upload (see anisotropyLevel).
+export let maxAnisotropy = 0;
+
 export function initGfxTier(webgl: THREE.WebGLRenderer): GfxTier {
   const hints = { ...runtimeHints(), gpuRenderer: rendererName(webgl) };
   const tier = tierFromHints(hints, isSoftwareGL(webgl));
   GFX = settingsFor(tier, hints);
+  try {
+    maxAnisotropy = webgl.capabilities.getMaxAnisotropy();
+  } catch {
+    maxAnisotropy = 0;
+  }
   return tier;
+}
+
+// Pure anisotropy-level decision (no GL/texture state) — unit-testable and
+// independent of init ordering:
+//   - low tier pays nothing (1)
+//   - once the GL max is known (>0), clamp the request to it
+//   - before it is known (max === 0, e.g. boot preload runs pre-initGfxTier),
+//     use the request as-is — GL clamps it to the hardware limit on upload, so
+//     this never over-spends. (The old per-site code set raw values the same way.)
+export function anisotropyLevel(tier: GfxTier, max: number, requested: number): number {
+  if (tier === 'low') return 1;
+  return max > 0 ? Math.min(requested, max) : requested;
+}
+
+// Anisotropic filtering for repeat-wrapped / mipmapped surfaces (terrain splat,
+// water normals, tiling canvas textures) — kills the grazing-angle shimmer the
+// anti-tiling craft otherwise leaves on the table. Returns the texture so callers
+// can chain; set needsUpdate yourself if the texture is already uploaded.
+export function anisotropic<T extends THREE.Texture>(tex: T, requested = 8): T {
+  tex.anisotropy = anisotropyLevel(GFX.tier, maxAnisotropy, requested);
+  return tex;
 }
 
 // One clock uniform shared by every onBeforeCompile shader (wind, water,

--- a/src/render/post.ts
+++ b/src/render/post.ts
@@ -4,22 +4,26 @@ import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js';
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js';
 import { OutputPass } from 'three/examples/jsm/postprocessing/OutputPass.js';
 import { ShaderPass } from 'three/examples/jsm/postprocessing/ShaderPass.js';
+import { SMAAPass } from 'three/examples/jsm/postprocessing/SMAAPass.js';
 import { N8AOPass } from 'n8ao';
 import { GFX, sharedUniforms } from './gfx';
 
 // Post chain: RenderPass -> N8AO (high: half-res Low, ultra: full-res Medium)
 // -> UnrealBloom -> OutputPass (ACES tonemap + sRGB, reads
-// renderer.toneMapping) -> GradePass (display space lift/gamma/gain,
-// saturation, vignette, faint animated grain).
+// renderer.toneMapping) -> SMAA (edge AA on the AO path) -> GradePass (display
+// space lift/gamma/gain, saturation, vignette, faint animated grain).
 //
 // N8AO replaced three's GTAOPass: better denoise at lower sample counts, and
 // cheap enough (half-res) to run on the high tier where GTAO was ultra-only.
 // It sits mid-chain so its autosetGamma leaves the buffer linear for bloom.
 //
 // AA: when N8AO is active it renders the scene into its own non-MSAA beauty
-// target, so geometry AA comes from bloom/grade softening + pixel ratio (the
-// composer target therefore skips MSAA storage — pure waste otherwise). The
-// no-AO fallback path keeps MSAA on the composer target.
+// target, so the composer target carries no MSAA — geometry edges would crawl
+// (worst at renderScale<1). A single cheap, temporal-free SMAA pass on the
+// tonemapped LDR image (after OutputPass) restores edge AA. It sits BEFORE the
+// grade so the grade's film grain is applied AFTER anti-aliasing — grain is
+// high-frequency by design and must not be averaged/smeared by the edge filter.
+// The no-AO fallback path keeps MSAA on the composer target and skips SMAA.
 
 const BLOOM_STRENGTH = 0.32; // subtle — fires/portals glow, sky must not blow out
 const BLOOM_RADIUS = 0.55;
@@ -62,6 +66,7 @@ export interface PostPipeline {
   composer: EffectComposer;
   bloom: UnrealBloomPass;
   ao: N8AOPass | null;
+  smaa: SMAAPass | null;
   grade: ShaderPass;
   setSize(width: number, height: number): void;
   render(): void;
@@ -124,6 +129,17 @@ export function buildComposer(
   composer.addPass(bloom);
   composer.addPass(new OutputPass());
 
+  // SMAA only on the AO path: that path carries no MSAA on the composer target
+  // (samples are gated off above when GFX.ao), so it is the only path with no
+  // true geometry AA. MSAA-when-not-AO and SMAA-when-AO are two halves of ONE
+  // decision — keep them gated on the same `GFX.ao` so a future tier can never
+  // end up with neither. The MSAA fallback already resolves edges → no SMAA there.
+  let smaa: SMAAPass | null = null;
+  if (GFX.ao) {
+    smaa = new SMAAPass(size.x, size.y); // resized with the chain via composer.setSize
+    composer.addPass(smaa);
+  }
+
   const grade = new ShaderPass(GradeShader);
   grade.uniforms.uTime = sharedUniforms.uTime; // shared clock drives the grain
   composer.addPass(grade);
@@ -139,6 +155,7 @@ export function buildComposer(
     composer,
     bloom,
     ao,
+    smaa,
     grade,
     setSize(width: number, height: number): void {
       composer.setSize(width, height); // also resizes every pass (N8AO, bloom)

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -308,6 +308,10 @@ export class Renderer {
     this.webgl.shadowMap.type = THREE.PCFSoftShadowMap;
     this.webgl.toneMapping = THREE.ACESFilmicToneMapping; // OutputPass reads this on the composer path
     this.webgl.toneMappingExposure = this.baseExposure;
+    // Pin the output encoding rather than relying on the three.js default — the
+    // low-tier direct-render path (no OutputPass) depends on it, and an implicit
+    // default is a latent footgun if Three is ever bumped.
+    this.webgl.outputColorSpace = THREE.SRGBColorSpace;
     this.camera = new THREE.PerspectiveCamera(CAMERA_BASE_FOV, this.viewport.width / this.viewport.height, 0.1, 950);
 
     this.scene.fog = new THREE.Fog(LOW_GFX ? 0xb6cddd : 0xa6c6e0, LOW_GFX ? 150 : 130, LOW_GFX ? 520 : 470);

--- a/src/render/terrain.ts
+++ b/src/render/terrain.ts
@@ -37,8 +37,10 @@ const ALBEDO_ANISOTROPY = 8;
 const NORMAL_ANISOTROPY = 4;
 
 function kickTerrainTex(key: string, file: string, srgb: boolean): void {
-  registerPreload(loadTexture(`/textures/terrain/${file}`, { srgb, repeat: true }).then((tex) => {
-    tex.anisotropy = srgb ? ALBEDO_ANISOTROPY : NORMAL_ANISOTROPY;
+  // anisotropy clamped to the device max inside loadTexture (was set unclamped here)
+  registerPreload(loadTexture(`/textures/terrain/${file}`, {
+    srgb, repeat: true, aniso: srgb ? ALBEDO_ANISOTROPY : NORMAL_ANISOTROPY,
+  }).then((tex) => {
     TERRAIN_TEX[key] = tex;
     return tex;
   }));

--- a/src/render/textures.ts
+++ b/src/render/textures.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { anisotropic } from './gfx';
 
 // Procedurally generated canvas textures — no external assets.
 
@@ -12,6 +13,9 @@ function makeCanvas(size: number, draw: (ctx: CanvasRenderingContext2D, size: nu
   tex.wrapS = THREE.RepeatWrapping;
   tex.wrapT = THREE.RepeatWrapping;
   tex.colorSpace = THREE.SRGBColorSpace;
+  // these are all tiling surface textures (CanvasTexture mipmaps by default) —
+  // clamped anisotropy removes grazing-angle shimmer; tier-gated to skip low
+  anisotropic(tex);
   return tex;
 }
 

--- a/src/render/water.ts
+++ b/src/render/water.ts
@@ -24,8 +24,8 @@ const SEGMENTS_PER_ZONE = 180; // ~2u vertex spacing — enough for the foam ban
 // so it does not pay network/decode/upload cost for water detail.
 const WATER_TEX: Record<string, THREE.Texture> = {};
 function kickWaterTex(key: string, file: string): void {
-  registerPreload(loadTexture(`/textures/water/${file}`, { repeat: true }).then((tex) => {
-    tex.anisotropy = 4;
+  // anisotropy clamped to the device max inside loadTexture (was set unclamped here)
+  registerPreload(loadTexture(`/textures/water/${file}`, { repeat: true, aniso: 4 }).then((tex) => {
     WATER_TEX[key] = tex;
     return tex;
   }));

--- a/tests/gfx_anisotropy.test.ts
+++ b/tests/gfx_anisotropy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { anisotropyLevel } from '../src/render/gfx';
+
+// Guards the init-ordering trap: terrain/water textures preload BEFORE
+// initGfxTier resolves the device max, so anisotropyLevel must fall back to the
+// requested value (GL clamps on upload) rather than clamping against a stale 0
+// — otherwise the headline "crisper grazing-angle ground" ships as anisotropy=1.
+describe('anisotropyLevel', () => {
+  it('low tier pays nothing', () => {
+    expect(anisotropyLevel('low', 16, 8)).toBe(1);
+    expect(anisotropyLevel('low', 0, 8)).toBe(1);
+  });
+
+  it('clamps the request to the known device max', () => {
+    expect(anisotropyLevel('high', 4, 8)).toBe(4);
+    expect(anisotropyLevel('ultra', 16, 8)).toBe(8);
+    expect(anisotropyLevel('high', 16, 4)).toBe(4);
+  });
+
+  it('falls back to the requested value before the GL max is known (max === 0)', () => {
+    expect(anisotropyLevel('high', 0, 8)).toBe(8);
+    expect(anisotropyLevel('ultra', 0, 4)).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

A small, render-only **Tier-1 quality pass** on the Three.js renderer — three changes that lift perceived image quality with no architecture change, **no `src/sim/` coupling**, and **no Three.js bump** (stays on the pinned r0.165; SMAA ships with its examples).

The headline is **true anti-aliasing**: with N8AO active the composer target carries no MSAA, so geometry edges had no AA at all and crawled (worst at `renderScale<1` / low pixelRatio). This was the renderer's single biggest quality gap.

## What changed

1. **SMAA edge AA** (`post.ts`) — a `SMAAPass` after `OutputPass` on the AO path (the only path without MSAA), placed **before** the Grade pass so the film grain lands *after* AA (grain is high-frequency and must not be averaged by the edge filter). MSAA-when-not-AO and SMAA-when-AO are two halves of one decision, gated on the same `GFX.ao`.
2. **Explicit output color space** (`renderer.ts`) — `renderer.outputColorSpace = SRGBColorSpace`. A no-op today (matches the r165 default) but removes a latent footgun: the low-tier direct-render path (no `OutputPass`) relied on the implicit default.
3. **Capability-clamped, tier-gated anisotropic filtering** (`gfx.ts`, `loader.ts`, `terrain.ts`, `water.ts`, `textures.ts`) — repeat-wrapped terrain splat / water normals and all procedural tiling canvas textures now get anisotropic filtering, clamped to the device max and **gated so the low tier pays nothing**. Replaces the previously *unclamped* per-site values (8/4, 4) with one helper.

### Deliberately not done
**Folding the Grade pass into `OutputPass`** (a frametime micro-opt) — optimal SMAA ordering needs the grade (grain) as its own pass *after* SMAA; folding would push grain before AA. The fold's only benefit was buying frametime to offset SMAA, which is cheap on the high/ultra tiers it runs on.

## Constraints respected
- **No render→sim dependency**; `src/sim/` untouched (determinism invariant intact).
- **No Three.js bump / no chain swap** — SMAA is from `three/examples` on the pinned r0.165.
- Builds on the existing centralized `GFX` tier system; low tier unaffected.
- `src/render/CLAUDE.md` chain doc updated to match.

## Verification
Rebased onto current `main` (the 4-tier `low|medium|high|ultra` graphics-preset renderer); merges cleanly.
- `tsc --noEmit` clean
- full vitest suite green (**1571/1572**; the single miss is a pre-existing, load-sensitive timeout in `tests/security.test.ts`'s rate-limit flood test — unrelated to render and passing 40/40 in isolation). Added `tests/gfx_anisotropy.test.ts` as a regression guard for the anisotropy init-ordering.
- production `npm run build` OK; SMAA bundles cleanly
- headless before/after at forced `?gfx=high` confirms edge AA (timber-frame / stone / character silhouette visibly smoother; ~11% less high-frequency content in the cropped frame)

## Review note
Went through an adversarial code review that caught an init-ordering bug (boot-time texture preloads clamping against a stale `maxAnisotropy` → terrain/water silently regressing to `anisotropy=1`). Fixed via a `max===0` fallback (GL clamps on upload anyway) and locked down with the new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
