### PR TITLE
[codex] fix Docker production build inputs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,7 @@ docs
 tests
 scripts/*
 !scripts/build_media_manifest.mjs
+!scripts/build_server.mjs
 !scripts/i18n_*.mjs
 deploy
 *.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
-COPY tsconfig.json vite.config.ts index.html admin.html ./
+COPY tsconfig.json vite.config.ts index.html admin.html play.html ./
 COPY src ./src
 COPY server ./server
 COPY headless ./headless


### PR DESCRIPTION
## Summary

Fix the Docker production build context for the latest `main` build.

- Copy `play.html` into the Docker build stage now that Vite includes it as a production Rollup input.
- Re-include `scripts/build_server.mjs` in `.dockerignore` so `npm run build:server` can run inside Docker after the antibot build refactor.

## Root Cause

`release/v0.12.0` added `play.html` as a Vite build input, but the Dockerfile still copied only `index.html` and `admin.html`. Vite failed before emitting `dist/.vite/manifest.json`, which caused the `woc-i18n-modulepreload` closeBundle hook to report an ENOENT for the missing manifest.

After fixing that missing HTML input, Docker also needed `scripts/build_server.mjs`, because `build:server` now invokes that script and `.dockerignore` was still excluding it.

## Validation

- `docker build --no-cache .`