### PR TITLE
[codex] Shrink hosted player card uploads

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -44,7 +44,7 @@ import { crestIdForEntity } from './unit_portrait';
 import { svgIcon } from './ui_icons';
 import { walletUiEnabled, wocBalance, wocBalanceVerified, verifiedWocBalance, onWalletUiChange } from './wallet_balance';
 import {
-  renderPlayerCardCanvas, cardCanvasToBlob, CARD_POSES,
+  renderPlayerCardCanvas, cardCanvasToBlob, cardCanvasToUploadBlob, CARD_POSES,
   type PlayerCardData, type PlayerCardStat,
 } from './player_card';
 import { cardHostingAvailable, publishCard, fetchReferralInfo, fetchStanding, type PublishedCard, type CharacterStanding } from './player_card_share';
@@ -6105,7 +6105,7 @@ export class Hud {
       if (state.published) return state.published;
       if (!state.canvas) throw new Error(t('playerCard.statusStillRendering'));
       setStatus(t('playerCard.statusPublishing'));
-      const pub = await publishCard(await cardCanvasToBlob(state.canvas));
+      const pub = await publishCard(await cardCanvasToUploadBlob(state.canvas));
       state.published = pub;
       linkInput.value = pub.url;
       linkRow.hidden = false;

--- a/src/ui/player_card.ts
+++ b/src/ui/player_card.ts
@@ -416,12 +416,33 @@ function hexWithAlpha(hex: string, alpha: number): string {
   return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
 }
 
-/** Export a composited card canvas to a PNG blob. */
-export function cardCanvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+function canvasToPngBlob(canvas: HTMLCanvasElement, context: string): Promise<Blob> {
   return new Promise((resolve, reject) => {
     canvas.toBlob((blob) => {
       if (blob) resolve(blob);
-      else reject(new Error('player-card: canvas.toBlob returned null'));
+      else reject(new Error(`player-card: ${context} canvas.toBlob returned null`));
     }, 'image/png');
   });
+}
+
+/** Export a composited card canvas to a PNG blob. */
+export function cardCanvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return canvasToPngBlob(canvas, 'export');
+}
+
+/** Export the public hosted card at Open Graph size instead of the 2x preview size. */
+export function cardCanvasToUploadBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  if (canvas.width === CARD_W && canvas.height === CARD_H) {
+    return cardCanvasToBlob(canvas);
+  }
+
+  const uploadCanvas = document.createElement('canvas');
+  uploadCanvas.width = CARD_W;
+  uploadCanvas.height = CARD_H;
+  const ctx = uploadCanvas.getContext('2d');
+  if (!ctx) throw new Error('player-card: could not create upload canvas');
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(canvas, 0, 0, CARD_W, CARD_H);
+  return canvasToPngBlob(uploadCanvas, 'upload');
 }


### PR DESCRIPTION
## Summary

Downscale the player card image to Open Graph dimensions before uploading it for the hosted public card page.

The in-modal preview, download, clipboard image, and native share file paths continue to use the existing full-resolution card canvas. Only the `/api/card` publish path sends the smaller 1200x630 PNG.

This also keeps dev-hosted share pages on the dev public origin. When `PUBLIC_ORIGIN` is absent in production mode, the card page now accepts known public game hosts such as `dev.worldofclaudecraft.com` instead of always falling back to `worldofclaudecraft.com`. Unknown hosts still fall back to the production origin.

## Why

The dev environment was returning `413 Request Entity Too Large` before the request reached the Node handler for larger card PNG uploads. The app already validates and serves 1200x630 cards, so publishing that size avoids proxy body-limit failures without changing the visual share surface.

After that fix, dev-created card pages still emitted `https://worldofclaudecraft.com/p/<slug>/card.png` in the share-page image URL because production-mode dev had no public origin configured. That made the card image look up the slug on the wrong host and 404.

## Deployment notes

- No new environment variables are introduced.
- Existing `PUBLIC_ORIGIN` is now passed through `docker-compose.yml` to the game container.
- Dev should set `PUBLIC_ORIGIN=https://dev.worldofclaudecraft.com` when using compose, and production should set `PUBLIC_ORIGIN=https://worldofclaudecraft.com`.
- Missing card page/image responses now send `Cache-Control: no-store, max-age=0` so edge caches do not retain stale `card.png` 404s.

## Validation

- `npx tsc --noEmit`
- `npx vitest run tests/player_card_share.test.ts tests/player_card_server.test.ts`
- `npm run build`
- `npm run build:server`
