### PR TITLE
fix(ui): tidy key-binding panel layout — 2 columns, uniform buttons, dividers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1420,18 +1420,23 @@
   .opt-list { display: flex; flex-direction: column; gap: 8px; align-items: stretch; padding: 4px 0; }
   .opt-btn { margin: 0; text-align: center; }
   .kb-rows { display: flex; flex-direction: column; gap: 2px; margin-bottom: 8px; }
-  /* Wide, multi-column key-binding layout (desktop). Categories flow into as many
-     columns as fit, so the tall Action Bar list no longer forces a long scroll. */
-  #options-menu.kb-wide { width: min(880px, calc(100vw - 32px)); }
-  .kb-cols { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-    gap: 4px 18px; align-items: start; margin-bottom: 8px; }
+  /* Wide, multi-column key-binding layout (desktop). Cap at two columns so each
+     category block stays wide enough for the longest action label (e.g. the
+     Movement rows) instead of clipping; the panel scrolls vertically when the
+     two columns run taller than the window (.window already sets overflow-y).
+     --kb-btn-w gives every key/toggle button one shared width. */
+  #options-menu.kb-wide { width: min(880px, calc(100vw - 32px)); --kb-btn-w: 96px; }
+  .kb-cols { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px 28px; align-items: start; margin-bottom: 8px; }
   .kb-col { min-width: 0; }
   .kb-col .kb-rows { margin-bottom: 0; }
   .kb-col .kb-cat { margin-top: 0; }
   .kb-cat { font-family: var(--title-font); color: var(--gold); font-size: 12px; letter-spacing: 0.5px;
-    text-transform: uppercase; margin: 8px 0 2px; border-bottom: 1px solid #463a1c; padding-bottom: 2px; }
-  .kb-row { display: grid; grid-template-columns: 1fr 78px 78px; align-items: center;
-    gap: 6px; padding: 2px 6px; border-radius: 4px; }
+    text-transform: uppercase; margin: 8px 0 4px; border-bottom: 1px solid #463a1c; padding-bottom: 4px; }
+  .kb-row { display: grid; grid-template-columns: minmax(0, 1fr) var(--kb-btn-w, 78px) var(--kb-btn-w, 78px);
+    align-items: center; gap: 6px; padding: 5px 8px; border-radius: 4px;
+    border-bottom: 1px solid #ffffff10; }
+  .kb-row:last-child { border-bottom: 0; }
   .kb-row:nth-of-type(odd) { background: #ffffff0a; }
   .kb-name { font-size: 12.5px; color: #e8e0c8; display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
   .kb-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -1443,9 +1448,9 @@
   .kb-toggle-row { margin-bottom: 6px; background: #ffffff0a; border-radius: 4px; }
   .kb-toggle-row .kb-toggle {
     grid-column: 2;
-    width: 78px;
-    min-width: 78px;
-    max-width: 78px;
+    width: var(--kb-btn-w, 78px);
+    min-width: var(--kb-btn-w, 78px);
+    max-width: var(--kb-btn-w, 78px);
     margin: 0;
     padding: 3px 6px;
     text-align: center;
@@ -1456,9 +1461,9 @@
     box-sizing: border-box;
   }
   .kb-toggle-row .kb-mouse-toggle {
-    width: 98px;
-    min-width: 98px;
-    max-width: 98px;
+    width: var(--kb-btn-w, 78px);
+    min-width: var(--kb-btn-w, 78px);
+    max-width: var(--kb-btn-w, 78px);
   }
   .kb-toggle.off { filter: grayscale(0.6) brightness(0.8); color: #b9ac82; }
   .set-rows { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }


### PR DESCRIPTION
## What & why

The desktop **Key Bindings** panel (Esc → Key Bindings) had a few layout issues:

- The category grid used `repeat(auto-fill, minmax(240px, 1fr))`, which at the 880px panel width produced **three ~240px columns**. After two 78px key buttons each row had ~70px left for the label, so the **Movement** rows (and others) clipped — *"Move Forwa…"*, *"Toggle Autor…"*, *"Cycle Friend…"*, *"Arena (Ashe…"*.
- Key cells (78px) and the toggle buttons (78px, plus a 98px mouse-button toggle) had **inconsistent widths**.
- Rows were tightly packed with no separators.

## Changes (pure CSS, `index.html` only)

- **Cap the grid at two columns** (`repeat(2, minmax(0, 1fr))`) so each block is wide enough for the longest label. The panel **scrolls vertically** when the taller two-column flow exceeds the window (`.window` already sets `overflow-y: auto`).
- **Uniform button width** via a new `--kb-btn-w: 96px` custom property applied to every key-capture cell and toggle (including the mouse-button toggle).
- **Horizontal row dividers + more row/category padding** to spread the list out.

No new i18n keys, no sim/wire/render changes. The **mobile** single-column touch layout is unchanged (still overridden to `1fr`), and benefits from the uniform widths + dividers too.

## Screenshots

**Before** — 3 columns, labels clipped:

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-kb-columns/before_panel.png)

**After** — 2 columns, full labels, uniform buttons, dividers, scrolls:

![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-kb-columns/after_panel.png)

**Mobile (touch)** — single column intact, uniform button width:

![mobile](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-kb-columns/mobile_panel.png)

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)