### PR TITLE
fix(sim): despawn hunter/warlock pet when its owner dies (immortal pet)

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -507,6 +507,13 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
         ctx.retargetMob(m);
       }
     }
+    // The owner's pet does not outlive them: without this the pet was orphaned
+    // (still owned, owner present-but-dead) so updatePet's despawn guard never
+    // fired and petPickTarget's `!owner.dead` gate left it idle and unkillable.
+    // Route it through handleDeath so the owned-mob branch below applies: warlock
+    // demons unravel, a hunter's beast leaves a revivable corpse (Revive Pet).
+    const pet = ctx.petOf(e.id);
+    if (pet) handleDeath(ctx, pet, killer);
     return;
   }
 

--- a/tests/pet_owner_death_despawn.test.ts
+++ b/tests/pet_owner_death_despawn.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { MOBS } from '../src/sim/data';
+import { createMob } from '../src/sim/entity';
+import { completeTame, petOf } from '../src/sim/pet/pet_commands';
+import { Sim } from '../src/sim/sim';
+import type { Entity } from '../src/sim/types';
+
+// Regression for the "immortal pet" bug: when a Hunter or Warlock OWNER dies, their
+// pet/demon used to keep living forever. handleDeath's player branch tore down the
+// dying player's own combat state but never touched the owned pet entity, so the pet
+// hit a dead spot in updatePet (the despawn guard only fires when the owner is ABSENT,
+// and petPickTarget is gated on `!owner.dead`): it could neither acquire targets nor be
+// cleaned up. It sat in the world at full HP, unkillable. The owner's death must now
+// kill the pet too: warlock demons unravel and despawn, hunter pets leave a revivable
+// corpse (classic Revive Pet), so neither stays immortal.
+
+type AnySim = Sim & Record<string, any>;
+type AnyEntity = Entity & Record<string, any>;
+
+function spawnWolf(sim: AnySim, near: AnyEntity, level = 2): AnyEntity {
+  const wolf = createMob(sim.nextId++, MOBS.forest_wolf, level, {
+    x: near.pos.x + 3,
+    y: near.pos.y,
+    z: near.pos.z,
+  }) as AnyEntity;
+  wolf.hostile = true;
+  sim.addEntity(wolf);
+  return wolf;
+}
+
+function killEntity(sim: AnySim, e: AnyEntity): void {
+  sim.dealDamage(null, e, e.maxHp + 100, false, 'physical', null, 'hit', true);
+}
+
+describe('a dead owner does not leave an immortal pet', () => {
+  it('a slain hunter leaves a revivable pet corpse, not an immortal pet', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'hunter', noPlayer: true }) as AnySim;
+    const hid = sim.addPlayer('hunter', 'Owner') as number;
+    sim.setPlayerLevel(12, hid);
+    const hunter = sim.entities.get(hid) as AnyEntity;
+    const wolf = spawnWolf(sim, hunter);
+    completeTame(sim.ctx, hunter, wolf);
+    const pet = petOf(sim.ctx, hid) as AnyEntity;
+    expect(pet).toBeTruthy();
+    expect(pet.dead).toBe(false);
+
+    killEntity(sim, hunter);
+    expect(hunter.dead).toBe(true);
+
+    // The pet is no longer a live, fighting entity.
+    expect(pet.dead).toBe(true);
+    expect(petOf(sim.ctx, hid)).toBeNull(); // no LIVE pet
+
+    // Hunter pets persist as a revivable corpse rather than vanishing outright.
+    for (let i = 0; i < 20 * 10; i++) sim.tick();
+    const corpse = petOf(sim.ctx, hid, true) as AnyEntity;
+    expect(corpse).toBeTruthy();
+    expect(corpse.id).toBe(pet.id);
+    expect(corpse.dead).toBe(true);
+  });
+
+  it('a slain warlock unravels their demon (fully despawns), not immortal', () => {
+    const sim = new Sim({ seed: 13, playerClass: 'warlock', noPlayer: true }) as AnySim;
+    const wpid = sim.addPlayer('warlock', 'Demonist') as number;
+    sim.setPlayerLevel(12, wpid);
+    const warlock = sim.entities.get(wpid) as AnyEntity;
+    warlock.resource = warlock.maxResource;
+    (sim as any).summonPet(warlock, 'imp');
+    const imp = petOf(sim.ctx, wpid) as AnyEntity;
+    expect(imp).toBeTruthy();
+    expect(MOBS[imp.templateId].family).toBe('demon');
+
+    killEntity(sim, warlock);
+    expect(warlock.dead).toBe(true);
+    expect(imp.dead).toBe(true);
+
+    // Brief corpse, then the demon is gone from the world entirely.
+    for (let i = 0; i < 20 * 5; i++) sim.tick();
+    expect(sim.entities.has(imp.id)).toBe(false);
+  });
+
+  it('is deterministic: the same seed kills the pet identically', () => {
+    const run = () => {
+      const sim = new Sim({ seed: 21, playerClass: 'hunter', noPlayer: true }) as AnySim;
+      const hid = sim.addPlayer('hunter', 'Owner') as number;
+      sim.setPlayerLevel(12, hid);
+      const hunter = sim.entities.get(hid) as AnyEntity;
+      completeTame(sim.ctx, hunter, spawnWolf(sim, hunter));
+      killEntity(sim, hunter);
+      const pet = petOf(sim.ctx, hid, true) as AnyEntity;
+      return { dead: pet.dead, hp: pet.hp, corpseTimer: pet.corpseTimer };
+    };
+    expect(run()).toEqual(run());
+  });
+});


### PR DESCRIPTION
## [CRITICAL] Hunter/Warlock pets become immortal when their owner dies

### The bug
When a Hunter or Warlock **player dies**, their summoned pet/demon used to live forever.

`handleDeath`'s player branch (`src/sim/combat/damage.ts`) tore down the dying player's own combat state and retargeted mobs off them, but never touched the **owned pet entity**. The pet then hit a dead spot in `updatePet` (`src/sim/pet/pet_ai.ts`):

- the despawn guard only fires when the owner is **absent** (logged out), not when the owner is present-but-dead, and
- `petPickTarget` is gated on `!owner.dead`.

So a dead owner's pet could neither acquire targets nor be cleaned up. It sat in the world at full HP, **unkillable**.

```mermaid
flowchart TD
    A[Player dies: handleDeath player branch] --> B[reset player combat state]
    B --> C[retarget mobs off the dead player]
    C --> D[return]
    D -. pet never touched .-> E["Pet entity (ownerId = dead player)"]
    E --> F{updatePet each tick}
    F --> G["owner present + in players map<br/>=> despawn guard does NOT fire"]
    F --> H["owner.dead === true<br/>=> petPickTarget skipped, no new target"]
    G --> I[Pet persists at full HP forever]
    H --> I
    I:::bug
    classDef bug fill:#fdd,stroke:#c00,color:#900;
```

### The fix
Route the owner's live pet through `handleDeath` in the player-death branch. The **existing** owned-mob death branch then applies uniformly, giving each class its classic behavior:

```mermaid
flowchart TD
    A[Player dies: handleDeath player branch] --> B[reset player combat state]
    B --> C[retarget mobs off the dead player]
    C --> P["pet = ctx.petOf(owner)"]
    P --> Q{pet exists?}
    Q -- no --> R[return]
    Q -- yes --> S["handleDeath(pet, killer)"]
    S --> T{"MOBS[pet].family === 'demon'?"}
    T -- "Warlock demon" --> U["corpseTimer = 3<br/>unravels, fully despawns"]
    T -- "Hunter beast" --> V["corpseTimer = Infinity<br/>revivable corpse (Revive Pet)"]
    U --> W[No immortal pet]
    V --> W
    W:::fix
    classDef fix fill:#dfd,stroke:#090,color:#060;
```

Death sequence after the fix:

```mermaid
sequenceDiagram
    participant K as Killer
    participant S as Sim (handleDeath)
    participant PL as Player entity
    participant PET as Pet entity
    K->>S: lethal damage to owner
    S->>PL: dead = true, clear combat, emit playerDeath
    S->>S: retarget mobs off the dead owner
    S->>S: pet = petOf(owner)  (live pet only)
    alt owner has a pet
        S->>PET: handleDeath(pet, killer)
        Note over PET: owned-mob branch:<br/>demon -> corpseTimer 3 (unravel)<br/>beast -> corpseTimer Infinity (revivable)
        PET-->>S: death + "{name} dies." (existing events)
    else no pet / stowed in delve
        Note over S: petOf() returns null, no-op
    end
```

### Why this is the minimal, parity-safe change
- **One shared sim path, three hosts.** `handleDeath` is pure `src/sim/` code run by the offline `Sim`, the authoritative server, and the headless RL env. No `IWorld` member, command, wire field, or `SimEvent` variant is added, so `ClientWorld` (`src/net/online.ts`) needs **no mirror**: online clients just drop the demon entity / render the hunter corpse from the normal snapshot + event path.
- **No new player-visible strings.** The pet's death reuses the pre-existing owned-mob `"{name} dies."` log, already matched by `log.entityDies` in `src/ui/sim_i18n.ts`. The S3 i18n guard is unaffected.
- **Determinism intact.** Killing an owned pet draws no RNG (the owned-mob branch returns before frenzy/death-throes/loot), so the parity gate's draw-order log is unperturbed.
- **Bounded recursion.** The nested `handleDeath(pet)` enters the `mob` + `ownerId !== null` branch and returns before any further `petOf` call: exactly one level deep.
- **Other "death" paths untouched.** Duels end at 1 HP and fiesta takedowns score-and-respawn, both returning before `handleDeath`, so pets there are safe. Ranked-arena elimination already used `handleDeath`, so the fix lands there consistently (arena never managed pets, so the immortal-pet bug applied there too).

### Tests
`tests/pet_owner_death_despawn.test.ts` (test-first; reproduced the bug before the fix):
- a slain **hunter** leaves a revivable pet corpse (not an immortal pet),
- a slain **warlock** unravels their demon (fully despawns within ~3s),
- a same-seed **determinism** assertion.

Verification (all green):

```
npx vitest run tests/pet_owner_death_despawn.test.ts   # 3 passed
npx vitest run tests/pet_command.test.ts tests/pet_commands_module.test.ts \
  tests/warlock_pets.test.ts tests/pet_ai.test.ts tests/pet_combat_regen.test.ts # 23 passed
npx vitest run tests/parity            # 154 passed (rng draw-order unperturbed)
npx vitest run tests/architecture.test.ts            # sim purity intact
npx vitest run tests/localization_fixes.test.ts      # S3 i18n guard green
npx tsc --noEmit                                     # clean
```

A `cross-platform-sync` parity review of the diff returned **SAFE TO SHIP** with no correctness/parity/requirement gaps.

> Note on screenshots: this is a non-visual sim-logic fix (a missing teardown step in the death handler), so the meaningful "visual" is the control-flow above plus the deterministic test reproduction rather than a posed in-client screenshot. Happy to add a browser before/after capture if a maintainer would like one.

cc @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)
