### PR TITLE
fix: include guide html in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --no-audit --no-fund
-COPY tsconfig.json vite.config.ts index.html admin.html play.html ./
+COPY tsconfig.json vite.config.ts index.html admin.html play.html guide.html ./
 COPY src ./src
 COPY server ./server
 COPY headless ./headless


### PR DESCRIPTION
## Summary
- include `guide.html` in the Docker build stage alongside the other Vite HTML inputs

## Why
The production deploy got past the missing wiki scripts after #865, then Docker failed because Vite's build input includes `guide.html` but the Dockerfile did not copy it into `/app`:

```text
Error: ENOENT: no such file or directory, open '/app/dist/.vite/manifest.json'
```

Vite transformed only one module because the guide input was absent, so the modulepreload plugin could not read the generated manifest.

## Validation
- `npm run build` passes locally with this fix
- Production health remained OK after the failed image build; the running container was not replaced