### PR TITLE
fix(render): keep skin preview colours on Low graphics

### DIFF
--- a/src/render/characters/assets.ts
+++ b/src/render/characters/assets.ts
@@ -172,8 +172,9 @@ for (const url of preloadUrls) {
 }
 
 // Skin textures: player alternate body atlases, loaded sRGB + flipY=false so
-// they line up with the glTF-embedded UVs. Standard tier only — low tier aliases
-// character models and keeps the default look.
+// they line up with the glTF-embedded UVs. These load on every tier so skin
+// selection previews and cosmetics keep distinct colours even on low graphics;
+// only emissive glow maps stay standard-tier only.
 const skinTexByUrl = new Map<string, THREE.Texture>();
 const skinEmisTexByUrl = new Map<string, THREE.Texture>();
 
@@ -186,19 +187,17 @@ function loadSkinTexInto(url: string, into: Map<string, THREE.Texture>): Promise
   });
 }
 
-if (GFX.standardMaterials) {
-  // Boot sweep skips lazyPreload keys (e.g. the cosmetic mech) — those load on
-  // demand via preloadMechAssets().
-  const bootUrls = new Set<string>();
-  for (const [key, list] of Object.entries(SKINS)) {
-    if (VISUALS[key]?.lazyPreload) continue;
-    for (const u of list) if (u) bootUrls.add(u);
-  }
-  for (const url of bootUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));
+// Boot sweep skips lazyPreload keys (e.g. the cosmetic mech) — those load on
+// demand via preloadMechAssets().
+const bootSkinUrls = new Set<string>();
+for (const [key, list] of Object.entries(SKINS)) {
+  if (VISUALS[key]?.lazyPreload) continue;
+  for (const u of list) if (u) bootSkinUrls.add(u);
 }
+for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));
 
 /** Resolved skin texture for a visual key + skin index, or null for the model's
- *  embedded default (index 0, unknown key, or low tier). */
+ *  embedded default (index 0, unknown key, or an atlas that is not loaded yet). */
 export function skinTexture(key: string, skinIndex: number): THREE.Texture | null {
   const url = SKINS[key]?.[skinIndex] ?? null;
   return url ? skinTexByUrl.get(url) ?? null : null;
@@ -222,8 +221,8 @@ export function preloadMechAssets(): Promise<void> {
   const jobs: Promise<unknown>[] = [
     loadGltf(def.url).then((g) => { gltfByUrl.set(def.url, g); }),
   ];
+  for (const url of SKINS.player_mech ?? []) if (url) jobs.push(loadSkinTexInto(url, skinTexByUrl));
   if (GFX.standardMaterials) {
-    for (const url of SKINS.player_mech ?? []) if (url) jobs.push(loadSkinTexInto(url, skinTexByUrl));
     for (const url of SKIN_EMISSIVE.player_mech ?? []) if (url) jobs.push(loadSkinTexInto(url, skinEmisTexByUrl));
   }
   mechAssetsPromise = Promise.all(jobs).then(() => undefined);
@@ -233,9 +232,9 @@ export function preloadMechAssets(): Promise<void> {
 export function mechAssetsReady(): boolean {
   const def = VISUALS.player_mech;
   if (!def || !gltfByUrl.has(assetUrl(def.url))) return false;
-  if (!GFX.standardMaterials) return true;
-  return (SKINS.player_mech ?? []).every((url) => !url || skinTexByUrl.has(url))
-    && (SKIN_EMISSIVE.player_mech ?? []).every((url) => !url || skinEmisTexByUrl.has(url));
+  const skinsReady = (SKINS.player_mech ?? []).every((url) => !url || skinTexByUrl.has(url));
+  if (!GFX.standardMaterials) return skinsReady;
+  return skinsReady && (SKIN_EMISSIVE.player_mech ?? []).every((url) => !url || skinEmisTexByUrl.has(url));
 }
 
 function resolvedGltf(url: string): GLTF {

--- a/tests/appearance_skin.test.ts
+++ b/tests/appearance_skin.test.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 import { ClientWorld } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
 import type { IWorld } from '../src/world_api';
+
+const characterAssetsSource = readFileSync(new URL('../src/render/characters/assets.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 
 describe('appearance skin selection', () => {
   it('updates offline player skin through the world contract', () => {
@@ -44,5 +47,14 @@ describe('appearance skin selection', () => {
     client.unequipMechChroma('amber_crimson');
 
     expect(sent).toEqual([{ t: 'cmd', cmd: 'unequip_mech_chroma', chroma: 'amber_crimson' }]);
+  });
+
+  it('loads alternate skin atlases on low graphics so previews keep distinct colours', () => {
+    expect(characterAssetsSource).toContain('These load on every tier so skin');
+    expect(characterAssetsSource).toContain('for (const url of bootSkinUrls) registerPreload(loadSkinTexInto(url, skinTexByUrl));');
+    expect(characterAssetsSource).toContain('for (const url of SKINS.player_mech ?? []) if (url) jobs.push(loadSkinTexInto(url, skinTexByUrl));');
+    expect(characterAssetsSource).toContain('if (!GFX.standardMaterials) return skinsReady;');
+    expect(characterAssetsSource).not.toContain('Standard tier only — low tier aliases');
+    expect(characterAssetsSource).not.toContain('if (GFX.standardMaterials) {\n  // Boot sweep skips lazyPreload keys');
   });
 });


### PR DESCRIPTION
## Summary

Fix skin selection previews on Low graphics.

When Low graphics was enabled, alternate skin atlases were not loaded, so the skins shown after the skin-select wheel all used the embedded/default texture and looked identical. This change loads alternate skin atlases on every graphics tier so class skins and Combat Mech chromas keep distinct colours in previews and cosmetics.

Emissive glow maps remain standard-tier only.

## Related issues

N/A.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/appearance_skin.test.ts tests/skin_event.test.ts`
  - `npx tsc --noEmit`

## Screenshots / recordings

N/A. Render asset loading fix for Low graphics skin/chroma previews.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused appearance skin and skin event tests passed.
- [x] **Typecheck passes.** `npx tsc --noEmit` passed.
- [ ] **Builds succeed.** Not run; focused validation only.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; covered by focused regression checks.
- [x] **Accessible.** No controls or player-facing strings changed.

### Localization (i18n)

- [x] **N/A. This PR adds no new player-visible strings.**

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
