### PR TITLE
fix: tune mech spinner rarity rates

### DIFF
--- a/src/sim/content/skins.ts
+++ b/src/sim/content/skins.ts
@@ -19,6 +19,22 @@ export const EVENT_SKIN_TOKEN_ID = 'event_skin_token';
 /** Ranks ordered low → high. A rolled rank unlocks its tier and all below it. */
 export const SKIN_RANKS: readonly SkinRank[] = ['uncommon', 'rare', 'epic'] as const;
 
+export const SKIN_RANK_ROLL_WEIGHTS: Readonly<Record<SkinRank, number>> = {
+  uncommon: 70,
+  rare: 25,
+  epic: 5,
+} as const;
+
+export function rollSkinRank(unitRoll: number): SkinRank {
+  const total = SKIN_RANKS.reduce((sum, rank) => sum + SKIN_RANK_ROLL_WEIGHTS[rank], 0);
+  let roll = Math.max(0, Math.min(0.999999999, unitRoll)) * total;
+  for (const rank of SKIN_RANKS) {
+    roll -= SKIN_RANK_ROLL_WEIGHTS[rank];
+    if (roll < 0) return rank;
+  }
+  return 'uncommon';
+}
+
 /** One selectable skin per tier (placeholder mapping onto existing alt skins). */
 export interface SkinTier {
   rank: SkinRank;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -38,8 +38,8 @@ import {
   ArenaFormat, ArenaStanding, ArenaCombatant, SkinCatalog, SkinRank,
 } from './types';
 import {
-  EVENT_SKIN_TOKEN_ID, MECH_CHROMAS, SKIN_RANKS, classHasSkin, mechChromaItemId, mechChromaSkinIndex,
-  rankAllowsMechChroma, rankAllowsSkin,
+  EVENT_SKIN_TOKEN_ID, MECH_CHROMAS, classHasSkin, mechChromaItemId, mechChromaSkinIndex,
+  rankAllowsMechChroma, rankAllowsSkin, rollSkinRank,
 } from './content/skins';
 
 const LEASH_DISTANCE = 45;
@@ -1059,9 +1059,7 @@ export class Sim {
    *  The token is consumed on claim (claimEventSkin), not here. */
   private openSkinSelect(meta: PlayerMeta, catalog: SkinCatalog, itemId: string): void {
     if (meta.pendingSkinRank === null) {
-      // Equal-weight roll through the deterministic Rng (vanilla determinism:
-      // never Math.random). int() is inclusive on both ends.
-      meta.pendingSkinRank = SKIN_RANKS[this.rng.int(0, SKIN_RANKS.length - 1)];
+      meta.pendingSkinRank = rollSkinRank(this.rng.next());
       meta.pendingSkinCatalog = catalog;
       meta.pendingSkinItemId = itemId;
     } else {

--- a/tests/skin_event.test.ts
+++ b/tests/skin_event.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
 import {
-  EVENT_SKIN_TIERS, EVENT_SKIN_TOKEN_ID, MECH_CHROMAS, SKIN_COUNTS, SKIN_RANKS, rankAllowsSkin,
+  EVENT_SKIN_TIERS, EVENT_SKIN_TOKEN_ID, MECH_CHROMAS, SKIN_COUNTS, SKIN_RANK_ROLL_WEIGHTS, SKIN_RANKS, rankAllowsSkin, rollSkinRank,
 } from '../src/sim/content/skins';
 import { SKINS } from '../src/render/characters/manifest';
 import type { PlayerClass, SimEvent, SkinRank } from '../src/sim/types';
@@ -50,6 +50,16 @@ describe('cosmetic skin-select event', () => {
 
   it('is deterministic: the same seed rolls the same rank', () => {
     expect(rollRank(123).rank).toBe(rollRank(123).rank);
+  });
+
+  it('uses 70/25/5 rarity roll weights', () => {
+    expect(SKIN_RANK_ROLL_WEIGHTS).toEqual({ uncommon: 70, rare: 25, epic: 5 });
+    expect(rollSkinRank(0)).toBe('uncommon');
+    expect(rollSkinRank(0.69999)).toBe('uncommon');
+    expect(rollSkinRank(0.7)).toBe('rare');
+    expect(rollSkinRank(0.94999)).toBe('rare');
+    expect(rollSkinRank(0.95)).toBe('epic');
+    expect(rollSkinRank(0.99999)).toBe('epic');
   });
 
   it('locks in an in-rank skin: applies it, consumes the token, clears the pending rank', () => {


### PR DESCRIPTION
## Summary
- Add shared deterministic roll weights for the cosmetic spinner.
- Set rarity rates to 70% uncommon, 25% rare, and 5% epic.
- Add boundary coverage for the exact rarity cutoffs.

## Validation
- `npx vitest run tests/skin_event.test.ts tests/aldric_meteor_quest.test.ts tests/game_sessions.test.ts`
- `npx tsc --noEmit`