### PR TITLE
fix(ui): clean up Game Menu entries

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -462,10 +462,6 @@ export class Hud {
   private skinEventSelectedKey = '';
   private skinEventRevealTimer: number | null = null;
   private skinEventWheelAngle = 0;
-  // DEV-ONLY (remove with the dev button in renderOptions): when true the overlay
-  // was opened with mock data, so Lock In applies via the free changeSkin path
-  // instead of claimEventSkin (which needs a server-rolled rank + token).
-  private skinEventDev = false;
   // 'class' = per-class event skins; 'mech' = the Combat Mech chroma catalog.
   private skinEventMode: 'class' | 'mech' = 'class';
   // Pending lazy-load of the mech GLB + chromas; the reveal waits on it.
@@ -5449,18 +5445,16 @@ export class Hud {
 
   /** Open the skin-select overlay for a server-rolled rank, defaulting the
    *  selection to the best skin the rank unlocks.
-   *  `opts.dev` opens it with mock data (no token/roll) for quick previewing.
    *  `opts.mech` opens the real Combat Mech cosmetic catalog. */
-  openSkinEvent(rank: SkinRank, opts?: { dev?: boolean; mech?: boolean }): void {
+  openSkinEvent(rank: SkinRank, opts?: { mech?: boolean }): void {
     for (let i = 0; i < 20 && this.closeAll(); i++) { /* close stacked HUD overlays before the roll reveal */ }
     this.skinEventRank = rank;
-    this.skinEventDev = opts?.dev ?? false;
     this.skinEventMode = opts?.mech ? 'mech' : 'class';
     if (this.skinEventMode === 'mech') {
       // Kick off the lazy asset fetch; the reveal waits on it before rendering.
       this.mechAssetsPromise = preloadMechAssets();
     } else {
-      this.skinEventTiers = this.skinEventDev ? this.randomDevSkinTiers() : EVENT_SKIN_TIERS;
+      this.skinEventTiers = EVENT_SKIN_TIERS;
     }
     this.skinEventWheelAngle = this.randomSkinEventLandingAngle(rank);
     const selected = this.defaultChoiceSelection(rank);
@@ -5500,7 +5494,6 @@ export class Hud {
     this.skinEventRank = null;
     this.skinEventTiers = EVENT_SKIN_TIERS;
     this.skinEventMode = 'class';
-    this.skinEventDev = false;
     this.skinEventSelectedKey = '';
     this.skinEventWheelAngle = 0;
     audio.bagClose();
@@ -5508,28 +5501,6 @@ export class Hud {
 
   private skinTierKey(tier: SkinTier): string {
     return `${tier.rank}:${tier.skin}`;
-  }
-
-  private randomSkinEventRank(): SkinRank {
-    const roll = Math.random();
-    if (roll < 0.58) return 'uncommon';
-    if (roll < 0.88) return 'rare';
-    return 'epic';
-  }
-
-  private randomDevSkinTiers(): SkinTier[] {
-    const count = skinCount(`player_${this.sim.cfg.playerClass}`);
-    const preferred = Array.from({ length: Math.max(0, count - 1) }, (_, i) => i + 1);
-    const fallback = Array.from({ length: Math.max(1, count) }, (_, i) => i);
-    const source = preferred.length >= SKIN_RANKS.length ? preferred : fallback;
-    const pool = [...source];
-
-    return SKIN_RANKS.map((rank) => {
-      if (!pool.length) pool.push(...source);
-      const idx = Math.floor(Math.random() * pool.length);
-      const [skin] = pool.splice(idx, 1);
-      return { rank, skin: skin ?? 0 };
-    });
   }
 
   private randomSkinEventLandingAngle(rank: SkinRank): number {
@@ -5700,20 +5671,14 @@ export class Hud {
     lockInBtn.addEventListener('click', () => {
       if (this.skinEventSelected < 0 || lockInBtn.disabled) return;
       if (mech) {
-        if (this.skinEventDev) this.showBanner(t('skinEvent.previewOnly'));
-        else {
-          this.sim.claimEventSkin(this.skinEventSelected);
-          this.showBanner(t('skinEvent.unlocked'));
-        }
+        this.sim.claimEventSkin(this.skinEventSelected);
+        this.showBanner(t('skinEvent.unlocked'));
         audio.levelUp();
         this.closeSkinEvent();
         if ($('#bags').style.display !== 'none') this.renderBags();
         return;
       }
-      // Dev preview has no server-rolled rank/token, so apply via the free skin
-      // changer; the real event commits through claimEventSkin.
-      if (this.skinEventDev) this.sim.changeSkin(this.skinEventSelected);
-      else this.sim.claimEventSkin(this.skinEventSelected);
+      this.sim.claimEventSkin(this.skinEventSelected);
       this.showBanner(t('skinEvent.unlocked'));
       audio.levelUp();
       this.closeSkinEvent();
@@ -7445,11 +7410,6 @@ export class Hud {
     add(t('hud.options.graphics'), () => goto('graphics'));
     add(t('hud.options.interface'), () => goto('interface'));
     add(t('hud.options.audio'), () => goto('audio'));
-    add(t('hud.options.interface'), () => goto('interface'));
-    // DEV-ONLY temporary trigger (remove when the event ships): opens the
-    // skin-select overlay previewing the real Combat Mech chroma catalog, without
-    // the item/server flow. English literal is intentional — it's throwaway.
-    add('Skin Select (dev)', () => { this.closeOptions(); this.openSkinEvent(this.randomSkinEventRank(), { dev: true, mech: true }); });
     add(t('hud.options.logout'), () => this.optionsHooks?.logout());
     add(t('hud.options.returnToGame'), () => this.closeOptions());
     el.appendChild(list);

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -58,6 +58,12 @@ describe('client HTML shell', () => {
     expect(html).toContain('aria-label="Quest Log"');
   });
 
+  it('keeps the game menu free of duplicate and dev-only entries', () => {
+    const interfaceEntries = hudTs.match(/add\(t\('hud\.options\.interface'\), \(\) => goto\('interface'\)\);/g) ?? [];
+    expect(interfaceEntries).toHaveLength(1);
+    expect(hudTs).not.toContain('Skin Select (dev)');
+  });
+
   it('only displays mobile touch controls after the game is active', () => {
     expect(html).toContain('body.mobile-touch.game-active #mobile-controls');
     expect(html).not.toContain('body.mobile-touch #mobile-controls { position: absolute; inset: 0; display: block;');


### PR DESCRIPTION
## Summary

Fix incorrect entries in the in-game Game Menu.

- Remove the duplicate `Interface` menu item.
- Remove the temporary `Skin Select (dev)` menu item from the player-facing menu.
- Remove the now-unused dev-only skin preview path while keeping the real skin event and Combat Mech cosmetic flow intact.
- Add a regression check so the Game Menu does not reintroduce duplicate or dev-only entries.

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts`
  - `npx tsc --noEmit`

## Screenshots / recordings

N/A. Game Menu entry cleanup.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused client shell test passed.
- [x] **Typecheck passes.** `npx tsc --noEmit` passed.
- [ ] **Builds succeed.** Not run; focused validation only.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; covered by targeted shell regression assertions.
- [x] **Accessible.** Removes duplicate/dev-only controls; no new controls or strings added.

### Localization (i18n)

- [x] **N/A. This PR adds no new player-visible strings.**

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
