### PR TITLE
feat(antibot): update seam to observe command content

### DIFF
--- a/server/bot_detector/contract.ts
+++ b/server/bot_detector/contract.ts
@@ -24,7 +24,7 @@ export interface BotTrackingContext { readonly [botTrackingBrand]: true }
 export interface BotDetector {
   createTrackingContext(ref: PlayerSessionRef): BotTrackingContext;
   releaseTrackingContext(ctx: BotTrackingContext): void;
-  observeCommand(ctx: BotTrackingContext, cmd: string, now: number): void;
+  observeCommand(ctx: BotTrackingContext, cmd: string, now: number, message?: unknown): void;
   observeEvent(ctx: BotTrackingContext, ev: SimEvent, now: number): void;
   observeInput(ctx: BotTrackingContext, frame: MoveInputFrame, now: number): void;
   observeProtocolAnomaly(ctx: BotTrackingContext, anomaly: ProtocolAnomaly, raw: string, now: number): void;

--- a/server/game.ts
+++ b/server/game.ts
@@ -1197,7 +1197,7 @@ export class GameServer {
       this.botDetector.observeProtocolAnomaly(session.botTrackingContext, 'unknown_type', raw, receivedAtMs);
       return;
     }
-    this.botDetector.observeCommand(session.botTrackingContext, String(msg.cmd ?? ''), receivedAtMs);
+    this.botDetector.observeCommand(session.botTrackingContext, String(msg.cmd ?? ''), receivedAtMs, msg);
     switch (msg.cmd) {
       case 'castSlot': sim.castAbilityBySlot(msg.slot | 0, pid); break;
       case 'cast': if (typeof msg.ability === 'string') sim.castAbility(msg.ability, pid); break;

--- a/tests/bot_detector_stub.test.ts
+++ b/tests/bot_detector_stub.test.ts
@@ -10,6 +10,7 @@ describe('bot-detector stub (open-source no-op)', () => {
 
     // A full observation cycle is inert and never escalates.
     detector.observeCommand(ctx, 'attack', Date.now());
+    detector.observeCommand(ctx, 'attack', Date.now(), {some: 'payload'});
     detector.observeEvent(ctx, { type: 'tradeDone' } as any, Date.now());
     detector.observeInput(ctx, { moveInput: emptyMoveInput(), facing: 0 }, Date.now());
     detector.observeProtocolAnomaly(ctx, 'unknown_command', '{"t":"cmd","cmd":"x"}', Date.now());


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

The bot detector seam currently exposes only the command name via `observeCommand`.
This extends the signature with an optional `message` parameter (the full raw WS
message object), so the private bot-detector implementation can inspect command
content for detection logic. Existing call sites and the stub are unaffected.


## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
 `npm test`

Ran the server with both 'no-op' and 'private' impl of bot detector.

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop**
- [ ] **Tested on  mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

