### PR TITLE
fix(server): gate login username with validUsernameShape before throttling

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -727,7 +727,14 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const body = await readBody(req);
       if (!(await passesTurnstile(req, body)))
         return json(res, 403, { error: 'verification failed, please try again' });
-      const username = typeof body.username === 'string' ? body.username : '';
+      // Gate the username through the same shape check registration enforces
+      // BEFORE it keys the per-account throttle map. A username that can't match
+      // the shape can never match a real account (register requires it), so
+      // collapse it to the empty sentinel: this skips authThrottled/findAccount/
+      // recordAuthFailure entirely, keeping an attacker from bloating the O(n)
+      // authFailures map with arbitrarily long, distinct keys.
+      const rawUsername = typeof body.username === 'string' ? body.username : '';
+      const username = validUsernameShape(rawUsername) ? rawUsername : '';
       // Per-account brute-force throttle (#93). The message is identical to a
       // bad-password response so it never reveals whether the account exists.
       if (username && authThrottled(username)) {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -3,8 +3,6 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
-import { Sim } from '../src/sim/sim';
 import {
   normalizeCharName,
   offensiveName,
@@ -14,25 +12,27 @@ import {
   validUsernameShape,
 } from '../server/auth';
 import {
-  rateLimited,
-  requestIp,
-  authThrottled,
-  recordAuthFailure,
-  clearAuthFailures,
   authFailureCount,
-  resetAuthFailures,
-  trackedIpCount,
-  resetRateLimits,
-  cardUploadRateLimited,
+  authThrottled,
   CARD_UPLOAD_MAX_PER_MINUTE,
+  cardUploadRateLimited,
+  clearAuthFailures,
+  rateLimited,
+  recordAuthFailure,
+  requestIp,
+  resetAuthFailures,
   resetCardUploadRateLimits,
-  walletLinkRateLimited,
-  WALLET_LINK_MAX_PER_MINUTE,
+  resetRateLimits,
   resetWalletLinkRateLimits,
-  wocBalanceRateLimited,
-  WOC_BALANCE_MAX_PER_MINUTE,
   resetWocBalanceRateLimits,
+  trackedIpCount,
+  WALLET_LINK_MAX_PER_MINUTE,
+  WOC_BALANCE_MAX_PER_MINUTE,
+  walletLinkRateLimited,
+  wocBalanceRateLimited,
 } from '../server/ratelimit';
+import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
+import { Sim } from '../src/sim/sim';
 
 function fakeReq(headers: Record<string, string>, remoteAddress: string) {
   const req: any = new EventEmitter();
@@ -159,33 +159,61 @@ describe('rate-limit client IP selection', () => {
   it('rate-limits card uploads by account across client IPs', () => {
     const accountId = 77;
     for (let i = 0; i < CARD_UPLOAD_MAX_PER_MINUTE; i++) {
-      expect(cardUploadRateLimited(fakeReq({ 'x-forwarded-for': `203.0.113.${i + 1}` }, '172.18.0.1'), accountId)).toBe(false);
+      expect(
+        cardUploadRateLimited(
+          fakeReq({ 'x-forwarded-for': `203.0.113.${i + 1}` }, '172.18.0.1'),
+          accountId,
+        ),
+      ).toBe(false);
     }
-    expect(cardUploadRateLimited(fakeReq({ 'x-forwarded-for': '203.0.113.250' }, '172.18.0.1'), accountId)).toBe(true);
+    expect(
+      cardUploadRateLimited(
+        fakeReq({ 'x-forwarded-for': '203.0.113.250' }, '172.18.0.1'),
+        accountId,
+      ),
+    ).toBe(true);
   });
 
   it('rate-limits card uploads by client IP across accounts', () => {
     const ip = '203.0.113.220';
     for (let i = 0; i < CARD_UPLOAD_MAX_PER_MINUTE; i++) {
-      expect(cardUploadRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 1000 + i)).toBe(false);
+      expect(
+        cardUploadRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 1000 + i),
+      ).toBe(false);
     }
-    expect(cardUploadRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 2000)).toBe(true);
+    expect(cardUploadRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 2000)).toBe(
+      true,
+    );
   });
 
   it('rate-limits wallet link/challenge attempts by account across client IPs', () => {
     const accountId = 77;
     for (let i = 0; i < WALLET_LINK_MAX_PER_MINUTE; i++) {
-      expect(walletLinkRateLimited(fakeReq({ 'x-forwarded-for': `203.0.114.${i + 1}` }, '172.18.0.1'), accountId)).toBe(false);
+      expect(
+        walletLinkRateLimited(
+          fakeReq({ 'x-forwarded-for': `203.0.114.${i + 1}` }, '172.18.0.1'),
+          accountId,
+        ),
+      ).toBe(false);
     }
-    expect(walletLinkRateLimited(fakeReq({ 'x-forwarded-for': '203.0.114.250' }, '172.18.0.1'), accountId)).toBe(true);
+    expect(
+      walletLinkRateLimited(
+        fakeReq({ 'x-forwarded-for': '203.0.114.250' }, '172.18.0.1'),
+        accountId,
+      ),
+    ).toBe(true);
   });
 
   it('rate-limits wallet link/challenge attempts by client IP across accounts', () => {
     const ip = '203.0.114.220';
     for (let i = 0; i < WALLET_LINK_MAX_PER_MINUTE; i++) {
-      expect(walletLinkRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 1000 + i)).toBe(false);
+      expect(
+        walletLinkRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 1000 + i),
+      ).toBe(false);
     }
-    expect(walletLinkRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 2000)).toBe(true);
+    expect(walletLinkRateLimited(fakeReq({ 'x-forwarded-for': ip }, '172.18.0.1'), 2000)).toBe(
+      true,
+    );
   });
 
   it('rate-limits the $WOC balance proxy per IP on its OWN bucket (decoupled from login/register)', () => {
@@ -280,7 +308,9 @@ describe('rate-limit client IP selection', () => {
     }
 
     // The admin-limited victim must still be limited under the admin policy.
-    expect(rateLimited(fakeReq({ 'x-forwarded-for': victim }, '172.18.0.1'), adminLimit)).toBe(true);
+    expect(rateLimited(fakeReq({ 'x-forwarded-for': victim }, '172.18.0.1'), adminLimit)).toBe(
+      true,
+    );
   });
 
   it('keeps the IP map bounded under a flood of distinct in-window clients', () => {
@@ -449,7 +479,10 @@ describe('malformed websocket frames cannot crash the server', () => {
   });
 
   it('still accepts a well-formed object frame', () => {
-    expect(parseFrame(JSON.stringify({ t: 'input', mi: { f: 1 } }))).toEqual({ t: 'input', mi: { f: 1 } });
+    expect(parseFrame(JSON.stringify({ t: 'input', mi: { f: 1 } }))).toEqual({
+      t: 'input',
+      mi: { f: 1 },
+    });
   });
 });
 
@@ -540,7 +573,10 @@ describe('username censorship', () => {
   });
 
   it('can load banned username terms from a configured file', () => {
-    const file = join(tmpdir(), `woc-banlist-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`);
+    const file = join(
+      tmpdir(),
+      `woc-banlist-${Date.now()}-${Math.random().toString(16).slice(2)}.txt`,
+    );
     writeFileSync(file, 'forbidden\n');
     try {
       withUsernameBanlist({ file }, () => {

--- a/tests/security.test.ts
+++ b/tests/security.test.ts
@@ -5,7 +5,14 @@ import { join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildWebSocketAuthMessage, buildWebSocketUrl } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
-import { normalizeCharName, offensiveName, offensiveUsername, validCharName, validUsername } from '../server/auth';
+import {
+  normalizeCharName,
+  offensiveName,
+  offensiveUsername,
+  validCharName,
+  validUsername,
+  validUsernameShape,
+} from '../server/auth';
 import {
   rateLimited,
   requestIp,
@@ -375,6 +382,40 @@ describe('per-account failed-login throttle (#93)', () => {
 
     // MAX_TRACKED_IPS is 10_000; allow a small margin for the just-recorded entry.
     expect(authFailureCount()).toBeLessThanOrEqual(10_001);
+  });
+
+  // Mirrors the login gate in server/main.ts: the raw body.username is run
+  // through validUsernameShape BEFORE it keys the throttle map, collapsing
+  // anything that can't be a real account to the empty sentinel (which short
+  // circuits authThrottled/findAccount/recordAuthFailure). Register already
+  // enforced the shape; login must too, or an attacker can flood the O(n)
+  // authFailures map with arbitrarily long, distinct keys.
+  const loginUsernameKey = (raw: unknown): string => {
+    const s = typeof raw === 'string' ? raw : '';
+    return validUsernameShape(s) ? s : '';
+  };
+
+  it('rejects unbounded/malformed login usernames before they key the throttle map', () => {
+    // Each of these can never match a registered account, so the gate must drop
+    // it to '' rather than letting it become a map key.
+    expect(loginUsernameKey('a'.repeat(5000))).toBe(''); // overlong (> 24)
+    expect(loginUsernameKey('a'.repeat(25))).toBe(''); // one past the 24 ceiling
+    expect(loginUsernameKey('ab')).toBe(''); // under the 3-char floor
+    expect(loginUsernameKey('bad name!')).toBe(''); // illegal chars
+    expect(loginUsernameKey(12345)).toBe(''); // non-string body field
+    // A legitimately shaped username passes through untouched.
+    expect(loginUsernameKey('Valid_User1')).toBe('Valid_User1');
+  });
+
+  it('keeps a flood of oversized login usernames out of the throttle map', () => {
+    // Without the gate, each distinct giant username becomes its own map entry,
+    // bloating memory and the per-call O(n) eviction scan. The gate funnels them
+    // all to '', which the route never records.
+    for (let i = 0; i < 2000; i++) {
+      const key = loginUsernameKey(`${'x'.repeat(4096)}_${i}`);
+      if (key) recordAuthFailure(key);
+    }
+    expect(authFailureCount()).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Problem

`/api/login` (`server/main.ts`) read `body.username` **raw** and used it directly to key the per-account failed-login throttle map (`authThrottled` / `recordAuthFailure` in `server/ratelimit.ts`). The username shape check (`validUsernameShape`: `^[A-Za-z0-9_]{3,24}$`) was applied on **register only**.

Consequences of the unbounded login username:

- An attacker can flood `/api/login` with arbitrarily long, distinct usernames. Each becomes its own key in the in-memory `authFailures` map (keyed by `username.trim().toLowerCase()`), bloating memory.
- The map's memory backstop runs an **O(n)** least-recently-active eviction scan on every record; oversized keys make both the map and the per-call scan expensive.

## Fix

A username that fails `validUsernameShape` can never match a real account (registration enforces the shape), so the login handler now gates the raw value through `validUsernameShape` and collapses a non-conforming value to the empty sentinel `''`:

```ts
const rawUsername = typeof body.username === 'string' ? body.username : '';
const username = validUsernameShape(rawUsername) ? rawUsername : '';
```

`''` already short-circuits `authThrottled` / `findAccount` / `recordAuthFailure` in the existing flow, so:

- The throttle map can only ever be keyed by validly-shaped (≤ 24 char) usernames.
- **No behavior change for legitimate logins.** The `401 invalid username or password` response is unchanged, so account existence is still not revealed (a malformed username gets the same 401 a genuinely-unknown account does).

## Tests

Two regression tests added to `tests/security.test.ts`, mirroring the route gate (the file's established idiom, cf. `parseFrame` mirroring `dispatchMessage`):

- malformed/oversized/non-string usernames collapse to `''`;
- a flood of 2000 oversized usernames never enters the throttle map (`authFailureCount() === 0`).

## Verification

```
npx tsc --noEmit                         # clean
npx vitest run tests/security.test.ts    # 49 passed
npx vitest run tests/account_server.test.ts tests/auth_utils.test.ts  # 38 passed
npm run build                            # built OK
```

This is a server-side throttle/security fix with no UI surface, so there is nothing to screenshot; the test output above is the behavioral evidence.

cc maintainers with push access (re-derived from the last 200 merged PRs): @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["/api/login body.username"] --> B{"Before"}
  B --> C["raw username keys the per-account throttle map"]
  C --> D["flood of long, distinct usernames bloats authFailures + O(n) eviction scan"]
  A --> E{"After"}
  E --> F{"validUsernameShape (^[A-Za-z0-9_]{3,24}$)?"}
  F -->|no| G["collapse to '' sentinel -> short-circuits throttle/findAccount"]
  F -->|yes| H["map only ever keyed by <=24-char usernames; same 401 response"]
```
