### PR TITLE
fix(game): keep auto-running while the Esc game menu is open

### DIFF
--- a/scripts/esc_autorun_shot.mjs
+++ b/scripts/esc_autorun_shot.mjs
@@ -1,12 +1,13 @@
-// Verification + VIDEO harness for "Escape pauses an autorun (R), it does not cancel it".
+// Verification + VIDEO harness for "the Esc menu lets an autorun (R) keep running".
 //
 // This is the autorun companion to esc_run_shot.mjs (which covers click-to-move).
 // Boots the offline world as a warrior at max graphics (?gfx=ultra), presses R to
 // toggle autorun, confirms the player is running, then opens the game menu with
-// Escape (as if to change a keybind or a setting) while the run is in flight. The
-// autorun latch must SURVIVE the menu: movement pauses while the menu is open
-// (suspendMovement), input.autorun stays true, and the run resumes the instant the
-// menu closes. Records a webm so the behavior is visible, not just asserted.
+// Escape (as if to change a keybind or a setting) while the run is in flight. In a
+// classic MMO the world never pauses, so the autorun latch must keep DRIVING the
+// player forward while the menu is open: the menu is genuinely open and
+// suspendMovement is set, input.autorun stays true, AND the player keeps covering
+// ground. Records a webm so the behavior is visible, not just asserted.
 //
 // Needs a dev server (default :5173, override with GAME_URL). Writes a video, key
 // screenshots, and a before/after state report to tmp/.
@@ -21,7 +22,9 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const browser = await puppeteer.launch({
   executablePath: BROWSER_PATH,
   headless: 'new',
-  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  userDataDir: process.env.CHROME_USER_DATA_DIR || undefined,
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader',
+    '--no-sandbox', '--disable-crash-reporter', '--disable-breakpad', '--no-crashpad'],
   defaultViewport: { width: 1600, height: 900, deviceScaleFactor: 2 },
 });
 const page = await browser.newPage();
@@ -72,37 +75,42 @@ const armed = await pos();
 const running = await waitForMove(start.pos, 3, 5000);
 await page.screenshot({ path: 'tmp/esc-autorun-1-running.png' });
 
-// 2) Press Escape to open the game menu mid-run. Movement suspends; the autorun
-//    latch must stay set (pause), not clear (cancel). Sample twice to show no walk.
+// 2) Press Escape to open the game menu mid-run. The menu opens (suspendMovement),
+//    the autorun latch stays set, and the player MUST keep running underneath it.
 await page.keyboard.press('Escape');
 await sleep(300);
 const menuOpen = await pos();
 await page.screenshot({ path: 'tmp/esc-autorun-2-menu-open.png' });
-await sleep(900);
-const stillOpen = await pos();
-const movedWhilePaused = Math.hypot(stillOpen.pos.x - menuOpen.pos.x, stillOpen.pos.z - menuOpen.pos.z);
+const ranDuringMenu = await waitForMove(menuOpen.pos, 2, 5000);
+const movedWhileMenuOpen = Math.hypot(ranDuringMenu.pos.x - menuOpen.pos.x, ranDuringMenu.pos.z - menuOpen.pos.z);
+await page.screenshot({ path: 'tmp/esc-autorun-3-running-with-menu.png' });
 
-// 3) Close the menu; the run resumes from where it paused.
+// 3) Close the menu; the run keeps going without interruption.
 await page.keyboard.press('Escape');
-const resumed = await waitForMove(menuOpen.pos, 2, 5000);
-await page.screenshot({ path: 'tmp/esc-autorun-3-resumed.png' });
-const movedAfterResume = Math.hypot(resumed.pos.x - menuOpen.pos.x, resumed.pos.z - menuOpen.pos.z);
+const afterClose = await waitForMove(ranDuringMenu.pos, 2, 5000);
+await page.screenshot({ path: 'tmp/esc-autorun-4-after-close.png' });
+const movedAfterClose = Math.hypot(afterClose.pos.x - ranDuringMenu.pos.x, afterClose.pos.z - ranDuringMenu.pos.z);
 
 await sleep(500);
 await recorder.stop();
 
 const report = {
-  start, armed, running, menuOpen, stillOpen, resumed,
+  start, armed, running, menuOpen, ranDuringMenu, afterClose,
   checks: {
     autorunEngaged: armed.autorun === true,                 // R toggled it on
     // The run was active before the menu: the player covered ground from spawn to
     // the point the menu opened (headless rAF throttling makes per-poll motion
     // bursty, so measure total displacement, not the mid-run poll).
     runningBeforeMenu: Math.hypot(menuOpen.pos.x - start.pos.x, menuOpen.pos.z - start.pos.z) >= 3,
-    autorunSurvivesMenu: menuOpen.autorun === true,         // the latch is kept, not cancelled
-    heldStillWhilePaused: movedWhilePaused < 0.5,           // suspended => no walking
-    autorunStillSetWhilePaused: stillOpen.autorun === true, // still latched mid-menu
-    resumedAfterClose: movedAfterResume > 1,                // run continues on close
+    menuActuallyOpen: ranDuringMenu.modalOpen === true,     // the game menu really is up
+    // suspendMovement is recomputed once per render frame, so sample it at the
+    // instant we confirm sustained motion (not +300ms after the keypress, when a
+    // sub-1fps ultra-graphics frame may not have ticked yet). A frame that moves
+    // the player is the same frame that set suspendMovement=true for the open menu.
+    movementSuspendedByMenu: ranDuringMenu.suspended === true,
+    autorunSurvivesMenu: ranDuringMenu.autorun === true,    // the latch is kept
+    keepsRunningWhileMenuOpen: movedWhileMenuOpen > 1,      // THE FIX: still moving with menu open
+    stillRunningAfterClose: movedAfterClose > 1,            // run continues uninterrupted
   },
 };
 fs.writeFileSync('tmp/esc-autorun-report.json', JSON.stringify(report, null, 2));
@@ -110,5 +118,5 @@ console.log(JSON.stringify(report, null, 2));
 
 await browser.close();
 const ok = Object.values(report.checks).every(Boolean);
-console.log(ok ? 'PASS: Escape pauses the autorun and it resumes.' : 'FAIL: see report.');
+console.log(ok ? 'PASS: the Esc menu lets the autorun keep running.' : 'FAIL: see report.');
 process.exit(ok ? 0 : 1);

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -707,7 +707,13 @@ export class Input {
 
   readMoveInput(): MoveInput {
     if (this.suspendMovement) {
-      return { forward: false, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
+      // A game menu / modal is open (or chat is focused). Suppress held keys and
+      // pointer/touch/gamepad movement so menu keystrokes never leak into the
+      // world, but keep the latched autorun running: in a classic MMO the world
+      // never pauses, so opening the Esc menu lets you keep auto-running while
+      // you change a setting. The latch itself is untouched, and the next manual
+      // forward/back key press still clears it.
+      return { forward: this.autorun, back: false, turnLeft: false, turnRight: false, strafeLeft: false, strafeRight: false, jump: false };
     }
     if (this.controllerMoveInput) return { ...this.controllerMoveInput };
     const held = (id: string) => this.heldAction(id);

--- a/tests/input.test.ts
+++ b/tests/input.test.ts
@@ -102,22 +102,35 @@ describe('Input autorun', () => {
     expect(input.readMoveInput().forward).toBe(true);
   });
 
-  it('opening the Escape menu pauses but does not cancel autorun, and it resumes on close', () => {
+  it('keeps autorun running while the Escape menu is open, then keeps running after close', () => {
     // The classic complaint: autorun, then hit Escape to change a keybind or a
-    // setting. Suspending movement (the open menu) must only pause forward motion
-    // for that frame, never clear the autorun latch, so closing the menu resumes
-    // the run instead of stranding the player.
+    // setting. In a classic MMO the world never pauses, so the open menu must let
+    // the latched autorun keep driving the player forward (you keep running while
+    // you use the menu), not strand them in place for the duration of the menu.
     const { input } = makeInput();
     input.toggleAutorun();
     expect(input.readMoveInput().forward).toBe(true);
 
     input.suspendMovement = true; // mirrors main.ts setting it while the game menu is open
-    expect(input.autorun).toBe(true); // latch survives the menu
-    expect(input.readMoveInput().forward).toBe(false); // held still while suspended
+    expect(input.autorun).toBe(true); // latch untouched by the menu
+    expect(input.readMoveInput().forward).toBe(true); // keeps running while suspended
 
     input.suspendMovement = false; // menu closed
     expect(input.autorun).toBe(true);
-    expect(input.readMoveInput().forward).toBe(true); // run resumes
+    expect(input.readMoveInput().forward).toBe(true); // still running
+  });
+
+  it('still suppresses a held movement key while suspended (menu keystrokes do not leak)', () => {
+    // Suspending movement must keep protecting the world from raw key holds while
+    // a modal/chat is focused; only the deliberate autorun latch is allowed to
+    // keep moving. With no autorun engaged, a held forward key produces no motion.
+    const { input, windowListeners } = makeInput();
+    windowListeners.get('keydown')!({ code: 'KeyW', repeat: false }); // hold forward
+    expect(input.readMoveInput().forward).toBe(true);
+
+    input.suspendMovement = true; // game menu / chat open
+    expect(input.autorun).toBe(false);
+    expect(input.readMoveInput().forward).toBe(false); // held key is suppressed
   });
 });
 


### PR DESCRIPTION
## Problem

Pressing Escape while auto-running (R) opened the game menu but **stopped the character in place** until the menu was closed. Opening the Esc menu (or any modal / focusing chat) sets `input.suspendMovement`, and `readMoveInput()` returned an all-false move intent while suspended, so a latched autorun was paused for the whole time the menu was up.

In a classic MMO the world never pauses: opening the game menu to change a keybind or a setting should let you keep auto-running, not strand you. (Follow-up to #827, which made autorun *survive* the menu; this makes it *keep running* through it.)

## Fix

`readMoveInput()`'s suspended branch now drives `forward` from the `autorun` latch only. Held movement keys and pointer/touch/gamepad movement stay fully suppressed, so menu/chat keystrokes still never leak into the world, and the next manual forward/back press still clears the latch as before.

```ts
if (this.suspendMovement) {
  // keep the latched autorun running; suppress everything else
  return { forward: this.autorun, back: false, turnLeft: false, turnRight: false,
           strafeLeft: false, strafeRight: false, jump: false };
}
```

Pure client input change. No `IWorld` / wire-protocol / server / i18n impact (no new player-visible strings).

## Tests

`tests/input.test.ts`:
- autorun keeps driving forward while `suspendMovement` is true (menu open), and after it closes;
- a held movement key with no autorun latch is still suppressed while suspended (the menu-keystroke-leak guard).

Full suite green (`npx vitest run`), `npx tsc --noEmit` clean, `npm run build` clean.

## Verification (max graphics)

`scripts/esc_autorun_shot.mjs` boots the offline world at `?gfx=ultra`, toggles autorun, opens the Esc menu mid-run, and asserts the player keeps covering ground while the menu is open and suspended. Screenshots and a video below.

All 7 harness checks pass: `autorunEngaged`, `runningBeforeMenu`, `menuActuallyOpen`, `movementSuspendedByMenu`, `autorunSurvivesMenu`, `keepsRunningWhileMenuOpen`, `stillRunningAfterClose`.

**1. Auto-running (R) before opening the menu**
![running](https://github.com/jgyy/world-of-claudecraft/raw/assets-autorun-esc/esc-autorun-1-running.png)

**2. Esc opens the Game Menu mid-run (movement suspended)**
![menu open](https://github.com/jgyy/world-of-claudecraft/raw/assets-autorun-esc/esc-autorun-2-menu-open.png)

**3. Still running with the menu open** (note the world has scrolled to new terrain and the quest tracker advanced from "Take the task" to "Seek the Marshal")
![running with menu](https://github.com/jgyy/world-of-claudecraft/raw/assets-autorun-esc/esc-autorun-3-running-with-menu.png)

**4. Menu closed, run continues uninterrupted**
![after close](https://github.com/jgyy/world-of-claudecraft/raw/assets-autorun-esc/esc-autorun-4-after-close.png)

Video (download to view): https://github.com/jgyy/world-of-claudecraft/raw/assets-autorun-esc/esc-autorun.mp4

---

cc maintainers with push access for review: @levy-street @FernandoX7 @Rubsey @TrevCavill @patrick261
