### PR TITLE
fix(sim): clear a caster's ground-AoE fields on zone change / teleport / respawn

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -2603,6 +2603,7 @@ export class GameServer {
           const e = sim.entities.get(pid);
           if (e) {
             const p = sim.groundPos(msg.x, msg.z);
+            sim.clearGroundAoEsFrom(e.id); // teleport warps off any field cast at the old spot
             e.pos = p;
             e.prevPos = { ...p };
             sim.grid.update(e);

--- a/src/sim/delves/runs.ts
+++ b/src/sim/delves/runs.ts
@@ -317,6 +317,7 @@ export function enterDelve(ctx: SimContext, delveId: string, tierId: string, pid
   stowPetForDelve(ctx, r.meta.entityId);
   const entry = delveModuleEntry(ctx, run);
   const p = r.e;
+  ctx.clearGroundAoEsFrom(p.id); // entering a delve warps you off any field cast outside
   p.pos = entry;
   p.prevPos = { ...entry };
   ctx.rebucket(p);
@@ -348,6 +349,7 @@ export function leaveDelve(ctx: SimContext, pid?: number): void {
   if (run?.companion) ctx.despawnDelveCompanion(run);
   restorePetFromDelveStash(ctx, r.meta.entityId);
   const p = r.e;
+  ctx.clearGroundAoEsFrom(p.id); // leaving a delve warps you off any field cast inside
   p.pos = ctx.groundPos(delve.doorPos.x, delve.doorPos.z - 4);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
@@ -536,6 +538,7 @@ export function ejectToDelveDoor(ctx: SimContext, pid: number, delve: DelveDef):
   if (!r) return;
   const p = r.e;
   p.dead = false;
+  ctx.clearGroundAoEsFrom(p.id); // ejecting to the door warps you off any field cast in the module
   p.pos = ctx.groundPos(delve.doorPos.x, delve.doorPos.z - 4);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
@@ -863,6 +866,7 @@ export function advanceDelveModule(ctx: SimContext, run: DelveRun): void {
   for (const pid of members) {
     const p = ctx.entities.get(pid);
     if (!p || p.dead) continue;
+    ctx.clearGroundAoEsFrom(p.id); // module-to-module travel is a teleport; drop the prior chamber's field
     p.pos = entry;
     p.prevPos = { ...entry };
     ctx.rebucket(p);

--- a/src/sim/entity_roster.ts
+++ b/src/sim/entity_roster.ts
@@ -152,6 +152,18 @@ export function tickGroundAoEs(ctx: SimContext): void {
   }
 }
 
+// Drop every ground-AoE field cast by this source. A GroundAoE stores a FIXED cast
+// position but resolves hostility through the live source entity, so a caster who
+// leaves the field's frame of reference (zone change / dungeon enter+leave / arena
+// teleport / death-respawn) would otherwise keep pulsing damage and kill credit at a
+// spot they have since left (#consecration-zone). Called at each warp site; the
+// per-tick drain (tickGroundAoEs) handles normal expiry.
+export function clearGroundAoEsFromSource(ctx: SimContext, sourceId: number): void {
+  for (let i = ctx.groundAoEs.length - 1; i >= 0; i--) {
+    if (ctx.groundAoEs[i].sourceId === sourceId) ctx.groundAoEs.splice(i, 1);
+  }
+}
+
 // -------------------------------------------------------------------------
 // Player death / respawn
 // -------------------------------------------------------------------------
@@ -167,6 +179,7 @@ export function releasePlayerSpirit(ctx: SimContext, pid?: number): void {
     return;
   }
   p.dead = false;
+  clearGroundAoEsFromSource(ctx, p.id); // respawn warps the spirit away; don't leave an orphan field
   // dying in a dungeon sends you to the graveyard of the zone its door is
   // in; dying outdoors, to your current zone's graveyard
   const dungeon = dungeonAt(p.pos.x);
@@ -202,6 +215,7 @@ export function releaseSpiritInDelve(ctx: SimContext, pid: number): void {
   }
   const p = r.e;
   p.dead = false;
+  clearGroundAoEsFromSource(ctx, p.id); // delve respawn warps to the module entry; drop the old field
   const entry = ctx.delveModuleEntry(run);
   p.pos = entry;
   p.prevPos = { ...entry };

--- a/src/sim/instances/dungeons.ts
+++ b/src/sim/instances/dungeons.ts
@@ -122,6 +122,7 @@ export function enterDungeon(ctx: SimContext, dungeonId: string, pid?: number): 
   }
   const origin = instanceOriginOf(inst);
   const p = r.e;
+  ctx.clearGroundAoEsFrom(p.id); // entering an instance warps you off any field you cast outside
   p.pos = ctx.groundPos(origin.x + dungeon.entry.x, origin.z + dungeon.entry.z);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);
@@ -180,6 +181,7 @@ export function leaveDungeon(ctx: SimContext, pid?: number): void {
       return;
     }
   }
+  ctx.clearGroundAoEsFrom(p.id); // leaving an instance warps you off any field you cast inside
   p.pos = ctx.groundPos(dungeon.doorPos.x, dungeon.doorPos.z - 4);
   p.prevPos = { ...p.pos };
   ctx.rebucket(p);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -117,6 +117,7 @@ import {
 } from './entity';
 import {
   addEntityToRoster,
+  clearGroundAoEsFromSource,
   type DelayedEvent,
   drainDelayedEvents,
   dropEntityFromRoster,
@@ -2000,6 +2001,7 @@ export class Sim {
       delveModuleEntry: sim.delveModuleEntry.bind(sim),
       failDelveRun: sim.failDelveRun.bind(sim),
       pulseGroundAoE: sim.pulseGroundAoE.bind(sim),
+      clearGroundAoEsFrom: sim.clearGroundAoEsFrom.bind(sim),
       enterCombat: sim.enterCombat.bind(sim),
       hexOutputMult: sim.hexOutputMult.bind(sim),
       critVulnBonus: sim.critVulnBonus.bind(sim),
@@ -2934,6 +2936,14 @@ export class Sim {
         direct,
       );
     }
+  }
+
+  // Drop a source's ground-AoE fields when it leaves the field's frame of reference
+  // (zone/instance change, teleport, respawn). Body lives in entity_roster.ts (the
+  // ground-AoE lifecycle owner); thin delegate keeps the seam binding and the
+  // server's dev_teleport path resolving on the Sim facade (#consecration-zone).
+  clearGroundAoEsFrom(sourceId: number): void {
+    clearGroundAoEsFromSource(this.ctx, sourceId);
   }
 
   // -------------------------------------------------------------------------

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -326,6 +326,11 @@ export interface SimContextCallbacks {
     threatOpts?: { flat?: number; mult?: number },
     direct?: boolean,
   ): void;
+  // Drop every ground-AoE field a source owns when it leaves the field's frame of
+  // reference (zone/instance change, teleport, respawn), so the field can't keep
+  // pulsing at the spot the caster has left (#consecration-zone). Body in
+  // entity_roster.ts (the ground-AoE lifecycle owner).
+  clearGroundAoEsFrom(sourceId: number): void;
 
   // C1 damage core: the post-mitigation damage/death/xp hub the extracted module
   // (src/sim/combat/damage.ts) owns plus the helpers it consumes (all still on Sim
@@ -782,6 +787,7 @@ export function createSimContext(host: SimContextHost): SimContext {
     delveModuleEntry: host.delveModuleEntry,
     failDelveRun: host.failDelveRun,
     pulseGroundAoE: host.pulseGroundAoE,
+    clearGroundAoEsFrom: host.clearGroundAoEsFrom,
     grantXp: host.grantXp,
     enterCombat: host.enterCombat,
     hexOutputMult: host.hexOutputMult,

--- a/src/sim/social/arena.ts
+++ b/src/sim/social/arena.ts
@@ -689,6 +689,7 @@ export function placeInArena(
   origin: { x: number; z: number },
   spawn: { x: number; z: number; facing: number },
 ): void {
+  ctx.clearGroundAoEsFrom(e.id); // arena teleport warps off any field cast outside the bout
   e.pos = ctx.groundPos(origin.x + spawn.x, origin.z + spawn.z);
   e.prevPos = { ...e.pos };
   e.facing = spawn.facing;
@@ -862,6 +863,7 @@ export function returnFromArena(ctx: SimContext, match: ArenaMatch): void {
       }
     }
     resetForArena(ctx, e);
+    ctx.clearGroundAoEsFrom(e.id); // leaving the bout warps you off any field cast in the arena
     e.pos = ctx.groundPos(ret.x, ret.z);
     e.prevPos = { ...e.pos };
     e.facing = ret.facing;

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -788,6 +788,7 @@ export function handleDevChat(
     const e = ctx.entities.get(pid);
     if (e) {
       const p = ctx.groundPos(Number(tpM[1]), Number(tpM[2]));
+      ctx.clearGroundAoEsFrom(e.id); // teleport warps off any field cast at the old spot (matches server dev_teleport)
       e.pos = p;
       e.prevPos = { ...p };
       ctx.grid.update(e);

--- a/tests/entity_roster.test.ts
+++ b/tests/entity_roster.test.ts
@@ -121,6 +121,7 @@ function makeCtx() {
     error: vi.fn(),
     clearEntityMarker,
     pulseGroundAoE,
+    clearGroundAoEsFrom: vi.fn(),
     dealDamage: vi.fn(),
     handleDeath: vi.fn(),
     cancelCast: vi.fn(),

--- a/tests/ground_aoe_zone_clear.test.ts
+++ b/tests/ground_aoe_zone_clear.test.ts
@@ -1,0 +1,100 @@
+// Regression for #consecration-zone: a ground-AoE field (e.g. paladin Consecration)
+// stores a FIXED cast position but resolves hostility through the live source entity.
+// pulseGroundAoE only bailed on a DEAD source, so a living caster who warped away
+// (zone change / dungeon enter+leave / arena teleport / death-respawn) left an orphan
+// field that kept dealing damage and kill credit at the spot they had left. The fix
+// drops a caster's ground-AoE fields whenever they leave the field's frame of
+// reference. These tests drive the real warp paths through a live Sim.
+
+import { describe, expect, it } from 'vitest';
+import { clearGroundAoEsFromSource, type GroundAoE } from '../src/sim/entity_roster';
+import { Sim } from '../src/sim/sim';
+
+const SEED = 20061;
+
+function paladin(): { sim: any; pid: number } {
+  const sim = new Sim({ seed: SEED, playerClass: 'paladin', autoEquip: true }) as any;
+  sim.setPlayerLevel(20); // Consecration learns at 18
+  const p = sim.player;
+  p.resource = p.maxResource;
+  return { sim, pid: p.id };
+}
+
+function castConsecration(sim: any, pid: number): void {
+  sim.castAbility('consecration', pid); // castTime 0, so the field registers immediately
+  expect(sim.ctx.groundAoEs.some((g: GroundAoE) => g.sourceId === pid)).toBe(true);
+}
+
+describe('ground-AoE clears when the caster leaves the field (#consecration-zone)', () => {
+  it('death-respawn drops the caster Consecration field', () => {
+    const { sim, pid } = paladin();
+    castConsecration(sim, pid);
+
+    sim.entities.get(pid).dead = true;
+    sim.releaseSpirit(pid); // warps the spirit to the graveyard
+
+    expect(sim.ctx.groundAoEs.some((g: GroundAoE) => g.sourceId === pid)).toBe(false);
+  });
+
+  it('entering a delve drops a field cast outside (the delve teleport surface)', () => {
+    const { sim, pid } = paladin();
+    sim.entities.get(pid).pos.x = 0;
+    sim.entities.get(pid).pos.z = 0;
+    castConsecration(sim, pid);
+
+    sim.enterDelve('collapsed_reliquary', 'normal'); // teleports the player into the delve module
+
+    expect(sim.delveRunForPlayer(pid)).toBeTruthy(); // the warp actually happened
+    expect(sim.ctx.groundAoEs.some((g: GroundAoE) => g.sourceId === pid)).toBe(false);
+  });
+
+  it('only the warping caster fields are cleared, others keep pulsing', () => {
+    const sim = new Sim({
+      seed: SEED,
+      playerClass: 'paladin',
+      autoEquip: true,
+      noPlayer: true,
+    }) as any;
+    const a = sim.addPlayer('paladin', 'Aldra');
+    const b = sim.addPlayer('paladin', 'Brael');
+    for (const id of [a, b]) {
+      sim.setPlayerLevel(20, id);
+      sim.entities.get(id).resource = sim.entities.get(id).maxResource;
+      castConsecration(sim, id);
+    }
+
+    sim.entities.get(a).dead = true;
+    sim.releaseSpirit(a);
+
+    expect(sim.ctx.groundAoEs.some((g: GroundAoE) => g.sourceId === a)).toBe(false);
+    expect(sim.ctx.groundAoEs.some((g: GroundAoE) => g.sourceId === b)).toBe(true);
+  });
+});
+
+describe('clearGroundAoEsFromSource (the entity_roster helper)', () => {
+  const make = (sourceId: number, over: Partial<GroundAoE> = {}): GroundAoE => ({
+    sourceId,
+    pos: { x: 0, y: 0, z: 0 },
+    radius: 8,
+    min: 28,
+    max: 34,
+    remaining: 10,
+    interval: 2,
+    tickTimer: 0,
+    school: 'holy',
+    ability: 'consecration',
+    ...over,
+  });
+
+  it('removes every field from the given source and leaves the rest', () => {
+    const ctx = { groundAoEs: [make(1), make(2), make(1, { ability: 'death_and_decay' })] } as any;
+    clearGroundAoEsFromSource(ctx, 1);
+    expect(ctx.groundAoEs.map((g: GroundAoE) => g.sourceId)).toEqual([2]);
+  });
+
+  it('is a no-op when the source owns no field', () => {
+    const ctx = { groundAoEs: [make(2), make(3)] } as any;
+    clearGroundAoEsFromSource(ctx, 1);
+    expect(ctx.groundAoEs.length).toBe(2);
+  });
+});

--- a/tests/sim_context.test.ts
+++ b/tests/sim_context.test.ts
@@ -86,6 +86,7 @@ const CALLBACK_KEYS = [
   'delveModuleEntry',
   'failDelveRun',
   'pulseGroundAoE',
+  'clearGroundAoEsFrom',
   // C1 damage-core surface.
   'grantXp',
   'enterCombat',
@@ -328,6 +329,7 @@ function makeFakeHost() {
     delveModuleEntry: vi.fn(() => ({ x: 0, y: 0, z: 0 })),
     failDelveRun: vi.fn(),
     pulseGroundAoE: vi.fn(),
+    clearGroundAoEsFrom: vi.fn(),
     grantXp: vi.fn(),
     enterCombat: vi.fn(),
     hexOutputMult: vi.fn(() => 1),


### PR DESCRIPTION
## Problem

A ground-AoE field (e.g. paladin **Consecration**) stores a **fixed cast position** but resolves hostility through the **live source entity**. `pulseGroundAoE` (`src/sim/sim.ts`) only bailed when the source was *dead*:

```ts
const source = this.entities.get(effect.sourceId);
if (!source || source.dead) return;
```

So a **living** caster who warps away (zone change, dungeon/delve enter or leave, arena teleport, death-respawn) leaves an **orphan field** that keeps dealing damage and kill credit at the spot they have since left.

## Fix

Add `clearGroundAoEsFromSource(ctx, sourceId)` in `src/sim/entity_roster.ts` (the ground-AoE lifecycle owner), expose it on the append-only `SimContext` seam as `clearGroundAoEsFrom` (with a thin `Sim` delegate so `server/` can reach it), and call it at every warp site:

- death-respawn, outdoor + delve (`entity_roster.ts`)
- dungeon enter / leave (`instances/dungeons.ts`)
- arena enter / exit (`social/arena.ts`)
- the full delve teleport surface: enter / eject-to-door / advance-module / leave (`delves/runs.ts`)
- both dev-teleport paths: server `dev_teleport` (`server/game.ts`) and offline `/devtp` (`social/chat.ts`), keeping host parity

Normal walking away is unaffected (classic Consecration stays ground-anchored); only *discontinuous* moves drop the field.

## Tests

`tests/ground_aoe_zone_clear.test.ts` (new): reproduces the bug (red first), then covers death-respawn + delve-enter integration through a real `Sim`, per-source isolation (one caster's field cleared, another's kept), and the helper unit + no-op.

```
Tests  5 passed (5)
```

Also green: `tsc --noEmit`, `tests/parity` (154, golden trace + rng draw order **unchanged** - no new draws on the hot path), `tests/architecture.test.ts` (sim purity), `tests/sim_context.test.ts`, `tests/entity_roster.test.ts`, dungeons/arena/delve suites, and `npm run build`.

## Note on screenshots

This is a server-side combat/timing fix with no persistent visual: the renderer draws `groundAoE` only as a transient per-pulse flash (`vfx.tick`, `renderer.ts`), with no decal or ring, so a still frame cannot depict the orphaned field or its removal. The failing-to-passing test is the evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["ground-AoE field: fixed cast position, hostility via live source"] --> B{"source state at pulse"}
  B -->|dead| C["pulseGroundAoE bails - field gone"]
  B -->|"alive + warped away (before)"| D["orphan field keeps damaging + giving kill credit at the old spot"]
  B -->|"alive + warped away (after)"| E["clearGroundAoEsFrom called at every warp site"]
  E --> F["zone change / dungeon / arena / delve / respawn / dev-teleport drop the field"]
  B -->|"alive + walking (any)"| G["field stays ground-anchored (classic)"]
```
