### PR TITLE
fix(server): bound decodeBase58 input length before decoding

### DIFF
--- a/server/wallet_link.ts
+++ b/server/wallet_link.ts
@@ -2,14 +2,22 @@
 // validation, the challenge-message format, and ed25519 signature verification.
 // Kept separate from server/wallet.ts (which does DB + HTTP) so it can be unit
 // tested without a database.
-import bs58 from 'bs58';
+
 import { ed25519 } from '@noble/curves/ed25519';
+import bs58 from 'bs58';
 
 // Base58 alphabet (Bitcoin/Solana). Testing the charset first guarantees the
-// decode below never throws, so no input-shape guard is needed around it.
+// decode below never throws.
 const BASE58 = /^[1-9A-HJ-NP-Za-km-z]+$/;
 
+// bs58.decode is O(n^2) in the input length. The longest input we ever
+// legitimately decode is a 64-byte ed25519 signature (~88 base58 chars), so a
+// generous 128-char cap keeps a hostile caller from pinning the loop with a huge
+// string while leaving every real address/signature comfortably under it.
+const MAX_BASE58_LEN = 128;
+
 export function decodeBase58(s: string): Uint8Array | null {
+  if (s.length > MAX_BASE58_LEN) return null;
   if (!BASE58.test(s)) return null;
   return bs58.decode(s);
 }
@@ -27,7 +35,11 @@ export function isSolanaAddress(s: unknown): s is string {
  * attacker-controlled and `@noble/curves` throws on malformed points — a forged
  * or garbage signature must read as `false`, never crash the request.
  */
-export function verifySolanaSignature(message: string, signatureB58: string, addressB58: string): boolean {
+export function verifySolanaSignature(
+  message: string,
+  signatureB58: string,
+  addressB58: string,
+): boolean {
   const sig = decodeBase58(signatureB58);
   const pub = decodeBase58(addressB58);
   if (sig === null || pub === null || sig.length !== 64 || pub.length !== 32) return false;

--- a/tests/wallet.test.ts
+++ b/tests/wallet.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
-import bs58 from 'bs58';
 import { ed25519 } from '@noble/curves/ed25519';
-import { isSolanaAddress, verifySolanaSignature, buildLinkMessage } from '../server/wallet_link';
+import bs58 from 'bs58';
+import { describe, expect, it } from 'vitest';
+import {
+  buildLinkMessage,
+  decodeBase58,
+  isSolanaAddress,
+  verifySolanaSignature,
+} from '../server/wallet_link';
 
 // A Solana wallet signMessage() is exactly ed25519 over the raw UTF-8 bytes, so
 // a @noble/curves keypair is an accurate stand-in for a real wallet here.
@@ -46,8 +51,36 @@ describe('wallet link signature verification', () => {
 
   it('rejects garbage / malformed input without throwing', () => {
     expect(verifySolanaSignature(message, 'not-a-signature', wallet.address)).toBe(false);
-    expect(verifySolanaSignature(message, bs58.encode(new Uint8Array(10)), wallet.address)).toBe(false);
+    expect(verifySolanaSignature(message, bs58.encode(new Uint8Array(10)), wallet.address)).toBe(
+      false,
+    );
     expect(verifySolanaSignature(message, sign(message, wallet.priv), 'has0OIlchars')).toBe(false);
+  });
+});
+
+describe('decodeBase58 length guard', () => {
+  // The decode is O(n^2) in the input length, so a hostile caller could pin the
+  // event loop with a very long string. The longest input we ever legitimately
+  // decode is a 64-byte ed25519 signature (~88 base58 chars), so anything past a
+  // generous 128-char cap is rejected before the decode runs.
+  it('decodes inputs at or below the cap', () => {
+    const sig = bs58.encode(
+      ed25519.sign(new TextEncoder().encode('m'), ed25519.utils.randomPrivateKey()),
+    );
+    expect(sig.length).toBeLessThanOrEqual(128);
+    expect(decodeBase58(sig)).not.toBeNull();
+    expect(decodeBase58('1'.repeat(128))).not.toBeNull();
+  });
+
+  it('rejects an over-long string without decoding it', () => {
+    // All-'1' is valid base58, so this is rejected by length alone, not charset.
+    expect(decodeBase58('1'.repeat(129))).toBeNull();
+    expect(decodeBase58('A'.repeat(10000))).toBeNull();
+  });
+
+  it('keeps over-long input out of isSolanaAddress and verifySolanaSignature', () => {
+    expect(isSolanaAddress('1'.repeat(129))).toBe(false);
+    expect(verifySolanaSignature('m', '1'.repeat(129), '1'.repeat(129))).toBe(false);
   });
 });
 
@@ -66,7 +99,13 @@ describe('isSolanaAddress', () => {
 
 describe('buildLinkMessage', () => {
   it('embeds account, wallet, nonce, and domain so the signed text is unambiguous', () => {
-    const m = buildLinkMessage({ domain: 'play.woc', accountId: 7, address: 'WALLET123', nonce: 'N1', issuedAt: 'T' });
+    const m = buildLinkMessage({
+      domain: 'play.woc',
+      accountId: 7,
+      address: 'WALLET123',
+      nonce: 'N1',
+      issuedAt: 'T',
+    });
     expect(m).toContain('Account: #7');
     expect(m).toContain('Wallet: WALLET123');
     expect(m).toContain('Nonce: N1');


### PR DESCRIPTION
## Problem
`decodeBase58` in `server/wallet_link.ts` has no input-length guard. `bs58.decode` runs an **O(n^2)** loop over the input, so a long attacker-controlled string fed through the wallet-link address/signature paths (`isSolanaAddress`, `verifySolanaSignature`) pins the event loop for the duration of the decode. The endpoints are rate-limited, so the impact is bounded, but the per-request work is still unnecessarily large and trivially avoidable.

The existing charset regex guaranteed the decode never *throws*, but said nothing about its *cost*.

## Fix
Reject any input longer than a 128-char cap before decoding:

```ts
if (s.length > MAX_BASE58_LEN) return null;
```

The longest input we ever legitimately decode is a 64-byte ed25519 signature, which base58-encodes to ~88 chars (a 32-byte address is ~44). A 128-char cap leaves comfortable headroom for every real address and signature while bounding the work. Note a tighter `> 64` cap would be **incorrect**: it would reject all valid 64-byte signatures and silently break `verifySolanaSignature`. Guarding inside `decodeBase58` protects all callers at once.

## Tests (test-first)
Added cases in `tests/wallet.test.ts`. The key assertion uses an all-`'1'` string, which is valid base58 (so it is rejected by length alone, not the charset), proving the guard is what does the work:

```
 Test Files  1 passed (1)
      Tests  11 passed (11)
```

Also re-ran `tests/malware_scan.test.ts` (the release-gate backstop that asserts the scanner stays quiet on the real wallet code): 72 passed. `tsc --noEmit` clean; Biome clean on both files.

## Screenshots
Not applicable: this is a pure, IO-free server helper with no UI surface. The green test run above is the behavioral evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["wallet-link address/signature -> decodeBase58"] --> B{"Before"}
  B --> C["charset regex only, no length cap"]
  C --> D["bs58.decode runs O(n^2) over a long string -> pins the event loop"]
  A --> E{"After"}
  E --> F{"length > MAX_BASE58_LEN (128)?"}
  F -->|yes| G["return null - reject before decoding"]
  F -->|no| H["decode (88-char signature fits with headroom)"]
```
