### PR TITLE
fix(ui): drop options language picker menu downward to avoid clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -1402,6 +1402,9 @@
   /* report dialog: dropdown drops downward (dialog sits high), full width */
   #report-window .ui-dd { display: block; }
   #report-window .ui-dd-menu { bottom: auto; top: calc(100% + 4px); }
+  /* options language picker: it is the first row of the Interface panel, so the
+     default upward menu clips off the panel top; drop it downward instead. */
+  .set-lang-select .ui-dd-menu { bottom: auto; top: calc(100% + 4px); }
   /* Choice-node option flyout */
   .tal-choice-pop { position: fixed; z-index: 90; width: 252px; background: #1a140a; border: 1px solid var(--gold); border-radius: 6px; box-shadow: 0 10px 24px #000c, inset 0 0 0 1px #ffd10022; padding: 5px; }
   .tal-choice-pop::before { content: ""; position: absolute; left: var(--tal-choice-caret-left, 50%); top: -6px; width: 10px; height: 10px; background: #1a140a; border-left: 1px solid var(--gold); border-top: 1px solid var(--gold); transform: translateX(-50%) rotate(45deg); }

--- a/play.html
+++ b/play.html
@@ -1142,6 +1142,9 @@
   /* report dialog: dropdown drops downward (dialog sits high), full width */
   #report-window .ui-dd { display: block; }
   #report-window .ui-dd-menu { bottom: auto; top: calc(100% + 4px); }
+  /* options language picker: it is the first row of the Interface panel, so the
+     default upward menu clips off the panel top; drop it downward instead. */
+  .set-lang-select .ui-dd-menu { bottom: auto; top: calc(100% + 4px); }
   /* Choice-node option flyout */
   .tal-choice-pop { position: fixed; z-index: 90; width: 252px; background: #1a140a; border: 1px solid var(--gold); border-radius: 6px; box-shadow: 0 10px 24px #000c, inset 0 0 0 1px #ffd10022; padding: 5px; }
   .tal-choice-pop::before { content: ""; position: absolute; left: var(--tal-choice-caret-left, 50%); top: -6px; width: 10px; height: 10px; background: #1a140a; border-left: 1px solid var(--gold); border-top: 1px solid var(--gold); transform: translateX(-50%) rotate(45deg); }


### PR DESCRIPTION
## Summary

The in-game Options > Interface language picker uses the custom `.ui-dd`
dropdown. Its menu opens upward by default (`bottom: calc(100% + 4px)`).
Because the language row is the first row of the Interface panel, the upward
menu is clipped off the top of the panel on desktop.

This adds a downward override scoped to `.set-lang-select`
(`bottom: auto; top: calc(100% + 4px)`), mirroring the existing
`#report-window .ui-dd-menu` rule. The change is applied in both build entries,
`index.html` and `play.html`, which carry the identical `.ui-dd` styles.

CSS only: no markup, behavior, or simulation change.

## Related issues

N/A

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx tsc --noEmit` (clean)
  - `npm run build` (succeeds; game + admin entries)
  - `npm test` (the only failures are 10 pre-existing, environment-only cases in
    `tests/mobile_controls.test.ts`, `tests/chat_timestamp.test.ts`, and
    `tests/clock_format.test.ts`, caused by running locally on Node 20
    (`navigator is not defined` / ICU); they reproduce on a clean checkout of the
    base branch and are unrelated to this CSS-only change. CI runs Node 22.)
- Manual steps:
  - Started `npm run dev`, opened the game, pressed Esc, opened Options >
    Interface, and clicked the Language picker.
  - Before: the option list opened upward and was clipped off the top of the
    panel. After: it opens downward, fully visible, no clipping.

## Screenshots / recordings
<img width="459" height="277" alt="Screenshot 2026-06-22 alle 20 13 59" src="https://github.com/user-attachments/assets/7c96fce3-d91d-4751-86a8-743a8dbd1ebf" />

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` shows only pre-existing, environment-only
      failures unrelated to this CSS-only change (see "How was this tested?");
      no `sim/`/`server/` behavior changed, so no tests added.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` is green. Server/headless untouched.

### Cross-platform

- [x] **Tested on desktop.** Verified the picker now drops downward without
      clipping. The override applies identically under `(pointer: coarse)`
      (downward from the first row), so it carries no new mobile clipping risk;
      not separately re-verified on a phone viewport.
- [x] **Accessible.** No ARIA/keyboard/markup change. The dropdown keeps its
      existing listbox semantics and keyboard navigation; only the open
      direction changed.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files. This change is hand-written CSS in the
      two HTML build entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
