### PR TITLE
fix(net): terminate WS sessions on unbounded send backpressure (OOM guard)

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -78,6 +78,7 @@ import { SocialService } from './social';
 import { PgSocialDb } from './social_db';
 import { TickProfiler } from './tick_profiler';
 import { holderInfoForPubkey } from './woc_balance';
+import { isBackpressureExceeded } from './ws_backpressure';
 
 const WORLD_SEED = 20061;
 const ALDRIC_METEOR_QUEST_ID = 'q_aldrics_fallen_star';
@@ -3642,8 +3643,23 @@ export class GameServer {
   }
 
   private sendRaw(session: ClientSession, payload: string): void {
-    if (session.ws.readyState === 1) {
-      session.ws.send(payload);
+    if (session.ws.readyState !== 1) return;
+    // A client that has stopped draining its socket lets ws.bufferedAmount grow
+    // without bound (send() never blocks); left unchecked one stuck reader OOMs
+    // the process and starves everyone. Terminate the offender instead. close()
+    // would try to flush the already-huge buffer, so destroy the socket: the
+    // 'close' handler funnels into the idempotent leave() for normal cleanup.
+    if (isBackpressureExceeded(session.ws.bufferedAmount)) {
+      if (!session.left) {
+        try {
+          session.ws.terminate();
+        } catch {
+          /* socket already torn down */
+        }
+        void this.leave(session, 'backpressure');
+      }
+      return;
     }
+    session.ws.send(payload);
   }
 }

--- a/server/ws_backpressure.ts
+++ b/server/ws_backpressure.ts
@@ -1,0 +1,24 @@
+// WebSocket send backpressure guard.
+//
+// `ws.send()` never blocks: bytes the peer has not yet acknowledged pile up in
+// the socket's outbound buffer, surfaced as `ws.bufferedAmount`. The server
+// pushes a snapshot to every session 20 times a second, so a single client that
+// stops draining its socket (a frozen tab, a wedged proxy, a deliberately
+// non-reading attacker) accumulates an unbounded write buffer and can OOM the
+// whole process, starving every other player. Checking only `readyState` does
+// not catch this: the socket is still OPEN, just not draining.
+//
+// The fix is to terminate any session whose unflushed buffer climbs past a hard
+// limit. The limit sits far above one legitimate burst: inbound frames are
+// capped at 16 KiB (maxPayload) and an interest-scoped snapshot is a few KiB, so
+// several MiB of backlog can only mean a client that is not reading.
+export const WS_BACKPRESSURE_LIMIT_BYTES = 8 * 1024 * 1024;
+
+// True when a socket's unflushed outbound buffer has grown past the limit, i.e.
+// the peer is not draining and the session should be torn down.
+export function isBackpressureExceeded(
+  bufferedAmount: number,
+  limit = WS_BACKPRESSURE_LIMIT_BYTES,
+): boolean {
+  return bufferedAmount > limit;
+}

--- a/tests/backpressure.test.ts
+++ b/tests/backpressure.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the db layer so no Postgres is needed; the send/backpressure path is
+// under test, mirroring snapshots.test.ts.
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+  walletForAccount: vi.fn(async () => null),
+  markAccountQuestComplete: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+  grantAccountMechChroma: vi.fn(async () => ({ completedQuestIds: [], mechChromaIds: [] })),
+}));
+
+import { GameServer } from '../server/game';
+import { WS_BACKPRESSURE_LIMIT_BYTES } from '../server/ws_backpressure';
+
+// A fake socket whose unflushed buffer size and lifecycle we control. send()
+// records frames; terminate() flips readyState and fires the 'close' handler
+// the real WebSocketServer wires to game.leave().
+function fakeWs(bufferedAmount: number) {
+  const sent: string[] = [];
+  const ws: any = {
+    readyState: 1,
+    bufferedAmount,
+    sent,
+    terminated: false,
+    send: (payload: string) => sent.push(payload),
+    terminate() {
+      ws.terminated = true;
+      ws.readyState = 3; // CLOSED
+    },
+  };
+  return ws;
+}
+
+function join(server: GameServer, ws: any, id: number, name: string) {
+  const session = server.join(ws, id, id, name, 'warrior', null);
+  if ('error' in session) throw new Error(session.error);
+  session.blockListLoaded = true;
+  return session;
+}
+
+describe('WebSocket send backpressure', () => {
+  let server: GameServer;
+  beforeEach(() => {
+    server = new GameServer();
+  });
+
+  it('terminates a session whose outbound buffer has grown past the limit', () => {
+    const ws = fakeWs(WS_BACKPRESSURE_LIMIT_BYTES + 1);
+    const session = join(server, ws, 1, 'Stuck');
+
+    (server as any).broadcastSnapshots();
+
+    expect(ws.terminated).toBe(true);
+    expect(session.left).toBe(true);
+    expect((server as any).clients.has(session.pid)).toBe(false);
+    // nothing was pushed onto the already-saturated buffer
+    expect(ws.sent.length).toBe(0);
+  });
+
+  it('keeps serving a healthy session that drains its socket', () => {
+    const ws = fakeWs(0);
+    const session = join(server, ws, 2, 'Healthy');
+
+    (server as any).broadcastSnapshots();
+
+    expect(ws.terminated).toBe(false);
+    expect(session.left).toBe(false);
+    expect((server as any).clients.has(session.pid)).toBe(true);
+    expect(ws.sent.length).toBeGreaterThan(0);
+  });
+
+  it('does not starve other players when one session is stuck', () => {
+    const stuck = fakeWs(WS_BACKPRESSURE_LIMIT_BYTES + 1);
+    const healthy = fakeWs(0);
+    join(server, stuck, 3, 'Stuck');
+    const live = join(server, healthy, 4, 'Healthy');
+
+    (server as any).broadcastSnapshots();
+
+    expect(stuck.terminated).toBe(true);
+    expect(healthy.terminated).toBe(false);
+    expect((server as any).clients.has(live.pid)).toBe(true);
+    expect(healthy.sent.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/ws_backpressure.test.ts
+++ b/tests/ws_backpressure.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { isBackpressureExceeded, WS_BACKPRESSURE_LIMIT_BYTES } from '../server/ws_backpressure';
+
+describe('isBackpressureExceeded', () => {
+  it('passes a healthy, draining socket', () => {
+    expect(isBackpressureExceeded(0)).toBe(false);
+    expect(isBackpressureExceeded(16 * 1024)).toBe(false);
+    expect(isBackpressureExceeded(WS_BACKPRESSURE_LIMIT_BYTES)).toBe(false);
+  });
+
+  it('trips once the unflushed buffer climbs past the limit', () => {
+    expect(isBackpressureExceeded(WS_BACKPRESSURE_LIMIT_BYTES + 1)).toBe(true);
+  });
+
+  it('honors a caller-supplied limit', () => {
+    expect(isBackpressureExceeded(100, 64)).toBe(true);
+    expect(isBackpressureExceeded(64, 64)).toBe(false);
+  });
+
+  it('treats a default limit far above one legitimate inbound frame (16 KiB maxPayload)', () => {
+    expect(WS_BACKPRESSURE_LIMIT_BYTES).toBeGreaterThan(16 * 1024 * 16);
+  });
+});


### PR DESCRIPTION
## Problem

`GameServer.sendRaw` (server/game.ts) gated sends on `ws.readyState` only, never on `ws.bufferedAmount`. Because `ws.send()` never blocks, a client that stops draining its socket (a frozen/backgrounded tab, a wedged proxy, or a deliberately non-reading attacker) accumulates an **unbounded** outbound write buffer.

The server pushes an interest-scoped snapshot to **every** session at 20 Hz, plus per-player events. So a single stuck reader grows without bound and can **OOM the entire process**, taking down every other player on the realm. `readyState` does not catch this: the socket is still `OPEN`, just not draining. This is exactly the failure the server `CLAUDE.md` warns about ("one socket must not be able to ... OOM the process").

## Fix

Guard `sendRaw` with a hard outbound-buffer limit. When a session's `bufferedAmount` climbs past it, tear that session down rather than keep queueing:

- `terminate()` the socket, not `close()` — `close()` begins a graceful handshake that still tries to flush the already-huge buffer; `terminate()` destroys it immediately and frees the memory.
- Cleanup funnels through the existing `'close'` handler into the idempotent `leave()`, so a terminated player is fully removed and can rejoin (same teardown contract as every other forced disconnect).

The limit is **8 MiB**, far above one legitimate burst: inbound frames are capped at 16 KiB (`maxPayload`) and an interest-scoped snapshot is a few KiB, so multiple MiB of backlog can only mean a non-draining peer.

## Design / repo conventions

- The decision is a pure, host-agnostic, unit-tested helper: `server/ws_backpressure.ts` (`isBackpressureExceeded` + `WS_BACKPRESSURE_LIMIT_BYTES`), mirroring the IO/pure split the server already favors.
- No wire-protocol change, no new player-facing strings (the S3 i18n guard is unaffected — `'backpressure'` is an internal leave reason).

## Tests

- `tests/ws_backpressure.test.ts` — pure threshold logic.
- `tests/backpressure.test.ts` — drives `GameServer` with a fake socket: a session whose `bufferedAmount` exceeds the limit is `terminate()`d and removed from `clients`, while healthy peers keep receiving snapshots in the same broadcast (proves no cross-session starvation).

All four touched suites green (`ws_backpressure`, `backpressure`, `snapshots`, `bandwidth`), full typecheck clean, Biome clean on changed files.

## A note on screenshots

This is a server-side memory-safety fix with no visual/UI surface, so there is nothing meaningful to screenshot. The behavior is verified by the integration test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["sendRaw pushes a snapshot to every session at 20 Hz"] --> B{"Before"}
  B --> C["gate on ws.readyState only"]
  C --> D["non-draining reader -> unbounded bufferedAmount -> OOMs the whole process"]
  A --> E{"After"}
  E --> F{"bufferedAmount > 8 MiB?"}
  F -->|yes| G["terminate() the socket -> 'close' -> idempotent leave()"]
  F -->|no| H["send (a legit burst is only a few KiB)"]
```
