### PR TITLE
fix(ui): trade money takes gold/silver/copper, not just copper

### DIFF
--- a/index.html
+++ b/index.html
@@ -4341,7 +4341,10 @@
   .trade-empty { color: var(--color-text-muted); font-size: 11px; padding: 4px; }
   .trade-money { margin-top: 6px; font-size: 12px; }
   .trade-money-label { display: block; margin-bottom: 4px; }
-  .trade-coins { display: flex; gap: 6px; align-items: center; }
+  .trade-coins { display: flex; gap: 4px; align-items: center; }
+  /* The coin disc sits between its input and the g/s/c tag; flex gap handles spacing, so drop the disc's own margins here. The tag hugs the disc (no preceding gap). */
+  .trade-coins .coin { margin: 0; }
+  .trade-coins .coin + .mkt-coin-tag { margin-left: -2px; }
   .trade-money input.coininput { width: 52px; }
   .trade-money input { width: 80px; background: #0d0d14; color: #ffd100; border: 1px solid var(--border); border-radius: 3px; padding: 3px 6px; user-select: text; }
   .trade-money .mkt-coin-tag { margin-right: 2px; }

--- a/index.html
+++ b/index.html
@@ -4340,7 +4340,11 @@
   .trade-item.mine:hover { background: #ffffff14; }
   .trade-empty { color: var(--color-text-muted); font-size: 11px; padding: 4px; }
   .trade-money { margin-top: 6px; font-size: 12px; }
+  .trade-money-label { display: block; margin-bottom: 4px; }
+  .trade-coins { display: flex; gap: 6px; align-items: center; }
+  .trade-money input.coininput { width: 52px; }
   .trade-money input { width: 80px; background: #0d0d14; color: #ffd100; border: 1px solid var(--border); border-radius: 3px; padding: 3px 6px; user-select: text; }
+  .trade-money .mkt-coin-tag { margin-right: 2px; }
   .trade-hint { font-size: 10.5px; color: #887c5c; margin-top: 8px; }
 
   /* ---------- elite target frame ---------- */

--- a/scripts/trade_money_shot.mjs
+++ b/scripts/trade_money_shot.mjs
@@ -65,12 +65,14 @@ const res = await page.evaluate(() => {
     threeFields: !!(g && s && c),
     legacyField: !!document.querySelector('#trade-copper'),
     g: g?.value, s: s?.value, c: c?.value,
+    coins: document.querySelectorAll('.trade-coins .coin.g, .trade-coins .coin.s, .trade-coins .coin.c').length,
   };
 });
 check(res.open, 'trade window is open');
 check(res.threeFields, 'trade money has three gold/silver/copper fields');
 check(!res.legacyField, 'the old single #trade-copper field is gone');
 check(res.g === '5' && res.s === '32' && res.c === '45', `53245c seeds 5g 32s 45c (got ${res.g}g ${res.s}s ${res.c}c)`);
+check(res.coins === 3, `each money field shows a gold/silver/copper coin glyph (got ${res.coins}/3)`);
 
 await sleep(400);
 const win = await page.$('#trade-window');

--- a/scripts/trade_money_shot.mjs
+++ b/scripts/trade_money_shot.mjs
@@ -1,0 +1,82 @@
+// Screenshot of the player Trade window's MONEY input. Before this fix the
+// "Your offer" money was a single raw-copper number box; now it is three
+// gold/silver/copper fields matching the World Market sell form, so a player
+// no longer has to hand-convert (e.g. 5g 32s 45c instead of typing 53245).
+// Boots the offline game headless at max graphics, stubs an open trade so the
+// REAL HUD renders updateTradeWindow(), and captures tmp/trade_money.png.
+// Run with `npm run dev` already up.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+const OUT = process.env.SHOT ?? 'tmp/trade_money.png';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fails = [];
+const check = (cond, msg) => { console.log(`${cond ? 'OK  ' : 'FAIL'}  ${msg}`); if (!cond) fails.push(msg); };
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,1000', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+  defaultViewport: { width: 1600, height: 1000, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => fails.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE-ERR:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 40000 });
+await page.waitForSelector('#btn-offline', { visible: true, timeout: 25000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await page.waitForSelector('#offline-select .mini-class[data-class="warrior"]', { visible: true, timeout: 25000 });
+await sleep(200);
+await page.evaluate(() => {
+  document.querySelector('#char-name').value = 'Hero';
+  document.querySelector('#offline-select .mini-class[data-class="warrior"]').click();
+  document.querySelector('#btn-start-offline').click();
+});
+// ?gfx=ultra under software rendering boots slowly (~30-40s); poll generously.
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 5, { timeout: 60000, polling: 300 });
+await sleep(2500); // let max-gfx scene settle
+
+// Stub an open trade and stage a money amount, then drive the real HUD render.
+const res = await page.evaluate(() => {
+  const hud = window.__game.hud;
+  const sim = window.__game.sim;
+  const TI = {
+    otherPid: 999,
+    otherName: 'Aldric',
+    myOffer: { items: [], copper: 53245 },
+    theirOffer: { items: [], copper: 12050 },
+    myAccepted: false,
+    theirAccepted: false,
+  };
+  Object.defineProperty(sim, 'tradeInfo', { configurable: true, get() { return TI; } });
+  hud.updateTradeWindow();            // opens window, resets stagedTrade to 0
+  hud.stagedTrade = { items: [], copper: 53245 };
+  hud.lastTradeSig = '';              // force a re-render with the staged amount
+  hud.updateTradeWindow();
+  const g = document.querySelector('#trade-g');
+  const s = document.querySelector('#trade-s');
+  const c = document.querySelector('#trade-c');
+  return {
+    open: document.querySelector('#trade-window')?.style.display === 'block',
+    threeFields: !!(g && s && c),
+    legacyField: !!document.querySelector('#trade-copper'),
+    g: g?.value, s: s?.value, c: c?.value,
+  };
+});
+check(res.open, 'trade window is open');
+check(res.threeFields, 'trade money has three gold/silver/copper fields');
+check(!res.legacyField, 'the old single #trade-copper field is gone');
+check(res.g === '5' && res.s === '32' && res.c === '45', `53245c seeds 5g 32s 45c (got ${res.g}g ${res.s}s ${res.c}c)`);
+
+await sleep(400);
+const win = await page.$('#trade-window');
+await win.screenshot({ path: OUT });
+console.log('wrote ' + OUT);
+
+await browser.close();
+console.log(fails.length === 0 ? '\nALL TRADE-MONEY CHECKS PASSED' : `\n${fails.length} CHECK(S) FAILED:\n - ` + fails.join('\n - '));
+process.exit(fails.length === 0 ? 0 : 1);

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5166,9 +5166,9 @@ export class Hud {
     const g = Math.floor(suggested / 10000), s = Math.floor((suggested % 10000) / 100), c = suggested % 100;
     form.innerHTML = qtyRow
       + `<div class="mkt-price-row"><label>${esc(t('itemUi.market.priceEach'))}</label>`
-      + `<input class="coininput" id="mkt-g" type="number" min="0" value="${g}" aria-label="${esc(t('itemUi.money.gold'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.goldShort'))}</span>`
-      + `<input class="coininput" id="mkt-s" type="number" min="0" max="99" value="${s}" aria-label="${esc(t('itemUi.money.silver'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.silverShort'))}</span>`
-      + `<input class="coininput" id="mkt-c" type="number" min="0" max="99" value="${c}" aria-label="${esc(t('itemUi.money.copper'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.copperShort'))}</span></div>`;
+      + `<input class="coininput" id="mkt-g" type="number" min="0" value="${g}" aria-label="${esc(t('itemUi.money.gold'))}"><span class="coin g" aria-hidden="true"></span><span class="mkt-coin-tag">${esc(t('itemUi.money.goldShort'))}</span>`
+      + `<input class="coininput" id="mkt-s" type="number" min="0" max="99" value="${s}" aria-label="${esc(t('itemUi.money.silver'))}"><span class="coin s" aria-hidden="true"></span><span class="mkt-coin-tag">${esc(t('itemUi.money.silverShort'))}</span>`
+      + `<input class="coininput" id="mkt-c" type="number" min="0" max="99" value="${c}" aria-label="${esc(t('itemUi.money.copper'))}"><span class="coin c" aria-hidden="true"></span><span class="mkt-coin-tag">${esc(t('itemUi.money.copperShort'))}</span></div>`;
     body.appendChild(form);
 
     const listBtn = document.createElement('button');
@@ -8000,9 +8000,9 @@ export class Hud {
           <div class="trade-items">${info.myOffer.items.map((s) => itemRow(s, true)).join('') || `<div class="trade-empty">${esc(t('hud.trade.emptyMine'))}</div>`}</div>
           <div class="trade-money"><span class="trade-money-label">${esc(t('hud.trade.money'))}:</span>
             <span class="trade-coins">
-              <input class="coininput" id="trade-g" type="number" min="0" value="${Math.floor(this.stagedTrade.copper / 10000)}" aria-label="${esc(t('itemUi.money.gold'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.goldShort'))}</span>
-              <input class="coininput" id="trade-s" type="number" min="0" max="99" value="${Math.floor((this.stagedTrade.copper % 10000) / 100)}" aria-label="${esc(t('itemUi.money.silver'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.silverShort'))}</span>
-              <input class="coininput" id="trade-c" type="number" min="0" max="99" value="${this.stagedTrade.copper % 100}" aria-label="${esc(t('itemUi.money.copper'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.copperShort'))}</span>
+              <input class="coininput" id="trade-g" type="number" min="0" value="${Math.floor(this.stagedTrade.copper / 10000)}" aria-label="${esc(t('itemUi.money.gold'))}"><span class="coin g" aria-hidden="true"></span><span class="mkt-coin-tag">${esc(t('itemUi.money.goldShort'))}</span>
+              <input class="coininput" id="trade-s" type="number" min="0" max="99" value="${Math.floor((this.stagedTrade.copper % 10000) / 100)}" aria-label="${esc(t('itemUi.money.silver'))}"><span class="coin s" aria-hidden="true"></span><span class="mkt-coin-tag">${esc(t('itemUi.money.silverShort'))}</span>
+              <input class="coininput" id="trade-c" type="number" min="0" max="99" value="${this.stagedTrade.copper % 100}" aria-label="${esc(t('itemUi.money.copper'))}"><span class="coin c" aria-hidden="true"></span><span class="mkt-coin-tag">${esc(t('itemUi.money.copperShort'))}</span>
             </span>
           </div>
         </div>

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -7998,7 +7998,13 @@ export class Hud {
         <div class="trade-col ${info.myAccepted ? 'accepted' : ''}">
           <h4>${esc(t('hud.trade.yourOffer'))}</h4>
           <div class="trade-items">${info.myOffer.items.map((s) => itemRow(s, true)).join('') || `<div class="trade-empty">${esc(t('hud.trade.emptyMine'))}</div>`}</div>
-          <label class="trade-money" for="trade-copper">${esc(t('hud.trade.money'))}: <input id="trade-copper" type="number" min="0" value="${this.stagedTrade.copper}" /> ${esc(t('hud.trade.copper'))}</label>
+          <div class="trade-money"><span class="trade-money-label">${esc(t('hud.trade.money'))}:</span>
+            <span class="trade-coins">
+              <input class="coininput" id="trade-g" type="number" min="0" value="${Math.floor(this.stagedTrade.copper / 10000)}" aria-label="${esc(t('itemUi.money.gold'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.goldShort'))}</span>
+              <input class="coininput" id="trade-s" type="number" min="0" max="99" value="${Math.floor((this.stagedTrade.copper % 10000) / 100)}" aria-label="${esc(t('itemUi.money.silver'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.silverShort'))}</span>
+              <input class="coininput" id="trade-c" type="number" min="0" max="99" value="${this.stagedTrade.copper % 100}" aria-label="${esc(t('itemUi.money.copper'))}"><span class="mkt-coin-tag">${esc(t('itemUi.money.copperShort'))}</span>
+            </span>
+          </div>
         </div>
         <div class="trade-col ${info.theirAccepted ? 'accepted' : ''}">
           <h4>${esc(t('hud.trade.theirOffer', { name: info.otherName }))}</h4>
@@ -8029,11 +8035,17 @@ export class Hud {
         }
       });
     });
-    const copperInput = el.querySelector('#trade-copper') as HTMLInputElement;
-    copperInput?.addEventListener('change', () => {
-      this.stagedTrade.copper = Math.max(0, Math.floor(Number(copperInput.value) || 0));
+    const goldInput = el.querySelector('#trade-g') as HTMLInputElement;
+    const silverInput = el.querySelector('#trade-s') as HTMLInputElement;
+    const copperInput = el.querySelector('#trade-c') as HTMLInputElement;
+    const syncTradeMoney = () => {
+      const gg = Math.max(0, Math.floor(Number(goldInput?.value) || 0));
+      const ss = Math.max(0, Math.floor(Number(silverInput?.value) || 0));
+      const cc = Math.max(0, Math.floor(Number(copperInput?.value) || 0));
+      this.stagedTrade.copper = gg * 10000 + ss * 100 + cc;
       this.pushTradeOffer();
-    });
+    };
+    [goldInput, silverInput, copperInput].forEach((input) => input?.addEventListener('change', syncTradeMoney));
     el.style.display = 'block';
   }
 


### PR DESCRIPTION
## Problem

The player **Trade window** offered money through a single **raw-copper** number box (`#trade-copper`). Everywhere else in the game — vendor prices, loot, market listings, and even the *other* side of the very same trade — already shows and accepts **gold / silver / copper**. So to offer `5g 32s 45c` a player had to mentally convert and type `53245`. That copper-only input was an asymmetry unique to this one form.

Note the "before" shot below: Aldric's offer already reads `1g 20s 50c`, while *my own* input is forced to raw `53245 copper`.

## Fix

Replace the single field with **three g/s/c inputs** that mirror the existing World Market sell form (`#mkt-g/s/c`):
- Seeded by decomposing the staged copper (`/10000`, `%10000/100`, `%100`).
- Recombined on change as `g*10000 + s*100 + c`.

Money is still stored as a **single copper integer** end to end — this is a display/input change only. **No sim, wire, or `IWorld` change.** It reuses the existing `itemUi.money.*` keys, so **no new translation keys** are introduced.

## Before / After

| Before (raw copper) | After (gold / silver / copper) |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-trade-money/trade_money_before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-trade-money/trade_money_after.png) |

Screenshots captured at **max graphics** (`?gfx=ultra`, DPR 2) via the new `scripts/trade_money_shot.mjs` E2E harness.

## Testing
- `npx tsc --noEmit` — clean
- `npx vitest run` — 2489 passed (the one pre-existing `i18n_completeness` failure re `wallet.holderTiers.*` is present on a pristine `release/v0.12.0` base and is unrelated to this change)
- `tests/localization_fixes.test.ts` (S3 i18n guard) — passes
- `scripts/trade_money_shot.mjs` — all checks pass (window opens, three fields present, `53245c` → `5g 32s 45c`)

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)