### PR TITLE
fix(content): unchain Korzul quest from Velkhar so the Sanctum runs once

### DIFF
--- a/docs/design/master-spec.md
+++ b/docs/design/master-spec.md
@@ -221,7 +221,7 @@ Ground sparkles: highwatch_summons ×2 at (1,654),(-2,657); ogre_war_totem ×7 a
 | q_sanctum_gate | The Sanctum Gate | brother_aldric_highwatch | collect 3 sanctum_key_shard (sparkles, gate plaza) | 4000 | 2000 | — | requires q_voice_below |
 | q_korgath | The Bound Guardian | scout_maren_highwatch | kill 1 korgath_the_bound | 4200 | 2500 | korgaths_chainwraps (all) | requires q_sanctum_gate, minLevel 18, suggestedPlayers 5 |
 | q_velkhar | The Grand Necromancer | brother_aldric_highwatch | kill 1 grand_necromancer_velkhar | 4500 | 3000 | boneguard_breastplate / staff_of_velkhar / shadowmeld_tunic | requires q_sanctum_gate, minLevel 18, suggestedPlayers 5 |
-| q_gravewyrm | Korzul the Gravewyrm | brother_aldric_highwatch | kill 1 korzul_the_gravewyrm | 5300 | 25000 | gravewyrm_scale_hauberk / wyrmcult_grand_robe / wyrmscale_jerkin | requires q_velkhar, minLevel 18, suggestedPlayers 5 |
+| q_gravewyrm | Korzul the Gravewyrm | brother_aldric_highwatch | kill 1 korzul_the_gravewyrm | 5300 | 25000 | gravewyrm_scale_hauberk / wyrmcult_grand_robe / wyrmscale_jerkin | requires q_sanctum_gate, minLevel 18, suggestedPlayers 5 |
 
 Ceiling check: q_gravewyrm 5,300 at L19 = 24.9% of 21,300 (under ceiling). The 18→20 stretch (40,700 XP) is carried by the SOLO-able lead-up chain (q_wyrm_sigils + q_breaking_the_seal + q_voice_below + q_sanctum_gate = 16,200) plus revenant/necromancer arcs (13,000) plus dungeon quests (14,000) — per the corrected dungeon math, NOT by dungeon trash kills.
 
@@ -241,7 +241,7 @@ Ceiling check: q_gravewyrm 5,300 at L19 = 24.9% of 21,300 (under ceiling). The 1
 
 `DungeonDef`: `{ id: 'gravewyrm_sanctum', name: 'Gravewyrm Sanctum', index: 2, doorPos: {x:0, z:880}, entry: {x:0,z:0}, exitOffset: {x:0,z:-6}, interior: 'sanctum' (stretched 3-chamber variant of the crypt builder — see §7; fallback: 'crypt'), suggestedPlayers: 5, enterText: 'The air goes cold. Something vast breathes below...', leaveText: 'You stagger back into the mountain wind.' }`
 
-Entry gating: q_velkhar/q_gravewyrm gated minLevel 18, suggestedPlayers 5.
+Entry gating: q_korgath, q_velkhar, and q_gravewyrm all require q_sanctum_gate, minLevel 18, suggestedPlayers 5. They are available together once the Sanctum gate is opened, so one party run can clear all three boss quests.
 
 **Layout (linear, 3 chambers, z 0→150):** Chamber 1 "The Boneworks" (z 10–60, boneguard/drakonid packs) → Korgath's Hall (z 60–75) → Chamber 2 "The Ritual Vault" (z 75–115, Velkhar) → Chamber 3 "The Wyrm's Hollow" (z 115–150, Korzul on a raised dais ringed by drakonid guards).
 

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -1387,7 +1387,10 @@ export const ZONE3_QUESTS: Record<string, QuestDef> = {
       mage: 'wyrmcult_grand_robe',
       rogue: 'wyrmscale_jerkin',
     },
-    requiresQuest: 'q_velkhar',
+    // Korzul shares the Sanctum with Korgath and Velkhar; gate it on opening
+    // the gate (like its sibling boss quests), not on Velkhar's turn-in, so the
+    // party can pick up all three and clear the instance in a single run.
+    requiresQuest: 'q_sanctum_gate',
     minLevel: 18,
     suggestedPlayers: 5,
   },

--- a/tests/zone3_sanctum_quests.test.ts
+++ b/tests/zone3_sanctum_quests.test.ts
@@ -1,0 +1,23 @@
+// The Gravewyrm Sanctum is a single dungeon instance with three boss quests:
+// Korgath at the threshold, Velkhar in the Ritual Vault, and Korzul on the
+// final dais. All three should be pickable BEFORE entering, so the party
+// clears the instance once. They must therefore gate on the same prerequisite
+// (q_sanctum_gate, "the way below stands open"), never on each other — gating
+// Korzul behind Velkhar's turn-in forces a second run of the same dungeon.
+import { describe, expect, it } from 'vitest';
+import { QUESTS } from '../src/sim/data';
+
+describe('Gravewyrm Sanctum dungeon quests are concurrently available', () => {
+  const SANCTUM_BOSS_QUESTS = ['q_korgath', 'q_velkhar', 'q_gravewyrm'];
+
+  it('every Sanctum boss quest gates on opening the gate, not on a prior boss', () => {
+    for (const id of SANCTUM_BOSS_QUESTS) {
+      expect(QUESTS[id], `${id} should exist`).toBeTruthy();
+      expect(QUESTS[id].requiresQuest, `${id} prerequisite`).toBe('q_sanctum_gate');
+    }
+  });
+
+  it('Korzul (q_gravewyrm) does not chain off Velkhar (q_velkhar)', () => {
+    expect(QUESTS.q_gravewyrm.requiresQuest).not.toBe('q_velkhar');
+  });
+});


### PR DESCRIPTION
## Problem

The **Gravewyrm Sanctum** is a single 5-player dungeon instance with three boss quests, all given at Highwatch:

- `q_korgath` (Korgath the Bound, at the threshold) -> requires `q_sanctum_gate`
- `q_velkhar` (Grand Necromancer Velkhar, in the Ritual Vault) -> requires `q_sanctum_gate`
- `q_gravewyrm` (**Korzul the Gravewyrm**, on the final dais) -> **requires `q_velkhar`**

Korgath and Velkhar both unlock the moment the gate is opened, so they can be picked up together and cleared in one pass. But Korzul chained off `q_velkhar`, whose kill objective is *inside* the same instance. You cannot turn in Velkhar until you have killed him in the dungeon, and you cannot pick up Korzul until you have turned in Velkhar, so the only way to get Korzul's quest is to leave and re-enter, **running the entire dungeon a second time** to reach the boss who stands on the dais just past Velkhar.

## Fix

Gate `q_gravewyrm` on `q_sanctum_gate`, exactly like its sibling boss quests. Now a party accepts all three Sanctum quests up front and clears the instance once. The narrative still holds: Velkhar falls in the vault earlier in the run, and Korzul is slain on the dais at the end.

One-line content change in `src/sim/content/zone3.ts`:

```diff
-    requiresQuest: 'q_velkhar',
+    requiresQuest: 'q_sanctum_gate',
```

### Quest graph: before

```mermaid
flowchart LR
  G["q_sanctum_gate"]
  K["q_korgath"]
  V["q_velkhar"]
  Z["q_gravewyrm (Korzul)"]
  G --> K
  G --> V
  V -->|requiresQuest| Z
```

![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-korzul-quest/korzul_before.png)

### Quest graph: after

```mermaid
flowchart LR
  G["q_sanctum_gate"]
  K["q_korgath"]
  V["q_velkhar"]
  Z["q_gravewyrm (Korzul)"]
  G --> K
  G --> V
  G --> Z
```

![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-korzul-quest/korzul_after.png)

## Tests

Added `tests/zone3_sanctum_quests.test.ts` (TDD: failing first, then green): asserts all three Sanctum boss quests share the `q_sanctum_gate` prerequisite and that Korzul never chains off Velkhar.

```
npx vitest run tests/zone3_sanctum_quests.test.ts tests/progression.test.ts \
  tests/quest_link_share.test.ts tests/localization_coverage.test.ts \
  tests/nythraxis_final_quest.test.ts tests/architecture.test.ts
# all green
```

No balance numbers, names, or player-facing strings changed, so the i18n catalogs and the generated `/wiki` content are untouched (referential-integrity and freshness gates stay green).

cc upstream maintainers with push access: @Rubsey @FernandoX7 @patrick261 @TrevCavill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
