### PR TITLE
fix(sim): pet that isn't fighting no longer blocks owner health regen

### DIFF
--- a/scripts/pet_combat_regen_shot.mjs
+++ b/scripts/pet_combat_regen_shot.mjs
@@ -1,0 +1,59 @@
+// Screenshot harness for the pet-combat health-regen fix.
+// Boots the offline world as a level-20 warlock at max graphics (?gfx=ultra),
+// summons an Infernal, drops the player to ~40% HP, and confirms out-of-combat
+// health regen resumes even while the demon lingers at the owner's side.
+// Captures the HUD before and after the regen ticks.
+//
+// Needs `npm run dev` (override with GAME_URL). Writes to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(200);
+await page.type('#char-name', 'Ruanhx');
+await page.click('#offline-select .mini-class[data-class="warlock"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game && window.__game.sim && window.__game.sim.player, { timeout: 30000 });
+await sleep(1500);
+
+// Level to 20, summon the Infernal, drop to 40% HP, force out of combat.
+const before = await page.evaluate(() => {
+  const g = window.__game; const sim = g.sim; const p = sim.player;
+  sim.setPlayerLevel(20);
+  sim.createDemonPet(p, 'infernal', false);
+  p.hp = Math.floor(p.maxHp * 0.4);
+  p.inCombat = false; p.combatTimer = 99;
+  return { hp: p.hp, maxHp: p.maxHp, mana: p.resource, maxMana: p.maxResource };
+});
+console.log('before:', JSON.stringify(before));
+await sleep(800);
+await page.screenshot({ path: 'tmp/pet-regen-before.png' });
+
+// Let the sim tick ~8 seconds of real out-of-combat time and re-read HP.
+await sleep(8000);
+const after = await page.evaluate(() => {
+  const p = window.__game.sim.player;
+  return { hp: p.hp, maxHp: p.maxHp, inCombat: p.inCombat };
+});
+console.log('after:', JSON.stringify(after));
+await page.screenshot({ path: 'tmp/pet-regen-after.png' });
+
+if (!(after.hp > before.hp)) { console.log('FAIL: hp did not regen'); }
+else console.log(`OK: hp ${before.hp} -> ${after.hp} out of combat`);
+
+await browser.close();

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -288,6 +288,12 @@ const PET_FOLLOW_DISTANCE = 3.5;
 const PET_TELEPORT_DISTANCE = 60; // owner this far away: pet warps to heel
 const PET_ASSIST_RANGE = 50; // how far the pet scans for enemies engaging the pair
 const PET_AGGRESSIVE_RANGE = 18; // aggressive pets look for idle enemies this close
+// A pet only keeps its OWNER flagged in combat while it is actively trading blows
+// (its combatTimer resets to 0 on every hit dealt/taken). A pet that merely holds a
+// target it is chasing or can't reach stops dragging the owner into perpetual combat
+// past this window, so the owner's out-of-combat health regen resumes. Matches the
+// 5s combat-linger used for the owner's own inCombat flag.
+const PET_COMBAT_LINGER = 5;
 const PET_TAUNT_RANGE = 5;
 const PET_GROWL_INTERVAL = 10; // controlled pets can tank by forcing attention
 const PET_FEED_DURATION = 5;
@@ -1721,8 +1727,10 @@ export class Sim {
         const tgt = this.entities.get(e.aggroTargetId);
         if (tgt && tgt.ownerId !== null) this.engagedPids.add(tgt.ownerId);
       }
-      // a player's pet that is engaging an enemy keeps its owner in combat
-      if (e.ownerId !== null && e.aggroTargetId !== null) this.engagedPids.add(e.ownerId);
+      // a player's pet that is actively fighting an enemy keeps its owner in
+      // combat. A pet merely holding a target it is not trading blows with (out of
+      // reach, stale) must not freeze the owner's health regen indefinitely (#regen)
+      if (e.ownerId !== null && e.aggroTargetId !== null && e.combatTimer < PET_COMBAT_LINGER) this.engagedPids.add(e.ownerId);
     }
     for (const meta of this.players.values()) {
       const p = this.entities.get(meta.entityId);

--- a/tests/pet_combat_regen.test.ts
+++ b/tests/pet_combat_regen.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d } from '../src/sim/types';
+
+// Regression for the "no passive health regen while not in combat" report
+// (imdutha / ruanhx): a warlock standing idle with a summoned Infernal could not
+// regenerate health. The owner stayed flagged `inCombat` because the pet held a
+// target it was not actually fighting, while mana kept regenerating on its own
+// 5-second rule. Out-of-combat health regen must resume once the pet stops
+// actively trading blows; a pet that IS fighting still keeps its owner in combat.
+
+function makeWarlock(seed = 7) {
+  const sim = new Sim({ seed, playerClass: 'warlock' as any, autoEquip: true });
+  const p: any = sim.player;
+  p.level = 20;
+  return { sim, p };
+}
+
+function summonInfernal(sim: Sim, p: any) {
+  (sim as any).createDemonPet(p, 'infernal', false);
+  for (const e of sim.entities.values()) if ((e as any).ownerId === p.id) return e as any;
+  throw new Error('pet not created');
+}
+
+function firstWildMob(sim: Sim) {
+  let best: any = null, bd = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || (e as any).ownerId !== null) continue;
+    const d = dist2d(sim.player.pos, e.pos);
+    if (d < bd) { bd = d; best = e; }
+  }
+  if (!best) throw new Error('no wild mob');
+  return best;
+}
+
+describe('pet-held combat does not block owner health regen', () => {
+  it('an idle pet (not trading blows) lets the owner regen health', () => {
+    const { sim, p } = makeWarlock();
+    const pet = summonInfernal(sim, p);
+    const mob = firstWildMob(sim);
+
+    // Give the pet a live, in-leash target it is NOT actually fighting: the mob
+    // sits ~30yd off (inside PET_LEASH 40 so the pet keeps it as a target) and we
+    // re-pin the pet beside the owner each tick so it never reaches melee range.
+    // The pet's combatTimer therefore climbs past the linger window.
+    const place = () => {
+      pet.pos = { x: p.pos.x, y: p.pos.y, z: p.pos.z };
+      mob.pos = { x: p.pos.x + 30, y: p.pos.y, z: p.pos.z };
+      pet.aggroTargetId = mob.id;
+    };
+
+    p.hp = Math.floor(p.maxHp * 0.4);
+    p.resource = Math.floor(p.maxResource * 0.4);
+    p.inCombat = false;
+    p.combatTimer = 99;
+    const hpStart = p.hp;
+
+    for (let i = 0; i < 200; i++) { place(); sim.tick(); }
+
+    expect(pet.aggroTargetId).toBe(mob.id); // pet still "has" the target
+    expect(p.hp).toBeGreaterThan(hpStart); // but the owner regenerates
+  });
+
+  it('a pet actively trading blows still keeps its owner in combat (no regen)', () => {
+    const { sim, p } = makeWarlock();
+    const pet = summonInfernal(sim, p);
+    const mob = firstWildMob(sim);
+
+    // Park a high-HP target in melee range of the pet so it keeps swinging:
+    // the pet's combatTimer stays low, so the owner stays in combat.
+    mob.hp = 1_000_000; mob.maxHp = 1_000_000;
+    pet.petMode = 'aggressive';
+    const place = () => {
+      pet.pos = { x: p.pos.x + 1, y: p.pos.y, z: p.pos.z };
+      mob.pos = { x: p.pos.x + 2, y: p.pos.y, z: p.pos.z };
+    };
+
+    p.hp = Math.floor(p.maxHp * 0.4);
+    p.inCombat = false;
+    p.combatTimer = 99;
+    const hpStart = p.hp;
+
+    for (let i = 0; i < 200; i++) { place(); sim.tick(); }
+
+    expect(pet.combatTimer).toBeLessThan(5); // pet is genuinely fighting
+    expect(p.hp).toBe(hpStart); // owner remains in combat, no health regen
+  });
+});


### PR DESCRIPTION
## The bug

Reported by imdutha (ruanhx): a player has **no passive health regen while out of combat**. In the video a max-level warlock stands idle next to a summoned Infernal with **full mana (2205/2205)** but **frozen HP (287/610)** that never moves over 17 seconds.

## Root cause

Out-of-combat health regen is gated on `!p.inCombat` (`src/sim/sim.ts`, `updateRegen`), while **mana** regen uses the separate 5-second rule (`fiveSecondRule >= 5`) and ignores `inCombat`. That asymmetry is the fingerprint: mana refills, HP freezes.

`p.inCombat` is recomputed each tick as:

```ts
p.inCombat = this.engagedPids.has(p.id) || p.combatTimer < 5;
```

A pet was added to `engagedPids` whenever it merely held an `aggroTargetId`:

```ts
if (e.ownerId !== null && e.aggroTargetId !== null) this.engagedPids.add(e.ownerId);
```

So a demon that holds a target it is **not actually fighting** (chasing something unreachable, or a stale target within leash) keeps its owner flagged in combat forever. Health regen never resumes; mana keeps ticking. Exactly the "full mana, stuck HP" state in the clip.

Reproduced deterministically: forcing the owner `inCombat` for 12s gives `hp 22 -> 22, mana 62 -> 128`.

## The fix

Only keep the owner in combat while the pet is **actively trading blows**:

```ts
if (e.ownerId !== null && e.aggroTargetId !== null && e.combatTimer < PET_COMBAT_LINGER) this.engagedPids.add(e.ownerId);
```

A pet's `combatTimer` resets to 0 on every hit dealt or taken (via `enterCombat` in `dealDamage`) and climbs otherwise, so it is a precise "is the pet really fighting" signal. A genuinely tanking pet (trading blows each swing) still keeps its owner in combat, preserving the deliberate hunter/warlock design. The wild-mob-chasing arm is intentionally unchanged (an enemy aggroed onto you should hold you in combat). Sim-only, deterministic (reads an existing sim-clock field), no wire/IWorld change.

## Tests

`tests/pet_combat_regen.test.ts`:
- idle pet holding a target it isn't fighting -> **owner regenerates** (fails before the fix: `expected 22 to be greater than 22`)
- pet actively trading blows -> **owner stays in combat, no regen** (guards the tank-pet design)

Full suite green: **2959 passed, 8 skipped**. `tsc --noEmit` clean, `npm run build` clean.

## Screenshots (max graphics, `?gfx=ultra`)

Warlock + Infernal, HP climbing while out of combat:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-pet-regen/pet-regen-before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-pet-regen/pet-regen-after.png) |

cc @levy-street @Rubsey @FernandoX7 @CharlieSaxton @maxpolaczuk @patrick261

🤖 Generated with [Claude Code](https://claude.com/claude-code)