### PR TITLE
fix: prevent iOS Safari focus-zoom on mobile inputs (game + admin)

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -196,6 +196,20 @@
     border-color: #b34a3a;
     color: #ff7a5e;
   }
+
+  /* Mobile zoom prevention: operators are users too, and the dashboard ships to
+     phones/tablets. iOS Safari auto-zooms the page when a focused control renders
+     below 16px (and ignores the viewport settings), so floor every focusable control
+     at 16px on coarse-pointer (touch) devices. !important beats #login input's
+     id-specificity (14px); pointer:coarse leaves desktop operators (fine pointer) at
+     the compact 14px and is the only reliable cross-browser fix. */
+  @media (pointer: coarse) {
+    input,
+    textarea,
+    select {
+      font-size: 16px !important;
+    }
+  }
 </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -387,6 +387,23 @@
     cursor: text;
   }
 
+  /* Mobile zoom prevention: iOS Safari (10+) auto-zooms the page whenever a focused
+     text-entry control renders below 16px, and it ignores the viewport scale-lock
+     in the <meta> above (that obedience was dropped for accessibility). 16px is the
+     documented threshold. Floor every focusable control at 16px on coarse-pointer
+     (touch) devices, which also covers tablets/iPad that the JS-driven
+     body.mobile-touch class (gated to <=940px) would miss. !important guarantees the
+     floor wins over the small classic-font rules regardless of selector specificity
+     (e.g. .prompt .prompt-number, which out-specifies a plain catch-all); pointer:coarse
+     leaves desktop (fine pointer) untouched. New inputs are covered automatically. */
+  @media (pointer: coarse) {
+    input,
+    textarea,
+    select {
+      font-size: 16px !important;
+    }
+  }
+
   #nameplates { position: fixed; left: 0; top: 0; width: var(--app-vw); height: var(--app-vh); overflow: hidden; pointer-events: none; z-index: 1; }
   #ui { position: fixed; left: 0; top: 0; width: var(--app-vw); max-width: 100vw; height: var(--app-vh); overflow: hidden; pointer-events: none; z-index: 10; }
   #ui > * { pointer-events: auto; }

--- a/scripts/mobile_input_zoom_check.mjs
+++ b/scripts/mobile_input_zoom_check.mjs
@@ -1,0 +1,177 @@
+// Mobile input focus-zoom regression check.
+//
+// iOS Safari (and Android Chrome) auto-zoom the page when a focused text-entry control
+// renders below 16px. The fix floors every input/textarea/select at 16px on
+// coarse-pointer (touch) devices. A headless browser cannot reproduce the iOS zoom
+// animation itself, so this asserts the exact property that drives it: the COMPUTED
+// font-size of every form control is >= 16px on touch, while desktop keeps its small
+// classic-MMO fonts. Runs across several phone screen sizes and also covers admin.html.
+//
+//   npm run dev    # (separate terminal, serves :5173)
+//   node scripts/mobile_input_zoom_check.mjs
+//   BASE_URL=http://localhost:5173 node scripts/mobile_input_zoom_check.mjs
+
+import puppeteer from 'puppeteer-core';
+import { mkdirSync } from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const BASE = (process.env.BASE_URL || 'http://localhost:5173').replace(/\/$/, '');
+mkdirSync('tmp', { recursive: true });
+
+// A spread of real phone logical viewports (CSS px) plus one very small legacy size.
+const PHONES = [
+  { name: 'iphone-se', width: 375, height: 667, dsf: 2 },
+  { name: 'iphone-13', width: 390, height: 844, dsf: 3 },
+  { name: 'iphone-15-pro-max', width: 430, height: 932, dsf: 3 },
+  { name: 'pixel-7', width: 412, height: 915, dsf: 2.625 },
+  { name: 'galaxy-s8', width: 360, height: 740, dsf: 3 },
+  { name: 'small-android', width: 320, height: 568, dsf: 2 },
+];
+
+let pass = 0;
+let fail = 0;
+const check = (name, cond, extra = '') => {
+  if (cond) { pass++; } else { fail++; console.log(`  FAIL: ${name}${extra ? ' -- ' + extra : ''}`); }
+};
+
+// Injected representatives for controls that only exist once a HUD window opens, each
+// wrapped in the ancestor that gives its real (highest-specificity) base rule so the
+// cascade is authentic. Includes the two controls a low-specificity catch-all misses.
+const GAME_INJECT = `
+  <div class="prompt"><input class="prompt-number" type="number" value="1"></div>
+  <input class="cd-input" type="text">
+  <textarea class="cd-input"></textarea>
+  <div class="char-row"><input class="rename-input" maxlength="16"></div>
+  <div class="mkt-price-row"><input class="coininput" type="number" value="1"></div>
+  <label class="trade-money"><input type="number" value="0"></label>
+  <textarea id="report-details"></textarea>
+`;
+const ADMIN_INJECT = `
+  <form id="login"><input id="login-username"><input id="login-password" type="password"></form>
+  <input id="account-search">
+  <input class="account-custom-expiry" type="datetime-local">
+  <input id="cf-warnings" type="number">
+  <form class="word-add"><input maxlength="64"></form>
+`;
+
+// Runs in the page: inject the representatives, then measure every form control.
+function measure(injectHtml) {
+  const host = document.createElement('div');
+  host.id = '__zoomtest';
+  host.style.cssText = 'position:fixed;left:-99999px;top:0;'; // rendered (not display:none) but offscreen
+  host.innerHTML = injectHtml;
+  // Clone <template> contents (the HUD markup, e.g. #chat-input) into the live DOM so
+  // template-defined controls are measured under the real cascade, not left inert.
+  for (const tpl of document.querySelectorAll('template')) {
+    host.appendChild(tpl.content.cloneNode(true));
+  }
+  document.body.appendChild(host);
+  const out = [];
+  for (const el of document.querySelectorAll('input, textarea, select')) {
+    const cs = getComputedStyle(el);
+    out.push({
+      tag: el.tagName.toLowerCase(),
+      type: (el.getAttribute('type') || '').toLowerCase(),
+      id: el.id || '',
+      cls: el.className || '',
+      px: parseFloat(cs.fontSize),
+      injected: host.contains(el),
+    });
+  }
+  return {
+    coarse: matchMedia('(pointer: coarse)').matches,
+    fine: matchMedia('(pointer: fine)').matches,
+    controls: out,
+  };
+}
+
+const label = (c) => `${c.tag}${c.type ? '[' + c.type + ']' : ''}${c.id ? '#' + c.id : ''}${c.cls ? '.' + String(c.cls).trim().split(/\s+/).join('.') : ''}`;
+// type=range / checkbox / radio / color / file / button do not render text, so font-size
+// never triggers focus-zoom on them -- exclude from the >=16 assertion (the rule still
+// harmlessly applies, we just do not require it).
+const NON_TEXT = new Set(['range', 'checkbox', 'radio', 'color', 'file', 'button', 'submit', 'reset', 'image']);
+const isTextEntry = (c) => !(c.tag === 'input' && NON_TEXT.has(c.type));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: true,
+  args: ['--use-angle=swiftshader', '--no-sandbox', '--disable-dev-shm-usage'],
+});
+
+async function loadTouch(url, viewport) {
+  const ctx = await browser.createBrowserContext();
+  const page = await ctx.newPage();
+  await page.setViewport({ ...viewport, isMobile: true, hasTouch: true, deviceScaleFactor: viewport.dsf });
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // Belt: force the coarse-pointer media so the @media(pointer:coarse) gate is exercised
+  // even if device-metrics emulation alone did not flip it.
+  try {
+    const client = await page.target().createCDPSession();
+    await client.send('Emulation.setEmulatedMedia', { features: [{ name: 'pointer', value: 'coarse' }] });
+  } catch { /* feature not emulable on this Chrome; rely on device emulation */ }
+  return { ctx, page };
+}
+
+console.log(`\n=== GAME CLIENT (${BASE}/) across ${PHONES.length} phone sizes ===`);
+for (const v of PHONES) {
+  const { ctx, page } = await loadTouch(`${BASE}/`, v);
+  const r = await page.evaluate(measure, GAME_INJECT);
+  check(`[${v.name}] pointer:coarse matches`, r.coarse, `coarse=${r.coarse} fine=${r.fine}`);
+  const textControls = r.controls.filter(isTextEntry);
+  const bad = textControls.filter((c) => !(c.px >= 16));
+  check(`[${v.name}] all ${textControls.length} text controls >= 16px`, bad.length === 0,
+    bad.map((c) => `${label(c)}=${c.px}px`).join(', '));
+  if (v.name === 'iphone-13') {
+    console.log(`  measured (${textControls.length} text controls): ` +
+      textControls.map((c) => `${label(c)}=${c.px}`).join(' | '));
+  }
+  await page.screenshot({ path: `tmp/zoom_game_${v.name}.png` }).catch(() => {});
+  await ctx.close();
+}
+
+console.log(`\n=== ADMIN (${BASE}/admin.html) across ${PHONES.length} phone sizes ===`);
+for (const v of PHONES) {
+  const { ctx, page } = await loadTouch(`${BASE}/admin.html`, v);
+  const r = await page.evaluate(measure, ADMIN_INJECT);
+  check(`[admin ${v.name}] pointer:coarse matches`, r.coarse);
+  const textControls = r.controls.filter(isTextEntry);
+  const bad = textControls.filter((c) => !(c.px >= 16));
+  check(`[admin ${v.name}] all ${textControls.length} text controls >= 16px`, bad.length === 0,
+    bad.map((c) => `${label(c)}=${c.px}px`).join(', '));
+  if (v.name === 'iphone-13') {
+    console.log(`  measured (${textControls.length} text controls): ` +
+      textControls.map((c) => `${label(c)}=${c.px}`).join(' | '));
+    await page.screenshot({ path: `tmp/zoom_admin_${v.name}.png` }).catch(() => {});
+  }
+  await ctx.close();
+}
+
+// Desktop regression: a fine/none pointer context must NOT trigger the floor, so the
+// small classic fonts must be retained (proves the fix is mobile-only).
+console.log(`\n=== DESKTOP regression (small fonts retained) ===`);
+{
+  const ctx = await browser.createBrowserContext();
+  const page = await ctx.newPage();
+  await page.setViewport({ width: 1440, height: 900, isMobile: false, hasTouch: false, deviceScaleFactor: 1 });
+  await page.goto(`${BASE}/`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  const r = await page.evaluate(measure, GAME_INJECT);
+  check('desktop is NOT pointer:coarse', !r.coarse, `coarse=${r.coarse}`);
+  const cd = r.controls.find((c) => c.tag === 'input' && /\bcd-input\b/.test(c.cls));
+  const pn = r.controls.find((c) => /\bprompt-number\b/.test(c.cls));
+  check('desktop .cd-input stays 12px', cd && Math.abs(cd.px - 12) < 0.6, cd ? `${cd.px}px` : 'not found');
+  check('desktop .prompt-number stays 12px', pn && Math.abs(pn.px - 12) < 0.6, pn ? `${pn.px}px` : 'not found');
+  await ctx.close();
+
+  const actx = await browser.createBrowserContext();
+  const apage = await actx.newPage();
+  await apage.setViewport({ width: 1440, height: 900, isMobile: false, hasTouch: false, deviceScaleFactor: 1 });
+  await apage.goto(`${BASE}/admin.html`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  const ar = await apage.evaluate(measure, ADMIN_INJECT);
+  const lu = ar.controls.find((c) => c.id === 'login-username');
+  check('desktop admin #login-username stays 14px', lu && Math.abs(lu.px - 14) < 0.6, lu ? `${lu.px}px` : 'not found');
+  await actx.close();
+}
+
+await browser.close();
+console.log(`\n==== ${pass} passed, ${fail} failed ====`);
+process.exit(fail > 0 ? 1 : 0);

--- a/src/admin/CLAUDE.md
+++ b/src/admin/CLAUDE.md
@@ -54,3 +54,10 @@ A new backend endpoint must be added in `server/admin.ts` first (see server/CLAU
   re-checks admin on every request; the UI gate is cosmetic.
 - `$('id')` throws if the element is missing — keep `admin.html` ids in sync with `main.ts`.
 - Don't import anything from `src/sim`, `src/render`, `src/ui`, `src/net`, or `IWorld` here.
+- **Mobile zoom:** operators are users, and the dashboard ships to phones/tablets. Every
+  `input`/`textarea`/`select` must render **≥16px** on touch or iOS Safari zooms the page
+  on focus. A `@media (pointer: coarse) { input, textarea, select { font-size: 16px !important } }`
+  floor in `admin.html` enforces this centrally (the `!important` beats id-specific rules
+  like `#login input`); keep it and don't add a per-control mobile font below 16px. Don't
+  add `user-scalable=no`/`maximum-scale` to the viewport (a WCAG failure that iOS ignores
+  for focus-zoom anyway). Check: `node scripts/mobile_input_zoom_check.mjs`.

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -32,7 +32,13 @@ held to these — verify in mobile portrait *and* landscape before calling UI wo
 - **Mobile touch** (gate on touch capability / runtime state, not only `max-width` —
   landscape phones need it too):
   - Every visible `input`/`select`/`textarea` is **≥16px** font, or iOS Safari
-    auto-zooms the page on focus.
+    auto-zooms the page on focus (iOS 10+ ignores the viewport `user-scalable=no`/
+    `maximum-scale`, so font-size is the only reliable fix). This is enforced centrally
+    by a `@media (pointer: coarse) { input, textarea, select { font-size: 16px !important } }`
+    floor in `index.html` (mirrored in `admin.html`), so new controls are covered for free
+    even when their own rule out-specifies a plain catch-all; the `!important` is what
+    wins. Don't set a per-control mobile font below 16px, and don't lean on the viewport
+    scale-lock. Regression check: `node scripts/mobile_input_zoom_check.mjs` (needs `npm run dev`).
   - Every tappable target (buttons, links, selects, tabs, icon-only controls, anything
     with `role="button"|"tab"|"option"`) is **≥40×40px**.
   - Narrow headers collapse to a hamburger drawer rather than wrapping/overflowing.


### PR DESCRIPTION
## Summary

On mobile, tapping any text field zoomed the whole page in. iOS Safari (10+)
auto-zooms the viewport whenever a focused `input`/`textarea`/`select` renders
below **16px**, and it deliberately ignores the viewport `user-scalable=no` /
`maximum-scale` (that obedience was dropped for accessibility), so the scale-lock
already in `index.html` did nothing. The repo only had a scattered allowlist of
per-component `body.mobile-touch` 16px overrides, which left gaps: the save/import
modal (`.cd-input`), the destroy/sell quantity prompts (`.prompt-number`, which
auto-focus), the character-select rename field, and the **entire admin dashboard**
(no mobile handling at all).

This adds one global floor in each HTML entry:

```css
@media (pointer: coarse) {
  input, textarea, select { font-size: 16px !important; }
}
```

- **`pointer: coarse`** covers phones *and* tablets, including a landscape iPad
  that the JS `body.mobile-touch` class misses (it is capped at `max-width: 940px`),
  and it never affects desktop (fine pointer), so the small classic-MMO fonts are
  unchanged there.
- **`!important`** is required to beat the higher-specificity small-font rules a
  plain catch-all would lose to: `.prompt .prompt-number` uses a two-class `font:`
  shorthand and admin `#login input` is id-specific.

It also documents the rule and its central enforcement in `src/ui/CLAUDE.md` and
`src/admin/CLAUDE.md`, and adds a headless regression check
(`scripts/mobile_input_zoom_check.mjs`).

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `node scripts/mobile_input_zoom_check.mjs` (with `npm run dev` running):
    **28/28 checks pass** across 6 phone viewports (iPhone SE / 13 / 15 Pro Max,
    Pixel 7, Galaxy S8, 320px Android) for both the game client and the admin page.
    Every `input`/`textarea`/`select` (14 game controls + 9 admin controls,
    including the previously at-risk `.cd-input`, `.prompt-number`, rename field,
    and `#login`) computes to **16px** on coarse-pointer, and a desktop
    (fine-pointer) context confirms the small fonts are retained (`.cd-input` 12px,
    `.prompt-number` 12px, admin login 14px).
  - `npm run build` (green).
  - `npm test` (2064 passed, 9 skipped).
  - `npx tsc --noEmit` (clean).
- Manual steps: inspected the game start screen and admin login at the smallest
  (320px) and largest phone sizes for overflow / layout shift; both render cleanly.

## Screenshots / recordings

The change is font-size-only: on mobile, input *text* renders at 16px instead of
12-14px; desktop is pixel-identical. Verified no overflow or layout shift on the
game start screen and admin login across all six phone sizes (screenshots captured
locally under `tmp/`).

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. No `sim/`/`server/` behavior changed
      (CSS + docs + a browser-driven regression script), so no unit tests were
      needed; the new `scripts/mobile_input_zoom_check.mjs` covers the behavior.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` is green. `build:server` / `build:env`
      not touched (N/A).

### Cross-platform

- [x] **Tested on desktop and mobile.** This is the change's whole domain:
      verified across six phone viewports and a desktop context. Inputs are now
      >=16px font on touch; no touch targets were changed.
- [x] **Accessible.** This is an accessibility improvement: focused inputs are
      legible at 16px and, unlike `user-scalable=no`, the fix preserves pinch-zoom
      (we did not add any scale-lock). No new interactive UI.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (CSS, a code comment, and a
      Node script only).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled anywhere.
- [x] I didn't hand-edit any generated files.
