### PR TITLE
fix(mobile): make High Scores responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -2230,6 +2230,129 @@
   .hs-lvl, .hs-vlvl { text-align: center; }
   .hs-xp { text-align: right; color: #ffe27a; font-variant-numeric: tabular-nums; }
   .hs-prestige { color: #ffd100; font-size: 11px; margin-right: 4px; }
+  body.mobile-touch .hs-panel {
+    width: 100%;
+    max-width: 560px;
+    padding: var(--spacing-md);
+  }
+  body.mobile-touch .hs-leaderboard {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+  body.mobile-touch .hs-head {
+    display: none;
+  }
+  body.mobile-touch .hs-row {
+    grid-template-columns: 38px minmax(0, 1fr);
+    grid-template-areas:
+      "rank name"
+      "rank realm"
+      "rank lvl"
+      "rank vlvl"
+      "rank xp";
+    align-items: start;
+    gap: 4px 10px;
+    padding: 10px 12px;
+    border: 1px solid rgba(78, 61, 29, 0.35);
+    background: rgba(255, 255, 255, 0.025);
+  }
+  body.mobile-touch .hs-rank { grid-area: rank; align-self: center; }
+  body.mobile-touch .hs-name {
+    grid-area: name;
+    min-width: 0;
+  }
+  body.mobile-touch .hs-realm { grid-area: realm; }
+  body.mobile-touch .hs-lvl { grid-area: lvl; }
+  body.mobile-touch .hs-vlvl { grid-area: vlvl; }
+  body.mobile-touch .hs-xp { grid-area: xp; }
+  body.mobile-touch .hs-realm,
+  body.mobile-touch .hs-lvl,
+  body.mobile-touch .hs-vlvl,
+  body.mobile-touch .hs-xp {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    min-width: 0;
+    text-align: right;
+  }
+  body.mobile-touch .hs-realm::before,
+  body.mobile-touch .hs-lvl::before,
+  body.mobile-touch .hs-vlvl::before,
+  body.mobile-touch .hs-xp::before {
+    content: attr(data-label);
+    color: var(--color-primary-dim);
+    font-family: var(--font-heading);
+    font-size: 10px;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+
+  @media (max-width: 680px) {
+    .hs-panel {
+      width: 100%;
+      max-width: 560px;
+      padding: var(--spacing-md);
+    }
+    .hs-leaderboard {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 0;
+      overflow-x: hidden;
+    }
+    .hs-head {
+      display: none;
+    }
+    .hs-row {
+      grid-template-columns: 38px minmax(0, 1fr);
+      grid-template-areas:
+        "rank name"
+        "rank realm"
+        "rank lvl"
+        "rank vlvl"
+        "rank xp";
+      align-items: start;
+      gap: 4px 10px;
+      padding: 10px 12px;
+      border: 1px solid rgba(78, 61, 29, 0.35);
+      background: rgba(255, 255, 255, 0.025);
+    }
+    .hs-rank { grid-area: rank; align-self: center; }
+    .hs-name {
+      grid-area: name;
+      min-width: 0;
+    }
+    .hs-realm { grid-area: realm; }
+    .hs-lvl { grid-area: lvl; }
+    .hs-vlvl { grid-area: vlvl; }
+    .hs-xp { grid-area: xp; }
+    .hs-realm,
+    .hs-lvl,
+    .hs-vlvl,
+    .hs-xp {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--spacing-sm);
+      min-width: 0;
+      text-align: right;
+    }
+    .hs-realm::before,
+    .hs-lvl::before,
+    .hs-vlvl::before,
+    .hs-xp::before {
+      content: attr(data-label);
+      color: var(--color-primary-dim);
+      font-family: var(--font-heading);
+      font-size: 10px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+    }
+  }
 
   /* News & Updates view (mirrored from GitHub Releases) */
   .news-panel {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2549,23 +2549,29 @@ async function loadHighscores(): Promise<void> {
     return;
   }
   const esc = (s: string): string => s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]!));
+  const rankLabel = t('game.leaderboard.rank');
+  const nameLabel = t('game.leaderboard.name');
+  const realmLabel = t('game.leaderboard.realmCol');
+  const levelLabel = t('game.leaderboard.level');
+  const virtualLevelLabel = t('game.leaderboard.vlevel');
+  const lifetimeXpLabel = t('game.leaderboard.lifetimeXp');
   const head = `<div class="hs-row hs-head">`
-    + `<span class="hs-rank">${t('game.leaderboard.rank')}</span>`
-    + `<span class="hs-name">${t('game.leaderboard.name')}</span>`
-    + `<span class="hs-realm">${t('game.leaderboard.realmCol')}</span>`
-    + `<span class="hs-lvl">${t('game.leaderboard.level')}</span>`
-    + `<span class="hs-vlvl">${t('game.leaderboard.vlevel')}</span>`
-    + `<span class="hs-xp">${t('game.leaderboard.lifetimeXp')}</span></div>`;
+    + `<span class="hs-rank">${rankLabel}</span>`
+    + `<span class="hs-name">${nameLabel}</span>`
+    + `<span class="hs-realm">${realmLabel}</span>`
+    + `<span class="hs-lvl">${levelLabel}</span>`
+    + `<span class="hs-vlvl">${virtualLevelLabel}</span>`
+    + `<span class="hs-xp">${lifetimeXpLabel}</span></div>`;
   const body = rows.map((r) => {
     const cls = CLASSES[r.cls];
     const star = r.prestigeRank > 0 ? `<span class="hs-prestige" title="${t('game.prestige.rank')} ${r.prestigeRank}">★${r.prestigeRank}</span>` : '';
     return `<div class="hs-row${r.rank <= 3 ? ' hs-top' : ''}">`
       + `<span class="hs-rank">${r.rank}</span>`
       + `<span class="hs-name"${cls ? ` title="${esc(classDisplayName(r.cls))}"` : ''}>${star}${esc(r.name)}</span>`
-      + `<span class="hs-realm">${esc(r.realm ?? '')}</span>`
-      + `<span class="hs-lvl">${r.level}</span>`
-      + `<span class="hs-vlvl">${r.virtualLevel}</span>`
-      + `<span class="hs-xp">${formatXp(r.lifetimeXp)}</span></div>`;
+      + `<span class="hs-realm" data-label="${esc(realmLabel)}">${esc(r.realm ?? '')}</span>`
+      + `<span class="hs-lvl" data-label="${esc(levelLabel)}">${r.level}</span>`
+      + `<span class="hs-vlvl" data-label="${esc(virtualLevelLabel)}">${r.virtualLevel}</span>`
+      + `<span class="hs-xp" data-label="${esc(lifetimeXpLabel)}">${formatXp(r.lifetimeXp)}</span></div>`;
   }).join('');
   host.innerHTML = head + body;
 }

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -174,6 +174,15 @@ describe('client HTML shell', () => {
     expect(html).toContain('body.mobile-touch .news-body ul {\n    list-style: none;\n    padding-left: 0;');
   });
 
+  it('renders the high scores leaderboard responsively on mobile', () => {
+    expect(mainTs).toContain('<span class="hs-realm" data-label="${esc(realmLabel)}">${esc(r.realm ?? \'\')}</span>');
+    expect(mainTs).toContain('<span class="hs-xp" data-label="${esc(lifetimeXpLabel)}">${formatXp(r.lifetimeXp)}</span>');
+    expect(html).toContain('body.mobile-touch .hs-head {\n    display: none;');
+    expect(html).toContain('body.mobile-touch .hs-row {\n    grid-template-columns: 38px minmax(0, 1fr);');
+    expect(html).toContain('grid-template-areas:\n      "rank name"\n      "rank realm"\n      "rank lvl"\n      "rank vlvl"\n      "rank xp";');
+    expect(html).toContain('body.mobile-touch .hs-realm::before,\n  body.mobile-touch .hs-lvl::before,\n  body.mobile-touch .hs-vlvl::before,\n  body.mobile-touch .hs-xp::before {\n    content: attr(data-label);');
+  });
+
   it('stacks selected character details on mobile', () => {
     expect(html).toContain('id="charselect-class-details"');
     expect(html).toContain('body.mobile-touch #charselect-panel #charselect-class-details .class-details-grid,\n  body.mobile-touch #charselect-panel #online-class-details .class-details-grid {\n    display: flex;\n    flex-direction: column;');


### PR DESCRIPTION
## Summary

Fix the homepage High Scores leaderboard on mobile.

- Render leaderboard rows as stacked, labeled cards on mobile-touch and narrow viewports.
- Keep the desktop six-column table layout for larger screens.
- Add translated data labels for mobile-only Realm, Level, Virtual Level, and Lifetime XP fields.
- Add a client shell regression check for the mobile leaderboard layout.

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts`
  - `npx tsc --noEmit`

## Screenshots / recordings

N/A. Mobile responsive layout fix for the homepage High Scores view.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused client shell test passed.
- [x] **Typecheck passes.** `npx tsc --noEmit` passed.
- [ ] **Builds succeed.** Not run; focused validation only.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; covered by targeted shell regression assertions.
- [x] **Accessible.** No new controls or strings; mobile labels reuse existing translated leaderboard column labels.

### Localization (i18n)

- [x] **N/A. This PR adds no new player-visible strings.** Existing translated leaderboard labels are reused.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
