### PR TITLE
feat(seo): add legal policy pages

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,177 @@
+# Privacy Policy
+
+**World of ClaudeCraft**
+
+Last updated: 21 June 2026
+
+This Privacy Policy explains what personal information we collect, why we collect it, how we use and share it, and the choices you have. It applies when you play World of ClaudeCraft (the "Game"), visit worldofclaudecraft.com (the "Site"), or use our mobile application (the "App"). The Game, Site, and App together are the "Service."
+
+**Who we are.** The Service is operated by Dream Home AI Limited, trading as Levy Street, New Zealand company number 8703066 ("we," "us," "our"), based in Wellington, New Zealand. We are the data controller for personal information processed through the Service.
+
+By using the Service you agree to this Policy. If you do not agree, do not use the Service.
+
+---
+
+## 1. The short version
+
+- You can play the offline browser version without an account and without giving us personal information.
+- To play online you create an account with a username and password. Your password is hashed. We do not store it in readable form.
+- We store your characters and progress so the world is there when you return.
+- Chat, character names, trades, and leaderboard scores are visible to other players. Treat anything you type or name as public.
+- We use limited technical data (such as your IP address) to run the servers, stop abuse, and keep the Game secure.
+- You can delete your characters and your account at any time.
+- We are an independent project and are not affiliated with or endorsed by any third-party company or brand. The $WOC token was created by a third party. See Section 14.
+
+The rest of this Policy gives the detail.
+
+---
+
+## 2. Information we collect
+
+**Account information.** When you register to play online we collect a username and a password. Passwords are stored only as a salted scrypt hash, never in plain text. If you provide an email address at registration or for account recovery, we store it to identify your account and to contact you about the Service.
+
+**Character and gameplay data.** When you create and play characters we store character names, chosen class, appearance, level, equipment, inventory, quests, position in the world, and in-game currency. This data persists in our database so your progress is saved between sessions.
+
+**Chat and social activity.** The Game includes chat (general, party, and similar channels), trading, duels, and parties. Messages you send and the social actions you take are transmitted to other players and may be stored on our servers for delivery, moderation, safety, and abuse prevention. Character names and leaderboard scores are shown publicly to other players and on high score and ranking screens.
+
+**Technical and log data.** When you connect to the Service we automatically receive technical information, including your IP address, device and browser type, operating system, language and display settings, session identifiers, session tokens (which expire after 7 days), connection timestamps, and error and performance logs. We use your IP address to rate-limit sign-in attempts and to detect and prevent abuse.
+
+**Optional wallet verification.** If you choose to verify a Solana wallet to display holder flair or a player-card badge, we store the public wallet address you provide. This is optional, is used only for cosmetic in-game display, and does not involve any transaction, signature that moves funds, or transfer of SOL. We do not access your private keys and cannot move your funds.
+
+**Cookies and local storage.** The Site and Game use cookies and browser local storage to keep you signed in (your session token), remember your settings and preferences (such as language, audio, and control options), and operate core features. You can clear or block these through your browser, but the online Game may not work correctly without them.
+
+**Advertising and analytics.** We use third-party advertising and analytics providers on the Site and in the App. These providers may set cookies or use device identifiers to measure usage and to serve and measure advertising. They collect information such as device identifiers, IP address, approximate location derived from IP, and interaction data, subject to their own privacy policies. Where required, we ask for your consent before using non-essential cookies or trackers, and we provide a way to manage your choices.
+
+**Donations.** If you donate through GitHub Sponsors, the payment is processed by GitHub and its payment providers. We do not receive or store your card or bank details. GitHub's privacy policy governs that processing.
+
+**Community channels.** Our Discord server and our GitHub repository are operated on third-party platforms. Information you share there is governed by those platforms' privacy policies, not this one.
+
+We do not knowingly collect sensitive personal information (such as health, religion, or precise geolocation) through the Service.
+
+---
+
+## 3. How we use information
+
+We use personal information to:
+
+- Create and maintain your account and authenticate you.
+- Run the Game, save your characters and progress, and deliver multiplayer features such as chat, parties, trading, and duels.
+- Operate, maintain, secure, and improve the Service, including debugging and performance work.
+- Prevent, detect, and respond to cheating, fraud, abuse, harassment, and security incidents.
+- Moderate user content and enforce our Terms.
+- Respond to your support requests and communicate with you about the Service.
+- Display optional cosmetic features you choose to enable, such as wallet-linked badges.
+- Comply with legal obligations and respond to lawful requests.
+
+---
+
+## 4. Legal bases for processing (EEA and UK users)
+
+Where the EU or UK General Data Protection Regulation applies, we rely on these legal bases:
+
+- **Performance of a contract:** to provide the Game and your account.
+- **Legitimate interests:** to secure the Service, prevent abuse, and improve the Game, balanced against your rights.
+- **Consent:** for non-essential cookies, advertising, and analytics where consent is required. You can withdraw consent at any time.
+- **Legal obligation:** where we must process information to comply with the law.
+
+---
+
+## 5. How we share information
+
+We do not sell your personal information. We share it only as follows:
+
+- **Other players:** character names, chat, trades, party activity, and leaderboard scores are visible to other users as a normal part of an online multiplayer game.
+- **Service providers:** hosting, database, content delivery, and infrastructure providers that run the Service on our behalf, under contracts that limit their use of the data.
+- **Advertising and analytics partners:** if enabled, as described in Section 2.
+- **Legal and safety:** to comply with the law, enforce our Terms, protect the rights, safety, and property of users, the public, or us, and respond to lawful requests.
+- **Business transfers:** in connection with a merger, acquisition, financing, or sale of assets, in which case we will require the recipient to honour this Policy or notify you of any material change.
+
+---
+
+## 6. Data retention
+
+We keep personal information only as long as needed for the purposes in this Policy.
+
+- **Account and character data:** retained for as long as your account remains active, so your characters and progress are preserved, and until you ask us to delete your account. We may close and delete accounts that have been inactive for a long period, but we are not obliged to.
+- **Chat and moderation records:** retained for as long as needed for safety, security, and abuse prevention, generally up to 24 months, then deleted or anonymised.
+- **Technical and log data:** retained for as long as needed to operate and secure the Service and to investigate incidents, generally up to 24 months.
+- **Backups:** residual copies may persist in encrypted backups for a limited period before they are overwritten.
+
+---
+
+## 7. Your rights and choices
+
+Depending on where you live, you may have some or all of these rights:
+
+- Access the personal information we hold about you.
+- Correct inaccurate information.
+- Delete your information.
+- Object to or restrict certain processing.
+- Receive a copy of your information in a portable format.
+- Withdraw consent where we rely on it.
+
+**New Zealand:** under the Privacy Act 2020 you may request access to and correction of your personal information.
+
+**EEA and UK:** you have the GDPR rights listed above and may lodge a complaint with your local data protection authority.
+
+**California:** under the CCPA and CPRA you may request to know, delete, and correct your personal information, and to opt out of the sale or sharing of personal information. We do not sell personal information. We will not discriminate against you for exercising these rights.
+
+To exercise any right, contact us using Section 13. We may need to verify your identity before we act.
+
+---
+
+## 8. Deleting your account and data
+
+You can delete individual characters in the Game using the delete option on the character screen. To delete your entire account and associated personal information, use the account deletion option in the Game or App, or contact us using Section 13. We will action verified deletion requests within a reasonable time, subject to legal retention requirements. Some residual data may remain in backups for a limited period as described in Section 6.
+
+---
+
+## 9. Children
+
+The Service is not directed to children under 13, and you must be at least 13 to create an account (or older where your country sets a higher minimum age for online services, such as 16 in some EEA states). We do not knowingly collect personal information from children under the applicable minimum age. If you believe a child has provided us personal information, contact us using Section 13 and we will delete it.
+
+---
+
+## 10. International data transfers
+
+We are based in New Zealand and may process your information in New Zealand and in other countries, including where our service providers operate. These countries may have different data protection laws than yours. Where required, we use appropriate safeguards for international transfers, such as standard contractual clauses.
+
+---
+
+## 11. How we protect information
+
+We use technical and organisational measures to protect personal information, including salted scrypt password hashing, encrypted connections (TLS and secure WebSockets), per-IP rate limiting on authentication, and session tokens that expire after 7 days. No method of transmission or storage is completely secure, so we cannot guarantee absolute security.
+
+---
+
+## 12. Third-party services and links
+
+The Service links to and integrates third-party services, including GitHub, GitHub Sponsors, Discord, and the Solana network. These services are controlled by others and have their own privacy policies. We are not responsible for their practices. Review their policies before using them.
+
+---
+
+## 13. Contact us
+
+For privacy questions or to exercise your rights:
+
+Email: tony@levystreet.com
+
+Postal: Dream Home AI Limited, 262 Thorndon Quay, Wellington 6011, New Zealand
+
+New Zealand users may also contact the Office of the Privacy Commissioner at privacy.org.nz.
+
+---
+
+## 14. No affiliation and the $WOC token
+
+World of ClaudeCraft is an independent, community project.
+
+It is not affiliated with, endorsed by, sponsored by, or associated with any third-party company, game, product, or brand. All third-party names and trademarks are the property of their respective owners.
+
+The $WOC token referenced by the community was created and is controlled by a third party. We do not issue, control, endorse, or guarantee it. It is not required to play, has no connection to your account data, and is not an investment offered by us. Wallet verification is cosmetic only. See our Terms and Conditions for more.
+
+---
+
+## 15. Changes to this Policy
+
+We may update this Policy from time to time. When we make material changes we will update the date above and, where appropriate, provide additional notice. Your continued use of the Service after an update means you accept the revised Policy.

--- a/TERMS_AND_CONDITIONS.md
+++ b/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,142 @@
+# Terms and Conditions
+
+**World of ClaudeCraft**
+
+Last updated: 21 June 2026
+
+## 1. Who we are and what these terms cover
+
+These Terms and Conditions (the "Terms") are a legal agreement between you and Dream Home AI Limited, trading as Levy Street, New Zealand company number 8703066 ("we," "us," "our"). They govern your use of World of ClaudeCraft (the "Game"), worldofclaudecraft.com (the "Site"), and our mobile application (the "App"), together the "Service."
+
+By using the Service you agree to these Terms and to our Privacy Policy. If you do not agree, do not use the Service.
+
+## 2. Changes to these terms
+
+We may update these Terms from time to time. When we make material changes we will update the date above and, where appropriate, give additional notice. Your continued use of the Service after an update means you accept the revised Terms.
+
+## 3. Eligibility
+
+You must be at least 13 years old to use the Service, or older where your country requires a higher minimum age for online services. If you are under the age of majority where you live, you may use the Service only with the involvement and consent of a parent or guardian who agrees to these Terms. The Service is not intended for children under 13.
+
+## 4. The Game and the source code
+
+We grant you a limited, personal, non-exclusive, non-transferable, revocable licence to access and play the Game for your own non-commercial entertainment, subject to these Terms.
+
+The Game's source code is published in a public repository for viewing only. All rights in the source code are reserved. Making the repository publicly viewable does not grant you any licence or right to use, copy, modify, distribute, or create derivative works from the code, for commercial or non-commercial purposes, except with our prior written permission. These Terms govern your use of the hosted Service we operate, which is separate from any rights in the code.
+
+## 5. Accounts
+
+To play online you create an account. You agree to provide accurate information, to keep your credentials secure, and to be responsible for all activity under your account. Do not share your account or use anyone else's. Tell us promptly if you suspect unauthorised use. We may refuse, reclaim, or rename accounts or characters that breach these Terms or that use names which are offensive, infringing, impersonating, or misleading.
+
+## 6. Acceptable use and code of conduct
+
+When using the Service you agree not to:
+
+- Cheat, exploit bugs, automate play, use bots, or use unauthorised third-party software to gain an advantage. Development and testing commands are for local development only and must not be used against the live Service.
+- Harass, threaten, defame, or abuse other players, or post hateful, obscene, or illegal content in chat, names, or anywhere else.
+- Impersonate any person or entity, including us or our staff.
+- Disrupt the Service, including through denial-of-service attacks, excessive automated requests, or attempts to overload or interfere with servers.
+- Access the Service through unauthorised means, scrape it, or probe, scan, or test its security without permission.
+- Reverse engineer, decompile, or attempt to extract source code from the hosted Service, except to the extent applicable law expressly allows and that right cannot be excluded.
+- Sell, trade for real money, or commercially exploit accounts, characters, in-game items, or in-game currency.
+- Use the Service for any unlawful purpose or in breach of these Terms.
+
+We may investigate suspected breaches and may suspend or terminate access, remove content, and report unlawful activity to authorities.
+
+## 7. User content
+
+The Service lets you create content, including character names and chat messages ("User Content"). You keep any rights you have in your User Content. You grant us a worldwide, non-exclusive, royalty-free licence to host, store, reproduce, transmit, display, and moderate your User Content for the purpose of operating, securing, and improving the Service.
+
+You are responsible for your User Content and confirm you have the right to share it and that it does not breach these Terms or any law. We may review, moderate, refuse, or remove User Content, and may withhold or remove names, at our discretion. We are not obliged to monitor User Content, but we may.
+
+## 8. Virtual items and in-game currency
+
+The Game includes virtual items, gear, and in-game currency. These have no monetary value and cannot be redeemed for real money or anything of value outside the Game. You do not own them. We grant you a limited, revocable licence to use them within the Game only. We may modify, remove, reset, or wipe virtual items, currency, characters, and game worlds at any time, including during testing and balancing, without liability or compensation. The Game is free to play, and we do not sell virtual items or currency.
+
+## 9. The $WOC token
+
+A token referred to as $WOC, associated with the community on the Solana network, was created and is controlled by a third party. We do not issue, mint, control, manage, promote as an investment, or guarantee the $WOC token or its value.
+
+- The token is not required to play and has no effect on your account, characters, or progress.
+- Wallet verification in the Game is cosmetic only. It displays optional flair or a badge and involves no transaction and no transfer of funds.
+- Nothing in the Service is financial, investment, legal, or tax advice, or an offer, solicitation, or recommendation to buy, sell, or hold any token or digital asset.
+- Digital assets are volatile and carry risk, including total loss, and may be regulated differently in different countries. You are solely responsible for your own decisions and for complying with the laws that apply to you.
+
+To the fullest extent permitted by law, we are not liable for any loss connected with the $WOC token or any third-party token, wallet, exchange, or blockchain.
+
+## 10. Donations
+
+Donations through GitHub Sponsors are voluntary and are processed by GitHub. Donations are not a purchase, are non-refundable except where the law requires, and do not entitle you to any product, in-game advantage, ownership, equity, token, or other benefit.
+
+## 11. Service availability and changes
+
+The Game is in active development and is provided on an evolving basis. We may change, suspend, limit, or discontinue all or part of the Service, including features, characters, items, and game worlds, at any time and without notice. We do not guarantee uptime, availability, or that the Service will be uninterrupted or error free. We may need to reset or wipe data for technical or balancing reasons.
+
+## 12. Third-party services
+
+The Service links to and relies on third-party services, including GitHub, Discord, the Solana network, and any advertising or analytics providers we use. We do not control these services and are not responsible for them. Your use of them is governed by their terms.
+
+## 13. Intellectual property and no affiliation
+
+World of ClaudeCraft is an independent, community project. It is not affiliated with, endorsed by, sponsored by, or associated with any third-party company, game, product, or brand. All third-party names, marks, and trademarks are the property of their respective owners. Any such names that appear are used only descriptively and do not imply any association.
+
+Except for your User Content, the Service and the source code, including their original content, features, design, and branding, are owned by us or our licensors and are protected by intellectual property laws. You may not copy, distribute, or create derivative works from the Service or the source code except as these Terms expressly allow or with our prior written permission.
+
+If you believe content on the Service infringes your intellectual property, contact us using Section 22 with enough detail to identify the work and the allegedly infringing material, and we will respond appropriately.
+
+## 14. Disclaimer of warranties
+
+To the fullest extent permitted by law, the Service is provided "as is" and "as available," without warranties of any kind, whether express, implied, or statutory, including warranties of merchantability, fitness for a particular purpose, title, and non-infringement. We do not warrant that the Service will be secure, uninterrupted, error free, or free of harmful components, or that data will not be lost.
+
+## 15. Consumer law
+
+Nothing in these Terms limits rights you have under laws that cannot be excluded, including, for consumers in New Zealand, the Consumer Guarantees Act 1993 and the Fair Trading Act 1986, and similar consumer protection laws elsewhere. Where the Service is supplied free of charge and for personal use, those guarantees apply only to the extent the law requires.
+
+## 16. Limitation of liability
+
+To the fullest extent permitted by law, we and our directors, employees, and contractors will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss of data, progress, profits, goodwill, or virtual items, arising from or related to your use of or inability to use the Service. To the extent we are found liable despite the above, our total liability for all claims relating to the Service is limited to NZD 100. Some jurisdictions do not allow certain limitations, so some of these may not apply to you.
+
+## 17. Indemnification
+
+You agree to indemnify and hold us harmless from any claims, losses, liabilities, and expenses, including reasonable legal fees, arising from your breach of these Terms, your User Content, or your misuse of the Service, to the extent permitted by law.
+
+## 18. Suspension and termination
+
+You may stop using the Service and delete your account at any time. We may suspend or terminate your access at any time, with or without notice, if you breach these Terms, if we are required to by law, or to protect the Service or other users. On termination, your licence to use the Service ends. Sections that by their nature should survive will survive, including Sections 8 to 17 and 19 to 22.
+
+## 19. Governing law and disputes
+
+These Terms are governed by the laws of New Zealand. The courts of New Zealand have non-exclusive jurisdiction over any dispute, without affecting any mandatory rights you have to bring proceedings in your country of residence.
+
+## 20. General
+
+If any provision of these Terms is held unenforceable, the rest remains in effect. Our failure to enforce a provision is not a waiver. You may not assign these Terms without our consent. We may assign them in connection with a merger, acquisition, or sale of assets. These Terms are the entire agreement between you and us regarding the Service.
+
+## 21. App store terms
+
+If you download the App from a third-party app store or platform (each a "Distributor"), the following additional terms apply. In the event of a conflict between these Terms and a Distributor's required terms, the Distributor's required terms apply for that App only and only to the extent of the conflict.
+
+### 21.1 Apple App Store
+
+These terms apply if you obtain the App from Apple. You acknowledge and agree that:
+
+1. **Acknowledgement.** These Terms are between you and us only, not with Apple. We, not Apple, are solely responsible for the App and its content.
+2. **Scope of licence.** The licence granted to you for the App is a non-transferable licence to use the App on any Apple-branded products that you own or control, as permitted by the Usage Rules in the Apple App Store Terms of Service, except that the App may be accessed by other accounts associated with you via Family Sharing or volume purchasing.
+3. **Maintenance and support.** We, not Apple, are solely responsible for any maintenance and support services. Apple has no obligation to provide any maintenance or support for the App.
+4. **Warranty.** We are solely responsible for any product warranties, whether express or implied by law, to the extent not effectively disclaimed. If the App fails to conform to any applicable warranty, you may notify Apple, and Apple will refund the purchase price of the App, if any. To the maximum extent permitted by law, Apple has no other warranty obligation with respect to the App.
+5. **Product claims.** We, not Apple, are responsible for addressing any claims by you or a third party relating to the App or your use of it, including product liability claims, claims that the App fails to conform to a legal or regulatory requirement, and claims under consumer protection, privacy, or similar laws.
+6. **Intellectual property.** In the event of a third-party claim that the App or your use of it infringes that third party's intellectual property rights, we, not Apple, are solely responsible for the investigation, defence, settlement, and discharge of that claim.
+7. **Legal compliance.** You represent and warrant that you are not located in a country subject to a U.S. Government embargo or designated as a "terrorist supporting" country, and that you are not listed on any U.S. Government list of prohibited or restricted parties.
+8. **Developer name and contact.** Questions, complaints, or claims regarding the App should be directed to us using the contact details in Section 22.
+9. **Third-party terms.** You must comply with applicable third-party terms of agreement when using the App.
+10. **Third-party beneficiary.** Apple and Apple's subsidiaries are third-party beneficiaries of these Terms, and upon your acceptance of these Terms, Apple will have the right, and will be deemed to have accepted the right, to enforce these Terms against you as a third-party beneficiary.
+
+### 21.2 Google Play
+
+These terms apply if you obtain the App from Google Play. Your use of the App must comply with the then-current Google Play Terms of Service. Google is not a party to these Terms and is not responsible for the App. Any claim relating to the App is between you and us, not Google.
+
+## 22. Contact us
+
+Email: tony@levystreet.com
+
+Postal: Dream Home AI Limited, 262 Thorndon Quay, Wellington 6011, New Zealand

--- a/index.html
+++ b/index.html
@@ -2406,7 +2406,9 @@
   }
 
   /* Footer donate link keeps the social-link shape but warms up on hover. */
-  .footer-lang-row { display: flex; justify-content: center; }
+  .footer-lang-row,
+  .footer-legal-row { display: flex; justify-content: center; }
+  .footer-legal-row { gap: 14px; flex-wrap: wrap; }
   .social-link.donate:hover,
   .social-link.donate:focus-visible { color: #ff9db3; border-color: #ff6b8b; box-shadow: 0 0 10px rgba(255, 107, 139, 0.35); }
 
@@ -7967,6 +7969,10 @@
         </a>
       </div>
       <div id="game-version">v0.10</div>
+      </div>
+      <div class="footer-legal-row">
+        <a href="/terms" class="footer-link" data-i18n="footer.terms">Terms of Service</a>
+        <a href="/privacy" class="footer-link" data-i18n="footer.privacy">Privacy Policy</a>
       </div>
       <div class="footer-lang-row">
         <div class="language-selector">

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -1,0 +1,211 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="dark" />
+  <meta name="theme-color" content="#08080d" />
+  <title>Privacy Policy - World of ClaudeCraft</title>
+  <meta name="description" content="Privacy Policy for World of ClaudeCraft, covering account data, gameplay data, cookies, analytics, and your choices." />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <link rel="canonical" href="https://worldofclaudecraft.com/privacy" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="World of ClaudeCraft" />
+  <meta property="og:title" content="Privacy Policy - World of ClaudeCraft" />
+  <meta property="og:description" content="Privacy Policy for World of ClaudeCraft, covering account data, gameplay data, cookies, analytics, and your choices." />
+  <meta property="og:url" content="https://worldofclaudecraft.com/privacy" />
+  <meta property="og:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+  <meta property="og:image:alt" content="World of ClaudeCraft" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Privacy Policy - World of ClaudeCraft" />
+  <meta name="twitter:description" content="Privacy Policy for World of ClaudeCraft, covering account data, gameplay data, cookies, analytics, and your choices." />
+  <meta name="twitter:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Privacy Policy - World of ClaudeCraft",
+    "url": "https://worldofclaudecraft.com/privacy",
+    "description": "Privacy Policy for World of ClaudeCraft, covering account data, gameplay data, cookies, analytics, and your choices.",
+    "inLanguage": "en",
+    "isPartOf": { "@type": "WebSite", "name": "World of ClaudeCraft", "url": "https://worldofclaudecraft.com/" },
+    "dateModified": "2026-06-21"
+  }
+  </script>
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Alegreya:ital,wght@0,400;0,500;0,700;1,400&family=Alegreya+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    :root { color-scheme: dark; --gold: #ffd100; --gold-dim: #c8a838; --gold-soft: #f3dfaa; --ink: #f0ebd8; --muted: #c4b899; --border: #6f5a2a; --line: rgba(215, 181, 109, 0.32); --line-soft: rgba(215, 181, 109, 0.14); --bg: #08080d; --panel-top: rgba(20, 20, 30, 0.94); --panel-bottom: rgba(6, 6, 11, 0.96); --font-display: 'Cinzel', 'Palatino Linotype', Palatino, Georgia, serif; --font-ui: 'Alegreya Sans', 'Segoe UI', system-ui, -apple-system, sans-serif; --font-serif: 'Alegreya', 'Palatino Linotype', Palatino, Georgia, serif; --r-sm: 4px; --r-md: 8px; }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; min-height: 100%; }
+    body { min-height: 100vh; min-height: 100dvh; color: var(--ink); font-family: var(--font-ui); -webkit-font-smoothing: antialiased; background: linear-gradient(90deg, rgba(5, 7, 12, 0.90), rgba(5, 7, 12, 0.56) 52%, rgba(5, 7, 12, 0.92)), radial-gradient(circle at 50% 8%, rgba(255, 209, 0, 0.16), transparent 40%), var(--bg) url('/loading-screen.jpg') center / cover fixed no-repeat; padding: max(18px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) max(22px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left)); }
+    body::before { content: ""; position: fixed; inset: 0; pointer-events: none; background: linear-gradient(rgba(255,255,255,0.018) 50%, rgba(0,0,0,0.035) 50%), radial-gradient(circle at 50% 100%, rgba(0,0,0,0.58), transparent 48%); background-size: 100% 4px, auto; }
+    .shell { position: relative; z-index: 1; width: min(1040px, 100%); margin: 0 auto; }
+    .topbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+    .brand { display: inline-flex; align-items: center; gap: 10px; color: var(--gold); text-decoration: none; font-family: var(--font-display); font-weight: 800; letter-spacing: 0.4px; }
+    .brand img { width: 38px; height: 38px; border-radius: 8px; box-shadow: 0 0 18px rgba(255, 209, 0, 0.22); }
+    .back-link { min-height: 40px; display: inline-flex; align-items: center; justify-content: center; padding: 8px 14px; border: 1px solid var(--border); border-radius: var(--r-sm); color: var(--gold-soft); background: rgba(8, 8, 13, 0.72); text-decoration: none; font-weight: 700; }
+    .back-link:hover, .back-link:focus-visible { color: var(--gold); border-color: var(--gold); outline: none; box-shadow: 0 0 14px rgba(255, 209, 0, 0.18); }
+    main { border: 1px solid var(--line); border-radius: var(--r-md); background: linear-gradient(180deg, var(--panel-top), var(--panel-bottom)); box-shadow: 0 22px 70px rgba(0,0,0,0.62), inset 0 1px 0 rgba(255,255,255,0.05); overflow: hidden; }
+    .hero { padding: clamp(22px, 5vw, 44px) clamp(18px, 5vw, 52px) clamp(16px, 3vw, 26px); border-bottom: 1px solid var(--line-soft); background: radial-gradient(circle at 18% 0%, rgba(255, 209, 0, 0.12), transparent 32%), linear-gradient(180deg, rgba(255,255,255,0.035), transparent); }
+    .eyebrow { margin: 0 0 10px; color: var(--gold-dim); font-family: var(--font-display); font-size: 12px; font-weight: 800; letter-spacing: 1.6px; text-transform: uppercase; }
+    h1 { margin: 0; color: var(--gold); font-family: var(--font-display); font-size: clamp(31px, 6vw, 58px); line-height: 1.05; letter-spacing: 0; text-shadow: 0 3px 18px rgba(0,0,0,0.65); }
+    .updated { margin: 12px 0 0; color: var(--muted); font-size: 15px; }
+    .content { padding: clamp(20px, 4vw, 42px) clamp(18px, 5vw, 52px) clamp(30px, 5vw, 56px); font-family: var(--font-serif); font-size: 17px; line-height: 1.68; }
+    .content h2, .content h3 { font-family: var(--font-display); letter-spacing: 0; color: var(--gold-soft); line-height: 1.22; }
+    .content h2 { margin: 34px 0 10px; font-size: clamp(22px, 3vw, 30px); }
+    .content h3 { margin: 26px 0 8px; font-size: clamp(18px, 2.4vw, 23px); }
+    .content p { margin: 0 0 16px; }
+    .content strong { color: var(--gold-soft); }
+    .content ul, .content ol { margin: 0 0 18px; padding-left: 24px; }
+    .content li { margin: 7px 0; padding-left: 4px; }
+    .content hr { border: 0; border-top: 1px solid var(--line-soft); margin: 28px 0; }
+    .token-name { white-space: nowrap; color: var(--gold); }
+    footer { margin-top: 18px; display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; color: var(--muted); font-size: 13px; }
+    footer a { color: var(--gold-soft); text-decoration: none; }
+    footer a:hover, footer a:focus-visible { color: var(--gold); outline: none; }
+    @media (max-width: 640px) { body { padding-left: 12px; padding-right: 12px; background-attachment: scroll; } .topbar { align-items: flex-start; flex-direction: column; } .back-link { width: 100%; } .content { font-size: 16px; } }
+    @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; } }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <nav class="topbar" aria-label="Legal page navigation">
+      <a class="brand" href="/" aria-label="World of ClaudeCraft home"><img src="/woc_logo_square.webp" alt="" /> <span>World of ClaudeCraft</span></a>
+      <a class="back-link" href="/">Return to Game</a>
+    </nav>
+    <main>
+      <header class="hero">
+        <p class="eyebrow">Legal</p>
+        <h1>Privacy Policy</h1>
+        <p class="updated">Last updated: 21 June 2026</p>
+      </header>
+      <article class="content">
+        <p><strong>World of ClaudeCraft</strong></p>
+        <p>This Privacy Policy explains what personal information we collect, why we collect it, how we use and share it, and the choices you have. It applies when you play World of ClaudeCraft (the "Game"), visit worldofclaudecraft.com (the "Site"), or use our mobile application (the "App"). The Game, Site, and App together are the "Service."</p>
+        <p><strong>Who we are.</strong> The Service is operated by Dream Home AI Limited, trading as Levy Street, New Zealand company number 8703066 ("we," "us," "our"), based in Wellington, New Zealand. We are the data controller for personal information processed through the Service.</p>
+        <p>By using the Service you agree to this Policy. If you do not agree, do not use the Service.</p>
+        <hr />
+        <h2>1. The short version</h2>
+        <ul>
+        <li>You can play the offline browser version without an account and without giving us personal information.</li>
+        <li>To play online you create an account with a username and password. Your password is hashed. We do not store it in readable form.</li>
+        <li>We store your characters and progress so the world is there when you return.</li>
+        <li>Chat, character names, trades, and leaderboard scores are visible to other players. Treat anything you type or name as public.</li>
+        <li>We use limited technical data (such as your IP address) to run the servers, stop abuse, and keep the Game secure.</li>
+        <li>You can delete your characters and your account at any time.</li>
+        <li>We are an independent project and are not affiliated with or endorsed by any third-party company or brand. The <span class="token-name">$WOC</span> token was created by a third party. See Section 14.</li>
+        </ul>
+        <p>The rest of this Policy gives the detail.</p>
+        <hr />
+        <h2>2. Information we collect</h2>
+        <p><strong>Account information.</strong> When you register to play online we collect a username and a password. Passwords are stored only as a salted scrypt hash, never in plain text. If you provide an email address at registration or for account recovery, we store it to identify your account and to contact you about the Service.</p>
+        <p><strong>Character and gameplay data.</strong> When you create and play characters we store character names, chosen class, appearance, level, equipment, inventory, quests, position in the world, and in-game currency. This data persists in our database so your progress is saved between sessions.</p>
+        <p><strong>Chat and social activity.</strong> The Game includes chat (general, party, and similar channels), trading, duels, and parties. Messages you send and the social actions you take are transmitted to other players and may be stored on our servers for delivery, moderation, safety, and abuse prevention. Character names and leaderboard scores are shown publicly to other players and on high score and ranking screens.</p>
+        <p><strong>Technical and log data.</strong> When you connect to the Service we automatically receive technical information, including your IP address, device and browser type, operating system, language and display settings, session identifiers, session tokens (which expire after 7 days), connection timestamps, and error and performance logs. We use your IP address to rate-limit sign-in attempts and to detect and prevent abuse.</p>
+        <p><strong>Optional wallet verification.</strong> If you choose to verify a Solana wallet to display holder flair or a player-card badge, we store the public wallet address you provide. This is optional, is used only for cosmetic in-game display, and does not involve any transaction, signature that moves funds, or transfer of SOL. We do not access your private keys and cannot move your funds.</p>
+        <p><strong>Cookies and local storage.</strong> The Site and Game use cookies and browser local storage to keep you signed in (your session token), remember your settings and preferences (such as language, audio, and control options), and operate core features. You can clear or block these through your browser, but the online Game may not work correctly without them.</p>
+        <p><strong>Advertising and analytics.</strong> We use third-party advertising and analytics providers on the Site and in the App. These providers may set cookies or use device identifiers to measure usage and to serve and measure advertising. They collect information such as device identifiers, IP address, approximate location derived from IP, and interaction data, subject to their own privacy policies. Where required, we ask for your consent before using non-essential cookies or trackers, and we provide a way to manage your choices.</p>
+        <p><strong>Donations.</strong> If you donate through GitHub Sponsors, the payment is processed by GitHub and its payment providers. We do not receive or store your card or bank details. GitHub's privacy policy governs that processing.</p>
+        <p><strong>Community channels.</strong> Our Discord server and our GitHub repository are operated on third-party platforms. Information you share there is governed by those platforms' privacy policies, not this one.</p>
+        <p>We do not knowingly collect sensitive personal information (such as health, religion, or precise geolocation) through the Service.</p>
+        <hr />
+        <h2>3. How we use information</h2>
+        <p>We use personal information to:</p>
+        <ul>
+        <li>Create and maintain your account and authenticate you.</li>
+        <li>Run the Game, save your characters and progress, and deliver multiplayer features such as chat, parties, trading, and duels.</li>
+        <li>Operate, maintain, secure, and improve the Service, including debugging and performance work.</li>
+        <li>Prevent, detect, and respond to cheating, fraud, abuse, harassment, and security incidents.</li>
+        <li>Moderate user content and enforce our Terms.</li>
+        <li>Respond to your support requests and communicate with you about the Service.</li>
+        <li>Display optional cosmetic features you choose to enable, such as wallet-linked badges.</li>
+        <li>Comply with legal obligations and respond to lawful requests.</li>
+        </ul>
+        <hr />
+        <h2>4. Legal bases for processing (EEA and UK users)</h2>
+        <p>Where the EU or UK General Data Protection Regulation applies, we rely on these legal bases:</p>
+        <ul>
+        <li><strong>Performance of a contract:</strong> to provide the Game and your account.</li>
+        <li><strong>Legitimate interests:</strong> to secure the Service, prevent abuse, and improve the Game, balanced against your rights.</li>
+        <li><strong>Consent:</strong> for non-essential cookies, advertising, and analytics where consent is required. You can withdraw consent at any time.</li>
+        <li><strong>Legal obligation:</strong> where we must process information to comply with the law.</li>
+        </ul>
+        <hr />
+        <h2>5. How we share information</h2>
+        <p>We do not sell your personal information. We share it only as follows:</p>
+        <ul>
+        <li><strong>Other players:</strong> character names, chat, trades, party activity, and leaderboard scores are visible to other users as a normal part of an online multiplayer game.</li>
+        <li><strong>Service providers:</strong> hosting, database, content delivery, and infrastructure providers that run the Service on our behalf, under contracts that limit their use of the data.</li>
+        <li><strong>Advertising and analytics partners:</strong> if enabled, as described in Section 2.</li>
+        <li><strong>Legal and safety:</strong> to comply with the law, enforce our Terms, protect the rights, safety, and property of users, the public, or us, and respond to lawful requests.</li>
+        <li><strong>Business transfers:</strong> in connection with a merger, acquisition, financing, or sale of assets, in which case we will require the recipient to honour this Policy or notify you of any material change.</li>
+        </ul>
+        <hr />
+        <h2>6. Data retention</h2>
+        <p>We keep personal information only as long as needed for the purposes in this Policy.</p>
+        <ul>
+        <li><strong>Account and character data:</strong> retained for as long as your account remains active, so your characters and progress are preserved, and until you ask us to delete your account. We may close and delete accounts that have been inactive for a long period, but we are not obliged to.</li>
+        <li><strong>Chat and moderation records:</strong> retained for as long as needed for safety, security, and abuse prevention, generally up to 24 months, then deleted or anonymised.</li>
+        <li><strong>Technical and log data:</strong> retained for as long as needed to operate and secure the Service and to investigate incidents, generally up to 24 months.</li>
+        <li><strong>Backups:</strong> residual copies may persist in encrypted backups for a limited period before they are overwritten.</li>
+        </ul>
+        <hr />
+        <h2>7. Your rights and choices</h2>
+        <p>Depending on where you live, you may have some or all of these rights:</p>
+        <ul>
+        <li>Access the personal information we hold about you.</li>
+        <li>Correct inaccurate information.</li>
+        <li>Delete your information.</li>
+        <li>Object to or restrict certain processing.</li>
+        <li>Receive a copy of your information in a portable format.</li>
+        <li>Withdraw consent where we rely on it.</li>
+        </ul>
+        <p><strong>New Zealand:</strong> under the Privacy Act 2020 you may request access to and correction of your personal information.</p>
+        <p><strong>EEA and UK:</strong> you have the GDPR rights listed above and may lodge a complaint with your local data protection authority.</p>
+        <p><strong>California:</strong> under the CCPA and CPRA you may request to know, delete, and correct your personal information, and to opt out of the sale or sharing of personal information. We do not sell personal information. We will not discriminate against you for exercising these rights.</p>
+        <p>To exercise any right, contact us using Section 13. We may need to verify your identity before we act.</p>
+        <hr />
+        <h2>8. Deleting your account and data</h2>
+        <p>You can delete individual characters in the Game using the delete option on the character screen. To delete your entire account and associated personal information, use the account deletion option in the Game or App, or contact us using Section 13. We will action verified deletion requests within a reasonable time, subject to legal retention requirements. Some residual data may remain in backups for a limited period as described in Section 6.</p>
+        <hr />
+        <h2>9. Children</h2>
+        <p>The Service is not directed to children under 13, and you must be at least 13 to create an account (or older where your country sets a higher minimum age for online services, such as 16 in some EEA states). We do not knowingly collect personal information from children under the applicable minimum age. If you believe a child has provided us personal information, contact us using Section 13 and we will delete it.</p>
+        <hr />
+        <h2>10. International data transfers</h2>
+        <p>We are based in New Zealand and may process your information in New Zealand and in other countries, including where our service providers operate. These countries may have different data protection laws than yours. Where required, we use appropriate safeguards for international transfers, such as standard contractual clauses.</p>
+        <hr />
+        <h2>11. How we protect information</h2>
+        <p>We use technical and organisational measures to protect personal information, including salted scrypt password hashing, encrypted connections (TLS and secure WebSockets), per-IP rate limiting on authentication, and session tokens that expire after 7 days. No method of transmission or storage is completely secure, so we cannot guarantee absolute security.</p>
+        <hr />
+        <h2>12. Third-party services and links</h2>
+        <p>The Service links to and integrates third-party services, including GitHub, GitHub Sponsors, Discord, and the Solana network. These services are controlled by others and have their own privacy policies. We are not responsible for their practices. Review their policies before using them.</p>
+        <hr />
+        <h2>13. Contact us</h2>
+        <p>For privacy questions or to exercise your rights:</p>
+        <p>Email: tony@levystreet.com</p>
+        <p>Postal: Dream Home AI Limited, 262 Thorndon Quay, Wellington 6011, New Zealand</p>
+        <p>New Zealand users may also contact the Office of the Privacy Commissioner at privacy.org.nz.</p>
+        <hr />
+        <h2>14. No affiliation and the <span class="token-name">$WOC</span> token</h2>
+        <p>World of ClaudeCraft is an independent, community project.</p>
+        <p>It is not affiliated with, endorsed by, sponsored by, or associated with any third-party company, game, product, or brand. All third-party names and trademarks are the property of their respective owners.</p>
+        <p>The <span class="token-name">$WOC</span> token referenced by the community was created and is controlled by a third party. We do not issue, control, endorse, or guarantee it. It is not required to play, has no connection to your account data, and is not an investment offered by us. Wallet verification is cosmetic only. See our Terms and Conditions for more.</p>
+        <hr />
+        <h2>15. Changes to this Policy</h2>
+        <p>We may update this Policy from time to time. When we make material changes we will update the date above and, where appropriate, provide additional notice. Your continued use of the Service after an update means you accept the revised Policy.</p>
+      </article>
+    </main>
+    <footer>
+      <a href="/privacy">Privacy Policy</a>
+      <a href="/terms">Terms and Conditions</a>
+      <a href="/links">Official Links</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -15,4 +15,14 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://worldofclaudecraft.com/privacy</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://worldofclaudecraft.com/terms</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
 </urlset>

--- a/public/terms.html
+++ b/public/terms.html
@@ -1,0 +1,183 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="dark" />
+  <meta name="theme-color" content="#08080d" />
+  <title>Terms and Conditions - World of ClaudeCraft</title>
+  <meta name="description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices." />
+  <meta name="robots" content="index, follow, max-image-preview:large" />
+  <link rel="canonical" href="https://worldofclaudecraft.com/terms" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="World of ClaudeCraft" />
+  <meta property="og:title" content="Terms and Conditions - World of ClaudeCraft" />
+  <meta property="og:description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices." />
+  <meta property="og:url" content="https://worldofclaudecraft.com/terms" />
+  <meta property="og:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+  <meta property="og:image:alt" content="World of ClaudeCraft" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Terms and Conditions - World of ClaudeCraft" />
+  <meta name="twitter:description" content="Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices." />
+  <meta name="twitter:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "Terms and Conditions - World of ClaudeCraft",
+    "url": "https://worldofclaudecraft.com/terms",
+    "description": "Terms and Conditions for World of ClaudeCraft, covering accounts, acceptable use, virtual items, app store terms, and legal notices.",
+    "inLanguage": "en",
+    "isPartOf": { "@type": "WebSite", "name": "World of ClaudeCraft", "url": "https://worldofclaudecraft.com/" },
+    "dateModified": "2026-06-21"
+  }
+  </script>
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Alegreya:ital,wght@0,400;0,500;0,700;1,400&family=Alegreya+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
+  <style>
+    :root { color-scheme: dark; --gold: #ffd100; --gold-dim: #c8a838; --gold-soft: #f3dfaa; --ink: #f0ebd8; --muted: #c4b899; --border: #6f5a2a; --line: rgba(215, 181, 109, 0.32); --line-soft: rgba(215, 181, 109, 0.14); --bg: #08080d; --panel-top: rgba(20, 20, 30, 0.94); --panel-bottom: rgba(6, 6, 11, 0.96); --font-display: 'Cinzel', 'Palatino Linotype', Palatino, Georgia, serif; --font-ui: 'Alegreya Sans', 'Segoe UI', system-ui, -apple-system, sans-serif; --font-serif: 'Alegreya', 'Palatino Linotype', Palatino, Georgia, serif; --r-sm: 4px; --r-md: 8px; }
+    * { box-sizing: border-box; }
+    html, body { margin: 0; min-height: 100%; }
+    body { min-height: 100vh; min-height: 100dvh; color: var(--ink); font-family: var(--font-ui); -webkit-font-smoothing: antialiased; background: linear-gradient(90deg, rgba(5, 7, 12, 0.90), rgba(5, 7, 12, 0.56) 52%, rgba(5, 7, 12, 0.92)), radial-gradient(circle at 50% 8%, rgba(255, 209, 0, 0.16), transparent 40%), var(--bg) url('/loading-screen.jpg') center / cover fixed no-repeat; padding: max(18px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right)) max(22px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left)); }
+    body::before { content: ""; position: fixed; inset: 0; pointer-events: none; background: linear-gradient(rgba(255,255,255,0.018) 50%, rgba(0,0,0,0.035) 50%), radial-gradient(circle at 50% 100%, rgba(0,0,0,0.58), transparent 48%); background-size: 100% 4px, auto; }
+    .shell { position: relative; z-index: 1; width: min(1040px, 100%); margin: 0 auto; }
+    .topbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+    .brand { display: inline-flex; align-items: center; gap: 10px; color: var(--gold); text-decoration: none; font-family: var(--font-display); font-weight: 800; letter-spacing: 0.4px; }
+    .brand img { width: 38px; height: 38px; border-radius: 8px; box-shadow: 0 0 18px rgba(255, 209, 0, 0.22); }
+    .back-link { min-height: 40px; display: inline-flex; align-items: center; justify-content: center; padding: 8px 14px; border: 1px solid var(--border); border-radius: var(--r-sm); color: var(--gold-soft); background: rgba(8, 8, 13, 0.72); text-decoration: none; font-weight: 700; }
+    .back-link:hover, .back-link:focus-visible { color: var(--gold); border-color: var(--gold); outline: none; box-shadow: 0 0 14px rgba(255, 209, 0, 0.18); }
+    main { border: 1px solid var(--line); border-radius: var(--r-md); background: linear-gradient(180deg, var(--panel-top), var(--panel-bottom)); box-shadow: 0 22px 70px rgba(0,0,0,0.62), inset 0 1px 0 rgba(255,255,255,0.05); overflow: hidden; }
+    .hero { padding: clamp(22px, 5vw, 44px) clamp(18px, 5vw, 52px) clamp(16px, 3vw, 26px); border-bottom: 1px solid var(--line-soft); background: radial-gradient(circle at 18% 0%, rgba(255, 209, 0, 0.12), transparent 32%), linear-gradient(180deg, rgba(255,255,255,0.035), transparent); }
+    .eyebrow { margin: 0 0 10px; color: var(--gold-dim); font-family: var(--font-display); font-size: 12px; font-weight: 800; letter-spacing: 1.6px; text-transform: uppercase; }
+    h1 { margin: 0; color: var(--gold); font-family: var(--font-display); font-size: clamp(31px, 6vw, 58px); line-height: 1.05; letter-spacing: 0; text-shadow: 0 3px 18px rgba(0,0,0,0.65); }
+    .updated { margin: 12px 0 0; color: var(--muted); font-size: 15px; }
+    .content { padding: clamp(20px, 4vw, 42px) clamp(18px, 5vw, 52px) clamp(30px, 5vw, 56px); font-family: var(--font-serif); font-size: 17px; line-height: 1.68; }
+    .content h2, .content h3 { font-family: var(--font-display); letter-spacing: 0; color: var(--gold-soft); line-height: 1.22; }
+    .content h2 { margin: 34px 0 10px; font-size: clamp(22px, 3vw, 30px); }
+    .content h3 { margin: 26px 0 8px; font-size: clamp(18px, 2.4vw, 23px); }
+    .content p { margin: 0 0 16px; }
+    .content strong { color: var(--gold-soft); }
+    .content ul, .content ol { margin: 0 0 18px; padding-left: 24px; }
+    .content li { margin: 7px 0; padding-left: 4px; }
+    .content hr { border: 0; border-top: 1px solid var(--line-soft); margin: 28px 0; }
+    .token-name { white-space: nowrap; color: var(--gold); }
+    footer { margin-top: 18px; display: flex; justify-content: center; gap: 16px; flex-wrap: wrap; color: var(--muted); font-size: 13px; }
+    footer a { color: var(--gold-soft); text-decoration: none; }
+    footer a:hover, footer a:focus-visible { color: var(--gold); outline: none; }
+    @media (max-width: 640px) { body { padding-left: 12px; padding-right: 12px; background-attachment: scroll; } .topbar { align-items: flex-start; flex-direction: column; } .back-link { width: 100%; } .content { font-size: 16px; } }
+    @media (prefers-reduced-motion: reduce) { *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; } }
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <nav class="topbar" aria-label="Legal page navigation">
+      <a class="brand" href="/" aria-label="World of ClaudeCraft home"><img src="/woc_logo_square.webp" alt="" /> <span>World of ClaudeCraft</span></a>
+      <a class="back-link" href="/">Return to Game</a>
+    </nav>
+    <main>
+      <header class="hero">
+        <p class="eyebrow">Legal</p>
+        <h1>Terms and Conditions</h1>
+        <p class="updated">Last updated: 21 June 2026</p>
+      </header>
+      <article class="content">
+        <p><strong>World of ClaudeCraft</strong></p>
+        <h2>1. Who we are and what these terms cover</h2>
+        <p>These Terms and Conditions (the "Terms") are a legal agreement between you and Dream Home AI Limited, trading as Levy Street, New Zealand company number 8703066 ("we," "us," "our"). They govern your use of World of ClaudeCraft (the "Game"), worldofclaudecraft.com (the "Site"), and our mobile application (the "App"), together the "Service."</p>
+        <p>By using the Service you agree to these Terms and to our Privacy Policy. If you do not agree, do not use the Service.</p>
+        <h2>2. Changes to these terms</h2>
+        <p>We may update these Terms from time to time. When we make material changes we will update the date above and, where appropriate, give additional notice. Your continued use of the Service after an update means you accept the revised Terms.</p>
+        <h2>3. Eligibility</h2>
+        <p>You must be at least 13 years old to use the Service, or older where your country requires a higher minimum age for online services. If you are under the age of majority where you live, you may use the Service only with the involvement and consent of a parent or guardian who agrees to these Terms. The Service is not intended for children under 13.</p>
+        <h2>4. The Game and the source code</h2>
+        <p>We grant you a limited, personal, non-exclusive, non-transferable, revocable licence to access and play the Game for your own non-commercial entertainment, subject to these Terms.</p>
+        <p>The Game's source code is published in a public repository for viewing only. All rights in the source code are reserved. Making the repository publicly viewable does not grant you any licence or right to use, copy, modify, distribute, or create derivative works from the code, for commercial or non-commercial purposes, except with our prior written permission. These Terms govern your use of the hosted Service we operate, which is separate from any rights in the code.</p>
+        <h2>5. Accounts</h2>
+        <p>To play online you create an account. You agree to provide accurate information, to keep your credentials secure, and to be responsible for all activity under your account. Do not share your account or use anyone else's. Tell us promptly if you suspect unauthorised use. We may refuse, reclaim, or rename accounts or characters that breach these Terms or that use names which are offensive, infringing, impersonating, or misleading.</p>
+        <h2>6. Acceptable use and code of conduct</h2>
+        <p>When using the Service you agree not to:</p>
+        <ul>
+        <li>Cheat, exploit bugs, automate play, use bots, or use unauthorised third-party software to gain an advantage. Development and testing commands are for local development only and must not be used against the live Service.</li>
+        <li>Harass, threaten, defame, or abuse other players, or post hateful, obscene, or illegal content in chat, names, or anywhere else.</li>
+        <li>Impersonate any person or entity, including us or our staff.</li>
+        <li>Disrupt the Service, including through denial-of-service attacks, excessive automated requests, or attempts to overload or interfere with servers.</li>
+        <li>Access the Service through unauthorised means, scrape it, or probe, scan, or test its security without permission.</li>
+        <li>Reverse engineer, decompile, or attempt to extract source code from the hosted Service, except to the extent applicable law expressly allows and that right cannot be excluded.</li>
+        <li>Sell, trade for real money, or commercially exploit accounts, characters, in-game items, or in-game currency.</li>
+        <li>Use the Service for any unlawful purpose or in breach of these Terms.</li>
+        </ul>
+        <p>We may investigate suspected breaches and may suspend or terminate access, remove content, and report unlawful activity to authorities.</p>
+        <h2>7. User content</h2>
+        <p>The Service lets you create content, including character names and chat messages ("User Content"). You keep any rights you have in your User Content. You grant us a worldwide, non-exclusive, royalty-free licence to host, store, reproduce, transmit, display, and moderate your User Content for the purpose of operating, securing, and improving the Service.</p>
+        <p>You are responsible for your User Content and confirm you have the right to share it and that it does not breach these Terms or any law. We may review, moderate, refuse, or remove User Content, and may withhold or remove names, at our discretion. We are not obliged to monitor User Content, but we may.</p>
+        <h2>8. Virtual items and in-game currency</h2>
+        <p>The Game includes virtual items, gear, and in-game currency. These have no monetary value and cannot be redeemed for real money or anything of value outside the Game. You do not own them. We grant you a limited, revocable licence to use them within the Game only. We may modify, remove, reset, or wipe virtual items, currency, characters, and game worlds at any time, including during testing and balancing, without liability or compensation. The Game is free to play, and we do not sell virtual items or currency.</p>
+        <h2>9. The <span class="token-name">$WOC</span> token</h2>
+        <p>A token referred to as <span class="token-name">$WOC</span>, associated with the community on the Solana network, was created and is controlled by a third party. We do not issue, mint, control, manage, promote as an investment, or guarantee the <span class="token-name">$WOC</span> token or its value.</p>
+        <ul>
+        <li>The token is not required to play and has no effect on your account, characters, or progress.</li>
+        <li>Wallet verification in the Game is cosmetic only. It displays optional flair or a badge and involves no transaction and no transfer of funds.</li>
+        <li>Nothing in the Service is financial, investment, legal, or tax advice, or an offer, solicitation, or recommendation to buy, sell, or hold any token or digital asset.</li>
+        <li>Digital assets are volatile and carry risk, including total loss, and may be regulated differently in different countries. You are solely responsible for your own decisions and for complying with the laws that apply to you.</li>
+        </ul>
+        <p>To the fullest extent permitted by law, we are not liable for any loss connected with the <span class="token-name">$WOC</span> token or any third-party token, wallet, exchange, or blockchain.</p>
+        <h2>10. Donations</h2>
+        <p>Donations through GitHub Sponsors are voluntary and are processed by GitHub. Donations are not a purchase, are non-refundable except where the law requires, and do not entitle you to any product, in-game advantage, ownership, equity, token, or other benefit.</p>
+        <h2>11. Service availability and changes</h2>
+        <p>The Game is in active development and is provided on an evolving basis. We may change, suspend, limit, or discontinue all or part of the Service, including features, characters, items, and game worlds, at any time and without notice. We do not guarantee uptime, availability, or that the Service will be uninterrupted or error free. We may need to reset or wipe data for technical or balancing reasons.</p>
+        <h2>12. Third-party services</h2>
+        <p>The Service links to and relies on third-party services, including GitHub, Discord, the Solana network, and any advertising or analytics providers we use. We do not control these services and are not responsible for them. Your use of them is governed by their terms.</p>
+        <h2>13. Intellectual property and no affiliation</h2>
+        <p>World of ClaudeCraft is an independent, community project. It is not affiliated with, endorsed by, sponsored by, or associated with any third-party company, game, product, or brand. All third-party names, marks, and trademarks are the property of their respective owners. Any such names that appear are used only descriptively and do not imply any association.</p>
+        <p>Except for your User Content, the Service and the source code, including their original content, features, design, and branding, are owned by us or our licensors and are protected by intellectual property laws. You may not copy, distribute, or create derivative works from the Service or the source code except as these Terms expressly allow or with our prior written permission.</p>
+        <p>If you believe content on the Service infringes your intellectual property, contact us using Section 22 with enough detail to identify the work and the allegedly infringing material, and we will respond appropriately.</p>
+        <h2>14. Disclaimer of warranties</h2>
+        <p>To the fullest extent permitted by law, the Service is provided "as is" and "as available," without warranties of any kind, whether express, implied, or statutory, including warranties of merchantability, fitness for a particular purpose, title, and non-infringement. We do not warrant that the Service will be secure, uninterrupted, error free, or free of harmful components, or that data will not be lost.</p>
+        <h2>15. Consumer law</h2>
+        <p>Nothing in these Terms limits rights you have under laws that cannot be excluded, including, for consumers in New Zealand, the Consumer Guarantees Act 1993 and the Fair Trading Act 1986, and similar consumer protection laws elsewhere. Where the Service is supplied free of charge and for personal use, those guarantees apply only to the extent the law requires.</p>
+        <h2>16. Limitation of liability</h2>
+        <p>To the fullest extent permitted by law, we and our directors, employees, and contractors will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss of data, progress, profits, goodwill, or virtual items, arising from or related to your use of or inability to use the Service. To the extent we are found liable despite the above, our total liability for all claims relating to the Service is limited to NZD 100. Some jurisdictions do not allow certain limitations, so some of these may not apply to you.</p>
+        <h2>17. Indemnification</h2>
+        <p>You agree to indemnify and hold us harmless from any claims, losses, liabilities, and expenses, including reasonable legal fees, arising from your breach of these Terms, your User Content, or your misuse of the Service, to the extent permitted by law.</p>
+        <h2>18. Suspension and termination</h2>
+        <p>You may stop using the Service and delete your account at any time. We may suspend or terminate your access at any time, with or without notice, if you breach these Terms, if we are required to by law, or to protect the Service or other users. On termination, your licence to use the Service ends. Sections that by their nature should survive will survive, including Sections 8 to 17 and 19 to 22.</p>
+        <h2>19. Governing law and disputes</h2>
+        <p>These Terms are governed by the laws of New Zealand. The courts of New Zealand have non-exclusive jurisdiction over any dispute, without affecting any mandatory rights you have to bring proceedings in your country of residence.</p>
+        <h2>20. General</h2>
+        <p>If any provision of these Terms is held unenforceable, the rest remains in effect. Our failure to enforce a provision is not a waiver. You may not assign these Terms without our consent. We may assign them in connection with a merger, acquisition, or sale of assets. These Terms are the entire agreement between you and us regarding the Service.</p>
+        <h2>21. App store terms</h2>
+        <p>If you download the App from a third-party app store or platform (each a "Distributor"), the following additional terms apply. In the event of a conflict between these Terms and a Distributor's required terms, the Distributor's required terms apply for that App only and only to the extent of the conflict.</p>
+        <h3>21.1 Apple App Store</h3>
+        <p>These terms apply if you obtain the App from Apple. You acknowledge and agree that:</p>
+        <ol>
+        <li><strong>Acknowledgement.</strong> These Terms are between you and us only, not with Apple. We, not Apple, are solely responsible for the App and its content.</li>
+        <li><strong>Scope of licence.</strong> The licence granted to you for the App is a non-transferable licence to use the App on any Apple-branded products that you own or control, as permitted by the Usage Rules in the Apple App Store Terms of Service, except that the App may be accessed by other accounts associated with you via Family Sharing or volume purchasing.</li>
+        <li><strong>Maintenance and support.</strong> We, not Apple, are solely responsible for any maintenance and support services. Apple has no obligation to provide any maintenance or support for the App.</li>
+        <li><strong>Warranty.</strong> We are solely responsible for any product warranties, whether express or implied by law, to the extent not effectively disclaimed. If the App fails to conform to any applicable warranty, you may notify Apple, and Apple will refund the purchase price of the App, if any. To the maximum extent permitted by law, Apple has no other warranty obligation with respect to the App.</li>
+        <li><strong>Product claims.</strong> We, not Apple, are responsible for addressing any claims by you or a third party relating to the App or your use of it, including product liability claims, claims that the App fails to conform to a legal or regulatory requirement, and claims under consumer protection, privacy, or similar laws.</li>
+        <li><strong>Intellectual property.</strong> In the event of a third-party claim that the App or your use of it infringes that third party's intellectual property rights, we, not Apple, are solely responsible for the investigation, defence, settlement, and discharge of that claim.</li>
+        <li><strong>Legal compliance.</strong> You represent and warrant that you are not located in a country subject to a U.S. Government embargo or designated as a "terrorist supporting" country, and that you are not listed on any U.S. Government list of prohibited or restricted parties.</li>
+        <li><strong>Developer name and contact.</strong> Questions, complaints, or claims regarding the App should be directed to us using the contact details in Section 22.</li>
+        <li><strong>Third-party terms.</strong> You must comply with applicable third-party terms of agreement when using the App.</li>
+        <li><strong>Third-party beneficiary.</strong> Apple and Apple's subsidiaries are third-party beneficiaries of these Terms, and upon your acceptance of these Terms, Apple will have the right, and will be deemed to have accepted the right, to enforce these Terms against you as a third-party beneficiary.</li>
+        </ol>
+        <h3>21.2 Google Play</h3>
+        <p>These terms apply if you obtain the App from Google Play. Your use of the App must comply with the then-current Google Play Terms of Service. Google is not a party to these Terms and is not responsible for the App. Any claim relating to the App is between you and us, not Google.</p>
+        <h2>22. Contact us</h2>
+        <p>Email: tony@levystreet.com</p>
+        <p>Postal: Dream Home AI Limited, 262 Thorndon Quay, Wellington 6011, New Zealand</p>
+      </article>
+    </main>
+    <footer>
+      <a href="/privacy">Privacy Policy</a>
+      <a href="/terms">Terms and Conditions</a>
+      <a href="/links">Official Links</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/server/main.ts
+++ b/server/main.ts
@@ -49,6 +49,10 @@ const STATIC_PAGE_ALIASES = new Map([
   ['/social-media-links/', '/links.html'],
   ['/play', '/play.html'],
   ['/play/', '/play.html'],
+  ['/privacy', '/privacy.html'],
+  ['/privacy/', '/privacy.html'],
+  ['/terms', '/terms.html'],
+  ['/terms/', '/terms.html'],
 ]);
 // How long chat logs are kept (0 = forever); pruned at boot and daily.
 const CHAT_LOG_RETENTION_DAYS = Number(process.env.CHAT_LOG_RETENTION_DAYS ?? 90);

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, it } from 'vitest';
 
 const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const playHtml = readFileSync(new URL('../play.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const privacyHtml = readFileSync(new URL('../public/privacy.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const termsHtml = readFileSync(new URL('../public/terms.html', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const viteConfig = readFileSync(new URL('../vite.config.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
+const serverMain = readFileSync(new URL('../server/main.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const mainTs = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const hudTs = readFileSync(new URL('../src/ui/hud.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
 const mobileControlsTs = readFileSync(new URL('../src/game/mobile_controls.ts', import.meta.url), 'utf8').replace(/\r\n/g, '\n');
@@ -55,6 +59,18 @@ describe('client HTML shell', () => {
     expect(playHtml).toContain('<link rel="canonical" href="https://worldofclaudecraft.com/play" />');
     expect(playHtml).toContain('<meta property="og:url" content="https://worldofclaudecraft.com/play" />');
     expect(playHtml).toContain('"url": "https://worldofclaudecraft.com/play"');
+    expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/privacy</loc>');
+    expect(sitemapXml).toContain('<loc>https://worldofclaudecraft.com/terms</loc>');
+    expect(privacyHtml).toContain('<link rel="canonical" href="https://worldofclaudecraft.com/privacy" />');
+    expect(privacyHtml).toContain('<h1>Privacy Policy</h1>');
+    expect(termsHtml).toContain('<link rel="canonical" href="https://worldofclaudecraft.com/terms" />');
+    expect(termsHtml).toContain('<h1>Terms and Conditions</h1>');
+    expect(html).toContain('href="/terms" class="footer-link" data-i18n="footer.terms"');
+    expect(html).toContain('href="/privacy" class="footer-link" data-i18n="footer.privacy"');
+    expect(viteConfig).toContain("['/privacy', '/privacy.html']");
+    expect(viteConfig).toContain("['/terms', '/terms.html']");
+    expect(serverMain).toContain("['/privacy', '/privacy.html']");
+    expect(serverMain).toContain("['/terms', '/terms.html']");
   });
 
   it('loads Meta Pixel outside local development and tracks level 5', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -61,6 +61,10 @@ const STATIC_PAGE_ALIASES = new Map([
   ['/social-media-links/', '/links.html'],
   ['/play', '/play.html'],
   ['/play/', '/play.html'],
+  ['/privacy', '/privacy.html'],
+  ['/privacy/', '/privacy.html'],
+  ['/terms', '/terms.html'],
+  ['/terms/', '/terms.html'],
 ]);
 function staticPageAliasPlugin() {
   const rewrite = (req: { url?: string }) => {


### PR DESCRIPTION
## Problem
The site needs crawlable, first-party Privacy Policy and Terms and Conditions pages for release and app store readiness. The main menu footer also needs stable links to those legal pages.

## Fix
- Add standalone legal pages at `/privacy` and `/terms`, generated from the local legal Markdown source documents.
- Wire pretty route aliases through both Vite dev middleware and the Node static page resolver.
- Add sitemap entries for both legal pages.
- Add Terms and Privacy footer links on the main menu using the existing localized footer keys.
- Extend client shell coverage for legal page canonicals, sitemap entries, footer links, and route alias wiring.

## Verification
- `npx vitest run tests/client_shell.test.ts`
- `npm run build:server`
- `npm run build`

## Notes
`npm run build` still reports the existing Meta Pixel noscript parse warning, cursor URL runtime-resolution warnings, and chunk size/dynamic import warnings. These are pre-existing and unrelated to this change.