### PR TITLE
refactor(ui): establish HUD window-extraction architecture, migrate Vendor first

### DIFF
--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -89,13 +89,13 @@ drives directly, plus a thin DOM/canvas consumer.
 `hud.ts` is one `Hud` class touched by nearly every PR; that is the merge-conflict tax
 this recipe pays down. Migrate one window at a time, on the rule of three, never as a
 big-bang split. **Reference: the Vendor window (`vendor_view.ts` + `vendor_window.ts`,
-the first window migrated this way) — copy its shape for the next one.**
+the first window migrated this way), copy its shape for the next one.**
 
 The split has three parts:
 1. **Pure view model** (`<window>_view.ts`): a DOM-free, i18n-free `build<Window>View(...)`
    that takes the raw world inputs and returns the structure the window draws (which rows,
    which prices, which flags). This is the only part with branching logic worth testing in
-   isolation. Unit-test it directly in `tests/<window>_view.test.ts` (no DOM) — see
+   isolation. Unit-test it directly in `tests/<window>_view.test.ts` (no DOM): see
    `tests/vendor_view.test.ts`. For sim-derived data add `expect(build()).toEqual(build())`.
 2. **Thin consumer** (`<window>_window.ts`): a `render<Window>(el, ...view, deps)` that paints
    the panel and wires clicks. It imports `t`/`esc`/`svgIcon`/formatters directly but takes
@@ -109,8 +109,9 @@ The split has three parts:
    module with `deps`.
 
 Keep the diff a move-plus-import, not a rewrite (root `extract-and-test` skill). Reuse
-existing `t()` keys where the markup is unchanged — a pure extraction adds no i18n keys
-(Vendor added none). All interpolated names still pass through `esc()`.
+existing `t()` keys where the markup is unchanged (a pure extraction adds no i18n keys;
+Vendor added none). All interpolated names still pass through `esc()`. For item-name
+display, import the shared `itemDisplayName` from `entity_i18n.ts` rather than re-copying it.
 
 ## i18n - IMPORTANT (sparse-overlay model; contributors add ENGLISH ONLY)
 The locale data is split across files. Touch the right one:

--- a/src/ui/CLAUDE.md
+++ b/src/ui/CLAUDE.md
@@ -85,6 +85,33 @@ direction the HUD modularization is heading; see the root Modularity section). T
 painters (`unit_portrait*`, `xp_bar.ts`) are the template: a host-agnostic core a Vitest
 drives directly, plus a thin DOM/canvas consumer.
 
+### Extracting a HUD window (the recipe)
+`hud.ts` is one `Hud` class touched by nearly every PR; that is the merge-conflict tax
+this recipe pays down. Migrate one window at a time, on the rule of three, never as a
+big-bang split. **Reference: the Vendor window (`vendor_view.ts` + `vendor_window.ts`,
+the first window migrated this way) — copy its shape for the next one.**
+
+The split has three parts:
+1. **Pure view model** (`<window>_view.ts`): a DOM-free, i18n-free `build<Window>View(...)`
+   that takes the raw world inputs and returns the structure the window draws (which rows,
+   which prices, which flags). This is the only part with branching logic worth testing in
+   isolation. Unit-test it directly in `tests/<window>_view.test.ts` (no DOM) — see
+   `tests/vendor_view.test.ts`. For sim-derived data add `expect(build()).toEqual(build())`.
+2. **Thin consumer** (`<window>_window.ts`): a `render<Window>(el, ...view, deps)` that paints
+   the panel and wires clicks. It imports `t`/`esc`/`svgIcon`/formatters directly but takes
+   `Hud`'s shared painters (`itemIcon`, `moneyHtml`, `itemTooltip`, `attachTooltip`,
+   `hideTooltip`) and the action callbacks (`onBuy`, `onClose`, …) as an injected `deps`
+   object. It owns no state and never imports `Hud`.
+3. **Hud stays the orchestrator.** Keep the `open<Window>`/`close<Window>` methods in `Hud`:
+   cross-window coordination (`closeOtherWindows`, bag re-centring, mobile teardown, body
+   classes) needs `Hud`'s private state and does not belong in the module. The per-render
+   method (e.g. `renderVendor`) shrinks to: resolve the entity, build the view, call the
+   module with `deps`.
+
+Keep the diff a move-plus-import, not a rewrite (root `extract-and-test` skill). Reuse
+existing `t()` keys where the markup is unchanged — a pure extraction adds no i18n keys
+(Vendor added none). All interpolated names still pass through `esc()`.
+
 ## i18n - IMPORTANT (sparse-overlay model; contributors add ENGLISH ONLY)
 The locale data is split across files. Touch the right one:
 - `i18n.catalog/` (nested) is the **authoritative source catalog** and drives
@@ -222,6 +249,16 @@ unit-testing.
 - **meters.ts** — DPS/HPS/threat meters, encounter-segmented; threat reads
   the mob's real `entity.threat` hate table. Uses `performance.now()` (UI timing
   only — fine here; that ban is sim-only).
+- **vendor_view.ts** / **vendor_window.ts**: the merchant vendor window, and the
+  first full window migrated out of `hud.ts` by the "Extracting a HUD window"
+  recipe above. The pure **view** (`vendor_view.ts`, DOM/i18n-free,
+  unit-tested in `tests/vendor_view.test.ts`) is `buildVendorView`, which decides
+  the sellable goods rows (item exists + has a buyValue) and the redeemable buyback
+  rows (item exists + count > 0) with prices. The thin **consumer**
+  (`vendor_window.ts`, `renderVendorWindow`) paints `#vendor-window` from that view
+  and takes `Hud`'s shared painters plus the buy/buyback/close callbacks as injected
+  `deps`. `Hud` keeps `openVendor`/`closeVendor` (cross-window orchestration);
+  `renderVendor` is now a thin bridge.
 - **player_context_menu.ts** — pure `chatPlayerContextActions()` returning
   whisper/invite/friend/ignore/report actions for the right-click-player menu.
 - **auth_utils.ts** — login/char-select form helpers: password toggle, ARIA

--- a/src/ui/entity_i18n.ts
+++ b/src/ui/entity_i18n.ts
@@ -1,5 +1,5 @@
 import { ABILITIES, CLASSES, DUNGEONS, ITEMS, MOBS, NPCS, QUESTS, ZONES } from '../sim/data';
-import type { PlayerClass } from '../sim/types';
+import type { ItemDef, PlayerClass } from '../sim/types';
 import {
   en,
   getLanguage,
@@ -207,6 +207,10 @@ export function tEntity(request: EntityTranslationRequest): string {
   const fallback = interpolateSource(canonicalEntityText(request), request.values);
   recordFallback(request, fallback);
   return fallback;
+}
+
+export function itemDisplayName(item: ItemDef): string {
+  return tEntity({ kind: 'item', id: item.id, field: 'name' });
 }
 
 export function resetEntityTranslationFallbackLog(): void {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -88,7 +88,7 @@ import {
 import { TouchPeekGuard, TOOLTIP_PEEK_MS } from './touch_peek';
 import { maskProfanity } from './profanity';
 import { formatMoney as formatLocalizedMoney, formatNumber, getLanguage, isSupportedLanguage, moneyParts, supportedLanguages, t, tOptional, tPlural, type SupportedLanguage, type TranslationKey } from './i18n';
-import { tEntity } from './entity_i18n';
+import { itemDisplayName, tEntity } from './entity_i18n';
 import { localizeServerText, localizeZone } from './server_i18n';
 import { localizeSimText, localizeSimAuraName } from './sim_i18n';
 import { tTalent, localizeTalentTitle } from './talent_i18n';
@@ -9779,10 +9779,6 @@ function abilityDisplayDescription(def: AbilityDef, damageText: string): string 
 
 function classDisplayName(cls: PlayerClass): string {
   return tEntity({ kind: 'class', id: cls, field: 'name' });
-}
-
-function itemDisplayName(item: ItemDef): string {
-  return tEntity({ kind: 'item', id: item.id, field: 'name' });
 }
 
 function itemDisplayNameFromSource(name: string): string {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -51,6 +51,8 @@ import { iconDataUrl, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_NAMES } from
 import { UnitPortraitPainter } from './unit_portrait_painter';
 import { crestIdForEntity } from './unit_portrait';
 import { svgIcon } from './ui_icons';
+import { buildVendorView } from './vendor_view';
+import { renderVendorWindow } from './vendor_window';
 import { shouldPlayCombatImpactForTarget, shouldPlayCritSfxForTarget, shouldPlayMobVoiceSfxForEntity } from './combat_sfx';
 import { nextVoicedYell, voicedYellGain, type VoicedYellState } from './voice_events';
 import { walletDisplayAvailable, walletUiEnabled, wocBalance, wocBalanceVerified, verifiedWocBalance, onWalletUiChange } from './wallet_balance';
@@ -5264,66 +5266,26 @@ export class Hud {
     if (this.openVendorNpcId === null) return;
     const npc = this.sim.entities.get(this.openVendorNpcId);
     if (!npc) return;
-    const el = $('#vendor-window');
-    // the rebuild replaces the hovered row (its mouseleave never fires) and
-    // collapses the scrolled list — drop the tooltip and restore the scroll
-    this.hideTooltip();
-    const scrollTop = el.scrollTop;
-    let html = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: entityDisplayName(npc) }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
-    el.innerHTML = html;
-    for (const itemId of npc.vendorItems) {
-      const item = ITEMS[itemId];
-      if (!item?.buyValue) continue;
-      const row = document.createElement('button');
-      row.type = 'button';
-      row.className = 'vendor-item';
-      const price = formatLocalizedMoney(item.buyValue);
-      const itemName = itemDisplayName(item);
-      row.setAttribute('aria-label', t('itemUi.vendor.buyAria', { item: itemName, price }));
-      row.innerHTML = `${this.itemIcon(item)}<span class="vi-name">${esc(itemName)}</span><span class="vi-price">${this.moneyHtml(item.buyValue)}</span>`;
-      row.addEventListener('click', () => {
-        this.sim.buyItem(npc.id, itemId);
-        if ($('#bags').style.display !== 'none') this.renderBags();
-        this.renderVendor();
-      });
-      this.attachTooltip(row, () => this.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuy'))}</div>`);
-      el.appendChild(row);
-    }
-    const buybackTitle = document.createElement('div');
-    buybackTitle.className = 'vendor-section-title';
-    buybackTitle.textContent = t('itemUi.vendor.buybackTitle');
-    el.appendChild(buybackTitle);
-    const buyback = this.sim.vendorBuyback.filter((s) => ITEMS[s.itemId] && s.count > 0);
-    if (buyback.length === 0) {
-      const empty = document.createElement('div');
-      empty.className = 'vendor-empty';
-      empty.textContent = t('itemUi.vendor.buybackEmpty');
-      el.appendChild(empty);
-    }
-    for (const s of buyback) {
-      const item = ITEMS[s.itemId]!;
-      const row = document.createElement('button');
-      row.type = 'button';
-      row.className = 'vendor-item';
-      const price = formatLocalizedMoney(item.sellValue);
-      const itemName = itemDisplayName(item);
-      row.setAttribute('aria-label', t('itemUi.vendor.buybackAria', { item: itemName, price }));
-      row.innerHTML = `${this.itemIcon(item)}<span class="vi-name">${esc(itemName)}${s.count > 1 ? ` x${s.count}` : ''}</span><span class="vi-price">${this.moneyHtml(item.sellValue)}</span>`;
-      row.addEventListener('click', () => {
-        this.sim.buyBackItem(s.itemId);
-        if ($('#bags').style.display !== 'none') this.renderBags();
-        this.renderVendor();
-      });
-      this.attachTooltip(row, () => this.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuyback'))}</div>`);
-      el.appendChild(row);
-    }
-    const hint = document.createElement('div');
-    hint.className = 'vendor-hint';
-    hint.textContent = t('itemUi.vendor.hint');
-    el.appendChild(hint);
-    el.querySelector('[data-close]')?.addEventListener('click', () => this.closeVendor());
-    el.style.display = 'block';
-    el.scrollTop = scrollTop;
+    const buyAndRefresh = (buy: () => void) => {
+      buy();
+      if ($('#bags').style.display !== 'none') this.renderBags();
+      this.renderVendor();
+    };
+    renderVendorWindow(
+      $('#vendor-window'),
+      entityDisplayName(npc),
+      buildVendorView(npc.vendorItems, this.sim.vendorBuyback, ITEMS),
+      {
+        itemIcon: (item) => this.itemIcon(item),
+        moneyHtml: (copper) => this.moneyHtml(copper),
+        itemTooltip: (item) => this.itemTooltip(item),
+        attachTooltip: (el, html) => this.attachTooltip(el, html),
+        hideTooltip: () => this.hideTooltip(),
+        onBuy: (itemId) => buyAndRefresh(() => this.sim.buyItem(npc.id, itemId)),
+        onBuyBack: (itemId) => buyAndRefresh(() => this.sim.buyBackItem(itemId)),
+        onClose: () => this.closeVendor(),
+      },
+    );
   }
 
   closeVendor(): void {

--- a/src/ui/vendor_view.ts
+++ b/src/ui/vendor_view.ts
@@ -1,0 +1,59 @@
+// Pure, host-agnostic view model for the vendor window.
+//
+// This is the pure-core half of the pure-core + thin-consumer split (root
+// CLAUDE.md Conventions; reference unit_portrait.ts / stat_tooltip.ts). It owns
+// the one thing the vendor window decides that is worth testing without a DOM:
+// which rows are sellable goods and which buyback slots are still redeemable,
+// and at what price. The DOM/i18n side lives in vendor_window.ts; rendering is
+// driven entirely off the structure returned here.
+//
+// DOM-free and i18n-free so tests/vendor_view.test.ts can drive it directly.
+
+import type { InvSlot, ItemDef } from '../sim/types';
+
+export interface VendorGoodsRow {
+  itemId: string;
+  item: ItemDef;
+  /** Copper the vendor sells this item for. Always > 0 for a goods row. */
+  price: number;
+}
+
+export interface VendorBuybackRow {
+  itemId: string;
+  item: ItemDef;
+  count: number;
+  /** Copper the player pays to buy the item back (the vendor sell value). */
+  price: number;
+}
+
+export interface VendorView {
+  goods: VendorGoodsRow[];
+  buyback: VendorBuybackRow[];
+}
+
+/**
+ * Build the structured vendor view from raw inputs.
+ *
+ * Goods: a vendor item is offered only if it exists in the item table and has a
+ * truthy buyValue (vendors never list a priceless item). Buyback: a stored slot
+ * is redeemable only if the item still exists and the stack count is positive.
+ */
+export function buildVendorView(
+  vendorItemIds: readonly string[],
+  buybackSlots: readonly InvSlot[],
+  items: Record<string, ItemDef>,
+): VendorView {
+  const goods: VendorGoodsRow[] = [];
+  for (const itemId of vendorItemIds) {
+    const item = items[itemId];
+    if (!item?.buyValue) continue;
+    goods.push({ itemId, item, price: item.buyValue });
+  }
+  const buyback: VendorBuybackRow[] = [];
+  for (const slot of buybackSlots) {
+    const item = items[slot.itemId];
+    if (!item || slot.count <= 0) continue;
+    buyback.push({ itemId: slot.itemId, item, count: slot.count, price: item.sellValue });
+  }
+  return { goods, buyback };
+}

--- a/src/ui/vendor_window.ts
+++ b/src/ui/vendor_window.ts
@@ -8,7 +8,7 @@
 // one panel and reports clicks back through the injected callbacks.
 
 import { esc } from './esc';
-import { tEntity } from './entity_i18n';
+import { itemDisplayName } from './entity_i18n';
 import { formatMoney as formatLocalizedMoney, t } from './i18n';
 import { svgIcon } from './ui_icons';
 import type { ItemDef } from '../sim/types';
@@ -30,10 +30,6 @@ export interface VendorWindowDeps {
   onClose(): void;
 }
 
-function itemDisplayName(item: ItemDef): string {
-  return tEntity({ kind: 'item', id: item.id, field: 'name' });
-}
-
 /** Paint the vendor panel from a prepared view. */
 export function renderVendorWindow(
   el: HTMLElement,
@@ -42,19 +38,19 @@ export function renderVendorWindow(
   deps: VendorWindowDeps,
 ): void {
   // The rebuild replaces the hovered row (its mouseleave never fires) and
-  // collapses the scrolled list — drop the tooltip and restore the scroll.
+  // collapses the scrolled list, drop the tooltip and restore the scroll.
   deps.hideTooltip();
   const scrollTop = el.scrollTop;
   el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: vendorName }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
 
-  for (const { itemId, item } of view.goods) {
+  for (const { itemId, item, price: priceCopper } of view.goods) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'vendor-item';
-    const price = formatLocalizedMoney(item.buyValue ?? 0);
+    const price = formatLocalizedMoney(priceCopper);
     const itemName = itemDisplayName(item);
     row.setAttribute('aria-label', t('itemUi.vendor.buyAria', { item: itemName, price }));
-    row.innerHTML = `${deps.itemIcon(item)}<span class="vi-name">${esc(itemName)}</span><span class="vi-price">${deps.moneyHtml(item.buyValue ?? 0)}</span>`;
+    row.innerHTML = `${deps.itemIcon(item)}<span class="vi-name">${esc(itemName)}</span><span class="vi-price">${deps.moneyHtml(priceCopper)}</span>`;
     row.addEventListener('click', () => deps.onBuy(itemId));
     deps.attachTooltip(row, () => deps.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuy'))}</div>`);
     el.appendChild(row);
@@ -71,14 +67,14 @@ export function renderVendorWindow(
     empty.textContent = t('itemUi.vendor.buybackEmpty');
     el.appendChild(empty);
   }
-  for (const { itemId, item, count } of view.buyback) {
+  for (const { itemId, item, count, price: priceCopper } of view.buyback) {
     const row = document.createElement('button');
     row.type = 'button';
     row.className = 'vendor-item';
-    const price = formatLocalizedMoney(item.sellValue);
+    const price = formatLocalizedMoney(priceCopper);
     const itemName = itemDisplayName(item);
     row.setAttribute('aria-label', t('itemUi.vendor.buybackAria', { item: itemName, price }));
-    row.innerHTML = `${deps.itemIcon(item)}<span class="vi-name">${esc(itemName)}${count > 1 ? ` x${count}` : ''}</span><span class="vi-price">${deps.moneyHtml(item.sellValue)}</span>`;
+    row.innerHTML = `${deps.itemIcon(item)}<span class="vi-name">${esc(itemName)}${count > 1 ? ` x${count}` : ''}</span><span class="vi-price">${deps.moneyHtml(priceCopper)}</span>`;
     row.addEventListener('click', () => deps.onBuyBack(itemId));
     deps.attachTooltip(row, () => deps.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuyback'))}</div>`);
     el.appendChild(row);

--- a/src/ui/vendor_window.ts
+++ b/src/ui/vendor_window.ts
@@ -1,0 +1,95 @@
+// Thin DOM consumer for the vendor window.
+//
+// The consumer half of the pure-core + thin-consumer split: it paints
+// #vendor-window from the structured VendorView (vendor_view.ts) and wires the
+// buy / buyback / close actions. It owns no state. The cross-window
+// orchestration (which windows to close, bag re-centring, mobile teardown)
+// stays in Hud because it needs Hud's private state; this module only renders
+// one panel and reports clicks back through the injected callbacks.
+
+import { esc } from './esc';
+import { tEntity } from './entity_i18n';
+import { formatMoney as formatLocalizedMoney, t } from './i18n';
+import { svgIcon } from './ui_icons';
+import type { ItemDef } from '../sim/types';
+import type { VendorView } from './vendor_view';
+
+/**
+ * Hud-supplied glue. The icon/money/tooltip painters live on Hud (shared with
+ * every other window); the action callbacks let Hud keep buy/buyback dispatch
+ * and re-render scheduling. The module never reaches into Hud directly.
+ */
+export interface VendorWindowDeps {
+  itemIcon(item: ItemDef): string;
+  moneyHtml(copper: number): string;
+  itemTooltip(item: ItemDef): string;
+  attachTooltip(el: HTMLElement, html: () => string): void;
+  hideTooltip(): void;
+  onBuy(itemId: string): void;
+  onBuyBack(itemId: string): void;
+  onClose(): void;
+}
+
+function itemDisplayName(item: ItemDef): string {
+  return tEntity({ kind: 'item', id: item.id, field: 'name' });
+}
+
+/** Paint the vendor panel from a prepared view. */
+export function renderVendorWindow(
+  el: HTMLElement,
+  vendorName: string,
+  view: VendorView,
+  deps: VendorWindowDeps,
+): void {
+  // The rebuild replaces the hovered row (its mouseleave never fires) and
+  // collapses the scrolled list — drop the tooltip and restore the scroll.
+  deps.hideTooltip();
+  const scrollTop = el.scrollTop;
+  el.innerHTML = `<div class="panel-title"><span>${esc(t('itemUi.vendor.goodsTitle', { name: vendorName }))}</span><button type="button" class="x-btn" data-close aria-label="${esc(t('itemUi.vendor.close'))}">${svgIcon('close')}</button></div>`;
+
+  for (const { itemId, item } of view.goods) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'vendor-item';
+    const price = formatLocalizedMoney(item.buyValue ?? 0);
+    const itemName = itemDisplayName(item);
+    row.setAttribute('aria-label', t('itemUi.vendor.buyAria', { item: itemName, price }));
+    row.innerHTML = `${deps.itemIcon(item)}<span class="vi-name">${esc(itemName)}</span><span class="vi-price">${deps.moneyHtml(item.buyValue ?? 0)}</span>`;
+    row.addEventListener('click', () => deps.onBuy(itemId));
+    deps.attachTooltip(row, () => deps.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuy'))}</div>`);
+    el.appendChild(row);
+  }
+
+  const buybackTitle = document.createElement('div');
+  buybackTitle.className = 'vendor-section-title';
+  buybackTitle.textContent = t('itemUi.vendor.buybackTitle');
+  el.appendChild(buybackTitle);
+
+  if (view.buyback.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'vendor-empty';
+    empty.textContent = t('itemUi.vendor.buybackEmpty');
+    el.appendChild(empty);
+  }
+  for (const { itemId, item, count } of view.buyback) {
+    const row = document.createElement('button');
+    row.type = 'button';
+    row.className = 'vendor-item';
+    const price = formatLocalizedMoney(item.sellValue);
+    const itemName = itemDisplayName(item);
+    row.setAttribute('aria-label', t('itemUi.vendor.buybackAria', { item: itemName, price }));
+    row.innerHTML = `${deps.itemIcon(item)}<span class="vi-name">${esc(itemName)}${count > 1 ? ` x${count}` : ''}</span><span class="vi-price">${deps.moneyHtml(item.sellValue)}</span>`;
+    row.addEventListener('click', () => deps.onBuyBack(itemId));
+    deps.attachTooltip(row, () => deps.itemTooltip(item) + `<div class="tt-sub">${esc(t('itemUi.tooltip.clickBuyback'))}</div>`);
+    el.appendChild(row);
+  }
+
+  const hint = document.createElement('div');
+  hint.className = 'vendor-hint';
+  hint.textContent = t('itemUi.vendor.hint');
+  el.appendChild(hint);
+
+  el.querySelector('[data-close]')?.addEventListener('click', () => deps.onClose());
+  el.style.display = 'block';
+  el.scrollTop = scrollTop;
+}

--- a/tests/vendor_view.test.ts
+++ b/tests/vendor_view.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { buildVendorView } from '../src/ui/vendor_view';
+import type { InvSlot, ItemDef } from '../src/sim/types';
+
+// Minimal ItemDef fixtures: buildVendorView only reads id / buyValue / sellValue.
+function item(id: string, opts: { buyValue?: number; sellValue?: number } = {}): ItemDef {
+  return { id, name: id, quality: 'common', slot: 'trinket', sellValue: opts.sellValue ?? 0, buyValue: opts.buyValue } as unknown as ItemDef;
+}
+
+function table(...items: ItemDef[]): Record<string, ItemDef> {
+  return Object.fromEntries(items.map((i) => [i.id, i]));
+}
+
+describe('buildVendorView goods', () => {
+  it('lists vendor items that exist and have a buyValue, in order', () => {
+    const items = table(item('bread', { buyValue: 5 }), item('water', { buyValue: 2 }));
+    const view = buildVendorView(['bread', 'water'], [], items);
+    expect(view.goods.map((g) => g.itemId)).toEqual(['bread', 'water']);
+    expect(view.goods.map((g) => g.price)).toEqual([5, 2]);
+  });
+
+  it('skips items missing from the table', () => {
+    const items = table(item('bread', { buyValue: 5 }));
+    const view = buildVendorView(['bread', 'ghost'], [], items);
+    expect(view.goods.map((g) => g.itemId)).toEqual(['bread']);
+  });
+
+  it('skips items with no or zero buyValue (priceless items are never sold)', () => {
+    const items = table(item('bread', { buyValue: 5 }), item('quest_token'), item('free', { buyValue: 0 }));
+    const view = buildVendorView(['bread', 'quest_token', 'free'], [], items);
+    expect(view.goods.map((g) => g.itemId)).toEqual(['bread']);
+  });
+
+  it('returns empty goods for an empty vendor', () => {
+    expect(buildVendorView([], [], {}).goods).toEqual([]);
+  });
+});
+
+describe('buildVendorView buyback', () => {
+  it('lists redeemable buyback slots with sell-value price and count', () => {
+    const items = table(item('sword', { sellValue: 12 }));
+    const buyback: InvSlot[] = [{ itemId: 'sword', count: 3 }];
+    const view = buildVendorView([], buyback, items);
+    expect(view.buyback).toEqual([{ itemId: 'sword', item: items.sword, count: 3, price: 12 }]);
+  });
+
+  it('skips slots whose item no longer exists or whose count is not positive', () => {
+    const items = table(item('sword', { sellValue: 12 }));
+    const buyback: InvSlot[] = [
+      { itemId: 'sword', count: 1 },
+      { itemId: 'ghost', count: 4 },
+      { itemId: 'sword', count: 0 },
+    ];
+    const view = buildVendorView([], buyback, items);
+    expect(view.buyback.map((b) => b.itemId)).toEqual(['sword']);
+    expect(view.buyback[0].count).toBe(1);
+  });
+
+  it('reports an empty buyback list distinctly from goods', () => {
+    const view = buildVendorView([], [], {});
+    expect(view.buyback).toEqual([]);
+  });
+});
+
+describe('buildVendorView is a pure projection', () => {
+  it('returns identical structure for identical input (no hidden state)', () => {
+    const items = table(item('bread', { buyValue: 5 }), item('sword', { sellValue: 12 }));
+    const goodsIds = ['bread'];
+    const buyback: InvSlot[] = [{ itemId: 'sword', count: 2 }];
+    expect(buildVendorView(goodsIds, buyback, items)).toEqual(buildVendorView(goodsIds, buyback, items));
+  });
+});


### PR DESCRIPTION
## Why

`src/ui/hud.ts` is the repo's largest file (~9.4k lines, a single `Hud` class) and, per the contributor notes, is touched in nearly every PR by 16 of 20 contributors. That makes it the dominant source of merge conflicts. The goal here is not to split it for a line count (root CLAUDE.md sanctions it as a monolith) but to **establish the architecture** for shrinking it gradually and safely: one self-contained window at a time, migrated behind the existing `src/ui` composition seam using the proven pure-core + thin-consumer split (`unit_portrait*`, `stat_tooltip*`, `xp_bar`).

## What

**1. The recipe, written down** (`src/ui/CLAUDE.md`): a new "Extracting a HUD window" section codifying the three-part split so the next window follows the same shape, plus a migration-order note (one at a time, on the rule of three, never big-bang).

**2. Vendor migrated as the canonical reference:**
- `src/ui/vendor_view.ts` — pure, DOM/i18n-free `buildVendorView`: decides which goods are sellable (item exists + has `buyValue`) and which buyback slots are redeemable (item exists + `count > 0`), with prices. Unit-tested in `tests/vendor_view.test.ts` (8 cases, no DOM).
- `src/ui/vendor_window.ts` — thin `renderVendorWindow` consumer: paints `#vendor-window` from the view, takes `Hud`'s shared painters (`itemIcon`/`moneyHtml`/`itemTooltip`/`attachTooltip`/`hideTooltip`) plus buy/buyback/close callbacks as injected `deps`. Owns no state, never imports `Hud`.
- `Hud` keeps `openVendor`/`closeVendor` (cross-window orchestration needs `Hud` private state); `renderVendor` shrinks from ~62 lines to a thin bridge.

## Scope discipline

Pure extraction: **no behavior change, no new i18n keys** (existing `itemUi.*` keys reused), all interpolated names still pass through `esc()`. The `hud.ts` diff reads as move-plus-import (-66/+26 in `renderVendor`).

## Verification

- `npx tsc --noEmit` clean
- `npm test` — **3002 passed, 8 skipped** (incl. `tests/architecture.test.ts`, `tests/localization_fixes.test.ts`, new `tests/vendor_view.test.ts`)
- `npm run build` passes
- Visual: vendor window renders identically (goods + buyback) after the migration:

![Vendor window after extraction](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-hud-vendor-extraction/vendor_window.png)

## Follow-ups (not in this PR)

Next candidates to migrate with this same recipe: Spellbook, Quest Log, Loot. Each is its own small PR.

cc @Rubsey @FernandoX7 @TrevCavill @patrick261 @maxpolaczuk @CharlieSaxton — this sets a shared pattern for `hud.ts`, so flagging everyone with direct push access for a look at the architecture direction before more windows follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)