### PR TITLE
fix(server): isolate each session in the broadcast/event/tick hot loops

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -60,6 +60,7 @@ import { enqueueActivity } from './discord_activity';
 import { discordFlairForAccount, grantRewardPoints } from './discord_db';
 import { enqueueRelay } from './discord_relay';
 import { formatDuration } from './duration';
+import { forEachGuarded, runGuarded } from './guarded_iter';
 import { IpBlockList } from './ip_block';
 import { loadActiveBlockedIps } from './ip_block_db';
 import { type LiveSharedIp, sharedIpsFromLiveSessions } from './live_shared_ips';
@@ -970,58 +971,69 @@ export class GameServer {
     let last = process.hrtime.bigint();
     let acc = 0;
     this.interval = setInterval(() => {
-      const now = process.hrtime.bigint();
-      let dt = Number(now - last) / 1e9;
-      last = now;
-      if (dt > 0.5) dt = 0.5;
-      acc += dt;
-      // Feed the authoritative UTC day to the sim so the delve daily reset (FR-5.1)
-      // works without the sim reading the wall clock itself (determinism invariant).
-      this.sim.utcDay = new Date().toISOString().slice(0, 10);
-      this.bcastGridNs = 0n;
-      this.bcastSelfNs = 0n;
-      this.bcSerializeNs = 0n;
-      this.bcVisits = 0;
-      this.bcSerializes = 0;
-      let mark = now;
-      const lap = (phase: string): void => {
-        const t = process.hrtime.bigint();
-        this.tickProfiler.add(phase, Number(t - mark) / 1e6);
-        mark = t;
-      };
-      while (acc >= DT) {
-        this.clearStaleInputs();
-        lap('stale');
-        const events = this.sim.tick();
-        lap('tick');
-        this.routeEvents(events);
-        this.detectActivity(events);
-        lap('events');
-        this.runAntibotTick();
-        lap('antibot');
-        acc -= DT;
-      }
-      this.broadcastSnapshots();
-      lap('broadcast');
-      this.tickProfiler.add('bcastGrid', Number(this.bcastGridNs) / 1e6);
-      this.tickProfiler.add('bcastSelf', Number(this.bcastSelfNs) / 1e6);
-      this.socialPosTimer += dt;
-      if (this.socialPosTimer >= 1) {
-        this.socialPosTimer = 0;
-        this.broadcastSocialPositions();
-      }
-      lap('social');
-      const tickMs = Number(process.hrtime.bigint() - now) / 1e6;
-      this.tickProfiler.commit(tickMs);
-      this.maybeLogTickPerf(tickMs);
-      this.tickMsAvg =
-        this.tickMsAvg === 0 ? tickMs : this.tickMsAvg + TICK_EMA_ALPHA * (tickMs - this.tickMsAvg);
-      this.saveTimer += dt;
-      if (this.saveTimer >= AUTOSAVE_SECONDS) {
-        this.saveTimer = 0;
-        void this.saveAll('autosave');
-        void this.saveMarket();
-      }
+      // The whole tick body runs guarded: an unguarded throw here (sim tick, a
+      // broadcast, an autosave kick-off) would unwind the callback and skip the
+      // rest of this tick for everyone. Log and let the next tick self-heal so a
+      // transient fault never starves the loop (server/CLAUDE.md).
+      runGuarded(
+        () => {
+          const now = process.hrtime.bigint();
+          let dt = Number(now - last) / 1e9;
+          last = now;
+          if (dt > 0.5) dt = 0.5;
+          acc += dt;
+          // Feed the authoritative UTC day to the sim so the delve daily reset (FR-5.1)
+          // works without the sim reading the wall clock itself (determinism invariant).
+          this.sim.utcDay = new Date().toISOString().slice(0, 10);
+          this.bcastGridNs = 0n;
+          this.bcastSelfNs = 0n;
+          this.bcSerializeNs = 0n;
+          this.bcVisits = 0;
+          this.bcSerializes = 0;
+          let mark = now;
+          const lap = (phase: string): void => {
+            const t = process.hrtime.bigint();
+            this.tickProfiler.add(phase, Number(t - mark) / 1e6);
+            mark = t;
+          };
+          while (acc >= DT) {
+            this.clearStaleInputs();
+            lap('stale');
+            const events = this.sim.tick();
+            lap('tick');
+            this.routeEvents(events);
+            this.detectActivity(events);
+            lap('events');
+            this.runAntibotTick();
+            lap('antibot');
+            acc -= DT;
+          }
+          this.broadcastSnapshots();
+          lap('broadcast');
+          this.tickProfiler.add('bcastGrid', Number(this.bcastGridNs) / 1e6);
+          this.tickProfiler.add('bcastSelf', Number(this.bcastSelfNs) / 1e6);
+          this.socialPosTimer += dt;
+          if (this.socialPosTimer >= 1) {
+            this.socialPosTimer = 0;
+            this.broadcastSocialPositions();
+          }
+          lap('social');
+          const tickMs = Number(process.hrtime.bigint() - now) / 1e6;
+          this.tickProfiler.commit(tickMs);
+          this.maybeLogTickPerf(tickMs);
+          this.tickMsAvg =
+            this.tickMsAvg === 0
+              ? tickMs
+              : this.tickMsAvg + TICK_EMA_ALPHA * (tickMs - this.tickMsAvg);
+          this.saveTimer += dt;
+          if (this.saveTimer >= AUTOSAVE_SECONDS) {
+            this.saveTimer = 0;
+            void this.saveAll('autosave');
+            void this.saveMarket();
+          }
+        },
+        (err) => console.error('[tick] guarded tick body threw, skipping this tick:', err),
+      );
     }, 50);
     // Refresh every online player's $WOC holder-tier flair off the 20 Hz loop:
     // an RPC call per wallet (cached for minutes inside holderInfoForPubkey) has
@@ -2763,96 +2775,103 @@ export class GameServer {
     if (this.clients.size === 0) return;
     const tick = this.sim.tickCount;
     const head = `{"t":"snap","tick":${tick},"time":${round2(this.sim.time)}`;
-    for (const session of this.clients.values()) {
-      const p = this.sim.entities.get(session.pid);
-      const meta = this.sim.meta(session.pid);
-      if (!p || !meta) continue;
-      let anchorEntity = p;
-      let anchorMeta = meta;
-      let anchorSession = session;
-      if (session.spectating) {
-        const spectateName = session.spectating.name;
-        const target = this.sessionByCharacterId(session.spectating.characterId);
-        const targetEntity = target ? this.sim.entities.get(target.pid) : null;
-        const targetMeta = target ? this.sim.meta(target.pid) : null;
-        if (!target || target.left || !targetEntity || !targetMeta) {
-          this.exitSpectate(session, false);
-          this.sendChatNotice(session, `${spectateName} is no longer online; spectate ended.`);
-        } else {
-          anchorEntity = targetEntity;
-          anchorMeta = targetMeta;
-          anchorSession = target;
-        }
-      }
-      const ents: string[] = [];
-      const keep: number[] = [];
-      const present = new Set<number>();
-      const gridStart = this.profileBroadcastPhases ? process.hrtime.bigint() : 0n;
-      this.sim.grid.forEachInRadius(
-        anchorEntity.pos.x,
-        anchorEntity.pos.z,
-        INTEREST_QUERY_RADIUS,
-        (e, d2) => {
-          if (this.profileBroadcastPhases) this.bcVisits++;
-          if (e.id === anchorEntity.id) return;
-          if (!this.canObserveEntity(anchorEntity, e, d2)) return;
-          const known = session.sentEnts.get(e.id);
-          // the viewer's current target stays in interest to the widest drop
-          // radius so its unit frame doesn't vanish mid-chase
-          const limitSq =
-            anchorEntity.targetId === e.id
-              ? NPC_DROP_RADIUS * NPC_DROP_RADIUS
-              : interestLimitSq(e, known !== undefined);
-          if (d2 > limitSq) return;
-          present.add(e.id);
-          const cache = this.wireCacheFor(e);
-          if (known === undefined) {
-            // first sight carries the at-rest state exactly, so no settle
-            // record is owed until it moves again
-            ents.push(cache.fullJson);
-            session.sentEnts.set(e.id, {
-              idVer: cache.idVer,
-              dynVer: cache.dynVer,
-              sentAtTick: tick,
-              settled: true,
-            });
-            return;
+    // Guard each session: a throw while building one player's snapshot must not
+    // starve every other session of its snapshot this tick (server/CLAUDE.md).
+    forEachGuarded(
+      this.clients.values(),
+      (session) => {
+        const p = this.sim.entities.get(session.pid);
+        const meta = this.sim.meta(session.pid);
+        if (!p || !meta) return;
+        let anchorEntity = p;
+        let anchorMeta = meta;
+        let anchorSession = session;
+        if (session.spectating) {
+          const spectateName = session.spectating.name;
+          const target = this.sessionByCharacterId(session.spectating.characterId);
+          const targetEntity = target ? this.sim.entities.get(target.pid) : null;
+          const targetMeta = target ? this.sim.meta(target.pid) : null;
+          if (!target || target.left || !targetEntity || !targetMeta) {
+            this.exitSpectate(session, false);
+            this.sendChatNotice(session, `${spectateName} is no longer online; spectate ended.`);
+          } else {
+            anchorEntity = targetEntity;
+            anchorMeta = targetMeta;
+            anchorSession = target;
           }
-          if (known.idVer !== cache.idVer) {
-            ents.push(cache.fullJson);
-            known.idVer = cache.idVer;
+        }
+        const ents: string[] = [];
+        const keep: number[] = [];
+        const present = new Set<number>();
+        const gridStart = this.profileBroadcastPhases ? process.hrtime.bigint() : 0n;
+        this.sim.grid.forEachInRadius(
+          anchorEntity.pos.x,
+          anchorEntity.pos.z,
+          INTEREST_QUERY_RADIUS,
+          (e, d2) => {
+            if (this.profileBroadcastPhases) this.bcVisits++;
+            if (e.id === anchorEntity.id) return;
+            if (!this.canObserveEntity(anchorEntity, e, d2)) return;
+            const known = session.sentEnts.get(e.id);
+            // the viewer's current target stays in interest to the widest drop
+            // radius so its unit frame doesn't vanish mid-chase
+            const limitSq =
+              anchorEntity.targetId === e.id
+                ? NPC_DROP_RADIUS * NPC_DROP_RADIUS
+                : interestLimitSq(e, known !== undefined);
+            if (d2 > limitSq) return;
+            present.add(e.id);
+            const cache = this.wireCacheFor(e);
+            if (known === undefined) {
+              // first sight carries the at-rest state exactly, so no settle
+              // record is owed until it moves again
+              ents.push(cache.fullJson);
+              session.sentEnts.set(e.id, {
+                idVer: cache.idVer,
+                dynVer: cache.dynVer,
+                sentAtTick: tick,
+                settled: true,
+              });
+              return;
+            }
+            if (known.idVer !== cache.idVer) {
+              ents.push(cache.fullJson);
+              known.idVer = cache.idVer;
+              known.dynVer = cache.dynVer;
+              known.sentAtTick = tick;
+              known.settled = false;
+              return;
+            }
+            if (
+              !isUpdateDue(tick, e, d2, anchorEntity, known.sentAtTick) ||
+              (known.dynVer === cache.dynVer && known.settled)
+            ) {
+              // not due at this distance tier yet, or unchanged and already
+              // settled: a bare id keeps it alive on the client
+              keep.push(e.id);
+              return;
+            }
+            // due, and either changed or owing its one settle record
+            known.settled = known.dynVer === cache.dynVer;
             known.dynVer = cache.dynVer;
             known.sentAtTick = tick;
-            known.settled = false;
-            return;
-          }
-          if (
-            !isUpdateDue(tick, e, d2, anchorEntity, known.sentAtTick) ||
-            (known.dynVer === cache.dynVer && known.settled)
-          ) {
-            // not due at this distance tier yet, or unchanged and already
-            // settled: a bare id keeps it alive on the client
-            keep.push(e.id);
-            return;
-          }
-          // due, and either changed or owing its one settle record
-          known.settled = known.dynVer === cache.dynVer;
-          known.dynVer = cache.dynVer;
-          known.sentAtTick = tick;
-          ents.push(cache.liteJson);
-        },
-      );
-      // forget entities that left interest, so a re-entry sends identity again
-      for (const id of session.sentEnts.keys()) {
-        if (!present.has(id)) session.sentEnts.delete(id);
-      }
-      const selfStart = this.profileBroadcastPhases ? process.hrtime.bigint() : 0n;
-      if (this.profileBroadcastPhases) this.bcastGridNs += selfStart - gridStart;
-      const selfJson = this.selfWireJson(session, anchorEntity, anchorMeta, anchorSession);
-      if (this.profileBroadcastPhases) this.bcastSelfNs += process.hrtime.bigint() - selfStart;
-      const keepJson = keep.length > 0 ? `,"keep":[${keep.join(',')}]` : '';
-      this.sendRaw(session, `${head},"self":${selfJson},"ents":[${ents.join(',')}]${keepJson}}`);
-    }
+            ents.push(cache.liteJson);
+          },
+        );
+        // forget entities that left interest, so a re-entry sends identity again
+        for (const id of session.sentEnts.keys()) {
+          if (!present.has(id)) session.sentEnts.delete(id);
+        }
+        const selfStart = this.profileBroadcastPhases ? process.hrtime.bigint() : 0n;
+        if (this.profileBroadcastPhases) this.bcastGridNs += selfStart - gridStart;
+        const selfJson = this.selfWireJson(session, anchorEntity, anchorMeta, anchorSession);
+        if (this.profileBroadcastPhases) this.bcastSelfNs += process.hrtime.bigint() - selfStart;
+        const keepJson = keep.length > 0 ? `,"keep":[${keep.join(',')}]` : '';
+        this.sendRaw(session, `${head},"self":${selfJson},"ents":[${ents.join(',')}]${keepJson}}`);
+      },
+      (err, session) =>
+        console.error(`[snap] failed to build snapshot for pid ${session.pid}, skipping:`, err),
+    );
     // >= rather than a modulo check: catch-up broadcasts can skip ticks
     if (tick - this.lastWireSweepTick >= WIRE_CACHE_SWEEP_TICKS) {
       this.lastWireSweepTick = tick;
@@ -3204,83 +3223,90 @@ export class GameServer {
   private routeEvents(events: SimEvent[]): void {
     if (events.length === 0 || this.clients.size === 0) return;
     const eventTime = Date.now();
-    for (const session of this.clients.values()) {
-      const p = this.sim.entities.get(session.pid);
-      if (!p) continue;
-      let anchorPid = session.pid;
-      let anchorPos = p.pos;
-      if (session.spectating) {
-        const target = this.sessionByCharacterId(session.spectating.characterId);
-        const targetEntity = target ? this.sim.entities.get(target.pid) : null;
-        if (!target || target.left || !targetEntity) continue;
-        anchorPid = target.pid;
-        anchorPos = targetEntity.pos;
-      }
-      const mine: SimEvent[] = [];
-      for (const ev of events) {
-        // ignore list: drop chat originating from a character this player has
-        // blocked, before it ever reaches their client
-        if (
-          !session.spectating &&
-          ev.type === 'chat' &&
-          session.blockedIds.size > 0 &&
-          this.isBlockedSender(session, ev.fromPid)
-        )
-          continue;
-        if (ev.pid !== undefined) {
+    // Guard each session: a throw while routing events to one player must not
+    // drop this tick's events for every other session (server/CLAUDE.md).
+    forEachGuarded(
+      this.clients.values(),
+      (session) => {
+        const p = this.sim.entities.get(session.pid);
+        if (!p) return;
+        let anchorPid = session.pid;
+        let anchorPos = p.pos;
+        if (session.spectating) {
+          const target = this.sessionByCharacterId(session.spectating.characterId);
+          const targetEntity = target ? this.sim.entities.get(target.pid) : null;
+          if (!target || target.left || !targetEntity) return;
+          anchorPid = target.pid;
+          anchorPos = targetEntity.pos;
+        }
+        const mine: SimEvent[] = [];
+        for (const ev of events) {
+          // ignore list: drop chat originating from a character this player has
+          // blocked, before it ever reaches their client
           if (
-            session.spectating &&
-            ev.pid === session.pid &&
+            !session.spectating &&
             ev.type === 'chat' &&
-            ev.channel !== 'say' &&
-            ev.channel !== 'yell'
-          ) {
-            if (this.isBlockedSender(session, ev.fromPid)) continue;
-            mine.push(ev);
-            if (ev.channel === 'whisper' && ev.to === undefined && ev.fromPid !== session.pid) {
-              session.lastWhisperFrom = ev.from;
-            }
-            this.botDetector.observeEvent(session.botTrackingContext, ev, eventTime);
+            session.blockedIds.size > 0 &&
+            this.isBlockedSender(session, ev.fromPid)
+          )
             continue;
-          }
-          if (ev.pid === anchorPid) {
+          if (ev.pid !== undefined) {
             if (
               session.spectating &&
+              ev.pid === session.pid &&
               ev.type === 'chat' &&
               ev.channel !== 'say' &&
               ev.channel !== 'yell'
             ) {
+              if (this.isBlockedSender(session, ev.fromPid)) continue;
+              mine.push(ev);
+              if (ev.channel === 'whisper' && ev.to === undefined && ev.fromPid !== session.pid) {
+                session.lastWhisperFrom = ev.from;
+              }
+              this.botDetector.observeEvent(session.botTrackingContext, ev, eventTime);
               continue;
             }
-            mine.push(ev);
-            // a sim-driven change to a heavy self field (loot, level-up, quest
-            // credit, ...) refreshes those fields on the next snapshot
-            if (HEAVY_SELF_EVENTS.has(ev.type)) session.selfHeavyDirty = true;
-            // remember the last person to whisper us, for /r reply (the
-            // recipient copy of a whisper has no `to`; the sender echo does)
-            if (
-              ev.type === 'chat' &&
-              ev.channel === 'whisper' &&
-              ev.to === undefined &&
-              ev.fromPid !== session.pid &&
-              !session.spectating
-            ) {
-              session.lastWhisperFrom = ev.from;
+            if (ev.pid === anchorPid) {
+              if (
+                session.spectating &&
+                ev.type === 'chat' &&
+                ev.channel !== 'say' &&
+                ev.channel !== 'yell'
+              ) {
+                continue;
+              }
+              mine.push(ev);
+              // a sim-driven change to a heavy self field (loot, level-up, quest
+              // credit, ...) refreshes those fields on the next snapshot
+              if (HEAVY_SELF_EVENTS.has(ev.type)) session.selfHeavyDirty = true;
+              // remember the last person to whisper us, for /r reply (the
+              // recipient copy of a whisper has no `to`; the sender echo does)
+              if (
+                ev.type === 'chat' &&
+                ev.channel === 'whisper' &&
+                ev.to === undefined &&
+                ev.fromPid !== session.pid &&
+                !session.spectating
+              ) {
+                session.lastWhisperFrom = ev.from;
+              }
+              if (!session.spectating) {
+                this.botDetector.observeEvent(session.botTrackingContext, ev, eventTime);
+              }
             }
-            if (!session.spectating) {
-              this.botDetector.observeEvent(session.botTrackingContext, ev, eventTime);
-            }
+            continue;
           }
-          continue;
+          // world events: only those near this player
+          const anchor = this.eventAnchor(ev);
+          if (anchor === null || dist2d(anchorPos, anchor) <= EVENT_RADIUS) {
+            mine.push(ev);
+          }
         }
-        // world events: only those near this player
-        const anchor = this.eventAnchor(ev);
-        if (anchor === null || dist2d(anchorPos, anchor) <= EVENT_RADIUS) {
-          mine.push(ev);
-        }
-      }
-      if (mine.length > 0) this.send(session, { t: 'events', list: mine });
-    }
+        if (mine.length > 0) this.send(session, { t: 'events', list: mine });
+      },
+      (err, session) =>
+        console.error(`[events] failed to route events for pid ${session.pid}, skipping:`, err),
+    );
   }
 
   // Maps a chat event's source pid to its character id and checks the

--- a/server/guarded_iter.ts
+++ b/server/guarded_iter.ts
@@ -1,0 +1,34 @@
+// Per-item isolation for the server's hot loops. The 50 ms tick callback and the
+// snapshot/event broadcast loops iterate every session unguarded, so a throw while
+// building or routing for one player's state unwinds the whole call and starves
+// every remaining session of snapshots/events for that tick. A condition that
+// persistently throws for one player would starve all players until that player
+// disconnects, which violates "one socket must not be able to crash the loop"
+// (server/CLAUDE.md). Run each item's body in its own try/catch: log and skip just
+// that item, never the rest.
+
+// Run `body` for every item, isolating each iteration. A throw in one item's body
+// is handed to `onError` (log and skip) and never stops the remaining items.
+export function forEachGuarded<T>(
+  items: Iterable<T>,
+  body: (item: T) => void,
+  onError: (err: unknown, item: T) => void,
+): void {
+  for (const item of items) {
+    try {
+      body(item);
+    } catch (err) {
+      onError(err, item);
+    }
+  }
+}
+
+// Run a single body in its own try/catch. A throw is handed to `onError` instead
+// of propagating, so a transient failure self-heals on the next call.
+export function runGuarded(body: () => void, onError: (err: unknown) => void): void {
+  try {
+    body();
+  } catch (err) {
+    onError(err);
+  }
+}

--- a/tests/guarded_iter.test.ts
+++ b/tests/guarded_iter.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { forEachGuarded, runGuarded } from '../server/guarded_iter';
+
+describe('forEachGuarded', () => {
+  it('runs the body for every item', () => {
+    const seen: number[] = [];
+    forEachGuarded(
+      [1, 2, 3],
+      (n) => seen.push(n),
+      () => {},
+    );
+    expect(seen).toEqual([1, 2, 3]);
+  });
+
+  it('keeps processing the remaining items when one body throws', () => {
+    // The bug: one player's bad state must not starve every other session of its
+    // snapshot/events for the tick. A throw on item 2 must not stop items 1 and 3.
+    const seen: number[] = [];
+    const errors: Array<{ item: number }> = [];
+    forEachGuarded(
+      [1, 2, 3],
+      (n) => {
+        if (n === 2) throw new Error('boom');
+        seen.push(n);
+      },
+      (_err, item) => errors.push({ item }),
+    );
+    expect(seen).toEqual([1, 3]);
+    expect(errors).toEqual([{ item: 2 }]);
+  });
+
+  it('isolates every item even when several throw', () => {
+    const seen: number[] = [];
+    const errored: number[] = [];
+    forEachGuarded(
+      [1, 2, 3, 4],
+      (n) => {
+        if (n % 2 === 0) throw new Error(`boom ${n}`);
+        seen.push(n);
+      },
+      (_err, item) => errored.push(item),
+    );
+    expect(seen).toEqual([1, 3]);
+    expect(errored).toEqual([2, 4]);
+  });
+
+  it('passes the offending item and the thrown error to onError', () => {
+    let capturedErr: unknown = null;
+    let capturedItem: string | null = null;
+    forEachGuarded(
+      ['ok', 'bad'],
+      (s) => {
+        if (s === 'bad') throw new Error('detail');
+      },
+      (err, item) => {
+        capturedErr = err;
+        capturedItem = item;
+      },
+    );
+    expect((capturedErr as Error).message).toBe('detail');
+    expect(capturedItem).toBe('bad');
+  });
+});
+
+describe('runGuarded', () => {
+  it('runs the body and swallows nothing on success', () => {
+    let ran = false;
+    let errored = false;
+    runGuarded(
+      () => {
+        ran = true;
+      },
+      () => {
+        errored = true;
+      },
+    );
+    expect(ran).toBe(true);
+    expect(errored).toBe(false);
+  });
+
+  it('routes a thrown error to onError instead of propagating', () => {
+    let captured: unknown = null;
+    expect(() =>
+      runGuarded(
+        () => {
+          throw new Error('tick blew up');
+        },
+        (err) => {
+          captured = err;
+        },
+      ),
+    ).not.toThrow();
+    expect((captured as Error).message).toBe('tick blew up');
+  });
+});

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -195,6 +195,38 @@ describe('spectate client POV', () => {
   });
 });
 
+describe('per-session isolation in the broadcast loop', () => {
+  it('keeps broadcasting to healthy sessions when one session throws', () => {
+    // Regression: the broadcast loop iterated every session unguarded, so a throw
+    // while building one player's snapshot unwound the whole call and starved every
+    // other session of its snapshot that tick (server/CLAUDE.md: one socket must
+    // not crash the loop). forEachGuarded must isolate the bad session.
+    const server = new GameServer();
+    const before = fakeWs();
+    const bad = fakeWs();
+    const after = fakeWs();
+    joinServer(server, before, 1, 'Before');
+    const badSession = joinServer(server, bad, 2, 'Broken');
+    // 'After' joins last, so it is iterated AFTER the throwing session: the real
+    // regression is that this one used to be starved when 'Broken' threw.
+    joinServer(server, after, 3, 'After');
+
+    // Force a throw only while serializing the bad session's self payload.
+    const original = (server as any).selfWireJson.bind(server);
+    vi.spyOn(server as any, 'selfWireJson').mockImplementation((session: any, ...rest: any[]) => {
+      if (session.pid === badSession.pid) throw new Error('corrupt self state');
+      return original(session, ...rest);
+    });
+
+    expect(() => broadcast(server)).not.toThrow();
+    // Both healthy sessions, on either side of the throw, still got a snapshot;
+    // only the broken one was skipped.
+    expect(lastSnap(before.sent)).not.toBeNull();
+    expect(lastSnap(after.sent)).not.toBeNull();
+    expect(lastSnap(bad.sent)).toBeNull();
+  });
+});
+
 describe('raid lockouts over the wire', () => {
   it('ships a granted lockout in self.lockouts and ClientWorld mirrors it end to end', () => {
     const server = new GameServer();


### PR DESCRIPTION
## Problem

The 50 ms tick callback and the per-session `broadcastSnapshots` and `routeEvents` loops in `server/game.ts` iterate every session with **no per-session try/catch**. A throw while building or routing for one player's state unwinds the whole call, so every remaining session that tick receives **no snapshot or events**.

The process-wide `uncaughtException` net (`server/main.ts`) keeps the process alive, so a *transient* throw self-heals on the next tick. But a condition that **persistently** throws for one player's state starves **all** players of snapshots/events every tick until that player disconnects. That violates the server invariant that one socket must not be able to crash the loop (`server/CLAUDE.md`: "one socket must not be able to crash the loop").

Affected sites:
- `broadcastSnapshots` per-session loop
- `routeEvents` per-session loop
- the 50 ms `setInterval` tick callback in `start()`

## Fix

Add a small host-agnostic module `server/guarded_iter.ts` (`forEachGuarded` / `runGuarded`) and wrap each per-session body and the whole tick callback in it. A throw now logs to the dev channel (`console.error`) and skips just that session (or that tick):

- A persistent fault degrades to **one** bad session instead of a server-wide snapshot/event outage.
- A transient fault still self-heals on the next tick.

The refactor is behavior-preserving: the only control-flow change is the per-session `continue` becoming `return` inside the new callbacks; the inner `for (const ev of events)` loop's `continue`s are untouched, and the serialized snapshot/event payloads are byte-identical. No wire-protocol, `IWorld`, `SimEvent`, command-dispatch, or i18n surface is touched (the new log literals are dev-channel English, out of i18n scope).

The outer tick `runGuarded` and the inner per-session `forEachGuarded` are intentional defense in depth: the inner guard isolates a single bad session; the outer guard is the only backstop for throws outside any per-session body (`sim.tick()`, antibot tick, social-position broadcast, autosave kick-off).

## Tests

- `tests/guarded_iter.test.ts`: unit tests for the isolation helpers (one throwing item does not stop the rest; the offending item and error reach `onError`; `runGuarded` does not propagate).
- `tests/snapshots.test.ts`: a `GameServer` regression test that forces a throw while serializing one session and asserts healthy sessions iterated **both before and after** the bad one still receive their snapshot.

Evidence (regression test against the `release/v0.16.0` `game.ts`, then with the fix):

```
### WITHOUT fix ###
 × keeps broadcasting to healthy sessions when one session throws
   AssertionError: expected [Function] to not throw an error but 'Error: corrupt self state' was thrown
 Tests  1 failed

### WITH fix ###
 Tests  1 passed
```

`npx tsc --noEmit` clean; `biome check` reports no errors on the changed files; server esbuild bundle builds.

Note: this is a server-internal robustness fix with no UI surface, so there is no screenshot to attach; the before/after test output above is the behavioral evidence.

cc maintainers for review: @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["tick: broadcastSnapshots / routeEvents iterate every session"] --> B{"Before"}
  B --> C["no per-session try/catch"]
  C --> D["one persistently-throwing session starves ALL sessions of snapshots/events every tick"]
  A --> E{"After"}
  E --> F["forEachGuarded per session + runGuarded around the whole tick callback"]
  F --> G["a throw logs + skips just that session/tick; everyone else keeps updating"]
```
