### PR TITLE
fix(ui): left-align $WOC wallet disclaimer so wrapped text reads cleanly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2159,7 +2159,7 @@
     color: var(--color-text-muted);
     font-size: 11px;
     line-height: 1.35;
-    text-align: right;
+    text-align: left;
   }
   .cs-wallet-help.is-attention { color: var(--gold); }
   .cs-wallet-help.is-verified { color: var(--color-text-success); }


### PR DESCRIPTION
## Problem

On the character-select screen, the **$WOC Wallet** disclaimer wraps to two lines, and because the text is right-aligned the trailing word (\"required.\") ends up flush against the **right** edge on its own line — looking detached and ragged instead of flowing from the start of the line.

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-wallet-align/before.png)

## Cause

`.cs-wallet-help` (`#wallet-help`) in `index.html` sets `text-align: right`. The help block is *already* right-anchored by its parent column — `.cs-wallet-main` is `display: flex; flex-direction: column; align-items: flex-end` — so the extra `text-align: right` only governs how the wrapped lines flow *inside* the block, producing the ragged-left wrap.

## Fix

One line: `text-align: right` → `text-align: left` on `.cs-wallet-help`.

The block stays tucked under the **Verify Wallet** button (its parent still right-aligns the box), but each wrapped line now starts at the same left edge, so \"required.\" reads naturally as a continuation. This also makes desktop consistent with the existing `@media (max-width: 720px)` override, which already sets `text-align: left` for the same element.

![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-wallet-align/after.png)

## Scope / safety

- Pure CSS, single line. No JS, no DOM, no sim/server/wire changes.
- No new strings — the disclaimer is the existing `wallet.helpDisconnected` i18n key, untouched, so no i18n work is needed.
- `is-attention` / `is-verified` state variants of this element are unaffected (they only change color).

Screenshots are the real `#charselect-panel` wallet block rendered from `index.html` (BEFORE forces the old `text-align: right`, AFTER is this branch).

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)