### PR TITLE
fix(keybinds): stop Damage Meters and Target Nearest Friendly sharing KeyH

### DIFF
--- a/src/game/keybinds.ts
+++ b/src/game/keybinds.ts
@@ -164,7 +164,7 @@ export const BIND_ACTIONS: BindAction[] = [
     defaults: ['KeyV'],
   },
   { id: 'talents', label: 'Talents', category: 'Interface', kind: 'edge', defaults: ['KeyN'] },
-  { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyH'] },
+  { id: 'meters', label: 'Damage Meters', category: 'Interface', kind: 'edge', defaults: ['KeyY'] },
   {
     id: 'social',
     label: 'Friends & Guild',

--- a/tests/keybinds.test.ts
+++ b/tests/keybinds.test.ts
@@ -93,8 +93,27 @@ describe('Keybinds defaults', () => {
     expect(kb.actionForCode('Equal')).toBe('slot11');
     expect(kb.actionForCode('KeyH')).toBe('targetFriendly');
     expect(kb.actionForCode('KeyJ')).toBe('targetFriendlyNext');
+    expect(kb.actionForCode('KeyY')).toBe('meters'); // moved off KeyH (collided with targetFriendly)
     expect(kb.actionForCode('KeyU')).toBe('discord');
     expect(kb.actionForCode('KeyZ')).toBe(null);
+  });
+
+  it('has no duplicate default code across non-shared actions', () => {
+    // A code on two non-shared actions makes the later one (in BIND_ACTIONS order)
+    // unreachable from its default: actionForCode returns the first match. This
+    // shipped once: meters and targetFriendly both defaulted to KeyH, so the
+    // Damage Meters key did nothing. Guard every default, not just that pair.
+    const seen = new Map<string, string>();
+    const dupes: string[] = [];
+    for (const a of BIND_ACTIONS) {
+      if (actionAllowsShared(a.id)) continue; // attackMove intentionally shares turnLeft's key
+      for (const code of a.defaults) {
+        const owner = seen.get(code);
+        if (owner) dupes.push(`${code}: ${owner} & ${a.id}`);
+        else seen.set(code, a.id);
+      }
+    }
+    expect(dupes).toEqual([]);
   });
 
   it('exposes primary/secondary codes and labels', () => {
@@ -233,7 +252,7 @@ describe('persistence', () => {
     expect(kb.actionForCode('KeyH')).toBe('targetFriendly');
     expect(kb.actionForCode('Enter')).toBe('chat');
     expect(kb.actionForCode('Equal')).toBe('slot11');
-    expect(kb.actionForCode('KeyY')).toBe(null);
+    expect(kb.actionForCode('KeyY')).toBe('meters'); // missing from the save, keeps its default
   });
 
   it('drops a retained default that a stored binding already claimed', () => {
@@ -286,7 +305,7 @@ describe('per-character scope', () => {
     // Bob never inherits Alice's change; he starts from defaults.
     expect(bob.actionForCode('KeyZ')).toBe(null);
     expect(bob.codeAt('jump', 0)).toBe('Space');
-    bob.bind('jump', 0, 'KeyY'); // also unbound by default
+    bob.bind('jump', 0, 'KeyY'); // KeyY now defaults to meters; rebinding steals it
     // Reloading each scope reads back only its own profile.
     expect(new Keybinds('char:alice').actionForCode('KeyZ')).toBe('jump');
     expect(new Keybinds('char:bob').actionForCode('KeyY')).toBe('jump');


### PR DESCRIPTION
## Summary

The "Damage Meters" keybind did nothing: pressing it never opened the meter
window. Root cause is a duplicate default key. Both `meters` and `targetFriendly`
defaulted to **KeyH**:

```ts
{ id: 'targetFriendly', ... defaults: ['KeyH'] },  // earlier in BIND_ACTIONS
{ id: 'meters',         ... defaults: ['KeyH'] },  // shadowed
```

`actionForCode` returns the first action whose codes include the pressed code,
and `targetFriendly` sits earlier in `BIND_ACTIONS`, so KeyH always resolved to
"Target Nearest Friendly" and `meters` was unreachable from its default. For
returning players it is worse: the load-time uniqueness sweep claims KeyH for
`targetFriendly` first and strips it from `meters`, so Damage Meters ends up with
no key at all.

History: `meters` had KeyH first; `targetFriendly` reused it later (#133) and,
sitting earlier in the list, shadowed it.

Fix (default only): move Damage Meters to **KeyY** (a free code) and keep
`targetFriendly` on KeyH so it stays paired with `targetFriendlyNext` (KeyJ). No
save migration is needed for most returning players: default-retention means a
save whose stored keybinds do not already claim KeyY picks up the working Damage
Meters default automatically (the persistence test asserts this: a save missing
`KeyY` keeps `meters` on its `KeyY` default). The only players who need to act
are the few who had previously remapped some other action onto KeyY; they can
rebind Damage Meters or use Reset Keybinds. The wiring and the corrected default
are right for new and reset users.

Also adds a regression guard that fails on any duplicate default code across
non-shared actions, so a future collision is caught at test time instead of
shipping a dead keybind.

## Related issues

N/A.

## Type of change

- [x] Bug fix

## How was this tested?

- Commands: `npx vitest run tests/keybinds.test.ts tests/input.test.ts`
  (58 passing, including the two new assertions and the no-duplicate-defaults
  guard), `npm test` (green except two pre-existing, unrelated ICU/timezone
  failures in `clock_format`/`chat_timestamp` that also fail on `main`),
  `npx tsc --noEmit` (clean), `npm run build` (succeeds).
- Manual steps: in the Options > Keybindings screen, Damage Meters now shows
  **Y** and Target Nearest Friendly shows **H**; pressing Y toggles the meter
  window; pressing H targets the nearest friendly. Before the change, pressing H
  only targeted a friendly and the meter window never appeared.

## Screenshots / recordings

Keybind-default change; the only visible surface is the Keybindings list (Damage
Meters: H to Y). Happy to attach a screenshot of the Keybindings panel if useful.

---

## Checklist

### Quality

- [x] **Tests pass.** Added a regression guard and updated the keybind default assertions.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` succeeds.

### Cross-platform

- [x] **Desktop verified.** Keyboard keybind; mobile uses on-screen controls and is unaffected.

### Localization (i18n)

- [x] **N/A.** No player-visible strings added (the on-screen key label derives from the code via `keyLabel`).

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` not enabled in any production path.
- [x] No generated files hand-edited.
