### PR TITLE
fix: key auction sellers by character id

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -800,7 +800,7 @@ export class GameServer {
         return { error: 'too many characters on this account are already in the world' };
       }
     }
-    const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined });
+    const pid = this.sim.addPlayer(cls, name, { state: state ?? undefined, characterId });
     if (isGm) {
       // GM characters: invulnerable, and always at the level cap (the row is
       // created without state, so the first join levels them up)
@@ -1052,6 +1052,10 @@ export class GameServer {
     } catch (err) {
       console.error('failed to save world market:', err);
     }
+  }
+
+  rekeyMarketSeller(characterId: number, oldName: string, newName: string): boolean {
+    return this.sim.rekeyMarketSeller(characterId, oldName, newName);
   }
 
   // Close every open play_sessions row; called on graceful shutdown so the

--- a/server/main.ts
+++ b/server/main.ts
@@ -908,6 +908,9 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
           }
           return json(res, 404, { error: 'character not found' });
         }
+        if (game.rekeyMarketSeller(characterId, character.name, c.name)) {
+          await game.saveMarket();
+        }
         return json(res, 200, {
           id: c.id,
           name: c.name,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -678,6 +678,9 @@ export type JoinableChannel = (typeof JOINABLE_CHANNELS)[number];
 // everything that belongs to the character sheet.
 export interface PlayerMeta {
   entityId: number;
+  // Stable database character id when running on the server. Offline/sim-only
+  // callers fall back to entityId for systems that need a rename-proof owner key.
+  characterId?: number;
   cls: PlayerClass;
   name: string;
   skin: number; // appearance index into the render SKINS[player_<cls>]; persisted, synced
@@ -769,13 +772,13 @@ export interface AwayStatus {
 // The World Market — a single shared, server-authoritative auction house run
 // by the Merchant NPC. Listings live in the sim (so offline play has a market
 // too and the rules are testable); the server persists them to Postgres.
-// Sellers are keyed by character name, which is globally unique, so proceeds
-// and returns reach the right player even while they are offline.
+// Sellers are keyed by stable character id where available, so proceeds and
+// returns still reach the right player after a character rename.
 // ---------------------------------------------------------------------------
 
 export interface MarketListing {
   id: number;
-  sellerKey: string; // stable seller identity (character name); '' for house stock
+  sellerKey: string; // stable seller identity (character id string); '' for house stock
   sellerName: string; // display name
   itemId: string;
   count: number;
@@ -785,7 +788,7 @@ export interface MarketListing {
 }
 
 // Gold + items awaiting pickup at the Merchant (sale proceeds, expired
-// listings), keyed by seller name so an offline seller can collect later.
+// listings), keyed by sellerKey so an offline seller can collect later.
 export interface MarketCollection {
   copper: number;
   items: InvSlot[];
@@ -1012,7 +1015,7 @@ export class Sim {
   // dungeon instances
   instances: InstanceSlot[] = [];
   // the World Market: one shared listing book, per-seller collections keyed by
-  // character name, and the Merchant entity these are anchored to
+  // stable character identity, and the Merchant entity these are anchored to
   marketListings: MarketListing[] = [];
   private marketCollections = new Map<string, MarketCollection>();
   private nextListingId = 1;
@@ -1183,7 +1186,7 @@ export class Sim {
   addPlayer(
     cls: PlayerClass,
     name: string,
-    opts?: { autoEquip?: boolean; state?: CharacterState },
+    opts?: { autoEquip?: boolean; state?: CharacterState; characterId?: number },
   ): number {
     const savedState = opts?.state ? sanitizeRemovedZone1Content(opts.state).state : undefined;
     // Characters saved inside a dungeon instance rejoin at its entrance —
@@ -1211,6 +1214,7 @@ export class Sim {
     const classDef = CLASSES[cls];
     const meta: PlayerMeta = {
       entityId: player.id,
+      characterId: opts?.characterId,
       cls,
       name,
       skin: savedState?.skin ?? 0,
@@ -13922,9 +13926,20 @@ export class Sim {
     return !!m && dist2d(e.pos, m.pos) <= MARKET_RANGE;
   }
 
-  private metaByName(name: string): PlayerMeta | null {
-    if (!name) return null;
-    for (const m of this.players.values()) if (m.name === name) return m;
+  private marketSellerKey(meta: PlayerMeta): string {
+    return String(meta.characterId ?? meta.entityId);
+  }
+
+  private marketListingBelongsTo(listing: MarketListing, meta: PlayerMeta): boolean {
+    if (listing.house) return false;
+    return listing.sellerKey === this.marketSellerKey(meta) || listing.sellerKey === meta.name;
+  }
+
+  private metaByMarketSellerKey(key: string): PlayerMeta | null {
+    if (!key) return null;
+    for (const m of this.players.values()) {
+      if (this.marketSellerKey(m) === key || m.name === key) return m;
+    }
     return null;
   }
 
@@ -13935,6 +13950,43 @@ export class Sim {
       this.marketCollections.set(key, c);
     }
     return c;
+  }
+
+  private mergeMarketCollections(fromKey: string, toKey: string): boolean {
+    if (!fromKey || fromKey === toKey) return false;
+    const from = this.marketCollections.get(fromKey);
+    if (!from) return false;
+    const to = this.collectionFor(toKey);
+    to.copper += from.copper;
+    to.items.push(...from.items.map((s) => ({ ...s })));
+    this.marketCollections.delete(fromKey);
+    return true;
+  }
+
+  private collectionForSeller(meta: PlayerMeta): MarketCollection | undefined {
+    const key = this.marketSellerKey(meta);
+    this.mergeMarketCollections(meta.name, key);
+    return this.marketCollections.get(key);
+  }
+
+  rekeyMarketSeller(characterId: number, oldName: string, newName: string): boolean {
+    if (!Number.isFinite(characterId)) return false;
+    const key = String(characterId);
+    let changed = this.mergeMarketCollections(oldName, key);
+    changed = this.mergeMarketCollections(newName, key) || changed;
+    for (const listing of this.marketListings) {
+      if (listing.house) continue;
+      if (
+        listing.sellerKey === key ||
+        listing.sellerKey === oldName ||
+        listing.sellerKey === newName
+      ) {
+        if (listing.sellerKey !== key || listing.sellerName !== newName) changed = true;
+        listing.sellerKey = key;
+        listing.sellerName = newName;
+      }
+    }
+    return changed;
   }
 
   // The Merchant always keeps a little stock so the market is never empty —
@@ -14028,8 +14080,9 @@ export class Sim {
       this.error(meta.entityId, 'That price is beyond what the Merchant will broker.');
       return;
     }
+    const sellerKey = this.marketSellerKey(meta);
     const mine = this.marketListings.reduce(
-      (n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0),
+      (n, l) => n + (this.marketListingBelongsTo(l, meta) ? 1 : 0),
       0,
     );
     if (mine >= MARKET_MAX_LISTINGS) {
@@ -14042,7 +14095,7 @@ export class Sim {
     this.removeItem(itemId, want, meta.entityId); // escrow
     this.marketListings.push({
       id: this.nextListingId++,
-      sellerKey: meta.name,
+      sellerKey,
       sellerName: meta.name,
       itemId,
       count: want,
@@ -14080,7 +14133,7 @@ export class Sim {
       this.marketListings.splice(idx, 1);
       return;
     }
-    if (!listing.house && listing.sellerKey === meta.name) {
+    if (this.marketListingBelongsTo(listing, meta)) {
       this.error(meta.entityId, 'That is your own listing — cancel it to reclaim it.');
       return;
     }
@@ -14094,7 +14147,7 @@ export class Sim {
       const proceeds = Math.max(0, Math.floor(listing.price * (1 - MARKET_CUT)));
       this.collectionFor(listing.sellerKey).copper += proceeds;
       this.marketListings.splice(idx, 1);
-      const sellerMeta = this.metaByName(listing.sellerKey);
+      const sellerMeta = this.metaByMarketSellerKey(listing.sellerKey);
       if (sellerMeta) {
         this.emit({
           type: 'loot',
@@ -14123,7 +14176,7 @@ export class Sim {
     const idx = this.marketListings.findIndex((l) => l.id === listingId);
     if (idx < 0) return;
     const listing = this.marketListings[idx];
-    if (listing.house || listing.sellerKey !== meta.name) {
+    if (!this.marketListingBelongsTo(listing, meta)) {
       this.error(meta.entityId, 'That is not your listing.');
       return;
     }
@@ -14148,7 +14201,7 @@ export class Sim {
       this.error(meta.entityId, 'You are too far from the Merchant.');
       return;
     }
-    const col = this.marketCollections.get(meta.name);
+    const col = this.collectionForSeller(meta);
     if (!col || (col.copper <= 0 && col.items.length === 0)) {
       this.error(meta.entityId, 'You have nothing to collect.');
       return;
@@ -14162,7 +14215,7 @@ export class Sim {
       });
     }
     for (const s of col.items) this.addItem(s.itemId, s.count, meta.entityId);
-    this.marketCollections.delete(meta.name);
+    this.marketCollections.delete(this.marketSellerKey(meta));
   }
 
   // Once a second: return expired player listings to their seller's collection.
@@ -14173,7 +14226,7 @@ export class Sim {
       if (l.house || this.time < l.expiresAt) continue;
       this.marketListings.splice(i, 1);
       this.collectionFor(l.sellerKey).items.push({ itemId: l.itemId, count: l.count });
-      const sellerMeta = this.metaByName(l.sellerKey);
+      const sellerMeta = this.metaByMarketSellerKey(l.sellerKey);
       if (sellerMeta) {
         const def = ITEMS[l.itemId];
         this.emit({
@@ -14213,7 +14266,7 @@ export class Sim {
     // SELL tab would then read "12/12" while only a handful of their listings
     // are visible. MARKET_MAX_LISTINGS (12) ≪ MARKET_WIRE_LIMIT (120), so a
     // seller's own goods always fit alongside a healthy slice of the market.
-    const isMine = (l: MarketListing) => !l.house && l.sellerKey === meta.name;
+    const isMine = (l: MarketListing) => this.marketListingBelongsTo(l, meta);
     const mineSorted = sorted.filter(isMine);
     const others = sorted.filter((l) => !isMine(l));
     const wired = [
@@ -14222,16 +14275,16 @@ export class Sim {
     ];
     const listings = wired.map((l) => ({
       id: l.id,
-      sellerName: l.sellerName,
+      sellerName: isMine(l) ? meta.name : l.sellerName,
       itemId: l.itemId,
       count: l.count,
       price: l.price,
       mine: isMine(l),
       house: l.house,
     }));
-    const col = this.marketCollections.get(meta.name);
+    const col = this.collectionForSeller(meta);
     const myListingCount = this.marketListings.reduce(
-      (n, l) => n + (!l.house && l.sellerKey === meta.name ? 1 : 0),
+      (n, l) => n + (this.marketListingBelongsTo(l, meta) ? 1 : 0),
       0,
     );
     return {
@@ -14819,7 +14872,7 @@ export class Sim {
   // and this.time (no new fields); the count is shown against MARKET_MAX_LISTINGS
   // so you know how much room you have left, mirroring the cap in marketList.
   private listingsReadout(meta: PlayerMeta): string {
-    const mine = this.marketListings.filter((l) => !l.house && l.sellerKey === meta.name);
+    const mine = this.marketListings.filter((l) => this.marketListingBelongsTo(l, meta));
     if (mine.length === 0) return 'You have no goods on the World Market.';
     const parts = mine.map((l) => {
       const name = ITEMS[l.itemId]?.name ?? l.itemId;

--- a/tests/aldric_meteor_quest.test.ts
+++ b/tests/aldric_meteor_quest.test.ts
@@ -21,7 +21,9 @@ function teleportTo(sim: Sim, x: number, z: number): void {
 }
 
 function standAtMerchant(sim: Sim): void {
-  const merchant = [...sim.entities.values()].find((e): e is Entity => e.kind === 'npc' && e.templateId === 'the_merchant');
+  const merchant = [...sim.entities.values()].find(
+    (e): e is Entity => e.kind === 'npc' && e.templateId === 'the_merchant',
+  );
   if (!merchant) throw new Error('merchant not found');
   teleportTo(sim, merchant.pos.x, merchant.pos.z);
 }
@@ -47,25 +49,38 @@ describe('Brother Aldric fallen star quest', () => {
     expect(ITEMS[REWARD_ITEM_ID]?.noMarketList).toBe(true);
     expect(ITEMS[RETURNED_CHROMA_ITEM_ID]?.name).toBe('Amber Crimson');
     expect(ITEMS[RETURNED_CHROMA_ITEM_ID]?.quality).toBe('uncommon');
-    expect(ITEMS[RETURNED_CHROMA_ITEM_ID]?.use).toEqual({ type: 'mechChroma', chromaId: 'amber_crimson' });
+    expect(ITEMS[RETURNED_CHROMA_ITEM_ID]?.use).toEqual({
+      type: 'mechChroma',
+      chromaId: 'amber_crimson',
+    });
     expect(questRewardItemId(quest, 'warrior')).toBe(REWARD_ITEM_ID);
 
     const meteorObjectDef = GROUND_OBJECTS.find((obj) => obj.itemId === METEOR_ITEM_ID);
     expect(meteorObjectDef).toBeTruthy();
-    expect(meteorObjectDef!.positions.some((pos) => Math.hypot(pos.x - 152, pos.z - 294) <= 8)).toBe(true);
+    expect(
+      meteorObjectDef!.positions.some((pos) => Math.hypot(pos.x - 152, pos.z - 294) <= 8),
+    ).toBe(true);
 
-    const sim = new Sim({ seed: 20061, playerClass: 'warrior', playerName: 'Reuben', autoEquip: false });
+    const sim = new Sim({
+      seed: 20061,
+      playerClass: 'warrior',
+      playerName: 'Reuben',
+      autoEquip: false,
+    });
     sim.player.level = 8;
 
-    const aldric = [...sim.entities.values()].find((e) => e.kind === 'npc' && e.templateId === 'brother_aldric_fen');
+    const aldric = [...sim.entities.values()].find(
+      (e) => e.kind === 'npc' && e.templateId === 'brother_aldric_fen',
+    );
     expect(aldric).toBeTruthy();
     teleportTo(sim, aldric!.pos.x + 1, aldric!.pos.z);
 
     sim.questLog.set(QUEST_ID, { questId: QUEST_ID, counts: [0], state: 'active' });
     expect(sim.questState(QUEST_ID)).toBe('active');
 
-    const meteorObject = [...sim.entities.values()]
-      .find((e) => e.kind === 'object' && e.objectItemId === METEOR_ITEM_ID);
+    const meteorObject = [...sim.entities.values()].find(
+      (e) => e.kind === 'object' && e.objectItemId === METEOR_ITEM_ID,
+    );
     expect(meteorObject).toBeTruthy();
     teleportTo(sim, meteorObject!.pos.x + 1, meteorObject!.pos.z);
 
@@ -99,8 +114,15 @@ describe('Brother Aldric fallen star quest', () => {
     expect(QUESTS[QUEST_ID].minLevel).toBe(5);
     expect(QUESTS[QUEST_ID]).toMatchObject({ retired: true });
 
-    const sim = new Sim({ seed: 20061, playerClass: 'warrior', playerName: 'Reuben', autoEquip: false });
-    const aldric = [...sim.entities.values()].find((e) => e.kind === 'npc' && e.templateId === 'brother_aldric_fen');
+    const sim = new Sim({
+      seed: 20061,
+      playerClass: 'warrior',
+      playerName: 'Reuben',
+      autoEquip: false,
+    });
+    const aldric = [...sim.entities.values()].find(
+      (e) => e.kind === 'npc' && e.templateId === 'brother_aldric_fen',
+    );
     expect(aldric).toBeTruthy();
     teleportTo(sim, aldric!.pos.x + 1, aldric!.pos.z);
 
@@ -137,7 +159,7 @@ describe('Brother Aldric fallen star quest', () => {
 
     sim.marketList(REWARD_ITEM_ID, 1, 100);
     expect(sim.countItem(REWARD_ITEM_ID)).toBe(1);
-    expect(sim.marketListings.find((l) => l.itemId === REWARD_ITEM_ID && l.sellerKey === 'Seller')).toBeUndefined();
+    expect(sim.marketListings.find((l) => l.itemId === REWARD_ITEM_ID)).toBeUndefined();
 
     const buyer = sim.addPlayer('mage', 'Buyer');
     teleportTo(sim, sim.player.pos.x + 1, sim.player.pos.z);
@@ -147,6 +169,8 @@ describe('Brother Aldric fallen star quest', () => {
     sim.tradeRequest(buyer);
     sim.tradeAccept(buyer);
     sim.tradeSetOffer([{ itemId: REWARD_ITEM_ID, count: 1 }], 0);
-    expect(sim.tradeFor(sim.playerId)?.offerA.items).toEqual([{ itemId: REWARD_ITEM_ID, count: 1 }]);
+    expect(sim.tradeFor(sim.playerId)?.offerA.items).toEqual([
+      { itemId: REWARD_ITEM_ID, count: 1 },
+    ]);
   });
 });

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -16,14 +16,16 @@ function merchant(sim: Sim): Entity {
 function standAtMerchant(sim: Sim, pid: number) {
   const m = merchant(sim);
   const e = sim.entities.get(pid)!;
-  e.pos.x = m.pos.x; e.pos.z = m.pos.z;
+  e.pos.x = m.pos.x;
+  e.pos.z = m.pos.z;
   e.pos.y = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
   e.prevPos = { ...e.pos };
 }
 
 function teleport(sim: Sim, pid: number, x: number, z: number) {
   const e = sim.entities.get(pid)!;
-  e.pos.x = x; e.pos.z = z;
+  e.pos.x = x;
+  e.pos.z = z;
   e.pos.y = groundHeight(x, z, sim.cfg.seed);
   e.prevPos = { ...e.pos };
 }
@@ -34,6 +36,15 @@ function copperOf(sim: Sim, pid: number): number {
 
 function errorsSince(sim: Sim): string[] {
   return sim.events.filter((e) => e.type === 'error').map((e) => (e as { text: string }).text);
+}
+
+function renameLiveCharacter(sim: Sim, pid: number, name: string) {
+  sim.players.get(pid)!.name = name;
+  sim.entities.get(pid)!.name = name;
+}
+
+function marketSellerKey(pid: number): string {
+  return String(pid);
 }
 
 describe('the World Market — the Merchant', () => {
@@ -78,7 +89,7 @@ describe('the World Market — the Merchant', () => {
     expect(sim.marketInfoFor(seller)!.totalCount).toBe(all.totalCount);
   });
 
-  it('lists a stack from a seller\'s bags into escrow', () => {
+  it("lists a stack from a seller's bags into escrow", () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');
     standAtMerchant(sim, seller);
@@ -89,7 +100,7 @@ describe('the World Market — the Merchant', () => {
 
     expect(errorsSince(sim)).toEqual([]);
     expect(sim.countItem('wolf_fang', seller)).toBe(1); // 2 escrowed
-    const mine = sim.marketListings.filter((l) => l.sellerKey === 'Seller');
+    const mine = sim.marketListings.filter((l) => l.sellerKey === marketSellerKey(seller));
     expect(mine.length).toBe(1);
     expect(mine[0]).toMatchObject({ itemId: 'wolf_fang', count: 2, price: 100, house: false });
     expect(Number.isFinite(mine[0].expiresAt)).toBe(true);
@@ -104,7 +115,7 @@ describe('the World Market — the Merchant', () => {
     sim.addItem('wolf_fang', 2, seller);
     sim.players.get(buyer)!.copper = 1000;
     sim.marketList('wolf_fang', 2, 100, seller);
-    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    const listing = sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller))!;
     sim.events.length = 0;
 
     sim.marketBuy(listing.id, buyer);
@@ -118,7 +129,7 @@ describe('the World Market — the Merchant', () => {
     expect(info.collectionCopper).toBe(95);
   });
 
-  it('collecting moves waiting gold into the seller\'s purse', () => {
+  it("collecting moves waiting gold into the seller's purse", () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');
     const buyer = sim.addPlayer('mage', 'Buyer');
@@ -127,7 +138,10 @@ describe('the World Market — the Merchant', () => {
     sim.addItem('wolf_fang', 1, seller);
     sim.players.get(buyer)!.copper = 500;
     sim.marketList('wolf_fang', 1, 200, seller);
-    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'Seller')!.id, buyer);
+    sim.marketBuy(
+      sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller))!.id,
+      buyer,
+    );
     expect(copperOf(sim, seller)).toBe(0);
 
     sim.marketCollect(seller);
@@ -143,7 +157,7 @@ describe('the World Market — the Merchant', () => {
     sim.addItem('wolf_fang', 1, seller);
     sim.players.get(seller)!.copper = 10000;
     sim.marketList('wolf_fang', 1, 100, seller);
-    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    const listing = sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller))!;
     sim.events.length = 0;
 
     sim.marketBuy(listing.id, seller);
@@ -155,6 +169,73 @@ describe('the World Market — the Merchant', () => {
     expect(sim.marketListings.some((l) => l.id === listing.id)).toBe(false);
   });
 
+  it('keeps listings owned by the same character after a rename', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.players.get(seller)!.copper = 10000;
+    sim.marketList('wolf_fang', 1, 100, seller);
+    const listing = sim.marketListings.find((l) => !l.house && l.itemId === 'wolf_fang')!;
+
+    renameLiveCharacter(sim, seller, 'Renamed');
+
+    const info = sim.marketInfoFor(seller)!;
+    expect(info.myListingCount).toBe(1);
+    expect(info.listings.find((l) => l.id === listing.id)?.mine).toBe(true);
+
+    sim.events.length = 0;
+    sim.marketBuy(listing.id, seller);
+    expect(errorsSince(sim).join(' ')).toMatch(/your own listing/i);
+    expect(copperOf(sim, seller)).toBe(10000);
+
+    sim.marketCancel(listing.id, seller);
+    expect(sim.countItem('wolf_fang', seller)).toBe(1);
+  });
+
+  it('keeps sale proceeds collectible by the same character after a rename', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller');
+    const buyer = sim.addPlayer('mage', 'Buyer');
+    standAtMerchant(sim, seller);
+    standAtMerchant(sim, buyer);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.players.get(buyer)!.copper = 500;
+    sim.marketList('wolf_fang', 1, 200, seller);
+    const listing = sim.marketListings.find((l) => !l.house && l.itemId === 'wolf_fang')!;
+
+    renameLiveCharacter(sim, seller, 'Renamed');
+    sim.marketBuy(listing.id, buyer);
+    expect(sim.marketInfoFor(seller)!.collectionCopper).toBe(190);
+
+    sim.marketCollect(seller);
+
+    expect(copperOf(sim, seller)).toBe(190);
+    expect(sim.marketInfoFor(seller)!.collectionCopper).toBe(0);
+  });
+
+  it('rekeys legacy name-bound market state during a forced rename', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer('warrior', 'Seller', { characterId: 77 });
+    standAtMerchant(sim, seller);
+    sim.addItem('wolf_fang', 1, seller);
+    sim.marketList('wolf_fang', 1, 200, seller);
+    const listing = sim.marketListings.find((l) => !l.house && l.itemId === 'wolf_fang')!;
+    listing.sellerKey = 'Seller';
+    listing.sellerName = 'Seller';
+    const internals = sim as unknown as {
+      marketCollections: Map<string, { copper: number; items: [] }>;
+    };
+    internals.marketCollections.set('Seller', { copper: 95, items: [] });
+
+    expect(sim.rekeyMarketSeller(77, 'Seller', 'Renamed')).toBe(true);
+    renameLiveCharacter(sim, seller, 'Renamed');
+
+    expect(listing).toMatchObject({ sellerKey: '77', sellerName: 'Renamed' });
+    expect(sim.marketInfoFor(seller)!.myListingCount).toBe(1);
+    expect(sim.marketInfoFor(seller)!.collectionCopper).toBe(95);
+  });
+
   it('rejects a purchase the buyer cannot afford', () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');
@@ -164,7 +245,7 @@ describe('the World Market — the Merchant', () => {
     sim.addItem('wolf_fang', 1, seller);
     sim.players.get(buyer)!.copper = 50;
     sim.marketList('wolf_fang', 1, 100, seller);
-    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    const listing = sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller))!;
     sim.events.length = 0;
 
     sim.marketBuy(listing.id, buyer);
@@ -186,13 +267,13 @@ describe('the World Market — the Merchant', () => {
     expect(copperOf(sim, buyer)).toBe(1000);
   });
 
-  it('returns expired listings to the seller\'s collection', () => {
+  it("returns expired listings to the seller's collection", () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');
     standAtMerchant(sim, seller);
     sim.addItem('wolf_fang', 1, seller);
     sim.marketList('wolf_fang', 1, 100, seller);
-    const listing = sim.marketListings.find((l) => l.sellerKey === 'Seller')!;
+    const listing = sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller))!;
     listing.expiresAt = sim.time - 1; // force it past due
     for (let i = 0; i < 20; i++) sim.tick(); // updateMarket runs once a second
 
@@ -211,7 +292,7 @@ describe('the World Market — the Merchant', () => {
     sim.marketList('wolf_fang', 1, 100, seller);
     expect(errorsSince(sim).join(' ')).toMatch(/Merchant/i);
     expect(sim.countItem('wolf_fang', seller)).toBe(1); // nothing escrowed
-    expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+    expect(sim.marketListings.some((l) => l.sellerKey === marketSellerKey(seller))).toBe(false);
     expect(sim.marketInfoFor(seller)).toBeNull(); // not streamed when far
   });
 
@@ -228,7 +309,7 @@ describe('the World Market — the Merchant', () => {
       // an error is surfaced, nothing is escrowed, and no listing is created
       expect(errorsSince(sim).length).toBeGreaterThan(0);
       expect(sim.countItem('wolf_fang', seller)).toBe(3); // nothing removed
-      expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+      expect(sim.marketListings.some((l) => l.sellerKey === marketSellerKey(seller))).toBe(false);
     }
   });
 
@@ -240,7 +321,7 @@ describe('the World Market — the Merchant', () => {
     sim.events.length = 0;
     sim.marketList('boar_hide', 1, 100, seller);
     expect(errorsSince(sim).join(' ')).toMatch(/quest items/i);
-    expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+    expect(sim.marketListings.some((l) => l.sellerKey === marketSellerKey(seller))).toBe(false);
   });
 
   it('will not broker items flagged as unsafe for the market', () => {
@@ -254,7 +335,7 @@ describe('the World Market — the Merchant', () => {
 
     expect(errorsSince(sim).join(' ')).toMatch(/cannot be listed on the World Market/i);
     expect(sim.countItem('alien_armor_plate', seller)).toBe(1);
-    expect(sim.marketListings.some((l) => l.sellerKey === 'Seller')).toBe(false);
+    expect(sim.marketListings.some((l) => l.sellerKey === marketSellerKey(seller))).toBe(false);
   });
 
   it('caps how many listings one seller may keep', () => {
@@ -267,7 +348,9 @@ describe('the World Market — the Merchant', () => {
     sim.events.length = 0;
     sim.marketList('wolf_fang', 1, 10, seller); // one too many
     expect(errorsSince(sim).join(' ')).toMatch(/at most/i);
-    expect(sim.marketListings.filter((l) => l.sellerKey === 'Seller').length).toBe(12);
+    expect(sim.marketListings.filter((l) => l.sellerKey === marketSellerKey(seller)).length).toBe(
+      12,
+    );
   });
 
   it('survives a save/load round-trip (persistence)', () => {
@@ -280,7 +363,10 @@ describe('the World Market — the Merchant', () => {
     sim.players.get(buyer)!.copper = 1000;
     sim.marketList('wolf_fang', 1, 300, seller); // this one will sell -> collection gold
     sim.marketList('wolf_fang', 2, 150, seller); // this one stays listed
-    sim.marketBuy(sim.marketListings.find((l) => l.sellerKey === 'Seller' && l.count === 1)!.id, buyer);
+    sim.marketBuy(
+      sim.marketListings.find((l) => l.sellerKey === marketSellerKey(seller) && l.count === 1)!.id,
+      buyer,
+    );
 
     const save = sim.serializeMarket();
     expect(save.listings.length).toBe(1); // only the unsold player listing (house excluded)
@@ -292,12 +378,19 @@ describe('the World Market — the Merchant', () => {
 
     const loaded = sim2.marketListings.filter((l) => !l.house);
     expect(loaded.length).toBe(1);
-    expect(loaded[0]).toMatchObject({ sellerKey: 'Seller', itemId: 'wolf_fang', count: 2, price: 150 });
+    expect(loaded[0]).toMatchObject({
+      sellerKey: marketSellerKey(seller),
+      itemId: 'wolf_fang',
+      count: 2,
+      price: 150,
+    });
     expect(Number.isFinite(loaded[0].expiresAt)).toBe(true);
     // house stock is reseeded, not duplicated from the save
     expect(sim2.marketListings.filter((l) => l.house).length).toBe(houseBefore);
     // the waiting sale proceeds came across too
-    const col = (sim2 as unknown as { marketCollections: Map<string, { copper: number }> }).marketCollections.get('Seller');
+    const col = (
+      sim2 as unknown as { marketCollections: Map<string, { copper: number }> }
+    ).marketCollections.get(marketSellerKey(seller));
     expect(col?.copper).toBe(285); // 300 - 5%
     // new listings keep climbing past the loaded ids
     const seller2 = sim2.addPlayer('warrior', 'Seller');
@@ -320,13 +413,20 @@ describe('the World Market — the Merchant', () => {
 
     // Flood the shared market with 200 other-seller listings whose names sort
     // first, pushing the seller's own goods well past MARKET_WIRE_LIMIT (120).
-    const internals = sim as unknown as { marketListings: Array<Record<string, unknown>>; nextListingId: number };
+    const internals = sim as unknown as {
+      marketListings: Array<Record<string, unknown>>;
+      nextListingId: number;
+    };
     for (let i = 0; i < 200; i++) {
       internals.marketListings.push({
         id: internals.nextListingId++,
-        sellerKey: `Other${i}`, sellerName: `Other${i}`,
-        itemId: 'aaa_filler', count: 1, price: 50,
-        expiresAt: sim.time + 1000, house: false,
+        sellerKey: `Other${i}`,
+        sellerName: `Other${i}`,
+        itemId: 'aaa_filler',
+        count: 1,
+        price: 50,
+        expiresAt: sim.time + 1000,
+        house: false,
       });
     }
 


### PR DESCRIPTION
## Summary
- key World Market seller ownership by stable character id instead of display name
- pass database character ids into the sim on server join
- rekey legacy name-bound listings and pending collections when a forced character rename succeeds, then persist market state
- add regression coverage for renamed sellers retaining ownership, collecting proceeds, and migrating legacy name-keyed market records

## Verification
- `npm test -- --run tests/market.test.ts tests/listings_command.test.ts tests/aldric_meteor_quest.test.ts`
- `npm test`
- `npm run i18n:gen`
- `npx biome check src/sim/sim.ts server/game.ts server/main.ts tests/market.test.ts tests/aldric_meteor_quest.test.ts --max-diagnostics=120` (passes with existing warnings)
- `npm run build`