### PR TITLE
fix(sim): pets path around obstacles instead of getting stuck and warping to the owner

### DIFF
--- a/scripts/pet_follow_chart.mjs
+++ b/scripts/pet_follow_chart.mjs
@@ -1,0 +1,57 @@
+// Before/after top-down trajectory of a pet heeling to its owner. BEFORE = old
+// greedy straight-line heel (slide-steering wedges against the obstacle and never
+// arrives). AFTER = new A* heel route around it. Same seed/world for both.
+import { Sim } from '../src/sim/sim.ts';
+import { isBlocked } from '../src/sim/colliders.ts';
+import { terrainHeight } from '../src/sim/world.ts';
+import { RUN_SPEED } from '../src/sim/types.ts';
+
+const SEED = 42;
+const PET = { x: -16, z: 10 }, OWN = { x: -30, z: 10 };
+const dist2d = (a, b) => Math.hypot(a.x - b.x, a.z - b.z);
+
+function newSim() {
+  const sim = new Sim({ seed: SEED, playerClass: 'hunter', noPlayer: true });
+  const pid = sim.addPlayer('hunter', 'Owner');
+  const owner = sim.entities.get(pid);
+  const pet = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead);
+  pet.ownerId = pid; pet.hostile = false; pet.hp = pet.maxHp; pet.petMode = 'passive';
+  const set = (e, x, z) => { e.pos = { x, y: terrainHeight(x, z, SEED), z }; e.prevPos = { ...e.pos }; };
+  set(pet, PET.x, PET.z); set(owner, OWN.x, OWN.z);
+  return { sim, owner, pet };
+}
+function traceAfter() {
+  const { sim, owner, pet } = newSim(); const path = [{ ...pet.pos }];
+  for (let i = 0; i < 20 * 10 && dist2d(pet.pos, owner.pos) > 3.5; i++) { sim.tick(); path.push({ ...pet.pos }); }
+  return path;
+}
+function traceBefore() {
+  const { sim, owner, pet } = newSim(); const path = [{ ...pet.pos }];
+  const speed = Math.max(pet.moveSpeed, RUN_SPEED * 1.1);
+  for (let i = 0; i < 20 * 10; i++) {
+    const d = dist2d(pet.pos, owner.pos); if (d <= 3.5) break;
+    if (d > 60) pet.pos = { ...owner.pos }; else sim.moveToward(pet, owner.pos, speed);
+    path.push({ ...pet.pos });
+  }
+  return path;
+}
+const before = traceBefore(), after = traceAfter();
+
+const VX0 = -34, VX1 = -6, VZ0 = -2, VZ1 = 24, S = 24, PAD = 26;
+const W = (VX1 - VX0) * S + PAD * 2, H = (VZ1 - VZ0) * S + PAD * 2;
+const sx = (x) => PAD + (x - VX0) * S, sy = (z) => H - PAD - (z - VZ0) * S;
+let cells = '';
+for (let x = VX0; x < VX1; x += 0.5) for (let z = VZ0; z < VZ1; z += 0.5)
+  if (isBlocked(SEED, x, z, 0.5)) cells += `<rect x="${sx(x)}" y="${sy(z + 0.5)}" width="${0.5 * S}" height="${0.5 * S}" fill="#5a4632"/>`;
+const poly = (p, c) => `<polyline fill="none" stroke="${c}" stroke-width="3" stroke-linejoin="round" points="${p.map((q) => `${sx(q.x).toFixed(1)},${sy(q.z).toFixed(1)}`).join(' ')}"/>`;
+const dot = (p, c, r = 6) => `<circle cx="${sx(p.x)}" cy="${sy(p.z)}" r="${r}" fill="${c}"/>`;
+const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" font-family="sans-serif">
+<rect width="${W}" height="${H}" fill="#11151c"/>${cells}
+${poly(before, '#e0564b')}${poly(after, '#46c97a')}
+${dot(before[0], '#ffffff')}${dot(OWN, '#ffd24a', 7)}
+<text x="14" y="22" fill="#e0564b" font-size="15">■ before: greedy heel wedges on the obstacle (never arrives)</text>
+<text x="14" y="42" fill="#46c97a" font-size="15">■ after: A* route around the obstacle to the owner</text>
+<text x="14" y="${H - 12}" fill="#9aa4b2" font-size="13">brown = blocked cells · white = pet start · yellow = owner · seed ${SEED}</text>
+</svg>`;
+process.stdout.write(svg);
+process.stderr.write(`before ends ${dist2d(before.at(-1), OWN).toFixed(1)}yd away; after ends ${dist2d(after.at(-1), OWN).toFixed(1)}yd away\n`);

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -308,6 +308,7 @@ const TELEPORT_SNAP_DIST_SQ = 40 * 40;
 function blankEntity(id: number): Entity {
   return {
     id, kind: 'mob', templateId: '', name: '', level: 1, mendTimer: 0, wardTimer: 0, rallyTimer: 0, warcryTimer: 0,
+    petPath: [], petPathCooldown: 0,
     pos: { x: 0, y: 0, z: 0 }, prevPos: { x: 0, y: 0, z: 0 }, facing: 0, prevFacing: 0,
     vx: 0, vz: 0, vy: 0, onGround: true, jumping: false, fallStartY: 0,
     hp: 1, maxHp: 1, resource: 0, maxResource: 0, resourceType: null,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -21,7 +21,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     chargeTargetId: null, chargeTimeLeft: 0, chargePath: [], followTargetId: null,
     sitting: false, eating: null, drinking: null,
     aiState: 'idle', tappedById: null, pulseTimer: 0, stompTimer: 0, stoneskinTimer: 0, terrifyTimer: 0, detonateTimer: Infinity, mendTimer: 0, wardTimer: 0, rallyTimer: 0, warcryTimer: 0, firedSummons: 0, summonedIds: [], enraged: false, healedThisPull: false,
-    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0,
+    threat: new Map(), forcedTargetId: null, forcedTargetTimer: 0, ownerId: null, petMode: 'defensive', petTauntTimer: 0, petPath: [], petPathCooldown: 0,
     spawnPos: { ...pos }, leashAnchor: null, evadeStall: 0, fleeTimer: 0, fleeReturnTimer: 0, hasFled: false, wanderTarget: null, wanderTimer: 0,
     aggroTargetId: null, respawnTimer: 0, corpseTimer: 0, lootable: false, loot: null,
     xpValue: 0, questIds: [], vendorItems: [], objectItemId: null, dungeonId: null,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -242,7 +242,9 @@ const FOLLOW_STOP_DIST = 3; // /follow trails this close behind the leader (yard
 const FOLLOW_MAX_RANGE = 60; // give up follow once the leader is this far away
 const PET_LEASH = 40; // yards from the owner before a pet gives up its target
 const PET_FOLLOW_DISTANCE = 3.5;
-const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
+const PET_TELEPORT_DISTANCE = 60; // owner this far AND no route exists: pet warps to heel (last resort)
+const PET_PATH_RECALC = 0.5; // seconds between heel-path A* recomputes per pet (throttle)
+const PET_PATH_SPAN = 96; // A* search half-window in cells; covers the teleport distance + slack
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_AGGRESSIVE_RANGE = 18; // aggressive pets look for idle enemies this close
 const PET_TAUNT_RANGE = 5;
@@ -5678,17 +5680,59 @@ export class Sim {
 
     // heel
     pet.swingTimer = Math.max(0, pet.swingTimer - DT);
+    this.petFollow(pet, owner);
+  }
+
+  // Heel locomotion: route the pet to its owner AROUND obstacles instead of
+  // letting greedy slide-steering wedge on a wall and then snapping the pet to
+  // the owner. Mirrors the warrior-charge path cache (`petPath`): A* is recomputed
+  // at most every PET_PATH_RECALC and otherwise the cached waypoints are followed.
+  // The 60yd teleport is kept only as a true last resort, for when no route to the
+  // owner exists at all (e.g. owner stranded across un-navigable terrain).
+  private petFollow(pet: Entity, owner: Entity): void {
+    pet.petPathCooldown = Math.max(0, pet.petPathCooldown - DT);
     const d = dist2d(pet.pos, owner.pos);
-    if (d > PET_TELEPORT_DISTANCE) {
-      pet.pos = { ...owner.pos };
-      pet.prevPos = { ...pet.pos };
-      // a warp is a teleport: keep the spatial grid exact this tick instead of
-      // waiting for the end-of-tick refresh, so same-tick aggro/AoE queries
-      // don't miss the pet at its old cell (matches every other teleport site)
-      this.rebucket(pet);
-    } else if (d > PET_FOLLOW_DISTANCE && !this.isRooted(pet)) {
-      this.moveToward(pet, owner.pos, Math.max(pet.moveSpeed, RUN_SPEED * 1.1) * this.moveSpeedMult(pet));
+    if (d <= PET_FOLLOW_DISTANCE) { pet.petPath = []; return; }
+    if (this.isRooted(pet)) return;
+
+    const swim = this.mobCanSwim(MOBS[pet.templateId]);
+    const recompute = (): void => {
+      pet.petPath = findPlayerPath(this.cfg.seed, pet.pos, owner.pos, PET_PATH_SPAN, false, swim)
+        .map((w) => ({ x: w.x, y: 0, z: w.z }));
+      pet.petPathCooldown = PET_PATH_RECALC;
+    };
+    // recompute when the throttle has elapsed and the cache is stale: empty, or
+    // its end no longer lands near the (now-moved) owner. findPlayerPath returns a
+    // single-waypoint straight line (length 1) when the goal is unreachable.
+    const end = pet.petPath[pet.petPath.length - 1];
+    const stale = !end || dist2d(end, owner.pos) > 4;
+    if (pet.petPathCooldown <= 0 && stale) recompute();
+    // drop waypoints we've reached; the last leg homes on the live owner position.
+    while (pet.petPath.length > 1 && dist2d(pet.pos, pet.petPath[0]) < 1) pet.petPath.shift();
+
+    // Last-resort teleport: only when the owner is far AND genuinely unreachable.
+    // We confirm with a FRESH path (ignoring the throttle) so a stale single-point
+    // cache from a moment ago can never trigger a spurious snap while a real route
+    // exists — e.g. right after a combat→heel transition.
+    if (pet.petPath.length <= 1 && d > PET_TELEPORT_DISTANCE
+      && !lineOfSightClear(this.cfg.seed, pet.pos, owner.pos, BODY_RADIUS)) {
+      recompute();
+      if (pet.petPath.length <= 1) {
+        pet.pos = { ...owner.pos };
+        pet.prevPos = { ...pet.pos };
+        pet.petPath = [];
+        // a warp is a teleport: keep the spatial grid exact this tick instead of
+        // waiting for the end-of-tick refresh, so same-tick aggro/AoE queries
+        // don't miss the pet at its old cell (matches every other teleport site)
+        this.rebucket(pet);
+        return;
+      }
     }
+
+    const routed = pet.petPath.length > 1;
+    const aim = routed ? pet.petPath[0] : owner.pos;
+    const speed = Math.max(pet.moveSpeed, RUN_SPEED * 1.1) * this.moveSpeedMult(pet);
+    this.moveToward(pet, aim, speed);
   }
 
   /** A ranged demon pet (imp) hurls a spell-school bolt: a telegraphed

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -245,6 +245,8 @@ const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far AND no route exists: pet warps to heel (last resort)
 const PET_PATH_RECALC = 0.5; // seconds between heel-path A* recomputes per pet (throttle)
 const PET_PATH_SPAN = 96; // A* search half-window in cells; covers the teleport distance + slack
+const PET_PATH_STALE_DISTANCE = 4; // path end this far from the (now-moved) owner: recompute the heel route
+const PET_WAYPOINT_REACHED = 1; // pet within this of the next waypoint: pop it and home on the next leg
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_AGGRESSIVE_RANGE = 18; // aggressive pets look for idle enemies this close
 const PET_TAUNT_RANGE = 5;
@@ -5705,10 +5707,10 @@ export class Sim {
     // its end no longer lands near the (now-moved) owner. findPlayerPath returns a
     // single-waypoint straight line (length 1) when the goal is unreachable.
     const end = pet.petPath[pet.petPath.length - 1];
-    const stale = !end || dist2d(end, owner.pos) > 4;
+    const stale = !end || dist2d(end, owner.pos) > PET_PATH_STALE_DISTANCE;
     if (pet.petPathCooldown <= 0 && stale) recompute();
     // drop waypoints we've reached; the last leg homes on the live owner position.
-    while (pet.petPath.length > 1 && dist2d(pet.pos, pet.petPath[0]) < 1) pet.petPath.shift();
+    while (pet.petPath.length > 1 && dist2d(pet.pos, pet.petPath[0]) < PET_WAYPOINT_REACHED) pet.petPath.shift();
 
     // Last-resort teleport: only when the owner is far AND genuinely unreachable.
     // We confirm with a FRESH path (ignoring the throttle) so a stale single-point

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -865,6 +865,8 @@ export interface Entity {
   ownerId: number | null; // controlled pets: owning player's entity id (null = wild)
   petMode: PetMode; // hunter pet behavior stance
   petTauntTimer: number; // controlled pet Growl cooldown
+  petPath: Vec3[]; // controlled pet heel route around obstacles; consumed front-to-back (like chargePath)
+  petPathCooldown: number; // seconds until this pet may recompute its heel path again
   pulseTimer: number; // boss aoe pulse countdown
   stompTimer: number; // boss War Stomp stun-pulse countdown
   stoneskinTimer: number; // periodic self-absorb barrier countdown

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -993,20 +993,23 @@ describe('pet heel warp', () => {
   it('keeps the spatial grid exact when a pet warps to its owner', () => {
     const sim = makeSim();
     const p = sim.player;
-    // park the owner in open space away from the spawn camp
-    teleportTo(sim, p.pos.x + 400, p.pos.z + 400);
+    // park the owner behind the spawn building, far enough that no heel route
+    // exists: the gap (87yd) exceeds the pet's A* search window and the building
+    // breaks line of sight, so the pet can only fall back to the last-resort warp.
+    teleportTo(sim, 0, 82);
 
-    // adopt a wild beast as a heeling pet and strand it far from the owner
+    // adopt a wild beast as a heeling pet and strand it on the far side of the wall
     const pet = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
     pet.ownerId = p.id;
     pet.hostile = false;
     pet.aggroTargetId = null;
     pet.inCombat = false;
-    pet.pos = { x: p.pos.x + 200, z: p.pos.z, y: p.pos.y };
+    pet.petMode = 'passive';
+    pet.pos = { x: 0, z: -5, y: p.pos.y };
     pet.prevPos = { ...pet.pos };
     (sim as any).grid.update(pet); // grid now buckets the pet at its far cell
 
-    // 200 yds away with nothing to fight: the pet warps back to heel
+    // unreachable owner with nothing to fight: the pet warps back to heel
     (sim as any).updatePet(pet);
     expect(dist2d(pet.pos, p.pos)).toBeLessThan(1);
 
@@ -1078,20 +1081,23 @@ describe('pet heel warp', () => {
   it('keeps the spatial grid exact when a pet warps to its owner', () => {
     const sim = makeSim();
     const p = sim.player;
-    // park the owner in open space away from the spawn camp
-    teleportTo(sim, p.pos.x + 400, p.pos.z + 400);
+    // park the owner behind the spawn building, far enough that no heel route
+    // exists: the gap (87yd) exceeds the pet's A* search window and the building
+    // breaks line of sight, so the pet can only fall back to the last-resort warp.
+    teleportTo(sim, 0, 82);
 
-    // adopt a wild beast as a heeling pet and strand it far from the owner
+    // adopt a wild beast as a heeling pet and strand it on the far side of the wall
     const pet = [...sim.entities.values()].find((e) => e.kind === 'mob' && !e.dead)!;
     pet.ownerId = p.id;
     pet.hostile = false;
     pet.aggroTargetId = null;
     pet.inCombat = false;
-    pet.pos = { x: p.pos.x + 200, z: p.pos.z, y: p.pos.y };
+    pet.petMode = 'passive';
+    pet.pos = { x: 0, z: -5, y: p.pos.y };
     pet.prevPos = { ...pet.pos };
     (sim as any).grid.update(pet); // grid now buckets the pet at its far cell
 
-    // 200 yds away with nothing to fight: the pet warps back to heel
+    // unreachable owner with nothing to fight: the pet warps back to heel
     (sim as any).updatePet(pet);
     expect(dist2d(pet.pos, p.pos)).toBeLessThan(1);
 

--- a/tests/pet_follow.test.ts
+++ b/tests/pet_follow.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { Entity, Vec3 } from '../src/sim/types';
+import { isBlocked } from '../src/sim/colliders';
+import { terrainHeight } from '../src/sim/world';
+
+// Pets heel by pathfinding around obstacles (like a warrior charge route) rather
+// than greedily wedging on a wall and then snapping to the owner. These tests pin
+// that behavior: routing around a static collider, determinism, no mid-play
+// teleport, and the last-resort warp only when the owner is truly unreachable.
+
+const SEED = 42;
+
+function place(e: Entity, x: number, z: number): void {
+  e.pos = { x, y: terrainHeight(x, z, SEED), z };
+  e.prevPos = { ...e.pos };
+}
+
+// Adopt an existing wild mob as a passive heel-only pet, then position the pet
+// and its owner explicitly. Passive mode guarantees the pet never picks a combat
+// target, so it stays in the heel branch under test.
+function setup(petAt: Vec3, ownerAt: Vec3): { sim: Sim; pet: Entity; owner: Entity } {
+  const sim = new Sim({ seed: SEED, playerClass: 'hunter', noPlayer: true });
+  const pid = sim.addPlayer('hunter', 'Aleph');
+  const owner = sim.entities.get(pid)!;
+  let pet: Entity | null = null;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) { pet = e; break; }
+  }
+  if (!pet) throw new Error('no wild mob to adopt');
+  pet.ownerId = pid;
+  pet.hostile = false;
+  pet.hp = pet.maxHp;
+  pet.petMode = 'passive';
+  place(pet, petAt.x, petAt.z);
+  place(owner, ownerAt.x, ownerAt.z);
+  return { sim, pet, owner };
+}
+
+function dist(a: Vec3, b: Vec3): number {
+  return Math.hypot(a.x - b.x, a.z - b.z);
+}
+
+describe('pet heel pathfinding', () => {
+  // The spawn building straddles z=3..12 at x≈0; a straight line from (0,-3) to
+  // (0,8) is blocked, so the pet must route around it.
+  const PET = { x: 0, y: 0, z: -3 };
+  const OWNER = { x: 0, y: 0, z: 8 };
+
+  it('routes around a static obstacle to reach the owner without passing through it', () => {
+    const { sim, pet, owner } = setup(PET, OWNER);
+    let maxStep = 0;
+    let everBlocked = false;
+    for (let i = 0; i < 20 * 8; i++) {
+      const before = { ...pet.pos };
+      sim.tick();
+      maxStep = Math.max(maxStep, dist(before, pet.pos));
+      if (isBlocked(SEED, pet.pos.x, pet.pos.z, 0.5)) everBlocked = true;
+    }
+    // converged onto the owner
+    expect(dist(pet.pos, owner.pos)).toBeLessThan(4);
+    // never tunneled through the collider
+    expect(everBlocked).toBe(false);
+    // moved smoothly the whole way — no teleport snap (a warp would be many yards)
+    expect(maxStep).toBeLessThan(1.5);
+  });
+
+  it('is deterministic — identical seed yields an identical heel path', () => {
+    const trace = () => {
+      const { sim, pet } = setup(PET, OWNER);
+      const path: Vec3[] = [];
+      for (let i = 0; i < 20 * 6; i++) { sim.tick(); path.push({ ...pet.pos }); }
+      return path;
+    };
+    expect(trace()).toEqual(trace());
+  });
+
+  it('does not teleport while following a distant owner over open ground', () => {
+    // 50yd away with a clear line of sight: the pet should run, never snap.
+    const { sim, pet, owner } = setup({ x: 200, y: 0, z: 200 }, { x: 200, y: 0, z: 250 });
+    let maxStep = 0;
+    for (let i = 0; i < 20 * 12; i++) {
+      const before = { ...pet.pos };
+      sim.tick();
+      maxStep = Math.max(maxStep, dist(before, pet.pos));
+    }
+    expect(maxStep).toBeLessThan(1.5);
+    expect(dist(pet.pos, owner.pos)).toBeLessThan(4);
+  });
+
+  it('does not snap on a stale unreachable path when a route actually exists', () => {
+    // Regression: the teleport must be confirmed by a FRESH A* attempt, not by a
+    // leftover single-waypoint cache. Owner is 62yd away with the line of sight
+    // blocked but a real route around exists, and the pet carries a stale "no
+    // route" cache with the throttle still active — it must path, never warp.
+    const { sim, pet, owner } = setup({ x: -138, y: 0, z: -160 }, { x: -200, y: 0, z: -160 });
+    expect(dist(pet.pos, owner.pos)).toBeGreaterThan(60);
+    pet.petPath = [{ ...owner.pos }]; // stale single-waypoint (looks "unreachable")
+    pet.petPathCooldown = 0.4; // throttle active: would skip recompute without the fresh-attempt guard
+    const before = { ...pet.pos };
+    sim.tick();
+    // moved by a normal step, not snapped to the owner
+    expect(dist(before, pet.pos)).toBeLessThan(1.5);
+    expect(dist(pet.pos, owner.pos)).toBeGreaterThan(30);
+  });
+
+  it('warps to the owner only as a last resort when no route exists', () => {
+    // 87yd apart with the spawn building breaking line of sight and the gap beyond
+    // the A* search window: no route can be found, so the pet snaps to heel.
+    const { sim, pet, owner } = setup({ x: 0, y: 0, z: -5 }, { x: 0, y: 0, z: 82 });
+    expect(dist(pet.pos, owner.pos)).toBeGreaterThan(60);
+    sim.tick();
+    expect(dist(pet.pos, owner.pos)).toBeLessThan(1);
+  });
+});


### PR DESCRIPTION
## Problem

Player pets follow their owner using greedy one-step slide-steering (`MOVE_SLIDE_FAN` in `moveToward`). Against **concave** geometry — a building corner, a fence run, a wall — that local greedy choice dead-ends: the pet wedges and stops closing the distance. Once it drifts past `PET_TELEPORT_DISTANCE` (60yd) the heel branch **snaps it onto the owner** — the familiar *"pet spawns next to you when you run away"* behavior.

![before/after pet pathfinding](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-pet-pathfind/pet_follow.png)

*Same seed/world. **Red (before):** greedy heel steers the wrong way along the obstacle and never arrives (ends 12.9yd off). **Green (after):** A\* routes around it to the owner (ends 3.3yd). Brown = blocked cells, white = pet start, yellow = owner.*

## Fix

Route the pet to its owner with the **existing deterministic A\*** (`findPlayerPath` in `pathfind.ts`, already used for warrior Charge) rather than greedy steering. A `petPath` waypoint cache mirrors the existing `chargePath`:

- A\* is recomputed **at most every `PET_PATH_RECALC` (0.5s)** per pet and bounded by `PET_PATH_SPAN`, so server cost stays small even with many pets. `moveToward`'s slide fan still owns the final yard of local collision.
- The 60yd teleport is kept **only as a genuine last resort** — and only after a *fresh* path attempt confirms the owner is truly unreachable (no multi-point route **and** no clear line of sight). A stale cache can never trigger a spurious snap (e.g. right after a combat→heel transition).
- **Combat/chase movement is unchanged** — this only touches the heel branch of `updatePet`.

## Scope & invariants

- **Determinism preserved** — A\* is a pure function of `cfg.seed`, draws no RNG, and the tick iteration order is unchanged. `petPathCooldown` decrements by the fixed `DT`.
- **No wire / `IWorld` / render / i18n changes** — pet position already streams via the normal entity snapshot, so smoother movement applies on all three hosts. New `petPath`/`petPathCooldown` fields are added to the `Entity` shape (`types.ts`, `entity.ts`) and the client mirror (`net/online.ts` `blankEntity`).

## Tests

New `tests/pet_follow.test.ts`: obstacle routing without tunneling through colliders, determinism (same seed ⇒ identical path), no mid-play teleport over open ground, last-resort warp only when genuinely unreachable, and a **regression** for the stale-cache false-teleport. Updated the existing pet-heel-warp grid test to trigger the warp via an unreachable setup. `scripts/pet_follow_chart.mjs` reproduces the chart above. Full suite green (2379 passing).

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton — would appreciate a review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
