### PR TITLE
feat(analytics): add Meta Pixel tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,16 @@
     gtag('config', 'G-BR5Z7GT7C2');
   }
 </script>
+<!-- Meta Pixel Code - skipped on localhost so dev sessions don't pollute analytics -->
+<script>
+  if (!['localhost', '127.0.0.1', '[::1]'].includes(location.hostname)) {
+    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');
+    fbq('init', '1692101265042180');
+    fbq('track', 'PageView');
+  }
+</script>
+<noscript><img height="1" width="1" style="display:none" alt="" src="https://www.facebook.com/tr?id=1692101265042180&ev=PageView&noscript=1" /></noscript>
+<!-- End Meta Pixel Code -->
 <style>
   :root {
     --gold: #ffd100;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -119,6 +119,11 @@ const esc = (value: unknown): string => String(value ?? '')
   .replace(/>/g, '&gt;')
   .replace(/"/g, '&quot;')
   .replace(/'/g, '&#39;');
+const trackMetaPixel = (eventName: string, data?: Record<string, unknown>): void => {
+  const fbq = (window as Window & { fbq?: (...args: unknown[]) => void }).fbq;
+  if (typeof fbq !== 'function') return;
+  fbq('trackCustom', eventName, data ?? {});
+};
 const castDisplayName = (id: string): string => {
   if (id === FISHING_CAST_ID) return t('abilityUi.cast.fishing');
   if (id === 'demon_heal') return t('abilityUi.cast.demonHeal');
@@ -3515,6 +3520,7 @@ export class Hud {
           this.showBanner(t('hud.core.levelBanner', { level: ev.level }));
           this.log(t('hud.core.levelLog', { level: ev.level }), '#ffd100');
           audio.levelUp();
+          if (ev.level === 5) trackMetaPixel('ReachedLevel5', { level: ev.level });
           // First talent point (and spec) unlock — nudge the player to the panel.
           if (ev.level === FIRST_TALENT_LEVEL && talentsFor(this.sim.cfg.playerClass)) {
             this.showBanner(t('game.talents.unlockBanner'));

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -52,6 +52,16 @@ describe('client HTML shell', () => {
     expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/links</loc>');
   });
 
+  it('loads Meta Pixel outside local development and tracks level 5', () => {
+    expect(html).toContain('https://connect.facebook.net/en_US/fbevents.js');
+    expect(html).toContain("fbq('init', '1692101265042180');");
+    expect(html).toContain("fbq('track', 'PageView');");
+    expect(html).toContain('https://www.facebook.com/tr?id=1692101265042180&ev=PageView&noscript=1');
+    expect(html).toContain("if (!['localhost', '127.0.0.1', '[::1]'].includes(location.hostname)) {");
+    expect(hudTs).toContain("fbq('trackCustom', eventName, data ?? {});");
+    expect(hudTs).toContain("if (ev.level === 5) trackMetaPixel('ReachedLevel5', { level: ev.level });");
+  });
+
   it('offers the quest log in the mobile controls drawer', () => {
     expect(html).toContain('id="mobile-extra-controls"');
     expect(html).toContain('id="mobile-quest"');


### PR DESCRIPTION
## Summary

Add Meta Pixel tracking to the site.

- Adds the Meta Pixel bootstrap for pixel ID `1692101265042180`.
- Keeps analytics disabled on localhost / loopback hosts, matching the existing Google tag behavior.
- Adds a custom `ReachedLevel5` Meta Pixel event when a player reaches level 5.
- Adds client shell regression coverage for the pixel bootstrap and level 5 hook.

## Related issues

N/A.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts`
  - `npx tsc --noEmit`

## Screenshots / recordings

N/A. Analytics instrumentation only.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused client shell test passed.
- [x] **Typecheck passes.** `npx tsc --noEmit` passed.
- [ ] **Builds succeed.** Not run; focused validation only.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; instrumentation is guarded by shell regression checks.
- [x] **Accessible.** No UI controls or player-facing copy changed.

### Localization (i18n)

- [x] **N/A. This PR adds no new player-visible strings.**

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
