### PR TITLE
fix(sim): fold debuff_ap into player attack power (PvP)

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -167,7 +167,10 @@ export function updateAuras(ctx: SimContext, e: Entity): void {
       e.auras.splice(i, 1);
       ctx.applyNonPlayerStatAura(e, a, -1);
       ctx.emit({ type: 'aura', targetId: e.id, name: a.name, gained: false });
-      if (a.kind.startsWith('buff') || a.kind.startsWith('form')) statsDirty = true;
+      // debuff_ap is the one non-buff kind recalcPlayerStats folds, so it must
+      // mark stats dirty on expiry or the AP cut would persist after the fade.
+      if (a.kind.startsWith('buff') || a.kind.startsWith('form') || a.kind === 'debuff_ap')
+        statsDirty = true;
     }
   }
   if (statsDirty && e.kind === 'player') {

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -184,6 +184,10 @@ export function recalcPlayerStats(
   let scaleMul = 1; // Fiesta buff_scale: body-size multiplier (>1 also adds hp)
   for (const a of e.auras) {
     if (a.kind === 'buff_ap') bonusAp += a.value;
+    // Attack-power debuff (Demoralizing Shout/Roar). Mobs fold this live in
+    // effectiveAttackPower; players bake it here, so without this arm the debuff
+    // was a no-op versus enemy players (PvP).
+    else if (a.kind === 'debuff_ap') bonusAp -= a.value;
     else if (a.kind === 'buff_armor') s.armor += a.value;
     else if (a.kind === 'buff_int') s.int += a.value;
     else if (a.kind === 'buff_agi') s.agi += a.value;
@@ -252,10 +256,14 @@ export function recalcPlayerStats(
       : cls === 'rogue' || cls === 'hunter'
         ? s.str + s.agi
         : s.str;
-  e.attackPower = Math.round((apFromStats + bonusAp) * (1 + (mods?.stats.apPct ?? 0)));
+  // Floor at 0 so a heavy debuff_ap stack can never bake a negative attack power
+  // (mirrors effectiveAttackPower's mob floor and the agi/spi floors above).
+  e.attackPower = Math.max(0, Math.round((apFromStats + bonusAp) * (1 + (mods?.stats.apPct ?? 0))));
   // Hunters: ranged AP = 2/agi (vanilla)
   e.rangedPower =
-    cls === 'hunter' ? Math.round((s.agi * 2 + bonusAp) * (1 + (mods?.stats.apPct ?? 0))) : 0;
+    cls === 'hunter'
+      ? Math.max(0, Math.round((s.agi * 2 + bonusAp) * (1 + (mods?.stats.apPct ?? 0))))
+      : 0;
   // Crit: ~1% per 20 agi at low level
   e.critChance = 0.05 + s.agi * 0.0005 + (mods?.stats.crit ?? 0);
   // Floored at 0: an off-balance debuff (negative buff_dodge) can drive dodge to nothing.

--- a/tests/demoralizing_shout.test.ts
+++ b/tests/demoralizing_shout.test.ts
@@ -3,15 +3,17 @@
 // effect (which lands a `debuff_ap` aura on every nearby hostile), so it is a
 // pure-data ability with zero sim-engine change.
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
-import { ABILITIES, CLASSES, abilitiesKnownAt } from '../src/sim/content/classes';
+import { ABILITIES, abilitiesKnownAt, CLASSES } from '../src/sim/content/classes';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
 import type { Entity } from '../src/sim/types';
 
 function spawnDummy(sim: Sim, target: Entity): Entity {
   const mob = createMob((sim as any).nextId++, MOBS['gravecaller_summoner'], 14, {
-    x: target.pos.x, y: target.pos.y, z: target.pos.z,
+    x: target.pos.x,
+    y: target.pos.y,
+    z: target.pos.z,
   });
   mob.hostile = true;
   (sim as any).addEntity(mob);
@@ -25,16 +27,25 @@ describe('warrior Demoralizing Shout', () => {
     expect(def.class).toBe('warrior');
     expect(def.learnLevel).toBe(14);
     expect(def.requiresTarget).toBe(false);
-    expect(def.effects[0]).toMatchObject({ type: 'aoeAttackPower', amount: 30, duration: 30, radius: 10 });
+    expect(def.effects[0]).toMatchObject({
+      type: 'aoeAttackPower',
+      amount: 30,
+      duration: 30,
+      radius: 10,
+    });
     expect(def.ranks?.[0]).toMatchObject({ level: 20 });
   });
 
   it('sits in the warrior learn order and gates on level', () => {
     expect(CLASSES.warrior.abilities).toContain('demoralizing_shout');
-    expect(abilitiesKnownAt('warrior', 13).some((k) => k.def.id === 'demoralizing_shout')).toBe(false);
+    expect(abilitiesKnownAt('warrior', 13).some((k) => k.def.id === 'demoralizing_shout')).toBe(
+      false,
+    );
     const at14 = abilitiesKnownAt('warrior', 14).find((k) => k.def.id === 'demoralizing_shout');
     expect(at14?.rank).toBe(1);
-    expect(abilitiesKnownAt('warrior', 20).find((k) => k.def.id === 'demoralizing_shout')?.rank).toBe(2);
+    expect(
+      abilitiesKnownAt('warrior', 20).find((k) => k.def.id === 'demoralizing_shout')?.rank,
+    ).toBe(2);
   });
 
   it('debuffs the attack power of nearby enemies on cast', () => {
@@ -52,6 +63,83 @@ describe('warrior Demoralizing Shout', () => {
     expect(aura).toBeTruthy();
     expect(aura!.value).toBe(30);
     expect(aura!.remaining).toBeGreaterThan(0);
+  });
+
+  it('cuts an enemy player effective attack power (PvP)', () => {
+    // PvP regression: debuff_ap landed on an enemy player but recalcPlayerStats
+    // never folded it, so the shout was a no-op versus players (it only bit mobs,
+    // whose AP is folded live in effectiveAttackPower). The aura must lower the
+    // target player's baked attackPower.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const casterId = sim.addPlayer('warrior', 'Caster');
+    const victimId = sim.addPlayer('warrior', 'Victim');
+    sim.setPlayerLevel(20, victimId);
+    const victim = sim.entities.get(victimId) as Entity;
+    const before = victim.attackPower;
+    expect(before).toBeGreaterThan(30);
+
+    (sim as any).applyAura(victim, {
+      id: 'demoralizing_shout_ap',
+      name: 'Demoralizing Shout',
+      kind: 'debuff_ap',
+      remaining: 30,
+      duration: 30,
+      value: 30,
+      sourceId: casterId,
+      school: 'physical',
+    });
+
+    expect(victim.attackPower).toBe(before - 30);
+  });
+
+  it('restores enemy player attack power when the debuff expires', () => {
+    // The baked-stat path must un-fold debuff_ap on expiry too: updateAuras only
+    // re-runs recalcPlayerStats when a stats-affecting aura drops, so debuff_ap
+    // has to mark stats dirty or the AP cut would persist forever after fade.
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const casterId = sim.addPlayer('warrior', 'Caster');
+    const victimId = sim.addPlayer('warrior', 'Victim');
+    sim.setPlayerLevel(20, victimId);
+    const victim = sim.entities.get(victimId) as Entity;
+    const before = victim.attackPower;
+
+    (sim as any).applyAura(victim, {
+      id: 'demoralizing_shout_ap',
+      name: 'Demoralizing Shout',
+      kind: 'debuff_ap',
+      remaining: 1,
+      duration: 1,
+      value: 30,
+      sourceId: casterId,
+      school: 'physical',
+    });
+    expect(victim.attackPower).toBe(before - 30);
+
+    for (let i = 0; i < 25 && victim.auras.some((a) => a.kind === 'debuff_ap'); i++) sim.tick();
+
+    expect(victim.auras.some((a) => a.kind === 'debuff_ap')).toBe(false);
+    expect(victim.attackPower).toBe(before);
+  });
+
+  it('floors a debuffed enemy player attack power at zero', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+    const casterId = sim.addPlayer('warrior', 'Caster');
+    const victimId = sim.addPlayer('warrior', 'Victim');
+    sim.setPlayerLevel(20, victimId);
+    const victim = sim.entities.get(victimId) as Entity;
+
+    (sim as any).applyAura(victim, {
+      id: 'demoralizing_shout_ap',
+      name: 'Demoralizing Shout',
+      kind: 'debuff_ap',
+      remaining: 30,
+      duration: 30,
+      value: victim.attackPower + 1000, // far exceeds base AP
+      sourceId: casterId,
+      school: 'physical',
+    });
+
+    expect(victim.attackPower).toBe(0);
   });
 
   it('does not touch a far-away enemy', () => {


### PR DESCRIPTION
## Problem

Player **Demoralizing Shout** (and the druid's **Demoralizing Roar**) land a `debuff_ap` aura, but it was a **no-op versus enemy players** (PvP). It worked against mobs and was silently ignored on players.

Root cause is an asymmetry in how attack power folds auras:

- **Mobs:** `effectiveAttackPower` (`src/sim/sim.ts`) folds `buff_ap`/`debuff_ap` from auras live every swing, but the loop is gated `if (e.kind !== 'player')`.
- **Players:** attack power is baked once in `recalcPlayerStats` (`src/sim/entity.ts`), whose aura loop folded every `buff_*` kind but **never `debuff_ap`**. So the aura landed and the buff icon showed, yet the target player's AP never moved.

## Fix (three parts)

1. **Fold `debuff_ap`** in the player aura loop (`entity.ts`).
2. **Floor** the baked `attackPower`/`rangedPower` at 0, so a heavy debuff stack can never bake a negative value. This mirrors `effectiveAttackPower`'s existing mob floor and the agi/spi floors already in `recalcPlayerStats`.
3. **Mark stats dirty on `debuff_ap` expiry** (`combat/auras.ts`). The expiry path only re-ran `recalcPlayerStats` for `buff*`/`form*` kinds; without this the AP cut would persist forever after the aura faded. The mob demoralize affix dodges this by modelling its cut as a negative `buff_ap`, so player Shout is the only `debuff_ap`-on-player consumer and the gap was latent until this fix reached it.

Pure deterministic arithmetic, no new `rng` draw: the golden-trace + draw-order parity gate stays green.

## Screenshots

Level-20 warrior character sheet, before vs after landing the `debuff_ap` aura (with this fix applied). Attack Power **122 -> 92** (-30) and Damage/sec **10.5 -> 8.3**. Before this fix the "after" panel still read 122 (the debuff was inert).

**Before debuff**

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-971-shots/pr-971/ap_before.jpg)

**After debuff (-30 AP)**

![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-971-shots/pr-971/ap_after.jpg)

## Fix flow

```mermaid
flowchart TD
  A["Demoralizing Shout lands a debuff_ap aura"] --> B{"Target kind?"}
  B -->|mob| C["effectiveAttackPower folds debuff_ap live - works"]
  B -->|"player (before)"| D["recalcPlayerStats folds buff_* only, debuff_ap skipped"]
  D --> E["Player AP unchanged in PvP - the NO-OP bug"]
  B -->|"player (after)"| F["recalcPlayerStats folds debuff_ap, AP floored at 0"]
  F --> G["AP drops in PvP"]
  G --> H["aura expiry marks stats dirty -> recalc"]
  H --> I["AP restored when the debuff fades"]
```

## Tests (test-first, each verified red before the fix)

`tests/demoralizing_shout.test.ts` gains three cases:
- enemy player effective AP drops by the debuff value (PvP),
- AP is restored after the debuff expires,
- AP floors at 0 when the debuff exceeds base AP.

```
npx vitest run tests/demoralizing_shout.test.ts   # 7 passed
npx tsc --noEmit                                   # clean
npx vitest run tests/parity tests/architecture.test.ts \
  tests/combat_auras.test.ts tests/character_sheet.test.ts   # 183 passed
```

cc @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
