### PR TITLE
[codex] Keep dev player card images on dev origin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
       # Target the game server 302-redirects /wiki to when hit directly (not via the
       # reverse proxy). Public origin in prod; localhost fallback for local dev.
       WIKI_URL: ${WIKI_URL:-http://localhost:8080/wiki/index.php/Main_Page}
+      # Runtime public origin for server-generated absolute URLs such as player-card
+      # Open Graph images. Set per environment, for example dev vs production.
+      PUBLIC_ORIGIN: ${PUBLIC_ORIGIN:-}
       USERNAME_BANLIST: ${USERNAME_BANLIST:-}
       USERNAME_BANLIST_FILE: ${USERNAME_BANLIST_FILE:-}
       CHAT_CENSOR_LIST: ${CHAT_CENSOR_LIST:-}

--- a/server/player_card.ts
+++ b/server/player_card.ts
@@ -35,6 +35,19 @@ const MAX_CARD_DECODED_BYTES = (2400 * 4 + 1) * 1260;
 const MAX_SLUG_LENGTH = 64;
 const MAX_SLUG_ATTEMPTS = 25;
 const DEFAULT_PRODUCTION_PUBLIC_ORIGIN = 'https://worldofclaudecraft.com';
+const TRUSTED_PUBLIC_HOST_ORIGINS = new Map([
+  ['worldofclaudecraft.com', DEFAULT_PRODUCTION_PUBLIC_ORIGIN],
+  ['www.worldofclaudecraft.com', DEFAULT_PRODUCTION_PUBLIC_ORIGIN],
+  ['dev.worldofclaudecraft.com', 'https://dev.worldofclaudecraft.com'],
+]);
+const CARD_NOT_FOUND_HEADERS = {
+  'Content-Type': 'text/plain',
+  'Cache-Control': 'no-store, max-age=0',
+} as const;
+const CARD_PAGE_NOT_FOUND_HEADERS = {
+  'Content-Type': 'text/html; charset=utf-8',
+  'Cache-Control': 'no-store, max-age=0',
+} as const;
 
 export const PUBLIC_CARD_LOCALES = [
   'en', 'es', 'es_ES', 'fr_FR', 'fr_CA', 'en_CA', 'it_IT', 'de_DE',
@@ -378,9 +391,15 @@ function firstHeaderValue(value: string | string[] | undefined): string {
   return (Array.isArray(value) ? value[0] ?? '' : value ?? '').split(',')[0].trim();
 }
 
+function trustedPublicOriginFromHost(req: http.IncomingMessage): string {
+  const raw = firstHeaderValue(req.headers.host).toLowerCase();
+  const host = raw.includes(':') ? raw.split(':')[0] : raw;
+  return TRUSTED_PUBLIC_HOST_ORIGINS.get(host) ?? '';
+}
+
 function requestOrigin(req: http.IncomingMessage): string {
   if (REALM_PUBLIC_ORIGIN) return REALM_PUBLIC_ORIGIN;
-  if (process.env.NODE_ENV === 'production') return DEFAULT_PRODUCTION_PUBLIC_ORIGIN;
+  if (process.env.NODE_ENV === 'production') return trustedPublicOriginFromHost(req) || DEFAULT_PRODUCTION_PUBLIC_ORIGIN;
   const fwd = firstHeaderValue(req.headers['x-forwarded-proto']).toLowerCase();
   const proto = fwd === 'http' || fwd === 'https'
     ? fwd
@@ -472,7 +491,7 @@ export async function handleCardRoutes(req: http.IncomingMessage, res: http.Serv
     let slug = '';
     try { slug = m ? decodeURIComponent(m[1]).toLowerCase() : ''; } catch { slug = ''; }
     if (!m || !isValidSlug(slug)) {
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.writeHead(404, CARD_NOT_FOUND_HEADERS);
       res.end('not found');
       return;
     }
@@ -488,7 +507,7 @@ export async function handleCardRoutes(req: http.IncomingMessage, res: http.Serv
 async function serveCardImage(res: http.ServerResponse, slug: string): Promise<void> {
   const card = await getPlayerCardBySlug(slug);
   if (!card) {
-    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.writeHead(404, CARD_NOT_FOUND_HEADERS);
     res.end('not found');
     return;
   }
@@ -507,7 +526,7 @@ async function serveCardPage(req: http.IncomingMessage, res: http.ServerResponse
   const card = await getPlayerCardMetaBySlug(slug);
   const origin = requestOrigin(req);
   if (!card) {
-    res.writeHead(404, { 'Content-Type': 'text/html; charset=utf-8' });
+    res.writeHead(404, CARD_PAGE_NOT_FOUND_HEADERS);
     res.end(missingCardHtml(origin, requestLocale(req)));
     return;
   }
@@ -517,9 +536,11 @@ async function serveCardPage(req: http.IncomingMessage, res: http.ServerResponse
 
 function cardPageHtml(opts: { slug: string; title: string; description: string; locale: PublicCardLocale; origin: string }): string {
   const { slug, title, description, locale, origin } = opts;
-  const pageUrl = `${origin}/p/${slug}`;
-  const imageUrl = `${pageUrl}/card.png`;
-  const playUrl = `${origin}/?ref=${encodeURIComponent(slug)}`;
+  const pagePath = `/p/${encodeURIComponent(slug)}`;
+  const imagePath = `${pagePath}/card.png`;
+  const playPath = `/?ref=${encodeURIComponent(slug)}`;
+  const pageUrl = `${origin}${pagePath}`;
+  const imageUrl = `${origin}${imagePath}`;
   const copy = publicCardCopy(locale);
   const t = escapeHtml(title);
   const d = escapeHtml(description);
@@ -567,9 +588,9 @@ function cardPageHtml(opts: { slug: string; title: string; description: string; 
 </head>
 <body>
   <h1>${t}</h1>
-  <img class="card" src="${escapeHtml(imageUrl)}" alt="${t}" width="1200" height="630">
+  <img class="card" src="${escapeHtml(imagePath)}" alt="${t}" width="1200" height="630">
   <p>${d}</p>
-  <a class="cta" href="${escapeHtml(playUrl)}">${cta}</a>
+  <a class="cta" href="${escapeHtml(playPath)}">${cta}</a>
   <footer>${gameName}</footer>
 </body>
 </html>`;
@@ -595,7 +616,7 @@ function missingCardHtml(origin: string, locale: PublicCardLocale): string {
 </style></head>
 <body><h1>${heading}</h1>
 <p>${description}</p>
-<p><a href="${escapeHtml(origin)}/">${cta}</a></p>
+<p><a href="/">${cta}</a></p>
 </body></html>`;
 }
 

--- a/tests/player_card_server.test.ts
+++ b/tests/player_card_server.test.ts
@@ -406,7 +406,8 @@ describe('GET /p/<slug>', () => {
     expect(html).toContain('<link rel="canonical" href="http://realm.example/p/sir-test">');
     expect(html).toContain('property="og:image" content="http://realm.example/p/sir-test/card.png"');
     expect(html).toContain('name="twitter:card" content="summary_large_image"');
-    expect(html).toContain('href="http://realm.example/?ref=sir-test"');
+    expect(html).toContain('src="/p/sir-test/card.png"');
+    expect(html).toContain('href="/?ref=sir-test"');
     // title/description are HTML-escaped
     expect(html).toContain('A &quot;Quote&quot; &lt;b&gt;');
     expect(html).toContain('desc &amp; more');
@@ -484,7 +485,8 @@ describe('GET /p/<slug>', () => {
     await handleCardRoutes(makeGetReq('/p/sir-test', { headers: { 'x-forwarded-proto': 'https' } }), res);
     const html = String(res.body);
     expect(html).toContain('property="og:image" content="https://realm.example/p/sir-test/card.png"');
-    expect(html).toContain('href="https://realm.example/?ref=sir-test"');
+    expect(html).toContain('src="/p/sir-test/card.png"');
+    expect(html).toContain('href="/?ref=sir-test"');
   });
 
   it('builds an https origin from an encrypted socket', async () => {
@@ -506,7 +508,8 @@ describe('GET /p/<slug>', () => {
       expect(html).toContain('<link rel="canonical" href="https://cards.example.com/p/sir-test">');
       expect(html).toContain('property="og:url" content="https://cards.example.com/p/sir-test"');
       expect(html).toContain('property="og:image" content="https://cards.example.com/p/sir-test/card.png"');
-      expect(html).toContain('href="https://cards.example.com/?ref=sir-test"');
+      expect(html).toContain('src="/p/sir-test/card.png"');
+      expect(html).toContain('href="/?ref=sir-test"');
       expect(html).not.toContain('evil.example');
       expect(html).not.toContain('javascript://');
     });
@@ -524,9 +527,27 @@ describe('GET /p/<slug>', () => {
       expect(html).toContain('<link rel="canonical" href="https://worldofclaudecraft.com/p/sir-test">');
       expect(html).toContain('property="og:url" content="https://worldofclaudecraft.com/p/sir-test"');
       expect(html).toContain('property="og:image" content="https://worldofclaudecraft.com/p/sir-test/card.png"');
-      expect(html).toContain('href="https://worldofclaudecraft.com/?ref=sir-test"');
+      expect(html).toContain('src="/p/sir-test/card.png"');
+      expect(html).toContain('href="/?ref=sir-test"');
       expect(html).not.toContain('evil.example');
       expect(html).not.toContain('javascript://');
+    });
+  });
+
+  it('uses the trusted dev host in production mode instead of the production fallback', async () => {
+    await withReloadedCardRoutes({ NODE_ENV: 'production' }, async (routes) => {
+      cardRows = [{ character_id: 5, account_id: 1, png: validCardPng, title: 't', description: 'd' }];
+      const res = makeRes();
+      await routes(makeGetReq('/p/sir-test', {
+        headers: { host: 'dev.worldofclaudecraft.com', 'x-forwarded-proto': 'https' },
+      }), res);
+      const html = String(res.body);
+      expect(res.statusCode).toBe(200);
+      expect(html).toContain('<link rel="canonical" href="https://dev.worldofclaudecraft.com/p/sir-test">');
+      expect(html).toContain('property="og:url" content="https://dev.worldofclaudecraft.com/p/sir-test"');
+      expect(html).toContain('property="og:image" content="https://dev.worldofclaudecraft.com/p/sir-test/card.png"');
+      expect(html).toContain('src="/p/sir-test/card.png"');
+      expect(html).toContain('href="/?ref=sir-test"');
     });
   });
 
@@ -545,7 +566,8 @@ describe('GET /p/<slug>', () => {
       expect(html).toContain('<link rel="canonical" href="https://ironforge.example.com/p/sir-test">');
       expect(html).toContain('property="og:url" content="https://ironforge.example.com/p/sir-test"');
       expect(html).toContain('property="og:image" content="https://ironforge.example.com/p/sir-test/card.png"');
-      expect(html).toContain('href="https://ironforge.example.com/?ref=sir-test"');
+      expect(html).toContain('src="/p/sir-test/card.png"');
+      expect(html).toContain('href="/?ref=sir-test"');
       expect(html).not.toContain('evil.example');
     });
   });
@@ -586,6 +608,7 @@ describe('GET /p/<slug>', () => {
     const res = makeRes();
     await handleCardRoutes(makeGetReq('/p/nope'), res);
     expect(res.statusCode).toBe(404);
+    expect(res.headers['Cache-Control']).toBe('no-store, max-age=0');
   });
 
   it('404s card.png for an unknown slug without serving image bytes', async () => {
@@ -594,6 +617,7 @@ describe('GET /p/<slug>', () => {
     await handleCardRoutes(makeGetReq('/p/ghost/card.png'), res);
     expect(res.statusCode).toBe(404);
     expect(String(res.headers['Content-Type'])).toContain('text/plain');
+    expect(res.headers['Cache-Control']).toBe('no-store, max-age=0');
     expect(res.body).toBe('not found');
     expect(res.headers['Content-Type']).not.toBe('image/png');
     // a card-lookup query DID run (the slug was valid), but nothing was served
@@ -619,6 +643,7 @@ describe('GET /p/<slug>', () => {
       expect(res.statusCode).toBe(404);
       expect(res.statusCode).not.toBe(500);
       expect(String(res.headers['Content-Type'])).toContain('text/plain');
+      expect(res.headers['Cache-Control']).toBe('no-store, max-age=0');
       expect(res.body).toBe('not found');
       expect(dbMock.query).not.toHaveBeenCalled();
     }


### PR DESCRIPTION
## Summary

Keep dev-hosted player-card share pages on the dev public origin.

The visible share-page wrapper now uses root-relative paths for the card image and CTA:

- `/p/<slug>/card.png`
- `/?ref=<slug>`

The Open Graph and Twitter metadata still use absolute URLs, as crawlers expect. When `PUBLIC_ORIGIN` is absent in production mode, those absolute metadata URLs now accept known public game hosts such as `dev.worldofclaudecraft.com` instead of always falling back to `worldofclaudecraft.com`. Unknown hosts still fall back to the production origin, preserving the Host-header poisoning protection.

This also passes the existing `PUBLIC_ORIGIN` variable through `docker-compose.yml`, and marks missing card page/image responses as non-cacheable so edge caches do not retain stale `card.png` 404s.

## Why

After #762 fixed the upload body size, dev-created share pages still emitted image URLs like:

`https://worldofclaudecraft.com/p/<slug>/card.png`

Those slugs exist on `dev.worldofclaudecraft.com`, not production, so the actual card image returned 404.

## Deployment notes

- No new environment variables are introduced.
- Existing `PUBLIC_ORIGIN` is now passed to the game container by compose.
- Dev should set `PUBLIC_ORIGIN=https://dev.worldofclaudecraft.com` when using compose.
- Production should set `PUBLIC_ORIGIN=https://worldofclaudecraft.com`.

## Validation

- `npx tsc --noEmit`
- `npx vitest run tests/player_card_server.test.ts tests/player_card_share.test.ts`
- `npm run build`
- `npm run build:server`
