### PR TITLE
fix(ui): reposition chat input above the chat box, autosize, block password managers

### DIFF
--- a/index.html
+++ b/index.html
@@ -4270,9 +4270,16 @@
   .realm-meta { display: contents; }
 
   /* ---------- chat ---------- */
-  #chat-input { position: absolute; left: 12px; bottom: 204px; width: 370px; display: none; z-index: 25;
+  /* The bar is anchored by its BOTTOM edge and JS re-anchors it just above the
+     chat box on focus (see anchorChatInput in src/main.ts); the 220px default
+     clears the tab strip + 184px frame before the first measurement lands. As a
+     textarea it grows upward (away from the chat log) up to max-height, then
+     scrolls. */
+  #chat-input { position: absolute; left: 12px; bottom: 220px; width: 370px; display: none; z-index: 25;
     background: #0d0d14ee; color: #e8e8e8; border: 2px solid var(--border); outline: 1px solid #000;
-    border-radius: 4px; padding: 7px 10px; font-size: 13px; user-select: text; }
+    border-radius: 4px; padding: 7px 10px; font-size: 13px; line-height: 1.35;
+    font-family: inherit; user-select: text; box-sizing: border-box; resize: none;
+    overflow-y: hidden; max-height: 110px; white-space: pre-wrap; word-break: break-word; }
 
   /* ---------- party frames ---------- */
   #party-frames { position: absolute; left: 12px; top: 12px; display: flex; flex-direction: column; gap: 6px; z-index: 5; }
@@ -7486,7 +7493,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" data-i18n-placeholder="hud.core.chatPlaceholder" placeholder="Say something... (/w name, /r, /p, /gu, /o, /general, /join world|lfg, /afk, /dnd)" autocomplete="off" />
+  <textarea id="chat-input" rows="1" maxlength="255" data-i18n-placeholder="hud.core.chatPlaceholder" placeholder="Say something... (/w name, /r, /p, /gu, /o, /general, /join world|lfg, /afk, /dnd)" autocomplete="off" autocapitalize="sentences" autocorrect="off" spellcheck="false" data-1p-ignore data-lpignore="true" data-bwignore data-form-type="other"></textarea>
   </template>
 
   <main id="start-screen">

--- a/play.html
+++ b/play.html
@@ -4071,9 +4071,11 @@
   .realm-meta { display: contents; }
 
   /* ---------- chat ---------- */
-  #chat-input { position: absolute; left: 12px; bottom: 204px; width: 370px; display: none; z-index: 25;
+  #chat-input { position: absolute; left: 12px; bottom: 220px; width: 370px; display: none; z-index: 25;
     background: #0d0d14ee; color: #e8e8e8; border: 2px solid var(--border); outline: 1px solid #000;
-    border-radius: 4px; padding: 7px 10px; font-size: 13px; user-select: text; }
+    border-radius: 4px; padding: 7px 10px; font-size: 13px; line-height: 1.35;
+    font-family: inherit; user-select: text; box-sizing: border-box; resize: none;
+    overflow-y: hidden; max-height: 110px; white-space: pre-wrap; word-break: break-word; }
 
   /* ---------- party frames ---------- */
   #party-frames { position: absolute; left: 12px; top: 12px; display: flex; flex-direction: column; gap: 6px; z-index: 5; }
@@ -7204,7 +7206,7 @@
     </div>
   </div>
 
-  <input id="chat-input" maxlength="200" data-i18n-placeholder="hud.core.chatPlaceholder" placeholder="Say something... (/w name, /r, /p, /gu, /o, /general, /join world|lfg, /afk, /dnd)" autocomplete="off" />
+  <textarea id="chat-input" rows="1" maxlength="255" data-i18n-placeholder="hud.core.chatPlaceholder" placeholder="Say something... (/w name, /r, /p, /gu, /o, /general, /join world|lfg, /afk, /dnd)" autocomplete="off" autocapitalize="sentences" autocorrect="off" spellcheck="false" data-1p-ignore data-lpignore="true" data-bwignore data-form-type="other"></textarea>
   </template>
 
   <main id="start-screen">

--- a/scripts/chat_input_reposition_shot.mjs
+++ b/scripts/chat_input_reposition_shot.mjs
@@ -1,0 +1,91 @@
+// Visual capture for the chat-input reposition + autosize fix.
+// Boots offline, opens the chat bar, and screenshots the bottom-left corner so
+// the chat input is shown relative to the chat box (tabs + log frame).
+//   01-empty   : freshly opened, single line, sitting ABOVE the tab strip
+//   02-long    : a long message wrapped onto several lines, grown upward
+// Saves to docs/pr-assets/chat-input-reposition/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const LABEL = process.env.SHOT_LABEL ?? 'after';
+const OUT = 'docs/pr-assets/chat-input-reposition';
+fs.mkdirSync(OUT, { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const CLIP = { x: 0, y: 560, width: 460, height: 340 };
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+// #btn-offline is a hidden E2E compat trigger; drive the flow via JS clicks so
+// off-screen / aria-hidden elements still fire their handlers.
+await page.evaluate(() => document.getElementById('btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Scribe');
+await page.evaluate(() => {
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]').click();
+  document.getElementById('btn-start-offline').click();
+});
+await page.waitForFunction(() => window.__game && window.__game.hud, { timeout: 30000 });
+await sleep(800);
+
+// Seed a few chat lines so the box has visible content behind the input.
+await page.evaluate(() => {
+  const hud = window.__game.hud;
+  hud.log('Welcome to Eastbrook Vale.', '#ffd100');
+  hud.log('You gain 12 experience.', '#7fd4ff');
+  hud.log('Aleph: pulling on 3, stack behind me.', '#f0ead8');
+  hud.log('Loot: [Webwood Silk] x2.', '#ffc864');
+});
+
+// Open the chat bar (the same path the Enter keybind uses).
+const openChat = async () => {
+  await page.evaluate(() => {
+    const el = document.getElementById('chat-input');
+    el.style.display = 'block';
+    el.dispatchEvent(new Event('focus'));
+    el.focus();
+  });
+  await sleep(250);
+};
+
+await openChat();
+await page.evaluate(() => {
+  const el = document.getElementById('chat-input');
+  el.value = '';
+  el.dispatchEvent(new Event('input'));
+});
+await sleep(200);
+await page.screenshot({ path: `${OUT}/01-empty-${LABEL}.png`, clip: CLIP });
+
+// Type a long message to exercise the upward autosize growth.
+await page.evaluate(() => {
+  const el = document.getElementById('chat-input');
+  el.value = 'Looking for a healer and a tank for Shadowfen Hollow, we have three DPS ready and saved to the heroic lockout, ping me here or whisper.';
+  el.dispatchEvent(new Event('input'));
+});
+await sleep(250);
+await page.screenshot({ path: `${OUT}/02-long-${LABEL}.png`, clip: CLIP });
+
+// Report measured geometry so the fix is provable, not just visual.
+const geom = await page.evaluate(() => {
+  const input = document.getElementById('chat-input').getBoundingClientRect();
+  const wrap = document.getElementById('chatlog-wrap').getBoundingClientRect();
+  return {
+    inputBottom: Math.round(input.bottom), inputTop: Math.round(input.top),
+    inputHeight: Math.round(input.height), boxTop: Math.round(wrap.top),
+    overlap: Math.round(input.bottom - wrap.top),
+  };
+});
+console.log(`[${LABEL}] geometry:`, JSON.stringify(geom));
+console.log(`[${LABEL}] input.bottom=${geom.inputBottom} box.top=${geom.boxTop} -> overlap=${geom.overlap}px (<=0 means clear)`);
+console.log('screenshots written to', OUT);
+await browser.close();

--- a/server/game.ts
+++ b/server/game.ts
@@ -1,5 +1,5 @@
 import type { WebSocket } from 'ws';
-import { Sim } from '../src/sim/sim';
+import { Sim, MAX_CHAT_MESSAGE_LEN } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, SimEvent, dist2d, emptyMoveInput } from '../src/sim/types';
 import { parseMoveInputFrame } from '../src/sim/move_input';
@@ -1249,7 +1249,7 @@ export class GameServer {
             if (sent) {
               this.chatLog.log({
                 accountId: session.accountId, characterId: session.characterId,
-                characterName: session.name, channel, message: body.trim().slice(0, 200),
+                characterName: session.name, channel, message: body.trim().slice(0, MAX_CHAT_MESSAGE_LEN),
               });
             }
           }).catch((err) => console.error(`${channel} chat failed:`, err));
@@ -1741,7 +1741,7 @@ export class GameServer {
             if (sent) {
               this.chatLog.log({
                 accountId: session.accountId, characterId: session.characterId,
-                characterName: session.name, channel, message: body.trim().slice(0, 200),
+                characterName: session.name, channel, message: body.trim().slice(0, MAX_CHAT_MESSAGE_LEN),
               });
             }
           }).catch((err) => console.error(`${channel} chat failed:`, err));

--- a/src/game/mobile_controls.ts
+++ b/src/game/mobile_controls.ts
@@ -435,10 +435,13 @@ export class MobileControls {
     if (document.body.classList.contains('mobile-chat-open')) {
       this.callbacks.onChat();
     } else {
-      const input = document.getElementById('chat-input') as HTMLInputElement | null;
+      const input = document.getElementById('chat-input') as HTMLTextAreaElement | null;
       if (input) {
         input.value = '';
         input.style.display = 'none';
+        // clear the autosized height so the next open starts at one line
+        input.style.height = '';
+        input.style.overflowY = '';
         input.blur();
       }
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -668,7 +668,7 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   });
   chatInput.addEventListener('keydown', (e) => {
     e.stopPropagation();
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && !e.isComposing) {
       // single-message semantics (like classic chat): Enter always sends,
       // never inserts a newline into the textarea.
       e.preventDefault();

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,7 @@ import { DT, INTERACT_RANGE, MELEE_RANGE, PlayerClass, RUN_SPEED, dist2d } from 
 import { togglePasswordVisibility, syncInputAriaState, validateForm, handleKeyboardActivation, validateCharacterName } from './ui/auth_utils';
 import { CLASSES, ABILITIES } from './sim/content/classes';
 import { CLASS_DETAILS, SIGNATURE_ABILITIES } from './ui/class_details_data';
+import { chatInputSize } from './ui/chat_input_autosize';
 import { iconDataUrl } from './ui/icons';
 import { ensureLocaleLoaded, formatDateTime, formatNumber, getLanguage, isLocaleResident, isSupportedLanguage, languageTag, setLanguage, t, tPlural, type SupportedLanguage, type TranslationKey } from './ui/i18n';
 import { tServer } from './ui/server_i18n';
@@ -601,8 +602,40 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   // Offline only: expose the dev "2v2 Fiesta vs Bots" practice toggle to the HUD.
   if (offlineSim) hud.setFiestaPracticeHook(() => offlineSim.startFiestaPractice());
 
-  const chatInput = $('#chat-input') as unknown as HTMLInputElement;
+  const chatInput = $('#chat-input') as unknown as HTMLTextAreaElement;
   const clickMoveMarker = $('#click-move-marker') as HTMLDivElement;
+  // Grow the chat bar to fit what's typed (up to its CSS max-height) so a long
+  // message wraps instead of scrolling a single line. Anchored by its bottom
+  // edge, the extra height extends upward, away from the chat log beneath it.
+  const CHAT_INPUT_MIN_H = 36;
+  const CHAT_INPUT_MAX_H = 110;
+  const autosizeChatInput = (): void => {
+    // Empty: pin to one line. (A long placeholder otherwise inflates a textarea's
+    // scrollHeight in Chromium, making the bar tall when empty and snapping to one
+    // line on the first keystroke.)
+    if (chatInput.value === '') {
+      chatInput.style.height = `${CHAT_INPUT_MIN_H}px`;
+      chatInput.style.overflowY = 'hidden';
+      return;
+    }
+    chatInput.style.height = 'auto';
+    const size = chatInputSize(chatInput.scrollHeight, {
+      minHeight: CHAT_INPUT_MIN_H, maxHeight: CHAT_INPUT_MAX_H,
+    });
+    chatInput.style.height = `${size.height}px`;
+    chatInput.style.overflowY = size.overflowY;
+  };
+  // Re-anchor the bar just above the (possibly moved / resized / tab-wrapped)
+  // chat box so it never overlaps it. Mobile keeps its own CSS placement.
+  const CHAT_INPUT_GAP = 6;
+  const anchorChatInput = (): void => {
+    if (document.body.classList.contains('mobile-touch')) return;
+    const wrap = document.getElementById('chatlog-wrap');
+    if (!wrap) return;
+    const rect = wrap.getBoundingClientRect();
+    if (rect.height <= 0) return;
+    chatInput.style.bottom = `${Math.round(window.innerHeight - rect.top + CHAT_INPUT_GAP)}px`;
+  };
   const recoverFromMobileKeyboard = (): void => {
     document.body.classList.remove('mobile-chat-open');
     syncAppViewport();
@@ -613,6 +646,8 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
   const closeChat = (): void => {
     chatInput.value = '';
     chatInput.style.display = 'none';
+    chatInput.style.height = '';
+    chatInput.style.overflowY = '';
     chatInput.blur();
     recoverFromMobileKeyboard();
   };
@@ -620,11 +655,23 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     // reflect the active chat-channel tab in the placeholder (e.g. "Message World")
     chatInput.placeholder = hud.activeChatPlaceholder();
     chatInput.style.display = 'block';
+    anchorChatInput();
+    autosizeChatInput();
     chatInput.focus();
   }
+  // Fired for every open path (keybind, whisper context menu, mobile toggle)
+  // since they all call focus().
+  chatInput.addEventListener('focus', () => { anchorChatInput(); autosizeChatInput(); });
+  chatInput.addEventListener('input', () => { autosizeChatInput(); anchorChatInput(); });
+  window.addEventListener('resize', () => {
+    if (chatInput.style.display === 'block') { anchorChatInput(); autosizeChatInput(); }
+  });
   chatInput.addEventListener('keydown', (e) => {
     e.stopPropagation();
     if (e.key === 'Enter') {
+      // single-message semantics (like classic chat): Enter always sends,
+      // never inserts a newline into the textarea.
+      e.preventDefault();
       // the active channel tab supplies the send prefix, so plain text goes to
       // that channel without the player retyping "/world" etc.
       const raw = chatInput.value;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7505,7 +7505,7 @@ export class Sim {
   // actor). `from` carries the actor's name so the client can render it as a
   // clickable name; `text` is the action predicate (e.g. "waves at Bet.").
   private broadcastEmote(actor: PlayerMeta, actorEntity: Entity, text: string): void {
-    const body = text.slice(0, 200);
+    const body = text.slice(0, MAX_CHAT_MESSAGE_LEN);
     for (const meta of this.players.values()) {
       const e = this.entities.get(meta.entityId);
       if (!e || dist2d(actorEntity.pos, e.pos) > SAY_RANGE) continue;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -199,6 +199,10 @@ const NEARBY_RANGE = 40; // /nearby scan radius — wider than say, tighter than
 const NEARBY_MAX = 10; // cap the /nearby list so a crowded camp can't spam chat
 const CHAT_BURST = 8; // messages a player may send back-to-back...
 const CHAT_REFILL = 2; // ...then this many more per second (caps spam amplifiers)
+// Max characters in a single chat line, matching classic WoW's 255-char editbox.
+// Authoritative cap: enforced here in the deterministic core so every host agrees;
+// the client maxlength + server chat-log slices mirror it.
+export const MAX_CHAT_MESSAGE_LEN = 255;
 const DUEL_FORFEIT_DISTANCE = 60;
 const TRADE_RANGE = 10;
 // The World Market (the Merchant's auction house)
@@ -7116,7 +7120,7 @@ export class Sim {
   chat(text: string, pid?: number): SentChat | null {
     const r = this.resolve(pid);
     if (!r) return null;
-    const raw = text.trim().slice(0, 200);
+    const raw = text.trim().slice(0, MAX_CHAT_MESSAGE_LEN);
     if (!raw) return null;
     if (!this.chatAllowed(r.meta.entityId)) {
       this.error(r.meta.entityId, 'You are sending messages too quickly.');

--- a/src/ui/chat_input_autosize.ts
+++ b/src/ui/chat_input_autosize.ts
@@ -1,0 +1,36 @@
+// Pure geometry for the auto-growing chat input. The chat bar is a textarea
+// anchored by its BOTTOM edge (see #chat-input in index.html), so growing its
+// height extends the box upward — away from the chat log beneath it. The DOM
+// consumer (src/main.ts) measures the textarea's natural content height
+// (scrollHeight) and feeds it here to get a clamped pixel height plus whether a
+// scrollbar is needed once the content exceeds the cap. Kept host-agnostic so a
+// Vitest unit test can pin the clamp behavior without a DOM.
+
+export interface ChatInputSizeLimits {
+  /** Minimum rendered height (a single line). */
+  minHeight: number;
+  /** Maximum rendered height before the textarea scrolls internally. */
+  maxHeight: number;
+}
+
+export interface ChatInputSize {
+  /** Pixel height to apply to the textarea. */
+  height: number;
+  /**
+   * 'hidden' while the content fits within maxHeight (no scrollbar, clean
+   * upward growth); 'auto' once it is capped so the overflow stays reachable.
+   */
+  overflowY: 'hidden' | 'auto';
+}
+
+// Clamp a measured content height to [minHeight, maxHeight]. When the content
+// exceeds the cap we surface a scrollbar instead of growing without bound.
+export function chatInputSize(scrollHeight: number, limits: ChatInputSizeLimits): ChatInputSize {
+  const min = Math.max(0, limits.minHeight);
+  const max = Math.max(min, limits.maxHeight);
+  const natural = Math.round(Number.isFinite(scrollHeight) ? scrollHeight : min);
+  const height = Math.min(max, Math.max(min, natural));
+  // Compare the rounded measurement so a fractional scrollHeight that rounds
+  // down to exactly `max` does not spuriously surface a scrollbar.
+  return { height, overflowY: natural > max ? 'auto' : 'hidden' };
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -1094,7 +1094,7 @@ export class Hud {
   }
 
   private syncChatPlaceholder(): void {
-    const input = document.getElementById('chat-input') as HTMLInputElement | null;
+    const input = document.getElementById('chat-input') as HTMLTextAreaElement | null;
     if (input) input.placeholder = this.activeChatPlaceholder();
   }
 
@@ -7880,11 +7880,14 @@ export class Hud {
   // Open the chat bar pre-filled with a whisper to this player (classic-MMO-style DM).
   private startWhisper(name: string): void {
     if (!name || name === this.sim.player.name) return;
-    const input = $('#chat-input') as unknown as HTMLInputElement;
+    const input = $('#chat-input') as unknown as HTMLTextAreaElement;
     input.value = `/w ${name} `;
     input.style.display = 'block';
     input.focus();
     input.setSelectionRange(input.value.length, input.value.length);
+    // Re-anchor + autosize the bar for the pre-filled value even if it was
+    // already open (focus alone won't re-fire); main.ts listens for 'input'.
+    input.dispatchEvent(new Event('input'));
   }
 
   // -------------------------------------------------------------------------

--- a/tests/chat_input_autosize.test.ts
+++ b/tests/chat_input_autosize.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { chatInputSize } from '../src/ui/chat_input_autosize';
+
+const LIMITS = { minHeight: 32, maxHeight: 110 };
+
+describe('chatInputSize', () => {
+  it('keeps the floor for an empty / single-line input', () => {
+    expect(chatInputSize(28, LIMITS)).toEqual({ height: 32, overflowY: 'hidden' });
+    expect(chatInputSize(32, LIMITS)).toEqual({ height: 32, overflowY: 'hidden' });
+  });
+
+  it('grows with content while it fits under the cap', () => {
+    expect(chatInputSize(60, LIMITS)).toEqual({ height: 60, overflowY: 'hidden' });
+    expect(chatInputSize(110, LIMITS)).toEqual({ height: 110, overflowY: 'hidden' });
+  });
+
+  it('caps height and shows a scrollbar once content overflows', () => {
+    expect(chatInputSize(140, LIMITS)).toEqual({ height: 110, overflowY: 'auto' });
+  });
+
+  it('rounds fractional measurements', () => {
+    expect(chatInputSize(60.6, LIMITS).height).toBe(61);
+  });
+
+  it('does not show a scrollbar when a fractional height rounds down to the cap', () => {
+    expect(chatInputSize(110.4, LIMITS)).toEqual({ height: 110, overflowY: 'hidden' });
+    // ...but a fraction that rounds up past the cap does.
+    expect(chatInputSize(110.6, LIMITS)).toEqual({ height: 110, overflowY: 'auto' });
+  });
+
+  it('falls back to the floor for a non-finite measurement', () => {
+    expect(chatInputSize(Number.NaN, LIMITS)).toEqual({ height: 32, overflowY: 'hidden' });
+  });
+});

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -76,11 +76,11 @@ describe('sent chat normalization', () => {
     expect(throttled).toBe(true);
   });
 
-  it('caps captured messages at 200 characters like Sim.chat', () => {
+  it('caps captured messages at 255 characters like Sim.chat', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     const sent = sim.chat('x'.repeat(500), a);
-    expect(sent?.message.length).toBe(200);
+    expect(sent?.message.length).toBe(255);
   });
 });
 

--- a/tests/chat_log.test.ts
+++ b/tests/chat_log.test.ts
@@ -12,7 +12,7 @@ vi.mock('../server/db', () => ({
 
 import { ChatLogger, type ChatLogRow } from '../server/chat_log';
 import { GameServer } from '../server/game';
-import { Sim } from '../src/sim/sim';
+import { MAX_CHAT_MESSAGE_LEN, Sim } from '../src/sim/sim';
 
 function row(message: string, channel = 'say'): ChatLogRow {
   return { accountId: 1, characterId: 2, characterName: 'Zyx', channel, message };
@@ -76,11 +76,11 @@ describe('sent chat normalization', () => {
     expect(throttled).toBe(true);
   });
 
-  it('caps captured messages at 255 characters like Sim.chat', () => {
+  it('caps captured messages at MAX_CHAT_MESSAGE_LEN characters like Sim.chat', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     const sent = sim.chat('x'.repeat(500), a);
-    expect(sent?.message.length).toBe(255);
+    expect(sent?.message.length).toBe(MAX_CHAT_MESSAGE_LEN);
   });
 });
 


### PR DESCRIPTION
## What & why

The chat input bar overlapped the chat box. It was anchored at a fixed `bottom: 204px`, which sits **~9px inside** the `CHAT / COMBAT LOG` tab strip above the chat log frame. It was also a single-line `<input>`, so a long message scrolled within one line instead of wrapping, and password managers (1Password / LastPass / Bitwarden / browser autofill) would attach to it.

This addresses all three asks:

1. **Reposition so it no longer overlaps.** `#chat-input` is now a `<textarea>` re-anchored just above `#chatlog-wrap` (tabs + frame) on focus / input / resize. It measures the box's real top, so it also handles the `compact-chat` frame and wrapped tab strips. Proven by measured geometry: **before = +9px overlap, after = −6px clear**.
2. **Block password managers.** `autocomplete="off"` plus `data-1p-ignore`, `data-lpignore`, `data-bwignore`, `data-form-type="other"`, `spellcheck="false"`.
3. **Grow vertically without overlapping, matching WoW's char count.** Anchored by its **bottom** edge, the textarea grows **upward** (away from the chat log) as you type, up to a cap, then scrolls. Matches classic WoW's **255-char** editbox: the authoritative cap moves to a shared `MAX_CHAT_MESSAGE_LEN` in the deterministic core (`Sim.chat`), mirrored by the client `maxlength` and the server chat-log slices so nothing silently truncates.

## Implementation notes

- Pure clamp logic in new `src/ui/chat_input_autosize.ts` (Vitest unit test); DOM wiring is a thin consumer in `src/main.ts`, per the repo's pure-core + thin-consumer convention.
- Enter still sends / Escape still closes (Enter now `preventDefault`s to suppress textarea newlines — single-message semantics).
- Mobile keeps its own CSS placement; close paths reset the autosized height.
- **No new i18n keys** — the placeholder reuses `hud.core.chatPlaceholder`.
- Determinism preserved: the cap is enforced in `src/sim/` and imported by the server.

## Screenshots

| | Before | After |
|---|---|---|
| **Empty / single line** | ![empty before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-chat-input-reposition/docs/pr-assets/chat-input-reposition/01-empty-before.png) | ![empty after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-chat-input-reposition/docs/pr-assets/chat-input-reposition/01-empty-after.png) |
| **Long message** | ![long before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-chat-input-reposition/docs/pr-assets/chat-input-reposition/02-long-before.png) | ![long after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-chat-input-reposition/docs/pr-assets/chat-input-reposition/02-long-after.png) |

Before, the long message is clipped to one line (`…we ha`) and the bar bites into the tab strip. After, it wraps onto multiple lines, grows upward, and clears the box.

## Testing

- `npx vitest run` — **2468 passed / 8 skipped** (incl. new `chat_input_autosize`, updated `chat_log` 200→255, `client_shell`, S3 i18n guard).
- `npm run build` — clean.
- Before/after geometry + screenshots via `scripts/chat_input_reposition_shot.mjs`.

Branched from `release/v0.12.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)