### PR TITLE
fix(input): restore right-click to start auto-attack on hostile mobs

### DIFF
--- a/src/game/interactions.ts
+++ b/src/game/interactions.ts
@@ -100,7 +100,11 @@ export function handlePickedEntity(
         hud.openQuestDialog(id);
       }
       else hud.showError(t('questUi.errors.tooFar'));
-    } else if (isActivePvpOpponent(world, e)) {
+    } else if ((e.kind === 'mob' && !e.dead && e.hostile) || isActivePvpOpponent(world, e)) {
+      // Right-click a hostile mob (or an active PvP opponent) to start auto-attack,
+      // the classic-MMO convention the attack tooltip promises. A camera right-drag
+      // can't reach this: clickPickFromMouseGesture drops a right gesture past the
+      // drag threshold, so only a deliberate right-click attacks.
       world.startAutoAttack();
     }
   } else if (button === 0) {

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -187,7 +187,12 @@ describe('activePvpOpponentIds', () => {
 });
 
 describe('handlePickedEntity', () => {
-  it('targets hostile mobs on right-click without starting auto-attack', () => {
+  it('targets and starts auto-attack on a hostile mob on right-click', () => {
+    // Right-clicking an enemy targets AND begins auto-attack, the classic-MMO
+    // convention the attack ability tooltip documents ("Right-clicking an enemy
+    // also attacks."). Camera right-drag never reaches here: clickPickFromMouseGesture
+    // rejects a right-button gesture that moved past the drag threshold, so this
+    // fires only on a deliberate right-click, never on a camera rotation.
     const player = stubEntity({ id: 1, kind: 'player' });
     const mob = stubEntity({ id: 2, kind: 'mob', hostile: true, pos: { x: 3, y: 0, z: 0 } });
     let targetId: number | null = null;
@@ -214,7 +219,7 @@ describe('handlePickedEntity', () => {
     handlePickedEntity(world, hud, 2, 2, 10, 20);
 
     expect(targetId).toBe(2);
-    expect(attacks).toBe(0);
+    expect(attacks).toBe(1);
   });
 
   it('starts auto-attack when right-clicking an active duel opponent', () => {


### PR DESCRIPTION
## Summary

Right-clicking a living hostile mob no longer starts auto-attack. The player is
forced to press the attack keybind (action-bar slot 1) to engage. Commit
6c069449 ("fix: prevent right-click mob aggro") dropped the mob branch from
`handlePickedEntity`'s right-click handler, leaving only the active-PvP-opponent
case, so right-clicking an enemy targets it but never attacks.

This is worth restoring on three grounds:

1. **It breaks a promise the game already makes.** The attack ability tooltip
   still reads: *"Toggle auto-attack on your target. Right-clicking an enemy also
   attacks."* The code stopped doing what the UI tells players it does.
2. **Right-click-to-engage is a load-bearing classic-MMO convention,** not a nicety.
   Across the genre the mouse contract is universal: left-click selects, right-click
   attacks/interacts. It is muscle memory for every player arriving from a classic
   MMO, and a micro-MMO that advertises classic fidelity removing it makes combat
   feel broken, not safer. Forcing a keybind press to start every fight is the
   anti-pattern here.
3. **The accidental-aggro concern is already solved one layer up, correctly.**
   `clickPickFromMouseGesture` rejects a right-button gesture that moves past the
   drag threshold (18px) or is held past the click window (280ms), so a camera
   right-drag never produces a pick. Only a deliberate, stationary right-click ever
   reaches this branch. Disabling attack entirely was a blunt fix for a problem the
   gesture disambiguation already prevents; it traded a real, expected feature for
   protection that was redundant.

The fix restores the `(mob && !dead && hostile)` condition alongside the PvP case,
and flips the regression test to assert auto-attack fires on a right-clicked
hostile mob.

## Related issues

N/A (regression from 6c069449, shipped since the last release).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/interactions.test.ts` (green), `npm test`
  (green except two pre-existing, unrelated ICU/timezone failures in
  `clock_format`/`chat_timestamp` that also fail on `main`), `npx tsc --noEmit`
  (clean), `npm run build` (succeeds).
- Manual steps: offline client, target nothing, right-click a hostile mob ->
  character begins auto-attacking it. Verified a camera right-drag over a mob
  still only rotates the camera and does not engage.

## Screenshots / recordings

Behavioral (no UI surface change). Happy to attach a short before/after clip if
useful.

---

## Checklist

### Quality

- [x] **Tests pass.** Updated the `interactions` regression test for the changed behavior.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` succeeds.

### Cross-platform

- [x] **Desktop verified.** Right-click is a desktop interaction; touch/mobile uses tap-to-target plus the on-screen attack button and is unaffected.

### Localization (i18n)

- [x] **N/A.** This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` not enabled in any production path.
- [x] No generated files hand-edited.
