### PR TITLE
fix(ui): let mobile players assign usable items to the action bar

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1053,6 +1053,19 @@
   .spell-hotbar-toggle {
     display: none;
   }
+  .item-hotbar-toggle {
+    display: none;
+  }
+  .bag-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+  .bag-row .bag-item {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+  }
   .panel-title-actions {
     display: flex;
     align-items: center;

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -1333,6 +1333,29 @@
   body.mobile-touch #spellbook .spell-hotbar-toggle:disabled {
     opacity: 0.45;
   }
+  body.mobile-touch #bags .item-hotbar-toggle {
+    min-width: 40px;
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 40px;
+    border: 2px solid #4a3d1d;
+    border-radius: 7px;
+    background: radial-gradient(circle at 35% 30%, #2d3048e0, #11121ee0 72%);
+    color: var(--gold);
+    font: 700 22px / 1 var(--ui-font);
+    box-shadow:
+      inset 0 1px 0 #ffffff14,
+      0 2px 6px #0008;
+  }
+  body.mobile-touch #bags .item-hotbar-toggle.remove {
+    color: #ffcf9c;
+    border-color: #8b4e2c;
+  }
+  body.mobile-touch #bags .item-hotbar-toggle:disabled {
+    opacity: 0.45;
+  }
   body.mobile-touch #spellbook .spellbook-reset {
     min-height: 40px;
     display: inline-flex;

--- a/src/ui/bags_window.ts
+++ b/src/ui/bags_window.ts
@@ -132,6 +132,13 @@ export interface BagsWindowDeps extends PainterHostPresentation {
   isHotbarItemId(itemId: string): boolean;
   setDragAction(action: { type: 'item'; id: string } | null): void;
   clearActionDropTargets(): void;
+  // Touch-path action-bar assign for usable items (the +/- toggle mirrors the
+  // spellbook's mobile ability toggle; drag-and-drop above is desktop-only). The
+  // hotbar layout is HUD state, so the painter reads/mutates it through these.
+  itemOnBar(itemId: string): boolean;
+  hasFreeHotbarSlot(): boolean;
+  /** Toggle the item on the action bar; returns whether the layout changed. */
+  toggleItemOnBar(itemId: string): boolean;
 }
 
 export class BagsWindow {
@@ -467,6 +474,11 @@ export class BagsWindow {
         ev.preventDefault();
         this.sellBagItem(s, ev);
       });
+      // Desktop assigns usable items to the action bar by drag-and-drop; touch has no
+      // drag, so hotbar-eligible items also get a +/- toggle (hidden on desktop via
+      // CSS), mirroring the spellbook's mobile ability toggle. Built as a sibling of
+      // the row and wrapped in a .bag-row when present.
+      let assignToggle: HTMLButtonElement | null = null;
       if (!this.deps.tradeOpen() && !this.deps.vendorOpen() && this.deps.isHotbarItemId(s.itemId)) {
         row.draggable = true;
         row.addEventListener('dragstart', (e) => {
@@ -480,6 +492,28 @@ export class BagsWindow {
           this.deps.setDragAction(null);
           this.deps.clearActionDropTargets();
         });
+        const onBar = this.deps.itemOnBar(s.itemId);
+        assignToggle = document.createElement('button');
+        assignToggle.type = 'button';
+        assignToggle.className = `item-hotbar-toggle${onBar ? ' remove' : ''}`;
+        assignToggle.dataset.itemId = s.itemId;
+        assignToggle.textContent = onBar ? '-' : '+';
+        assignToggle.setAttribute(
+          'aria-label',
+          t(onBar ? 'hudChrome.spellbook.removeFromBarAria' : 'hudChrome.spellbook.addToBarAria', {
+            name: itemName,
+          }),
+        );
+        assignToggle.setAttribute('aria-pressed', onBar ? 'true' : 'false');
+        assignToggle.disabled = !onBar && !this.deps.hasFreeHotbarSlot();
+        assignToggle.addEventListener('pointerdown', (ev) => ev.stopPropagation());
+        assignToggle.addEventListener('click', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
+          if (!this.deps.toggleItemOnBar(s.itemId)) return;
+          audio.click();
+          this.render();
+        });
       }
       this.deps.attachTooltip(row, () => {
         const key = bagTooltipHintKey(item, this.bagMode());
@@ -489,7 +523,15 @@ export class BagsWindow {
           : '';
         return this.deps.itemTooltip(item) + extra + link;
       });
-      grid.appendChild(row);
+      if (assignToggle) {
+        const rowWrap = document.createElement('div');
+        rowWrap.className = 'bag-row';
+        rowWrap.appendChild(row);
+        rowWrap.appendChild(assignToggle);
+        grid.appendChild(rowWrap);
+      } else {
+        grid.appendChild(row);
+      }
     }
     // Free-slot squares (unfiltered view only): the classic empty sockets that
     // make the remaining capacity visible at a glance. Decorative, not focusable.

--- a/src/ui/hotbar.ts
+++ b/src/ui/hotbar.ts
@@ -78,6 +78,32 @@ export function placeItemOnSlot(
   return next;
 }
 
+// First slot index holding the given item, or -1. Mirrors the ability lookup so
+// the bags +/- toggle can show whether a usable item is already on the bar.
+export function hotbarItemIndex(actions: readonly HotbarAction[], itemId: string): number {
+  return actions.findIndex((action) => action?.type === 'item' && action.id === itemId);
+}
+
+// Toggle a usable item on the action bar: if it is already assigned, clear every
+// slot that holds it; otherwise place it in the first empty slot. Returns the
+// (possibly unchanged) layout plus whether it changed, so a full bar with the
+// item absent is a no-op. This is the touch path equivalent of the spellbook's
+// ability +/- toggle, since drag-and-drop is unavailable on mobile.
+export function toggleHotbarItem(
+  actions: readonly HotbarAction[],
+  itemId: string,
+): { actions: HotbarAction[]; changed: boolean } {
+  if (hotbarItemIndex(actions, itemId) !== -1) {
+    const next = actions.map((action) =>
+      action?.type === 'item' && action.id === itemId ? null : action,
+    );
+    return { actions: next, changed: true };
+  }
+  const empty = actions.indexOf(null);
+  if (empty === -1) return { actions: actions.slice(), changed: false };
+  return { actions: placeItemOnSlot(actions, itemId, empty), changed: true };
+}
+
 export function swapHotbarSlots(
   actions: readonly HotbarAction[],
   sourceIndex: number,

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -205,6 +205,7 @@ import {
   encodeHotbarAction,
   HOTBAR_ACTION_MIME,
   type HotbarAction,
+  hotbarItemIndex,
   parseHotbarAction,
   parseHotbarActions,
   placeAbilityOnSlot,
@@ -212,6 +213,7 @@ import {
   shouldSeedFormBar,
   swapHotbarSlots,
   syncHotbarActions,
+  toggleHotbarItem,
 } from './hotbar';
 import {
   formatMoney as formatLocalizedMoney,
@@ -3203,6 +3205,21 @@ export class Hud {
       this.dragAction = action ? { action, sourceIndex: null } : null;
     },
     clearActionDropTargets: () => this.clearActionDropTargets(),
+    // Touch-path action-bar assign for usable items (drag-and-drop is desktop-only),
+    // mirroring the spellbook's mobile ability toggle. The hotbar layout stays HUD
+    // state, so the painter reads/mutates it through these closures.
+    itemOnBar: (itemId) => hotbarItemIndex(this.hotbarActions, itemId) !== -1,
+    hasFreeHotbarSlot: () => this.firstEmptyHotbarIndex() !== -1,
+    toggleItemOnBar: (itemId) => {
+      const next = toggleHotbarItem(this.hotbarActions, itemId);
+      if (!next.changed) return false;
+      this.hotbarActions = next.actions;
+      this.saveSlotMap();
+      // Keep the spellbook's ability +/- disabled-states in sync (a filled/freed
+      // slot changes whether abilities can still be added).
+      this.spellbookWindow.refreshHotbarControls();
+      return true;
+    },
   });
   // World Market window painter (market_view.ts core + market_window.ts painter).
   // It composes the shared presentation bag (icon/money/tooltip) and owns the

--- a/tests/hotbar.test.ts
+++ b/tests/hotbar.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { CLASSES } from '../src/sim/content/classes';
 import {
-  buildDefaultFormBar, classHasFormBars, clearHotbarSlot, hotbarActionsEqual, parseHotbarActions,
-  placeAbilityOnSlot, placeItemOnSlot, shouldSeedFormBar, syncHotbarActions,
+  buildDefaultFormBar, classHasFormBars, clearHotbarSlot, hotbarActionsEqual, hotbarItemIndex,
+  parseHotbarActions, placeAbilityOnSlot, placeItemOnSlot, shouldSeedFormBar, syncHotbarActions,
+  toggleHotbarItem,
 } from '../src/ui/hotbar';
 
 const abilityIds = new Set(['fireball', 'frost_armor', 'arcane_intellect', 'polymorph', 'shared_id']);
@@ -304,5 +305,61 @@ describe('hotbar slot sync', () => {
       null,
       { type: 'ability', id: 'blink' },
     ]);
+  });
+});
+
+describe('item hotbar toggle (mobile assign path)', () => {
+  it('reports the first slot holding an item, or -1', () => {
+    const slots = [
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'item' as const, id: 'health_potion' },
+      { type: 'item' as const, id: 'mana_potion' },
+    ];
+
+    expect(hotbarItemIndex(slots, 'mana_potion')).toBe(2);
+    expect(hotbarItemIndex(slots, 'health_potion')).toBe(1);
+    expect(hotbarItemIndex(slots, 'baked_bread')).toBe(-1);
+    // an ability with the same id must not count as the item being on the bar
+    expect(hotbarItemIndex(slots, 'fireball')).toBe(-1);
+  });
+
+  it('assigns an absent item to the first empty slot', () => {
+    const slots = [{ type: 'ability' as const, id: 'fireball' }, null, null];
+
+    expect(toggleHotbarItem(slots, 'health_potion')).toEqual({
+      actions: [{ type: 'ability', id: 'fireball' }, { type: 'item', id: 'health_potion' }, null],
+      changed: true,
+    });
+  });
+
+  it('removes an item from every slot that holds it', () => {
+    const slots = [
+      { type: 'item' as const, id: 'health_potion' },
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'item' as const, id: 'health_potion' },
+    ];
+
+    expect(toggleHotbarItem(slots, 'health_potion')).toEqual({
+      actions: [null, { type: 'ability', id: 'fireball' }, null],
+      changed: true,
+    });
+  });
+
+  it('is a no-op when the bar is full and the item is absent', () => {
+    const slots = [
+      { type: 'ability' as const, id: 'fireball' },
+      { type: 'item' as const, id: 'mana_potion' },
+    ];
+
+    expect(toggleHotbarItem(slots, 'health_potion')).toEqual({ actions: slots, changed: false });
+  });
+
+  it('does not mutate the input layout', () => {
+    const slots = [{ type: 'ability' as const, id: 'fireball' }, null];
+    const snapshot = JSON.parse(JSON.stringify(slots));
+
+    toggleHotbarItem(slots, 'health_potion');
+
+    expect(slots).toEqual(snapshot);
   });
 });


### PR DESCRIPTION
## Summary

On mobile, players could assign abilities to the action bar (through the spellbook's `+`/`-` tap toggle) but never usable items like Health or Mana potions. Items reach the bar only via HTML5 drag-and-drop, which is unavailable on touch, so there was no way to slot a potion, food, or drink on a phone.

This mirrors the spellbook's mobile toggle for hotbar-eligible bag items: each such row gets a `+`/`-` button that is hidden on desktop (drag-and-drop there is unchanged) and shown on touch. The slot logic is backed by two pure, unit-tested helpers in `src/ui/hotbar.ts` (`hotbarItemIndex`, `toggleHotbarItem`) so the behavior is covered without a DOM.

- `+` adds the item to the first empty slot; it is disabled when the bar is full.
- `-` removes the item from every slot that holds it.
- The toggle is a sibling of the bag-item button (wrapped in a `.bag-row` div), never a `<button>` nested inside a `<button>`.

## Related issues

N/A (reported as a v0.14.1 mobile usability bug).

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/hotbar.test.ts tests/architecture.test.ts` (34 pass; 5 new cases for the item toggle)
  - `npx tsc --noEmit` (clean)
  - `npm test` (3500 pass, 8 skipped; the only 2 failures are pre-existing on the base branch and unrelated to this change: `clock_format` / `chat_timestamp` render midnight as `24:00` on Node 20's Intl, which passes on the project's Node 22+ target)
  - `npm run build` (succeeds)
- Manual steps (mobile viewport, touch):
  - Open Bags. Potions/food/drink now show a `+` button; non-usable items do not.
  - Bar with free slots: `+` is active; tapping it places the potion on the bar and the button flips to `-`.
  - Full bar: `+` is disabled for items not yet on the bar.
  - Tapping `-` removes the potion from the bar.
  - Desktop unchanged: the toggle stays hidden and drag-and-drop still works.

## Screenshots / recordings

<!-- Mobile (touch), portrait: -->
- Full bar: `+` disabled for potions
- <img width="1468" height="74" alt="Screenshot 2026-06-24 alle 00 36 04" src="https://github.com/user-attachments/assets/1f0364e4-f67a-4389-9868-3ab39eeabee9" />
- Bar with free slots: `+` active
<img width="1478" height="87" alt="Screenshot 2026-06-24 alle 00 36 53" src="https://github.com/user-attachments/assets/feb0aca7-0e22-46e0-895e-f75d2f4de0fb" />
- After tapping `+`: button shows `-`
<img width="1469" height="75" alt="Screenshot 2026-06-24 alle 00 37 09" src="https://github.com/user-attachments/assets/020b6d12-e33c-4953-824e-44be65653d63" />
- Potion assigned on the action bar
<img width="498" height="54" alt="Screenshot 2026-06-24 alle 00 37 16" src="https://github.com/user-attachments/assets/74cb4c8f-fdef-4cc7-9d46-cb167215f3f1" />

---

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green (see note on the 2 pre-existing Node-20 Intl failures above). Added unit tests for the new `hotbar.ts` helpers.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build` succeeds. Server/headless not touched.

### Cross-platform

- [x] **Tested on desktop and mobile.** Toggle is mobile-only (hidden on desktop), 40x40px tap target, mirrors the existing spellbook toggle styling.
- [x] **Accessible.** Button is keyboard-operable with `aria-pressed` reflecting on/off-bar state and a `disabled` state when the bar is full, matching the spellbook ability toggle.

### Localization (i18n)

- [x] N/A. This PR adds no new `t()` keys. The toggle's accessible name composes the already-localized item name with the `+`/`-` symbol, exactly as the shipped spellbook ability toggle does.

### Hygiene

- [x] No secrets, credentials, or `.env` committed; `ALLOW_DEV_COMMANDS` not touched.
- [x] No generated files hand-edited (`git status` after build shows only the four source files).
