### PR TITLE
feat(sim): leash combat pets back to a far-away owner

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -667,6 +667,7 @@ function blankEntity(id: number): Entity {
     petPath: [],
     petPathCooldown: 0,
     castPushbackReduction: 0,
+    petFarTimer: 0,
     pos: { x: 0, y: 0, z: 0 },
     prevPos: { x: 0, y: 0, z: 0 },
     facing: 0,

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -92,6 +92,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     petTauntTimer: 0,
     petPath: [],
     petPathCooldown: 0,
+    petFarTimer: 0,
     spawnPos: { ...pos },
     leashAnchor: null,
     evadeStall: 0,

--- a/src/sim/pet/pet_ai.ts
+++ b/src/sim/pet/pet_ai.ts
@@ -61,6 +61,43 @@ const PET_AGGRESSIVE_RANGE = 18; // aggressive pets look for idle enemies this c
 // 1200 ticks = 60s at 20Hz. Stops hunters/warlocks parking an aggressive pet to
 // farm XP/loot while AFK; the pet still DEFENDS an idle owner. Tunable.
 const PET_OWNER_IDLE_TICKS = 1200;
+// Far-leash reunite: a pet kept beyond PET_FAR_LEASH_DISTANCE from its owner for
+// PET_FAR_LEASH_SECONDS straight warps to the owner unconditionally (no route/LOS
+// check). The catch-all for a pet STRANDED when its owner teleports into a
+// dungeon/arena instance (origins sit thousands of yards off in world space),
+// where the normal heel path/teleport can't bridge the gap. Strictly beyond every
+// normal follow/leash range (PET_FOLLOW_DISTANCE 3.5, PET_LEASH 40, PET_ASSIST_RANGE
+// 50, PET_TELEPORT_DISTANCE 60) so it only fires when the pet is genuinely lost.
+const PET_FAR_LEASH_DISTANCE = 90; // yards from the owner that start the reunite timer
+const PET_FAR_LEASH_SECONDS = 15; // continuous seconds beyond it before the warp
+
+// Reunite a stranded pet. The timer accumulates while the pet is beyond
+// PET_FAR_LEASH_DISTANCE and resets the moment it is back in range; at
+// PET_FAR_LEASH_SECONDS the pet is snapped onto the owner (inheriting the owner's
+// instance) with its heel path / combat target cleared, so it cleanly resumes
+// following an owner who zoned away. Returns true on the warp tick so updatePet
+// skips the rest of this tick's AI. The heel pathfinder can never bridge an
+// instance teleport, so this is the only thing that guarantees the reunion.
+function updatePetFarLeash(ctx: SimContext, pet: Entity, owner: Entity): boolean {
+  if (dist2d(pet.pos, owner.pos) <= PET_FAR_LEASH_DISTANCE) {
+    pet.petFarTimer = 0;
+    return false;
+  }
+  pet.petFarTimer += DT;
+  if (pet.petFarTimer < PET_FAR_LEASH_SECONDS) return false;
+  pet.petFarTimer = 0;
+  pet.pos = { ...owner.pos };
+  pet.prevPos = { ...pet.pos };
+  pet.dungeonId = owner.dungeonId;
+  pet.petPath = [];
+  pet.aggroTargetId = null;
+  pet.inCombat = false;
+  pet.forcedTargetId = null;
+  pet.forcedTargetTimer = 0;
+  // Teleport: keep the spatial grid exact this tick (matches every other warp).
+  ctx.rebucket(pet);
+  return true;
+}
 
 export function updatePet(ctx: SimContext, pet: Entity): void {
   const owner = pet.ownerId !== null ? ctx.entities.get(pet.ownerId) : null;
@@ -68,6 +105,9 @@ export function updatePet(ctx: SimContext, pet: Entity): void {
     ctx.despawnPersistentPet(pet);
     return;
   }
+  // Reunite a stranded pet before any other AI (an owner who zoned into an
+  // instance is unreachable by the heel pathfinder).
+  if (updatePetFarLeash(ctx, pet, owner)) return;
   if (ctx.isStunned(pet)) return;
   ctx.syncPetAspect(pet, owner);
   pet.petTauntTimer = Math.max(0, pet.petTauntTimer - DT);
@@ -170,6 +210,10 @@ export function petFollow(ctx: SimContext, pet: Entity, owner: Entity): void {
     if (pet.petPath.length <= 1) {
       pet.pos = { ...owner.pos };
       pet.prevPos = { ...pet.pos };
+      // Warping to heel also reunites the pet with the owner's instance: an owner
+      // who is unreachable is usually one who zoned into a dungeon/arena, so carry
+      // the dungeonId across (matches the far-leash reunite).
+      pet.dungeonId = owner.dungeonId;
       pet.petPath = [];
       // a warp is a teleport: keep the spatial grid exact this tick instead of
       // waiting for the end-of-tick refresh, so same-tick aggro/AoE queries

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1393,6 +1393,7 @@ export interface Entity {
   petManualTauntPending?: boolean; // manual Growl command waiting until the pet reaches range
   petPath: Vec3[]; // controlled pet heel route around obstacles; consumed front-to-back (like chargePath)
   petPathCooldown: number; // seconds until this pet may recompute its heel path again
+  petFarTimer: number; // controlled pet: seconds spent beyond the far-leash distance from its owner; resets on return, triggers a reunite warp at PET_FAR_LEASH_SECONDS
   pulseTimer: number; // boss aoe pulse countdown
   stompTimer: number; // boss War Stomp stun-pulse countdown
   stoneskinTimer: number; // periodic self-absorb barrier countdown

--- a/tests/pet_far_leash.test.ts
+++ b/tests/pet_far_leash.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import { dist2d, type Entity, type Vec3 } from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+// A controlled pet (hunter/warlock) whose owner teleports far away (e.g. into a
+// dungeon/arena instance, whose origin sits thousands of yards off in world space)
+// can be left stranded: the heel pathfinder cannot bridge that gap. The far-leash
+// timer reunites the pet, warping it onto the owner after PET_FAR_LEASH_SECONDS
+// spent beyond PET_FAR_LEASH_DISTANCE. These tests pin that behavior deterministically.
+
+const SEED = 42;
+
+function place(e: Entity, x: number, z: number): void {
+  e.pos = { x, y: terrainHeight(x, z, SEED), z };
+  e.prevPos = { ...e.pos };
+}
+
+// Root the pet so it cannot move under its own power. This isolates the far-leash
+// timer from the heel locomotion: a rooted pet's petFollow returns early (so the
+// 60yd last-resort heel warp can never fire), the distance to a stationary owner
+// stays constant, and the ONLY thing that can teleport the pet is the far-leash.
+function root(pet: Entity): void {
+  pet.auras.push({
+    id: 't_root',
+    name: 'Test Root',
+    kind: 'root',
+    remaining: 1e6,
+    duration: 1e6,
+    value: 0,
+    sourceId: pet.id,
+    school: 'nature',
+  });
+}
+
+// Adopt an existing wild mob as a passive heel-only pet (mirrors pet_follow.test.ts).
+// Passive mode guarantees the pet never picks a combat target, so it stays in the
+// heel branch and only the far-leash logic can move it across the map.
+function setup(petAt: Vec3, ownerAt: Vec3): { sim: Sim; pet: Entity; owner: Entity } {
+  const sim = new Sim({ seed: SEED, playerClass: 'hunter', noPlayer: true });
+  const pid = sim.addPlayer('hunter', 'Aleph');
+  const owner = sim.entities.get(pid)!;
+  let pet: Entity | null = null;
+  for (const e of sim.entities.values()) {
+    if (e.kind === 'mob' && !e.dead && e.ownerId === null) {
+      pet = e;
+      break;
+    }
+  }
+  if (!pet) throw new Error('no wild mob to adopt');
+  pet.ownerId = pid;
+  pet.hostile = false;
+  pet.hp = pet.maxHp;
+  pet.petMode = 'passive';
+  place(pet, petAt.x, petAt.z);
+  place(owner, ownerAt.x, ownerAt.z);
+  return { sim, pet, owner };
+}
+
+describe('pet far-leash reunite', () => {
+  it('warps a stranded pet back to its owner after ~15s very far away', () => {
+    // 200yd apart: well beyond every normal follow/leash range (max 60yd).
+    const { sim, pet, owner } = setup({ x: 300, y: 0, z: 300 }, { x: 300, y: 0, z: 500 });
+    root(pet);
+    expect(dist2d(pet.pos, owner.pos)).toBeGreaterThan(90);
+
+    let teleportTick = -1;
+    for (let i = 1; i <= 20 * 16; i++) {
+      sim.tick();
+      if (teleportTick === -1 && dist2d(pet.pos, owner.pos) < 5) teleportTick = i;
+    }
+
+    // reunited onto the owner, with the timer reset
+    expect(dist2d(pet.pos, owner.pos)).toBeLessThan(1);
+    expect(pet.petFarTimer).toBe(0);
+    // the warp is the 15s far-leash, not the instant 60yd heel last-resort (which a
+    // rooted pet can never reach): it fires right around tick 300 (15s at 20Hz).
+    expect(teleportTick).toBeGreaterThanOrEqual(290);
+    expect(teleportTick).toBeLessThanOrEqual(310);
+  });
+
+  it('does not teleport while the pet is within range, and never accumulates the timer', () => {
+    // 12yd apart: beyond the heel follow distance but well within the far-leash
+    // range, so the pet just heels in normally and the timer stays pinned at 0.
+    const { sim, pet, owner } = setup({ x: 300, y: 0, z: 300 }, { x: 300, y: 0, z: 312 });
+    let maxStep = 0;
+    for (let i = 0; i < 20 * 16; i++) {
+      const before = { ...pet.pos };
+      sim.tick();
+      maxStep = Math.max(maxStep, dist2d(before, pet.pos));
+      expect(pet.petFarTimer).toBe(0);
+    }
+    // converged onto the owner by walking, never snapped
+    expect(dist2d(pet.pos, owner.pos)).toBeLessThan(4);
+    expect(maxStep).toBeLessThan(1.5);
+  });
+
+  it('resets the timer if the pet returns to range before 15s elapse', () => {
+    const { sim, pet, owner } = setup({ x: 300, y: 0, z: 300 }, { x: 300, y: 0, z: 500 });
+    root(pet);
+    // accumulate part of the way (10s) while far
+    for (let i = 0; i < 20 * 10; i++) sim.tick();
+    expect(pet.petFarTimer).toBeGreaterThan(5);
+    // bring the pet back within range: the very next tick must clear the timer
+    place(pet, owner.pos.x, owner.pos.z - 3);
+    sim.tick();
+    expect(pet.petFarTimer).toBe(0);
+  });
+
+  it('reunites with an owner who teleported into a different instance/dungeon', () => {
+    // The primary bug: the owner zones into an instance (a far-off origin in world
+    // space) and gains a dungeonId; the stranded pet must be warped to the owner's
+    // CURRENT location and inherit the instance. Uses a real summoned warlock imp
+    // (a persistent demon pet) rather than an adopted overworld mob, so the
+    // reunite isn't pre-empted by the overworld culling a stranded wild adoptee.
+    const sim = new Sim({ seed: SEED, playerClass: 'warlock' });
+    const owner = sim.player;
+    sim.castAbility('summon_imp');
+    for (let i = 0; i < 140; i++) sim.tick(); // resolve the ~5s summon cast
+    let pet: Entity | null = null;
+    for (const e of sim.entities.values()) {
+      if (e.kind === 'mob' && e.ownerId === owner.id && !e.dead) pet = e;
+    }
+    if (!pet) throw new Error('imp was not summoned');
+
+    // owner teleports thousands of yards away into a dungeon instance
+    place(owner, 5000, 5000);
+    owner.dungeonId = 'hollow_crypt';
+    expect(dist2d(pet.pos, owner.pos)).toBeGreaterThan(1000);
+
+    for (let i = 0; i < 20 * 16; i++) sim.tick();
+
+    expect(dist2d(pet.pos, owner.pos)).toBeLessThan(1);
+    expect(pet.dungeonId).toBe('hollow_crypt');
+    expect(pet.petFarTimer).toBe(0);
+  });
+
+  it('is deterministic: identical seed yields an identical reunite', () => {
+    const trace = (): { tick: number; pos: Vec3 } => {
+      const { sim, pet, owner } = setup({ x: 300, y: 0, z: 300 }, { x: 300, y: 0, z: 500 });
+      root(pet);
+      let tick = -1;
+      for (let i = 1; i <= 20 * 16; i++) {
+        sim.tick();
+        if (tick === -1 && dist2d(pet.pos, owner.pos) < 5) tick = i;
+      }
+      return { tick, pos: { ...pet.pos } };
+    };
+    expect(trace()).toEqual(trace());
+  });
+});


### PR DESCRIPTION
## What
Hunter/warlock combat pets now **reunite with their owner** after being very far away for ~15 seconds straight. This fixes the bug where a pet is left stranded out in the world when its owner teleports into a dungeon/arena instance: instance origins sit thousands of yards away in world space, so the normal heel pathfinder can never bridge the gap and the pet just stays behind.

## How
- `sim.ts`: two tuning consts in the `PET_*` block - `PET_FAR_LEASH_DISTANCE = 90` (yards; strictly beyond every normal follow/leash range - follow 3.5, leash 40, assist 50, teleport 60, follow-max 60, so it only fires when genuinely lost) and `PET_FAR_LEASH_SECONDS = 15`.
- New `updatePetFarLeash(pet, owner)`, called first thing in `updatePet` (before stun/target AI). It accumulates `petFarTimer` by `DT` while the pet is beyond the far distance and resets it the moment the pet is back in range. At 15s it snaps the pet onto the owner, sets `pet.dungeonId = owner.dungeonId` (so it follows across the instance boundary), clears `petPath`/`aggroTargetId`/`inCombat`/`forcedTarget*`, and `rebucket`s the spatial grid (matching every other teleport site). Returns true on the warp tick so the rest of that tick's AI is skipped.
- `types.ts` / `entity.ts` / `online.ts`: new `Entity.petFarTimer`, initialized to 0 (sim + ClientWorld parity).

Determinism preserved: the timer uses the fixed `DT` step and the sim clock, no `Math.random`/wall-clock.

## Tests
`tests/pet_far_leash.test.ts` (5 deterministic cases): the warp fires at ~15s beyond range; no warp / timer stays 0 while in range; the timer resets if the pet returns before 15s; the simulated instance teleport (owner moved 5000yd away + `dungeonId` changed) reunites the pet within 1yd and inherits the `dungeonId`; identical seed -> identical reunite. Existing pet/follow/warlock-pet/sim suites and `tsc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)