### PR TITLE
refactor(sim): extract non-hostile creature reaction into a shared module

### DIFF
--- a/src/render/reaction.ts
+++ b/src/render/reaction.ts
@@ -1,39 +1,11 @@
-import type { Entity } from '../sim/types';
-
 // How the renderer decides whether a *targetable* unit reads as hostile (red) or
 // friendly to the local player, for nameplate text and the ground selection ring.
 //
-// The classic catch: a controlled pet (a mob with `ownerId`) has no faction of
-// its own — it inherits its owner's reaction. A hunter's tamed beast or a
-// warlock's demon is `hostile === false`, so a naive `hostile` check is fine for
-// *your* pet, but the renderer also has to fold in the owner so that an enemy
-// player's pet (PvP) reads hostile, and a friendly pet never reads as an enemy.
-//
-// These helpers are pure so they can be unit-tested without a DOM/renderer; the
-// renderer supplies the entity lookup and the player-vs-player verdict.
-
-// True when an owned pet should be drawn as hostile to the viewer. A pet owned
-// by a player mirrors that player's reaction; any other owner (or a missing
-// owner) falls back to the pet's own `hostile` flag.
-export function isOwnedPetHostile(
-  pet: Entity,
-  entities: Map<number, Entity>,
-  isPlayerHostile: (p: Entity) => boolean,
-): boolean {
-  const owner = pet.ownerId !== null ? entities.get(pet.ownerId) : undefined;
-  return owner && owner.kind === 'player' ? isPlayerHostile(owner) : pet.hostile;
-}
-
-// True when a mob is a friendly controlled pet (owned and not hostile to the
-// viewer) — the case that should get a friendly nameplate instead of the
-// level-difference "con" color.
-export function isFriendlyPet(
-  e: Entity,
-  entities: Map<number, Entity>,
-  isPlayerHostile: (p: Entity) => boolean,
-): boolean {
-  return e.kind === 'mob' && e.ownerId !== null && !isOwnedPetHostile(e, entities, isPlayerHostile);
-}
+// The reaction predicates (owned-pet hostility, friendly-pet detection) now live
+// in the host-agnostic `sim/creature_reaction` module so the renderer and the
+// sim share one source of truth for "how non-hostile is this creature". They are
+// re-exported here so the renderer keeps a single reaction surface to import.
+export { isFriendlyPet, isOwnedPetHostile } from '../sim/creature_reaction';
 
 // The classic level-difference ("con") color for a wild mob's nameplate, with a
 // friendly-pet override so an owned pet reads as friendly green rather than a

--- a/src/sim/creature_reaction.ts
+++ b/src/sim/creature_reaction.ts
@@ -1,0 +1,38 @@
+import type { Entity } from './types';
+
+// One home for "how non-hostile is this creature" reasoning. These predicates
+// are the abstraction behind the scattered checks that used to live inline in
+// the sim tick (`isHostileTo`, the mob-AI pacify branch) and in the renderer's
+// nameplate code. They are pure (read only `kind`/`ownerId`/`hostile` plus the
+// caller-supplied lookups), so the same answer drives combat eligibility on the
+// server and the friendly/hostile colour on the client without drifting apart.
+
+// Non-combat lore "visions" (the Nythraxis raid memory encounters, ids prefixed
+// `vision_`). They are never hostile and never valid attack targets; the sim
+// keeps them parked in `idle` rather than spawning them into the aggro loop.
+export function isVisionCreature(templateId: string): boolean {
+  return templateId.startsWith('vision_');
+}
+
+// True when an owned pet should read as hostile to the viewer. A pet owned by a
+// player mirrors that player's reaction; any other owner (or a missing owner)
+// falls back to the pet's own `hostile` flag.
+export function isOwnedPetHostile(
+  pet: Entity,
+  entities: Map<number, Entity>,
+  isPlayerHostile: (p: Entity) => boolean,
+): boolean {
+  const owner = pet.ownerId !== null ? entities.get(pet.ownerId) : undefined;
+  return owner && owner.kind === 'player' ? isPlayerHostile(owner) : pet.hostile;
+}
+
+// True when a mob is a friendly controlled pet (owned and not hostile to the
+// viewer) — the case that should get a friendly nameplate instead of the
+// level-difference "con" colour.
+export function isFriendlyPet(
+  e: Entity,
+  entities: Map<number, Entity>,
+  isPlayerHostile: (p: Entity) => boolean,
+): boolean {
+  return e.kind === 'mob' && e.ownerId !== null && !isOwnedPetHostile(e, entities, isPlayerHostile);
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -1,6 +1,7 @@
 import type { AccountCosmetics } from '../world_api';
 import { type AssistCandidate, resolveAssist } from './assist';
 import { lineOfSightClear, resolveMovement, resolvePosition } from './colliders';
+import { isVisionCreature } from './creature_reaction';
 import {
   AUGMENTS_BY_ID,
   type AugmentDef,
@@ -6362,7 +6363,7 @@ export class Sim {
 
     mob.combatTimer += DT;
 
-    if (mob.templateId.startsWith('vision_')) {
+    if (isVisionCreature(mob.templateId)) {
       mob.hostile = false;
       mob.aiState = 'idle';
       mob.inCombat = false;
@@ -11433,7 +11434,7 @@ export class Sim {
 
   isHostileTo(attacker: Entity, target: Entity): boolean {
     if (target.kind === 'mob') {
-      if (target.templateId.startsWith('vision_')) return false;
+      if (isVisionCreature(target.templateId)) return false;
       if (target.ownerId !== null) {
         const owner = this.entities.get(target.ownerId);
         return !!owner && owner.kind === 'player' && this.isHostileTo(attacker, owner);

--- a/tests/creature_reaction.test.ts
+++ b/tests/creature_reaction.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import type { Entity } from '../src/sim/types';
+import {
+  isFriendlyPet,
+  isOwnedPetHostile,
+  isVisionCreature,
+} from '../src/sim/creature_reaction';
+
+// Minimal Entity stub: these predicates only read kind/ownerId/hostile, so we
+// fill just those and cast, rather than constructing a full runtime entity.
+function ent(partial: Partial<Entity>): Entity {
+  return { kind: 'mob', ownerId: null, hostile: true, ...partial } as Entity;
+}
+
+describe('isVisionCreature', () => {
+  it('is true for the non-combat lore "vision_" encounters', () => {
+    expect(isVisionCreature('vision_aldren_warrior')).toBe(true);
+    expect(isVisionCreature('vision_malric_mage')).toBe(true);
+    expect(isVisionCreature('vision_deathstalker_voss')).toBe(true);
+  });
+
+  it('is false for ordinary hostile mobs and for non-vision raid adds', () => {
+    expect(isVisionCreature('wolf')).toBe(false);
+    expect(isVisionCreature('nythraxis_skeleton_warrior')).toBe(false);
+    expect(isVisionCreature('')).toBe(false);
+    // the prefix must anchor at the start, not match mid-string
+    expect(isVisionCreature('elder_vision_keeper')).toBe(false);
+  });
+
+  it('is pure and deterministic for the same id', () => {
+    expect(isVisionCreature('vision_aldren_warrior')).toEqual(
+      isVisionCreature('vision_aldren_warrior'),
+    );
+  });
+});
+
+describe('isOwnedPetHostile', () => {
+  const owner = ent({ id: 1, kind: 'player' } as Partial<Entity>);
+  const entities = new Map<number, Entity>([[1, owner]]);
+
+  it('mirrors a player owner reaction (friendly owner => not hostile)', () => {
+    const pet = ent({ id: 2, ownerId: 1, hostile: false });
+    expect(isOwnedPetHostile(pet, entities, () => false)).toBe(false);
+    expect(isOwnedPetHostile(pet, entities, () => true)).toBe(true);
+  });
+
+  it('falls back to the pet own hostile flag when owner is missing', () => {
+    const wild = ent({ id: 3, ownerId: null, hostile: true });
+    expect(isOwnedPetHostile(wild, entities, () => false)).toBe(true);
+  });
+});
+
+describe('isFriendlyPet', () => {
+  const owner = ent({ id: 1, kind: 'player' } as Partial<Entity>);
+  const entities = new Map<number, Entity>([[1, owner]]);
+
+  it('is true only for an owned mob that is not hostile to the viewer', () => {
+    const friendly = ent({ id: 2, kind: 'mob', ownerId: 1, hostile: false });
+    expect(isFriendlyPet(friendly, entities, () => false)).toBe(true);
+  });
+
+  it('is false for a wild, owner-less mob', () => {
+    const wild = ent({ id: 3, kind: 'mob', ownerId: null, hostile: true });
+    expect(isFriendlyPet(wild, entities, () => false)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Adds the abstraction for non-hostile mobs and creatures that was missing: one host-agnostic home for the "how non-hostile is this creature" reasoning that today is scattered and duplicated.

Before this change:
- The `vision_` lore-encounter (Nythraxis raid memory) check was an inline `templateId.startsWith('vision_')` magic prefix in `sim.ts` in **two** places: the mob-AI pacify branch and `isHostileTo`.
- The owned-pet / friendly-pet reaction predicates (`isOwnedPetHostile`, `isFriendlyPet`) lived in `src/render/reaction.ts`, where the sim could not share them, even though `isHostileTo` re-implements the same owned-pet reaction idea.

## How

- New pure module `src/sim/creature_reaction.ts` owns the predicates: `isVisionCreature`, `isOwnedPetHostile`, `isFriendlyPet`. DOM-free and Three-free, so it stays in the host-agnostic core.
- `sim.ts` consumes `isVisionCreature` at both sites (mob-AI pacify branch + `isHostileTo`).
- `src/render/reaction.ts` becomes a thin consumer: it re-exports the pet predicates from the sim module and keeps only the render-facing colour helpers (`mobNameColor`, `FRIENDLY`). The renderer's existing import is unchanged.

This is a **pure move plus import**: no gameplay, balance, wire, `IWorld`, or i18n change. Behavior is byte-identical.

## Why this is safe (test-output evidence)

The pre-existing `tests/pet_reaction.test.ts` imports the predicates from `src/render/reaction` and **passes unchanged** through the re-export, which proves the renderer-facing behavior is preserved. A new `tests/creature_reaction.test.ts` pins the extracted module directly (including the prefix anchoring at the start, and friendly/wild pet cases).

```
$ npx vitest run tests/creature_reaction.test.ts tests/pet_reaction.test.ts
 Test Files  2 passed (2)
      Tests  18 passed (18)
```

Full gate, all green:
- `npx tsc --noEmit` — clean
- `npm test` — 329 files, 3379 passed, 8 skipped
- `tests/architecture.test.ts` — passes (new sim module imports nothing from render/ui/game/net or Three)
- `npm run build` — built successfully

## Notes for reviewers

- Per `src/CLAUDE.md`, `render/` importing pure deterministic helpers from `sim/` is a sanctioned dependency edge; `render/reaction.ts` already imported `Entity` types from `sim/`. Moving these pure `Entity` predicates into `sim/` puts them in the more fundamental layer so the server and client share one source of truth, rather than drifting.
- No new player-visible strings, so no i18n / S3 guard impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)