### PR TITLE
fix(quests): despawn idle bound guardian

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -128,7 +128,8 @@ const PARTY_MAX = 5;
 const RAID_MIN = 5;
 const RAID_MAX = 10;
 const RAID_GROUP_MAX = 5;
-const VARKAS_BONEGUARD_DAMAGE_IDLE_DESPAWN_SECONDS = 60;
+const DAMAGE_IDLE_DESPAWN_SECONDS = 60;
+const DAMAGE_IDLE_DESPAWN_MOB_IDS = new Set(['varkas_boneguard', 'bound_guardian']);
 const RAID_ALLOWED_DUNGEON_IDS = new Set(['nythraxis_crypt', 'nythraxis_boss_arena']);
 const RAID_REQUIRED_DUNGEON_IDS = new Set(['nythraxis_boss_arena']);
 const PARTY_XP_RANGE = 80; // yards: members this close share kill xp/credit
@@ -1673,8 +1674,8 @@ export class Sim {
         e.despawnTimer -= DT;
         if (e.despawnTimer <= 0) despawnIds.push(e.id);
       }
-      if (e.kind === 'mob' && e.templateId === 'varkas_boneguard' && !e.dead) {
-        e.damageIdleDespawnTimer = (e.damageIdleDespawnTimer ?? VARKAS_BONEGUARD_DAMAGE_IDLE_DESPAWN_SECONDS) - DT;
+      if (e.kind === 'mob' && DAMAGE_IDLE_DESPAWN_MOB_IDS.has(e.templateId) && !e.dead && !e.inCombat) {
+        e.damageIdleDespawnTimer = (e.damageIdleDespawnTimer ?? DAMAGE_IDLE_DESPAWN_SECONDS) - DT;
         if (e.damageIdleDespawnTimer <= 0) despawnIds.push(e.id);
       }
       if (e.overheadEmoteId && this.time >= e.overheadEmoteUntil) {
@@ -4136,8 +4137,8 @@ export class Sim {
     this.emit({ type: 'damage', sourceId: source?.id ?? -1, targetId: target.id, amount, crit, school, ability, kind });
 
     if (amount > 0) {
-      if (target.kind === 'mob' && target.templateId === 'varkas_boneguard') {
-        target.damageIdleDespawnTimer = VARKAS_BONEGUARD_DAMAGE_IDLE_DESPAWN_SECONDS;
+      if (target.kind === 'mob' && DAMAGE_IDLE_DESPAWN_MOB_IDS.has(target.templateId)) {
+        target.damageIdleDespawnTimer = DAMAGE_IDLE_DESPAWN_SECONDS;
       }
       for (let i = target.auras.length - 1; i >= 0; i--) {
         if (target.auras[i].breaksOnDamage) {

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1119,12 +1119,15 @@ describe('quest npc roles', () => {
     }
   });
 
-  it('despawns Varkas Boneguards after 60 seconds without damage and resets on damage taken', () => {
+  it('despawns Varkas Boneguards after 60 seconds out of combat without damage and resets on damage taken', () => {
     const sim = makeSim();
     const boneguard = createMob(909900, MOBS.varkas_boneguard, 19, { x: 0, y: 0, z: 0 });
     boneguard.maxHp = 1000;
     boneguard.hp = 1000;
     (sim as unknown as { addEntity(e: Entity): void }).addEntity(boneguard);
+    teleportTo(sim, 0, -2);
+    sim.player.maxHp = 100000;
+    sim.player.hp = sim.player.maxHp;
 
     for (let i = 0; i < 59 * 20; i++) sim.tick();
     expect(sim.entities.has(boneguard.id)).toBe(true);
@@ -1134,11 +1137,58 @@ describe('quest npc roles', () => {
     }).dealDamage(sim.player, boneguard, 5, false, 'physical', 'Test Strike', 'hit', true);
     expect(boneguard.damageIdleDespawnTimer).toBe(60);
 
+    boneguard.damageIdleDespawnTimer = 1;
+    boneguard.inCombat = true;
+    sim.tick();
+    expect(sim.entities.has(boneguard.id)).toBe(true);
+    expect(boneguard.damageIdleDespawnTimer).toBe(1);
+
+    teleportTo(sim, 100, 100);
+    boneguard.inCombat = false;
+    boneguard.aiState = 'idle';
+    boneguard.aggroTargetId = null;
+    boneguard.damageIdleDespawnTimer = 60;
     for (let i = 0; i < 59 * 20; i++) sim.tick();
     expect(sim.entities.has(boneguard.id)).toBe(true);
 
     for (let i = 0; i < 2 * 20; i++) sim.tick();
     expect(sim.entities.has(boneguard.id)).toBe(false);
+  });
+
+  it('despawns the Bound Guardian after 60 seconds out of combat without damage and resets on damage taken', () => {
+    const sim = makeSim();
+    const ritual = [...sim.entities.values()].find((e) => e.kind === 'object' && e.objectItemId === 'crypt_ritual_circle')!;
+    teleportTo(sim, ritual.pos.x, ritual.pos.z);
+    sim.questLog.set('q_nythraxis_bound_guardian', { questId: 'q_nythraxis_bound_guardian', counts: [0, 0, 0], state: 'active' });
+    sim.addItem('crypt_keystone', 1);
+    sim.player.maxHp = 100000;
+    sim.player.hp = sim.player.maxHp;
+
+    sim.pickUpObject(ritual.id);
+
+    const guardian = [...sim.entities.values()].find((e) => e.templateId === 'bound_guardian')!;
+    expect(guardian).toBeTruthy();
+
+    guardian.damageIdleDespawnTimer = 1;
+    sim.tick();
+    expect(sim.entities.has(guardian.id)).toBe(true);
+    expect(guardian.damageIdleDespawnTimer).toBe(1);
+
+    (sim as unknown as {
+      dealDamage(source: Entity, target: Entity, amount: number, crit: boolean, school: string, ability: string | null, kind: 'hit', noRage?: boolean): void;
+    }).dealDamage(sim.player, guardian, 5, false, 'physical', 'Test Strike', 'hit', true);
+    expect(guardian.damageIdleDespawnTimer).toBe(60);
+
+    teleportTo(sim, ritual.pos.x + 100, ritual.pos.z + 100);
+    guardian.inCombat = false;
+    guardian.aiState = 'idle';
+    guardian.aggroTargetId = null;
+    guardian.damageIdleDespawnTimer = 60;
+    for (let i = 0; i < 59 * 20; i++) sim.tick();
+    expect(sim.entities.has(guardian.id)).toBe(true);
+
+    for (let i = 0; i < 2 * 20; i++) sim.tick();
+    expect(sim.entities.has(guardian.id)).toBe(false);
   });
 
   it('shares Nythraxis ritual circle progress with nearby party members', () => {


### PR DESCRIPTION
## Summary

Adds the same 60-second damage-idle despawn behavior used by Varkas Boneguards to The Bound Guardian.

The shared despawn timer now only counts down while the mob is out of combat, and taking damage resets the timer to 60 seconds. This prevents the Bound Guardian from lingering forever after the quest summon is
abandoned, while keeping both the guardian and his adds active during combat.

  ## Type of change

  - [ ] Feature: new functionality
  - [x] Bug fix
  - [ ] Refactor or performance (no behavior change)
  - [ ] Documentation
  - [x] Tests
  - [ ] Build, CI, or tooling
  - [ ] Breaking change (please call it out in the summary)

  ## How was this tested?

  - Commands:
    - `npx vitest run tests/fixes.test.ts`
    - `npx tsc --noEmit`
    - `npm test`
    - `npm run build`
  - Manual steps:
    - Reverted Patrickgm locally to `q_nythraxis_bound_guardian`.
    - Spawned The Bound Guardian from the ritual circle.
    - Confirmed the guardian despawns after being left out of combat.

  ## Screenshots / recordings

  N/A

  ---

  ## Checklist

  ### Quality

  - [x] **Tests pass.** `npm test` is green. I added or updated tests for any
        `sim/` or `server/` behavior I changed.
  - [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
        TypeScript `strict`).
  - [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
        `npm run build:env` if I touched those.

  ### Cross-platform

  - [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
        phone-sized viewport in both portrait and landscape. Touch targets stay at
        least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
  - [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
        respect for `prefers-reduced-motion` (only if this change adds or edits UI).

  ### Localization (i18n)

  - [ ] **New player-visible strings are translated into every supported locale.**
        Every user-facing string is a `t()` key, added to `en` first, then given a
        real translation in every locale in `supportedLanguages`
        (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
  - [ ] Numbers, money, dates, units, and percents go through the i18n formatters
        (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
  - [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
        the client boundary in this same change, and
        `npx vitest run tests/localization_fixes.test.ts` passes.
  - [x] N/A. This PR adds no player-visible strings.

  ### Hygiene

  - [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
        not enabled in any production path.
  - [x] I didn't hand-edit generated files such as
        `src/render/assets/manifest.generated.ts`. They're regenerated by the build.