### PR TITLE
fix(render): smooth camera-driven player facing instead of snapping

### DIFF
--- a/scripts/facing_snap_shot.mjs
+++ b/scripts/facing_snap_shot.mjs
@@ -1,0 +1,96 @@
+// Verification + screenshot harness for "character model snaps/rotates wrongly".
+//
+// Boots the offline world as a warrior at max graphics (?gfx=ultra). Then drives
+// the renderer directly to reproduce the camera-driven facing override: it seeds
+// the self model at facing 0 (override disengaged), then engages the override at
+// a target ~180deg away (the camera orbited fully behind) and samples the self
+// model's group.rotation.y per sync() call. With the fix the per-frame yaw change
+// is capped (smooth turn); before the fix the first frame jumped the whole ~PI
+// gap (the instant backward snap). Calls run inside one synchronous evaluate so
+// the rAF loop cannot interleave and re-seed mid-measurement.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 60000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Turnwyn');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.hud && window.__game?.renderer, { timeout: 60000 });
+await sleep(2500);
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const r = g.renderer;
+  const id = g.world.player.id;
+  const grp = r.views.get(id)?.group;
+  if (!grp) return { error: 'no self view' };
+  const p = g.world.player;
+  // Seed: model facing 0, override disengaged.
+  p.facing = 0; p.prevFacing = 0;
+  r.sync(1, 1 / 60, null);
+  const start = grp.rotation.y;
+  // Engage the override ~180deg behind (camera orbited fully around) and sample.
+  const target = Math.PI * 0.99;
+  const deltas = [];
+  let prev = grp.rotation.y;
+  for (let i = 0; i < 60; i++) {
+    r.sync(1, 1 / 60, target);
+    const cur = grp.rotation.y;
+    let d = cur - prev;
+    while (d > Math.PI) d -= 2 * Math.PI;
+    while (d < -Math.PI) d += 2 * Math.PI;
+    deltas.push(Math.abs(d));
+    prev = cur;
+  }
+  const wrap = (a) => { while (a > Math.PI) a -= 2 * Math.PI; while (a < -Math.PI) a += 2 * Math.PI; return a; };
+  return {
+    start,
+    target,
+    firstFrameDelta: deltas[0],
+    maxFrameDelta: Math.max(...deltas),
+    framesToTurn: deltas.filter((d) => d > 1e-5).length,
+    finalGap: Math.abs(wrap(prev - target)),
+  };
+});
+
+console.log('=== facing snap verification (ultra build) ===');
+console.log(JSON.stringify(result, null, 2));
+const cap = 10 / 60; // SELF_TURN_MAX_RATE / 60Hz
+const ok = result.firstFrameDelta !== undefined
+  && result.firstFrameDelta <= cap + 1e-6
+  && result.maxFrameDelta <= cap + 1e-6
+  && result.framesToTurn > 1
+  && result.finalGap < 1e-3;
+console.log('PASS:', ok, `(per-frame cap ${cap.toFixed(4)} rad; a teleport would be ~${(Math.PI).toFixed(2)} rad)`);
+
+// Max-graphics in-world screenshot of the character.
+await page.evaluate(() => {
+  // tuck the camera in behind for a clean character framing if knobs are public
+  const r = window.__game.renderer;
+  if ('camDist' in r) r.camDist = 14;
+  if ('camPitch' in r) r.camPitch = 0.28;
+});
+await sleep(800);
+await page.screenshot({ path: 'tmp/facing-snap-ultra.png' });
+console.log('screenshot -> tmp/facing-snap-ultra.png');
+
+await browser.close();
+process.exit(ok ? 0 : 1);

--- a/src/render/facing_smooth.ts
+++ b/src/render/facing_smooth.ts
@@ -1,0 +1,46 @@
+// Rate-limit the local player model's visual yaw, factored out of the renderer
+// so it can be reasoned about and unit-tested without a WebGL context.
+//
+// The camera can drive the player's heading (classic right-mouse mouselook, or
+// the always-on Mouse Camera mode while a movement key is held). While that
+// override is DISENGAGED the player freely orbits the camera (camYaw) yet the
+// model keeps showing the interpolated sim facing, so the two diverge by up to
+// 180deg. Applying the override as a raw assignment then snaps the model across
+// that whole gap in a single frame - the model "instantly rotates backwards".
+// Clamping the per-frame change to a max angular velocity makes the model rotate
+// smoothly to follow the camera instead of teleporting. The cap sits well above
+// any intentional input (keyboard TURN_SPEED is PI rad/s, a normal mouse drag is
+// only a few degrees per frame) so ordinary turning passes straight through and
+// only a discontinuity, or a violent flick, gets smoothed.
+
+export const SELF_TURN_MAX_RATE = 10; // rad/sec cap on camera-driven model yaw
+const MAX_FRAME_DT = 1 / 30; // clamp long frames so a hitch cannot over-rotate
+
+/** Shortest signed angular distance from `from` to `to`, in (-PI, PI]. */
+export function wrapAngle(d: number): number {
+  while (d > Math.PI) d -= 2 * Math.PI;
+  while (d < -Math.PI) d += 2 * Math.PI;
+  return d;
+}
+
+/**
+ * Move `current` toward `target` by at most `maxStep` radians, taking the
+ * shortest path around the +/-PI wrap. Changes within `maxStep` snap to target.
+ */
+export function approachAngle(current: number, target: number, maxStep: number): number {
+  const step = Math.max(0, maxStep);
+  const d = wrapAngle(target - current);
+  if (Math.abs(d) <= step) return target;
+  return current + Math.sign(d) * step;
+}
+
+/**
+ * Advance the player model's displayed yaw one frame toward a camera-driven
+ * target, capped at SELF_TURN_MAX_RATE so it can never teleport. `current` is the
+ * yaw shown last frame (seed it from the live interpolated facing on first
+ * engage); `frameDt` is the frame delta in seconds.
+ */
+export function stepSelfFacing(current: number, target: number, frameDt: number): number {
+  const dt = Math.min(Math.max(0, frameDt), MAX_FRAME_DT);
+  return approachAngle(current, target, SELF_TURN_MAX_RATE * dt);
+}

--- a/src/render/facing_smooth.ts
+++ b/src/render/facing_smooth.ts
@@ -15,6 +15,10 @@
 
 export const SELF_TURN_MAX_RATE = 10; // rad/sec cap on camera-driven model yaw
 const MAX_FRAME_DT = 1 / 30; // clamp long frames so a hitch cannot over-rotate
+// Override is considered converged onto the sim facing once within this gap, at
+// which point the renderer drops it and hands control back to the interpolated
+// facing. Small enough to be visually indistinguishable from a perfect match.
+export const SELF_FACING_CONVERGE_EPS = 1e-4; // rad
 
 /** Shortest signed angular distance from `from` to `to`, in (-PI, PI]. */
 export function wrapAngle(d: number): number {
@@ -43,4 +47,22 @@ export function approachAngle(current: number, target: number, maxStep: number):
 export function stepSelfFacing(current: number, target: number, frameDt: number): number {
   const dt = Math.min(Math.max(0, frameDt), MAX_FRAME_DT);
   return approachAngle(current, target, SELF_TURN_MAX_RATE * dt);
+}
+
+/**
+ * Disengage frame: the camera-driven override has been released, so step the
+ * model's displayed yaw back toward the live interpolated sim `facing` under the
+ * SAME rate limiter rather than snapping to it. This avoids a one-frame snap-back
+ * when the override is dropped mid-flick before the rate-limited model had caught
+ * up. Returns the next yaw plus whether it has converged onto the sim facing; the
+ * caller clears its stored override only once `done` is true.
+ */
+export function releaseSelfFacing(
+  current: number,
+  simFacing: number,
+  frameDt: number,
+): { facing: number; done: boolean } {
+  const next = stepSelfFacing(current, simFacing, frameDt);
+  const done = Math.abs(wrapAngle(simFacing - next)) <= SELF_FACING_CONVERGE_EPS;
+  return { facing: done ? simFacing : next, done };
 }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -16,6 +16,7 @@ import { mechAssetsReady, preloadMechAssets } from './characters/assets';
 import { isVisuallyDead } from './anim_state';
 import { clickMarkerAnim, clickMarkerColor, CLICK_MARKER_LIFETIME } from './click_marker';
 import { LocoTrack, newLocoTrack, updateLocomotion } from './locomotion';
+import { stepSelfFacing } from './facing_smooth';
 import type { SpatialAudioSink, Surface } from './audio_sink';
 import { buildPropMaterialPrewarmGroup, buildProps } from './props';
 import { plankTexture, sparkleTexture } from './textures';
@@ -628,6 +629,11 @@ export class Renderer {
   private tmpV2 = new THREE.Vector3();
   private selfRenderPosition = new THREE.Vector3();
   private selfRenderPositionReady = false;
+  // Last yaw applied to the local player while the camera was driving its facing
+  // (mouselook / mouse-camera). Null when the override is disengaged, so the next
+  // engage re-seeds from the live interpolated facing instead of snapping. See
+  // facing_smooth.ts for why the camera-driven yaw must be rate-limited.
+  private selfFacingOverride: number | null = null;
   private cameraLookAt = new THREE.Vector3();
   // floating /say-/yell bubbles, keyed by speaker entity id
   private chatBubbles = new Map<number, { el: HTMLDivElement; until: number }>();
@@ -2951,7 +2957,16 @@ export class Renderer {
       const z = isSelf ? selfPos.z : e.prevPos.z + (e.pos.z - e.prevPos.z) * ea;
       v.group.position.set(x, y, z);
       let facing = e.prevFacing + shortestAngle(e.prevFacing, e.facing) * ea;
-      if (id === p.id && renderFacingOverride !== null) facing = renderFacingOverride;
+      if (id === p.id && renderFacingOverride !== null) {
+        // Rate-limit the camera-driven heading so engaging mouselook (or starting
+        // to move in Mouse Camera mode) rotates the model smoothly toward the
+        // camera instead of teleporting it up to 180deg in a single frame. Seed
+        // from the current interpolated facing on first engage.
+        facing = stepSelfFacing(this.selfFacingOverride ?? facing, renderFacingOverride, dt);
+        this.selfFacingOverride = facing;
+      } else if (id === p.id) {
+        this.selfFacingOverride = null;
+      }
       v.group.rotation.y = facing;
 
       if (e.kind === 'object') {

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -16,7 +16,7 @@ import { mechAssetsReady, preloadMechAssets } from './characters/assets';
 import { isVisuallyDead } from './anim_state';
 import { clickMarkerAnim, clickMarkerColor, CLICK_MARKER_LIFETIME } from './click_marker';
 import { LocoTrack, newLocoTrack, updateLocomotion } from './locomotion';
-import { stepSelfFacing } from './facing_smooth';
+import { stepSelfFacing, releaseSelfFacing } from './facing_smooth';
 import type { SpatialAudioSink, Surface } from './audio_sink';
 import { buildPropMaterialPrewarmGroup, buildProps } from './props';
 import { plankTexture, sparkleTexture } from './textures';
@@ -2964,8 +2964,14 @@ export class Renderer {
         // from the current interpolated facing on first engage.
         facing = stepSelfFacing(this.selfFacingOverride ?? facing, renderFacingOverride, dt);
         this.selfFacingOverride = facing;
-      } else if (id === p.id) {
-        this.selfFacingOverride = null;
+      } else if (id === p.id && this.selfFacingOverride !== null) {
+        // Disengage frame: route the return to the interpolated sim facing
+        // through the SAME rate limiter so releasing mouselook mid-flick (before
+        // the model caught up to the camera) rotates back smoothly instead of
+        // snapping. Hold the override until it has converged onto the sim facing.
+        const r = releaseSelfFacing(this.selfFacingOverride, facing, dt);
+        facing = r.facing;
+        this.selfFacingOverride = r.done ? null : r.facing;
       }
       v.group.rotation.y = facing;
 

--- a/tests/facing_smooth.test.ts
+++ b/tests/facing_smooth.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { stepSelfFacing, approachAngle, SELF_TURN_MAX_RATE } from '../src/render/facing_smooth';
+
+const FRAME_60 = 1 / 60;
+
+describe('approachAngle', () => {
+  it('takes the shortest path across the +/-PI wrap', () => {
+    // from 3.0 to -3.0 is +0.28 the short way, not -6.0 the long way
+    const r = approachAngle(3.0, -3.0, 1);
+    expect(r).toBeCloseTo(-3.0, 5); // within one big step, snaps to target
+  });
+
+  it('clamps a large change to maxStep along the shortest direction', () => {
+    expect(approachAngle(0, Math.PI, 0.1)).toBeCloseTo(0.1, 6);
+    expect(approachAngle(0, -Math.PI / 2, 0.1)).toBeCloseTo(-0.1, 6);
+  });
+
+  it('passes a small change straight through', () => {
+    expect(approachAngle(0, 0.05, 0.2)).toBeCloseTo(0.05, 6);
+  });
+});
+
+describe('stepSelfFacing', () => {
+  it('NEVER teleports the model across a near-180deg camera-driven jump in one frame', () => {
+    // Reproduces the bug: standing in mouse-camera mode the player orbits the
+    // camera ~180deg away from the model facing, then starts moving so the
+    // override engages. The old code did `facing = override` (instant snap).
+    const from = 0;
+    const target = Math.PI - 0.01; // camera orbited almost fully behind
+    const next = stepSelfFacing(from, target, FRAME_60);
+    const moved = Math.abs(next - from);
+    expect(moved).toBeLessThan(Math.PI); // not a teleport
+    // capped at the configured max angular velocity for one 60Hz frame
+    expect(moved).toBeCloseTo(SELF_TURN_MAX_RATE * FRAME_60, 5);
+  });
+
+  it('reaches the target smoothly over several frames', () => {
+    let f = 0;
+    const target = Math.PI - 0.01;
+    let frames = 0;
+    while (Math.abs(f - target) > 1e-6 && frames < 1000) {
+      f = stepSelfFacing(f, target, FRAME_60);
+      frames++;
+    }
+    expect(frames).toBeGreaterThan(1); // took more than a single snap frame
+    expect(frames).toBeLessThan(120); // but converges quickly (well under ~1s)
+    expect(f).toBeCloseTo(target, 5);
+  });
+
+  it('does NOT rate-limit intentional input below the cap (keyboard TURN_SPEED = PI rad/s)', () => {
+    // one 60Hz frame of keyboard turning is PI/60 rad, far under the cap, so it
+    // must pass through unchanged - no lag added to normal turning.
+    const perFrame = Math.PI / 60;
+    const next = stepSelfFacing(0, perFrame, FRAME_60);
+    expect(next).toBeCloseTo(perFrame, 6);
+  });
+
+  it('clamps an over-long frame so a hitch cannot over-rotate', () => {
+    const moved = Math.abs(stepSelfFacing(0, Math.PI, 0.5) - 0);
+    // 0.5s would be a huge step; it is clamped to the MAX_FRAME_DT budget
+    expect(moved).toBeLessThanOrEqual(SELF_TURN_MAX_RATE * (1 / 30) + 1e-9);
+  });
+});

--- a/tests/facing_smooth.test.ts
+++ b/tests/facing_smooth.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { stepSelfFacing, approachAngle, SELF_TURN_MAX_RATE } from '../src/render/facing_smooth';
+import {
+  stepSelfFacing,
+  approachAngle,
+  releaseSelfFacing,
+  SELF_TURN_MAX_RATE,
+  SELF_FACING_CONVERGE_EPS,
+} from '../src/render/facing_smooth';
 
 const FRAME_60 = 1 / 60;
 
@@ -59,5 +65,52 @@ describe('stepSelfFacing', () => {
     const moved = Math.abs(stepSelfFacing(0, Math.PI, 0.5) - 0);
     // 0.5s would be a huge step; it is clamped to the MAX_FRAME_DT budget
     expect(moved).toBeLessThanOrEqual(SELF_TURN_MAX_RATE * (1 / 30) + 1e-9);
+  });
+});
+
+describe('releaseSelfFacing', () => {
+  it('does NOT snap back to the sim facing in one frame when released mid-flick', () => {
+    // Override held the model partway through a near-180deg flick toward the
+    // camera; on release the sim facing is still the original heading, so a raw
+    // assignment would snap the whole gap back in one frame. The rate limiter
+    // must cap it instead.
+    const heldOverride = 1.5; // model rotated partway toward camera
+    const simFacing = -1.5; // sim heading still the other way (~PI gap)
+    const r = releaseSelfFacing(heldOverride, simFacing, FRAME_60);
+    const moved = Math.abs(r.facing - heldOverride);
+    expect(moved).toBeLessThan(Math.PI); // not a teleport
+    expect(moved).toBeCloseTo(SELF_TURN_MAX_RATE * FRAME_60, 5);
+    expect(r.done).toBe(false); // still far from the sim facing, keep the override
+  });
+
+  it('converges back onto the sim facing over several frames, then reports done', () => {
+    let f = 1.5;
+    const simFacing = -1.5;
+    let frames = 0;
+    let done = false;
+    while (!done && frames < 1000) {
+      const r = releaseSelfFacing(f, simFacing, FRAME_60);
+      f = r.facing;
+      done = r.done;
+      frames++;
+    }
+    expect(frames).toBeGreaterThan(1); // took more than a single snap frame
+    expect(frames).toBeLessThan(120); // converges quickly (well under ~1s)
+    expect(done).toBe(true);
+    expect(f).toBe(simFacing); // snaps exactly onto sim facing on the converged frame
+  });
+
+  it('reports done immediately and matches the sim facing when already converged', () => {
+    const simFacing = 0.7;
+    const r = releaseSelfFacing(simFacing + SELF_FACING_CONVERGE_EPS / 2, simFacing, FRAME_60);
+    expect(r.done).toBe(true);
+    expect(r.facing).toBe(simFacing);
+  });
+
+  it('takes the shortest path back across the +/-PI wrap on release', () => {
+    // override at 3.0, sim facing at -3.0: shortest path is +0.28, not -6.0.
+    const r = releaseSelfFacing(3.0, -3.0, FRAME_60);
+    // one small step toward -3.0 the short (positive-wrapping) way
+    expect(r.facing).toBeGreaterThan(3.0);
   });
 });


### PR DESCRIPTION
## Problem
The character model **snaps/rotates wrongly**:
- It **instantly rotates backwards** when it should be facing forward.
- It **snaps to a direction** when you hold right-mouse to rotate the camera.

## Root cause
The player model's facing can be driven by the camera yaw, in two modes:
- classic **right-mouse mouselook**, and
- the always-on **Mouse Camera mode** while a movement key is held.

The renderer applied that override as a raw assignment at `renderer.ts`:

```ts
let facing = e.prevFacing + shortestAngle(e.prevFacing, e.facing) * ea;
if (id === p.id && renderFacingOverride !== null) facing = renderFacingOverride; // instant
v.group.rotation.y = facing;
```

The angle math itself is correct (camera-forward `(sin camYaw, cos camYaw)` matches model facing `(sin f, cos f)` , no 180 deg convention error). The defect is that the assignment is **un-rate-limited**. While the override is *disengaged* (standing still in Mouse Camera mode, or before a right-drag crosses the camera-drag threshold) the player freely orbits the camera while the model keeps showing the interpolated sim facing, so the two diverge by up to 180 deg. The instant the override engages, the model discharges that whole gap in a single frame: the "instant backward snap".

## Fix
Rate-limit the **local player's** camera-driven yaw to a max angular velocity (10 rad/s), seeded from the live interpolated facing on first engage. The cap sits well above any intentional input (keyboard `TURN_SPEED` is PI rad/s; a normal mouse drag is only a few degrees per frame), so ordinary turning passes straight through and only a discontinuity (or a violent flick) is smoothed. The model now rotates smoothly to follow the camera instead of teleporting.

- Scoped to `id === p.id`; mobs and other players keep their existing interpolation.
- **Presentation-only**: no sim, wire, `IWorld`, or i18n change.
- Angle math extracted into a pure, host-agnostic module `src/render/facing_smooth.ts` with unit tests.

## Verification
- `tests/facing_smooth.test.ts` (TDD, red then green): shortest-path wrap, per-frame cap, multi-frame convergence, sub-cap pass-through, long-frame clamp.
- Full suite: **3059 passed**, 8 skipped, `npm run build` green.
- Live `?gfx=ultra` build (`scripts/facing_snap_shot.mjs`) reproduces the engage and confirms the first-frame yaw change is capped at **0.167 rad** over **19 frames** to complete a ~180 deg turn, versus the old single-frame **~3.14 rad** teleport:

```
firstFrameDelta: 0.1667   maxFrameDelta: 0.1667   framesToTurn: 19   finalGap: 0
PASS (per-frame cap 0.1667 rad; a teleport would be ~3.14 rad)
```

### Max-graphics screenshot
![character at gfx=ultra](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/assets-facing-snap/facing-snap-ultra.png)

cc @levy-street @Rubsey @FernandoX7 @TrevCavill @CharlieSaxton @patrick261 @sf-chris @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)