### PR TITLE
fix(content): reroute roads around props so colliders stop knocking travelers off the path

### DIFF
--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -1036,27 +1036,31 @@ export const ZONE1_OBJECTS: GroundObjectDef[] = [
 export const ZONE1_ROADS: { x: number; z: number }[][] = [
   [
     { x: 0, z: 8 },
+    { x: -5, z: 14 },
     { x: -8, z: 30 },
     { x: -15, z: 55 },
     { x: -2, z: 78 },
-  ], // north to wolves
+  ], // north to wolves (bends west of the market stall)
   [
     { x: 8, z: 2 },
-    { x: 30, z: 8 },
+    { x: 24, z: 2 },
+    { x: 36, z: 8 },
     { x: 55, z: 12 },
-  ], // east to boars
+  ], // east to boars (dips south past the paddock fence)
   [
     { x: 6, z: -6 },
     { x: 30, z: -30 },
     { x: 50, z: -50 },
-    { x: 65, z: -65 },
-  ], // southeast to bandits
+    { x: 57, z: -58 },
+  ], // southeast to bandits (stops at the camp edge, not on the campfire)
   [
     { x: -8, z: 6 },
-    { x: -35, z: 25 },
+    { x: -13, z: 5 },
+    { x: -21, z: 0 },
+    { x: -34, z: 18 },
     { x: -58, z: 48 },
     { x: -66, z: 58 },
-  ], // northwest to lake
+  ], // northwest to lake (crosses below the fence's south end)
   [
     { x: -6, z: -6 },
     { x: -30, z: -28 },
@@ -1065,10 +1069,12 @@ export const ZONE1_ROADS: { x: number; z: number }[][] = [
   ], // southwest to mine
   [
     { x: 6, z: 8 },
-    { x: 35, z: 35 },
+    { x: 16, z: 5 },
+    { x: 24, z: 2 },
+    { x: 40, z: 28 },
     { x: 60, z: 60 },
     { x: 78, z: 74 },
-  ], // northeast to ruins
+  ], // northeast to ruins (skirts the house and crosses past the fence end)
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -70,6 +70,10 @@ export const ZONE2_ROADS: { x: number; z: number }[][] = [
     { x: 20, z: 470 },
     { x: 45, z: 515 },
   ], // -> cult camp -> Bastion
+  [{ x: 0, z: 80 }, { x: 0, z: 180 }, { x: -8, z: 240 }, { x: 0, z: 300 }],         // Eastbrook -> Fenbridge
+  [{ x: 4, z: 308 }, { x: 20, z: 314 }, { x: 30, z: 323 }, { x: 45, z: 336 }, { x: 92, z: 350 }, { x: 102, z: 392 }, { x: 90, z: 420 }], // -> Drowned Chapel (east of the house and fence)
+  [{ x: -6, z: 308 }, { x: -40, z: 370 }, { x: -80, z: 420 }],                      // -> Troll Mounds
+  [{ x: 2, z: 312 }, { x: 10, z: 400 }, { x: 26, z: 466 }, { x: 30, z: 474 }, { x: 45, z: 515 }],      // -> cult camp -> Bastion (skirts the gravecaller tents)
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -60,7 +60,6 @@ export const ZONE2_ROADS: { x: number; z: number }[][] = [
     { x: 92, z: 350 },
     { x: 102, z: 392 },
     { x: 90, z: 420 },
-  ], // -> Drowned Chapel
   ], // -> Drowned Chapel (east of the house and fence)
   [
     { x: -6, z: 308 },
@@ -70,13 +69,6 @@ export const ZONE2_ROADS: { x: number; z: number }[][] = [
   [
     { x: 2, z: 312 },
     { x: 10, z: 400 },
-    { x: 20, z: 470 },
-    { x: 45, z: 515 },
-  ], // -> cult camp -> Bastion
-  [{ x: 0, z: 80 }, { x: 0, z: 180 }, { x: -8, z: 240 }, { x: 0, z: 300 }],         // Eastbrook -> Fenbridge
-  [{ x: 4, z: 308 }, { x: 20, z: 314 }, { x: 30, z: 323 }, { x: 45, z: 336 }, { x: 92, z: 350 }, { x: 102, z: 392 }, { x: 90, z: 420 }], // -> Drowned Chapel (east of the house and fence)
-  [{ x: -6, z: 308 }, { x: -40, z: 370 }, { x: -80, z: 420 }],                      // -> Troll Mounds
-  [{ x: 2, z: 312 }, { x: 10, z: 400 }, { x: 26, z: 466 }, { x: 30, z: 474 }, { x: 45, z: 515 }],      // -> cult camp -> Bastion (skirts the gravecaller tents)
     { x: 26, z: 466 },
     { x: 30, z: 474 },
     { x: 45, z: 515 },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -54,11 +54,14 @@ export const ZONE2_ROADS: { x: number; z: number }[][] = [
   ], // Eastbrook -> Fenbridge
   [
     { x: 4, z: 308 },
+    { x: 20, z: 314 },
+    { x: 30, z: 323 },
     { x: 45, z: 336 },
     { x: 92, z: 350 },
     { x: 102, z: 392 },
     { x: 90, z: 420 },
   ], // -> Drowned Chapel
+  ], // -> Drowned Chapel (east of the house and fence)
   [
     { x: -6, z: 308 },
     { x: -40, z: 370 },
@@ -74,6 +77,10 @@ export const ZONE2_ROADS: { x: number; z: number }[][] = [
   [{ x: 4, z: 308 }, { x: 20, z: 314 }, { x: 30, z: 323 }, { x: 45, z: 336 }, { x: 92, z: 350 }, { x: 102, z: 392 }, { x: 90, z: 420 }], // -> Drowned Chapel (east of the house and fence)
   [{ x: -6, z: 308 }, { x: -40, z: 370 }, { x: -80, z: 420 }],                      // -> Troll Mounds
   [{ x: 2, z: 312 }, { x: 10, z: 400 }, { x: 26, z: 466 }, { x: 30, z: 474 }, { x: 45, z: 515 }],      // -> cult camp -> Bastion (skirts the gravecaller tents)
+    { x: 26, z: 466 },
+    { x: 30, z: 474 },
+    { x: 45, z: 515 },
+  ], // -> cult camp -> Bastion (skirts the gravecaller tents)
 ];
 
 // ---------------------------------------------------------------------------

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -48,15 +48,20 @@ export const ZONE3_ROADS: { x: number; z: number }[][] = [
     { x: 0, z: 660 },
   ], // Fenbridge -> Highwatch
   [
-    { x: -6, z: 666 },
+    { x: -4, z: 664 },
+    { x: -6, z: 659 },
+    { x: -16, z: 658 },
+    { x: -30, z: 680 },
     { x: -60, z: 700 },
     { x: -110, z: 735 },
-  ], // -> ogre war-camp
+  ], // -> ogre war-camp (passes south of the inn and stalls)
   [
     { x: 6, z: 668 },
+    { x: 10, z: 675 },
+    { x: 22, z: 678 },
     { x: 70, z: 720 },
     { x: 110, z: 760 },
-  ], // -> Stormcrag
+  ], // -> Stormcrag (rounds the north side of the house)
   [
     { x: 0, z: 676 },
     { x: 0, z: 780 },

--- a/tests/road_corridors.test.ts
+++ b/tests/road_corridors.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { ROADS } from '../src/sim/data';
+import { resolvePosition } from '../src/sim/colliders';
+
+// Roads are the deterministic travel paths that mobs/quests route along and that
+// players naturally follow. A static prop collider (building, stall, tent, well,
+// crate, campfire, fence) sitting on a road centerline shoves a road-walker
+// sideways the moment they pass it: the "random colliders knock you off the path"
+// bug. Decorations (trees/rocks) already avoid roads (generateDecorations excludes
+// roadDistance < 5); props had no such guard. This test pins the invariant so a
+// future road tweak or new prop can't silently re-introduce an on-road collider.
+//
+// We walk every road centerline at the live world seed and resolve each sample
+// through the SAME collision function the server runs (resolvePosition). If a
+// collider overlaps the centerline it pushes the point; a player should never be
+// displaced more than a fraction of a body radius while following the road.
+
+const SEED = 20061; // the fixed persistent world seed (src/main.ts, server/main.ts)
+const BODY_RADIUS = 0.5;
+const MAX_PUSH = 0.5; // yards; below a single body radius == still on the path
+const STEP = 0.3; // sample spacing along the centerline
+
+function maxCenterlinePush(road: { x: number; z: number }[]): { push: number; x: number; z: number } {
+  let worst = 0;
+  let wx = road[0]?.x ?? 0;
+  let wz = road[0]?.z ?? 0;
+  for (let i = 0; i < road.length - 1; i++) {
+    const a = road[i];
+    const b = road[i + 1];
+    const dx = b.x - a.x;
+    const dz = b.z - a.z;
+    const len = Math.hypot(dx, dz);
+    const n = Math.max(1, Math.floor(len / STEP));
+    for (let s = 0; s <= n; s++) {
+      const t = s / n;
+      const x = a.x + dx * t;
+      const z = a.z + dz * t;
+      const res = resolvePosition(SEED, x, z, BODY_RADIUS);
+      const push = Math.hypot(res.x - x, res.z - z);
+      if (push > worst) {
+        worst = push;
+        wx = x;
+        wz = z;
+      }
+    }
+  }
+  return { push: worst, x: wx, z: wz };
+}
+
+describe('road corridors stay clear of prop colliders', () => {
+  ROADS.forEach((road, idx) => {
+    it(`road ${idx} does not push a road-walker off the path`, () => {
+      const { push, x, z } = maxCenterlinePush(road);
+      expect(
+        push,
+        `road ${idx} pushes a centerline walker ${push.toFixed(2)}yd at (${x.toFixed(1)}, ${z.toFixed(1)}) ` +
+          `- a prop collider overlaps the road; reroute the road around it`,
+      ).toBeLessThanOrEqual(MAX_PUSH);
+    });
+  });
+});

--- a/tests/road_corridors.test.ts
+++ b/tests/road_corridors.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { ROADS } from '../src/sim/data';
+import { describe, expect, it } from 'vitest';
 import { resolvePosition } from '../src/sim/colliders';
+import { ROADS } from '../src/sim/data';
 
 // Roads are the deterministic travel paths that mobs/quests route along and that
 // players naturally follow. A static prop collider (building, stall, tent, well,
@@ -20,7 +20,11 @@ const BODY_RADIUS = 0.5;
 const MAX_PUSH = 0.5; // yards; below a single body radius == still on the path
 const STEP = 0.3; // sample spacing along the centerline
 
-function maxCenterlinePush(road: { x: number; z: number }[]): { push: number; x: number; z: number } {
+function maxCenterlinePush(road: { x: number; z: number }[]): {
+  push: number;
+  x: number;
+  z: number;
+} {
   let worst = 0;
   let wx = road[0]?.x ?? 0;
   let wz = road[0]?.z ?? 0;


### PR DESCRIPTION
## The bug

\"Random colliders\" knock players sideways while they follow a road. The roads themselves look fine, but invisible static-prop colliders sit **on the road centerline**, so the server's collision resolver shoves any road-walker off the path the moment they pass one.

## Root cause

Decorations (trees/rocks) already avoid roads: `generateDecorations` skips any placement within 5yd of a road (`src/sim/world.ts`). Hand-placed **props** (buildings, stalls, tents, wells, crates, campfires, fences) had **no such guard**, and several authored roads were drawn straight through one:

| Road | Prop it clipped | Sideways shove |
|---|---|---|
| Eastbrook -> ruins | house at (10,12) | **3.4 yd** |
| Highwatch -> ogre camp | inn/stall at (-7.5,667) | 2.0 yd |
| Fenbridge -> Bastion | gravecaller tent at (20,466) | 1.4 yd |
| + 5 more across zones 1-3 | fences / buildings / a campfire | 0.7-1.4 yd |

I found these by walking every road centerline at the live world seed (20061) through the exact `resolvePosition` the server runs, and measuring the push.

## The fix

Per maintainer preference, **roads are rerouted around the props** (props stay exactly where they are). 8 road polylines across `zone1/2/3.ts` gain a few waypoints so each centerline clears every prop by a full body radius. Fences needed crossings routed past their padded ends; one bandit-camp road now stops at the camp edge instead of on the campfire.

Verified: every road centerline now pushes a body-radius walker **<= 0.16 yd** (was up to 3.4 yd).

## Regression guard

New `tests/road_corridors.test.ts` walks every road in `ROADS` at the live seed and asserts a body-radius walker is never displaced more than 0.5 yd, so a future road edit or new prop can't silently re-introduce an on-road collider.

## Before / after

Red = old roads cutting through prop colliders; green = rerouted roads skirting them (brown = buildings, circles = stalls/wells/tents/campfires, bars = fences).

![road reroute before/after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-roads-clear/roads_before_after.png)

## Tests
- `tests/road_corridors.test.ts` (new) - 14 roads pass
- `tests/architecture.test.ts`, `tests/map_terrain.test.ts`, `tests/progression.test.ts` pass
- Full `npm test` green (one unrelated `delves.test.ts` timeout flake that passes in isolation)

Determinism preserved: only road waypoint data changed; no RNG, no new balance numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)