### PR TITLE
fix(game): pressing Escape should pause a run, not cancel it

### DIFF
--- a/scripts/esc_autorun_shot.mjs
+++ b/scripts/esc_autorun_shot.mjs
@@ -1,0 +1,114 @@
+// Verification + VIDEO harness for "Escape pauses an autorun (R), it does not cancel it".
+//
+// This is the autorun companion to esc_run_shot.mjs (which covers click-to-move).
+// Boots the offline world as a warrior at max graphics (?gfx=ultra), presses R to
+// toggle autorun, confirms the player is running, then opens the game menu with
+// Escape (as if to change a keybind or a setting) while the run is in flight. The
+// autorun latch must SURVIVE the menu: movement pauses while the menu is open
+// (suspendMovement), input.autorun stays true, and the run resumes the instant the
+// menu closes. Records a webm so the behavior is visible, not just asserted.
+//
+// Needs a dev server (default :5173, override with GAME_URL). Writes a video, key
+// screenshots, and a before/after state report to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 60000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Autowyn');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.hud && window.__game?.input, { timeout: 60000 });
+await sleep(2000);
+
+const pos = () => page.evaluate(() => ({
+  modalOpen: window.__game.hud.isModalOpen(),
+  suspended: window.__game.input.suspendMovement,
+  autorun: window.__game.input.autorun,
+  pos: { x: window.__game.world.player.pos.x, z: window.__game.world.player.pos.z },
+}));
+// Poll until the player has moved at least `min` yards from `from`, or timeout.
+const waitForMove = async (from, min, ms) => {
+  const t0 = Date.now();
+  let last = from;
+  while (Date.now() - t0 < ms) {
+    last = await pos();
+    if (Math.hypot(last.pos.x - from.x, last.pos.z - from.z) >= min) break;
+    await sleep(100);
+  }
+  return last;
+};
+
+// Start recording the whole sequence.
+const recorder = await page.screencast({ path: 'tmp/esc-autorun.webm' });
+
+// Face north so the run heads into open ground, then press R to toggle autorun
+// (KeyR is the vanilla default for the 'autorun' edge action).
+const start = await page.evaluate(() => {
+  window.__game.input.autorun = false;
+  return { pos: { x: window.__game.world.player.pos.x, z: window.__game.world.player.pos.z } };
+});
+await page.keyboard.press('KeyR');
+const armed = await pos();
+
+// 1) Confirm autorun is actually carrying the player before we touch the menu.
+const running = await waitForMove(start.pos, 3, 5000);
+await page.screenshot({ path: 'tmp/esc-autorun-1-running.png' });
+
+// 2) Press Escape to open the game menu mid-run. Movement suspends; the autorun
+//    latch must stay set (pause), not clear (cancel). Sample twice to show no walk.
+await page.keyboard.press('Escape');
+await sleep(300);
+const menuOpen = await pos();
+await page.screenshot({ path: 'tmp/esc-autorun-2-menu-open.png' });
+await sleep(900);
+const stillOpen = await pos();
+const movedWhilePaused = Math.hypot(stillOpen.pos.x - menuOpen.pos.x, stillOpen.pos.z - menuOpen.pos.z);
+
+// 3) Close the menu; the run resumes from where it paused.
+await page.keyboard.press('Escape');
+const resumed = await waitForMove(menuOpen.pos, 2, 5000);
+await page.screenshot({ path: 'tmp/esc-autorun-3-resumed.png' });
+const movedAfterResume = Math.hypot(resumed.pos.x - menuOpen.pos.x, resumed.pos.z - menuOpen.pos.z);
+
+await sleep(500);
+await recorder.stop();
+
+const report = {
+  start, armed, running, menuOpen, stillOpen, resumed,
+  checks: {
+    autorunEngaged: armed.autorun === true,                 // R toggled it on
+    // The run was active before the menu: the player covered ground from spawn to
+    // the point the menu opened (headless rAF throttling makes per-poll motion
+    // bursty, so measure total displacement, not the mid-run poll).
+    runningBeforeMenu: Math.hypot(menuOpen.pos.x - start.pos.x, menuOpen.pos.z - start.pos.z) >= 3,
+    autorunSurvivesMenu: menuOpen.autorun === true,         // the latch is kept, not cancelled
+    heldStillWhilePaused: movedWhilePaused < 0.5,           // suspended => no walking
+    autorunStillSetWhilePaused: stillOpen.autorun === true, // still latched mid-menu
+    resumedAfterClose: movedAfterResume > 1,                // run continues on close
+  },
+};
+fs.writeFileSync('tmp/esc-autorun-report.json', JSON.stringify(report, null, 2));
+console.log(JSON.stringify(report, null, 2));
+
+await browser.close();
+const ok = Object.values(report.checks).every(Boolean);
+console.log(ok ? 'PASS: Escape pauses the autorun and it resumes.' : 'FAIL: see report.');
+process.exit(ok ? 0 : 1);

--- a/scripts/esc_run_shot.mjs
+++ b/scripts/esc_run_shot.mjs
@@ -1,0 +1,112 @@
+// Verification + screenshot harness for "Escape pauses the run, it does not cancel it".
+//
+// Boots the offline world as a warrior at max graphics (?gfx=ultra), enables
+// click-to-move, sends the player running to a far destination, then opens the
+// game menu with Escape while the run is in flight. With the fix the click-move
+// destination survives the menu (input.clickMoveTarget stays set) and the run
+// resumes when the menu closes; before the fix opening the menu cleared it.
+//
+// Needs a dev server (default :5173, override with GAME_URL). Writes screenshots
+// and a before/after state report to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+
+// Enable click-to-move before any script runs (settings load from localStorage
+// at startup; the Settings object is not exposed on window.__game).
+await page.evaluateOnNewDocument(() => {
+  try {
+    const cur = JSON.parse(localStorage.getItem('woc_settings') ?? '{}');
+    localStorage.setItem('woc_settings', JSON.stringify({ ...cur, clickToMove: 1 }));
+  } catch { /* storage unavailable */ }
+});
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 60000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Runwyn');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.hud && window.__game?.input, { timeout: 60000 });
+await sleep(2000);
+
+// Enable click-to-move and send the player on a long run to a clear destination.
+const start = await page.evaluate(() => {
+  const g = window.__game;
+  const p = g.world.player;
+  const dest = { x: p.pos.x, z: p.pos.z + 120 }; // 120 yd due north, well past arrival
+  g.input.setClickMoveTarget(dest, 0.5, null, [dest], false);
+  return { hasTarget: !!g.input.clickMoveTarget, pos: { x: p.pos.x, z: p.pos.z } };
+});
+const pos = () => page.evaluate(() => ({
+  modalOpen: window.__game.hud.isModalOpen(),
+  suspended: window.__game.input.suspendMovement,
+  hasTarget: !!window.__game.input.clickMoveTarget,
+  pos: { x: window.__game.world.player.pos.x, z: window.__game.world.player.pos.z },
+}));
+// Poll until the player has moved at least `min` yards from `from`, or timeout.
+const waitForMove = async (from, min, ms) => {
+  const t0 = Date.now();
+  let last = from;
+  while (Date.now() - t0 < ms) {
+    last = await pos();
+    if (Math.hypot(last.pos.x - from.x, last.pos.z - from.z) >= min) break;
+    await sleep(100);
+  }
+  return last;
+};
+
+// 1) Confirm the run is actually under way before we touch the menu.
+const running = await waitForMove(start.pos, 3, 4000);
+await page.screenshot({ path: 'tmp/esc-run-1-running.png' });
+
+// 2) Press Escape to open the game menu mid-run. This suspends movement; the run
+//    must PAUSE (destination kept), not cancel. Sample twice to show no walking.
+await page.keyboard.press('Escape');
+await sleep(300);
+const menuOpen = await pos();
+await page.screenshot({ path: 'tmp/esc-run-2-menu-open.png' });
+await sleep(700);
+const stillOpen = await pos();
+const movedWhilePaused = Math.hypot(stillOpen.pos.x - menuOpen.pos.x, stillOpen.pos.z - menuOpen.pos.z);
+
+// 3) Close the menu; the run resumes from where it paused.
+await page.keyboard.press('Escape');
+const resumed = await waitForMove(menuOpen.pos, 2, 5000);
+await page.screenshot({ path: 'tmp/esc-run-3-resumed.png' });
+const movedAfterResume = Math.hypot(resumed.pos.x - menuOpen.pos.x, resumed.pos.z - menuOpen.pos.z);
+
+const report = {
+  start, running, menuOpen, stillOpen, resumed,
+  checks: {
+    // The run was active before the menu: the player covered ground from spawn to
+    // the point the menu opened (headless rAF throttling makes per-poll motion
+    // bursty, so measure total displacement, not the mid-run poll).
+    runningBeforeMenu: running.hasTarget && Math.hypot(menuOpen.pos.x - start.pos.x, menuOpen.pos.z - start.pos.z) >= 3,
+    targetSurvivesMenu: menuOpen.hasTarget,          // the fix
+    heldStillWhilePaused: movedWhilePaused < 0.5,    // suspended => no walking
+    resumedAfterClose: movedAfterResume > 1,         // run continues
+  },
+};
+fs.writeFileSync('tmp/esc-run-report.json', JSON.stringify(report, null, 2));
+console.log(JSON.stringify(report, null, 2));
+
+await browser.close();
+const ok = Object.values(report.checks).every(Boolean);
+console.log(ok ? 'PASS: Escape pauses the run and it resumes.' : 'FAIL: see report.');
+process.exit(ok ? 0 : 1);

--- a/src/game/click_move.ts
+++ b/src/game/click_move.ts
@@ -87,7 +87,18 @@ export function manualMovementOverrides(mi: {
   return mi.forward || mi.back || mi.turnLeft || mi.turnRight || mi.strafeLeft || mi.strafeRight;
 }
 
-export function clickMoveShouldCancel(mi: {
+// How an active click-to-move run should resolve this frame:
+// - 'cancel'  : a real interrupt (mouselook, death, feature disabled, or a manual
+//               directional key). The destination is discarded.
+// - 'pause'   : movement is suspended by an open game menu (or a load transition).
+//               The destination is kept and the player simply holds still, so the
+//               run resumes the moment the menu closes, the same way autorun
+//               survives the menu instead of being cancelled by it.
+// - 'continue': keep walking toward the destination.
+// Cancel wins over pause: a genuine interrupt during a menu still ends the run.
+export type ClickMoveAction = 'cancel' | 'pause' | 'continue';
+
+export function resolveClickMoveAction(mi: {
   forward: boolean; back: boolean; turnLeft: boolean; turnRight: boolean;
   strafeLeft: boolean; strafeRight: boolean; jump: boolean;
 }, state: {
@@ -95,10 +106,10 @@ export function clickMoveShouldCancel(mi: {
   movementSuspended: boolean;
   playerDead: boolean;
   enabled: boolean;
-}): boolean {
-  return state.mouselook
-    || state.movementSuspended
-    || state.playerDead
-    || !state.enabled
-    || manualMovementOverrides(mi);
+}): ClickMoveAction {
+  if (state.mouselook || state.playerDead || !state.enabled || manualMovementOverrides(mi)) {
+    return 'cancel';
+  }
+  if (state.movementSuspended) return 'pause';
+  return 'continue';
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import { music } from './game/music';
 import { voice } from './game/voice';
 import { sfx } from './game/sfx';
 import { activePvpOpponentIds, handlePickedEntity, hoverCursorKind, isAttackableEntity } from './game/interactions';
-import { clickMoveShouldCancel, clickMoveShouldWalk, clickMoveStep, distance2d, latencyAdjustedStopDistance, stepAngleToward } from './game/click_move';
+import { clickMoveShouldWalk, clickMoveStep, distance2d, latencyAdjustedStopDistance, resolveClickMoveAction, stepAngleToward } from './game/click_move';
 import { Api, isAuthError, ClientWorld, CharacterSummary, NATIVE_APP, type ReleaseEntry } from './net/online';
 import { setWalletDisplayAvailable, setWocBalance, setWalletUiEnabled, resolveWocBalanceUpdate } from './ui/wallet_balance';
 import {
@@ -1268,13 +1268,18 @@ async function startGame(world: IWorld, offlineSim: Sim | null, online: ClientWo
     const mi = input.readMoveInput();
     let facing: number | null = mouselook ? input.camYaw : null;
     if (input.clickMoveTarget) {
-      if (clickMoveShouldCancel(mi, {
+      const action = resolveClickMoveAction(mi, {
         mouselook,
         movementSuspended: input.suspendMovement,
         playerDead: world.player.dead,
         enabled: settings.get('clickToMove') > 0 || settings.get('attackMove'),
-      })) {
+      });
+      if (action === 'cancel') {
         input.clearClickMove();
+      } else if (action === 'pause') {
+        // Game menu is up: hold the destination and stand still; the run resumes
+        // when the menu closes. mi is already all-false here (movement suspended).
+        return { mi, facing };
       } else {
         if (input.clickMoveEntityId !== null) {
           const e = world.entities.get(input.clickMoveEntityId);

--- a/tests/click_move.test.ts
+++ b/tests/click_move.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { CLICK_MOVE_FORWARD_CONE, angleDelta, clickMoveShouldCancel, clickMoveShouldWalk, clickMoveStep, facingToward, latencyAdjustedStopDistance, manualMovementOverrides, stepAngleToward } from '../src/game/click_move';
+import { CLICK_MOVE_FORWARD_CONE, angleDelta, clickMoveShouldWalk, clickMoveStep, facingToward, latencyAdjustedStopDistance, manualMovementOverrides, resolveClickMoveAction, stepAngleToward } from '../src/game/click_move';
 
 const NO_INPUT = { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
 
@@ -35,32 +35,58 @@ describe('click-to-move math (#95)', () => {
     expect(manualMovementOverrides({ ...NO_INPUT, strafeLeft: true })).toBe(true);
   });
 
-  it('jump does not cancel click-to-move — you keep travelling through the hop', () => {
+  it('jump does not cancel click-to-move, you keep travelling through the hop', () => {
     expect(manualMovementOverrides({ ...NO_INPUT, jump: true })).toBe(false);
-    expect(clickMoveShouldCancel({ ...NO_INPUT, jump: true }, {
+    expect(resolveClickMoveAction({ ...NO_INPUT, jump: true }, {
       mouselook: false,
       movementSuspended: false,
       playerDead: false,
       enabled: true,
-    })).toBe(false);
+    })).toBe('continue');
   });
 
   it('cancels click-to-move when the player dies', () => {
-    expect(clickMoveShouldCancel(NO_INPUT, {
+    expect(resolveClickMoveAction(NO_INPUT, {
       mouselook: false,
       movementSuspended: false,
       playerDead: true,
       enabled: true,
-    })).toBe(true);
+    })).toBe('cancel');
   });
 
   it('keeps click-to-move active while enabled and uninterrupted', () => {
-    expect(clickMoveShouldCancel(NO_INPUT, {
+    expect(resolveClickMoveAction(NO_INPUT, {
       mouselook: false,
       movementSuspended: false,
       playerDead: false,
       enabled: true,
-    })).toBe(false);
+    })).toBe('continue');
+  });
+
+  // Opening the Esc/game menu suspends movement. That must PAUSE the run (keep the
+  // destination so it resumes when the menu closes), not silently cancel it.
+  it('pauses (does not cancel) click-to-move while movement is suspended by a menu', () => {
+    expect(resolveClickMoveAction(NO_INPUT, {
+      mouselook: false,
+      movementSuspended: true,
+      playerDead: false,
+      enabled: true,
+    })).toBe('pause');
+  });
+
+  it('a real interrupt still cancels even while suspended (cancel wins over pause)', () => {
+    expect(resolveClickMoveAction({ ...NO_INPUT, forward: true }, {
+      mouselook: false,
+      movementSuspended: true,
+      playerDead: false,
+      enabled: true,
+    })).toBe('cancel');
+    expect(resolveClickMoveAction(NO_INPUT, {
+      mouselook: false,
+      movementSuspended: true,
+      playerDead: true,
+      enabled: true,
+    })).toBe('cancel');
   });
 
   it('only walks forward when aimed within the cone, else turns in place', () => {

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -101,6 +101,24 @@ describe('Input autorun', () => {
     expect(input.autorun).toBe(true);
     expect(input.readMoveInput().forward).toBe(true);
   });
+
+  it('opening the Escape menu pauses but does not cancel autorun, and it resumes on close', () => {
+    // The classic complaint: autorun, then hit Escape to change a keybind or a
+    // setting. Suspending movement (the open menu) must only pause forward motion
+    // for that frame, never clear the autorun latch, so closing the menu resumes
+    // the run instead of stranding the player.
+    const { input } = makeInput();
+    input.toggleAutorun();
+    expect(input.readMoveInput().forward).toBe(true);
+
+    input.suspendMovement = true; // mirrors main.ts setting it while the game menu is open
+    expect(input.autorun).toBe(true); // latch survives the menu
+    expect(input.readMoveInput().forward).toBe(false); // held still while suspended
+
+    input.suspendMovement = false; // menu closed
+    expect(input.autorun).toBe(true);
+    expect(input.readMoveInput().forward).toBe(true); // run resumes
+  });
 });
 
 describe('Input click-to-move marker pulses', () => {


### PR DESCRIPTION
## Problem

Pressing **Escape** to open the game menu while running silently **cancels** an in-progress click-to-move run. When you reopen movement, the destination is gone and you just stand there. Escape (opening the menu) should *pause* the run and let it resume on close, the way autorun already behaves.

## Root cause

Opening the Esc/game menu sets `input.suspendMovement` (main.ts) so WASD does not walk the character behind the menu. That same flag was also fed to `clickMoveShouldCancel`, which permanently called `clearClickMove()`. Autorun never had this bug: it is a flag that `readMoveInput` simply gates while suspended and resumes when the menu closes.

## Fix

Give click-to-move the same pause-not-cancel treatment. Replace the boolean `clickMoveShouldCancel` with a tri-state `resolveClickMoveAction` returning `'cancel' | 'pause' | 'continue'`:

- **cancel**: real interrupts (mouselook, death, feature disabled, a manual directional key). Destination discarded.
- **pause**: movement suspended by an open menu (or load transition). Destination kept, player holds still, run resumes on close.
- **continue**: keep walking.

Cancel wins over pause, so a genuine interrupt during a menu still ends the run. Pure-core change in `src/game/click_move.ts` with a thin consumer in main.ts's `resolveMove`.

## Tests

- `tests/click_move.test.ts`: pause vs cancel vs continue, including "suspended menu pauses (not cancels)" and "a real interrupt still cancels even while suspended."
- `scripts/esc_run_shot.mjs`: headless max-graphics harness. All checks green: `runningBeforeMenu`, `targetSurvivesMenu`, `heldStillWhilePaused`, `resumedAfterClose`.
- `npx tsc --noEmit` clean; `npm run build` clean.

No player-facing strings changed, so no i18n impact.

## Screenshots (`?gfx=ultra`)

Running to a destination, then Esc opens the menu mid-run (run paused, destination kept), then closing resumes it:

| 1. Running | 2. Esc menu open (paused) | 3. Resumed after close |
|---|---|---|
| ![running](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-esc-run/esc-run-1-running.png) | ![menu open](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-esc-run/esc-run-2-menu-open.png) | ![resumed](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-esc-run/esc-run-3-resumed.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)