### PR TITLE
feat(release): automate app version bump across package.json, Android, and iOS

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_checklist.yml
+++ b/.github/ISSUE_TEMPLATE/release_checklist.yml
@@ -1,0 +1,52 @@
+name: Release checklist
+description: Track the steps to cut and ship a new release (web + iOS + Android)
+title: "Release vX.Y.Z"
+labels: ["release"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this checklist to cut a release. Fill in the version below, then work
+        through the boxes. See `docs/mobile-store-release.md` for the store details.
+  - type: input
+    id: version
+    attributes:
+      label: Target version
+      description: The semver this release will ship as.
+      placeholder: 0.15.0
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Bump the version
+      description: >
+        One command updates package.json, android/app/build.gradle
+        (versionName + versionCode) and the iOS project (MARKETING_VERSION +
+        CURRENT_PROJECT_VERSION) in a single commit and tag. Do not edit these by hand.
+      options:
+        - label: Ran `npm version <X.Y.Z>` (or `npm version minor`/`patch`/`major`) and pushed the resulting commit and tag.
+          required: false
+        - label: Confirmed all three manifests show the new version and the native build numbers incremented.
+          required: false
+  - type: checkboxes
+    attributes:
+      label: Verify
+      options:
+        - label: "`npm test` passes."
+          required: false
+        - label: "`npm run build` succeeds."
+          required: false
+        - label: Ran the release malware-audit gate.
+          required: false
+  - type: checkboxes
+    attributes:
+      label: Ship
+      options:
+        - label: Web deploy is live (see `DEPLOY.md`).
+          required: false
+        - label: "iOS archive built via `npm run native:open:ios` and submitted to App Store Connect."
+          required: false
+        - label: "Android bundle built via `npm run native:open:android` and submitted to Play Console."
+          required: false
+        - label: Release notes added under `docs/release-notes/`.
+          required: false

--- a/docs/mobile-store-release.md
+++ b/docs/mobile-store-release.md
@@ -12,6 +12,38 @@ bundle the built Vite client and connect to the production backend at
 - Cloudflare Turnstile must allow the native WebView origins used by Capacitor:
   `capacitor://localhost` for iOS and `http://localhost` for Android.
 
+## Versioning
+
+The app version lives in three files that must stay in lockstep:
+
+| File | Field(s) |
+|---|---|
+| `package.json` | `version` |
+| `android/app/build.gradle` | `versionName`, `versionCode` |
+| `ios/App/App.xcodeproj/project.pbxproj` | `MARKETING_VERSION`, `CURRENT_PROJECT_VERSION` |
+
+Do not edit these by hand. Bump them all in one step with npm's built-in
+`version` command, which fires the `version` lifecycle hook
+(`scripts/version_sync.mjs`) and folds the native files into the same commit and
+tag:
+
+```sh
+npm version 0.15.0        # exact version
+npm version minor         # or patch / major
+```
+
+This sets the marketing version (`version` / `versionName` / `MARKETING_VERSION`)
+to the new semver across all three files and increments the native build numbers
+(`versionCode` / `CURRENT_PROJECT_VERSION`), which the App Store and Play Store
+require to strictly increase on every upload.
+
+To resync the native manifests to the current `package.json` version without
+cutting a release commit (e.g. after a manual edit), run:
+
+```sh
+npm run version:sync
+```
+
 ## Commands
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "description": "World of Claudecraft — a WoW-Classic-style micro-MMO + headless RL training environment",
   "scripts": {
     "dev": "vite",
+    "version:sync": "node scripts/version_sync.mjs",
+    "version": "node scripts/version_sync.mjs && git add android/app/build.gradle ios/App/App.xcodeproj/project.pbxproj",
     "build": "npm run i18n:build && npm run i18n:admin && npm run i18n:scan && npm run wiki:content && npm run sitemap:build && node scripts/build_media_manifest.mjs generate && vite build && node scripts/build_media_manifest.mjs emit",
     "wiki:content": "node scripts/wiki/build_content.mjs",
     "sitemap:build": "node scripts/build_sitemap.mjs",

--- a/scripts/version_sync.mjs
+++ b/scripts/version_sync.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Sync the app version across the three release manifests so a single
+// `npm version <x.y.z>` bumps all of them in one commit:
+//   - package.json                                "version"           (npm owns this)
+//   - android/app/build.gradle                    versionName + versionCode
+//   - ios/App/App.xcodeproj/project.pbxproj       MARKETING_VERSION + CURRENT_PROJECT_VERSION
+//
+// The marketing/semver string is copied verbatim; the native build numbers
+// (versionCode / CURRENT_PROJECT_VERSION) are monotonically incremented, because
+// the App Store and Play Store require a strictly higher build number on every
+// upload even when the marketing version is unchanged (e.g. a resubmission).
+//
+// Pure string transforms live here and are unit-tested (tests/version_sync.test.ts);
+// the file I/O at the bottom only runs when invoked as a CLI.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export function setGradleVersionName(gradle, version) {
+  if (!/^\s*versionName\s+"[^"]*"/m.test(gradle)) {
+    throw new Error('version_sync: no versionName line found in build.gradle');
+  }
+  return gradle.replace(/(^\s*versionName\s+")[^"]*(")/m, `$1${version}$2`);
+}
+
+export function bumpGradleVersionCode(gradle) {
+  const m = gradle.match(/^(\s*versionCode\s+)(\d+)/m);
+  if (!m) throw new Error('version_sync: no versionCode line found in build.gradle');
+  const next = Number(m[2]) + 1;
+  return gradle.replace(/(^\s*versionCode\s+)\d+/m, `$1${next}`);
+}
+
+export function setMarketingVersion(pbxproj, version) {
+  if (!/MARKETING_VERSION\s*=/.test(pbxproj)) {
+    throw new Error('version_sync: no MARKETING_VERSION line found in project.pbxproj');
+  }
+  return pbxproj.replace(/(MARKETING_VERSION\s*=\s*)[^;]*(;)/g, `$1${version}$2`);
+}
+
+export function bumpCurrentProjectVersion(pbxproj) {
+  const matches = [...pbxproj.matchAll(/CURRENT_PROJECT_VERSION\s*=\s*(\d+)\s*;/g)];
+  if (matches.length === 0) {
+    throw new Error('version_sync: no CURRENT_PROJECT_VERSION line found in project.pbxproj');
+  }
+  // One shared next value across all build configs, derived from the max so the
+  // pair can never end up out of sync.
+  const next = Math.max(...matches.map((m) => Number(m[1]))) + 1;
+  return pbxproj.replace(/(CURRENT_PROJECT_VERSION\s*=\s*)\d+(\s*;)/g, `$1${next}$2`);
+}
+
+// Pure planner: given the target semver and current file contents, return the
+// fully rewritten contents. No I/O, so tests can exercise the whole pipeline.
+export function planVersionSync({ version, gradle, pbxproj }) {
+  return {
+    gradle: bumpGradleVersionCode(setGradleVersionName(gradle, version)),
+    pbxproj: bumpCurrentProjectVersion(setMarketingVersion(pbxproj, version)),
+  };
+}
+
+const GRADLE_PATH = 'android/app/build.gradle';
+const PBXPROJ_PATH = 'ios/App/App.xcodeproj/project.pbxproj';
+
+function main() {
+  const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
+  // Prefer an explicit CLI arg; otherwise use whatever version package.json holds
+  // (npm has already written the new version by the time the `version` hook runs).
+  const version = process.argv[2] ?? pkg.version;
+  if (!/^\d+\.\d+\.\d+/.test(version)) {
+    throw new Error(`version_sync: refusing to sync invalid version "${version}"`);
+  }
+
+  const gradlePath = resolve(root, GRADLE_PATH);
+  const pbxprojPath = resolve(root, PBXPROJ_PATH);
+  const plan = planVersionSync({
+    version,
+    gradle: readFileSync(gradlePath, 'utf8'),
+    pbxproj: readFileSync(pbxprojPath, 'utf8'),
+  });
+  writeFileSync(gradlePath, plan.gradle);
+  writeFileSync(pbxprojPath, plan.pbxproj);
+  console.log(`version_sync: set native manifests to ${version} (build numbers bumped)`);
+}
+
+// Run only as a CLI, never on import (so tests stay pure).
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/tests/version_sync.test.ts
+++ b/tests/version_sync.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import {
+  bumpCurrentProjectVersion,
+  bumpGradleVersionCode,
+  planVersionSync,
+  setGradleVersionName,
+  setMarketingVersion,
+} from '../scripts/version_sync.mjs';
+
+const GRADLE = `    defaultConfig {
+        applicationId "com.worldofclaudecraft"
+        versionCode 4
+        versionName "0.14.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }`;
+
+const PBXPROJ = `\t\t\t\tCODE_SIGN_STYLE = Automatic;
+\t\t\t\tCURRENT_PROJECT_VERSION = 4;
+\t\t\t\tMARKETING_VERSION = 0.14.0;
+\t\t\t\tASSET = foo;
+\t\t\t\tCURRENT_PROJECT_VERSION = 4;
+\t\t\t\tMARKETING_VERSION = 0.14.0;`;
+
+describe('setGradleVersionName', () => {
+  it('rewrites versionName to the target semver, leaving versionCode untouched', () => {
+    const out = setGradleVersionName(GRADLE, '0.15.0');
+    expect(out).toContain('versionName "0.15.0"');
+    expect(out).toContain('versionCode 4');
+  });
+
+  it('preserves indentation and surrounding lines', () => {
+    const out = setGradleVersionName(GRADLE, '1.2.3');
+    expect(out).toContain('        versionName "1.2.3"');
+    expect(out).toContain('applicationId "com.worldofclaudecraft"');
+  });
+
+  it('throws if no versionName line exists (fail loud, never silently no-op)', () => {
+    expect(() => setGradleVersionName('versionCode 4', '0.15.0')).toThrow(/versionName/);
+  });
+});
+
+describe('bumpGradleVersionCode', () => {
+  it('increments the integer build number by one', () => {
+    const out = bumpGradleVersionCode(GRADLE);
+    expect(out).toContain('versionCode 5');
+    expect(out).toContain('versionName "0.14.0"');
+  });
+
+  it('throws if no versionCode line exists', () => {
+    expect(() => bumpGradleVersionCode('versionName "0.14.0"')).toThrow(/versionCode/);
+  });
+});
+
+describe('setMarketingVersion', () => {
+  it('rewrites every MARKETING_VERSION occurrence (Debug + Release configs)', () => {
+    const out = setMarketingVersion(PBXPROJ, '0.15.0');
+    expect(out.match(/MARKETING_VERSION = 0\.15\.0;/g)).toHaveLength(2);
+    expect(out).not.toContain('MARKETING_VERSION = 0.14.0;');
+  });
+
+  it('throws if no MARKETING_VERSION line exists', () => {
+    expect(() => setMarketingVersion('CURRENT_PROJECT_VERSION = 4;', '0.15.0')).toThrow(
+      /MARKETING_VERSION/,
+    );
+  });
+});
+
+describe('bumpCurrentProjectVersion', () => {
+  it('increments every CURRENT_PROJECT_VERSION occurrence to the same next value', () => {
+    const out = bumpCurrentProjectVersion(PBXPROJ);
+    expect(out.match(/CURRENT_PROJECT_VERSION = 5;/g)).toHaveLength(2);
+    expect(out).not.toContain('CURRENT_PROJECT_VERSION = 4;');
+  });
+
+  it('uses one shared next value even if occurrences were out of sync (max + 1)', () => {
+    const skewed = 'CURRENT_PROJECT_VERSION = 4;\nCURRENT_PROJECT_VERSION = 7;';
+    const out = bumpCurrentProjectVersion(skewed);
+    expect(out.match(/CURRENT_PROJECT_VERSION = 8;/g)).toHaveLength(2);
+  });
+
+  it('throws if no CURRENT_PROJECT_VERSION line exists', () => {
+    expect(() => bumpCurrentProjectVersion('MARKETING_VERSION = 0.14.0;')).toThrow(
+      /CURRENT_PROJECT_VERSION/,
+    );
+  });
+});
+
+describe('planVersionSync', () => {
+  it('produces fully synced gradle and pbxproj for a new semver', () => {
+    const plan = planVersionSync({ version: '0.15.0', gradle: GRADLE, pbxproj: PBXPROJ });
+    expect(plan.gradle).toContain('versionName "0.15.0"');
+    expect(plan.gradle).toContain('versionCode 5');
+    expect(plan.pbxproj.match(/MARKETING_VERSION = 0\.15\.0;/g)).toHaveLength(2);
+    expect(plan.pbxproj.match(/CURRENT_PROJECT_VERSION = 5;/g)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Problem

Cutting a release currently means hand-editing the app version in three places and keeping them in sync:

- `package.json` -> `version`
- `android/app/build.gradle` -> `versionName` (and bumping `versionCode`)
- `ios/App/App.xcodeproj/project.pbxproj` -> `MARKETING_VERSION` (and `CURRENT_PROJECT_VERSION`)

Easy to miss one, and a mismatched or non-incremented native build number gets rejected at store upload.

## What this does

Hooks into npm's built-in `version` lifecycle so a single command bumps everything in one commit and tag:

```sh
npm version 0.15.0     # or: npm version minor | patch | major
```

`scripts/version_sync.mjs` runs from the `version` hook and the package.json `version` script `git add`s the native files into the same version commit. The marketing/semver string is copied verbatim across all three files; the native build numbers (`versionCode` / `CURRENT_PROJECT_VERSION`) are incremented, because the App Store and Play Store require a strictly higher build number on every upload even when the marketing version is unchanged.

`npm run version:sync` resyncs the native manifests to the current package.json version without cutting a release commit.

## Demo

```
$ grep "\"version\"" package.json; grep -E "versionName|versionCode" android/app/build.gradle; grep -m1 -E "MARKETING_VERSION|CURRENT_PROJECT_VERSION" ios/App/App.xcodeproj/project.pbxproj
  "version": "0.14.0",
        versionCode 4
        versionName "0.14.0"
				CURRENT_PROJECT_VERSION = 4;
				MARKETING_VERSION = 0.14.0;

$ npm version minor      # 0.14.0 -> 0.15.0, all three files + git tag, one commit
> node scripts/version_sync.mjs && git add android/app/build.gradle ios/App/App.xcodeproj/project.pbxproj
version_sync: set native manifests to 0.15.0 (build numbers bumped)

# result:
  "version": "0.15.0",
        versionCode 5
        versionName "0.15.0"
				CURRENT_PROJECT_VERSION = 5;
				MARKETING_VERSION = 0.15.0;
```

## Also included

- **Release-checklist issue template** (`.github/ISSUE_TEMPLATE/release_checklist.yml`) that surfaces the version-bump step plus verify/ship boxes, addressing the "include it in the release issue checklist" half of the request.
- **Versioning section** in `docs/mobile-store-release.md`.

## Tests

Pure string transforms are factored into testable functions and covered by `tests/version_sync.test.ts` (11 cases: rewrites, multi-config iOS, monotonic build-number increment, and fail-loud guards when a field is missing). Biome-clean.

```
npx vitest run tests/version_sync.test.ts   # 11 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)