### PR TITLE
[codex] retry disconnect character saves

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -49,6 +49,9 @@ const WIRE_CACHE_SWEEP_TICKS = 1200;
 const EVENT_RADIUS = 90;
 const AUTOSAVE_SECONDS = 30;
 const SAVE_CONCURRENCY = 4;
+const LEAVE_SAVE_MAX_ATTEMPTS = 5;
+const LEAVE_SAVE_RETRY_BASE_MS = 250;
+const LEAVE_SAVE_RETRY_MAX_MS = 4000;
 const CHAT_RATE_BURST = 5;
 const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
@@ -320,6 +323,10 @@ function chatChannelHint(session: ClientSession, text: string): string {
   if (/^\/(?:general|world)\s/i.test(text)) return 'general';
   if (/^\/(?:s|say)\s/i.test(text)) return 'say';
   return session.rememberedChat.channel;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export class GameServer {
@@ -759,11 +766,31 @@ export class GameServer {
     if (session.dbSessionId !== null) {
       void closePlaySession(session.dbSessionId).catch((err) => console.error('failed to close play session:', err));
     }
-    await this.saveCharacter(session).catch((err) => console.error('save on leave failed:', err));
+    await this.saveCharacterOnLeave(session);
     this.sessionsByCharacterId.delete(session.characterId);
     this.sim.removePlayer(session.pid);
     // Departures are no longer broadcast to the realm — the leaving player has
     // already disconnected, so there is no one to show their own notice to.
+  }
+
+  private async saveCharacterOnLeave(session: ClientSession): Promise<void> {
+    for (let attempt = 1; attempt <= LEAVE_SAVE_MAX_ATTEMPTS; attempt++) {
+      try {
+        await this.saveCharacter(session);
+        return;
+      } catch (err) {
+        if (attempt === LEAVE_SAVE_MAX_ATTEMPTS) {
+          console.error(`save on leave failed after ${attempt} attempts for ${session.name}:`, err);
+          return;
+        }
+        const retryMs = Math.min(
+          LEAVE_SAVE_RETRY_BASE_MS * 2 ** (attempt - 1),
+          LEAVE_SAVE_RETRY_MAX_MS,
+        );
+        console.error(`save on leave failed for ${session.name}; retrying in ${retryMs}ms:`, err);
+        await delay(retryMs);
+      }
+    }
   }
 
   async saveCharacter(session: ClientSession): Promise<void> {

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -178,6 +178,41 @@ describe('GameServer sessions', () => {
     expect((server as any).sessionByCharacterId(101)).toBe(rejoined);
   });
 
+  it('retries failed disconnect saves before releasing the character for rejoin', async () => {
+    vi.useFakeTimers();
+    vi.mocked(saveCharacterState).mockReset();
+    vi.mocked(saveCharacterState)
+      .mockRejectedValueOnce(new Error('temporary database outage'))
+      .mockRejectedValueOnce(new Error('temporary database outage'))
+      .mockResolvedValueOnce(undefined);
+
+    try {
+      const server = new GameServer();
+      const session = expectJoined(server.join(fakeWs(), 11, 101, 'Indexa', 'warrior', null));
+      const leaving = server.leave(session, 'test');
+
+      await vi.waitFor(() => {
+        expect(saveCharacterState).toHaveBeenCalledTimes(1);
+      });
+      expect(server.join(fakeWs(), 12, 101, 'Indexa', 'warrior', null)).toEqual({
+        error: 'character already in world',
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      await vi.waitFor(() => {
+        expect(saveCharacterState).toHaveBeenCalledTimes(2);
+      });
+
+      await vi.runOnlyPendingTimersAsync();
+      await leaving;
+
+      expect(saveCharacterState).toHaveBeenCalledTimes(3);
+      expect((server as any).sessionByCharacterId(101)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('serializes overlapping saves for one character so an older write cannot land last', async () => {
     vi.mocked(saveCharacterState).mockReset();
     vi.mocked(saveCharacterState).mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- Retries the final character save on disconnect up to 5 attempts with exponential backoff.
- Keeps the character ID reserved until the disconnect save retry flow finishes, so fast relog cannot load stale DB state while the old session is still flushing.
- Adds a regression test covering transient disconnect-save failures before rejoin is allowed.

## Root Cause

`release/v0.10.1` already blocks fast relog while the disconnect save is pending, but a transient DB save failure still caused the leave path to continue after one failed attempt. That released the character for rejoin without a successful final save.

## Validation

- `npx vitest run tests/game_sessions.test.ts tests/snapshots.test.ts`
- `npm run build:server`