### PR TITLE
fix(talents): scale Consecration damage via Holy Shield (groundAoE in scaleEffect)

### DIFF
--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -3536,6 +3536,12 @@ function scaleEffect(
         min: Math.round(eff.min * dmgMult + flat),
         max: Math.round(eff.max * dmgMult + flat),
       };
+    case 'groundAoE':
+      return {
+        ...eff,
+        min: Math.round(eff.min * dmgMult + flat),
+        max: Math.round(eff.max * dmgMult + flat),
+      };
     case 'aoeRoot':
       return { ...eff, min: Math.round(eff.min * dmgMult), max: Math.round(eff.max * dmgMult) };
     case 'drainTick':

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -3581,24 +3581,6 @@ function scaleEffect(
       return { ...eff, amount: Math.round(eff.amount * dmgMult + flat) };
     default:
       return eff;
-    case 'weaponDamage': return { ...eff, bonus: Math.round(eff.bonus * dmgMult + flat) };
-    case 'weaponStrike': return { ...eff, bonus: Math.round(eff.bonus * dmgMult + flat) };
-    case 'directDamage': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
-    case 'dot': return { ...eff, total: Math.round(eff.total * dmgMult + flat) };
-    case 'aoeDamage': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
-    case 'groundAoE': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
-    case 'aoeRoot': return { ...eff, min: Math.round(eff.min * dmgMult), max: Math.round(eff.max * dmgMult) };
-    case 'drainTick': return { ...eff, min: Math.round(eff.min * dmgMult), max: Math.round(eff.max * dmgMult) };
-    case 'finisherDamage': return { ...eff, base: Math.round(eff.base * dmgMult + flat), perCombo: Math.round(eff.perCombo * dmgMult) };
-    case 'imbue': return { ...eff, bonus: Math.round(eff.bonus * dmgMult + flat), judgeMin: eff.judgeMin === undefined ? undefined : Math.round(eff.judgeMin * dmgMult + flat), judgeMax: eff.judgeMax === undefined ? undefined : Math.round(eff.judgeMax * dmgMult + flat) };
-    case 'heal': return { ...eff, min: Math.round(eff.min * healMult + flat), max: Math.round(eff.max * healMult + flat) };
-    case 'hot': return { ...eff, total: Math.round(eff.total * healMult + flat) };
-    case 'absorb': return { ...eff, amount: Math.round(eff.amount * healMult + flat) };
-    case 'buffTarget': return { ...eff, value: Math.round(eff.value * dmgMult + flat) };
-    case 'selfBuff': return { ...eff, value: Math.round(eff.value * dmgMult + flat) };
-    case 'lifeTap': return { ...eff, mana: Math.round(eff.mana * dmgMult + flat) };
-    case 'gainResource': return { ...eff, amount: Math.round(eff.amount * dmgMult + flat) };
-    default: return eff;
   }
 }
 

--- a/src/sim/content/classes.ts
+++ b/src/sim/content/classes.ts
@@ -3575,6 +3575,24 @@ function scaleEffect(
       return { ...eff, amount: Math.round(eff.amount * dmgMult + flat) };
     default:
       return eff;
+    case 'weaponDamage': return { ...eff, bonus: Math.round(eff.bonus * dmgMult + flat) };
+    case 'weaponStrike': return { ...eff, bonus: Math.round(eff.bonus * dmgMult + flat) };
+    case 'directDamage': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
+    case 'dot': return { ...eff, total: Math.round(eff.total * dmgMult + flat) };
+    case 'aoeDamage': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
+    case 'groundAoE': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
+    case 'aoeRoot': return { ...eff, min: Math.round(eff.min * dmgMult), max: Math.round(eff.max * dmgMult) };
+    case 'drainTick': return { ...eff, min: Math.round(eff.min * dmgMult), max: Math.round(eff.max * dmgMult) };
+    case 'finisherDamage': return { ...eff, base: Math.round(eff.base * dmgMult + flat), perCombo: Math.round(eff.perCombo * dmgMult) };
+    case 'imbue': return { ...eff, bonus: Math.round(eff.bonus * dmgMult + flat), judgeMin: eff.judgeMin === undefined ? undefined : Math.round(eff.judgeMin * dmgMult + flat), judgeMax: eff.judgeMax === undefined ? undefined : Math.round(eff.judgeMax * dmgMult + flat) };
+    case 'heal': return { ...eff, min: Math.round(eff.min * healMult + flat), max: Math.round(eff.max * healMult + flat) };
+    case 'hot': return { ...eff, total: Math.round(eff.total * healMult + flat) };
+    case 'absorb': return { ...eff, amount: Math.round(eff.amount * healMult + flat) };
+    case 'buffTarget': return { ...eff, value: Math.round(eff.value * dmgMult + flat) };
+    case 'selfBuff': return { ...eff, value: Math.round(eff.value * dmgMult + flat) };
+    case 'lifeTap': return { ...eff, mana: Math.round(eff.mana * dmgMult + flat) };
+    case 'gainResource': return { ...eff, amount: Math.round(eff.amount * dmgMult + flat) };
+    default: return eff;
   }
 }
 

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6780,7 +6780,7 @@ export class Hud {
   }
 
   // The plain-text form of a chat string with [[q:id]]/[[i:id]] tokens replaced by
-  // [Name] — used for 3D chat bubbles, which can't host interactive spans.
+  // [Name], used for 3D chat bubbles, which can't host interactive spans.
   private chatLinkPlainText(text: string): string {
     return parseChatSegments(text)
       .map((s) => {

--- a/tests/talents.test.ts
+++ b/tests/talents.test.ts
@@ -529,6 +529,18 @@ describe('Sim integration — active talents & ability modifiers', () => {
     expect(slam.castTime).toBeCloseTo(1.5 * 0.5); // Improved Slam r2 -50% -> 0.75s
   });
 
+  it('scales Consecration ground-AoE damage with Holy Shield (groundAoE effect)', () => {
+    const base = effOf(abilitiesKnownAt('paladin', 20).find((k) => k.def.id === 'consecration'));
+    const mods = computeTalentModifiers('paladin', alloc({ spec: 'protection', ranks: { prot_holy_shield: 2 } }));
+    const buffed = effOf(abilitiesKnownAt('paladin', 20, mods).find((k) => k.def.id === 'consecration'));
+    // Holy Shield r2 => +24% Consecration damage on the groundAoE tick magnitudes.
+    expect(buffed.min).toBe(Math.round(base.min * 1.24));
+    expect(buffed.max).toBe(Math.round(base.max * 1.24));
+    expect(buffed.min).toBeGreaterThan(base.min);
+    // shared content data must NOT be mutated by the modifier pass
+    expect(effOf(abilitiesKnownAt('paladin', 20).find((k) => k.def.id === 'consecration')).min).toBe(base.min);
+  });
+
   it('a choice node applies only the chosen option ability mod', () => {
     const baseMin = effOf(abilitiesKnownAt('warrior', 20).find((k) => k.def.id === 'cleave')).min;
     const sweeping = effOf(

--- a/tests/talents.test.ts
+++ b/tests/talents.test.ts
@@ -531,14 +531,21 @@ describe('Sim integration — active talents & ability modifiers', () => {
 
   it('scales Consecration ground-AoE damage with Holy Shield (groundAoE effect)', () => {
     const base = effOf(abilitiesKnownAt('paladin', 20).find((k) => k.def.id === 'consecration'));
-    const mods = computeTalentModifiers('paladin', alloc({ spec: 'protection', ranks: { prot_holy_shield: 2 } }));
-    const buffed = effOf(abilitiesKnownAt('paladin', 20, mods).find((k) => k.def.id === 'consecration'));
+    const mods = computeTalentModifiers(
+      'paladin',
+      alloc({ spec: 'protection', ranks: { prot_holy_shield: 2 } }),
+    );
+    const buffed = effOf(
+      abilitiesKnownAt('paladin', 20, mods).find((k) => k.def.id === 'consecration'),
+    );
     // Holy Shield r2 => +24% Consecration damage on the groundAoE tick magnitudes.
     expect(buffed.min).toBe(Math.round(base.min * 1.24));
     expect(buffed.max).toBe(Math.round(base.max * 1.24));
     expect(buffed.min).toBeGreaterThan(base.min);
     // shared content data must NOT be mutated by the modifier pass
-    expect(effOf(abilitiesKnownAt('paladin', 20).find((k) => k.def.id === 'consecration')).min).toBe(base.min);
+    expect(
+      effOf(abilitiesKnownAt('paladin', 20).find((k) => k.def.id === 'consecration')).min,
+    ).toBe(base.min);
   });
 
   it('a choice node applies only the chosen option ability mod', () => {


### PR DESCRIPTION
## Problem

The **Holy Shield** talent (`prot_holy_shield`, `talents_classic.ts`) is documented as *"Increases Consecration damage by 12% and threat by 8% per rank"*, but the **damage half is a no-op**. Only the threat bonus (`global.threatPct`) ever applies.

## Root cause

The talent contributes an `ability: [{ ability: 'consecration', dmgPct: 0.12 }]` modifier. `applyTalentMods` (`src/sim/content/classes.ts`) folds that into a damage multiplier and maps every effect through `scaleEffect`. But `scaleEffect`'s per-effect-type `switch` had **no `groundAoE` case** -- and Consecration's only effect is `{ type: 'groundAoE', ... }`. So the effect fell through to `default: return eff` and came back unscaled.

`groundAoE` is structurally a twin of `aoeDamage` (both carry `min`/`max`/`radius`), but it is a distinct union member, so it was simply missed.

## Fix

Add a `groundAoE` case to `scaleEffect`, mirroring `aoeDamage` (scale `min`/`max` by the damage multiplier, keeping the `flat` term so a future flat-damage talent on a ground AoE also lands).

```ts
case 'groundAoE': return { ...eff, min: Math.round(eff.min * dmgMult + flat), max: Math.round(eff.max * dmgMult + flat) };
```

## Test

Added test-first in `tests/talents.test.ts`: snapshot-locks Consecration's `groundAoE` magnitudes before/after Holy Shield r2 (+24%) and asserts the shared content data is not mutated by the modifier pass. It fails before the fix (28 stays 28) and passes after (28 -> 35 on min).

## Verification

- `npx vitest run tests/talents.test.ts` (47 passed)
- `npx vitest run tests/sim.test.ts tests/progression.test.ts` (101 passed)
- `npx vitest run tests/architecture.test.ts` (sim purity, passed)
- `npx tsc --noEmit` clean

No balance numbers invented; the talent's existing `dmgPct` now simply reaches the ground-AoE tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["Holy Shield contributes dmgPct 0.12 to Consecration"] --> B["applyTalentMods -> scaleEffect"]
  B --> C{"per-effect-type switch"}
  C -->|aoeDamage| D["scaled by dmgMult"]
  C -->|"groundAoE (before)"| E["no case -> default returns eff UNSCALED"]
  E --> F["Consecration damage bonus = NO-OP (only threat applied)"]
  C -->|"groundAoE (after)"| G["scale min/max by dmgMult + flat"]
  G --> H["Consecration damage actually increases (28 -> 35 at r2)"]
```
