### PR TITLE
fix(sim): only direct damage walks a mob's leash anchor (Lightning Shield no longer enables unlimited kiting)

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -140,6 +140,10 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
             a.name,
             'hit',
             true,
+            undefined,
+            // Periodic (DoT) ticks are not a direct attack: they must not walk a
+            // mob's leash anchor, so a DoT-kited mob still leashes home.
+            false,
           );
           if (e.dead) return;
         } else if (a.kind === 'hot') {

--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -261,7 +261,21 @@ export function meleeSwing(
   if (!attacker.dead) {
     for (const a of target.auras) {
       if (a.kind === 'thorns') {
-        ctx.dealDamage(target, attacker, a.value, false, a.school, a.name, 'hit', true);
+        // Reflect (Thorns / Lightning Shield) is incidental, not a direct attack:
+        // pass direct=false so it never walks the mob's leash anchor (else a kited
+        // mob meleeing a shielded player would never leash home).
+        ctx.dealDamage(
+          target,
+          attacker,
+          a.value,
+          false,
+          a.school,
+          a.name,
+          'hit',
+          true,
+          undefined,
+          false,
+        );
       }
     }
     // innate "spiked hide" mobs (e.g. bristleback boars) reflect on every hit
@@ -276,6 +290,8 @@ export function meleeSwing(
         spikes.name ?? 'Spiked Hide',
         'hit',
         true,
+        undefined,
+        false, // reflected damage shield: incidental, never walks the leash anchor
       );
     }
   }

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -67,6 +67,11 @@ export function dealDamage(
   kind: 'hit' | 'miss' | 'dodge',
   noRage = false,
   threatOpts?: { flat?: number; mult?: number },
+  // Whether this is a DIRECT attack (auto-attack swing or a direct-hit spell) as
+  // opposed to incidental damage (Lightning Shield/Thorns/spiked-hide reflect, DoT
+  // ticks). Only direct damage may walk a mob's leash anchor; passive damage must
+  // let the mob leash (evade home) so it can't be kited an unlimited distance.
+  direct = true,
 ): void {
   if (target.dead) return;
   if (target.gm) return; // GM characters are invulnerable — every damage path funnels here
@@ -294,7 +299,7 @@ export function dealDamage(
   }
 
   if (source && source.id !== target.id) ctx.enterCombat(source, target);
-  ctx.refreshMobLeashFromAction(source, target);
+  if (direct) ctx.refreshMobLeashFromAction(source, target);
 
   // classic threat: damage (and the ability's flat bonus) lands on the mob's
   // hate table, scaled by the attacker's stance/form modifiers

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -409,7 +409,7 @@ export function runEffects(
           school: ability.school,
           fx: 'nova',
         });
-        ctx.pulseGroundAoE(groundEffect, threatOpts);
+        ctx.pulseGroundAoE(groundEffect, threatOpts, true);
         ctx.groundAoEs.push(groundEffect);
         break;
       }

--- a/src/sim/mob/mob_swing.ts
+++ b/src/sim/mob/mob_swing.ts
@@ -370,7 +370,22 @@ export function runMobSwingAffixes(
   if (!mob.dead) {
     for (const a of target.auras) {
       if (a.kind === 'thorns') {
-        ctx.dealDamage(target, mob, a.value, false, a.school, a.name, 'hit', true);
+        // Reflect (Thorns / Lightning Shield) fired by a mob's own swing is
+        // incidental, not a direct attack: direct=false so it never walks the
+        // mob's leash anchor (else a kited mob meleeing a shielded player would
+        // be re-anchored every swing and never leash home).
+        ctx.dealDamage(
+          target,
+          mob,
+          a.value,
+          false,
+          a.school,
+          a.name,
+          'hit',
+          true,
+          undefined,
+          false,
+        );
       }
     }
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2870,7 +2870,11 @@ export class Sim {
   // updateGroundAoEs (the drain) moved to entity_roster.ts (tickGroundAoEs); it pulses
   // through this.ctx.pulseGroundAoE. pulseGroundAoE STAYS here (shared entry point,
   // also called on-cast from the effect path).
-  private pulseGroundAoE(effect: GroundAoE, threatOpts?: { flat?: number; mult?: number }): void {
+  private pulseGroundAoE(
+    effect: GroundAoE,
+    threatOpts?: { flat?: number; mult?: number },
+    direct = false,
+  ): void {
     const source = this.entities.get(effect.sourceId);
     if (!source || source.dead) return;
     this.emit({
@@ -2893,10 +2897,7 @@ export class Sim {
         'hit',
         false,
         threatOpts,
-        // Recurring ground-AoE ticks (Consecration, Rain of Fire, ...) are
-        // periodic, not a direct attack: like a DoT they must not walk a mob's
-        // leash anchor. The initial cast hit (effect_dispatch) stays direct.
-        false,
+        direct,
       );
     }
   }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2893,6 +2893,10 @@ export class Sim {
         'hit',
         false,
         threatOpts,
+        // Recurring ground-AoE ticks (Consecration, Rain of Fire, ...) are
+        // periodic, not a direct attack: like a DoT they must not walk a mob's
+        // leash anchor. The initial cast hit (effect_dispatch) stays direct.
+        false,
       );
     }
   }
@@ -3323,6 +3327,7 @@ export class Sim {
     kind: 'hit' | 'miss' | 'dodge',
     noRage = false,
     threatOpts?: { flat?: number; mult?: number },
+    direct = true,
   ): void {
     dealDamageImpl(
       this.ctx,
@@ -3335,6 +3340,7 @@ export class Sim {
       kind,
       noRage,
       threatOpts,
+      direct,
     );
   }
 

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -299,7 +299,11 @@ export interface SimContextCallbacks {
   delveRunForPlayer(pid: number): DelveRun | null;
   delveModuleEntry(run: DelveRun): Vec3;
   failDelveRun(run: DelveRun): void;
-  pulseGroundAoE(effect: GroundAoE, threatOpts?: { flat?: number; mult?: number }): void;
+  pulseGroundAoE(
+    effect: GroundAoE,
+    threatOpts?: { flat?: number; mult?: number },
+    direct?: boolean,
+  ): void;
 
   // C1 damage core: the post-mitigation damage/death/xp hub the extracted module
   // (src/sim/combat/damage.ts) owns plus the helpers it consumes (all still on Sim

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -173,6 +173,7 @@ export interface SimContextCallbacks {
     kind: 'hit' | 'miss' | 'dodge',
     noRage?: boolean,
     threatOpts?: { flat?: number; mult?: number },
+    direct?: boolean,
   ): void;
   handleDeath(entity: Entity, killer: Entity | null): void;
   cancelCast(entity: Entity): void;

--- a/tests/combat_effect_dispatch.test.ts
+++ b/tests/combat_effect_dispatch.test.ts
@@ -11,29 +11,37 @@ import { describe, expect, it } from 'vitest';
 import { runEffects } from '../src/sim/combat/effect_dispatch';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
-import type { ResolvedAbility } from '../src/sim/sim';
+import type { PlayerMeta, ResolvedAbility } from '../src/sim/sim';
 import { Sim } from '../src/sim/sim';
-import type { Entity, PlayerClass } from '../src/sim/types';
+import type { Aura, Entity, PlayerClass } from '../src/sim/types';
 
-type AnySim = Sim & Record<string, any>;
-type AnyEntity = Entity & Record<string, any>;
+type TestSim = Sim & {
+  nextId: number;
+  players: Map<number, PlayerMeta>;
+  addEntity(entity: Entity): void;
+};
 
-function makeSim(cls: PlayerClass, level: number): { sim: AnySim; p: AnyEntity; meta: any } {
-  const sim = new Sim({ seed: 4242, playerClass: cls, autoEquip: true }) as AnySim;
+function harness(sim: Sim): TestSim {
+  return sim as unknown as TestSim;
+}
+
+function makeSim(cls: PlayerClass, level: number): { sim: TestSim; p: Entity; meta: PlayerMeta } {
+  const sim = harness(new Sim({ seed: 4242, playerClass: cls, autoEquip: true }));
   sim.setPlayerLevel(level);
-  const p = sim.player as AnyEntity;
+  const p = sim.player;
   const meta = sim.players.get(p.id);
+  if (!meta) throw new Error(`missing player meta for ${p.id}`);
   p.resource = p.maxResource;
   return { sim, p, meta };
 }
 
 // An idle hostile target in range + faced, so an offensive ability resolves + lands.
-function spawnTarget(sim: AnySim, p: AnyEntity, level = 1, dz = 4): AnyEntity {
-  const mob = createMob(sim.nextId++, MOBS['forest_wolf'], level, {
+function spawnTarget(sim: TestSim, p: Entity, level = 1, dz = 4): Entity {
+  const mob = createMob(sim.nextId++, MOBS.forest_wolf, level, {
     x: p.pos.x,
     y: p.pos.y,
     z: p.pos.z + dz,
-  }) as AnyEntity;
+  });
   mob.maxHp = 50000;
   mob.hp = 50000;
   mob.hostile = true;
@@ -46,7 +54,7 @@ function spawnTarget(sim: AnySim, p: AnyEntity, level = 1, dz = 4): AnyEntity {
 
 // Resolve an ability the way the cast lifecycle does; throw (narrowing null away) so
 // a content change that stops the ability resolving fails loudly instead of silently.
-function resolve(sim: AnySim, abilityId: string, pid: number): ResolvedAbility {
+function resolve(sim: TestSim, abilityId: string, pid: number): ResolvedAbility {
   const res = sim.ctx.resolvedAbility(abilityId, pid) as ResolvedAbility | null;
   if (!res) throw new Error(`${abilityId} did not resolve`);
   return res;
@@ -64,7 +72,7 @@ describe('effect_dispatch: a single cast fans into every listed effect', () => {
     // directDamage effect: the mob took a hit.
     expect(mob.hp).toBeLessThan(hp0);
     // dot effect (same cast): a damage-over-time aura sourced by the druid landed.
-    expect(mob.auras.some((a: any) => a.kind === 'dot' && a.sourceId === p.id)).toBe(true);
+    expect(mob.auras.some((a: Aura) => a.kind === 'dot' && a.sourceId === p.id)).toBe(true);
   });
 
   it('rogue eviscerate: finisherDamage lands AND the combo-spend reset fires after the loop', () => {
@@ -85,6 +93,12 @@ describe('effect_dispatch: a single cast fans into every listed effect', () => {
     const { sim, p, meta } = makeSim('paladin', 20);
     const mob = spawnTarget(sim, p, 8, 2); // within the 8yd consecration radius
     const before = sim.ctx.groundAoEs.length;
+    mob.aiState = 'chase';
+    mob.aggroTargetId = p.id;
+    mob.inCombat = true;
+    p.inCombat = true;
+    mob.leashAnchor = { ...mob.pos, x: mob.pos.x - 10 };
+    const anchorBefore = { ...mob.leashAnchor };
     const res = resolve(sim, 'consecration', p.id);
 
     runEffects(sim.ctx, p, meta, null, res); // consecration is self-centered (no target)
@@ -92,6 +106,15 @@ describe('effect_dispatch: a single cast fans into every listed effect', () => {
     expect(sim.ctx.groundAoEs.length).toBe(before + 1); // groundAoEs.push happened
     // the immediate on-cast pulse (pulseGroundAoE) hit the in-radius mob.
     expect(mob.hp).toBeLessThan(mob.maxHp);
+    expect(mob.leashAnchor).not.toEqual(anchorBefore);
+    expect(mob.leashAnchor.x).toBeCloseTo(mob.pos.x);
+    expect(mob.leashAnchor.z).toBeCloseTo(mob.pos.z);
+
+    const anchorAfterCast = { ...mob.leashAnchor };
+    mob.pos = { x: mob.pos.x + 3, y: mob.pos.y, z: mob.pos.z };
+    sim.ctx.pulseGroundAoE(sim.ctx.groundAoEs[0]);
+    expect(mob.leashAnchor.x).toBeCloseTo(anchorAfterCast.x);
+    expect(mob.leashAnchor.z).toBeCloseTo(anchorAfterCast.z);
   });
 });
 

--- a/tests/mob_leash_reflect.test.ts
+++ b/tests/mob_leash_reflect.test.ts
@@ -12,16 +12,44 @@ import { describe, expect, it } from 'vitest';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { Sim } from '../src/sim/sim';
-import { LEASH_DISTANCE } from '../src/sim/types';
+import type { Entity, Vec3 } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 
 const makeSim = () => new Sim({ seed: 42, playerClass: 'shaman', autoEquip: true });
 
-function aggroedMob(sim: Sim): any {
-  const seed = (sim as any).cfg.seed;
+type SimHarness = Sim & {
+  cfg: { seed: number };
+  addEntity(entity: Entity): void;
+  dealDamage(
+    source: Entity | null,
+    target: Entity,
+    amount: number,
+    crit: boolean,
+    school: string,
+    ability: string | null,
+    kind: 'hit' | 'miss' | 'dodge',
+    noRage?: boolean,
+    threatOpts?: { flat?: number; mult?: number },
+    direct?: boolean,
+  ): void;
+  mobSwing(mob: Entity, target: Entity): void;
+};
+
+function harness(sim: Sim): SimHarness {
+  return sim as unknown as SimHarness;
+}
+
+function leashAnchor(mob: Entity): Vec3 {
+  if (!mob.leashAnchor) throw new Error(`missing leash anchor for ${mob.name}`);
+  return mob.leashAnchor;
+}
+
+function aggroedMob(sim: Sim): Entity {
+  const h = harness(sim);
+  const seed = h.cfg.seed;
   const pos = { x: 200, y: terrainHeight(200, 200, seed), z: 200 };
-  const mob = createMob(900100, MOBS.forest_wolf, 5, pos) as any;
-  (sim as any).addEntity(mob);
+  const mob = createMob(900100, MOBS.forest_wolf, 5, pos);
+  h.addEntity(mob);
   mob.aiState = 'chase';
   mob.aggroTargetId = sim.player.id;
   mob.inCombat = true;
@@ -34,18 +62,18 @@ describe('mob leash: only direct damage refreshes the anchor', () => {
     const sim = makeSim();
     const mob = aggroedMob(sim);
     mob.pos = { x: mob.pos.x + 5, y: mob.pos.y, z: mob.pos.z };
-    (sim as any).dealDamage(sim.player, mob, 10, false, 'physical', 'Lightning Bolt', 'hit');
-    expect(mob.leashAnchor.x).toBeCloseTo(mob.pos.x);
-    expect(mob.leashAnchor.z).toBeCloseTo(mob.pos.z);
+    harness(sim).dealDamage(sim.player, mob, 10, false, 'physical', 'Lightning Bolt', 'hit');
+    expect(leashAnchor(mob).x).toBeCloseTo(mob.pos.x);
+    expect(leashAnchor(mob).z).toBeCloseTo(mob.pos.z);
   });
 
   it('reflected (indirect) damage leaves the leash anchor where it was', () => {
     const sim = makeSim();
     const mob = aggroedMob(sim);
-    const anchorBefore = { ...mob.leashAnchor };
+    const anchorBefore = { ...leashAnchor(mob) };
     mob.pos = { x: mob.pos.x + 5, y: mob.pos.y, z: mob.pos.z };
     // Lightning Shield reflect: player-sourced, but not a direct attack.
-    (sim as any).dealDamage(
+    harness(sim).dealDamage(
       sim.player,
       mob,
       10,
@@ -57,8 +85,8 @@ describe('mob leash: only direct damage refreshes the anchor', () => {
       undefined,
       false, // direct = false
     );
-    expect(mob.leashAnchor.x).toBeCloseTo(anchorBefore.x);
-    expect(mob.leashAnchor.z).toBeCloseTo(anchorBefore.z);
+    expect(leashAnchor(mob).x).toBeCloseTo(anchorBefore.x);
+    expect(leashAnchor(mob).z).toBeCloseTo(anchorBefore.z);
   });
 
   it('a real mob swing into Lightning Shield does NOT walk the leash anchor', () => {
@@ -72,7 +100,7 @@ describe('mob leash: only direct damage refreshes the anchor', () => {
     sim.player.hp = sim.player.maxHp;
     // Move the mob away from its anchor so a (buggy) refresh would be detectable:
     // anchor stays at the spawn while the mob body is 60yd off (past LEASH_DISTANCE).
-    const anchorBefore = { ...mob.leashAnchor };
+    const anchorBefore = { ...leashAnchor(mob) };
     mob.pos = { x: mob.pos.x + 60, y: mob.pos.y, z: mob.pos.z };
     sim.player.pos = { x: mob.pos.x + 1, y: mob.pos.y, z: mob.pos.z };
     sim.player.auras.push({
@@ -87,13 +115,9 @@ describe('mob leash: only direct damage refreshes the anchor', () => {
     });
     const hpBefore = mob.hp;
     // Swing many times; misses/dodges are fine, we only need reflects to land.
-    for (let i = 0; i < 200; i++) (sim as any).mobSwing(mob, sim.player);
+    for (let i = 0; i < 200; i++) harness(sim).mobSwing(mob, sim.player);
     expect(mob.hp).toBeLessThan(hpBefore); // reflect actually connected
-    expect(mob.leashAnchor.x).toBeCloseTo(anchorBefore.x);
-    expect(mob.leashAnchor.z).toBeCloseTo(anchorBefore.z);
+    expect(leashAnchor(mob).x).toBeCloseTo(anchorBefore.x);
+    expect(leashAnchor(mob).z).toBeCloseTo(anchorBefore.z);
   });
 });
-
-function dist(a: { x: number; z: number }, b: { x: number; z: number }): number {
-  return Math.hypot(a.x - b.x, a.z - b.z);
-}

--- a/tests/mob_leash_reflect.test.ts
+++ b/tests/mob_leash_reflect.test.ts
@@ -1,0 +1,99 @@
+// Regression: passive/reflected/periodic damage must NOT refresh a mob's leash
+// anchor — only a direct attack (auto-attack or direct spell) may walk the tether.
+//
+// Repro: a Shaman with Lightning Shield (modelled as a `thorns` aura) is meleed by
+// a mob. The reflect deals damage back to the mob via dealDamage(player, mob, ...).
+// Before the fix that reflect refreshed the mob's leashAnchor every swing, so the
+// mob could be dragged unlimited distance from home and never evade. The mob should
+// instead leash (evade) once dragged past LEASH_DISTANCE, since reflect damage is
+// not a direct attack.
+
+import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import { LEASH_DISTANCE } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+const makeSim = () => new Sim({ seed: 42, playerClass: 'shaman', autoEquip: true });
+
+function aggroedMob(sim: Sim): any {
+  const seed = (sim as any).cfg.seed;
+  const pos = { x: 200, y: terrainHeight(200, 200, seed), z: 200 };
+  const mob = createMob(900100, MOBS.forest_wolf, 5, pos) as any;
+  (sim as any).addEntity(mob);
+  mob.aiState = 'chase';
+  mob.aggroTargetId = sim.player.id;
+  mob.inCombat = true;
+  mob.leashAnchor = { ...mob.pos };
+  return mob;
+}
+
+describe('mob leash: only direct damage refreshes the anchor', () => {
+  it('a direct hit walks the leash anchor to the mob position', () => {
+    const sim = makeSim();
+    const mob = aggroedMob(sim);
+    mob.pos = { x: mob.pos.x + 5, y: mob.pos.y, z: mob.pos.z };
+    (sim as any).dealDamage(sim.player, mob, 10, false, 'physical', 'Lightning Bolt', 'hit');
+    expect(mob.leashAnchor.x).toBeCloseTo(mob.pos.x);
+    expect(mob.leashAnchor.z).toBeCloseTo(mob.pos.z);
+  });
+
+  it('reflected (indirect) damage leaves the leash anchor where it was', () => {
+    const sim = makeSim();
+    const mob = aggroedMob(sim);
+    const anchorBefore = { ...mob.leashAnchor };
+    mob.pos = { x: mob.pos.x + 5, y: mob.pos.y, z: mob.pos.z };
+    // Lightning Shield reflect: player-sourced, but not a direct attack.
+    (sim as any).dealDamage(
+      sim.player,
+      mob,
+      10,
+      false,
+      'nature',
+      'Lightning Shield',
+      'hit',
+      true,
+      undefined,
+      false, // direct = false
+    );
+    expect(mob.leashAnchor.x).toBeCloseTo(anchorBefore.x);
+    expect(mob.leashAnchor.z).toBeCloseTo(anchorBefore.z);
+  });
+
+  it('a real mob swing into Lightning Shield does NOT walk the leash anchor', () => {
+    // Drives the actual mobSwing reflect path (mob/mob_swing.ts), the route that
+    // fires when a mob melees a shielded Shaman — the reported repro.
+    const sim = makeSim();
+    const mob = aggroedMob(sim);
+    mob.maxHp = 1_000_000;
+    mob.hp = mob.maxHp;
+    sim.player.maxHp = 1_000_000;
+    sim.player.hp = sim.player.maxHp;
+    // Move the mob away from its anchor so a (buggy) refresh would be detectable:
+    // anchor stays at the spawn while the mob body is 60yd off (past LEASH_DISTANCE).
+    const anchorBefore = { ...mob.leashAnchor };
+    mob.pos = { x: mob.pos.x + 60, y: mob.pos.y, z: mob.pos.z };
+    sim.player.pos = { x: mob.pos.x + 1, y: mob.pos.y, z: mob.pos.z };
+    sim.player.auras.push({
+      id: 'lshield',
+      name: 'Lightning Shield',
+      kind: 'thorns',
+      remaining: 600,
+      duration: 600,
+      value: 13,
+      sourceId: sim.player.id,
+      school: 'nature',
+    });
+    const hpBefore = mob.hp;
+    // Swing many times; misses/dodges are fine, we only need reflects to land.
+    for (let i = 0; i < 200; i++) (sim as any).mobSwing(mob, sim.player);
+    expect(mob.hp).toBeLessThan(hpBefore); // reflect actually connected
+    expect(mob.leashAnchor.x).toBeCloseTo(anchorBefore.x);
+    expect(mob.leashAnchor.z).toBeCloseTo(anchorBefore.z);
+  });
+});
+
+function dist(a: { x: number; z: number }, b: { x: number; z: number }): number {
+  return Math.hypot(a.x - b.x, a.z - b.z);
+}


### PR DESCRIPTION
## Problem

A mob's **leash anchor** (the point it is allowed to be dragged `LEASH_DISTANCE` away from before it evades home) was refreshed to the mob's current position on **every** player/pet-sourced damage instance, not just direct attacks. `dealDamage` unconditionally called `refreshMobLeashFromAction(source, target)`.

That means **incidental** damage re-anchored the mob too:
- **Lightning Shield / Thorns** reflect (a `thorns` aura) — when a mob melees a shielded player, the reflect deals damage back to the mob, re-anchoring it every swing.
- innate **spiked-hide** mob reflect
- **periodic DoT** ticks
- recurring **ground-AoE** pulses (Consecration, Rain of Fire, ...)

Repro (as reported): put **Lightning Shield on a Shaman** and let a mob melee you while you run. Each swing's reflect walks the leash anchor to the mob, so the mob never leashes and can be kited an unlimited distance.

## Fix

Only a **direct attack** (auto-attack swing or a direct-hit spell) should walk the tether. Added an explicit `direct = true` trailing parameter to `dealDamage`, threaded through the `SimContext` seam and the `Sim` delegate, and gated `refreshMobLeashFromAction` on it. The incidental damage sources now pass `direct: false`:

| Path | File |
|---|---|
| Thorns / Lightning Shield reflect (player swing) | `src/sim/combat/auto_attack.ts` |
| Thorns / Lightning Shield reflect (mob swing — the reported repro path) | `src/sim/mob/mob_swing.ts` |
| Innate spiked-hide reflect | `src/sim/combat/auto_attack.ts` |
| Periodic DoT tick | `src/sim/combat/auras.ts` |
| Recurring ground-AoE pulse | `src/sim/sim.ts` (`pulseGroundAoE`) |

Deliberately left **direct** (still refresh the anchor): auto-attacks, ranged auto-shot/wand, direct-damage spell effects, the initial ground-AoE cast hit, channeled drain ticks (the channel must be maintained at the target), and pet attacks.

## Determinism / parity

The flag only gates a pure field write (`target.leashAnchor = { ...target.pos }`) — it draws no rng, emits no event, and changes no mutation order. The golden-trace + rng-draw-order parity gate stays byte-identical (`tests/parity` green).

## Tests

Adds `tests/mob_leash_reflect.test.ts`:
- a direct hit walks the anchor to the mob;
- indirect (reflect/DoT) damage leaves the anchor where it was;
- driving the **real** `mobSwing` Lightning Shield reflect path many times leaves the anchor fixed (verified to fail without the fix).

Full suite green except one unrelated pre-existing flaky timeout in `tests/delves.test.ts` (passes in isolation). `tests/architecture.test.ts` (sim purity/determinism) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["dealDamage to a mob"] --> B{"Before"}
  B --> C["always refreshMobLeashFromAction (walks the leash anchor)"]
  C --> D["reflect (Lightning Shield/Thorns), DoT, ground-AoE re-anchor the mob -> unlimited kiting"]
  A --> E{"After: explicit direct flag"}
  E -->|"direct=true (auto-attack, direct spell, channel, pet)"| F["walk the leash anchor"]
  E -->|"direct=false (thorns/lightning-shield reflect, DoT tick, ground-AoE pulse)"| G["anchor unchanged -> mob leashes home"]
```
