### PR TITLE
fix(sim): keep market listings whose item id is no longer known (CRITICAL data-loss)

### DIFF
--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -299,7 +299,10 @@ export class Market {
     const listing = this.marketListings[idx];
     const def = ITEMS[listing.itemId];
     if (!def) {
-      this.marketListings.splice(idx, 1);
+      // The item id is no longer known (a content edit). Do not silently delete
+      // the listing: that destroys the seller's escrowed goods with no refund.
+      // Leave it intact so the owner can cancel/reclaim it; just refuse the buy.
+      this.ctx.error(meta.entityId, 'That listing is no longer available.');
       return;
     }
     if (this.marketListingBelongsTo(listing, meta)) {
@@ -497,7 +500,14 @@ export class Market {
   loadMarket(save: MarketSave | null | undefined): void {
     if (!save) return;
     for (const l of save.listings ?? []) {
-      if (!l || typeof l.itemId !== 'string' || !ITEMS[l.itemId]) continue;
+      // Keep a listing whose item id is no longer in ITEMS (a content rename,
+      // retirement, or typo). Dropping it would silently destroy every escrowed
+      // copy on the next restart and never refund the seller. An unknown id is
+      // dormant, recoverable data (the owner can reclaim it into bags, exactly
+      // as the character load path keeps unknown ids verbatim); a re-added or
+      // corrected id rehydrates it. Display/buy paths already guard on ITEMS[id].
+      if (!l || typeof l.itemId !== 'string') continue;
+      if (!ITEMS[l.itemId]) console.warn(`market: keeping listing with unknown item id ${l.itemId}`);
       this.marketListings.push({
         id: l.id,
         sellerKey: String(l.sellerKey ?? ''),
@@ -518,8 +528,11 @@ export class Market {
       if (!c || typeof c.key !== 'string') continue;
       this.marketCollections.set(c.key, {
         copper: Math.max(0, Math.floor(c.copper) || 0),
+        // Keep returned/expired-listing items even when their id is unknown, for
+        // the same reason as listings above: a content edit must not silently
+        // empty a player's pending pickups. The id stays dormant until corrected.
         items: (c.items ?? [])
-          .filter((s) => s && ITEMS[s.itemId])
+          .filter((s) => s && typeof s.itemId === 'string')
           .map((s) => ({ itemId: s.itemId, count: Math.max(1, s.count | 0) })),
       });
     }

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -507,7 +507,8 @@ export class Market {
       // as the character load path keeps unknown ids verbatim); a re-added or
       // corrected id rehydrates it. Display/buy paths already guard on ITEMS[id].
       if (!l || typeof l.itemId !== 'string') continue;
-      if (!ITEMS[l.itemId]) console.warn(`market: keeping listing with unknown item id ${l.itemId}`);
+      if (!ITEMS[l.itemId])
+        console.warn(`market: keeping listing with unknown item id ${l.itemId}`);
       this.marketListings.push({
         id: l.id,
         sellerKey: String(l.sellerKey ?? ''),

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -401,6 +401,54 @@ describe('the World Market — the Merchant', () => {
     expect(new Set(ids).size).toBe(ids.length); // no id collisions
   });
 
+  it('keeps listings and collection items whose item id is no longer known', () => {
+    // A content edit (rename/retire/typo of an item id) must NOT vaporize every
+    // in-flight copy of that item sitting on the market at the next restart.
+    // The character load path keeps unknown ids verbatim as dormant data; the
+    // market must do the same so a re-added or corrected id rehydrates later.
+    const save = {
+      listings: [
+        {
+          id: 7,
+          sellerKey: '12',
+          sellerName: 'Seller',
+          itemId: 'retired_relic', // not in ITEMS
+          count: 2,
+          price: 300,
+          secondsLeft: 600,
+        },
+      ],
+      collections: [
+        {
+          key: '12',
+          copper: 50,
+          items: [
+            { itemId: 'wolf_fang', count: 1 }, // still known
+            { itemId: 'removed_widget', count: 3 }, // not in ITEMS
+          ],
+        },
+      ],
+      nextListingId: 8,
+    };
+
+    const sim = makeWorld();
+    sim.loadMarket(save);
+
+    // the unknown-id listing survived the load, escrowed goods intact
+    const loaded = sim.marketListings.filter((l) => !l.house);
+    expect(loaded.length).toBe(1);
+    expect(loaded[0]).toMatchObject({ itemId: 'retired_relic', count: 2, price: 300 });
+
+    // the unknown-id collection item survived alongside the known one, and it
+    // round-trips back out so it is not lost on the next save either (asserted
+    // via the public serialize path, since the collection map is Market-private)
+    const out = sim.serializeMarket();
+    expect(out.listings.find((l) => l.itemId === 'retired_relic')).toBeTruthy();
+    expect(
+      out.collections.find((c) => c.key === '12')?.items.map((s) => s.itemId).sort(),
+    ).toEqual(['removed_widget', 'wolf_fang']);
+  });
+
   it('always wires a seller their own listings even when the market overflows the wire cap', () => {
     const sim = makeWorld();
     const seller = sim.addPlayer('warrior', 'Seller');

--- a/tests/market.test.ts
+++ b/tests/market.test.ts
@@ -445,7 +445,10 @@ describe('the World Market — the Merchant', () => {
     const out = sim.serializeMarket();
     expect(out.listings.find((l) => l.itemId === 'retired_relic')).toBeTruthy();
     expect(
-      out.collections.find((c) => c.key === '12')?.items.map((s) => s.itemId).sort(),
+      out.collections
+        .find((c) => c.key === '12')
+        ?.items.map((s) => s.itemId)
+        .sort(),
     ).toEqual(['removed_widget', 'wolf_fang']);
   });
 


### PR DESCRIPTION
## The bug (CRITICAL, data-loss axis)

Renaming or removing an item id silently destroys **every in-flight copy of that item on the World Market** at the next server restart, with no log line.

When the server reloads the market (`loadMarket`, `src/sim/sim.ts`), it throws away:
- any **listing** whose item id is no longer in `ITEMS` (`if (!l || typeof l.itemId !== 'string' || !ITEMS[l.itemId]) continue;`) — the escrowed item is gone and the seller is never paid or refunded; and
- any returned/expired-listing **collection item** whose id is unknown (`.filter((s) => s && ITEMS[s.itemId])`) — a player's pending pickups vanish (collection gold survives, only the items are dropped).

An item id stops being recognized the moment someone edits content: renaming an item id, retiring an item, or a typo in `src/sim/content/`. So a normal content change, shipped in a normal update, deletes every copy of that item sitting on the market when the server next restarts.

This is the **only** player-asset store that silently drops unknown ids. The character load path keeps unknown ids verbatim as dormant, recoverable data, so a renamed id on your character survives a save/load. The same id sitting in the market was destroyed.

### When to suspect this one
Item losses that line up in time with a content update or version bump, or that happen with no content change but across server restarts/scaling.

## The fix

On load, **keep** listings and collection items with an unknown item id instead of dropping them. The entry stays dormant and recoverable, exactly like bags, until the id is re-added or corrected:
- Display path (`marketInfoFor`) already falls back to the raw id for the name (`ITEMS[l.itemId]?.name ?? l.itemId`), so a kept-but-unknown listing renders gracefully.
- Cancel/reclaim (`marketCancel` -> `addItem`) keeps unknown ids in bags just like the character load path, so the owner can always reclaim escrowed goods.
- The buy path previously **also** silently deleted an unknown-id listing with no refund; it now refuses the buy and leaves the listing intact for the owner to reclaim.
- The kept listing id is logged on load so the loss-that-isn't is at least visible.

Additive, no schema change (market is a JSONB `world_state` row).

## Tests

New persistence test in `tests/market.test.ts` loads a save containing an unknown listing id and an unknown collection-item id and asserts both survive the load and the serialize round-trip. Written test-first (failed on the old drop, passes after the fix).

```
Test Files  2 passed (2)
     Tests  24 passed (24)   # tests/market.test.ts + tests/architecture.test.ts
```

Also green: `npx tsc --noEmit`, `tests/localization_fixes.test.ts` (S3 i18n guard — reuses the existing "That listing is no longer available." string, no new key), `npm run build`.

## A note for the content-change checklist

Renaming or retiring a **live** item id is a market-data-affecting operation. With this fix the data survives as dormant/recoverable rather than being destroyed, but a rename should still pair the old id forward (or keep an alias) so listings rehydrate with a real name.

cc @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["loadMarket on server restart"] --> B{"listing item id still in ITEMS?"}
  B -->|"no (before)"| C["drop the listing + collection items"]
  C --> D["escrowed item destroyed, seller never paid/refunded, no log line"]
  B -->|"no (after)"| E["keep dormant + recoverable, log the kept id"]
  E --> F["display falls back to raw id; buy refuses; cancel reclaims to bags"]
  B -->|yes| G["load normally"]
```
