### PR TITLE
fix(mobile): improve News card layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2279,6 +2279,13 @@
     margin: 0;
     text-shadow: 1px 1px 2px #000;
   }
+  .news-item-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    margin-left: auto;
+  }
   .news-tag {
     font-family: var(--font-sans);
     font-size: 11px;
@@ -2296,7 +2303,6 @@
     padding: 1px 6px;
   }
   .news-date {
-    margin-left: auto;
     font-family: var(--font-sans);
     font-size: 11px;
     color: var(--color-text-muted, #b9ac82);
@@ -2307,7 +2313,8 @@
     line-height: 1.55;
     color: var(--color-text-light);
     word-wrap: break-word;
-    overflow-wrap: anywhere;
+    overflow-wrap: break-word;
+    word-break: normal;
     max-height: 460px;
     overflow-y: auto;
     padding-right: 8px;
@@ -2347,6 +2354,28 @@
     text-decoration: none;
   }
   .news-link:hover, .news-link:focus-visible { text-decoration: underline; }
+
+  body.mobile-touch .news-item-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  body.mobile-touch .news-item-title {
+    width: 100%;
+  }
+  body.mobile-touch .news-item-meta {
+    width: 100%;
+    margin-left: 0;
+  }
+  body.mobile-touch .news-body {
+    text-align: left;
+  }
+  body.mobile-touch .news-body ul {
+    list-style: none;
+    padding-left: 0;
+  }
+  body.mobile-touch .news-body li {
+    margin: var(--spacing-xs) 0;
+  }
 
   /* Wiki view with integrated Controls Guide */
   .wiki-container-layout {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2642,7 +2642,7 @@ async function loadNews(): Promise<void> {
       : '';
     return `<article class="news-item">`
       + `<div class="news-item-head">`
-      + `<h3 class="news-item-title">${title}</h3>${tag}${badge}${when}</div>`
+      + `<h3 class="news-item-title">${title}</h3><div class="news-item-meta">${tag}${badge}${when}</div></div>`
       + `<div class="news-body">${renderReleaseBody(r.body)}</div>${link}</article>`;
   }).join('');
 }

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -159,6 +159,15 @@ describe('client HTML shell', () => {
     expect(mainTs).not.toContain("visualViewport?.addEventListener('scroll', syncAppViewport)");
   });
 
+  it('places news release metadata below the heading on mobile', () => {
+    expect(mainTs).toContain('<h3 class="news-item-title">${title}</h3><div class="news-item-meta">${tag}${badge}${when}</div></div>');
+    expect(html).toContain('body.mobile-touch .news-item-head {\n    flex-direction: column;\n    align-items: flex-start;');
+    expect(html).toContain('body.mobile-touch .news-item-meta {\n    width: 100%;\n    margin-left: 0;');
+    expect(html).toContain('overflow-wrap: break-word;\n    word-break: normal;');
+    expect(html).toContain('body.mobile-touch .news-body {\n    text-align: left;');
+    expect(html).toContain('body.mobile-touch .news-body ul {\n    list-style: none;\n    padding-left: 0;');
+  });
+
   it('stacks selected character details on mobile', () => {
     expect(html).toContain('id="charselect-class-details"');
     expect(html).toContain('body.mobile-touch #charselect-panel #charselect-class-details .class-details-grid,\n  body.mobile-touch #charselect-panel #online-class-details .class-details-grid {\n    display: flex;\n    flex-direction: column;');


### PR DESCRIPTION
## Summary

Fix mobile layout issues in the News & Updates release cards.

- Wrap the release version/date/badge metadata in a dedicated row.
- On mobile, place that metadata row under the release heading instead of letting the date get pushed off to the side.
- Adjust release-note body wrapping so Highlights text stays left aligned and flows as readable paragraph-style blocks on mobile.

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts`

## Screenshots / recordings

N/A. Mobile CSS/layout fix for the homepage News & Updates view.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused client shell test passed.
- [ ] **Typecheck passes.** Not run; HTML/CSS and markup-only client change.
- [ ] **Builds succeed.** Not run; focused validation only.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; covered by targeted shell regression assertions.
- [x] **Accessible.** No new controls or user-facing strings; existing release content semantics remain intact.

### Localization (i18n)

- [x] **N/A. This PR adds no new player-visible strings.**

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
