### PR TITLE
[codex] keep rested lifetime XP integral

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -4182,7 +4182,7 @@ export class Sim {
     // amount drawn down, so the effective award is up to 2x while the pool lasts.
     let restedBonus = 0;
     if (opts?.fromKill && p.level < MAX_LEVEL && meta.restedXp > 0) {
-      restedBonus = Math.min(meta.restedXp, amount);
+      restedBonus = Math.min(Math.floor(meta.restedXp), amount);
       meta.restedXp -= restedBonus;
       amount += restedBonus;
     }

--- a/tests/rested_xp.test.ts
+++ b/tests/rested_xp.test.ts
@@ -73,6 +73,20 @@ describe('rested XP — consumption', () => {
     expect(meta.restedXp).toBe(0);
   });
 
+  it('keeps lifetime XP integral when consuming fractional rested XP', () => {
+    const sim = makeSim();
+    const meta = sim.meta(sim.playerId)!;
+    meta.restedXp = 48.00625;
+
+    sim.grantXp(100, meta, { fromKill: true });
+    const state = sim.serializeCharacter(sim.playerId)!;
+
+    expect(state.lifetimeXp).toBe(148);
+    expect(Number.isInteger(state.lifetimeXp)).toBe(true);
+    expect(() => BigInt(String(state.lifetimeXp))).not.toThrow();
+    expect(meta.restedXp).toBeCloseTo(0.00625, 5);
+  });
+
   it('does NOT consume rested XP for non-kill awards (e.g. quests)', () => {
     const sim = makeSim();
     const meta = sim.meta(sim.playerId)!;


### PR DESCRIPTION
## Summary

- Floors the rested XP bonus before adding it to kill XP.
- Preserves fractional rested XP in the rested pool instead of leaking it into persisted `lifetimeXp`.
- Adds a regression test proving serialized `lifetimeXp` remains integer-safe and parseable as a bigint.

## Root Cause

Rested XP accrues fractionally per tick. When a kill consumed a fractional rested pool, that fractional bonus was added to the XP award and persisted into `state.lifetimeXp`. The database lifetime-XP indexes cast `state->>'lifetimeXp'` to `bigint`, so values like `3296.3171875` caused character saves to fail.

## Validation

- `npx vitest run tests/rested_xp.test.ts tests/xp.test.ts tests/game_sessions.test.ts`
- `npm run build:server`
- Local Postgres cast check: fractional JSON lifetime XP fails as expected; fixed integer lifetime XP casts successfully.