### PR TITLE
fix(content): spread Brightwood Glade mobs and clear Ranger Elwyn's post

### DIFF
--- a/scripts/brightwood_density_metric.mjs
+++ b/scripts/brightwood_density_metric.mjs
@@ -1,0 +1,63 @@
+// Quantifies how spread-out the Brightwood Glade wildlife is, plus how much
+// breathing room Ranger Elwyn has from the nearest mob. Bundles src/sim with
+// esbuild (no browser/server needed) and reads real spawned positions from a
+// fixed-seed Sim. Run on two git states to get a before/after comparison:
+//
+//   node scripts/brightwood_density_metric.mjs
+//
+import { build } from 'esbuild';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const out = join(mkdtempSync(join(tmpdir(), 'bw-')), 'sim.mjs');
+await build({
+  stdin: {
+    contents: `export { Sim } from './src/sim/sim.ts';\nexport { NPCS } from './src/sim/data.ts';`,
+    resolveDir: process.cwd(), sourcefile: 'entry.ts', loader: 'ts',
+  },
+  bundle: true, format: 'esm', platform: 'node', outfile: out,
+});
+
+const { Sim, NPCS } = await import(out);
+
+// The 11 Brightwood Glade species (the "huge area of mobs north of spawn").
+const GLADE = new Set([
+  'brightwood_hare', 'glade_fox', 'spotted_fawn', 'meadow_crane',
+  'thornpelt_badger', 'dawnmane_doe', 'bramble_lynx', 'brightwood_stag',
+  'grovetusk_boar', 'sunhide_bear', 'brightwood_monarch',
+]);
+
+const sim = new Sim({ seed: 1337, playerClass: 'warrior' });
+const mobs = [...sim.entities.values()].filter(
+  (e) => e.kind === 'mob' && GLADE.has(e.templateId),
+);
+
+const dist = (a, b) => Math.hypot(a.pos.x - b.pos.x, a.pos.z - b.pos.z);
+
+// Nearest-neighbour distance for every glade mob.
+const nn = mobs.map((m) => {
+  let best = Infinity;
+  for (const o of mobs) if (o !== m) best = Math.min(best, dist(m, o));
+  return best;
+});
+nn.sort((a, b) => a - b);
+const mean = nn.reduce((s, v) => s + v, 0) / nn.length;
+const median = nn[Math.floor(nn.length / 2)];
+
+// Bounding box / footprint of the cluster.
+const xs = mobs.map((m) => m.pos.x), zs = mobs.map((m) => m.pos.z);
+const span = (arr) => Math.max(...arr) - Math.min(...arr);
+
+// Ranger Elwyn's clearance: distance from his post to the nearest glade mob.
+const elwyn = NPCS.ranger_elwyn.pos;
+const elwynClear = Math.min(
+  ...mobs.map((m) => Math.hypot(m.pos.x - elwyn.x, m.pos.z - elwyn.z)),
+);
+
+console.log(`Brightwood Glade: ${mobs.length} mobs (seed 1337)`);
+console.log(`  footprint        : ${span(xs).toFixed(0)} x  by  ${span(zs).toFixed(0)} z`);
+console.log(`  nearest-neighbour: mean ${mean.toFixed(2)}y, median ${median.toFixed(2)}y, min ${nn[0].toFixed(2)}y`);
+console.log(`  mobs within 6y of another: ${nn.filter((d) => d < 6).length} / ${nn.length}`);
+console.log(`Ranger Elwyn @ (${elwyn.x}, ${elwyn.z})`);
+console.log(`  clearance to nearest glade mob: ${elwynClear.toFixed(2)}y`);

--- a/scripts/brightwood_spread_shot.mjs
+++ b/scripts/brightwood_spread_shot.mjs
@@ -1,0 +1,58 @@
+// Screenshot evidence for the Brightwood Glade re-spacing (zone1.ts camps + the
+// Ranger Elwyn post). Boots an offline god-moded hunter, lifts the camera high
+// for a wide framing, and captures: (1) the spread-out glade from the south,
+// (2) Ranger Elwyn standing in his cleared buffer ahead of the treeline.
+//
+// Needs `npm run dev` on :5173 (override with GAME_URL). Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,1200', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 1200 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Gladewatch'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await page.click('#offline-select .mini-class[data-class="hunter"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.sim?.player, { timeout: 30000 });
+await sleep(1500);
+
+const place = (x, z, pitch, dist) => page.evaluate((args) => {
+  const g = window.__game;
+  const p = g.sim.player;
+  g.sim.setPlayerLevel(10, p.id);
+  p.gm = true; p.maxHp = 99999; p.hp = 99999; p.maxMp = 99999; p.mp = 99999;
+  p.pos.x = args.x; p.pos.z = args.z; p.prevPos = { ...p.pos };
+  g.input.camYaw = 0; g.input.camPitch = args.pitch;
+  if (g.input.camDist !== undefined) g.input.camDist = args.dist;
+}, { x, z, pitch, dist });
+
+// 1) Stand at the south frontier and look north across the whole spread glade.
+await place(30, 110, 0.62, 60);
+await sleep(2500);
+await page.screenshot({ path: 'tmp/brightwood_spread.png' });
+
+// 2) Ranger Elwyn in his cleared buffer (he sits at x=35, z=105). Drop in just
+//    south of him and look north so both the warden and the open ground read.
+await place(35, 92, 0.40, 26);
+await sleep(2500);
+await page.screenshot({ path: 'tmp/ranger_elwyn_clearing.png' });
+
+await browser.close();
+console.log('wrote tmp/brightwood_spread.png and tmp/ranger_elwyn_clearing.png');

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -531,8 +531,9 @@ export const ZONE1_NPCS: Record<string, NpcDef> = {
   },
   ranger_elwyn: {
     id: 'ranger_elwyn', name: 'Ranger Elwyn', title: 'Glade Warden',
-    // posted at the south edge of Brightwood Glade, watching the treeline
-    pos: { x: 35, z: 118 }, facing: 0, color: 0x3a7d44,
+    // posted in the open treeline south of Brightwood Glade, a clear buffer
+    // ahead of the nearest wildlife camp so adventurers can parley in peace
+    pos: { x: 35, z: 105 }, facing: 0, color: 0x3a7d44,
     questIds: ['q_brightwood_thinning', 'q_brightwood_monarch'],
     greeting: 'Quiet, $C — the glade is calm today, and I mean to keep it that way.',
   },
@@ -912,18 +913,23 @@ export const ZONE1_CAMPS: CampDef[] = [
   // Undead: ruins northeast
   { mobId: 'restless_bones', center: { x: 80, z: 78 }, radius: 18, count: 8 },
   { mobId: 'captain_verlan', center: { x: 92, z: 90 }, radius: 4, count: 1 },
-  // Brightwood Glade: wildlife grove in the far north
-  { mobId: 'brightwood_hare', center: { x: 20, z: 132 }, radius: 22, count: 6 },
-  { mobId: 'glade_fox', center: { x: 48, z: 128 }, radius: 20, count: 5 },
-  { mobId: 'spotted_fawn', center: { x: 30, z: 145 }, radius: 18, count: 5 },
-  { mobId: 'meadow_crane', center: { x: 8, z: 150 }, radius: 16, count: 4 },
-  { mobId: 'thornpelt_badger', center: { x: 58, z: 150 }, radius: 16, count: 4 },
-  { mobId: 'dawnmane_doe', center: { x: 32, z: 138 }, radius: 20, count: 5 },
-  { mobId: 'bramble_lynx', center: { x: 60, z: 132 }, radius: 18, count: 6 },
-  { mobId: 'brightwood_stag', center: { x: 24, z: 156 }, radius: 16, count: 4 },
-  { mobId: 'grovetusk_boar', center: { x: 52, z: 162 }, radius: 14, count: 4 },
-  { mobId: 'sunhide_bear', center: { x: 36, z: 166 }, radius: 12, count: 3 },
-  { mobId: 'brightwood_monarch', center: { x: 38, z: 170 }, radius: 4, count: 1 },
+  // Brightwood Glade: wildlife grove in the far north. The camps fan out across
+  // the whole grove rather than piling on top of one another, so each species
+  // keeps its own pocket of meadow and quests here can actually be picked apart.
+  // Counts are unchanged (the RNG draw order is load-bearing for determinism);
+  // only the disc centres/radii spread, and every disc stays z+radius <= 178
+  // (the zone's north boundary sits at z=180).
+  { mobId: 'brightwood_hare', center: { x: -8, z: 126 }, radius: 22, count: 6 },
+  { mobId: 'glade_fox', center: { x: 50, z: 124 }, radius: 18, count: 5 },
+  { mobId: 'spotted_fawn', center: { x: 18, z: 150 }, radius: 16, count: 5 },
+  { mobId: 'meadow_crane', center: { x: -18, z: 142 }, radius: 16, count: 4 },
+  { mobId: 'thornpelt_badger', center: { x: 64, z: 156 }, radius: 16, count: 4 },
+  { mobId: 'dawnmane_doe', center: { x: 28, z: 136 }, radius: 18, count: 5 },
+  { mobId: 'bramble_lynx', center: { x: 78, z: 140 }, radius: 18, count: 6 },
+  { mobId: 'brightwood_stag', center: { x: 2, z: 162 }, radius: 16, count: 4 },
+  { mobId: 'grovetusk_boar', center: { x: 50, z: 164 }, radius: 14, count: 4 },
+  { mobId: 'sunhide_bear', center: { x: 28, z: 166 }, radius: 12, count: 3 },
+  { mobId: 'brightwood_monarch', center: { x: 42, z: 172 }, radius: 4, count: 1 },
 ];
 
 // Spawned LAST in the merged CAMPS array (see data.ts) so these appended draws


### PR DESCRIPTION
## Problem

North of the spawn point, the **Brightwood Glade** wildlife grove crammed all 11 camps into a roughly 64yd-wide box. Their spawn discs (radii 12 to 22yd) overlapped so heavily that the area read as one wall of beasts, and the two Brightwood quests (`q_brightwood_thinning`, `q_brightwood_monarch`) were hard to pick apart in the crush.

Worse, the questgiver **Ranger Elwyn** stood at `(35, 118)`, only **4.7yd** from the nearest mob, so handing out quests "made no sense" with the swarm right on top of him (per the report, "moving them a tad will help, lol").

## Fix

Pure content data change in `src/sim/content/zone1.ts`:

- **Fan the 11 glade camps out across the whole grove** (footprint widens from 64 to 110yd on the x axis), giving each species its own pocket of meadow.
- **Move Ranger Elwyn south to `(35, 105)`**, into a cleared buffer about 20yd ahead of the nearest camp, where he can actually watch the treeline.

**Determinism preserved:** mob `count`s and camp ordering are untouched, so the RNG draw order at world construction is identical and no other zone's deterministic spawns shift. Only the glade's own positions move. Every disc stays `z + radius <= 178` (the zone's north boundary is `z = 180`). No player strings change, so there is no i18n surface.

## Evidence

Measured headlessly on seed 1337 with the added `scripts/brightwood_density_metric.mjs`:

| metric | before | after |
|---|---|---|
| cluster footprint (x) | 64yd | **110yd** |
| nearest-neighbour median | 4.53yd | **6.68yd** |
| mobs crowded (within 6yd of another) | 36/47 | **21/47** |
| Ranger Elwyn clearance to nearest mob | 4.71yd | **19.97yd** |

The glade, fanned out across the meadow instead of a single pile:

![spread glade](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-brightwood-spread/brightwood_spread.png)

Ranger Elwyn in his cleared buffer, wildlife pushed back to the treeline:

![ranger elwyn clearing](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-brightwood-spread/ranger_elwyn_clearing.png)

## Testing

- `npx tsc --noEmit` clean
- `npx vitest run tests/fixes.test.ts tests/progression.test.ts tests/sim.test.ts` all pass (163)
- New `scripts/brightwood_density_metric.mjs` (headless spacing metric) and `scripts/brightwood_spread_shot.mjs` (wide screenshot harness)

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)