### PR TITLE
Fix/loot roll tooltip layering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1127,6 +1127,7 @@
     right: max(14px, env(safe-area-inset-right));
     bottom: calc(112px + env(safe-area-inset-bottom));
     z-index: 65;
+    pointer-events: auto;
     display: none;
     flex-direction: column;
     gap: 8px;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -5115,12 +5115,14 @@ export class Hud {
 
   private lootRollRoot(): HTMLElement {
     let root = document.getElementById('loot-rolls');
+    const uiRoot = document.getElementById('ui');
     if (!root) {
       root = document.createElement('div');
       root.id = 'loot-rolls';
       root.setAttribute('aria-live', 'polite');
-      document.body.appendChild(root);
     }
+    if (uiRoot && root.parentElement !== uiRoot) uiRoot.appendChild(root);
+    else if (!root.parentElement) document.body.appendChild(root);
     return root;
   }
 


### PR DESCRIPTION
## Summary

Fixes loot roll item tooltips rendering behind stacked loot roll panels.

Loot roll panels now mount inside the main HUD layer so the existing tooltip z-index can render item descriptions above the roll stack. The roll stack keeps pointer events enabled so Need, Greed, and Pass remain
clickable.

  ## Type of change

  - [x] Bug fix
  - [ ] Feature: new functionality
  - [ ] Refactor or performance (no behavior change)
  - [ ] Documentation
  - [ ] Tests
  - [ ] Build, CI, or tooling
  - [ ] Breaking change (please call it out in the summary)

  ## How was this tested?

  - Commands:
    - `npx tsc --noEmit`
    - `npm test`
    - `npm run build`
  - Manual steps:
    - Triggered a legendary loot roll locally.
    - Hovered the rolled item while multiple roll panels were visible.
    - Confirmed the item tooltip renders in front of the roll panels and roll buttons remain clickable.

  ## Screenshots / recordings

  N/A

  ---

  ## Checklist

  ### Quality

  - [x] **Tests pass.** `npm test` is green. I added or updated tests for any
        `sim/` or `server/` behavior I changed.
  - [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
        TypeScript `strict`).
  - [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
        `npm run build:env` if I touched those.

  ### Cross-platform

  - [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
        phone-sized viewport in both portrait and landscape. Touch targets stay at
        least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
  - [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
        respect for `prefers-reduced-motion` (only if this change adds or edits UI).

  ### Localization (i18n)

  - [ ] **New player-visible strings are translated into every supported locale.**
        Every user-facing string is a `t()` key, added to `en` first, then given a
        real translation in every locale in `supportedLanguages`
        (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
  - [ ] Numbers, money, dates, units, and percents go through the i18n formatters
        (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
  - [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
        the client boundary in this same change, and
        `npx vitest run tests/localization_fixes.test.ts` passes.
  - [x] N/A. This PR adds no player-visible strings.

  ### Hygiene

  - [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
        not enabled in any production path.
  - [x] I didn't hand-edit generated files such as
        `src/render/assets/manifest.generated.ts`. They're regenerated by the build.