### PR TITLE
fix(server): surface every kick to the client so a kicked player can rejoin

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -580,7 +580,7 @@ export class GameServer {
     for (const session of this.clients.values()) {
       const action = this.botDetector.handleTick(session.botTrackingContext, now, ANTIBOT_ENFORCE);
       if (action === 'kick') {
-        void this.leave(session, 'disconnected');
+        void this.kickSession(session, 'rejected by server', 'disconnected');
       }
     }
   }
@@ -803,6 +803,20 @@ export class GameServer {
       .catch((err) => console.error('presence announce failed:', err));
   }
 
+  // Tear down a live session as a kick: tell the client why, close the socket,
+  // then run the normal leave() cleanup. Sending the error frame and closing the
+  // socket (not just calling leave) is what lets net/online.ts surface the
+  // disconnect and return the app to character select, so a kicked player can
+  // rejoin. Every forced-disconnect path (moderation, IP block, character
+  // takeover, and the anti-bot tick) funnels through here so none can
+  // half-tear-down a session, leaving the world without the client and wedging
+  // the player "connected" with no way back in.
+  private kickSession(session: ClientSession, clientError: string, leaveReason: string): Promise<void> {
+    this.send(session, { t: 'error', error: clientError });
+    try { session.ws.close(); } catch { /* connection already closing */ }
+    return this.leave(session, leaveReason);
+  }
+
   async leave(session: ClientSession, reason: string): Promise<void> {
     if (session.left || !this.clients.has(session.pid)) return;
     session.left = true;
@@ -997,9 +1011,7 @@ export class GameServer {
   disconnectAccount(accountId: number, reason: string): void {
     for (const session of [...this.clients.values()]) {
       if (session.accountId !== accountId) continue;
-      this.send(session, { t: 'error', error: reason });
-      try { session.ws.close(); } catch { /* connection already closing */ }
-      void this.leave(session, 'moderation action');
+      void this.kickSession(session, reason, 'moderation action');
     }
   }
 
@@ -1014,9 +1026,7 @@ export class GameServer {
     // Ownership is also enforced at the REST layer; re-check here so this method
     // can never disconnect a session that belongs to another account.
     if (!session || session.accountId !== accountId) return 'not-online';
-    this.send(session, { t: 'error', error: 'character taken over' });
-    try { session.ws.close(); } catch { /* connection already closing */ }
-    await this.leave(session, 'character taken over');
+    await this.kickSession(session, 'character taken over', 'character taken over');
     return 'taken-over';
   }
 
@@ -1117,9 +1127,7 @@ export class GameServer {
   disconnectByIp(ip: string, reason: string): void {
     for (const session of [...this.clients.values()]) {
       if (session.ip !== ip || session.isAdmin) continue;
-      this.send(session, { t: 'error', error: reason });
-      try { session.ws.close(); } catch { /* connection already closing */ }
-      void this.leave(session, 'moderation action');
+      void this.kickSession(session, reason, 'moderation action');
     }
   }
 
@@ -1127,9 +1135,7 @@ export class GameServer {
     const now = Date.now();
     for (const session of [...this.clients.values()]) {
       if (session.isAdmin || !this.ipBlockList.isBlocked(session.ip, now)) continue;
-      this.send(session, { t: 'error', error: reason });
-      try { session.ws.close(); } catch { /* connection already closing */ }
-      void this.leave(session, 'moderation action');
+      void this.kickSession(session, reason, 'moderation action');
     }
   }
 

--- a/tests/game_sessions.test.ts
+++ b/tests/game_sessions.test.ts
@@ -385,4 +385,36 @@ describe('GameServer sessions', () => {
     expect(await server.takeOverCharacter(81, 800)).toBe('not-online');
     expect(ws.close).not.toHaveBeenCalled();
   });
+
+  it('an anti-bot kick notifies the client and closes the socket so the player can rejoin', async () => {
+    // Regression: the anti-bot kick used to call leave() WITHOUT sending an error
+    // frame or closing the socket (unlike disconnectAccount/takeOverCharacter).
+    // The character was removed from the world but the client stayed wedged
+    // "connected" — no onclose/error fired, so the app never returned to
+    // character select and the player could not rejoin.
+    vi.mocked(saveCharacterState).mockResolvedValue(undefined);
+    const server = new GameServer();
+    const ws = fakeWs();
+    expectJoined(server.join(ws, 90, 900, 'Imdutha', 'warrior', null));
+
+    // Force the bot detector to kick on the next anti-bot tick.
+    (server as any).botDetector = {
+      ...(server as any).botDetector,
+      handleTick: () => 'kick',
+      releaseTrackingContext: () => {},
+    };
+    (server as any).runAntibotTick();
+    await vi.waitFor(() => {
+      expect((server as any).sessionByCharacterId(900)).toBeNull();
+    });
+
+    // The client is told why and the socket is torn down (mirrors the other
+    // kick paths), so net/online.ts surfaces the disconnect and the app can
+    // return to character select.
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ t: 'error', error: 'rejected by server' }));
+    expect(ws.close).toHaveBeenCalled();
+
+    // The character slot is freed: the same character can enter the world again.
+    expectJoined(server.join(fakeWs(), 90, 900, 'Imdutha', 'warrior', null));
+  });
 });


### PR DESCRIPTION
## The bug

Reported in-game: a player ("imdutha") was kicked while playing and then **could not rejoin** the world.

## Root cause

The anti-bot kick in `runAntibotTick` (server/game.ts) tore down the server-side session via `leave(session)` **without** sending a `{t:'error'}` frame or closing the WebSocket. The other four forced-disconnect paths (`disconnectAccount`, `takeOverCharacter`, `disconnectByIp`, `disconnectBlockedSessions`) all do error-frame then `ws.close()` then `leave()`; the anti-bot path was the odd one out.

Result: the server removed the player from the world, but the socket stayed open and the client was never told. `src/net/online.ts` stayed wedged `connected = true` (no `onclose`, no `error` frame), so the app never returned to character select and the player could not get back in. Their character was already gone from the world while a dead session lingered.

## The fix

Extract a single `kickSession(session, clientError, leaveReason)` helper (send error frame -> `ws.close()` -> `leave()`) and funnel **all five** forced-disconnect sites through it, so none can half-tear-down a session. The anti-bot path now sends the already-localized `'rejected by server'` message (mapped to `loading.connectionRejected` in `main.ts`), matching the existing kick paths, so **no new i18n key** is added. `leave()` remains idempotent (the `session.left` guard), so the socket close also triggering the `ws.on('close')` handler is a safe no-op.

## Tests

Test-first. New regression test in `tests/game_sessions.test.ts` drives `runAntibotTick` with a kicking bot detector and asserts the client receives the error frame, the socket is closed, the character slot is freed, and the same character can enter the world again. `npx tsc --noEmit`, the S3 i18n guard (`localization_fixes`), and `admin`/`security`/`snapshots`/`game_sessions` suites all pass.

## Visual proof (gfx=ultra)

The anti-bot detector is a private module (a no-op stub in this OSS tree) so it cannot be triggered directly; the capture exercises the **same `kickSession` helper** through the reachable takeover path. Before the fix, an anti-bot kick produced **no overlay at all** (silent wedge); after the fix, every kick path surfaces the disconnect and the player can return to login and rejoin.

In-world at max graphics (the session that gets kicked):

![in world](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-kick-rejoin/kick-rejoin-1-inworld.png)

The client now surfaces the disconnect (the fix) with a Return to Login path, instead of staying wedged "connected":

![disconnect overlay](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-kick-rejoin/kick-rejoin-2-disconnected.png)

## Scope

Pure server-side change (server/game.ts) plus its test. No wire-protocol change, no client change, no new i18n key, no schema change. Behavior of the four already-working kick paths is byte-identical (same send -> close -> leave sequence, now shared).

cc maintainers with merge access for review: @FernandoX7 @Rubsey @TrevCavill @patrick261