### PR TITLE
[codex] Add Travel Form live diagnostics for release v0.13

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -1,7 +1,7 @@
 import type { WebSocket } from 'ws';
 import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
-import { DT, Entity, EQUIP_SLOTS, EquipSlot, SimEvent, dist2d, emptyMoveInput } from '../src/sim/types';
+import { DT, Entity, EQUIP_SLOTS, EquipSlot, RUN_SPEED, SimEvent, dist2d, emptyMoveInput } from '../src/sim/types';
 import { parseMoveInputFrame } from '../src/sim/move_input';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
@@ -159,6 +159,15 @@ export interface AdminServerStats {
   heapUsedBytes: number;
 }
 
+export interface AdminLiveAura {
+  id: string;
+  name: string;
+  kind: string;
+  value: number;
+  remaining: number;
+  duration: number;
+}
+
 export interface AdminLivePlayer {
   pid: number;
   accountId: number;
@@ -173,6 +182,10 @@ export interface AdminLivePlayer {
   zone: string;
   sessionSeconds: number;
   lastSaveSecondsAgo: number;
+  moveSpeedMultiplier: number;
+  runSpeed: number;
+  swimming: boolean;
+  auras: AdminLiveAura[];
 }
 
 export interface RestartCountdownStatus {
@@ -935,6 +948,7 @@ export class GameServer {
       const zone = e.dungeonId
         ? (DUNGEONS[e.dungeonId]?.name ?? e.dungeonId)
         : zoneAt(e.pos.z).name;
+      const moveSpeedMultiplier = round2((this.sim as any).moveSpeedMult(e));
       players.push({
         pid: session.pid,
         accountId: session.accountId,
@@ -949,6 +963,17 @@ export class GameServer {
         zone,
         sessionSeconds: Math.round((now - session.joinedAt) / 1000),
         lastSaveSecondsAgo: Math.round((now - session.lastSave) / 1000),
+        moveSpeedMultiplier,
+        runSpeed: round2(RUN_SPEED * moveSpeedMultiplier),
+        swimming: this.sim.isSwimming(e),
+        auras: e.auras.map((a) => ({
+          id: a.id,
+          name: a.name,
+          kind: a.kind,
+          value: a.value,
+          remaining: round2(a.remaining),
+          duration: a.duration,
+        })),
       });
     }
     return players.sort((a, b) => b.sessionSeconds - a.sessionSeconds);

--- a/src/admin/types.ts
+++ b/src/admin/types.ts
@@ -71,6 +71,17 @@ export interface LivePlayer {
   zone: string;
   sessionSeconds: number;
   lastSaveSecondsAgo: number;
+  moveSpeedMultiplier: number;
+  runSpeed: number;
+  swimming: boolean;
+  auras: {
+    id: string;
+    name: string;
+    kind: string;
+    value: number;
+    remaining: number;
+    duration: number;
+  }[];
 }
 
 export interface Activity {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -420,7 +420,7 @@ function yellVoiceKey(text: string): string {
 export class Hud {
   private static readonly BAR_ABILITY_SLOTS = 11; // bar slots 1..11; slot 0 is the fixed Attack toggle
   private static ddSeq = 0; // monotonic id source for buildDropdown listbox/option ARIA wiring
-  private static readonly FORM_TOGGLE_IDS = new Set(['bear_form', 'cat_form']); // shift toggles, castable in any form
+  private static readonly FORM_TOGGLE_IDS = new Set(['bear_form', 'cat_form', 'travel_form']); // shift toggles, castable in any form
   private abilityButtons: { btn: HTMLButtonElement; label: HTMLSpanElement; countEl: HTMLSpanElement; keybindEl: HTMLSpanElement; cdOverlay: HTMLDivElement; cdText: HTMLDivElement; lastIcon: string }[] = [];
   private hotbarActions: HotbarAction[] = []; // index = barSlot-1
   private loadedSlotMapFromStorage = false;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -478,6 +478,7 @@ describe('client HTML shell', () => {
   });
 
   it('keeps the active druid form toggle on its form action bar', () => {
+    expect(hudTs).toContain("new Set(['bear_form', 'cat_form', 'travel_form'])");
     expect(hudTs).toContain("if (this.activeHotbarForm === 'bear') return 'bear_form';");
     expect(hudTs).toContain("if (this.activeHotbarForm === 'cat') return 'cat_form';");
     expect(hudTs).toContain('if (formToggle && knownAbilityIds.includes(formToggle)) autoPlaceAbilityIds.add(formToggle);');

--- a/tests/druid_spell_pack.test.ts
+++ b/tests/druid_spell_pack.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import { AuraKind } from '../src/sim/types';
+import { AuraKind, dist2d } from '../src/sim/types';
 import { ABILITIES, CLASSES, abilitiesKnownAt } from '../src/sim/content/classes';
+import { groundHeight, WATER_LEVEL } from '../src/sim/world';
 
 const NEW_DRUID = [
   'travel_form', 'enrage', 'bash', 'faerie_fire', 'hibernate',
@@ -10,6 +11,42 @@ const NEW_DRUID = [
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function placeOnGround(sim: Sim, pid: number, x: number, z: number) {
+  const e = sim.entities.get(pid)!;
+  e.pos = { x, y: groundHeight(x, z, sim.cfg.seed), z };
+  e.prevPos = { ...e.pos };
+  e.fallStartY = e.pos.y;
+  e.onGround = true;
+}
+
+function advanceTicks(sim: Sim, ticks: number) {
+  for (let i = 0; i < ticks; i++) sim.tick();
+}
+
+function castTravelForm(sim: Sim, pid: number) {
+  const e = sim.entities.get(pid)!;
+  sim.setPlayerLevel(20, pid);
+  e.resource = e.maxResource;
+  sim.castAbility('travel_form', pid);
+  sim.tick();
+}
+
+function horizontalTravel(sim: Sim, pid: number, ticks: number): number {
+  const e = sim.entities.get(pid)!;
+  const start = { ...e.pos };
+  advanceTicks(sim, ticks);
+  return dist2d(start, e.pos);
+}
+
+function findDeepWater(seed: number): { x: number; z: number } {
+  for (let z = -50; z <= 950; z += 5) {
+    for (let x = -170; x <= 170; x += 5) {
+      if (groundHeight(x, z, seed) < WATER_LEVEL - 1.25) return { x, z };
+    }
+  }
+  throw new Error('test fixture needs a deep-water coordinate');
 }
 
 // Push a shapeshift toggle aura directly (forms use the 3600s sentinel).
@@ -126,6 +163,111 @@ describe('druid spell pack — casting applies effects', () => {
     sim.castAbility('travel_form', a);
     sim.tick();
     expect(e.auras.some((au) => au.kind === 'form_travel'), 'travel_form should shift even in combat').toBe(true);
+  });
+
+  it('Travel Form moves the druid 40% faster than normal forward movement', () => {
+    const baseline = makeWorld();
+    const walking = baseline.addPlayer('druid', 'Walker');
+    placeOnGround(baseline, walking, 0, 40);
+    baseline.players.get(walking)!.moveInput.forward = true;
+
+    const travel = makeWorld();
+    const runner = travel.addPlayer('druid', 'Runner');
+    placeOnGround(travel, runner, 0, 40);
+    castTravelForm(travel, runner);
+    travel.players.get(runner)!.moveInput.forward = true;
+
+    const ticks = 40;
+    const walkingDistance = horizontalTravel(baseline, walking, ticks);
+    const travelDistance = horizontalTravel(travel, runner, ticks);
+
+    expect(walkingDistance).toBeGreaterThan(0);
+    expect(travelDistance / walkingDistance).toBeCloseTo(1.4, 2);
+  });
+
+  it('Travel Form speed applies while following another player', () => {
+    const normal = makeWorld();
+    const normalLeader = normal.addPlayer('warrior', 'Leader');
+    const normalFollower = normal.addPlayer('druid', 'Follower');
+    placeOnGround(normal, normalLeader, 0, 90);
+    placeOnGround(normal, normalFollower, 0, 40);
+    normal.chat('/follow Leader', normalFollower);
+    normal.tick();
+
+    const travel = makeWorld();
+    const travelLeader = travel.addPlayer('warrior', 'Leader');
+    const travelFollower = travel.addPlayer('druid', 'Follower');
+    placeOnGround(travel, travelLeader, 0, 90);
+    placeOnGround(travel, travelFollower, 0, 40);
+    castTravelForm(travel, travelFollower);
+    travel.chat('/follow Leader', travelFollower);
+    travel.tick();
+
+    const ticks = 10;
+    const normalDistance = horizontalTravel(normal, normalFollower, ticks);
+    const travelDistance = horizontalTravel(travel, travelFollower, ticks);
+
+    expect(normalDistance).toBeGreaterThan(0);
+    expect(travelDistance / normalDistance).toBeCloseTo(1.4, 2);
+  });
+
+  it('Travel Form still gets the swim penalty in deep water', () => {
+    const walking = makeWorld();
+    const walker = walking.addPlayer('druid', 'Walker');
+    const water = findDeepWater(walking.cfg.seed);
+    placeOnGround(walking, walker, water.x, water.z);
+    const walkerEntity = walking.entities.get(walker)!;
+    walkerEntity.pos.y = WATER_LEVEL - 0.75;
+    walkerEntity.onGround = false;
+    walking.players.get(walker)!.moveInput.forward = true;
+
+    const travel = makeWorld();
+    const runner = travel.addPlayer('druid', 'Runner');
+    placeOnGround(travel, runner, water.x, water.z);
+    const runnerEntity = travel.entities.get(runner)!;
+    runnerEntity.pos.y = WATER_LEVEL - 0.75;
+    runnerEntity.onGround = false;
+    castTravelForm(travel, runner);
+    runnerEntity.pos.y = WATER_LEVEL - 0.75;
+    runnerEntity.onGround = false;
+    travel.players.get(runner)!.moveInput.forward = true;
+
+    const ticks = 20;
+    const dryBaseline = 7 * (ticks / 20);
+    const swimmingDistance = horizontalTravel(walking, walker, ticks);
+    const travelSwimmingDistance = horizontalTravel(travel, runner, ticks);
+
+    expect(swimmingDistance / dryBaseline).toBeCloseTo(0.65, 2);
+    expect(travelSwimmingDistance / dryBaseline).toBeCloseTo(0.91, 2);
+    expect(travelSwimmingDistance / swimmingDistance).toBeCloseTo(1.4, 2);
+  });
+
+  it('Travel Form cancels Prowl instead of inheriting the stealth speed penalty', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('druid', 'Prowler');
+    const e = sim.entities.get(pid)!;
+    sim.setPlayerLevel(20, pid);
+
+    e.resource = e.maxResource;
+    sim.castAbility('cat_form', pid);
+    sim.tick();
+    expect(e.auras.some((a) => a.kind === 'form_cat')).toBe(true);
+    advanceTicks(sim, 40);
+
+    e.resource = e.maxResource;
+    sim.castAbility('prowl', pid);
+    sim.tick();
+    expect(e.auras.some((a) => a.id === 'prowl' && a.kind === 'stealth')).toBe(true);
+    expect((sim as any).moveSpeedMult(e)).toBeCloseTo(0.7);
+    advanceTicks(sim, 40);
+
+    e.resource = e.maxResource;
+    sim.castAbility('travel_form', pid);
+    sim.tick();
+
+    expect(e.auras.some((a) => a.kind === 'form_travel')).toBe(true);
+    expect(e.auras.some((a) => a.kind === 'stealth')).toBe(false);
+    expect((sim as any).moveSpeedMult(e)).toBeCloseTo(1.4);
   });
 
   it('Dash grants +50% movement speed in cat form', () => {

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -7,6 +7,7 @@ vi.mock('../server/db', () => ({
   openPlaySession: vi.fn(async () => 1),
   closePlaySession: vi.fn(async () => {}),
   insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
   markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
   grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
 }));
@@ -180,6 +181,29 @@ describe('delta snapshots', () => {
     const client = bareClient(session.pid);
     (client as any).applySnapshot(snap);
     expect(client.player.swingTimer).toBeCloseTo(1.7, 1);
+  });
+
+  it('includes live aura and movement diagnostics in admin online rows', () => {
+    const druidServer = new GameServer();
+    const fc = fakeWs();
+    const druid = joinServer(druidServer, fc, 10, 'Newkali', 'druid');
+    const player = druidServer.sim.entities.get(druid.pid)!;
+    druidServer.sim.setPlayerLevel(20, druid.pid);
+    player.resource = player.maxResource;
+
+    druidServer.sim.castAbility('travel_form', druid.pid);
+    druidServer.sim.tick();
+
+    const row = druidServer.liveSessions().find((p) => p.characterId === 10)!;
+    expect(row.moveSpeedMultiplier).toBeCloseTo(1.4);
+    expect(row.runSpeed).toBeCloseTo(9.8);
+    expect(row.swimming).toBe(false);
+    expect(row.auras).toContainEqual(expect.objectContaining({
+      id: 'travel_form',
+      name: 'Travel Form',
+      kind: 'form_travel',
+      value: 1.4,
+    }));
   });
 
   it('sell command forwards bounded stack quantities', () => {


### PR DESCRIPTION
## Summary

Adds release/v0.13.0 diagnostics and regression coverage for the Travel Form speed report:

- admin `/admin/api/online` rows now include active auras, movement multiplier, dry run speed, and swimming state
- Travel Form movement tests cover normal movement, follow movement, swimming, and Prowl cancellation
- Travel Form is included in the form-toggle hotbar allowlist so it stays available on form bars

## Why

Newkali can visually appear in Travel Form while `/speed` reports 100% of normal. The admin online payload will let us inspect the server truth while the player is live: whether `form_travel` is present, what value it has, whether any slow/stealth aura is active, and what multiplier the server computes.

## Validation

- `npm test -- tests/snapshots.test.ts tests/druid_spell_pack.test.ts tests/speed_command.test.ts tests/form_command.test.ts tests/client_shell.test.ts tests/follow.test.ts`
- `npm run build`

Build passes with existing Vite warnings around the Meta Pixel noscript HTML, cursor asset resolution, admin i18n dynamic imports, and chunk size.