### PR TITLE
fix(market): always wire a seller their own listings (12/12 count vs visible mismatch)

### DIFF
--- a/scripts/market_listing_count_shot.mjs
+++ b/scripts/market_listing_count_shot.mjs
@@ -1,0 +1,88 @@
+// Evidence for the market-listing-count fix. Reproduces a busy shared market
+// (>120 listings) where a seller holds all 12 of their slots, then captures the
+// market window's Sell tab ("X / 12 slots") alongside the Browse tab. Before the
+// fix the seller's own goods sort past MARKET_WIRE_LIMIT and never wire, so the
+// Browse list shows none of them while Sell still reads 12/12. After the fix the
+// seller's listings are always wired (the "Reclaim" rows on page 1).
+//
+// Run with max graphics: GFX=ultra. Toggle which build you screenshot with
+// LABEL=before|after (purely cosmetic — affects only the output filenames).
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const GFX = process.env.GFX ?? 'ultra';
+const LABEL = process.env.LABEL ?? 'after';
+const URL = `${process.env.GAME_URL ?? 'http://localhost:5173'}/?gfx=${GFX}`;
+const OUT = 'tmp/market_count';
+fs.mkdirSync(OUT, { recursive: true });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,1000', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 1000 },
+});
+const page = await browser.newPage();
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+await page.waitForSelector('#btn-offline', { timeout: 30000 });
+await tap('#btn-offline');
+await wait(300);
+await page.evaluate(() => {
+  document.querySelector('#char-name').value = 'Strider';
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]')?.click();
+});
+await tap('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.hud && window.__game?.sim, { timeout: 30000 });
+await wait(1500);
+
+// Stand the player on the Merchant, list all 12 of their slots, then flood the
+// market with 200 cheaper other-seller listings that sort first.
+const setup = await page.evaluate(() => {
+  const { sim, hud } = window.__game;
+  const me = [...sim.players.keys()][0];
+  let merch = null;
+  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') merch = e;
+  const pe = sim.entities.get(me);
+  pe.pos.x = merch.pos.x; pe.pos.z = merch.pos.z; pe.prevPos = { ...pe.pos };
+
+  sim.addItem('wolf_fang', 12, me);
+  for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 200 + i, me);
+
+  let id = sim.nextListingId;
+  for (let i = 0; i < 200; i++) {
+    sim.marketListings.push({
+      id: id++, sellerKey: `Trader${i}`, sellerName: `Trader${i}`,
+      itemId: 'bone_fragments', count: 1, price: 40 + (i % 30), expiresAt: sim.time + 1000, house: false,
+    });
+  }
+  sim.nextListingId = id;
+  const info = sim.marketInfoFor(me);
+  return {
+    total: sim.marketListings.length,
+    myListingCount: info.myListingCount,
+    wired: info.listings.length,
+    mineWired: info.listings.filter((l) => l.mine).length,
+  };
+});
+console.log(`[${LABEL}]`, JSON.stringify(setup));
+
+// Open the market and capture the Browse tab (page 1).
+await page.evaluate(() => window.__game.hud.openMarket());
+await wait(600);
+const clip = await page.evaluate(() => {
+  const el = document.querySelector('#market-window');
+  const r = el.getBoundingClientRect();
+  return { x: Math.round(r.x), y: Math.round(r.y), width: Math.round(r.width), height: Math.round(r.height) };
+});
+await page.screenshot({ path: `${OUT}/${LABEL}_browse.png`, clip });
+
+// Switch to the Sell tab where the "X / 12 listing slots" note lives.
+await page.evaluate(() => { const h = window.__game.hud; h.marketTab = 'sell'; h.renderMarket(); });
+await wait(400);
+await page.screenshot({ path: `${OUT}/${LABEL}_sell.png`, clip });
+
+await browser.close();
+console.log(`saved ${OUT}/${LABEL}_browse.png and ${OUT}/${LABEL}_sell.png`);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -9522,9 +9522,19 @@ export class Sim {
       const nb = ITEMS[b.itemId]?.name ?? b.itemId;
       return na.localeCompare(nb) || a.price - b.price;
     });
-    const listings = sorted.slice(0, MARKET_WIRE_LIMIT).map((l) => ({
+    // Always wire the seller their own listings first, then fill the rest of the
+    // wire budget with everyone else's. Without this, on a busy shared market a
+    // seller's goods can sort past MARKET_WIRE_LIMIT and never reach them — the
+    // SELL tab would then read "12/12" while only a handful of their listings
+    // are visible. MARKET_MAX_LISTINGS (12) ≪ MARKET_WIRE_LIMIT (120), so a
+    // seller's own goods always fit alongside a healthy slice of the market.
+    const isMine = (l: MarketListing) => !l.house && l.sellerKey === meta.name;
+    const mineSorted = sorted.filter(isMine);
+    const others = sorted.filter((l) => !isMine(l));
+    const wired = [...mineSorted, ...others.slice(0, Math.max(0, MARKET_WIRE_LIMIT - mineSorted.length))];
+    const listings = wired.map((l) => ({
       id: l.id, sellerName: l.sellerName, itemId: l.itemId, count: l.count,
-      price: l.price, mine: !l.house && l.sellerKey === meta.name, house: l.house,
+      price: l.price, mine: isMine(l), house: l.house,
     }));
     const col = this.marketCollections.get(meta.name);
     const myListingCount = this.marketListings.reduce((n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -307,4 +307,37 @@ describe('the World Market — the Merchant', () => {
     const ids = sim2.marketListings.map((l) => l.id);
     expect(new Set(ids).size).toBe(ids.length); // no id collisions
   });
+
+  it('always wires a seller their own listings even when the market overflows the wire cap', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+
+    // The seller fills all 12 of their slots. Their item name ('wolf_fang')
+    // sorts late in the alphabet on purpose.
+    sim.addItem('wolf_fang', 12, seller);
+    for (let i = 0; i < 12; i++) sim.marketList('wolf_fang', 1, 100 + i, seller);
+
+    // Flood the shared market with 200 other-seller listings whose names sort
+    // first, pushing the seller's own goods well past MARKET_WIRE_LIMIT (120).
+    const internals = sim as unknown as { marketListings: Array<Record<string, unknown>>; nextListingId: number };
+    for (let i = 0; i < 200; i++) {
+      internals.marketListings.push({
+        id: internals.nextListingId++,
+        sellerKey: `Other${i}`, sellerName: `Other${i}`,
+        itemId: 'aaa_filler', count: 1, price: 50,
+        expiresAt: sim.time + 1000, house: false,
+      });
+    }
+
+    const info = sim.marketInfoFor(seller)!;
+    // The "X / 12" slot count the SELL tab shows.
+    expect(info.myListingCount).toBe(12);
+    // Every one of the seller's own listings must be present in the wired set,
+    // so the count never claims more than the player can actually see.
+    const mineWired = info.listings.filter((l) => l.mine).length;
+    expect(mineWired).toBe(info.myListingCount);
+    // The wire cap is still respected overall.
+    expect(info.listings.length).toBeLessThanOrEqual(120);
+  });
 });


### PR DESCRIPTION
## The report
> The world market is showing that I am listing **12 / 12 items** but only am listing like **4**.

## Root cause
The World Market ships at most `MARKET_WIRE_LIMIT` (**120**) listings per snapshot, taken off a **single global alphabetical sort** of every listing on the shared market:

```ts
const listings = sorted.slice(0, MARKET_WIRE_LIMIT).map(...)
```

But the "X / 12 slots used" figure (`myListingCount`) is computed over **every** stored listing the seller owns:

```ts
const myListingCount = this.marketListings.reduce(
  (n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0), 0);
```

On a busy shared market (>120 listings) a seller's own goods can sort **past slot 120** and never get wired to their client. The Sell tab still reads **12 / 12** (counted server-side over all listings), while the Browse list shows only the few of the seller's items that happened to land inside the first 120 — exactly the "12/12 but I only see ~4" symptom.

`marketInfoFor` is server-authoritative and deterministic; the client only renders what it is sent, so the count and the visible list disagree.

## The fix
Partition the wired set so the seller's **own** listings are always included first, then fill the remaining wire budget with everyone else's. Because `MARKET_MAX_LISTINGS` (12) ≪ `MARKET_WIRE_LIMIT` (120), a seller's goods always fit alongside a healthy slice of the wider market, and the "X / 12" count can never exceed what the player can actually see. The 120-listing wire cap is still respected overall.

Pure `src/sim/` logic — no wire-format change, no new player-visible strings, no i18n. Same change runs identically in the offline browser world, the authoritative server, and the headless RL env.

## Evidence (`?gfx=ultra`)
Busy market: 233 total listings, seller holds all 12 slots (`wolf_fang`, which sorts late). Diagnostic from the harness:

| | `myListingCount` | listings wired | **seller's own wired** |
|---|---|---|---|
| **before** | 12 | 120 | **0** |
| **after** | 12 | 120 | **12** |

**Sell tab — both builds read "using 12/12 listing slots":**

![sell tab](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-market-count/before_sell.png)

**Browse — before (none of the seller's 12 are visible; all other traders' "Buy" rows):**

![before browse](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-market-count/before_browse.png)

**Browse — after (the seller's own "Reclaim" listings are always wired):**

![after browse](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-market-count/after_browse.png)

## Tests
- New regression test in `tests/market.test.ts`: floods the market past the wire cap and asserts every one of the seller's listings is wired (`mineWired === myListingCount`). Fails on base, passes with the fix.
- `npx vitest run tests/market.test.ts tests/market_filters.test.ts tests/listings_command.test.ts` → 27 pass.
- `npx tsc --noEmit` clean. Full suite: 2447 pass; the only 3 failures are the pre-existing gitignored-i18n-registry freshness tests (`i18n_status_registry`, `localization_fixes`, `i18n_completeness`) which fail identically on the untouched base — unrelated to this change.
- New screenshot harness: `scripts/market_listing_count_shot.mjs`.

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)
