### PR TITLE
feat(ui): open the quest log when a tracked quest is clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -968,8 +968,15 @@
   #quest-tracker .qt-header:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 2px; }
   #quest-tracker .qt-chevron { font-size: 10px; line-height: 1; }
   #quest-tracker .qt-count { color: var(--gold-dim); font-weight: 400; }
-  /* keep the toggle a comfortable touch target on coarse (touch) pointers */
-  @media (pointer: coarse) { #quest-tracker .qt-header { min-height: 40px; } }
+  /* keep the toggle + quest rows a comfortable touch target on coarse (touch) pointers */
+  @media (pointer: coarse) { #quest-tracker .qt-header, #quest-tracker .qt-quest { min-height: 40px; } }
+  /* Each tracked quest is a <button>: clicking it opens the quest log focused on
+     that quest. Native button chrome is reset so it keeps the plain tracker look,
+     and pointer events are re-enabled over the otherwise click-through overlay. */
+  #quest-tracker .qt-quest { display: block; width: 100%; text-align: left; background: none;
+    border: 0; padding: 0; margin: 0; color: inherit; font: inherit; cursor: pointer; pointer-events: auto; }
+  #quest-tracker .qt-quest:hover .qt-title { color: #fff; }
+  #quest-tracker .qt-quest:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 2px; }
   #quest-tracker .qt-title { font-weight: bold; margin-top: 8px; font-family: var(--title-font); }
   #quest-tracker .qt-obj { color: #e8e0c8; font-size: 11px; margin-left: 8px; }
   #quest-tracker .qt-obj.done,

--- a/index.html
+++ b/index.html
@@ -972,12 +972,15 @@
   @media (pointer: coarse) { #quest-tracker .qt-header, #quest-tracker .qt-quest { min-height: 40px; } }
   /* Each tracked quest is a <button>: clicking it opens the quest log focused on
      that quest. Native button chrome is reset so it keeps the plain tracker look,
-     and pointer events are re-enabled over the otherwise click-through overlay. */
+     and pointer events are re-enabled over the otherwise click-through overlay.
+     The inter-row gap is the button's own top padding rather than a title
+     margin: a top margin on the first child collapses out of the borderless,
+     zero-padding button, leaving a dead click-through strip between rows. */
   #quest-tracker .qt-quest { display: block; width: 100%; text-align: left; background: none;
-    border: 0; padding: 0; margin: 0; color: inherit; font: inherit; cursor: pointer; pointer-events: auto; }
+    border: 0; padding: 8px 0 0; margin: 0; color: inherit; font: inherit; cursor: pointer; pointer-events: auto; }
   #quest-tracker .qt-quest:hover .qt-title { color: #fff; }
   #quest-tracker .qt-quest:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 2px; }
-  #quest-tracker .qt-title { font-weight: bold; margin-top: 8px; font-family: var(--title-font); }
+  #quest-tracker .qt-title { font-weight: bold; font-family: var(--title-font); }
   #quest-tracker .qt-obj { color: #e8e0c8; font-size: 11px; margin-left: 8px; }
   #quest-tracker .qt-obj.done,
   .qd-obj.done,

--- a/play.html
+++ b/play.html
@@ -819,12 +819,15 @@
   @media (pointer: coarse) { #quest-tracker .qt-header, #quest-tracker .qt-quest { min-height: 40px; } }
   /* Each tracked quest is a <button>: clicking it opens the quest log focused on
      that quest. Native button chrome is reset so it keeps the plain tracker look,
-     and pointer events are re-enabled over the otherwise click-through overlay. */
+     and pointer events are re-enabled over the otherwise click-through overlay.
+     The inter-row gap is the button's own top padding rather than a title
+     margin: a top margin on the first child collapses out of the borderless,
+     zero-padding button, leaving a dead click-through strip between rows. */
   #quest-tracker .qt-quest { display: block; width: 100%; text-align: left; background: none;
-    border: 0; padding: 0; margin: 0; color: inherit; font: inherit; cursor: pointer; pointer-events: auto; }
+    border: 0; padding: 8px 0 0; margin: 0; color: inherit; font: inherit; cursor: pointer; pointer-events: auto; }
   #quest-tracker .qt-quest:hover .qt-title { color: #fff; }
   #quest-tracker .qt-quest:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 2px; }
-  #quest-tracker .qt-title { font-weight: bold; margin-top: 8px; font-family: var(--title-font); }
+  #quest-tracker .qt-title { font-weight: bold; font-family: var(--title-font); }
   #quest-tracker .qt-obj { color: #e8e0c8; font-size: 11px; margin-left: 8px; }
   #quest-tracker .qt-obj.done,
   .qd-obj.done,

--- a/play.html
+++ b/play.html
@@ -815,8 +815,15 @@
   #quest-tracker .qt-header:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 2px; }
   #quest-tracker .qt-chevron { font-size: 10px; line-height: 1; }
   #quest-tracker .qt-count { color: var(--gold-dim); font-weight: 400; }
-  /* keep the toggle a comfortable touch target on coarse (touch) pointers */
-  @media (pointer: coarse) { #quest-tracker .qt-header { min-height: 40px; } }
+  /* keep the toggle + quest rows a comfortable touch target on coarse (touch) pointers */
+  @media (pointer: coarse) { #quest-tracker .qt-header, #quest-tracker .qt-quest { min-height: 40px; } }
+  /* Each tracked quest is a <button>: clicking it opens the quest log focused on
+     that quest. Native button chrome is reset so it keeps the plain tracker look,
+     and pointer events are re-enabled over the otherwise click-through overlay. */
+  #quest-tracker .qt-quest { display: block; width: 100%; text-align: left; background: none;
+    border: 0; padding: 0; margin: 0; color: inherit; font: inherit; cursor: pointer; pointer-events: auto; }
+  #quest-tracker .qt-quest:hover .qt-title { color: #fff; }
+  #quest-tracker .qt-quest:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; border-radius: 2px; }
   #quest-tracker .qt-title { font-weight: bold; margin-top: 8px; font-family: var(--title-font); }
   #quest-tracker .qt-obj { color: #e8e0c8; font-size: 11px; margin-left: 8px; }
   #quest-tracker .qt-obj.done,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -788,7 +788,7 @@ export class Hud {
       const header = target.closest('.qt-header');
       const quest = target.closest('.qt-quest') as HTMLElement | null;
       if (!header && !quest) return;
-      if (e.key === 'Enter' || e.key === ' ' || e.code === 'Space') {
+      if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         e.stopPropagation();
         if (header) this.toggleQuestTrackerCollapsed();

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -765,24 +765,34 @@ export class Hud {
     $('#mm-spell').addEventListener('click', () => this.toggleSpellbook());
     $('#mm-talents')?.addEventListener('click', () => this.toggleTalents());
     $('#mm-quest').addEventListener('click', () => this.toggleQuestLog());
-    // Collapse/expand the on-screen quest tracker by clicking its header. The
-    // overlay is click-through (pointer-events:none) except the header button, so
-    // delegate on the stable container (the header is rebuilt on each render).
+    // Quest tracker clicks. The overlay is click-through (pointer-events:none)
+    // except its buttons (the header and each quest row), so delegate on the
+    // stable container since both are rebuilt on each render. The header button
+    // toggles collapse; clicking a quest row opens the quest log focused on that
+    // quest (the classic-MMO affordance, matching the L keybind / minimap button).
     $('#quest-tracker').addEventListener('click', (e) => {
-      if ((e.target as HTMLElement).closest('.qt-header')) this.toggleQuestTrackerCollapsed();
+      const target = e.target as HTMLElement;
+      if (target.closest('.qt-header')) { this.toggleQuestTrackerCollapsed(); return; }
+      const quest = target.closest('.qt-quest') as HTMLElement | null;
+      if (quest?.dataset.questId) this.openQuestLogTo(quest.dataset.questId);
     });
     // Keyboard activation: handle Enter/Space here and stop the event before it
     // bubbles to the window-level game keybinds (Enter is bound to Open Chat,
     // Space is preventDefault'd for jump), which would otherwise hijack the
-    // focused header button's native activation. The tracker is a non-modal
-    // overlay, so canUseGameKeys() stays true and those binds fire while it has
-    // focus; stopping propagation here keeps the toggle reachable by keyboard.
+    // focused button's native activation. The tracker is a non-modal overlay, so
+    // canUseGameKeys() stays true and those binds fire while it has focus;
+    // stopping propagation here keeps the header toggle and quest rows reachable
+    // by keyboard.
     $('#quest-tracker').addEventListener('keydown', (e) => {
-      if (!(e.target as HTMLElement).closest('.qt-header')) return;
+      const target = e.target as HTMLElement;
+      const header = target.closest('.qt-header');
+      const quest = target.closest('.qt-quest') as HTMLElement | null;
+      if (!header && !quest) return;
       if (e.key === 'Enter' || e.key === ' ' || e.code === 'Space') {
         e.preventDefault();
         e.stopPropagation();
-        this.toggleQuestTrackerCollapsed();
+        if (header) this.toggleQuestTrackerCollapsed();
+        else if (quest?.dataset.questId) this.openQuestLogTo(quest.dataset.questId);
       }
     });
     $('#mm-map').addEventListener('click', () => this.toggleMap());
@@ -3131,12 +3141,18 @@ export class Hud {
     let html = `<button type="button" class="qt-header" aria-expanded="${!view.collapsed}" aria-controls="qt-list" title="${hint}">`
       + `<span class="qt-chevron" aria-hidden="true">${chevron}</span>`
       + `<span class="qt-h-label">${esc(t('questUi.tracker.title'))}</span>${count}</button>`;
+    // Each quest is a <button>: a left-click (or keyboard activation) opens the
+    // quest log focused on that quest. The delegated #quest-tracker listeners
+    // (see the event-binding constructor) route it to openQuestLogTo; the button
+    // re-enables pointer events over the otherwise click-through overlay. Its
+    // accessible name is the quest title + objective text it already contains.
     let rows = '';
     for (const q of view.quests) {
-      rows += `<div class="qt-title">${esc(q.title)}${q.complete ? ` <span class="quest-complete">(${esc(t('questUi.tracker.complete'))})</span>` : ''}</div>`;
+      let body = `<div class="qt-title">${esc(q.title)}${q.complete ? ` <span class="quest-complete">(${esc(t('questUi.tracker.complete'))})</span>` : ''}</div>`;
       for (const o of q.objectives) {
-        rows += `<div class="qt-obj${o.done ? ' done' : ''}">- ${esc(this.questProgressText(o.label, o.current, o.total))}</div>`;
+        body += `<div class="qt-obj${o.done ? ' done' : ''}">- ${esc(this.questProgressText(o.label, o.current, o.total))}</div>`;
       }
+      rows += `<button type="button" class="qt-quest" data-quest-id="${esc(q.id)}">${body}</button>`;
     }
     return `${html}<div id="qt-list">${rows}</div>`;
   }
@@ -8005,12 +8021,26 @@ export class Hud {
     el.style.display = 'block';
   }
 
+  /** Open the quest log focused on a specific tracked quest. Used when a quest in
+   *  the #quest-tracker overlay is left-clicked (or keyboard-activated): select
+   *  that quest, then open the log. If the log is already open, just re-render
+   *  with the new selection rather than toggling it shut. */
+  private openQuestLogTo(questId: string): void {
+    if (this.sim.questLog.has(questId)) this.selectedQuestLogId = questId;
+    if ($('#quest-log-window').style.display === 'block') { this.renderQuestLog(); return; }
+    this.toggleQuestLog();
+  }
+
   private closeQuestLog(restoreFocus = true): void {
     $('#quest-log-window').style.display = 'none';
     this.hideTooltip();
     const target = this.questLogReturnFocus;
     this.questLogReturnFocus = null;
-    if (restoreFocus) this.restoreFocus(target);
+    // Fall back to the minimap quest-log button when the original focus target is
+    // gone: opening the log from a tracker quest row captures that row's button,
+    // which updateQuestTracker's innerHTML rebuild can detach, so without a stable
+    // fallback focus would drop to <body> on close.
+    if (restoreFocus) this.restoreFocus(target, $('#mm-quest'));
   }
 
   renderQuestLog(): void {

--- a/tests/quest_tracker.test.ts
+++ b/tests/quest_tracker.test.ts
@@ -34,6 +34,14 @@ describe('questTrackerView', () => {
     expect(v.quests[1].objectives.map((o) => o.done)).toEqual([true, true]); // 6/6, 4/4
   });
 
+  it('exposes each quest id so the tracker can open the log to it', () => {
+    // The #quest-tracker click handler reads data-quest-id off each rendered
+    // quest button and passes it to openQuestLogTo, so the view must carry the
+    // quest id (in order) for every expanded row.
+    const v = questTrackerView(QUESTS, false);
+    expect(v.quests.map((q) => q.id)).toEqual(['warden', 'webwood']);
+  });
+
   it('collapsed: header only, but keeps the quest count', () => {
     const v = questTrackerView(QUESTS, true);
     expect(v.visible).toBe(true);


### PR DESCRIPTION
## Summary

Left-clicking a quest in the on-screen quest tracker now opens the Quest Log focused on that quest. Previously the only ways to open the log were the **L** keybind and the minimap button, so clicking a tracked quest did nothing, a small but real bit of friction versus the classic-MMO behavior players expect.

Each tracked quest now renders as a `<button class="qt-quest">` that re-enables pointer events over the otherwise click-through tracker overlay and routes (through the existing delegated `#quest-tracker` listeners) to a new `openQuestLogTo(questId)`: it selects that quest and opens the log, or just re-renders the selection if the log is already open. The header still toggles collapse, and the **L** keybind / minimap button are unchanged.

Implementation notes:
- Quest rows are real buttons, so keyboard activation (Enter/Space) reuses the same `preventDefault` + `stopPropagation` handling the header already uses (so the window-level keybinds for Open Chat / jump are not hijacked).
- The `.qt-quest` styling and the `>=40px` coarse-pointer touch-target floor were added to **both** game entries (`index.html` and `play.html`), which each carry their own copy of the HUD CSS.
- `closeQuestLog` now passes a stable focus-restoration fallback (the minimap quest-log button), so closing the log does not drop focus to `<body>` when the originating tracker row has been rebuilt away.

## Related issues

N/A

## Type of change

- [x] Feature: new functionality

## How was this tested?

- Commands:
  - `npm test` (Vitest suite green; the one local failure is `i18n_extra_tables`, a pre-existing Windows-only path-separator quirk in the test that flags its own allow-listed files and passes on Linux CI; this PR adds no `Intl` usage)
  - `npx tsc --noEmit` (clean)
  - `npm run build` (client build succeeds)
- Manual steps (offline client, `npm run dev`):
  - Accepted a quest so the tracker appeared, then left-clicked the quest: the Quest Log opened focused on that quest.
  - Confirmed the header still collapses/expands, **L** still toggles the log, and Tab to a quest + Enter/Space opens it.

## Screenshots / recordings

This is an interaction change (left-clicking a tracked quest opens the log focused on it), described above with repro steps. Happy to add a short clip if that would help review.

---

## Checklist

### Quality

- [x] **Tests pass.** Added a unit test for the tracker view's quest-id contract (the data the click handler reads). No `sim/` or `server/` behavior changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build`. Server/headless were not touched (CI builds those too).

### Cross-platform

- [x] **Desktop tested.** Click, header collapse, L keybind, and keyboard activation all verified in the offline client.
- [ ] Mobile: the quest rows carry the `>=40px` coarse-pointer touch-target floor in both `index.html` and `play.html` (code-level, mirroring the header rule). A phone-viewport pass in portrait and landscape would be a welcome extra check.
- [x] **Accessible.** Rows are real `<button>` elements: keyboard-operable (Enter/Space), visible `:focus-visible` outline, accessible name from the contained quest title + objective text, and a stable focus-restoration fallback on close. No new motion.

### Localization (i18n)

- [x] **N/A. This PR adds no player-visible strings.** (The interaction intentionally avoids any new tooltip/label, so the i18n catalog and generated artifacts are untouched.)

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is untouched.
- [x] No generated files were hand-edited.
