### PR TITLE
fix: include wiki build scripts in docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,7 +10,10 @@ tests
 scripts/*
 !scripts/build_media_manifest.mjs
 !scripts/build_server.mjs
+!scripts/build_sitemap.mjs
 !scripts/i18n_*.mjs
+!scripts/wiki/
+!scripts/wiki/*.mjs
 deploy
 *.md
 .venv


### PR DESCRIPTION
## Summary
- re-include `scripts/build_sitemap.mjs` in the Docker build context
- re-include `scripts/wiki/*.mjs` so `npm run wiki:content` works inside Docker

## Why
The production deploy for `main` failed during `docker compose up -d --build` because `.dockerignore` excluded the new v0.14 wiki build script:

```text
Error: Cannot find module '/app/scripts/wiki/build_content.mjs'
```

`npm run build` now also invokes `wiki:content` and `sitemap:build`, so these scripts need to be present in the Docker context.

## Validation
- `npm run build` passes locally from `origin/main` + this fix
- Production health remained OK after the failed deploy; the failure happened during image build before container restart