### PR TITLE
fix(ui): keep perf frame-time graph from sticking at the expanded width

### DIFF
--- a/index.html
+++ b/index.html
@@ -2069,7 +2069,13 @@
   #perf-overlay .perf-row[data-sev="good"] .perf-value { color: #76e08a; }
   #perf-overlay .perf-row[data-sev="warn"] .perf-value { color: #ffcf5a; }
   #perf-overlay .perf-row[data-sev="bad"]  .perf-value { color: #ff6f63; }
-  #perf-overlay .perf-graph { display: none; width: 100%; height: 26px; margin-top: 4px; }
+  /* The graph wrapper reserves the sparkline's height but contributes nothing to
+     the panel's intrinsic width, so the absolutely-positioned canvas (whose large
+     HiDPI backing-store width is its intrinsic width) can never prop the
+     shrink-wrapped panel open and leave the graph stuck at a wider metric set's
+     width when the user switches back to a smaller one. */
+  #perf-overlay .perf-graph-wrap { display: none; position: relative; width: 100%; height: 26px; margin-top: 4px; }
+  #perf-overlay .perf-graph { position: absolute; inset: 0; display: block; width: 100%; height: 100%; }
   #perf-overlay .perf-badges { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 4px; }
   #perf-overlay .perf-badges:empty { display: none; margin: 0; }
   #perf-overlay .perf-badge { font-size: calc(9.5px * var(--perf-scale)); font-variant: small-caps; letter-spacing: 0.4px;

--- a/scripts/perf_graph_reset_shot.mjs
+++ b/scripts/perf_graph_reset_shot.mjs
@@ -1,0 +1,96 @@
+// Before/after visual proof for the perf frame-time graph reset fix.
+//
+// Boots the offline game at max graphics (?gfx=ultra) in headless Chromium,
+// enables the performance overlay with EVERY metric + the sparkline (the wide
+// "expanded" view), shoots it, then switches the metric set back to Minimal
+// (FPS only) and shoots again. Before the fix the graph stayed pinned at the
+// expanded width; after the fix it shrinks with the panel. Crops land in tmp/.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH as EDGE } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+
+const ALL_METRICS = {
+  fps: true, frameTime: true, fps1Low: true, fps01Low: true, hitches: true,
+  ping: true, jitter: true, snapshot: true, connection: true,
+  drawCalls: true, triangles: true, geometries: true, textures: true,
+  programs: true, renderScale: true, gpu: true, memory: true, entities: true,
+};
+const MINIMAL_METRICS = Object.fromEntries(Object.keys(ALL_METRICS).map((k) => [k, k === 'fps']));
+
+const browser = await puppeteer.launch({
+  executablePath: EDGE,
+  headless: 'new',
+  args: ['--window-size=1600,1000', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 1000 },
+});
+const page = await browser.newPage();
+const errors = [];
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message));
+page.on('console', (msg) => { if (msg.type() === 'error') errors.push('CONSOLE: ' + msg.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 30000 });
+await page.waitForSelector('#btn-offline', { timeout: 15000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await new Promise((r) => setTimeout(r, 250));
+await page.type('#char-name', 'Adventurer');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game && window.__game.hud && window.__game.hud.optionsHooks, { timeout: 30000 });
+await new Promise((r) => setTimeout(r, 1500));
+
+const overlayBox = () => page.evaluate(() => {
+  const el = document.querySelector('#perf-overlay');
+  const r = el.getBoundingClientRect();
+  const c = el.querySelector('.perf-graph');
+  const cr = c ? c.getBoundingClientRect() : null;
+  return {
+    panelW: Math.round(r.width),
+    graphW: cr ? Math.round(cr.width) : 0,
+    graphCssW: c ? c.style.width : '',
+    x: r.x, y: r.y, width: r.width, height: r.height,
+  };
+});
+
+async function shoot(name) {
+  const box = await overlayBox();
+  await page.screenshot({
+    path: `tmp/${name}.png`,
+    clip: { x: Math.max(0, box.x - 8), y: Math.max(0, box.y - 8), width: box.width + 16, height: box.height + 16 },
+  });
+  console.log(`${name}:`, JSON.stringify({ panelW: box.panelW, graphW: box.graphW, graphCssW: box.graphCssW }));
+  return box;
+}
+
+// 1) Everything + graph: the wide, expanded overlay.
+await page.evaluate((metrics) => {
+  const h = window.__game.hud.optionsHooks;
+  h.onSettingChange('showFps', true);
+  h.perfOverlay.patch({ graph: true, thresholds: true, metrics });
+}, ALL_METRICS);
+await new Promise((r) => setTimeout(r, 2800));
+const everything = await shoot('perf_graph_everything');
+
+// 2) Switch the metric set back to Minimal (FPS only). The graph must shrink with
+//    the panel rather than staying stuck at the expanded width.
+await page.evaluate((metrics) => {
+  window.__game.hud.optionsHooks.perfOverlay.patch({ metrics });
+}, MINIMAL_METRICS);
+// Wait for the overlay to re-render down to the single FPS row + settle.
+await page.waitForFunction(
+  () => document.querySelectorAll('#perf-overlay .perf-row').length <= 1,
+  { timeout: 8000 },
+);
+await new Promise((r) => setTimeout(r, 800));
+const minimal = await shoot('perf_graph_minimal');
+
+const shrank = minimal.graphW < everything.graphW - 20;
+const pinned = /px$/.test(minimal.graphCssW);
+console.log(`graph shrank on Minimal: ${shrank} (everything=${everything.graphW}px -> minimal=${minimal.graphW}px)`);
+console.log(`canvas pins an absolute px width: ${pinned} (style.width="${minimal.graphCssW}")`);
+console.log(errors.length ? 'ERRORS:\n' + errors.join('\n') : 'no page errors');
+
+await browser.close();
+if (!shrank || pinned) process.exit(1);

--- a/src/ui/perf_graph_painter.ts
+++ b/src/ui/perf_graph_painter.ts
@@ -24,6 +24,28 @@ export interface FrameGraphGeometry {
 /** Wild stalls are clamped so normal variance stays legible. */
 export const MAX_VISIBLE_MS = 100;
 
+export interface FrameGraphCanvasMetrics {
+  /** HiDPI backing-store dimensions (device pixels) for `canvas.width/height`. */
+  pxW: number;
+  pxH: number;
+  /** Device-pixel-ratio actually used (clamped to 2 to bound memory). */
+  dpr: number;
+}
+
+/** Device-pixel backing-store size for a measured CSS width/height. The canvas's
+ *  *display* width is deliberately left to CSS (`width:100%`) so it follows its
+ *  panel rather than pinning it: writing an absolute px display width once caused
+ *  the sparkline to prop the shrink-wrapped overlay open, leaving the graph stuck
+ *  at the expanded width when metrics were removed. Pure: no canvas, no DOM. */
+export function frameGraphCanvasMetrics(cssW: number, cssH: number, devicePixelRatio: number): FrameGraphCanvasMetrics {
+  const dpr = Math.min(2, devicePixelRatio > 0 ? devicePixelRatio : 1);
+  return {
+    pxW: Math.max(1, Math.round(cssW * dpr)),
+    pxH: Math.max(1, Math.round(cssH * dpr)),
+    dpr,
+  };
+}
+
 /** Map frame-time samples (ms, oldest->newest) to sparkline coordinates. The
  *  vertical range auto-scales from 2x target up to the worst sample, capped at
  *  MAX_VISIBLE_MS. Pure: no canvas, no DOM. */

--- a/src/ui/perf_overlay.ts
+++ b/src/ui/perf_overlay.ts
@@ -10,7 +10,7 @@
 
 import { formatNumber, t } from './i18n';
 import type { PerfOverlayConfig } from './perf_overlay_config';
-import { paintFrameTimeGraph } from './perf_graph_painter';
+import { frameGraphCanvasMetrics, paintFrameTimeGraph } from './perf_graph_painter';
 import {
   DEFAULT_PERF_BG_RGB, DEFAULT_PERF_FG, overlayFractionFromPixel, overlayPixelPosition,
   PERF_OVERLAY_MARGIN, rgbaFromHex,
@@ -29,6 +29,7 @@ export class PerfOverlay {
   private readonly el: HTMLDivElement;
   private readonly badgesEl: HTMLDivElement;
   private readonly rowsEl: HTMLDivElement;
+  private readonly graphWrap: HTMLDivElement;
   private readonly canvas: HTMLCanvasElement;
   private readonly rowEls = new Map<PerfMetricKey, RowEls>();
 
@@ -53,9 +54,16 @@ export class PerfOverlay {
     this.badgesEl.className = 'perf-badges';
     this.rowsEl = document.createElement('div');
     this.rowsEl.className = 'perf-rows';
+    // The sparkline canvas lives in a fixed-height wrapper and is absolutely
+    // positioned (see CSS), so its large backing-store intrinsic width never
+    // feeds the shrink-wrapped panel's width: the panel sizes to its rows, and
+    // the graph can never get stuck at an old, wider metric set's width.
+    this.graphWrap = document.createElement('div');
+    this.graphWrap.className = 'perf-graph-wrap';
     this.canvas = document.createElement('canvas');
     this.canvas.className = 'perf-graph';
-    this.el.append(this.badgesEl, this.rowsEl, this.canvas);
+    this.graphWrap.append(this.canvas);
+    this.el.append(this.badgesEl, this.rowsEl, this.graphWrap);
 
     // Drag-to-move (only active in placement mode). Pointer events cover mouse +
     // touch + pen consistently across Chromium/Firefox/Safari.
@@ -158,19 +166,19 @@ export class PerfOverlay {
 
   private renderGraph(view: PerfOverlayView): void {
     if (!view.graph || view.graph.samples.length < 2) {
-      this.canvas.style.display = 'none';
+      this.graphWrap.style.display = 'none';
       return;
     }
-    this.canvas.style.display = 'block';
-    const cssW = Math.max(60, this.rowsEl.clientWidth || this.el.clientWidth || 120);
+    this.graphWrap.style.display = 'block';
+    // Measure the wrapper, not the canvas: the wrapper follows the panel (which
+    // is sized by its rows), so the width never feeds back from the canvas.
+    const cssW = Math.max(60, this.graphWrap.clientWidth || this.rowsEl.clientWidth || this.el.clientWidth || 120);
     const cssH = 26;
-    const dpr = Math.min(2, window.devicePixelRatio || 1);
-    const pxW = Math.max(1, Math.round(cssW * dpr));
-    const pxH = Math.max(1, Math.round(cssH * dpr));
+    const { pxW, pxH, dpr } = frameGraphCanvasMetrics(cssW, cssH, window.devicePixelRatio || 1);
+    // Only the HiDPI backing store is set here; the canvas display size is the
+    // wrapper's (CSS `position:absolute; inset:0`), so it can't pin the panel.
     if (this.canvas.width !== pxW) this.canvas.width = pxW;
     if (this.canvas.height !== pxH) this.canvas.height = pxH;
-    this.canvas.style.width = `${cssW}px`;
-    this.canvas.style.height = `${cssH}px`;
 
     const ctx = this.canvas.getContext('2d');
     if (!ctx) return;

--- a/tests/perf_graph_painter.test.ts
+++ b/tests/perf_graph_painter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { frameGraphGeometry, MAX_VISIBLE_MS } from '../src/ui/perf_graph_painter';
+import { frameGraphCanvasMetrics, frameGraphGeometry, MAX_VISIBLE_MS } from '../src/ui/perf_graph_painter';
 
 const TARGET = 1000 / 60; // ~16.67ms
 
@@ -46,5 +46,26 @@ describe('frameGraphGeometry', () => {
   it('handles an empty sample list', () => {
     const geo = frameGraphGeometry([], TARGET, 100, 26);
     expect(geo.points).toEqual([]);
+  });
+});
+
+describe('frameGraphCanvasMetrics', () => {
+  it('scales the backing store by the device pixel ratio', () => {
+    expect(frameGraphCanvasMetrics(320, 26, 2)).toEqual({ pxW: 640, pxH: 52, dpr: 2 });
+    expect(frameGraphCanvasMetrics(120, 26, 1)).toEqual({ pxW: 120, pxH: 26, dpr: 1 });
+  });
+
+  it('clamps the device pixel ratio to 2 to bound backing-store memory', () => {
+    expect(frameGraphCanvasMetrics(100, 26, 3).dpr).toBe(2);
+  });
+
+  it('falls back to 1x for a non-positive device pixel ratio', () => {
+    expect(frameGraphCanvasMetrics(100, 26, 0).dpr).toBe(1);
+  });
+
+  it('never produces a zero-sized backing store', () => {
+    const m = frameGraphCanvasMetrics(0, 0, 1);
+    expect(m.pxW).toBeGreaterThanOrEqual(1);
+    expect(m.pxH).toBeGreaterThanOrEqual(1);
   });
 });

--- a/tests/perf_overlay.test.ts
+++ b/tests/perf_overlay.test.ts
@@ -1,0 +1,114 @@
+// Regression guard for the perf-overlay DOM consumer (src/ui/perf_overlay.ts).
+//
+// The frame-time sparkline canvas must NEVER pin its own CSS width to an absolute
+// pixel value. Doing so makes the canvas prop the shrink-wrapped panel open: the
+// next `rowsEl.clientWidth` read stays wide, so switching the metric set from
+// "Everything" back to "Minimal" left the graph stuck at the expanded width (only
+// a full overlay off/on cleared it). The canvas follows the panel via CSS
+// `width:100%` instead, so it can never inflate the measurement it is sized from.
+//
+// Vitest runs in plain Node here (no jsdom), so we hand-roll the minimal DOM the
+// consumer touches, mirroring the stub style of tests/input.test.ts.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { PerfOverlay } from '../src/ui/perf_overlay';
+import { defaultPerfOverlayConfig } from '../src/ui/perf_overlay_config';
+import type { PerfOverlayView } from '../src/ui/perf_overlay_model';
+
+function fakeStyle(): any {
+  const store: Record<string, string> = {};
+  return new Proxy(store, {
+    get(target, prop: string) {
+      if (prop === 'setProperty') return (n: string, v: string) => { target[n] = v; };
+      return target[prop] ?? '';
+    },
+    set(target, prop: string, value: string) {
+      target[prop] = value;
+      return true;
+    },
+  });
+}
+
+// One fake element covers div + canvas; `clientWidth` simulates a wide panel.
+function fakeEl(tag: string, clientWidth: number): any {
+  return {
+    tagName: tag,
+    className: '',
+    textContent: '',
+    style: fakeStyle(),
+    dataset: {} as Record<string, string>,
+    width: 0,
+    height: 0,
+    clientWidth,
+    childElementCount: 0,
+    offsetWidth: clientWidth,
+    offsetHeight: 40,
+    offsetParent: null,
+    classList: { add() {}, remove() {}, toggle() {} },
+    setAttribute() {},
+    replaceChildren() {},
+    append() {},
+    appendChild() {},
+    remove() {},
+    addEventListener() {},
+    getBoundingClientRect() { return { left: 0, top: 0, width: clientWidth, height: 40 }; },
+    getContext() {
+      // A no-op 2D context: every method is a stub, every prop a sink.
+      return new Proxy({}, { get: () => () => {} });
+    },
+  };
+}
+
+const WIDE = 320;
+
+function makeOverlay() {
+  (globalThis as any).window = { innerWidth: 1280, innerHeight: 720, devicePixelRatio: 2, addEventListener() {} };
+  (globalThis as any).document = { createElement: (tag: string) => fakeEl(tag, WIDE) };
+  const host = fakeEl('div', WIDE);
+  const overlay = new PerfOverlay(host);
+  overlay.setEnabled(true);
+  overlay.applyConfig(defaultPerfOverlayConfig());
+  // The canvas is the 3rd child appended in the constructor; grab it back.
+  const canvas = (overlay as any).canvas as ReturnType<typeof fakeEl>;
+  return { overlay, canvas };
+}
+
+function viewWithGraph(): PerfOverlayView {
+  return {
+    rows: [],
+    badges: [],
+    graph: { samples: [16, 17, 16, 18, 16, 17], targetMs: 1000 / 60 },
+  };
+}
+
+describe('PerfOverlay graph sizing', () => {
+  afterEach(() => {
+    delete (globalThis as any).window;
+    delete (globalThis as any).document;
+  });
+
+  it('never pins an absolute pixel CSS width on the canvas (display size is CSS-driven)', () => {
+    const { overlay, canvas } = makeOverlay();
+    overlay.render(viewWithGraph());
+    // Pinning `<measured>px` here is what let the canvas prop the panel open; the
+    // canvas display size now comes from CSS (`position:absolute; width:100%`).
+    expect(canvas.style.width.endsWith('px')).toBe(false);
+  });
+
+  it('toggles the graph wrapper, not the canvas, so hidden it reserves no width', () => {
+    const { overlay } = makeOverlay();
+    const wrap = (overlay as any).graphWrap as { style: { display: string } };
+    overlay.render({ rows: [], badges: [], graph: { samples: [16], targetMs: 1000 / 60 } });
+    expect(wrap.style.display).toBe('none'); // <2 samples => hidden
+    overlay.render(viewWithGraph());
+    expect(wrap.style.display).toBe('block');
+  });
+
+  it('still scales the backing store from the measured width and DPR', () => {
+    const { overlay, canvas } = makeOverlay();
+    overlay.render(viewWithGraph());
+    // dpr clamped to 2; backing pixels = measured CSS width * dpr.
+    expect(canvas.width).toBe(WIDE * 2);
+    expect(canvas.height).toBe(26 * 2);
+  });
+});


### PR DESCRIPTION
## What

The performance overlay's frame-time graph got **stuck at the expanded width**: after switching the metric set from **Everything** back to **Minimal**, the sparkline stayed as wide as the full panel instead of shrinking with it. As the reporter noted, only a full overlay off/on cleared it, a simple graph off/on did not. Thanks to the player who reported this.

## Root cause

`renderGraph()` measured `rowsEl.clientWidth` and wrote it straight back as an absolute pixel `canvas.style.width`. Because the overlay panel shrink-wraps to its widest child, the now-wide canvas **propped the panel open**, so the next `clientWidth` read stayed wide even after the extra metric rows were removed. The canvas was feeding its own measurement.

Removing the inline px width was not enough on its own: a `<canvas>`'s backing-store `width` attribute (its HiDPI intrinsic width, ~2x the CSS width) still feeds the panel's `max-content` sizing, capped at the panel `max-width`. So the canvas kept pinning the panel either way.

## Fix

Wrap the canvas in a fixed-height `.perf-graph-wrap` and position the canvas `absolute` (`inset:0`), so its intrinsic width never reaches the panel's intrinsic sizing. The panel now sizes to its rows and the graph follows it. The HiDPI backing store is derived from a new pure, unit-tested helper `frameGraphCanvasMetrics()`. A fake-DOM regression test pins that the canvas never receives an absolute px CSS width and that the wrapper (not the canvas) is what toggles visibility.

## Before / after (max graphics, `?gfx=ultra`)

Everything (expanded), then Minimal: the graph correctly shrinks from 342px to 60px instead of staying stuck.

| Everything (expanded) | Minimal (after switch) |
|---|---|
| ![everything](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-perf-graph-reset/perf_graph_everything.png) | ![minimal](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-perf-graph-reset/perf_graph_minimal.png) |

## Testing

- `npx vitest run tests/perf_overlay.test.ts tests/perf_graph_painter.test.ts tests/perf_overlay_model.test.ts tests/perf_overlay_config.test.ts tests/client_shell.test.ts tests/architecture.test.ts` (96 passing)
- `npx tsc --noEmit` clean, `npm run build` clean
- Visual harness `scripts/perf_graph_reset_shot.mjs` asserts the graph shrinks (342px -> 60px) and is never pinned to a px width

No new i18n keys, no sim/server changes (pure client UI).

cc @Rubsey @FernandoX7 @TrevCavill @CharlieSaxton @patrick261 @sf-chris @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
