### PR TITLE
fix(render): shrink oversized snow & rain precipitation sprites

### DIFF
--- a/scripts/weather_shot.mjs
+++ b/scripts/weather_shot.mjs
@@ -1,0 +1,59 @@
+// Ambient precipitation: capture snowfall in the peaks and rain in the marsh.
+// Verifies the precip sprites read as real flakes/drops, not boulders visible
+// from across the map. Needs `npm run dev` (:5173). Writes PNGs into tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Flurry');
+await page.evaluate(() => document.querySelector('#offline-select .mini-class[data-class="mage"]').click());
+await page.evaluate(() => document.querySelector('#btn-start-offline').click());
+await new Promise((r) => setTimeout(r, 3000));
+
+await page.evaluate(() => { const p = window.__game.sim.player; p.maxHp = p.hp = 99999; });
+
+// god-mode + teleport; let the precip field cross-fade in and animate.
+const tp = async (x, z, yaw = 0) => {
+  await page.evaluate((x, z, yaw) => {
+    const g = window.__game;
+    const p = g.sim.player;
+    if (p.dead) g.sim.releaseSpirit();
+    p.maxHp = p.hp = 99999;
+    p.pos.x = x; p.pos.z = z; p.facing = yaw;
+    g.input.camYaw = yaw;
+  }, x, z, yaw);
+  // precip cross-fades over ~2s; give it a few seconds to fill in + fall
+  await new Promise((r) => setTimeout(r, 4000));
+};
+
+// peaks -> snow, marsh -> rain (same z bands the motes tour uses)
+await tp(40, 720, 0.5);
+await page.screenshot({ path: 'tmp/weather_snow_peaks.png' });
+await tp(60, 360, 0.5);
+await page.screenshot({ path: 'tmp/weather_rain_marsh.png' });
+
+// report the live material size so the fix is verifiable in the log, not just by eye
+const stats = await page.evaluate(() => {
+  const w = window.__game.renderer.weather;
+  return { mode: w.mode, size: w.material.size, opacity: +w.material.opacity.toFixed(2) };
+});
+console.log('weather:', JSON.stringify(stats));
+console.log(errors.length ? 'ERRORS:\n' + errors.slice(0, 15).join('\n') : 'no page errors');
+await browser.close();

--- a/src/render/weather.ts
+++ b/src/render/weather.ts
@@ -31,10 +31,15 @@ interface PrecipStyle {
 }
 
 const STYLES: Record<Precip, PrecipStyle> = {
-  // soft, slow, wind-swayed flakes — sized up so they read against bright snowfields
-  snow: { color: 0xffffff, size: 2.7, fall: 6.5, fallVar: 2.5, sway: 1.6, target: 0.95, texture: 'flake' },
-  // fast, near-vertical streaks with a faint cool tint
-  rain: { color: 0x9fc4e0, size: 2.4, fall: 52, fallVar: 14, sway: 0.5, target: 0.7, texture: 'streak' },
+  // soft, slow, wind-swayed flakes. `size` is in world units (sizeAttenuation),
+  // so it must read as a real flake (~a hand's width), not a boulder — anything
+  // approaching a yard stays huge on screen even far off and looks like flying
+  // snowballs. Kept just above the ambient motes (0.5) so it still registers
+  // against bright snowfields.
+  snow: { color: 0xffffff, size: 0.45, fall: 6.5, fallVar: 2.5, sway: 1.6, target: 0.95, texture: 'flake' },
+  // fast, near-vertical streaks with a faint cool tint; a touch taller than a
+  // flake so the streak still reads, but nowhere near the old yard-long drops.
+  rain: { color: 0x9fc4e0, size: 0.6, fall: 52, fallVar: 14, sway: 0.5, target: 0.7, texture: 'streak' },
 };
 
 // Tiny deterministic RNG (mulberry32) so particle seeding never reaches for


### PR DESCRIPTION
## Problem
Ambient precipitation (`src/render/weather.ts`) renders with `sizeAttenuation: true`, so the `PointsMaterial` `size` is in **world units**. Snow was `2.7` and rain `2.4` world-units per sprite — each flake/drop drawn as a ~2.5-yard billboard. Combined with `frustumCulled = false` and a 70×70 camera-relative spawn box, the flakes stayed large on screen far from the camera, reading as **"snowballs" floating across the whole map** rather than falling snow. Rain had the identical oversizing.

## Fix
Bring both to believable physical sizes, just above the ambient motes (`0.5`) so they still register against bright snowfields without dominating the distance:

| precip | before | after |
|---|---|---|
| snow | 2.7 | **0.45** |
| rain | 2.4 | **0.6** |

Render-only, presentation-only change — determinism and sim state are untouched (weather is off the determinism contract, like the other ambient render effects).

Also adds `scripts/weather_shot.mjs` to capture snow (peaks) / rain (marsh) and log the live material size for verification.

## Before / After (snowfall in the peaks, same vantage)
Before (old 2.7 — giant snowballs visible into the distance):

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-weather-sizing/weather_before.png)

After (0.45 — subtle, believable flakes):

![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-weather-sizing/weather_after.png)

## Verification
- `npx tsc --noEmit` clean
- `npm test` → **2026 passed**, 9 skipped
- `node scripts/weather_shot.mjs` → `weather: {"mode":"rain","size":0.6,...}`, no page errors

cc maintainers with merge/push access: @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)