### PR TITLE
[codex] Keep low quality loot out of need/greed rolls

### DIFF
--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -193,7 +193,7 @@ export interface LootStrategies {
 
 export const DEFAULT_PARTY_LOOT_STRATEGIES: LootStrategies = {
   currency: 'fair-split',
-  commonItems: 'need-greed',
+  commonItems: 'looter-takes-all',
   premiumItems: 'need-greed',
 };
 

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -572,7 +572,7 @@ describe('boss loot and encounter resets', () => {
     expect(mob.loot).toBeNull();
   });
 
-  it('poor and common corpse drops open need-greed rolls among nearby party members', () => {
+  it('poor and common corpse drops are looted directly by the looter without need-greed rolls', () => {
     const sim = makeSim();
     const a = sim.playerId;
     const b = sim.addPlayer('mage', 'Bert');
@@ -590,12 +590,12 @@ describe('boss loot and encounter resets', () => {
     sim.events.length = 0;
     sim.lootCorpse(mob.id, a);
 
-    expect(sim.countItem('wolf_fang', a) + sim.countItem('wolf_fang', b)).toBe(0);
-    expect(sim.countItem('raw_mirror_trout', a) + sim.countItem('raw_mirror_trout', b)).toBe(0);
+    expect(sim.countItem('wolf_fang', a)).toBe(1);
+    expect(sim.countItem('raw_mirror_trout', a)).toBe(1);
+    expect(sim.countItem('wolf_fang', b)).toBe(0);
+    expect(sim.countItem('raw_mirror_trout', b)).toBe(0);
     const prompts = sim.events.filter((e) => e.type === 'lootRoll');
-    expect(prompts).toHaveLength(4);
-    expect(prompts.filter((e) => e.itemId === 'wolf_fang')).toHaveLength(2);
-    expect(prompts.filter((e) => e.itemId === 'raw_mirror_trout')).toHaveLength(2);
+    expect(prompts).toHaveLength(0);
     expect(mob.loot).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

Poor and common corpse drops now keep the direct-loot behavior instead of opening need/greed prompts for every nearby party member. Uncommon and better drops still use the premium need/greed strategy.

## Why

The release branch was prompting need/greed rolls for grey/white drops, which made ordinary loot noisy and slowed down normal corpse looting.

## Validation

- `npm test -- tests/fixes.test.ts tests/loot_drops.test.ts`
- `npm run build`

Build passes with existing Vite warnings around the Meta Pixel noscript HTML, cursor asset resolution, admin i18n dynamic imports, and chunk size.