### PR TITLE
feat(sim): re-grant missing quest items from prior quests on accept

### DIFF
--- a/scripts/quest_item_fallback_shot.mjs
+++ b/scripts/quest_item_fallback_shot.mjs
@@ -1,0 +1,88 @@
+// Quest-item fallback screenshots (max graphics, ?gfx=ultra).
+// Demonstrates: a player attuned for "The Bound Guardian" who no longer holds
+// the Crypt Keystone accepts the quest, and the sim re-grants the keystone so
+// the quest is not permanently blocked. Captures the bag BEFORE (no keystone)
+// and AFTER (keystone re-granted) plus the quest tracker.
+// Offline flow (no server). Needs `npm run dev`. Writes PNGs to tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+
+const QUEST = 'q_nythraxis_bound_guardian';
+const PREREQ = 'q_nythraxis_sealed_crypt';
+const KEYSTONE = 'crypt_keystone';
+const GIVER = 'brother_aldric_highwatch';
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+});
+const page = await browser.newPage();
+await page.setViewport({ width: 1600, height: 960, deviceScaleFactor: 1 });
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (m) => { if (m.type() === 'error') errors.push('CONSOLE: ' + m.text()); });
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const tap = (sel) => page.evaluate((s) => document.querySelector(s)?.click(), sel);
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await tap('#btn-offline');
+await wait(200);
+await page.evaluate(() => {
+  const n = document.querySelector('#char-name');
+  if (n) { n.value = 'Attuned'; n.dispatchEvent(new Event('input', { bubbles: true })); }
+});
+await tap('#offline-select .mini-class[data-class="warrior"]');
+await tap('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.sim && window.__game?.hud, { timeout: 30000 });
+await wait(2500);
+
+// Set up the progression-block scenario: attuned (prereq done), high enough
+// level, standing on the quest giver, and WITHOUT the keystone in the bag.
+const before = await page.evaluate(({ QUEST, PREREQ, KEYSTONE, GIVER }) => {
+  const sim = window.__game.sim;
+  const pid = sim.player.id ?? sim.player.entityId;
+  sim.player.maxHp = 99999; sim.player.hp = 99999;
+  sim.player.level = 20;
+  const meta = sim.players.get(pid);
+  meta.questsDone.add(PREREQ);
+  // ensure no keystone is held
+  meta.inventory = meta.inventory.filter((s) => s.itemId !== KEYSTONE);
+  const aldric = [...sim.entities.values()].find((e) => e.kind === 'npc' && e.templateId === GIVER && !e.dead);
+  const p = sim.entities.get(pid);
+  p.pos.x = aldric.pos.x; p.pos.z = aldric.pos.z;
+  return { keystone: sim.countItem(KEYSTONE, pid), state: sim.questState(QUEST, pid) };
+}, { QUEST, PREREQ, KEYSTONE, GIVER });
+console.log('BEFORE accept:', JSON.stringify(before));
+
+await page.evaluate(() => window.__game.hud.toggleBags?.());
+await wait(600);
+await page.screenshot({ path: 'tmp/quest_fallback_before.png' });
+
+// Accept the quest through the real sim path -> the fallback re-grants the keystone.
+const after = await page.evaluate(({ QUEST, KEYSTONE }) => {
+  const sim = window.__game.sim;
+  const pid = sim.player.id ?? sim.player.entityId;
+  sim.acceptQuest(QUEST, pid);
+  return { keystone: sim.countItem(KEYSTONE, pid), state: sim.players.get(pid).questLog.get(QUEST)?.state };
+}, { QUEST, KEYSTONE });
+console.log('AFTER accept:', JSON.stringify(after));
+await wait(800);
+await page.screenshot({ path: 'tmp/quest_fallback_after.png' });
+
+// World view at max graphics with the quest tracker showing.
+await page.evaluate(() => window.__game.hud.toggleBags?.());
+await wait(400);
+await page.screenshot({ path: 'tmp/quest_fallback_world.png' });
+
+console.log('errors:', errors.slice(0, 5));
+await browser.close();
+if (before.keystone !== 0 || after.keystone !== 1) {
+  console.error('UNEXPECTED: fallback did not behave as designed');
+  process.exit(1);
+}
+console.log('OK: keystone 0 -> 1 on accept');

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -748,7 +748,8 @@ export const ZONE3_QUESTS: Record<string, QuestDef> = {
     ],
     xpReward: 5200, copperReward: 3500,
     itemRewards: { warrior: 'kings_signet', mage: 'kings_signet', rogue: 'kings_signet' },
-    requiresQuest: 'q_nythraxis_sealed_crypt', minLevel: 20, suggestedPlayers: 5,
+    requiresQuest: 'q_nythraxis_sealed_crypt', requiredItems: ['crypt_keystone'],
+    minLevel: 20, suggestedPlayers: 5,
   },
   q_nythraxis_scourges_end: {
     id: 'q_nythraxis_scourges_end', name: 'Scourge\'s End',

--- a/src/sim/quest_fallback.ts
+++ b/src/sim/quest_fallback.ts
@@ -1,0 +1,31 @@
+import type { QuestDef } from './types';
+
+// Quest item fallback.
+//
+// Some quests need a quest item that the player obtained during earlier
+// progression rather than during the quest itself (the canonical case is the
+// Crypt Keystone: rewarded by "The Abandoned Crypt", then used at the ritual
+// circle in the follow-up "The Bound Guardian"). If that item is no longer in
+// the player's inventory when they accept the quest (dropped, discarded, or the
+// quest was abandoned and re-accepted), the player is permanently blocked: the
+// item is no longer obtainable, so the objective can never be met.
+//
+// A QuestDef declares such items via `requiredItems`. On accept, the Sim
+// re-grants any the player is missing, which keeps the quest completable. This
+// generalizes what used to be a single hardcoded special case in `acceptQuest`.
+//
+// Pure and host-agnostic (no Sim/DOM/Rng): the caller supplies a `hasItem`
+// predicate so inventory access stays on the Sim side, and gets back the
+// de-duplicated list of item ids to grant.
+export function questFallbackGrants(
+  quest: QuestDef,
+  hasItem: (itemId: string) => boolean,
+): string[] {
+  const required = quest.requiredItems;
+  if (!required || required.length === 0) return [];
+  const grants: string[] = [];
+  for (const itemId of required) {
+    if (!hasItem(itemId) && !grants.includes(itemId)) grants.push(itemId);
+  }
+  return grants;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -23,6 +23,7 @@ import {
 import { Rng } from './rng';
 import { SpatialGrid } from './spatial';
 import { orderTabTargets } from './tab_target';
+import { questFallbackGrants } from './quest_fallback';
 import {
   HEAL_THREAT_FACTOR, MELEE_SWITCH_MULT, RANGED_SWITCH_MULT,
   TAUNT_FORCE_SECONDS, addThreat, clearThreat, stealthDetectionRadius, threatEntries, threatModifier, topThreatValue,
@@ -7969,8 +7970,10 @@ export class Sim {
       return;
     }
     meta.questLog.set(questId, { questId, counts: quest.objectives.map(() => 0), state: 'active' });
-    if (questId === 'q_nythraxis_bound_guardian' && this.countItem('crypt_keystone', meta.entityId) <= 0) {
-      this.addItem('crypt_keystone', 1, meta.entityId);
+    // Re-grant any quest item this quest needs from earlier progression but the player
+    // no longer holds, so a missing item can never permanently block the quest.
+    for (const itemId of questFallbackGrants(quest, (id) => this.countItem(id, meta.entityId) > 0)) {
+      this.addItem(itemId, 1, meta.entityId);
     }
     this.emit({ type: 'questAccepted', questId, pid: meta.entityId });
     this.emit({ type: 'log', text: `Quest accepted: ${quest.name}`, color: '#ff0', pid: meta.entityId });

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -773,6 +773,8 @@ export interface QuestDef {
   copperReward: number;
   itemRewards: Partial<Record<PlayerClass, string>>;
   requiresQuest?: string; // prerequisite quest id (must be turned in)
+  requiredItems?: string[]; // quest items obtained earlier (e.g. a prerequisite reward) that this
+  // quest needs; re-granted on accept if the player no longer has them, to avoid a progression block
   minLevel?: number;
   retired?: boolean; // remains finishable if already accepted, but cannot be newly accepted
   suggestedPlayers?: number; // group quests ("Suggested players: 5")

--- a/tests/quest_fallback.test.ts
+++ b/tests/quest_fallback.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { questFallbackGrants } from '../src/sim/quest_fallback';
+import { QUESTS } from '../src/sim/data';
+import { Sim } from '../src/sim/sim';
+import { groundHeight } from '../src/sim/world';
+import type { Entity, QuestDef } from '../src/sim/types';
+
+const BOUND_GUARDIAN = 'q_nythraxis_bound_guardian';
+const KEYSTONE = 'crypt_keystone';
+const HIGHWATCH_ALDRIC = 'brother_aldric_highwatch';
+
+function quest(extra: Partial<QuestDef>): QuestDef {
+  return {
+    id: 'q_test', name: 'Test', giverNpcId: 'g', turnInNpcId: 'g',
+    text: '', completionText: '', objectives: [], xpReward: 0, copperReward: 0,
+    itemRewards: {}, ...extra,
+  };
+}
+
+describe('questFallbackGrants (pure)', () => {
+  it('returns nothing when the quest declares no required items', () => {
+    expect(questFallbackGrants(quest({}), () => false)).toEqual([]);
+    expect(questFallbackGrants(quest({ requiredItems: [] }), () => false)).toEqual([]);
+  });
+
+  it('grants a required item the player is missing', () => {
+    expect(questFallbackGrants(quest({ requiredItems: ['a'] }), () => false)).toEqual(['a']);
+  });
+
+  it('does not grant a required item the player already holds', () => {
+    expect(questFallbackGrants(quest({ requiredItems: ['a'] }), () => true)).toEqual([]);
+  });
+
+  it('grants only the missing subset and de-duplicates', () => {
+    const have = new Set(['b']);
+    const out = questFallbackGrants(
+      quest({ requiredItems: ['a', 'b', 'c', 'a'] }),
+      (id) => have.has(id),
+    );
+    expect(out).toEqual(['a', 'c']);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const q = quest({ requiredItems: ['x', 'y'] });
+    const run = () => questFallbackGrants(q, (id) => id === 'y');
+    expect(run()).toEqual(run());
+  });
+
+  it('the Bound Guardian quest declares the Crypt Keystone as a required item', () => {
+    expect(QUESTS[BOUND_GUARDIAN].requiredItems).toContain(KEYSTONE);
+  });
+});
+
+// Integration: drive the real Sim.acceptQuest path and assert the keystone is
+// re-granted on accept when missing (the original progression-block scenario),
+// and not duplicated when already held.
+function makeAttunedPlayerAtGiver(): { sim: Sim; pid: number } {
+  const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+  const pid = sim.addPlayer('warrior', 'Tester');
+  const meta = sim.players.get(pid)!;
+  // Satisfy accept gates: prerequisite done + minLevel.
+  meta.questsDone.add('q_nythraxis_sealed_crypt');
+  const p = sim.entities.get(pid)! as Entity;
+  p.level = 20;
+  // Stand on the quest giver so the proximity check passes.
+  const aldric = [...sim.entities.values()].find(
+    (e) => e.kind === 'npc' && e.templateId === HIGHWATCH_ALDRIC && !e.dead,
+  )!;
+  p.pos.x = aldric.pos.x;
+  p.pos.z = aldric.pos.z;
+  p.pos.y = groundHeight(p.pos.x, p.pos.z, sim.cfg.seed);
+  p.prevPos = { ...p.pos };
+  (sim as unknown as { rebucket(e: Entity): void }).rebucket(p);
+  return { sim, pid };
+}
+
+describe('Sim.acceptQuest quest-item fallback', () => {
+  it('re-grants the Crypt Keystone when the player accepts the quest without it', () => {
+    const { sim, pid } = makeAttunedPlayerAtGiver();
+    expect(sim.countItem(KEYSTONE, pid)).toBe(0);
+    sim.acceptQuest(BOUND_GUARDIAN, pid);
+    expect(sim.players.get(pid)!.questLog.get(BOUND_GUARDIAN)?.state).toBe('active');
+    expect(sim.countItem(KEYSTONE, pid)).toBe(1);
+  });
+
+  it('does not duplicate the keystone when the player already holds one', () => {
+    const { sim, pid } = makeAttunedPlayerAtGiver();
+    sim.addItem(KEYSTONE, 1, pid);
+    sim.acceptQuest(BOUND_GUARDIAN, pid);
+    expect(sim.countItem(KEYSTONE, pid)).toBe(1);
+  });
+});


### PR DESCRIPTION
## What and why

A quest can need a quest item that the player obtained during **earlier** progression rather than during the quest itself. The canonical case is the **Crypt Keystone**: it is the reward of *The Abandoned Crypt* (`q_nythraxis_sealed_crypt`) and is then *used at the ritual circle* in the follow-up *The Bound Guardian* (`q_nythraxis_bound_guardian`).

If that item was dropped, discarded, or lost by abandoning and re-accepting the quest, the player was **permanently blocked**: the item is no longer obtainable, so the objective could never be met. This is the progression-block this PR fixes.

## Approach

Quests now declare such items via a new optional `requiredItems?: string[]` field on `QuestDef`. On accept, the `Sim` re-grants any the player is missing.

The decision lives in a small **pure module** (`src/sim/quest_fallback.ts`, `questFallbackGrants`) behind a `hasItem` predicate, unit-tested in isolation, with the `Sim` a thin consumer (the repo's `threat.ts`/`pathfind.ts` pattern). It **generalizes and replaces** the single hardcoded keystone branch that previously lived in `acceptQuest`.

```ts
// acceptQuest, replacing the old `if (questId === 'q_nythraxis_bound_guardian' ...)` hack:
for (const itemId of questFallbackGrants(quest, (id) => this.countItem(id, meta.entityId) > 0)) {
  this.addItem(itemId, 1, meta.entityId);
}
```

`q_nythraxis_bound_guardian` now carries `requiredItems: ['crypt_keystone']`, **preserving** the previous behavior for all classes (note the keystone is only a class *reward* for 3 of 9 classes, so the data field is grant-on-need, not inferred from `itemRewards`).

## Notes on invariants

- **Deterministic**: no RNG involved; the pure function is order-stable and de-duplicates.
- **No new player-visible strings**: the grant reuses `addItem`'s existing `loot` emit, so no `sim_i18n` change and the S3 guard passes unchanged.
- **Accept is already gated** by `computeQuestState` (prerequisite must be in `questsDone`), so this only ever re-grants an item from genuinely-completed prior progression.

## Tests

New `tests/quest_fallback.test.ts`: pure-core cases (missing/held/subset/dedup/determinism) **and** a `Sim.acceptQuest` regression that drives the real path and asserts the keystone is re-granted (0 -> 1) on accept and not duplicated when held.

```
tsc --noEmit            clean
quest_fallback.test.ts  8 passed
architecture.test.ts    pass   (sim stays DOM/Three-free, RNG-clean)
localization_fixes.ts   pass   (no new emits)
nythraxis_final_quest / nythraxis_raid / quest_repeat_repro / progression   pass
npm run build           ok
```

## Screenshots (`?gfx=ultra`, max graphics)

End-to-end in the real offline client: attuned player standing at Brother Aldric in Highwatch with **no keystone**, accepts the quest, and the sim re-grants it. Verified output: `BEFORE {"keystone":0,"state":"available"}` -> `AFTER {"keystone":1,"state":"active"}`.

Before accept (no keystone, Thornpeak Heights / Highwatch):
![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-quest-fallback/quest_fallback_before.png)

After accept (keystone re-granted, quest active):
![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-quest-fallback/quest_fallback_after.png)

World view at max graphics:
![world](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-quest-fallback/quest_fallback_world.png)

Repro harness: `scripts/quest_item_fallback_shot.mjs` (needs `npm run dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)