### PR TITLE
fix(sim): persist parked mana for shapeshifted druids on save

### DIFF
--- a/src/sim/serialize_resource.ts
+++ b/src/sim/serialize_resource.ts
@@ -1,0 +1,35 @@
+// Which resource value to persist for a character at save time.
+//
+// Druid forms swap the live resource bar: bear runs on rage, cat on energy, and
+// the character's real mana is parked in `e.savedMana` (see recalcPlayerStats in
+// entity.ts). Forms are auras and are NOT persisted, so a reloaded character is
+// always rebuilt in caster form. That makes saving the live form bar a bug: a
+// mana class would persist e.g. 35 (rage) and reload clamped to 35 MANA.
+//
+// This leaf decides the value to write into CharacterState.resource. Kept pure
+// and host-agnostic so a Vitest drives it directly and serializeCharacter stays a
+// thin consumer.
+
+import type { ResourceType } from './types';
+
+/**
+ * The resource value to persist for a character.
+ *
+ * @param classResourceType the class's natural resource (CLASSES[cls].resourceType)
+ * @param liveResourceType   the entity's CURRENT bar (rage/energy while shifted)
+ * @param liveResource       the entity's current resource amount (e.resource)
+ * @param savedMana          mana parked while shifted (e.savedMana; 0 when unshifted)
+ */
+export function persistedResource(
+  classResourceType: ResourceType | null,
+  liveResourceType: ResourceType | null,
+  liveResource: number,
+  savedMana: number,
+): number {
+  // A mana class whose live bar is something else (rage/energy) is shapeshifted:
+  // its real pool sits in savedMana. Persist that, so the reload path (which
+  // rebuilds the character in caster form) restores the mana instead of the form
+  // bar. Every other case persists the live resource unchanged.
+  if (classResourceType === 'mana' && liveResourceType !== 'mana') return savedMana;
+  return liveResource;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -186,6 +186,7 @@ import { prestige as prestigeImpl, updateRested } from './progression/xp';
 import { questFallbackGrants } from './quest_fallback';
 import { sanitizeRemovedZone1Content } from './removed_zone1_content';
 import { Rng } from './rng';
+import { persistedResource } from './serialize_resource';
 import { createSimContext, type SimContext, type SimContextHost } from './sim_context';
 import * as chatMod from './social/chat';
 import * as tradeMod from './social/trade';
@@ -1413,7 +1414,10 @@ export class Sim {
       restedXp: meta.restedXp,
       copper: meta.copper,
       hp: e.hp,
-      resource: e.resource,
+      // A druid saved while shifted runs on rage/energy with its mana parked in
+      // savedMana; persist the parked mana so reload (always caster form) restores
+      // it instead of clamping the form bar into the mana pool.
+      resource: persistedResource(CLASSES[meta.cls].resourceType, e.resourceType, e.resource, e.savedMana),
       pos: { x: e.pos.x, z: e.pos.z },
       facing: e.facing,
       equipment: { ...meta.equipment },

--- a/tests/shapeshift_resource_persist.test.ts
+++ b/tests/shapeshift_resource_persist.test.ts
@@ -1,0 +1,89 @@
+// Bug: a druid saved while shapeshifted persisted the FORM bar (bear rage / cat
+// energy) into CharacterState.resource. On reload addPlayer sees the class is a
+// mana class and clamps that small number into the mana bar, so the druid loads
+// with e.g. 35 mana and has to regen back. The parked mana lives in e.savedMana;
+// persistence must normalize to it. Forms are auras and are NOT persisted, so the
+// reloaded character is always in caster form and the saved resource must be mana.
+
+import { describe, expect, it } from 'vitest';
+import { recalcPlayerStats } from '../src/sim/entity';
+import { persistedResource } from '../src/sim/serialize_resource';
+import { Sim } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+}
+
+// Put a druid into bear form through the real stat path: push the toggle aura,
+// then recompute derived stats (which parks mana into savedMana and swaps the
+// bar to rage), then simulate combat having built some rage.
+function shiftToBear(sim: Sim, pid: number): void {
+  const e = sim.entities.get(pid)!;
+  const meta = sim.meta(pid)!;
+  e.auras.push({
+    id: 'bear_form',
+    name: 'Bear Form',
+    kind: 'form_bear',
+    remaining: 3600,
+    duration: 3600,
+    value: 1,
+    sourceId: pid,
+    school: 'physical',
+  });
+  recalcPlayerStats(e, meta.cls, meta.equipment, meta.talentMods);
+}
+
+describe('shapeshifted druid resource persistence', () => {
+  it('persists parked mana, not the live form bar, so reload restores mana', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('druid', 'Ursa');
+    const e = sim.entities.get(pid)!;
+    shiftToBear(sim, pid);
+    expect(e.resourceType).toBe('rage'); // sanity: we are in form
+    const parked = e.savedMana;
+    expect(parked).toBeGreaterThan(50); // a real mana pool was set aside
+    e.resource = 35; // built up 35 rage in bear form
+
+    const state = sim.serializeCharacter(pid)!;
+    // The saved value is the parked mana, never the 35 rage.
+    expect(state.resource).toBe(parked);
+
+    const sim2 = makeWorld();
+    const pid2 = sim2.addPlayer('druid', 'Ursa', { state });
+    const e2 = sim2.entities.get(pid2)!;
+    expect(e2.resourceType).toBe('mana'); // reloads in caster form
+    expect(e2.resource).toBe(Math.min(e2.maxResource, parked));
+    expect(e2.resource).toBeGreaterThan(50); // NOT the 35 form bar
+  });
+
+  it('leaves an unshifted mana class untouched (saves live mana)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('druid', 'Caster');
+    const e = sim.entities.get(pid)!;
+    e.resource = 42;
+    expect(sim.serializeCharacter(pid)!.resource).toBe(42);
+  });
+
+  it('leaves a non-mana class untouched (rogue energy round-trips)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('rogue', 'Sneak');
+    const e = sim.entities.get(pid)!;
+    e.resource = 77;
+    expect(sim.serializeCharacter(pid)!.resource).toBe(77);
+  });
+});
+
+describe('persistedResource (pure)', () => {
+  it('returns parked mana for a shifted mana class', () => {
+    expect(persistedResource('mana', 'rage', 35, 480)).toBe(480);
+    expect(persistedResource('mana', 'energy', 100, 320)).toBe(320);
+  });
+  it('returns the live resource when the bar already matches the class', () => {
+    expect(persistedResource('mana', 'mana', 250, 0)).toBe(250);
+    expect(persistedResource('energy', 'energy', 77, 0)).toBe(77);
+    expect(persistedResource('rage', 'rage', 40, 0)).toBe(40);
+  });
+  it('is identity for null-resource classes', () => {
+    expect(persistedResource(null, null, 0, 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem
A druid saved while shapeshifted reloads with a wrong, very low resource. In bear/cat form `recalcPlayerStats` (`entity.ts`) parks the real mana in `e.savedMana` and repurposes `e.resource` to hold the form bar (bear rage / cat energy). `serializeCharacter` persisted that form bar verbatim, e.g. `35`. On reload `addPlayer` sees the class is a mana class and clamps `35` into the **mana** pool, so the druid loads with ~35 mana and has to self-heal/regen back up.

Forms are auras and are **not** persisted, so the reload always rebuilds the character in caster form. That means the persisted value must be the parked mana, not the form bar.

## Fix
New pure, host-agnostic leaf `src/sim/serialize_resource.ts`:

```ts
persistedResource(classResourceType, liveResourceType, liveResource, savedMana)
```

Returns the parked `savedMana` when a mana class is currently on a non-mana form bar, and the live resource otherwise. `serializeCharacter` consumes it; every non-shifted and non-mana class is byte-identical to before. Kept as a leaf so a Vitest drives it directly and the `sim.ts` coordinator stays a thin consumer (per `src/sim/CLAUDE.md`).

## Tests
`tests/shapeshift_resource_persist.test.ts`:
- shifted druid: serialize -> reload restores mana (not the 35 form bar), via the real `recalcPlayerStats` form path
- unshifted mana class and rogue energy round-trip unchanged
- pure-function unit cases (shifted mana class, matching bar, null-resource class)

Determinism unaffected (no rng draws in the serialize path); `tests/parity`, `tests/persistence_round_trip`, `tests/form_command`, `tests/architecture`, `tests/low_resource` all green. `tsc --noEmit` clean. No player-visible strings changed (S3 i18n guard not implicated). Backend-only persistence fix, so no screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["druid in bear/cat form"] --> B["recalcPlayerStats parks mana in savedMana; resource holds form bar (rage/energy)"]
  B --> C{"serializeCharacter"}
  C -->|before| D["persists the form bar value (e.g. 35)"]
  D --> E["reload clamps 35 into the MANA pool -> loads with ~35 mana"]
  C -->|after| F["persistedResource() returns the parked savedMana"]
  F --> G["reload rebuilds in caster form with real mana restored"]
```
