### PR TITLE
fix(sim): persist ability and combat-potion cooldowns across logout

### DIFF
--- a/scripts/cooldown_persist_shot.mjs
+++ b/scripts/cooldown_persist_shot.mjs
@@ -1,0 +1,101 @@
+// Visual proof for the cooldown-persistence fix: spell/potion cooldowns used to
+// reset on logout, letting players bypass them by relogging. Boots the offline
+// game, puts the warrior on real ability + combat-potion cooldowns, shows the
+// /cooldowns readout, then drives the REAL save/load path (sim.serializeCharacter
+// -> sim.addPlayer({state})) to relog the character and shows the cooldowns
+// survive. The "old behaviour" panel is the same character loaded with the
+// cooldowns field stripped, i.e. exactly what a pre-fix save produced.
+// Screenshots land in tmp/. Needs `npm run dev` already running.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const fails = [];
+const check = (cond, msg) => { console.log(`${cond ? 'OK  ' : 'FAIL'}  ${msg}`); if (!cond) fails.push(msg); };
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--no-sandbox'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+const page = await browser.newPage();
+await page.bringToFront();
+page.on('pageerror', (e) => fails.push('PAGEERROR: ' + e.message));
+
+await page.goto(URL, { waitUntil: 'networkidle0', timeout: 45000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.evaluate(() => {
+  const card = document.querySelector('#offline-select .mini-class[data-class="warrior"]') || document.querySelector('.class-card[data-class="warrior"]');
+  card?.click();
+});
+await sleep(150);
+await page.evaluate(() => { const n = document.querySelector('#char-name'); if (n) n.value = 'Sprinter'; });
+await page.evaluate(() => document.querySelector('#btn-start-offline')?.click());
+await page.waitForFunction(() => window.__game?.sim?.entities?.size > 5, { timeout: 60000, polling: 250 });
+await sleep(2500);
+await page.evaluate(() => document.querySelector('.tut-skip')?.click());
+await sleep(300);
+
+// --- stage real cooldowns on the controlled warrior and show the readout.
+const before = await page.evaluate(() => {
+  const g = window.__game;
+  const sim = g.sim;
+  const pid = g.world.playerId;
+  const e = sim.entities.get(pid);
+  e.cooldowns.set('charge', 9);
+  e.cooldowns.set('shield_wall', 180);
+  e.potionCooldownUntil = sim.time + 42;
+  g.world.chat('/cooldowns');
+  return { active: [...e.cooldowns.entries()], potionLeft: Math.round(e.potionCooldownUntil - sim.time) };
+});
+check(before.active.length === 2, `staged 2 ability cooldowns + potion (${before.potionLeft}s)`);
+await sleep(700);
+await page.screenshot({ path: 'tmp/cooldown_1_active.png' });
+
+// --- relog through the REAL save/load path and compare fixed vs pre-fix load.
+const relog = await page.evaluate(() => {
+  const sim = window.__game.sim;
+  const pid = window.__game.world.playerId;
+  // REAL serialize: with the fix this now carries a `cooldowns` snapshot.
+  const state = sim.serializeCharacter(pid);
+  // Fixed load: addPlayer restores the cooldown deltas, re-anchored to the clock.
+  const fixedPid = sim.addPlayer('warrior', 'Relogged', { state });
+  const fixed = sim.entities.get(fixedPid);
+  // Pre-fix load: a save with no `cooldowns` field (exactly the old behaviour).
+  const legacy = { ...state }; delete legacy.cooldowns;
+  const oldPid = sim.addPlayer('warrior', 'OldRelog', { state: legacy });
+  const old = sim.entities.get(oldPid);
+  const fmt = (e) => ({
+    abilities: [...e.cooldowns.entries()].map(([id, r]) => `${id} (${Math.ceil(r)}s)`),
+    potionLeft: e.potionCooldownUntil > sim.time ? Math.round(e.potionCooldownUntil - sim.time) : 0,
+  });
+  return { saved: state.cooldowns, fixed: fmt(fixed), old: fmt(old) };
+});
+check(!!relog.saved && !!relog.saved.abilities, 'serializeCharacter now writes a cooldowns snapshot');
+check(relog.fixed.abilities.length === 2 && relog.fixed.potionLeft > 0, 'FIXED relog preserves ability + potion cooldowns');
+check(relog.old.abilities.length === 0 && relog.old.potionLeft === 0, 'pre-fix relog wiped every cooldown (the exploit)');
+
+// Overlay a labelled evidence card built from the REAL captured values.
+await page.evaluate((d) => {
+  const card = document.createElement('div');
+  card.style.cssText = 'position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);z-index:99999;width:760px;font:14px/1.5 system-ui,sans-serif;color:#eee;background:rgba(12,14,20,.94);border:1px solid #3a4256;border-radius:10px;padding:20px 24px;box-shadow:0 10px 40px rgba(0,0,0,.6)';
+  const row = (label, v, ok) => `<div style="margin:6px 0"><b style="color:${ok ? '#7fdc7f' : '#ff8a8a'}">${label}</b><br><span style="color:#cfd6e6">abilities: ${v.abilities.join(', ') || '(none)'} &nbsp;|&nbsp; potion: ${v.potionLeft ? v.potionLeft + 's' : '(none)'}</span></div>`;
+  card.innerHTML =
+    '<div style="font-size:17px;font-weight:700;margin-bottom:4px">Cooldown persistence across logout</div>' +
+    '<div style="color:#9aa3b8;margin-bottom:14px">driven through the real sim.serializeCharacter / sim.addPlayer save+load path</div>' +
+    `<div style="margin:6px 0;color:#9aa3b8">Before logout: charge (9s), shield_wall (180s), potion (${d.before.potionLeft}s)</div>` +
+    row('After relog, BEFORE fix (cooldowns wiped, exploitable):', d.old, false) +
+    row('After relog, AFTER fix (cooldowns preserved):', d.fixed, true);
+  document.body.appendChild(card);
+}, { before, ...relog });
+await sleep(400);
+await page.screenshot({ path: 'tmp/cooldown_2_relog_compare.png' });
+
+await browser.close();
+console.log(fails.length ? `\nFAILURES:\n- ${fails.join('\n- ')}` : '\nAll checks passed.');
+process.exit(fails.length ? 1 : 0);

--- a/src/sim/cooldown_persist.ts
+++ b/src/sim/cooldown_persist.ts
@@ -1,0 +1,60 @@
+// Persisting ability cooldowns across save/load.
+//
+// An Entity's `cooldowns` map holds REMAINING seconds per ability (decremented by
+// DT each tick in combat/auras.ts), and `potionCooldownUntil` is an ABSOLUTE
+// sim-time. Neither used to be serialized, so a logout dropped them and a relog
+// reset every cooldown, letting a player bypass long cooldowns (Sprint, Shield
+// Wall, the shared combat-potion timer) by reconnecting.
+//
+// The sim is clock-agnostic (no Date.now), so we persist REMAINING-time deltas, not
+// wall-clock expiry: cooldowns freeze for the duration of the logout and resume on
+// load. That fully removes the reset exploit while staying deterministic. (Hours-long
+// raid lockouts keep their own absolute-ms scheme; short combat cooldowns do not need
+// real-time decay.) This is a pure leaf so a Vitest drives it without a live Sim.
+
+/** Cooldown snapshot stored inside CharacterState (JSONB). All times are remaining
+ *  seconds, so they are independent of any particular Sim clock. */
+export interface SavedCooldowns {
+  /** abilityId -> remaining seconds */
+  abilities?: Record<string, number>;
+  /** remaining seconds on the shared combat-potion cooldown (#103) */
+  potion?: number;
+}
+
+const positive = (n: number): boolean => Number.isFinite(n) && n > 0;
+
+/** Snapshot the live cooldown state as remaining-time deltas. Returns undefined when
+ *  nothing is on cooldown so a clean character serializes without the field. */
+export function serializeCooldowns(
+  cooldowns: Map<string, number>,
+  potionCooldownUntil: number,
+  now: number,
+): SavedCooldowns | undefined {
+  const abilities: Record<string, number> = {};
+  for (const [id, remaining] of cooldowns) {
+    if (positive(remaining)) abilities[id] = remaining;
+  }
+  const potion = potionCooldownUntil - now;
+  const out: SavedCooldowns = {};
+  if (Object.keys(abilities).length > 0) out.abilities = abilities;
+  if (positive(potion)) out.potion = potion;
+  return out.abilities || out.potion !== undefined ? out : undefined;
+}
+
+/** Re-anchor a saved snapshot onto a fresh entity's (empty) cooldown map at the
+ *  current clock. Mutates `cooldowns` in place and returns the new
+ *  `potionCooldownUntil` (the entity default, -1, when none was saved). Non-finite
+ *  and non-positive entries are dropped defensively. */
+export function applyCooldowns(
+  saved: SavedCooldowns | undefined,
+  cooldowns: Map<string, number>,
+  now: number,
+): number {
+  if (!saved) return -1;
+  if (saved.abilities) {
+    for (const [id, remaining] of Object.entries(saved.abilities)) {
+      if (positive(remaining)) cooldowns.set(id, remaining);
+    }
+  }
+  return positive(saved.potion ?? -1) ? now + (saved.potion as number) : -1;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -132,6 +132,7 @@ import {
   tickGroundAoEs,
 } from './entity_roster';
 import { canEquipItem } from './equipment_rules';
+import { applyCooldowns, type SavedCooldowns, serializeCooldowns } from './cooldown_persist';
 import { formatMoney } from './format_money';
 import {
   LEADERBOARD_PAGE_SIZE,
@@ -803,6 +804,10 @@ export interface CharacterState {
   loadouts?: SavedLoadout[];
   activeLoadout?: number;
   raidLockouts?: Record<string, number>;
+  // Ability/potion cooldowns as remaining-time deltas (JSONB; optional so pre-fix
+  // saves load cleanly with no cooldowns). Persisted so logging out and back in no
+  // longer wipes cooldowns and lets a player bypass them by relogging.
+  cooldowns?: SavedCooldowns;
   pet?: PetState | null;
   skin?: number; // appearance index (JSONB; optional so pre-skin saves load as 0)
   skinCatalog?: SkinCatalog;
@@ -1330,6 +1335,9 @@ export class Sim {
             : 0;
     }
     player.swingTimer = 0;
+    // Restore ability/potion cooldowns so a relog cannot reset them (see
+    // cooldown_persist.ts). Re-anchored to this sim's clock; a fresh character has none.
+    player.potionCooldownUntil = applyCooldowns(savedState?.cooldowns, player.cooldowns, this.time);
     if (savedState?.pet) this.restorePet(player, savedState.pet);
     return player.id;
   }
@@ -1444,6 +1452,7 @@ export class Sim {
       raidLockouts: Object.fromEntries(
         [...meta.raidLockouts].filter(([, until]) => until > this.lockoutNowMs()),
       ),
+      cooldowns: serializeCooldowns(e.cooldowns, e.potionCooldownUntil, this.time),
       pet: this.serializePet(pid),
       skin: meta.skin,
       skinCatalog: meta.skinCatalog,

--- a/tests/cooldown_persist.test.ts
+++ b/tests/cooldown_persist.test.ts
@@ -1,0 +1,105 @@
+// Bug fix: spell/ability cooldowns (Sprint, etc.) and the shared combat-potion
+// cooldown were never serialized, so logging out and back in wiped them and let a
+// player bypass long cooldowns by relogging. cooldown_persist.ts is the pure leaf
+// that snapshots the remaining time (clock-independent deltas) and re-anchors it on
+// load; this test pins both the leaf and the full Sim serializeCharacter <-> addPlayer
+// round-trip.
+
+import { describe, expect, it } from 'vitest';
+import { applyCooldowns, serializeCooldowns } from '../src/sim/cooldown_persist';
+import { Sim } from '../src/sim/sim';
+
+describe('cooldown_persist leaf', () => {
+  it('round-trips ability cooldowns as remaining seconds (frozen across the save)', () => {
+    const cds = new Map<string, number>([
+      ['sprint', 22.5],
+      ['shield_wall', 180],
+    ]);
+    const saved = serializeCooldowns(cds, -1, 0)!;
+    expect(saved.abilities).toEqual({ sprint: 22.5, shield_wall: 180 });
+
+    // load into a fresh entity's empty map at an unrelated clock value: the
+    // remaining time is preserved (re-anchored), not the original absolute clock.
+    const fresh = new Map<string, number>();
+    const potion = applyCooldowns(saved, fresh, 9999);
+    expect(fresh.get('sprint')).toBe(22.5);
+    expect(fresh.get('shield_wall')).toBe(180);
+    expect(potion).toBe(-1); // no potion cooldown was saved
+  });
+
+  it('persists the shared combat-potion cooldown as remaining time, re-anchored on load', () => {
+    // potionCooldownUntil is absolute sim-time; at now=100 with 40s left it is 140.
+    const saved = serializeCooldowns(new Map(), 140, 100)!;
+    expect(saved.potion).toBe(40);
+    // restoring into a sim whose clock reads 5 re-anchors to 5 + 40 = 45.
+    const until = applyCooldowns(saved, new Map(), 5);
+    expect(until).toBe(45);
+  });
+
+  it('returns undefined when nothing is on cooldown (keeps clean saves minimal)', () => {
+    expect(serializeCooldowns(new Map(), -1, 0)).toBeUndefined();
+    // already-expired potion (until <= now) is not persisted.
+    expect(serializeCooldowns(new Map(), 50, 60)).toBeUndefined();
+  });
+
+  it('ignores non-finite and non-positive values from a tampered/legacy save', () => {
+    const fresh = new Map<string, number>();
+    const until = applyCooldowns(
+      { abilities: { good: 10, zero: 0, neg: -5, nan: Number.NaN }, potion: -1 },
+      fresh,
+      0,
+    );
+    expect([...fresh.keys()]).toEqual(['good']);
+    expect(until).toBe(-1);
+  });
+
+  it('applyCooldowns(undefined) leaves an empty map and no potion cooldown', () => {
+    const fresh = new Map<string, number>();
+    expect(applyCooldowns(undefined, fresh, 0)).toBe(-1);
+    expect(fresh.size).toBe(0);
+  });
+});
+
+describe('Sim cooldown persistence round-trip (anti-relog-reset)', () => {
+  const makeWorld = () => new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+
+  it('an ability cooldown survives serializeCharacter -> addPlayer (no relog reset)', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Sprinter');
+    const e = sim.entities.get(pid)!;
+    e.cooldowns.set('sprint', 25);
+    e.potionCooldownUntil = sim.time + 30;
+
+    const state = sim.serializeCharacter(pid)!;
+    const sim2 = makeWorld();
+    const pid2 = sim2.addPlayer('warrior', 'Sprinter', { state });
+    const e2 = sim2.entities.get(pid2)!;
+    expect(e2.cooldowns.get('sprint')).toBe(25);
+    expect(e2.potionCooldownUntil).toBe(sim2.time + 30);
+  });
+
+  it('a populated character round-trips deep-equal through serialize -> load -> serialize', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Onco');
+    const e = sim.entities.get(pid)!;
+    e.cooldowns.set('sprint', 25);
+    e.cooldowns.set('shield_wall', 180);
+    e.potionCooldownUntil = sim.time + 30;
+
+    const s1 = sim.serializeCharacter(pid)!;
+    expect(s1.cooldowns).toEqual({ abilities: { sprint: 25, shield_wall: 180 }, potion: 30 });
+    const sim2 = makeWorld();
+    const pid2 = sim2.addPlayer('warrior', 'Onco', { state: s1 });
+    expect(sim2.serializeCharacter(pid2)).toEqual(s1);
+  });
+
+  it('a character with no cooldowns still round-trips deep-equal', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Idle');
+    const s1 = sim.serializeCharacter(pid)!;
+    expect(s1.cooldowns).toBeUndefined();
+    const sim2 = makeWorld();
+    const pid2 = sim2.addPlayer('warrior', 'Idle', { state: s1 });
+    expect(sim2.serializeCharacter(pid2)).toEqual(s1);
+  });
+});


### PR DESCRIPTION
## Problem

Spell/ability cooldowns reset on logout, letting players bypass them by relogging. `Entity.cooldowns` is a `Map<abilityId, remainingSeconds>` (decremented each tick in `combat/auras.ts`) and the shared combat-potion timer is `Entity.potionCooldownUntil`. Neither was ever written by `serializeCharacter` nor restored by `addPlayer`, so a fresh login started from `new Map()` with no cooldowns.

Result: a player on a long Sprint / Shield Wall / combat-potion cooldown could log out and back in to clear it instantly. This is server-authoritative state, so it affected the live online realm, not just offline play.

```mermaid
sequenceDiagram
    actor P as Player
    participant S as Sim (server)
    participant DB as Postgres (JSONB)
    P->>S: cast Sprint (60s cooldown)
    Note over S: e.cooldowns.set('sprint', 60)
    P->>S: logout
    S->>DB: serializeCharacter (no cooldowns field)
    P->>S: login
    DB->>S: addPlayer(state)
    Note over S: new Entity -> cooldowns = new Map() (EMPTY)
    S-->>P: Sprint ready again immediately ❌ exploit
```

## Fix

A pure leaf `src/sim/cooldown_persist.ts` snapshots cooldowns as **remaining-time deltas** (clock-independent, so no `Date.now` and determinism is preserved) and re-anchors them onto the fresh entity on load. Wired into `CharacterState` (new optional `cooldowns` field), `serializeCharacter`, and `addPlayer`.

```mermaid
sequenceDiagram
    actor P as Player
    participant S as Sim (server)
    participant DB as Postgres (JSONB)
    P->>S: logout (Sprint 47s left)
    S->>DB: serializeCooldowns -> { abilities: { sprint: 47 }, potion: ... }
    P->>S: login
    DB->>S: addPlayer(state)
    Note over S: applyCooldowns -> e.cooldowns.set('sprint', 47)
    S-->>P: Sprint still on cooldown ✅
```

Cooldowns **freeze** for the duration of the logout rather than continue ticking. That fully closes the reset exploit while keeping the sim wall-clock-free (hours-long raid lockouts keep their own absolute-ms scheme; short combat cooldowns don't need real-time decay). Pre-fix saves (no `cooldowns` field) load cleanly with no cooldowns. The ~1.5s GCD is intentionally not persisted (far shorter than any relog, not an abuse vector).

## Proof (driven through the real `serializeCharacter` / `addPlayer` save+load path in the live offline engine)

![cooldown relog comparison](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-cooldown/docs/pr/cooldown_2_relog_compare.png)

The "BEFORE fix" row is the same character loaded with the `cooldowns` field stripped, i.e. exactly what a pre-fix save produced. Reproduce with `node scripts/cooldown_persist_shot.mjs` (needs `npm run dev`).

## Tests

`tests/cooldown_persist.test.ts` (test-first): covers the leaf (delta round-trip, re-anchoring onto a different clock, empty -> `undefined`, tampered/legacy non-finite values) and the full Sim `serializeCharacter <-> addPlayer` round-trip (empty + populated deep-equal).

- `npx vitest run tests/cooldown_persist.test.ts` - 8 passing
- `npx vitest run tests/persistence_round_trip.test.ts tests/cooldowns_command.test.ts` - green
- `npx vitest run tests/parity tests/sim.test.ts` - 242 passing (no rng / tick-phase change)
- `tests/architecture.test.ts` + S3 i18n guard (`tests/localization_fixes.test.ts`) - green
- `npx tsc --noEmit` - clean

## Notes for reviewers

- Determinism preserved: the leaf draws no rng, no wall-clock; the `addPlayer` call sits before `restorePet` and changes no draw order.
- Out of scope (flagged, not fixed): the pet Growl cooldown (`petTauntTimer`) is recreated fresh by `serializePet`; it is short and a separate subsystem. Happy to follow up if you'd like it included.

cc @Rubsey @FernandoX7 @TrevCavill @patrick261 @CharlieSaxton @maxpolaczuk
