### PR TITLE
feat(web): add /press coming-soon page

### DIFF
--- a/public/press.html
+++ b/public/press.html
@@ -1,0 +1,1383 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="color-scheme" content="dark" />
+  <meta name="theme-color" content="#08080d" />
+  <title>World of ClaudeCraft - Press</title>
+  <meta name="description" data-i18n-content="metaDescription" content="The World of ClaudeCraft press kit is being assembled. For press inquiries, contact woc@levystreet.com. Any official statement not from our channels is not us." />
+
+  <link rel="canonical" href="https://worldofclaudecraft.com/press" />
+
+  <!-- Open Graph / Twitter -->
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="World of ClaudeCraft" />
+  <meta property="og:title" data-i18n-content="pageTitle" content="World of ClaudeCraft - Press" />
+  <meta property="og:description" data-i18n-content="metaDescription" content="The World of ClaudeCraft press kit is coming soon. For press inquiries, contact woc@levystreet.com." />
+  <meta property="og:url" content="https://worldofclaudecraft.com/press" />
+  <meta property="og:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+  <meta property="og:image:alt" content="World of ClaudeCraft" />
+  <meta property="og:locale" content="en_US" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" data-i18n-content="pageTitle" content="World of ClaudeCraft - Press" />
+  <meta name="twitter:description" data-i18n-content="metaDescription" content="The World of ClaudeCraft press kit is coming soon. For press inquiries, contact woc@levystreet.com." />
+  <meta name="twitter:image" content="https://worldofclaudecraft.com/woc_logo_square.webp" />
+  <meta name="twitter:image:alt" content="World of ClaudeCraft" />
+
+  <!-- Structured data: declares the upcoming press page and ties it to the brand,
+       so search + answer engines associate official press contact with this realm only. -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "name": "World of ClaudeCraft - Press",
+    "url": "https://worldofclaudecraft.com/press",
+    "description": "The World of ClaudeCraft press kit is coming soon. For press inquiries, contact woc@levystreet.com.",
+    "inLanguage": "en",
+    "isPartOf": { "@type": "WebSite", "name": "World of ClaudeCraft", "url": "https://worldofclaudecraft.com/" },
+    "about": {
+      "@type": "Organization",
+      "name": "World of ClaudeCraft",
+      "url": "https://worldofclaudecraft.com/",
+      "logo": "https://worldofclaudecraft.com/woc_logo_square.webp",
+      "email": "woc@levystreet.com",
+      "sameAs": [
+        "https://x.com/WoClaudecraft",
+        "https://www.instagram.com/worldofclaudecraft/",
+        "https://www.tiktok.com/@worldofclaudecraft",
+        "https://www.youtube.com/@WoClaudeCraft",
+        "https://www.reddit.com/r/WorldofClaudecraft/",
+        "https://github.com/levy-street/world-of-claudecraft"
+      ]
+    }
+  }
+  </script>
+
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&family=Alegreya:ital,wght@0,400;0,500;1,400&family=Alegreya+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <style>
+    /* Every colour and reusable constant is a token here; nothing below :root
+       hard-codes a colour. RGB triplets (--c-*) exist so the same hue can be
+       composited at any alpha via rgba(var(--c-*), a) without repeating literals.
+       This page shares the design system of links.html and merch.html so the
+       realm's standalone pages feel like one set. */
+    :root {
+      color-scheme: dark;
+
+      /* colour channels (R, G, B) for alpha compositing */
+      --c-black: 0, 0, 0;
+      --c-white: 255, 255, 255;
+      --c-gold: 255, 209, 0;        /* primary accent */
+      --c-parch: 215, 181, 109;     /* parchment gold */
+      --c-deep: 5, 7, 12;           /* splash edge darken */
+      --c-ink-dark: 26, 20, 7;      /* ink on gold */
+      --c-hero-shade: 120, 86, 12;  /* hero lip shadow */
+      --c-hero-low: 202, 161, 47;   /* hero gradient base */
+
+      /* brand gold ramp */
+      --gold: rgb(var(--c-gold));
+      --gold-dim: #c8a838;
+      --gold-soft: #f3dfaa;
+      --gold-parch: rgb(var(--c-parch));
+      --gold-hi: #fff3cf;
+
+      /* ink / text */
+      --ink: #f0ebd8;
+      --muted: #998d6a;
+      --muted-safe: #c4b899;
+      --ink-on-gold: rgb(var(--c-ink-dark));
+
+      /* lines / borders / focus */
+      --border: #6f5a2a;
+      --border-default: #4e3d1d;
+      --focus: var(--gold-soft);
+      --line: rgba(var(--c-parch), 0.38);
+      --line-soft: rgba(var(--c-parch), 0.14);
+
+      /* verified wax seal */
+      --wax: #7c1f1a;
+      --wax-rim: #a83a2c;
+
+      /* surfaces */
+      --bg-0: #08080d;
+      --bg-1: #050509;
+      --bg-photo: #080b12;
+      --surface-top: rgba(20, 20, 30, 0.94);
+      --surface-bottom: rgba(6, 6, 11, 0.96);
+      --row-top: #1b1b26;
+      --row-bottom: #101019;
+      --row-top-hover: #23232f;
+      --row-bottom-hover: #14141d;
+
+      /* hero gilded plate */
+      --hero-top: #ffe87a;
+      --hero-mid: rgb(var(--c-gold));
+      --hero-bottom: rgb(var(--c-hero-low));
+      --hero-border: #e9c54a;
+      --hero-lip: #6f5212;
+
+      /* radii / spacing / motion */
+      --r-sm: 4px;
+      --r-md: 8px;
+      --r-pill: 999px;
+      --sp-1: 4px;
+      --sp-2: 8px;
+      --sp-3: 16px;
+      --sp-4: 24px;
+      --gap-row: 10px;
+      --pad-page: clamp(16px, 4vw, 40px);
+      --ease: cubic-bezier(0.4, 0, 0.2, 1);
+      --dur: 0.25s;
+
+      /* type */
+      --font-display: 'Cinzel', 'Palatino Linotype', Palatino, Georgia, serif;
+      --font-ui: 'Alegreya Sans', 'Segoe UI', system-ui, -apple-system, sans-serif;
+      --font-serif: 'Alegreya', 'Palatino Linotype', Palatino, Georgia, serif;
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; }
+
+    body {
+      min-height: 100vh;
+      min-height: 100dvh;
+      display: grid;
+      /* Explicit track so the column tracks the viewport, not the content's
+         max-content width; without this the centered console can spill at <360px. */
+      grid-template-columns: minmax(0, 1fr);
+      place-items: center;
+      overflow-x: hidden;
+      color: var(--ink);
+      font-family: var(--font-ui);
+      -webkit-font-smoothing: antialiased;
+      -webkit-tap-highlight-color: transparent;
+      padding:
+        max(var(--pad-page), env(safe-area-inset-top))
+        max(var(--pad-page), env(safe-area-inset-right))
+        max(var(--pad-page), env(safe-area-inset-bottom))
+        max(var(--pad-page), env(safe-area-inset-left));
+      background:
+        linear-gradient(90deg, rgba(var(--c-deep), 0.86), rgba(var(--c-deep), 0.40) 52%, rgba(var(--c-deep), 0.88)),
+        radial-gradient(circle at 50% 30%, rgba(var(--c-gold), 0.14), transparent 42%),
+        var(--bg-photo) url("/loading-screen.jpg") center / cover no-repeat;
+    }
+
+    /* Parallax only where a fine pointer exists; avoids iOS background jank. */
+    @media (hover: hover) and (pointer: fine) {
+      body { background-attachment: fixed; }
+    }
+
+    /* CRT scanline + bottom vignette (decorative, out of the a11y tree). */
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      background:
+        linear-gradient(rgba(var(--c-white), 0.022) 50%, rgba(var(--c-black), 0.03) 50%),
+        radial-gradient(circle at 50% 92%, rgba(var(--c-black), 0.55), transparent 46%);
+      background-size: 100% 4px, auto;
+    }
+
+    /* Faint torch glow that breathes (disabled under reduced motion). */
+    body::after {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      background: radial-gradient(circle at 50% 16%, rgba(var(--c-gold), 0.10), transparent 38%);
+      animation: torch 7s ease-in-out infinite;
+    }
+    @keyframes torch { 0%, 100% { opacity: 0.85; } 50% { opacity: 1; } }
+
+    /* ---------- skip link + screen-reader helper ---------- */
+    .skip {
+      position: absolute;
+      left: 10px;
+      top: -64px;
+      z-index: 20;
+      padding: 10px 16px;
+      border-radius: var(--r-pill);
+      background: var(--gold);
+      color: var(--ink-on-gold);
+      font: 700 13px/1 var(--font-ui);
+      text-decoration: none;
+      transition: top var(--dur) var(--ease);
+    }
+    .skip:focus { top: 10px; outline: 2px solid var(--gold-soft); outline-offset: 2px; }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    /* ---------- the console panel ---------- */
+    .console {
+      position: relative;
+      z-index: 1;
+      width: min(560px, 100%);
+      margin: 0 auto;
+      padding: clamp(24px, 5vw, 40px) clamp(20px, 4vw, 36px);
+      border: 1px solid var(--line);
+      border-radius: var(--r-md);
+      /* High-alpha tint keeps text on a controlled dark base for WCAG AA, while a
+         hint of the splash still bleeds through the blur for the glass feel. */
+      background: linear-gradient(170deg, var(--surface-top), var(--surface-bottom));
+      backdrop-filter: blur(14px) saturate(1.05);
+      -webkit-backdrop-filter: blur(14px) saturate(1.05);
+      box-shadow:
+        0 26px 90px rgba(var(--c-black), 0.55),
+        0 0 0 1px rgba(var(--c-black), 0.6),
+        inset 0 1px 0 rgba(var(--c-white), 0.07),
+        inset 0 0 60px rgba(var(--c-black), 0.35);
+    }
+    /* Carved double-bezel inlay. */
+    .console::before {
+      content: "";
+      position: absolute;
+      inset: 6px;
+      pointer-events: none;
+      border: 1px solid rgba(var(--c-gold), 0.16);
+      border-radius: 6px;
+    }
+
+    /* ---------- crest / header ---------- */
+    .crest { text-align: center; }
+    .logo {
+      display: block;
+      width: min(360px, 82%);
+      height: auto;
+      margin: 0 auto clamp(14px, 3vw, 22px);
+      filter: drop-shadow(0 10px 28px rgba(var(--c-black), 0.66));
+    }
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      margin: 0 0 8px;
+      color: var(--gold-parch);
+      font: 700 12px/1 var(--font-ui);
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+    }
+    .eyebrow::before, .eyebrow::after {
+      content: "";
+      width: 28px;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--gold-dim));
+    }
+    .eyebrow::after { background: linear-gradient(90deg, var(--gold-dim), transparent); }
+
+    h1.title {
+      margin: 0;
+      font-family: var(--font-display);
+      font-weight: 800;
+      font-size: clamp(30px, 6.5vw, 46px);
+      line-height: 1.02;
+      letter-spacing: 0.01em;
+      color: var(--gold-soft); /* solid fallback before the gilded clip */
+      text-shadow: 0 2px 0 rgba(var(--c-black), 0.6), 0 0 26px rgba(var(--c-gold), 0.18);
+      background: linear-gradient(180deg, var(--gold-hi), var(--gold-soft) 42%, var(--gold-dim) 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    /* "Coming soon" badge under the title. */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin: 14px auto 0;
+      padding: 6px 14px;
+      border: 1px solid rgba(var(--c-gold), 0.36);
+      border-radius: var(--r-pill);
+      background: linear-gradient(180deg, rgba(var(--c-gold), 0.10), rgba(var(--c-gold), 0.03));
+      color: var(--gold-soft);
+      font: 700 11.5px/1 var(--font-ui);
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+    }
+    .badge__dot {
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: var(--gold);
+      box-shadow: 0 0 8px rgba(var(--c-gold), 0.7);
+      animation: pulse 2.4s ease-in-out infinite;
+    }
+    @keyframes pulse { 0%, 100% { opacity: 0.5; transform: scale(0.85); } 50% { opacity: 1; transform: scale(1.1); } }
+
+    .tagline {
+      margin: 14px auto 0;
+      max-width: 42ch;
+      font-family: var(--font-serif);
+      font-style: italic;
+      font-size: clamp(14.5px, 3.4vw, 16px);
+      line-height: 1.55;
+      color: var(--ink);
+    }
+
+    .rule {
+      position: relative;
+      width: 70%;
+      height: 1px;
+      margin: clamp(16px, 3vw, 22px) auto;
+      background: linear-gradient(90deg, transparent, var(--gold-dim), transparent);
+    }
+    .rule::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 50%;
+      width: 6px;
+      height: 6px;
+      background: var(--gold);
+      transform: translate(-50%, -50%) rotate(45deg);
+      box-shadow: 0 0 8px rgba(var(--c-gold), 0.6);
+    }
+
+    /* ---------- the ward (verify-official decree) ---------- */
+    .ward {
+      display: flex;
+      gap: var(--sp-3);
+      align-items: flex-start;
+      margin: clamp(18px, 3.5vw, 26px) 0;
+      padding: 16px 18px;
+      border: 1px solid rgba(var(--c-gold), 0.30);
+      border-left: 3px solid var(--gold);
+      border-radius: var(--r-sm);
+      background: linear-gradient(180deg, rgba(var(--c-gold), 0.07), rgba(var(--c-gold), 0.02));
+      box-shadow: inset 0 1px 0 rgba(var(--c-white), 0.05);
+    }
+    .ward__sigil {
+      flex: 0 0 auto;
+      width: 34px;
+      height: 34px;
+      color: var(--gold);
+      filter: drop-shadow(0 0 10px rgba(var(--c-gold), 0.35));
+    }
+    .ward__title {
+      margin: 0 0 5px;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 15px;
+      letter-spacing: 0.04em;
+      color: var(--gold-soft);
+    }
+    .ward__body {
+      margin: 0;
+      font-family: var(--font-serif);
+      font-style: italic;
+      font-size: 14.5px;
+      line-height: 1.55;
+      color: var(--ink);
+    }
+    .ward__body strong { color: var(--gold); font-weight: 700; font-style: normal; }
+    @media (max-width: 480px) {
+      .ward { flex-direction: column; align-items: center; text-align: center; }
+    }
+
+    /* ---------- the preview (what is being assembled) ---------- */
+    .preview { margin-top: clamp(16px, 3vw, 22px); }
+    .preview__head {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 12px;
+      margin: 0 0 12px;
+      color: var(--gold-parch);
+      font: 700 12px/1 var(--font-ui);
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+    }
+    .preview__head::before, .preview__head::after {
+      content: "";
+      width: 22px;
+      height: 1px;
+      background: linear-gradient(90deg, transparent, var(--gold-dim));
+    }
+    .preview__head::after { background: linear-gradient(90deg, var(--gold-dim), transparent); }
+
+    .items {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-row);
+    }
+
+    /* A static, non-interactive row: same plate look as a link button but no
+       hover lift, focus ring, or pointer affordance (there is nothing to open yet). */
+    .item {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      width: 100%;
+      min-height: 56px;
+      padding: 12px 16px;
+      border: 1px solid var(--border-default);
+      border-radius: var(--r-sm);
+      background: linear-gradient(180deg, var(--row-top), var(--row-bottom));
+      box-shadow:
+        inset 0 1px 0 rgba(var(--c-white), 0.05),
+        inset 0 -2px 0 rgba(var(--c-black), 0.45);
+    }
+    .item__icon {
+      flex: 0 0 auto;
+      display: grid;
+      place-items: center;
+      width: 40px;
+      height: 40px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border-default);
+      background: radial-gradient(120% 120% at 50% 35%, rgba(var(--c-gold), 0.10), rgba(var(--c-black), 0.25));
+      box-shadow: inset 0 1px 0 rgba(var(--c-white), 0.05);
+      color: var(--gold-parch);
+    }
+    .item__icon .ic { width: 22px; height: 22px; display: block; }
+    .item__text { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1 1 auto; overflow: hidden; }
+    .item__label {
+      font: 700 16px/1.15 var(--font-ui);
+      letter-spacing: 0.02em;
+      color: var(--gold-soft);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .item__desc {
+      font-family: var(--font-serif);
+      font-size: 13px;
+      line-height: 1.2;
+      color: var(--muted-safe);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .item__tag {
+      flex: 0 0 auto;
+      padding: 3px 9px;
+      border: 1px solid rgba(var(--c-gold), 0.30);
+      border-radius: var(--r-pill);
+      font: 700 10px/1 var(--font-ui);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--gold-parch);
+      background: rgba(var(--c-gold), 0.06);
+    }
+
+    /* ---------- the menu (real CTAs) ---------- */
+    .menu { margin-top: clamp(18px, 3.5vw, 26px); }
+    .menu:focus { outline: none; }
+    .rows {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--gap-row);
+    }
+
+    .btn {
+      position: relative;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      width: 100%;
+      min-height: 56px;
+      padding: 12px 16px;
+      border: 1px solid var(--border);
+      border-radius: var(--r-sm);
+      color: var(--ink);
+      text-decoration: none;
+      background: linear-gradient(180deg, var(--row-top), var(--row-bottom));
+      box-shadow:
+        inset 0 1px 0 rgba(var(--c-white), 0.06),
+        inset 0 -2px 0 rgba(var(--c-black), 0.5),
+        0 2px 0 rgba(var(--c-black), 0.6);
+      transition:
+        transform var(--dur) var(--ease),
+        border-color var(--dur) var(--ease),
+        box-shadow var(--dur) var(--ease),
+        background var(--dur) var(--ease);
+    }
+
+    .btn__icon {
+      flex: 0 0 auto;
+      display: grid;
+      place-items: center;
+      width: 40px;
+      height: 40px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border-default);
+      background: radial-gradient(120% 120% at 50% 35%, rgba(var(--c-gold), 0.10), rgba(var(--c-black), 0.25));
+      box-shadow: inset 0 1px 0 rgba(var(--c-white), 0.05);
+      color: var(--gold-parch);
+      transition: color var(--dur) var(--ease), border-color var(--dur) var(--ease);
+    }
+    .btn__icon .ic { width: 22px; height: 22px; display: block; }
+
+    .btn__text { display: flex; flex-direction: column; gap: 2px; min-width: 0; flex: 1 1 auto; overflow: hidden; }
+    .btn__label {
+      font: 700 16px/1.15 var(--font-ui);
+      letter-spacing: 0.02em;
+      color: var(--gold-soft);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .btn__handle {
+      font-family: var(--font-serif);
+      font-size: 13px;
+      line-height: 1.2;
+      color: var(--muted-safe);
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .btn__chev {
+      flex: 0 0 auto;
+      display: grid;
+      place-items: center;
+      width: 16px;
+      height: 16px;
+      color: var(--gold-dim);
+      opacity: 0.55;
+      transition: opacity var(--dur) var(--ease), transform var(--dur) var(--ease);
+    }
+    .btn__chev svg { width: 14px; height: 14px; display: block; }
+
+    @media (hover: hover) {
+      .btn:hover {
+        border-color: var(--gold-dim);
+        background: linear-gradient(180deg, var(--row-top-hover), var(--row-bottom-hover));
+        transform: translateY(-1px);
+        box-shadow:
+          0 0 0 1px rgba(var(--c-gold), 0.18),
+          inset 0 1px 0 rgba(var(--c-white), 0.07),
+          0 6px 18px rgba(var(--c-black), 0.5),
+          0 0 22px rgba(var(--c-gold), 0.10);
+      }
+      .btn:hover .btn__icon { color: var(--gold); border-color: var(--gold-dim); }
+      .btn:hover .btn__chev { opacity: 1; transform: translateX(3px); }
+    }
+
+    .btn:focus-visible {
+      outline: 2px solid var(--focus);
+      outline-offset: 3px;
+      border-color: var(--gold-dim);
+    }
+    .btn:active {
+      transform: translateY(1px);
+      box-shadow: inset 0 2px 6px rgba(var(--c-black), 0.6), inset 0 1px 0 rgba(var(--c-white), 0.04);
+    }
+
+    /* ---------- the hero plate (Press inquiries) ---------- */
+    .btn--hero {
+      min-height: 66px;
+      margin-bottom: clamp(14px, 3vw, 20px);
+      border-radius: var(--r-md);
+      overflow: hidden;
+      border: 1px solid var(--hero-border);
+      color: var(--ink-on-gold);
+      background: linear-gradient(180deg, var(--hero-top) 0%, var(--hero-mid) 42%, var(--hero-bottom) 100%);
+      box-shadow:
+        inset 0 1px 0 rgba(var(--c-white), 0.55),
+        inset 0 -3px 0 rgba(var(--c-hero-shade), 0.55),
+        0 6px 0 var(--hero-lip),
+        0 10px 28px rgba(var(--c-black), 0.5),
+        0 0 30px rgba(var(--c-gold), 0.24);
+      animation: breathe 3.2s ease-in-out infinite;
+    }
+    .btn--hero .btn__icon {
+      width: 44px;
+      height: 44px;
+      border-color: rgba(var(--c-hero-shade), 0.5);
+      background: radial-gradient(120% 120% at 50% 35%, rgba(var(--c-white), 0.45), rgba(var(--c-hero-low), 0.25));
+      color: var(--ink-on-gold);
+      box-shadow: inset 0 1px 0 rgba(var(--c-white), 0.5);
+    }
+    .btn--hero .btn__icon .ic { width: 28px; height: 28px; }
+    .btn--hero .btn__label {
+      font-family: var(--font-display);
+      font-weight: 800;
+      font-size: clamp(17px, 4.2vw, 22px);
+      letter-spacing: 0.04em;
+      line-height: 1.1;
+      color: var(--ink-on-gold);
+      text-shadow: 0 1px 0 rgba(var(--c-white), 0.35);
+      /* The hero label wraps instead of truncating on very narrow phones
+         (overrides the nowrap/ellipsis shared with the secondary rows). */
+      white-space: normal;
+      overflow: visible;
+      text-overflow: clip;
+    }
+    .btn--hero .btn__handle { color: rgba(var(--c-ink-dark), 0.82); font-style: normal; }
+    .btn--hero .btn__chev { color: var(--ink-on-gold); opacity: 0.6; }
+
+    /* Sheen sweep across the gilded plate. */
+    .btn--hero::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 40%;
+      transform: skewX(-18deg) translateX(-160%);
+      background: linear-gradient(90deg, transparent, rgba(var(--c-white), 0.5), transparent);
+      animation: sheen 4.5s var(--ease) infinite;
+      pointer-events: none;
+    }
+    @keyframes sheen {
+      0% { transform: skewX(-18deg) translateX(-160%); }
+      55%, 100% { transform: skewX(-18deg) translateX(360%); }
+    }
+    @keyframes breathe {
+      0%, 100% {
+        box-shadow:
+          inset 0 1px 0 rgba(var(--c-white), 0.55),
+          inset 0 -3px 0 rgba(var(--c-hero-shade), 0.55),
+          0 6px 0 var(--hero-lip),
+          0 10px 28px rgba(var(--c-black), 0.5),
+          0 0 26px rgba(var(--c-gold), 0.22);
+      }
+      50% {
+        box-shadow:
+          inset 0 1px 0 rgba(var(--c-white), 0.55),
+          inset 0 -3px 0 rgba(var(--c-hero-shade), 0.55),
+          0 6px 0 var(--hero-lip),
+          0 10px 28px rgba(var(--c-black), 0.5),
+          0 0 40px rgba(var(--c-gold), 0.40);
+      }
+    }
+    @media (hover: hover) {
+      .btn--hero:hover { filter: brightness(1.04); transform: translateY(-2px); }
+    }
+    .btn--hero:focus-visible { outline: 2px solid var(--gold-soft); outline-offset: 3px; }
+    .btn--hero:active {
+      transform: translateY(4px);
+      box-shadow:
+        inset 0 1px 0 rgba(var(--c-white), 0.55),
+        inset 0 -2px 0 rgba(var(--c-hero-shade), 0.55),
+        0 2px 0 var(--hero-lip),
+        0 4px 14px rgba(var(--c-black), 0.5),
+        0 0 30px rgba(var(--c-gold), 0.3);
+    }
+
+    /* ---------- footer ---------- */
+    .foot {
+      margin-top: clamp(18px, 3.5vw, 24px);
+      padding-top: var(--sp-3);
+      border-top: 1px solid var(--line-soft);
+      text-align: center;
+    }
+    .foot__note {
+      margin: 0 0 6px;
+      font-family: var(--font-serif);
+      font-style: italic;
+      font-size: 13px;
+      color: var(--muted-safe);
+    }
+    .foot__copy {
+      margin: 0;
+      font-family: var(--font-ui);
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      color: var(--muted-safe);
+      opacity: 0.85;
+    }
+
+    /* ---------- small screens ---------- */
+    @media (max-width: 560px) {
+      .console { padding: 22px 16px; }
+      .logo { width: 86%; }
+      body { background-position: center; }
+    }
+
+    /* ---------- user preferences ---------- */
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+        scroll-behavior: auto !important;
+      }
+    }
+
+    @media (prefers-contrast: more) {
+      body { background: var(--bg-1); }
+      body::before, body::after { display: none; }
+      .console {
+        background: var(--bg-1);
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+        border-color: var(--gold-soft);
+      }
+      h1.title {
+        background: none;
+        -webkit-text-fill-color: var(--gold-soft);
+        color: var(--gold-soft);
+      }
+      .ward { background: rgba(var(--c-black), 0.5); border-color: var(--gold-soft); }
+      .item, .btn { border-color: var(--gold-dim); }
+    }
+
+    @media (forced-colors: active) {
+      .console::before, body::before, body::after { display: none; }
+      h1.title {
+        background: none;
+        -webkit-text-fill-color: CanvasText;
+        color: CanvasText;
+      }
+      .item, .btn { border-color: CanvasText; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#menu" data-i18n="skip">Skip to press contact</a>
+
+  <main class="console" aria-labelledby="title">
+    <header class="crest">
+      <img class="logo" src="/worldofclaudecraft-logo.png" alt="World of ClaudeCraft" data-i18n-alt="logoAlt" />
+      <p class="eyebrow" data-i18n="eyebrow">Press</p>
+      <h1 id="title" class="title" data-i18n="heading">Press Kit Coming Soon</h1>
+      <p class="badge"><span class="badge__dot" aria-hidden="true"></span><span data-i18n="badge">Coming soon</span></p>
+      <p class="tagline" data-i18n="tagline">The official World of ClaudeCraft press kit is being assembled. For press inquiries today, reach the team directly.</p>
+      <div class="rule" aria-hidden="true"></div>
+    </header>
+
+    <section class="ward" role="note" aria-labelledby="ward-title">
+      <svg class="ward__sigil" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+        <path d="M12 2.5 19 5v6c0 4.6-3.1 7.9-7 9.8C8.1 18.9 5 15.6 5 11V5l7-2.5Z" />
+        <path d="m8.7 11.7 2.4 2.4 4.3-4.8" />
+      </svg>
+      <div>
+        <h2 id="ward-title" class="ward__title" data-i18n="wardTitle">Trust only official statements.</h2>
+        <p class="ward__body" data-i18n-html="wardBody">Official announcements come only from the channels listed on our official links page. Anyone issuing a 'statement' or asking for money or accounts in our name anywhere else is an <strong>impersonator</strong>. Report them to the mods.</p>
+      </div>
+    </section>
+
+    <section class="preview" aria-labelledby="preview-title">
+      <h2 id="preview-title" class="preview__head" data-i18n="previewTitle">In the kit</h2>
+      <ul class="items">
+        <li class="item">
+          <span class="item__icon" aria-hidden="true">
+            <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" focusable="false"><rect x="5" y="3" width="14" height="18" rx="1"/><path d="M8 7h8M8 11h8M8 15h5"/></svg>
+          </span>
+          <span class="item__text">
+            <span class="item__label" data-i18n="itemFactLabel">Fact Sheet</span>
+            <span class="item__desc" data-i18n="itemFactDesc">Key facts about the game</span>
+          </span>
+          <span class="item__tag" data-i18n="itemTag">Soon</span>
+        </li>
+        <li class="item">
+          <span class="item__icon" aria-hidden="true">
+            <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M12 3.5 14.6 9l6 .5-4.6 3.9 1.5 5.9L12 16.9 6.5 19.3 8 13.4 3.4 9.5l6-.5L12 3.5Z"/></svg>
+          </span>
+          <span class="item__text">
+            <span class="item__label" data-i18n="itemAssetsLabel">Logos &amp; Brand Assets</span>
+            <span class="item__desc" data-i18n="itemAssetsDesc">Logos in every format</span>
+          </span>
+          <span class="item__tag" data-i18n="itemTag">Soon</span>
+        </li>
+        <li class="item">
+          <span class="item__icon" aria-hidden="true">
+            <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" focusable="false"><rect x="3" y="5" width="18" height="14" rx="2"/><circle cx="9" cy="11" r="2"/><path d="m5 18 4-3 3 2 3-3 4 4"/></svg>
+          </span>
+          <span class="item__text">
+            <span class="item__label" data-i18n="itemMediaLabel">Screenshots &amp; Trailers</span>
+            <span class="item__desc" data-i18n="itemMediaDesc">High-res captures and video</span>
+          </span>
+          <span class="item__tag" data-i18n="itemTag">Soon</span>
+        </li>
+        <li class="item">
+          <span class="item__icon" aria-hidden="true">
+            <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" focusable="false"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m4 7 8 6 8-6"/></svg>
+          </span>
+          <span class="item__text">
+            <span class="item__label" data-i18n="itemContactLabel">Press Contact</span>
+            <span class="item__desc" data-i18n="itemContactDesc">A direct line to the team</span>
+          </span>
+          <span class="item__tag" data-i18n="itemTag">Soon</span>
+        </li>
+      </ul>
+    </section>
+
+    <nav id="menu" class="menu" tabindex="-1" aria-label="Press actions" data-i18n-aria="menuLabel">
+      <a class="btn btn--hero" href="mailto:woc@levystreet.com?subject=Press%20inquiry%20-%20World%20of%20ClaudeCraft">
+        <span class="btn__icon" aria-hidden="true">
+          <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" focusable="false"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="m4 7 8 6 8-6"/></svg>
+        </span>
+        <span class="btn__text">
+          <span class="btn__label" data-i18n="contactLabel">Press Inquiries</span>
+          <span class="btn__handle" data-i18n="contactSub">woc@levystreet.com</span>
+        </span>
+        <span class="btn__chev" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9 6l6 6-6 6"/></svg>
+        </span>
+      </a>
+
+      <ul class="rows">
+        <li>
+          <a class="btn btn--row" href="https://worldofclaudecraft.com/links" target="_blank" rel="noopener noreferrer">
+            <span class="btn__icon" aria-hidden="true">
+              <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" focusable="false"><path d="M12 3.5 14.6 9l6 .5-4.6 3.9 1.5 5.9L12 16.9 6.5 19.3 8 13.4 3.4 9.5l6-.5L12 3.5Z"/></svg>
+            </span>
+            <span class="btn__text">
+              <span class="btn__label" data-i18n="followLabel">Official Channels</span>
+              <span class="btn__handle" data-i18n="followSub">worldofclaudecraft.com/links</span>
+            </span>
+            <span class="btn__chev" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9 6l6 6-6 6"/></svg>
+            </span>
+            <span class="sr-only" data-i18n="opensNewTab"> (opens in new tab)</span>
+          </a>
+        </li>
+        <li>
+          <a class="btn btn--row" href="https://worldofclaudecraft.com/" target="_blank" rel="noopener noreferrer">
+            <span class="btn__icon" aria-hidden="true">
+              <svg class="ic" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false"><path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2Zm0 1.5a8.5 8.5 0 1 1 0 17 8.5 8.5 0 0 1 0-17Z"/><path d="M10 8.25v7.5a.5.5 0 0 0 .76.43l6.2-3.75a.5.5 0 0 0 0-.86l-6.2-3.75A.5.5 0 0 0 10 8.25Z"/></svg>
+            </span>
+            <span class="btn__text">
+              <span class="btn__label" data-i18n="playLabel">Play the Game</span>
+              <span class="btn__handle" data-i18n="playSub">worldofclaudecraft.com</span>
+            </span>
+            <span class="btn__chev" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false"><path d="M9 6l6 6-6 6"/></svg>
+            </span>
+            <span class="sr-only" data-i18n="opensNewTab"> (opens in new tab)</span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+
+    <footer class="foot">
+      <p class="foot__note" data-i18n="footNote">No press kit is live yet. Any 'official statement' not from our channels is not us.</p>
+      <p class="foot__copy" data-i18n="copyright">2026 World of ClaudeCraft</p>
+    </footer>
+  </main>
+
+  <script>
+    (() => {
+      // Self-contained 14-locale copy map. These standalone pages ship outside the
+      // app bundle, so they do NOT use t(); every locale must be filled here in the
+      // same change (no build-time English-fill backstop). The loader only writes a
+      // key when present, so a missing locale would silently leak the English default.
+      const copy = {
+        en: {
+          pageTitle: "World of ClaudeCraft - Press",
+          metaDescription: "The World of ClaudeCraft press kit is coming soon. For press inquiries, contact woc@levystreet.com. If a statement is not on our official channels, it is not us.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Skip to press contact",
+          eyebrow: "Press",
+          heading: "Press Kit Coming Soon",
+          badge: "Coming soon",
+          tagline: "The official World of ClaudeCraft press kit is being assembled. For press inquiries today, reach the team directly.",
+          wardTitle: "Trust only official statements.",
+          wardBody: "Official announcements come only from the channels listed on our official links page. Anyone issuing a 'statement' or asking for money or accounts in our name anywhere else is an <strong>impersonator</strong>. Report them to the mods.",
+          previewTitle: "In the kit",
+          itemFactLabel: "Fact Sheet",
+          itemFactDesc: "Key facts about the game",
+          itemAssetsLabel: "Logos & Brand Assets",
+          itemAssetsDesc: "Logos in every format",
+          itemMediaLabel: "Screenshots & Trailers",
+          itemMediaDesc: "High-res captures and video",
+          itemContactLabel: "Press Contact",
+          itemContactDesc: "A direct line to the team",
+          itemTag: "Soon",
+          menuLabel: "Press actions",
+          contactLabel: "Press Inquiries",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Official Channels",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Play the Game",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (opens in new tab)",
+          footNote: "No press kit is live yet. Any 'official statement' not from our channels is not us.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        es: {
+          pageTitle: "World of ClaudeCraft - Prensa",
+          metaDescription: "El kit de prensa oficial de World of ClaudeCraft llegará pronto. Para consultas de prensa, escribe a woc@levystreet.com. Si una declaración no está en nuestros canales oficiales, no somos nosotros.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Saltar al contacto de prensa",
+          eyebrow: "Prensa",
+          heading: "Kit de prensa próximamente",
+          badge: "Próximamente",
+          tagline: "El kit de prensa oficial de World of ClaudeCraft se está preparando. Para consultas de prensa hoy, contacta directamente con el equipo.",
+          wardTitle: "Confía solo en declaraciones oficiales.",
+          wardBody: "Los anuncios oficiales provienen únicamente de los canales que figuran en nuestra página de enlaces oficiales. Cualquiera que emita una 'declaración' o pida dinero o cuentas en nuestro nombre en otro lugar es un <strong>impostor</strong>. Repórtalo ante los moderadores.",
+          previewTitle: "En el kit",
+          itemFactLabel: "Ficha técnica",
+          itemFactDesc: "Datos clave sobre el juego",
+          itemAssetsLabel: "Logotipos y recursos de marca",
+          itemAssetsDesc: "Logotipos en todos los formatos",
+          itemMediaLabel: "Capturas y tráileres",
+          itemMediaDesc: "Imágenes en alta resolución y vídeo",
+          itemContactLabel: "Contacto de prensa",
+          itemContactDesc: "Una línea directa con el equipo",
+          itemTag: "Pronto",
+          menuLabel: "Acciones de prensa",
+          contactLabel: "Consultas de prensa",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Canales oficiales",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Juega ahora",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (se abre en una pestaña nueva)",
+          footNote: "Todavía no hay ningún kit de prensa activo. Cualquier 'declaración oficial' que no provenga de nuestros canales no somos nosotros.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        es_ES: {
+          pageTitle: "World of ClaudeCraft - Prensa",
+          metaDescription: "El kit de prensa oficial de World of ClaudeCraft llegará pronto. Para consultas de prensa, escribe a woc@levystreet.com. Si una declaración no está en nuestros canales oficiales, no somos nosotros.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Saltar al contacto de prensa",
+          eyebrow: "Prensa",
+          heading: "Kit de prensa próximamente",
+          badge: "Próximamente",
+          tagline: "El kit de prensa oficial de World of ClaudeCraft se está preparando. Para consultas de prensa hoy, ponte en contacto directamente con el equipo.",
+          wardTitle: "Confía solo en declaraciones oficiales.",
+          wardBody: "Los anuncios oficiales proceden únicamente de los canales que aparecen en nuestra página de enlaces oficiales. Cualquiera que emita una 'declaración' o pida dinero o cuentas en nuestro nombre en otro sitio es un <strong>impostor</strong>. Denúncialo a los moderadores.",
+          previewTitle: "En el kit",
+          itemFactLabel: "Ficha técnica",
+          itemFactDesc: "Datos clave sobre el juego",
+          itemAssetsLabel: "Logotipos y recursos de marca",
+          itemAssetsDesc: "Logotipos en todos los formatos",
+          itemMediaLabel: "Capturas y tráileres",
+          itemMediaDesc: "Imágenes en alta resolución y vídeo",
+          itemContactLabel: "Contacto de prensa",
+          itemContactDesc: "Una línea directa con el equipo",
+          itemTag: "Pronto",
+          menuLabel: "Acciones de prensa",
+          contactLabel: "Consultas de prensa",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Canales oficiales",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Jugar",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (se abre en una pestaña nueva)",
+          footNote: "Todavía no hay ningún kit de prensa activo. Cualquier 'declaración oficial' que no proceda de nuestros canales no somos nosotros.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        fr_FR: {
+          pageTitle: "World of ClaudeCraft - Presse",
+          metaDescription: "Le kit presse officiel de World of ClaudeCraft arrive bientôt. Pour toute demande presse, contactez woc@levystreet.com. Si une déclaration ne figure pas sur nos canaux officiels, ce n'est pas nous.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Aller au contact presse",
+          eyebrow: "Presse",
+          heading: "Kit presse bientôt disponible",
+          badge: "Bientôt disponible",
+          tagline: "Le kit presse officiel de World of ClaudeCraft est en préparation. Pour toute demande presse dès aujourd'hui, contactez directement l'équipe.",
+          wardTitle: "Ne vous fiez qu'aux déclarations officielles.",
+          wardBody: "Les annonces officielles proviennent uniquement des canaux figurant sur notre page de liens officiels. Quiconque publie une 'déclaration' ou demande de l'argent ou des comptes en notre nom ailleurs est un <strong>imposteur</strong>. Signalez-le aux modérateurs.",
+          previewTitle: "Dans le kit",
+          itemFactLabel: "Fiche d'information",
+          itemFactDesc: "Les faits essentiels sur le jeu",
+          itemAssetsLabel: "Logos et éléments de marque",
+          itemAssetsDesc: "Logos dans tous les formats",
+          itemMediaLabel: "Captures et bandes-annonces",
+          itemMediaDesc: "Captures haute résolution et vidéo",
+          itemContactLabel: "Contact presse",
+          itemContactDesc: "Une ligne directe avec l'équipe",
+          itemTag: "Bientôt",
+          menuLabel: "Actions presse",
+          contactLabel: "Demandes presse",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Canaux officiels",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Jouer",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (s'ouvre dans un nouvel onglet)",
+          footNote: "Aucun kit presse n'est encore en ligne. Toute 'déclaration officielle' qui ne provient pas de nos canaux n'est pas de nous.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        fr_CA: {
+          pageTitle: "World of ClaudeCraft - Presse",
+          metaDescription: "La trousse de presse officielle de World of ClaudeCraft arrive bientôt. Pour toute demande des médias, écrivez à woc@levystreet.com. Si une déclaration ne figure pas sur nos canaux officiels, ce n'est pas nous.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Aller au contact presse",
+          eyebrow: "Presse",
+          heading: "Trousse de presse bientôt disponible",
+          badge: "Bientôt disponible",
+          tagline: "La trousse de presse officielle de World of ClaudeCraft est en préparation. Pour toute demande des médias dès aujourd'hui, contactez directement l'équipe.",
+          wardTitle: "Ne vous fiez qu'aux déclarations officielles.",
+          wardBody: "Les annonces officielles proviennent uniquement des canaux figurant sur notre page de liens officiels. Quiconque publie une 'déclaration' ou demande de l'argent ou des comptes en notre nom ailleurs est un <strong>imposteur</strong>. Signalez-le aux modérateurs.",
+          previewTitle: "Dans la trousse",
+          itemFactLabel: "Fiche d'information",
+          itemFactDesc: "Les faits essentiels sur le jeu",
+          itemAssetsLabel: "Logos et éléments de marque",
+          itemAssetsDesc: "Logos dans tous les formats",
+          itemMediaLabel: "Captures et bandes-annonces",
+          itemMediaDesc: "Captures haute résolution et vidéo",
+          itemContactLabel: "Contact presse",
+          itemContactDesc: "Une ligne directe avec l'équipe",
+          itemTag: "Bientôt",
+          menuLabel: "Actions presse",
+          contactLabel: "Demandes des médias",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Canaux officiels",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Jouer",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (s'ouvre dans un nouvel onglet)",
+          footNote: "Aucune trousse de presse n'est encore en ligne. Toute 'déclaration officielle' qui ne provient pas de nos canaux n'est pas de nous.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        en_CA: {
+          pageTitle: "World of ClaudeCraft - Press",
+          metaDescription: "The World of ClaudeCraft press kit is coming soon. For press inquiries, contact woc@levystreet.com. If a statement is not on our official channels, it is not us.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Skip to press contact",
+          eyebrow: "Press",
+          heading: "Press Kit Coming Soon",
+          badge: "Coming soon",
+          tagline: "The official World of ClaudeCraft press kit is being assembled. For press inquiries today, reach the team directly.",
+          wardTitle: "Trust only official statements.",
+          wardBody: "Official announcements come only from the channels listed on our official links page. Anyone issuing a 'statement' or asking for money or accounts in our name anywhere else is an <strong>impersonator</strong>. Report them to the mods.",
+          previewTitle: "In the kit",
+          itemFactLabel: "Fact Sheet",
+          itemFactDesc: "Key facts about the game",
+          itemAssetsLabel: "Logos & Brand Assets",
+          itemAssetsDesc: "Logos in every format",
+          itemMediaLabel: "Screenshots & Trailers",
+          itemMediaDesc: "High-res captures and video",
+          itemContactLabel: "Press Contact",
+          itemContactDesc: "A direct line to the team",
+          itemTag: "Soon",
+          menuLabel: "Press actions",
+          contactLabel: "Press Inquiries",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Official Channels",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Play the Game",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (opens in new tab)",
+          footNote: "No press kit is live yet. Any 'official statement' not from our channels is not us.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        it_IT: {
+          pageTitle: "World of ClaudeCraft - Stampa",
+          metaDescription: "Il kit stampa ufficiale di World of ClaudeCraft sta arrivando. Per richieste stampa, scrivi a woc@levystreet.com. Se una dichiarazione non è sui nostri canali ufficiali, non siamo noi.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Vai al contatto stampa",
+          eyebrow: "Stampa",
+          heading: "Kit stampa in arrivo",
+          badge: "In arrivo",
+          tagline: "Il kit stampa ufficiale di World of ClaudeCraft è in preparazione. Per richieste stampa oggi, contatta direttamente il team.",
+          wardTitle: "Fidati solo delle dichiarazioni ufficiali.",
+          wardBody: "Gli annunci ufficiali provengono solo dai canali elencati nella nostra pagina dei link ufficiali. Chiunque diffonda una 'dichiarazione' o chieda denaro o account a nome nostro altrove è un <strong>impostore</strong>. Segnalalo ai moderatori.",
+          previewTitle: "Nel kit",
+          itemFactLabel: "Scheda informativa",
+          itemFactDesc: "Dati chiave sul gioco",
+          itemAssetsLabel: "Loghi e risorse del marchio",
+          itemAssetsDesc: "Loghi in ogni formato",
+          itemMediaLabel: "Screenshot e trailer",
+          itemMediaDesc: "Immagini ad alta risoluzione e video",
+          itemContactLabel: "Contatto stampa",
+          itemContactDesc: "Una linea diretta con il team",
+          itemTag: "Presto",
+          menuLabel: "Azioni stampa",
+          contactLabel: "Richieste stampa",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Canali ufficiali",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Gioca ora",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (si apre in una nuova scheda)",
+          footNote: "Nessun kit stampa è ancora attivo. Qualsiasi 'dichiarazione ufficiale' che non provenga dai nostri canali non siamo noi.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        de_DE: {
+          pageTitle: "World of ClaudeCraft - Presse",
+          metaDescription: "Das offizielle Pressekit von World of ClaudeCraft kommt bald. Für Presseanfragen kontaktiere woc@levystreet.com. Wenn eine Aussage nicht auf unseren offiziellen Kanälen steht, sind wir es nicht.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Zum Pressekontakt springen",
+          eyebrow: "Presse",
+          heading: "Pressekit kommt bald",
+          badge: "Demnächst",
+          tagline: "Das offizielle Pressekit von World of ClaudeCraft wird gerade zusammengestellt. Für Presseanfragen erreichst du das Team schon heute direkt.",
+          wardTitle: "Vertraue nur offiziellen Aussagen.",
+          wardBody: "Offizielle Ankündigungen kommen ausschließlich von den Kanälen, die auf unserer offiziellen Linkseite aufgeführt sind. Wer anderswo eine 'Erklärung' abgibt oder in unserem Namen Geld oder Konten verlangt, ist ein <strong>Betrüger</strong>. Melde ihn den Moderatoren.",
+          previewTitle: "Im Kit",
+          itemFactLabel: "Datenblatt",
+          itemFactDesc: "Die wichtigsten Fakten zum Spiel",
+          itemAssetsLabel: "Logos & Markenmaterial",
+          itemAssetsDesc: "Logos in jedem Format",
+          itemMediaLabel: "Screenshots & Trailer",
+          itemMediaDesc: "Hochauflösende Aufnahmen und Video",
+          itemContactLabel: "Pressekontakt",
+          itemContactDesc: "Eine direkte Leitung zum Team",
+          itemTag: "Bald",
+          menuLabel: "Presseaktionen",
+          contactLabel: "Presseanfragen",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Offizielle Kanäle",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Jetzt spielen",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (wird in einem neuen Tab geöffnet)",
+          footNote: "Es ist noch kein Pressekit live. Jede 'offizielle Aussage', die nicht von unseren Kanälen stammt, sind nicht wir.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        zh_CN: {
+          pageTitle: "World of ClaudeCraft - 媒体",
+          metaDescription: "World of ClaudeCraft 官方媒体资料包即将推出。媒体咨询请联系 woc@levystreet.com。若某声明未出现在我们的官方渠道，那就不是我们。",
+          logoAlt: "World of ClaudeCraft",
+          skip: "跳至媒体联系",
+          eyebrow: "媒体",
+          heading: "媒体资料包即将推出",
+          badge: "敬请期待",
+          tagline: "World of ClaudeCraft 官方媒体资料包正在筹备中。如有媒体咨询，今天即可直接联系团队。",
+          wardTitle: "只相信官方声明。",
+          wardBody: "官方公告仅来自我们官方链接页面所列的渠道。任何在其他地方以我们名义发布'声明'或索要金钱或账号的人都是<strong>冒充者</strong>。请向版主举报。",
+          previewTitle: "资料包内容",
+          itemFactLabel: "概况说明",
+          itemFactDesc: "关于游戏的关键事实",
+          itemAssetsLabel: "标志与品牌素材",
+          itemAssetsDesc: "各种格式的标志",
+          itemMediaLabel: "截图与预告片",
+          itemMediaDesc: "高清截图与视频",
+          itemContactLabel: "媒体联系",
+          itemContactDesc: "直接联系团队",
+          itemTag: "即将",
+          menuLabel: "媒体操作",
+          contactLabel: "媒体咨询",
+          contactSub: "woc@levystreet.com",
+          followLabel: "官方渠道",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "开始游戏",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: "（在新标签页中打开）",
+          footNote: "目前尚无媒体资料包上线。任何并非来自我们渠道的'官方声明'都不是我们。",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        zh_TW: {
+          pageTitle: "World of ClaudeCraft - 媒體",
+          metaDescription: "World of ClaudeCraft 官方媒體資料包即將推出。媒體洽詢請聯絡 woc@levystreet.com。若某聲明未出現在我們的官方管道，那就不是我們。",
+          logoAlt: "World of ClaudeCraft",
+          skip: "跳至媒體聯絡",
+          eyebrow: "媒體",
+          heading: "媒體資料包即將推出",
+          badge: "敬請期待",
+          tagline: "World of ClaudeCraft 官方媒體資料包正在籌備中。如有媒體洽詢，今天即可直接聯絡團隊。",
+          wardTitle: "只相信官方聲明。",
+          wardBody: "官方公告僅來自我們官方連結頁面所列的管道。任何在其他地方以我們名義發布'聲明'或索取金錢或帳號的人都是<strong>冒充者</strong>。請向版主檢舉。",
+          previewTitle: "資料包內容",
+          itemFactLabel: "概況說明",
+          itemFactDesc: "關於遊戲的關鍵資訊",
+          itemAssetsLabel: "標誌與品牌素材",
+          itemAssetsDesc: "各種格式的標誌",
+          itemMediaLabel: "截圖與預告片",
+          itemMediaDesc: "高解析度截圖與影片",
+          itemContactLabel: "媒體聯絡",
+          itemContactDesc: "直接聯絡團隊",
+          itemTag: "即將",
+          menuLabel: "媒體操作",
+          contactLabel: "媒體洽詢",
+          contactSub: "woc@levystreet.com",
+          followLabel: "官方管道",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "開始遊戲",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: "（在新分頁中開啟）",
+          footNote: "目前尚無媒體資料包上線。任何並非來自我們管道的'官方聲明'都不是我們。",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        ko_KR: {
+          pageTitle: "World of ClaudeCraft - 보도",
+          metaDescription: "World of ClaudeCraft 공식 보도 자료집이 곧 공개됩니다. 보도 문의는 woc@levystreet.com으로 연락하세요. 공식 채널에 없는 발표라면 저희가 아닙니다.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "보도 연락처로 건너뛰기",
+          eyebrow: "보도",
+          heading: "보도 자료집 준비 중",
+          badge: "곧 공개",
+          tagline: "World of ClaudeCraft 공식 보도 자료집을 준비하고 있습니다. 보도 문의는 지금 바로 팀에 직접 연락하세요.",
+          wardTitle: "공식 발표만 신뢰하세요.",
+          wardBody: "공식 발표는 공식 링크 페이지에 나열된 채널에서만 나옵니다. 다른 곳에서 저희 이름으로 '성명'을 내거나 돈이나 계정을 요구하는 사람은 <strong>사칭자</strong>입니다. 운영진에게 신고하세요.",
+          previewTitle: "자료집 구성",
+          itemFactLabel: "팩트 시트",
+          itemFactDesc: "게임에 대한 핵심 정보",
+          itemAssetsLabel: "로고 및 브랜드 자료",
+          itemAssetsDesc: "모든 형식의 로고",
+          itemMediaLabel: "스크린샷 및 트레일러",
+          itemMediaDesc: "고해상도 캡처와 영상",
+          itemContactLabel: "보도 연락처",
+          itemContactDesc: "팀과의 직접 연결",
+          itemTag: "곧",
+          menuLabel: "보도 작업",
+          contactLabel: "보도 문의",
+          contactSub: "woc@levystreet.com",
+          followLabel: "공식 채널",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "게임 플레이",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (새 탭에서 열림)",
+          footNote: "아직 공개된 보도 자료집이 없습니다. 저희 채널에서 나오지 않은 '공식 성명'은 저희가 아닙니다.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        ja_JP: {
+          pageTitle: "World of ClaudeCraft - プレス",
+          metaDescription: "World of ClaudeCraft の公式プレスキットは近日公開予定です。報道関係のお問い合わせは woc@levystreet.com まで。公式チャンネル以外の発表は当方ではありません。",
+          logoAlt: "World of ClaudeCraft",
+          skip: "プレス連絡先へスキップ",
+          eyebrow: "プレス",
+          heading: "プレスキットは近日公開",
+          badge: "近日公開",
+          tagline: "World of ClaudeCraft の公式プレスキットを準備中です。報道関係のお問い合わせは、今すぐチームへ直接ご連絡ください。",
+          wardTitle: "公式発表のみを信頼してください。",
+          wardBody: "公式発表は、公式リンクページに記載されたチャンネルからのみ行われます。それ以外の場所で当方を名乗って'声明'を出したり、金銭やアカウントを要求したりする者は<strong>なりすまし</strong>です。モデレーターに報告してください。",
+          previewTitle: "キットの内容",
+          itemFactLabel: "ファクトシート",
+          itemFactDesc: "ゲームの主要情報",
+          itemAssetsLabel: "ロゴとブランド素材",
+          itemAssetsDesc: "あらゆる形式のロゴ",
+          itemMediaLabel: "スクリーンショットとトレーラー",
+          itemMediaDesc: "高解像度の画像と動画",
+          itemContactLabel: "プレス連絡先",
+          itemContactDesc: "チームへの直通窓口",
+          itemTag: "近日",
+          menuLabel: "プレス操作",
+          contactLabel: "報道関係のお問い合わせ",
+          contactSub: "woc@levystreet.com",
+          followLabel: "公式チャンネル",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "ゲームをプレイ",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: "（新しいタブで開きます）",
+          footNote: "プレスキットはまだ公開されていません。当方のチャンネル以外の'公式声明'は当方ではありません。",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        pt_BR: {
+          pageTitle: "World of ClaudeCraft - Imprensa",
+          metaDescription: "O kit de imprensa oficial de World of ClaudeCraft está chegando. Para consultas de imprensa, contate woc@levystreet.com. Se uma declaração não estiver em nossos canais oficiais, não somos nós.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Pular para o contato de imprensa",
+          eyebrow: "Imprensa",
+          heading: "Kit de imprensa em breve",
+          badge: "Em breve",
+          tagline: "O kit de imprensa oficial de World of ClaudeCraft está sendo montado. Para consultas de imprensa hoje, fale diretamente com a equipe.",
+          wardTitle: "Confie apenas em declarações oficiais.",
+          wardBody: "Os anúncios oficiais vêm apenas dos canais listados em nossa página de links oficiais. Quem emite uma 'declaração' ou pede dinheiro ou contas em nosso nome em qualquer outro lugar é um <strong>impostor</strong>. Denuncie aos moderadores.",
+          previewTitle: "No kit",
+          itemFactLabel: "Ficha técnica",
+          itemFactDesc: "Fatos principais sobre o jogo",
+          itemAssetsLabel: "Logotipos e recursos da marca",
+          itemAssetsDesc: "Logotipos em todos os formatos",
+          itemMediaLabel: "Capturas e trailers",
+          itemMediaDesc: "Imagens em alta resolução e vídeo",
+          itemContactLabel: "Contato de imprensa",
+          itemContactDesc: "Uma linha direta com a equipe",
+          itemTag: "Em breve",
+          menuLabel: "Ações de imprensa",
+          contactLabel: "Consultas de imprensa",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Canais oficiais",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Jogar",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (abre em uma nova aba)",
+          footNote: "Nenhum kit de imprensa está ativo ainda. Qualquer 'declaração oficial' que não venha dos nossos canais não somos nós.",
+          copyright: "2026 World of ClaudeCraft"
+        },
+        ru_RU: {
+          pageTitle: "World of ClaudeCraft - Пресса",
+          metaDescription: "Официальный пресс-кит World of ClaudeCraft скоро появится. По вопросам прессы пишите на woc@levystreet.com. Если заявление не размещено на наших официальных каналах, это не мы.",
+          logoAlt: "World of ClaudeCraft",
+          skip: "Перейти к контактам для прессы",
+          eyebrow: "Пресса",
+          heading: "Пресс-кит скоро будет",
+          badge: "Скоро",
+          tagline: "Официальный пресс-кит World of ClaudeCraft сейчас готовится. По вопросам прессы уже сегодня свяжитесь с командой напрямую.",
+          wardTitle: "Доверяйте только официальным заявлениям.",
+          wardBody: "Официальные объявления публикуются только на каналах, указанных на нашей официальной странице ссылок. Любой, кто публикует 'заявление' или просит деньги либо аккаунты от нашего имени где-либо ещё, является <strong>самозванцем</strong>. Сообщите о нём модераторам.",
+          previewTitle: "В пресс-ките",
+          itemFactLabel: "Сводка фактов",
+          itemFactDesc: "Ключевые сведения об игре",
+          itemAssetsLabel: "Логотипы и фирменные материалы",
+          itemAssetsDesc: "Логотипы во всех форматах",
+          itemMediaLabel: "Скриншоты и трейлеры",
+          itemMediaDesc: "Изображения высокого разрешения и видео",
+          itemContactLabel: "Контакт для прессы",
+          itemContactDesc: "Прямая связь с командой",
+          itemTag: "Скоро",
+          menuLabel: "Действия для прессы",
+          contactLabel: "Запросы прессы",
+          contactSub: "woc@levystreet.com",
+          followLabel: "Официальные каналы",
+          followSub: "worldofclaudecraft.com/links",
+          playLabel: "Играть",
+          playSub: "worldofclaudecraft.com",
+          opensNewTab: " (откроется в новой вкладке)",
+          footNote: "Пресс-кит ещё не запущен. Любое 'официальное заявление' не с наших каналов - это не мы.",
+          copyright: "2026 World of ClaudeCraft"
+        }
+      };
+
+      const supported = Object.keys(copy);
+      const normalize = (value) => (value ? value.replace(/-/g, "_") : "");
+      const params = new URLSearchParams(window.location.search);
+      const requested = normalize(params.get("lang"));
+      let saved = "";
+      try { saved = normalize(localStorage.getItem("locale")); } catch (e) { saved = ""; }
+      const browser = normalize(navigator.language);
+      const language = supported.includes(requested)
+        ? requested
+        : supported.includes(saved)
+          ? saved
+          : supported.includes(browser)
+            ? browser
+            : "en";
+      const strings = copy[language] || copy.en;
+
+      document.documentElement.lang = language.replace(/_/g, "-");
+      if (strings.pageTitle) document.title = strings.pageTitle;
+
+      document.querySelectorAll("[data-i18n]").forEach((el) => {
+        const key = el.getAttribute("data-i18n");
+        if (key && strings[key] != null) el.textContent = strings[key];
+      });
+      document.querySelectorAll("[data-i18n-html]").forEach((el) => {
+        const key = el.getAttribute("data-i18n-html");
+        if (key && strings[key] != null) el.innerHTML = strings[key];
+      });
+      document.querySelectorAll("[data-i18n-alt]").forEach((el) => {
+        const key = el.getAttribute("data-i18n-alt");
+        if (key && strings[key] != null) el.setAttribute("alt", strings[key]);
+      });
+      document.querySelectorAll("[data-i18n-aria]").forEach((el) => {
+        const key = el.getAttribute("data-i18n-aria");
+        if (key && strings[key] != null) el.setAttribute("aria-label", strings[key]);
+      });
+      document.querySelectorAll("[data-i18n-content]").forEach((el) => {
+        const key = el.getAttribute("data-i18n-content");
+        if (key && strings[key] != null) el.setAttribute("content", strings[key]);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -16,6 +16,11 @@
     <priority>0.5</priority>
   </url>
   <url>
+    <loc>https://worldofclaudecraft.com/press</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
     <loc>https://worldofclaudecraft.com/play</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>

--- a/server/main.ts
+++ b/server/main.ts
@@ -168,6 +168,8 @@ const STATIC_PAGE_ALIASES = new Map([
   ['/terms/', '/terms.html'],
   ['/merch', '/merch.html'],
   ['/merch/', '/merch.html'],
+  ['/press', '/press.html'],
+  ['/press/', '/press.html'],
   ['/data-deletion', '/data-deletion.html'],
   ['/data-deletion/', '/data-deletion.html'],
   ['/support', '/support.html'],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -74,6 +74,8 @@ const STATIC_PAGE_ALIASES = new Map([
   ['/terms/', '/terms.html'],
   ['/merch', '/merch.html'],
   ['/merch/', '/merch.html'],
+  ['/press', '/press.html'],
+  ['/press/', '/press.html'],
   ['/data-deletion', '/data-deletion.html'],
   ['/data-deletion/', '/data-deletion.html'],
   ['/support', '/support.html'],


### PR DESCRIPTION
## What

Adds a standalone **Press** landing page served at `/press` (and `/press/`). It is a coming-soon press-kit shell: it leads with a press-inquiries contact, an anti-impersonator notice, and a preview of what the full kit will contain, so journalists landing today get a real contact point and the URL is ready for the full kit later.

It clones the exact self-contained recipe of `merch.html` so the realm's standalone pages stay one consistent set: inline CSS design system (shared `:root` tokens, Cinzel/Alegreya fonts, CRT/torch chrome), an inline **14-locale** i18n dictionary, and the same `data-i18n*` language auto-loader (`?lang=` then `localStorage` then `navigator.language` then `en`).

## How it's wired

```mermaid
flowchart LR
  U[Visitor hits /press] --> A{STATIC_PAGE_ALIASES}
  A -->|dev / preview| V[vite.config.ts rewrite]
  A -->|production| S[server/main.ts serveStatic]
  V --> H[public/press.html]
  S --> H
  H --> L[inline 14-locale loader<br/>?lang then localStorage<br/>then navigator.language then en]
  L --> R[localized page]
  SM[public/sitemap.xml] -.->|/press url| Crawl[search + answer engines]
```

Changes are additive only, no `src/` modules and no new Vite input:

- `public/press.html` - the page (HTML + inline CSS + inline i18n + loader)
- `vite.config.ts` and `server/main.ts` - add `/press` + `/press/` to `STATIC_PAGE_ALIASES` (dev and prod parity)
- `public/sitemap.xml` - add the `/press` URL (preserved byte-for-byte by `build_sitemap.mjs`)

## i18n

All 14 locales (`en, es, es_ES, fr_FR, fr_CA, en_CA, it_IT, de_DE, zh_CN, zh_TW, ko_KR, ja_JP, pt_BR, ru_RU`) are filled in the same change. Per `public/CLAUDE.md` these standalone pages have **no** build-time English-fill or `pending` gate, so a missing locale would silently leak English; a key/locale-completeness check confirmed all 30 keys exist in every locale and every `data-i18n*` DOM reference resolves.

## Verification

- `npm run build` green; `dist/press.html` emitted and `/press` preserved in `dist/sitemap.xml`
- `/press` returns HTTP 200 in dev via the alias
- Rendered at desktop, mobile, and `?lang=ja_JP` (title swaps to `World of ClaudeCraft - プレス`)

### Screenshots

Desktop:

![desktop](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-press/.prassets/press-desktop.png)

Mobile:

![mobile](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-press/.prassets/press-mobile.png)

Japanese (`?lang=ja_JP`):

![japanese](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-press/.prassets/press-ja.png)

## Notes / follow-ups

- Press contact reuses the existing official address `woc@levystreet.com` (same one `/support` uses) rather than introducing a new mailbox.
- Discoverable via `sitemap.xml`; intentionally not linked from `links.html` yet.
- Framed as "press kit coming soon" so it can grow into a full presskit()-style kit (fact sheet, brand assets, screenshots/trailers) at the same URL.

cc upstream maintainers with push access: @Rubsey @FernandoX7 @patrick261 @TrevCavill

🤖 Generated with [Claude Code](https://claude.com/claude-code)