### PR TITLE
fix(server): cap chat text before the hard-word filter scan

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -74,7 +74,7 @@ import { nextRaidResetMs } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createSerialWriter } from './serial_writer';
 import type { Presence, PresenceStatus, SocialActor, SocialTransport } from './social';
-import { SocialService } from './social';
+import { GUILD_MESSAGE_MAX, SocialService } from './social';
 import { PgSocialDb } from './social_db';
 import { TickProfiler } from './tick_profiler';
 import { holderInfoForPubkey } from './woc_balance';
@@ -113,6 +113,10 @@ const LOCKPICK_ACTIONS = new Set<PickAction>(['hardSet', 'set', 'steady', 'ease'
 const LEAVE_SAVE_MAX_ATTEMPTS = 5;
 const LEAVE_SAVE_RETRY_BASE_MS = 250;
 const LEAVE_SAVE_RETRY_MAX_MS = 4000;
+// Guild/officer chat prefixes: shared between enforceChatPolicy (which must
+// scan the exact body guildChat/officerChat will deliver) and the chat router.
+const GUILD_CHAT_PREFIX = /^\/(?:g|gu|guild)\s+([\s\S]+)$/i;
+const OFFICER_CHAT_PREFIX = /^\/(?:o|officer)\s+([\s\S]+)$/i;
 const CHAT_RATE_BURST = 5;
 const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
@@ -2295,8 +2299,8 @@ export class GameServer {
         // guild and officer chat are persistent + cross-zone, so they live in
         // the server's SocialService rather than the sim (no guild concept).
         // MMO convention: /g is guild; /general remains world chat.
-        const gm = /^\/(?:g|gu|guild)\s+([\s\S]+)$/i.exec(text);
-        const om = gm ? null : /^\/(?:o|officer)\s+([\s\S]+)$/i.exec(text);
+        const gm = GUILD_CHAT_PREFIX.exec(text);
+        const om = gm ? null : OFFICER_CHAT_PREFIX.exec(text);
         if (gm || om) {
           const channel = gm ? 'guild' : 'officer';
           const match = gm ?? om;
@@ -3420,12 +3424,26 @@ export class GameServer {
       );
       return true;
     }
-    // Only the first MAX_CHAT_MESSAGE_LEN chars are ever routed or stored, but a
-    // WS frame can carry up to maxPayload (16 KiB). Cap the text before scanning
-    // so the filter never burns ~64-170x CPU on bytes nobody will see (bounded
-    // only by the chat token bucket), and never mutes for a slur that is sliced
-    // off before delivery.
-    const scanned = text.length > MAX_CHAT_MESSAGE_LEN ? text.slice(0, MAX_CHAT_MESSAGE_LEN) : text;
+    // Only a bounded prefix of the text is ever routed or stored, but a WS frame
+    // can carry up to maxPayload (16 KiB). Cap the text before scanning so the
+    // filter never burns ~64-170x CPU on bytes nobody will see (bounded only by
+    // the chat token bucket), and never mutes for a slur that is sliced off
+    // before delivery. The cap must match what will actually be routed: /g and
+    // /o strip a variable-length prefix and leading whitespace before slicing
+    // their body (guildChat/officerChat in social.ts), so a raw-position slice
+    // of the frame can miss a hard word placed past the cap by padding the
+    // prefix. Normalize the same way here before capping.
+    const gm = GUILD_CHAT_PREFIX.exec(text);
+    const om = gm ? null : OFFICER_CHAT_PREFIX.exec(text);
+    const routedBody = (gm ?? om)?.[1].trim();
+    const scanned =
+      routedBody !== undefined
+        ? routedBody.length > GUILD_MESSAGE_MAX
+          ? routedBody.slice(0, GUILD_MESSAGE_MAX)
+          : routedBody
+        : text.length > MAX_CHAT_MESSAGE_LEN
+          ? text.slice(0, MAX_CHAT_MESSAGE_LEN)
+          : text;
     const hit = this.chatFilter.findHardHit(scanned);
     if (!hit) return false;
 

--- a/server/game.ts
+++ b/server/game.ts
@@ -3420,7 +3420,13 @@ export class GameServer {
       );
       return true;
     }
-    const hit = this.chatFilter.findHardHit(text);
+    // Only the first MAX_CHAT_MESSAGE_LEN chars are ever routed or stored, but a
+    // WS frame can carry up to maxPayload (16 KiB). Cap the text before scanning
+    // so the filter never burns ~64-170x CPU on bytes nobody will see (bounded
+    // only by the chat token bucket), and never mutes for a slur that is sliced
+    // off before delivery.
+    const scanned = text.length > MAX_CHAT_MESSAGE_LEN ? text.slice(0, MAX_CHAT_MESSAGE_LEN) : text;
+    const hit = this.chatFilter.findHardHit(scanned);
     if (!hit) return false;
 
     const outcome = this.chatFilter.escalate(session.chatStrikes);
@@ -3457,7 +3463,7 @@ export class GameServer {
       characterName: session.name,
       term: hit,
       channel,
-      message: text,
+      message: scanned,
       action: outcome.kind,
       muteSeconds: outcome.muteSeconds,
     }).catch((err) => console.error('recordChatViolation failed:', err));

--- a/server/social.ts
+++ b/server/social.ts
@@ -82,11 +82,21 @@ export interface SocialDb {
   // guilds (a character belongs to at most one)
   // create the guild and seat its leader in one transaction, so a racing or
   // duplicate create packet can never orphan a leaderless guild
-  createGuildWithLeader(name: string, leaderId: number): Promise<{ guildId: number } | { error: 'name_taken' | 'already_in_guild' }>;
+  createGuildWithLeader(
+    name: string,
+    leaderId: number,
+  ): Promise<{ guildId: number } | { error: 'name_taken' | 'already_in_guild' }>;
   deleteGuild(id: number): Promise<void>;
-  guildMembership(charId: number): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null>;
+  guildMembership(
+    charId: number,
+  ): Promise<{ guildId: number; guildName: string; rank: GuildRank } | null>;
   // seat a member atomically, enforcing the cap under concurrent accepts
-  addGuildMemberAtomic(guildId: number, charId: number, rank: GuildRank, limit: number): Promise<'ok' | 'full' | 'already_member' | 'no_guild'>;
+  addGuildMemberAtomic(
+    guildId: number,
+    charId: number,
+    rank: GuildRank,
+    limit: number,
+  ): Promise<'ok' | 'full' | 'already_member' | 'no_guild'>;
   removeGuildMember(charId: number): Promise<void>;
   setGuildRank(charId: number, rank: GuildRank): Promise<void>;
   guildMembers(guildId: number): Promise<(CharInfo & { rank: GuildRank })[]>;
@@ -127,7 +137,9 @@ const FRIEND_LIMIT = 50;
 const BLOCK_LIMIT = 50;
 const GUILD_MEMBER_LIMIT = 100;
 const GUILD_INVITE_TTL_MS = 60_000;
-const GUILD_MESSAGE_MAX = 200;
+// Exported so the chat-policy filter gate in game.ts can cap the scanned text
+// to exactly what guildChat/officerChat will deliver (see enforceChatPolicy).
+export const GUILD_MESSAGE_MAX = 200;
 
 export function validateGuildName(name: string): string | null {
   const trimmed = String(name ?? '').trim();
@@ -138,10 +150,17 @@ export function validateGuildName(name: string): string | null {
   return trimmed;
 }
 
-const RANK_LABEL: Record<GuildRank, string> = { leader: 'Guild Master', officer: 'Officer', member: 'Member' };
+const RANK_LABEL: Record<GuildRank, string> = {
+  leader: 'Guild Master',
+  officer: 'Officer',
+  member: 'Member',
+};
 
 export class SocialService {
-  private pendingGuildInvites = new Map<number, { guildId: number; guildName: string; fromName: string; expiresAt: number }>();
+  private pendingGuildInvites = new Map<
+    number,
+    { guildId: number; guildName: string; fromName: string; expiresAt: number }
+  >();
 
   constructor(
     private readonly db: SocialDb,
@@ -181,9 +200,17 @@ export class SocialService {
   }
 
   // Collapse a character's online presence into the fields a roster row needs.
-  private presence(charId: number): { online: boolean; zone?: string; status?: PresenceStatus; x?: number; z?: number } {
+  private presence(charId: number): {
+    online: boolean;
+    zone?: string;
+    status?: PresenceStatus;
+    x?: number;
+    z?: number;
+  } {
     const loc = this.tx.locationOf(charId);
-    return loc ? { online: true, zone: loc.zone, status: loc.status, x: loc.x, z: loc.z } : { online: false };
+    return loc
+      ? { online: true, zone: loc.zone, status: loc.status, x: loc.x, z: loc.z }
+      : { online: false };
   }
 
   private push(charId: number): void {
@@ -202,9 +229,15 @@ export class SocialService {
   // reporting the right error to the actor. Returns null on failure.
   private async resolveTarget(actor: SocialActor, name: string): Promise<CharInfo | null> {
     const wanted = String(name ?? '').trim();
-    if (!wanted) { this.err(actor.characterId, 'Specify a character name.'); return null; }
+    if (!wanted) {
+      this.err(actor.characterId, 'Specify a character name.');
+      return null;
+    }
     const target = await this.db.findCharacterByName(wanted);
-    if (!target) { this.err(actor.characterId, `No character named '${wanted}' exists.`); return null; }
+    if (!target) {
+      this.err(actor.characterId, `No character named '${wanted}' exists.`);
+      return null;
+    }
     return target;
   }
 
@@ -215,18 +248,30 @@ export class SocialService {
   async friendAdd(actor: SocialActor, name: string): Promise<void> {
     const target = await this.resolveTarget(actor, name);
     if (!target) return;
-    if (target.id === actor.characterId) { this.err(actor.characterId, 'You cannot befriend yourself.'); return; }
+    if (target.id === actor.characterId) {
+      this.err(actor.characterId, 'You cannot befriend yourself.');
+      return;
+    }
     // friends and ignore are mutually exclusive — blockAdd drops an ignored
     // player from your friends, so friendAdd must refuse the reverse, or a
     // player could end up both ignored and friended at once.
     const blocks = await this.db.listBlocks(actor.characterId);
     if (blocks.some((b) => b.id === target.id)) {
-      this.err(actor.characterId, `You are ignoring ${target.name}. Remove them from your ignore list first.`);
+      this.err(
+        actor.characterId,
+        `You are ignoring ${target.name}. Remove them from your ignore list first.`,
+      );
       return;
     }
     const friends = await this.db.listFriends(actor.characterId);
-    if (friends.some((f) => f.id === target.id)) { this.err(actor.characterId, `${target.name} is already your friend.`); return; }
-    if (friends.length >= FRIEND_LIMIT) { this.err(actor.characterId, 'Your friends list is full.'); return; }
+    if (friends.some((f) => f.id === target.id)) {
+      this.err(actor.characterId, `${target.name} is already your friend.`);
+      return;
+    }
+    if (friends.length >= FRIEND_LIMIT) {
+      this.err(actor.characterId, 'Your friends list is full.');
+      return;
+    }
     await this.db.addFriend(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} added to friends.`);
     this.push(actor.characterId);
@@ -234,9 +279,15 @@ export class SocialService {
 
   async friendRemove(actor: SocialActor, name: string): Promise<void> {
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
-    if (!target) { this.err(actor.characterId, `No character named '${name}' on your friends list.`); return; }
+    if (!target) {
+      this.err(actor.characterId, `No character named '${name}' on your friends list.`);
+      return;
+    }
     const friends = await this.db.listFriends(actor.characterId);
-    if (!friends.some((f) => f.id === target.id)) { this.err(actor.characterId, `${target.name} is not on your friends list.`); return; }
+    if (!friends.some((f) => f.id === target.id)) {
+      this.err(actor.characterId, `${target.name} is not on your friends list.`);
+      return;
+    }
     await this.db.removeFriend(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} removed from friends.`);
     this.push(actor.characterId);
@@ -249,11 +300,13 @@ export class SocialService {
     const notified = new Set<number>();
     for (const watcherId of watchers) {
       if (!this.tx.isOnline(watcherId)) continue;
-      this.tx.deliver(watcherId, [{
-        type: 'log',
-        text: online ? `${actor.name} has come online.` : `${actor.name} has gone offline.`,
-        color: '#7fd4ff',
-      }]);
+      this.tx.deliver(watcherId, [
+        {
+          type: 'log',
+          text: online ? `${actor.name} has come online.` : `${actor.name} has gone offline.`,
+          color: '#7fd4ff',
+        },
+      ]);
       this.push(watcherId);
       notified.add(watcherId);
     }
@@ -278,10 +331,19 @@ export class SocialService {
   async blockAdd(actor: SocialActor, name: string): Promise<void> {
     const target = await this.resolveTarget(actor, name);
     if (!target) return;
-    if (target.id === actor.characterId) { this.err(actor.characterId, 'You cannot ignore yourself.'); return; }
+    if (target.id === actor.characterId) {
+      this.err(actor.characterId, 'You cannot ignore yourself.');
+      return;
+    }
     const blocks = await this.db.listBlocks(actor.characterId);
-    if (blocks.some((b) => b.id === target.id)) { this.err(actor.characterId, `${target.name} is already ignored.`); return; }
-    if (blocks.length >= BLOCK_LIMIT) { this.err(actor.characterId, 'Your ignore list is full.'); return; }
+    if (blocks.some((b) => b.id === target.id)) {
+      this.err(actor.characterId, `${target.name} is already ignored.`);
+      return;
+    }
+    if (blocks.length >= BLOCK_LIMIT) {
+      this.err(actor.characterId, 'Your ignore list is full.');
+      return;
+    }
     await this.db.addBlock(actor.characterId, target.id);
     // ignoring someone also drops them from your friends list
     await this.db.removeFriend(actor.characterId, target.id);
@@ -292,9 +354,15 @@ export class SocialService {
 
   async blockRemove(actor: SocialActor, name: string): Promise<void> {
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
-    if (!target) { this.err(actor.characterId, `No character named '${name}' on your ignore list.`); return; }
+    if (!target) {
+      this.err(actor.characterId, `No character named '${name}' on your ignore list.`);
+      return;
+    }
     const blocks = await this.db.listBlocks(actor.characterId);
-    if (!blocks.some((b) => b.id === target.id)) { this.err(actor.characterId, `${target.name} is not on your ignore list.`); return; }
+    if (!blocks.some((b) => b.id === target.id)) {
+      this.err(actor.characterId, `${target.name} is not on your ignore list.`);
+      return;
+    }
     await this.db.removeBlock(actor.characterId, target.id);
     this.info(actor.characterId, `${target.name} is no longer ignored.`);
     this.tx.onBlocksChanged(actor.characterId, await this.db.blockedIds(actor.characterId));
@@ -307,52 +375,102 @@ export class SocialService {
 
   async guildCreate(actor: SocialActor, rawName: string): Promise<void> {
     const name = validateGuildName(rawName);
-    if (!name) { this.err(actor.characterId, 'Guild names are 3-24 letters (spaces allowed).'); return; }
-    const result = await this.db.createGuildWithLeader(name, actor.characterId);
-    if ('error' in result) {
-      this.err(actor.characterId, result.error === 'name_taken'
-        ? `A guild named '${name}' already exists.`
-        : 'You are already in a guild.');
+    if (!name) {
+      this.err(actor.characterId, 'Guild names are 3-24 letters (spaces allowed).');
       return;
     }
-    this.info(actor.characterId, `You found the guild <${name}>! You are its Guild Master.`, '#40ff7f');
+    const result = await this.db.createGuildWithLeader(name, actor.characterId);
+    if ('error' in result) {
+      this.err(
+        actor.characterId,
+        result.error === 'name_taken'
+          ? `A guild named '${name}' already exists.`
+          : 'You are already in a guild.',
+      );
+      return;
+    }
+    this.info(
+      actor.characterId,
+      `You found the guild <${name}>! You are its Guild Master.`,
+      '#40ff7f',
+    );
     this.push(actor.characterId);
   }
 
   async guildInvite(actor: SocialActor, name: string): Promise<void> {
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
-    if (membership.rank === 'member') { this.err(actor.characterId, 'Only officers and the Guild Master may invite.'); return; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return;
+    }
+    if (membership.rank === 'member') {
+      this.err(actor.characterId, 'Only officers and the Guild Master may invite.');
+      return;
+    }
     const target = await this.resolveTarget(actor, name);
     if (!target) return;
-    if (target.id === actor.characterId) { this.err(actor.characterId, 'You are already in the guild.'); return; }
-    if (!this.tx.isOnline(target.id)) { this.err(actor.characterId, `${target.name} must be online to be invited.`); return; }
-    if (await this.db.guildMembership(target.id)) { this.err(actor.characterId, `${target.name} is already in a guild.`); return; }
+    if (target.id === actor.characterId) {
+      this.err(actor.characterId, 'You are already in the guild.');
+      return;
+    }
+    if (!this.tx.isOnline(target.id)) {
+      this.err(actor.characterId, `${target.name} must be online to be invited.`);
+      return;
+    }
+    if (await this.db.guildMembership(target.id)) {
+      this.err(actor.characterId, `${target.name} is already in a guild.`);
+      return;
+    }
     const existing = this.pendingGuildInvites.get(target.id);
     if (existing && existing.expiresAt >= this.now()) {
-      this.err(actor.characterId, `${target.name} already has a pending guild invitation.`); return;
+      this.err(actor.characterId, `${target.name} already has a pending guild invitation.`);
+      return;
     }
     const members = await this.db.guildMembers(membership.guildId);
-    if (members.length >= GUILD_MEMBER_LIMIT) { this.err(actor.characterId, 'Your guild is full.'); return; }
+    if (members.length >= GUILD_MEMBER_LIMIT) {
+      this.err(actor.characterId, 'Your guild is full.');
+      return;
+    }
     this.pendingGuildInvites.set(target.id, {
       guildId: membership.guildId,
       guildName: membership.guildName,
       fromName: actor.name,
       expiresAt: this.now() + GUILD_INVITE_TTL_MS,
     });
-    this.tx.deliver(target.id, [{ type: 'guildInvite', fromName: actor.name, guildName: membership.guildName }]);
+    this.tx.deliver(target.id, [
+      { type: 'guildInvite', fromName: actor.name, guildName: membership.guildName },
+    ]);
     this.info(actor.characterId, `You have invited ${target.name} to the guild.`);
   }
 
   async guildAccept(actor: SocialActor): Promise<void> {
     const invite = this.pendingGuildInvites.get(actor.characterId);
     this.pendingGuildInvites.delete(actor.characterId);
-    if (!invite || invite.expiresAt < this.now()) { this.err(actor.characterId, 'The guild invitation has expired.'); return; }
-    const result = await this.db.addGuildMemberAtomic(invite.guildId, actor.characterId, 'member', GUILD_MEMBER_LIMIT);
-    if (result === 'no_guild') { this.err(actor.characterId, 'That guild no longer exists.'); return; }
-    if (result === 'already_member') { this.err(actor.characterId, 'You are already in a guild.'); return; }
-    if (result === 'full') { this.err(actor.characterId, 'That guild is full.'); return; }
-    await this.broadcastGuild(invite.guildId, [{ type: 'log', text: `${actor.name} has joined the guild.`, color: '#40ff7f' }]);
+    if (!invite || invite.expiresAt < this.now()) {
+      this.err(actor.characterId, 'The guild invitation has expired.');
+      return;
+    }
+    const result = await this.db.addGuildMemberAtomic(
+      invite.guildId,
+      actor.characterId,
+      'member',
+      GUILD_MEMBER_LIMIT,
+    );
+    if (result === 'no_guild') {
+      this.err(actor.characterId, 'That guild no longer exists.');
+      return;
+    }
+    if (result === 'already_member') {
+      this.err(actor.characterId, 'You are already in a guild.');
+      return;
+    }
+    if (result === 'full') {
+      this.err(actor.characterId, 'That guild is full.');
+      return;
+    }
+    await this.broadcastGuild(invite.guildId, [
+      { type: 'log', text: `${actor.name} has joined the guild.`, color: '#40ff7f' },
+    ]);
     await this.pushGuild(invite.guildId);
   }
 
@@ -362,22 +480,34 @@ export class SocialService {
 
   async guildLeave(actor: SocialActor): Promise<void> {
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return;
+    }
     const members = await this.db.guildMembers(membership.guildId);
     const others = members.filter((m) => m.id !== actor.characterId);
     // classic-MMO rule: the Guild Master cannot quit while others remain — they must
     // hand leadership over (Promote to Guild Master) or disband the guild.
     if (membership.rank === 'leader' && others.length > 0) {
-      this.err(actor.characterId, 'As Guild Master you must promote a new leader or disband the guild before leaving.');
+      this.err(
+        actor.characterId,
+        'As Guild Master you must promote a new leader or disband the guild before leaving.',
+      );
       return;
     }
     await this.db.removeGuildMember(actor.characterId);
     if (others.length === 0) {
       // last member out: the guild ceases to exist
       await this.db.deleteGuild(membership.guildId);
-      this.info(actor.characterId, `You have left <${membership.guildName}>. The guild has disbanded.`, '#ffd100');
+      this.info(
+        actor.characterId,
+        `You have left <${membership.guildName}>. The guild has disbanded.`,
+        '#ffd100',
+      );
     } else {
-      await this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${actor.name} has left the guild.`, color: '#ffd100' }]);
+      await this.broadcastGuild(membership.guildId, [
+        { type: 'log', text: `${actor.name} has left the guild.`, color: '#ffd100' },
+      ]);
       this.info(actor.characterId, `You have left <${membership.guildName}>.`);
       await this.pushGuild(membership.guildId);
     }
@@ -388,18 +518,32 @@ export class SocialService {
   // leader steps down to Officer.
   async guildTransferLeader(actor: SocialActor, name: string): Promise<void> {
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
-    if (membership.rank !== 'leader') { this.err(actor.characterId, 'Only the Guild Master may promote a new leader.'); return; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return;
+    }
+    if (membership.rank !== 'leader') {
+      this.err(actor.characterId, 'Only the Guild Master may promote a new leader.');
+      return;
+    }
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
-    if (!target || target.id === actor.characterId) { this.err(actor.characterId, `No such guild member '${name}'.`); return; }
+    if (!target || target.id === actor.characterId) {
+      this.err(actor.characterId, `No such guild member '${name}'.`);
+      return;
+    }
     const targetMembership = await this.db.guildMembership(target.id);
     if (!targetMembership || targetMembership.guildId !== membership.guildId) {
-      this.err(actor.characterId, `${target.name} is not in your guild.`); return;
+      this.err(actor.characterId, `${target.name} is not in your guild.`);
+      return;
     }
     await this.db.setGuildRank(target.id, 'leader');
     await this.db.setGuildRank(actor.characterId, 'officer');
     await this.broadcastGuild(membership.guildId, [
-      { type: 'log', text: `${target.name} is now the Guild Master of <${membership.guildName}>.`, color: '#ffd100' },
+      {
+        type: 'log',
+        text: `${target.name} is now the Guild Master of <${membership.guildName}>.`,
+        color: '#ffd100',
+      },
     ]);
     await this.pushGuild(membership.guildId);
   }
@@ -407,8 +551,14 @@ export class SocialService {
   // /gdisband: the Guild Master dissolves the entire guild.
   async guildDisband(actor: SocialActor): Promise<void> {
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
-    if (membership.rank !== 'leader') { this.err(actor.characterId, 'Only the Guild Master may disband the guild.'); return; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return;
+    }
+    if (membership.rank !== 'leader') {
+      this.err(actor.characterId, 'Only the Guild Master may disband the guild.');
+      return;
+    }
     const members = await this.db.guildMembers(membership.guildId);
     await this.db.deleteGuild(membership.guildId);
     for (const m of members) {
@@ -421,50 +571,96 @@ export class SocialService {
 
   async guildKick(actor: SocialActor, name: string): Promise<void> {
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
-    if (membership.rank === 'member') { this.err(actor.characterId, 'Only officers and the Guild Master may remove members.'); return; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return;
+    }
+    if (membership.rank === 'member') {
+      this.err(actor.characterId, 'Only officers and the Guild Master may remove members.');
+      return;
+    }
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
-    if (!target) { this.err(actor.characterId, `No character named '${name}'.`); return; }
-    if (target.id === actor.characterId) { this.err(actor.characterId, 'Use Leave Guild to remove yourself.'); return; }
+    if (!target) {
+      this.err(actor.characterId, `No character named '${name}'.`);
+      return;
+    }
+    if (target.id === actor.characterId) {
+      this.err(actor.characterId, 'Use Leave Guild to remove yourself.');
+      return;
+    }
     const targetMembership = await this.db.guildMembership(target.id);
     if (!targetMembership || targetMembership.guildId !== membership.guildId) {
-      this.err(actor.characterId, `${target.name} is not in your guild.`); return;
+      this.err(actor.characterId, `${target.name} is not in your guild.`);
+      return;
     }
-    if (targetMembership.rank === 'leader') { this.err(actor.characterId, 'You cannot remove the Guild Master.'); return; }
+    if (targetMembership.rank === 'leader') {
+      this.err(actor.characterId, 'You cannot remove the Guild Master.');
+      return;
+    }
     if (targetMembership.rank === 'officer' && membership.rank !== 'leader') {
-      this.err(actor.characterId, 'Only the Guild Master may remove an officer.'); return;
+      this.err(actor.characterId, 'Only the Guild Master may remove an officer.');
+      return;
     }
     await this.db.removeGuildMember(target.id);
     if (this.tx.isOnline(target.id)) {
       this.info(target.id, `You have been removed from <${membership.guildName}>.`, '#ffd100');
       this.push(target.id);
     }
-    await this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${target.name} has been removed from the guild by ${actor.name}.`, color: '#ffd100' }]);
+    await this.broadcastGuild(membership.guildId, [
+      {
+        type: 'log',
+        text: `${target.name} has been removed from the guild by ${actor.name}.`,
+        color: '#ffd100',
+      },
+    ]);
     await this.pushGuild(membership.guildId);
   }
 
   async guildSetRank(actor: SocialActor, name: string, rank: GuildRank): Promise<void> {
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return; }
-    if (membership.rank !== 'leader') { this.err(actor.characterId, 'Only the Guild Master may change ranks.'); return; }
-    if (rank === 'leader') { this.err(actor.characterId, 'Use a guild transfer to hand over leadership.'); return; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return;
+    }
+    if (membership.rank !== 'leader') {
+      this.err(actor.characterId, 'Only the Guild Master may change ranks.');
+      return;
+    }
+    if (rank === 'leader') {
+      this.err(actor.characterId, 'Use a guild transfer to hand over leadership.');
+      return;
+    }
     const target = await this.db.findCharacterByName(String(name ?? '').trim());
-    if (!target || target.id === actor.characterId) { this.err(actor.characterId, `No such guild member '${name}'.`); return; }
+    if (!target || target.id === actor.characterId) {
+      this.err(actor.characterId, `No such guild member '${name}'.`);
+      return;
+    }
     const targetMembership = await this.db.guildMembership(target.id);
     if (!targetMembership || targetMembership.guildId !== membership.guildId) {
-      this.err(actor.characterId, `${target.name} is not in your guild.`); return;
+      this.err(actor.characterId, `${target.name} is not in your guild.`);
+      return;
     }
-    if (targetMembership.rank === rank) { this.err(actor.characterId, `${target.name} is already ${RANK_LABEL[rank]}.`); return; }
+    if (targetMembership.rank === rank) {
+      this.err(actor.characterId, `${target.name} is already ${RANK_LABEL[rank]}.`);
+      return;
+    }
     await this.db.setGuildRank(target.id, rank);
-    await this.broadcastGuild(membership.guildId, [{ type: 'log', text: `${target.name} is now ${RANK_LABEL[rank]}.`, color: '#40ff7f' }]);
+    await this.broadcastGuild(membership.guildId, [
+      { type: 'log', text: `${target.name} is now ${RANK_LABEL[rank]}.`, color: '#40ff7f' },
+    ]);
     await this.pushGuild(membership.guildId);
   }
 
   async guildChat(actor: SocialActor, rawText: string): Promise<boolean> {
-    const text = String(rawText ?? '').trim().slice(0, GUILD_MESSAGE_MAX);
+    const text = String(rawText ?? '')
+      .trim()
+      .slice(0, GUILD_MESSAGE_MAX);
     if (!text) return false;
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return false; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return false;
+    }
     const event: SocialEvent = { type: 'chat', from: actor.name, text, channel: 'guild' };
     const members = await this.db.guildMembers(membership.guildId);
     for (const m of members) {
@@ -479,11 +675,19 @@ export class SocialService {
 
   // Officer chat (/o): officers + Guild Master only, delivered to the same.
   async officerChat(actor: SocialActor, rawText: string): Promise<boolean> {
-    const text = String(rawText ?? '').trim().slice(0, GUILD_MESSAGE_MAX);
+    const text = String(rawText ?? '')
+      .trim()
+      .slice(0, GUILD_MESSAGE_MAX);
     if (!text) return false;
     const membership = await this.db.guildMembership(actor.characterId);
-    if (!membership) { this.err(actor.characterId, 'You are not in a guild.'); return false; }
-    if (membership.rank === 'member') { this.err(actor.characterId, 'Only officers and the Guild Master can use officer chat.'); return false; }
+    if (!membership) {
+      this.err(actor.characterId, 'You are not in a guild.');
+      return false;
+    }
+    if (membership.rank === 'member') {
+      this.err(actor.characterId, 'Only officers and the Guild Master can use officer chat.');
+      return false;
+    }
     const members = await this.db.guildMembers(membership.guildId);
     for (const m of members) {
       if ((m.rank === 'officer' || m.rank === 'leader') && this.tx.isOnline(m.id)) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6780,7 +6780,7 @@ export class Hud {
   }
 
   // The plain-text form of a chat string with [[q:id]]/[[i:id]] tokens replaced by
-  // [Name] — used for 3D chat bubbles, which can't host interactive spans.
+  // [Name], used for 3D chat bubbles, which can't host interactive spans.
   private chatLinkPlainText(text: string): string {
     return parseChatSegments(text)
       .map((s) => {

--- a/tests/chat_filter_cap.test.ts
+++ b/tests/chat_filter_cap.test.ts
@@ -16,6 +16,7 @@ vi.mock('../server/db', () => ({
 
 import { DEFAULT_ESCALATION } from '../server/chat_filter';
 import { type ClientSession, GameServer } from '../server/game';
+import { GUILD_MESSAGE_MAX } from '../server/social';
 import { MAX_CHAT_MESSAGE_LEN } from '../src/sim/sim';
 
 const HARD = 'zzslur';
@@ -60,5 +61,35 @@ describe('chat policy cap (server scans at most the routed slice)', () => {
     const pad = 'a '.repeat(10); // tokens kept short so the slur stays whole
     const text = `${pad}${HARD}`.slice(0, MAX_CHAT_MESSAGE_LEN);
     expect(enforce(server, session, text)).toBe(true);
+  });
+
+  // guild/officer chat routes body = /^\/(?:g|gu|guild)\s+([\s\S]+)$/ group 1,
+  // trimmed and capped at GUILD_MESSAGE_MAX (server/social.ts guildChat), not a
+  // raw-position slice of the frame. A raw-position cap can be defeated by
+  // padding the command with whitespace past the cap, since the stripped
+  // whitespace length is unbounded: the slur then lands outside the scanned
+  // slice while still being exactly what guildChat delivers.
+  it('flags a /g message whose slur is pushed past the raw cap by padding', () => {
+    const server = serverWithHardWord();
+    const session = joinSession(server);
+    const padded = `/g${' '.repeat(MAX_CHAT_MESSAGE_LEN + 10)}${HARD}`;
+    expect(enforce(server, session, padded)).toBe(true);
+  });
+
+  it('flags an /o message whose slur is pushed past the raw cap by padding', () => {
+    const server = serverWithHardWord();
+    const session = joinSession(server);
+    const padded = `/o${' '.repeat(MAX_CHAT_MESSAGE_LEN + 10)}${HARD}`;
+    expect(enforce(server, session, padded)).toBe(true);
+  });
+
+  it('does NOT flag a /g slur past the routed guild body cap', () => {
+    const server = serverWithHardWord();
+    const session = joinSession(server);
+    // The slur sits after GUILD_MESSAGE_MAX chars of the routed body, so it is
+    // sliced off before guildChat delivers the message; the filter must not
+    // burn a scan on it either.
+    const padded = `/g ${'a'.repeat(GUILD_MESSAGE_MAX + 5)} ${HARD}`;
+    expect(enforce(server, session, padded)).toBe(false);
   });
 });

--- a/tests/chat_filter_cap.test.ts
+++ b/tests/chat_filter_cap.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The server only ever routes/stores the first MAX_CHAT_MESSAGE_LEN chars of a
+// chat message, but the WS frame can be up to maxPayload (16 KiB). The hard-word
+// filter must not scan past that cap: doing so burns ~64-170x CPU on bytes that
+// are never delivered, and would punitively mute a sender for a slur that is
+// sliced off before anyone sees it.
+
+vi.mock('../server/db', () => ({
+  pool: { query: vi.fn(async () => ({ rows: [] })) },
+  saveCharacterState: vi.fn(async () => {}),
+  openPlaySession: vi.fn(async () => 1),
+  closePlaySession: vi.fn(async () => {}),
+  insertChatLogs: vi.fn(async () => {}),
+}));
+
+import { DEFAULT_ESCALATION } from '../server/chat_filter';
+import { type ClientSession, GameServer } from '../server/game';
+import { MAX_CHAT_MESSAGE_LEN } from '../src/sim/sim';
+
+const HARD = 'zzslur';
+
+function serverWithHardWord(): GameServer {
+  const server = new GameServer();
+  server.chatFilter.load({ soft: [], hard: [HARD], config: DEFAULT_ESCALATION });
+  return server;
+}
+
+function joinSession(server: GameServer): ClientSession {
+  const ws = { readyState: 1, send: vi.fn(), close: vi.fn() } as any;
+  const result = server.join(ws, 11, 101, 'Talker', 'warrior', null);
+  if ('error' in result) throw new Error(result.error);
+  return result;
+}
+
+function enforce(server: GameServer, session: ClientSession, text: string): boolean {
+  return (server as any).enforceChatPolicy(session, text);
+}
+
+describe('chat policy cap (server scans at most the routed slice)', () => {
+  it('flags a hard word that lands within the routed slice', () => {
+    const server = serverWithHardWord();
+    const session = joinSession(server);
+    expect(enforce(server, session, `hey ${HARD} there`)).toBe(true);
+  });
+
+  it('does NOT flag a hard word that only appears past the routed cap', () => {
+    const server = serverWithHardWord();
+    const session = joinSession(server);
+    // Padding longer than the cap, with the slur only after it: this slur is
+    // sliced off before delivery, so it must neither mute nor cost a full scan.
+    const text = `${'a'.repeat(MAX_CHAT_MESSAGE_LEN + 50)} ${HARD}`;
+    expect(enforce(server, session, text)).toBe(false);
+  });
+
+  it('still flags a hard word sitting exactly at the cap boundary', () => {
+    const server = serverWithHardWord();
+    const session = joinSession(server);
+    // Slur ends right at the cap (fits within the routed slice).
+    const pad = 'a '.repeat(10); // tokens kept short so the slur stays whole
+    const text = `${pad}${HARD}`.slice(0, MAX_CHAT_MESSAGE_LEN);
+    expect(enforce(server, session, text)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

`enforceChatPolicy` (server/game.ts) runs the hard-word filter
(`findHardWord` -> `text.match(TOKEN_RE)`, a Unicode tokenizing regex) over
the **entire** trimmed chat text. A `chat` message rides a WS frame that can
be up to the `maxPayload` of 16 KiB, but only the first
`MAX_CHAT_MESSAGE_LEN` (255) chars are ever routed to other players or stored.

So every chat send scans up to ~64-170x more text than will ever be
delivered. The work is bounded only by the chat token bucket, making it a
cheap per-message CPU-amplification vector against the single shared world
loop.

It is also a correctness bug: a hard word sitting **past** char 255 currently
triggers a punitive mute, even though it is sliced off before anyone sees the
message.

## Fix

Cap the text to `MAX_CHAT_MESSAGE_LEN` before scanning (and bound the
recorded-violation `message` to the same slice). The filter now never inspects
bytes that are not part of the routed/stored message.

## Tests

`tests/chat_filter_cap.test.ts` pins the behavior via `GameServer`:
- a hard word within the routed slice still flags (mute path intact),
- a hard word that only appears past the cap no longer flags,
- a hard word ending exactly at the cap boundary still flags.

Verified: new test red before / green after, `tests/chat_filter.test.ts`,
`tests/game_sessions.test.ts`, the S3 i18n guard
(`tests/localization_fixes.test.ts`), and `tsc --noEmit` all pass.

cc @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  A["chat WS frame, up to 16 KiB maxPayload"] --> B{"Before"}
  B --> C["findHardWord scans the ENTIRE trimmed text"]
  C --> D["~64-170x routed slice: CPU amplification + a slur past char 255 unfairly mutes"]
  A --> E{"After"}
  E --> F["slice to MAX_CHAT_MESSAGE_LEN (255) first"]
  F --> G["filter scans only the routed/stored slice"]
```
