### PR TITLE
fix(auth): store session tokens hashed at rest

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,4 +1,4 @@
-import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
+import { createHash, randomBytes, scrypt, timingSafeEqual } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { englishDataset, englishRecommendedTransformers, RegExpMatcher } from 'obscenity';
 
@@ -32,6 +32,17 @@ export function verifyPassword(password: string, stored: string): Promise<boolea
 
 export function newToken(): string {
   return randomBytes(32).toString('hex');
+}
+
+// Session tokens are stored HASHED at rest, never in plaintext. A token is a
+// 256-bit CSPRNG value (newToken), so a fast unsalted SHA-256 is sufficient:
+// there is nothing to brute-force and no per-row salt is needed (lookup is by
+// value, so the hash must be deterministic). The raw token is returned to the
+// client exactly once; only its digest is persisted, so a leaked auth_tokens
+// table yields irreversible hashes rather than live bearer tokens. Used by
+// saveToken/accountForToken in server/db.ts.
+export function hashToken(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
 }
 
 const CONFUSABLE_CHARS: Record<string, string> = {

--- a/server/db.ts
+++ b/server/db.ts
@@ -3,6 +3,7 @@ import { LEADERBOARD_MAX } from '../src/sim/leaderboard_page';
 import { sanitizeRemovedZone1Content } from '../src/sim/removed_zone1_content';
 import type { CharacterState, MailSave, MarketSave } from '../src/sim/sim';
 import type { ArenaFormat, PlayerClass } from '../src/sim/types';
+import { hashToken } from './auth';
 import { seedChatFilterDefaults } from './chat_filter_db';
 import type { ChatLogRow } from './chat_log';
 import { DISCORD_SCHEMA } from './discord_db';
@@ -72,6 +73,9 @@ CREATE TABLE IF NOT EXISTS accounts (
   last_login TIMESTAMPTZ
 );
 CREATE TABLE IF NOT EXISTS auth_tokens (
+  -- Stores the SHA-256 hash of the bearer token (hex), never the raw token.
+  -- Every read and write hashes the token via hashToken() in auth.ts; the
+  -- plaintext token is returned to the client once and is never persisted.
   token TEXT PRIMARY KEY,
   account_id INT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -875,17 +879,20 @@ export async function saveToken(
   scope: TokenScope = 'full',
   label: string | null = null,
 ): Promise<void> {
+  // Persist only the hash — see hashToken() in auth.ts. The caller keeps the
+  // raw token to hand back to the client.
   await pool.query(
     `INSERT INTO auth_tokens (token, account_id, expires_at, scope, label)
      VALUES ($1, $2, now() + ($3 || ' hours')::interval, $4, $5)`,
-    [token, accountId, String(ttlHours), scope, label],
+    [hashToken(token), accountId, String(ttlHours), scope, label],
   );
 }
 
 export async function accountForToken(token: string): Promise<number | null> {
+  // Look up by the hash of the presented token; the table never holds plaintext.
   const res = await pool.query(
     'SELECT account_id FROM auth_tokens WHERE token = $1 AND expires_at > now()',
-    [token],
+    [hashToken(token)],
   );
   return res.rows[0]?.account_id ?? null;
 }
@@ -899,7 +906,7 @@ export async function accountAndScopeForToken(
 ): Promise<{ accountId: number; scope: TokenScope } | null> {
   const res = await pool.query(
     'SELECT account_id, scope FROM auth_tokens WHERE token = $1 AND expires_at > now()',
-    [token],
+    [hashToken(token)],
   );
   const row = res.rows[0];
   if (!row) return null;
@@ -969,7 +976,7 @@ export async function revokeTokensExcept(
   if (keepToken) {
     await pool.query('DELETE FROM auth_tokens WHERE account_id = $1 AND token <> $2', [
       accountId,
-      keepToken,
+      hashToken(keepToken),
     ]);
   } else {
     await pool.query('DELETE FROM auth_tokens WHERE account_id = $1', [accountId]);
@@ -977,7 +984,7 @@ export async function revokeTokensExcept(
 }
 
 export async function revokeToken(token: string): Promise<void> {
-  await pool.query('DELETE FROM auth_tokens WHERE token = $1', [token]);
+  await pool.query('DELETE FROM auth_tokens WHERE token = $1', [hashToken(token)]);
 }
 
 // Revoke a read-scoped token by value (OAuth/RFC-7009 revocation, companion
@@ -985,7 +992,7 @@ export async function revokeToken(token: string): Promise<void> {
 // never be deleted through this path. Returns true if a row was removed.
 export async function revokeReadToken(token: string): Promise<boolean> {
   const res = await pool.query(`DELETE FROM auth_tokens WHERE token = $1 AND scope = 'read'`, [
-    token,
+    hashToken(token),
   ]);
   return (res.rowCount ?? 0) > 0;
 }

--- a/tests/token_hash.test.ts
+++ b/tests/token_hash.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { hashToken, newToken } from '../server/auth';
+
+describe('hashToken (session tokens hashed at rest)', () => {
+  it('returns the SHA-256 hex digest of the token', () => {
+    expect(hashToken('hello')).toBe(createHash('sha256').update('hello').digest('hex'));
+  });
+
+  it('is deterministic, so a lookup-by-hash matches the stored hash', () => {
+    const token = newToken();
+    expect(hashToken(token)).toBe(hashToken(token));
+  });
+
+  it('produces a 64-char hex digest regardless of input length', () => {
+    for (const t of ['', 'x', newToken(), 'a'.repeat(500)]) {
+      expect(hashToken(t)).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('maps distinct tokens to distinct hashes', () => {
+    const a = newToken();
+    const b = newToken();
+    expect(a).not.toBe(b);
+    expect(hashToken(a)).not.toBe(hashToken(b));
+    expect(hashToken('token-a')).not.toBe(hashToken('token-b'));
+  });
+
+  it('never returns the raw token (a leaked table holds only digests)', () => {
+    const token = newToken();
+    expect(hashToken(token)).not.toBe(token);
+  });
+});


### PR DESCRIPTION
## What

Persist the **SHA-256 hash** of each bearer token in `auth_tokens` instead of the raw token. Lookups hash the presented token and compare digests, so the table never holds a usable credential.

- `hashToken()` added in `server/auth.ts` — deterministic SHA-256 (no per-row salt: a token is a 256-bit CSPRNG value from `newToken()`, so there's nothing to brute-force and the lookup must be by value).
- `saveToken` / `accountForToken` (`server/db.ts`) hash on the way in and out. **All callers are unchanged** — the raw token is still returned to the client exactly once and is never persisted.
- The schema comment on `auth_tokens.token` now documents that it stores a hash. Column name/type are unchanged (the digest is also 64 hex chars), so there's **no migration / `ALTER TABLE`**.
- Added `tests/token_hash.test.ts`.

## Why

Defense-in-depth (CWE-312, plaintext storage of a credential). It is **not exploitable on a default deploy** — Postgres binds to loopback and isn't externally reachable — so this is hardening, not a live bug: if an `auth_tokens` dump ever leaks (a backup, a replica, a log), an attacker gets irreversible digests instead of live sessions. Mirrors how `password_hash` is already handled.

## One operational note

Existing rows are plaintext, so after deploy current sessions stop matching and users log in again once (tokens already expire within 7 days). Optionally run `DELETE FROM auth_tokens;` on deploy to clear the stale plaintext rows immediately — not required; they fail closed and expire on their own.

## Testing

- `tests/token_hash.test.ts` covers: digest equals `sha256(token)`, determinism (so a lookup matches the stored hash), 64-hex output for varied inputs, distinct tokens → distinct hashes, and that the raw token is never returned.
- I verified the hashing logic with a standalone `node:crypto` check (all assertions pass). I could **not** run the full `vitest` suite locally — my environment wouldn't install the repo's dependencies — so please let CI confirm the suite stays green.

## A note on how this was reported

Found via a security audit. Your `SECURITY.md` asks for private reports through the GitHub advisory form, and I tried that first — but the form 404s, which means Private Vulnerability Reporting isn't enabled on the repo. Since this change is pure best-practice hardening that reveals no exploit, I'm sending it as a normal PR rather than sitting on it. If you enable PVR (Settings → Code security → Private vulnerability reporting), I'm glad to route anything more sensitive through it.

— Opened by @aaronjmars · audit by [Aeon](https://github.com/aeonframework/aeon)
