### PR TITLE
feat(antibot): pass session metadata to the bot-detector seam

### DIFF
--- a/server/bot_detector/contract.ts
+++ b/server/bot_detector/contract.ts
@@ -22,7 +22,7 @@ export interface BotTrackingContext { readonly [botTrackingBrand]: true }
 
 
 export interface BotDetector {
-  createTrackingContext(ref: PlayerSessionRef): BotTrackingContext;
+  createTrackingContext(ref: PlayerSessionRef, meta?: unknown): BotTrackingContext;
   releaseTrackingContext(ctx: BotTrackingContext): void;
   observeCommand(ctx: BotTrackingContext, cmd: string, now: number, message?: unknown): void;
   observeEvent(ctx: BotTrackingContext, ev: SimEvent, now: number): void;

--- a/server/bot_detector/stub.ts
+++ b/server/bot_detector/stub.ts
@@ -5,7 +5,7 @@ const HANDLE = {} as unknown as BotTrackingContext;
 
 export function createBotDetector(): BotDetector {
   return {
-    createTrackingContext: () => HANDLE,
+    createTrackingContext: (_ref, _meta) => HANDLE,
     releaseTrackingContext: () => {},
     observeCommand: () => {},
     observeEvent: () => {},

--- a/server/game.ts
+++ b/server/game.ts
@@ -728,7 +728,7 @@ export class GameServer {
     );
     this.applyAccountQuestLockouts(pid, accountCosmetics);
     const sessionIp = meta.ip ?? '';
-    const botTrackingContext = this.botDetector.createTrackingContext({ accountId, characterId, name, ip: sessionIp });
+    const botTrackingContext = this.botDetector.createTrackingContext({ accountId, characterId, name, ip: sessionIp }, meta);
     const session: ClientSession = {
       ws, accountId, accountCosmetics, characterId, pid, name,
       lastSave: Date.now(), alive: true, joinedAt: Date.now(), dbSessionId: null, left: false,

--- a/tests/bot_detector_stub.test.ts
+++ b/tests/bot_detector_stub.test.ts
@@ -6,7 +6,10 @@ import { emptyMoveInput } from '../src/sim/types';
 describe('bot-detector stub (open-source no-op)', () => {
   it('satisfies the BotDetector seam and detects nothing', () => {
     const detector: BotDetector = createBotDetector();
-    const ctx = detector.createTrackingContext({ accountId: 1, characterId: 1, name: 'X', ip: '1.2.3.4' });
+    const ctx = detector.createTrackingContext(
+      { accountId: 1, characterId: 1, name: 'X', ip: '1.2.3.4' },
+      { some: 'meta-value', another: 'meta' },
+    );
 
     // A full observation cycle is inert and never escalates.
     detector.observeCommand(ctx, 'attack', Date.now());


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

Adds an optional opaque `meta` parameter to `BotDetector.createTrackingContext`, populated with the session's existing join metadata.

## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

<!-- The commands you ran and the manual steps you walked through. Be specific. -->

Played locally

## Screenshots / recordings

<!--
If this PR changes anything a player or operator sees (HUD, windows, tooltips,
mobile controls, admin dashboard), please add before/after screenshots or a
short clip, on desktop and mobile where relevant. Remove this section for non-UI
changes.
-->

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

(New tests pass, the failing one is from the release branch)

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
