### PR TITLE
feat(bot-detector): expose runtime snapshots and suspicious players

### DIFF
--- a/server/bot_detector/contract.ts
+++ b/server/bot_detector/contract.ts
@@ -1,13 +1,9 @@
-import type { SimEvent } from '../../src/sim/types';
 import type { MoveInputFrame } from '../../src/sim/move_input';
+import type { SimEvent } from '../../src/sim/types';
 
 export type EnforcementAction = 'none' | 'kick';
 
-export type ProtocolAnomaly =
-  | 'invalid_json'
-  | 'non_object'
-  | 'unknown_type'
-  | 'unknown_command';
+export type ProtocolAnomaly = 'invalid_json' | 'non_object' | 'unknown_type' | 'unknown_command';
 
 export interface PlayerSessionRef {
   accountId: number;
@@ -16,10 +12,52 @@ export interface PlayerSessionRef {
   ip: string;
 }
 
+export interface SessionRuntimeSnapshot {
+  capturedAt: number;
+  simTime: number;
+  x: number;
+  z: number;
+  facing: number;
+  dead: boolean;
+  inCombat: boolean;
+  targetId: number | null;
+  instanceSlot: number | null;
+  instanceDungeonId: string | null;
+  level: number;
+  classId: string;
+  hp: number;
+  maxHp: number;
+  resource: number;
+  maxResource: number;
+  resourceType: string | null;
+  autoAttack: boolean;
+  followTargetId: number | null;
+  moveSpeed: number;
+  onGround: boolean;
+}
+
+export interface SuspiciousEvidence {
+  kind: string;
+  weight: number;
+  detail: string;
+  expiresAt: number;
+}
+
+export type SuspiciousPlayerState = 'SUSPICIOUS' | 'CONFIRMED';
+
+export interface SuspiciousPlayer {
+  ref: PlayerSessionRef;
+  snapshot: SessionRuntimeSnapshot | null;
+  state: SuspiciousPlayerState;
+  score: number;
+  evidence: SuspiciousEvidence[];
+}
+
 // The brand makes this handle impossible to construct or read outside this module.
 declare const botTrackingBrand: unique symbol;
-export interface BotTrackingContext { readonly [botTrackingBrand]: true }
-
+export interface BotTrackingContext {
+  readonly [botTrackingBrand]: true;
+}
 
 export interface BotDetector {
   createTrackingContext(ref: PlayerSessionRef, meta?: unknown): BotTrackingContext;
@@ -27,6 +65,17 @@ export interface BotDetector {
   observeCommand(ctx: BotTrackingContext, cmd: string, now: number, message?: unknown): void;
   observeEvent(ctx: BotTrackingContext, ev: SimEvent, now: number): void;
   observeInput(ctx: BotTrackingContext, frame: MoveInputFrame, now: number): void;
-  observeProtocolAnomaly(ctx: BotTrackingContext, anomaly: ProtocolAnomaly, raw: string, now: number): void;
-  handleTick(ctx: BotTrackingContext, now: number, enforce: boolean): EnforcementAction;
+  observeProtocolAnomaly(
+    ctx: BotTrackingContext,
+    anomaly: ProtocolAnomaly,
+    raw: string,
+    now: number,
+  ): void;
+  handleTick(
+    ctx: BotTrackingContext,
+    now: number,
+    enforce: boolean,
+    snapshot: SessionRuntimeSnapshot | null,
+  ): EnforcementAction;
+  listSuspiciousPlayers(): SuspiciousPlayer[];
 }

--- a/server/bot_detector/stub.ts
+++ b/server/bot_detector/stub.ts
@@ -12,5 +12,6 @@ export function createBotDetector(): BotDetector {
     observeInput: () => {},
     observeProtocolAnomaly: () => {},
     handleTick: () => 'none',
+    listSuspiciousPlayers: () => [],
   };
 }

--- a/server/game.ts
+++ b/server/game.ts
@@ -22,7 +22,12 @@ import {
 import { type CommandName, isOverheadEmoteId } from '../src/world_api';
 import { recordOnlineSample } from './admin_db';
 import { offensiveName } from './auth';
-import type { BotDetector, BotTrackingContext } from './bot_detector/contract';
+import type {
+  BotDetector,
+  BotTrackingContext,
+  SessionRuntimeSnapshot,
+  SuspiciousPlayer,
+} from './bot_detector/contract';
 import { ChatFilter } from './chat_filter';
 import { applyChatStrike, loadChatFilterState, recordChatViolation } from './chat_filter_db';
 import { ChatLogger } from './chat_log';
@@ -779,11 +784,48 @@ export class GameServer {
   private runAntibotTick(): void {
     const now = Date.now();
     for (const session of this.clients.values()) {
-      const action = this.botDetector.handleTick(session.botTrackingContext, now, ANTIBOT_ENFORCE);
+      const action = this.botDetector.handleTick(
+        session.botTrackingContext,
+        now,
+        ANTIBOT_ENFORCE,
+        this.captureBotDetectionSnapshot(session, now),
+      );
       if (action === 'kick') {
         void this.kickSession(session, 'rejected by server', 'disconnected');
       }
     }
+  }
+
+  private captureBotDetectionSnapshot(
+    session: ClientSession,
+    capturedAt: number,
+  ): SessionRuntimeSnapshot | null {
+    const e = this.sim.entities.get(session.pid);
+    if (!e) return null;
+    const instance = this.sim.instanceInfoAt(e.pos);
+    return {
+      capturedAt,
+      simTime: this.sim.time,
+      x: e.pos.x,
+      z: e.pos.z,
+      facing: e.facing,
+      dead: e.dead,
+      inCombat: e.inCombat,
+      targetId: e.targetId,
+      instanceSlot: instance?.slot ?? null,
+      instanceDungeonId: instance?.dungeonId ?? null,
+      level: e.level,
+      classId: e.templateId,
+      hp: e.hp,
+      maxHp: e.maxHp,
+      resource: e.resource,
+      maxResource: e.maxResource,
+      resourceType: e.resourceType,
+      autoAttack: e.autoAttack,
+      followTargetId: e.followTargetId,
+      moveSpeed: e.moveSpeed,
+      onGround: e.onGround,
+    };
   }
 
   private clearStaleInputs(): void {
@@ -1241,6 +1283,10 @@ export class GameServer {
       rssBytes: mem.rss,
       heapUsedBytes: mem.heapUsed,
     };
+  }
+
+  suspiciousPlayers(): SuspiciousPlayer[] {
+    return this.botDetector.listSuspiciousPlayers();
   }
 
   liveSessions(): AdminLivePlayer[] {

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -11,9 +11,9 @@
 //
 // Sim keeps same-named thin delegates (enterDungeon/leaveDungeon/instanceKeyFor/
 // instanceOriginOf/enterCrypt/leaveCrypt/updateDoorTriggers/updateInstances/
-// instanceSlotAt) so every foreign `this.X` call site resolves unchanged, and the
-// seam exposes instanceKeyFor/instanceOriginOf/enterDungeon/leaveDungeon for the
-// N1/quest/delve code that reaches them through `ctx`.
+// instanceSlotAt/instanceInfoAt) so every foreign `this.X` call site resolves unchanged,
+// and the seam exposes instanceKeyFor/instanceOriginOf/enterDungeon/leaveDungeon for
+// the N1/quest/delve code that reaches them through `ctx`.
 
 import { DUNGEON_X_THRESHOLD, DUNGEONS, dungeonAt, instanceOrigin, MOBS } from '../data';
 import { createGroundObject, createMob } from '../entity';
@@ -294,9 +294,18 @@ export function updateInstances(ctx: SimContext): void {
 }
 
 export function instanceSlotAt(ctx: SimContext, pos: Vec3): number | null {
+  return instanceInfoAt(ctx, pos)?.slot ?? null;
+}
+
+export function instanceInfoAt(
+  ctx: SimContext,
+  pos: Vec3,
+): { slot: number; dungeonId: string } | null {
   for (const inst of ctx.instances) {
     const origin = instanceOriginOf(inst);
-    if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) return inst.slot;
+    if (Math.abs(pos.x - origin.x) < 120 && Math.abs(pos.z - origin.z) < 250) {
+      return { slot: inst.slot, dungeonId: inst.dungeonId };
+    }
   }
   return null;
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -189,6 +189,7 @@ export type { MarketSave } from './market';
 import {
   enterCrypt as enterCryptImpl,
   enterDungeon as enterDungeonImpl,
+  instanceInfoAt as instanceInfoAtImpl,
   instanceKeyFor as instanceKeyForImpl,
   instanceOriginOf as instanceOriginOfImpl,
   instanceSlotAt as instanceSlotAtImpl,
@@ -5185,6 +5186,10 @@ export class Sim {
 
   instanceSlotAt(pos: Vec3): number | null {
     return instanceSlotAtImpl(this.ctx, pos);
+  }
+
+  instanceInfoAt(pos: Vec3): { slot: number; dungeonId: string } | null {
+    return instanceInfoAtImpl(this.ctx, pos);
   }
 
   private error(pid: number, text: string, reason?: ErrorReason): void {

--- a/tests/bot_detector_stub.test.ts
+++ b/tests/bot_detector_stub.test.ts
@@ -1,7 +1,31 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import type { BotDetector, SessionRuntimeSnapshot } from '../server/bot_detector/contract';
 import { createBotDetector } from '../server/bot_detector/stub';
-import type { BotDetector } from '../server/bot_detector/contract';
 import { emptyMoveInput } from '../src/sim/types';
+
+const snapshot: SessionRuntimeSnapshot = {
+  capturedAt: 1_000,
+  simTime: 12.5,
+  x: 1,
+  z: 2,
+  facing: 0.5,
+  dead: false,
+  inCombat: false,
+  targetId: null,
+  instanceSlot: null,
+  instanceDungeonId: null,
+  level: 1,
+  classId: 'warrior',
+  hp: 100,
+  maxHp: 100,
+  resource: 0,
+  maxResource: 100,
+  resourceType: 'rage',
+  autoAttack: false,
+  followTargetId: null,
+  moveSpeed: 7,
+  onGround: true,
+};
 
 describe('bot-detector stub (open-source no-op)', () => {
   it('satisfies the BotDetector seam and detects nothing', () => {
@@ -13,11 +37,12 @@ describe('bot-detector stub (open-source no-op)', () => {
 
     // A full observation cycle is inert and never escalates.
     detector.observeCommand(ctx, 'attack', Date.now());
-    detector.observeCommand(ctx, 'attack', Date.now(), {some: 'payload'});
+    detector.observeCommand(ctx, 'attack', Date.now(), { some: 'payload' });
     detector.observeEvent(ctx, { type: 'tradeDone' } as any, Date.now());
     detector.observeInput(ctx, { moveInput: emptyMoveInput(), facing: 0 }, Date.now());
     detector.observeProtocolAnomaly(ctx, 'unknown_command', '{"t":"cmd","cmd":"x"}', Date.now());
-    expect(detector.handleTick(ctx, Date.now(), true)).toBe('none');
+    expect(detector.handleTick(ctx, Date.now(), true, snapshot)).toBe('none');
+    expect(detector.listSuspiciousPlayers()).toEqual([]);
 
     detector.releaseTrackingContext(ctx);
   });

--- a/tests/fixes.test.ts
+++ b/tests/fixes.test.ts
@@ -426,8 +426,12 @@ describe('the Hollow Crypt doors', () => {
     expect(eb.pos.x).toBeGreaterThan(DUNGEON_X_THRESHOLD);
     const slotA = sim.instanceSlotAt(ea.pos);
     const slotB = sim.instanceSlotAt(eb.pos);
+    const infoA = sim.instanceInfoAt(ea.pos);
+    const infoB = sim.instanceInfoAt(eb.pos);
     expect(slotA).not.toBeNull();
     expect(slotA).toBe(slotB);
+    expect(infoA).toEqual({ slot: slotA, dungeonId: 'hollow_crypt' });
+    expect(infoB).toEqual(infoA);
   });
 
   it('solo players from different groups get different instances', () => {


### PR DESCRIPTION
<!--
Thanks for contributing to World of ClaudeCraft!

New here? The contributing guide is available in your language:
https://github.com/levy-street/world-of-claudecraft/blob/main/CONTRIBUTING.md

Filling this out helps reviewers understand and merge your work faster. Anything
that doesn't apply to your change, feel free to delete or mark as N/A.
-->

## Summary

We want better live observability for bot detection and richer player-state context inside detector strategies, without exposing mutable sim internals.


## Changes

- Extend the bot detector seam with `SessionRuntimeSnapshot` and `listSuspiciousPlayers()`
- Capture authoritative per-session runtime snapshots during the antibot tick

 
## Related issues

<!-- e.g. "Closes #123" or "Part of #456". Remove this section if it doesn't apply. -->

## Type of change

<!-- Check all that apply. -->

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

Unit tested + played locally (with both private and no-op bot detector impl).


## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [x] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [x] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
