### PR TITLE
fix(server): guard character saves during relog

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -339,6 +339,7 @@ export class GameServer {
   private saveTimer = 0;
   private socialPosTimer = 0;
   private saveAllInFlight: Promise<void> | null = null;
+  private readonly characterSaveQueues = new Map<number, Promise<void>>();
   private restartCountdownStartedAt: number | null = null;
   private readonly restartCountdownTimers: NodeJS.Timeout[] = [];
   private readonly startedAt = Date.now();
@@ -742,10 +743,9 @@ export class GameServer {
   }
 
   async leave(session: ClientSession, reason: string): Promise<void> {
-    if (!this.clients.has(session.pid)) return;
+    if (session.left || !this.clients.has(session.pid)) return;
     session.left = true;
     this.clients.delete(session.pid);
-    this.sessionsByCharacterId.delete(session.characterId);
     if (session.ip) {
       const prev = this.ipSessionCounts.get(session.ip) ?? 1;
       if (prev <= 1) this.ipSessionCounts.delete(session.ip);
@@ -760,20 +760,32 @@ export class GameServer {
       void closePlaySession(session.dbSessionId).catch((err) => console.error('failed to close play session:', err));
     }
     await this.saveCharacter(session).catch((err) => console.error('save on leave failed:', err));
+    this.sessionsByCharacterId.delete(session.characterId);
     this.sim.removePlayer(session.pid);
     // Departures are no longer broadcast to the realm — the leaving player has
     // already disconnected, so there is no one to show their own notice to.
   }
 
   async saveCharacter(session: ClientSession): Promise<void> {
-    const state = this.sim.serializeCharacter(session.pid);
-    const e = this.sim.entities.get(session.pid);
-    if (state && e) {
-      // Use the SERIALIZED level (not e.level): during a 2v2 Fiesta bout e.level
-      // is temporarily 20, but serializeCharacter reports the real level — so the
-      // character-list/leaderboard `level` column never reflects the temp state.
-      await saveCharacterState(session.characterId, state.level, state);
-      session.lastSave = Date.now();
+    const previous = this.characterSaveQueues.get(session.characterId);
+    const run = (previous ? previous.catch(() => {}) : Promise.resolve()).then(async () => {
+      const state = this.sim.serializeCharacter(session.pid);
+      const e = this.sim.entities.get(session.pid);
+      if (state && e) {
+        // Use the SERIALIZED level (not e.level): during a 2v2 Fiesta bout e.level
+        // is temporarily 20, but serializeCharacter reports the real level — so the
+        // character-list/leaderboard `level` column never reflects the temp state.
+        await saveCharacterState(session.characterId, state.level, state);
+        session.lastSave = Date.now();
+      }
+    });
+    this.characterSaveQueues.set(session.characterId, run);
+    try {
+      await run;
+    } finally {
+      if (this.characterSaveQueues.get(session.characterId) === run) {
+        this.characterSaveQueues.delete(session.characterId);
+      }
     }
   }
 

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -19,6 +19,7 @@ vi.mock('../server/db', () => ({
 }));
 
 import { GameServer, type ClientSession } from '../server/game';
+import { saveCharacterState } from '../server/db';
 
 function fakeWs() {
   return {
@@ -149,6 +150,62 @@ describe('GameServer sessions', () => {
 
     const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
     expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
+  });
+
+  it('blocks a fast relog until the disconnect save releases the character id', async () => {
+    const server = new GameServer();
+    const first = expectJoined(server.join(fakeWs(), 11, 101, 'Indexa', 'warrior', null));
+
+    let resolveSave!: () => void;
+    const slowSave = new Promise<void>((resolve) => { resolveSave = resolve; });
+    vi.mocked(saveCharacterState).mockImplementationOnce(() => slowSave);
+
+    const leaving = server.leave(first, 'test');
+    await vi.waitFor(() => {
+      expect(saveCharacterState).toHaveBeenCalled();
+    });
+
+    expect((server as any).sessionByCharacterId(101)).toBe(first);
+    expect(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null)).toEqual({
+      error: 'character already in world',
+    });
+
+    resolveSave();
+    await leaving;
+
+    expect((server as any).sessionByCharacterId(101)).toBeNull();
+    const rejoined = expectJoined(server.join(fakeWs(), 13, 101, 'Indexa', 'warrior', null));
+    expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
+  });
+
+  it('serializes overlapping saves for one character so an older write cannot land last', async () => {
+    vi.mocked(saveCharacterState).mockReset();
+    vi.mocked(saveCharacterState).mockResolvedValue(undefined);
+
+    const server = new GameServer();
+    const session = expectJoined(server.join(fakeWs(), 11, 101, 'Saverace', 'warrior', null));
+
+    let resolveFirstSave!: () => void;
+    const firstSave = new Promise<void>((resolve) => { resolveFirstSave = resolve; });
+    vi.mocked(saveCharacterState).mockImplementationOnce(() => firstSave);
+
+    const first = server.saveCharacter(session);
+    await vi.waitFor(() => {
+      expect(saveCharacterState).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(saveCharacterState).mock.calls[0][2].questsDone).not.toContain('q_wolves');
+
+    server.sim.meta(session.pid)!.questsDone.add('q_wolves');
+    const second = server.saveCharacter(session);
+    await Promise.resolve();
+    expect(saveCharacterState).toHaveBeenCalledTimes(1);
+
+    resolveFirstSave();
+    await first;
+    await second;
+
+    expect(saveCharacterState).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(saveCharacterState).mock.calls[1][2].questsDone).toContain('q_wolves');
   });
 
   it('closes the play session even when the open insert lands after the player has left', async () => {


### PR DESCRIPTION
## Summary

  Fixes a character persistence race where a fast logout/relog could load stale quest state from the database before the previous session's disconnect save finished.

  The server now keeps the character ID reserved until the disconnect save completes, so a fast relog is briefly rejected instead of loading old state. Character saves are also serialized per character so an older
  autosave cannot land after a newer save and overwrite progress.

  ## Related issues

  N/A

  ## Type of change

  - [ ] Feature: new functionality
  - [x] Bug fix
  - [ ] Refactor or performance (no behavior change)
  - [ ] Documentation
  - [x] Tests
  - [ ] Build, CI, or tooling
  - [ ] Breaking change (please call it out in the summary)

  ## How was this tested?

  - Commands:
    - `npx vitest run tests/game_sessions.test.ts tests/snapshots.test.ts tests/fixes.test.ts`

  - Manual steps:
    - Reproduced the bug locally on unpatched `release/v0.10.1` by adding a temporary local Postgres trigger that delayed `characters.state` saves by 20 seconds.
    - Completed/advanced quest state, logged out, immediately re-entered the same character during the delayed save, and confirmed quest state reverted.
    - Reapplied this fix with the same 20-second DB delay still active.
    - Repeated the same fast relog flow and confirmed re-entry was blocked with `Character is already in world` until the disconnect save completed.
    - After retrying post-save, confirmed the character loaded at the correct saved state.

  ## Screenshots / recordings

  N/A. Server-side persistence fix only.

  ---

  ## Checklist

  ### Quality

  - [x] **Tests pass.** `npm test` is green. I added or updated tests for any
        `sim/` or `server/` behavior I changed.
  - [ ] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
        TypeScript `strict`).
  - [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
        `npm run build:env` if I touched those.

  ### Cross-platform

  - [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
        phone-sized viewport in both portrait and landscape. Touch targets stay at
        least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
  - [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
        respect for `prefers-reduced-motion` (only if this change adds or edits UI).

  ### Localization (i18n)

  - [ ] **New player-visible strings are translated into every supported locale.**
        Every user-facing string is a `t()` key, added to `en` first, then given a
        real translation in every locale in `supportedLanguages`
        (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
  - [ ] Numbers, money, dates, units, and percents go through the i18n formatters
        (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
  - [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
        the client boundary in this same change, and
        `npx vitest run tests/localization_fixes.test.ts` passes.
  - [x] N/A. This PR adds no player-visible strings.

  ### Hygiene

  - [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
        not enabled in any production path.
  - [x] I didn't hand-edit generated files such as
        `src/render/assets/manifest.generated.ts`. They're regenerated by the build.