### PR TITLE
fix(mobile): stack language selector layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -6170,8 +6170,23 @@
   body.mobile-touch .header-actions {
     width: 100%;
     display: flex;
+    flex-direction: column;
+    align-items: center;
     justify-content: center;
     margin-top: 0;
+  }
+  body.mobile-touch .footer-bar {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  body.mobile-touch .footer-left {
+    align-items: center;
+  }
+  body.mobile-touch .footer-lang-row {
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
   }
   body.mobile-touch .language-selector {
     width: 100%;
@@ -6247,8 +6262,23 @@
     .header-actions {
       width: 100%;
       display: flex;
+      flex-direction: column;
+      align-items: center;
       justify-content: center;
       margin-top: 0;
+    }
+    .footer-bar {
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    .footer-left {
+      align-items: center;
+    }
+    .footer-lang-row {
+      width: 100%;
+      flex-direction: column;
+      align-items: center;
     }
     .language-selector {
       width: 100%;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -153,6 +153,8 @@ describe('client HTML shell', () => {
     expect(html).toContain('padding-top: calc(var(--spacing-sm) + env(safe-area-inset-top));');
     expect(html).toContain('padding-right: max(var(--spacing-md), env(safe-area-inset-right));');
     expect(html).toContain('body.mobile-touch #homepage-views-container {\n    padding-top: var(--spacing-lg);\n    padding-right: max(var(--spacing-md), env(safe-area-inset-right));');
+    expect(html).toContain('body.mobile-touch .header-actions {\n    width: 100%;\n    display: flex;\n    flex-direction: column;\n    align-items: center;');
+    expect(html).toContain('body.mobile-touch .footer-lang-row {\n    width: 100%;\n    flex-direction: column;\n    align-items: center;');
     expect(html).not.toContain('body.mobile-touch .homepage-header {\n    display: flex;\n    position: relative;');
     expect(mainTs).not.toContain("visualViewport?.addEventListener('scroll', syncAppViewport)");
   });


### PR DESCRIPTION
## Summary

Fix the homepage language selector alignment on larger mobile phone displays.

The mobile-touch homepage menu now stacks header actions vertically and keeps the footer language selector in a centered vertical layout, even on wider phone viewports that do not hit the narrow `max-width` breakpoint. This prevents the selector from being laid out horizontally beside the footer social/version content.

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts`

## Screenshots / recordings

N/A. CSS layout fix for mobile homepage/footer language selector alignment.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused client shell test passed.
- [ ] **Typecheck passes.** Not run; CSS/test-only change.
- [ ] **Builds succeed.** Not run; focused validation only.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; covered by targeted shell regression assertions.
- [x] **Accessible.** No new controls or user-facing strings; existing selector semantics are unchanged.

### Localization (i18n)

- [x] **N/A. This PR adds no new player-visible strings.**

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
