### PR TITLE
fix(sim): prevent fleeing mobs from evade-resetting

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -261,7 +261,7 @@ function blankEntity(id: number): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, terrifyTimer: 0, detonateTimer: Infinity, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
-    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { x: 0, y: 0, z: 0 }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, fleeReturnTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff, skinCatalog: 'class', skin: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -22,7 +22,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, terrifyTimer: 0, detonateTimer: Infinity, mendTimer: 0, wardTimer: 0, rallyTimer: 0, warcryTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
     threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
-    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
+    spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, fleeReturnTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,
     dead: false, scale: 1, color: 0xffffff, skinCatalog: 'class', skin: 0,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -67,6 +67,8 @@ const BACKPEDAL_MULT = 0.65;
 const FLEE_HP_THRESHOLD = 0.2;
 const FLEE_DURATION = 5;
 const FLEE_SPEED_MULT = 1.4;
+const FLEE_MAX_SPEED = RUN_SPEED;
+const FLEE_RETURN_GRACE = 8;
 const FLEE_HELP_RADIUS = 8;
 // Only sentient, cowardly families flee; beasts/undead/elementals/dragonkin fight
 // to the death. Elites, rares, and bosses never flee regardless of family.
@@ -1668,7 +1670,7 @@ export class Sim {
     if (!aura || e.auras.some((a) => a.kind === 'root')) return false;
     const angle = Number.isFinite(aura.value) ? aura.value : e.facing;
     const dest = this.groundPos(e.pos.x + Math.sin(angle) * 10, e.pos.z + Math.cos(angle) * 10);
-    this.moveToward(e, dest, e.moveSpeed * FLEE_SPEED_MULT * this.moveSpeedMult(e));
+    this.moveToward(e, dest, this.fleeMoveSpeed(e));
     return true;
   }
   // Silence locks out spell (non-physical) casts but leaves physical abilities,
@@ -1751,6 +1753,16 @@ export class Sim {
       if (ms) speed += ms;
     }
     return slow * speed;
+  }
+
+  private fleeMoveSpeed(e: Entity): number {
+    return Math.min(e.moveSpeed * FLEE_SPEED_MULT, FLEE_MAX_SPEED) * this.moveSpeedMult(e);
+  }
+
+  private recoverFromFlee(mob: Entity, target: Entity, leash: number, leashAnchor: Vec3): void {
+    mob.aiState = dist2d(mob.pos, target.pos) > MELEE_RANGE ? 'chase' : 'attack';
+    mob.fleeTimer = 0;
+    if (dist2d(mob.pos, leashAnchor) >= leash - 1) mob.fleeReturnTimer = FLEE_RETURN_GRACE;
   }
 
   // Fiesta "Moon Boots" power-up: a buff_jump aura multiplies jump height.
@@ -3191,7 +3203,7 @@ export class Sim {
     mob.forcedTargetTimer = TAUNT_FORCE_SECONDS;
     if (mob.aiState === 'idle') this.aggroMob(mob, p, false);
     else if (mob.aiState === 'chase' || mob.aiState === 'attack') mob.aggroTargetId = p.id;
-    else if (mob.aiState === 'flee') { mob.aggroTargetId = p.id; mob.aiState = 'attack'; mob.fleeTimer = 0; }
+    else if (mob.aiState === 'flee') { mob.aggroTargetId = p.id; mob.aiState = 'attack'; mob.fleeTimer = 0; mob.fleeReturnTimer = 0; }
     this.enterCombat(p, mob);
   }
 
@@ -4636,7 +4648,11 @@ export class Sim {
         const spell = MOBS[mob.templateId]?.petSpell;
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
         const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
-        if (dist2d(mob.pos, leashAnchor) > leash) {
+        if (mob.fleeReturnTimer > 0) {
+          mob.fleeReturnTimer = Math.max(0, mob.fleeReturnTimer - DT);
+          if (dist2d(mob.pos, leashAnchor) <= leash - 1) mob.fleeReturnTimer = 0;
+        }
+        if (dist2d(mob.pos, leashAnchor) > leash && mob.fleeReturnTimer <= 0) {
           mob.aiState = 'evade';
           mob.aggroTargetId = null;
           clearThreat(mob);
@@ -4774,20 +4790,20 @@ export class Sim {
       case 'flee': {
         const target = mob.aggroTargetId !== null ? this.entities.get(mob.aggroTargetId) : null;
         if (!target || target.dead) { this.retargetMob(mob); break; }
-        // Outran the leash while panicking: drop the pull and reset home.
+        const fleeSpeed = this.fleeMoveSpeed(mob);
+        // A panic flee should not be the thing that breaks leash and full-heals
+        // the mob. If it reaches the leash edge, it recovers and re-engages;
+        // normal chase/attack leash checks still handle genuine dragged pulls.
         const leash = mob.spawnPos.x > DUNGEON_X_THRESHOLD ? DUNGEON_LEASH_DISTANCE : LEASH_DISTANCE;
         const leashAnchor = mob.leashAnchor ?? mob.spawnPos;
-        if (dist2d(mob.pos, leashAnchor) > leash) {
-          mob.aiState = 'evade';
-          mob.aggroTargetId = null;
-          clearThreat(mob);
-          mob.leashAnchor = null;
+        if (dist2d(mob.pos, leashAnchor) >= leash - fleeSpeed * DT) {
+          this.recoverFromFlee(mob, target, leash, leashAnchor);
           break;
         }
         mob.fleeTimer -= DT;
         if (mob.fleeTimer <= 0) {
           // Recover nerve and turn to fight again; hasFled keeps it from re-fleeing.
-          mob.aiState = 'attack';
+          this.recoverFromFlee(mob, target, leash, leashAnchor);
           mob.swingTimer = Math.min(mob.swingTimer, 0.4);
           break;
         }
@@ -4797,7 +4813,7 @@ export class Sim {
         mob.facing = away;
         if (!this.isRooted(mob)) {
           const fleePos = this.groundPos(mob.pos.x + Math.sin(away) * 10, mob.pos.z + Math.cos(away) * 10);
-          this.moveToward(mob, fleePos, mob.moveSpeed * FLEE_SPEED_MULT * this.moveSpeedMult(mob));
+          this.moveToward(mob, fleePos, fleeSpeed);
         }
         break;
       }
@@ -4836,6 +4852,7 @@ export class Sim {
     mob.leashAnchor = null;
     mob.evadeStall = 0;
     mob.fleeTimer = 0;
+    mob.fleeReturnTimer = 0;
     mob.hasFled = false;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
@@ -5804,6 +5821,9 @@ export class Sim {
     mob.inCombat = false;
     mob.leashAnchor = null;
     mob.evadeStall = 0;
+    mob.fleeTimer = 0;
+    mob.fleeReturnTimer = 0;
+    mob.hasFled = false;
     clearThreat(mob);
     this.despawnSummonedAdds(mob);
     mob.firedSummons = 0;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -881,6 +881,7 @@ export interface Entity {
   leashAnchor: Vec3 | null; // refreshed by hostile player/pet actions; spawnPos remains the true home
   evadeStall: number; // seconds an evading mob has failed to get closer to home; snaps it home if it can't path back (e.g. across water)
   fleeTimer: number; // seconds left in a low-HP panic flee; counts down in the 'flee' state
+  fleeReturnTimer: number; // grace after a panic flee hits leash edge, letting it run back before normal leash reset resumes
   hasFled: boolean; // a cowardly mob flees only once per pull; cleared when it resets at spawn
   wanderTarget: Vec3 | null;
   wanderTimer: number;

--- a/tests/mob_flee.test.ts
+++ b/tests/mob_flee.test.ts
@@ -4,7 +4,7 @@
 // only ONCE per pull, and elites/bosses/beasts never flee.
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import { dist2d } from '../src/sim/types';
+import { DT, RUN_SPEED, dist2d } from '../src/sim/types';
 import type { Entity } from '../src/sim/types';
 
 function makeSim() {
@@ -25,6 +25,7 @@ function engageLowHp(sim: Sim, mob: Entity, templateId: string, hpFrac: number) 
   mob.enraged = false;
   mob.hasFled = false;
   mob.fleeTimer = 0;
+  mob.fleeReturnTimer = 0;
   mob.pos = { x: sim.player.pos.x + 3, z: sim.player.pos.z, y: sim.player.pos.y };
   mob.prevPos = { ...mob.pos };
   mob.spawnPos = { ...mob.pos };
@@ -32,6 +33,17 @@ function engageLowHp(sim: Sim, mob: Entity, templateId: string, hpFrac: number) 
   mob.aiState = 'attack';
   mob.aggroTargetId = sim.playerId;
   mob.inCombat = true;
+}
+
+function moveEntityToward(e: Entity, target: Entity, step: number) {
+  const dx = target.pos.x - e.pos.x;
+  const dz = target.pos.z - e.pos.z;
+  const d = Math.hypot(dx, dz);
+  if (d <= 0) return;
+  const s = Math.min(step, d);
+  e.pos.x += (dx / d) * s;
+  e.pos.z += (dz / d) * s;
+  e.prevPos = { ...e.pos };
 }
 
 describe('cowardly mobs flee at low HP', () => {
@@ -66,6 +78,63 @@ describe('cowardly mobs flee at low HP', () => {
 
     expect(mob.aiState === 'flee' || mob.hasFled).toBe(true);
     expect(dist2d(mob.pos, sim.player.pos)).toBeGreaterThan(before);
+  });
+
+  it('does not flee faster than a player can run', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+    mob.moveSpeed = RUN_SPEED * 2;
+
+    sim.tick();
+    expect(mob.aiState).toBe('flee');
+    const before = { ...mob.pos };
+
+    sim.tick();
+
+    expect(dist2d(before, mob.pos)).toBeLessThanOrEqual(RUN_SPEED * DT + 1e-6);
+  });
+
+  it('stays in the pull instead of evade-resetting when the player chases a fleeing mob', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+    mob.moveSpeed = RUN_SPEED * 2;
+
+    sim.tick();
+    expect(mob.aiState).toBe('flee');
+
+    for (let i = 0; i < 20 * 6; i++) {
+      moveEntityToward(sim.player, mob, RUN_SPEED * DT);
+      sim.tick();
+      if (mob.aiState === 'attack') break;
+    }
+
+    expect(mob.aiState).toBe('attack');
+    expect(mob.hp).toBeLessThan(mob.maxHp);
+    expect(mob.hasFled).toBe(true);
+  });
+
+  it('re-engages instead of evade-resetting when fleeing reaches the leash edge', () => {
+    const sim = makeSim();
+    const mob = wildMobs(sim)[0];
+    engageLowHp(sim, mob, 'gravecaller_cultist', 0.1);
+    mob.leashAnchor = { x: mob.pos.x - 44.9, z: mob.pos.z, y: mob.pos.y };
+    sim.player.pos = { x: mob.pos.x - 20, z: mob.pos.z, y: mob.pos.y };
+
+    sim.tick();
+    expect(mob.aiState).toBe('flee');
+
+    sim.tick();
+
+    expect(mob.aiState).toBe('chase');
+    expect(mob.hp).toBeLessThan(mob.maxHp);
+    expect(mob.hasFled).toBe(true);
+
+    sim.tick();
+
+    expect(mob.aiState).not.toBe('evade');
+    expect(mob.hp).toBeLessThan(mob.maxHp);
   });
 
   it('calls a nearby same-family ally into the fight when it flees', () => {


### PR DESCRIPTION
## Summary

  Fixes low-health fleeing mobs outrunning players and triggering an evade reset/full heal.

  Panic flee movement is now capped at normal player run speed, and mobs that hit the leash edge while fleeing get a short return grace so they can re-engage instead of immediately evading and healing to full.

  Adds regression coverage for flee speed, chased fleeing mobs, and leash-edge recovery.

  ## Related issues

  N/A - reported during local testing.

  ## Type of change

  - [ ] Feature: new functionality
  - [x] Bug fix
  - [ ] Refactor or performance (no behavior change)
  - [ ] Documentation
  - [x] Tests
  - [ ] Build, CI, or tooling
  - [ ] Breaking change

  ## How was this tested?

  - Commands:
    - `npx vitest run tests/mob_flee.test.ts`
    - `npx vitest run tests/mob_flee.test.ts tests/mob_chill.test.ts tests/mob_frostbite.test.ts tests/sim.test.ts tests/threat.test.ts`
    - `npm run test` before the final speed-cap adjustment/rebase
  - Manual steps:
    - Rebuilt/restarted the local authoritative server and Vite client.
    - Tested fleeing behavior locally against Vale Bandit.

  ## Screenshots / recordings

  N/A - sim behavior fix with no UI changes.

  ---

  ## Checklist

  ### Quality

  - [x] **Tests pass.** Targeted sim tests pass. `npm test` was run before the final speed-cap adjustment and passed.
  - [ ] **Typecheck passes.** `npx tsc --noEmit` was not run.
  - [ ] **Builds succeed.** Full build was not run; local server bundle was rebuilt while restarting the test server.

  ### Cross-platform

  - [ ] **Tested on desktop and mobile.** N/A - no UI changes.
  - [ ] **Accessible.** N/A - no UI changes.

  ### Localization (i18n)

  - [ ] **New player-visible strings are translated into every supported locale.**
  - [ ] Numbers, money, dates, units, and percents go through the i18n formatters.
  - [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.
  - [x] N/A. This PR adds no player-visible strings.

  ### Hygiene

  - [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
  - [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.