### PR TITLE
Revert mech cosmetic unequip return patch

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -6,7 +6,6 @@ import {
   cloneAllocation, computeTalentModifiers, emptyAllocation, talentPointsAtLevel, pointsSpent,
   type TalentAllocation, type SavedLoadout, type Role,
 } from '../sim/content/talents';
-import { mechChromaItemId, mechChromaSkinIndex } from '../sim/content/skins';
 import {
   Entity, EquipSlot, InvSlot, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
@@ -865,27 +864,6 @@ export class ClientWorld implements IWorld {
     this.cmd({ cmd: 'claim_event_skin', skin: idx });
   }
   unequipMechChroma(chromaId: string): void {
-    const itemId = mechChromaItemId(chromaId);
-    const skin = mechChromaSkinIndex(chromaId);
-    if (itemId && skin >= 0 && this.accountCosmetics.mechChromaIds.includes(chromaId)) {
-      this.accountCosmetics = {
-        ...this.accountCosmetics,
-        mechChromaIds: this.accountCosmetics.mechChromaIds.filter((id) => id !== chromaId),
-      };
-      const current = this.entities.get(this.playerId);
-      if (current?.skinCatalog === 'mech' && current.skin === skin) {
-        current.skin = 0;
-        current.skinCatalog = 'class';
-      }
-      const existing = this.inventory.find((slot) => slot.itemId === itemId);
-      this.inventory = existing
-        ? this.inventory.map((slot) => (
-          slot.itemId === itemId ? { ...slot, count: slot.count + 1 } : slot
-        ))
-        : [...this.inventory, { itemId, count: 1 }];
-      this.invChanged = true;
-      this.cosmeticsChanged = true;
-    }
     this.cmd({ cmd: 'unequip_mech_chroma', chroma: chromaId });
   }
   releaseSpirit(): void {

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -705,7 +705,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
   amber_crimson_armor_plate: {
     id: 'amber_crimson_armor_plate', name: 'Amber Crimson', kind: 'tool', quality: 'uncommon',
     use: { type: 'mechChroma', chromaId: 'amber_crimson' },
-    sellValue: 0, noVendorSell: true, noDiscard: true,
+    sellValue: 0, noVendorSell: true, noDiscard: true, noMarketList: true,
   },
   deacons_cleaver: {
     id: 'deacons_cleaver', name: "Deacon's Cleaver", kind: 'weapon', slot: 'mainhand', quality: 'uncommon',

--- a/tests/appearance_skin.test.ts
+++ b/tests/appearance_skin.test.ts
@@ -32,24 +32,17 @@ describe('appearance skin selection', () => {
     expect(sent).toEqual([{ t: 'cmd', cmd: 'change_skin', skin: 2, catalog: 'class' }]);
   });
 
-  it('sends the online mech chroma unequip command and mirrors the returned item immediately', () => {
+  it('sends the online mech chroma unequip command through the world contract', () => {
     const sent: unknown[] = [];
     const client: ClientWorld = Object.create(ClientWorld.prototype);
     Object.assign(client, {
       connected: true,
       ws: { readyState: 1, send: (raw: string) => sent.push(JSON.parse(raw)) },
-      playerId: 7,
-      entities: new Map([[7, { id: 7, skin: 0, skinCatalog: 'mech' }]]),
-      accountCosmetics: { completedQuestIds: [], mechChromaIds: ['amber_crimson'] },
-      inventory: [],
     });
     (globalThis as any).WebSocket = { OPEN: 1 };
 
     client.unequipMechChroma('amber_crimson');
 
-    expect(client.accountCosmetics.mechChromaIds).toEqual([]);
-    expect(client.player.skinCatalog).toBe('class');
-    expect(client.inventory).toEqual([{ itemId: 'amber_crimson_armor_plate', count: 1 }]);
     expect(sent).toEqual([{ t: 'cmd', cmd: 'unequip_mech_chroma', chroma: 'amber_crimson' }]);
   });
 });

--- a/tests/skin_event.test.ts
+++ b/tests/skin_event.test.ts
@@ -128,32 +128,6 @@ describe('cosmetic skin-select event', () => {
     expect(sim.countItem('amber_crimson_armor_plate')).toBe(0);
   });
 
-  it('returns a market-listable specific mech cosmetic item when unequipped', () => {
-    const sim = new Sim({ seed: 1, playerClass: 'shaman', playerName: 'Seller' });
-    const merchant = [...sim.entities.values()].find((e) => e.kind === 'npc' && e.templateId === 'the_merchant');
-    if (!merchant) throw new Error('merchant not found');
-    const pos = sim.groundPos(merchant.pos.x, merchant.pos.z);
-    sim.player.pos = { ...pos };
-    sim.player.prevPos = { ...pos };
-
-    sim.addItem('amber_crimson_armor_plate', 1);
-    sim.useItem('amber_crimson_armor_plate');
-    expect((sim as any).unequipMechChroma('amber_crimson')).toBe(true);
-
-    sim.sellItem('amber_crimson_armor_plate');
-    sim.discardItem('amber_crimson_armor_plate');
-    expect(sim.countItem('amber_crimson_armor_plate')).toBe(1);
-
-    sim.marketList('amber_crimson_armor_plate', 1, 100);
-
-    expect(sim.countItem('amber_crimson_armor_plate')).toBe(0);
-    expect(sim.marketListings.some((listing) => (
-      listing.itemId === 'amber_crimson_armor_plate'
-      && listing.sellerKey === 'Seller'
-      && listing.price === 100
-    ))).toBe(true);
-  });
-
   it('can equip a mech cosmetic as the active live appearance catalog', () => {
     const sim = new Sim({ seed: 1, playerClass: 'shaman', playerName: 'Mechwearer' });
 


### PR DESCRIPTION
## Summary
- Reverts `a7869be` (`fix: return tradable mech cosmetic on unequip`)
- Removes the dev-debugging unequip behavior and related focused assertions
- Leaves the other release/v0.10.1 changes intact

## Why
The unequip behavior is working locally but not on dev, so this backs out the patch from the release branch while the dev-only issue is investigated separately.

## Validation
- `npm test -- --run tests/skin_event.test.ts`