### PR TITLE
fix: restore full raid frame ordering

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -217,6 +217,7 @@ import {
   minimapZoomValue,
   nextMinimapZoom,
 } from './minimap_zoom';
+import { selectPartyFrameMembers } from './party_frames';
 import {
   type PerfOverlayHooks,
   PerfOverlaySettingsPanel,
@@ -491,9 +492,6 @@ const ITEM_STAT_LABEL_KEYS: Partial<Record<keyof Stats, TranslationKey>> = {
 const classCss = (cls: string): string =>
   `#${((CLASSES as Record<string, { color: number }>)[cls]?.color ?? 0x5fa8ff).toString(16).padStart(6, '0')}`;
 
-// Party frames dim and the minimap pins members to the rim once they pass
-// this range (yards) — just inside the server's ~120 yd interest scope.
-const PARTY_RANGE_YD = 100;
 const EMOTE_WHEEL_LIMIT = 8;
 const DEFAULT_EMOTE_WHEEL: OverheadEmoteId[] = [
   'wave',
@@ -4099,7 +4097,7 @@ export class Hud {
 
   private renderAuras(el: HTMLElement, e: Entity, mode: 'all' | 'debuffs'): void {
     // cheap diff: rebuild only when the aura set changes
-    const sig = e.auras.map((a) => a.id + Math.ceil(a.remaining) + 'x' + (a.stacks ?? 0)).join('|');
+    const sig = e.auras.map((a) => `${a.id}${Math.ceil(a.remaining)}x${a.stacks ?? 0}`).join('|');
     if ((el as any).__sig === sig) return;
     (el as any).__sig = sig;
     el.innerHTML = '';
@@ -10720,14 +10718,8 @@ export class Hud {
       this.lastPartySig = '';
       return;
     }
-    const p = this.sim.player;
     const myGroup = info.members.find((m) => m.pid === this.sim.playerId)?.group ?? 1;
-    const others = info.members
-      .map((m) => ({
-        ...m,
-        oor: !m.dead && Math.hypot(m.x - p.pos.x, m.z - p.pos.z) > PARTY_RANGE_YD,
-      }))
-      .filter((m) => m.pid !== this.sim.playerId && (!info.raid || m.group === myGroup));
+    const others = selectPartyFrameMembers(info, this.sim.playerId, this.sim.player.pos);
     // include combat/range state so the frames rebuild when a badge changes
     const sig = `${others.map((m) => `${m.pid}:${m.group}:${m.hp}/${m.mhp}:${m.res}:${m.dead}:${m.inCombat}:${m.oor ? 1 : 0}:${m.level}`).join('|')}L${info.leader}:R${info.raid ? 1 : 0}:G${myGroup}`;
     if (sig === this.lastPartySig) return;

--- a/src/ui/party_frames.ts
+++ b/src/ui/party_frames.ts
@@ -1,0 +1,24 @@
+import type { PartyInfo, PartyMemberInfo } from '../world_api';
+
+export const PARTY_FRAME_RANGE_YD = 100;
+
+export type PartyFrameMember = PartyMemberInfo & { oor: boolean };
+
+export function selectPartyFrameMembers(
+  info: PartyInfo,
+  playerId: number,
+  playerPos: { x: number; z: number },
+  rangeYd = PARTY_FRAME_RANGE_YD,
+): PartyFrameMember[] {
+  return info.members
+    .map((member, index) => ({ member, index }))
+    .sort((a, b) =>
+      info.raid ? a.member.group - b.member.group || a.index - b.index : a.index - b.index,
+    )
+    .map(({ member }) => member)
+    .filter((m) => m.pid !== playerId)
+    .map((m) => ({
+      ...m,
+      oor: !m.dead && Math.hypot(m.x - playerPos.x, m.z - playerPos.z) > rangeYd,
+    }));
+}

--- a/tests/party_frames.test.ts
+++ b/tests/party_frames.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { selectPartyFrameMembers } from '../src/ui/party_frames';
+import type { PartyInfo, PartyMemberInfo } from '../src/world_api';
+
+const member = (pid: number, group: 1 | 2, x = 0, z = 0): PartyMemberInfo => ({
+  pid,
+  name: `Raid${pid}`,
+  cls: 'priest',
+  level: 20,
+  hp: 100,
+  mhp: 100,
+  res: 100,
+  mres: 100,
+  rtype: 'mana',
+  x,
+  z,
+  dead: 0,
+  inCombat: 0,
+  group,
+});
+
+describe('party frame member selection', () => {
+  it('shows every other raid member across raid groups', () => {
+    const info: PartyInfo = {
+      leader: 1,
+      raid: true,
+      members: [
+        member(1, 1),
+        member(2, 1),
+        member(3, 1),
+        member(4, 1),
+        member(5, 1),
+        member(6, 2),
+        member(7, 2),
+        member(8, 2),
+        member(9, 2),
+        member(10, 2),
+      ],
+    };
+
+    const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 });
+
+    expect(frames.map((m) => m.pid)).toEqual([2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(frames.filter((m) => m.group === 2)).toHaveLength(5);
+  });
+
+  it('matches the raid social tab ordering when raid groups are interleaved', () => {
+    const info: PartyInfo = {
+      leader: 1,
+      raid: true,
+      members: [member(1, 1), member(6, 2), member(2, 1), member(7, 2), member(3, 1), member(4, 1)],
+    };
+
+    const frames = selectPartyFrameMembers(info, 1, { x: 0, z: 0 });
+
+    expect(frames.map((m) => m.pid)).toEqual([2, 3, 4, 6, 7]);
+  });
+
+  it('marks live out-of-range members without hiding them', () => {
+    const info: PartyInfo = {
+      leader: 1,
+      raid: true,
+      members: [member(1, 1), member(2, 2, 150, 0)],
+    };
+
+    expect(selectPartyFrameMembers(info, 1, { x: 0, z: 0 })[0]).toMatchObject({
+      pid: 2,
+      oor: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Restores left-side raid frames for the full raid instead of limiting the frames to the player's subgroup.

The raid frame member selection now lives in a small helper that:
- includes every other raid member across both raid groups
- keeps the player's own character out of the raid frames, since they already have the player frame
- marks out-of-range members without hiding them
- orders frames to match the Raid tab: Group 1 first, then Group 2, preserving member order within each group

## Root Cause

The HUD party frame logic filtered raid members down to the current player's subgroup. After raid group management was added, healers could no longer see all raid members in the left-side frames.

## Validation

- `npm run i18n:gen`
- `git diff --exit-code -- src/ui/i18n.resolved.generated src/admin/i18n.resolved.generated src/ui/i18n.status.summary.json`
- `npm run security:gate`
- `npm test` — 356 files passed, 3668 tests passed, 8 skipped
- `npx tsc --noEmit`
- `npm run build:env`
- `npm run build:server`
- `npm run build`
- `npx @biomejs/biome ci src/ui/party_frames.ts tests/party_frames.test.ts --max-diagnostics=80`
- `npx @biomejs/biome ci --changed --since=origin/release/v0.15.0 --no-errors-on-unmatched --max-diagnostics=120`
- `git diff --check`

Note: the changed-file Biome command exits successfully but still reports existing warnings in `src/ui/hud.ts`.