### PR TITLE
feat(seo): add play landing route

### DIFF
--- a/play.html
+++ b/play.html
@@ -1,0 +1,7771 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+<meta name="theme-color" content="#050509" />
+<meta name="mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-title" content="ClaudeCraft" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+<meta name="screen-orientation" content="landscape" />
+<meta name="orientation" content="landscape" />
+<title data-i18n="seo.title">World of ClaudeCraft: Classic-Style Web MMO</title>
+<meta name="description" data-i18n-content="seo.description" content="Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!" />
+<meta name="robots" content="index, follow, max-image-preview:large" />
+<link rel="manifest" href="/manifest.webmanifest" />
+
+<!-- i18n stored-locale modulepreload (Phase 4 / Lazy Locales). For a returning visitor
+     whose stored locale (localStorage key "locale") is non-English, inject a high-priority
+     <link rel="modulepreload"> for THAT locale's content-hashed chunk before the main
+     module parses, so the locale chunk is parser-discoverable and in flight early rather
+     than discovered only after main parses + runs its runtime-keyed dynamic import (the
+     main-then-locale waterfall). The production build templates the { locale: chunkUrl }
+     map over the build sentinel below (see scripts/i18n_modulepreload.mjs); in dev the
+     sentinel is undefined and the try/catch makes this a no-op. Reads ONLY
+     localStorage.locale, injects ONLY one
+     same-origin preload for the ONE stored locale - never speculative, no third-party
+     origin. crossorigin matches Vite's module request so the browser dedupes to one fetch. -->
+<script>
+  (function () {
+    try {
+      var loc = localStorage.getItem('locale');
+      if (!loc) return;
+      var map = __I18N_LOCALE_CHUNKS__;
+      var href = map && map[loc];
+      // Require a string so an attacker-set localStorage.locale ("__proto__" etc.) that
+      // resolves a prototype key to a non-URL value cannot reach link.href.
+      if (typeof href !== 'string') return;
+      var link = document.createElement('link');
+      link.rel = 'modulepreload';
+      link.href = href;
+      link.crossOrigin = 'anonymous';
+      document.head.appendChild(link);
+    } catch (e) {
+      // No stored locale / no templated map (dev) / storage blocked: do nothing.
+    }
+  })();
+</script>
+
+<!-- Cloudflare Turnstile (bot gate on login/registration). Rendered explicitly
+     by src/main.ts only when VITE_TURNSTILE_SITEKEY is configured. -->
+<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+
+<!-- Canonical URL -->
+<link rel="canonical" href="https://worldofclaudecraft.com/play" />
+
+<!-- GEO / Multilingual Alternates -->
+<link rel="alternate" hreflang="en" href="https://worldofclaudecraft.com/play" />
+<link rel="alternate" hreflang="es" href="https://worldofclaudecraft.com/play?lang=es" />
+<link rel="alternate" hreflang="es-ES" href="https://worldofclaudecraft.com/play?lang=es_ES" />
+<link rel="alternate" hreflang="fr-FR" href="https://worldofclaudecraft.com/play?lang=fr_FR" />
+<link rel="alternate" hreflang="fr-CA" href="https://worldofclaudecraft.com/play?lang=fr_CA" />
+<link rel="alternate" hreflang="en-CA" href="https://worldofclaudecraft.com/play?lang=en_CA" />
+<link rel="alternate" hreflang="it-IT" href="https://worldofclaudecraft.com/play?lang=it_IT" />
+<link rel="alternate" hreflang="de-DE" href="https://worldofclaudecraft.com/play?lang=de_DE" />
+<link rel="alternate" hreflang="zh-CN" href="https://worldofclaudecraft.com/play?lang=zh_CN" />
+<link rel="alternate" hreflang="zh-TW" href="https://worldofclaudecraft.com/play?lang=zh_TW" />
+<link rel="alternate" hreflang="ko-KR" href="https://worldofclaudecraft.com/play?lang=ko_KR" />
+<link rel="alternate" hreflang="ja-JP" href="https://worldofclaudecraft.com/play?lang=ja_JP" />
+<link rel="alternate" hreflang="pt-BR" href="https://worldofclaudecraft.com/play?lang=pt_BR" />
+<link rel="alternate" hreflang="ru-RU" href="https://worldofclaudecraft.com/play?lang=ru_RU" />
+<link rel="alternate" hreflang="x-default" href="https://worldofclaudecraft.com/play" />
+
+<!-- Open Graph / Facebook -->
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="World of ClaudeCraft" />
+<meta property="og:title" data-i18n-content="seo.title" content="World of ClaudeCraft: Classic-Style Web MMO" />
+<meta property="og:description" data-i18n-content="seo.description" content="Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!" />
+<meta property="og:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+<meta property="og:url" content="https://worldofclaudecraft.com/play" />
+
+<!-- Twitter / X -->
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" data-i18n-content="seo.title" content="World of ClaudeCraft: Classic-Style Web MMO" />
+<meta name="twitter:description" data-i18n-content="seo.description" content="Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!" />
+<meta name="twitter:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+
+<!-- Structured Data (Schema.org JSON-LD VideoGame) -->
+<script id="structured-data" type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "VideoGame",
+  "name": "World of ClaudeCraft",
+  "alternateName": "World of Claudecraft",
+  "genre": "MMORPG",
+  "playMode": "MultiPlayer",
+  "applicationCategory": "Game",
+  "operatingSystem": "Web Browser",
+  "url": "https://worldofclaudecraft.com/play",
+  "image": "https://worldofclaudecraft.com/woc_logo_square.webp",
+  "description": "Embark on an epic adventure in World of ClaudeCraft, a classic-style micro-MMO playable directly in your browser. Join a persistent shared realm, level up classes, and defeat enemies!",
+  "inLanguage": "en",
+  "sameAs": [
+    "https://github.com/levy-street/world-of-claudecraft",
+    "https://discord.gg/GjhnUsBtw"
+  ]
+}
+</script>
+
+<link rel="icon" href="/favicon.ico" sizes="any" />
+<link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png" />
+<link rel="icon" type="image/png" sizes="192x192" href="/icon-192.png" />
+<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+<link rel="preload" as="image" href="/loading-screen.jpg" />
+<link rel="preload" as="image" href="./ui/cursors/gauntlet.png" />
+<link rel="preload" as="image" href="./ui/cursors/arrow.png" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400..700&family=Alegreya:ital,wght@0,400;0,500;0,700;1,400&family=Alegreya+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<!-- Google tag (gtag.js) - skipped on localhost so dev sessions don't pollute analytics -->
+<script>
+  if (!['localhost', '127.0.0.1', '[::1]'].includes(location.hostname)) {
+    const s = document.createElement('script');
+    s.async = true;
+    s.src = 'https://www.googletagmanager.com/gtag/js?id=G-BR5Z7GT7C2';
+    document.head.appendChild(s);
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function(){ dataLayer.push(arguments); };
+    gtag('js', new Date());
+    gtag('config', 'G-BR5Z7GT7C2');
+  }
+</script>
+<style>
+  :root {
+    --gold: #ffd100;
+    --gold-dim: #c8a838;
+    --border: #6f5a2a;
+    --panel-bg: linear-gradient(170deg, #15151fF2 0%, #0b0b12F2 60%, #08080dF2 100%);
+    /* Typography — Cinzel (heraldic display/headings), Alegreya Sans (UI + body),
+       Alegreya (serif flavour prose). Legacy token names alias the canonical set
+       so every existing usage resolves to the new system. */
+    --font-display: 'Cinzel', 'Palatino Linotype', Palatino, Georgia, serif;
+    --font-ui: 'Alegreya Sans', 'Segoe UI', system-ui, 'Helvetica Neue', sans-serif;
+    --font-serif: 'Alegreya', 'Palatino Linotype', Palatino, Georgia, serif;
+    --title-font: var(--font-display);
+    --font-heading: var(--font-display);
+    --ui-font: var(--font-ui);
+    --font-sans: var(--font-ui);
+    --body-font: var(--font-ui);
+    
+    /* --gold is the single source of truth for the primary accent */
+    --color-primary: var(--gold);
+    --color-primary-dim: var(--gold-dim);
+    --color-primary-glow: rgba(255, 209, 0, 0.2);
+    --color-primary-glow-heavy: rgba(255, 209, 0, 0.4);
+
+    /* resource bars / unit-frame states / auras (previously hardcoded across CSS + JS) */
+    --color-hp: #1eb838;
+    --color-mana: #2b7bd4;
+    --color-rage: #c0392b;
+    --color-energy: #e4c531;
+    --color-hostile: #ff6b5e;
+    --color-friendly: #9fdc7f;
+    --color-buff: #3a6ea8;
+    --color-debuff: #c0392b;
+    
+    --color-bg-dark: #08080d;
+    --color-bg-input: #0a0a0f;
+    --color-border-default: #4e3d1d;
+    --color-border-focus: #c8a838;
+    --color-border-invalid: #ff8f85;
+    --color-border-valid: #48e060;
+    
+    --color-text-light: #f0ebd8;
+    --color-text-muted: #998d6a;
+    --color-text-error: #ff8f85;
+    --color-text-success: #7fdc4f;
+    
+    --spacing-xs: 4px;
+    --spacing-sm: 8px;
+    --spacing-md: 16px;
+    --spacing-lg: 24px;
+    
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    
+    --transition-speed: 0.25s;
+    --transition-ease: cubic-bezier(0.4, 0, 0.2, 1);
+
+    /* Custom scrollbar tokens */
+    --scrollbar-thumb: #5c4722;
+    --scrollbar-track: rgba(10, 10, 15, 0.7);
+    --scrollbar-thumb-hover: #7c6233;
+    --scrollbar-border: #7c6233;
+    --app-vw: 100vw;
+    --app-vh: 100vh;
+    /* Shared with src/game/cursors.ts — keep hotspots in sync.
+       --cursor-arrow = default; --cursor-point = interactive/hover (gauntlet finger). */
+    --cursor-arrow: url('./ui/cursors/arrow.png') 7 2, default;
+    --cursor-point: url('./ui/cursors/gauntlet.png') 6 4, pointer;
+    --cursor-grab: url('./ui/cursors/hand-grab.png') 11 16, grabbing;
+    /* Back-compat aliases */
+    --cursor-hand: var(--cursor-arrow);
+    --cursor-sword: var(--cursor-point);
+    --cursor-shield: var(--cursor-point);
+  }
+  * { 
+    box-sizing: border-box; 
+    margin: 0; 
+    padding: 0; 
+    user-select: none; 
+  }
+  ul, ol, li {
+    list-style: none;
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* Only apply standard scrollbar properties in browsers that do not support WebKit scrollbar styling (like Firefox) */
+  @supports not selector(::-webkit-scrollbar) {
+    * {
+      scrollbar-width: thin;
+      scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track); 
+    }
+  }
+  
+  /* Global custom scrollbar styling */
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
+    border-radius: 4px;
+    border: 1px solid rgba(255, 255, 255, 0.03);
+    box-shadow: inset 0 0 6px rgba(0,0,0,0.5);
+  }
+  ::-webkit-scrollbar-thumb {
+    background: linear-gradient(180deg, var(--scrollbar-thumb) 0%, #3a2b10 100%);
+    border-radius: 4px;
+    border: 1px solid var(--scrollbar-border);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 1px 3px rgba(0, 0, 0, 0.5);
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: linear-gradient(180deg, var(--scrollbar-thumb-hover) 0%, #4f3b17 100%);
+    border-color: var(--color-border-focus);
+  }
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  [hidden] { display: none !important; }
+  html, body {
+    width: var(--app-vw); height: var(--app-vh); min-width: 100%; min-height: 100%;
+    overflow-x: hidden; overflow-y: hidden; background: #000; font-family: var(--ui-font);
+    touch-action: pan-y; overscroll-behavior-y: auto;
+    -webkit-text-size-adjust: 100%;
+    cursor: var(--cursor-arrow); /* custom arrow is the global default */
+  }
+  body.game-active {
+    overflow: hidden;
+    touch-action: none;
+    overscroll-behavior: none;
+  }
+  #game-canvas { position: fixed; left: 0; top: 0; width: var(--app-vw); height: var(--app-vh); display: block; z-index: 0; }
+  .click-move-marker {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 56px;
+    height: 56px;
+    pointer-events: none;
+    opacity: 0;
+    z-index: 2;
+    transform: translate(-999px, -999px);
+    transition: opacity 45ms ease-out;
+    filter: drop-shadow(0 2px 5px #000d);
+    --ctm-color: #7ef06b;
+    --ctm-core: #d9ffd1;
+    --ctm-edge: #245f1f;
+  }
+  .click-move-marker.active { opacity: 0.98; }
+  .click-move-marker.entity {
+    --ctm-color: #ffd35a;
+    --ctm-core: #fff0a8;
+    --ctm-edge: #6b4a10;
+  }
+  /* Held in place (rooted/stunned): recolor the destination pip red and pulse it
+     so a frozen click-to-move reads as "can't move yet", not a stuck game. */
+  .click-move-marker.blocked {
+    --ctm-color: #ff5a4d;
+    --ctm-core: #ffd2cc;
+    --ctm-edge: #5f1a14;
+    animation: click-move-blocked 900ms ease-in-out infinite;
+  }
+  @keyframes click-move-blocked { 0%, 100% { opacity: 0.55; } 50% { opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    .click-move-marker.blocked { animation: none; opacity: 0.9; }
+  }
+  .click-move-marker::before {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 5px;
+    height: 5px;
+    background: var(--ctm-core);
+    border: 1px solid var(--ctm-edge);
+    border-radius: 50%;
+    box-shadow: 0 0 8px color-mix(in srgb, var(--ctm-color) 85%, transparent);
+    transform: translate(-50%, -50%);
+  }
+  .click-move-marker::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 14px;
+    height: 14px;
+    border: 1px solid color-mix(in srgb, var(--ctm-color) 72%, transparent);
+    border-radius: 50%;
+    opacity: 0;
+    transform: translate(-50%, -50%);
+  }
+  .click-move-marker.pulse::after {
+    animation: click-move-core 220ms ease-out both;
+  }
+  .ctm-arrow {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 11px;
+    height: 11px;
+    opacity: 0;
+    transform-origin: center;
+    will-change: transform, opacity;
+  }
+  .click-move-marker.pulse .ctm-arrow { animation: click-move-collapse 260ms cubic-bezier(.16,1,.3,1) both; }
+  .ctm-arrow::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-style: solid;
+    border-color: var(--ctm-core);
+    border-width: 2px 2px 0 0;
+    box-shadow: 1.5px -1.5px 0 color-mix(in srgb, var(--ctm-edge) 58%, transparent);
+  }
+  .ctm-n { --ctm-x0: -5.5px; --ctm-y0: -36px; --ctm-x1: -5.5px; --ctm-y1: -23px; --ctm-r: 135deg; transform: translate(-5.5px, -36px) rotate(135deg); }
+  .ctm-e { --ctm-x0: 25px; --ctm-y0: -5.5px; --ctm-x1: 12px; --ctm-y1: -5.5px; --ctm-r: -135deg; transform: translate(25px, -5.5px) rotate(-135deg); }
+  .ctm-s { --ctm-x0: -5.5px; --ctm-y0: 25px; --ctm-x1: -5.5px; --ctm-y1: 12px; --ctm-r: -45deg; transform: translate(-5.5px, 25px) rotate(-45deg); }
+  .ctm-w { --ctm-x0: -36px; --ctm-y0: -5.5px; --ctm-x1: -23px; --ctm-y1: -5.5px; --ctm-r: 45deg; transform: translate(-36px, -5.5px) rotate(45deg); }
+  @keyframes click-move-collapse {
+    0% { opacity: 0.95; transform: translate(var(--ctm-x0), var(--ctm-y0)) rotate(var(--ctm-r, 0deg)) scale(1.05); }
+    16% { opacity: 1; }
+    72% { opacity: 0.95; transform: translate(var(--ctm-x1), var(--ctm-y1)) rotate(var(--ctm-r, 0deg)) scale(0.78); }
+    100% { opacity: 0; transform: translate(var(--ctm-x1), var(--ctm-y1)) rotate(var(--ctm-r, 0deg)) scale(0.62); }
+  }
+  @keyframes click-move-core {
+    0% { opacity: 0; transform: translate(-50%, -50%) scale(0.35); }
+    50% { opacity: 0.9; }
+    100% { opacity: 0; transform: translate(-50%, -50%) scale(1.7); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .ctm-arrow,
+    .click-move-marker.pulse::after {
+      animation-duration: 0.01ms;
+      animation-iteration-count: 1;
+    }
+  }
+
+  /* Pre-game screens use the same hand / sword cursors as in-world (cursors.ts). */
+  #start-screen,
+  #loading-screen.visible {
+    cursor: var(--cursor-hand);
+  }
+  #start-screen :is(
+    .btn, .btn-play, .server-select-trigger, .server-select-option,
+    .social-link, .realm-row, .char-row, .class-card,
+    .password-toggle, #btn-toggle-controls, .btn-close-drawer
+  ) {
+    cursor: var(--cursor-sword);
+  }
+  #start-screen :is(input, textarea) {
+    cursor: text;
+  }
+
+  /* Mobile zoom prevention: iOS Safari (10+) auto-zooms the page whenever a focused
+     text-entry control renders below 16px, and it ignores the viewport scale-lock
+     in the <meta> above (that obedience was dropped for accessibility). 16px is the
+     documented threshold. Floor every focusable control at 16px on coarse-pointer
+     (touch) devices, which also covers tablets/iPad that the JS-driven
+     body.mobile-touch class (gated to <=940px) would miss. !important guarantees the
+     floor wins over the small classic-font rules regardless of selector specificity
+     (e.g. .prompt .prompt-number, which out-specifies a plain catch-all); pointer:coarse
+     leaves desktop (fine pointer) untouched. New inputs are covered automatically. */
+  @media (pointer: coarse) {
+    input,
+    textarea,
+    select {
+      font-size: 16px !important;
+    }
+  }
+
+  #nameplates { position: fixed; left: 0; top: 0; width: var(--app-vw); height: var(--app-vh); overflow: hidden; pointer-events: none; z-index: 1; }
+  #ui { position: fixed; left: 0; top: 0; width: var(--app-vw); max-width: 100vw; height: var(--app-vh); overflow: hidden; pointer-events: none; z-index: 10; }
+  #ui > * { pointer-events: auto; }
+  #ui > .click-move-marker,
+  #ui > .click-move-marker * { pointer-events: none; }
+
+  .panel {
+    background: var(--panel-bg);
+    border: 2px solid var(--border);
+    outline: 1px solid #000;
+    border-radius: 6px;
+    box-shadow: 0 2px 16px #000c, inset 0 0 24px #0006, inset 0 1px 0 #ffffff14;
+    color: #e8d8a8;
+  }
+  .panel-title {
+    font-family: var(--title-font);
+    color: var(--gold);
+    font-size: 15px;
+    letter-spacing: 0.5px;
+    text-shadow: 1px 1px 2px #000;
+    border-bottom: 1px solid #463a1c;
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .window .panel-title { cursor: move; touch-action: none; }
+  .window .panel-title .x-btn { cursor: var(--cursor-point); }
+  .window.window-dragging { cursor: move; }
+  .x-btn { color: #c9b27a; cursor: var(--cursor-point); font-size: 14px; padding: 0 4px; border: 1px solid #463a1c; border-radius: 3px; background: #1a1410; font-family: var(--ui-font); }
+  .x-btn:hover { color: #fff; border-color: var(--gold-dim); }
+  .x-btn:focus-visible,
+  .action-btn:focus-visible,
+  .chat-tab:focus-visible,
+  .micro-btn:focus-visible,
+  .mobile-btn:focus-visible,
+  .vendor-item:focus-visible,
+  .bag-item:focus-visible,
+  .mkt-tab:focus-visible,
+  .mkt-btn:focus-visible,
+  .mkt-list-btn:focus-visible {
+    outline: 2px solid var(--color-border-focus);
+    outline-offset: 2px;
+  }
+  .panel-subtitle { color: var(--color-text-muted); font-size: 11px; font-weight: 400; }
+  .gold { color: var(--gold); }
+
+  /* ---------- UI chrome icons (inline SVG from ui_icons.ts, tinted via currentColor) ---------- */
+  .ui-icon { width: 1em; height: 1em; display: inline-block; vertical-align: -0.125em; flex: none; pointer-events: none; }
+  .x-btn .ui-icon { width: 12px; height: 12px; vertical-align: middle; }
+  .micro-btn .ui-icon { width: 18px; height: 18px; vertical-align: middle; }
+  .pfm-crest { width: 16px; height: 16px; vertical-align: -3px; margin-right: 3px; border-radius: 3px; }
+
+  /* ---------- nameplates ---------- */
+  .nameplate { position: absolute; left: 0; top: 0; text-align: center; pointer-events: none;
+    text-shadow: 1px 1px 2px #000; white-space: nowrap; will-change: transform; }
+  .nameplate.has-emote { z-index: 30; }
+  .np-name { font-size: 12px; font-weight: bold; font-family: var(--title-font); letter-spacing: 0.3px; display: inline-block; vertical-align: middle; }
+  /* $WOC holder-tier flair badge, inline to the left of a player's name */
+  .np-tier { display: inline-block; width: 15px; height: 15px; vertical-align: middle; margin-right: 3px;
+    filter: drop-shadow(0 1px 1px #000); }
+  .np-hpbar { width: 78px; height: 6px; background: #2a0000; border: 1px solid #000; margin: 1px auto 0; border-radius: 2px; }
+  .np-hpfill { height: 100%; background: linear-gradient(#48e060, #1d7a32); border-radius: 2px; }
+  .np-castbar { position: relative; width: 78px; height: 8px; background: #1a1205; border: 1px solid #000;
+    margin: 1px auto 0; border-radius: 2px; overflow: hidden; }
+  .np-castfill { height: 100%; background: linear-gradient(#ffe27a, #d99a18); border-radius: 1px; transition: width 0.05s linear; }
+  .np-castbar.channel .np-castfill { background: linear-gradient(#7ad0ff, #2f7fd6); }
+  .np-castlabel { position: absolute; inset: 0; font-size: 8px; line-height: 8px; font-weight: bold;
+    color: #fff; text-shadow: 1px 1px 1px #000; letter-spacing: 0.2px; }
+  /* threat plate: this mob is aggroed on me — red bar + soft glow */
+  .nameplate.np-threat .np-hpbar { border-color: #ff5a4a; box-shadow: 0 0 6px #ff3b2e99; }
+  .nameplate.np-threat .np-hpfill { background: linear-gradient(#ff6b5e, #a01818); }
+  /* classic "dragon frame" cue: elite mobs get a golden bar frame, bosses a red one */
+  .np-hpbar.elite { border-color: #f2c84b; box-shadow: 0 0 5px 1px #f2c84baa, inset 0 0 2px #ffe9a0cc; }
+  .np-hpbar.boss { border-color: #ff5a3c; box-shadow: 0 0 7px 1px #ff5a3ccc, inset 0 0 2px #ffd2a0dd; }
+  .np-marker { font-size: 24px; font-weight: bold; height: 26px; font-family: var(--title-font); }
+  .np-marker.avail { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }
+  .np-marker.ready { color: var(--gold); text-shadow: 0 0 6px #ffd10088, 1px 1px 2px #000; }
+  .np-marker.active { color: #b9b9b9; }
+  .np-marker.loot { color: var(--gold); font-size: 14px; }
+  /* party raid/target marker — floats above the name; display toggled in JS so
+     it reserves no vertical space when absent. Drop-shadow adds a dark halo on
+     top of the icon's baked outline for legibility against the bright world. */
+  .np-raidmark { width: 30px; height: 30px; margin: 0 auto 1px; background-size: contain;
+    background-repeat: no-repeat; background-position: center;
+    filter: drop-shadow(0 0 2px #000) drop-shadow(0 1px 1px #000); }
+  /* rogue/druid combo points — a centered row of pips over the nameplate,
+     display toggled in JS so it reserves no space when the player has none. */
+  .np-combo { display: flex; justify-content: center; gap: 3px; margin: 0 auto 2px; height: 7px; }
+  .np-combo-pip { width: 7px; height: 7px; border-radius: 50%; background: #3a1010;
+    border: 1px solid #000; box-sizing: border-box; }
+  .np-combo-pip.lit { background: radial-gradient(circle at 35% 30%, #ffe07a, #e8453a 70%);
+    box-shadow: 0 0 4px #ff6a3caa; border-color: #5a0c08; }
+  .np-emote { display: inline-flex; align-items: center; justify-content: center; gap: 5px; min-width: 62px; height: 42px;
+    padding: 3px 9px 3px 4px; margin: 0 auto 5px; border-radius: 999px; border: 2px solid #f2d27a;
+    background: linear-gradient(#3a2a16, #16100a); color: #ffe9a3; font: 800 11px/1 var(--title-font);
+    letter-spacing: 0; box-shadow: 0 2px 0 #050301, 0 0 16px #ffd65a66, inset 0 1px 0 #fff4;
+    position: relative; z-index: 3; text-shadow: 0 1px 1px #000; will-change: transform, opacity; animation: emote-pop 260ms cubic-bezier(0.22, 1, 0.36, 1); }
+  .np-emote-icon { width: 34px; height: 34px; flex: 0 0 auto; image-rendering: auto;
+    filter: drop-shadow(0 2px 1px #0009); }
+  .np-emote-label { display: block; max-width: 56px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  @keyframes emote-pop { from { transform: translateY(8px) scale(0.86); opacity: 0; } to { transform: none; opacity: 1; } }
+
+  /* ---------- chat bubbles (/say, /yell) ---------- */
+  .chat-bubble { position: absolute; left: 0; top: 0; max-width: 220px; pointer-events: none;
+    background: rgba(252, 250, 240, 0.93); color: #1d1610; border: 1px solid #8a7a55;
+    border-radius: 10px; padding: 4px 9px; font-size: 12px; line-height: 1.3;
+    text-align: center; overflow-wrap: break-word; will-change: transform; z-index: 21; }
+  .chat-bubble.yell { font-weight: bold; color: #7a1408; border-color: #c43a2a; }
+
+  /* ---------- unit frames ---------- */
+  .unitframe { position: absolute; top: 12px; display: flex; gap: 0; align-items: center; }
+  #player-frame {
+    position: relative;
+    top: auto;
+    left: auto;
+    width: 612px;
+    margin: 0 auto 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  #player-frame .uf-bars {
+    flex: 1;
+    width: auto;
+    min-width: 0;
+    max-width: 520px;
+  }
+  #target-frame { left: 12px; top: 12px; display: none; z-index: 6; }
+  .portrait-wrap { position: relative; width: 64px; height: 64px; z-index: 2; }
+  .portrait {
+    width: 60px; height: 60px; border-radius: 50%;
+    border: 3px solid var(--border); outline: 1px solid #000;
+    background: radial-gradient(circle at 35% 30%, #3a3a4e, #14141c);
+    box-shadow: 0 2px 8px #000c, inset 0 0 12px #0009;
+    display: flex; align-items: center; justify-content: center;
+  }
+  /* Display size is fixed by the frame; the canvas backing store is scaled by
+     devicePixelRatio in unit_portrait_painter.ts, so this just maps it back to 1:1 CSS px. */
+  .portrait canvas { width: 100%; height: 100%; display: block; border-radius: 50%; }
+  .level-chip {
+    position: absolute; bottom: -3px; left: -3px; width: 24px; height: 24px;
+    background: radial-gradient(circle at 40% 35%, #4a3a14, #241c08);
+    border: 2px solid var(--gold-dim); border-radius: 50%;
+    color: var(--gold); font-size: 12px; font-weight: bold;
+    display: flex; align-items: center; justify-content: center;
+    text-shadow: 1px 1px 1px #000; z-index: 3;
+  }
+  /* crossed-swords combat indicator on the player portrait (classic WoW) */
+  .combat-flash {
+    position: absolute; top: -4px; right: -4px; width: 22px; height: 22px;
+    display: none; align-items: center; justify-content: center;
+    color: #ff5040; font-size: 15px; line-height: 1; z-index: 4;
+    pointer-events: none; text-shadow: 0 0 4px #000, 0 0 6px #ff5040;
+  }
+  #player-frame.combat .combat-flash { display: flex; animation: pf-combat-pulse 1s ease-in-out infinite; }
+  #player-frame.combat .portrait { border-color: #e74c3c; box-shadow: 0 0 8px #e74c3c99, inset 0 0 12px #0009; }
+  .uf-bars { width: 190px; margin-left: -8px; padding: 5px 8px 5px 14px;
+    background: var(--panel-bg); border: 2px solid var(--border); outline: 1px solid #000;
+    border-radius: 0 6px 6px 0; box-shadow: 0 2px 10px #000a; }
+  #target-frame .portrait-wrap { order: 2; }
+  /* The disc sits as a medallion over the bar's right end: enough overlap that
+     the circle covers the bar's (rounded) seam-side corners (no poke, no crescent
+     gap), with extra right padding so the HP bar/text never slips under the disc. */
+  #target-frame .uf-bars { order: 1; margin-left: 0; margin-right: -18px; border-radius: 6px 11px 11px 6px; padding: 5px 26px 5px 8px; }
+  #target-frame .level-chip { left: auto; right: -3px; }
+  /* "resting" zZz marker on the player portrait while seated / eating / drinking */
+  .rest-indicator {
+    position: absolute; top: -6px; right: -6px; width: 22px; height: 22px;
+    border-radius: 50%; z-index: 3; display: none;
+    align-items: center; justify-content: center;
+    color: #aee3ff; font-weight: bold; font-size: 13px; font-style: italic;
+    text-shadow: 0 0 6px #4fc3ff, 1px 1px 1px #000;
+    background: radial-gradient(circle at 40% 35%, #14304a, #08141c);
+    border: 2px solid #4fc3ff88; box-shadow: 0 0 8px #4fc3ff66;
+  }
+  .rest-indicator.on { display: flex; animation: rest-pulse 2s ease-in-out infinite; }
+  @keyframes rest-pulse { 0%, 100% { opacity: 1; transform: translateY(0); } 50% { opacity: 0.55; transform: translateY(-2px); } }
+  .uf-name { font-size: 13px; font-weight: bold; font-family: var(--title-font); color: var(--gold);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-shadow: 1px 1px 2px #000; }
+  .bar { position: relative; height: 15px; background: #1a1a1a; border: 1px solid #000; margin-top: 3px; border-radius: 2px; overflow: hidden; }
+  .bar-fill { position: absolute; inset: 0; width: 100%; transform-origin: left;
+    background-image: linear-gradient(rgba(255,255,255,0.25), rgba(255,255,255,0.02) 45%, rgba(0,0,0,0.15)); }
+  .bar-text { position: absolute; inset: 0; text-align: center; font-size: 10px; line-height: 15px; color: #fff; text-shadow: 1px 1px 1px #000; font-weight: bold; }
+  .hp .bar-fill { background-color: var(--color-hp); }
+  .mana .bar-fill { background-color: var(--color-mana); }
+  .rage .bar-fill { background-color: var(--color-rage); }
+  .energy .bar-fill { background-color: var(--color-energy); }
+  /* Damage-absorb shield overlay (Power Word: Shield, Ice Barrier, …): a hatched
+     translucent segment laid over the health bar, extending past current health. */
+  .bar-absorb { position: absolute; inset: 0; width: 100%; transform-origin: left; transform: scaleX(0);
+    background: repeating-linear-gradient(115deg, rgba(255,255,255,0.42) 0 5px, rgba(190,225,255,0.16) 5px 10px);
+    box-shadow: inset 0 0 6px rgba(255,255,255,0.4); pointer-events: none; transition: transform 0.12s linear; }
+  .bar-absorb.overshield { background: repeating-linear-gradient(115deg, rgba(255,236,160,0.55) 0 5px, rgba(255,214,90,0.24) 5px 10px);
+    box-shadow: inset 0 0 7px rgba(255,225,140,0.6); }
+  /* Low-mana/energy warning: the resource fill pulses brighter and a short
+     caption appears at the end of the bar. Driven by --lr-opacity / --lr-pulse
+     set from the HUD (intensity scales as the bar nears empty). */
+  .bar.low { --lr-opacity: 0.7; --lr-pulse: 1s; }
+  .bar.low .bar-fill {
+    box-shadow: 0 0 5px 1px rgba(150, 205, 255, var(--lr-opacity)), inset 0 0 4px rgba(220, 240, 255, 0.9);
+    animation: low-resource-pulse var(--lr-pulse) ease-in-out infinite;
+  }
+  .bar.energy.low .bar-fill { box-shadow: 0 0 5px 1px rgba(255, 225, 110, var(--lr-opacity)), inset 0 0 4px rgba(255, 245, 200, 0.9); }
+  .low-resource-label {
+    display: none; position: absolute; top: 0; right: 5px; line-height: 15px;
+    font-size: 9px; font-weight: bold; letter-spacing: 0.5px;
+    color: #eaf4ff; text-shadow: 0 0 3px #000, 1px 1px 1px #000; text-transform: uppercase; pointer-events: none;
+    animation: low-resource-pulse var(--lr-pulse, 1s) ease-in-out infinite;
+  }
+  .bar.energy.low .low-resource-label { color: #fff3c2; }
+  @keyframes low-resource-pulse { 0%, 100% { filter: brightness(1); opacity: 0.6; } 50% { filter: brightness(1.7); opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    .bar.low .bar-fill, .low-resource-label { animation: none; }
+    .low-resource-label { opacity: 1; }
+  }
+  .combo-row { display: flex; gap: 4px; margin-top: 4px; height: 10px; }
+  .combo-pip { width: 12px; height: 10px; border-radius: 50%; border: 1px solid #5c2020; background: #2a0d0d; }
+  .combo-pip.on { background: radial-gradient(circle at 35% 30%, #ff7a5e, #c0392b); box-shadow: 0 0 5px #ff5533aa; border-color: #ffad99; }
+
+  /* ---------- buff bar ---------- */
+  #buff-bar { position: absolute; right: 196px; top: 14px; display: flex; flex-direction: row-reverse; flex-wrap: wrap; gap: 4px; max-width: 320px; pointer-events: auto; }
+  .buff { width: 28px; height: 28px; border: 1px solid var(--color-buff); border-radius: 4px;
+    position: relative; cursor: default; background-color: #10141c;
+    background-size: cover; background-position: center; background-repeat: no-repeat; }
+  .buff.debuff { border-color: var(--color-debuff); }
+  .buff .dur { position: absolute; bottom: -13px; left: 0; right: 0; text-align: center; font-size: 9px; color: #eee; text-shadow: 1px 1px 1px #000; }
+
+  /* ---------- cast bar ---------- */
+  #castbar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 200px; width: 300px;
+    height: 24px; display: none; border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; background: #100c08; overflow: hidden; }
+  #castbar .fill { height: 100%; width: 0%; background: linear-gradient(#ffe48a, #c9941a 60%, #9a6f12);
+    box-shadow: inset 0 1px 0 #fff5; }
+  #castbar.channel .fill { background: linear-gradient(#8ad4ff, #1a74c9 60%, #125a9a); }
+  #castbar .label { position: absolute; inset: 0; text-align: center; font-size: 12px; line-height: 21px;
+    color: #fff; text-shadow: 1px 1px 2px #000; font-family: var(--title-font); }
+  #castbar .timer { position: absolute; top: 0; right: 6px; line-height: 21px; font-size: 11px;
+    color: #fff; text-shadow: 1px 1px 2px #000; font-family: var(--title-font); font-variant-numeric: tabular-nums; }
+  /* swing timer: sits just under the cast bar, steel-on-amber to read as melee */
+  #swingbar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 174px; width: 220px;
+    height: 12px; display: none; border: 1px solid var(--border); outline: 1px solid #000; border-radius: 3px;
+    background: #0c0a07; overflow: hidden; }
+  #swingbar .fill { height: 100%; width: 0%; background: linear-gradient(#ffcf7a, #d97b1e 60%, #8a4a10);
+    box-shadow: inset 0 1px 0 #fff4; transition: width 60ms linear; }
+  #swingbar.ready .fill { background: linear-gradient(#d8e8ff, #8fb6e6 60%, #5b86b8); }
+  #swingbar .label { position: absolute; inset: 0; text-align: center; font-size: 9px; line-height: 12px;
+    color: #fff; text-shadow: 1px 1px 1px #000; font-family: var(--title-font); letter-spacing: .5px; }
+
+  /* ---------- bottom cluster ---------- */
+  #bottom-bar { position: absolute; left: 50%; transform: translateX(-50%); bottom: 6px; text-align: center; }
+  #xpbar { width: 612px; height: 10px; background: #14101e; border: 1px solid #000; outline: 1px solid #3a3148;
+    margin: 0 auto 4px; position: relative; border-radius: 2px; overflow: hidden; }
+  #xpbar .fill { height: 100%; width: 0%; background: linear-gradient(#b85eff, #6a1bb0); transition: background .3s; }
+  /* Rested XP overlay (classic inn-rested bonus): a blue segment ahead of the fill. */
+  #xpbar .rested { position: absolute; top: 0; height: 100%; left: 0; width: 0%; background: linear-gradient(#5fb0ff, #2b6fd0); opacity: 0.5; }
+  #xpbar.rested { outline-color: #2b6fd0; box-shadow: 0 0 6px #4a9eff55; }
+  #xpbar .ticks { position: absolute; inset: 0; display: flex; }
+  #xpbar .ticks i { flex: 1; border-right: 1px solid #00000055; }
+  #xpbar .label { position: absolute; inset: 0; font-size: 9px; color: #fff; text-align: center; line-height: 10px; text-shadow: 1px 1px 1px #000; opacity: 0; transition: opacity .15s; }
+  #xpbar:hover .label { opacity: 1; }
+  /* Post-cap overflow bar (Max-Level XP Overflow): gold/prestige tint. */
+  #xpbar.overflow { outline-color: #b8902a; box-shadow: 0 0 6px #f5c84355; }
+  #xpbar.overflow .fill { background: linear-gradient(#ffe27a, #d99a1c); }
+  #actionbar-row { display: flex; align-items: flex-end; gap: 8px; }
+  /* xp bar stacks directly on the action bar; the taller side-button
+     column must not push it up (it used to float ~150px above the bar) */
+  #actionbar-stack { display: flex; flex-direction: column; position: relative; }
+  #petbar { display: none; position: absolute; left: 0; top: -52px; gap: 6px; padding: 0; margin: 0;
+    background: transparent; border: 0; outline: 0; box-shadow: none; }
+  .petbar-group { display: flex; gap: 4px; padding: 4px; border: 2px solid #000; outline: 1px solid #5b4618;
+    border-radius: 6px; background: linear-gradient(170deg, #15131fdd, #09080edd); box-shadow: 0 2px 8px #000c; }
+  .pet-btn { width: 38px; height: 38px; padding: 0; border: 2px solid #4a3d1d; border-radius: 6px;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); color: #f3df9a; cursor: var(--cursor-point);
+    position: relative; box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009; }
+  .pet-btn .icon-label { position: absolute; inset: 1px; border-radius: 4px; background-size: cover; background-position: center; background-repeat: no-repeat; pointer-events: none; }
+  .pet-btn:hover { border-color: var(--gold); }
+  .pet-btn.active { border-color: var(--gold); box-shadow: inset 0 0 0 1px #ffd10066, 0 0 6px #ffd10033; }
+  .pet-btn.cooldown { filter: grayscale(.8) brightness(.65); cursor: default; }
+  .pet-btn .cdtext { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    font-size: 13px; color: var(--gold); text-shadow: 1px 1px 2px #000; font-weight: bold; pointer-events: none; }
+  #actionbar { display: flex; gap: 4px; padding: 6px; }
+  .action-btn { width: 46px; height: 46px; position: relative; border: 2px solid #4a3d1d; border-radius: 6px;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); color: #fff; cursor: var(--cursor-point);
+    font-family: var(--title-font); text-shadow: 1px 1px 2px #000;
+    box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009; }
+  .action-btn .icon-label { position: absolute; inset: 1px; border-radius: 4px;
+    background-size: cover; background-position: center; background-repeat: no-repeat; pointer-events: none; }
+  .action-btn:hover { border-color: var(--gold); }
+  .action-btn:active { transform: translateY(1px); }
+  .action-btn.used { border-color: var(--color-border-focus); box-shadow: 0 0 10px #ffd100aa, inset 0 0 0 1px #ffd10077, inset 0 1px 0 #ffffff28; }
+  .action-btn.empty { background: #0d0d13; cursor: default; box-shadow: inset 0 0 10px #000; }
+  .action-btn .keybind { position: absolute; top: 1px; right: 3px; font-size: 9px; color: #ddd; font-family: var(--ui-font); }
+  .action-btn .item-count { position: absolute; right: 3px; bottom: 1px; min-width: 10px; text-align: right;
+    font-size: 10px; color: #fff; font-family: var(--ui-font); font-weight: bold; text-shadow: 1px 1px 2px #000; }
+  .action-btn .cdtext { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    font-size: 17px; color: var(--gold); text-shadow: 1px 1px 2px #000; }
+  .action-btn .cd-overlay { position: absolute; left: 0; right: 0; bottom: 0; background: #000d; height: 0%; border-radius: 0 0 4px 4px; }
+  .action-btn.unusable .icon-label { filter: grayscale(1) brightness(0.5); }
+  .action-btn.oor .icon-label { filter: brightness(0.55) saturate(0.4); }
+  .action-btn.queued { border-color: #fff; box-shadow: 0 0 9px #ffd100cc, inset 0 1px 0 #ffffff18; }
+  .action-btn:not(.empty)[draggable="true"] { cursor: grab; }
+  .action-btn.drop-target { border-color: #7fd1ff; box-shadow: 0 0 8px #7fd1ff88; }
+  /* micro-menu: bottom-right, stacked upward, sitting just above the
+     Discord/GitHub buttons (both right-aligned to the same edge). */
+  #side-buttons { position: absolute; right: 16px; bottom: 74px;
+    display: flex; flex-direction: column; gap: 4px; z-index: 19; }
+  .micro-btn { width: 34px; height: 30px; border: 2px solid #4a3d1d; border-radius: 5px;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f); color: #d8c89a; cursor: var(--cursor-point);
+    font-size: 12px; font-weight: bold; box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009; position: relative; }
+  /* hover flyout: the button's background grows leftward to reveal its label.
+     The panel tucks 6px under the button (z-index:-1) so it reads as one surface. */
+  .micro-btn::before {
+    content: attr(aria-label);
+    position: absolute; right: calc(100% - 6px); top: 0; height: 100%;
+    display: flex; align-items: center; box-sizing: border-box;
+    max-width: 0; padding: 0; overflow: hidden; opacity: 0; white-space: nowrap;
+    font-family: var(--font-ui); font-size: 12px; font-weight: 600; letter-spacing: .3px; line-height: 1;
+    color: #d8c89a;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f);
+    border: 2px solid #4a3d1d; border-right: none; border-radius: 5px 0 0 5px;
+    box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009;
+    pointer-events: none; z-index: -1;
+    transition: max-width .2s ease, opacity .15s ease, padding .2s ease, border-color .12s ease, color .12s ease; }
+  .micro-btn:hover::before { max-width: 220px; opacity: 1; padding: 0 18px 0 12px; }
+  .micro-btn:hover, .micro-btn:hover::before { border-color: var(--gold); color: #fff; }
+  /* talent button glows while unspent talent points are available */
+  .micro-btn.has-points, .mobile-btn.has-points { border-color: var(--gold); color: #fff; animation: tal-pulse 1.6s ease-in-out infinite; }
+  @keyframes tal-pulse { 0%, 100% { box-shadow: 0 0 5px #ffd10066; } 50% { box-shadow: 0 0 12px #ffd100dd; } }
+  .micro-btn .keybind { position: absolute; bottom: -1px; right: 2px; font-size: 8px; color: #998; }
+  /* music button: a bigger note with a small diagonal slash when audio is off */
+  #mm-music .ui-icon { width: 22px; height: 22px; }
+  .micro-btn.mm-muted::after {
+    content: ''; position: absolute; left: 50%; top: 50%; width: 17px; height: 2px; border-radius: 2px;
+    background: #f0e8d2; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.7);
+    transform: translate(-50%, -50%) rotate(-45deg); pointer-events: none; }
+
+  /* ---------- chat frame ---------- */
+  /* width shrinks on narrower screens so the chat never overlaps the centred
+     bottom bar (≈612px wide); caps at 370px when there's room. */
+  #chatlog-wrap { position: absolute; left: 12px; bottom: 8px; width: min(370px, calc(50vw - 330px)); }
+  #chatlog-tabs { display: flex; flex-wrap: wrap; gap: 2px; margin-left: 6px; margin-bottom: -1px; position: relative; z-index: 2; }
+  .chat-tab { height: 22px; padding: 0 12px; border: 1px solid #3a321d; border-bottom: none;
+    border-radius: 6px 6px 0 0; background: linear-gradient(#1c1824, #0d0b13); color: #95886a;
+    cursor: var(--cursor-point); font-family: var(--title-font); font-size: 12px; text-shadow: 1px 1px 1px #000; }
+  .chat-tab.active { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#2a2436, #161220); }
+  /* "add channel" (+) tab: square, icon-only, slightly de-emphasised */
+  .chat-tab-add { padding: 0; width: 26px; font-size: 15px; line-height: 1; color: #b6a472; }
+  .chat-tab-add:hover { color: var(--gold); }
+  /* a channel tab filters the shared chat pane to its own messages */
+  .chat-pane .chat-hidden { display: none; }
+  #chatlog-frame { height: 184px; padding: 0; overflow: hidden; border-radius: 0 6px 6px 6px; }
+  .chat-pane { display: none; height: 100%; overflow-y: auto; overflow-x: hidden; padding: 7px 10px;
+    font-size: 11px; line-height: 1.45; }
+  .chat-pane.active { display: block; }
+  .chat-pane div { text-shadow: 1px 1px 1px #000; overflow-wrap: break-word; user-select: text; }
+  .chat-player-name { cursor: var(--cursor-point); text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 2px; }
+  .chat-player-name:hover { filter: brightness(1.25); }
+  .chat-player-name:focus-visible { outline: 2px solid var(--color-border-focus); outline-offset: 2px; }
+  .chat-pane::-webkit-scrollbar { width: 8px; }
+  .chat-pane::-webkit-scrollbar-track { background: #0b0b10; }
+  .chat-pane::-webkit-scrollbar-thumb { background: #4a3d1d; border-radius: 4px; }
+  #report-window { width: 320px; z-index: 95; }
+  #report-window .panel-title { display: flex; justify-content: space-between; align-items: center; }
+  #report-window [data-close] { background: transparent; border: 0; color: #c9b27a; cursor: var(--cursor-point); font-size: 16px; }
+  .report-label { display: block; color: #c9b27a; font-size: 12px; margin: 8px 0 4px; }
+  #report-window select, #report-window textarea {
+    width: 100%; background: #101018; border: 1px solid #4a3d1d; border-radius: 4px; color: #e8d8a8; padding: 6px;
+  }
+  #report-window textarea { height: 96px; resize: none; }
+  .report-error { min-height: 16px; color: #ff7a5e; font-size: 12px; margin-top: 6px; }
+  .report-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
+
+  /* ---------- quest tracker ---------- */
+  #quest-tracker { position: absolute; right: 14px; top: 262px; width: 240px; font-size: 12px;
+    color: var(--gold); text-shadow: 1px 1px 2px #000; pointer-events: none; }
+  #quest-tracker .qt-header { font-family: var(--title-font); font-size: 14px; border-bottom: 1px solid #ffd10044; margin-bottom: 4px; padding-bottom: 2px; }
+  #quest-tracker .qt-title { font-weight: bold; margin-top: 8px; font-family: var(--title-font); }
+  #quest-tracker .qt-obj { color: #e8e0c8; font-size: 11px; margin-left: 8px; }
+  #quest-tracker .qt-obj.done,
+  .qd-obj.done,
+  .quest-complete { color: var(--color-text-success); }
+
+  /* ---------- combat meters ---------- */
+  #meters-window { width: 240px; padding: 8px 10px; display: none; align-self: flex-end; margin-bottom: 6px; text-align: left; }
+  #meters-window .panel-title { margin-bottom: 4px; }
+  .mt-tab { background: #1a1410; border: 1px solid #463a1c; border-radius: 3px; color: #c9b27a;
+    font-size: 11px; padding: 1px 7px; cursor: var(--cursor-point); }
+  .mt-tab.on { color: var(--gold); border-color: var(--gold-dim); background: #2a2010; }
+  .mt-view { font-size: 12px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 1px #000; }
+  .mt-sub { font-size: 10px; color: #9c8f6e; margin: 1px 0 6px; }
+  .mt-row { position: relative; height: 17px; margin-bottom: 3px; background: #14100c; border: 1px solid #000;
+    border-radius: 2px; overflow: hidden; }
+  .mt-row.aggro { border-color: #c0392b; }
+  .mt-fill { position: absolute; inset: 0; border-radius: 1px; }
+  .mt-label { position: absolute; left: 5px; top: 0; line-height: 17px; font-size: 11px; color: #fff;
+    text-shadow: 1px 1px 1px #000; font-weight: bold; }
+  .mt-num { position: absolute; right: 5px; top: 0; line-height: 17px; font-size: 10px; color: #ffe;
+    text-shadow: 1px 1px 1px #000; }
+  body.mobile-touch #meters-window .mt-rows {
+    max-height: 82px;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+  body.mobile-touch #meters-window .panel-title {
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+  body.mobile-touch #meters-window .mt-tab {
+    padding: 1px 5px;
+  }
+
+  /* ---------- minimap ---------- */
+  #minimap-wrap { position: absolute; right: 12px; top: 10px; width: 170px; text-align: center; }
+  #zone-label { font-size: 13px; color: var(--gold); font-family: var(--title-font); text-shadow: 1px 1px 3px #000; margin-bottom: 3px; letter-spacing: 0.5px; }
+  #minimap { border-radius: 50%; border: 4px solid var(--border); outline: 1px solid #000; box-shadow: 0 0 14px #000c, inset 0 0 20px #0008; }
+  /* Digital clock pinned to the bottom of the minimap ring, classic-WoW style. */
+  #minimap-clock { position: absolute; left: 50%; bottom: -3px; transform: translateX(-50%);
+    min-width: 52px; padding: 1px 8px; cursor: pointer; user-select: none;
+    font-family: var(--font-ui); font-size: 12px; font-weight: 600; letter-spacing: .4px;
+    color: var(--gold); text-shadow: 1px 1px 2px #000;
+    background: radial-gradient(circle at 50% 30%, #2c2c3a, #14141d);
+    border: 2px solid var(--border); border-radius: 8px; box-shadow: 0 2px 4px #0009, inset 0 1px 0 #ffffff14; }
+  #minimap-clock:hover { color: #fff; border-color: #c9a86a; }
+  #minimap-coords { margin-top: 4px; display: inline-block; padding: 1px 8px; font-size: 11px; font-variant-numeric: tabular-nums;
+    color: #e8d9b0; background: #0008; border: 1px solid var(--border); border-radius: 9px; text-shadow: 1px 1px 2px #000; letter-spacing: 0.3px; }
+
+  /* heading compass — a horizontal rose strip beneath the minimap */
+  #compass { position: relative; width: 162px; margin: 5px auto 0; }
+  #compass-strip { position: relative; height: 18px; overflow: hidden;
+    border: 2px solid var(--border); border-radius: 5px;
+    background: linear-gradient(#1c1a14, #100f0b);
+    box-shadow: inset 0 0 8px #000a;
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 18%, #000 82%, transparent); }
+  #compass-track { position: absolute; inset: 0; }
+  .compass-mark { position: absolute; top: 50%; transform: translate(-50%, -50%);
+    font-family: var(--title-font); font-size: 11px; color: #b9ad86;
+    text-shadow: 1px 1px 2px #000; pointer-events: none; white-space: nowrap; }
+  .compass-mark.major { font-size: 13px; color: var(--gold); font-weight: 700; }
+  /* the fixed centre caret marks the direction the player faces */
+  #compass-center { position: absolute; left: 50%; top: -2px; width: 0; height: 0;
+    transform: translateX(-50%); border-left: 5px solid transparent;
+    border-right: 5px solid transparent; border-top: 6px solid var(--gold);
+    filter: drop-shadow(0 1px 1px #000); }
+  #compass-heading { margin-top: 2px; font-family: var(--title-font); font-size: 12px;
+    color: var(--gold); letter-spacing: 1px; text-shadow: 1px 1px 2px #000; }
+  /* minimap zoom control: a compact gold pill pinned to the bottom rim of the
+     round minimap. Vertical centre holds the live zoom readout (e.g. "2×"). */
+  #minimap-zoom { position: absolute; left: 50%; bottom: -6px; transform: translateX(-50%);
+    display: flex; align-items: center; gap: 4px; padding: 1px 4px; z-index: 2;
+    background: radial-gradient(circle at 50% 30%, #2c2c3a, #15151f); border: 1px solid #4a3d1d;
+    border-radius: 9px; box-shadow: 0 1px 3px #000a; }
+  .minimap-zoom-btn { width: 17px; height: 17px; padding: 0; line-height: 1; font-size: 14px; font-weight: bold;
+    color: #d8c89a; background: none; border: none; cursor: pointer; border-radius: 4px; font-family: var(--title-font); }
+  .minimap-zoom-btn:hover:not(:disabled) { color: #fff; background: #ffffff1a; }
+  .minimap-zoom-btn:disabled { opacity: 0.3; cursor: default; }
+  #minimap-zoom-label { min-width: 24px; font-size: 11px; color: var(--gold); font-family: var(--title-font);
+    text-shadow: 1px 1px 2px #000; letter-spacing: 0.3px; }
+
+  /* ---------- community HUD ---------- */
+  /* Discord/GitHub: bottom-right, directly below the micro-menu, right-aligned with it. */
+  /* Discord/GitHub: standalone square buttons matching the micro-menu (no panel
+     container) — only the hover border keeps each service's brand colour. */
+  #community-hud { position: absolute; right: 16px; bottom: 14px; display: flex; align-items: center; gap: 4px; z-index: 19; }
+  #community-menu { display: contents; }
+  .community-toggle { display: none; }
+  .community-tray { display: flex; align-items: center; gap: 4px; }
+  .community-link { width: 34px; height: 30px; display: inline-flex; align-items: center; justify-content: center;
+    color: #d8c89a; text-decoration: none; border: 2px solid #4a3d1d; border-radius: 5px;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f);
+    box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009; transition: color .15s, border-color .15s; }
+  .community-link:hover { color: #fff; border-color: #7f8cff; }          /* Discord brand */
+  .community-link.github:hover { color: #fff; border-color: #e4e4ea; }   /* GitHub brand */
+  .community-link svg { width: 18px; height: 18px; flex: none; display: block; }
+  .community-link span { display: none; }
+  /* Donate is the one labelled community button — show its text and auto-width to fit. */
+  .community-link.donate { width: auto; gap: 6px; padding: 0 11px;
+    font-family: var(--font-ui); font-size: 12px; font-weight: 600; letter-spacing: .3px; }
+  .community-link.donate span { display: inline; line-height: 1; }
+  .community-link.donate:hover { color: #fff; border-color: #ff6b8b; }    /* Donate */
+
+  /* ---------- windows ---------- */
+  /* All modal windows share one position: centred on the page. Per-window rules
+     below set only size/look — never position. (Loot is the one exception: it
+     pops at the cursor, so openLoot() sets inline left/top + transform:none.) */
+  .window { position: absolute; display: none; padding: 12px; z-index: 20;
+    left: 50%; top: 10vh; transform: translateX(-50%);
+    max-height: calc(85vh - 24px); overflow-y: auto; }
+  #quest-dialog { width: 440px; }
+  .qd-text { font-size: 12.5px; line-height: 1.55; color: #e8e0c8; margin-bottom: 10px; font-family: var(--font-serif); }
+  .qd-sub { font-family: var(--title-font); color: var(--gold); font-size: 13px; margin: 8px 0 4px; }
+  .qd-obj { font-size: 12px; color: #cfc6a8; margin: 2px 0; }
+  .qd-req { display: inline-block; margin: 0 0 10px; padding: 2px 9px; font-family: var(--title-font);
+    font-size: 11px; letter-spacing: 0.3px; color: var(--gold); background: #1a140a66;
+    border: 1px solid var(--color-border-default); border-radius: 4px; }
+  .quest-muted { color: var(--color-text-muted); font-size: 11px; }
+  .quest-suggested { color: var(--color-text-error); font-size: 11px; }
+  .quest-return { margin-top: var(--spacing-sm); color: var(--color-text-muted); }
+  .qd-reward-row { display: flex; gap: 6px; align-items: center; margin-top: 4px; }
+  .qd-reward-label { color: var(--color-text-muted); font-size: 11px; }
+  .qd-reward-name { font-size: 12px; }
+  .qd-list-item { display: block; width: 100%; padding: 5px 8px; cursor: var(--cursor-point); border: 0; border-radius: 4px; background: transparent; text-align: left; font-size: 13px; color: var(--gold); font-family: var(--title-font); }
+  .qd-text, .qd-sub, .qd-obj, .qd-req, .qd-reward-label, .qd-reward-name, .qd-list-item,
+  .quest-muted, .quest-suggested, .ql-item, .ql-empty { overflow-wrap: anywhere; }
+  .qd-reward-row { flex-wrap: wrap; }
+  .qd-reward-name { min-width: 0; }
+  .qd-list-item:hover { background: #ffffff14; }
+  .qd-list-item:focus-visible,
+  .ql-item:focus-visible { outline: 3px solid var(--color-border-focus); outline-offset: 2px; }
+  .btn { background: linear-gradient(#8a3326, #5a1d12 55%, #471409); color: #ffd9a0; border: 1px solid #a86;
+    outline: 1px solid #000; border-radius: 4px; padding: 6px 16px; font-size: 12.5px; cursor: var(--cursor-point);
+    margin-top: 10px; margin-right: 8px; font-family: var(--title-font); letter-spacing: 0.4px;
+    text-shadow: 1px 1px 1px #000; box-shadow: inset 0 1px 0 #ffffff2a, 0 2px 4px #0008;
+    transition: filter var(--transition-speed), box-shadow var(--transition-speed), border-color var(--transition-speed); }
+  .btn:hover {
+    filter: brightness(1.25);
+    box-shadow: inset 0 1px 0 #ffffff2a, 0 2px 4px #0008, 0 0 8px var(--color-primary-glow);
+  }
+  .btn:focus-visible {
+    outline: 3px solid var(--color-border-focus) !important;
+    outline-offset: 2px !important;
+    box-shadow: 0 0 8px var(--color-primary-glow) !important;
+  }
+  .btn:active { transform: translateY(1px); }
+  .btn:disabled { filter: grayscale(1) brightness(0.7); cursor: default; box-shadow: none; }
+
+  #loot-window { width: 230px; }
+  .loot-item { display: flex; align-items: center; gap: 8px; padding: 4px; font-size: 12px; cursor: default; border-radius: 4px; }
+  .loot-item:hover { background: #ffffff10; }
+
+  .item-icon { width: 28px; height: 28px; border-radius: 4px; flex: none; display: block;
+    object-fit: cover; background: #0d0d13; border: 1px solid #888; }
+  .q-poor { border-color: #9d9d9d !important; }
+  .q-common { border-color: #b8b8b8 !important; }
+  .q-uncommon { border-color: #1eff00 !important; }
+  .q-rare { border-color: #0070dd !important; }
+  .q-epic { border-color: #a335ee !important; box-shadow: 0 0 6px #a335ee66; }
+
+  /* character window */
+  #char-window { width: 600px; }
+  .paperdoll { display: flex; gap: 10px; align-items: flex-start; }
+  .equip-col { display: flex; flex-direction: column; gap: 5px; width: 150px; flex-shrink: 0; }
+  .equip-col-right .equip-slot { flex-direction: row-reverse; text-align: right; }
+  .equip-slot { display: flex; gap: 7px; align-items: center; width: 100%; }
+  .equip-slot > div { min-width: 0; }
+  .equip-slot .slot-name { font-size: 10px; color: #998d6a; }
+  .equip-slot .slot-item { font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .char-model-panel { flex: 1; min-width: 0; min-height: 172px; border: 1px solid #463a1c; border-radius: 5px; background: rgba(0, 0, 0, 0.28); overflow: hidden; display: flex; flex-direction: column; }
+  .char-model-preview { width: 100%; flex: 1; min-height: 0; }
+  .char-model-preview canvas { display: block; width: 100% !important; height: 100% !important; }
+  .char-skin-row { justify-content: center; align-items: center; margin: 0; padding: 6px 0 8px; flex-shrink: 0; }
+  .char-stats { font-size: 12px; line-height: 1.65; color: #cfc6a8; margin-top: 10px; border-top: 1px solid #463a1c; padding-top: 8px;
+    display: grid; grid-template-columns: 1fr 1fr; gap: 0 12px; }
+  .char-stats b { color: #fff; font-weight: normal; }
+
+  /* spellbook */
+  #spellbook { width: 430px; }
+  .spellbook-class, .spell-rank { color: var(--color-text-muted); font-size: 11px; }
+  .spell-list { display: flex; flex-direction: column; gap: 2px; }
+  .spell-row { display: flex; gap: 10px; min-height: 46px; padding: 6px; border-radius: 4px; align-items: center; }
+  .spell-row:hover { background: #ffffff0e; }
+  .spell-row:focus-visible { outline: 2px solid var(--color-border-focus); outline-offset: 2px; background: var(--color-primary-glow); }
+  .spell-row.locked .spell-icon { filter: grayscale(1) brightness(0.5); }
+  .spell-row.locked .spell-name { color: var(--color-text-muted); }
+  .spell-row .spell-text { min-width: 0; flex: 1; }
+  .spell-row[draggable="true"] { cursor: grab; }
+  .spell-row .spell-name { font-size: 13px; color: #fff; font-family: var(--title-font); }
+  .spell-row .spell-sub { font-size: 11px; color: var(--color-text-muted); }
+  .spell-row .spell-name, .spell-row .spell-sub { overflow-wrap: anywhere; }
+  .spell-icon { width: 34px; height: 34px; border-radius: 5px; flex: none;
+    background-color: #15151f; background-size: cover; background-position: center; background-repeat: no-repeat;
+    border: 2px solid #4a3d1d; }
+  .spell-hotbar-toggle { display: none; }
+
+  /* quest log */
+  #quest-log-window { width: 520px; }
+  #quest-log-window .ql-cols { display: flex; gap: 12px; }
+  .ql-list { width: 180px; border-right: 1px solid #463a1c; padding-right: 8px; }
+  .ql-item { display: block; width: 100%; padding: 4px 6px; border: 0; background: transparent; text-align: left; font-size: 12px; color: #d8c89a; cursor: var(--cursor-point); border-radius: 3px; font-family: var(--title-font); }
+  .ql-item:hover, .ql-item.sel { background: #ffffff14; color: var(--gold); }
+  .ql-detail { flex: 1; font-size: 12px; max-height: 380px; overflow-y: auto; }
+  .ql-empty { color: var(--color-text-muted); font-size: 12px; padding: var(--spacing-xs); }
+  .ql-detail-title { font-size: 15px; }
+  .ql-detail-text { margin-top: var(--spacing-sm); }
+
+  /* post-cap progression: character-sheet block + milestone badges */
+  .char-progression { margin-top: 10px; border-top: 1px solid #463a1c; padding-top: 8px; }
+  .cp-title { font-family: var(--title-font); color: var(--gold); font-size: 12px; letter-spacing: .4px; margin-bottom: 4px; }
+  .char-progression .cp-stats { border-top: none; margin-top: 0; padding-top: 0; }
+  .cp-milestones { font-size: 11.5px; color: #b9ac82; margin-top: 6px; display: flex; flex-wrap: wrap; gap: 5px; align-items: center; }
+  .cp-none { color: #7c7256; font-style: italic; }
+  .ms-badge { display: inline-block; font-size: 10.5px; padding: 1px 7px; border-radius: 8px; font-family: var(--title-font);
+    border: 1px solid #b8902a; color: #ffe27a; background: #2a210c; }
+  .ms-badge.ms-border { border-color: #c97bff; color: #e6c8ff; background: #2a1838; }
+  .cp-actions { margin-top: 8px; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .cp-actions .btn[disabled] { opacity: 0.45; cursor: not-allowed; filter: grayscale(0.5); pointer-events: none; }
+  .cp-hint { font-size: 11px; color: #b9ac82; }
+
+  /* lifetime-XP leaderboard panel (modeled on the quest-log window) */
+  #leaderboard-window { width: 480px; }
+  .lb-body { margin-top: 8px; max-height: 56vh; overflow-y: auto; }
+  .lb-loading, .lb-empty { font-size: 12px; color: #b9ac82; padding: 10px 4px; text-align: center; }
+  .lb-row { display: grid; grid-template-columns: 44px 1fr 44px 48px 96px; align-items: center; gap: 6px; padding: 4px 8px; font-size: 12px; border-radius: 3px; }
+  .lb-row:nth-child(odd) { background: #ffffff08; }
+  .lb-head { color: var(--gold); font-family: var(--title-font); font-size: 11px; letter-spacing: .3px; background: none; border-bottom: 1px solid #463a1c; }
+  .lb-rank { text-align: center; color: #d8c89a; }
+  .lb-name { color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .lb-lvl, .lb-vlvl { text-align: center; color: #cfc6a8; }
+  .lb-xp { text-align: right; color: #ffe27a; }
+  .lb-row.lb-mine { background: #f5c84322; outline: 1px solid #b8902a; }
+  .lb-you { color: #b8902a; font-size: 10px; }
+  .lb-prestige { color: #ffd100; font-size: 10px; }
+  .lb-sticky { position: sticky; bottom: 0; margin-top: 6px; border-top: 1px solid #463a1c; background: #160f08; padding-top: 4px; }
+
+  /* talents & specializations panel */
+  #talents-window { width: min(600px, calc(100vw - 24px)); }
+  .tal-tabs { display: flex; gap: 6px; margin: 8px 0 6px; }
+  .tal-tab { position: relative; flex: 1; display: flex; align-items: center; justify-content: center; gap: 7px; text-align: center; min-height: 34px; padding: 6px 8px; font-size: 12px; font-family: var(--title-font); color: #d8c89a; background: #1c1609; border: 1px solid #463a1c; border-radius: 4px; cursor: var(--cursor-point); }
+  .tal-tab.active { color: #fff7dc; background: #3a2d10; border-color: #ffd100; box-shadow: inset 0 0 0 1px #ffd10055, 0 0 8px #b8902a55; }
+  .tal-tab.active::after { content: ""; position: absolute; left: 10px; right: 10px; bottom: -1px; height: 2px; background: #ffd100; border-radius: 2px; }
+  .tal-tab .tt-pts { min-width: 20px; height: 18px; display: inline-flex; align-items: center; justify-content: center; font-size: 10px; color: #f4df9f; background: #0f0b06; border: 1px solid #5f4b1a; border-radius: 9px; font-family: var(--body-font); }
+  .tal-head { display: flex; justify-content: space-between; align-items: center; font-size: 12px; color: #d8c89a; margin: 2px 2px 6px; }
+  .tal-head b { color: var(--gold); }
+  #tal-body { overflow-x: auto; overflow-y: visible; padding: 0 8px 8px; margin: 0 -8px; }
+  .tal-tree { position: relative; margin: 6px auto; }
+  .tal-arrows { position: absolute; left: 0; top: 0; pointer-events: none; z-index: 0; }
+  .tal-node { position: absolute; width: 46px; height: 46px; display: flex; align-items: center; justify-content: center; cursor: var(--cursor-point); background: #15110a; border: 2px solid #5a4a22; color: #e8dcb0; user-select: none; box-sizing: border-box; z-index: 1; }
+  .tal-node .tal-icon { position: absolute; inset: 2px; display: block; background-color: #15110a; background-size: cover; background-position: center; background-repeat: no-repeat; z-index: 1; }
+  .tal-node.circle { border-radius: 50%; }
+  .tal-node.circle .tal-icon { border-radius: 50%; }
+  .tal-node.square { border-radius: 7px; }
+  .tal-node.square .tal-icon { border-radius: 5px; }
+  .tal-node.octagon { border-radius: 8px; }
+  .tal-node.octagon .tal-icon { inset: 3px; border-radius: 6px; clip-path: polygon(24% 0,76% 0,100% 24%,100% 76%,76% 100%,24% 100%,0 76%,0 24%); }
+  .tal-node.avail { border-color: #b98b27; box-shadow: 0 0 0 1px #0b0804, 0 0 7px #9a772855; }
+  .tal-node.avail::after { content: "+"; position: absolute; left: -6px; top: -7px; min-width: 15px; height: 15px; display: flex; align-items: center; justify-content: center; color: #120d04; background: #f5c843; border: 1px solid #332403; border-radius: 50%; font: 700 12px/1 var(--body-font); z-index: 3; }
+  .tal-node.filled { border-color: #f5c843; color: #fff; background: #2c2410; box-shadow: inset 0 0 0 2px #120d04, 0 0 10px #b8902a99; }
+  .tal-node.filled::after, .tal-node.maxed::after { content: "✓"; position: absolute; left: -6px; top: -7px; min-width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; color: #120d04; background: #ffd100; border: 1px solid #332403; border-radius: 50%; font: 700 11px/1 var(--body-font); z-index: 3; }
+  .tal-node.maxed { border-color: #ffe27a; box-shadow: inset 0 0 0 2px #120d04, 0 0 13px #ffd100cc; }
+  .tal-node.maxed::after { content: "★"; font-size: 10px; }
+  .tal-node.locked { opacity: 0.48; filter: grayscale(0.75) brightness(0.72); cursor: not-allowed; }
+  .tal-node.dormant { border-color: #ff6d5a; box-shadow: inset 0 0 0 2px #2a0905, 0 0 10px #c0392bcc; }
+  .tal-node.dormant::after { content: "!"; position: absolute; left: -6px; top: -7px; min-width: 16px; height: 16px; display: flex; align-items: center; justify-content: center; color: #fff6e8; background: #c0392b; border: 1px solid #3a0803; border-radius: 50%; font: 800 11px/1 var(--body-font); z-index: 3; }
+  .tal-rank { position: absolute; right: -6px; bottom: -7px; min-width: 20px; text-align: center; font-size: 10px; color: #fff6d5; background: #171006; border: 1px solid #ffd100; border-radius: 8px; padding: 0 4px; line-height: 14px; z-index: 4; box-shadow: 0 1px 4px #000a; }
+  .tal-specs { display: flex; gap: 8px; margin: 10px 0; }
+  .tal-spec { position: relative; flex: 1; padding: 8px 6px; border: 1px solid #463a1c; border-radius: 6px; background: #1a1409; cursor: var(--cursor-point); text-align: center; }
+  .tal-spec.sel { border-color: #ffd100; background: #2c2410; box-shadow: inset 0 0 0 1px #ffd10055, 0 0 10px #b8902a66; }
+  .tal-spec.sel::after { content: "✓"; position: absolute; right: 6px; top: 6px; width: 17px; height: 17px; display: flex; align-items: center; justify-content: center; color: #120d04; background: #ffd100; border: 1px solid #332403; border-radius: 50%; font: 700 11px/1 var(--body-font); }
+  .tal-spec .ts-icon { width: 42px; height: 42px; margin: 0 auto; border-radius: 6px; display: flex; align-items: center; justify-content: center; background: #15110a; color: #fff; border: 1px solid #5a4a22; font: 26px/1 "Apple Color Emoji", "Segoe UI Emoji", var(--body-font); text-shadow: 0 1px 2px #000; }
+  .tal-spec.sel .ts-icon { border-color: #ffd100; box-shadow: 0 0 8px #ffd10066; }
+  .tal-spec .ts-name { font-size: 12px; color: #fff; font-family: var(--title-font); margin-top: 2px; }
+  .tal-spec .ts-role { font-size: 10px; color: var(--gold); text-transform: uppercase; letter-spacing: .4px; }
+  .tal-mastery { font-size: 11px; color: #c8b888; margin: 4px 2px 6px; padding: 6px 8px; border: 1px solid #463a1c; border-radius: 4px; background: #14100a; }
+  .tal-mastery b { color: var(--gold); }
+  .tal-help { margin: -2px 2px 6px; font-size: 11px; line-height: 1.35; color: #a99b76; }
+  .tal-foot { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(170px, .9fr); gap: 8px; margin-top: 10px; border-top: 1px solid #463a1c; padding-top: 8px; }
+  .tal-build-card { display: grid; gap: 6px; align-content: start; padding: 7px; border: 1px solid #3f341a; border-radius: 6px; background: #120e08; box-shadow: inset 0 0 0 1px #0008; }
+  .tal-build-current { background: #171208; border-color: #59461d; }
+  .tal-build-create { background: #10120d; }
+  .tal-build-head { display: flex; gap: 7px; align-items: center; justify-content: space-between; min-width: 0; color: var(--gold); font-family: var(--title-font); font-size: 12px; }
+  .tal-build-head .ui-dd { min-width: 132px; flex: 1 1 150px; font-family: var(--body-font); }
+  .tal-build-actions { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+  .tal-build-help { font-size: 11px; line-height: 1.35; color: #a99b76; }
+  .tal-foot .btn { padding: 5px 10px; font-size: 12px; }
+  .tal-foot .btn.tal-primary { border-color: #8f7025; color: #ffe6a8; background: linear-gradient(#7a5f21, #4d3810); }
+  .tal-foot .btn.tal-secondary { color: #d8c89a; border-color: #4b3d1d; background: #171208; }
+  .tal-foot .btn[disabled] { opacity: 0.45; pointer-events: none; cursor: not-allowed; }
+  .tal-foot select, .tal-foot input { background: #14100a; color: #e8dcb0; border: 1px solid #463a1c; border-radius: 4px; font-size: 11px; padding: 4px; }
+  .tal-spacer { flex: 1; }
+  .tal-empty { font-size: 12px; color: #b9ac82; text-align: center; padding: 18px; }
+  .tal-coming-soon { display: flex; flex-direction: column; gap: 6px; align-items: center; max-width: 360px; margin: 14px auto; line-height: 1.45; }
+  .tal-coming-soon b { color: var(--gold); font-family: var(--title-font); font-size: 14px; }
+  @media (max-width: 460px) {
+    .tal-head { align-items: flex-start; gap: 4px; flex-direction: column; }
+    .tal-foot { grid-template-columns: 1fr; }
+    .tal-specs { gap: 6px; }
+    .tal-spec { padding: 7px 4px; }
+    .tal-spec .ts-icon { width: 34px; height: 34px; }
+    .tal-spec .ts-name { font-size: 10.5px; }
+    .tal-spec .ts-role { font-size: 9px; }
+  }
+  /* in-app input modal field (Save / Import / Export — replaces window.prompt) */
+  .cd-field { margin: 8px 0; }
+  .cd-input { width: 100%; box-sizing: border-box; background: #14100a; color: #e8dcb0; border: 1px solid #5a4a22; border-radius: 4px; padding: 7px 8px; font-size: 12px; font-family: inherit; }
+  .cd-input:focus { outline: none; border-color: var(--gold); }
+  textarea.cd-input { resize: vertical; min-height: 48px; word-break: break-all; }
+  /* shared in-app dropdown (replaces native <select> — loadouts, report reason) */
+  .ui-dd { position: relative; display: inline-block; }
+  .ui-dd-btn { min-width: 112px; width: 100%; display: inline-flex; align-items: center; justify-content: space-between; gap: 6px; }
+  .ui-dd-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ui-dd-caret { font-size: 9px; opacity: 0.8; }
+  .ui-dd-menu { position: absolute; bottom: calc(100% + 4px); left: 0; min-width: 100%; max-height: 184px; overflow-y: auto; background: #1a140a; border: 1px solid var(--gold); border-radius: 5px; box-shadow: 0 6px 18px #000a; z-index: 80; padding: 3px; }
+  .ui-dd-menu[hidden] { display: none; }
+  .ui-dd-item { padding: 5px 8px; font-size: 12px; color: #e8dcb0; border-radius: 3px; cursor: var(--cursor-point); white-space: nowrap; }
+  .ui-dd-item:hover { background: #ffffff12; }
+  .ui-dd-item.sel { color: var(--gold); }
+  /* report dialog: dropdown drops downward (dialog sits high), full width */
+  #report-window .ui-dd { display: block; }
+  #report-window .ui-dd-menu { bottom: auto; top: calc(100% + 4px); }
+  /* Choice-node option flyout */
+  .tal-choice-pop { position: fixed; z-index: 90; width: 252px; background: #1a140a; border: 1px solid var(--gold); border-radius: 6px; box-shadow: 0 10px 24px #000c, inset 0 0 0 1px #ffd10022; padding: 5px; }
+  .tal-choice-pop::before { content: ""; position: absolute; left: var(--tal-choice-caret-left, 50%); top: -6px; width: 10px; height: 10px; background: #1a140a; border-left: 1px solid var(--gold); border-top: 1px solid var(--gold); transform: translateX(-50%) rotate(45deg); }
+  .tal-choice-opt { position: relative; display: flex; gap: 8px; align-items: flex-start; padding: 8px 28px 8px 8px; border: 1px solid transparent; border-radius: 4px; cursor: var(--cursor-point); }
+  .tal-choice-opt:hover, .tal-choice-opt:focus-visible { background: #ffffff10; border-color: #6f5a2a; outline: none; }
+  .tal-choice-opt.sel { background: #2c2410; border-color: var(--gold); box-shadow: inset 0 0 0 1px #ffd10033; }
+  .tal-choice-opt.sel::after { content: "✓"; position: absolute; right: 8px; top: 8px; width: 15px; height: 15px; display: flex; align-items: center; justify-content: center; color: #120d04; background: #ffd100; border-radius: 50%; font: 700 10px/1 var(--body-font); }
+  .tco-icon { width: 28px; height: 28px; flex: none; border-radius: 4px; display: block; background-color: #15110a; background-size: cover; background-position: center; background-repeat: no-repeat; border: 1px solid #5a4a22; }
+  .tco-text { display: flex; flex-direction: column; gap: 2px; font-size: 11px; color: #c8b888; }
+  .tco-text b { color: #fff; font-size: 12px; }
+
+  /* generic confirm dialog (prestige) */
+  #confirm-dialog { left: 50%; top: 50%; transform: translate(-50%, -50%); width: 360px; padding: 14px; z-index: 60; }
+  #confirm-dialog .cd-body { font-size: 12.5px; line-height: 1.55; color: #e8e0c8; margin: 10px 0; }
+  #confirm-dialog .cd-actions { display: flex; justify-content: flex-end; gap: 8px; }
+  #confirm-dialog .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }
+
+  /* player card: char-window entry button + share modal */
+  .pc-share-row { margin-top: 10px; display: flex; justify-content: center; }
+  .pc-share-btn { display: inline-flex; align-items: center; gap: 7px; }
+  .pc-share-ico { flex: none; }
+  #player-card-modal { z-index: 320; }
+  #player-card-modal .pc-modal { width: min(680px, 96vw); max-height: calc(100vh - 32px);
+    max-height: calc(100dvh - 32px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    padding: 16px; display: flex; flex-direction: column;
+    overflow-y: auto; overflow-x: hidden; overscroll-behavior: contain; -webkit-overflow-scrolling: touch; }
+  /* keep the action row / status from being squished to zero on short viewports —
+     the panel scrolls instead (BUG: mobile clipped the lower controls). */
+  #player-card-modal .pc-modal > * { flex: none; }
+  #player-card-modal .pc-preview { margin: 12px 0; min-height: 120px; display: flex;
+    align-items: center; justify-content: center; overflow: hidden; }
+  #player-card-modal .pc-preview.pc-loading { color: #c8b888; font-size: 13px; font-style: italic; }
+  /* cap the 1200×630 preview's on-screen height so it doesn't fill the whole panel
+     on landscape phones, pushing the buttons below the fold. */
+  #player-card-modal .pc-card-canvas { width: 100%; height: auto; max-height: min(46vh, 360px);
+    object-fit: contain; display: block; border-radius: 8px;
+    box-shadow: 0 8px 28px rgba(0,0,0,.55); }
+  #player-card-modal .pc-poses { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; margin-bottom: 10px; }
+  #player-card-modal .pc-pose { min-width: 84px; padding: 5px 12px; font-size: 12px; opacity: 0.72; }
+  #player-card-modal .pc-pose.sel { opacity: 1; border-color: var(--gold); color: var(--gold); }
+  #player-card-modal .pc-options { display: flex; justify-content: center; margin: 0 0 10px; }
+  #player-card-modal .pc-wallet-toggle { min-width: 210px; display: inline-flex; align-items: center; justify-content: space-between; gap: 12px; }
+  #player-card-modal .pc-wallet-toggle.off { opacity: 0.78; }
+  #player-card-modal .pc-toggle-state { color: var(--gold); font-weight: 700; }
+  #player-card-modal .pc-wallet-toggle.off .pc-toggle-state { color: #9b8b62; }
+  #player-card-modal .pc-actions { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
+  #player-card-modal .pc-actions .btn { min-width: 110px; }
+  #player-card-modal .pc-actions .cd-ok { background: linear-gradient(#8a6a26, #5a4413 55%, #473409); color: #ffe6a8; }
+  #player-card-modal .pc-link { margin-top: 12px; }
+  #player-card-modal .pc-link[hidden] { display: none; }
+  #player-card-modal .pc-link-label { display: block; font-size: 11.5px; color: #c8b888; margin-bottom: 4px; }
+  #player-card-modal .pc-link-input { width: 100%; box-sizing: border-box; padding: 8px 10px; font-size: 12.5px;
+    color: var(--gold); background: #120d07; border: 1px solid #463a1c; border-radius: 5px; font-family: var(--ui-font); }
+  #player-card-modal .pc-status { margin-top: 10px; min-height: 16px; font-size: 12px;
+    color: #c8b888; text-align: center; }
+  @media (pointer: coarse) {
+    #player-card-modal .pc-pose,
+    #player-card-modal .pc-wallet-toggle,
+    #player-card-modal .pc-actions .btn {
+      min-height: 40px;
+      box-sizing: border-box;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
+    #player-card-modal .pc-link-input {
+      font-size: 16px;
+    }
+  }
+
+  /* vendor */
+  #vendor-window { width: 400px; }
+  .vendor-item { display: flex; gap: 8px; align-items: center; width: 100%; padding: 5px; border: 0; border-radius: 4px; cursor: var(--cursor-point); background: transparent; color: inherit; font-family: var(--ui-font); text-align: left; }
+  .vendor-item:hover { background: #ffffff10; }
+  .vendor-item .vi-name { font-size: 12px; flex: 1; }
+  .vendor-item .vi-price { font-size: 11px; color: #ddd; }
+  .vendor-section-title { margin-top: 8px; padding-top: 7px; border-top: 1px solid #463a1c; color: var(--gold); font-family: var(--title-font); font-size: 12px; }
+  .vendor-empty { padding: 5px; font-size: 11px; color: #887c5c; }
+  .vendor-hint { font-size: 11px; color: #c8b888; margin-top: 8px; border-top: 1px solid #463a1c; padding-top: 6px; }
+
+  /* bags — centred in the bottom gap between the action cluster and micro-menu */
+  #bags {
+    --bags-bar-half: 306px;
+    --bags-gap: 12px;
+    --bags-micro-r: calc(16px + 34px + var(--bags-gap));
+    --bags-slot-w: max(180px, calc(100vw - 50% - var(--bags-bar-half) - var(--bags-gap) - var(--bags-micro-r)));
+    left: calc((100% + 50% + var(--bags-bar-half) + var(--bags-gap) - var(--bags-micro-r)) / 2);
+    right: auto;
+    bottom: 6px;
+    top: auto;
+    width: min(310px, var(--bags-slot-w));
+    transform: translateX(-50%);
+    max-height: calc(100vh - 18px);
+    overflow: hidden;
+    flex-direction: column;
+  }
+  #bags .panel-title { flex: none; }
+  #bags .bag-grid { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+  #bags .money { flex: none; display: flex; align-items: center; gap: 10px; }
+  /* coins stay right-aligned whether or not the $WOC chip is present */
+  #bags .money .money-inline { margin-left: auto; }
+  .woc-balance { display: inline-flex; align-items: center; gap: 5px; color: var(--gold-dim); font-weight: 600; white-space: nowrap; }
+  .woc-balance.is-preview { color: #b8a66f; }
+  .woc-balance.is-verified { color: var(--color-text-success); }
+  .woc-coin { display: inline-block; width: 11px; height: 11px; border-radius: 50%; background: radial-gradient(circle at 35% 30%, #c9a3ff, #6b3fa0); box-shadow: 0 0 4px rgba(150, 90, 230, 0.5); }
+  .bag-grid { display: flex; flex-direction: column; gap: 2px; }
+  .bag-item { display: flex; gap: 8px; align-items: center; width: 100%; font-size: 12px; padding: 3px 4px; border: 0; border-radius: 3px; cursor: var(--cursor-point); background: transparent; color: inherit; font-family: var(--ui-font); text-align: left; }
+  .bag-item:hover { background: #ffffff12; }
+  .bag-item .bi-count { margin-left: auto; color: #ccc; }
+  .bag-empty { font-size: 12px; color: var(--color-text-muted); padding: 6px; }
+  .money { margin-top: 8px; font-size: 12px; color: var(--gold); text-align: right; }
+  .money-inline, .coin-part { display: inline-flex; align-items: center; }
+  .coin { display: inline-block; width: 11px; height: 11px; border-radius: 50%; vertical-align: -1px; margin-left: 6px; margin-right: 2px; }
+  .coin.g { background: radial-gradient(circle at 35% 30%, #ffe98a, #b8860b); }
+  .coin.s { background: radial-gradient(circle at 35% 30%, #e8e8e8, #888); }
+  .coin.c { background: radial-gradient(circle at 35% 30%, #e8a87a, #8b4513); }
+
+  /* social: friends / guild / ignore */
+  #social-window { width: 348px; height: 560px; max-height: calc(100vh - 24px);
+    flex-direction: column; overflow-x: hidden; box-sizing: border-box; }
+  #social-window.open { display: flex; }
+  .soc-realm-tag { color: #7fd4ff; font-size: 11px; font-weight: 400; }
+  .soc-tabs { display: flex; gap: 4px; margin: 6px 0 8px; flex: none; }
+  .soc-tab { flex: 1; padding: 7px 0; font-size: 13px; font-family: var(--title-font); color: #d8c89a; cursor: var(--cursor-point);
+    background: #1a1410; border: 1px solid #463a1c; border-radius: 4px; text-align: center; }
+  .soc-tab:hover { color: var(--gold); }
+  .soc-tab:focus-visible,
+  .soc-x:focus-visible,
+  .soc-name.soc-link:focus-visible,
+  .soc-sugg-item:focus-visible,
+  .trade-item.mine:focus-visible {
+    outline: 2px solid var(--color-border-focus);
+    outline-offset: 2px;
+  }
+  .soc-tab.on { color: var(--gold); border-color: #6f5a2a; background: linear-gradient(#2a2436, #161220); }
+  .soc-body { overflow-y: auto; overflow-x: hidden; flex: 1; min-height: 80px; }
+  .soc-row { display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 13px; padding: 6px 6px; border-radius: 4px; }
+  .soc-row > span:not(.soc-dot):not(.soc-meta):not(.soc-actions) { min-width: 0; flex: 1 1 auto; }
+  .soc-row:hover { background: #ffffff10; }
+  .soc-dot { width: 10px; height: 10px; border-radius: 50%; flex: none; background: #555; box-shadow: 0 0 4px #0008; }
+  .soc-dot.online { background: #46d246; box-shadow: 0 0 5px #46d246aa; }
+  .soc-dot.combat { background: #ff5040; box-shadow: 0 0 5px #ff5040aa; }
+  .soc-dot.dungeon { background: #c98bff; box-shadow: 0 0 5px #c98bffaa; }
+  .soc-dot.dead { background: #888; }
+  /* name column flexes and ellipsis-truncates so it never pushes the other columns */
+  .soc-id { display: flex; flex-direction: column; min-width: 0; flex: 1 1 auto; }
+  .soc-name { color: #f0ead8; font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  button.soc-name { border: 0; background: transparent; padding: 0; font-family: var(--ui-font); font-size: inherit; text-align: left; }
+  .soc-name.soc-link { cursor: var(--cursor-point); }
+  .soc-name.soc-link:hover { color: #ff80ff; text-decoration: underline; }
+  .soc-name .rank { color: #c9b27a; font-weight: 400; font-size: 10px; margin-left: 4px; display: inline-block; text-decoration: none; }
+  .soc-sub { color: #998d6a; font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  /* status column never word-wraps (zone + status stack via an explicit break) */
+  .soc-meta { color: #998d6a; font-size: 11px; text-align: right; line-height: 1.25; white-space: nowrap; flex: none; }
+  .soc-meta .zone { color: #7fd4ff; }
+  .soc-actions { display: flex; gap: 5px; margin-left: 4px; flex: none; }
+  .soc-x { color: #e0c89a; cursor: var(--cursor-point); font-size: 15px; line-height: 1; min-width: 26px; height: 26px;
+    display: inline-flex; align-items: center; justify-content: center; padding: 0 5px;
+    border: 1px solid #5a4a26; border-radius: 4px; background: #221a10; font-family: var(--ui-font); }
+  .soc-x:hover { color: #fff0b0; border-color: #8a6f34; background: #2e2416; }
+  .soc-notice { flex: none; display: none; font-size: 11px; padding: 5px 7px; margin-top: 6px; border-radius: 4px; }
+  .soc-notice.err { color: #ffb0a0; background: #3a1512; border: 1px solid #6e2a1e; }
+  .soc-notice.ok { color: #bfe8a0; background: #16280f; border: 1px solid #2f5a22; }
+  .soc-add { display: flex; gap: 6px; margin-top: 8px; flex: none; position: relative; }
+  .soc-add.soc-leave { justify-content: flex-end; }
+  .soc-add input { flex: 1; background: #120f0c; border: 1px solid #463a1c; border-radius: 4px; color: #f0ead8; padding: 5px 7px; font-size: 12px; }
+  .soc-add .btn { margin: 0; padding: 5px 12px; font-size: 11px; }
+  .soc-suggest { position: absolute; left: 0; right: 0; bottom: calc(100% + 3px); display: none; z-index: 30;
+    background: #14110d; border: 1px solid #6f5a2a; border-radius: 5px; max-height: 210px; overflow-y: auto;
+    box-shadow: 0 -6px 18px #000a; }
+  .soc-sugg-item { display: flex; width: 100%; align-items: center; gap: 8px; padding: 7px 9px; cursor: var(--cursor-point); font-size: 13px;
+    border: 0; background: transparent; color: inherit; font-family: var(--ui-font); text-align: left; }
+  .soc-sugg-item:hover, .soc-sugg-item.active { background: #2f2740; }
+  .soc-sugg-item.active { box-shadow: inset 2px 0 0 var(--gold); }
+  .soc-empty { color: #887c5c; font-size: 12px; padding: 10px 6px; text-align: center; }
+  .soc-guild-head { font-family: var(--title-font); color: var(--gold); font-size: 15px; padding: 2px 4px 6px; }
+  .soc-guild-head .gm { color: #998d6a; font-size: 11px; }
+
+  /* map */
+  #map-window { padding: 14px; }
+  /* zoom controls, matching the micro-menu button look */
+  #map-zoom { position: absolute; right: 22px; bottom: 22px; display: flex; flex-direction: column; gap: 5px; z-index: 2; }
+  .map-zoom-btn { width: 32px; height: 32px; font-size: 20px; font-weight: bold; line-height: 1;
+    border: 2px solid #4a3d1d; border-radius: 5px; color: #d8c89a; cursor: var(--cursor-point);
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f);
+    box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009; display: flex; align-items: center; justify-content: center; }
+  .map-zoom-btn:hover { border-color: var(--gold); color: #fff; }
+  #map-close {
+    position: absolute;
+    right: 8px;
+    top: 8px;
+    z-index: 2;
+  }
+
+  /* ---------- Ashen Coliseum (arena) ---------- */
+  #arena-window { width: 360px; padding: 14px; }
+  .arena-sub { font-family: var(--title-font); color: var(--gold); font-size: 12px; margin: 12px 0 5px; border-bottom: 1px solid #463a1c; padding-bottom: 3px; }
+  .arena-rank { display: flex; align-items: baseline; gap: 10px; margin: 2px 0 6px; }
+  .arena-rank .rating { font-family: var(--title-font); font-size: 30px; color: #ffb24a; text-shadow: 0 0 10px #cc5a1466, 1px 1px 2px #000; }
+  .arena-rank .wl { font-size: 12px; color: #cfc6a8; }
+  .arena-rank .wl b { color: #7fdc4f; } .arena-rank .wl i { color: #ff7a6a; font-style: normal; }
+  #arena-window .btn { width: 100%; margin: 4px 0 0; box-sizing: border-box; text-align: center; }
+  #arena-window .btn.leave { background: linear-gradient(#5a4a18, #3a2f0d 55%, #2a2208); color: #ffe6a8; }
+  .arena-note { font-size: 11.5px; color: #b6ad8c; line-height: 1.45; margin: 4px 0 2px; font-family: Georgia, serif; }
+  .arena-brackets { display: flex; gap: 6px; margin: 6px 0 4px; }
+  .arena-bracket { flex: 1; padding: 5px 0; font-family: var(--title-font); font-size: 12px; color: #cfc6a8;
+    background: linear-gradient(#3a3018, #2a2208); border: 1px solid #5a4a20; cursor: var(--cursor-point); border-radius: 4px; }
+  .arena-bracket.active { color: #ffb24a; border-color: #8a6a28; background: linear-gradient(#5a4a18, #3a2f0d 55%, #2a2208); }
+  .arena-bracket.locked { opacity: 0.45; cursor: not-allowed; }
+  .arena-bracket-tag { color: #998d6a; font-size: 11px; margin-left: 4px; }
+  .arena-party { margin: 6px 0 4px; padding: 8px 10px; border: 1px solid #5a4a20; border-radius: 6px;
+    background: linear-gradient(#1a1408aa, #0d0a04aa); }
+  .arena-party-title { font-family: var(--title-font); font-size: 11px; color: var(--gold); margin-bottom: 5px; letter-spacing: 0.3px; }
+  .arena-party-row { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; padding: 3px 0; font-size: 12px; }
+  .arena-party-row.me .apr-name { color: #ffd100; }
+  .arena-party-row .apr-name { color: #cfe0ff; font-weight: bold; }
+  .arena-party-row .apr-meta { color: #8c8468; font-size: 10.5px; white-space: nowrap; }
+  .arena-party-invite { border-left: 2px solid #6a5a28; padding-left: 8px; margin-top: 4px; }
+  .arena-warn { color: #ff9a7a; border-left: 2px solid #aa4a28; padding-left: 8px; }
+  #arena-window .btn.disabled { opacity: 0.55; cursor: not-allowed; filter: grayscale(0.25); }
+  .arena-queue-status { font-size: 12px; color: #ffd100; margin-top: 6px; text-align: center; }
+  .ladder-row { display: grid; grid-template-columns: 24px 1fr auto auto; gap: 8px; align-items: center;
+    font-size: 12px; padding: 3px 6px; border-radius: 4px; color: #e0d6b4; }
+  .ladder-row.me { background: #ffb24a1f; outline: 1px solid #ffb24a55; }
+  .ladder-row .rank { color: #998d6a; text-align: right; }
+  .ladder-row .lr-name { color: #cfe0ff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .ladder-row .lr-rating { color: #ffb24a; font-family: var(--title-font); }
+  .ladder-row .lr-wl { color: #8c8468; font-size: 10.5px; }
+  .ladder-empty { font-size: 11.5px; color: #8c8468; font-style: italic; padding: 4px 6px; }
+
+  /* in-match banner: opponent + countdown/timer, pinned under the top center */
+  #arena-status { position: absolute; top: 70px; left: 50%; transform: translateX(-50%);
+    display: none; text-align: center; pointer-events: none; z-index: 18;
+    background: linear-gradient(#1a120bdd, #0d0805dd); border: 1px solid #cc5a14;
+    border-radius: 8px; padding: 6px 16px 5px; box-shadow: 0 2px 14px #000a, inset 0 0 16px #cc5a1422; min-width: 220px; }
+  #arena-status .as-vs { font-family: var(--title-font); font-size: 13px; color: #ffb24a; text-shadow: 1px 1px 2px #000; letter-spacing: 0.5px; }
+  #arena-status .as-vs .opp { color: #ff8d7a; }
+  #arena-status .as-lvl { color: #b6ad8c; font-size: 11px; font-family: Georgia, serif; }
+  #arena-status .as-teams { display: flex; align-items: center; gap: 10px; justify-content: center; }
+  #arena-status .as-team { text-align: center; min-width: 80px; }
+  #arena-status .as-team .as-label { display: block; font-family: var(--title-font); font-size: 9px; letter-spacing: 0.6px; text-transform: uppercase; margin-bottom: 2px; }
+  #arena-status .as-team.allies .as-label { color: #7fdc4f; }
+  #arena-status .as-team.allies .as-names { color: #b8e8a0; font-size: 12px; }
+  #arena-status .as-team.enemies .as-label { color: #ff8d7a; }
+  #arena-status .as-team.enemies .as-names { color: #ffb0a0; font-size: 12px; }
+  #arena-status .as-mid { font-family: var(--title-font); font-size: 11px; color: #ffb24a; opacity: 0.85; }
+  #arena-status .as-timer { font-size: 11px; color: #d8cba0; margin-top: 4px; }
+
+  /* ---------- The World Market (the Merchant's auction house) ---------- */
+  #market-window { width: 470px; height: min(640px, calc(85vh - 24px)); display: none; flex-direction: column; overflow: hidden; min-height: 0; }
+  .mkt-tabs { display: flex; gap: 4px; margin: 2px 0 8px; }
+  .mkt-tab { flex: 1; text-align: center; font-family: var(--title-font); font-size: 12px; color: #cabb8c;
+    padding: 5px 4px; border: 0; border-radius: 4px 4px 0 0; cursor: var(--cursor-point); background: #ffffff08; border-bottom: 2px solid transparent; }
+  .mkt-tab:hover { background: #ffffff14; color: #ffe6a8; }
+  .mkt-tab.sel { color: var(--gold); background: #ffffff16; border-bottom-color: #cc9a3c; }
+  .mkt-tab .pip { color: #9fdc7f; font-size: 10.5px; }
+  .mkt-search { width: 100%; box-sizing: border-box; margin: 2px 0 8px; padding: 7px 10px; font-size: 16px;
+    background: #120d07; border: 1px solid #5a4a2a; border-radius: 6px; color: #ffe6a8; font-family: Georgia, serif; }
+  .mkt-search::placeholder { color: #8c8468; font-style: italic; }
+  .mkt-search:focus-visible { outline: 2px solid #cc9a3c; outline-offset: 1px; border-color: #cc9a3c; }
+  .mkt-filters { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin: 0 0 8px; position: relative; z-index: 3; }
+  .mkt-filters.has-subtype { grid-template-columns: 1fr 1fr 1fr; }
+  .mkt-filter { display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+  .mkt-filter span { font-family: var(--title-font); font-size: 10px; letter-spacing: 0.4px; color: #cabb8c; text-transform: uppercase; }
+  .mkt-select { position: relative; min-width: 0; }
+  .mkt-select-btn { width: 100%; min-width: 0; min-height: 32px; display: flex; align-items: center; justify-content: space-between; gap: 8px;
+    border: 1px solid #6f5a2a; border-radius: 5px; background: #120d07; color: #f0e4c8; font-family: var(--font-ui); font-size: 13px;
+    padding: 5px 8px; cursor: var(--cursor-point); box-shadow: inset 0 1px 0 #ffffff12; text-align: left; }
+  .mkt-select-btn:hover, .mkt-select.open .mkt-select-btn { border-color: #cc9a3c; color: #ffe6a8; background: #181107; }
+  .mkt-select-btn:focus-visible { outline: 2px solid var(--color-border-focus); outline-offset: 2px; }
+  .mkt-select-btn > span:first-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: inherit; font: inherit; text-transform: none; letter-spacing: 0; }
+  .mkt-select-chevron { width: 8px; height: 8px; flex: none; border-right: 2px solid #cabb8c; border-bottom: 2px solid #cabb8c; transform: translateY(-2px) rotate(45deg); }
+  .mkt-select.open .mkt-select-chevron { transform: translateY(2px) rotate(225deg); }
+  .mkt-select-menu { position: absolute; left: 0; top: calc(100% + 4px); width: 100%; max-height: 236px; overflow-y: auto;
+    padding: 5px; border: 1px solid #6f5a2a; border-radius: 6px; background: #140f09f7; box-shadow: 0 10px 24px #000c, inset 0 1px 0 #ffffff12; z-index: 20; }
+  .mkt-select-option { width: 100%; display: block; border: 0; border-radius: 4px; background: transparent; color: #f0e4c8;
+    font-family: var(--font-ui); font-size: 13px; line-height: 1.2; text-align: left; padding: 7px 8px; cursor: var(--cursor-point); }
+  .mkt-select-option:hover, .mkt-select-option:focus-visible { outline: 0; background: #ffffff14; color: #ffe6a8; }
+  .mkt-select-option.sel { background: #cc9a3c2e; color: var(--gold); }
+  #market-body { overflow-y: auto; flex: 1; min-height: 0; padding-right: 2px; }
+  .mkt-note { font-size: 11.5px; color: #b6ad8c; line-height: 1.45; margin: 2px 0 8px; font-family: Georgia, serif; }
+  .mkt-row { display: grid; grid-template-columns: 30px 1fr auto auto; gap: 9px; align-items: center;
+    padding: 5px 6px; border-radius: 4px; font-size: 12px; }
+  .mkt-row:hover { background: #ffffff0d; }
+  .mkt-row .mkt-name { overflow: hidden; }
+  .mkt-row .mkt-name .nm { display: block; }
+  .mkt-row .mkt-name .stack { color: var(--color-text-light); }
+  .mkt-row .mkt-name .seller { font-size: 10.5px; color: #8c8468; }
+  .mkt-row .mkt-name .seller.house { color: #d4af37; }
+  .mkt-row .mkt-price { font-size: 11.5px; color: #ffe6a8; white-space: nowrap; text-align: right; }
+  .mkt-btn { font-family: var(--title-font); font-size: 11px; cursor: var(--cursor-point); border-radius: 4px; padding: 4px 11px;
+    border: 1px solid #5a4a18; background: linear-gradient(#3a6a28, #244a18 60%, #1a3812); color: #d6ffc8; white-space: nowrap; }
+  .mkt-btn:hover { filter: brightness(1.18); }
+  .mkt-btn.cancel { background: linear-gradient(#6a3a18, #4a2810 60%, #381c0c); color: #ffd8b8; }
+  .mkt-page { display: flex; align-items: center; justify-content: space-between; gap: 8px;
+    margin: 8px 0 2px; padding: 7px 6px 0; border-top: 1px solid #5a4a2a; }
+  .mkt-page-info { flex: 1; text-align: center; font-family: var(--font-ui); font-size: 11.5px; color: #cabb8c; }
+  .mkt-page-btn { min-width: 72px; min-height: 28px; border: 1px solid #6f5a2a; border-radius: 4px;
+    background: #181107; color: #f0e4c8; font-family: var(--title-font); font-size: 10.5px; cursor: var(--cursor-point); }
+  .mkt-page-btn:hover:not(:disabled), .mkt-page-btn:focus-visible { border-color: #cc9a3c; color: #ffe6a8; outline: 0; }
+  .mkt-page-btn:disabled { opacity: 0.45; cursor: var(--cursor-arrow); }
+  .mkt-empty { font-size: 12px; color: #887c5c; font-style: italic; padding: 10px 6px; text-align: center; }
+  .mkt-sell-pick { display: flex; gap: 10px; align-items: center; padding: 8px; border: 1px dashed #5a4a2a; border-radius: 6px; margin-bottom: 10px; }
+  .mkt-sell-pick.empty { color: #998d6a; font-size: 12px; justify-content: center; font-style: italic; }
+  .mkt-sell-pick .ps-name { font-size: 13px; }
+  .mkt-price-form { display: flex; flex-direction: column; gap: 9px; }
+  .mkt-price-row { display: flex; gap: 8px; align-items: center; font-size: 12px; color: #cabb8c; }
+  .mkt-price-row label { min-width: 76px; }
+  .mkt-price-row .coininput { width: 56px; background: #120d07; border: 1px solid #5a4a2a; color: #ffe6a8;
+    border-radius: 4px; padding: 4px 6px; font-family: var(--ui-font, inherit); font-size: 12px; }
+  .mkt-coin-tag { color: #998d6a; font-size: 11px; margin-right: 6px; }
+  .mkt-list-btn { font-family: var(--title-font); font-size: 13px; cursor: var(--cursor-point); border-radius: 5px; padding: 8px;
+    border: 1px solid #5a4a18; background: linear-gradient(#5a4a18, #3a2f0d 55%, #2a2208); color: #ffe6a8; margin-top: 4px; }
+  .mkt-list-btn:hover { filter: brightness(1.15); }
+  .mkt-list-btn:disabled { opacity: 0.5; cursor: default; filter: none; }
+  .mkt-collect { display: flex; align-items: center; justify-content: space-between; gap: 10px;
+    padding: 8px; background: #ffffff0a; border-radius: 6px; margin-bottom: 8px; }
+  #map-canvas { border: 2px solid var(--border); outline: 1px solid #000; border-radius: 4px; touch-action: none; }
+
+  /* ---------- options / game menu (Esc) ---------- */
+  #options-menu { width: 420px; z-index: 40; }
+  .opt-list { display: flex; flex-direction: column; gap: 8px; align-items: stretch; padding: 4px 0; }
+  .opt-btn { margin: 0; text-align: center; }
+  .kb-rows { display: flex; flex-direction: column; gap: 2px; margin-bottom: 8px; }
+  /* Wide, multi-column key-binding layout (desktop). Categories flow into as many
+     columns as fit, so the tall Action Bar list no longer forces a long scroll. */
+  #options-menu.kb-wide { width: min(880px, calc(100vw - 32px)); }
+  .kb-cols { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 4px 18px; align-items: start; margin-bottom: 8px; }
+  .kb-col { min-width: 0; }
+  .kb-col .kb-rows { margin-bottom: 0; }
+  .kb-col .kb-cat { margin-top: 0; }
+  .kb-cat { font-family: var(--title-font); color: var(--gold); font-size: 12px; letter-spacing: 0.5px;
+    text-transform: uppercase; margin: 8px 0 2px; border-bottom: 1px solid #463a1c; padding-bottom: 2px; }
+  .kb-row { display: grid; grid-template-columns: 1fr 78px 78px; align-items: center;
+    gap: 6px; padding: 2px 6px; border-radius: 4px; }
+  .kb-row:nth-of-type(odd) { background: #ffffff0a; }
+  .kb-name { font-size: 12.5px; color: #e8e0c8; display: flex; align-items: center; justify-content: space-between; gap: 8px; min-width: 0; }
+  .kb-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .kb-inline-key { flex: 0 0 auto; color: #ffd100; font-family: var(--title-font); font-size: 11px; opacity: 0.9; }
+  .kb-key { margin: 0; text-align: center; padding: 3px 6px; font-size: 12px;
+    background: linear-gradient(#2c2c3a, #15151f); color: #ffd9a0; border-color: #4a3d1d; }
+  .kb-key.capturing { border-color: var(--gold); color: #fff; box-shadow: 0 0 8px #ffd100aa; }
+  .kb-note { font-size: 11px; color: #b9ac82; margin: 2px 0 6px; min-height: 14px; line-height: 1.4; }
+  .kb-toggle-row { margin-bottom: 6px; background: #ffffff0a; border-radius: 4px; }
+  .kb-toggle-row .kb-toggle {
+    grid-column: 2;
+    width: 78px;
+    min-width: 78px;
+    max-width: 78px;
+    margin: 0;
+    padding: 3px 6px;
+    text-align: center;
+    font-size: 12px;
+    font-family: var(--ui-font);
+    line-height: 1.2;
+    justify-self: start;
+    box-sizing: border-box;
+  }
+  .kb-toggle-row .kb-mouse-toggle {
+    width: 98px;
+    min-width: 98px;
+    max-width: 98px;
+  }
+  .kb-toggle.off { filter: grayscale(0.6) brightness(0.8); color: #b9ac82; }
+  .set-rows { display: flex; flex-direction: column; gap: 6px; margin-bottom: 6px; }
+  .set-row { display: grid; grid-template-columns: 120px 1fr 48px; align-items: center; gap: 10px; padding: 3px 6px; }
+  .set-name { font-size: 12.5px; color: #e8e0c8; }
+  .set-slider { width: 100%; accent-color: var(--gold); cursor: var(--cursor-point); }
+  .set-val { font-size: 12px; color: #ffd9a0; text-align: right; font-variant-numeric: tabular-nums; }
+  .set-toggle { margin: 0; padding: 3px 14px; }
+  .set-toggle.off { filter: grayscale(0.6) brightness(0.8); }
+  .set-lang-select { grid-column: 2 / 4; width: 100%; margin: 0; }
+  .set-choice { display: flex; flex-wrap: wrap; gap: 4px; grid-column: 2 / 4; }
+  .set-choice-btn { margin: 0; min-height: 40px; padding: 3px 9px; font-size: 12px; }
+  .set-choice-btn.sel { outline: 1px solid var(--gold); box-shadow: inset 0 0 8px #ffd10033; color: #fff4c7; }
+  .set-note { font-size: 11px; color: #b9ac82; margin: 6px 0 2px; line-height: 1.4; }
+  .set-seg { display: flex; gap: 4px; }
+  .set-seg-btn { margin: 0; padding: 3px 12px; opacity: 0.7; }
+  .set-seg-btn.active { opacity: 1; box-shadow: 0 0 0 1px var(--gold) inset; color: #ffd9a0; }
+  .set-row.disabled { opacity: 0.45; }
+  .chat-ts { color: #8f8a76; font-variant-numeric: tabular-nums; }
+
+  /* ---------- emote wheel ---------- */
+  #emote-wheel { position: absolute; left: 50%; top: 50%; width: 330px; height: 330px;
+    transform: translate(-50%, -50%); z-index: 80; display: none; pointer-events: auto;
+    animation: emote-wheel-in 180ms cubic-bezier(0.22, 1, 0.36, 1); }
+  .emote-wheel-ring { position: absolute; inset: 24px; border-radius: 50%;
+    background: radial-gradient(circle, #24190dcc 0 24%, #3a2a17e6 25% 55%, #080706e0 56% 100%);
+    border: 2px solid #8a682c; box-shadow: 0 0 0 1px #000, 0 12px 34px #000b, inset 0 0 34px #000b; }
+  .emote-wheel-item, .emote-wheel-edit { position: absolute; transform: translate(-50%, -50%);
+    display: flex; align-items: center; justify-content: center; text-align: center; font-family: var(--title-font);
+    letter-spacing: 0; border: 2px solid #3f3118; color: #f0dfaf; background: linear-gradient(#2b2418, #16110b);
+    box-shadow: 0 2px 0 #000, inset 0 1px 0 #ffffff12; transition: transform 130ms cubic-bezier(0.25, 1, 0.5, 1), filter 130ms; }
+  .emote-wheel-item { width: 82px; height: 78px; border-radius: 50%; padding: 4px; flex-direction: column; gap: 1px; font-size: 10px; line-height: 1.05; }
+  .emote-wheel-edit { left: 50%; top: 50%; width: 62px; height: 62px; border-radius: 50%; font-size: 12px; }
+  .emote-wheel-item.selected, .emote-wheel-edit.selected { color: #231506; border-color: #ffe27a;
+    background: linear-gradient(#fff0a8, #c9821e); box-shadow: 0 0 18px #ffd65aaa, 0 3px 0 #4a2108;
+    transform: translate(-50%, -50%) scale(1.08); filter: brightness(1.08); }
+  .emote-wheel-icon { width: 42px; height: 42px; display: block; filter: drop-shadow(0 2px 1px #0009); }
+  .emote-wheel-label { max-width: 70px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #emote-editor { width: 390px; }
+  .emote-editor-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; padding: 8px 2px 10px; }
+  .emote-editor-item { min-height: 58px; border: 1px solid #463a1c; border-radius: 6px; background: #15110a;
+    color: #d8c89a; cursor: var(--cursor-point); font-family: var(--title-font); font-size: 11px; display: flex;
+    align-items: center; gap: 6px; padding: 6px; text-align: left; transition: transform 130ms cubic-bezier(0.25, 1, 0.5, 1), filter 130ms; }
+  .emote-editor-icon { width: 34px; height: 34px; flex: 0 0 auto; filter: drop-shadow(0 2px 1px #0009); }
+  .emote-editor-item.selected { color: #211507; border-color: #ffe27a; background: linear-gradient(#fff0a8, #c9821e); }
+  .emote-editor-item:not(:disabled):hover { transform: translateY(-1px); filter: brightness(1.08); }
+  .emote-editor-item:disabled { opacity: 0.45; cursor: not-allowed; filter: grayscale(0.6); }
+  .emote-editor-footer { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .emote-editor-count { color: #ffd100; font-family: var(--title-font); font-size: 12px; }
+  @keyframes emote-wheel-in { from { transform: translate(-50%, -50%) scale(0.94); opacity: 0; } to { transform: translate(-50%, -50%) scale(1); opacity: 1; } }
+  @media (prefers-reduced-motion: reduce) {
+    .np-emote, #emote-wheel { animation: none; }
+    .emote-wheel-item, .emote-wheel-edit, .emote-editor-item { transition: none; }
+  }
+
+  /* tooltip */
+  #tooltip { position: absolute; display: none; z-index: 100; pointer-events: none; max-width: 280px;
+    padding: 8px 10px; font-size: 12px; line-height: 1.5; }
+  #tooltip .tt-title { font-family: var(--title-font); font-size: 13.5px; color: #fff; }
+  #tooltip .tt-sub { color: #998d6a; font-size: 11px; }
+  .tt-opt-icon { width: 16px; height: 16px; display: inline-block; vertical-align: -3px; border-radius: 3px; margin-right: 2px; background-size: cover; background-position: center; background-repeat: no-repeat; }
+  #tooltip .tt-desc { color: #ffd100; margin-top: 4px; font-size: 11.5px; }
+  #tooltip .tt-stat { color: #fff; font-size: 11.5px; }
+  #tooltip .tt-green { color: #1eff00; font-size: 11.5px; }
+  #tooltip .tt-red { color: #ff5040; font-size: 11.5px; }
+  /* item comparison block (hover an equippable item to see the worn one + deltas) */
+  #tooltip .tt-cmp { margin-top: 6px; padding-top: 5px; border-top: 1px solid #3a3526; }
+  #tooltip .tt-cmp-head { color: #8a7f5e; font-size: 10px; text-transform: uppercase; letter-spacing: .5px; margin-top: 3px; }
+  #tooltip .tt-cmp-body { opacity: .7; }
+
+  /* ---------- floating combat text ---------- */
+  .fct { position: absolute; font-weight: bold; pointer-events: none; text-shadow: 1px 1px 3px #000;
+    animation: fct-rise 1.1s ease-out forwards; font-size: 17px; transform: translate(-50%, -50%);
+    font-family: var(--title-font); z-index: 5; }
+  .fct.crit { font-size: 26px; animation: fct-crit 1.2s ease-out forwards; }
+  @keyframes fct-rise { from { opacity: 1; margin-top: 0; } to { opacity: 0; margin-top: -76px; } }
+  @keyframes fct-crit { 0% { opacity: 1; margin-top: 0; } 15% { transform: translate(-50%,-50%) scale(1.5); }
+    100% { opacity: 0; margin-top: -86px; transform: translate(-50%,-50%) scale(1); } }
+  /* Combat-text size — Interface > Combat Text Size (--fct-scale, default 1). */
+  .fct { font-size: calc(17px * var(--fct-scale, 1)); }
+  .fct.crit { font-size: calc(26px * var(--fct-scale, 1)); }
+
+  /* ---------- Interface & Comfort settings ----------
+     Each rule is driven by a CSS custom property set on :root from main.ts, or by
+     a body class toggled there. Defaults reproduce the classic look exactly. */
+  /* Tooltip Text Size (--tooltip-scale). Children carry explicit px sizes, so each
+     is rescaled rather than relying on cascade. */
+  #tooltip { font-size: calc(12px * var(--tooltip-scale, 1)); }
+  #tooltip .tt-title { font-size: calc(13.5px * var(--tooltip-scale, 1)); }
+  #tooltip .tt-sub { font-size: calc(11px * var(--tooltip-scale, 1)); }
+  #tooltip .tt-desc, #tooltip .tt-stat, #tooltip .tt-green { font-size: calc(11.5px * var(--tooltip-scale, 1)); }
+  /* Chat Text Size (--chat-font-scale) + Chat Background Opacity (--chat-opacity). */
+  .chat-pane { font-size: calc(11px * var(--chat-font-scale, 1)); }
+  #chatlog-frame { background: linear-gradient(170deg,
+      rgba(21, 21, 31, var(--chat-opacity, 0.95)) 0%,
+      rgba(8, 8, 13, var(--chat-opacity, 0.95)) 100%); }
+  /* HUD Opacity (--hud-opacity) — fades frames/windows as a whole. */
+  .panel, .window { opacity: var(--hud-opacity, 1); }
+  /* Compact Chat — shorter chat frame for a smaller footprint. */
+  body.compact-chat #chatlog-frame { height: 120px; }
+  /* High-Contrast Text — thicker dark outline behind HUD labels. */
+  body.high-contrast-text .chat-pane div,
+  body.high-contrast-text .panel,
+  body.high-contrast-text .set-name,
+  body.high-contrast-text .tt-stat,
+  body.high-contrast-text .tt-desc { text-shadow: 0 0 2px #000, 1px 1px 2px #000, -1px -1px 2px #000; }
+  /* Reduce Motion — drop HUD animations/transitions (mirrors prefers-reduced-motion). */
+  body.reduce-motion .fct { animation-duration: 0.01ms !important; }
+  body.reduce-motion *, body.reduce-motion *::before, body.reduce-motion *::after {
+    animation-duration: 0.01ms !important; animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important; scroll-behavior: auto !important; }
+  /* Frosted Panels — opt-in backdrop blur behind HUD panels & windows. */
+  body.frosted-panels .panel, body.frosted-panels .window {
+    backdrop-filter: blur(7px) saturate(1.05); -webkit-backdrop-filter: blur(7px) saturate(1.05); }
+  /* Show FPS — small readout, hidden until toggled on (main.ts flips display). */
+  #fps-overlay { position: absolute; top: 6px; right: 8px; display: none; z-index: 60;
+    font-family: var(--title-font); font-size: 12px; color: var(--gold); pointer-events: none;
+    text-shadow: 1px 1px 2px #000; background: rgba(8, 8, 13, 0.55); padding: 2px 7px;
+    border-radius: 4px; border: 1px solid #463a1c; }
+
+  /* ---------- 2v2 Fiesta HUD ---------- */
+  #fiesta-score { position: absolute; left: 50%; top: 10px; transform: translateX(-50%);
+    display: none; align-items: center; gap: 10px; z-index: 16; pointer-events: none;
+    font-family: var(--title-font); border-radius: 14px; padding: 6px 12px;
+    box-shadow: 0 4px 24px #000b, 0 0 0 2px #ff3df055; background: #140a1cdd; }
+  #fiesta-score .fs-team { display: flex; gap: 8px; align-items: center; }
+  #fiesta-score .fs-team.theirs { flex-direction: row-reverse; }
+  #fiesta-score .fp { position: relative; width: 42px; height: 42px; border-radius: 9px; overflow: hidden;
+    border: 2px solid #ffffff33; background: #0008; transition: filter .2s, border-color .2s; }
+  #fiesta-score .fs-team.mine .fp { border-color: #1b9fff88; }
+  #fiesta-score .fs-team.theirs .fp { border-color: #ff2d6688; }
+  #fiesta-score .fp.me { border-color: #ffd24a; box-shadow: 0 0 10px #ffd24a99; }
+  #fiesta-score .fp.down { filter: grayscale(1) brightness(.5); }
+  #fiesta-score .fp-face { width: 100%; height: 100%; object-fit: cover; display: block; }
+  #fiesta-score .fp-kills { position: absolute; right: 1px; bottom: 0; font-size: 13px; font-weight: 900;
+    color: #fff; text-shadow: 0 0 4px #000, 1px 1px 2px #000; padding: 0 2px; }
+  #fiesta-score .fs-core { display: flex; align-items: center; gap: 12px; }
+  #fiesta-score .fs-num { font-size: 40px; font-weight: 900; color: #fff; text-shadow: 0 0 14px #000, 1px 1px 2px #000; min-width: 42px; text-align: center; }
+  #fiesta-score .fs-num.mine { color: #6bc2ff; }
+  #fiesta-score .fs-num.theirs { color: #ff7090; }
+  #fiesta-score .fs-mid { display: flex; flex-direction: column; align-items: center; justify-content: center;
+    padding: 2px 6px; gap: 3px; }
+  #fiesta-score .fs-title { font-size: 13px; letter-spacing: 2px; font-weight: 800;
+    background: linear-gradient(90deg,#ff3df0,#ffd24a,#1b9fff); -webkit-background-clip: text; background-clip: text; color: transparent; }
+  #fiesta-score .fs-waves { display: flex; gap: 5px; }
+  #fiesta-score .fw-dot { width: 9px; height: 9px; border-radius: 50%; background: #ffffff22; box-shadow: inset 0 0 0 1px #ffffff44; }
+  #fiesta-score .fw-dot.on { background: #ffd24a; box-shadow: 0 0 8px #ffd24a; }
+  #fiesta-score .fs-limit { font-size: 10px; color: #cbbcd8; letter-spacing: .5px; }
+  #fiesta-score.flash-mine { animation: fiesta-flash-mine .5s ease-out; }
+  #fiesta-score.flash-theirs { animation: fiesta-flash-theirs .5s ease-out; }
+  @keyframes fiesta-flash-mine { 0% { box-shadow: 0 4px 20px #000a, 0 0 0 6px #1b9fffcc; } 100% { box-shadow: 0 4px 20px #000a, 0 0 0 2px #ff3df055; } }
+  @keyframes fiesta-flash-theirs { 0% { box-shadow: 0 4px 20px #000a, 0 0 0 6px #ff2d66cc; } 100% { box-shadow: 0 4px 20px #000a, 0 0 0 2px #ff3df055; } }
+
+  #fiesta-respawn { position: absolute; left: 50%; top: 44%; transform: translate(-50%,-50%);
+    display: none; flex-direction: column; align-items: center; gap: 2px; z-index: 17; pointer-events: none;
+    font-family: var(--title-font); text-align: center; }
+  #fiesta-respawn .fr-title { font-size: 24px; font-weight: 800; color: #ff5a7a; letter-spacing: 2px; text-shadow: 0 0 16px #000, 2px 2px 4px #000; }
+  #fiesta-respawn .fr-count { font-size: 64px; font-weight: 900; color: #fff; line-height: 1; text-shadow: 0 0 24px #ff3df0aa, 2px 2px 6px #000; }
+  #fiesta-respawn .fr-sub { font-size: 14px; color: #d8c8e8; letter-spacing: 1px; }
+
+  #fiesta-augments { position: absolute; left: 50%; bottom: 150px; transform: translateX(-50%);
+    display: none; flex-direction: column; align-items: center; gap: 8px; z-index: 18; }
+  #fiesta-augments .fa-head { font-family: var(--title-font); font-size: 16px; font-weight: 800; color: #ffd24a;
+    letter-spacing: 1px; text-shadow: 0 0 10px #000, 1px 1px 2px #000; }
+  #fiesta-augments .fa-tier { font-size: 12px; padding: 2px 8px; border-radius: 8px; margin-left: 6px; vertical-align: middle; }
+  #fiesta-augments .fa-tier.silver { background: #9aa7b3; color: #1a1f24; }
+  #fiesta-augments .fa-tier.gold { background: #ffcb45; color: #3a2a00; }
+  #fiesta-augments .fa-tier.prismatic { background: linear-gradient(90deg,#ff3df0,#1b9fff,#ffd24a); color: #fff; }
+  #fiesta-augments .fa-cards { display: flex; gap: 12px; }
+  .fa-card { width: 188px; min-height: 116px; padding: 14px; border-radius: 12px; cursor: pointer;
+    display: flex; flex-direction: column; gap: 8px; text-align: left; color: #f3ecff;
+    background: linear-gradient(160deg, #241834f0, #140c1ef5); border: 2px solid #5a4a78;
+    box-shadow: 0 6px 18px #000a; transition: border-color .15s, box-shadow .15s, translate .15s; }
+  .fa-card:hover, .fa-card:focus-visible { border-color: #ffd24a; box-shadow: 0 10px 28px #000c, 0 0 16px #ffd24a55; translate: 0 -3px; outline: none; }
+  .fa-card.silver { border-color: #8b97a3; }
+  .fa-card.gold { border-color: #ffcb45; }
+  .fa-card.prismatic { border-color: #ff3df0; box-shadow: 0 6px 18px #000a, 0 0 14px #ff3df055; }
+  .fa-card .fa-name { font-family: var(--title-font); font-size: 17px; font-weight: 800; color: #ffe7a0; }
+  .fa-card .fa-desc { font-size: 13px; line-height: 1.35; color: #d8cce8; flex: 1; }
+  .fa-card .fa-icon { width: 34px; height: 34px; display: grid; place-items: center; border-radius: 9px;
+    background: #0006; box-shadow: inset 0 0 0 1px #ffffff22; }
+  .fa-card .fa-icon svg { width: 22px; height: 22px; }
+  .fa-card .fa-cat { font-size: 10px; letter-spacing: 1.5px; text-transform: uppercase; font-weight: 800; opacity: .9; }
+  .cat-offense { color: #ff5a5a; } .cat-defense { color: #5aa6ff; } .cat-sustain { color: #5ce08a; }
+  .cat-mobility { color: #32e0ff; } .cat-utility { color: #ffd24a; }
+  /* augment-pending indicator */
+  #fiesta-pending { position: absolute; left: 50%; top: 64px; transform: translateX(-50%);
+    display: none; align-items: center; gap: 8px; z-index: 15; pointer-events: none;
+    font-family: var(--title-font); font-size: 13px; font-weight: 800; color: #ffe7a0;
+    padding: 5px 12px; border-radius: 20px; background: #2a1f0edd; box-shadow: 0 0 0 1px #ffd24a55, 0 3px 12px #0008;
+    animation: fpend-pulse 1.4s ease-in-out infinite; }
+  #fiesta-pending .fpend-gem { width: 18px; height: 18px; color: #ffd24a; display: grid; place-items: center; }
+  #fiesta-pending .fpend-gem svg { width: 18px; height: 18px; }
+  @keyframes fpend-pulse { 0%,100% { box-shadow: 0 0 0 1px #ffd24a55, 0 3px 12px #0008; } 50% { box-shadow: 0 0 10px 2px #ffd24a88, 0 3px 12px #0008; } }
+  /* falling confetti for the killing team */
+  .fiesta-confetti { position: absolute; inset: 0; overflow: hidden; pointer-events: none; z-index: 14; }
+  .fiesta-confetti i { position: absolute; top: -16px; width: 9px; height: 14px; border-radius: 2px; opacity: .95;
+    animation: confetti-fall linear forwards; }
+  @keyframes confetti-fall { 0% { transform: translateY(-20px) rotate(0deg); opacity: 1; }
+    100% { transform: translateY(102vh) rotate(540deg); opacity: .6; } }
+
+  .fiesta-word { position: absolute; left: 50%; top: 33%; transform: translate(-50%,-50%);
+    font-family: var(--title-font); font-weight: 900; color: var(--fw-color, #ffd24a); pointer-events: none;
+    z-index: 19; letter-spacing: 2px; text-shadow: 0 0 18px #000, 0 0 8px var(--fw-color, #ffd24a), 3px 3px 6px #000;
+    white-space: nowrap; animation: fiesta-word-pop 1.4s cubic-bezier(.2,1.4,.3,1) forwards; }
+  .fiesta-word.tier0 { font-size: 26px; }
+  .fiesta-word.tier1 { font-size: 34px; }
+  .fiesta-word.tier2 { font-size: 46px; }
+  .fiesta-word.tier3 { font-size: 60px; }
+  @keyframes fiesta-word-pop {
+    0% { opacity: 0; transform: translate(-50%,-50%) scale(.3) rotate(-6deg); }
+    15% { opacity: 1; transform: translate(-50%,-50%) scale(1.18) rotate(2deg); }
+    30% { transform: translate(-50%,-50%) scale(1) rotate(0deg); }
+    75% { opacity: 1; transform: translate(-50%,-58%) scale(1); }
+    100% { opacity: 0; transform: translate(-50%,-72%) scale(.95); } }
+  .btn.fiesta-practice { background: linear-gradient(135deg,#ff3df0,#1b9fff); border-color: #ff3df0; color: #fff; font-weight: 800; }
+  .btn.fiesta-practice:hover { box-shadow: 0 0 14px #ff3df088; }
+  .arena-bracket.fiesta { background: linear-gradient(135deg,#ff3df033,#1b9fff22); }
+  .arena-bracket.fiesta.active { background: linear-gradient(135deg,#ff3df0,#1b9fff); color: #fff; border-color: #ff3df0; }
+  .arena-bracket-tag.fiesta { background: linear-gradient(90deg,#ff3df0,#1b9fff); color: #fff; }
+  @media (prefers-reduced-motion: reduce) {
+    .fiesta-word { animation: fiesta-word-fade 1.4s ease-out forwards; }
+    @keyframes fiesta-word-fade { 0%,75% { opacity: 1; } 100% { opacity: 0; } }
+    #fiesta-score.flash-mine, #fiesta-score.flash-theirs, #fiesta-pending { animation: none; }
+    .fiesta-confetti { display: none; }
+  }
+  body.mobile-touch #fiesta-score .fs-num { font-size: 26px; }
+  body.mobile-touch #fiesta-score .fp { width: 34px; height: 34px; }
+  body.mobile-touch .fa-card { width: 150px; min-height: 104px; padding: 11px; }
+  body.mobile-touch #fiesta-augments { bottom: 200px; }
+  body.mobile-touch .fiesta-word.tier3 { font-size: 44px; }
+  body.mobile-touch .fiesta-word.tier2 { font-size: 36px; }
+
+  /* ---------- center messages ---------- */
+  #error-msg { position: absolute; left: 50%; top: 21%; transform: translateX(-50%); color: #ff2020;
+    font-size: 18px; font-weight: bold; font-family: var(--title-font); text-shadow: 1px 1px 3px #000;
+    opacity: 0; transition: opacity .4s; pointer-events: none; }
+  #banner { position: absolute; left: 50%; top: 28%; transform: translateX(-50%); color: var(--gold);
+    font-size: 38px; font-weight: bold; text-shadow: 0 0 18px #00000088, 2px 2px 6px #000; opacity: 0;
+    transition: opacity 1.2s; pointer-events: none; font-family: var(--title-font); letter-spacing: 1px; white-space: nowrap; }
+  #subzone-banner { position: absolute; left: 50%; top: 35%; transform: translateX(-50%); color: #fff;
+    font-size: 22px; font-weight: bold; text-shadow: 0 0 14px #00000088, 1px 1px 4px #000; opacity: 0;
+    transition: opacity 1.2s; pointer-events: none; font-family: var(--title-font); letter-spacing: 1px; white-space: nowrap; }
+
+  /* ---------- low-health screen vignette ---------- */
+  /* Pulsing red edge glow that fades in as the player nears death. Opacity and
+     pulse cadence are driven from JS via the --lhv-* custom properties; the
+     element stays hidden (display:none) until .active is set. Sits above the
+     world but below the HUD frames, and never eats pointer events. */
+  #low-health-vignette { position: fixed; inset: 0; display: none; z-index: 4; pointer-events: none;
+    --lhv-opacity: 0; --lhv-pulse: 1.6s;
+    background: radial-gradient(ellipse at center,
+      rgba(120,0,0,0) 42%, rgba(150,0,0,0.35) 74%, rgba(190,0,0,0.85) 100%);
+    animation: lhv-breathe var(--lhv-pulse) ease-in-out infinite; }
+  #low-health-vignette.active { display: block; }
+  @keyframes lhv-breathe {
+    0%, 100% { opacity: calc(var(--lhv-opacity) * 0.55); }
+    50%      { opacity: var(--lhv-opacity); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    #low-health-vignette { animation: none; opacity: var(--lhv-opacity); }
+  }
+
+  /* ---------- death overlay ---------- */
+  #death-overlay { position: absolute; inset: 0; background: radial-gradient(ellipse at center, #40000077 0%, #300000bb 100%);
+    display: none; align-items: center; justify-content: center; flex-direction: column; gap: 18px; z-index: 30; }
+  #death-overlay h2 { color: #ddd; font-size: 44px; text-shadow: 2px 2px 8px #000; font-family: var(--title-font); }
+  
+  /* Hide all other UI components while the start screen is visible to prevent keyboard focus leakage */
+  body:has(#start-screen:not([style*="display: none"])) #ui {
+    display: none !important;
+  }
+
+  /* ---------- start screen layout overhaul ---------- */
+  #start-screen {
+    position: absolute;
+    inset: 0;
+    background: transparent;
+    display: flex;
+    flex-direction: column;
+    z-index: 100;
+    padding: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    touch-action: pan-y;
+    overscroll-behavior-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Global Header Styling */
+  .homepage-header {
+    width: 100%;
+    background: linear-gradient(180deg, rgba(28, 24, 16, 0.98) 0%, rgba(11, 11, 18, 0.95) 100%);
+    border-bottom: 2px solid transparent;
+    border-image: linear-gradient(to right, rgba(78, 61, 29, 0.2), var(--color-primary-dim), rgba(78, 61, 29, 0.2)) 1;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    padding: var(--spacing-sm) var(--spacing-lg);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.6);
+    z-index: 20;
+    flex-shrink: 0;
+    position: sticky;
+    top: 0;
+  }
+
+  .header-menu-container {
+    display: contents;
+  }
+
+  .header-logo-container {
+    display: flex;
+    align-items: center;
+    justify-self: start;
+  }
+
+  .header-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    justify-self: end;
+  }
+
+  .header-logo-btn {
+    background: none;
+    border: none;
+    cursor: var(--cursor-point);
+    padding: 0;
+    display: flex;
+    align-items: center;
+    border-radius: var(--radius-sm);
+    transition: filter var(--transition-speed);
+  }
+
+  .header-logo-btn:hover {
+    filter: brightness(1.2);
+  }
+
+  .header-logo-btn:focus-visible {
+    outline: 3px solid var(--color-border-focus) !important;
+    outline-offset: 2px !important;
+  }
+
+  .header-logo {
+    height: 40px;
+    width: 40px;
+    margin: 0;
+    border-radius: var(--radius-sm);
+    filter: drop-shadow(0 0 10px rgba(199, 148, 26, 0.3)) drop-shadow(1px 1px 2px #000);
+  }
+
+  #title-logo {
+    width: min(216px, 50vw);
+    height: auto;
+    filter: drop-shadow(0 0 20px rgba(199, 148, 26, 0.25)) drop-shadow(2px 2px 4px #000);
+    animation: logo-pulse 2.5s ease-in-out infinite alternate;
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .mobile-menu-toggle {
+    display: none;
+    flex-direction: column;
+    justify-content: space-between;
+    width: 40px;
+    height: 40px;
+    background: none;
+    border: none;
+    cursor: var(--cursor-point);
+    padding: 11px 8px;
+    z-index: 20;
+    border-radius: var(--radius-sm);
+    transition: box-shadow var(--transition-speed);
+  }
+  .mobile-menu-toggle:focus-visible {
+    outline: 3px solid var(--color-border-focus);
+    outline-offset: 4px;
+    box-shadow: 0 0 8px var(--color-primary-glow);
+  }
+  .hamburger-bar {
+    width: 24px;
+    align-self: center;
+    height: 2px;
+    background-color: var(--color-primary-dim);
+    border-radius: 1px;
+    transition: transform var(--transition-speed), opacity var(--transition-speed), background-color var(--transition-speed);
+  }
+  .mobile-menu-toggle:hover .hamburger-bar,
+  .mobile-menu-toggle:focus-visible .hamburger-bar {
+    background-color: var(--color-primary);
+  }
+  
+  /* Animate to X when open */
+  .homepage-header.menu-open .mobile-menu-toggle .hamburger-bar:nth-child(1) {
+    transform: translateY(8px) rotate(45deg);
+  }
+  .homepage-header.menu-open .mobile-menu-toggle .hamburger-bar:nth-child(2) {
+    opacity: 0;
+  }
+  .homepage-header.menu-open .mobile-menu-toggle .hamburger-bar:nth-child(3) {
+    transform: translateY(-8px) rotate(-45deg);
+  }
+
+  /* Navigation Bar */
+  .homepage-nav {
+    display: flex;
+    align-items: center;
+    justify-self: center;
+  }
+
+  .nav-list {
+    display: flex;
+    gap: var(--spacing-sm);
+  }
+
+  .nav-link {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    font-family: var(--font-heading);
+    font-size: 13.5px;
+    letter-spacing: 0.5px;
+    padding: 6px var(--spacing-md);
+    cursor: var(--cursor-point);
+    transition: color var(--transition-speed) var(--transition-ease),
+                border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                background-color var(--transition-speed) var(--transition-ease);
+  }
+
+  .nav-link:hover,
+  .nav-link:focus-visible {
+    color: var(--color-primary);
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 8px var(--color-primary-glow);
+    background-color: rgba(255, 209, 0, 0.03);
+    outline: none;
+  }
+
+  .nav-link.active {
+    color: var(--color-primary);
+    border-color: var(--color-border-focus);
+    background: linear-gradient(180deg, rgba(200, 168, 56, 0.2) 0%, rgba(110, 90, 42, 0.05) 60%, rgba(11, 11, 18, 0.4) 100%);
+    box-shadow: inset 0 0 5px rgba(255, 209, 0, 0.15), 0 0 8px var(--color-primary-glow);
+  }
+
+  body.mobile-touch .nav-link {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  /* Language Selector */
+  .language-selector {
+    position: relative;
+    display: inline-block;
+  }
+
+  .lang-select-dropdown {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: var(--color-bg-input) url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23c8a838' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E") no-repeat right 14px center / 12px;
+    color: var(--color-primary-dim);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    padding: 6px 36px 6px 16px; /* Custom chevron layout with padding */
+    font-family: var(--font-heading);
+    font-size: 13px;
+    cursor: var(--cursor-point);
+    outline: none;
+    transition: border-color var(--transition-speed), color var(--transition-speed), box-shadow var(--transition-speed);
+    user-select: auto;
+    -webkit-user-select: auto;
+  }
+
+  .lang-select-dropdown:hover,
+  .lang-select-dropdown:focus-visible {
+    border-color: var(--color-border-focus);
+    color: var(--color-primary);
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23ffd100' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+    box-shadow: 0 0 8px var(--color-primary-glow);
+  }
+
+  body.mobile-touch .lang-select-dropdown {
+    min-height: 40px;
+    font-size: 16px;
+    padding: 10px 36px 10px 16px;
+  }
+
+  .homepage-music-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 40px;
+    height: 40px;
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(180deg, rgba(31, 27, 18, 0.95), rgba(9, 9, 14, 0.95));
+    color: var(--color-primary);
+    cursor: var(--cursor-point);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 2px 8px rgba(0, 0, 0, 0.45);
+    transition: color var(--transition-speed) var(--transition-ease),
+                border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                background-color var(--transition-speed) var(--transition-ease);
+  }
+
+  .homepage-music-btn .ui-icon {
+    width: 22px;
+    height: 22px;
+  }
+
+  .homepage-music-btn:hover,
+  .homepage-music-btn:focus-visible {
+    color: #fff3bd;
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 10px var(--color-primary-glow), inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    outline: none;
+  }
+
+  .homepage-music-btn.is-muted {
+    color: #cdbd8e;
+  }
+
+  .homepage-music-btn.is-muted::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    width: 22px;
+    height: 2px;
+    border-radius: 2px;
+    background: #f0e8d2;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.75);
+    transform: translate(-50%, -50%) rotate(-45deg);
+    pointer-events: none;
+  }
+
+  /* Donate: the header's primary call-to-action (filled gold so it reads as the
+     main action, unlike the ghost nav links). Mirrored as a footer social link
+     and an in-game community button. */
+  .donate-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-height: 40px;
+    box-sizing: border-box;
+    padding: 7px 16px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--gold-dim);
+    background: #f0c34d;
+    color: #2a1c05;
+    font-family: var(--font-heading);
+    font-size: 13.5px;
+    font-weight: 700;
+    letter-spacing: 0;
+    text-decoration: none;
+    white-space: nowrap;
+    box-shadow: 0 2px 10px rgba(255, 209, 0, 0.25), inset 0 1px 0 rgba(255, 255, 255, 0.35);
+    transition: filter var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                transform var(--transition-speed) var(--transition-ease);
+  }
+  .donate-cta:hover,
+  .donate-cta:focus-visible {
+    filter: brightness(1.08);
+    background: #ffd86b;
+    box-shadow: 0 0 14px rgba(255, 209, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    transform: translateY(-1px);
+    outline: none;
+  }
+  .donate-cta svg { width: 16px; height: 16px; display: block; }
+
+  /* Wallet verification CTA. It is a gold action until the account has a
+     server-verified wallet, then settles into a green verified state. */
+  .wallet-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    min-height: 40px;
+    box-sizing: border-box;
+    padding: 7px 14px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--gold-dim);
+    background: rgba(11, 11, 18, 0.55);
+    color: var(--gold);
+    font-family: var(--font-heading);
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                color var(--transition-speed) var(--transition-ease);
+  }
+  .wallet-cta:hover,
+  .wallet-cta:focus-visible {
+    border-color: var(--gold);
+    box-shadow: 0 0 12px var(--color-primary-glow);
+    outline: none;
+  }
+  .wallet-cta svg { width: 16px; height: 16px; display: block; }
+  .wallet-cta.is-connected { color: var(--color-text-light); border-color: var(--color-mana); }
+  .wallet-cta.needs-link {
+    color: #1a1304;
+    border-color: var(--gold);
+    background: linear-gradient(180deg, #ffd86b, #c99423);
+    box-shadow: 0 0 12px rgba(255, 209, 0, 0.38), inset 0 1px 0 rgba(255, 255, 255, 0.38);
+  }
+  .wallet-cta.needs-link:hover,
+  .wallet-cta.needs-link:focus-visible {
+    border-color: #ffe38a;
+    box-shadow: 0 0 16px rgba(255, 209, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.45);
+  }
+  .wallet-cta.is-linked { color: var(--color-text-success); border-color: var(--color-text-success); }
+  .wallet-cta.connect-app {
+    color: #07150b;
+    border-color: var(--color-text-success);
+    background: linear-gradient(180deg, #a7e8b0, #54aa67);
+    box-shadow: 0 0 12px rgba(88, 203, 112, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.34);
+  }
+  .wallet-cta.connect-app:hover,
+  .wallet-cta.connect-app:focus-visible {
+    border-color: #c7f2cf;
+    box-shadow: 0 0 16px rgba(88, 203, 112, 0.42), inset 0 1px 0 rgba(255, 255, 255, 0.44);
+  }
+  .wallet-cta.is-connected #wallet-label {
+    font-family: 'SFMono-Regular', ui-monospace, 'Courier New', monospace;
+    font-size: 12px;
+    letter-spacing: 0;
+  }
+  .wallet-cta.is-linked #wallet-label {
+    font-family: var(--font-heading);
+    font-size: 13px;
+    letter-spacing: 0.4px;
+  }
+  .wallet-cta.connect-app #wallet-label {
+    font-family: var(--font-heading);
+    font-size: 13px;
+    letter-spacing: 0.4px;
+  }
+  .wallet-cta.busy { opacity: 0.6; pointer-events: none; }
+
+  /* Wallet row inside the (logged-in) character-select panel: the account
+     context where linking actually belongs. */
+  .cs-wallet {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 12px;
+    padding-top: 12px;
+    border-top: 1px solid rgba(199, 148, 26, 0.18);
+  }
+  .cs-wallet[hidden] { display: none; }
+  .cs-wallet-label {
+    font-family: var(--font-heading);
+    color: var(--gold-dim);
+    font-size: 13px;
+    letter-spacing: 0.4px;
+    white-space: nowrap;
+  }
+  .cs-wallet-main {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+    min-width: 0;
+  }
+  .cs-wallet-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
+  .wallet-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 32px;
+    box-sizing: border-box;
+    padding: 5px 9px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(92, 214, 126, 0.42);
+    background: rgba(20, 56, 28, 0.38);
+    color: var(--color-text-success);
+    font-family: 'SFMono-Regular', ui-monospace, 'Courier New', monospace;
+    font-size: 12px;
+    line-height: 1.15;
+    letter-spacing: 0;
+    white-space: nowrap;
+  }
+  .wallet-status::before {
+    content: "";
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 8px rgba(92, 214, 126, 0.5);
+    flex: 0 0 auto;
+  }
+  .wallet-status[hidden] { display: none; }
+  .cs-wallet-help {
+    max-width: min(390px, 48vw);
+    color: var(--color-text-muted);
+    font-size: 11px;
+    line-height: 1.35;
+    text-align: left;
+  }
+  .cs-wallet-help.is-attention { color: var(--gold); }
+  .cs-wallet-help.is-verified { color: var(--color-text-success); }
+  /* Secondary wallet controls for account verification and wallet-app session state. */
+  .wallet-mini {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    min-height: 40px;
+    box-sizing: border-box;
+    padding: 6px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border-default);
+    background: rgba(11, 11, 18, 0.55);
+    color: var(--color-text-muted);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: color var(--transition-speed) var(--transition-ease),
+                border-color var(--transition-speed) var(--transition-ease);
+  }
+  .wallet-mini svg { width: 14px; height: 14px; display: block; }
+  .wallet-mini:hover,
+  .wallet-mini:focus-visible { color: var(--color-text-light); border-color: var(--gold-dim); outline: none; }
+  #btn-wallet-unlink:hover,
+  #btn-wallet-unlink:focus-visible,
+  #btn-wallet-signout:hover,
+  #btn-wallet-signout:focus-visible { color: var(--color-text-error); border-color: var(--color-text-error); }
+  .wallet-mini[hidden] { display: none; }
+  .cs-wallet-hidden-note {
+    margin-top: 12px;
+    min-height: 34px;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(199, 148, 26, 0.28);
+    background: rgba(18, 14, 8, 0.64);
+    color: var(--gold-dim);
+    font-size: 12px;
+    line-height: 1.35;
+    text-align: right;
+  }
+  .cs-wallet-hidden-note[hidden] { display: none; }
+
+  .wallet-picker-backdrop {
+    z-index: 340;
+  }
+  .wallet-picker-modal {
+    width: min(420px, 100%);
+    max-height: calc(100vh - 48px);
+    box-sizing: border-box;
+    padding: 18px;
+    overflow: auto;
+  }
+  .wallet-picker-help,
+  .wallet-picker-empty {
+    margin: 8px 0 12px;
+    color: var(--color-text-muted);
+    font-size: 12.5px;
+    line-height: 1.45;
+  }
+  .wallet-picker-list {
+    display: grid;
+    gap: 8px;
+  }
+  .wallet-picker-option {
+    display: grid;
+    grid-template-columns: 34px minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
+    min-height: 52px;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--color-border-default);
+    background: rgba(11, 11, 18, 0.72);
+    color: var(--color-text-light);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    text-align: left;
+    cursor: pointer;
+    transition: border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                background var(--transition-speed) var(--transition-ease);
+  }
+  .wallet-picker-option:hover,
+  .wallet-picker-option:focus-visible {
+    border-color: var(--gold);
+    background: rgba(29, 24, 14, 0.86);
+    box-shadow: 0 0 12px rgba(199, 148, 26, 0.28);
+    outline: none;
+  }
+  .wallet-picker-option.selected {
+    border-color: var(--color-text-success);
+    box-shadow: inset 0 0 0 1px rgba(92, 214, 126, 0.2);
+  }
+  .wallet-picker-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    object-fit: contain;
+    background: rgba(255, 255, 255, 0.08);
+  }
+  .wallet-picker-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .wallet-picker-badge {
+    color: var(--color-text-success);
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 720px) {
+    .cs-wallet { align-items: flex-start; flex-direction: column; }
+    .cs-wallet-main { align-items: flex-start; width: 100%; }
+    .cs-wallet-actions { justify-content: flex-start; }
+    .cs-wallet-help { max-width: 100%; text-align: left; }
+    .cs-wallet-hidden-note { text-align: left; }
+  }
+
+  /* Footer donate link keeps the social-link shape but warms up on hover. */
+  .footer-lang-row { display: flex; justify-content: center; }
+  .social-link.donate:hover,
+  .social-link.donate:focus-visible { color: #ff9db3; border-color: #ff6b8b; box-shadow: 0 0 10px rgba(255, 107, 139, 0.35); }
+
+  /* Views Container */
+  #homepage-views-container {
+    flex: 1 0 auto;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+    width: 100%;
+    position: relative;
+    padding: var(--spacing-lg);
+  }
+
+  /* View Sections */
+  .view-section {
+    grid-column: 1;
+    grid-row: 1;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    position: relative;
+    transition: opacity 0.2s ease-in-out, transform 0.2s ease-in-out;
+  }
+
+  .view-section[hidden] {
+    display: none !important;
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  /* Hero view specific layout */
+  #hero-view {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-lg);
+    justify-content: center;
+    min-height: min-content;
+  }
+
+  /* Larger screens: pull the whole hero (logo + console) toward the top. */
+  @media (min-width: 1024px) {
+    #hero-view {
+      justify-content: flex-start;
+      padding-top: clamp(16px, 4vh, 64px);
+    }
+  }
+
+  /* Keep positioning for subpanels inside hero-view play flow */
+  #hero-view #mode-select,
+  #hero-view #login-panel,
+  #hero-view #charselect-panel,
+  #hero-view #offline-select,
+  #hero-view #realm-panel {
+    margin-top: 10px;
+  }
+
+  /* Project Stats Panel */
+  .stats-panel-premium {
+    width: 100%;
+    max-width: 580px;
+    padding: var(--spacing-md) var(--spacing-lg);
+    margin-bottom: var(--spacing-sm);
+    background: linear-gradient(180deg, rgba(21, 21, 31, 0.94) 0%, rgba(11, 11, 18, 0.96) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.7), inset 0 0 15px rgba(0, 0, 0, 0.5);
+    text-align: center;
+  }
+
+  .stats-panel-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 16px;
+    letter-spacing: 1.2px;
+    text-transform: uppercase;
+    margin-bottom: var(--spacing-md);
+    text-shadow: 1px 1px 2px #000;
+  }
+
+  .stats-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-md);
+  }
+
+  /* Realm Status now lives under the Play CTA — match the console width and
+     give it breathing room beneath the button. */
+  /* Frosted-glass console card around the play landing — gives the central UI
+     its own surface so the cinematic backdrop can stay vivid behind it. */
+  #mode-select {
+    width: 100%;
+    max-width: 472px;
+    margin-inline: auto;
+    padding: 26px 26px 22px;
+    /* Match the auth-panel-premium container style */
+    background: linear-gradient(180deg, rgba(21, 21, 31, 0.96) 0%, rgba(11, 11, 18, 0.98) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.8),
+                inset 0 0 20px rgba(0, 0, 0, 0.6),
+                inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+  }
+
+  /* Realm stats — live counts shown in the realm dropdown (trigger sub-line +
+     the opened Online option). */
+  .realm-status-sep {
+    display: inline-block;
+    width: 1px;
+    height: 11px;
+    margin: 0 4px;
+    vertical-align: middle;
+    background: rgba(255, 209, 0, 0.3);
+  }
+  .server-realm-line .stats-value,
+  .server-opt-stats .stats-value {
+    font-family: var(--font-ui);
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--color-text-light);
+    margin-right: 2px;
+  }
+  .server-opt-stats {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+  }
+  .server-realm-line[hidden],
+  .server-sub-offline[hidden] { display: none; }
+
+  /* Tip — an inner section of the play container (divider above), not a box. */
+  .play-tip {
+    margin-top: 18px;
+    padding-top: 16px;
+    border-top: 1px solid rgba(255, 209, 0, 0.14);
+  }
+  .play-tip #performance-tip {
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    background: none;
+    border: none;
+    font-size: 12.5px;
+    text-align: center;
+  }
+
+
+  .stats-item {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    border-right: 1px solid rgba(78, 61, 29, 0.3);
+  }
+
+  .stats-item:last-child {
+    border-right: none;
+  }
+
+  .stats-label {
+    font-family: var(--font-heading);
+    color: var(--color-text-muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .stats-value {
+    color: var(--color-text-light);
+    font-family: var(--font-heading);
+    font-size: 16px;
+    font-weight: bold;
+    text-shadow: 1px 1px 1px #000;
+  }
+
+  #stat-players-online {
+    color: var(--color-text-success);
+    text-shadow: 0 0 6px rgba(127, 220, 79, 0.2), 1px 1px 1px #000;
+  }
+
+  /* Parchment Skeleton Panels */
+  .parchment-panel {
+    background: radial-gradient(circle, #2d261b 0%, #15110a 100%);
+    border: 3px double var(--color-border-default);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.8),
+                inset 0 0 40px rgba(0, 0, 0, 0.9),
+                0 0 0 1px #000;
+    border-radius: var(--radius-md);
+    padding: var(--spacing-lg);
+    position: relative;
+    width: 100%;
+    max-width: 600px;
+    text-align: center;
+    margin: auto;
+  }
+
+  .skeleton-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-lg) var(--spacing-lg);
+  }
+
+  .skeleton-icon-wrapper {
+    color: var(--color-primary-dim);
+    filter: drop-shadow(0 0 8px var(--color-primary-glow-heavy));
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .skeleton-svg-icon {
+    width: 54px;
+    height: 54px;
+  }
+
+  .skeleton-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 22px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    text-shadow: 2px 2px 4px #000;
+  }
+
+  .skeleton-desc {
+    font-family: var(--font-sans);
+    color: var(--color-text-light);
+    font-size: 13.5px;
+    line-height: 1.6;
+    max-width: 440px;
+    text-shadow: 1px 1px 2px #000;
+  }
+
+  .coming-soon-badge {
+    display: inline-block;
+    padding: 6px var(--spacing-md);
+    background: rgba(0, 0, 0, 0.5);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    color: var(--color-primary-dim);
+    font-family: var(--font-heading);
+    font-size: 11px;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    box-shadow: inset 0 0 8px #000;
+    margin-top: var(--spacing-xs);
+  }
+
+  /* "Browse the Wiki" launcher: reuses the .btn skin but renders as an anchor. */
+  .wiki-cta {
+    display: inline-block;
+    text-decoration: none;
+    margin-top: var(--spacing-sm);
+  }
+
+  /* Home-page global leaderboard (Max-Level XP Overflow) */
+  .hs-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-lg);
+    max-width: 720px;
+  }
+  .hs-leaderboard {
+    width: 100%;
+    margin-top: var(--spacing-sm);
+    text-align: left;
+  }
+  .hs-loading, .hs-empty, .hs-error {
+    color: var(--color-text-light);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    text-align: center;
+    padding: 18px 0;
+  }
+  .hs-error { color: #e08a7a; }
+  .hs-row {
+    display: grid;
+    grid-template-columns: 48px 1fr 120px 56px 64px 120px;
+    align-items: center;
+    gap: 8px;
+    padding: 7px 12px;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    color: var(--color-text-light);
+    border-radius: var(--radius-sm);
+  }
+  .hs-row:nth-child(even) { background: rgba(255, 255, 255, 0.035); }
+  .hs-head {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 11px;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    border-bottom: 1px solid var(--color-border-default);
+    background: none !important;
+  }
+  .hs-rank { text-align: center; font-weight: 700; color: var(--color-primary-dim); }
+  .hs-row.hs-top .hs-rank { color: #ffd86b; text-shadow: 0 0 8px #f5c84366; }
+  .hs-name { color: #fff; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .hs-realm, .hs-lvl, .hs-vlvl { color: var(--color-text-muted, #b9ac82); }
+  .hs-lvl, .hs-vlvl { text-align: center; }
+  .hs-xp { text-align: right; color: #ffe27a; font-variant-numeric: tabular-nums; }
+  .hs-prestige { color: #ffd100; font-size: 11px; margin-right: 4px; }
+  body.mobile-touch .hs-panel {
+    width: 100%;
+    max-width: 560px;
+    padding: var(--spacing-md);
+  }
+  body.mobile-touch .hs-leaderboard {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+  body.mobile-touch .hs-head {
+    display: none;
+  }
+  body.mobile-touch .hs-row {
+    grid-template-columns: 38px minmax(0, 1fr);
+    grid-template-areas:
+      "rank name"
+      "rank realm"
+      "rank lvl"
+      "rank vlvl"
+      "rank xp";
+    align-items: start;
+    gap: 4px 10px;
+    padding: 10px 12px;
+    border: 1px solid rgba(78, 61, 29, 0.35);
+    background: rgba(255, 255, 255, 0.025);
+  }
+  body.mobile-touch .hs-rank { grid-area: rank; align-self: center; }
+  body.mobile-touch .hs-name {
+    grid-area: name;
+    min-width: 0;
+  }
+  body.mobile-touch .hs-realm { grid-area: realm; }
+  body.mobile-touch .hs-lvl { grid-area: lvl; }
+  body.mobile-touch .hs-vlvl { grid-area: vlvl; }
+  body.mobile-touch .hs-xp { grid-area: xp; }
+  body.mobile-touch .hs-realm,
+  body.mobile-touch .hs-lvl,
+  body.mobile-touch .hs-vlvl,
+  body.mobile-touch .hs-xp {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    min-width: 0;
+    text-align: right;
+  }
+  body.mobile-touch .hs-realm::before,
+  body.mobile-touch .hs-lvl::before,
+  body.mobile-touch .hs-vlvl::before,
+  body.mobile-touch .hs-xp::before {
+    content: attr(data-label);
+    color: var(--color-primary-dim);
+    font-family: var(--font-heading);
+    font-size: 10px;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+  }
+
+  @media (max-width: 680px) {
+    .hs-panel {
+      width: 100%;
+      max-width: 560px;
+      padding: var(--spacing-md);
+    }
+    .hs-leaderboard {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      min-width: 0;
+      overflow-x: hidden;
+    }
+    .hs-head {
+      display: none;
+    }
+    .hs-row {
+      grid-template-columns: 38px minmax(0, 1fr);
+      grid-template-areas:
+        "rank name"
+        "rank realm"
+        "rank lvl"
+        "rank vlvl"
+        "rank xp";
+      align-items: start;
+      gap: 4px 10px;
+      padding: 10px 12px;
+      border: 1px solid rgba(78, 61, 29, 0.35);
+      background: rgba(255, 255, 255, 0.025);
+    }
+    .hs-rank { grid-area: rank; align-self: center; }
+    .hs-name {
+      grid-area: name;
+      min-width: 0;
+    }
+    .hs-realm { grid-area: realm; }
+    .hs-lvl { grid-area: lvl; }
+    .hs-vlvl { grid-area: vlvl; }
+    .hs-xp { grid-area: xp; }
+    .hs-realm,
+    .hs-lvl,
+    .hs-vlvl,
+    .hs-xp {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--spacing-sm);
+      min-width: 0;
+      text-align: right;
+    }
+    .hs-realm::before,
+    .hs-lvl::before,
+    .hs-vlvl::before,
+    .hs-xp::before {
+      content: attr(data-label);
+      color: var(--color-primary-dim);
+      font-family: var(--font-heading);
+      font-size: 10px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+    }
+  }
+
+  /* News & Updates view (mirrored from GitHub Releases) */
+  .news-panel {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-lg);
+    max-width: 860px;
+  }
+  .news-feed {
+    width: 100%;
+    margin-top: var(--spacing-sm);
+    text-align: left;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+  .news-loading, .news-empty, .news-error {
+    width: 100%;
+    color: var(--color-text-light);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    text-align: center;
+    padding: 28px 0;
+  }
+  .news-error { color: #e08a7a; }
+  .news-item {
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    background: rgba(255, 255, 255, 0.025);
+    padding: var(--spacing-md) var(--spacing-lg);
+  }
+  .news-item-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    margin-bottom: var(--spacing-sm);
+    border-bottom: 1px solid rgba(78, 61, 29, 0.3);
+    padding-bottom: var(--spacing-sm);
+  }
+  .news-item-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 16px;
+    margin: 0;
+    text-shadow: 1px 1px 2px #000;
+  }
+  .news-item-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    margin-left: auto;
+  }
+  .news-tag {
+    font-family: var(--font-sans);
+    font-size: 11px;
+    color: var(--color-text-muted, #b9ac82);
+    font-variant-numeric: tabular-nums;
+  }
+  .news-badge {
+    font-family: var(--font-sans);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #ffd86b;
+    border: 1px solid #ffd86b66;
+    border-radius: var(--radius-sm);
+    padding: 1px 6px;
+  }
+  .news-date {
+    font-family: var(--font-sans);
+    font-size: 11px;
+    color: var(--color-text-muted, #b9ac82);
+  }
+  .news-body {
+    font-family: var(--font-sans);
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--color-text-light);
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: normal;
+    max-height: 460px;
+    overflow-y: auto;
+    padding-right: 8px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-border-default) transparent;
+  }
+  .news-body::-webkit-scrollbar { width: 8px; }
+  .news-body::-webkit-scrollbar-track { background: transparent; }
+  .news-body::-webkit-scrollbar-thumb {
+    background: var(--color-border-default);
+    border-radius: 4px;
+  }
+  .news-body > :first-child { margin-top: 0; }
+  .news-body > :last-child { margin-bottom: 0; }
+  .news-body h1, .news-body h2, .news-body h3 {
+    font-family: var(--font-heading);
+    color: var(--color-primary-dim, #d9c896);
+    font-size: 14px;
+    margin: var(--spacing-md) 0 var(--spacing-xs);
+  }
+  .news-body p { margin: var(--spacing-xs) 0; }
+  .news-body ul { margin: var(--spacing-xs) 0; padding-left: 20px; }
+  .news-body li { margin: 2px 0; }
+  .news-body code {
+    font-family: var(--font-mono, monospace);
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: 3px;
+    padding: 1px 4px;
+    font-size: 12px;
+  }
+  .news-body a { color: #ffd86b; text-decoration: underline; }
+  .news-item-foot { margin-top: var(--spacing-sm); }
+  .news-link {
+    font-family: var(--font-sans);
+    font-size: 12px;
+    color: #ffd86b;
+    text-decoration: none;
+  }
+  .news-link:hover, .news-link:focus-visible { text-decoration: underline; }
+
+  body.mobile-touch .news-item-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  body.mobile-touch .news-item-title {
+    width: 100%;
+  }
+  body.mobile-touch .news-item-meta {
+    width: 100%;
+    margin-left: 0;
+  }
+  body.mobile-touch .news-body {
+    text-align: left;
+  }
+  body.mobile-touch .news-body ul {
+    list-style: none;
+    padding-left: 0;
+  }
+  body.mobile-touch .news-body li {
+    margin: var(--spacing-xs) 0;
+  }
+
+  /* Wiki view with integrated Controls Guide */
+  .wiki-container-layout {
+    max-width: 800px;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-lg);
+    padding: var(--spacing-lg) var(--spacing-lg);
+  }
+
+  .wiki-guide-intro {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacing-sm);
+    border-bottom: 1px solid rgba(78, 61, 29, 0.3);
+    padding-bottom: var(--spacing-md);
+    width: 100%;
+  }
+
+  .wiki-controls-guide {
+    width: 100%;
+    text-align: left;
+  }
+
+  .controls-guide-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 16px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: var(--spacing-md);
+    text-align: center;
+    text-shadow: 1px 1px 2px #000;
+  }
+
+  .controls-guide-content {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-md);
+  }
+
+  @media (max-width: 680px) {
+    .controls-guide-content {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Global Footer Styling */
+  .homepage-footer {
+    position: relative;
+    width: 100%;
+    background: rgba(11, 11, 18, 0.95);
+    border-top: 2px solid var(--color-border-default);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: var(--spacing-md) var(--spacing-lg);
+    flex-shrink: 0;
+    text-align: center;
+    margin-top: auto;
+  }
+
+  .footer-bar {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    flex-wrap: wrap;
+  }
+  .footer-left {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+  }
+  .footer-social-row {
+    display: flex;
+    gap: var(--spacing-sm);
+    justify-content: center;
+  }
+  @media (max-width: 640px) {
+    .footer-bar,
+    .footer-left { justify-content: center; }
+  }
+
+  .footer-text-row {
+    color: var(--color-text-muted);
+    font-family: var(--font-heading);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    text-shadow: 1px 1px 1px #000;
+  }
+
+  .footer-link {
+    color: var(--color-text-muted);
+    text-decoration: none;
+    transition: color var(--transition-speed) var(--transition-ease);
+  }
+
+  .footer-link:hover,
+  .footer-link:focus-visible {
+    color: var(--color-primary);
+    outline: none;
+  }
+
+  .homepage-footer #game-version {
+    color: rgba(255, 255, 255, 0.25);
+    font-family: var(--font-heading);
+    font-size: 11px;
+    position: static;
+    margin: 0;
+    text-shadow: none;
+  }
+
+  .social-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px var(--spacing-md);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(180deg, #1b1b26 0%, #0d0d14 100%);
+    color: var(--color-primary-dim);
+    font-family: var(--font-heading);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    text-decoration: none;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+    transition: all var(--transition-speed) var(--transition-ease);
+  }
+
+  .social-link:hover,
+  .social-link:focus-visible {
+    color: var(--color-primary);
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 10px var(--color-primary-glow);
+    outline: none;
+  }
+
+  .social-link svg { display: block; }
+
+  body.mobile-touch .social-link {
+    min-height: 40px;
+  }
+
+  /* ---------- loading screen (entering the world) ---------- */
+  #loading-screen {
+    position: absolute;
+    inset: 0;
+    z-index: 150;
+    display: none;
+    background: #0a0d14 url('/loading-screen.jpg') center / cover no-repeat;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    padding: 6vh 0 7vh;
+    opacity: 1;
+    transition: opacity .35s ease;
+  }
+  #loading-screen.visible { display: flex; }
+  #loading-screen.fade { opacity: 0; }
+  #loading-screen .ls-logo {
+    width: min(380px, 64vw);
+    height: auto;
+    filter: drop-shadow(0 0 24px #000c) drop-shadow(2px 2px 5px #000);
+  }
+  .ls-progress { display: flex; flex-direction: column; align-items: center; gap: 9px; }
+  .ls-bar {
+    width: min(420px, 70vw);
+    height: 14px;
+    border: 2px solid var(--color-border-default);
+    outline: 1px solid #000;
+    border-radius: 8px;
+    background: #0009;
+    overflow: hidden;
+    box-shadow: 0 2px 14px #000c, inset 0 1px 4px #000a;
+  }
+  #ls-fill { height: 100%; width: 0%; background: linear-gradient(180deg, var(--color-primary), var(--color-primary-dim)); transition: width .2s ease; }
+  #ls-status { color: var(--color-text-light); font-family: var(--font-heading); font-size: 13px; text-shadow: 1px 1px 2px #000; }
+
+  /* ---------- play console (realm selector + Play CTA) ---------- */
+  .play-console {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    width: 100%;
+    max-width: 420px;
+    margin-inline: auto;
+  }
+
+  /* Realm selector — themed dropdown, defaults to Online */
+  .server-select { position: relative; width: 100%; }
+  .server-select-caption {
+    display: block;
+    text-align: center;
+    margin-bottom: 8px;
+    font-family: var(--font-heading);
+    font-size: 11px;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+    text-shadow: 1px 1px 2px #000;
+  }
+  .server-select-trigger {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    min-height: 58px;
+    padding: 10px 16px;
+    cursor: var(--cursor-point);
+    text-align: left;
+    color: var(--color-text-light);
+    background: linear-gradient(180deg, rgba(24, 24, 34, 0.92) 0%, rgba(12, 12, 19, 0.94) 100%);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    transition: border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease);
+  }
+  .server-select-trigger:hover,
+  .server-select-trigger:focus-visible,
+  .server-select-trigger[aria-expanded="true"] {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 18px var(--color-primary-glow), 0 6px 18px rgba(0, 0, 0, 0.6);
+    outline: none;
+  }
+  .server-dot {
+    flex: none;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--color-text-muted);
+    box-shadow: 0 0 8px currentColor;
+  }
+  .server-dot[data-mode="online"] { background: var(--color-hp); color: var(--color-hp); }
+  .server-dot[data-mode="offline"] { background: var(--color-primary-dim); color: var(--color-primary-dim); }
+  .server-select-text { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+  .server-select-value {
+    font-family: var(--font-ui);
+    font-weight: 700;
+    font-size: 16px;
+    color: var(--color-text-light);
+    line-height: 1.2;
+  }
+  .server-select-sub {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .server-select-chevron {
+    flex: none;
+    width: 18px;
+    height: 18px;
+    color: var(--color-primary-dim);
+    transition: transform var(--transition-speed) var(--transition-ease), color var(--transition-speed) var(--transition-ease);
+  }
+  .server-select-trigger[aria-expanded="true"] .server-select-chevron { transform: rotate(180deg); color: var(--color-primary); }
+
+  .server-select-menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 40;
+    margin: 0;
+    padding: 6px;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    background: linear-gradient(180deg, rgba(24, 24, 34, 0.98) 0%, rgba(11, 11, 18, 0.99) 100%);
+    border: 1px solid var(--color-border-focus);
+    border-radius: var(--radius-md);
+    box-shadow: 0 18px 42px rgba(0, 0, 0, 0.7), 0 0 0 1px rgba(0, 0, 0, 0.5);
+  }
+  .server-select-menu:not([hidden]) {
+    animation: server-menu-in 140ms var(--transition-ease) both;
+    transform-origin: top center;
+  }
+  @keyframes server-menu-in {
+    from { opacity: 0; transform: translateY(-6px) scale(0.985); }
+    to   { opacity: 1; transform: translateY(0) scale(1); }
+  }
+  .server-select-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 11px;
+    padding: 11px 12px;
+    min-height: 44px;
+    border-radius: var(--radius-sm);
+    cursor: var(--cursor-point);
+    transition: background var(--transition-speed) var(--transition-ease);
+  }
+  .server-select-option .server-dot { margin-top: 5px; }
+  .server-select-option:hover,
+  .server-select-option:focus-visible,
+  .server-select-option.is-active {
+    background: rgba(255, 209, 0, 0.08);
+    outline: none;
+  }
+  .server-select-option.is-selected { background: rgba(255, 209, 0, 0.06); }
+  .server-opt-text { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+  .server-opt-name {
+    font-family: var(--font-ui);
+    font-weight: 700;
+    font-size: 14.5px;
+    color: var(--color-text-light);
+  }
+  .server-opt-desc {
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--color-text-muted);
+  }
+  .server-opt-check {
+    flex: none;
+    width: 17px;
+    height: 17px;
+    margin-top: 4px;
+    color: var(--color-primary);
+    opacity: 0;
+    transition: opacity var(--transition-speed) var(--transition-ease);
+  }
+  .server-select-option.is-selected .server-opt-check { opacity: 1; }
+
+  /* Primary CTA — forged-gold Play button */
+  .btn-play {
+    position: relative;
+    isolation: isolate;
+    overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    width: 100%;
+    min-height: 66px;
+    padding: 16px 48px;
+    cursor: var(--cursor-point);
+    font-family: var(--font-heading);
+    font-weight: 700;
+    font-size: 24px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: #2a1c05;
+    background: linear-gradient(180deg, #f8da78 0%, #e2b03a 44%, #b7820f 100%);
+    border: 1px solid #ffe6a0;
+    border-radius: var(--radius-md);
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.45),
+      0 14px 30px rgba(0, 0, 0, 0.55),
+      0 0 26px rgba(255, 209, 0, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.6),
+      inset 0 -3px 8px rgba(120, 74, 6, 0.55);
+    transition: transform 0.12s var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                filter var(--transition-speed) var(--transition-ease);
+  }
+  .btn-play:hover,
+  .btn-play:focus-visible {
+    transform: translateY(-2px);
+    filter: brightness(1.06);
+    box-shadow:
+      0 0 0 1px rgba(0, 0, 0, 0.45),
+      0 18px 38px rgba(0, 0, 0, 0.6),
+      0 0 40px rgba(255, 209, 0, 0.5),
+      inset 0 1px 0 rgba(255, 255, 255, 0.7),
+      inset 0 -3px 8px rgba(120, 74, 6, 0.55);
+    outline: none;
+  }
+  .btn-play:active { transform: translateY(1px) scale(0.99); }
+  .btn-play-glyph { flex: none; width: 22px; height: 22px; filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.35)); }
+  .btn-play-label { line-height: 1; text-shadow: 0 1px 0 rgba(255, 255, 255, 0.3); }
+  /* Diagonal sheen sweep on hover */
+  .btn-play-sheen {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background: linear-gradient(105deg, transparent 38%, rgba(255, 255, 255, 0.55) 50%, transparent 62%);
+    transform: translateX(-130%);
+    pointer-events: none;
+  }
+  .btn-play:hover .btn-play-sheen,
+  .btn-play:focus-visible .btn-play-sheen { animation: btn-play-sheen 0.9s var(--transition-ease); }
+  @keyframes btn-play-sheen {
+    from { transform: translateX(-130%); }
+    to   { transform: translateX(130%); }
+  }
+
+  .play-hint {
+    margin: 0;
+    min-height: 1.4em;
+    text-align: center;
+    font-size: 13px;
+    line-height: 1.4;
+    color: var(--color-text-muted);
+    text-shadow: 1px 1px 2px #000;
+  }
+
+  /* Hidden automation hooks — present in the DOM, never seen or tabbed to. */
+  .play-compat-trigger {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    border: 0;
+    opacity: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+  #performance-tip {
+    margin-top: var(--spacing-lg);
+    font-size: 14px;
+    color: var(--color-text-muted);
+    font-family: var(--font-sans);
+    text-align: center;
+    max-width: 600px;
+    margin-left: auto;
+    margin-right: auto;
+    line-height: 1.6;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: rgba(11, 11, 18, 0.6);
+    border-radius: var(--radius-md);
+    border: 1px dashed rgba(199, 148, 26, 0.2);
+    text-shadow: 1px 1px 2px #000;
+  }
+  #performance-tip b {
+    color: var(--color-primary);
+    text-transform: uppercase;
+    font-family: var(--font-heading);
+    letter-spacing: 0.8px;
+    margin-right: var(--spacing-xs);
+  }
+  .auth-panel { width: 100%; max-width: 360px; padding: 16px; }
+  .auth-panel input {
+    display: block;
+    width: 100%;
+    margin-bottom: 10px;
+    background: var(--color-bg-input);
+    color: var(--color-text-light);
+    border: 2px solid var(--color-border-default);
+    outline: none;
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
+    font-size: 16px;
+    font-family: var(--font-sans);
+    user-select: text;
+    transition: border-color var(--transition-speed);
+  }
+  .auth-panel input:focus-visible {
+    border-color: var(--color-border-focus);
+    outline: none;
+  }
+  .char-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-sm);
+    border-bottom: 1px solid rgba(78, 61, 29, 0.25);
+    transition: background-color var(--transition-speed);
+    border-radius: var(--radius-sm);
+  }
+  .char-row:hover {
+    background: rgba(255,255,255,0.02);
+  }
+  .char-row:focus-visible {
+    outline: 2px solid var(--color-primary);
+    background: rgba(255,255,255,0.04);
+  }
+  .char-row.sel {
+    background: rgba(255, 209, 0, 0.08);
+    border-bottom-color: rgba(255, 209, 0, 0.4);
+    box-shadow: inset 0 0 8px rgba(255, 209, 0, 0.1);
+  }
+  .char-row .char-name {
+    font-family: var(--font-heading);
+    color: var(--color-text-light);
+    font-size: 16px;
+    min-width: 90px;
+    text-shadow: 1px 1px 2px #000;
+  }
+  .char-row .char-sub { color: var(--color-text-muted); font-size: 12px; flex: 1; }
+  .char-row .btn { margin: 0; padding: 6px 12px; font-size: 11.5px; }
+  .char-row .char-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 0 0 auto;
+  }
+  .char-row.online .char-name { color: var(--color-text-success); text-shadow: 0 0 8px rgba(127,220,79,0.3); }
+  .char-row.rename-required .char-name { color: #ffbf66; }
+  .char-row .rename-input {
+    width: 150px;
+    padding: 5px 7px;
+    background: #101018;
+    border: 1px solid #4a3d1d;
+    border-radius: 4px;
+    color: #e8d8a8;
+  }
+  .char-create {
+    margin-top: 14px;
+    border-top: 1px solid rgba(78, 61, 29, 0.3);
+    padding-top: 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+  .char-create .auth-label {
+    align-self: center;
+    color: var(--color-primary);
+    font-size: 13px;
+    margin-bottom: var(--spacing-xs);
+  }
+  #new-char-name {
+    text-align: center;
+    font-family: var(--font-heading);
+    width: 240px;
+    margin: 0 auto var(--spacing-md) auto;
+  }
+
+  .mini-class-row {
+    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+    margin-bottom: var(--spacing-md);
+    list-style: none;
+    padding: 0;
+    margin-left: 0;
+  }
+  .mini-class[data-class="warrior"] { --class-color: #c79c6e; }
+  .mini-class[data-class="paladin"] { --class-color: #f58cba; }
+  .mini-class[data-class="hunter"] { --class-color: #abd473; }
+  .mini-class[data-class="rogue"] { --class-color: #fff569; }
+  .mini-class[data-class="priest"] { --class-color: #ffffff; }
+  .mini-class[data-class="shaman"] { --class-color: #0070de; }
+  .mini-class[data-class="mage"] { --class-color: #69ccf0; }
+  .mini-class[data-class="warlock"] { --class-color: #9482c9; }
+  .mini-class[data-class="druid"] { --class-color: #ff7d0a; }
+
+  .mini-class {
+    text-align: center;
+    padding: 8px 4px;
+    border: 2px solid var(--color-border-default);
+    border-radius: 5px;
+    cursor: var(--cursor-point);
+    font-size: 11px;
+    color: var(--color-text-muted);
+    background: #15151f;
+    font-family: var(--font-heading);
+    transition: border-color var(--transition-speed), color var(--transition-speed), box-shadow var(--transition-speed);
+  }
+  .mini-class:hover,
+  .mini-class:focus-visible {
+    border-color: var(--class-color);
+    color: var(--color-text-light);
+    box-shadow: 0 0 8px var(--color-primary-glow);
+    outline: none;
+  }
+  .mini-class.sel {
+    border-color: var(--class-color);
+    color: #fff;
+    box-shadow: 0 0 10px var(--class-color);
+  }
+
+  /* ---------- Skin picker (alternate body textures) ---------- */
+  .skin-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin: 10px 0 2px;
+    min-height: 0;
+  }
+  .skin-row:empty { display: none; }
+  .skin-swatch {
+    width: 34px;
+    height: 34px;
+    border-radius: 8px;
+    border: 2px solid rgba(255, 255, 255, 0.18);
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--color-text-secondary, #b9b9c7);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: var(--cursor-point);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.12s, box-shadow 0.12s, color 0.12s;
+  }
+  .skin-swatch:hover,
+  .skin-swatch:focus-visible {
+    border-color: rgba(255, 255, 255, 0.5);
+    color: #fff;
+  }
+  .skin-swatch.sel {
+    border-color: var(--class-color, #69ccf0);
+    color: #fff;
+    box-shadow: 0 0 9px var(--class-color, #69ccf0);
+  }
+  .skin-unequip-btn {
+    min-height: 34px;
+    min-width: 40px;
+    padding: 0 10px;
+    border-radius: 8px;
+    border: 2px solid rgba(202, 164, 114, 0.48);
+    background: rgba(60, 38, 28, 0.42);
+    color: var(--color-text-secondary, #d6c1a0);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: var(--cursor-point);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: border-color 0.12s, box-shadow 0.12s, color 0.12s;
+  }
+  .skin-unequip-btn:hover,
+  .skin-unequip-btn:focus-visible {
+    border-color: rgba(255, 218, 160, 0.8);
+    color: #fff;
+    box-shadow: 0 0 8px rgba(202, 164, 114, 0.45);
+  }
+
+  /* ---------- Premium Accessible Login Form styling ---------- */
+  .auth-panel-premium {
+    width: 100%;
+    max-width: 400px;
+    padding: var(--spacing-lg);
+    background: linear-gradient(180deg, rgba(21, 21, 31, 0.96) 0%, rgba(11, 11, 18, 0.98) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.8),
+                inset 0 0 20px rgba(0, 0, 0, 0.6),
+                inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    backdrop-filter: blur(12px);
+    transition: border-color var(--transition-speed) var(--transition-ease);
+  }
+  
+  .auth-panel-premium:has(input:focus) {
+    border-color: rgba(200, 168, 56, 0.5);
+  }
+
+  /* Smooth cross-fade transition classes */
+  .panel-transition {
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out !important;
+  }
+  .panel-fade-out {
+    opacity: 0 !important;
+    transform: translateY(-8px) !important;
+  }
+  .panel-fade-in {
+    opacity: 1 !important;
+    transform: translateY(0) !important;
+  }
+  .panel-fade-in-start {
+    opacity: 0 !important;
+    transform: translateY(8px) !important;
+  }
+
+  .auth-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 24px;
+    text-align: center;
+    margin-bottom: var(--spacing-lg);
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    text-shadow: 0 0 10px rgba(255, 209, 0, 0.3), 2px 2px 4px rgba(0, 0, 0, 0.8);
+  }
+
+  .auth-field {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: var(--spacing-md);
+    position: relative;
+    text-align: left;
+  }
+
+  .auth-label {
+    font-family: var(--font-heading);
+    color: var(--color-text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    margin-bottom: var(--spacing-xs);
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    transition: color var(--transition-speed) var(--transition-ease);
+  }
+
+  .auth-field:has(input:focus) .auth-label {
+    color: var(--color-primary);
+  }
+
+  .auth-panel-premium input {
+    display: block;
+    width: 100%;
+    background: var(--color-bg-input);
+    color: var(--color-text-light);
+    border: 2px solid var(--color-border-default);
+    outline: none;
+    border-radius: var(--radius-sm);
+    padding: 10px 14px;
+    font-size: 14px;
+    font-family: var(--font-sans);
+    user-select: text;
+    margin-bottom: 0;
+    transition: border-color var(--transition-speed) var(--transition-ease),
+                box-shadow var(--transition-speed) var(--transition-ease),
+                background-color var(--transition-speed) var(--transition-ease);
+  }
+
+  .auth-panel-premium input:focus-visible {
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 8px var(--color-primary-glow);
+    background-color: #12121a;
+    outline: none;
+  }
+
+  body.mobile-touch .auth-panel-premium input {
+    font-size: 16px;
+  }
+
+  .password-wrapper {
+    width: 100%;
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .password-wrapper input {
+    padding-right: 44px;
+  }
+
+  .password-toggle {
+    position: absolute;
+    right: 2px;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: var(--cursor-point);
+    padding: 0 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    transition: color var(--transition-speed) var(--transition-ease);
+  }
+
+  .password-toggle:hover {
+    color: var(--color-primary);
+  }
+
+  .password-toggle:focus-visible {
+    outline: 2px solid var(--color-border-focus);
+    color: var(--color-primary);
+  }
+
+  .password-toggle .eye-slash {
+    display: block;
+  }
+
+  .password-toggle[aria-pressed="true"] .eye-slash {
+    display: none;
+  }
+
+  .visually-hidden:where(:not(:focus-within, :active)) {
+    position: absolute !important;
+    clip-path: inset(50%) !important;
+    overflow: hidden !important;
+    width: 1px !important;
+    height: 1px !important;
+    margin: -1px !important;
+    padding: 0 !important;
+    border: 0 !important;
+    white-space: nowrap !important;
+  }
+
+  .auth-field-error {
+    display: none;
+    color: var(--color-text-error);
+    font-size: 11px;
+    margin-bottom: var(--spacing-xs);
+    font-family: var(--font-sans);
+    font-weight: 500;
+  }
+
+  .auth-turnstile {
+    display: flex;
+    justify-content: center;
+    margin: 4px 0;
+  }
+  .auth-turnstile:empty {
+    display: none;
+  }
+
+  .auth-error {
+    color: #ffc2c2;
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.4;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.8);
+    text-align: center;
+    padding: 12px 16px;
+    background: linear-gradient(180deg, rgba(55, 15, 15, 0.95) 0%, rgba(35, 8, 8, 0.98) 100%);
+    border: 1px solid #c0392b;
+    border-radius: var(--radius-md);
+    display: none;
+    position: relative;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.65),
+                inset 0 1px 1px rgba(255, 255, 255, 0.1),
+                inset 0 -1px 1px rgba(0, 0, 0, 0.2);
+    margin: var(--spacing-md) auto;
+    width: 100%;
+    max-width: 340px;
+  }
+  
+  .auth-error::before {
+    content: "\26A0\FE0E"; /* warning sign, text-presentation — inherits the error colour */
+    display: inline-block;
+    margin-right: 8px;
+    font-size: 14px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 1px solid var(--color-border-invalid);
+    text-align: center;
+    line-height: 14px;
+    vertical-align: middle;
+    filter: drop-shadow(0 0 2px rgba(255, 143, 133, 0.6));
+  }
+
+  .auth-error:not(:empty) {
+    display: block;
+  }
+
+  .auth-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-sm);
+    margin-top: var(--spacing-md);
+  }
+  .auth-panel .btn,
+  .confirm-modal .btn,
+  #mobile-preflight-continue {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .auth-actions-split {
+    max-width: 400px;
+    margin: 0 auto;
+  }
+
+  .btn-primary {
+    background: linear-gradient(180deg, #4a3a14 0%, #241c08 100%);
+    color: var(--color-primary);
+    border: 1px solid var(--color-border-default);
+  }
+  .btn-danger {
+    background: linear-gradient(180deg, #5a1714 0%, #250807 100%);
+    border: 1px solid #9f2d24;
+    color: #ffd0c8;
+  }
+  .btn-danger:hover:not(:disabled) {
+    border-color: #d64a3d;
+    color: #fff0ec;
+  }
+  .btn-danger:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+  }
+  #btn-login {
+    grid-column: span 2;
+  }
+
+  .btn-primary:hover,
+  .btn-primary:focus-visible {
+    background: linear-gradient(180deg, #5e491a 0%, #35290c 100%);
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 10px rgba(255, 209, 0, 0.2);
+    outline: none;
+  }
+
+  .btn-secondary {
+    background: linear-gradient(180deg, #1b1b26 0%, #0d0d14 100%);
+    color: var(--color-text-light);
+    border: 1px solid #2e2e3d;
+  }
+
+  .btn-secondary:hover,
+  .btn-secondary:focus-visible {
+    background: linear-gradient(180deg, #272736 0%, #151520 100%);
+    border-color: var(--color-text-muted);
+    outline: none;
+  }
+
+  .btn-back {
+    background: linear-gradient(180deg, #1b1b26 0%, #0d0d14 100%);
+    color: var(--color-text-light);
+    border: 1px solid #2e2e3d;
+  }
+
+  .btn-back:hover,
+  .btn-back:focus-visible {
+    background: linear-gradient(180deg, #2c1a17 0%, #170d0b 100%);
+    border-color: #8c3226;
+    color: #ff8f85;
+    outline: none;
+  }
+
+  .auth-panel-premium input:user-invalid,
+  .auth-panel-premium input.user-invalid-fallback {
+    border-color: var(--color-border-invalid);
+    background-color: rgba(255, 143, 133, 0.03);
+  }
+
+  .auth-panel-premium input:user-valid {
+    border-color: var(--color-border-valid);
+  }
+
+  /* Display field errors when invalid */
+  .auth-field:has(input:user-invalid) .auth-field-error,
+  .auth-field:has(input.user-invalid-fallback) .auth-field-error {
+    display: block;
+  }
+
+  /* ---------- Animated Backdrop ---------- */
+  #start-screen-backdrop {
+    /* fixed (not absolute) so the atmospheric backdrop stays pinned to the
+       viewport and keeps covering as the homepage scrolls — an absolute
+       inset:0 child of the scrolling #start-screen only spans the first
+       viewport height, leaving bare #040408 below the fold. */
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    overflow: hidden;
+    background: #040408;
+  }
+
+  .portal-ring {
+    position: absolute;
+    width: 140vmax;
+    height: 140vmax;
+    left: 50%;
+    top: 30%;
+    transform: translate(-50%, -50%) rotate(0deg);
+    background: conic-gradient(
+      from 0deg,
+      transparent 0%,
+      rgba(255, 209, 0, 0.04) 20%,
+      rgba(255, 209, 0, 0.08) 40%,
+      transparent 60%,
+      rgba(42, 58, 85, 0.1) 80%,
+      transparent 100%
+    );
+    filter: blur(80px);
+    animation: rotate-portal 45s linear infinite;
+    opacity: 0.5;
+  }
+
+  .portal-ring-reverse {
+    position: absolute;
+    width: 160vmax;
+    height: 160vmax;
+    left: 50%;
+    top: 30%;
+    transform: translate(-50%, -50%) rotate(0deg);
+    background: conic-gradient(
+      from 180deg,
+      transparent 0%,
+      rgba(42, 58, 85, 0.06) 25%,
+      rgba(255, 209, 0, 0.03) 50%,
+      transparent 75%,
+      rgba(255, 209, 0, 0.05) 100%
+    );
+    filter: blur(100px);
+    animation: rotate-portal-reverse 60s linear infinite;
+    opacity: 0.38;
+  }
+
+  .nebula-overlay {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 30%, rgba(42, 58, 85, 0.4) 0%, rgba(10, 13, 20, 0.95) 70%);
+    /* soft-light (not color-dodge) so the radial vignette darkens edges for legibility
+       without blowing the trailer's highlights into a glare. */
+    mix-blend-mode: soft-light;
+    animation: breathe-nebula 12s ease-in-out infinite alternate;
+  }
+
+  /* ---------- looping cinematic backdrop ---------- */
+  .bg-trailer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center 42%;
+    /* held dark + slightly desaturated so the gold UI and white type stay dominant;
+       JS fades opacity in once the first frame is actually playing. */
+    opacity: 0;
+    filter: saturate(1.08) contrast(1.02) brightness(1);
+    transform: scale(1.04); /* hide cover-fit edge crawl + give a faint Ken-Burns drift */
+    transition: opacity 1.1s ease;
+    will-change: opacity;
+    pointer-events: none;
+  }
+  /* Static key-art backdrop is shown by default (no JS reveal needed). */
+  .bg-home { opacity: 0.85; }
+  /* The backdrop only shows on the Play page; switchMainView toggles this when
+     navigating to High Scores / Wiki / News / Download. */
+  #start-screen-backdrop.trailer-off .bg-trailer,
+  #start-screen-backdrop.trailer-off .bg-trailer-fade { display: none; }
+
+  /* trailer-ready: reveal the layer (also used for the static poster on
+     reduced-motion / save-data). trailer-playing: add drift only when truly playing. */
+  #start-screen-backdrop.trailer-ready .bg-trailer { opacity: 0.85; }
+  #start-screen-backdrop.trailer-playing .bg-trailer {
+    animation: trailer-drift 38s ease-in-out infinite alternate;
+  }
+  .bg-trailer-scrim {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    /* three stacked layers: top + bottom darkening for header/CTA legibility,
+       an edge vignette, and a brand-tinted wash to keep the palette cohesive. */
+    background:
+      linear-gradient(180deg, rgba(4, 4, 8, 0.46) 0%, rgba(4, 4, 8, 0.06) 30%, rgba(4, 4, 8, 0.08) 60%, rgba(4, 4, 8, 0.58) 100%),
+      radial-gradient(130% 100% at 50% 42%, transparent 52%, rgba(4, 4, 8, 0.34) 100%),
+      linear-gradient(180deg, rgba(20, 17, 8, 0.08), rgba(8, 10, 18, 0.12));
+  }
+  @keyframes trailer-drift {
+    0%   { transform: scale(1.04) translate3d(0, 0, 0); }
+    100% { transform: scale(1.12) translate3d(-1.4%, -1.4%, 0); }
+  }
+
+  /* Black wipe that fades the backdrop in on first play and on every loop. */
+  .bg-trailer-fade {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    background: #040408;
+    opacity: 1;
+    pointer-events: none;
+  }
+  .bg-trailer-fade.revealed { opacity: 0; }
+  .bg-trailer-fade.is-fading { animation: trailer-fade-in 1.1s ease-out forwards; }
+  .bg-trailer-fade.is-fading-out { animation: trailer-fade-out 0.35s ease-in forwards; }
+  @keyframes trailer-fade-in {
+    0%   { opacity: 1; }
+    100% { opacity: 0; }
+  }
+  @keyframes trailer-fade-out {
+    0%   { opacity: 0; }
+    100% { opacity: 1; }
+  }
+
+  .embers-container {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .ember {
+    position: absolute;
+    background: radial-gradient(circle, rgba(255, 170, 0, 0.8) 0%, rgba(255, 85, 0, 0) 70%);
+    border-radius: 50%;
+    filter: drop-shadow(0 0 4px rgba(255, 130, 0, 0.6));
+    animation: float-up linear infinite;
+    opacity: 0;
+  }
+
+  /* Focus Indicator Styling (A11y compliance) */
+  [tabindex="0"]:focus-visible,
+  button:focus-visible,
+  a:focus-visible {
+    outline: 3px solid var(--color-border-focus) !important;
+    outline-offset: 2px !important;
+  }
+
+  /* Support prefers-reduced-motion for motion sensitivity / visionOS prevention */
+  @media (prefers-reduced-motion: reduce) {
+    .portal-ring,
+    .portal-ring-reverse,
+    .nebula-overlay,
+    .ember,
+    #title-logo,
+    .class-card,
+    .bg-trailer,
+    .btn-play-sheen,
+    .server-select-menu:not([hidden]),
+    .btn-play {
+      animation: none !important;
+      transition: none !important;
+      transform: none !important;
+    }
+    .portal-ring {
+      opacity: 0.25 !important;
+      transform: translate(-50%, -50%) rotate(15deg) !important;
+    }
+    .portal-ring-reverse,
+    .embers-container {
+      display: none !important;
+    }
+    #title-logo {
+      filter: drop-shadow(0 0 20px rgba(255, 209, 0, 0.35)) drop-shadow(2px 2px 5px #000) !important;
+    }
+    /* No black wipe with reduced motion — reveal the static poster immediately. */
+    .bg-trailer-fade {
+      opacity: 0 !important;
+      animation: none !important;
+    }
+  }
+
+  @keyframes rotate-portal {
+    0% { transform: translate(-50%, -50%) rotate(0deg); }
+    100% { transform: translate(-50%, -50%) rotate(360deg); }
+  }
+
+  @keyframes rotate-portal-reverse {
+    0% { transform: translate(-50%, -50%) rotate(360deg); }
+    100% { transform: translate(-50%, -50%) rotate(0deg); }
+  }
+
+  @keyframes logo-pulse {
+    0% { filter: drop-shadow(0 0 20px rgba(199, 148, 26, 0.25)) drop-shadow(2px 2px 4px #000); }
+    100% { filter: drop-shadow(0 0 35px rgba(255, 209, 0, 0.5)) drop-shadow(2px 2px 6px #000); }
+  }
+
+  @keyframes breathe-nebula {
+    0% { opacity: 0.8; filter: brightness(1); }
+    100% { opacity: 0.95; filter: brightness(1.25); }
+  }
+
+  @keyframes float-up {
+    0% {
+      transform: translateY(110vh) translateX(0) scale(var(--ember-scale, 1));
+      opacity: 0;
+    }
+    10% {
+      opacity: var(--ember-opacity, 0.75);
+    }
+    90% {
+      opacity: var(--ember-opacity, 0.75);
+    }
+    100% {
+      transform: translateY(-10vh) translateX(var(--drift, 50px)) scale(var(--ember-scale, 1));
+      opacity: 0;
+    }
+  }
+
+  .cs-realm { font-size: 11px; color: #7fd4ff; font-family: var(--title-font); letter-spacing: 0.3px; }
+  .btn.btn-small { padding: 4px 10px; font-size: 11px; margin: 0 0 10px; }
+  #realm-panel { width: 100%; max-width: 440px; }
+  #realm-list { margin: 8px 0 12px; max-height: 50vh; overflow-y: auto; border: 1px solid #463a1c; border-radius: 5px; }
+  .realm-loading { padding: 16px; text-align: center; color: #887c5c; font-size: 13px; }
+  .realm-row { display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 10px;
+    padding: 9px 12px; cursor: var(--cursor-point); border-bottom: 1px solid #2a2418; }
+  .realm-row:last-child { border-bottom: none; }
+  .realm-row:hover { background: #ffffff10; }
+  .realm-row.sel { background: linear-gradient(#2a2436, #161220); box-shadow: inset 3px 0 0 var(--gold); }
+  .realm-row.offline { opacity: 0.55; }
+  .realm-name { font-family: var(--title-font); font-size: 15px; color: #f0ead8; }
+  .realm-name .rn-chars { color: #7fd4ff; font-size: 11px; margin-left: 8px; }
+  .realm-name .rn-rec { color: #40d264; font-size: 10px; margin-left: 6px; border: 1px solid #2f5a22; border-radius: 3px; padding: 0 4px; }
+  .realm-sub { font-size: 11px; color: #998d6a; margin-top: 2px; }
+  .realm-type { font-size: 11px; color: #c9b27a; font-family: var(--title-font); }
+  .realm-pop { font-size: 12px; font-family: var(--title-font); min-width: 64px; text-align: right; }
+  .realm-pop.low { color: #46d246; }
+  .realm-pop.med { color: #ffd100; }
+  .realm-pop.high { color: #ff9030; }
+  .realm-pop.full { color: #ff5040; }
+  .realm-pop.offline { color: #888; }
+  .realm-meta { display: contents; }
+
+  /* ---------- chat ---------- */
+  #chat-input { position: absolute; left: 12px; bottom: 204px; width: 370px; display: none; z-index: 25;
+    background: #0d0d14ee; color: #e8e8e8; border: 2px solid var(--border); outline: 1px solid #000;
+    border-radius: 4px; padding: 7px 10px; font-size: 13px; user-select: text; }
+
+  /* ---------- party frames ---------- */
+  #party-frames { position: absolute; left: 12px; top: 12px; display: flex; flex-direction: column; gap: 6px; z-index: 5; }
+  #party-frames.below-target { top: 96px; }
+  .party-frame { --cls: #7fb8ff; width: 170px; padding: 4px 8px 5px; cursor: var(--cursor-point);
+    transition: opacity 0.2s ease, box-shadow 0.2s ease; }
+  .party-frame .pfm-name { font-size: 12px; font-family: var(--title-font); display: flex;
+    justify-content: space-between; align-items: center; gap: 6px; }
+  .party-frame .pfm-id { color: var(--cls); letter-spacing: 0.3px; overflow: hidden;
+    text-overflow: ellipsis; white-space: nowrap; text-shadow: 1px 1px 1px #000; }
+  .party-frame .pfm-meta { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+  .party-frame .pfm-name .lead { color: var(--gold); font-size: 10px; }
+  .party-frame .pf-badge { font-size: 10px; line-height: 1; filter: drop-shadow(0 0 2px #000); }
+  .party-frame .pf-badge.combat { animation: pf-combat-pulse 1s ease-in-out infinite; }
+  .party-frame .bar { height: 9px; margin-top: 2px; }
+  .party-frame.combat { box-shadow: 0 0 7px #e74c3c99; }
+  .party-frame.dead { opacity: 0.7; }
+  .party-frame.dead .pfm-id { color: #888 !important; text-shadow: none; }
+  .party-frame.oor { opacity: 0.45; }
+  .party-frame:hover { outline: 1px solid var(--gold-dim); opacity: 1; }
+  @keyframes pf-combat-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+  #party-leave { font-size: 10px; padding: 2px 8px; margin: 0; }
+
+  /* ---------- context menu ---------- */
+  #ctx-menu { position: absolute; z-index: 90; padding: 6px; min-width: 150px; display: none; }
+  #ctx-menu .ctx-title { font-family: var(--title-font); color: var(--gold); font-size: 13px; padding: 3px 8px; border-bottom: 1px solid #463a1c; margin-bottom: 4px; }
+  #ctx-menu .ctx-item { padding: 5px 10px; font-size: 12.5px; color: #e8d8a8; cursor: var(--cursor-point); border-radius: 4px; }
+  #ctx-menu .ctx-item:hover { background: #ffffff18; color: #fff; }
+  #ctx-menu .ctx-item:focus-visible { background: #ffffff18; color: #fff; outline: 2px solid var(--color-border-focus); outline-offset: 2px; }
+  #ctx-menu .ctx-mark { display: inline-block; width: 18px; height: 18px; vertical-align: middle;
+    margin-right: 8px; background-size: contain; background-repeat: no-repeat; background-position: center; }
+
+  /* ---------- prompts (invite/trade/duel) ---------- */
+  #prompt-stack { position: absolute; left: 50%; top: 34%; transform: translateX(-50%); z-index: 80;
+    display: flex; flex-direction: column; gap: 10px; }
+  .prompt { padding: 14px 18px; text-align: center; min-width: 300px; }
+  .prompt .prompt-text { font-size: 13.5px; color: #e8e0c8; margin-bottom: 4px; font-family: Georgia, serif; }
+  .prompt .prompt-number {
+    width: 82px; margin: 8px 8px 6px 0; padding: 5px 7px; border: 1px solid #5d4a25;
+    border-radius: 3px; background: #08080d; color: #f4e6bd; font: 12px var(--ui-font);
+    text-align: center; box-shadow: inset 0 1px 3px #000;
+  }
+  .prompt .prompt-number:focus { outline: 1px solid var(--gold-dim); }
+
+  /* ---------- trade window ---------- */
+  #trade-window { width: 460px; box-sizing: border-box; overflow-x: hidden; }
+  .trade-cols { display: flex; gap: 12px; }
+  .trade-col { flex: 1; }
+  .trade-col h4 { font-family: var(--title-font); font-size: 12.5px; color: var(--gold); margin-bottom: 6px; }
+  .trade-col.accepted h4::after { content: ' ✓'; color: #1eff00; }
+  .trade-items { min-height: 120px; border: 1px solid #463a1c; border-radius: 4px; padding: 4px; background: #0c0c12; }
+  .trade-item { display: flex; gap: 6px; align-items: center; width: 100%; font-size: 11.5px; padding: 3px; border: 0;
+    border-radius: 3px; background: transparent; color: inherit; font-family: var(--ui-font); text-align: left; }
+  .trade-item.mine { cursor: var(--cursor-point); }
+  .trade-item.mine:hover { background: #ffffff14; }
+  .trade-empty { color: var(--color-text-muted); font-size: 11px; padding: 4px; }
+  .trade-money { margin-top: 6px; font-size: 12px; }
+  .trade-money input { width: 80px; background: #0d0d14; color: #ffd100; border: 1px solid var(--border); border-radius: 3px; padding: 3px 6px; user-select: text; }
+  .trade-hint { font-size: 10.5px; color: #887c5c; margin-top: 8px; }
+
+  /* ---------- elite target frame ---------- */
+  #target-frame.elite .portrait { border-color: var(--gold); box-shadow: 0 0 12px #ffd10066, 0 2px 8px #000c; }
+  #tf-elite-tag { font-size: 9px; color: var(--gold); font-family: var(--title-font); letter-spacing: 1px; text-align: center; display: none; }
+  #target-frame.elite #tf-elite-tag { display: block; }
+
+  /* ---------- Collapsible Controls Drawer ---------- */
+  #btn-toggle-controls {
+    grid-row: 3;
+    grid-column: 1;
+    margin-top: 12px;
+    background: linear-gradient(180deg, #1b1b26 0%, #0d0d14 100%);
+    color: var(--color-primary-dim);
+    border: 1px solid var(--color-border-default);
+    padding: 8px var(--spacing-md);
+    font-family: var(--font-heading);
+    font-size: 12.5px;
+    letter-spacing: 0.5px;
+    cursor: var(--cursor-point);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 4px 10px rgba(0,0,0,0.4);
+    transition: all var(--transition-speed) var(--transition-ease);
+  }
+
+  #btn-toggle-controls .btn-icon {
+    vertical-align: middle;
+    margin-right: 6px;
+  }
+
+  #btn-toggle-controls:hover,
+  #btn-toggle-controls:focus-visible {
+    color: var(--color-primary);
+    border-color: var(--color-border-focus);
+    box-shadow: 0 0 10px var(--color-primary-glow);
+    outline: none;
+  }
+
+  .controls-drawer-panel {
+    position: fixed;
+    right: var(--spacing-lg);
+    top: var(--spacing-lg);
+    bottom: var(--spacing-lg);
+    width: min(340px, calc(100% - 2 * var(--spacing-lg)));
+    background: linear-gradient(180deg, rgba(21, 21, 31, 0.98) 0%, rgba(11, 11, 18, 0.99) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: -5px 0 25px rgba(0, 0, 0, 0.8);
+    display: flex;
+    flex-direction: column;
+    z-index: 110;
+    padding: var(--spacing-md);
+    animation: slide-in-drawer var(--transition-speed) var(--transition-ease);
+  }
+
+  @media (max-width: 400px) {
+    .controls-drawer-panel {
+      right: 0;
+      top: 0;
+      bottom: 0;
+      width: 100%;
+      border-radius: 0;
+      border: none;
+      border-left: 2px solid var(--color-border-default);
+    }
+  }
+
+  @keyframes slide-in-drawer {
+    from { transform: translateX(360px); opacity: 0; }
+    to { transform: translateX(0); opacity: 1; }
+  }
+
+  .drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #4e3d1d;
+    padding-bottom: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+  }
+
+  .drawer-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 16px;
+    letter-spacing: 0.5px;
+    text-shadow: 1px 1px 2px #000;
+  }
+
+  .drawer-content {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+    padding-right: 4px;
+  }
+
+  .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+    text-align: left;
+  }
+
+  .control-group h4 {
+    font-family: var(--font-heading);
+    color: var(--color-primary-dim);
+    font-size: 12px;
+    border-bottom: 1px dashed rgba(200, 168, 56, 0.2);
+    padding-bottom: 2px;
+    margin-bottom: 2px;
+    text-transform: uppercase;
+  }
+
+  .control-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 12px;
+    color: var(--color-text-light);
+  }
+
+  .key-combo {
+    display: inline-flex;
+    gap: 2px;
+  }
+
+  .keycap {
+    background: linear-gradient(135deg, #2c2c35 0%, #15151c 100%);
+    border: 1px solid #3c3c4a;
+    border-bottom: 3px solid #0a0a0d;
+    border-radius: 4px;
+    color: var(--color-primary);
+    font-family: var(--font-heading);
+    font-weight: bold;
+    font-size: 11px;
+    padding: 3px 6px;
+    display: inline-block;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.5), inset 0 1px 0 rgba(255,255,255,0.1);
+    text-shadow: 0 -1px 0 #000;
+  }
+
+
+
+  /* ---------- Clean up styles (previously inline) ---------- */
+  #char-list {
+    margin-bottom: var(--spacing-md);
+    max-height: 180px;
+    overflow-y: auto;
+    list-style: none;
+    padding: 0;
+  }
+
+  #tf-debuffs {
+    display: flex;
+    gap: 3px;
+    margin-top: 3px;
+  }
+
+  .fatal-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 16px;
+    z-index: 200;
+    color: var(--color-text-light);
+    font-family: var(--font-heading);
+    font-size: 20px;
+    text-shadow: 1px 1px 3px #000;
+  }
+
+  .char-list-message {
+    color: var(--color-text-muted);
+    font-size: 12px;
+    padding: 6px 0;
+    text-align: center;
+  }
+
+  .char-list-error {
+    color: var(--color-text-error);
+  }
+
+  .text-center-lg {
+    text-align: center;
+    margin-top: var(--spacing-lg);
+  }
+
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 300;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(0, 0, 0, 0.72);
+  }
+  .modal-backdrop[hidden] {
+    display: none;
+  }
+  .confirm-modal {
+    width: min(420px, 100%);
+    padding: 18px;
+  }
+  .confirm-modal h2 {
+    margin: 0 0 10px;
+    color: var(--color-text-light);
+    font-family: var(--font-heading);
+    font-size: 22px;
+  }
+  .confirm-modal p {
+    margin: 8px 0;
+    color: var(--color-text-muted);
+    line-height: 1.45;
+  }
+  .confirm-modal strong {
+    color: var(--color-primary);
+  }
+  .confirm-modal .auth-label {
+    display: block;
+    margin-top: 14px;
+  }
+  .confirm-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-sm);
+    margin-top: 14px;
+  }
+
+  /* ---------- Premium Class Details Panel ---------- */
+  .class-details-panel {
+    background: linear-gradient(135deg, rgba(20, 20, 30, 0.96) 0%, rgba(10, 10, 15, 0.98) 100%);
+    border: 2px solid var(--color-border-default);
+    box-shadow: inset 0 0 15px rgba(0,0,0,0.8), 0 6px 20px rgba(0,0,0,0.6);
+    border-radius: var(--radius-md);
+    padding: var(--spacing-md);
+    margin-bottom: var(--spacing-md);
+    color: var(--color-text-light);
+    font-family: var(--font-sans);
+    transition: opacity var(--transition-speed) var(--transition-ease),
+                transform var(--transition-speed) var(--transition-ease),
+                border-color var(--transition-speed) var(--transition-ease);
+    opacity: 0;
+    transform: translateY(10px);
+    pointer-events: none;
+    text-align: left;
+    height: 520px;
+    overflow-y: auto;
+    box-sizing: border-box;
+  }
+  .class-details-panel.visible {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .class-details-content {
+    transition: opacity 0.15s ease-in-out, transform 0.15s ease-in-out;
+    opacity: 1;
+    transform: translateY(0);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
+
+  .class-details-content.fade-out {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  
+  @media (prefers-reduced-motion: reduce) {
+    .class-details-panel,
+    .class-details-content,
+    .details-stat-bar-fill,
+    .panel-transition,
+    .panel-fade-out,
+    .panel-fade-in-start,
+    .panel-fade-in,
+    .social-links-fade-out {
+      transition: none !important;
+      transform: none !important;
+      animation: none !important;
+    }
+  }
+
+  .class-details-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    padding-bottom: var(--spacing-sm);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .class-details-header-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .class-details-name {
+    font-family: var(--font-heading);
+    font-size: 20px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    text-shadow: 1px 1px 2px #000;
+    color: var(--class-color);
+  }
+
+  .class-details-role {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .class-details-role.role-tank { color: #e5c158; }
+  .class-details-role.role-dps { color: #c73c3c; }
+  .class-details-role.role-ranged { color: #abd473; }
+  .class-details-role.role-healer { color: #58beea; }
+  .class-details-role.role-hybrid { color: #ffd100; }
+
+  .class-details-lore {
+    font-size: 12px;
+    line-height: 1.5;
+    color: #a0aabf;
+    margin-bottom: var(--spacing-md);
+    font-style: italic;
+  }
+
+  .class-details-grid {
+    display: grid;
+    grid-template-columns: 1fr 1.25fr;
+    gap: var(--spacing-md);
+  }
+  #online-class-details {
+    height: 250px;
+    margin-bottom: var(--spacing-sm);
+  }
+  #online-class-details .class-details-grid {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-sm);
+  }
+
+  @media (max-width: 480px) {
+    .class-details-grid {
+      grid-template-columns: 1fr;
+      gap: var(--spacing-md);
+    }
+  }
+
+  .details-section-title {
+    font-family: var(--font-heading);
+    color: var(--color-primary);
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    margin-bottom: var(--spacing-sm);
+    border-bottom: 1px solid rgba(255, 209, 0, 0.15);
+    padding-bottom: 2px;
+  }
+
+  .details-stat-bar-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+    font-size: 11px;
+  }
+
+  .details-stat-label {
+    width: 60px;
+    color: var(--color-text-muted);
+  }
+
+  .details-stat-bar-track {
+    flex-grow: 1;
+    height: 8px;
+    background: #111116;
+    border: 1px solid #2e2412;
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .details-stat-bar-fill {
+    height: 100%;
+    border-radius: 3px;
+    background-color: var(--class-color);
+    background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.35) 0%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0) 100%);
+    transition: width 0.5s cubic-bezier(0.1, 0.8, 0.3, 1);
+    box-shadow: 0 0 12px var(--class-color), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  }
+
+  .details-stat-val {
+    width: 18px;
+    text-align: right;
+    font-weight: bold;
+    color: var(--color-text-light);
+  }
+
+  .details-gear-row {
+    font-size: 11px;
+    margin-bottom: 8px;
+    color: var(--color-text-muted);
+  }
+
+  .details-gear-row strong {
+    color: var(--color-text-light);
+  }
+
+  .badge {
+    display: inline-block;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: bold;
+    text-transform: uppercase;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--color-text-light);
+  }
+
+  .badge-resource.resource-mana {
+    background: rgba(0, 112, 222, 0.15);
+    border-color: rgba(0, 112, 222, 0.4);
+    color: #69ccf0;
+  }
+  
+  .badge-resource.resource-energy {
+    background: rgba(255, 245, 105, 0.12);
+    border-color: rgba(255, 245, 105, 0.4);
+    color: #fff569;
+  }
+
+  .badge-resource.resource-rage {
+    background: rgba(199, 156, 110, 0.15);
+    border-color: rgba(199, 156, 110, 0.4);
+    color: #c79c6e;
+  }
+
+
+
+  /* Signature Abilities Section */
+  .details-spells-section {
+    grid-column: span 2;
+    padding-top: var(--spacing-lg);
+    padding-bottom: var(--spacing-lg);
+  }
+
+  .details-spells-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .details-spell-item {
+    font-size: 11px;
+    line-height: 1.45;
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 209, 0, 0.08);
+    border-radius: var(--radius-sm);
+    padding: 8px 12px;
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.4);
+  }
+
+  .details-spell-icon-img {
+    width: 32px;
+    height: 32px;
+    border-radius: 4px;
+    border: 1px solid rgba(255, 209, 0, 0.3);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+    flex-shrink: 0;
+  }
+
+  .details-spell-text {
+    color: #a0aabf;
+  }
+
+  .details-spell-text strong {
+    color: var(--color-primary);
+    display: block;
+    font-size: 11px;
+    margin-bottom: 2px;
+    font-family: var(--font-heading);
+    letter-spacing: 0.3px;
+  }
+
+  /* Selection highlight styling for offline cards */
+  .class-card.sel {
+    border-color: var(--class-color) !important;
+    box-shadow: 0 0 16px var(--class-color), inset 0 0 10px rgba(0, 0, 0, 0.8) !important;
+  }
+  .class-card.sel h2 {
+    text-shadow: 0 0 8px var(--class-color);
+  }
+
+  /* ---------- mobile touch controls (runtime-gated with body.mobile-touch + game-active) ---------- */
+  #mobile-controls { display: none; }
+  #mobile-preflight { display: none; }
+  #rotate-device { display: none; }
+  body.mobile-touch #game-canvas { touch-action: none; }
+  body.mobile-touch #ui { touch-action: none; }
+  body.mobile-touch.game-active,
+  body.mobile-touch.game-active #ui,
+  body.mobile-touch.game-active #nameplates,
+  body.mobile-touch.game-active #mobile-controls,
+  body.mobile-touch.game-active #mobile-controls *,
+  body.mobile-touch.game-active #bottom-bar,
+  body.mobile-touch.game-active #bottom-bar *,
+  body.mobile-touch.game-active .action-btn,
+  body.mobile-touch.game-active .mobile-btn {
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-touch-callout: none;
+  }
+  body.mobile-touch.game-active input,
+  body.mobile-touch.game-active textarea,
+  body.mobile-touch.game-active select,
+  body.mobile-touch.game-active [contenteditable=""],
+  body.mobile-touch.game-active [contenteditable="true"] {
+    user-select: text;
+    -webkit-user-select: text;
+    -webkit-touch-callout: default;
+  }
+  body.mobile-touch.game-active #mobile-controls { position: absolute; inset: 0; display: block; pointer-events: none; z-index: 60; opacity: var(--touch-opacity, 1); }
+  body.mobile-touch.game-active #ui { z-index: 80; }
+  body.mobile-touch.mobile-more-open #mobile-controls { z-index: 140; }
+  body.mobile-touch.game-active #ui,
+  body.mobile-touch.game-active #nameplates,
+  body.mobile-touch.game-active #mobile-controls {
+    overflow: hidden;
+    scrollbar-width: none;
+  }
+  body.mobile-touch.game-active #ui::-webkit-scrollbar,
+  body.mobile-touch.game-active #nameplates::-webkit-scrollbar,
+  body.mobile-touch.game-active #mobile-controls::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+    display: none;
+  }
+  body.mobile-touch.game-active::-webkit-scrollbar {
+    height: 0;
+  }
+  body.mobile-touch.game-active *::-webkit-scrollbar {
+    height: 0;
+  }
+  body.mobile-touch.game-active *::-webkit-scrollbar:horizontal {
+    height: 0;
+    display: none;
+  }
+  body.mobile-touch .mobile-joystick {
+    position: absolute; left: max(18px, env(safe-area-inset-left)); bottom: calc(26px + env(safe-area-inset-bottom));
+    width: 122px; height: 122px; border-radius: 50%; pointer-events: auto; touch-action: none;
+    border: 2px solid #b7a35a80; background: radial-gradient(circle at 50% 50%, #1b1b2960 0%, #0b0b1280 62%, #0505089a 100%);
+    box-shadow: 0 3px 18px #0008, inset 0 1px 0 #ffffff12, inset 0 0 26px #0008;
+    opacity: 0.4; transition: opacity .18s ease;
+    /* Joystick Size setting: grow/shrink from the anchored bottom corner so the
+       pad stays in the same screen position while resizing. --joy-scale is set
+       on #mobile-controls by applySetting('joystickScale'). */
+    transform: scale(var(--joy-scale, 1)); transform-origin: left bottom;
+  }
+  body.mobile-touch .mobile-joystick.active { opacity: 1; }
+  @media (prefers-reduced-motion: reduce) {
+    body.mobile-touch .mobile-joystick { transition: none; }
+  }
+  body.mobile-touch .mobile-joystick::before {
+    content: ''; position: absolute; inset: 28px; border-radius: 50%; border: 1px solid #ffffff18;
+  }
+  /* Floating move joystick: a lower-left capture zone lets the thumb land
+     anywhere; the joystick rests dimmed at home until touched, then springs to
+     the touch point with a gold "engaged" glow. */
+  body.mobile-touch #mobile-move-zone {
+    position: absolute; left: 0; bottom: 0; width: min(30vw, 132px); min-width: 112px; max-width: 132px; height: min(36vh, 172px);
+    pointer-events: auto; touch-action: none; z-index: 1;
+  }
+  body.mobile-touch.mobile-chat-open #mobile-move-zone { pointer-events: none; }
+  body.mobile-touch #mobile-move-joystick { opacity: .5; transition: opacity .12s linear; }
+  body.mobile-touch #mobile-move-joystick.floating {
+    opacity: 1; bottom: auto; left: 0; transition: none;
+  }
+  body.mobile-touch #mobile-move-joystick.active {
+    border-color: var(--gold);
+    box-shadow: 0 3px 18px #0008, inset 0 1px 0 #ffffff12, inset 0 0 26px #0008, 0 0 16px 3px #e3c66a55;
+  }
+  body.mobile-touch #mobile-camera-joystick {
+    left: auto; right: max(18px, env(safe-area-inset-right)); transform-origin: right bottom;
+  }
+  body.mobile-touch #mobile-camera-joystick.recentering {
+    animation: mobile-recenter-pulse 0.22s ease-out;
+  }
+  @keyframes mobile-recenter-pulse {
+    0% { box-shadow: 0 3px 18px #0008, inset 0 1px 0 #ffffff12, inset 0 0 26px #0008; border-color: #b7a35a80; }
+    45% { box-shadow: 0 0 22px 4px #e3d47588, inset 0 0 26px #0008; border-color: #e3d475e0; }
+    100% { box-shadow: 0 3px 18px #0008, inset 0 1px 0 #ffffff12, inset 0 0 26px #0008; border-color: #b7a35a80; }
+  }
+  body.mobile-touch .mobile-stick {
+    position: absolute; left: 50%; top: 50%; width: 54px; height: 54px; margin: -27px 0 0 -27px; border-radius: 50%;
+    border: 2px solid #e3d475b8; background: radial-gradient(circle at 35% 30%, #867ab6aa, #1d1d2b9a 70%);
+    box-shadow: 0 2px 10px #0009, inset 0 1px 0 #ffffff1c; transition: transform .06s linear;
+  }
+  body.mobile-touch .mobile-joy-label {
+    position: absolute; left: 0; right: 0; bottom: -18px; text-align: center; font-size: 9px; color: #c8b888; text-shadow: 1px 1px 2px #000;
+  }
+  body.mobile-touch #mobile-combat-controls {
+    position: absolute; left: 50%; bottom: calc(3px + env(safe-area-inset-bottom));
+    transform: translateX(-50%) scale(var(--btn-scale, 1)); transform-origin: center bottom;
+    display: grid; grid-template-columns: 124px repeat(6, 58px); gap: 8px; pointer-events: auto; align-items: end; z-index: 30;
+  }
+  body.mobile-touch .mobile-btn {
+    width: 58px; height: 54px; border: 2px solid #4a3d1d; border-radius: 8px;
+    background: radial-gradient(circle at 35% 30%, #2d3048d8, #11121ed8 72%); color: #eee8ff; cursor: var(--cursor-point);
+    font-size: 22px; font-weight: bold; text-shadow: 1px 1px 2px #000; box-shadow: inset 0 1px 0 #ffffff14, 0 2px 8px #0009;
+    display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1px;
+  }
+  body.mobile-touch .mobile-btn .ui-icon { width: 22px; height: 22px; }
+  body.mobile-touch #mobile-attack-nearest { width: 124px; color: #ffdf9c; border-color: #8b4e2c; }
+  body.mobile-touch #mobile-more {
+    position: static;
+    z-index: 19;
+  }
+  body.mobile-touch .mobile-btn:active { transform: translateY(1px); border-color: var(--gold); color: #fff; }
+  body.mobile-touch #mobile-autorun {
+    position: static;
+    pointer-events: auto;
+    z-index: 19;
+  }
+  body.mobile-touch #mobile-autorun.active {
+    border-color: var(--gold); color: #fff;
+    background: radial-gradient(circle at 35% 30%, #5a4a1ed8, #2a230fd8 72%);
+    box-shadow: inset 0 1px 0 #ffffff20, 0 0 12px #e3c46a80;
+  }
+  body.mobile-touch.mobile-window-open #mobile-autorun { display: none; }
+  body.mobile-touch .mobile-btn.is-on { border-color: var(--gold); color: #fff; }
+  body.mobile-touch .mobile-btn:not(.is-on)#mobile-haptics { opacity: 0.55; }
+  body.mobile-touch .mobile-btn .mobile-label { display: block; margin-top: 1px; font-size: 8px; font-family: var(--ui-font); color: #bfb28a; }
+  body.mobile-touch #mobile-extra-controls {
+    position: fixed;
+    left: 50%;
+    top: max(14px, env(safe-area-inset-top));
+    bottom: auto;
+    transform: translateX(-50%);
+    display: none;
+    width: min(560px, calc(100vw - 32px - env(safe-area-inset-left) - env(safe-area-inset-right)));
+    padding: 10px;
+    pointer-events: auto;
+    z-index: 100;
+    border: 2px solid #5b4618;
+    border-radius: 10px;
+    background: linear-gradient(170deg, #15151ff2, #08080df8);
+    box-shadow: 0 8px 28px #000d, inset 0 1px 0 #ffffff12;
+    /* Top-centred modal: cap to the safe viewport so short landscape phones can
+       scroll the full menu without hiding rows behind controls or browser chrome. */
+    max-width: calc(100vw - 32px - env(safe-area-inset-left) - env(safe-area-inset-right));
+    max-height: calc(100dvh - 32px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+  body.mobile-touch.mobile-more-open #mobile-extra-controls { display: flex; flex-direction: column; }
+  body.mobile-touch #mobile-extra-controls .panel-title {
+    min-height: 32px;
+    margin-bottom: 8px;
+    padding-bottom: 6px;
+    cursor: move;
+    touch-action: none;
+  }
+  body.mobile-touch #mobile-extra-controls .panel-title .x-btn {
+    min-width: 32px;
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  body.mobile-touch #mobile-extra-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-auto-rows: 42px;
+    gap: 7px;
+  }
+  body.mobile-touch #mobile-extra-controls .mobile-btn {
+    width: 100%;
+    height: 42px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 8px;
+    padding: 0 10px;
+    font-size: 17px;
+  }
+  body.mobile-touch #mobile-extra-controls .mobile-label {
+    display: inline;
+    margin: 0;
+    font-size: 10px;
+    color: #e6d8ae;
+  }
+  body.mobile-touch #mobile-extra-controls .mobile-btn .ui-icon {
+    flex: 0 0 22px;
+  }
+  /* A toggle tray button (e.g. Nameplates) glows gold while its feature is on. */
+  body.mobile-touch #mobile-extra-controls .mobile-btn.active {
+    border-color: var(--gold);
+    box-shadow: 0 0 8px #ffd10066, inset 0 0 6px #ffd10033;
+  }
+  body.mobile-touch #mobile-extra-controls .mobile-btn.active .mobile-label { color: var(--gold); }
+  /* music toggle: a diagonal slash over the note signals "off" (mirrors #mm-music) */
+  body.mobile-touch #mobile-music { position: relative; }
+  body.mobile-touch #mobile-music.mm-muted::after {
+    content: ''; position: absolute; left: 21px; top: 50%; width: 24px; height: 2px; border-radius: 2px;
+    background: #f0e8d2; box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.7);
+    transform: translate(-50%, -50%) rotate(-45deg); pointer-events: none;
+  }
+  body.mobile-touch #bottom-bar {
+    left: calc(max(18px, env(safe-area-inset-left)) + 154px);
+    right: calc(max(18px, env(safe-area-inset-right)) + 154px);
+    bottom: calc(64px + env(safe-area-inset-bottom));
+    width: auto;
+    transform: none;
+    z-index: 18;
+    display: flex;
+    justify-content: center;
+    pointer-events: none;
+  }
+  body.mobile-touch #actionbar-row {
+    pointer-events: auto;
+    width: 100%;
+    min-width: 0;
+  }
+  body.mobile-touch #xpbar {
+    display: none;
+  }
+  body.mobile-touch #player-frame {
+    --xp-ring-start: 210deg;
+    --xp-ring-arc: 360deg;
+  }
+  body.mobile-touch #player-frame::before {
+    content: "";
+    position: absolute;
+    left: -5px;
+    top: -5px;
+    width: 73px;
+    height: 73px;
+    z-index: 2;
+    opacity: 0.96;
+    pointer-events: none;
+    border-radius: 50%;
+    background:
+      conic-gradient(from var(--xp-ring-start),
+        #b85eff 0deg calc(var(--xp-fill, 0) * 360deg),
+        rgba(125, 88, 158, 0.34) calc(var(--xp-fill, 0) * 360deg) var(--xp-ring-arc),
+        transparent var(--xp-ring-arc) 360deg);
+    box-shadow: 0 0 8px rgba(184, 94, 255, 0.28);
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 6px));
+    mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 6px));
+  }
+  body.mobile-touch #player-frame:has(#xpbar.overflow)::before {
+    background:
+      conic-gradient(from var(--xp-ring-start),
+        #ffe27a 0deg calc(var(--xp-fill, 0) * 360deg),
+        rgba(184, 144, 42, 0.34) calc(var(--xp-fill, 0) * 360deg) var(--xp-ring-arc),
+        transparent var(--xp-ring-arc) 360deg);
+    box-shadow: 0 0 9px rgba(245, 200, 67, 0.34);
+  }
+  body.mobile-touch #xpbar .fill,
+  body.mobile-touch #xpbar .ticks { display: none; }
+  body.mobile-touch #xpbar .label { display: none; }
+  body.mobile-touch #castbar {
+    position: fixed;
+    left: calc(max(18px, env(safe-area-inset-left)) + 132px);
+    bottom: calc(17px + env(safe-area-inset-bottom));
+    width: min(170px, calc(50vw - 164px));
+    min-width: 112px;
+    height: 6px;
+    transform: none;
+    z-index: 19;
+    border-width: 1px;
+    border-radius: 2px;
+    opacity: 0.9;
+  }
+  body.mobile-touch #castbar .label { display: none; }
+  body.mobile-touch #actionbar-row { display: block; }
+  body.mobile-touch #actionbar-stack {
+    width: 100%;
+    min-width: 0;
+  }
+  body.mobile-touch #petbar {
+    position: fixed;
+    left: 50%;
+    top: max(8px, env(safe-area-inset-top));
+    transform: translateX(-50%);
+    align-self: auto;
+    margin: 0;
+    z-index: 28;
+    pointer-events: auto;
+  }
+  body.mobile-touch #side-buttons { display: none; }
+  body.mobile-touch #actionbar {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 4px;
+    padding: 4px;
+    width: 100%;
+    max-width: 100%;
+    min-height: 50px;
+    box-sizing: border-box;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-x;
+    background: linear-gradient(170deg, #15151fc8, #08080dd8);
+  }
+  body.mobile-touch #actionbar.many-spells { grid-template-columns: none; }
+  body.mobile-touch .action-btn { width: 42px; height: 42px; flex: 0 0 42px; border-radius: 7px; }
+  body.mobile-touch.mobile-hotbar-dragging #actionbar { touch-action: none; }
+  body.mobile-touch .action-btn.mobile-drag-source {
+    border-color: var(--gold);
+    box-shadow: 0 0 12px #ffd100aa, inset 0 0 0 1px #ffd10077;
+  }
+  body.mobile-touch .action-btn:not(.used):not(.queued):not(.drop-target):hover { border-color: #4a3d1d; }
+  body.mobile-touch .action-btn .icon-label { border-radius: 6px; }
+  body.mobile-touch .action-btn .cd-text { font-size: 13px; }
+  body.mobile-touch .action-btn .keybind { display: none; }
+  body.mobile-touch .action-btn:first-child { display: none; }
+  body.mobile-touch .action-btn.empty { display: none; }
+  body.mobile-touch #community-hud {
+    right: max(8px, env(safe-area-inset-right));
+    top: 130px;
+    bottom: auto;
+    width: 70px;
+    padding: 0;
+    display: block;
+  }
+  body.mobile-touch #community-menu {
+    display: block;
+    position: relative;
+    width: 100%;
+  }
+  body.mobile-touch #community-menu > summary { list-style: none; }
+  body.mobile-touch #community-menu > summary::-webkit-details-marker { display: none; }
+  body.mobile-touch .community-toggle {
+    width: 44px;
+    height: 44px;
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #d8c89a;
+    border: 2px solid #4a3d1d;
+    border-radius: 8px;
+    background: radial-gradient(circle at 35% 30%, #2c2c3a, #15151f);
+    box-shadow: inset 0 1px 0 #ffffff18, 0 2px 4px #0009;
+    cursor: var(--cursor-point);
+  }
+  body.mobile-touch .community-toggle svg {
+    width: 20px;
+    height: 20px;
+    display: block;
+  }
+  body.mobile-touch #community-menu[open] .community-toggle {
+    color: #fff;
+    border-color: var(--gold-dim);
+  }
+  body.mobile-touch .community-tray {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    display: none;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 5px;
+    width: 118px;
+    padding: 5px;
+    border: 2px solid #3d3218;
+    border-radius: 8px;
+    background: linear-gradient(170deg, #15151fe8, #08080df0);
+    box-shadow: 0 4px 14px #000b, inset 0 1px 0 #ffffff12;
+    z-index: 90;
+  }
+  body.mobile-touch #community-menu[open] .community-tray { display: flex; }
+  body.mobile-touch .community-link {
+    width: 100%;
+    height: 40px;
+    gap: 7px;
+    padding: 0 9px;
+    justify-content: flex-start;
+    font-size: 12px;
+    font-weight: 700;
+  }
+  body.mobile-touch .community-link svg {
+    width: 20px;
+    height: 20px;
+  }
+  body.mobile-touch .community-link span { display: inline; line-height: 1; }
+  body.mobile-touch .community-link.donate { display: inline-flex; width: 100%; padding: 0 9px; font-size: 12px; }
+  body.mobile-touch #chatlog-wrap { left: max(10px, env(safe-area-inset-left)); bottom: calc(160px + env(safe-area-inset-bottom)); width: min(340px, calc(100vw - 20px)); display: none; z-index: 24; }
+  body.mobile-touch.mobile-chat-open #chatlog-wrap { display: block; }
+  /* Long-pressing the Chat button toggles a read-only peek at the log without
+     raising the keyboard composer. It must not eat taps meant for the world. */
+  body.mobile-touch.mobile-chatlog-peek #chatlog-wrap { display: block; pointer-events: none; }
+  body.mobile-touch.mobile-chatlog-peek #mobile-chat {
+    border-color: var(--gold); box-shadow: 0 0 0 1px var(--gold), 0 0 10px #c9a84d66;
+  }
+  body.mobile-touch #chatlog-frame { height: 126px; }
+  body.mobile-touch #chatlog-tabs { transform: scale(0.92); transform-origin: left bottom; }
+  body.mobile-touch #chat-input {
+    left: max(10px, env(safe-area-inset-left));
+    bottom: calc(296px + env(safe-area-inset-bottom));
+    width: min(360px, calc(100vw - 20px));
+    min-height: 40px;
+    box-sizing: border-box;
+    font-size: 16px;
+  }
+  body.mobile-touch #player-frame {
+    position: fixed;
+    left: max(8px, env(safe-area-inset-left));
+    top: max(8px, env(safe-area-inset-top));
+    z-index: 21;
+    width: 300px;
+    margin: 0;
+    display: flex;
+    justify-content: flex-start;
+    transform: scale(0.82);
+    transform-origin: left top;
+  }
+  body.mobile-touch #player-frame .portrait-wrap { z-index: 3; }
+  body.mobile-touch #player-frame .uf-bars {
+    position: relative;
+    z-index: 1;
+    width: 224px;
+    max-width: 224px;
+    flex: none;
+  }
+  body.mobile-touch #target-frame {
+    left: max(8px, env(safe-area-inset-left));
+    top: calc(max(8px, env(safe-area-inset-top)) + 72px);
+    transform: scale(0.82);
+    transform-origin: left top;
+  }
+  body.mobile-touch #party-frames {
+    position: fixed;
+    left: max(8px, env(safe-area-inset-left));
+    top: calc(max(8px, env(safe-area-inset-top)) + 74px);
+    gap: 0;
+    z-index: 5;
+  }
+  body.mobile-touch #party-frames.below-target {
+    top: calc(max(8px, env(safe-area-inset-top)) + 130px);
+  }
+  body.mobile-touch #party-frames .party-frame {
+    width: 132px;
+    min-height: 30px;
+    padding: 3px 6px;
+    border-radius: 0;
+    border-bottom-width: 1px;
+    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.55);
+  }
+  body.mobile-touch #party-frames .party-frame:first-child {
+    border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+  }
+  body.mobile-touch #party-frames .party-frame:not(:first-child) {
+    margin-top: -1px;
+  }
+  body.mobile-touch #party-frames .party-frame .pfm-name {
+    min-height: 14px;
+    gap: 3px;
+    font-size: 10px;
+    line-height: 1.1;
+  }
+  body.mobile-touch #party-frames .party-frame .pfm-id {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+  }
+  body.mobile-touch #party-frames .pfm-crest {
+    width: 12px;
+    height: 12px;
+    margin-right: 2px;
+    border-radius: 2px;
+    flex: 0 0 auto;
+  }
+  body.mobile-touch #party-frames .party-frame .pfm-meta {
+    gap: 2px;
+  }
+  body.mobile-touch #party-frames .party-frame .pfm-name .lead,
+  body.mobile-touch #party-frames .party-frame .pf-badge {
+    font-size: 9px;
+  }
+  body.mobile-touch #party-frames .party-frame .bar {
+    height: 5px;
+    margin-top: 1px;
+  }
+  body.mobile-touch #party-frames #party-leave {
+    width: 132px;
+    min-height: 32px;
+    margin: -1px 0 0;
+    padding: 4px 6px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    font-size: 10px;
+  }
+  body.mobile-touch #buff-bar { right: max(10px, env(safe-area-inset-right)); top: max(140px, env(safe-area-inset-top)); max-width: 180px; }
+  body.mobile-touch #minimap-wrap { right: max(8px, env(safe-area-inset-right)); top: max(8px, env(safe-area-inset-top)); transform: scale(0.72); transform-origin: right top; }
+  body.mobile-touch #quest-tracker { right: max(10px, env(safe-area-inset-right)); top: max(150px, env(safe-area-inset-top)); width: 190px; font-size: 11px; }
+  body.mobile-touch #meters-window {
+    position: fixed;
+    left: calc(max(18px, env(safe-area-inset-left)) + 132px);
+    right: auto;
+    top: auto;
+    bottom: calc(31px + env(safe-area-inset-bottom));
+    width: min(220px, calc(50vw - 144px));
+    min-width: 142px;
+    max-height: min(170px, calc(100vh - 128px));
+    overflow: hidden;
+    z-index: 25;
+  }
+  /* Left-handed mirror: swap the two thumb joysticks (and the bottom HUD that
+     hugs them) so the movement stick sits under the right thumb. Opt-in via the
+     "Left-handed Touch" toggle in Key Bindings; centred combat buttons stay put. */
+  body.mobile-touch.mobile-left-handed .mobile-joystick {
+    left: auto; right: max(18px, env(safe-area-inset-right));
+  }
+  body.mobile-touch.mobile-left-handed #mobile-camera-joystick {
+    right: auto; left: max(18px, env(safe-area-inset-left));
+  }
+  body.mobile-touch.mobile-left-handed #mobile-more {
+    left: auto; right: auto;
+  }
+  body.mobile-touch.mobile-left-handed #mobile-extra-controls {
+    left: 50%;
+    right: auto;
+  }
+  body.mobile-touch.mobile-left-handed #castbar {
+    left: auto; right: calc(max(18px, env(safe-area-inset-right)) + 132px);
+  }
+  body.mobile-touch.mobile-left-handed #meters-window {
+    left: auto; right: calc(max(18px, env(safe-area-inset-right)) + 132px);
+  }
+  body.mobile-touch #banner {
+    top: 18%;
+    max-width: calc(100vw - 24px);
+    font-size: 26px;
+    line-height: 1.12;
+    text-align: center;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  body.mobile-touch .window { max-width: calc(100vw - 20px); max-height: calc(100vh - 40px); }
+  body.mobile-touch.mobile-window-open #ui {
+    z-index: 90;
+  }
+  body.mobile-touch #options-menu,
+  body.mobile-touch #quest-log-window,
+  body.mobile-touch #spellbook,
+  body.mobile-touch #vendor-window,
+  body.mobile-touch #market-window,
+  body.mobile-touch #quest-dialog {
+    left: 10px; right: 10px; top: 10px; width: auto; transform: none;
+    box-sizing: border-box; overflow-y: auto;
+  }
+  body.mobile-touch #vendor-window,
+  body.mobile-touch #market-window {
+    max-height: calc(58vh - 20px);
+  }
+  body.mobile-touch #market-window {
+    max-height: calc(58vh - 20px);
+    overflow: hidden;
+  }
+  body.mobile-touch .mkt-filters,
+  body.mobile-touch .mkt-filters.has-subtype { grid-template-columns: 1fr; }
+  body.mobile-touch .mkt-select-btn { min-height: 40px; font-size: 16px; }
+  body.mobile-touch .mkt-select-option { min-height: 40px; font-size: 16px; }
+  body.mobile-touch #social-window,
+  body.mobile-touch #trade-window {
+    position: fixed;
+    left: 10px;
+    right: 10px;
+    width: auto;
+    max-width: calc(100vw - 20px);
+    box-sizing: border-box;
+    overflow-x: hidden;
+  }
+  body.mobile-touch #social-window {
+    bottom: 10px;
+    height: min(560px, calc(100vh - 20px));
+  }
+  body.mobile-touch #trade-window {
+    top: 10px;
+    transform: none;
+    max-height: calc(100vh - 20px);
+    overflow-y: auto;
+  }
+  body.mobile-touch #trade-window .trade-cols {
+    flex-direction: column;
+  }
+  body.mobile-touch #bags {
+    position: fixed;
+    left: max(10px, env(safe-area-inset-left));
+    right: max(10px, env(safe-area-inset-right));
+    top: max(10px, env(safe-area-inset-top));
+    bottom: calc(72px + env(safe-area-inset-bottom));
+    width: auto;
+    transform: none;
+    max-height: none;
+    box-sizing: border-box;
+    overflow: hidden;
+    z-index: 95;
+  }
+  body.mobile-touch #bags .bag-grid {
+    min-height: 150px;
+  }
+  body.mobile-touch .vendor-item,
+  body.mobile-touch .bag-item,
+  body.mobile-touch .mkt-tab,
+  body.mobile-touch .mkt-btn,
+  body.mobile-touch .mkt-list-btn,
+  body.mobile-touch #loot-window .btn,
+  body.mobile-touch .soc-tab,
+  body.mobile-touch .soc-x,
+  body.mobile-touch .soc-sugg-item,
+  body.mobile-touch .trade-item.mine,
+  body.mobile-touch #social-window .btn,
+  body.mobile-touch #trade-window .btn {
+    min-height: 40px;
+    font-size: 16px;
+  }
+  body.mobile-touch .soc-add input,
+  body.mobile-touch .trade-money input {
+    min-height: 40px;
+    font-size: 16px;
+    box-sizing: border-box;
+  }
+  body.mobile-touch .soc-x,
+  body.mobile-touch .soc-name.soc-link {
+    min-width: 40px;
+  }
+  body.mobile-touch .soc-name.soc-link {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    white-space: normal;
+    overflow: visible;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+  }
+  body.mobile-touch .x-btn {
+    min-width: 40px;
+    min-height: 40px;
+    padding: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    font-size: 16px;
+  }
+  body.mobile-touch #player-card-modal .pc-pose,
+  body.mobile-touch #player-card-modal .pc-wallet-toggle,
+  body.mobile-touch #player-card-modal .pc-actions .btn {
+    min-height: 40px;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  body.mobile-touch #player-card-modal .pc-link-input {
+    font-size: 16px;
+  }
+  body.mobile-touch #char-window {
+    left: 10px;
+    top: 10px;
+    width: min(360px, calc(100vw - 20px));
+    max-height: calc(100vh - 20px);
+    box-sizing: border-box;
+    overflow-y: auto;
+  }
+  /* Narrow the flanking equip columns so both fit beside the model on a phone. */
+  body.mobile-touch .equip-col { width: 108px; }
+  body.mobile-touch .equip-slot .slot-name { font-size: 9px; }
+  body.mobile-touch .equip-slot .slot-item { font-size: 10px; }
+  body.mobile-touch .mkt-price-row {
+    flex-wrap: wrap;
+  }
+  body.mobile-touch .mkt-price-row .coininput {
+    min-height: 40px;
+    font-size: 16px;
+    box-sizing: border-box;
+  }
+  body.mobile-touch #quest-log-window,
+  body.mobile-touch #quest-dialog {
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 20px);
+  }
+  body.mobile-touch #quest-log-window,
+  body.mobile-touch #vendor-window,
+  body.mobile-touch #quest-dialog {
+    left: 50%;
+    right: auto;
+    top: 12px;
+    width: clamp(320px, 76vw, 680px);
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 92px);
+    transform: translateX(-50%);
+  }
+  body.mobile-touch.vendor-open #vendor-window,
+  body.mobile-touch.vendor-open #bags {
+    position: fixed;
+    top: max(10px, env(safe-area-inset-top));
+    bottom: calc(72px + env(safe-area-inset-bottom));
+    width: auto;
+    max-width: none;
+    max-height: none;
+    transform: none;
+    box-sizing: border-box;
+    z-index: 95;
+  }
+  body.mobile-touch.vendor-open #vendor-window {
+    left: max(10px, env(safe-area-inset-left));
+    right: 50vw;
+    display: block;
+    overflow-y: auto;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    border-right-width: 1px;
+  }
+  body.mobile-touch.vendor-open #bags {
+    left: 50vw;
+    right: max(10px, env(safe-area-inset-right));
+    overflow: hidden;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: 0;
+  }
+  body.mobile-touch.vendor-open #vendor-window .panel-title,
+  body.mobile-touch.vendor-open #bags .panel-title {
+    height: 47px;
+    min-height: 47px;
+    padding-bottom: 6px;
+    margin-bottom: 8px;
+    box-sizing: border-box;
+  }
+  body.mobile-touch.vendor-open #vendor-window .panel-title .x-btn {
+    display: none;
+  }
+  body.mobile-touch #spellbook,
+  body.mobile-touch #options-menu,
+  body.mobile-touch #options-menu.kb-wide {
+    left: 50%;
+    right: auto;
+    top: 12px;
+    width: min(560px, calc(100vw - 170px));
+    max-height: calc(100vh - 92px);
+    transform: translateX(-50%);
+  }
+  /* On touch, stack the categories back into a single column so the large
+     touch targets keep their full width. */
+  body.mobile-touch .kb-cols { grid-template-columns: 1fr; gap: 0 0; }
+  body.mobile-touch #talents-window {
+    position: fixed;
+    left: 50%;
+    right: auto;
+    top: 50%;
+    width: min(600px, calc(100vw - 20px));
+    max-width: calc(100vw - 20px);
+    max-height: calc(100vh - 24px);
+    transform: translate(-50%, -50%);
+    z-index: 95 !important;
+  }
+  body.mobile-touch #spellbook [data-close] {
+    min-width: 40px;
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    box-sizing: border-box;
+    font-size: 16px;
+  }
+  body.mobile-touch #spellbook .spell-row {
+    min-height: 52px;
+    padding-right: 4px;
+  }
+  body.mobile-touch #spellbook .spell-hotbar-toggle {
+    min-width: 40px;
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 40px;
+    border: 2px solid #4a3d1d;
+    border-radius: 7px;
+    background: radial-gradient(circle at 35% 30%, #2d3048e0, #11121ee0 72%);
+    color: var(--gold);
+    font: 700 22px/1 var(--ui-font);
+    box-shadow: inset 0 1px 0 #ffffff14, 0 2px 6px #0008;
+  }
+  body.mobile-touch #spellbook .spell-hotbar-toggle.remove {
+    color: #ffcf9c;
+    border-color: #8b4e2c;
+  }
+  body.mobile-touch #spellbook .spell-hotbar-toggle:disabled {
+    opacity: 0.45;
+  }
+  body.mobile-touch #quest-dialog .qd-list-item,
+  body.mobile-touch #quest-log-window .ql-item,
+  body.mobile-touch #quest-dialog .btn,
+  body.mobile-touch #quest-log-window .btn,
+  body.mobile-touch #quest-dialog [data-close],
+  body.mobile-touch #quest-log-window [data-close] {
+    min-width: 40px;
+    min-height: 40px;
+    font-size: 16px;
+  }
+  body.mobile-touch #quest-dialog .qd-text,
+  body.mobile-touch #quest-log-window .qd-text,
+  body.mobile-touch #quest-dialog .qd-obj,
+  body.mobile-touch #quest-log-window .qd-obj,
+  body.mobile-touch #quest-log-window .ql-empty {
+    font-size: 16px;
+  }
+  body.mobile-touch #quest-log-window .ql-cols {
+    gap: var(--spacing-sm);
+    min-width: 0;
+  }
+  body.mobile-touch #quest-log-window .ql-list {
+    width: min(42%, 220px);
+    min-width: 0;
+  }
+  body.mobile-touch #quest-log-window .ql-detail {
+    min-width: 0;
+  }
+  body.mobile-touch #options-menu .btn {
+    min-height: 40px;
+    padding-top: 9px;
+    padding-bottom: 9px;
+    font-size: 16px;
+  }
+  body.mobile-touch #report-window {
+    left: 10px !important;
+    right: 10px !important;
+    width: auto !important;
+    box-sizing: border-box;
+  }
+  body.mobile-touch #report-window select,
+  body.mobile-touch #report-window textarea {
+    min-height: 40px;
+    font-size: 16px;
+  }
+  body.mobile-touch #report-window [data-close],
+  body.mobile-touch #report-window .btn {
+    min-width: 40px;
+    min-height: 40px;
+  }
+  body.mobile-touch #ctx-menu .ctx-item {
+    display: flex;
+    align-items: center;
+    min-height: 40px;
+    font-size: 16px;
+  }
+  body.mobile-touch #social-window {
+    left: 50%;
+    right: auto;
+    top: 44%;
+    bottom: auto;
+    width: min(360px, calc(100vw - 170px));
+    height: min(380px, calc(100vh - 116px));
+    max-height: calc(100vh - 116px);
+    transform: translate(-50%, -50%);
+    z-index: 45;
+  }
+  body.mobile-touch #map-window {
+    left: 50%;
+    top: calc(46% - env(safe-area-inset-bottom));
+    width: min(46vw, 330px);
+    max-width: calc(100vw - 220px);
+    padding: 8px;
+    transform: translate(-50%, -50%);
+  }
+  body.mobile-touch #map-canvas {
+    width: 100%;
+    height: auto;
+    display: block;
+  }
+  body.mobile-touch #map-close {
+    right: 5px;
+    top: 5px;
+  }
+  body.mobile-touch #controls-hint {
+    max-width: min(360px, 92vw); margin-top: 18px; line-height: 1.45; font-size: 10px;
+  }
+  body.mobile-touch #mode-select {
+    width: 100%;
+    max-width: min(440px, calc(100vw - 32px - env(safe-area-inset-left) - env(safe-area-inset-right)));
+    margin-inline: auto;
+    padding: 20px 18px 18px;
+  }
+  body.mobile-touch .play-console {
+    width: 100%;
+    gap: 16px;
+  }
+  body.mobile-touch .btn-play {
+    font-size: 21px;
+    letter-spacing: 2px;
+    min-height: 60px;
+    padding: 14px 32px;
+  }
+  body.mobile-touch[data-start-panel="realm-panel"] #homepage-views-container,
+  body.mobile-touch[data-start-panel="charselect-panel"] #homepage-views-container,
+  body.mobile-touch[data-start-panel="login-panel"] #homepage-views-container {
+    align-items: center;
+  }
+  body.mobile-touch[data-start-panel="realm-panel"] #hero-view,
+  body.mobile-touch[data-start-panel="charselect-panel"] #hero-view,
+  body.mobile-touch[data-start-panel="login-panel"] #hero-view {
+    justify-content: center;
+    min-height: calc(var(--app-vh) - 178px);
+  }
+  body.mobile-touch[data-start-panel="realm-panel"] #realm-panel,
+  body.mobile-touch[data-start-panel="login-panel"] #login-panel {
+    margin-top: 0;
+    width: min(360px, calc(100vw - 48px));
+  }
+  body.mobile-touch .realm-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    padding: 10px;
+  }
+  body.mobile-touch .realm-row > div:first-child {
+    min-width: 0;
+  }
+  body.mobile-touch .realm-name,
+  body.mobile-touch .realm-sub {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  body.mobile-touch .realm-name .rn-chars,
+  body.mobile-touch .realm-name .rn-rec {
+    display: inline-block;
+    max-width: 100%;
+    vertical-align: middle;
+  }
+  body.mobile-touch .realm-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    justify-content: center;
+    gap: 2px;
+    min-width: 48px;
+  }
+  body.mobile-touch .realm-type,
+  body.mobile-touch .realm-pop {
+    min-width: 0;
+    line-height: 1.1;
+    text-align: right;
+    white-space: nowrap;
+  }
+  body.mobile-touch .realm-pop {
+    font-size: 11px;
+  }
+  body.mobile-touch .portal-ring,
+  body.mobile-touch .portal-ring-reverse,
+  body.mobile-touch .nebula-overlay {
+    animation: none;
+  }
+  body.mobile-touch .portal-ring,
+  body.mobile-touch .portal-ring-reverse {
+    filter: none;
+    opacity: 0.18;
+  }
+  body.mobile-touch .nebula-overlay {
+    mix-blend-mode: normal;
+    opacity: 0.78;
+  }
+  body.mobile-touch .embers-container {
+    display: none;
+  }
+  body.mobile-touch .class-row { grid-template-columns: repeat(2, minmax(138px, 1fr)); gap: 8px; width: min(340px, 92vw); }
+  body.mobile-touch .class-card { padding: 9px 8px 8px; }
+  body.mobile-touch #title-logo { width: min(252px, 52vw); margin-bottom: 18px; }
+  body.mobile-preflight-open #mobile-preflight.visible {
+    position: fixed; inset: 0; z-index: 250; display: flex; align-items: center; justify-content: center;
+    padding: max(18px, env(safe-area-inset-top)) max(18px, env(safe-area-inset-right)) max(18px, env(safe-area-inset-bottom)) max(18px, env(safe-area-inset-left));
+    background: radial-gradient(circle at 50% 42%, #12172bf2, #030407f8 74%);
+    pointer-events: auto;
+  }
+  #mobile-preflight .preflight-panel {
+    width: min(440px, 92vw); max-height: min(520px, 88vh); overflow: auto; padding: 22px 22px 20px;
+    border: 1px solid #c9a84d88; border-radius: 8px;
+    background: linear-gradient(180deg, #171a25f7, #0a0b10fa);
+    box-shadow: 0 18px 60px #000d, inset 0 1px 0 #ffffff14;
+    color: #e8d8a8; text-align: left;
+  }
+  #mobile-preflight h2 {
+    margin: 0 0 8px; color: var(--gold); font-family: var(--title-font); font-size: 24px; font-weight: 400; text-align: center;
+  }
+  #mobile-preflight-detail {
+    margin: 0 0 14px; color: #f0dfab; font-size: 13px; line-height: 1.45; text-align: center;
+  }
+  #mobile-preflight-steps {
+    margin: 0 0 18px 18px; padding: 0; color: #cfc09a; font-size: 12px; line-height: 1.55;
+  }
+  #mobile-preflight-steps li { margin-bottom: 7px; }
+  #mobile-preflight-continue { width: 100%; }
+  body.mobile-touch.game-active #rotate-device {
+    position: absolute; inset: 0; z-index: 190; display: none; align-items: center; justify-content: center; text-align: center;
+    background: radial-gradient(circle at 50% 45%, #161826f0, #040509f6); color: #f5e7b2; font-family: var(--title-font);
+    padding: 28px; text-shadow: 1px 1px 3px #000; pointer-events: auto;
+  }
+  #rotate-device .rotate-icon { font-size: 48px; margin-bottom: 14px; }
+  #rotate-device .rotate-title { color: var(--gold); font-size: 24px; margin-bottom: 8px; }
+  #rotate-device .rotate-sub { font-family: var(--ui-font); font-size: 13px; color: #c9b27a; line-height: 1.45; }
+
+  @media (orientation: portrait) {
+    body.mobile-touch.game-active #rotate-device { display: flex; }
+    body.mobile-touch #mobile-combat-controls {
+      grid-template-columns: 96px repeat(6, 42px);
+      gap: 4px;
+    }
+    body.mobile-touch .mobile-btn { width: 42px; height: 44px; font-size: 16px; }
+    body.mobile-touch #mobile-attack-nearest { width: 96px; }
+  }
+
+  @media (orientation: landscape) {
+    body.mobile-touch .play-console {
+      width: 100%;
+      max-width: 460px;
+      gap: 12px;
+    }
+    body.mobile-touch .server-select-caption { margin-bottom: 5px; }
+    body.mobile-touch .btn-play {
+      min-height: 54px;
+      font-size: 20px;
+    }
+    body.mobile-touch .mobile-joystick {
+      width: 100px; height: 100px; bottom: calc(15px + env(safe-area-inset-bottom));
+      opacity: 0.72; border-color: #d2bd6a66;
+    }
+    body.mobile-touch #mobile-move-joystick { left: max(20px, env(safe-area-inset-left)); }
+    body.mobile-touch #mobile-camera-joystick { right: max(20px, env(safe-area-inset-right)); }
+    body.mobile-touch .mobile-joystick::before { inset: 23px; }
+    body.mobile-touch .mobile-stick {
+      width: 44px; height: 44px; margin: -22px 0 0 -22px;
+    }
+    body.mobile-touch .mobile-joy-label { bottom: -15px; font-size: 8px; color: #d7c987aa; }
+    body.mobile-touch #mobile-combat-controls {
+      bottom: calc(2px + env(safe-area-inset-bottom)); grid-template-columns: 115px repeat(6, 54px); gap: 7px;
+    }
+    body.mobile-touch .mobile-btn { width: 54px; height: 48px; font-size: 20px; background: radial-gradient(circle at 35% 30%, #2d3048bf, #11121ec2 72%); }
+    body.mobile-touch #mobile-attack-nearest { width: 115px; }
+    body.mobile-touch #mobile-extra-controls {
+      left: 50%;
+      top: max(10px, env(safe-area-inset-top));
+      bottom: auto;
+      padding: 8px;
+      max-height: calc(100dvh - 28px - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+    }
+    body.mobile-touch #mobile-extra-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      grid-auto-rows: 40px;
+      gap: 6px;
+    }
+    body.mobile-touch.mobile-left-handed #mobile-extra-controls {
+      left: 50%;
+      right: auto;
+    }
+    body.mobile-touch #mobile-extra-controls .mobile-btn {
+      width: 100%;
+      height: 40px;
+      font-size: 16px;
+      padding: 0 9px;
+    }
+    body.mobile-touch #mobile-extra-controls .mobile-label { font-size: 9px; }
+    body.mobile-touch #bottom-bar {
+      left: calc(max(20px, env(safe-area-inset-left)) + 136px);
+      right: calc(max(20px, env(safe-area-inset-right)) + 136px);
+      bottom: calc(57px + env(safe-area-inset-bottom));
+    }
+    body.mobile-touch #actionbar { gap: 4px; padding: 4px; background: linear-gradient(170deg, #15151fa8, #08080db8); }
+    body.mobile-touch #actionbar.many-spells { grid-template-columns: none; }
+    body.mobile-touch .action-btn { width: 40px; height: 40px; flex-basis: 40px; }
+    body.mobile-touch #xpbar {
+      display: none;
+    }
+    body.mobile-touch #player-frame::before {
+      left: -5px;
+      top: -5px;
+      width: 73px;
+      height: 73px;
+      -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 6px));
+      mask: radial-gradient(farthest-side, transparent calc(100% - 7px), #000 calc(100% - 6px));
+    }
+    body.mobile-touch #castbar {
+      left: calc(max(20px, env(safe-area-inset-left)) + 112px);
+      bottom: calc(15px + env(safe-area-inset-bottom));
+      width: min(160px, calc(50vw - 166px));
+      min-width: 100px;
+      height: 5px;
+    }
+    body.mobile-touch #petbar {
+      top: max(6px, env(safe-area-inset-top));
+      transform: translateX(-50%) scale(0.88);
+      transform-origin: center top;
+    }
+    body.mobile-touch #community-hud { top: 108px; right: max(8px, env(safe-area-inset-right)); width: 62px; padding: 4px; gap: 4px; }
+    body.mobile-touch .community-toggle { width: 40px; height: 40px; }
+    body.mobile-touch .community-link { height: 40px; }
+    body.mobile-touch .community-link svg { width: 20px; height: 20px; }
+    body.mobile-touch #chatlog-wrap { left: max(10px, env(safe-area-inset-left)); bottom: calc(112px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }
+    body.mobile-touch #chatlog-frame { height: 92px; }
+    body.mobile-touch #chat-input { left: max(10px, env(safe-area-inset-left)); bottom: calc(213px + env(safe-area-inset-bottom)); width: min(330px, 44vw); }
+    body.mobile-touch #player-frame {
+      left: max(6px, env(safe-area-inset-left));
+      top: max(6px, env(safe-area-inset-top));
+      width: 300px;
+      transform: scale(0.6);
+    }
+    body.mobile-touch #player-frame .uf-bars {
+      width: 224px;
+      max-width: 224px;
+    }
+    body.mobile-touch #target-frame {
+      left: max(6px, env(safe-area-inset-left));
+      top: calc(max(6px, env(safe-area-inset-top)) + 56px);
+      transform: scale(0.6);
+    }
+    body.mobile-touch #party-frames {
+      left: max(6px, env(safe-area-inset-left));
+      top: calc(max(6px, env(safe-area-inset-top)) + 58px);
+    }
+    body.mobile-touch #party-frames.below-target {
+      top: calc(max(6px, env(safe-area-inset-top)) + 100px);
+    }
+    body.mobile-touch #party-frames .party-frame {
+      width: 118px;
+      min-height: 25px;
+      padding: 2px 5px;
+    }
+    body.mobile-touch #party-frames .party-frame .pfm-name {
+      min-height: 12px;
+      font-size: 9px;
+    }
+    body.mobile-touch #party-frames .pfm-crest {
+      width: 10px;
+      height: 10px;
+    }
+    body.mobile-touch #party-frames .party-frame .bar {
+      height: 4px;
+    }
+    body.mobile-touch #party-frames #party-leave {
+      width: 118px;
+      min-height: 28px;
+      font-size: 9px;
+    }
+    body.mobile-touch #buff-bar { right: calc(98px + env(safe-area-inset-right)); top: max(8px, env(safe-area-inset-top)); max-width: 160px; transform: scale(0.85); transform-origin: right top; }
+    body.mobile-touch #minimap-wrap { right: max(6px, env(safe-area-inset-right)); top: max(6px, env(safe-area-inset-top)); transform: scale(0.46); }
+    body.mobile-touch #quest-tracker { display: none; }
+    body.mobile-touch #meters-window {
+      position: fixed;
+      left: calc(max(20px, env(safe-area-inset-left)) + 112px);
+      right: auto;
+      top: auto;
+      bottom: calc(26px + env(safe-area-inset-bottom));
+      width: min(190px, calc(50vw - 142px));
+      min-width: 128px;
+      max-height: min(135px, calc(100vh - 112px));
+      transform: none;
+    }
+    body.mobile-touch #banner {
+      top: 18%;
+      max-width: calc(100vw - 24px);
+      font-size: 26px;
+      line-height: 1.12;
+      text-align: center;
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
+    body.mobile-touch #subzone-banner { top: 25%; font-size: 18px; }
+    body.mobile-touch #error-msg { top: 16%; font-size: 16px; }
+    body.mobile-touch #mobile-preflight .preflight-panel { width: min(520px, 84vw); padding: 18px 22px; }
+    body.mobile-touch #mobile-preflight h2 { font-size: 22px; }
+    body.mobile-touch #mobile-preflight-detail { font-size: 12px; }
+    body.mobile-touch #mobile-preflight-steps { font-size: 11px; }
+  }
+
+  /* ---------- Unified Character Select Layout ---------- */
+  .charselect-layout {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-md);
+  }
+
+  .charselect-col-left {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .charselect-col-right {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    gap: var(--spacing-sm);
+    min-height: 0;
+  }
+
+  .char-preview-container {
+    width: 100%;
+    height: 240px;
+    background: rgba(0, 0, 0, 0.4);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    position: relative;
+    overflow: hidden;
+    box-sizing: border-box;
+    flex-shrink: 0;
+  }
+
+  .char-preview-container canvas {
+    display: block;
+    width: 100% !important;
+    height: 100% !important;
+  }
+
+  .char-input-group {
+    position: relative;
+    width: 100%;
+    max-width: 240px;
+    margin: 0 auto var(--spacing-md) auto;
+  }
+
+  #new-char-name,
+  #char-name {
+    width: 100% !important;
+    margin: 0 !important;
+  }
+
+  /* Style name validation errors as absolute-positioned tooltips directly below the input */
+  #charselect-panel .auth-error,
+  #charcreate-panel .auth-error,
+  #offline-select .auth-error {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 200;
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    font-size: 11px;
+    line-height: 1.3;
+    box-shadow: none;
+    background: none;
+    border: none;
+    border-radius: 0;
+    color: #ffc2c2;
+    font-family: var(--font-sans);
+    font-weight: 500;
+    text-align: center;
+  }
+  #charselect-panel .auth-error::before,
+  #charcreate-panel .auth-error::before,
+  #offline-select .auth-error::before {
+    content: none;
+  }
+
+  /* The roster fills its column; sizing handled in the charselect-screen block. */
+  #charselect-panel #char-list {
+    margin: 0;
+    overflow-y: auto;
+  }
+
+  .mobile-char-tabs {
+    display: none;
+  }
+
+  @media (min-width: 900px) {
+    #charselect-panel,
+    #charcreate-panel,
+    #offline-select {
+      width: min(1160px, 96vw) !important;
+      max-width: none !important;
+      height: min(640px, calc(100vh - 190px));
+      min-height: 520px;
+      box-sizing: border-box;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    #charselect-panel .auth-title,
+    #charcreate-panel .auth-title,
+    #offline-select .auth-title {
+      margin-bottom: var(--spacing-sm);
+      flex-shrink: 0;
+    }
+
+    .charselect-layout {
+      display: grid;
+      grid-template-columns: 1.1fr 0.9fr;
+      gap: 28px;
+      flex-grow: 1;
+      min-height: 0;
+      align-items: stretch;
+    }
+
+    .charselect-col-left {
+      height: 100%;
+      justify-content: space-between;
+      min-height: 0;
+    }
+
+    .charselect-col-right {
+      min-height: 0;
+    }
+
+    #charselect-panel #char-list {
+      flex: 1 1 auto;
+      min-height: 0;
+    }
+
+    #charselect-panel .char-create,
+    #charcreate-panel .char-create,
+    #offline-select .char-create {
+      flex-grow: 1;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      margin-top: 0;
+    }
+
+    #charselect-panel .char-create {
+      border-top: 1px solid rgba(78, 61, 29, 0.3);
+      padding-top: 12px;
+    }
+
+    .class-details-panel {
+      height: auto !important; /* Force to fill parent height */
+      flex-grow: 1;
+      min-height: 0;
+      margin-bottom: 0 !important;
+    }
+
+    /* Restore two-column stats/gear columns inside class details on desktop */
+    .class-details-grid {
+      grid-template-columns: 1fr 1.25fr;
+      gap: var(--spacing-md);
+    }
+
+    /* Logo scales up with the viewport on desktop — bigger screen, bigger wordmark. */
+    #title-logo {
+      width: clamp(204px, 12vw, 264px) !important;
+    }
+  }
+
+  body.mobile-touch #charselect-panel,
+  body.mobile-touch #charcreate-panel {
+    width: min(380px, calc(100vw - 48px));
+    min-height: calc(var(--app-vh) - 178px);
+    max-height: none;
+    display: flex;
+    flex-direction: column;
+    overflow: visible;
+  }
+  body.mobile-touch #charselect-panel .auth-title,
+  body.mobile-touch #charcreate-panel .auth-title {
+    font-size: 21px;
+    margin-bottom: 8px;
+    overflow-wrap: anywhere;
+  }
+  body.mobile-touch #charselect-panel .cs-realm,
+  body.mobile-touch #btn-change-realm {
+    font-size: 11px;
+  }
+  body.mobile-touch .mobile-char-tabs {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    margin: 12px 0;
+  }
+  body.mobile-touch .mobile-char-tab {
+    min-height: 40px;
+    border: 1px solid #4a3d1d;
+    border-radius: 5px;
+    background: linear-gradient(#201b28, #100e16);
+    color: #c9b27a;
+    font-family: var(--title-font);
+    font-size: 12px;
+    cursor: var(--cursor-point);
+  }
+  body.mobile-touch .mobile-char-tab.active {
+    color: var(--gold);
+    border-color: var(--gold-dim);
+    background: linear-gradient(#2a2436, #161220);
+    box-shadow: inset 0 -2px 0 #cc9a3c;
+  }
+  body.mobile-touch #charselect-panel[data-mobile-tab="characters"] .char-create,
+  body.mobile-touch #charselect-panel[data-mobile-tab="characters"] .charselect-col-right,
+  body.mobile-touch #charselect-panel[data-mobile-tab="create"] #char-list {
+    display: none;
+  }
+  body.mobile-touch #charselect-panel[data-mobile-tab="create"] .char-create {
+    border-top: 0;
+    margin-top: 0;
+    padding-top: 0;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel .charselect-layout {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    gap: 12px;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel .charselect-col-left {
+    flex-direction: column;
+    display: flex;
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel .charselect-col-right {
+    display: flex;
+    flex: 1 1 auto;
+    width: 100%;
+    min-height: 0;
+  }
+  body.mobile-touch #charselect-panel #char-list {
+    flex: 1 1 auto;
+    max-height: none;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    overflow: visible;
+  }
+  body.mobile-touch #charselect-panel #charselect-class-details,
+  body.mobile-touch #charselect-panel #online-class-details {
+    flex: 1 1 auto;
+    width: 100%;
+    height: auto;
+    min-height: 0;
+    max-height: none;
+    margin-bottom: 0;
+    overflow: visible;
+  }
+  body.mobile-touch #charselect-panel #charselect-class-details .class-details-content,
+  body.mobile-touch #charselect-panel #online-class-details .class-details-content {
+    min-height: 100%;
+    height: auto;
+  }
+  body.mobile-touch #charselect-panel #charselect-class-details .class-details-grid,
+  body.mobile-touch #charselect-panel #online-class-details .class-details-grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+  }
+  body.mobile-touch .char-row {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 6px;
+    padding: 10px;
+    margin-bottom: 8px;
+    border: 1px solid rgba(78, 61, 29, 0.35);
+    background: rgba(0, 0, 0, 0.2);
+  }
+  body.mobile-touch .char-row .char-name {
+    min-width: 0;
+    font-size: 15px;
+    overflow-wrap: anywhere;
+  }
+  body.mobile-touch .char-row .char-sub {
+    font-size: 11px;
+  }
+  body.mobile-touch .char-row .char-actions {
+    display: grid;
+    grid-template-columns: 0.85fr 1.15fr;
+    gap: 7px;
+    width: 100%;
+  }
+  body.mobile-touch .char-row .btn {
+    width: 100%;
+    padding: 7px 8px;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+  body.mobile-touch #charcreate-panel .mini-class-row,
+  body.mobile-touch #offline-select .mini-class-row {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 7px;
+  }
+  body.mobile-touch #charcreate-panel .mini-class,
+  body.mobile-touch #offline-select .mini-class {
+    min-width: 0;
+    min-height: 40px;
+    padding: 9px 6px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  /* ===================================================================
+     Character-select & create screens (v2) — full-height roster, no heavy
+     bounding box, left-aligned realm dropdown, portrait-framed roster rows.
+     Scoped to .charselect-screen / .cs-* so the offline panel is untouched.
+     =================================================================== */
+  .charselect-screen {
+    width: 100%;
+    max-width: min(1160px, 96vw);
+    margin: 0 auto;
+    background: none;
+    border: 0;
+    outline: none;
+    box-shadow: none;
+    backdrop-filter: none;
+    padding: 0;
+    text-align: left;
+  }
+  .cs-head {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+  .cs-title { text-align: left; margin: 0; }
+
+  /* Realm dropdown — left-aligned, sits above the roster */
+  .cs-realm-switch { position: relative; }
+  .cs-realm-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-height: 40px;
+    padding: 7px 12px;
+    background: linear-gradient(180deg, rgba(28, 28, 40, 0.92), rgba(14, 14, 22, 0.96));
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    color: #e9e3d2;
+    font-family: var(--title-font);
+    font-size: 13px;
+    cursor: var(--cursor-point);
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .cs-realm-btn:hover { border-color: var(--gold-dim); }
+  .cs-realm-btn:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+  .cs-realm-caption {
+    font-size: 10px;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: #8a93a8;
+  }
+  .cs-realm-name { color: #7fd4ff; font-weight: 600; }
+  .cs-realm-caret { width: 16px; height: 16px; color: #9aa0b4; transition: transform 0.18s ease; }
+  .cs-realm-btn[aria-expanded="true"] .cs-realm-caret { transform: rotate(180deg); }
+  .cs-realm-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    z-index: 60;
+    min-width: 280px;
+    max-width: 360px;
+    max-height: 320px;
+    overflow-y: auto;
+    padding: 6px;
+    background: linear-gradient(180deg, rgba(24, 24, 34, 0.98), rgba(12, 12, 19, 0.99));
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.7);
+  }
+  /* Flat rows — no nested container box; the menu panel is the only container. */
+  .cs-realm-menu .realm-row {
+    display: flex !important;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border: 0;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    box-shadow: none;
+    padding: 9px 12px;
+  }
+  .cs-realm-menu .realm-row:hover { background: rgba(255, 255, 255, 0.06); }
+  .cs-realm-menu .realm-row.sel { background: rgba(255, 209, 0, 0.1); box-shadow: none; }
+  .cs-realm-row .realm-name { font-size: 14px; }
+
+  /* Body: roster | showcase */
+  .cs-body { display: flex; flex-direction: column; gap: 16px; }
+  .cs-list-col { display: flex; flex-direction: column; min-height: 0; gap: 12px; }
+  .cs-list-col #char-list {
+    list-style: none;
+    margin: 0;
+    padding: 2px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
+    overflow-y: auto;
+  }
+  .cs-list-actions { display: flex; gap: 10px; flex: 0 0 auto; }
+  .cs-list-actions .btn { margin: 0; flex: 1 1 auto; }
+  .cs-new-btn { font-family: var(--title-font); }
+
+  /* The detail column is the framed scroll container: its dark background +
+     border stay fixed while the avatar and class card scroll inside it, so the
+     border never clips the content. The avatar sits on this dark section. */
+  .cs-detail-col {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: 6px;
+    overflow-y: auto;
+    background: linear-gradient(135deg, rgba(20, 20, 30, 0.96) 0%, rgba(10, 10, 15, 0.98) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.6), 0 6px 20px rgba(0, 0, 0, 0.5);
+    padding: 20px;
+  }
+  .cs-preview {
+    flex: 0 0 auto;
+    height: 230px;
+    min-height: 230px;
+    background: transparent;
+    border: 0;
+    box-shadow: none;
+    border-radius: 0;
+  }
+  /* Inner class card is now frameless — the outer column provides the frame. */
+  .cs-detail-col .class-details-panel {
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    height: auto !important;
+    max-height: none;
+    overflow: visible;
+    margin: 0;
+    padding: 0;
+    flex: 0 0 auto;
+  }
+  /* Create screen: the form sits in its own framed panel (mirrors the showcase). */
+  .cs-create-col {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow-y: auto;
+    background: linear-gradient(135deg, rgba(20, 20, 30, 0.96) 0%, rgba(10, 10, 15, 0.98) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.6), 0 6px 20px rgba(0, 0, 0, 0.5);
+    padding: 18px;
+  }
+  .cs-create-col .char-create { flex: 1 1 auto; }
+
+  /* Themed character-name input */
+  .char-create input {
+    width: 100%;
+    box-sizing: border-box;
+    background: rgba(8, 8, 14, 0.85);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-sm);
+    color: #f0ead8;
+    font-family: var(--title-font);
+    font-size: 16px;
+    letter-spacing: 0.5px;
+    padding: 11px 14px;
+    text-align: center;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  }
+  .char-create input::placeholder { color: #8a8597; }
+  .char-create input:focus {
+    outline: none;
+    border-color: var(--gold);
+    box-shadow: 0 0 0 2px rgba(255, 209, 0, 0.22);
+  }
+
+  /* Skin / appearance selector with portrait previews */
+  .skin-picker { margin-top: 14px; }
+  .cs-section-header,
+  .skin-picker-header {
+    font-family: var(--title-font);
+    font-size: 12px;
+    letter-spacing: 0.6px;
+    text-transform: uppercase;
+    color: #c9b27a;
+    margin-bottom: 10px;
+  }
+  .cs-create-col .mini-class-row { margin-top: 0; }
+  /* Extra breathing room between the name input and the Class label. */
+  .cs-create-col .char-input-group + .cs-section-header { margin-top: 16px; }
+  /* Pack the form from the top so each label sits the same fixed distance above
+     its content (no space-between stretching the Name/Class gaps). */
+  #charcreate-panel .char-create { justify-content: flex-start; }
+  .skin-swatch-portrait {
+    width: 54px;
+    height: 54px;
+    border-radius: 10px;
+    padding: 0;
+    overflow: hidden;
+  }
+  .skin-swatch-portrait .skin-swatch-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: 50% 16%;
+    display: block;
+  }
+
+  /* Create form: full-width input, no top divider, stretched children */
+  .cs-create-col .char-create { border-top: 0; margin-top: 0; padding-top: 0; align-items: stretch; }
+  .cs-create-col .char-input-group { max-width: none; width: 100%; margin: 0 0 14px 0; }
+  .cs-create-col #new-char-name { width: 100%; margin: 0; }
+
+  /* Appearance: a full-width 4-up grid of larger portrait previews */
+  .cs-create-col .skin-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    width: 100%;
+    margin: 0;
+  }
+  .cs-create-col .skin-swatch-portrait { width: 100%; height: auto; aspect-ratio: 1 / 1; border-radius: 12px; }
+
+  /* Login/Create-account toggle link */
+  .auth-switch {
+    margin: 16px 0 0;
+    text-align: center;
+    font-size: 13px;
+    color: var(--color-text-muted);
+  }
+  .auth-link {
+    background: none;
+    border: 0;
+    padding: 0 0 0 4px;
+    color: var(--gold);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-weight: 700;
+    cursor: var(--cursor-point);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .auth-link { font-weight: 500; }
+  .auth-link:hover { color: #ffe27a; }
+
+  /* Login actions: Back (30%) and the primary action on one row */
+  #login-panel .auth-actions-row { display: flex; flex-direction: row; gap: 10px; }
+  #login-panel .auth-actions-row .btn { margin: 0; }
+  #login-panel #btn-login-back { flex: 0 0 30%; }
+  #login-panel #btn-login { flex: 1 1 auto; }
+  .auth-link:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 3px; }
+
+  /* Class buttons with a portrait preview of that class */
+  .mini-class.has-portrait {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    justify-content: flex-start;
+    text-align: left;
+    padding: 7px 10px;
+  }
+  .mini-class-portrait {
+    width: 36px;
+    height: 36px;
+    border-radius: 7px;
+    object-fit: cover;
+    object-position: 50% 15%;
+    flex: 0 0 auto;
+    background: radial-gradient(circle at 50% 34%, #232234, #0c0c14);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+  .mini-class-label { flex: 1 1 auto; min-width: 0; }
+
+  /* Char-select left roster also sits in a framed container (like create) */
+  .cs-list-col {
+    background: linear-gradient(135deg, rgba(20, 20, 30, 0.96) 0%, rgba(10, 10, 15, 0.98) 100%);
+    border: 2px solid var(--color-border-default);
+    border-radius: var(--radius-md);
+    box-shadow: inset 0 0 15px rgba(0, 0, 0, 0.6), 0 6px 20px rgba(0, 0, 0, 0.5);
+    padding: 14px;
+  }
+  /* Keep roster row frames from being clipped by the scroll viewport */
+  .cs-list-col #char-list { padding: 2px; overflow-x: hidden; }
+
+  /* Actions: full width, Back 40% and the primary action the rest */
+  .cs-form-actions, .cs-list-actions { display: flex; gap: 10px; margin-top: 14px; }
+  .cs-form-actions .btn, .cs-list-actions .btn { margin: 0; }
+  /* Pin the create-form actions to the bottom of the panel. */
+  #charcreate-panel .cs-form-actions { margin-top: auto; padding-top: 16px; }
+  #btn-charcreate-back, #btn-charselect-back { flex: 0 0 40%; }
+  #btn-create-char, #btn-new-character { flex: 1 1 auto; }
+
+  /* Roster rows get a portrait + class ring */
+  #char-list .char-row {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 10px 12px;
+    border: 1px solid rgba(78, 61, 29, 0.3);
+    border-radius: var(--radius-sm);
+    background: linear-gradient(180deg, rgba(30, 28, 38, 0.55), rgba(16, 15, 22, 0.6));
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  #char-list .char-row:hover { border-color: rgba(255, 209, 0, 0.35); background: rgba(255, 209, 0, 0.05); }
+  #char-list .char-row.sel { border-color: var(--gold-dim); background: linear-gradient(180deg, rgba(58, 48, 24, 0.5), rgba(28, 24, 14, 0.6)); box-shadow: inset 0 0 0 1px rgba(255, 209, 0, 0.25); }
+  /* name stacked over level/class, vertically centered with the portrait */
+  #char-list .char-row .char-id {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2px;
+  }
+  #char-list .char-row .char-name { min-width: 0; }
+  #char-list .char-row .char-sub { flex: 0 0 auto; }
+  #char-list .char-row .char-actions { flex: 0 0 auto; }
+  .char-list-message { list-style: none; padding: 18px; text-align: center; color: var(--color-text-muted); font-size: 13px; }
+
+  /* Class color tokens — any element with data-class exposes --class-color */
+  [data-class="warrior"] { --class-color: #c79c6e; }
+  [data-class="paladin"] { --class-color: #f58cba; }
+  [data-class="hunter"]  { --class-color: #abd473; }
+  [data-class="rogue"]   { --class-color: #fff569; }
+  [data-class="priest"]  { --class-color: #ffffff; }
+  [data-class="shaman"]  { --class-color: #0070de; }
+  [data-class="mage"]    { --class-color: #69ccf0; }
+  [data-class="warlock"] { --class-color: #9482c9; }
+  [data-class="druid"]   { --class-color: #ff7d0a; }
+
+  /* Portrait chip — a class-ringed headshot rendered from the 3D model.
+     The ring clips the image; the chip itself stays overflow-visible so the
+     class badge can overlay the rim without being cut off. */
+  .portrait-chip {
+    position: relative;
+    flex: 0 0 auto;
+    display: inline-block;
+    overflow: visible;
+    filter: drop-shadow(0 3px 6px rgba(0, 0, 0, 0.6));
+  }
+  .portrait-chip .portrait-ring {
+    display: grid;
+    place-items: center;
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    overflow: hidden;
+    background: radial-gradient(circle at 50% 34%, #232234, #0c0c14);
+    border: 2px solid var(--class-color, var(--color-border-default));
+    box-shadow: inset 0 0 10px color-mix(in oklab, var(--class-color, #888) 35%, transparent), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  }
+  .portrait-chip .portrait-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .portrait-chip.is-fallback .portrait-img { padding: 14%; box-sizing: border-box; }
+  .portrait-chip .portrait-badge {
+    position: absolute;
+    right: -4%;
+    bottom: -4%;
+    width: 44%;
+    height: 44%;
+    border-radius: 50%;
+    border: 1.5px solid #0c0c14;
+    background: #0c0c14;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
+    z-index: 1;
+  }
+  .portrait-sm { width: 46px; height: 46px; }
+  .portrait-md { width: 72px; height: 72px; }
+  .portrait-lg { width: 120px; height: 120px; }
+  .portrait-sm .portrait-badge { border-width: 1px; }
+
+  /* Profile/character-window header with a portrait beside the name */
+  .panel-title.char-title-portrait { display: flex; align-items: center; gap: 12px; }
+  .panel-title.char-title-portrait .char-title-text { flex: 1 1 auto; min-width: 0; }
+  .panel-title.char-title-portrait .portrait-chip { flex: 0 0 auto; }
+
+  /* Context-menu header with a portrait */
+  .ctx-title-player { display: flex; align-items: center; gap: 9px; }
+  .ctx-title-player .ctx-title-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+
+  /* Inspect-other-player profile window */
+  #inspect-window { width: 280px; }
+  .inspect-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    padding: 18px 16px 8px;
+    text-align: center;
+  }
+  .inspect-card .portrait-chip { width: 132px; height: 132px; }
+  .inspect-name { font-family: var(--title-font); font-size: 20px; color: #f0ead8; }
+  .inspect-meta { font-size: 13px; color: var(--color-text-muted); }
+  /* $WOC holder-tier flair badge in the inspect/profile window */
+  .inspect-holder { display: inline-flex; align-items: center; gap: 8px; margin-top: 6px;
+    padding: 5px 14px 5px 6px; border: 1px solid var(--color-border-default);
+    border-radius: 999px; background: rgba(11, 11, 18, 0.55); }
+  .inspect-holder-badge { width: 32px; height: 32px; display: block; filter: drop-shadow(0 1px 2px #000); }
+  .inspect-holder-text { display: flex; flex-direction: column; align-items: flex-start; line-height: 1.2; }
+  .inspect-holder-name { font-family: var(--title-font); font-size: 14px; color: #f0ead8; }
+  .inspect-holder-sub { font-size: 11px; color: var(--color-text-muted); }
+
+  @media (min-width: 900px) {
+    /* Both screens share the same split so the right showcase panel is
+       identical in width on select + create (the roster column is the smaller). */
+    .cs-body,
+    .cs-body-create {
+      flex: 1 1 auto;
+      min-height: 0;
+      display: grid;
+      grid-template-columns: 0.85fr 1.15fr;
+      gap: 28px;
+      align-items: stretch;
+    }
+    .cs-list-col, .cs-detail-col, .cs-create-col { height: 100%; }
+  }
+
+  body.mobile-touch .charselect-screen { max-width: none; }
+  body.mobile-touch .cs-body { flex: 1 1 auto; min-height: 0; }
+  body.mobile-touch .cs-detail-col .cs-preview { min-height: 200px; }
+  body.mobile-touch #char-list .char-row {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas: "portrait id" "actions actions";
+    column-gap: 12px;
+    row-gap: 8px;
+    align-items: center;
+  }
+  body.mobile-touch #char-list .char-row .portrait-chip { grid-area: portrait; align-self: center; }
+  body.mobile-touch #char-list .char-row .char-id { grid-area: id; }
+  body.mobile-touch #char-list .char-row .char-actions { grid-area: actions; display: grid; grid-template-columns: 0.85fr 1.15fr; gap: 7px; width: 100%; }
+
+  body.mobile-touch .mobile-menu-toggle {
+    display: flex;
+  }
+  body.mobile-touch .homepage-header {
+    display: flex;
+    position: sticky;
+    top: 0;
+    z-index: 120;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding-top: calc(var(--spacing-sm) + env(safe-area-inset-top));
+    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+    padding-bottom: var(--spacing-sm);
+    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+  }
+  body.mobile-touch #homepage-views-container {
+    padding-top: var(--spacing-lg);
+    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+    padding-bottom: var(--spacing-lg);
+    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+  }
+  body.mobile-touch .header-menu-container {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: rgba(11, 11, 18, 0.98);
+    border-bottom: 2px solid var(--color-border-default);
+    flex-direction: column;
+    align-items: center;
+    padding: var(--spacing-md);
+    gap: var(--spacing-md);
+    box-shadow: 0 10px 20px rgba(0,0,0,0.8);
+    z-index: 99;
+  }
+  body.mobile-touch .homepage-header.menu-open .header-menu-container {
+    display: flex;
+  }
+  body.mobile-touch .homepage-nav {
+    width: 100%;
+    justify-content: center;
+  }
+  body.mobile-touch .nav-list {
+    flex-direction: column;
+    width: 100%;
+    gap: 4px;
+  }
+  body.mobile-touch .nav-link {
+    width: 100%;
+    text-align: center;
+    padding: var(--spacing-sm);
+    font-size: 14px;
+  }
+  body.mobile-touch .header-actions {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin-top: 0;
+  }
+  body.mobile-touch .footer-bar {
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+  body.mobile-touch .footer-left {
+    align-items: center;
+  }
+  body.mobile-touch .footer-lang-row {
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+  }
+  body.mobile-touch .language-selector {
+    width: 100%;
+    max-width: 240px;
+  }
+  body.mobile-touch .lang-select-dropdown {
+    width: 100%;
+  }
+
+  @media (max-width: 860px) {
+    #community-hud { top: auto; }
+    #quest-tracker { top: 260px; right: 12px; width: 190px; }
+
+    /* Mobile First Homepage Header and Hamburger Menu */
+    .mobile-menu-toggle {
+      display: flex;
+    }
+    .homepage-header {
+      display: flex;
+      position: sticky;
+      top: 0;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      padding-top: calc(var(--spacing-sm) + env(safe-area-inset-top));
+      padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+      padding-bottom: var(--spacing-sm);
+      padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+    }
+    #homepage-views-container {
+      padding-top: var(--spacing-lg);
+      padding-right: max(var(--spacing-md), env(safe-area-inset-right));
+      padding-bottom: var(--spacing-lg);
+      padding-left: max(var(--spacing-md), env(safe-area-inset-left));
+    }
+    .header-menu-container {
+      display: none;
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      background: rgba(11, 11, 18, 0.98);
+      border-bottom: 2px solid var(--color-border-default);
+      flex-direction: column;
+      align-items: center;
+      padding: var(--spacing-md);
+      gap: var(--spacing-md);
+      box-shadow: 0 10px 20px rgba(0,0,0,0.8);
+      z-index: 99;
+    }
+    .homepage-header.menu-open .header-menu-container {
+      display: flex;
+    }
+    .homepage-nav {
+      width: 100%;
+      justify-content: center;
+    }
+    .nav-list {
+      flex-direction: column;
+      width: 100%;
+      gap: 4px;
+    }
+    .nav-link {
+      width: 100%;
+      text-align: center;
+      min-height: 40px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: var(--spacing-sm);
+      font-size: 14px;
+    }
+    .header-actions {
+      width: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      margin-top: 0;
+    }
+    .footer-bar {
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+    }
+    .footer-left {
+      align-items: center;
+    }
+    .footer-lang-row {
+      width: 100%;
+      flex-direction: column;
+      align-items: center;
+    }
+    .language-selector {
+      width: 100%;
+      max-width: 240px;
+    }
+    .lang-select-dropdown {
+      width: 100%;
+      font-size: 16px; /* Prevents mobile Safari auto-zoom */
+      padding: 10px 36px 10px 16px; /* Increases height for a better touch target */
+    }
+
+    /* Mobile First Responsive Footer */
+    .footer-social-row {
+      flex-direction: row;
+      width: auto;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+    }
+    .social-link {
+      width: 42px;
+      min-height: 40px;
+      padding: 0;
+      justify-content: center;
+    }
+    .social-link span { display: none; }
+    .social-link svg { width: 18px; height: 18px; }
+  }
+
+  /* ---------- Cosmetic skin-select event overlay ---------- */
+  .skin-event-overlay {
+    position: fixed; inset: 0; z-index: 50; display: none;
+    align-items: center; justify-content: center; padding: 20px;
+    background: radial-gradient(120% 120% at 50% 0%, #0b0b12d0, #05050aee 70%);
+  }
+  .skin-event-overlay.open { display: flex; }
+  .se-wheel-stage {
+    position: relative; width: min(520px, calc(100vw - 32px)); aspect-ratio: 1;
+    display: grid; place-items: center;
+    opacity: 0; transform: scale(0.74);
+    animation: se-wheel-stage-in 620ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+  .se-wheel {
+    position: relative; width: min(430px, 82vw); aspect-ratio: 1; border-radius: 50%;
+    border: 2px solid #6f5724;
+    background:
+      radial-gradient(circle at 50% 50%, #14110a 0 21%, transparent 22%),
+      radial-gradient(circle at 50% 50%, transparent 0 54%, #d9b34c30 55% 56%, transparent 57%),
+      conic-gradient(from -90deg,
+        #1e3519 0deg 210deg,
+        #12304a 210deg 315deg,
+        #3b2048 315deg 360deg);
+    box-shadow: 0 0 0 8px #0e0b05, 0 0 34px #000, inset 0 0 34px #000, inset 0 0 0 4px #c9a13a22;
+    transform: rotate(calc(2160deg + var(--land-angle, 0deg)));
+    animation: se-wheel-spin 5s cubic-bezier(0.16, 1, 0.3, 1) 700ms both;
+    will-change: transform;
+  }
+  .se-wheel::before {
+    content: ""; position: absolute; inset: 0; border-radius: 50%; pointer-events: none;
+    background:
+      repeating-conic-gradient(from 9deg, rgba(255,255,255,0.055) 0deg 1deg, transparent 1deg 8deg),
+      repeating-radial-gradient(circle at 47% 42%, rgba(255,255,255,0.04) 0 1px, transparent 1px 7px),
+      radial-gradient(circle at 35% 28%, rgba(255,255,255,0.08), transparent 28%);
+    opacity: 0.25;
+    mix-blend-mode: soft-light;
+  }
+  .se-wheel::after {
+    content: ""; position: absolute; inset: 23%; border-radius: 50%;
+    border: 1px solid #6f5724; background: radial-gradient(circle, #16120a, #050506 72%);
+    box-shadow: inset 0 0 20px #000;
+  }
+  .se-wheel-labels {
+    position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%;
+    overflow: visible; pointer-events: none;
+  }
+  .se-wheel-labels path { fill: none; stroke: none; }
+  .se-wheel-labels text {
+    font-family: var(--title-font); font-size: 9px; letter-spacing: 1px;
+    text-transform: uppercase; text-anchor: middle; stroke-linejoin: round;
+  }
+  .se-wheel-label-bg {
+    paint-order: stroke; stroke-width: 11px; opacity: 0.94;
+  }
+  .se-wheel-label-bg.uncommon { fill: #1e3519; stroke: #1e3519; }
+  .se-wheel-label-bg.rare { fill: #12304a; stroke: #12304a; }
+  .se-wheel-label-bg.epic { fill: #3b2048; stroke: #3b2048; }
+  .se-wheel-label-fg {
+    fill: #d7c58c; paint-order: stroke; stroke: #050506; stroke-width: 1.8px;
+    text-anchor: middle;
+  }
+  .se-wheel-pointer {
+    position: absolute; top: 10px; left: 50%; z-index: 2;
+    width: 0; height: 0; transform: translateX(-50%);
+    border-left: 18px solid transparent; border-right: 18px solid transparent; border-top: 32px solid #d9b34c;
+    filter: drop-shadow(0 2px 4px #000);
+  }
+  .se-wheel-result {
+    position: absolute; z-index: 3; display: grid; place-items: center; width: 160px; height: 160px;
+    border-radius: 50%; border: 1px solid #6f5724; background: #100d08;
+    color: var(--tier-color, #fff); font-family: var(--title-font); font-size: 24px; letter-spacing: 0.6px; text-transform: uppercase;
+    text-shadow: 1px 1px 2px #000; opacity: 0; transform: scale(0.72);
+    animation: se-wheel-result 620ms cubic-bezier(0.16, 1, 0.3, 1) 5.6s both;
+  }
+  .se-wheel-result::before {
+    content: ""; position: absolute; inset: -18px; border-radius: 50%;
+    border: 1px solid color-mix(in srgb, var(--tier-color, #fff) 70%, transparent);
+    opacity: 0; transform: scale(0.7);
+    animation: se-wheel-ring 760ms cubic-bezier(0.16, 1, 0.3, 1) 5.62s both;
+  }
+  .se-wheel-result i {
+    position: absolute; left: 50%; top: 50%; width: 6px; height: 6px; border-radius: 50%;
+    background: var(--tier-color, #fff); box-shadow: 0 0 12px var(--tier-color, #fff);
+    opacity: 0; transform: translate(-50%, -50%);
+    animation: se-wheel-particle 760ms cubic-bezier(0.16, 1, 0.3, 1) 5.62s both;
+  }
+  .se-wheel-result i:nth-child(2) { --tx: -96px; --ty: -38px; }
+  .se-wheel-result i:nth-child(3) { --tx: -60px; --ty: 78px; }
+  .se-wheel-result i:nth-child(4) { --tx: 8px; --ty: -106px; }
+  .se-wheel-result i:nth-child(5) { --tx: 78px; --ty: -70px; }
+  .se-wheel-result i:nth-child(6) { --tx: 104px; --ty: 20px; }
+  .se-wheel-result i:nth-child(7) { --tx: 46px; --ty: 92px; }
+  .se-wheel-result i:nth-child(8) { --tx: -110px; --ty: 28px; }
+  .se-wheel-result i:nth-child(9) { --tx: 0; --ty: 112px; }
+  .se-wheel-result b {
+    position: absolute; left: 50%; top: 50%; width: 4px; height: 14px; border-radius: 4px;
+    background: linear-gradient(180deg, #f4df91, var(--tier-color, #fff));
+    box-shadow: 0 0 12px var(--tier-color, #fff);
+    opacity: 0; transform: translate(-50%, -50%) scaleY(0.35);
+    animation: se-wheel-spark 840ms cubic-bezier(0.16, 1, 0.3, 1) 5.48s both;
+  }
+  .se-wheel-result b:nth-of-type(1) { --tx: -260px; --ty: -14px; --rot: 86deg; animation-delay: 5.46s; }
+  .se-wheel-result b:nth-of-type(2) { --tx: -226px; --ty: -118px; --rot: 56deg; animation-delay: 5.48s; }
+  .se-wheel-result b:nth-of-type(3) { --tx: -146px; --ty: -224px; --rot: 28deg; animation-delay: 5.5s; }
+  .se-wheel-result b:nth-of-type(4) { --tx: -32px; --ty: -270px; --rot: 8deg; animation-delay: 5.47s; }
+  .se-wheel-result b:nth-of-type(5) { --tx: 88px; --ty: -248px; --rot: -22deg; animation-delay: 5.51s; }
+  .se-wheel-result b:nth-of-type(6) { --tx: 204px; --ty: -166px; --rot: -48deg; animation-delay: 5.49s; }
+  .se-wheel-result b:nth-of-type(7) { --tx: 270px; --ty: -42px; --rot: -82deg; animation-delay: 5.53s; }
+  .se-wheel-result b:nth-of-type(8) { --tx: 250px; --ty: 92px; --rot: -110deg; animation-delay: 5.5s; }
+  .se-wheel-result b:nth-of-type(9) { --tx: 158px; --ty: 218px; --rot: -142deg; animation-delay: 5.52s; }
+  .se-wheel-result b:nth-of-type(10) { --tx: 22px; --ty: 278px; --rot: -176deg; animation-delay: 5.48s; }
+  .se-wheel-result b:nth-of-type(11) { --tx: -114px; --ty: 246px; --rot: 152deg; animation-delay: 5.54s; }
+  .se-wheel-result b:nth-of-type(12) { --tx: -232px; --ty: 136px; --rot: 120deg; animation-delay: 5.56s; }
+  .se-wheel-result b:nth-of-type(13) { --tx: -284px; --ty: 58px; --rot: 102deg; animation-delay: 5.44s; }
+  .se-wheel-result b:nth-of-type(14) { --tx: -198px; --ty: -206px; --rot: 42deg; animation-delay: 5.57s; }
+  .se-wheel-result b:nth-of-type(15) { --tx: -72px; --ty: -294px; --rot: 14deg; animation-delay: 5.43s; }
+  .se-wheel-result b:nth-of-type(16) { --tx: 56px; --ty: -286px; --rot: -10deg; animation-delay: 5.59s; }
+  .se-wheel-result b:nth-of-type(17) { --tx: 174px; --ty: -226px; --rot: -36deg; animation-delay: 5.45s; }
+  .se-wheel-result b:nth-of-type(18) { --tx: 294px; --ty: -2px; --rot: -90deg; animation-delay: 5.58s; }
+  .se-wheel-result b:nth-of-type(19) { --tx: 286px; --ty: 132px; --rot: -116deg; animation-delay: 5.46s; }
+  .se-wheel-result b:nth-of-type(20) { --tx: 106px; --ty: 282px; --rot: -160deg; animation-delay: 5.6s; }
+  .se-wheel-result b:nth-of-type(21) { --tx: -54px; --ty: 304px; --rot: 168deg; animation-delay: 5.47s; }
+  .se-wheel-result b:nth-of-type(22) { --tx: -176px; --ty: 236px; --rot: 138deg; animation-delay: 5.55s; }
+  .se-wheel-result b:nth-of-type(23) { --tx: -306px; --ty: -76px; --rot: 74deg; animation-delay: 5.49s; }
+  .se-wheel-result b:nth-of-type(24) { --tx: 230px; --ty: 214px; --rot: -132deg; animation-delay: 5.53s; }
+  @keyframes se-wheel-stage-in {
+    to { opacity: 1; transform: scale(1); }
+  }
+  @keyframes se-wheel-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(calc(2160deg + var(--land-angle, 0deg))); }
+  }
+  @keyframes se-wheel-result {
+    0% { opacity: 0; transform: scale(0.72); }
+    68% { opacity: 1; transform: scale(1.1); }
+    100% { opacity: 1; transform: scale(1); }
+  }
+  @keyframes se-wheel-ring {
+    0% { opacity: 0; transform: scale(0.72); }
+    35% { opacity: 0.9; }
+    100% { opacity: 0; transform: scale(1.55); }
+  }
+  @keyframes se-wheel-particle {
+    0% { opacity: 0; transform: translate(-50%, -50%) scale(0.5); }
+    20% { opacity: 1; }
+    100% { opacity: 0; transform: translate(calc(-50% + var(--tx, 0px)), calc(-50% + var(--ty, 0px))) scale(0.2); }
+  }
+  @keyframes se-wheel-spark {
+    0% { opacity: 0; transform: translate(-50%, -50%) rotate(var(--rot, 0deg)) scaleY(0.25); }
+    18% { opacity: 1; }
+    100% { opacity: 0; transform: translate(calc(-50% + var(--tx, 0px)), calc(-50% + var(--ty, 0px))) rotate(var(--rot, 0deg)) scaleY(1); }
+  }
+  .skin-event-panel {
+    width: 100%; max-width: 1160px; max-height: calc(100vh - 40px);
+    display: flex; flex-direction: column; padding: 0; overflow: hidden;
+    background: transparent; border: 0; box-shadow: none;
+  }
+  .se-body {
+    display: grid; grid-template-columns: minmax(330px, 430px) minmax(420px, 1fr);
+    gap: 22px; min-height: 0; max-height: calc(100vh - 40px); flex: 1; overflow: hidden;
+  }
+  .se-left {
+    display: flex; flex-direction: column; gap: 12px; min-width: 0; min-height: 0;
+    border: 1px solid #463a1c; border-radius: 8px; background: #100d08;
+    padding: 14px;
+  }
+  .se-roll-banner {
+    flex: 0 0 auto; border: 1px solid color-mix(in srgb, var(--tier-color, #fff) 45%, #463a1c);
+    border-radius: 8px; padding: 10px 12px; background: linear-gradient(180deg, #1b150d, #0f0c07);
+    color: var(--tier-color, #fff); font-family: var(--title-font); font-size: 18px;
+    letter-spacing: 0.4px; text-transform: uppercase; text-align: center;
+    text-shadow: 1px 1px 2px #000;
+    box-shadow: inset 0 0 18px color-mix(in srgb, var(--tier-color, #fff) 14%, transparent);
+  }
+  .se-tiers {
+    display: flex; flex-direction: column; gap: 14px; flex: 1 1 auto; min-width: 0;
+    overflow-y: auto; overflow-x: hidden; padding: 2px 8px 8px 2px;
+  }
+  .se-tier {
+    border: 1px solid #463a1c; border-radius: 8px; background: #14110a;
+    width: 100%; box-sizing: border-box; padding: 12px; overflow: visible;
+  }
+  .se-tier.locked { opacity: 0.55; }
+  .se-tier-head { display: flex; align-items: baseline; justify-content: space-between; gap: 10px; margin-bottom: 8px; }
+  .se-tier-name { font-family: var(--title-font); font-size: 15px; letter-spacing: 0.5px; text-transform: uppercase; color: var(--tier-color, #fff); text-shadow: 1px 1px 2px #000; }
+  .se-tier-hint { font-size: 13px; color: var(--color-text-muted, #b5aa86); display: inline-flex; align-items: center; gap: 6px; }
+  .se-swatches { display: flex; flex-wrap: wrap; gap: 10px; padding: 4px; }
+  .se-swatch {
+    position: relative; width: clamp(76px, 7vw, 88px); height: clamp(76px, 7vw, 88px); border-radius: 8px;
+    border: 2px solid var(--tier-color, #555); background: #0d0d12;
+    cursor: var(--cursor-point); padding: 0; overflow: hidden;
+    display: flex; align-items: center; justify-content: center;
+    color: #cfc6a8; font-size: 16px; font-family: var(--title-font);
+    transition: box-shadow 0.12s, border-color 0.12s;
+  }
+  .se-swatch img { width: 100%; height: 100%; object-fit: cover; display: block; }
+  .se-swatch:hover:not(:disabled), .se-swatch:focus-visible { box-shadow: 0 0 10px var(--tier-color, #888); }
+  .se-swatch.sel { box-shadow: 0 0 0 2px #0b0b12, 0 0 0 4px var(--tier-color, #fff), 0 0 12px var(--tier-color, #fff); }
+  .se-swatch.sel::after { content: "✓"; position: absolute; right: 3px; bottom: 1px; font-size: 12px; color: #fff; text-shadow: 0 0 3px #000, 1px 1px 2px #000; }
+  .se-swatch.locked { opacity: 0.58; filter: grayscale(0.78) brightness(0.78); }
+  .se-swatch.locked.sel { opacity: 0.78; }
+  .se-swatch.unavailable { cursor: default; opacity: 0.38; filter: grayscale(0.9) brightness(0.65); }
+  .se-swatch:disabled { cursor: default; opacity: 0.4; filter: grayscale(0.7); }
+  .se-swatch .se-lock { font-size: 18px; opacity: 0.85; }
+  .se-preview-col {
+    min-width: 0; min-height: 0; display: flex; flex-direction: column;
+    border: 1px solid #463a1c; border-radius: 8px; background: #0f0d12;
+    padding: 0;
+  }
+  .se-preview {
+    position: relative; flex: 1; min-height: min(58vh, 560px); border-radius: 8px;
+    border: 0; overflow: hidden;
+    background: radial-gradient(120% 90% at 50% 20%, #2a2640, #0a0a12 75%);
+  }
+  .se-preview canvas { width: 100% !important; height: 100% !important; display: block; cursor: grab; }
+  .se-preview-hint { position: absolute; left: 0; right: 0; bottom: 6px; text-align: center; font-size: 10.5px; color: #cfc6a8b0; pointer-events: none; text-shadow: 1px 1px 2px #000; }
+  .se-preview-name { flex: 0 0 auto; text-align: center; padding: 8px 10px 4px; font-size: 14px; font-weight: 600; letter-spacing: 0.02em; color: var(--gold, #e8d9a8); min-height: 1.4em; }
+  .se-preview-name:empty { display: none; }
+  .se-lockin { margin: 0; width: 100%; min-height: 46px; padding: 12px 16px; font-size: 15px; flex: 0 0 auto; }
+  .se-lockin:disabled { filter: grayscale(0.8) brightness(0.7); cursor: default; }
+  @media (max-width: 860px) {
+    .skin-event-panel { max-height: calc(100vh - 40px); }
+    .se-body { grid-template-columns: 1fr; overflow-y: auto; }
+    .se-left, .se-preview-col { min-height: auto; }
+    .se-preview { min-height: 220px; }
+    .se-tiers { overflow: visible; }
+    .se-swatch { width: 72px; height: 72px; }
+  }
+  @media (max-height: 700px) and (min-width: 861px) {
+    .se-body { min-height: 0; }
+    .se-preview { min-height: 360px; }
+    .se-tiers { gap: 12px; }
+    .se-swatch { width: 68px; height: 68px; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .se-swatch { transition: none; }
+    .se-wheel-stage { animation: none; opacity: 1; transform: scale(1); }
+    .se-wheel { animation: none; transform: rotate(var(--land-angle, 0deg)); }
+    .se-wheel-result { animation: none; opacity: 1; transform: scale(1); }
+    .se-wheel-result::before, .se-wheel-result i { animation: none; display: none; }
+  }
+</style>
+</head>
+<body data-start-panel="mode-select">
+  <canvas id="game-canvas"></canvas>
+  <div id="nameplates"></div>
+
+  <template id="game-ui-template">
+  <div id="ui">
+    <div id="fps-overlay" aria-hidden="true"></div>
+    <div id="click-move-marker" class="click-move-marker" aria-hidden="true">
+      <span class="ctm-arrow ctm-n"></span>
+      <span class="ctm-arrow ctm-e"></span>
+      <span class="ctm-arrow ctm-s"></span>
+      <span class="ctm-arrow ctm-w"></span>
+    </div>
+    <div id="target-frame" class="unitframe">
+      <div class="portrait-wrap">
+        <div class="portrait"><canvas id="tf-portrait" width="54" height="54"></canvas></div>
+        <div class="level-chip" id="tf-level"></div>
+        <div id="tf-elite-tag" data-i18n="hud.core.elite">ELITE</div>
+      </div>
+      <div class="uf-bars">
+        <div class="uf-name" id="tf-name"></div>
+        <div class="bar hp"><div class="bar-fill" id="tf-hp"></div><div class="bar-absorb" id="tf-absorb"></div><div class="bar-text" id="tf-hp-text"></div></div>
+        <div class="combo-row" id="combo-row"></div>
+        <div class="uf-buffs" id="tf-debuffs"></div>
+      </div>
+    </div>
+
+    <div id="party-frames"></div>
+
+    <div id="buff-bar"></div>
+
+    <div id="ctx-menu" class="panel"></div>
+    <div id="prompt-stack"></div>
+    <div id="trade-window" class="window panel"></div>
+
+    <div id="castbar"><div class="fill"></div><div class="label"></div><div class="timer"></div></div>
+    <div id="swingbar"><div class="fill"></div><div class="label"></div></div>
+
+    <div id="minimap-wrap">
+      <div id="zone-label" data-i18n="entities.zones.eastbrook_vale.name">Eastbrook Vale</div>
+      <canvas id="minimap" width="162" height="162"></canvas>
+      <div id="minimap-clock" data-i18n-title="hudChrome.widgets.clockTitle" title="Local time — click to toggle 12/24-hour">--:--</div>
+      <div id="minimap-coords" data-i18n-title="hudChrome.widgets.worldCoordinates" data-i18n-aria="hudChrome.widgets.coordinates" title="Your current world coordinates" aria-label="Coordinates">0, 0</div>
+      <div id="compass" data-i18n-aria="hudChrome.widgets.heading" aria-label="Heading">
+        <div id="compass-strip"><div id="compass-track"></div></div>
+        <div id="compass-center"></div>
+        <div id="compass-heading">N</div>
+      </div>
+      <div id="minimap-zoom" data-i18n-aria="hudChrome.widgets.minimapZoom" aria-label="Minimap zoom">
+        <button class="minimap-zoom-btn" id="minimap-zoom-out" data-i18n-title="hud.core.zoomOut" data-i18n-aria="hud.core.zoomOut" title="Zoom out" aria-label="Zoom out minimap">&minus;</button>
+        <span id="minimap-zoom-label" aria-live="polite">1×</span>
+        <button class="minimap-zoom-btn" id="minimap-zoom-in" data-i18n-title="hud.core.zoomIn" data-i18n-aria="hud.core.zoomIn" title="Zoom in" aria-label="Zoom in minimap">+</button>
+      </div>
+    </div>
+
+    <div id="community-hud" data-i18n-aria="hud.core.communityLinks" aria-label="Community links">
+      <details id="community-menu">
+        <summary class="community-toggle" data-i18n-title="hud.core.communityLinks" data-i18n-aria="hud.core.communityLinks" title="Community links" aria-label="Community links">
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M7.5 11.5a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm9 0a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7ZM1.7 19.6c.5-3.6 2.6-5.5 5.8-5.5s5.3 1.9 5.8 5.5c.1.6-.4 1.1-1 1.1H2.7c-.6 0-1.1-.5-1-1.1Zm9.7-4.6c1.1-.7 2.8-.9 5.1-.9 3.2 0 5.3 1.9 5.8 5.5.1.6-.4 1.1-1 1.1h-6.6c-.3-2.3-1.4-4.2-3.3-5.7Z"/></svg>
+        </summary>
+        <div class="community-tray">
+          <a class="community-link discord" href="https://discord.gg/GjhnUsBtw" target="_blank" rel="noopener noreferrer" data-i18n-title="a11y.discordCommunity" data-i18n-aria="a11y.discordCommunity" title="Join the World of ClaudeCraft Discord community" aria-label="Join the World of ClaudeCraft Discord community">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.32 4.37A19.8 19.8 0 0 0 15.36 2.8a13.66 13.66 0 0 0-.64 1.32 18.47 18.47 0 0 0-5.45 0 13.02 13.02 0 0 0-.65-1.32 19.73 19.73 0 0 0-4.96 1.58C.53 9.03-.32 13.56.1 18.02a19.9 19.9 0 0 0 6.08 3.08c.49-.67.93-1.38 1.3-2.13-.72-.27-1.41-.6-2.06-.98.17-.13.34-.26.5-.4a14.16 14.16 0 0 0 12.16 0c.16.14.33.27.5.4-.65.39-1.34.72-2.07.99.38.74.81 1.45 1.31 2.12a19.86 19.86 0 0 0 6.08-3.08c.5-5.17-.85-9.66-3.58-13.65ZM8.02 15.28c-1.18 0-2.15-1.08-2.15-2.41 0-1.33.95-2.42 2.15-2.42 1.2 0 2.17 1.1 2.15 2.42 0 1.33-.95 2.41-2.15 2.41Zm7.96 0c-1.18 0-2.15-1.08-2.15-2.41 0-1.33.95-2.42 2.15-2.42 1.2 0 2.17 1.1 2.15 2.42 0 1.33-.95 2.41-2.15 2.41Z"/></svg>
+            <span>Discord</span>
+          </a>
+          <a class="community-link github" href="https://github.com/levy-street/world-of-claudecraft" target="_blank" rel="noopener noreferrer" data-i18n-title="a11y.githubProject" data-i18n-aria="a11y.githubProject" title="Open the World of ClaudeCraft GitHub project" aria-label="Open the World of ClaudeCraft GitHub project">
+            <svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+            <span>GitHub</span>
+          </a>
+          <a class="community-link donate" href="https://github.com/sponsors/levy-street" target="_blank" rel="noopener noreferrer" data-i18n-title="a11y.donateProject" data-i18n-aria="a11y.donateProject" title="Support the project" aria-label="Donate to support World of ClaudeCraft">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+            <span data-i18n="nav.donate">Donate</span>
+          </a>
+        </div>
+      </details>
+    </div>
+
+    <div id="quest-tracker"></div>
+
+    <div id="bottom-bar">
+      <div id="actionbar-row">
+        <div id="actionbar-stack">
+          <div id="player-frame" class="unitframe">
+            <div class="portrait-wrap">
+              <div class="portrait"><canvas id="pf-portrait" width="54" height="54"></canvas></div>
+              <div class="level-chip" id="pf-level">1</div>
+              <div class="combat-flash" id="pf-combat" data-i18n-title="hud.social.status.combat" data-i18n-aria="hud.social.status.combat" title="In Combat" aria-label="In Combat">⚔</div>
+              <div class="rest-indicator" id="pf-rest" data-i18n-title="hudChrome.rest.resting" data-i18n-aria="hudChrome.rest.resting" title="Resting" aria-label="Resting">z</div>
+            </div>
+            <div class="uf-bars">
+              <div class="uf-name" id="pf-name"></div>
+              <div class="bar hp"><div class="bar-fill" id="pf-hp"></div><div class="bar-absorb" id="pf-absorb"></div><div class="bar-text" id="pf-hp-text"></div></div>
+              <div class="bar mana" id="pf-resource"><div class="bar-fill" id="pf-res"></div><div class="bar-text" id="pf-res-text"></div><div class="low-resource-label" id="pf-low-resource"></div></div>
+            </div>
+          </div>
+          <div id="petbar" class="panel"></div>
+          <div id="xpbar"><div class="fill"></div><div class="rested"></div><div class="ticks"></div><div class="label"></div></div>
+          <div id="actionbar" class="panel"></div>
+        </div>
+        <div id="meters-window" class="panel">
+          <div class="panel-title">
+            <span class="mt-tabs">
+              <button class="mt-tab on" data-tab="dmg" data-i18n="hud.meters.damageShort">Dmg</button>
+              <button class="mt-tab" data-tab="heal" data-i18n="hud.meters.healingShort">Heal</button>
+              <button class="mt-tab" data-tab="threat" data-i18n="hud.meters.threat">Threat</button>
+            </span>
+            <span>
+              <button class="x-btn mt-prev" data-i18n-title="hud.meters.olderSegment" title="Older segment" data-icon="prev"></button>
+              <button class="x-btn mt-next" data-i18n-title="hud.meters.newerSegment" title="Newer segment" data-icon="next"></button>
+              <button class="x-btn mt-close" data-i18n-title="hud.meters.close" data-i18n-aria="hud.meters.close" title="Close meters" aria-label="Close meters" data-icon="close"></button>
+            </span>
+          </div>
+          <div class="mt-view"></div>
+          <div class="mt-sub"></div>
+          <div class="mt-rows"></div>
+        </div>
+      </div>
+    </div>
+
+    <div id="chatlog-wrap">
+      <!-- Tabs (built-in Chat/Combat + player-added channel tabs + "add") are
+           rendered by the HUD (hud.ts initChatTabs); this stays empty. -->
+      <div id="chatlog-tabs" role="tablist"></div>
+      <div id="chatlog-frame" class="panel">
+        <div id="chatlog" class="chat-pane active"></div>
+        <div id="combatlog" class="chat-pane"></div>
+      </div>
+    </div>
+
+    <div id="quest-dialog" class="window panel"></div>
+    <div id="loot-window" class="window panel"></div>
+    <div id="bags" class="window panel"></div>
+    <div id="char-window" class="window panel"></div>
+    <div id="inspect-window" class="window panel"></div>
+    <div id="spellbook" class="window panel"></div>
+    <div id="talents-window" class="window panel"></div>
+    <div id="quest-log-window" class="window panel"></div>
+    <div id="vendor-window" class="window panel"></div>
+    <div id="map-window" class="window panel">
+      <button class="x-btn" id="map-close" data-i18n-title="hud.core.closeMap" data-i18n-aria="hud.core.closeMap" title="Close map" aria-label="Close map" data-icon="close"></button>
+      <div id="map-zoom">
+        <button class="map-zoom-btn" id="map-zoom-in" data-i18n-title="hud.core.zoomIn" data-i18n-aria="hud.core.zoomIn" title="Zoom in" aria-label="Zoom in">+</button>
+        <button class="map-zoom-btn" id="map-zoom-out" data-i18n-title="hud.core.zoomOut" data-i18n-aria="hud.core.zoomOut" title="Zoom out" aria-label="Zoom out">&minus;</button>
+      </div>
+      <canvas id="map-canvas" width="560" height="560"></canvas>
+    </div>
+    <div id="arena-window" class="window panel"></div>
+    <div id="leaderboard-window" class="window panel"></div>
+    <div id="market-window" class="window panel"></div>
+    <div id="arena-status"></div>
+    <div id="options-menu" class="window panel"></div>
+    <div id="emote-editor" class="window panel"></div>
+    <div id="social-window" class="window panel"></div>
+    <div id="report-window" class="window panel"></div>
+    <div id="side-buttons">
+      <button class="micro-btn" id="mm-char" data-i18n-title="hud.keybinds.actions.char" data-i18n-aria="hud.keybinds.actions.char" title="Character" aria-label="Character" data-icon="character"><span class="keybind">c</span></button>
+      <button class="micro-btn" id="mm-spell" data-i18n-title="abilityUi.spellbook.title" data-i18n-aria="abilityUi.spellbook.title" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="keybind">p</span></button>
+      <button class="micro-btn" id="mm-talents" data-i18n-title="game.talents.title" data-i18n-aria="game.talents.title" title="Talents" aria-label="Talents" data-icon="talents"><span class="keybind">n</span></button>
+      <button class="micro-btn" id="mm-quest" data-i18n-title="questUi.log.title" data-i18n-aria="questUi.log.title" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="keybind">l</span></button>
+      <button class="micro-btn" id="mm-map" data-i18n-title="hud.keybinds.actions.map" data-i18n-aria="hud.keybinds.actions.map" title="World Map" aria-label="World Map" data-icon="map"><span class="keybind">m</span></button>
+      <button class="micro-btn" id="mm-bag" data-i18n-title="itemUi.bags.title" data-i18n-aria="itemUi.bags.title" title="Bags" aria-label="Bags" data-icon="bags"><span class="keybind">b</span></button>
+      <button class="micro-btn" id="mm-arena" data-i18n-title="hud.keybinds.actions.arena" data-i18n-aria="hud.keybinds.actions.arena" title="Arena (Ashen Coliseum)" aria-label="Arena (Ashen Coliseum)" data-icon="arena"><span class="keybind">g</span></button>
+      <button class="micro-btn" id="mm-leaderboard" data-i18n-title="game.leaderboard.title" data-i18n-aria="game.leaderboard.title" title="Leaderboard" aria-label="Leaderboard" data-icon="leaderboard"><span class="keybind">k</span></button>
+      <button class="micro-btn" id="mm-emote" data-i18n-aria="hudChrome.emoteWheel.label" aria-label="Emotes" data-icon="emote"><span class="keybind">x</span></button>
+      <button class="micro-btn" id="mm-music" data-i18n-title="hud.options.music" data-i18n-aria="hud.options.music" title="Music" aria-label="Music" data-icon="music"></button>
+      <button class="micro-btn" id="mm-social" data-i18n-title="hud.keybinds.actions.social" data-i18n-aria="hud.keybinds.actions.social" title="Friends &amp; Guild" aria-label="Friends &amp; Guild" data-icon="social"><span class="keybind">o</span></button>
+      <button class="micro-btn" id="mm-options" data-i18n-title="hud.options.gameMenu" data-i18n-aria="hud.options.gameMenu" title="Game Menu" aria-label="Game Menu" data-icon="menu"><span class="keybind">esc</span></button>
+    </div>
+    <div id="tooltip" class="panel"></div>
+
+    <div id="error-msg"></div>
+    <div id="banner"></div>
+    <div id="low-health-vignette"></div>
+    <div id="subzone-banner"></div>
+
+    <div id="death-overlay">
+      <h2 data-i18n="hud.core.deathTitle">You have died.</h2>
+      <button class="btn" id="release-btn" data-i18n="hud.core.releaseSpirit">Release Spirit</button>
+    </div>
+  </div>
+
+  <input id="chat-input" maxlength="200" data-i18n-placeholder="hud.core.chatPlaceholder" placeholder="Say something... (/w name, /r, /p, /gu, /o, /general, /join world|lfg, /afk, /dnd)" autocomplete="off" />
+  </template>
+
+  <main id="start-screen">
+    <!-- Keep the backdrop here at the top level so it spans the entire screen behind content -->
+    <div id="start-screen-backdrop" aria-hidden="true">
+      <!-- Looping cinematic background video; poster = static key-art for instant paint + fallback. -->
+      <video id="bg-home" class="bg-trailer bg-home" autoplay loop muted playsinline preload="auto" poster="/home-bg.png" aria-hidden="true">
+        <source src="/home-bg.mp4" type="video/mp4" />
+      </video>
+      <div class="bg-trailer-scrim"></div>
+      <div class="portal-ring"></div>
+      <div class="portal-ring-reverse"></div>
+      <div class="nebula-overlay"></div>
+    </div>
+
+    <header class="homepage-header">
+      <div class="header-logo-container">
+        <button type="button" class="header-logo-btn" id="header-logo-btn" data-i18n-aria="a11y.goHome" data-i18n-title="a11y.goHome" aria-label="Go to homepage" title="Go to homepage">
+          <img class="header-logo" src="/icon-192.png" data-i18n-alt="serverUnavailable.logoAlt" alt="World of ClaudeCraft" />
+        </button>
+      </div>
+      
+      <button type="button" class="mobile-menu-toggle" id="mobile-menu-toggle" data-i18n-aria="a11y.toggleMenu" aria-label="Toggle menu" aria-expanded="false">
+        <span class="hamburger-bar"></span>
+        <span class="hamburger-bar"></span>
+        <span class="hamburger-bar"></span>
+      </button>
+      
+      <div class="header-menu-container" id="header-menu-container">
+        <nav data-i18n-aria="a11y.mainNavigation" aria-label="Main navigation" class="homepage-nav">
+          <ul class="nav-list" role="list">
+            <li class="nav-item">
+              <button type="button" class="nav-link active" id="nav-btn-play" aria-selected="true" aria-pressed="true" data-i18n="nav.play">Play</button>
+            </li>
+            <li class="nav-item">
+              <button type="button" class="nav-link" id="nav-btn-highscores" aria-selected="false" aria-pressed="false" data-i18n="nav.highscores">High Scores</button>
+            </li>
+            <li class="nav-item">
+              <button type="button" class="nav-link" id="nav-btn-wiki" aria-selected="false" aria-pressed="false" data-i18n="nav.wiki">Wiki</button>
+            </li>
+            <li class="nav-item">
+              <button type="button" class="nav-link" id="nav-btn-news" aria-selected="false" aria-pressed="false" data-i18n="nav.news">News</button>
+            </li>
+            <li class="nav-item">
+              <button type="button" class="nav-link" id="nav-btn-download" aria-selected="false" aria-pressed="false" data-i18n="nav.download">Download</button>
+            </li>
+            <li class="nav-item">
+              <button type="button" class="nav-link" id="nav-btn-login" aria-selected="false" aria-pressed="false" data-i18n="nav.loginRegister">Login/Register</button>
+            </li>
+          </ul>
+        </nav>
+
+        <div class="header-actions">
+          <button type="button" class="homepage-music-btn" id="homepage-music-toggle" data-i18n-title="hud.options.music" data-i18n-aria="hud.options.music" title="Music" aria-label="Music" aria-pressed="true" data-icon="music"></button>
+          <a class="donate-cta" href="https://github.com/sponsors/levy-street" target="_blank" rel="noopener noreferrer" data-i18n-title="a11y.donateProject" data-i18n-aria="a11y.donateProject" title="Support the project" aria-label="Donate to support World of ClaudeCraft">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+            <span data-i18n="nav.donate">Donate</span>
+          </a>
+        </div>
+      </div>
+    </header>
+
+    <div id="homepage-views-container">
+      <section id="hero-view" class="view-section" aria-hidden="false">
+        <h1 class="visually-hidden">World of ClaudeCraft</h1>
+        
+        <!-- Main Logo -->
+        <img class="main-logo" id="title-logo" src="/worldofclaudecraft-logo.png" data-i18n-alt="serverUnavailable.logoAlt" alt="World of ClaudeCraft" />
+
+        <div id="mode-select">
+          <div class="play-console">
+            <!-- Realm selector: a themed dropdown that defaults to Online and can switch to Offline.
+                 It only chooses the destination; the Play button below commits. -->
+            <div class="server-select" id="server-select" data-mode="online">
+              <button type="button" class="server-select-trigger" id="server-select-trigger"
+                aria-haspopup="listbox" aria-expanded="false" aria-controls="server-select-menu"
+                data-i18n-aria="mode.serverAria" aria-label="Select realm: Online or Offline">
+                <span class="server-dot" data-mode="online" aria-hidden="true"></span>
+                <span class="server-select-text">
+                  <span class="server-select-value" id="server-select-value" data-i18n="mode.serverOnline">Online</span>
+                  <span class="server-select-sub" id="server-select-sub">
+                    <span class="server-realm-line" data-mode="online">
+                      <b class="stats-value js-stat-accounts">…</b> <span data-i18n="stats.accountsCreated">Players</span>
+                    </span>
+                    <span class="server-sub-offline" data-mode="offline" data-i18n="mode.serverOfflineSub" hidden>Instant local world</span>
+                  </span>
+                </span>
+                <svg class="server-select-chevron" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+              </button>
+              <ul class="server-select-menu" id="server-select-menu" role="listbox" data-i18n-aria="mode.serverAria" aria-label="Select realm: Online or Offline" hidden>
+                <li class="server-select-option is-selected" id="server-opt-online" role="option" data-mode="online" tabindex="-1" aria-selected="true">
+                  <span class="server-dot" data-mode="online" aria-hidden="true"></span>
+                  <span class="server-opt-text">
+                    <span class="server-opt-name" data-i18n="mode.serverOnline">Online</span>
+                    <span class="server-opt-desc" data-i18n="mode.onlineDesc">Log in to the realm. Your characters live on the server and you share the world with everyone else who's on.</span>
+                    <span class="server-opt-stats">
+                      <b class="stats-value js-stat-accounts">…</b> <span data-i18n="stats.accountsCreated">Players</span>
+                    </span>
+                  </span>
+                  <svg class="server-opt-check" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                </li>
+                <li class="server-select-option" id="server-opt-offline" role="option" data-mode="offline" tabindex="-1" aria-selected="false">
+                  <span class="server-dot" data-mode="offline" aria-hidden="true"></span>
+                  <span class="server-opt-text">
+                    <span class="server-opt-name" data-i18n="mode.serverOffline">Offline</span>
+                    <span class="server-opt-desc" data-i18n="mode.offlineDesc">Instant single-player world in your browser. Nothing is saved: perfect for a quick brawl or testing.</span>
+                  </span>
+                  <svg class="server-opt-check" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg>
+                </li>
+              </ul>
+            </div>
+
+            <button type="button" class="btn-play" id="btn-play" data-i18n-aria="mode.playAria" aria-label="Play World of ClaudeCraft">
+              <span class="btn-play-sheen" aria-hidden="true"></span>
+              <span class="btn-play-label" data-i18n="mode.play">Play</span>
+            </button>
+          </div>
+
+          <!-- Hidden, non-focusable compatibility triggers. Stable hooks the automated
+               tours / E2E scripts use to drive the online & offline flows directly. -->
+          <button type="button" id="btn-online" class="play-compat-trigger" tabindex="-1" aria-hidden="true"></button>
+          <button type="button" id="btn-offline" class="play-compat-trigger" tabindex="-1" aria-hidden="true"></button>
+
+          <!-- Tip — part of the same play container (divider above). -->
+          <div class="play-tip">
+            <p id="performance-tip"><b data-i18n="mode.tipTitle">TIP:</b> <span data-i18n="mode.tipText">For the smoothest experience, turn off ad blocker extensions on this site. Community reports found some blockers can cause lag.</span></p>
+          </div>
+        </div>
+
+        <form id="login-panel" class="panel auth-panel auth-panel-premium" data-auth-mode="login" hidden novalidate>
+          <h2 class="auth-title" id="auth-title" data-i18n="auth.enterRealm">Enter the Realm</h2>
+          
+          <div class="auth-field">
+            <label for="login-user" class="auth-label" data-i18n="auth.username">Username</label>
+            <div id="login-user-error" class="auth-field-error" aria-live="polite" data-i18n="auth.usernameError">Please enter your username.</div>
+            <input 
+              id="login-user" 
+              name="username"
+              type="text" 
+              maxlength="24" 
+              data-i18n-placeholder="auth.usernamePlaceholder"
+              placeholder="Enter username" 
+              autocomplete="username" 
+              required 
+              aria-describedby="login-user-error"
+            />
+          </div>
+
+          <div class="auth-field">
+            <label for="login-pass" class="auth-label" data-i18n="auth.password">Password</label>
+            <div id="login-pass-error" class="auth-field-error" aria-live="polite" data-i18n="auth.passwordError">Please enter your password.</div>
+            <div class="password-wrapper">
+              <input 
+                id="login-pass" 
+                name="password"
+                type="password" 
+                maxlength="128" 
+                data-i18n-placeholder="auth.passwordPlaceholder"
+                placeholder="Enter password" 
+                autocomplete="current-password" 
+                required 
+                aria-describedby="login-pass-error"
+              />
+              <button type="button" class="password-toggle" id="btn-toggle-password" data-i18n-aria="auth.showPassword" aria-label="Show password" aria-pressed="false">
+                <svg class="eye-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                  <circle cx="12" cy="12" r="3"></circle>
+                  <line class="eye-slash" x1="2" y1="2" x2="22" y2="22" stroke="currentColor" stroke-width="2" stroke-linecap="round"></line>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Cloudflare Turnstile widget mounts here when configured (src/main.ts). -->
+          <div id="cf-turnstile-container" class="auth-turnstile"></div>
+
+          <div id="login-error" class="auth-error" aria-live="polite"></div>
+
+          <div class="auth-actions auth-actions-row">
+            <button type="button" class="btn btn-back" id="btn-login-back" data-i18n="auth.back">Back</button>
+            <button type="submit" class="btn btn-primary" id="btn-login" data-i18n="auth.logIn">Log In</button>
+          </div>
+          <p class="auth-switch">
+            <span id="auth-switch-prompt" data-i18n="auth.noAccountPrompt">New to the realm?</span>
+            <button type="button" class="auth-link" id="btn-auth-toggle" data-i18n="auth.createAccount">Create Account</button>
+          </p>
+        </form>
+
+        <div id="realm-panel" class="panel auth-panel auth-panel-premium" hidden>
+          <h2 class="auth-title"><span data-i18n="auth.realmList">Realm List</span> <span id="realm-list-user" class="cs-realm"></span></h2>
+          <div id="realm-list"><div class="realm-loading" data-i18n="auth.loadingRealms">Loading realms...</div></div>
+          <div class="auth-actions auth-actions-split">
+            <button type="button" class="btn btn-secondary" id="btn-realm-back" data-i18n="auth.back">Back</button>
+          </div>
+        </div>
+
+        <div id="charselect-panel" class="panel charselect-screen" hidden>
+          <header class="cs-head">
+            <h2 class="auth-title cs-title"><span data-i18n="auth.characters">Characters:</span> <span id="charselect-user" class="gold"></span></h2>
+            <div class="cs-head-row">
+              <div class="cs-realm-switch">
+                <button type="button" id="btn-change-realm" class="cs-realm-btn" aria-haspopup="listbox" aria-expanded="false" data-i18n-aria="auth.changeRealm" aria-label="Change Realm">
+                  <span class="cs-realm-caption" data-i18n="auth.realm">Realm</span>
+                  <span id="charselect-realm" class="cs-realm-name"></span>
+                  <svg class="cs-realm-caret" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M7 10l5 5 5-5z"/></svg>
+                </button>
+                <div id="cs-realm-menu" class="cs-realm-menu" role="listbox" data-i18n-aria="auth.realmList" aria-label="Realm List" hidden></div>
+              </div>
+              <div class="cs-wallet cs-wallet-group">
+                <span class="cs-wallet-label" data-i18n="wallet.label">$WOC Wallet</span>
+                <div class="cs-wallet-main">
+                  <div class="cs-wallet-actions">
+                    <button type="button" class="wallet-cta" id="btn-wallet" data-i18n-title="wallet.connectTitle" data-i18n-aria="wallet.connectAria" title="Verify your Solana wallet" aria-label="Verify your Solana wallet">
+                      <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h13a1 1 0 0 1 1 1v2"></path><path d="M3 7v10a2 2 0 0 0 2 2h14a1 1 0 0 0 1-1v-3"></path><path d="M21 11h-4a2 2 0 0 0 0 4h4a1 1 0 0 0 1-1v-2a1 1 0 0 0-1-1Z"></path></svg>
+                      <span id="wallet-label" data-i18n="wallet.connect">Verify Wallet</span>
+                    </button>
+                    <span class="wallet-status" id="wallet-status" aria-live="polite" hidden></span>
+                    <button type="button" class="wallet-mini" id="btn-wallet-switch" data-i18n-title="wallet.switchTitle" data-i18n-aria="wallet.switchAria" title="Verify a different wallet" aria-label="Verify a different wallet" hidden>
+                      <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14"></path><polyline points="7 23 3 19 7 15"></polyline><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
+                      <span data-i18n="wallet.switch">Switch</span>
+                    </button>
+                    <button type="button" class="wallet-mini" id="btn-wallet-unlink" data-i18n-title="wallet.unlinkTitle" data-i18n-aria="wallet.unlinkAria" title="Remove wallet verification from this account" aria-label="Remove wallet verification from this account" hidden>
+                      <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.07 0l2.12-2.12a5 5 0 0 0-7.07-7.07L11 4.93"></path><path d="M14 11a5 5 0 0 0-7.07 0L4.81 13.12a5 5 0 0 0 7.07 7.07L13 19.07"></path><path d="M3 3l18 18"></path></svg>
+                      <span data-i18n="wallet.unlink">Unlink</span>
+                    </button>
+                    <button type="button" class="wallet-mini" id="btn-wallet-signout" data-i18n-title="wallet.signOutTitle" data-i18n-aria="wallet.signOutAria" title="Disconnect the wallet app on this browser" aria-label="Disconnect the wallet app on this browser" hidden>
+                      <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>
+                      <span data-i18n="wallet.signOut">Disconnect</span>
+                    </button>
+                    <button type="button" class="wallet-mini" id="btn-wallet-hide" data-i18n-title="wallet.hideTitle" data-i18n-aria="wallet.hideAria" title="Hide wallet row on this screen" aria-label="Hide wallet row on this screen">
+                      <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3.5-6 10-6 10 6 10 6-3.5 6-10 6S2 12 2 12Z"></path><circle cx="12" cy="12" r="3"></circle><path d="M3 3l18 18"></path></svg>
+                      <span data-i18n="wallet.hide">Hide</span>
+                    </button>
+                  </div>
+                  <div class="cs-wallet-help" id="wallet-help" data-i18n="wallet.helpDisconnected">Verify a Solana wallet to enable holder flair and player-card badges. No transaction or SOL required.</div>
+                </div>
+              </div>
+              <div class="cs-wallet-hidden-note" id="wallet-hidden-note" role="status" aria-live="polite" hidden></div>
+            </div>
+          </header>
+          <div class="cs-body">
+            <!-- Left: full-height character roster -->
+            <div class="cs-list-col">
+              <ul id="char-list" role="list"></ul>
+              <div class="cs-list-actions">
+                <button type="button" class="btn btn-secondary" id="btn-charselect-back" data-i18n="auth.back">Back</button>
+                <button type="button" class="btn btn-primary cs-new-btn" id="btn-new-character" data-i18n="auth.newCharacter">New Character</button>
+              </div>
+            </div>
+            <!-- Right: selected character showcase -->
+            <div class="cs-detail-col">
+              <div class="char-preview-container cs-preview" id="online-preview-container">
+                <canvas id="char-preview-canvas"></canvas>
+              </div>
+              <div id="charselect-class-details" class="class-details-panel" aria-live="polite"></div>
+            </div>
+          </div>
+        </div>
+
+        <div id="charcreate-panel" class="panel charselect-screen" hidden>
+          <header class="cs-head">
+            <h2 class="auth-title cs-title" data-i18n="auth.createCharacter">Create a Character</h2>
+          </header>
+          <div class="cs-body cs-body-create">
+            <div class="cs-create-col">
+              <div class="char-create">
+                <div class="cs-section-header" data-i18n="auth.name">Name</div>
+                <div class="char-input-group">
+                  <input id="new-char-name" maxlength="16" data-i18n-placeholder="auth.characterNamePlaceholder" placeholder="Character Name" data-i18n-aria="auth.characterName" aria-label="Character Name" aria-describedby="charselect-error" autocomplete="off" />
+                  <div id="charselect-error" class="auth-error" aria-live="polite"></div>
+                </div>
+                <div class="cs-section-header" data-i18n="auth.class">Class</div>
+                <ul class="mini-class-row" role="list">
+                  <li class="mini-class" data-class="warrior" role="button" tabindex="0" data-i18n-aria="classes.warriorAria" data-i18n="classes.warrior" aria-label="Warrior class" aria-pressed="false">Warrior</li>
+                  <li class="mini-class" data-class="paladin" role="button" tabindex="0" data-i18n-aria="classes.paladinAria" data-i18n="classes.paladin" aria-label="Paladin class" aria-pressed="false">Paladin</li>
+                  <li class="mini-class" data-class="hunter" role="button" tabindex="0" data-i18n-aria="classes.hunterAria" data-i18n="classes.hunter" aria-label="Hunter class" aria-pressed="false">Hunter</li>
+                  <li class="mini-class" data-class="rogue" role="button" tabindex="0" data-i18n-aria="classes.rogueAria" data-i18n="classes.rogue" aria-label="Rogue class" aria-pressed="false">Rogue</li>
+                  <li class="mini-class" data-class="priest" role="button" tabindex="0" data-i18n-aria="classes.priestAria" data-i18n="classes.priest" aria-label="Priest class" aria-pressed="false">Priest</li>
+                  <li class="mini-class" data-class="shaman" role="button" tabindex="0" data-i18n-aria="classes.shamanAria" data-i18n="classes.shaman" aria-label="Shaman class" aria-pressed="false">Shaman</li>
+                  <li class="mini-class" data-class="mage" role="button" tabindex="0" data-i18n-aria="classes.mageAria" data-i18n="classes.mage" aria-label="Mage class" aria-pressed="false">Mage</li>
+                  <li class="mini-class" data-class="warlock" role="button" tabindex="0" data-i18n-aria="classes.warlockAria" data-i18n="classes.warlock" aria-label="Warlock class" aria-pressed="false">Warlock</li>
+                  <li class="mini-class" data-class="druid" role="button" tabindex="0" data-i18n-aria="classes.druidAria" data-i18n="classes.druid" aria-label="Druid class" aria-pressed="false">Druid</li>
+                </ul>
+                <div class="skin-picker">
+                  <div class="skin-picker-header" data-i18n="auth.appearance">Appearance</div>
+                  <div id="online-skin-row" class="skin-row" role="list" data-i18n-aria="auth.appearance" aria-label="Appearance"></div>
+                </div>
+                <div class="auth-actions cs-form-actions">
+                  <button class="btn btn-secondary" id="btn-charcreate-back" data-i18n="auth.back">Back</button>
+                  <button class="btn btn-primary" id="btn-create-char" data-i18n="auth.create">Create</button>
+                </div>
+              </div>
+            </div>
+            <div class="cs-detail-col">
+              <div class="char-preview-container cs-preview" id="charcreate-preview-container"></div>
+              <div id="charcreate-class-details" class="class-details-panel" aria-live="polite"></div>
+            </div>
+          </div>
+        </div>
+
+        <div id="offline-select" class="panel auth-panel auth-panel-premium" hidden>
+          <h2 class="auth-title" data-i18n="auth.offlineCharacter">Offline Character</h2>
+          <div class="charselect-layout">
+            <!-- Left Column: Character Name & Class Chips & Actions -->
+            <div class="charselect-col-left">
+              <div class="char-create">
+                <label for="char-name" class="auth-label" data-i18n="auth.characterName">Character Name</label>
+                <div class="char-input-group">
+                  <input id="char-name" maxlength="16" data-i18n-placeholder="auth.characterNamePlaceholder" placeholder="Character name" value="" aria-describedby="offline-error" autocomplete="off" />
+                  <div id="offline-error" class="auth-error" aria-live="polite"></div>
+                </div>
+                <ul class="mini-class-row" role="list">
+                  <li class="mini-class" data-class="warrior" role="button" tabindex="0" data-i18n-aria="classes.warriorAria" data-i18n="classes.warrior" aria-label="Warrior class" aria-pressed="false">Warrior</li>
+                  <li class="mini-class" data-class="paladin" role="button" tabindex="0" data-i18n-aria="classes.paladinAria" data-i18n="classes.paladin" aria-label="Paladin class" aria-pressed="false">Paladin</li>
+                  <li class="mini-class" data-class="hunter" role="button" tabindex="0" data-i18n-aria="classes.hunterAria" data-i18n="classes.hunter" aria-label="Hunter class" aria-pressed="false">Hunter</li>
+                  <li class="mini-class" data-class="rogue" role="button" tabindex="0" data-i18n-aria="classes.rogueAria" data-i18n="classes.rogue" aria-label="Rogue class" aria-pressed="false">Rogue</li>
+                  <li class="mini-class" data-class="priest" role="button" tabindex="0" data-i18n-aria="classes.priestAria" data-i18n="classes.priest" aria-label="Priest class" aria-pressed="false">Priest</li>
+                  <li class="mini-class" data-class="shaman" role="button" tabindex="0" data-i18n-aria="classes.shamanAria" data-i18n="classes.shaman" aria-label="Shaman class" aria-pressed="false">Shaman</li>
+                  <li class="mini-class" data-class="mage" role="button" tabindex="0" data-i18n-aria="classes.mageAria" data-i18n="classes.mage" aria-label="Mage class" aria-pressed="false">Mage</li>
+                  <li class="mini-class" data-class="warlock" role="button" tabindex="0" data-i18n-aria="classes.warlockAria" data-i18n="classes.warlock" aria-label="Warlock class" aria-pressed="false">Warlock</li>
+                  <li class="mini-class" data-class="druid" role="button" tabindex="0" data-i18n-aria="classes.druidAria" data-i18n="classes.druid" aria-label="Druid class" aria-pressed="false">Druid</li>
+                </ul>
+                <div id="offline-skin-row" class="skin-row" role="list" data-i18n-aria="auth.appearance" aria-label="Skin"></div>
+                <div class="auth-actions">
+                  <button type="button" class="btn btn-primary" id="btn-start-offline" data-i18n="auth.enterWorld">Enter World</button>
+                  <button type="button" class="btn btn-secondary" id="btn-offline-back" data-i18n="auth.back">Back</button>
+                </div>
+              </div>
+            </div>
+            <!-- Right Column: Detailed Class Info & Preview -->
+            <div class="charselect-col-right">
+              <div class="char-preview-container" id="offline-preview-container"></div>
+              <div id="offline-class-details" class="class-details-panel" aria-live="polite"></div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="highscores-view" class="view-section" hidden aria-hidden="true">
+        <div class="parchment-panel hs-panel">
+          <div class="skeleton-icon-wrapper">
+            <svg viewBox="0 0 24 24" class="skeleton-svg-icon" aria-hidden="true">
+              <path fill="currentColor" d="M12 2C11.5 2 6 4 6 4V10C6 14.41 9.59 18 12 18.5C14.41 18 18 14.41 18 10V4C18 4 12.5 2 12 2M12 16.5C10.32 15.5 8 12.78 8 10V5.37L12 3.91L16 5.37V10C16 12.78 13.68 15.5 12 16.5Z"/>
+            </svg>
+          </div>
+          <h2 class="skeleton-title" data-i18n="highscores.title">High Scores Leaderboard</h2>
+          <p class="skeleton-desc" data-i18n="game.leaderboard.globalSubtitle">Top champions across all realms</p>
+          <div id="hs-leaderboard" class="hs-leaderboard" aria-live="polite">
+            <div class="hs-loading" data-i18n="game.leaderboard.loading">Loading rankings…</div>
+          </div>
+        </div>
+      </section>
+
+      <section id="wiki-view" class="view-section" hidden aria-hidden="true">
+        <div class="parchment-panel skeleton-panel wiki-container-layout">
+          <div class="wiki-guide-intro">
+            <div class="skeleton-icon-wrapper">
+              <svg viewBox="0 0 24 24" class="skeleton-svg-icon" aria-hidden="true">
+                <path fill="currentColor" d="M19 2H6c-1.2 0-2 .9-2 2v16c0 1.1.9 2 2 2h13c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m-1 18H6V4h12v16zM8 6h8v2H8V6zm0 4h8v2H8v-2zm0 4h5v2H8v-2z"/>
+              </svg>
+            </div>
+            <h2 class="skeleton-title" data-i18n="wiki.title">Game Wiki & Guide</h2>
+            <p class="skeleton-desc" data-i18n="wiki.desc">Discover the secrets of the realm, class guides, and strategies.</p>
+            <a class="btn wiki-cta" href="/wiki" target="_blank" rel="noopener noreferrer" data-i18n="wiki.cta">Browse the Wiki</a>
+          </div>
+          
+          <div class="wiki-controls-guide">
+            <h3 class="controls-guide-title" data-i18n="controls.title">Controls Guide</h3>
+            <div class="controls-guide-content">
+              <div class="control-group">
+                <h4 data-i18n="controls.movement">Movement</h4>
+                <div class="control-row"><span class="key-combo"><kbd class="keycap">W</kbd><kbd class="keycap">A</kbd><kbd class="keycap">S</kbd><kbd class="keycap">D</kbd></span> <span data-i18n="controls.moveTurn">Move / Turn</span></div>
+                <div class="control-row"><span class="key-combo"><kbd class="keycap">Q</kbd><kbd class="keycap">E</kbd></span> <span data-i18n="controls.strafe">Strafe Left/Right</span></div>
+                <div class="control-row"><kbd class="keycap">Space</kbd> <span data-i18n="controls.jump">Jump</span></div>
+                <div class="control-row"><kbd class="keycap">R</kbd> <span data-i18n="controls.autorun">Toggle Autorun</span></div>
+              </div>
+              <div class="control-group">
+                <h4 data-i18n="controls.combat">Combat & Interaction</h4>
+                <div class="control-row"><kbd class="keycap">Tab</kbd> <span data-i18n="controls.target">Target Enemy</span></div>
+                <div class="control-row"><span class="key-combo"><kbd class="keycap">1</kbd>–<kbd class="keycap">9</kbd> <kbd class="keycap">0</kbd></span> <span data-i18n="controls.spells">Cast Spells</span></div>
+                <div class="control-row"><kbd class="keycap">F</kbd> <span data-i18n="controls.interact">Interact / Loot</span></div>
+                <div class="control-row"><kbd class="keycap">V</kbd> <span data-i18n="controls.nameplates">Toggle Nameplates</span></div>
+              </div>
+              <div class="control-group">
+                <h4 data-i18n="controls.camera">Camera & Mouse</h4>
+                <div class="control-row"><span data-i18n="controls.rightDrag">Right-Drag</span> <span data-i18n="controls.mouselook">Mouselook</span></div>
+                <div class="control-row"><span data-i18n="controls.leftDrag">Left-Drag</span> <span data-i18n="controls.orbit">Orbit Camera</span></div>
+                <div class="control-row"><span data-i18n="controls.mouseWheel">Mouse Wheel</span> <span data-i18n="controls.zoom">Zoom</span></div>
+              </div>
+              <div class="control-group">
+                <h4 data-i18n="controls.interfaces">Interfaces</h4>
+                <div class="control-row"><kbd class="keycap">C</kbd> <span data-i18n="controls.charPane">Character Pane</span></div>
+                <div class="control-row"><kbd class="keycap">P</kbd> <span data-i18n="controls.spellbook">Spellbook</span></div>
+                <div class="control-row"><kbd class="keycap">N</kbd> <span data-i18n="game.talents.title">Talents</span></div>
+                <div class="control-row"><kbd class="keycap">L</kbd> <span data-i18n="controls.questLog">Quest Log</span></div>
+                <div class="control-row"><kbd class="keycap">M</kbd> <span data-i18n="controls.worldMap">World Map</span></div>
+                <div class="control-row"><kbd class="keycap">B</kbd> <span data-i18n="controls.bags">Bags Inventory</span></div>
+                <div class="control-row"><kbd class="keycap">X</kbd> <span data-i18n="controls.emoteWheel">Hold Emote Wheel</span></div>
+                <div class="control-row"><kbd class="keycap">O</kbd> <span data-i18n="controls.friends">Friends & Guild</span></div>
+                <div class="control-row"><kbd class="keycap">Enter</kbd> <span data-i18n="controls.chat">Open Chat</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="news-view" class="view-section" hidden aria-hidden="true">
+        <div class="parchment-panel news-panel">
+          <div class="skeleton-icon-wrapper">
+            <svg viewBox="0 0 24 24" class="skeleton-svg-icon" aria-hidden="true">
+              <path fill="currentColor" d="M22 6c0-1.1-.9-2-2-2H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6m-2 0l-8 5l-8-5h16m0 12H4V8l8 5l8-5v10z"/>
+            </svg>
+          </div>
+          <h2 class="skeleton-title" data-i18n="news.title">News & Updates</h2>
+          <p class="skeleton-desc" data-i18n="news.desc">Read the latest patch notes, events, and community updates.</p>
+          <div id="news-feed" class="news-feed" aria-live="polite">
+            <div class="news-loading" data-i18n="news.loading">Loading the latest updates…</div>
+          </div>
+        </div>
+      </section>
+
+      <section id="download-view" class="view-section" hidden aria-hidden="true">
+        <div class="parchment-panel skeleton-panel">
+          <div class="skeleton-icon-wrapper">
+            <svg viewBox="0 0 24 24" class="skeleton-svg-icon" aria-hidden="true">
+              <path fill="currentColor" d="M5 20h14v-2H5v2m14-9h-4V3H9v8H5l7 7l7-7z"/>
+            </svg>
+          </div>
+          <h2 class="skeleton-title" data-i18n="download.title">Download Desktop Launcher</h2>
+          <p class="skeleton-desc" data-i18n="download.desc">Get the standalone launcher for optimized performance and full-screen play.</p>
+          <div class="coming-soon-badge" data-i18n="comingSoon.placeholder">Coming Soon...</div>
+        </div>
+      </section>
+    </div>
+
+    <div id="delete-character-modal" class="modal-backdrop" hidden>
+      <div class="confirm-modal panel auth-panel-premium" role="dialog" aria-modal="true" aria-labelledby="delete-character-title">
+        <h2 id="delete-character-title" data-i18n="deleteCharacter.title">Delete Character</h2>
+        <p id="delete-character-body"></p>
+        <span id="delete-character-name" hidden></span>
+        <label for="delete-character-confirm" class="auth-label" data-i18n="deleteCharacter.confirmLabel">Type the character name to confirm</label>
+        <input id="delete-character-confirm" maxlength="16" autocomplete="off" />
+        <div id="delete-character-error" class="auth-error" aria-live="polite"></div>
+        <div class="confirm-actions">
+          <button type="button" class="btn btn-secondary" id="btn-cancel-delete-character" data-i18n="deleteCharacter.cancel">Cancel</button>
+          <button type="button" class="btn btn-danger" id="btn-confirm-delete-character" disabled data-i18n="deleteCharacter.confirm">Delete Permanently</button>
+        </div>
+      </div>
+    </div>
+
+    <footer class="homepage-footer">
+      <div class="footer-bar">
+      <div class="footer-left">
+      <div class="footer-social-row">
+        <a class="social-link" href="https://github.com/levy-street/world-of-claudecraft" target="_blank" rel="noopener noreferrer" data-i18n-aria="a11y.githubProject" aria-label="Open the World of ClaudeCraft GitHub project">
+          <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span data-i18n="footer.githubLabel">Open Source Project</span>
+        </a>
+        <a class="social-link" href="https://discord.gg/GjhnUsBtw" target="_blank" rel="noopener noreferrer" data-i18n-aria="a11y.discordCommunity" aria-label="Join the World of ClaudeCraft Discord community">
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path fill="currentColor" d="M20.32 4.37A19.8 19.8 0 0 0 15.36 2.8a13.66 13.66 0 0 0-.64 1.32 18.47 18.47 0 0 0-5.45 0 13.02 13.02 0 0 0-.65-1.32 19.73 19.73 0 0 0-4.96 1.58C.53 9.03-.32 13.56.1 18.02a19.9 19.9 0 0 0 6.08 3.08c.49-.67.93-1.38 1.3-2.13-.72-.27-1.41-.6-2.06-.98.17-.13.34-.26.5-.4a14.16 14.16 0 0 0 12.16 0c.16.14.33.27.5.4-.65.39-1.34.72-2.07.99.38.74.81 1.45 1.31 2.12a19.86 19.86 0 0 0 6.08-3.08c.5-5.17-.85-9.66-3.58-13.65ZM8.02 15.28c-1.18 0-2.15-1.08-2.15-2.41 0-1.33.95-2.42 2.15-2.42 1.2 0 2.17 1.1 2.15 2.42 0 1.33-.95 2.41-2.15 2.41Zm7.96 0c-1.18 0-2.15-1.08-2.15-2.41 0-1.33.95-2.42 2.15-2.42 1.2 0 2.17 1.1 2.15 2.42 0 1.33-.95 2.41-2.15 2.41Z"/></svg>
+          <span data-i18n="footer.discordLabel">Join the Discord</span>
+        </a>
+        <a class="social-link donate" href="https://github.com/sponsors/levy-street" target="_blank" rel="noopener noreferrer" data-i18n-title="a11y.donateProject" data-i18n-aria="a11y.donateProject" title="Support the project" aria-label="Donate to support World of ClaudeCraft">
+          <svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>
+          <span data-i18n="nav.donate">Donate</span>
+        </a>
+      </div>
+      <div id="game-version">v0.10</div>
+      </div>
+      <div class="footer-lang-row">
+        <div class="language-selector">
+          <label for="lang-select" class="visually-hidden" data-i18n="a11y.languageSelection">Language selection</label>
+          <select id="lang-select" class="lang-select-dropdown">
+            <option value="en">English (US)</option>
+            <option value="es">Español (LatAm)</option>
+            <option value="es_ES">Español (España)</option>
+            <option value="fr_FR">Français (France)</option>
+            <option value="fr_CA">Français (Canada)</option>
+            <option value="en_CA">English (Canada)</option>
+            <option value="it_IT">Italiano</option>
+            <option value="de_DE">Deutsch</option>
+            <option value="zh_CN">简体中文</option>
+            <option value="zh_TW">繁體中文</option>
+            <option value="ko_KR">한국어</option>
+            <option value="ja_JP">日本語</option>
+            <option value="pt_BR">Português (Brasil)</option>
+            <option value="ru_RU">Русский</option>
+          </select>
+          <span id="lang-select-status" class="visually-hidden" role="status" aria-live="polite"></span>
+        </div>
+      </div>
+      </div>
+    </footer>
+  </main>
+
+  <div id="mobile-controls" data-i18n-aria="hud.core.mobileControls" aria-label="Mobile controls">
+    <div id="mobile-move-zone" aria-hidden="true"></div>
+    <div id="mobile-move-joystick" class="mobile-joystick" data-i18n-aria="hud.core.mobileMove" aria-label="Move">
+      <div id="mobile-move-stick" class="mobile-stick"></div>
+      <div class="mobile-joy-label" data-i18n="hud.core.mobileMove">Move</div>
+    </div>
+    <div id="mobile-camera-joystick" class="mobile-joystick" data-i18n-aria="hud.core.mobileCamera" aria-label="Camera">
+      <div id="mobile-camera-stick" class="mobile-stick"></div>
+      <div class="mobile-joy-label" data-i18n="hud.core.mobileCamera">Camera</div>
+    </div>
+    <div id="mobile-combat-controls">
+      <button class="mobile-btn" id="mobile-attack-nearest" data-i18n-title="hud.keybinds.actions.attack" data-i18n-aria="hud.keybinds.actions.attack" title="Attack" aria-label="Attack" data-icon="attack"><span class="mobile-label" data-i18n="hud.core.mobileAttack">Attack</span></button>
+      <button class="mobile-btn" id="mobile-autorun" data-i18n-title="hud.keybinds.actions.autorun" data-i18n-aria="hud.keybinds.actions.autorun" title="Toggle autorun" aria-label="Toggle autorun" data-icon="autorun"><span class="mobile-label" data-i18n="hudChrome.mobile.autorun">Autorun</span></button>
+      <button class="mobile-btn" id="mobile-jump" data-i18n-title="hud.keybinds.actions.jump" data-i18n-aria="hud.keybinds.actions.jump" title="Jump" aria-label="Jump" data-icon="jump"><span class="mobile-label" data-i18n="hudChrome.mobile.jump">Jump</span></button>
+      <button class="mobile-btn" id="mobile-target" data-i18n-title="hud.keybinds.actions.target" data-i18n-aria="hud.keybinds.actions.target" title="Target Nearest Enemy" aria-label="Target Nearest Enemy" data-icon="target"><span class="mobile-label" data-i18n="hud.core.mobileTarget">Target</span></button>
+      <button class="mobile-btn" id="mobile-interact" data-i18n-title="hud.keybinds.actions.interact" data-i18n-aria="hud.keybinds.actions.interact" title="Interact / Loot" aria-label="Interact / Loot" data-icon="interact"><span class="mobile-label" data-i18n="hud.core.mobileUse">Use</span></button>
+      <button class="mobile-btn" id="mobile-chat" data-i18n-title="hud.keybinds.actions.chat" data-i18n-aria="hud.keybinds.actions.chat" title="Open Chat" aria-label="Open Chat" data-icon="chat"><span class="mobile-label" data-i18n="hud.core.mobileChat">Chat</span></button>
+      <button class="mobile-btn" id="mobile-more" data-i18n-title="hud.core.mobileMoreAria" data-i18n-aria="hud.core.mobileMoreAria" title="Show more menus" aria-label="Show more menus" data-icon="more"><span class="mobile-label" data-i18n="hud.core.mobileMore">More</span></button>
+    </div>
+      <div id="mobile-extra-controls" class="window panel" role="dialog" aria-modal="true" aria-labelledby="mobile-more-title">
+        <div class="panel-title">
+          <span id="mobile-more-title" data-i18n="hud.core.mobileMore">More</span>
+          <button type="button" class="x-btn" id="mobile-more-close" data-i18n-title="hud.options.returnToGame" data-i18n-aria="hud.options.returnToGame" title="Return to Game" aria-label="Return to Game" data-icon="close"></button>
+        </div>
+        <div id="mobile-extra-grid">
+          <button class="mobile-btn" id="mobile-social" data-i18n-title="hud.keybinds.actions.social" data-i18n-aria="hud.keybinds.actions.social" title="Friends &amp; Guild" aria-label="Friends &amp; Guild" data-icon="social"><span class="mobile-label" data-i18n="hud.core.mobileSocial">Social</span></button>
+          <button class="mobile-btn" id="mobile-emote" data-i18n-title="hudChrome.emoteWheel.label" data-i18n-aria="hudChrome.emoteWheel.label" title="Emotes" aria-label="Emotes" data-icon="emote"><span class="mobile-label" data-i18n="hudChrome.emoteWheel.label">Emotes</span></button>
+          <button class="mobile-btn" id="mobile-arena" data-i18n-title="hud.keybinds.actions.arena" data-i18n-aria="hud.keybinds.actions.arena" title="Arena (Ashen Coliseum)" aria-label="Arena (Ashen Coliseum)" data-icon="arena"><span class="mobile-label" data-i18n="hud.core.mobileArena">Arena</span></button>
+          <button class="mobile-btn" id="mobile-menu" data-i18n-title="hud.options.gameMenu" data-i18n-aria="hud.options.gameMenu" title="Game Menu" aria-label="Game Menu" data-icon="menu"><span class="mobile-label" data-i18n="hud.core.mobileMenu">Menu</span></button>
+          <button class="mobile-btn" id="mobile-quest" data-i18n-title="questUi.log.title" data-i18n-aria="questUi.log.title" title="Quest Log" aria-label="Quest Log" data-icon="questlog"><span class="mobile-label" data-i18n="questUi.log.title">Quests</span></button>
+          <button class="mobile-btn" id="mobile-char" data-i18n-title="hud.keybinds.actions.char" data-i18n-aria="hud.keybinds.actions.char" title="Character" aria-label="Character" data-icon="character"><span class="mobile-label" data-i18n="hud.keybinds.actions.char">Character</span></button>
+          <button class="mobile-btn" id="mobile-bags" data-i18n-title="hud.keybinds.actions.bags" data-i18n-aria="hud.keybinds.actions.bags" title="Bags" aria-label="Bags" data-icon="bags"><span class="mobile-label" data-i18n="hud.keybinds.actions.bags">Bags</span></button>
+          <button class="mobile-btn" id="mobile-spellbook" data-i18n-title="abilityUi.spellbook.title" data-i18n-aria="abilityUi.spellbook.title" title="Spellbook" aria-label="Spellbook" data-icon="spellbook"><span class="mobile-label" data-i18n="abilityUi.spellbook.title">Spellbook</span></button>
+          <button class="mobile-btn" id="mobile-talents" data-i18n-title="game.talents.title" data-i18n-aria="game.talents.title" title="Talents" aria-label="Talents" data-icon="talents"><span class="mobile-label" data-i18n="game.talents.title">Talents</span></button>
+          <button class="mobile-btn" id="mobile-map" data-i18n-title="hud.keybinds.actions.map" data-i18n-aria="hud.keybinds.actions.map" title="World Map" aria-label="World Map" data-icon="map"><span class="mobile-label" data-i18n="hud.core.mobileMap">Map</span></button>
+          <button class="mobile-btn" id="mobile-leaderboard" data-i18n-title="game.leaderboard.title" data-i18n-aria="game.leaderboard.title" title="Leaderboard" aria-label="Leaderboard" data-icon="leaderboard"><span class="mobile-label" data-i18n="hudChrome.mobile.leaderboard">Ranks</span></button>
+          <button class="mobile-btn active" id="mobile-nameplates" data-i18n-title="hud.keybinds.actions.nameplates" data-i18n-aria="hud.keybinds.actions.nameplates" title="Toggle nameplates" aria-label="Toggle nameplates" data-icon="nameplates"><span class="mobile-label" data-i18n="hudChrome.mobile.nameplates">Names</span></button>
+          <button class="mobile-btn" id="mobile-music" data-i18n-title="hud.options.music" data-i18n-aria="hud.options.music" title="Music" aria-label="Toggle music" data-icon="music"><span class="mobile-label" data-i18n="hud.options.music">Music</span></button>
+          <button class="mobile-btn" id="mobile-haptics" data-i18n-title="hudChrome.mobile.toggleHaptics" data-i18n-aria="hudChrome.mobile.toggleHaptics" title="Toggle haptic feedback" aria-label="Toggle haptic feedback" aria-pressed="true" data-icon="vibrate"><span class="mobile-label" data-i18n="hudChrome.mobile.haptics">Haptics</span></button>
+        </div>
+      </div>
+  </div>
+  <div id="mobile-preflight" role="dialog" aria-modal="true" aria-labelledby="mobile-preflight-title">
+    <div class="preflight-panel">
+      <h2 id="mobile-preflight-title" data-i18n="mobilePreflight.title">Play in Landscape Fullscreen</h2>
+      <p id="mobile-preflight-detail"></p>
+      <ol id="mobile-preflight-steps"></ol>
+      <button class="btn" id="mobile-preflight-continue" data-i18n="mobilePreflight.continue">Continue to Game</button>
+    </div>
+  </div>
+  <div id="rotate-device">
+    <div>
+      <div class="rotate-icon">↻</div>
+      <div class="rotate-title" data-i18n="mobilePreflight.rotateTitle">Rotate to Landscape</div>
+      <div class="rotate-sub" data-i18n="mobilePreflight.rotateSub">Play in landscape fullscreen for the best mobile experience.</div>
+    </div>
+  </div>
+
+  <div id="loading-screen">
+    <img class="ls-logo" src="/worldofclaudecraft-logo.png" data-i18n-alt="serverUnavailable.logoAlt" alt="World of ClaudeCraft" />
+    <div class="ls-progress">
+      <div class="ls-bar"><div id="ls-fill"></div></div>
+      <div id="ls-status" data-i18n="loading.enteringWorld">Entering the world...</div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/main.ts"></script>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -10,4 +10,9 @@
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
+  <url>
+    <loc>https://worldofclaudecraft.com/play</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>

--- a/server/main.ts
+++ b/server/main.ts
@@ -39,9 +39,16 @@ import { recordUsageCacheEvent, recordUsageMetric, setUsageCacheSize } from './p
 const PORT = Number(process.env.PORT ?? 8787);
 const STATIC_DIR = path.join(__dirname, '..', 'dist');
 const WIKI_URL = process.env.WIKI_URL ?? 'http://localhost:8080/wiki/index.php/Main_Page';
-// Pretty URLs that all serve the standalone "official channels" / link-tree page.
-const LINKS_ALIASES = new Set([
-  '/links', '/links/', '/social', '/social/', '/social-media-links', '/social-media-links/',
+// Pretty URLs that serve standalone static HTML pages.
+const STATIC_PAGE_ALIASES = new Map([
+  ['/links', '/links.html'],
+  ['/links/', '/links.html'],
+  ['/social', '/links.html'],
+  ['/social/', '/links.html'],
+  ['/social-media-links', '/links.html'],
+  ['/social-media-links/', '/links.html'],
+  ['/play', '/play.html'],
+  ['/play/', '/play.html'],
 ]);
 // How long chat logs are kept (0 = forever); pruned at boot and daily.
 const CHAT_LOG_RETENTION_DAYS = Number(process.env.CHAT_LOG_RETENTION_DAYS ?? 90);
@@ -255,8 +262,8 @@ function serveStatic(req: http.IncomingMessage, res: http.ServerResponse): void 
     res.end();
     return;
   }
-  // Pretty-URL aliases for the standalone official-channels page (public/ -> dist/links.html).
-  if (LINKS_ALIASES.has(urlPath)) urlPath = '/links.html';
+  // Pretty-URL aliases for standalone static pages.
+  urlPath = STATIC_PAGE_ALIASES.get(urlPath) ?? urlPath;
   if (urlPath === '/' || urlPath === '/admin' || urlPath === '/admin/') urlPath = `/${shell}`;
   // normalize once and reuse for BOTH file resolution and cache policy —
   // otherwise /assets/../x would serve a mutable file with immutable caching

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const playHtml = readFileSync(new URL('../play.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const mainTs = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const hudTs = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const mobileControlsTs = readFileSync(new URL('../src/game/mobile_controls.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
@@ -50,6 +51,10 @@ describe('client HTML shell', () => {
     expect(robotsTxt).toContain('Sitemap: https://worldofclaudecraft.com/sitemap.xml');
     expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/</loc>');
     expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/links</loc>');
+    expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/play</loc>');
+    expect(playHtml).toContain('<link rel="canonical" href="https://worldofclaudecraft.com/play" />');
+    expect(playHtml).toContain('<meta property="og:url" content="https://worldofclaudecraft.com/play" />');
+    expect(playHtml).toContain('"url": "https://worldofclaudecraft.com/play"');
   });
 
   it('loads Meta Pixel outside local development and tracks level 5', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,22 +50,29 @@ const appBuildId = env([
   'CF_PAGES_COMMIT_SHA',
 ]) ?? gitSha() ?? appBuildDate.replace(/[-:TZ.]/g, '').slice(0, 12);
 
-// Pretty-URL aliases for the standalone official-channels page (public/links.html).
-// Mirrors the production server's rewrite in server/main.ts (LINKS_ALIASES) so the
-// same /links, /social, /social-media-links paths resolve in dev and preview too.
-const LINKS_ALIASES = new Set([
-  '/links', '/links/', '/social', '/social/', '/social-media-links', '/social-media-links/',
+// Pretty-URL aliases for standalone static HTML pages. Mirrors the production
+// server rewrite in server/main.ts so these paths resolve in dev and preview too.
+const STATIC_PAGE_ALIASES = new Map([
+  ['/links', '/links.html'],
+  ['/links/', '/links.html'],
+  ['/social', '/links.html'],
+  ['/social/', '/links.html'],
+  ['/social-media-links', '/links.html'],
+  ['/social-media-links/', '/links.html'],
+  ['/play', '/play.html'],
+  ['/play/', '/play.html'],
 ]);
-function linksAliasPlugin() {
+function staticPageAliasPlugin() {
   const rewrite = (req: { url?: string }) => {
     const url = req.url ?? '';
     const pathOnly = url.split('?')[0];
-    if (LINKS_ALIASES.has(pathOnly)) req.url = '/links.html' + url.slice(pathOnly.length);
+    const target = STATIC_PAGE_ALIASES.get(pathOnly);
+    if (target) req.url = target + url.slice(pathOnly.length);
   };
   const attach = (server: { middlewares: { use: (fn: (req: { url?: string }, res: unknown, next: () => void) => void) => void } }) => {
     server.middlewares.use((req, _res, next) => { rewrite(req); next(); });
   };
-  return { name: 'woc-links-alias', configureServer: attach, configurePreviewServer: attach };
+  return { name: 'woc-static-page-alias', configureServer: attach, configurePreviewServer: attach };
 }
 
 // Phase 4 (i18n Lazy Locales): after the production build, resolve each lazy locale
@@ -96,7 +103,7 @@ function i18nModulepreloadPlugin() {
 
 export default defineConfig({
   base: '/',
-  plugins: [linksAliasPlugin(), i18nModulepreloadPlugin()],
+  plugins: [staticPageAliasPlugin(), i18nModulepreloadPlugin()],
   resolve: { alias: { '#bot-detector': botDetectorImpl } },
   define: {
     __APP_VERSION__: JSON.stringify(appVersion),
@@ -133,6 +140,7 @@ export default defineConfig({
       input: {
         main: fileURLToPath(new URL('index.html', import.meta.url)),
         admin: fileURLToPath(new URL('admin.html', import.meta.url)),
+        play: fileURLToPath(new URL('play.html', import.meta.url)),
       },
     },
   },


### PR DESCRIPTION
## Summary

Adds the new standalone `/play` landing page route.

- Adds `play.html` as a Vite build entry so production emits `dist/play.html`.
- Routes `/play` and `/play/` to `play.html` in Vite dev/preview and the production static server.
- Adds `https://worldofclaudecraft.com/play` to the sitemap.
- Aligns the play page canonical, hreflang, Open Graph, and JSON-LD URL metadata with `/play`.
- Adds client shell regression coverage for the new sitemap entry and play page SEO metadata.

## Related issues

N/A.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [x] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/client_shell.test.ts`
  - `npm run build:server`
  - `npm run build`

## Screenshots / recordings

N/A. Static route and SEO metadata wiring only.

---

## Checklist

### Quality

- [x] **Tests pass.** Focused client shell test passed.
- [ ] **Typecheck passes.** Not run; this change only wires static HTML route metadata and sitemap coverage.
- [x] **Builds succeed.** `npm run build:server` and `npm run build` passed.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Not manually exercised in browser; route wiring is covered by build output and shell regression checks.
- [x] **Accessible.** No interactive behavior was changed by the route wiring.

### Localization (i18n)

- [x] **N/A. This PR adds no new app `t()` keys.** `play.html` is a provided standalone page and this PR only changes its route metadata.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`.
