### PR TITLE
fix(content): Druid Dash (and Travel Form) do nothing — buff_speed value encoded as delta, not multiplier

### DIFF
--- a/scripts/dash_speed_chart.mjs
+++ b/scripts/dash_speed_chart.mjs
@@ -1,0 +1,169 @@
+// Before/after proof for the Druid "Dash" fix (buff_speed multiplier).
+// Drives the REAL offline Sim in-page: a level-20 druid in cat form runs
+// straight forward for 15s under three conditions and we chart cumulative
+// distance travelled:
+//   - No Dash            (baseline, mult 1.0)
+//   - Dash BEFORE fix    (value 0.5 -> Math.max(1,0.5)=1.0 -> identical to baseline)
+//   - Dash AFTER fix     (value 1.5 -> 50% faster)
+// The bug is visible as the "before" line lying exactly on the baseline.
+// Needs `npm run dev` (override with GAME_URL). Writes tmp/dash-speed-chart.png.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1280,820', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1280, height: 820 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Thornroot');
+await page.evaluate(() => {
+  const el = document.querySelector('#offline-select .mini-class[data-class="druid"]');
+  if (el) el.click();
+});
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game && window.__game.sim && window.__game.sim.player,
+  { timeout: 30000 });
+await sleep(800);
+
+const series = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  sim.setPlayerLevel(20, p.id);
+  p.gm = true;
+
+  const TICKS = 300; // 15s at 20Hz
+
+  function run(value) {
+    // Measure displacement from wherever the druid currently stands (each run
+    // resumes from the previous run's endpoint — fine, we record a fresh origin).
+    p.facing = 0;
+    p.auras = p.auras.filter((a) => a.kind !== 'buff_speed' && a.kind !== 'form_cat');
+    // Cat ("Wolf") form so Dash's gate is satisfied for realism.
+    p.auras.push({ id: 'wolf_form', name: 'Wolf Form', kind: 'form_cat',
+      remaining: 3600, duration: 3600, value: 1, sourceId: p.id, school: 'physical' });
+    if (value != null) {
+      p.auras.push({ id: 'dash', name: 'Dash', kind: 'buff_speed',
+        remaining: 15, duration: 15, value, sourceId: p.id, school: 'physical' });
+    }
+    const sx = p.pos.x, sz = p.pos.z;
+    const dists = [];
+    for (let i = 0; i < TICKS; i++) {
+      sim.moveInput.forward = true; // re-assert each tick (sync loop, no RAF interleave)
+      sim.tick();
+      dists.push(Math.hypot(p.pos.x - sx, p.pos.z - sz));
+    }
+    return dists;
+  }
+
+  return {
+    none: run(null),
+    before: run(0.5),
+    after: run(1.5),
+  };
+});
+
+// Draw the chart on a canvas overlay and screenshot it.
+await page.evaluate((s) => {
+  const TICKS = s.none.length;
+  const W = 1180, H = 720, PAD = 80;
+  const cv = document.createElement('canvas');
+  cv.id = 'dash-chart';
+  cv.width = W; cv.height = H;
+  Object.assign(cv.style, { position: 'fixed', left: '50px', top: '50px', zIndex: 99999,
+    background: '#11151c', border: '1px solid #2c3a4a', borderRadius: '8px' });
+  document.body.appendChild(cv);
+  const ctx = cv.getContext('2d');
+  ctx.fillStyle = '#11151c'; ctx.fillRect(0, 0, W, H);
+
+  const all = [...s.none, ...s.before, ...s.after];
+  const maxD = Math.max(...all) * 1.05;
+  const x = (t) => PAD + (t / (TICKS - 1)) * (W - PAD * 1.3);
+  const y = (d) => H - PAD - (d / maxD) * (H - PAD * 2);
+
+  // axes + grid
+  ctx.strokeStyle = '#39414f'; ctx.fillStyle = '#9aa6b8';
+  ctx.font = '15px system-ui, sans-serif'; ctx.lineWidth = 1;
+  for (let gy = 0; gy <= 5; gy++) {
+    const d = (maxD / 5) * gy;
+    const yy = y(d);
+    ctx.beginPath(); ctx.moveTo(PAD, yy); ctx.lineTo(W - PAD * 0.3, yy); ctx.stroke();
+    ctx.fillText(`${d.toFixed(0)} yd`, 10, yy + 5);
+  }
+  for (let sec = 0; sec <= 15; sec += 3) {
+    const xx = x(sec * 20);
+    ctx.fillText(`${sec}s`, xx - 8, H - PAD + 24);
+  }
+
+  const line = (data, color, dash) => {
+    ctx.strokeStyle = color; ctx.lineWidth = 3.5; ctx.setLineDash(dash || []);
+    ctx.beginPath();
+    data.forEach((d, t) => { const xx = x(t), yy = y(d); t ? ctx.lineTo(xx, yy) : ctx.moveTo(xx, yy); });
+    ctx.stroke(); ctx.setLineDash([]);
+  };
+  // Draw baseline first, then before (dashed, on top) so the overlap is visible.
+  line(s.none, '#6b7688');
+  line(s.before, '#e8c34a', [10, 8]);
+  line(s.after, '#4ad07a');
+
+  // title + legend
+  ctx.fillStyle = '#e8edf4'; ctx.font = '600 24px system-ui, sans-serif';
+  ctx.fillText('Druid Dash — distance run over 15s (cat form, straight line)', PAD, 38);
+  const legend = [
+    ['#4ad07a', 'Dash AFTER fix (value 1.5)  → +50% distance'],
+    ['#e8c34a', 'Dash BEFORE fix (value 0.5) → no effect (overlaps baseline)'],
+    ['#6b7688', 'No Dash (baseline)'],
+  ];
+  ctx.font = '16px system-ui, sans-serif';
+  legend.forEach(([c, label], i) => {
+    const ly = 70 + i * 26;
+    ctx.fillStyle = c; ctx.fillRect(PAD, ly - 12, 26, 6);
+    ctx.fillStyle = '#cdd6e3'; ctx.fillText(label, PAD + 38, ly - 4);
+  });
+
+  // numeric callout
+  const fd = (a) => a[a.length - 1].toFixed(1);
+  ctx.fillStyle = '#8b95a6'; ctx.font = '15px system-ui, sans-serif';
+  ctx.fillText(`final: after ${fd(s.after)} yd · before ${fd(s.before)} yd · none ${fd(s.none)} yd`,
+    PAD, H - 18);
+}, series);
+
+await sleep(200);
+const el = await page.$('#dash-chart');
+await el.screenshot({ path: 'tmp/dash-speed-chart.png' });
+console.log('wrote tmp/dash-speed-chart.png');
+
+// --- second artifact: real in-game cast, buff bar shows Dash active ---
+await page.evaluate(() => {
+  const cv = document.querySelector('#dash-chart'); if (cv) cv.remove();
+  const g = window.__game, sim = g.sim, p = sim.player;
+  // Enter Wolf (cat) form and cast Dash through the real ability pipeline.
+  p.auras = p.auras.filter((a) => a.kind !== 'buff_speed');
+  if (!p.auras.some((a) => a.kind === 'form_cat')) sim.castAbility('cat_form', p.id);
+  sim.tick();
+  p.resource = 100;
+  sim.castAbility('dash', p.id);
+  sim.tick();
+});
+await sleep(900);
+await page.screenshot({ path: 'tmp/dash-buff-active.png' });
+console.log('wrote tmp/dash-buff-active.png');
+console.log('final distances:',
+  'none', series.none.at(-1).toFixed(1),
+  'before', series.before.at(-1).toFixed(1),
+  'after', series.after.at(-1).toFixed(1));
+
+await browser.close();

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -1447,7 +1447,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     id: 'travel_form', name: 'Travel Form', class: 'druid', learnLevel: 16,
     cost: 30, castTime: 0, cooldown: 0, range: 0, school: 'nature',
     requiresTarget: false, requiresOutOfCombat: true,
-    effects: [{ type: 'selfBuff', kind: 'buff_speed', value: 0.4, duration: 3600 }],
+    effects: [{ type: 'selfBuff', kind: 'buff_speed', value: 1.4, duration: 3600 }],
     description: 'Take on a swift travel form, increasing movement speed by 40%. Cannot be used in combat.',
   },
   enrage: {
@@ -1482,7 +1482,7 @@ export const ABILITIES: Record<string, AbilityDef> = {
     id: 'dash', name: 'Dash', class: 'druid', learnLevel: 18,
     cost: 0, castTime: 0, cooldown: 60, range: 0, school: 'physical',
     requiresTarget: false, offGcd: true, requiresForm: 'cat',
-    effects: [{ type: 'selfBuff', kind: 'buff_speed', value: 0.5, duration: 15 }],
+    effects: [{ type: 'selfBuff', kind: 'buff_speed', value: 1.5, duration: 15 }],
     description: 'Sprint forward, increasing movement speed by 50% for 15 sec. Wolf Form only.',
   },
   pounce: {

--- a/tests/druid_spell_pack.test.ts
+++ b/tests/druid_spell_pack.test.ts
@@ -95,5 +95,24 @@ describe('druid spell pack — casting applies effects', () => {
     sim.tick();
     const buff = e.auras.find((au) => au.kind === 'buff_speed');
     expect(buff, 'travel_form should apply a buff_speed aura').toBeTruthy();
+    // The aura must actually speed the druid up: buff_speed is a multiplier,
+    // so a +40% form has to resolve to an effective mult > 1.
+    expect((sim as any).moveSpeedMult(e)).toBeGreaterThan(1);
+  });
+
+  it('Dash actually increases movement speed in cat form', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('druid', 'Runner');
+    const e = sim.entities.get(a)!;
+    sim.setPlayerLevel(20, a);
+    giveForm(sim, a, 'form_cat', 'Wolf Form');
+    const base = (sim as any).moveSpeedMult(e);
+    sim.castAbility('dash', a);
+    sim.tick();
+    const buff = e.auras.find((au) => au.kind === 'buff_speed');
+    expect(buff, 'dash should apply a buff_speed aura').toBeTruthy();
+    // The whole point of Dash: the effective move-speed multiplier must rise.
+    expect((sim as any).moveSpeedMult(e)).toBeGreaterThan(base);
+    expect((sim as any).moveSpeedMult(e)).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
## The bug

Druid **Dash** has no effect — casting it never increases movement speed. **Travel Form** has the same latent bug.

## Root cause

`buff_speed.value` is an **absolute movement multiplier**, and `moveSpeedMult` floors it at 1:

```ts
// src/sim/sim.ts
if (a.kind === 'buff_speed') speed = Math.max(speed, a.value);
```

Every other speed buff follows that convention — Sprint `1.7`, Aspect of the Cheetah `1.3`, Ghost Wolf `1.4`. But Dash and Travel Form encoded the **percentage delta** instead of the multiplier:

| Ability | Was | Resolves to | Should be |
|---|---|---|---|
| Dash | `0.5` | `Math.max(1, 0.5)` = **1.0** (no effect) | `1.5` (+50%) |
| Travel Form | `0.4` | `Math.max(1, 0.4)` = **1.0** (no effect) | `1.4` (+40%) |

The sub-1 floor silently swallowed the bug — the aura applied, it just did nothing. Both values now match what their own tooltips already promise ("by 50%" / "by 40%").

## Proof

Real offline `Sim`, a level-20 druid in Wolf (cat) form running straight for 15s. **Before-fix (yellow) lies exactly on the no-Dash baseline; after-fix (green) pulls ahead ~50%.**

![distance chart](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-dash-fix/dash-speed-chart.png)

In-game cast through the real ability pipeline (no errors):

![dash active](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-dash-fix/dash-buff-active.png)

## Tests

Strengthened `tests/druid_spell_pack.test.ts`. The old Travel Form test only checked that an aura *existed* — which passed even when the aura did nothing. New assertions check the effective `moveSpeedMult` actually rises:

- `Dash actually increases movement speed in cat form`
- Travel Form now asserts `moveSpeedMult > 1`

Both fail on `main`/`release`, pass with the fix. Full suite green (`npm test` → 2081 passed), `tsc --noEmit` clean.

## Changes
- `src/sim/content/classes.ts` — Dash `0.5`→`1.5`, Travel Form `0.4`→`1.4` (numbers only; descriptions unchanged, no new i18n keys)
- `tests/druid_spell_pack.test.ts` — behavioral assertions on effective speed
- `scripts/dash_speed_chart.mjs` — the before/after chart harness

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)