### PR TITLE
fix(sim): route forgeable-facing combat gates through one hardened predicate

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -28,19 +28,18 @@
 // `ctx.rng` stream, drawn in the exact pre-move positions.
 
 import { CLASSES, MOBS } from '../data';
+import { withinMeleeArc } from '../positional';
 import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { addThreat } from '../threat';
 import {
-  angleTo,
   armorReduction,
   DT,
   dist2d,
   type Entity,
   MELEE_ARC,
   MELEE_RANGE,
-  normAngle,
   swingMissChance,
 } from '../types';
 import { spendResource } from './casting_lifecycle';
@@ -98,8 +97,7 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
   if (isStunned(p)) return;
   if (isDisarmed(p)) return; // weapon knocked away: no auto-attack swings
   const d = dist2d(p.pos, t.pos);
-  const facingDiff = Math.abs(normAngle(angleTo(p.pos, t.pos) - p.facing));
-  if (facingDiff > MELEE_ARC) return;
+  if (!withinMeleeArc(p.facing, p.pos, t.pos, MELEE_ARC)) return;
 
   // ranged auto-attack: hunters (auto shot, dead zone inside minRange) and
   // casters (wand-style, no dead zone so they don't run into melee — #94)

--- a/src/sim/combat/casting_lifecycle.ts
+++ b/src/sim/combat/casting_lifecycle.ts
@@ -28,13 +28,13 @@
 // tests/architecture.test.ts.
 
 import { ITEMS, MOBS } from '../data';
+import { isBehindTarget, withinMeleeArc } from '../positional';
 import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta, ResolvedAbility } from '../sim';
 import type { SimContext } from '../sim_context';
 import { abilityScalingPower, channelTickBonus } from '../spell_scaling';
 import type { AbilityDef, Entity } from '../types';
 import {
-  angleTo,
   CAST_COMPLETE_EPS,
   CAST_PUSHBACK_SEC,
   CHANNEL_PUSHBACK_FRACTION,
@@ -44,7 +44,6 @@ import {
   FISHING_CAST_ID,
   MELEE_ARC,
   MELEE_RANGE,
-  normAngle,
 } from '../types';
 import { isLockedOut, isSilenced, isStunned, tonguesMult } from './cc';
 import { isSpellResisted } from './spell_resist';
@@ -284,8 +283,7 @@ export function castAbility(ctx: SimContext, abilityId: string, pid?: number): v
       ctx.error(p.id, 'Line of sight.');
       return;
     }
-    const facingDiff = Math.abs(normAngle(angleTo(p.pos, target.pos) - p.facing));
-    if (facingDiff > MELEE_ARC) {
+    if (!withinMeleeArc(p.facing, p.pos, target.pos, MELEE_ARC)) {
       ctx.error(p.id, 'You must be facing your target.');
       return;
     }
@@ -306,8 +304,10 @@ export function castAbility(ctx: SimContext, abilityId: string, pid?: number): v
           ctx.error(p.id, 'You must wield a dagger.');
           return;
         }
-        const behindDiff = Math.abs(normAngle(angleTo(target.pos, p.pos) - target.facing));
-        if (behindDiff < Math.PI / 2) {
+        // `target.facing` is forgeable for a player target; see positional.ts.
+        // This gate is a bonus-ability requirement layered on top of the real
+        // server gates (range + a live hostile target), never a hittability gate.
+        if (!isBehindTarget(target.facing, target.pos, p.pos)) {
           ctx.error(p.id, 'You must be behind your target.');
           return;
         }

--- a/src/sim/positional.ts
+++ b/src/sim/positional.ts
@@ -1,0 +1,40 @@
+// Positional combat predicates: the single, canonical home for "am I facing my
+// target" (front arc) and "am I behind my target" (rear arc) checks.
+//
+// SECURITY INVARIANT (why this module exists):
+// An entity's `facing` is CLIENT-SUPPLIED for players (see server/game.ts, where
+// `e.facing = frame.facing`). It is therefore FORGEABLE: a cheat client can report
+// any orientation, decoupled from where it is actually moving or looking. (Mob
+// facing is server-computed via `angleTo`, so it is trustworthy.)
+//
+// Consequently these predicates MUST only ever gate BONUSES or extra requirements
+// on top of the real server gates, never decide whether an entity is hittable at
+// all. The authoritative, non-forgeable gates are RANGE and TARGET VALIDITY
+// (distance + a live, hostile, line-of-sight target), both derived from
+// server-tracked positions. A future "hittable only from behind" mechanic must NOT
+// gate hittability on `isBehindTarget`; it stays a damage/effect modifier, with
+// range + target validity remaining the hard gates. Routing every positional check
+// through here keeps that rule auditable in one place.
+//
+// Both predicates canonicalize the angle difference through `normAngle`, so they
+// return the correct result for ANY finite `facing` (including the large
+// accumulated yaw the keyboard-turn path sends, which is bounded but not
+// normalized at ingestion). `src/sim`-pure: imports only sibling sim math.
+
+import { angleTo, normAngle, type Vec3 } from './types';
+
+// True when `to` lies within `arc` radians of where `facing` points from `from`.
+// Mirrors the front-arc gate: the caster must be facing (roughly toward) the
+// target. Boundary is inclusive (exactly `arc` away still counts as facing).
+export function withinMeleeArc(facing: number, from: Vec3, to: Vec3, arc: number): boolean {
+  return Math.abs(normAngle(angleTo(from, to) - facing)) <= arc;
+}
+
+// True when `attackerPos` sits in the rear arc of a target oriented along
+// `targetFacing` (more than 90 degrees off the target's facing). Mirrors the
+// backstab/ambush "must be behind your target" gate. Boundary (exactly to the
+// side, 90 degrees) counts as NOT behind, matching the original `< Math.PI / 2`
+// rejection.
+export function isBehindTarget(targetFacing: number, targetPos: Vec3, attackerPos: Vec3): boolean {
+  return Math.abs(normAngle(angleTo(targetPos, attackerPos) - targetFacing)) >= Math.PI / 2;
+}

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6780,7 +6780,7 @@ export class Hud {
   }
 
   // The plain-text form of a chat string with [[q:id]]/[[i:id]] tokens replaced by
-  // [Name] — used for 3D chat bubbles, which can't host interactive spans.
+  // [Name], used for 3D chat bubbles, which can't host interactive spans.
   private chatLinkPlainText(text: string): string {
     return parseChatSegments(text)
       .map((s) => {

--- a/tests/positional.test.ts
+++ b/tests/positional.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { isBehindTarget, withinMeleeArc } from '../src/sim/positional';
+import { angleTo, MELEE_ARC, type Vec3 } from '../src/sim/types';
+
+const at = (x: number, z: number): Vec3 => ({ x, y: 0, z });
+
+describe('withinMeleeArc (front-arc gate)', () => {
+  const from = at(0, 0);
+  const target = at(0, 10); // due +z
+
+  it('passes when the caster faces the target', () => {
+    expect(withinMeleeArc(angleTo(from, target), from, target, MELEE_ARC)).toBe(true);
+  });
+
+  it('fails when the caster faces away from the target', () => {
+    expect(withinMeleeArc(angleTo(from, target) + Math.PI, from, target, MELEE_ARC)).toBe(false);
+  });
+
+  it('treats exactly-arc as still facing (inclusive boundary)', () => {
+    expect(withinMeleeArc(angleTo(from, target) + MELEE_ARC, from, target, MELEE_ARC)).toBe(true);
+    expect(withinMeleeArc(angleTo(from, target) - MELEE_ARC, from, target, MELEE_ARC)).toBe(true);
+  });
+
+  it('is robust to a forged, non-normalized facing many turns wound up', () => {
+    // A cheat client can send a huge accumulated yaw; normAngle canonicalizes it,
+    // so a value coterminal with "facing the target" still passes, and one
+    // coterminal with "facing away" still fails. The result never depends on the
+    // raw winding.
+    const toward = angleTo(from, target);
+    expect(withinMeleeArc(toward + 400 * Math.PI, from, target, MELEE_ARC)).toBe(true);
+    expect(withinMeleeArc(toward + Math.PI + 400 * Math.PI, from, target, MELEE_ARC)).toBe(false);
+  });
+});
+
+describe('isBehindTarget (backstab/ambush rear-arc gate)', () => {
+  const target = at(0, 0);
+  const targetFacing = 0; // target looks down +z
+
+  it('is true when the attacker stands behind the target', () => {
+    expect(isBehindTarget(targetFacing, target, at(0, -10))).toBe(true);
+  });
+
+  it('is false when the attacker stands in front of the target', () => {
+    expect(isBehindTarget(targetFacing, target, at(0, 10))).toBe(false);
+  });
+
+  it('treats exactly to-the-side (90 degrees) as behind (inclusive boundary, matching the original < PI/2 rejection)', () => {
+    expect(isBehindTarget(targetFacing, target, at(10, 0))).toBe(true);
+    expect(isBehindTarget(targetFacing, target, at(-10, 0))).toBe(true);
+  });
+
+  it('is robust to a forged, non-normalized target facing', () => {
+    // The "behind" check reads the TARGET's facing, which is forgeable for a
+    // player target. Canonicalization means the predicate still reports the true
+    // geometric relationship for any coterminal facing value; it cannot be flipped
+    // by winding the angle. (Hittability must never be gated on this; see module.)
+    const attackerBehind = at(0, -10);
+    expect(isBehindTarget(400 * Math.PI, target, attackerBehind)).toBe(true);
+    expect(isBehindTarget(Math.PI + 400 * Math.PI, target, attackerBehind)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Client-supplied `facing` is **forgeable** for player entities: the server stores it verbatim (`server/game.ts`: `e.facing = frame.facing`). It fed two combat positional gates, inlined in two modules:

- the **front-arc** gate ("You must be facing your target") in `combat/casting_lifecycle.ts` and `combat/auto_attack.ts`, keyed on the attacker's `p.facing`;
- the **backstab/ambush "behind"** gate ("You must be behind your target") in `combat/casting_lifecycle.ts`, keyed on the *target's* `facing`.

This change extracts both checks into a new pure `src/sim/positional.ts` (`withinMeleeArc`, `isBehindTarget`) and routes all three call sites through it.

## Why

There is **no range/position advantage today** (range + a live, hostile, in-LoS target are the real, non-forgeable server gates, and mob facing is server-computed via `angleTo`, so it is trustworthy). But the logic was duplicated inline, and any future "hittable only from behind" mechanic that re-derived a behind-check from a player's forgeable `target.facing` would be exploitable on day one.

`positional.ts` documents the load-bearing invariant: **positional facing checks may gate bonuses or extra requirements only, never hittability.** Centralizing the predicate gives any future positional mechanic one vetted, unit-tested helper instead of a fresh inline copy that could reintroduce the hole.

## How

- Both predicates canonicalize the angle difference through `normAngle`, so they return the correct result for any finite (even forged, non-normalized) facing.
- Boundary semantics preserved exactly: front-arc rejects `diff > MELEE_ARC`; behind rejects `diff < PI/2`.
- This is a behavior-identical MOVE: the determinism/parity gate (`tests/parity`) stays green.

## Tests

- New `tests/positional.test.ts` pins the arc/rear boundaries and proves canonicalization is robust to forged, non-normalized facing.
- Green locally: `tests/parity`, `tests/combat_casting_lifecycle`, `tests/combat_auto_attack`, `tests/mob_combat`, `tests/architecture` (sim-purity), `tests/positional`; `npx tsc --noEmit`, `biome check`, and `npm run build` all pass.

No player-visible strings changed (the two error literals are preserved), so no i18n work is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Fix flow (before / after)

```mermaid
flowchart TD
  subgraph Before["Before: inline, duplicated facing math"]
   A1["casting_lifecycle front-arc gate"] --> X1["inline facing check"]
   A2["auto_attack front-arc gate"] --> X2["inline facing check"]
   A3["backstab behind gate"] --> X3["inline facing check (forgeable target.facing)"]
  end
  subgraph After["After: one vetted predicate"]
   B1["casting_lifecycle"] --> P["positional.ts: withinMeleeArc / isBehindTarget"]
   B2["auto_attack"] --> P
   B3["backstab"] --> P
   P --> N["invariant: facing gates bonuses only, never hittability"]
  end
```
