### PR TITLE
feat(seo): add /merch to sitemap for search and GEO discovery

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.4</priority>
   </url>
   <url>
+    <loc>https://worldofclaudecraft.com/merch</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://worldofclaudecraft.com/play</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
## What

Adds the `/merch` route to `public/sitemap.xml` so search crawlers and generative answer engines (GEO) can discover the merch landing page.

## Why

The `/merch` coming-soon page shipped in #840 is reachable through the `/merch` and `/merch/` aliases in `server/main.ts` and `vite.config.ts`, but it was never added to the sitemap. Every other public route (`/`, `/links`, `/play`, `/privacy`, `/terms`, `/data-deletion`, `/support`) is listed, so `/merch` was the lone gap. Crawlers and LLM answer engines walk the sitemap referenced from `robots.txt` to find pages, so an unlisted route is effectively undiscoverable even though it resolves fine.

## Change

A single `<url>` entry for the canonical `/merch` URL (no trailing slash, matching the alias target), placed next to the other landing pages:

```xml
<url>
  <loc>https://worldofclaudecraft.com/merch</loc>
  <changefreq>monthly</changefreq>
  <priority>0.5</priority>
</url>
```

- `changefreq: monthly` and `priority: 0.5` (above the link-tree/legal pages, below `/` and `/play`) since the page will change when products launch.
- Only `public/sitemap.xml` is hand-edited; `dist/sitemap.xml` is a build artifact and regenerates on `npm run build`.
- XML validated well-formed (8 `<url>` entries, up from 7). No code, i18n, or sim changes.

## Screenshot

The `/merch` page now covered by the sitemap (rendered standalone; logo asset not served in the harness):

![merch page](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-merch-sitemap/merch_page.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)