### PR TITLE
fix(game): retry pointer lock so camera rotate never escapes to a second monitor

### DIFF
--- a/scripts/pointer_lock_camera_shot.mjs
+++ b/scripts/pointer_lock_camera_shot.mjs
@@ -8,8 +8,9 @@
 // the behavior the bug was missing).
 //
 // Needs a dev server (default :5173, override with GAME_URL). Writes to tmp/.
-import puppeteer from 'puppeteer-core';
+
 import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
 import { BROWSER_PATH } from './browser_path.mjs';
 
 const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
@@ -24,7 +25,9 @@ const browser = await puppeteer.launch({
 });
 const page = await browser.newPage();
 page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
-page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('CONSOLE:', m.text());
+});
 
 await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
 await page.waitForSelector('#btn-offline', { timeout: 60000 });
@@ -64,31 +67,68 @@ const dragResult = await page.evaluate(async () => {
   window.__lockRequests = 0;
   const proto = Element.prototype;
   const orig = proto.requestPointerLock;
-  proto.requestPointerLock = function (...a) { window.__lockRequests++; return orig ? orig.apply(this, a) : undefined; };
+  proto.requestPointerLock = function (...a) {
+    window.__lockRequests++;
+    return orig ? orig.apply(this, a) : undefined;
+  };
   window.__game.input.setLockCursorOnRotate(true);
   // Headless Chromium reports the page as fullscreen, which (correctly) triggers
   // the fix's fullscreen carve-out. Real windowed users (esp. dual-monitor) are
   // NOT fullscreen, so emulate that to exercise the normal pointer-lock path.
-  window.__diag = { fullscreenBefore: !!document.fullscreenElement, webkitBefore: !!document.webkitFullscreenElement };
+  window.__diag = {
+    fullscreenBefore: !!document.fullscreenElement,
+    webkitBefore: !!document.webkitFullscreenElement,
+  };
   Object.defineProperty(document, 'fullscreenElement', { get: () => null, configurable: true });
-  Object.defineProperty(document, 'webkitFullscreenElement', { get: () => null, configurable: true });
+  Object.defineProperty(document, 'webkitFullscreenElement', {
+    get: () => null,
+    configurable: true,
+  });
   const yaw0 = window.__game.input.camYaw;
   const rect = canvas.getBoundingClientRect();
   const cx = rect.left + rect.width / 2;
   const cy = rect.top + rect.height / 2;
   // Right-button press, then drag well past the threshold (classic orbit).
-  canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: cx, clientY: cy, bubbles: true }));
+  canvas.dispatchEvent(
+    new MouseEvent('mousedown', { button: 2, clientX: cx, clientY: cy, bubbles: true }),
+  );
   const trace = [];
   for (let i = 1; i <= 10; i++) {
-    window.dispatchEvent(new MouseEvent('mousemove', { movementX: 12, movementY: 0, clientX: cx + i * 12, clientY: cy, bubbles: true }));
-    trace.push({ i, active: window.__game.input.isCameraDragActive?.(), locks: window.__lockRequests });
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        movementX: 12,
+        movementY: 0,
+        clientX: cx + i * 12,
+        clientY: cy,
+        bubbles: true,
+      }),
+    );
+    trace.push({
+      i,
+      active: window.__game.input.isCameraDragActive?.(),
+      locks: window.__lockRequests,
+    });
     await new Promise((r) => setTimeout(r, 16));
   }
-  window.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: cx + 120, clientY: cy, bubbles: true }));
-  return { lockRequests: window.__lockRequests, rotated: Math.abs(window.__game.input.camYaw - yaw0) > 0.001, trace, pointerLockEl: !!document.pointerLockElement };
+  window.dispatchEvent(
+    new MouseEvent('mouseup', { button: 2, clientX: cx + 120, clientY: cy, bubbles: true }),
+  );
+  return {
+    lockRequests: window.__lockRequests,
+    rotated: Math.abs(window.__game.input.camYaw - yaw0) > 0.001,
+    trace,
+    pointerLockEl: !!document.pointerLockElement,
+  };
 });
 await page.screenshot({ path: 'tmp/pointer-lock-2-after-drag.png' });
-console.log('camera drag -> requestPointerLock calls:', dragResult.lockRequests, '| camera rotated:', dragResult.rotated, '| pointerLockEl:', dragResult.pointerLockEl);
+console.log(
+  'camera drag -> requestPointerLock calls:',
+  dragResult.lockRequests,
+  '| camera rotated:',
+  dragResult.rotated,
+  '| pointerLockEl:',
+  dragResult.pointerLockEl,
+);
 console.log('trace:', JSON.stringify(dragResult.trace));
 console.log('diag:', JSON.stringify(await page.evaluate(() => window.__diag)));
 
@@ -101,7 +141,7 @@ console.log('diag:', JSON.stringify(await page.evaluate(() => window.__diag)));
 const retryResult = await page.evaluate(async () => {
   const canvas = document.querySelector('canvas');
   let calls = 0;
-  Element.prototype.requestPointerLock = function () {
+  Element.prototype.requestPointerLock = () => {
     calls++;
     // Reject the first attempt (Chrome's post-exit cooldown), accept after.
     return calls === 1 ? Promise.reject(new Error('cooldown')) : Promise.resolve();
@@ -109,18 +149,35 @@ const retryResult = await page.evaluate(async () => {
   const rect = canvas.getBoundingClientRect();
   const cx = rect.left + rect.width / 2;
   const cy = rect.top + rect.height / 2;
-  canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: cx, clientY: cy, bubbles: true }));
+  canvas.dispatchEvent(
+    new MouseEvent('mousedown', { button: 2, clientX: cx, clientY: cy, bubbles: true }),
+  );
   const trace = [];
   for (let i = 1; i <= 6; i++) {
-    window.dispatchEvent(new MouseEvent('mousemove', { movementX: 12, movementY: 0, clientX: cx + i * 12, clientY: cy, bubbles: true }));
+    window.dispatchEvent(
+      new MouseEvent('mousemove', {
+        movementX: 12,
+        movementY: 0,
+        clientX: cx + i * 12,
+        clientY: cy,
+        bubbles: true,
+      }),
+    );
     // Let the rejected promise settle so the pending flag clears before the next move.
     await new Promise((r) => setTimeout(r, 20));
     trace.push({ i, calls });
   }
-  window.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: cx + 80, clientY: cy, bubbles: true }));
+  window.dispatchEvent(
+    new MouseEvent('mouseup', { button: 2, clientX: cx + 80, clientY: cy, bubbles: true }),
+  );
   return { totalCalls: calls, retried: calls >= 2, trace };
 });
-console.log('rejected-first-lock retry -> requestPointerLock calls:', retryResult.totalCalls, '| retried after failure:', retryResult.retried);
+console.log(
+  'rejected-first-lock retry -> requestPointerLock calls:',
+  retryResult.totalCalls,
+  '| retried after failure:',
+  retryResult.retried,
+);
 console.log('retry trace:', JSON.stringify(retryResult.trace));
 
 await browser.close();

--- a/scripts/pointer_lock_camera_shot.mjs
+++ b/scripts/pointer_lock_camera_shot.mjs
@@ -92,5 +92,36 @@ console.log('camera drag -> requestPointerLock calls:', dragResult.lockRequests,
 console.log('trace:', JSON.stringify(dragResult.trace));
 console.log('diag:', JSON.stringify(await page.evaluate(() => window.__diag)));
 
+// Regression for the dual-monitor bug: requestPointerLock is async and can be
+// REJECTED (Chrome throttles a request issued shortly after exitPointerLock, and
+// the drag-release path exits the lock every time). The old one-shot guard
+// latched after the first attempt, so a single rejection left the cursor free
+// for the rest of the drag and it slipped onto a second monitor. Reject the
+// first request and confirm a later move RE-REQUESTS it.
+const retryResult = await page.evaluate(async () => {
+  const canvas = document.querySelector('canvas');
+  let calls = 0;
+  Element.prototype.requestPointerLock = function () {
+    calls++;
+    // Reject the first attempt (Chrome's post-exit cooldown), accept after.
+    return calls === 1 ? Promise.reject(new Error('cooldown')) : Promise.resolve();
+  };
+  const rect = canvas.getBoundingClientRect();
+  const cx = rect.left + rect.width / 2;
+  const cy = rect.top + rect.height / 2;
+  canvas.dispatchEvent(new MouseEvent('mousedown', { button: 2, clientX: cx, clientY: cy, bubbles: true }));
+  const trace = [];
+  for (let i = 1; i <= 6; i++) {
+    window.dispatchEvent(new MouseEvent('mousemove', { movementX: 12, movementY: 0, clientX: cx + i * 12, clientY: cy, bubbles: true }));
+    // Let the rejected promise settle so the pending flag clears before the next move.
+    await new Promise((r) => setTimeout(r, 20));
+    trace.push({ i, calls });
+  }
+  window.dispatchEvent(new MouseEvent('mouseup', { button: 2, clientX: cx + 80, clientY: cy, bubbles: true }));
+  return { totalCalls: calls, retried: calls >= 2, trace };
+});
+console.log('rejected-first-lock retry -> requestPointerLock calls:', retryResult.totalCalls, '| retried after failure:', retryResult.retried);
+console.log('retry trace:', JSON.stringify(retryResult.trace));
+
 await browser.close();
 console.log('wrote tmp/pointer-lock-1-keybind-panel.png and tmp/pointer-lock-2-after-drag.png');

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -1,14 +1,18 @@
 // Default (Mouse Camera off): classic-MMO-style — WASD + A/D keyboard turn, Q/E strafe,
 // left-drag orbits, right-drag mouselooks, both buttons run forward.
 // Optional Mouse Camera (on): OSRS-style — WASD is camera-relative, A/D strafe,
-// mouse drag rotates the orbit (no pointer lock), no keyboard turn.
+// mouse drag rotates the orbit, no keyboard turn.
 // Shared: space jump, wheel zoom, Tab target, rebindable action bar, R autorun.
 
 import { sanitizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
 import type { MoveInput } from '../sim/types';
 import { cursorForHover, type HoverCursorKind } from './cursors';
 import { comboCode, isModifierCode, type Keybinds, makeCombo } from './keybinds';
-import { shouldEngagePointerLock, shouldReleasePointerLock } from './pointer_lock';
+import {
+  shouldEngagePointerLock,
+  shouldReleasePointerLock,
+  shouldRequestDragLock,
+} from './pointer_lock';
 import { clickPickFromMouseGesture, DEFAULT_CLICK_PICK_MAX_MS } from './pointer_pick';
 
 const BASE_LOOK_SENS = 0.0045;
@@ -141,7 +145,13 @@ export class Input {
   // +1 normal, -1 inverts the vertical mouselook axis (settings: invertLookY).
   private lookPitchSign = 1;
   private downButton = -1;
-  private pointerLockRequestedForDrag = false;
+  // True while a requestPointerLock() promise for the current drag is still
+  // unsettled. NOT a one-shot "ever requested" latch: requestPointerLock is
+  // async and can be rejected (Chrome throttles a request issued shortly after
+  // exitPointerLock), so we clear this when the request settles and re-attempt
+  // the lock on the next move, otherwise a single rejected request would leave
+  // the cursor free for the rest of the drag (it then slips onto a 2nd monitor).
+  private pointerLockPending = false;
   private downX = 0;
   private downY = 0;
   private downAt = 0;
@@ -189,7 +199,17 @@ export class Input {
     window.addEventListener('pointerup', (e) => this.onMouseUp(e));
     window.addEventListener('pointercancel', (e) => this.onMouseUp(e));
     document.addEventListener('pointerlockchange', () => {
+      // The request settled (locked or exited): no request is in flight anymore.
+      // Clearing here also covers browsers whose requestPointerLock returns void
+      // instead of a promise, so a failed lock is retried on the next move.
+      this.pointerLockPending = false;
       if (!document.pointerLockElement) this.releaseCapture('pointerlock');
+    });
+    document.addEventListener('pointerlockerror', () => {
+      // The lock was rejected (e.g. Chrome's post-exit cooldown). Clear the
+      // pending flag so the next move re-requests it instead of leaving the
+      // cursor free to slip onto a second monitor for the rest of the drag.
+      this.pointerLockPending = false;
     });
     document.addEventListener('visibilitychange', () => {
       if (document.hidden) this.releaseCapture('hidden');
@@ -279,7 +299,7 @@ export class Input {
     this.clickMoveMouseButton = button;
     if (button !== null && this.downButton === button) {
       this.cameraDragActive = false;
-      this.pointerLockRequestedForDrag = false;
+      this.pointerLockPending = false;
     }
     this.updateCursor();
   }
@@ -343,7 +363,7 @@ export class Input {
       // for the async pointerlockchange, so the in-flight drag cannot leave the
       // request flag latched (which would block re-acquiring the lock).
       this.cameraDragActive = false;
-      this.pointerLockRequestedForDrag = false;
+      this.pointerLockPending = false;
     }
     this.updateCursor();
   }
@@ -579,7 +599,7 @@ export class Input {
     this.rightDown = false;
     this.cameraDragActive = false;
     this.downButton = -1;
-    this.pointerLockRequestedForDrag = false;
+    this.pointerLockPending = false;
     // Focus loss (blur / tab hidden) means the OS will swallow the matching
     // keyup, so we must forget held movement keys or they'd stick on. A pointer
     // -lock exit is different: the window still has focus and keyup will fire
@@ -760,7 +780,7 @@ export class Input {
     // Pointer lock is requested lazily once a drag actually begins (see
     // onMouseMove) — NOT on every press, which spammed the browser "mouse
     // capture" banner on every right-click used to attack/look (#116).
-    this.pointerLockRequestedForDrag = false;
+    this.pointerLockPending = false;
     this.updateCursor();
   }
 
@@ -796,7 +816,7 @@ export class Input {
     if (pick) this.cb.onClickPick(pick.x, pick.y, pick.button);
     if (!this.leftDown && !this.rightDown) this.cameraDragActive = false;
     this.downButton = -1;
-    this.pointerLockRequestedForDrag = false;
+    this.pointerLockPending = false;
     this.updateCursor();
   }
 
@@ -816,33 +836,58 @@ export class Input {
     if (!this.cameraDragActive) {
       if (this.dragDistance < CAMERA_DRAG_START_DISTANCE && heldMs < CAMERA_DRAG_START_MS) return;
       this.cameraDragActive = true;
-      // Engage pointer lock the instant a press becomes a real camera drag, in
-      // BOTH camera modes, so rotation never begins with a free cursor that can
-      // reach the screen edge (movementX clamps to 0 and the camera freezes) or
-      // slip onto a second monitor. One lock per drag, none for a plain click
-      // (#116); fullscreen stays a plain drag because Chrome forces its own
-      // "press and hold Esc" prompt there.
-      if (
-        !this.pointerLockRequestedForDrag &&
-        shouldEngagePointerLock({
-          lockOnRotate: this.lockCursorOnRotate,
-          isFullscreen: this.isBrowserFullscreen(),
-          alreadyLocked: document.pointerLockElement === this.canvas,
-        })
-      ) {
-        this.pointerLockRequestedForDrag = true;
-        this.canvas.requestPointerLock?.();
-      }
+      this.maybeEngageDragLock();
       this.noteIntent('look');
       this.updateCursor();
       return;
     }
+    // Keep (re)attempting the lock while the drag continues: requestPointerLock
+    // is async and can be rejected, so the first attempt above may have failed.
+    // Retrying here is what stops the cursor escaping onto a second monitor.
+    this.maybeEngageDragLock();
     this.camYaw -= mx * this.lookSensitivity;
     this.camPitch = Math.min(
       1.35,
       Math.max(-0.4, this.camPitch + my * this.lookSensitivity * this.lookPitchSign),
     );
     if (mx !== 0 || my !== 0) this.noteIntent('look');
+  }
+
+  // Engage pointer lock the instant a press becomes a real camera drag, in BOTH
+  // camera modes, so rotation never begins with a free cursor that can reach the
+  // screen edge (movementX clamps to 0 and the camera freezes) or slip onto a
+  // second monitor. None for a plain click (#116); fullscreen stays a plain drag
+  // because Chrome forces its own "press and hold Esc" prompt there.
+  //
+  // requestPointerLock is async and can reject (e.g. Chrome throttles a request
+  // issued shortly after exitPointerLock, which happens on every drag release).
+  // We mark the request pending, clear it when it settles (promise, or the
+  // pointerlockchange/pointerlockerror events for void-returning browsers), and
+  // let onMouseMove call this again so a rejected lock is retried next move
+  // instead of leaving the cursor free for the rest of the drag.
+  private maybeEngageDragLock(): void {
+    if (
+      !shouldRequestDragLock({
+        dragActive: this.cameraDragActive,
+        lockOnRotate: this.lockCursorOnRotate,
+        isFullscreen: this.isBrowserFullscreen(),
+        alreadyLocked: document.pointerLockElement === this.canvas,
+        requestPending: this.pointerLockPending,
+      })
+    )
+      return;
+    this.pointerLockPending = true;
+    const req = this.canvas.requestPointerLock?.() as unknown as Promise<void> | undefined;
+    if (req && typeof req.then === 'function') {
+      req.then(
+        () => {
+          this.pointerLockPending = false;
+        },
+        () => {
+          this.pointerLockPending = false;
+        },
+      );
+    }
   }
 
   private noteIntent(kind: 'move' | 'look' | 'zoom'): void {

--- a/src/game/input.ts
+++ b/src/game/input.ts
@@ -8,11 +8,7 @@ import { sanitizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
 import type { MoveInput } from '../sim/types';
 import { cursorForHover, type HoverCursorKind } from './cursors';
 import { comboCode, isModifierCode, type Keybinds, makeCombo } from './keybinds';
-import {
-  shouldEngagePointerLock,
-  shouldReleasePointerLock,
-  shouldRequestDragLock,
-} from './pointer_lock';
+import { shouldReleasePointerLock, shouldRequestDragLock } from './pointer_lock';
 import { clickPickFromMouseGesture, DEFAULT_CLICK_PICK_MAX_MS } from './pointer_pick';
 
 const BASE_LOOK_SENS = 0.0045;

--- a/src/game/pointer_lock.ts
+++ b/src/game/pointer_lock.ts
@@ -30,6 +30,42 @@ export function shouldEngagePointerLock(input: PointerLockEngageInput): boolean 
   return input.lockOnRotate && !input.isFullscreen && !input.alreadyLocked;
 }
 
+export interface DragLockRequestInput {
+  /** A camera drag is currently in progress (cursor must stay pinned). */
+  dragActive: boolean;
+  /** The "Lock cursor while rotating" setting (default on). */
+  lockOnRotate: boolean;
+  /** Browser fullscreen (see PointerLockEngageInput). */
+  isFullscreen: boolean;
+  /** Whether the canvas already holds the pointer lock. */
+  alreadyLocked: boolean;
+  /** A previous requestPointerLock() promise is still unsettled. */
+  requestPending: boolean;
+}
+
+/**
+ * True when, on a mouse-move during an active camera drag, we should (re)issue
+ * requestPointerLock. Unlike shouldEngagePointerLock this also gates on the drag
+ * still running and on no request already being in flight, so a FAILED lock is
+ * retried on the next move instead of leaving the OS cursor free for the rest of
+ * the drag. requestPointerLock is async and can be rejected (e.g. Chrome
+ * throttles a request issued shortly after exitPointerLock); the original
+ * one-shot guard latched after the first attempt and never retried, so a single
+ * rejected request left the cursor free to hit the screen edge or slip onto a
+ * second monitor.
+ */
+export function shouldRequestDragLock(input: DragLockRequestInput): boolean {
+  return (
+    input.dragActive &&
+    !input.requestPending &&
+    shouldEngagePointerLock({
+      lockOnRotate: input.lockOnRotate,
+      isFullscreen: input.isFullscreen,
+      alreadyLocked: input.alreadyLocked,
+    })
+  );
+}
+
 export interface PointerLockReleaseInput {
   /** Any camera-rotation mouse button still held. */
   anyButtonDown: boolean;

--- a/tests/pointer_lock.test.ts
+++ b/tests/pointer_lock.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
   shouldEngagePointerLock,
   shouldReleasePointerLock,
@@ -7,26 +7,36 @@ import {
 
 describe('shouldEngagePointerLock', () => {
   it('engages when a drag starts, the setting is on, not fullscreen, not yet locked', () => {
-    expect(shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: false })).toBe(true);
+    expect(
+      shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: false }),
+    ).toBe(true);
   });
 
   it('engages regardless of camera mode (the function takes no mode: both classic and Mouse Camera reach here)', () => {
     // Regression for the reported bug: in Mouse Camera mode the lock was never
     // requested, so the cursor escaped to the screen edge / second monitor.
     // The decision must not depend on the mode at all.
-    expect(shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: false })).toBe(true);
+    expect(
+      shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: false }),
+    ).toBe(true);
   });
 
   it('does not engage when the setting is off', () => {
-    expect(shouldEngagePointerLock({ lockOnRotate: false, isFullscreen: false, alreadyLocked: false })).toBe(false);
+    expect(
+      shouldEngagePointerLock({ lockOnRotate: false, isFullscreen: false, alreadyLocked: false }),
+    ).toBe(false);
   });
 
   it('does not engage in fullscreen (Chrome shows its own unavoidable prompt)', () => {
-    expect(shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: true, alreadyLocked: false })).toBe(false);
+    expect(
+      shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: true, alreadyLocked: false }),
+    ).toBe(false);
   });
 
   it('does not re-engage when already locked (avoids re-showing the browser banner mid-drag)', () => {
-    expect(shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: true })).toBe(false);
+    expect(
+      shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: true }),
+    ).toBe(false);
   });
 });
 

--- a/tests/pointer_lock.test.ts
+++ b/tests/pointer_lock.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { shouldEngagePointerLock, shouldReleasePointerLock } from '../src/game/pointer_lock';
+import {
+  shouldEngagePointerLock,
+  shouldReleasePointerLock,
+  shouldRequestDragLock,
+} from '../src/game/pointer_lock';
 
 describe('shouldEngagePointerLock', () => {
   it('engages when a drag starts, the setting is on, not fullscreen, not yet locked', () => {
@@ -23,6 +27,46 @@ describe('shouldEngagePointerLock', () => {
 
   it('does not re-engage when already locked (avoids re-showing the browser banner mid-drag)', () => {
     expect(shouldEngagePointerLock({ lockOnRotate: true, isFullscreen: false, alreadyLocked: true })).toBe(false);
+  });
+});
+
+describe('shouldRequestDragLock', () => {
+  const base = {
+    dragActive: true,
+    lockOnRotate: true,
+    isFullscreen: false,
+    alreadyLocked: false,
+    requestPending: false,
+  };
+
+  it('requests when a drag is active, the setting is on, not locked, nothing pending', () => {
+    expect(shouldRequestDragLock(base)).toBe(true);
+  });
+
+  it('retries on a later move after a prior request FAILED (this is the dual-monitor fix)', () => {
+    // First request rejected (e.g. Chrome post-exit cooldown): pending cleared,
+    // still not locked, drag continuing. The next move must re-request rather
+    // than leaving the cursor free to slip onto a second monitor.
+    expect(shouldRequestDragLock({ ...base, requestPending: false, alreadyLocked: false })).toBe(
+      true,
+    );
+  });
+
+  it('does not request while a request is still in flight (no spamming)', () => {
+    expect(shouldRequestDragLock({ ...base, requestPending: true })).toBe(false);
+  });
+
+  it('does not request once the lock is held', () => {
+    expect(shouldRequestDragLock({ ...base, alreadyLocked: true })).toBe(false);
+  });
+
+  it('does not request when no drag is active', () => {
+    expect(shouldRequestDragLock({ ...base, dragActive: false })).toBe(false);
+  });
+
+  it('respects the setting being off and fullscreen', () => {
+    expect(shouldRequestDragLock({ ...base, lockOnRotate: false })).toBe(false);
+    expect(shouldRequestDragLock({ ...base, isFullscreen: true })).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Problem

> Lock cursor while rotating doesn't work if you have a second monitor (the mouse slips into it).

Camera rotation pointer-locks the canvas so the OS cursor cannot leave the window during a drag (added in #849). On a multi-monitor setup the cursor still slips onto the second display mid-rotate.

## Root cause

The lock was requested **once** when a drag crossed the start threshold, then a one-shot guard (`pointerLockRequestedForDrag`) latched and was never retried for the rest of that drag.

But `requestPointerLock()` is **asynchronous and can be rejected**: Chrome throttles a lock request issued shortly after `exitPointerLock()`, and the drag-release path exits the lock on **every** `mouseup`. So rapid orbiting trips that cooldown, the request fails, the fire-and-forget failure (`canvas.requestPointerLock?.()`) is ignored, and with the guard already latched the cursor stays free for the whole drag.

- Single monitor: the free cursor harmlessly hits the screen edge (`movementX` clamps to 0), which is why #849 looked fixed.
- Multi-monitor: there is no edge, so the cursor slips onto the second display.

## Fix

Treat the guard as "a request is currently **in flight**" rather than "ever requested":

- Clear it when the request **settles** - via the returned promise, plus the `pointerlockchange`/`pointerlockerror` events for browsers whose `requestPointerLock` returns `void`.
- Re-attempt the lock on subsequent moves while the drag continues, so a **rejected** lock is retried on the next move instead of leaving the cursor free.

The decision is a new pure, DOM-free, unit-tested helper `shouldRequestDragLock` (same pattern as `shouldEngagePointerLock`/`shouldReleasePointerLock`). No behaviour change to the success path: still one lock per drag, none for a plain click (#116), fullscreen still stays a plain drag.

## Verification

`tests/pointer_lock.test.ts` adds cases for `shouldRequestDragLock` (incl. the retry-after-failure case). `scripts/pointer_lock_camera_shot.mjs` gains a rejected-first-lock scenario. Harness output (`node scripts/pointer_lock_camera_shot.mjs`):

```
camera drag -> requestPointerLock calls: 1 | camera rotated: true   # success path: no spam
rejected-first-lock retry -> requestPointerLock calls: 5 | retried after failure: true
retry trace: [{"i":1,"calls":0},{"i":2,"calls":1},{"i":3,"calls":2},{"i":4,"calls":3},{"i":5,"calls":4},{"i":6,"calls":5}]
```

Before this fix the retry trace would stay pinned at `calls: 1` (latched), leaving the cursor free. `npx vitest run tests/pointer_lock.test.ts tests/input.test.ts tests/architecture.test.ts` is green.

Key Bindings panel (toggle unchanged, default On):

![Key Bindings panel](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-pointer-lock-retry/keybind-panel.png)

After a driven camera drag:

![After drag](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-pointer-lock-retry/after-drag.png)

## Notes

- Pure-core + thin-consumer split per repo conventions; `src/sim/` untouched, no new deps, no new i18n keys (toggle already shipped in #849).
- Also fixes a stale header comment in `input.ts` (Mouse Camera does pointer-lock since #849).

cc @levy-street @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
