### PR TITLE
feat(ui): wide horizontal Key Bindings layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1335,6 +1335,14 @@
   .opt-list { display: flex; flex-direction: column; gap: 8px; align-items: stretch; padding: 4px 0; }
   .opt-btn { margin: 0; text-align: center; }
   .kb-rows { display: flex; flex-direction: column; gap: 2px; margin-bottom: 8px; }
+  /* Wide, multi-column key-binding layout (desktop). Categories flow into as many
+     columns as fit, so the tall Action Bar list no longer forces a long scroll. */
+  #options-menu.kb-wide { width: min(880px, calc(100vw - 32px)); }
+  .kb-cols { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 4px 18px; align-items: start; margin-bottom: 8px; }
+  .kb-col { min-width: 0; }
+  .kb-col .kb-rows { margin-bottom: 0; }
+  .kb-col .kb-cat { margin-top: 0; }
   .kb-cat { font-family: var(--title-font); color: var(--gold); font-size: 12px; letter-spacing: 0.5px;
     text-transform: uppercase; margin: 8px 0 2px; border-bottom: 1px solid #463a1c; padding-bottom: 2px; }
   .kb-row { display: grid; grid-template-columns: 1fr 78px 78px; align-items: center;
@@ -5107,7 +5115,8 @@
     display: none;
   }
   body.mobile-touch #spellbook,
-  body.mobile-touch #options-menu {
+  body.mobile-touch #options-menu,
+  body.mobile-touch #options-menu.kb-wide {
     left: 50%;
     right: auto;
     top: 12px;
@@ -5115,6 +5124,9 @@
     max-height: calc(100vh - 92px);
     transform: translateX(-50%);
   }
+  /* On touch, stack the categories back into a single column so the large
+     touch targets keep their full width. */
+  body.mobile-touch .kb-cols { grid-template-columns: 1fr; gap: 0 0; }
   body.mobile-touch #talents-window {
     position: fixed;
     left: 50%;

--- a/scripts/keybinds_layout_shot.mjs
+++ b/scripts/keybinds_layout_shot.mjs
@@ -1,0 +1,74 @@
+// Key Bindings panel layout screenshots: the wide multi-column desktop layout
+// (Esc > Key Bindings) plus the single-column mobile-touch fallback. Offline
+// flow (no server). Needs `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const CLASS = process.env.GAME_CLASS ?? 'warrior';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1280, height: 900 });
+
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await tap('#btn-offline');
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Keybinder'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap(`#offline-select .mini-class[data-class="${CLASS}"]`);
+await tap('#btn-start-offline');
+await wait(3000);
+
+const openKeybinds = () => page.evaluate(() => {
+  const hud = window.__game.hud;
+  hud.toggleOptionsMenu();
+  hud.optionsView = 'keybinds';
+  hud.renderOptions();
+});
+const panelClip = () => page.evaluate(() => {
+  const el = document.querySelector('#options-menu');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) };
+});
+
+// --- Desktop: wide multi-column layout ---
+await openKeybinds();
+await wait(400);
+await page.screenshot({ path: 'tmp/keybinds_wide_full.png' });
+const wide = await panelClip();
+if (wide && wide.width > 0) await page.screenshot({ path: 'tmp/keybinds_wide_panel.png', clip: wide });
+console.log('desktop panel width:', wide?.width);
+
+// --- Mobile: single-column touch fallback ---
+await page.evaluate(() => { window.__game.hud.closeOptions(); });
+// Landscape phone — avoids the portrait "rotate to landscape" overlay.
+await page.setViewport({ width: 844, height: 412 });
+await page.evaluate(() => document.body.classList.add('mobile-touch'));
+await wait(200);
+await openKeybinds();
+await wait(400);
+await page.screenshot({ path: 'tmp/keybinds_mobile_full.png' });
+const mob = await panelClip();
+if (mob && mob.width > 0) await page.screenshot({ path: 'tmp/keybinds_mobile_panel.png', clip: mob });
+console.log('mobile panel width:', mob?.width);
+
+if (errors.length) console.log('PAGE ERRORS:\n' + errors.join('\n'));
+console.log('wrote tmp/keybinds_wide_panel.png, tmp/keybinds_wide_full.png, tmp/keybinds_mobile_panel.png, tmp/keybinds_mobile_full.png');
+await browser.close();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -7473,6 +7473,9 @@ export class Hud {
   }
 
   private renderOptions(): void {
+    // The wide multi-column layout belongs to the keybinds view only; clear it
+    // so the other sub-views (and the main menu) keep their default width.
+    if (this.optionsView !== 'keybinds') $('#options-menu').classList.remove('kb-wide');
     if (this.optionsView === 'keybinds') { this.renderKeybinds(); return; }
     if (this.optionsView === 'graphics') { this.renderGraphics(); return; }
     if (this.optionsView === 'audio') { this.renderAudio(); return; }
@@ -7970,6 +7973,9 @@ export class Hud {
 
   private renderKeybinds(): void {
     const el = $('#options-menu');
+    // Wide, multi-column layout for the key-binding view only; other options
+    // sub-views (graphics/audio/interface) keep the default 420px width.
+    el.classList.add('kb-wide');
     el.innerHTML = `<div class="panel-title"><span>${esc(t('hud.options.keyBindings'))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('hud.options.returnToGame'))}">${svgIcon('close')}</button></div>`;
     this.settingToggleKeybind(el, t('hud.options.mouseCamera'), 'mouseCamera');
     this.settingToggleKeybind(el, t('hud.options.clickToMove'), 'clickToMove');
@@ -7981,18 +7987,24 @@ export class Hud {
     note.className = 'kb-note';
     note.textContent = this.keybindNote || t('hud.options.keybindHelpMouseCamera');
     el.appendChild(note);
-    const rows = document.createElement('div');
-    rows.className = 'kb-rows';
+    const cols = document.createElement('div');
+    cols.className = 'kb-cols';
     // The Attack Move key is only meaningful (and only rebindable) while its mode
     // is on; otherwise hide its row so it can't shadow Turn Left's A in the list.
     const attackMoveOn = !!this.optionsHooks?.settings.get('attackMove');
     for (const category of BIND_CATEGORIES) {
       const visible = BIND_ACTIONS.filter((a) => a.category === category && (a.id !== 'attackMove' || attackMoveOn));
       if (visible.length === 0) continue;
+      // Each category is its own column block (header + its rows) so the wide
+      // grid can flow categories side by side; on mobile they stack to one column.
+      const col = document.createElement('div');
+      col.className = 'kb-col';
       const header = document.createElement('div');
       header.className = 'kb-cat';
       header.textContent = BIND_CATEGORY_LABEL_KEYS[category] ? t(BIND_CATEGORY_LABEL_KEYS[category]) : category;
-      rows.appendChild(header);
+      col.appendChild(header);
+      const rows = document.createElement('div');
+      rows.className = 'kb-rows';
       for (const action of visible) {
         const row = document.createElement('div');
         row.className = 'kb-row';
@@ -8019,8 +8031,10 @@ export class Hud {
         }
         rows.appendChild(row);
       }
+      col.appendChild(rows);
+      cols.appendChild(col);
     }
-    el.appendChild(rows);
+    el.appendChild(cols);
     const reset = document.createElement('button');
     reset.className = 'btn';
     reset.textContent = t('hud.options.resetToDefaults');


### PR DESCRIPTION
## Problem

The **Key Bindings** options panel (Esc → Key Bindings) stacked every category — Movement, Targeting, Interface, **Action Bar** — in a single 420px-wide column. With the long Action Bar list, the panel overflowed its `max-height` and forced a lot of vertical scrolling to reach a binding.

## Change

Lay the categories out **side by side** in a self-responsive grid, so most/all bindings are visible at once with little or no scrolling.

- `renderKeybinds()` wraps each category in its own `.kb-col` block (header + its rows) inside a `.kb-cols` grid. The per-row key-capture logic, buttons, and `actionDisplayName()` calls are **unchanged** — only the container nesting changed.
- `#options-menu.kb-wide` widens to `min(880px, 100vw - 32px)` **for the keybinds view only**; the class is cleared when the other options sub-views (Graphics/Audio/Interface) render, so they keep their 420px width.
- `.kb-cols` uses `repeat(auto-fill, minmax(240px, 1fr))`, so it picks 1/2/3 columns based on available width — responsive by construction.

## Mobile (still handled)

`body.mobile-touch` collapses `.kb-cols` back to a **single column** and restores the existing touch width (`min(560px, 100vw - 170px)`), so touch users keep today's single-column layout and large (≥40px) touch targets. Verified in landscape (portrait shows the game's existing "rotate to landscape" gate).

## Screenshots

**Desktop — wide multi-column (880px):**

![Desktop wide keybinds panel](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-keybinds-horizontal/tmp/keybinds_wide_panel.png)

**Mobile — single-column touch fallback (560px):**

![Mobile keybinds panel](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-keybinds-horizontal/tmp/keybinds_mobile_full.png)

## Notes / safety

- **Pure presentation.** No `src/sim/`, wire, or `IWorld` changes.
- **No new i18n keys** — all labels reuse existing `t()` calls, so this is PR-tier green with zero locale work.
- Adds `scripts/keybinds_layout_shot.mjs` to reproduce both screenshots (offline; needs `npm run dev`).
- `npx tsc --noEmit` clean; full `npm test` green (2080 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)