### PR TITLE
fix(ui): preserve bag scroll position when using an item

### DIFF
--- a/scripts/bag_scroll_shot.mjs
+++ b/scripts/bag_scroll_shot.mjs
@@ -1,0 +1,93 @@
+// Verification + screenshot harness for the bag-scroll-preservation fix.
+// Boots the offline world as a mage, fills the bags past one screenful (so the
+// .bag-grid scroll container actually scrolls), opens the bags, scrolls to the
+// bottom, then clicks a mana potion to consume it. With the fix the list stays
+// put; without it the list snaps back to the top.
+//
+// Needs a dev server (default :5173, override with GAME_URL). Renders at max
+// graphics via ?gfx=ultra. Writes screenshots + a scrollTop report to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+const TAG = process.env.SHOT_TAG ?? 'after';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 60000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Potionwyn');
+await page.click('#offline-select .mini-class[data-class="mage"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.hud, { timeout: 60000 });
+await sleep(2500);
+
+// Fill the bags with many DISTINCT items (stacks would collapse to one row) so
+// the .bag-grid actually overflows and scrolls, plus a mana potion to consume.
+await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const distinct = [
+    'acolytes_circlet', 'amber_hide', 'apprentice_robe', 'apprentice_staff', 'baked_bread',
+    'bandit_bandana', 'blessed_wax', 'boar_hide', 'bone_fragments', 'boundstone_girdle',
+    'boundstone_helm', 'bramblehide_jerkin', 'brightwood_venison', 'bristleback_maul',
+    'bristlehide_spaulders', 'bronzework_mace', 'caravan_quilted_vest', 'caravan_warden_dirk',
+    'crossroads_saber', 'cryptbone_greaves', 'cryptbone_helm', 'cryptbone_pauldrons',
+    'cryptstalker_jerkin', 'drovers_staff', 'eastbrook_arming_sword', 'eastbrook_chain_vest',
+    'eastbrook_wool_trousers', 'elixir_of_the_bear', 'embroidered_mantle', 'footpad_jerkin',
+    'glade_pelt', 'gnarled_staff', 'gorraks_cleaver',
+  ];
+  for (const id of distinct) sim.addItem(id, 1);
+  sim.addItem('minor_mana_potion', 5);
+});
+await page.evaluate(() => {
+  const el = document.querySelector('#bags');
+  // toggleBags() reads the *inline* display; force it closed then open so we
+  // get a guaranteed fresh render regardless of the default state.
+  el.style.display = 'none';
+  window.__game.hud.toggleBags();
+});
+await sleep(500);
+
+// Scroll the grid to the bottom and capture the offset + the bottom item.
+const before = await page.evaluate(() => {
+  const grid = document.querySelector('#bags .bag-grid');
+  grid.scrollTop = 300; // scroll partway down (stable, unclamped)
+  return { scrollTop: grid.scrollTop, scrollHeight: grid.scrollHeight, clientHeight: grid.clientHeight };
+});
+await sleep(200);
+await page.screenshot({ path: `tmp/bag-scroll-${TAG}-1-scrolled.png` });
+
+// Consume a mana potion the same way a player would: click its bag row.
+const used = await page.evaluate(() => {
+  const rows = [...document.querySelectorAll('#bags .bag-item')];
+  const row = rows.find((r) => /Mana Potion/i.test(r.textContent || ''));
+  if (!row) return false;
+  row.click();
+  return true;
+});
+await sleep(400);
+
+const after = await page.evaluate(() => {
+  const grid = document.querySelector('#bags .bag-grid');
+  return { scrollTop: grid.scrollTop, scrollHeight: grid.scrollHeight };
+});
+await page.screenshot({ path: `tmp/bag-scroll-${TAG}-2-after-use.png` });
+
+const report = { tag: TAG, usedPotion: used, before, after, preserved: Math.abs(before.scrollTop - after.scrollTop) < 4 };
+fs.writeFileSync(`tmp/bag-scroll-${TAG}-report.json`, JSON.stringify(report, null, 2));
+console.log('REPORT', JSON.stringify(report));
+
+await browser.close();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5375,6 +5375,10 @@ export class Hud {
   renderBags(): void {
     const el = $('#bags');
     const sim = this.sim;
+    // .bag-grid (not #bags) is the scroll container; it is recreated on every
+    // rebuild, so capture its scroll offset and reapply it to the fresh grid —
+    // otherwise using an item (e.g. a potion) snaps the list back to the top.
+    const prevScrollTop = el.querySelector('.bag-grid')?.scrollTop ?? 0;
     el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.bags.title'))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.bags.close'))}">${svgIcon('close')}</button></div>`;
     const grid = document.createElement('div');
     grid.className = 'bag-grid';
@@ -5452,6 +5456,7 @@ export class Hud {
       grid.appendChild(row);
     }
     el.appendChild(grid);
+    grid.scrollTop = prevScrollTop;
     const money = document.createElement('div');
     money.className = 'money';
     money.innerHTML = `${this.wocBalanceHtml()}${this.moneyHtml(sim.copper)}`;


### PR DESCRIPTION
## Problem
Using an item from the **Bags** window — e.g. drinking a mana potion — snapped the inventory list back to the **top**, losing the player's scroll position. Anyone consuming potions mid-fight from a long bag had to re-scroll every single time.

## Root cause
`renderBags()` (`src/ui/hud.ts`) rebuilds the window with `el.innerHTML = …` and recreates the `.bag-grid` element on every call. The scroll container is **`.bag-grid`** (`overflow-y:auto`), **not** `#bags` — so each rebuild produced a fresh element that always started at `scrollTop = 0`. Any re-render (item use → `useItem` → `renderBags`, vendor buy, inventory delta, wallet refresh) reset the scroll.

The sibling `renderVendor()` already guards against this for its own list; bags simply never got the same treatment, and they need a slightly different shape because the scrolling node is the *re-created child*, not the window itself.

## Fix
Capture the old grid's `scrollTop` before the rebuild and reapply it to the new grid once it's populated. Two lines, mirroring the established `renderVendor()` pattern. **Pure presentation — no sim / wire / i18n / determinism changes.**

```ts
const prevScrollTop = el.querySelector('.bag-grid')?.scrollTop ?? 0;
// … rebuild …
el.appendChild(grid);
grid.scrollTop = prevScrollTop;
```

## Verification
New offline harness `scripts/bag_scroll_shot.mjs` (boots a mage, fills the bags past one screenful with distinct items, scrolls partway, consumes a mana potion), rendered at **max graphics (`?gfx=ultra`)**:

| | scroll before use | scroll after use |
|---|---|---|
| **Before (v0.12.0)** | 300 | **0** (snaps to top) |
| **After (this PR)** | 300 | **300** (preserved) |

### Before — list snaps back to the top after using the potion
![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-bagscroll/before-2-after-use.png)

### After — list stays exactly where it was
![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-bagscroll/after-2-after-use.png)

- `npx tsc --noEmit` clean
- `npx vitest run tests/bags_command.test.ts` green (3/3)

cc @levy-street @Rubsey @FernandoX7 @patrick261 @maxpolaczuk @CharlieSaxton

🤖 Generated with [Claude Code](https://claude.com/claude-code)