### PR TITLE
Include private bot detector overlay in Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@ dist
 dist-env
 dist-server
 .git
+private/**/.git
 python
 docs
 tests

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,8 @@ src/admin/i18n.resolved.generated/*.tmp
 src/ui/i18n.status.json
 
 # private extensions (e.g. bot-detector)
-private/
+private/*
+!private/.dockerkeep
 
 # test artifacts & screenshots
 tmp/

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -146,8 +146,10 @@ For off-box safety, sync the directory to S3 occasionally:
   (`server/bot_detector/stub.ts`). Detection hooks are wired in, but they observe
   nothing and never act. To bundle the real behavioral detector, clone the private
   `bot_detector` repo into `private/bot_detector` **before** `npm run build` (or
-  `npm run build:server`). That directory is not part of the public checkout. At
-  build time, confirm which implementation was picked:
+  `npm run build:server`). The Docker build copies `private/` into the build stage,
+  so the same rule applies to deploys that run `docker compose build`: the private
+  checkout must exist before the image is built. That directory is not part of the
+  public checkout. At build time, confirm which implementation was picked:
   `[build:server] bot detector: stub (no-op)` vs `… bot detector: private`.
 - **Anti-bot runtime knobs**: `MAX_WS_PER_IP_HARD` (default `20`) caps simultaneous
   WebSocket connections per source IP; extra connections are refused at the

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ COPY server ./server
 COPY headless ./headless
 COPY scripts ./scripts
 COPY public ./public
+# Optional private extensions live under ./private. Public checkouts contain only
+# a placeholder, so builds still fall back to public stubs; deploys can clone the
+# private bot detector into private/bot_detector before this Docker build.
+COPY private ./private
 # Public client config is inlined into the bundle at build time (Vite reads
 # VITE_* from the environment). Empty defaults keep optional UI disabled:
 # Turnstile widget off. Passed through from compose build args.

--- a/private/.dockerkeep
+++ b/private/.dockerkeep
@@ -1,0 +1,2 @@
+This directory is copied into Docker builds so deploy-time private extensions can
+be bundled when present. Keep the real private contents git-ignored.


### PR DESCRIPTION
## Summary

Makes production/dev Docker builds able to bundle the private `wocc-bot-protection` overlay when deploy automation checks it out at `private/bot_detector` before `docker compose build`.

The public fallback behavior is preserved:
- public checkouts now contain only `private/.dockerkeep`
- real private contents remain git-ignored
- Docker copies `private/` into the build stage
- `scripts/build_server.mjs` still chooses the private detector only when `private/bot_detector/src/index.ts` exists, otherwise it bundles the no-op stub

## Why

The app already resolves `#bot-detector` to the private overlay in local builds, but the Dockerfile did not copy `private/` into the image build context. That meant deploys could clone the private repo on the host and still build the no-op stub into the production image.

## Deploy expectation after this PR

Before `docker compose build`, deploy automation should ensure:

```bash
/opt/eastbrook/private/bot_detector/src/index.ts
```

exists and is fresh from `levy-street/wocc-bot-protection`.

Build logs should then show:

```text
[build:server] bot detector: private
```

Without that checkout, public/stub builds should continue to show:

```text
[build:server] bot detector: stub (no-op)
```

## Validation

- `npm run build:server` with no private overlay: passed, logged `bot detector: stub (no-op)`.
- `npm run build:server` with temporary `private/bot_detector` copied from `../wocc-bot-protection`: passed, logged `bot detector: private`.
- `docker build --target build -t woc-private-overlay-copy-smoke .` with public placeholder only: passed, logged `bot detector: stub (no-op)`.
- `docker build --target build -t woc-private-overlay-active-smoke .` with temporary private overlay: passed; prior uncached run logged `bot detector: private`.
- `git diff --check`: passed.
