### PR TITLE
fix(audio): stop footsteps comb-filtering into a metallic jingle

### DIFF
--- a/scripts/footstep_walk_shot.mjs
+++ b/scripts/footstep_walk_shot.mjs
@@ -1,0 +1,39 @@
+// Visual context for the footstep-audio PR: spawn offline, walk, and screenshot
+// the character mid-stride. (The fix itself is audible; see the spectrograms.)
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const OUT = 'tmp/sfx_pr';
+fs.mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Strider');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await new Promise((r) => setTimeout(r, 2500));
+
+// walk forward; screenshot mid-stride (footsteps are firing on this path)
+await page.keyboard.down('w');
+await new Promise((r) => setTimeout(r, 1200));
+await page.screenshot({ path: `${OUT}/walking.png` });
+await new Promise((r) => setTimeout(r, 800));
+await page.screenshot({ path: `${OUT}/walking2.png` });
+await page.keyboard.up('w');
+
+const st = await page.evaluate(() => {
+  const p = window.__game.sim.player;
+  return { x: +p.pos.x.toFixed(1), z: +p.pos.z.toFixed(1) };
+});
+console.log('walked to', JSON.stringify(st));
+await browser.close();

--- a/src/game/sfx.ts
+++ b/src/game/sfx.ts
@@ -22,6 +22,12 @@ export interface PlayOpts {
   rate?: number;       // playback-rate multiplier (default 1); ±6% jitter added
   cooldown?: number;   // min seconds between plays of this key (default 0.03)
   jitter?: boolean;    // randomize rate/gain slightly (default true)
+  // Percussive amplitude envelope. `release` truncates the clip to a crisp
+  // transient that fully decays within `attack + release` seconds — used by fast
+  // retriggered sounds (footsteps) so successive plays of the same sample don't
+  // pile up and comb-filter into a metallic ring. 0 (default) plays the clip flat.
+  attack?: number;     // fade-in seconds (default 0 = instant)
+  release?: number;    // fade-out seconds; the clip is stopped once it ends
 }
 
 interface LoopSlot {
@@ -137,12 +143,37 @@ class Sfx {
     src.buffer = buf;
     src.playbackRate.value = (opts?.rate ?? 1) * (jitter ? 1 + (Math.random() * 2 - 1) * 0.06 : 1);
     const g = ctx.createGain();
-    g.gain.value = (opts?.gain ?? 1) * (jitter ? 1 + (Math.random() * 2 - 1) * 0.1 : 1);
+    const peak = (opts?.gain ?? 1) * (jitter ? 1 + (Math.random() * 2 - 1) * 0.1 : 1);
     const panner = this.makePanner(x, y, z);
     src.connect(g).connect(panner).connect(master);
     this.active++;
     src.onended = () => { this.active--; src.disconnect(); g.disconnect(); panner.disconnect(); };
+    this.applyEnvelope(src, g, peak, now, opts);
+  }
+
+  /** Set the gain envelope on a one-shot source and start it. With no
+   *  attack/release this is a flat play at `peak`; with a `release` the source is
+   *  shaped into a short transient and stopped early so rapid retriggers of the
+   *  same clip can't overlap and comb-filter. */
+  private applyEnvelope(src: AudioBufferSourceNode, g: GainNode, peak: number, now: number, opts?: PlayOpts): void {
+    const attack = Math.max(0, opts?.attack ?? 0);
+    const release = Math.max(0, opts?.release ?? 0);
+    if (attack === 0 && release === 0) {
+      g.gain.value = peak;
+      src.start();
+      return;
+    }
+    const a = Math.max(0.001, attack);
+    g.gain.setValueAtTime(0.0001, now);
+    g.gain.linearRampToValueAtTime(peak, now + a);
     src.start();
+    if (release > 0) {
+      // Effective clip length at this playback rate; never schedule past it.
+      const clip = src.buffer ? src.buffer.duration / (src.playbackRate.value || 1) : a + release;
+      const end = Math.min(now + clip, now + a + release);
+      g.gain.setTargetAtTime(0.0001, Math.max(now + a, end - release), release / 3);
+      try { src.stop(end + 0.03); } catch { /* stop unsupported in stub */ }
+    }
   }
 
   /** Non-positional one-shot (personal/UI sounds that shouldn't pan). */
@@ -217,10 +248,23 @@ class Sfx {
   // Implemented here so the surface→clip and ambience→loop mappings live in one
   // place; the renderer depends only on the SpatialAudioSink interface.
 
-  /** One footfall. `surface` ∈ grass|dirt|stone|wood|snow|water → foot_<surface>. */
+  /** One footfall. `surface` ∈ grass|dirt|stone|wood|snow|water → foot_<surface>.
+   *  Footsteps fire every ~0.22s at a run but the clips are ~0.48s, so a flat
+   *  retrigger would overlap two pitch-jittered copies of one sample and
+   *  comb-filter into a metallic "jingle". Two fixes: a short `release` shapes
+   *  each footfall into a transient that decays before the next, and alternating
+   *  the pitch per step reads as two distinct feet rather than one looping sample. */
   footstep(x: number, y: number, z: number, surface: string, running: boolean, _self: boolean): void {
-    this.playAt(`foot_${surface}`, x, y, z, { gain: running ? 0.8 : 0.55, rate: running ? 1.06 : 1, cooldown: 0.05 });
+    this.footTick = (this.footTick + 1) & 1;
+    const foot = this.footTick === 0 ? 0.97 : 1.04; // left/right
+    this.playAt(`foot_${surface}`, x, y, z, {
+      gain: running ? 0.8 : 0.55,
+      rate: (running ? 1.06 : 1) * foot,
+      cooldown: 0.05,
+      release: running ? 0.17 : 0.22, // < the tightest stride gap (~0.22s at run)
+    });
   }
+  private footTick = 0;
 
   /** Jump / land / water-entry / swim-stroke. */
   movement(kind: 'jump' | 'land' | 'splash' | 'swim', x: number, y: number, z: number, _self: boolean): void {

--- a/tests/sfx.test.ts
+++ b/tests/sfx.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { sfx } from '../src/game/sfx';
+
+// The footstep "jingling" bug: foot clips are ~0.48s but steps fire every ~0.22s
+// at a run, so flat retriggers overlap two pitch-jittered copies of one sample and
+// comb-filter into a metallic ring. footstep() must (a) shape each play into a
+// short transient that is stopped before the next step and (b) alternate pitch
+// per step. These tests pin both behaviours via a minimal WebAudio stub.
+
+interface FakeSource {
+  buffer: { duration: number } | null;
+  playbackRate: { value: number };
+  onended: (() => void) | null;
+  started: boolean;
+  stopAt: number | null;
+  connect(n: unknown): unknown;
+  start(): void;
+  stop(t?: number): void;
+}
+
+const sources: FakeSource[] = [];
+let nowT = 0;
+
+function installAudioStub(): void {
+  sources.length = 0;
+  nowT += 1000; // monotonic across tests so the singleton's cooldown map never blocks
+  const param = () => ({ value: 0, setValueAtTime() {}, linearRampToValueAtTime() {}, setTargetAtTime() {} });
+  class FakeCtx {
+    get currentTime() { return nowT; }
+    destination = {};
+    listener = {} as Record<string, unknown>;
+    createGain() { return { gain: param(), connect(n: unknown) { return n; }, disconnect() {} }; }
+    createPanner() {
+      return {
+        panningModel: '', distanceModel: '', refDistance: 0, maxDistance: 0, rolloffFactor: 0,
+        setPosition() {}, connect(n: unknown) { return n; }, disconnect() {},
+      };
+    }
+    createBufferSource(): FakeSource {
+      const s: FakeSource = {
+        buffer: null, playbackRate: { value: 1 }, onended: null, started: false, stopAt: null,
+        connect(n: unknown) { return n; },
+        start() { this.started = true; },
+        stop(t?: number) { this.stopAt = t ?? 0; },
+      };
+      sources.push(s);
+      return s;
+    }
+    resume() { return Promise.resolve(); }
+  }
+  (globalThis as never as { AudioContext: unknown }).AudioContext = FakeCtx;
+}
+
+beforeEach(() => {
+  installAudioStub();
+  // Neutralize the ±jitter so alternation is the only pitch variable under test.
+  Math.random = () => 0.5;
+  sfx.init();
+  // Inject decoded buffers directly (skip async fetch/decode in preload).
+  const buffers = (sfx as unknown as { buffers: Map<string, { duration: number }> }).buffers;
+  buffers.set('foot_grass', { duration: 0.48 });
+});
+
+describe('footstep audio', () => {
+  it('shapes each footfall into a transient stopped before the next step', () => {
+    sfx.footstep(0, 0, 0, 'grass', true, true);
+    const src = sources.at(-1)!;
+    expect(src.started).toBe(true);
+    // running release 0.17s + tail margin → stopped well under the ~0.22s gap,
+    // and far under the raw 0.48s clip that caused the overlap ring.
+    expect(src.stopAt).not.toBeNull();
+    expect(src.stopAt! - nowT).toBeLessThan(0.22);
+  });
+
+  it('alternates pitch between consecutive steps (left/right foot)', () => {
+    sfx.footstep(0, 0, 0, 'grass', false, true);
+    const a = sources.at(-1)!.playbackRate.value;
+    nowT += 0.5; // clear the per-key cooldown so the next step actually plays
+    sfx.footstep(0, 0, 0, 'grass', false, true);
+    const b = sources.at(-1)!.playbackRate.value;
+    expect(Math.abs(a - b)).toBeGreaterThan(0.05);
+  });
+});


### PR DESCRIPTION
## The bug

Walking/running produces a high, metallic **jingling** ring instead of clean footfalls.

## Root cause

Footstep clips (`public/audio/sfx/foot_*.mp3`) are **~0.48s** long, but the renderer's distance accumulator fires a step as often as **every ~0.22s at a run** (`FOOT_STRIDE_RUN / FOOT_RUN_SPEED`). So each footfall played the *full* sample flat while the previous copy was still sounding. Two overlapping copies of the same clip, each nudged by the existing ±6% playback-rate jitter, sum into a moving **comb filter** — which the ear hears as a tinny "jingle."

The artifact is visible in a spectrogram of a simulated run cadence:

| Before — overlapping copies smear into a continuous comb wash | After — discrete, cleanly separated footfalls |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/9468b70a7b3bf2c6c9a1fd81c54ae81f9794508b/before_spectrum.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/9468b70a7b3bf2c6c9a1fd81c54ae81f9794508b/after_spectrum.png) |

## The fix (`src/game/sfx.ts` only — pure client audio, no sim/wire/`IWorld` change)

- **Percussive envelope.** `playAt` gains an optional `attack`/`release`; `footstep()` uses a short `release` so each step is shaped into a crisp transient that fully decays *before* the next step fires — removing the overlap that caused the comb filter.
- **Per-step pitch alternation.** The sfx prompt catalog already documented that "the engine pitch-randomizes **and alternates**," but alternation was never actually implemented. Consecutive steps now alternate pitch slightly, so a run reads as two distinct feet instead of one looping sample.

Net effect: footsteps are crisp and varied; the jingle is gone.

## Tests

- New `tests/sfx.test.ts` (WebAudio stubbed) pins both behaviours: each footfall is stopped before the next step's gap, and consecutive steps alternate pitch.
- `npx tsc --noEmit` clean; full suite green (2082 passed).
- No player-visible strings changed → no i18n work.

In-game context (warrior walking through Eastbrook):

![walking](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/9468b70a7b3bf2c6c9a1fd81c54ae81f9794508b/walking.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)