### PR TITLE
fix(ui): give every stat-buff aura kind a deliberate buff-bar icon

### DIFF
--- a/scripts/aura_icons_grid_shot.mjs
+++ b/scripts/aura_icons_grid_shot.mjs
@@ -1,0 +1,78 @@
+// Screenshot harness for the buff-bar aura icons. Renders every generic
+// `aura_<kind>` recipe (the icon a buff shows when it is applied with a NON-ability
+// id: an elixir, scroll, Fiesta power-up, or a mob stat-drain) in a labeled grid,
+// with the four kinds that previously fell back to the meaningless abilityFallback
+// medallion (buff_agi, buff_spi, buff_scale, buff_jump) marked NEW.
+//
+// Pure-icon render, no game boot needed. Needs `npm run dev` on :5173 (override with
+// GAME_URL). ?gfx=ultra requested for parity with "max graphics" capture sessions.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--window-size=1100,720', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1100, height: 720, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await sleep(600);
+
+// The buff-bar kinds players can see, in buff-bar order. `new: true` marks the
+// kinds this change added a deliberate recipe for.
+const KINDS = [
+  { kind: 'buff_ap', label: 'Attack Power' }, { kind: 'buff_sta', label: 'Stamina' },
+  { kind: 'buff_int', label: 'Intellect' }, { kind: 'buff_agi', label: 'Agility', new: true },
+  { kind: 'buff_spi', label: 'Spirit', new: true }, { kind: 'buff_armor', label: 'Armor' },
+  { kind: 'buff_dodge', label: 'Dodge' }, { kind: 'buff_speed', label: 'Speed' },
+  { kind: 'buff_haste', label: 'Haste' }, { kind: 'buff_allstats', label: 'All Stats' },
+  { kind: 'buff_scale', label: 'Empowered (size)', new: true },
+  { kind: 'buff_jump', label: 'Leap (jump)', new: true },
+  { kind: 'thorns', label: 'Thorns' }, { kind: 'absorb', label: 'Absorb' },
+  { kind: 'imbue', label: 'Weapon Imbue' }, { kind: 'hot', label: 'Heal over Time' },
+  { kind: 'form_bear', label: 'Bear Form' },
+];
+
+await page.evaluate(async (kinds) => {
+  const { iconDataUrl } = await import('/src/ui/icons.ts');
+  document.body.style.margin = '0';
+  const root = document.createElement('div');
+  root.style.cssText =
+    'background:#15110c;color:#e9dcc0;font:14px system-ui;padding:28px;min-height:100vh;' +
+    'background-image:radial-gradient(circle at 30% 0%,#241a10,#0d0a06);';
+  document.body.innerHTML = '';
+  document.body.appendChild(root);
+  const title = document.createElement('h1');
+  title.textContent = 'Buff-bar aura icons: every stat-buff kind now ships a deliberate icon';
+  title.style.cssText = 'font:700 22px Georgia,serif;color:#d4af37;margin:0 0 18px';
+  root.appendChild(title);
+  const grid = document.createElement('div');
+  grid.style.cssText = 'display:flex;flex-wrap:wrap;gap:14px';
+  root.appendChild(grid);
+  for (const k of kinds) {
+    const cell = document.createElement('div');
+    cell.style.cssText = 'width:120px;text-align:center';
+    const img = document.createElement('img');
+    img.src = iconDataUrl('aura', 'aura_' + k.kind, 80);
+    img.style.cssText = 'width:64px;height:64px;border-radius:8px;' +
+      (k.new ? 'box-shadow:0 0 0 3px #d4af37' : '');
+    cell.appendChild(img);
+    const label = document.createElement('div');
+    label.textContent = k.label + (k.new ? ' (new)' : '');
+    label.style.cssText = 'font-size:11px;margin-top:6px;color:' + (k.new ? '#f0d98c' : '#b8a988');
+    cell.appendChild(label);
+    grid.appendChild(cell);
+  }
+}, KINDS);
+
+await sleep(400);
+await page.screenshot({ path: 'tmp/aura_icons_grid.png', fullPage: true });
+console.log('wrote tmp/aura_icons_grid.png');
+await browser.close();

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -1361,16 +1361,29 @@ const AURA_RECIPES: Record<string, IconRecipe> = {
   aura_buff_ap: r('fury', 'gold', ['fist']),
   aura_buff_armor: r('steel', 'steel', ['shield']),
   aura_buff_int: r('arcane', 'arcanePink', ['eye']),
+  // Agility (Elixir/Scroll of Agility, and the mob Withering drain that rides
+  // buff_agi): a green wing in motion reads as quickness, distinct from the
+  // boot of buff_speed and the brown paw of form_bear.
+  aura_buff_agi: r('nature', 'leafGreen', ['wing'], ['motion']),
   aura_buff_dodge: r('storm', 'sky', ['shield'], ['motion']),
   aura_buff_speed: r('earth', 'leather', ['boot'], ['motion']),
   aura_buff_haste: r('storm', 'sky', ['lightning']),
   aura_absorb: r('holy', 'silverWhite', ['shield'], ['glow']),
   aura_imbue: r('holy', 'holyGold', ['sword', { p: 'sunburst', ...TL }]),
   aura_buff_allstats: r('arcane', 'arcanePink', ['gem']),
+  // Spirit (Elixir/Scroll of Spirit, and the mob Spirit Siphon drain that rides
+  // buff_spi): a luminous droplet for restorative regen, distinct from the heart
+  // of buff_sta and the eye of buff_int.
+  aura_buff_spi: r('holy', 'silverWhite', ['droplet'], ['glow']),
   aura_thorns: r('nature', 'leafGreen', ['leaf', { p: 'claw_slash', ...BR }]),
   aura_cost_tax: r('shadow', 'shadowPurple', ['gem', { p: 'droplet', ...BR }], ['drips']),
   aura_heal_absorb: r('shadow', 'shadowPurple', ['heart'], ['drips']),
   aura_form_bear: r('earth', 'earthBrown', ['paw']),
+  // 2v2 Fiesta power-ups (applied with non-ability ids, so they hit this generic
+  // path): buff_scale enlarges the body (a fiery roar = grow/empower), buff_jump
+  // raises jump height (a winged boot = leap).
+  aura_buff_scale: r('fury', 'ember', ['roar']),
+  aura_buff_jump: r('storm', 'sky', ['wing', { p: 'boot', ...BR }]),
 };
 
 // Crests: class / mob-family / status glyphs, painted with the same primitive
@@ -1830,6 +1843,13 @@ export function abilityIconRecipe(id: string): IconRecipe {
 }
 export function hasExplicitAbilityIcon(id: string): boolean {
   return id in ABILITY_RECIPES;
+}
+// True when a buff/debuff KIND (e.g. 'buff_agi') has a deliberate generic recipe in
+// AURA_RECIPES, used for auras applied with a non-ability id (elixirs, scrolls, Fiesta
+// power-ups, mob stat drains). Without one the buff bar shows the arbitrary
+// abilityFallback medallion. Guarded by tests/aura_icons.test.ts.
+export function hasExplicitAuraIcon(kind: string): boolean {
+  return `aura_${kind}` in AURA_RECIPES;
 }
 
 const DEFAULT_ICON_SIZE = 96; // crisp at 46px buttons on 2x displays

--- a/tests/aura_icons.test.ts
+++ b/tests/aura_icons.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { ABILITIES } from '../src/sim/data';
-import { iconDataUrl } from '../src/ui/icons';
+import { iconDataUrl, hasExplicitAuraIcon } from '../src/ui/icons';
 
 // Buff/debuff aura frames (the player buff bar and a mob's DoT debuffs, both via
 // Hud.renderAuras) request their icon with kind 'aura'. When the aura carries a
@@ -42,6 +42,31 @@ describe('aura icons reuse image-based ability art', () => {
       expect(iconDataUrl('aura', id), `aura ${id}`).toBe(expected);
       // and it matches what the action bar shows for the same ability
       expect(iconDataUrl('aura', id)).toBe(iconDataUrl('ability', id));
+    }
+  });
+});
+
+// Most active buffs come from a class ability and reuse that ability's art (above).
+// But a buff can also be applied with an id that is NOT an ability: an elixir
+// (`elixir_<itemId>`), a scroll, a Fiesta power-up, or a stat drain from a mob. For
+// those, Hud.renderAuras falls back to a generic `aura_<kind>` recipe (see the
+// `ABILITIES[a.id] ? a.id : `aura_${a.kind}`` gate). If a buff_* kind has no entry
+// in AURA_RECIPES it renders an arbitrary, meaningless medallion (the `abilityFallback`
+// icon) — the "old skill icon" players see on the buff bar. Every stat-buff kind must
+// therefore ship a deliberate aura recipe. Mirror of the AuraKind `buff_*` members in
+// src/sim/types.ts: add a kind there ⇒ add its recipe + this entry in the same change.
+const BUFF_AURA_KINDS = [
+  'buff_ap', 'buff_armor', 'buff_int', 'buff_agi', 'buff_dodge', 'buff_speed',
+  'buff_haste', 'buff_sta', 'buff_allstats', 'buff_spi', 'buff_scale', 'buff_jump',
+] as const;
+
+describe('every stat-buff aura kind has a deliberate buff-bar icon', () => {
+  it('no buff_* kind falls back to the generic medallion', () => {
+    for (const kind of BUFF_AURA_KINDS) {
+      expect(
+        hasExplicitAuraIcon(kind),
+        `aura_${kind} needs a deliberate AURA_RECIPES entry (currently renders the generic fallback)`,
+      ).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Active buffs were showing old, generic "skill" icons

The active-buffs bar resolves each buff's icon by **ability id** when the aura was applied by a class ability, and otherwise by a generic `aura_<kind>` recipe:

```ts
// src/ui/hud.ts (renderAuras)
iconDataUrl('aura', ABILITIES[a.id] ? a.id : `aura_${a.kind}`)
```

Four buff **kinds** had no `AURA_RECIPES` entry, so any buff applied with a **non-ability id** fell through to `abilityFallback`, which hashes the id string into an arbitrary, meaningless medallion. That placeholder is the "old skill icon" players see on the buff bar. Affected kinds and where they come from:

| Kind | Source (non-ability id) |
|---|---|
| `buff_agi` | Elixir / Scroll of Agility (and the mob Withering drain) |
| `buff_spi` | Elixir / Scroll of Spirit (and the mob Spirit Siphon drain) |
| `buff_scale` | 2v2 Fiesta power-up (`powerup_<id>_<kind>` aura) |
| `buff_jump` | 2v2 Fiesta power-up |

Buffs applied by a class ability were already fine: every one of the 152 class abilities ships PNG skill art, and the aura reuses it. The gap was only these non-ability buffs.

## Fix

Add a deliberate, distinct recipe for each of the four kinds, drawn from the **existing** icon primitive vocabulary (no new painters):

- `buff_agi` -> a green wing in motion (quickness)
- `buff_spi` -> a luminous droplet (restorative regen)
- `buff_scale` -> a fiery roar (grow / empower)
- `buff_jump` -> a winged boot (leap)

Each is visually distinct from the existing stat-buff icons (`buff_speed`'s boot, `form_bear`'s paw, `buff_sta`'s heart, `buff_int`'s eye).

To keep this from regressing, `hasExplicitAuraIcon(kind)` is exported and `tests/aura_icons.test.ts` now asserts **every** `buff_*` `AuraKind` ships a deliberate recipe, so a newly added buff kind can no longer silently render the fallback medallion.

`scripts/aura_icons_grid_shot.mjs` is the before/after screenshot harness (mirrors the existing `ability_icons_grid_shot.mjs`).

### Screenshot (max graphics, `?gfx=ultra`)

The four newly fixed kinds are ringed in gold:

![buff-bar aura icons](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-buff-aura-icons/aura_icons_grid.png)

## On the character login/select description

I also investigated the char-select "class description" signature-ability icons. Those already resolve their shipped PNG art correctly for all 9 classes (verified `SIGNATURE_ABILITIES` membership in `ABILITY_IMAGE_IDS` and rendered them), so no change was needed there. Happy to dig further if you've seen a specific class showing a wrong icon there.

## Testing
- `npx vitest run tests/aura_icons.test.ts tests/ability_icons.test.ts` (10 passed)
- `npx tsc --noEmit` clean
- Determinism / `src/sim` untouched; no new player-visible strings, so no i18n changes.

cc @Rubsey @FernandoX7 @TrevCavill @CharlieSaxton @patrick261 @sf-chris @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
