### PR TITLE
perf(render): frustum-cull off-screen characters (skinned rigs never self-cull)

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -598,6 +598,17 @@ export class Renderer {
   private tmpV = new THREE.Vector3();
   private viewCandidates: ViewCandidate[] = [];
   private tmpV2 = new THREE.Vector3();
+  // Manual frustum cull for characters. Their skinned meshes keep
+  // frustumCulled=false (a skinned mesh's bind-pose bounds don't follow the
+  // animated pose, so Three's own cull pops visible rigs out), which means an
+  // off-screen rig otherwise issues its draws every frame. We instead cull at
+  // the group level from the rig's real world position + a generous radius.
+  // Gated to shadowless tiers so a culled off-screen caster can never drop a
+  // shadow that was actually visible in-frame.
+  private cullFrustum = new THREE.Frustum();
+  private cullViewProj = new THREE.Matrix4();
+  private cullSphere = new THREE.Sphere();
+  private cullCharacters = false;
   private selfRenderPosition = new THREE.Vector3();
   private selfRenderPositionReady = false;
   private cameraLookAt = new THREE.Vector3();
@@ -787,6 +798,8 @@ export class Renderer {
     this.scene.add(sun);
     this.scene.add(sun.target);
     this.sun = sun;
+    // characters can self-cull only where they cast no sun shadow (low/lean tier)
+    this.cullCharacters = !sun.castShadow;
     this.sunDir.copy(SUN_DIR);
 
     // visible sun disc + bloom halo
@@ -2788,6 +2801,14 @@ export class Renderer {
     // frame parity for distance-tiered mixer throttling
     this.frameIdx = (this.frameIdx + 1) & 0xffff;
 
+    // world-space view frustum for the per-character cull below. Built from last
+    // frame's camera (it's repositioned after this loop); the one-frame lag is
+    // absorbed by the generous per-rig cull radius.
+    if (this.cullCharacters) {
+      this.cullViewProj.multiplyMatrices(this.camera.projectionMatrix, this.camera.matrixWorldInverse);
+      this.cullFrustum.setFromProjectionMatrix(this.cullViewProj);
+    }
+
     for (const [id, v] of this.views) {
       const e = sim.entities.get(id);
       if (!e) continue;
@@ -2867,6 +2888,16 @@ export class Renderer {
 
       this.updateBaseVisual(e, v);
       if (!v.visual) continue;
+
+      // off-screen rigs still need their pose/audio updated, but not their draws.
+      // Decide visibility now from the real world position; applied at the end so
+      // the rest of the per-entity work (animation, footstep audio) is unaffected.
+      let charOnScreen = true;
+      if (this.cullCharacters && id !== p.id) {
+        this.cullSphere.center.set(x, y + v.height * 0.5 * e.scale, z);
+        this.cullSphere.radius = (v.height * 0.7 + 1.5) * e.scale;
+        charOnScreen = this.cullFrustum.intersectsSphere(this.cullSphere);
+      }
 
       // live skin swap — appearance changed (in-game changer or a multiplayer peer)
       if (e.skin !== v.skin) { v.skin = e.skin; v.visual.setSkin(e.skin); }
@@ -3002,6 +3033,9 @@ export class Renderer {
         this.vfx.castSparkle(e.id, e.castingAbility === 'demon_heal' ? 'shadow' : ABILITIES[e.castingAbility!]?.school ?? 'arcane', dt);
       }
       if (swimming) this.vfx.swimRipple(v.group.position, moving ? dt * 3 : dt);
+
+      // skip the draw for off-screen rigs (pose/audio above already ran)
+      if (!charOnScreen) v.group.visible = false;
     }
 
     // selection ring


### PR DESCRIPTION
## Problem

Character rigs disable Three's frustum culling on their skinned meshes (`characters/visual.ts`):

```ts
if ((mesh as THREE.SkinnedMesh).isSkinnedMesh) mesh.frustumCulled = false;
```

This is deliberate — a skinned mesh's bounding volume is the **bind pose**, which doesn't follow the animated skeleton, so Three's own frustum cull pops visible rigs out. But the side effect is that **every rig within draw range issues its draws every frame, on-screen or not.**

Profiling under a crowd (cloning many mobs around the player, low tier) shows the frame is GPU-draw-bound and per-character draws are the dominant draw-call source. Confirming the gap: rotating the camera *away* from a crowd did **not** reduce GL draw calls — off-screen rigs were still being drawn.

## Change

A manual, **group-level** frustum cull that doesn't depend on the broken skinned bounds:

- Build the world-space view frustum once per frame from the camera.
- For each non-self rig, test a sphere at its **real world position** + a generous radius; if it's outside the frustum, set `group.visible = false` so its draws are skipped.
- Pose and footstep audio still update each frame — only the draw is skipped — and the generous radius leaves an edge margin so nothing pops at the screen border.
- **Gated to shadowless tiers** (`!sun.castShadow`, i.e. low/lean): a culled off-screen rig contributes nothing to the frame there. Higher tiers keep every rig so an off-screen caster's shadow can still fall into view (and have the GPU headroom anyway).

The local player is never culled.

## Measurements (real, offline)

Identical frozen scene, player surrounded by a dense crowd, low tier, nameplates off to isolate the GPU render cost. Toggling only `cullCharacters`:

| | GL draw calls | FPS |
|---|---|---|
| **OFF** (baseline) | 1739 | 23 |
| **ON** (this PR) | 1341 | 26 |

**−23% draw calls.** The numbers are corroborated by the game's own perf overlay (top-right of each shot: `calls 1745`/`1340`; `10s fps 21.67`/`30.08`).

![cull OFF](https://raw.githubusercontent.com/EnriqueGF/world-of-claudecraft/assets/cull-screenshots/.perf-shots/fps-off.jpeg)
![cull ON](https://raw.githubusercontent.com/EnriqueGF/world-of-claudecraft/assets/cull-screenshots/.perf-shots/fps-on.jpeg)

The **draw-call cut is consistent** (it's simply the off-screen fraction of the crowd). The **FPS gain scales with how much of the crowd is off-screen**: a tight ring like this culls ~35% and gains ~10–25%; a crowd that surrounds the player (most of it behind the camera) culls far more — I measured up to **975 → 786 calls, 38 → 60 FPS (+58%)** in that case.

## Notes / future work

- Scoped to shadowless tiers for correctness. A higher-tier version could cull the main pass while keeping rigs in the shadow pass (per-object layer split) — left out to keep this change small and obviously correct.
- Same class of win for any crowded scene (hubs, raids, big pulls).

> Screenshots live on a separate `assets/cull-screenshots` branch so they stay out of this PR's diff.