### PR TITLE
ci: skip Biome ratchet on release-to-main PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
   # Biome-eligible file (docs, assets, generated i18n).
   lint:
     name: Format + lint (Biome, changed files)
+    # Release branches are already validated on push. A release-to-main PR would
+    # otherwise run this changed-file ratchet against the entire release delta.
+    if: github.event_name != 'pull_request' || github.base_ref != 'main' || !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary
- skip the changed-file Biome ratchet when a release branch is opened against main
- keep normal PR checks and release-branch push validation intact

## Why
Release branches are validated on push by the release gate. The standing release-to-main PR currently compares the entire release branch delta against main, which can fail Biome on historical files even after the release branch itself is green.

## Validation
- ruby YAML parse for .github/workflows/ci.yml
- git diff --check