### PR TITLE
fix(sim): walk down slopes instead of detaching mid-hill

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2066,7 +2066,15 @@ export class Sim {
         p.fallStartY = ground;
       }
     } else {
-      if (ground < p.pos.y - 0.4) {
+      // Distinguish a walkable downhill slope from a genuine cliff/ledge. The
+      // drop the ground can take in one tick scales with how far we moved: a
+      // slope no steeper than MAX_CLIMB_SLOPE (the same gate that blocks uphill
+      // climbs) is walkable, so we snap down to follow it instead of falling.
+      // Only a steeper-than-walkable drop counts as walking off a ledge. The
+      // 0.4 base keeps a near-stationary player snapped over tiny terrain noise.
+      const run = Math.hypot(p.pos.x - p.prevPos.x, p.pos.z - p.prevPos.z);
+      const maxStepDown = 0.4 + run * MAX_CLIMB_SLOPE;
+      if (ground < p.pos.y - maxStepDown) {
         // walked off a ledge — not a jump, so fences still block
         p.onGround = false;
         p.jumping = false;

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -262,6 +262,47 @@ describe('movement directions', () => {
     expect(sim.player.pos.z).toBeGreaterThan(zAtLaunch);
     expect(Math.abs(sim.player.pos.x - xAtLaunch)).toBeLessThan(0.05);
   });
+
+  it('walks down a walkable slope without going airborne', () => {
+    const seed = 42;
+    // One run-tick covers ~0.35 yd horizontally (RUN_SPEED 7 * DT 1/20). Find a
+    // dry spot whose forward terrain drops more than the old fixed 0.4 ledge
+    // threshold yet stays within the walkable MAX_CLIMB_SLOPE (1.5) — exactly the
+    // case that used to fling the player off a "ledge" mid-hill.
+    const STEP = 0.35;
+    // A dry forward step that drops more than the old 0.4 ledge threshold yet
+    // stays within the walkable MAX_CLIMB_SLOPE (1.5, so <= 0.525 over one step).
+    let found: { x: number; z: number; facing: number } | null = null;
+    outer:
+    for (let x = -250; x <= 250 && !found; x += 2) {
+      for (let z = -250; z <= 250; z += 2) {
+        if (terrainHeight(x, z, seed) < WATER_LEVEL) continue;
+        for (let f = 0; f < Math.PI * 2; f += Math.PI / 12) {
+          const h0 = terrainHeight(x, z, seed);
+          const h1 = terrainHeight(x + Math.sin(f) * STEP, z + Math.cos(f) * STEP, seed);
+          const drop = h0 - h1;
+          if (drop > 0.42 && drop <= STEP * 1.5 && h1 > WATER_LEVEL) {
+            found = { x, z, facing: f };
+            break outer;
+          }
+        }
+      }
+    }
+    expect(found).not.toBeNull();
+    const sim = makeSim('warrior', seed);
+    teleportTo(sim, found!.x, found!.z);
+    sim.player.facing = found!.facing;
+    const y0 = sim.player.pos.y;
+    sim.moveInput.forward = true;
+    sim.tick();
+    // Descended past the old 0.4 ledge threshold but stayed glued to the ground
+    // instead of being flung into a fall (the bug forced a jump to get down).
+    expect(sim.player.onGround).toBe(true);
+    expect(sim.player.vy).toBe(0);
+    expect(y0 - sim.player.pos.y).toBeGreaterThan(0.4);
+    expect(sim.player.pos.y).toBeCloseTo(
+      terrainHeight(sim.player.pos.x, sim.player.pos.z, seed), 5);
+  });
 });
 
 describe('combat', () => {


### PR DESCRIPTION
## Problem

Running **down** hills is broken: you have to jump to get down, while you can walk **up** a slope at any angle. On a normal hillside, holding *forward* downhill leaves the character stuck stuttering near the top — only a jump makes progress down the slope.

## Root cause

The grounded branch of the vertical-physics step in `src/sim/sim.ts` decided "did I walk off a ledge?" with a **fixed 0.4 yd** vertical threshold:

```ts
if (ground < p.pos.y - 0.4) {   // any drop > 0.4 yd ⇒ treated as a ledge
  p.onGround = false; ...
}
```

At run speed the player covers ~0.35 yd per 20 Hz tick (`RUN_SPEED 7 × DT 1/20`), so any walkable downhill steeper than ~`0.4 / 0.35 ≈ 1.14` rise/run crossed that threshold every tick. The player detached, horizontal velocity was zeroed, they fell straight back down, re-grounded, nudged forward, detached again — i.e. **stuttered in place and could not descend**.

Meanwhile **uphill** uses a proper *slope* gate (`(h1 - h0)/run > MAX_CLIMB_SLOPE` ⇒ wall), so climbing snaps to terrain at any walkable angle. The two directions were inconsistent.

## Fix

Make descent symmetric with ascent. A drop is a genuine cliff/ledge only if it is **steeper than the walkable `MAX_CLIMB_SLOPE` (1.5)** over the distance actually moved this tick; otherwise snap down and follow the ground:

```ts
const run = Math.hypot(p.pos.x - p.prevPos.x, p.pos.z - p.prevPos.z);
const maxStepDown = 0.4 + run * MAX_CLIMB_SLOPE;
if (ground < p.pos.y - maxStepDown) { /* real ledge → fall */ }
else { p.pos.y = ground; /* walk down the slope */ }
```

The `0.4` base is retained so a near-stationary player still snaps over tiny terrain noise. Determinism is preserved (no RNG, no new timing); steep cliffs still drop you.

## Verification

- New regression test `tests/sim.test.ts › walks down a walkable slope without going airborne` drives the **real `Sim`** down a walkable hillside. It **fails before** the fix (`onGround` flips false) and **passes after**.
- Full sim suite green; `tsc --noEmit` clean; whole test suite passes (2027 tests).

Before/after height-per-tick on the same hill (seed 42, holding *forward*) — **airborne 50/60 ticks before → grounded 60/60 after**:

![hill descent before/after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/6358cf549cad421d509e3792dfd30449f5b36c66/img/hill_fix.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
