### PR TITLE
fix(sim): Tab targets on-screen / in-combat enemies, not off-screen ones

### DIFF
--- a/scripts/tab_target_shot.mjs
+++ b/scripts/tab_target_shot.mjs
@@ -1,0 +1,97 @@
+// Screenshot proof for the Tab targeting fix at max graphics (?gfx=ultra).
+// Boots the offline game, relocates two hostile mobs around the player (one in
+// front / on screen and farther, one closer but directly behind), aligns the
+// camera with the player's facing, then presses Tab. Before the fix Tab picked
+// the nearest mob (behind, off screen); after the fix it picks the on-screen
+// one. Writes PNGs to tmp/. Needs `npm run dev` (:5173). Override URL with
+// GAME_URL=.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+const W = 1600, H = 900;
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: [`--window-size=${W},${H}`, '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: W, height: H },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 45000 });
+await page.waitForSelector('#nav-btn-play', { visible: true, timeout: 20000 });
+await tap('#nav-btn-play');
+await new Promise((r) => setTimeout(r, 400));
+await tap('#btn-offline');
+await page.waitForSelector('#char-name', { timeout: 20000 });
+await new Promise((r) => setTimeout(r, 300));
+await page.focus('#char-name');
+await page.type('#char-name', 'Tabby');
+await tap('#offline-select .mini-class[data-class="warrior"]');
+await new Promise((r) => setTimeout(r, 200));
+await tap('#btn-start-offline');
+await page.waitForFunction(() => window.__game && window.__game.sim && window.__game.sim.player, { timeout: 40000 });
+await new Promise((r) => setTimeout(r, 3000)); // settle the ultra pipeline
+await tap('.tut-skip'); // dismiss the new-adventurer tutorial overlay for a clean frame
+await new Promise((r) => setTimeout(r, 300));
+
+// Stage two hostile mobs around the player and look where the player faces.
+const staged = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.hp = p.maxHp = 999999;
+  p.facing = 0; // facing +Z
+
+  const mobs = [];
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && e.ownerId === null && !e.dead) mobs.push(e);
+  }
+  if (mobs.length < 2) return { ok: false, count: mobs.length };
+
+  const place = (e, dx, dz) => {
+    e.pos.x = p.pos.x + dx;
+    e.pos.z = p.pos.z + dz;
+    e.pos.y = p.pos.y;
+    e.prevPos = { ...e.pos };
+    e.dead = false; e.hp = e.maxHp;
+    sim.rebucket(e);
+  };
+  const front = mobs[0], behind = mobs[1];
+  place(front, 1, 22);   // on screen, farther
+  place(behind, 0, -6);  // off screen (behind), closer
+  // Park any other nearby mobs far away so only our two are candidates.
+  for (let i = 2; i < mobs.length; i++) place(mobs[i], 9000, 9000);
+
+  g.renderer.camYaw = 0;      // look toward +Z, same as the player faces
+  g.renderer.camPitch = 0.34;
+  g.renderer.camDist = 13;
+  sim.targetEntity(null);     // clear any current target
+  return { ok: true, frontId: front.id, behindId: behind.id, frontName: front.name, behindName: behind.name };
+});
+console.log('staged:', JSON.stringify(staged));
+if (!staged.ok) { console.error('not enough mobs', staged); await browser.close(); process.exit(1); }
+await new Promise((r) => setTimeout(r, 1200));
+await page.screenshot({ path: 'tmp/tab_target_01_no_target.png' });
+
+// Press Tab: the fix selects the on-screen mob, not the closer one behind.
+await page.keyboard.press('Tab');
+await new Promise((r) => setTimeout(r, 1200));
+const sel = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  return { targetId: sim.player.targetId };
+});
+console.log('after Tab, targetId =', sel.targetId,
+  sel.targetId === staged.frontId ? '(ON-SCREEN mob, correct)' : '(WRONG: behind mob)');
+await page.screenshot({ path: 'tmp/tab_target_02_after_tab.png' });
+
+if (errors.length) console.log('page errors:\n' + errors.join('\n'));
+await browser.close();
+console.log('done; wrote tmp/tab_target_01_no_target.png and tmp/tab_target_02_after_tab.png');

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -22,6 +22,7 @@ import {
 } from './content/augments';
 import { Rng } from './rng';
 import { SpatialGrid } from './spatial';
+import { orderTabTargets } from './tab_target';
 import {
   HEAL_THREAT_FACTOR, MELEE_SWITCH_MULT, RANGED_SWITCH_MULT,
   TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatEntries, threatModifier, topThreatValue,
@@ -7158,10 +7159,20 @@ export class Sim {
     const p = r.e;
     const candidates = this.enemyCandidates(p);
     if (candidates.length === 0) return;
-    candidates.sort((a, b) => a.d - b.d);
-    const curIdx = candidates.findIndex((c) => c.e.id === p.targetId);
-    const next = candidates[(curIdx + 1) % candidates.length];
-    p.targetId = next.e.id;
+    // Cycle the enemies the player can see / is fighting first; off-screen ones
+    // stay reachable but never steal the selection (see tab_target.ts).
+    const ordered = orderTabTargets(
+      candidates.map((c) => ({
+        id: c.e.id,
+        dx: c.e.pos.x - p.pos.x,
+        dz: c.e.pos.z - p.pos.z,
+        d: c.d,
+        engaged: c.e.aggroTargetId === p.id || c.e.targetId === p.id,
+      })),
+      p.facing,
+    );
+    const curIdx = ordered.indexOf(p.targetId ?? -1);
+    p.targetId = ordered[(curIdx + 1) % ordered.length];
   }
 
   targetNearestEnemy(pid?: number): void {

--- a/src/sim/tab_target.ts
+++ b/src/sim/tab_target.ts
@@ -1,0 +1,61 @@
+// Tab target cycling order.
+//
+// Classic-style Tab targeting should cycle the enemies a player can actually
+// see and fight, not the nearest blip anywhere in radius. The sim has no
+// camera (the same code runs on the authoritative server and headless), so
+// "on screen" is modelled deterministically from the player's facing: the
+// forward vector is (sin(facing), cos(facing)) (see player movement in
+// sim.ts), and a target counts as on screen when it falls inside a front cone
+// around that vector. "In combat with you" is supplied by the caller from sim
+// aggro state. Candidates are ranked into priority tiers so engaged, on-screen
+// enemies cycle first, while off-screen ones stay reachable as a last resort
+// instead of stealing the selection. Ties break by distance then id, so the
+// order is stable and replay-deterministic.
+
+export interface TabCandidate {
+  id: number;
+  // Target position relative to the player (target.pos - player.pos), in yards.
+  dx: number;
+  dz: number;
+  // Planar distance to the player, in yards.
+  d: number;
+  // True when this enemy is in combat with the player (aggroed onto / targeting them).
+  engaged: boolean;
+}
+
+// Half-angle of the front cone treated as "on screen", in radians. ~70 degrees
+// each side (a ~140 degree field) generously covers the third-person camera's
+// view without picking enemies directly behind the player.
+export const TAB_FRONT_CONE_HALF = (70 * Math.PI) / 180;
+
+function onScreen(c: TabCandidate, facing: number, coneHalf: number): boolean {
+  // A target on top of the player has no meaningful direction; treat as visible.
+  if (c.d <= 1e-6) return true;
+  const fx = Math.sin(facing);
+  const fz = Math.cos(facing);
+  // Cosine of the angle between facing and the direction to the target.
+  const cos = (fx * c.dx + fz * c.dz) / c.d;
+  return cos >= Math.cos(coneHalf);
+}
+
+// Lower tier = cycles first. 0: engaged and on screen, 1: on screen,
+// 2: engaged but off screen, 3: neither.
+function tier(c: TabCandidate, facing: number, coneHalf: number): number {
+  const vis = onScreen(c, facing, coneHalf);
+  if (c.engaged && vis) return 0;
+  if (vis) return 1;
+  if (c.engaged) return 2;
+  return 3;
+}
+
+// Return candidate ids in the order Tab should cycle them.
+export function orderTabTargets(
+  candidates: TabCandidate[],
+  facing: number,
+  coneHalf: number = TAB_FRONT_CONE_HALF,
+): number[] {
+  return candidates
+    .map((c) => ({ id: c.id, t: tier(c, facing, coneHalf), d: c.d }))
+    .sort((a, b) => a.t - b.t || a.d - b.d || a.id - b.id)
+    .map((c) => c.id);
+}

--- a/tests/tab_target.test.ts
+++ b/tests/tab_target.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { orderTabTargets, TabCandidate } from '../src/sim/tab_target';
+
+// Player faces +Z (facing 0): forward is (sin 0, cos 0) = (0, 1).
+const FACING_NORTH = 0;
+
+describe('orderTabTargets', () => {
+  it('cycles an on-screen enemy before a closer one behind the player', () => {
+    // Behind the player (-Z) but very close; in front (+Z) but farther.
+    const behind: TabCandidate = { id: 1, dx: 0, dz: -5, d: 5, engaged: false };
+    const front: TabCandidate = { id: 2, dx: 0, dz: 30, d: 30, engaged: false };
+    const order = orderTabTargets([behind, front], FACING_NORTH);
+    // The on-screen enemy leads even though it is farther away.
+    expect(order[0]).toBe(2);
+    // The off-screen one is still reachable, just last.
+    expect(order).toEqual([2, 1]);
+  });
+
+  it('prioritizes an enemy in combat with the player over an idle on-screen one', () => {
+    const engagedFar: TabCandidate = { id: 1, dx: 2, dz: 30, d: 30, engaged: true };
+    const idleNear: TabCandidate = { id: 2, dx: 0, dz: 5, d: 5, engaged: false };
+    const order = orderTabTargets([engagedFar, idleNear], FACING_NORTH);
+    // Both are on screen, so the engaged one wins (tier 0 vs 1).
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('orders on-screen enemies nearest first', () => {
+    const far: TabCandidate = { id: 1, dx: 0, dz: 30, d: 30, engaged: false };
+    const near: TabCandidate = { id: 2, dx: 0, dz: 8, d: 8, engaged: false };
+    const mid: TabCandidate = { id: 3, dx: 0, dz: 15, d: 15, engaged: false };
+    expect(orderTabTargets([far, near, mid], FACING_NORTH)).toEqual([2, 3, 1]);
+  });
+
+  it('keeps an engaged enemy behind the player reachable but after visible ones', () => {
+    const engagedBehind: TabCandidate = { id: 1, dx: 0, dz: -10, d: 10, engaged: true };
+    const idleFront: TabCandidate = { id: 2, dx: 0, dz: 20, d: 20, engaged: false };
+    const order = orderTabTargets([engagedBehind, idleFront], FACING_NORTH);
+    // On-screen idle (tier 1) leads engaged-but-off-screen (tier 2).
+    expect(order).toEqual([2, 1]);
+  });
+
+  it('is deterministic and stable for ties', () => {
+    const a: TabCandidate = { id: 7, dx: 0, dz: 10, d: 10, engaged: false };
+    const b: TabCandidate = { id: 3, dx: 1, dz: 10, d: 10, engaged: false };
+    const run = () => orderTabTargets([a, b], FACING_NORTH);
+    // Same tier and distance: lower id breaks the tie, and repeat runs match.
+    expect(run()).toEqual([3, 7]);
+    expect(run()).toEqual(run());
+  });
+});

--- a/tests/tab_target_sim.test.ts
+++ b/tests/tab_target_sim.test.ts
@@ -1,0 +1,48 @@
+// Tab targeting should cycle the enemies a player can see / is fighting, not
+// the nearest blip regardless of where the player is looking. Reproduces the
+// bug where Tab selected an off-screen mob behind the player over a visible one.
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+
+const SEED = 31337;
+
+function spawnMob(sim: Sim, id: number, dx: number, dz: number) {
+  const p = sim.entities.get(sim.playerId)!;
+  const mob = createMob(id, MOBS.ridge_stalker, 13, { x: p.pos.x + dx, y: p.pos.y, z: p.pos.z + dz });
+  sim.entities.set(mob.id, mob);
+  (sim as any).rebucket(mob);
+  return mob;
+}
+
+describe('Sim.tabTarget on-screen / in-combat cycling', () => {
+  it('targets the on-screen enemy before a closer one behind the player', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const p = sim.entities.get(sim.playerId)!;
+    p.facing = 0; // facing +Z
+    (sim as any).rebucket(p);
+    const behindClose = spawnMob(sim, 900001, 0, -6); // behind, near
+    const frontFar = spawnMob(sim, 900002, 0, 25); // in front, far
+
+    sim.tabTarget();
+    expect(p.targetId).toBe(frontFar.id);
+
+    // Cycling reaches the off-screen one rather than dropping it.
+    sim.tabTarget();
+    expect(p.targetId).toBe(behindClose.id);
+  });
+
+  it('prefers an enemy engaged with the player', () => {
+    const sim = new Sim({ seed: SEED, playerClass: 'warrior' });
+    const p = sim.entities.get(sim.playerId)!;
+    p.facing = 0;
+    (sim as any).rebucket(p);
+    const idleNear = spawnMob(sim, 900011, 0, 6); // on screen, idle, near
+    const engagedFar = spawnMob(sim, 900012, 0, 28); // on screen, far, aggroed
+    engagedFar.aggroTargetId = p.id;
+
+    sim.tabTarget();
+    expect(p.targetId).toBe(engagedFar.id);
+  });
+});


### PR DESCRIPTION
## Problem

Tab targeting selected the nearest enemy anywhere in the 40yd radius, sorted purely by distance, with no awareness of where the player is looking or who they are fighting. The result: Tab would lock onto a mob behind the player or otherwise off screen instead of cycling the ones in view / in combat with you.

`Sim.tabTarget()` gathered candidates with `enemyCandidates()` (a flat radius query) and did `candidates.sort((a,b) => a.d - b.d)` then cycled by distance. No facing, no combat state.

## Fix

The sim has no camera (the same deterministic core runs the authoritative server and the headless RL env, and online Tab is just a `{cmd:'tab'}` to the server), so "on screen" is modelled deterministically from the player's `facing`: a front cone around the forward vector `(sin(facing), cos(facing))`. "In combat with you" reuses existing aggro state (a mob whose `aggroTargetId` or `targetId` is the player). No new entity state.

Candidates are ranked into priority tiers, then by distance, then id (stable + replay-deterministic):

| Tier | Meaning |
|---|---|
| 0 | engaged **and** on screen |
| 1 | on screen |
| 2 | engaged but off screen |
| 3 | neither |

Off-screen enemies stay reachable as a last resort (so Tab never loses access to a valid target) but never steal the selection from a visible / engaged one.

Per the repo's module-first + test-first conventions, the ordering is a new pure module `src/sim/tab_target.ts` (`orderTabTargets`), with `Sim.tabTarget` reduced to a thin consumer. `src/sim/` stays DOM/Three-free (architecture guard passes).

## Tests

- `tests/tab_target.test.ts` - unit tests for `orderTabTargets` (front-cone, tier priority, distance ordering, determinism).
- `tests/tab_target_sim.test.ts` - Sim-level regression: reproduces the bug (Tab picked the closer behind mob) and pins the fix (picks the on-screen / engaged one).

Both written failing-first against the real code path. Full suite green (281 files), `tsc --noEmit` clean, architecture + S3 i18n guards pass. No player-facing strings changed, so no i18n surface.

## Screenshot (max graphics, `?gfx=ultra`)

Two Forest Wolves staged: one on screen but farther, one closer but directly behind. Pressing Tab selects the on-screen wolf (target frame, top-left), not the nearer one behind the player. Repro script: `scripts/tab_target_shot.mjs`.

![after Tab](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-tab-target/_assets/tab_target_02_after_tab.png)

cc @levy-street @Rubsey @FernandoX7 @CharlieSaxton @maxpolaczuk @patrick261