### PR TITLE
fix: retire Aldric fallen star quest

### DIFF
--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -434,6 +434,7 @@ export const ZONE2_QUESTS: Record<string, QuestDef> = {
     xpReward: 900, copperReward: 300,
     itemRewards: { warrior: 'alien_armor_plate', mage: 'alien_armor_plate', rogue: 'alien_armor_plate' },
     minLevel: 5,
+    retired: true,
   },
   q_deepfen_purge: {
     id: 'q_deepfen_purge', name: 'Back to the Shallows',

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -612,6 +612,7 @@ export function computeQuestState(
   if (!quest) return 'unavailable';
   if (quest.requiresQuest && !questsDone.has(quest.requiresQuest)) return 'unavailable';
   if (quest.minLevel && playerLevel < quest.minLevel) return 'unavailable';
+  if (quest.retired) return 'unavailable';
   return 'available';
 }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -754,6 +754,7 @@ export interface QuestDef {
   itemRewards: Partial<Record<PlayerClass, string>>;
   requiresQuest?: string; // prerequisite quest id (must be turned in)
   minLevel?: number;
+  retired?: boolean; // remains finishable if already accepted, but cannot be newly accepted
   suggestedPlayers?: number; // group quests ("Suggested players: 5")
 }
 

--- a/tests/aldric_meteor_quest.test.ts
+++ b/tests/aldric_meteor_quest.test.ts
@@ -27,9 +27,10 @@ function standAtMerchant(sim: Sim): void {
 }
 
 describe('Brother Aldric fallen star quest', () => {
-  it('is offered by Mirefen Aldric and rewards a mech cosmetic roll through the meteor pickup', () => {
+  it('keeps existing accepted players able to finish and claim the mech cosmetic roll', () => {
     const quest = QUESTS[QUEST_ID];
     expect(quest).toBeTruthy();
+    expect(quest).toMatchObject({ retired: true });
     expect(quest.giverNpcId).toBe('brother_aldric_fen');
     expect(quest.turnInNpcId).toBe('brother_aldric_fen');
     expect(quest.objectives).toEqual([
@@ -60,7 +61,7 @@ describe('Brother Aldric fallen star quest', () => {
     expect(aldric).toBeTruthy();
     teleportTo(sim, aldric!.pos.x + 1, aldric!.pos.z);
 
-    sim.acceptQuest(QUEST_ID);
+    sim.questLog.set(QUEST_ID, { questId: QUEST_ID, counts: [0], state: 'active' });
     expect(sim.questState(QUEST_ID)).toBe('active');
 
     const meteorObject = [...sim.entities.values()]
@@ -94,26 +95,32 @@ describe('Brother Aldric fallen star quest', () => {
     expect(sim.equipment.chest).not.toBe(REWARD_ITEM_ID);
   });
 
-  it('opens to level-5 players (minLevel 5) and stays gated below', () => {
+  it('is retired for fresh players while preserving existing ready turn-ins', () => {
     expect(QUESTS[QUEST_ID].minLevel).toBe(5);
+    expect(QUESTS[QUEST_ID]).toMatchObject({ retired: true });
 
     const sim = new Sim({ seed: 20061, playerClass: 'warrior', playerName: 'Reuben', autoEquip: false });
     const aldric = [...sim.entities.values()].find((e) => e.kind === 'npc' && e.templateId === 'brother_aldric_fen');
     expect(aldric).toBeTruthy();
     teleportTo(sim, aldric!.pos.x + 1, aldric!.pos.z);
 
-    // Below the requirement: the quest is unavailable and accepting is a no-op.
-    sim.setPlayerLevel(4);
+    sim.setPlayerLevel(5);
     expect(sim.questState(QUEST_ID)).toBe('unavailable');
     sim.acceptQuest(QUEST_ID);
     expect(sim.questLog.has(QUEST_ID)).toBe(false);
     expect(sim.questState(QUEST_ID)).toBe('unavailable');
 
-    // Exactly at the requirement: the gate is inclusive, so a level-5 player can start.
-    sim.setPlayerLevel(5);
-    expect(sim.questState(QUEST_ID)).toBe('available');
-    sim.acceptQuest(QUEST_ID);
-    expect(sim.questState(QUEST_ID)).toBe('active');
+    sim.talkToNpc(aldric!.id);
+    expect(sim.questLog.has(QUEST_ID)).toBe(false);
+
+    sim.questLog.set(QUEST_ID, { questId: QUEST_ID, counts: [1], state: 'ready' });
+    sim.addItem(METEOR_ITEM_ID, 1);
+    expect(sim.questState(QUEST_ID)).toBe('ready');
+
+    sim.turnInQuest(QUEST_ID);
+    expect(sim.questState(QUEST_ID)).toBe('done');
+    expect(sim.countItem(METEOR_ITEM_ID)).toBe(0);
+    expect(sim.countItem(REWARD_ITEM_ID)).toBe(1);
   });
 
   it('keeps the cosmetic item out of vendor sell, destroy, and market flows while allowing trade', () => {


### PR DESCRIPTION
## Summary
- Add a `retired` quest flag for quests that should remain valid for saved active/ready/done states but cannot be newly accepted.
- Mark `q_aldrics_fallen_star` retired so Brother Aldric no longer offers it to fresh players.
- Keep existing accepted/ready players able to complete the quest and receive the mech cosmetic reward.

## Validation
- `npx vitest run tests/aldric_meteor_quest.test.ts`
- `npx vitest run tests/aldric_meteor_quest.test.ts tests/game_sessions.test.ts tests/progression.test.ts tests/fixes.test.ts`
- `npx tsc --noEmit`
- `npm run build`

Build completed with existing Vite chunk/dynamic-import warnings only.