### PR TITLE
fix(sim): make weapon imbues a mutually-exclusive single slot

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2962,6 +2962,13 @@ export class Sim {
           break;
         }
         case 'imbue': {
+          for (let i = p.auras.length - 1; i >= 0; i--) {
+            const a = p.auras[i];
+            if (a.kind === 'imbue' && a.id !== ability.id) {
+              p.auras.splice(i, 1);
+              this.emit({ type: 'aura', targetId: p.id, name: a.name, gained: false });
+            }
+          }
           this.applyAura(p, {
             id: ability.id, name: ability.name, kind: 'imbue',
             remaining: eff.duration, duration: eff.duration, value: eff.bonus,

--- a/tests/imbue_exclusive.test.ts
+++ b/tests/imbue_exclusive.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import type { Entity, PlayerClass } from '../src/sim/types';
+import type { Entity, PlayerClass, SimEvent } from '../src/sim/types';
 
 // Weapon imbues (shaman rockbiter/flametongue/frostbrand, rogue instant/deadly
 // poison, paladin seal) are a single weapon-enchant slot: classic allows exactly
@@ -18,12 +18,13 @@ function makePlayer(cls: PlayerClass, level: number): { sim: Sim; p: Entity } {
 
 // Cast an instant imbue and let it resolve, clearing the GCD/cost gate first so a
 // rapid sequence of casts all land (mirrors how a player chains them in practice).
-function cast(sim: Sim, p: Entity, ability: string): void {
+// Returns the events drained by the resolving tick so callers can assert on emits.
+function cast(sim: Sim, p: Entity, ability: string): SimEvent[] {
   p.gcdRemaining = 0;
   p.cooldowns.delete(ability);
   p.resource = p.maxResource;
   sim.castAbility(ability, p.id);
-  sim.tick();
+  return sim.tick();
 }
 
 const imbues = (p: Entity) => p.auras.filter((a) => a.kind === 'imbue');
@@ -47,6 +48,16 @@ describe('weapon imbues are a mutually-exclusive single slot (H2-1)', () => {
     expect(imbues(p)[0].id).toBe('deadly_poison');
     // and the surviving bonus is the single enchant's value, never the +22 sum
     expect(imbues(p)[0].value).toBe(14);
+  });
+
+  it('emits an aura-lost event for the displaced imbue so the old buff icon clears', () => {
+    const { sim, p } = makePlayer('shaman', 16);
+    cast(sim, p, 'rockbiter_weapon');
+    const events = cast(sim, p, 'flametongue_weapon');
+    // the replaced imbue is announced lost (this is what clears its client buff icon)
+    expect(events).toContainEqual({ type: 'aura', targetId: p.id, name: 'Rockbiter Weapon', gained: false });
+    // and the new imbue is announced gained
+    expect(events).toContainEqual({ type: 'aura', targetId: p.id, name: 'Flametongue Weapon', gained: true });
   });
 
   it('re-casting the same imbue refreshes in place (still one aura)', () => {

--- a/tests/imbue_exclusive.test.ts
+++ b/tests/imbue_exclusive.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { Entity, PlayerClass } from '../src/sim/types';
+
+// Weapon imbues (shaman rockbiter/flametongue/frostbrand, rogue instant/deadly
+// poison, paladin seal) are a single weapon-enchant slot: classic allows exactly
+// one active at a time. The deterministic sim must never carry two `imbue` auras,
+// because meleeSwing sums every one of them (H2-1). These tests pin that a fresh
+// imbue replaces any other, so the per-swing bonus can never stack.
+
+function makePlayer(cls: PlayerClass, level: number): { sim: Sim; p: Entity } {
+  const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+  const pid = sim.addPlayer(cls, 'Imbuer');
+  sim.setPlayerLevel(level, pid);
+  sim.tick();
+  return { sim, p: sim.entities.get(pid)! };
+}
+
+// Cast an instant imbue and let it resolve, clearing the GCD/cost gate first so a
+// rapid sequence of casts all land (mirrors how a player chains them in practice).
+function cast(sim: Sim, p: Entity, ability: string): void {
+  p.gcdRemaining = 0;
+  p.cooldowns.delete(ability);
+  p.resource = p.maxResource;
+  sim.castAbility(ability, p.id);
+  sim.tick();
+}
+
+const imbues = (p: Entity) => p.auras.filter((a) => a.kind === 'imbue');
+
+describe('weapon imbues are a mutually-exclusive single slot (H2-1)', () => {
+  it('shaman cannot stack rockbiter + flametongue + frostbrand', () => {
+    const { sim, p } = makePlayer('shaman', 16);
+    cast(sim, p, 'rockbiter_weapon');
+    cast(sim, p, 'flametongue_weapon');
+    cast(sim, p, 'frostbrand_weapon');
+    // exactly one imbue survives: the most recently applied
+    expect(imbues(p)).toHaveLength(1);
+    expect(imbues(p)[0].id).toBe('frostbrand_weapon');
+  });
+
+  it('rogue cannot stack instant + deadly poison', () => {
+    const { sim, p } = makePlayer('rogue', 20);
+    cast(sim, p, 'instant_poison');
+    cast(sim, p, 'deadly_poison');
+    expect(imbues(p)).toHaveLength(1);
+    expect(imbues(p)[0].id).toBe('deadly_poison');
+    // and the surviving bonus is the single enchant's value, never the +22 sum
+    expect(imbues(p)[0].value).toBe(14);
+  });
+
+  it('re-casting the same imbue refreshes in place (still one aura)', () => {
+    const { sim, p } = makePlayer('shaman', 16);
+    cast(sim, p, 'rockbiter_weapon');
+    const dur = imbues(p)[0].remaining;
+    // tick a little so the refresh is observable, then re-cast the same one
+    for (let i = 0; i < 10; i++) sim.tick();
+    expect(imbues(p)[0].remaining).toBeLessThan(dur);
+    cast(sim, p, 'rockbiter_weapon');
+    expect(imbues(p)).toHaveLength(1);
+    expect(imbues(p)[0].id).toBe('rockbiter_weapon');
+    expect(imbues(p)[0].remaining).toBe(dur); // refreshed to full
+  });
+
+  it('paladin seal remains a single imbue (unchanged) and still carries judge values', () => {
+    const { sim, p } = makePlayer('paladin', 4);
+    cast(sim, p, 'seal_of_righteousness');
+    expect(imbues(p)).toHaveLength(1);
+    expect(imbues(p)[0].id).toBe('seal_of_righteousness');
+    expect(imbues(p)[0].value2).toBeDefined(); // judge min/max preserved
+  });
+
+  it('is deterministic: same seed yields the same single-imbue result', () => {
+    const run = () => {
+      const { sim, p } = makePlayer('shaman', 16);
+      cast(sim, p, 'rockbiter_weapon');
+      cast(sim, p, 'flametongue_weapon');
+      return imbues(p).map((a) => ({ id: a.id, value: a.value }));
+    };
+    expect(run()).toEqual(run());
+    expect(run()).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Imbues (shaman rockbiter/flametongue/frostbrand, rogue instant/deadly poison, paladin seal) were keyed per ability id, so distinct ids coexisted and meleeSwing summed every one of them. A shaman ran all three for +40 per swing (vs the intended ~14) and a rogue stacked both poisons for +22.

Clear any other imbue before applying a new one, so only one weapon enchant is ever active. Refreshing the same imbue still dedups via applyAura's (id, sourceId) key.

## Summary

Weapon imbues stacked across abilities (audit finding **H2-1**). The `case 'imbue'` handler in `src/sim/sim.ts` applied each imbue as a distinct aura keyed by `ability.id`, and `applyAura` only dedups by `(id, sourceId)`. Since `meleeSwing` sums every
`kind === 'imbue'` aura, a shaman could run Rockbiter + Flametongue + Frostbrand at once for +40 flat on every swing and weapon special (Stormstrike) versus the intended single-imbue max of ~14, and a rogue could stack Instant + Deadly Poison for +22. Classic allows exactly one weapon enchant at a time.

Fix: imbues are now a mutually-exclusive single slot. The handler clears any *other* imbue aura on the caster (emitting the normal aura-lost event) before applying the new one, mirroring the repo's existing toggle-buff replacement pattern. Because only one imbue aura ever exists, every consumer (auto-attacks, weapon specials, paladin judgement) is capped automatically. Re-casting the *same* imbue still falls through to `applyAura`'s `(id, sourceId)` dedup, so refresh-in-place is unchanged.

Safe across classes: only shaman (weapon imbues), rogue (poisons), and paladin (one seal) use `kind === 'imbue'`, and no class holds two kinds at once, so replacement never strips a buff a class wants to keep. Seals keep their `value2`/`value3` judge values.

## Related issues

N/A for a GitHub issue.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

Test-first per the repo bug-fix workflow: added `tests/imbue_exclusive.test.ts`, which reproduces the stacking (fails pre-fix with 3 shaman imbues / 2 rogue poisons), then pins the single-slot behavior, same-imbue refresh-in-place, the unchanged paladin seal (including its judge `value2`), and determinism.

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npx vitest run tests/imbue_exclusive.test.ts tests/flametongue.test.ts tests/frostbrand.test.ts tests/social.test.ts tests/architecture.test.ts` (55 passed)
  - `npx vitest run tests/sim.test.ts tests/progression.test.ts tests/talents.test.ts` (145 passed, no regressions)
  - `npm test` (full suite green)
  - `npm run build` (succeeds)
- Manual steps: none (deterministic sim logic, covered by Vitest).

## Screenshots / recordings

N/A. No player- or operator-visible UI change.

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green. I added `tests/imbue_exclusive.test.ts`
      for the `sim/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` succeeds. (Server/env bundles untouched by
      this change.)

### Cross-platform

- ~[x] Tested on desktop and mobile.~ N/A: no UI change.
- ~[ ] Accessible.~ N/A: no UI change.

### Localization (i18n)

- ~[ ] New player-visible strings are translated into every supported locale.~
- ~[ ] Numbers, money, dates, units, and percents go through the i18n formatters.~
- ~[ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized.~
- [x] N/A. This PR adds no player-visible strings. The aura-lost event reuses an
      existing ability name already handled by the client matcher.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files. The fix touches only the `case 'imbue'` handler in `src/sim/sim.ts`, the new test, and the audit doc.

