### PR TITLE
fix(ui): hide #start-screen scrollbar to keep homepage full-bleed

### DIFF
--- a/index.html
+++ b/index.html
@@ -1648,6 +1648,12 @@
     touch-action: pan-y;
     overscroll-behavior-y: auto;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+  }
+  #start-screen::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
   }
 
   /* Global Header Styling */


### PR DESCRIPTION
#start-screen is the homepage scroll container (position: absolute; inset: 0; overflow-y: auto). The global ::-webkit-scrollbar { width: 8px } makes it a classic, space-reserving bar, so once content (~865px) is taller than the viewport (any height below ~856px — landscape phones, short desktop windows) the scrollbar carved a gutter off the right edge, shrinking the full-width header/footer and shifting centered content left. Phones with 0px overlay scrollbars were unaffected, hence the height/browser dependence.

Hide #start-screen's own scrollbar (scrollbar-width: none + ::-webkit-scrollbar { display: none }), matching the existing #ui pattern. The page stays full-bleed at any height and remains scrollable; inner panels (news/leaderboard) keep their own scrollbars.

<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

Fixes the right-edge gap that ran down the whole homepage — the navigation bar
and footer no longer reached the right side of the screen, and centered content
was nudged left.

`#start-screen` is the homepage scroll container (`position: absolute; inset: 0;
overflow-y: auto`). The global `::-webkit-scrollbar { width: 8px }`
(`index.html:231`) makes it a **classic, space-reserving** scrollbar. The
homepage content is ~865px tall, so once the viewport is shorter than that
(anything under ~856px — landscape phones, short/desktop windows) `#start-screen`
overflows vertically and the scrollbar carves a gutter off the right edge. That
shrinks the full-width header/footer and shifts the centered console left,
producing the asymmetric gap. Phones use 0px overlay scrollbars, so they were
never affected — which is why the bug was both height- and browser-dependent.

Fix: hide `#start-screen`'s own scrollbar (`scrollbar-width: none` +
`#start-screen::-webkit-scrollbar { display: none }`), matching the existing
full-bleed scroll-container pattern used for `#ui` (`index.html:4406-4418`). The
page stays edge-to-edge at any viewport height and remains scrollable
(wheel/touch/keyboard). Inner panels (news, leaderboard) keep their own
scrollbars — the rule only targets `#start-screen`.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/homepage_foundation.test.ts tests/client_shell.test.ts` → 37 passed
  - `npx tsc --noEmit` → clean
  - `npm run build` → green
- Manual steps:
  - Loaded the homepage in headless Chromium at phone-sized, mobile-touch viewports.
  - Reproduced the original behavior at heights below ~856px (content overflows
    `#start-screen`); confirmed full-width header/footer reach the right edge with
    the fix applied.
  - Checked portrait (390×844), short (381×760) and landscape (844×390), plus a
    tall viewport (no overflow) — no regression; layout stays full-bleed and centered.

## Screenshots / recordings

- **Before:** ~15px empty strip down the right edge; nav bar and footer stop short of the screen edge on viewports under ~856px tall.
<img width="381" height="673" alt="image" src="https://github.com/user-attachments/assets/92644d5a-d220-455a-bc0d-69e1a8a3e36c" />

- **After:** header, footer, and content span edge-to-edge at every height.
<img width="378" height="669" alt="image" src="https://github.com/user-attachments/assets/239ae1e8-88d3-4f31-bbd9-a60a92ad958a" />

---

## Checklist

### Quality

- [x] **Tests pass.** Ran `tests/homepage_foundation.test.ts` and
      `tests/client_shell.test.ts` (37 passed). CSS-only change — no `sim/` or
      `server/` behavior changed, so no new tests needed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` is green. (`build:server` / `build:env`
      untouched — no server/headless code changed.)

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified at phone-sized viewports in
      portrait and landscape and at short/tall desktop heights. No touch-target or
      font-size changes (CSS scrollbar-visibility only).
- [ ] ~Accessible.~ N/A — no UI elements added or edited; content remains
      keyboard/wheel/touch scrollable.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] No hand-edited generated files. Only `index.html` changed; `npm run build`
      regenerated manifests but those are not part of this change.


> **Tip:** commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a scope where it fits (`feat(talents): ...`, `fix(net): ...`). It's a
> convention we like, not a requirement. Clear, descriptive messages are what
> matter most.

---

A complete checklist and a green CI run (tests, typecheck, and builds) are what
we look for before merging. Smaller, focused PRs land faster than large ones, and
reviewers may suggest changes, which is a normal and friendly part of the
process. Thank you for helping build World of ClaudeCraft. Questions? Join us on
[Discord](https://discord.gg/GjhnUsBtw).
