### PR TITLE
ci: restore release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ on:
     branches:
       - main
       - 'dev-*'
-      # Temporarily disabled so release/v0.10.0 can ship an urgent production fix.
-      # TODO: re-enable the release gate after the pending localization work is done.
-      # - 'release/**'
+      - 'release/**'
   workflow_dispatch:
 
 permissions:
@@ -69,7 +67,7 @@ jobs:
 
   release-gate:
     name: Release gate (full 14-locale)
-    if: false
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')
     runs-on: ubuntu-latest
 
     # The release tier; this single flag turns on every release-only check.


### PR DESCRIPTION
## Summary
- Re-enable CI on `release/**` pushes.
- Restore the full release-gate condition for release branch pushes.
- Remove the temporary urgent-production bypass comments.

## Validation
- Reviewed `.github/workflows/ci.yml` diff only; this is a workflow-only restore.