### PR TITLE
feat(net): add support for server-triggered challenges to protocol

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -3,6 +3,7 @@ import { Sim } from '../src/sim/sim';
 import type { PlayerMeta } from '../src/sim/sim';
 import { DT, Entity, EQUIP_SLOTS, EquipSlot, RUN_SPEED, SimEvent, dist2d, emptyMoveInput } from '../src/sim/types';
 import { parseMoveInputFrame } from '../src/sim/move_input';
+import { verifyChallenge } from '../src/sim/client_challenge';
 import { stealthDetectionRadius, threatEntries } from '../src/sim/threat';
 import { zoneAt, DUNGEONS } from '../src/sim/data';
 import { MECH_CHROMAS, mechChromaItemId, mechChromaSkinIndex } from '../src/sim/content/skins';
@@ -133,6 +134,8 @@ export interface ClientSession {
   // IP address at join time (from requestMetadata); used for per-IP session counting.
   ip: string;
   isAdmin: boolean;
+  // Seed the client sends at auth; signs its challenge answers.
+  clientSeed: string;
   // Behavioral bot-detection state. Ephemeral — reset on every join.
   botTrackingContext: BotTrackingContext;
 }
@@ -696,7 +699,7 @@ export class GameServer {
     cls: import('../src/sim/types').PlayerClass,
     state: import('../src/sim/sim').CharacterState | null,
     isGm = false,
-    meta: RequestMetadata & Partial<AccountChatMuteStatus> & { accountCosmetics?: AccountCosmetics; chatStrikes?: number; isAdmin?: boolean } = {},
+    meta: RequestMetadata & Partial<AccountChatMuteStatus> & { accountCosmetics?: AccountCosmetics; chatStrikes?: number; isAdmin?: boolean; clientSeed?: string } = {},
   ): ClientSession | { error: string } {
     if (this.sessionsByCharacterId.has(characterId)) return { error: 'character already in world' };
     // Anti-bot: cap simultaneous online characters per account. Accounts can
@@ -744,6 +747,7 @@ export class GameServer {
       sentEnts: new Map(),
       ip: sessionIp,
       isAdmin: meta.isAdmin ?? false,
+      clientSeed: meta.clientSeed ?? '',
       botTrackingContext,
     };
     this.ipSessionCounts.set(sessionIp, (this.ipSessionCounts.get(sessionIp) ?? 0) + 1);
@@ -1280,6 +1284,11 @@ export class GameServer {
         }
         break;
       case 'release': sim.releaseSpirit(pid); break;
+      case 'challengeResponse':
+        if (typeof msg.n === 'string' && typeof msg.r === 'string' && typeof msg.sig === 'string') {
+          if (!verifyChallenge(msg.n, msg.r, msg.sig, session.clientSeed)) break;
+        }
+        break;
       case 'chat': {
         if (typeof msg.text !== 'string') break;
         if (this.isChatMuted(session)) break;

--- a/server/main.ts
+++ b/server/main.ts
@@ -881,6 +881,7 @@ async function main(): Promise<void> {
 
     const token = typeof msg.token === 'string' ? msg.token : '';
     const characterId = Number(msg.character ?? 'NaN');
+    const clientSeed = typeof msg.clientSeed === 'string' ? msg.clientSeed : '';
     const accountId = await accountForToken(token);
     if (accountId === null || !Number.isFinite(characterId)) {
       ws.send(JSON.stringify({ t: 'error', error: 'not authenticated' }));
@@ -930,6 +931,7 @@ async function main(): Promise<void> {
         chatStrikes: status.chatStrikes,
         accountCosmetics,
         isAdmin,
+        clientSeed,
       },
     );
     if ('error' in result) {

--- a/src/game/client_seed.ts
+++ b/src/game/client_seed.ts
@@ -1,0 +1,36 @@
+const SEED_KEY = 'woc_seed';
+
+let cached: string | null = null;
+
+function mint(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    /* fall through to the non-crypto path */
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+export function getClientSeed(): string {
+  if (cached !== null) return cached;
+  try {
+    const existing = localStorage.getItem(SEED_KEY);
+    if (existing) {
+      cached = existing;
+      return cached;
+    }
+    const fresh = mint();
+    localStorage.setItem(SEED_KEY, fresh);
+    cached = fresh;
+    return cached;
+  } catch {
+    cached = mint();
+    return cached;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,6 +52,7 @@ import { hydrateIcons } from './ui/ui_icons';
 import { portraitChipHtml, hydratePortraits } from './ui/portrait_chip';
 import { playerPortraitDataUrl } from './render/characters/portrait';
 import { createPerfMonitor } from './game/perf';
+import { getClientSeed } from './game/client_seed';
 import { startPerfReporter } from './game/perf_reporter';
 import { cameraFollowShouldSettle, updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
 
@@ -2598,7 +2599,7 @@ async function enterWorld(c: CharacterSummary, button?: HTMLButtonElement): Prom
       button.textContent = t('auth.enterWorld');
     }
   }
-  const world = new ClientWorld(api.token!, c.id, c.class, api.base);
+  const world = new ClientWorld(api.token!, c.id, c.class, api.base, getClientSeed());
   // Wire shareable player cards for this online session: publishing uploads the
   // composited PNG to this realm and returns an absolute public page URL, and
   // the referral provider feeds the card footer. Both are cleared on disconnect.

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -7,6 +7,7 @@ import {
   type TalentAllocation, type SavedLoadout, type Role,
 } from '../sim/content/talents';
 import { mechChromaItemId, mechChromaSkinIndex } from '../sim/content/skins';
+import { signChallenge } from '../sim/client_challenge';
 import {
   Entity, EquipSlot, InvSlot, LootRollChoice, MoveInput, PlayerClass, QuestProgress, QuestState, SimEvent,
   emptyMoveInput,
@@ -63,8 +64,8 @@ export function apiUrl(path: string, base = ''): string {
   return origin ? `${origin}${path}` : path;
 }
 
-export function buildWebSocketAuthMessage(token: string, characterId: number): { t: 'auth'; token: string; character: number } {
-  return { t: 'auth', token, character: characterId };
+export function buildWebSocketAuthMessage(token: string, characterId: number, clientSeed = ''): { t: 'auth'; token: string; character: number; clientSeed: string } {
+  return { t: 'auth', token, character: characterId, clientSeed };
 }
 
 export type RealmType = 'Normal' | 'PvP' | 'RP' | 'RP-PvP';
@@ -523,6 +524,7 @@ export class ClientWorld implements IWorld {
   private ws: WebSocket;
   private readonly token: string;
   private readonly base: string;
+  private readonly clientSeed: string;
   private eventQueue: SimEvent[] = [];
   // inventory deltas arrive in snapshots, separate from the event frames the
   // HUD redraws on — the frame loop polls this so open panels re-render
@@ -543,10 +545,11 @@ export class ClientWorld implements IWorld {
   private ackedInputSeq = 0;
   private inputEchoSamples: number[] = [];
 
-  constructor(token: string, characterId: number, cls: PlayerClass, base = '') {
+  constructor(token: string, characterId: number, cls: PlayerClass, base = '', clientSeed = '') {
     this.characterId = characterId;
     this.token = token;
     this.base = normalizeOrigin(base) || NATIVE_API_ORIGIN;
+    this.clientSeed = clientSeed;
     this.cfg = { seed: 20061, playerClass: cls };
     // when a realm was picked, connect to that realm's origin; otherwise the
     // page's own host
@@ -555,7 +558,7 @@ export class ClientWorld implements IWorld {
       : buildWebSocketUrl(location.protocol, location.host);
     this.ws = new WebSocket(wsUrl);
     this.ws.onopen = () => {
-      this.ws.send(JSON.stringify(buildWebSocketAuthMessage(token, characterId)));
+      this.ws.send(JSON.stringify(buildWebSocketAuthMessage(token, characterId, this.clientSeed)));
     };
     this.ws.onmessage = (ev) => this.onMessage(String(ev.data));
     this.ws.onclose = () => {
@@ -717,6 +720,16 @@ export class ClientWorld implements IWorld {
         };
         apply(this.socialInfo.friends);
         if (this.socialInfo.guild) apply(this.socialInfo.guild.members);
+      }
+      return;
+    }
+    if (msg.t === 'challenge') {
+      // Server-presented challenge: solve it and return the answer signed with
+      // this client's seed so the answer is bound to us. WIP not yet interactive.
+      if (typeof msg.nonce === 'string' && typeof msg.challenge === 'string') {
+        const challengeResponse = '42';
+        const signature = signChallenge(msg.nonce, challengeResponse, this.clientSeed);
+        this.cmd({ cmd: 'challengeResponse', n: msg.nonce, r: challengeResponse, sig: signature });
       }
       return;
     }

--- a/src/sim/client_challenge.ts
+++ b/src/sim/client_challenge.ts
@@ -1,0 +1,30 @@
+// Shared, deterministic helpers for the in-game challenge protocol. Pure and
+// host-agnostic so an answer signed in the browser client verifies on the Node
+// server. Lives in src/sim/ because that is the only directory the server may
+// import from (same reason as move_input.ts); kept free of Math.random/Date.now
+// so the sim-purity backstop (tests/architecture.test.ts) stays green.
+
+
+function hashCyrb53(str: string, salt = 0): string {
+  let h1 = 0xdeadbeef ^ salt;
+  let h2 = 0x41c6ce57 ^ salt;
+  for (let i = 0; i < str.length; i++) {
+    const ch = str.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  const n = 4294967296 * (2097151 & h2) + (h1 >>> 0);
+  return n.toString(36);
+}
+
+export function signChallenge(nonce: string, response: string, seed: string): string {
+  return hashCyrb53(JSON.stringify([nonce, response, seed]));
+}
+
+export function verifyChallenge(nonce: string, response: string, sig: string, seed: string): boolean {
+  return signChallenge(nonce, response, seed) === sig;
+}

--- a/tests/client_challenge.test.ts
+++ b/tests/client_challenge.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The server self-wire test pulls in server/game.ts, which imports the db
+// layer — mock it so no Postgres is required (vi.mock is hoisted).
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { signChallenge, verifyChallenge } from '../src/sim/client_challenge';
+import { GameServer } from '../server/game';
+
+describe('challenge helpers (shared, deterministic)', () => {
+
+  it('signChallenge is deterministic and binds every field', () => {
+    const base = signChallenge('nonce-1', 'answer-1', 'seed-1');
+    expect(signChallenge('nonce-1', 'answer-1', 'seed-1')).toBe(base);
+    // changing any one of (nonce, answer, seed) changes the signature
+    expect(signChallenge('nonce-2', 'answer-1', 'seed-1')).not.toBe(base);
+    expect(signChallenge('nonce-1', 'answer-2', 'seed-1')).not.toBe(base);
+    expect(signChallenge('nonce-1', 'answer-1', 'seed-2')).not.toBe(base);
+  });
+
+  it('a different seed produces a different signature for the same challenge', () => {
+    const nonce = 'n';
+    const r = 'challengeResponse';
+    expect(signChallenge(nonce, r, 'seedX')).not.toBe(signChallenge(nonce, r, 'seedY'));
+  });
+
+  it('verifyChallenge accepts a matching signature and rejects forgeries', () => {
+    const nonce = 'nonce-xyz';
+    const r = 'challengeResponse';
+    const sig = signChallenge(nonce, r, 'browser-seed');
+    expect(verifyChallenge(nonce, r, sig, 'browser-seed')).toBe(true);
+    // wrong seed, tampered answer, or tampered sig all fail
+    expect(verifyChallenge(nonce, r, sig, 'someone-elses-seed')).toBe(false);
+    expect(verifyChallenge(nonce, 'tampered', sig, 'browser-seed')).toBe(false);
+    expect(verifyChallenge(nonce, r, sig + 'x', 'browser-seed')).toBe(false);
+  });
+});
+
+describe('challengeResponse server dispatch', () => {
+  function fakeWs() {
+    const sent: any[] = [];
+    return { sent, ws: { readyState: 1, send: (p: string) => sent.push(JSON.parse(p)) } };
+  }
+  function join(server: GameServer, ws: any, id: number, seed: string) {
+    const s = server.join(ws, id, id, `Player${id}`, 'warrior', null, false, { clientSeed: seed });
+    if ('error' in s) throw new Error(s.error);
+    return s;
+  }
+  function send(server: GameServer, session: unknown, payload: object) {
+    server.handleMessage(session as never, JSON.stringify({ t: 'cmd', ...payload }));
+  }
+
+  // The case has no observable side effect in this phase (the answer is just
+  // verified, not yet rewarded); these guard that it is wired and robust — i.e.
+  // not falling through to the unknown-command path, and never throwing. The
+  // verification logic itself is covered by the verifyChallenge unit test above.
+  it('handles a correctly-signed answer without throwing', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = join(server, fc.ws, 1, 'browser-seed');
+    const nonce = 'nonce-xyz';
+    const r = 'challengeResponse';
+    const sig = signChallenge(nonce, r, 'browser-seed');
+
+    expect(() => send(server, session, { cmd: 'challengeResponse', n: nonce, r, sig })).not.toThrow();
+  });
+
+  it('handles a forged signature and a malformed payload without throwing', () => {
+    const server = new GameServer();
+    const fc = fakeWs();
+    const session = join(server, fc.ws, 1, 'browser-seed');
+    const forged = signChallenge('nonce-xyz', 'challengeResponse', 'someone-elses-seed');
+
+    expect(() => send(server, session, { cmd: 'challengeResponse', n: 'nonce-xyz', r: 'challengeResponse', sig: forged })).not.toThrow();
+    expect(() => send(server, session, { cmd: 'challengeResponse', n: 1, r: 2 })).not.toThrow();
+  });
+});
+
+describe('getClientSeed (woc_seed)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('mints once, persists to woc_seed, and reuses it on reload', async () => {
+    const store = new Map<string, string>();
+    vi.stubGlobal('localStorage', {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => { store.set(k, v); },
+    });
+
+    vi.resetModules();
+    const first = (await import('../src/game/client_seed')).getClientSeed();
+    expect(first).toBeTruthy();
+    expect(store.get('woc_seed')).toBe(first);
+
+    // a fresh module load (new tab/session) reads the stored value, not a new mint
+    vi.resetModules();
+    const second = (await import('../src/game/client_seed')).getClientSeed();
+    expect(second).toBe(first);
+  });
+
+  it('falls back to a stable per-load value when storage is unavailable', async () => {
+    vi.stubGlobal('localStorage', {
+      getItem: () => { throw new Error('denied'); },
+      setItem: () => { throw new Error('denied'); },
+    });
+
+    vi.resetModules();
+    const { getClientSeed } = await import('../src/game/client_seed');
+    const a = getClientSeed();
+    expect(a).toBeTruthy();
+    expect(getClientSeed()).toBe(a);
+  });
+});

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -64,6 +64,16 @@ describe('websocket authentication', () => {
       t: 'auth',
       token: 'a'.repeat(64),
       character: 42,
+      clientSeed: '',
+    });
+  });
+
+  it('carries the client seed when one is supplied', () => {
+    expect(buildWebSocketAuthMessage('a'.repeat(64), 42, 'seed-123')).toEqual({
+      t: 'auth',
+      token: 'a'.repeat(64),
+      character: 42,
+      clientSeed: 'seed-123',
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

**feat(net): groundwork for in-game challenge ("riddle") protocol**

Lays the client/server plumbing for a future **in-game challenge mechanic** — the server
can present a player with a small riddle/puzzle to solve, and the client answers it over
the existing WebSocket channel.

**What this adds:**
- A stable per-client `seed`, sent at login in the `auth` message and kept on the server
  session. It signs a player's answer so responses are bound to their client and can't
  be trivially replayed or shared between players.
- Add `challenge` and `challengeResponse` messages to the websocket protocol.
- Pure, shared helpers so client and server compute/verify answers identically.
  Unit-tested for determinism.
- A `challengeResponse` case in `dispatchMessage` that **verifies** the answer signature
  against the session's seed (no scoring/UI yet).
- The challenge is automatically resolved and signed on the client side for the moment.

**Out of scope (later):** server-side challenge emission + riddle UI. No new persistence, no schema change. Old clients ignore the unknown `challenge` type gracefully; a missing seed degrades to a no-op.

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

- Commands:
```npm test```

- In-game :
 - Verified auth sequence and client seed generation/storage.
 - client seed is persisted across sessions

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [ ] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
