### PR TITLE
fix(ui): use image-based skill art for buff/debuff aura icons

### DIFF
--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1855,7 +1855,10 @@ export function iconDataUrl(kind: IconKind, id: string, size: number = DEFAULT_I
     const img = weaponIconUrl(id);
     if (img) return img;
   }
-  if (kind === 'ability') {
+  // Abilities, and auras that carry a real ability id (a DoT/buff applied by that
+  // ability), share the same image-based skill art. abilityImageUrl returns null
+  // for generic aura_<kind> ids, so those still fall through to the procedural recipe.
+  if (kind === 'ability' || kind === 'aura') {
     const img = abilityImageUrl(id);
     if (img) return img;
   }

--- a/tests/aura_icons.test.ts
+++ b/tests/aura_icons.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { ABILITIES } from '../src/sim/data';
+import { iconDataUrl } from '../src/ui/icons';
+
+// Buff/debuff aura frames (the player buff bar and a mob's DoT debuffs, both via
+// Hud.renderAuras) request their icon with kind 'aura'. When the aura carries a
+// real ability id that ships an image-based skill icon (public/ui/skills/<class>/<id>.png),
+// the aura must show that SAME image, not the older procedural recipe — otherwise a
+// DoT/buff renders one art on the action bar and a different one as an aura.
+//
+// Note: this suite runs in the default `node` env (no canvas), so it only exercises
+// the early-return image branch of iconDataUrl. Ids without an image fall through to
+// the procedural canvas path, which needs a DOM and is covered by the renderer E2E.
+
+// A representative DoT (debuff) per applicable class plus a few persistent buffs —
+// every id below is in ABILITY_IMAGE_IDS, so it has a shipped PNG.
+const IMAGE_AURA_IDS = [
+  'corruption', 'curse_of_agony', 'immolate', // warlock DoTs
+  'serpent_sting',                            // hunter DoT
+  'rend',                                     // warrior DoT
+  'moonfire', 'insect_swarm', 'rip',          // druid DoTs
+  'flame_shock',                              // shaman DoT
+  'shadow_word_pain',                         // priest DoT
+  'rupture', 'garrote',                       // rogue DoTs
+  'arcane_intellect', 'mark_of_the_wild',     // buffs
+  'battle_shout', 'power_word_fortitude',     // buffs
+];
+
+describe('aura icons reuse image-based ability art', () => {
+  it('every sampled aura id actually ships a PNG (guards the fixture)', () => {
+    for (const id of IMAGE_AURA_IDS) {
+      const url = iconDataUrl('ability', id);
+      expect(url, `${id} should have an image-based ability icon`).toMatch(/^\/ui\/skills\//);
+    }
+  });
+
+  it('an aura with an image-backed ability id renders that image, not a procedural data URL', () => {
+    for (const id of IMAGE_AURA_IDS) {
+      const cls = ABILITIES[id]?.class;
+      expect(cls, `${id} must be a known ability`).toBeTruthy();
+      const expected = `/ui/skills/${cls}/${id}.png`;
+      expect(iconDataUrl('aura', id), `aura ${id}`).toBe(expected);
+      // and it matches what the action bar shows for the same ability
+      expect(iconDataUrl('aura', id)).toBe(iconDataUrl('ability', id));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Buff and debuff aura frames (the player buff bar and a targeted mob's DoT debuffs, both rendered by `Hud.renderAuras`) request their icon through `iconDataUrl` with `kind 'aura'`. That call only consulted the new image-based skill art (`public/ui/skills/<class>/<id>.png`, shipped in v0.14.0) for `kind 'ability'`, so an aura carrying a real ability id fell through to the older procedural recipe.

The visible result: a DoT or buff showed the new PNG on the action bar but a different, procedural glyph as an aura on the player frame and on a targeted mob.

This extends the image branch in `iconDataUrl` to `kind 'aura'`. `abilityImageUrl` returns `null` for generic `aura_<kind>` ids, so ambient/source-less auras still render their procedural recipe; only auras whose source is an image-backed ability now reuse that art, matching the action bar. Single fix point covers both surfaces (`renderAuras` is the one renderer for the player buff bar and the target debuffs).

## Related issues

N/A

## Type of change

- [x] Bug fix
- [ ] Feature: new functionality
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npx vitest run tests/aura_icons.test.ts tests/ability_icons.test.ts` (green)
  - `npx tsc --noEmit` (clean)
  - `npm run build` (succeeds)
  - `npm test` (full suite): the only failures are 10 pre-existing, environment-related cases in `tests/mobile_controls.test.ts` (`navigator is not defined`), `tests/chat_timestamp.test.ts`, and `tests/clock_format.test.ts`. Verified these same 10 fail on the clean `release/v0.14.0` base without this commit, so they are not introduced here.
- Manual steps (desktop, offline world via `npm run dev`):
  - Cast a self-buff (e.g. warrior Battle Shout, mage Arcane Intellect) and confirmed the player buff bar shows the image-based skill icon instead of the procedural glyph.
  - Applied a DoT to a mob (e.g. Warlock Corruption/Immolate, Warrior Rend) and confirmed the target frame debuff shows the same image-based icon as the action bar.

Added `tests/aura_icons.test.ts`, which asserts aura icons match the action-bar image for a DoT/buff sample across classes.

## Screenshots / recordings

Buff bar icon:

<img width="492" height="260" alt="Screenshot 2026-06-22 alle 14 02 19" src="https://github.com/user-attachments/assets/c808174b-3693-4b3e-b1d4-e491be7fb148" />


Mob DoT debuff icon:
<img width="271" height="127" alt="Screenshot 2026-06-22 alle 14 03 14" src="https://github.com/user-attachments/assets/32934c1e-75bb-44de-a93a-4c057c3ebc1f" />

---

## Checklist

### Quality

- [x] **Tests pass.** Added `tests/aura_icons.test.ts` for the changed behavior. `npm test` is green apart from 10 pre-existing, unrelated environment failures that also fail on the base branch (detailed above).
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` succeeds. Server/headless untouched.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on desktop. This change only swaps the icon source URL passed to an existing `background-image`; it adds no layout, sizing, or DOM change, so the buff/debuff frame renders identically on mobile.
- [ ] **Accessible.** N/A: no markup, focus, ARIA, or motion change (icon image source only).

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings (icon art source only; aura tooltips and names are unchanged).

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files.
