### PR TITLE
fix(sim): let the overworld Sunken Bastion ward stone be collected

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7087,7 +7087,11 @@ export class Sim {
       && e.templateId === NYTHRAXIS_BOSS_ID
       && !e.dead
       && dist2d(e.spawnPos, ward.pos) < NYTHRAXIS_WARDSTONE_RANGE);
-    if (!boss?.nythraxis || boss.nythraxis.deathlessCastRemaining <= 0) return true;
+    // No Nythraxis boss in range: this is not a raid wardstone but the overworld
+    // "Sunken Bastion" quest ward stone (same item id). Fall through so the normal
+    // quest pickup runs, instead of swallowing the interaction.
+    if (!boss) return false;
+    if (!boss.nythraxis || boss.nythraxis.deathlessCastRemaining <= 0) return true;
     const channel = boss.nythraxis.wardChannels.find((c) => c.objectId === ward.id);
     if (!channel || channel.complete) return true;
     if (channel.playerId === player.id) return true;

--- a/tests/bastion_ward_stone.test.ts
+++ b/tests/bastion_ward_stone.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { GROUND_OBJECTS, ITEMS, QUESTS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+const QUEST_ID = 'q_bastion_door';
+const WARD_ITEM_ID = 'bastion_ward_stone';
+
+function teleportTo(sim: Sim, x: number, z: number): void {
+  const pos = sim.groundPos(x, z);
+  sim.player.pos = { ...pos };
+  sim.player.prevPos = { ...pos };
+}
+
+describe('The Sunken Bastion ward stone', () => {
+  it('collects an overworld ward stone for q_bastion_door', () => {
+    // The quest "The Sunken Bastion" collects the ward-stone ground object.
+    const quest = QUESTS[QUEST_ID];
+    expect(quest.objectives).toEqual([
+      { type: 'collect', itemId: WARD_ITEM_ID, count: 1, label: 'Bastion Ward Stone' },
+    ]);
+    expect(ITEMS[WARD_ITEM_ID]?.questId).toBe(QUEST_ID);
+    expect(GROUND_OBJECTS.find((o) => o.itemId === WARD_ITEM_ID)).toBeTruthy();
+
+    const sim = new Sim({ seed: 20061, playerClass: 'warrior', playerName: 'Reuben', autoEquip: false });
+    sim.player.level = 15;
+    sim.questLog.set(QUEST_ID, { questId: QUEST_ID, counts: [0], state: 'active' });
+    expect(sim.questState(QUEST_ID)).toBe('active');
+
+    // The overworld ward stone shares its item id with the Nythraxis raid
+    // wardstones. Before the fix, tryStartNythraxisWardChannel claimed the
+    // interaction for ANY ward stone, even with no boss nearby, so the quest
+    // pickup never ran and the objective could never be completed.
+    const wardStone = [...sim.entities.values()]
+      .find((e): e is Entity => e.kind === 'object' && e.objectItemId === WARD_ITEM_ID);
+    expect(wardStone).toBeTruthy();
+    teleportTo(sim, wardStone!.pos.x + 1, wardStone!.pos.z);
+
+    sim.pickUpObject(wardStone!.id);
+
+    expect(sim.countItem(WARD_ITEM_ID)).toBe(1);
+    expect(sim.questState(QUEST_ID)).toBe('ready');
+  });
+});


### PR DESCRIPTION
## Summary

In the quest "The Sunken Bastion" (`q_bastion_door`) the ward stone could not be
picked up by any means: neither right-click nor the interact (F) key did
anything at all. The objective is a `collect` of the `bastion_ward_stone` ground
object, but `pickUpObject` never reached the collect path, so the quest was
uncompletable.

Root cause is a shared item id. The overworld quest ward stone and the Nythraxis
raid wardstones both use `bastion_ward_stone`
(`NYTHRAXIS_WARDSTONE_ITEM_ID`). `tryStartNythraxisWardChannel`, which runs first
in `pickUpObject`, returned `true` ("interaction handled, stop") for *any* object
with that id, even when no Nythraxis boss was anywhere near, which is exactly the
overworld case. `pickUpObject` then early-exited before the quest collect logic
ran, so the stone was inert.

Fix: when no Nythraxis boss is found within range of the ward stone, return
`false` so the interaction falls through to the normal quest pickup. The raid
path is unchanged: with the boss present it still gates and channels exactly as
before.

```diff
   const boss = [...this.entities.values()].find((e) =>
     e.kind === 'mob' && e.templateId === NYTHRAXIS_BOSS_ID && !e.dead
     && dist2d(e.spawnPos, ward.pos) < NYTHRAXIS_WARDSTONE_RANGE);
-  if (!boss?.nythraxis || boss.nythraxis.deathlessCastRemaining <= 0) return true;
+  // No boss in range: this is the overworld "Sunken Bastion" quest ward stone
+  // (same item id), not a raid wardstone. Fall through to normal quest pickup.
+  if (!boss) return false;
+  if (!boss.nythraxis || boss.nythraxis.deathlessCastRemaining <= 0) return true;
```

## Related issues

N/A (regression present since the last release).

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/bastion_ward_stone.test.ts` (new, green),
  `npx vitest run tests/nythraxis_raid.test.ts tests/nythraxis_final_quest.test.ts tests/nythraxis_aldric_npc.test.ts`
  (77 passing, raid path unaffected), `npm test` (green except two pre-existing,
  unrelated ICU/timezone failures in `clock_format`/`chat_timestamp` that also
  fail on `main`), `npx tsc --noEmit` (clean), `npm run build` and
  `npm run build:server` (succeed), `npx vitest run tests/architecture.test.ts`
  (sim purity intact).
- Manual steps: ran the online stack with `ALLOW_DEV_COMMANDS=1`, right-clicked an
  overworld ward stone at (43, 512). Before the fix the click was silently
  swallowed; now the interaction reaches `pickUpObject` (shows the "cannot take
  yet" deny without the quest active, and collects + advances the quest to *ready*
  with it active, as the unit test asserts deterministically).

The new test reproduces the bug (red before the change) and asserts the overworld
ward stone collects and advances `q_bastion_door` to ready.

---

## Checklist

### Quality

- [x] **Tests pass.** Added `tests/bastion_ward_stone.test.ts` for the changed sim behavior; existing Nythraxis raid suite still green.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` and `npm run build:server` succeed.

### Localization (i18n)

- [x] **N/A.** This PR adds no player-visible strings (control-flow only; the deny toast it now reaches already existed).

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` not enabled in any production path (used only locally for manual testing).
- [x] No generated files hand-edited.
