### PR TITLE
fix(ui): stop raid arena label overlapping the dungeon name on the world map

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -48,6 +48,7 @@ import { sfx } from '../game/sfx';
 import { voice } from '../game/voice';
 import { music, musicZoneForLocation, shouldResetMusicForDungeonEntry } from '../game/music';
 import { iconDataUrl, QUALITY_COLOR, raidMarkerDataUrl, RAID_MARKER_NAMES } from './icons';
+import { overworldDungeonPortals } from './map_dungeon_portals';
 import { UnitPortraitPainter } from './unit_portrait_painter';
 import { crestIdForEntity } from './unit_portrait';
 import { svgIcon } from './ui_icons';
@@ -3802,10 +3803,11 @@ export class Hud {
       ctx.fillText(text, mx, my);
     };
     zone.pois.forEach((poi, poiIndex) => label(poi.x, poi.z, zonePoiLabel(zone.id, poiIndex)));
-    // dungeon entrance portals in this zone
-    for (const dungeon of DUNGEON_LIST) {
-      if (dungeon.doorPos.z < zone.zMin || dungeon.doorPos.z >= zone.zMax) continue;
-      const { mx, my } = toMap(dungeon.doorPos.x, dungeon.doorPos.z);
+    // dungeon entrance portals in this zone (raids reached only through an
+    // internal door share their parent's doorPos and carry no overworld portal,
+    // so their label does not overlap the parent's, see overworldDungeonPortals)
+    for (const portal of overworldDungeonPortals(DUNGEON_LIST, zone.zMin, zone.zMax)) {
+      const { mx, my } = toMap(portal.x, portal.z);
       ctx.fillStyle = '#c084ff';
       ctx.beginPath();
       ctx.arc(mx, my, 5, 0, Math.PI * 2);
@@ -3813,7 +3815,7 @@ export class Hud {
       ctx.stroke();
       ctx.fillStyle = '#e0c0ff';
       ctx.font = 'bold 12px Georgia';
-      const dungeonName = dungeonDisplayName(dungeon.id);
+      const dungeonName = dungeonDisplayName(portal.id);
       ctx.strokeText(dungeonName, mx, my - 9);
       ctx.fillText(dungeonName, mx, my - 9);
       ctx.font = 'bold 13px Georgia';

--- a/src/ui/map_dungeon_portals.ts
+++ b/src/ui/map_dungeon_portals.ts
@@ -1,0 +1,32 @@
+// Which dungeons get an overworld portal dot + label on the world map, for a
+// given zone band. Pure data logic, no DOM: the HUD map loop is the thin consumer.
+//
+// This mirrors the door-spawn rule in sim.ts (a dungeon with overworldDoor ===
+// false has no physical overworld entrance, so it must not appear as an overworld
+// map portal either). Without this filter, dungeons that deliberately share a
+// doorPos with their parent (the Nythraxis raid arena reuses the Abandoned Crypt
+// door, since it is reached through a sealed door inside the crypt) stamp a second
+// label at the identical map point, so the dungeon and raid names overlap.
+import type { DungeonDef } from '../sim/types';
+
+export interface MapDungeonPortal {
+  id: string;
+  x: number;
+  z: number;
+}
+
+// Portals to draw for the zone whose band is [zMin, zMax). Matches the map loop's
+// own bounds test (door z in [zMin, zMax)).
+export function overworldDungeonPortals(
+  dungeons: readonly DungeonDef[],
+  zMin: number,
+  zMax: number,
+): MapDungeonPortal[] {
+  const portals: MapDungeonPortal[] = [];
+  for (const d of dungeons) {
+    if (d.overworldDoor === false) continue;
+    if (d.doorPos.z < zMin || d.doorPos.z >= zMax) continue;
+    portals.push({ id: d.id, x: d.doorPos.x, z: d.doorPos.z });
+  }
+  return portals;
+}

--- a/tests/map_dungeon_portals.test.ts
+++ b/tests/map_dungeon_portals.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { overworldDungeonPortals } from '../src/ui/map_dungeon_portals';
+import { DUNGEON_LIST } from '../src/sim/data';
+import type { DungeonDef } from '../src/sim/types';
+
+// A dungeon-shaped fixture; only the fields the portal filter reads matter.
+const def = (over: Partial<DungeonDef>): DungeonDef => ({
+  id: 'x', name: 'X', index: 0, doorPos: { x: 0, z: 0 },
+  entry: { x: 0, z: 0 }, exitOffset: { x: 0, z: 0 }, spawns: [],
+  interior: 'crypt', suggestedPlayers: 5, enterText: '', leaveText: '',
+  ...over,
+});
+
+describe('overworldDungeonPortals', () => {
+  it('includes a normal dungeon whose door is inside the zone band', () => {
+    const dungeons = [def({ id: 'crypt', doorPos: { x: 10, z: 50 } })];
+    const portals = overworldDungeonPortals(dungeons, 0, 100);
+    expect(portals).toEqual([{ id: 'crypt', x: 10, z: 50 }]);
+  });
+
+  it('excludes dungeons reachable only through an internal door (overworldDoor === false)', () => {
+    const dungeons = [
+      def({ id: 'crypt', doorPos: { x: -152, z: 610 } }),
+      def({ id: 'raid', doorPos: { x: -152, z: 610 }, overworldDoor: false }),
+    ];
+    const portals = overworldDungeonPortals(dungeons, 600, 700);
+    expect(portals).toEqual([{ id: 'crypt', x: -152, z: 610 }]);
+  });
+
+  it('clips to the [zMin, zMax) band like the map loop does', () => {
+    const dungeons = [
+      def({ id: 'below', doorPos: { x: 0, z: 599 } }),
+      def({ id: 'lo', doorPos: { x: 0, z: 600 } }),
+      def({ id: 'hi', doorPos: { x: 0, z: 699 } }),
+      def({ id: 'atMax', doorPos: { x: 0, z: 700 } }),
+    ];
+    expect(overworldDungeonPortals(dungeons, 600, 700).map((p) => p.id)).toEqual(['lo', 'hi']);
+  });
+
+  it('never returns two real dungeon portals at the same map position (no name collision)', () => {
+    // Across the whole zone span, every visible portal must sit at a distinct
+    // (x,z): two labels at one point are exactly the overlap bug.
+    const portals = overworldDungeonPortals(DUNGEON_LIST, -100000, 100000);
+    const seen = new Set<string>();
+    for (const p of portals) {
+      const key = `${p.x},${p.z}`;
+      expect(seen.has(key), `duplicate portal at ${key}`).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it('drops the Nythraxis raid arena (shares the Abandoned Crypt door) from real content', () => {
+    const ids = overworldDungeonPortals(DUNGEON_LIST, -100000, 100000).map((p) => p.id);
+    expect(ids).toContain('nythraxis_crypt');
+    expect(ids).not.toContain('nythraxis_boss_arena');
+  });
+});


### PR DESCRIPTION
## Problem

On the world map, the **dungeon name and the raid name overlap each other** in Thornpeak Heights. The Nythraxis raid arena label is stamped directly on top of the Abandoned Crypt label at the same portal dot, so the two read as one garbled string.

### Root cause

`nythraxis_boss_arena` (the raid) deliberately shares its `doorPos` with `nythraxis_crypt` (`{ x: -152, z: 610 }`): the raid is reached through a sealed door **inside** the crypt, not from the overworld. That is why the raid carries `overworldDoor: false` and `sim.ts` spawns no physical door for it.

The world-map portal loop in `hud.ts`, however, drew a label for **every** dungeon in `DUNGEON_LIST` at its `doorPos`, with no `overworldDoor` check, so both names landed on the same pixel.

## Fix

Mirror the door-spawn rule already in `sim.ts`: a dungeon with `overworldDoor === false` has no overworld entrance, so it gets no overworld map portal either. The decision is extracted into a small, pure, unit-tested module (`src/ui/map_dungeon_portals.ts`, `overworldDungeonPortals()`), and the HUD map loop becomes a thin consumer (pure-core + thin-consumer, per the repo's modularity guidance).

This keeps the map honest with the world: no door in 3D, no portal on the map.

## Before / After (world map, `?gfx=ultra`)

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-dungeon-raid-map-label/map-before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-dungeon-raid-map-label/map-after.png) |

The raid arena no longer paints a second label over the crypt; only "Abandoned Crypt" remains.

## Tests

- New `tests/map_dungeon_portals.test.ts`: band clipping, `overworldDoor: false` exclusion, a no-two-portals-share-a-position invariant, and an assertion against real `DUNGEON_LIST` data that `nythraxis_boss_arena` is dropped while `nythraxis_crypt` stays. Verified the suite fails on the pre-fix behavior and passes with the fix.
- `npx tsc --noEmit` clean; `tests/architecture.test.ts` green.

Pure UI/data change: no sim behavior, wire protocol, or i18n keys touched (reuses the existing `dungeonDisplayName`).

cc @Rubsey @FernandoX7 @patrick261 @TrevCavill @CharlieSaxton @sf-chris @maxpolaczuk for review / push access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
