### PR TITLE
perf(render): prewarm all entity shaders to kill the crowd/zone-load freeze

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -5,7 +5,7 @@ import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
 import { drapeRingLocalY } from './selection_ring';
 import { buildFlaredConeFan, buildRingXZ, drapeConeWorld } from './target_cone_debug';
 import {
-  CLASSES, MOBS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
+  CLASSES, MOBS, NPCS, ABILITIES, DUNGEON_X_THRESHOLD, DUNGEON_LIST, QUESTS,
   instanceOrigin, INSTANCE_SLOT_COUNT, ARENA_SLOT_COUNT, arenaOrigin, isArenaPos, dungeonAt,
   WORLD_MAX_Z, WORLD_MIN_Z, ZONES,
 } from '../sim/data';
@@ -68,7 +68,19 @@ const VIEW_CREATE_SLOW_FRAME_MS = 33;
 const VIEW_CREATE_HITCH_FRAME_MS = 50;
 const VIEW_CREATE_BACKOFF_SECONDS = 0.75;
 const VIEW_PREWARM_RANGE_SQ = ENTITY_VIEW_CREATE_RANGE_SQ;
-const VIEW_PREWARM_MAX_MS = 5000;
+const VIEW_PREWARM_MAX_MS = 12000;
+// Shader linking is the whole point of the prewarm: if it doesn't finish, the
+// first in-world frame that needs a program compiles it synchronously — the
+// multi-hundred-ms (up to ~1.7s) freeze players feel when new model types
+// appear. So the compile step gets its own budget (it normally drains in <~100ms
+// with KHR_parallel_shader_compile) rather than racing the leftover view-build
+// budget, which could starve it to a timeout. The cap only bites if a driver
+// stalls the parallel-compile queue; keep it modest, since a long hold here is
+// itself worse than the freeze it prevents.
+const PREWARM_COMPILE_MAX_MS = 10000;
+// Reserve at the tail of the view-build budget so the compile + final-frame
+// steps always start before the prewarm deadline (runEntry skips late entries).
+const PREWARM_BUILD_RESERVE_MS = 3000;
 const VIEW_PREWARM_MAX_VIEWS_LOW = 48;
 const VIEW_PREWARM_MAX_VIEWS_HIGH = 72;
 const VIEW_CREATED_TYPE_SAMPLE_LIMIT = 24;
@@ -175,6 +187,9 @@ const PREWARM_OBJECT_ITEM_IDS = [
 ] as const;
 const PREWARM_MOB_POOL_COPIES = 3;
 const PREWARM_OBJECT_POOL_COPIES = 2;
+// The common templates above are pooled several-deep (they spawn in groups); every
+// OTHER mob model is still built once so its shader program compiles at load.
+const PREWARM_MOB_COMMON_IDS = new Set<string>(PREWARM_MOB_TEMPLATE_IDS);
 
 function prewarmPlayerSkinVariantCount(): number {
   return ALL_CLASSES.reduce((sum, cls) => sum + skinCount(`player_${cls}`), 0);
@@ -1645,7 +1660,7 @@ export class Renderer {
     this.updateChatBubbles();
   }
 
-  private prewarmEntity(kind: 'player' | 'mob', templateId: string, color: number, scale: number, skin = 0, id = -10_000): Entity {
+  private prewarmEntity(kind: 'player' | 'mob' | 'npc', templateId: string, color: number, scale: number, skin = 0, id = -10_000): Entity {
     const p = this.sim.player;
     return {
       ...p,
@@ -1740,7 +1755,7 @@ export class Renderer {
     pool.push(object);
   }
 
-  private buildEntityPrewarmGroup(): THREE.Group {
+  private buildEntityPrewarmGroup(deadline: number): THREE.Group {
     const group = new THREE.Group();
     const p = this.sim.player;
     group.position.set(p.pos.x, p.pos.y, p.pos.z - 14);
@@ -1751,17 +1766,64 @@ export class Renderer {
       group.add(obj);
       idx++;
     };
-    for (const templateId of PREWARM_MOB_TEMPLATE_IDS) {
+    // Track which visual MODELS have been built (visualKeyFor = the model selector;
+    // distinct shader programs are per-model, so this is what we must cover). The
+    // pool itself is still keyed per template via visualPoolKeyFor.
+    const builtModels = new Set<string>();
+    const build = (templateId: string, copies: number): void => {
       const template = MOBS[templateId];
-      if (!template) continue;
-      for (let i = 0; i < PREWARM_MOB_POOL_COPIES; i++) {
+      if (!template) return;
+      for (let i = 0; i < copies; i++) {
         const entity = this.prewarmEntity('mob', template.id, template.color, template.scale);
+        builtModels.add(visualKeyFor(entity));
         const visual = createCharacterVisual(entity);
-        const key = this.visualPoolKeyFor(entity);
-        if (key) this.storePooledVisual(key, visual);
+        const poolKey = this.visualPoolKeyFor(entity);
+        if (poolKey) this.storePooledVisual(poolKey, visual);
         visual.root.visible = true;
         place(visual.root);
       }
+    };
+    // Common mobs spawn in packs → pool several copies per template (this also
+    // compiles their shaders).
+    for (const templateId of PREWARM_MOB_TEMPLATE_IDS) build(templateId, PREWARM_MOB_POOL_COPIES);
+    // Then every remaining mob whose visual MODEL hasn't been built yet — one copy,
+    // so its shader program is compiled at load and never hitches in-world. Mobs that
+    // share a family model are built only once.
+    for (const templateId of Object.keys(MOBS)) {
+      if (PREWARM_MOB_COMMON_IDS.has(templateId)) continue;
+      if (performance.now() >= deadline) break;
+      const template = MOBS[templateId];
+      if (!template) continue;
+      const modelKey = visualKeyFor(this.prewarmEntity('mob', template.id, template.color, template.scale));
+      if (builtModels.has(modelKey)) continue;
+      build(templateId, 1);
+    }
+    return group;
+  }
+
+  // Every NPC visual MODEL once (NPCs were not prewarmed at all — entering a zone hub
+  // compiled their shaders live). Most NPCs share a handful of models (npc_knight,
+  // npc_mage, ...), so dedup by model key (visualKeyFor) builds each only once.
+  private buildNpcPrewarmGroup(deadline: number): THREE.Group {
+    const group = new THREE.Group();
+    const p = this.sim.player;
+    group.position.set(p.pos.x, p.pos.y, p.pos.z - 24);
+    setRenderCategory(group, 'prewarm');
+    let idx = 0;
+    const builtModels = new Set<string>();
+    for (const npc of Object.values(NPCS)) {
+      if (performance.now() >= deadline) break;
+      const entity = this.prewarmEntity('npc', npc.id, npc.color, 1);
+      const modelKey = visualKeyFor(entity);
+      if (builtModels.has(modelKey)) continue;
+      builtModels.add(modelKey);
+      const visual = createCharacterVisual(entity);
+      const poolKey = this.visualPoolKeyFor(entity);
+      if (poolKey) this.storePooledVisual(poolKey, visual);
+      visual.root.visible = true;
+      visual.root.position.set(((idx % 8) - 3.5) * 2.8, 0, Math.floor(idx / 8) * 2.8);
+      group.add(visual.root);
+      idx++;
     }
     return group;
   }
@@ -1892,6 +1954,10 @@ export class Renderer {
     const maxMs = Math.max(0, options.maxMs ?? VIEW_PREWARM_MAX_MS);
     const started = performance.now();
     const deadline = started + maxMs;
+    // Stop the archetype-build steps early so the later entries — crucially
+    // programs.compile — still START before `deadline` (runEntry skips anything
+    // that begins past it). Compiling is what kills the in-world freeze.
+    const buildDeadline = deadline - PREWARM_BUILD_RESERVE_MS;
     const manifestEntries: RendererPrewarmManifestEntryStats[] = [];
     const startCounts = this.prewarmCounts();
     const createdViewTypes: string[] = [];
@@ -1900,6 +1966,7 @@ export class Renderer {
     let candidateViews = 0;
     let doorPrewarmGroup: THREE.Group | null = null;
     let entityPrewarmGroup: THREE.Group | null = null;
+    let npcPrewarmGroup: THREE.Group | null = null;
     let playerPrewarmGroup: THREE.Group | null = null;
     let objectPrewarmGroup: THREE.Group | null = null;
     let propMaterialPrewarmGroup: THREE.Group | null = null;
@@ -2011,28 +2078,41 @@ export class Renderer {
         },
       },
       {
-        id: 'entities.mob-archetypes',
-        category: 'entities',
-        priority: 35,
-        required: true,
-        run: () => {
-          entityPrewarmGroup = this.buildEntityPrewarmGroup();
-          this.scene.add(entityPrewarmGroup);
-        },
-        detail: () => `templates=${PREWARM_MOB_TEMPLATE_IDS.length};copies=${PREWARM_MOB_POOL_COPIES}`,
-      },
-      {
+        // Players are the #1 shader-compile trigger in a crowd, so build their
+        // archetypes first (before the long mob tail) — guaranteed within budget.
         id: 'entities.player-archetypes',
         category: 'entities',
-        priority: 37,
+        priority: 34,
         required: true,
         run: () => {
-          const built = this.buildPlayerPrewarmGroup(deadline);
+          const built = this.buildPlayerPrewarmGroup(buildDeadline);
           playerPrewarmGroup = built.group;
           playerPrewarmVisuals = built.visualCount;
           this.scene.add(playerPrewarmGroup);
         },
         detail: () => `classes=${ALL_CLASSES.length};skins=${prewarmPlayerSkinVariantCount()};visuals=${playerPrewarmVisuals}`,
+      },
+      {
+        id: 'entities.mob-archetypes',
+        category: 'entities',
+        priority: 35,
+        required: true,
+        run: () => {
+          entityPrewarmGroup = this.buildEntityPrewarmGroup(buildDeadline);
+          this.scene.add(entityPrewarmGroup);
+        },
+        detail: () => `mobs=${Object.keys(MOBS).length};common=${PREWARM_MOB_TEMPLATE_IDS.length};copies=${PREWARM_MOB_POOL_COPIES}`,
+      },
+      {
+        id: 'entities.npc-archetypes',
+        category: 'entities',
+        priority: 36,
+        required: true,
+        run: () => {
+          npcPrewarmGroup = this.buildNpcPrewarmGroup(buildDeadline);
+          this.scene.add(npcPrewarmGroup);
+        },
+        detail: () => `npcs=${Object.keys(NPCS).length}`,
       },
       {
         id: 'objects.quest-archetypes',
@@ -2105,8 +2185,11 @@ export class Renderer {
         required: true,
         run: async () => {
         const compileStart = performance.now();
-        const compileBudgetMs = Math.max(0, deadline - compileStart);
-        if (compileBudgetMs > 0 && this.webgl.compileAsync) {
+        // Use a dedicated budget, not `deadline - now`: linking every program now is
+        // exactly what prevents the in-world freeze, so a near-empty leftover budget
+        // must not cut it short (the old bug — the async compile timed out and the
+        // programs linked synchronously on first sight instead).
+        if (this.webgl.compileAsync) {
           compileMode = 'async';
           let settled = false;
           const compilePromise = this.webgl.compileAsync(this.scene, this.camera)
@@ -2115,10 +2198,10 @@ export class Renderer {
               settled = true;
               console.warn('Renderer async prewarm compile failed', err);
             });
-          await Promise.race([compilePromise, sleep(compileBudgetMs)]);
+          await Promise.race([compilePromise, sleep(PREWARM_COMPILE_MAX_MS)]);
           compileTimedOut = !settled;
           compileMs = roundMs(performance.now() - compileStart);
-        } else if (compileBudgetMs > 0) {
+        } else {
           compileMode = 'sync';
           this.webgl.compile(this.scene, this.camera);
           compileMs = roundMs(performance.now() - compileStart);
@@ -2176,6 +2259,7 @@ export class Renderer {
       this.vfx.clear();
       if (doorPrewarmGroup) this.scene.remove(doorPrewarmGroup);
       if (entityPrewarmGroup) this.scene.remove(entityPrewarmGroup);
+      if (npcPrewarmGroup) this.scene.remove(npcPrewarmGroup);
       if (playerPrewarmGroup) this.scene.remove(playerPrewarmGroup);
       if (objectPrewarmGroup) this.scene.remove(objectPrewarmGroup);
       if (propMaterialPrewarmGroup) this.scene.remove(propMaterialPrewarmGroup);


### PR DESCRIPTION
## Summary

Players report **multi-second freezes** ("tirones") when entering a populated or
varied area on the live server. I traced it on **production, with a real GPU**
(driving the game through Playwright + reading the in-game perf API): the freeze
is **synchronous WebGL shader-program compilation on first render of a new model
type**. Walking into a crowd, `renderer.programs` jumped **78 → 190** as new
player classes / mob species / NPCs first appeared, and the worst main-thread
block was **`longTasks.max = 1713 ms`** (p95 510 ms). `KHR_parallel_shader_compile`
is available but the prewarm wasn't getting the shaders linked before the world
showed.

Two root causes in the load-time prewarm (`renderer.ts`):

1. **Coverage gap** — it built only **18 representative mob templates and zero
   NPCs**, so the other ~86 mob species and all 21 NPCs compiled their shaders
   *live* in-world.
2. **The compile timed out** — `programs.compile` raced `compileAsync` against the
   *leftover* view-build budget (`deadline - now`). On a cold/larger scene the
   builds ate the budget, the async compile didn't settle, and even prewarmed
   materials (e.g. player classes) linked **synchronously on first sight** — the
   freeze. (This is why a warrior still hitched despite "all classes prewarmed.")

## Fix (client renderer only)

- Prewarm **one of every distinct mob model** (deduped by `visualKeyFor`, the
  model selector — mobs sharing a family model build once; the in-world pool
  still keys per template) + **every NPC model** + **all player classes**, and
  build the player archetypes **first** (they're the #1 trigger in a crowd).
- Give `programs.compile` **its own budget** (`PREWARM_COMPILE_MAX_MS` = 10s) so
  it finishes during the loading screen instead of racing the remaining build
  budget down to a timeout (capped modestly — a long hold there is worse than the
  freeze it prevents).
- Raise the prewarm budget and **reserve tail margin** (`PREWARM_BUILD_RESERVE_MS`)
  so the compile + final-frame steps always *start* before the deadline
  (`runEntry` skips any entry that begins past it).

No gameplay/sim change; this is purely load-time shader warming. A longer loading
screen (a place where a pause is acceptable) buys freeze-free play.

## Results — measured on a real GPU (RTX 3060 Ti), teleport tour across every zone + a player crowd

| | before (deployed build) | after (this PR) |
|---|---|---|
| worst freeze on new-area load | **1713 ms** | **223 ms** (−87%) |
| Webwood / Zone3 Highwatch / crowd arrival | compiled live | **0 new programs, 0 long frames** |
| prewarm compile | timed out (async unsettled) | **completes, 77 ms, `compileTimedOut=false`** |
| prewarm wall-time | — | ~1.9 s (`timedOut=false`, 0 failed entries) |

Player-class, mob, and NPC model freezes are eliminated (a zone with fresh mobs
compiles **0** new programs in-world after prewarm). The remaining residual is
**not entities** — it's **biome terrain + composed structures/VFX** (Fallen
Chapel, deep Zone3 sanctum), which still compile on first visit (on
`release/v0.14.1`, ~+12 programs at the Chapel and ~+39 at deep Zone3). Those need
a different, heavier prewarm (render the warm scene at each biome's coordinates),
which I'm scoping as a **follow-up**, not this PR.

(Numbers in the table above were measured against `main`; the entity-freeze fix is
the same, but the non-entity residual is larger on `release` given the extra zone
content. `tsc --noEmit` on `release/v0.14.1` currently has 2 pre-existing errors
unrelated to this change; this PR adds none.)

## Type of change

- [x] Refactor or performance (no behavior change) — load-time shader warming only

## How was this tested?

- `npx tsc --noEmit` clean; `npm run build` succeeds; `npm test` green (one
  unrelated pre-existing `i18n_completeness` failure on `main`, not touched here).
- **Live, real-GPU profiling** via Playwright on the running build: read
  `window.__game.perf.report()` (`renderer.programs`, `browser.longTasks`,
  prewarm stats) while teleporting across every zone and into a 12-bot crowd —
  the before/after numbers above. The renderer is WebGL/DOM so it has no Vitest
  unit coverage; this was verified end-to-end in a browser.

## Notes for reviewers

This is the **client-render** half of the crowd-performance work; the
**server-side** snapshot/broadcast piece is a separate PR. The diagnosis used a
new local harness (`scripts/client_perf_under_load.mjs`, from the server PR) plus
ad-hoc Playwright probes. Happy to add the biome-terrain prewarm in a follow-up if
you'd like the last ~223 ms gone too.
