### PR TITLE
fix(sim): re-summon the Bound Guardian after it despawns unkilled (lost kill credit / signet)

### DIFF
--- a/scripts/bound_guardian_resummon_shot.mjs
+++ b/scripts/bound_guardian_resummon_shot.mjs
@@ -1,0 +1,95 @@
+// Screenshot the Bound Guardian re-summon fix (max graphics, ?gfx=ultra) in the
+// offline client. Boots the game, places the player on the crypt ritual circle
+// with the quest active and the Crypt Keystone in hand, summons the guardian,
+// force-despawns it as the idle-despawn would (leash/wipe), then re-uses the
+// ritual circle to prove a fresh guardian is summoned and the kill stays
+// reachable. Captures the re-summoned boss and its elite target frame.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 30000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 200));
+await page.type('#char-name', 'Brannok');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => !!window.__game && !!window.__game.sim, { timeout: 30000 });
+await new Promise((r) => setTimeout(r, 800));
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const p = sim.player;
+  p.maxHp = 100000; p.hp = 100000;
+
+  const ritual = [...sim.entities.values()].find((e) => e.kind === 'object' && e.objectItemId === 'crypt_ritual_circle');
+  const to = (x, z) => { p.pos.x = x; p.pos.z = z; p.prevPos = { ...p.pos }; };
+  to(ritual.pos.x, ritual.pos.z);
+
+  sim.questLog.set('q_nythraxis_bound_guardian', { questId: 'q_nythraxis_bound_guardian', counts: [0, 0, 0], state: 'active' });
+  sim.addItem('crypt_keystone', 1);
+
+  // First summon, then simulate the idle-despawn that previously stranded the quest.
+  sim.pickUpObject(ritual.id);
+  const first = [...sim.entities.values()].find((e) => e.templateId === 'bound_guardian' && !e.dead);
+  sim.entities.delete(first.id);
+  const goneAfterDespawn = ![...sim.entities.values()].some((e) => e.templateId === 'bound_guardian' && !e.dead);
+
+  // Re-use the ritual circle: with the fix, a fresh guardian is summoned even
+  // though the interact objective (counts[0]) is already satisfied.
+  to(ritual.pos.x, ritual.pos.z);
+  sim.pickUpObject(ritual.id);
+  const guardian = [...sim.entities.values()].find((e) => e.templateId === 'bound_guardian' && !e.dead);
+
+  // Frame the re-summoned boss for the shot.
+  guardian.pos.x = p.pos.x + 6; guardian.pos.z = p.pos.z;
+  sim.targetEntity(guardian.id);
+  p.facing = Math.atan2(guardian.pos.x - p.pos.x, guardian.pos.z - p.pos.z);
+  g.input.camYaw = p.facing;
+
+  return {
+    interactCount: sim.questLog.get('q_nythraxis_bound_guardian').counts[0],
+    keystone: sim.countItem('crypt_keystone', sim.playerId),
+    goneAfterDespawn,
+    resummoned: !!guardian,
+    name: guardian?.name,
+    level: guardian?.level,
+  };
+});
+console.log('bound_guardian resummon:', JSON.stringify(result));
+
+await new Promise((r) => setTimeout(r, 1000));
+await page.screenshot({ path: 'tmp/bound_guardian_resummon_full.png' });
+
+const box = await page.evaluate(() => {
+  const el = document.querySelector('#target-frame');
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { x: r.left, y: r.top, w: r.width, h: r.height };
+});
+if (box) {
+  const pad = 18;
+  await page.screenshot({
+    path: 'tmp/bound_guardian_resummon_targetframe.png',
+    clip: {
+      x: Math.max(0, box.x - pad), y: Math.max(0, box.y - pad),
+      width: box.w + pad * 2, height: box.h + pad * 2,
+    },
+  });
+}
+
+console.log('saved tmp/bound_guardian_resummon_full.png, tmp/bound_guardian_resummon_targetframe.png');
+await browser.close();

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -7784,11 +7784,23 @@ export class Sim {
       quest.objectives.forEach((objective, objectiveIndex) => {
         if (objective.type !== 'interact' || objective.targetObjectItemId !== obj.objectItemId) return;
         handled = true;
-        if (qp.counts[objectiveIndex] >= objective.count) return;
-        if (obj.objectItemId === 'crypt_ritual_circle' && !this.countItem('crypt_keystone', meta.entityId)) {
+        const isRitual = obj.objectItemId === 'crypt_ritual_circle';
+        if (isRitual && !this.countItem('crypt_keystone', meta.entityId)) {
           this.error(meta.entityId, 'The ritual circle is silent without the Crypt Keystone.');
           return;
         }
+        // Re-summon the Bound Guardian whenever the player still owes the kill.
+        // The interact objective is one-shot, but a guardian lost to the idle
+        // despawn (leash, wipe) must stay reachable or the kill/collect/signet
+        // dead-ends with no way to retry. summonQuestMob no-ops if one is alive.
+        if (isRitual) {
+          const killIdx = quest.objectives.findIndex((o) => o.type === 'kill' && o.targetMobId === 'bound_guardian');
+          if (killIdx >= 0 && qp.counts[killIdx] < quest.objectives[killIdx].count) {
+            this.summonQuestMob('bound_guardian', obj.pos, meta.entityId);
+          }
+        }
+        // The interact objective itself (and its one-time vision) only credits once.
+        if (qp.counts[objectiveIndex] >= objective.count) return;
         const shared = this.sharedNythraxisObjectParticipants(meta, obj, qp.questId, objectiveIndex);
         for (const member of shared) {
           const memberQp = member.questLog.get(qp.questId);
@@ -7806,7 +7818,6 @@ export class Sim {
         }
         const visionId = this.summonQuestVision(obj.objectItemId, obj.pos);
         this.emitQuestObjectVision(obj.objectItemId, shared.map((m) => m.entityId), visionId);
-        if (obj.objectItemId === 'crypt_ritual_circle') this.summonQuestMob('bound_guardian', obj.pos, meta.entityId);
       });
     }
     return handled;

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -1191,6 +1191,48 @@ describe('quest npc roles', () => {
     expect(sim.entities.has(guardian.id)).toBe(false);
   });
 
+  it('re-summons the Bound Guardian at the ritual circle after the first one despawns unkilled', () => {
+    const sim = makeSim();
+    const ritual = [...sim.entities.values()].find((e) => e.kind === 'object' && e.objectItemId === 'crypt_ritual_circle')!;
+    teleportTo(sim, ritual.pos.x, ritual.pos.z);
+    sim.questLog.set('q_nythraxis_bound_guardian', { questId: 'q_nythraxis_bound_guardian', counts: [0, 0, 0], state: 'active' });
+    sim.addItem('crypt_keystone', 1);
+
+    sim.pickUpObject(ritual.id);
+    const first = [...sim.entities.values()].find((e) => e.templateId === 'bound_guardian')!;
+    expect(first).toBeTruthy();
+    // interact objective is one-shot; it should not block re-summoning the guardian
+    expect(sim.questLog.get('q_nythraxis_bound_guardian')?.counts[0]).toBe(1);
+
+    // the guardian leashes and idle-despawns without ever being killed
+    first.inCombat = false;
+    first.aiState = 'idle';
+    first.aggroTargetId = null;
+    first.damageIdleDespawnTimer = 0.05;
+    sim.tick();
+    expect([...sim.entities.values()].some((e) => e.templateId === 'bound_guardian' && !e.dead)).toBe(false);
+
+    // re-using the ritual circle must summon a fresh guardian so the kill is reachable
+    teleportTo(sim, ritual.pos.x, ritual.pos.z);
+    sim.pickUpObject(ritual.id);
+    const second = [...sim.entities.values()].find((e) => e.templateId === 'bound_guardian' && !e.dead);
+    expect(second).toBeTruthy();
+    // interact count stays satisfied; the keystone is retained for the retry
+    expect(sim.questLog.get('q_nythraxis_bound_guardian')?.counts[0]).toBe(1);
+    expect(sim.countItem('crypt_keystone', sim.playerId)).toBe(1);
+  });
+
+  it('does not re-summon the Bound Guardian once the kill objective is complete', () => {
+    const sim = makeSim();
+    const ritual = [...sim.entities.values()].find((e) => e.kind === 'object' && e.objectItemId === 'crypt_ritual_circle')!;
+    teleportTo(sim, ritual.pos.x, ritual.pos.z);
+    sim.questLog.set('q_nythraxis_bound_guardian', { questId: 'q_nythraxis_bound_guardian', counts: [1, 1, 0], state: 'active' });
+    sim.addItem('crypt_keystone', 1);
+
+    sim.pickUpObject(ritual.id);
+    expect([...sim.entities.values()].some((e) => e.templateId === 'bound_guardian' && !e.dead)).toBe(false);
+  });
+
   it('shares Nythraxis ritual circle progress with nearby party members', () => {
     const sim = makeSim();
     const allyPid = sim.addPlayer('mage', 'Ally');


### PR DESCRIPTION
## Problem

A player on **The Bound Guardian** (`q_nythraxis_bound_guardian`) reported killing the guardian in a party but getting **no kill credit, no King's Signet, and no way to re-summon** it.

Root cause: the guardian's summon was wedged inside the crypt **ritual circle's interact-objective early-out** in `interactObjectForQuests`:

```ts
if (qp.counts[objectiveIndex] >= objective.count) return; // also blocked the summon
...
if (obj.objectItemId === 'crypt_ritual_circle') this.summonQuestMob('bound_guardian', ...);
```

That gate correctly makes the **interact** objective one-shot, but it also governed the boss spawn as a side effect. Once the circle was used once, the objective locked. If the guardian was then lost **without** being killed, the player was permanently stranded:

- The guardian leashes and **idle-despawns after 60s out of combat** (`DAMAGE_IDLE_DESPAWN_MOB_IDS`), e.g. on a party wipe or by stepping out of its aggro radius.
- After that, the **kill** and **collect** objectives were unreachable, the **King's Signet** never dropped, and re-using the circle did nothing, with the **Crypt Keystone** still in the bag.

This matches all three reported symptoms: "didn't count", "didn't give signet loot", and "couldn't re-summon".

## Fix

Decouple the (re)summon from the interact credit. The ritual circle now re-summons the guardian **whenever the player still owes the kill**, keeping the one-time interact credit and its vision gated as before:

- `summonQuestMob` already no-ops while a guardian is alive nearby, so this **cannot stack bosses**.
- The summon **stops once the kill objective is credited**, so a defeated guardian is never re-spawned.
- The Crypt Keystone is retained (it was never consumed), so the retry just works.

Pure `src/sim/` change: no new strings, no balance numbers, deterministic.

## Tests (test-first)

`tests/fixes.test.ts`:
- Reproduces the stuck state (summon -> idle-despawn unkilled -> re-interact) and asserts a **fresh guardian is summoned** while the interact count (`1`) and keystone (`1`) are retained.
- Guard: **no** guardian is summoned once the kill objective is already credited.

```
Test Files  6 passed (6)
Tests  189 passed (189)
```
(`fixes`, `architecture`, `nythraxis_final_quest`, `nythraxis_raid`, `quest_fallback`, `social`)

## Screenshots (offline client, `?gfx=ultra`)

Re-summoned guardian after an unkilled despawn, driven by `scripts/bound_guardian_resummon_shot.mjs`
(`goneAfterDespawn: true, resummoned: true, interactCount: 1, keystone: 1`):

![Re-summoned Bound Guardian](https://github.com/jgyy/world-of-claudecraft/raw/pr-assets-bound-guardian-resummon/bound_guardian_resummon_full.png)

![Boss target frame](https://github.com/jgyy/world-of-claudecraft/raw/pr-assets-bound-guardian-resummon/bound_guardian_resummon_targetframe.png)

cc @Rubsey @FernandoX7 @TrevCavill @CharlieSaxton @patrick261 @sf-chris @maxpolaczuk for review (maintainers with merge access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
