### PR TITLE
fix(pvp): add diminishing returns to stuns (break chain-stun lock)

### DIFF
--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -19,6 +19,7 @@ import { recalcPlayerStats } from '../entity';
 import type { GroundAoE } from '../entity_roster';
 import type { PlayerMeta, ResolvedAbility } from '../sim';
 import type { SimContext } from '../sim_context';
+import { stunDrCategory } from '../stun_dr';
 import { addThreat } from '../threat';
 import type { AbilityDef, Entity } from '../types';
 import { armorReduction, meleeMissChance } from '../types';
@@ -132,7 +133,7 @@ export function runEffects(
         const dur = ctx.diminishedCrowdControlDuration(
           p,
           target,
-          'stun',
+          stunDrCategory(ability.id),
           eff.base + eff.perCombo * spentCombo,
         );
         if (dur === null) break;
@@ -306,7 +307,12 @@ export function runEffects(
       }
       case 'stun': {
         if (!target || target.dead) break;
-        const remaining = ctx.diminishedCrowdControlDuration(p, target, 'stun', eff.duration);
+        const remaining = ctx.diminishedCrowdControlDuration(
+          p,
+          target,
+          stunDrCategory(ability.id),
+          eff.duration,
+        );
         if (remaining === null) break;
         ctx.applyAura(target, {
           id: `${ability.id}_stun`,

--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -129,7 +129,13 @@ export function runEffects(
       }
       case 'finisherStun': {
         if (!target || target.dead || spentCombo <= 0) break;
-        const dur = eff.base + eff.perCombo * spentCombo;
+        const dur = ctx.diminishedCrowdControlDuration(
+          p,
+          target,
+          'stun',
+          eff.base + eff.perCombo * spentCombo,
+        );
+        if (dur === null) break;
         ctx.applyAura(target, {
           id: `${ability.id}_stun`,
           name: ability.name,
@@ -300,12 +306,14 @@ export function runEffects(
       }
       case 'stun': {
         if (!target || target.dead) break;
+        const remaining = ctx.diminishedCrowdControlDuration(p, target, 'stun', eff.duration);
+        if (remaining === null) break;
         ctx.applyAura(target, {
           id: `${ability.id}_stun`,
           name: ability.name,
           kind: 'stun',
-          remaining: eff.duration,
-          duration: eff.duration,
+          remaining,
+          duration: remaining,
           value: 0,
           sourceId: p.id,
           school: ability.school,

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -230,6 +230,7 @@ import {
 import * as fiestaBotsMod from './social/fiesta_bots';
 import { PartyMachine } from './social/party';
 import { SpatialGrid } from './spatial';
+import { isStunDrCategory } from './stun_dr';
 import { Targeting } from './targeting';
 import {
   addThreat,
@@ -3111,7 +3112,7 @@ export class Sim {
         ? PVP_POLYMORPH_DR_RESET
         : category === 'fear'
           ? PVP_FEAR_DR_RESET
-          : category === 'stun'
+          : isStunDrCategory(category)
             ? PVP_STUN_DR_RESET
             : PVP_ROOT_DR_RESET;
     if (category === 'polymorph') {

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -355,6 +355,7 @@ const ARENA_LADDER_SIZE = 10; // live online standings shipped to clients
 // imported back (above) for the fiestaMatchInfo presentation accessor, which stays
 // on Sim. (A2 already moved FIESTA_COUNTDOWN to social/arena.ts.)
 const PVP_ROOT_DR_RESET = 18; // seconds before a repeated PvP root is fresh again
+const PVP_STUN_DR_RESET = 18; // stuns share the root-style 100/50/25/immune scheme
 const PVP_POLYMORPH_DR_RESET = 60;
 const PVP_FEAR_DR_RESET = 60;
 const PVP_CC_DR_MULTIPLIERS = [1, 0.5, 0.25] as const;
@@ -3110,7 +3111,9 @@ export class Sim {
         ? PVP_POLYMORPH_DR_RESET
         : category === 'fear'
           ? PVP_FEAR_DR_RESET
-          : PVP_ROOT_DR_RESET;
+          : category === 'stun'
+            ? PVP_STUN_DR_RESET
+            : PVP_ROOT_DR_RESET;
     if (category === 'polymorph') {
       target.ccDr.set(category, { stage: stage + 1, resetAt: this.time + reset });
       return PVP_POLYMORPH_DR_DURATIONS[Math.min(stage, PVP_POLYMORPH_DR_DURATIONS.length - 1)];

--- a/src/sim/stun_dr.ts
+++ b/src/sim/stun_dr.ts
@@ -1,0 +1,33 @@
+import type { CrowdControlDrCategory } from './types';
+
+// Classic-era stun diminishing returns are NOT one shared bucket. Same-category
+// stuns diminish together (full -> half -> quarter -> immune), but stuns split
+// into independent categories so a rogue's opener stun does not eat into the
+// diminishing chain of a controlled stun:
+//   - openerStun:     from-stealth openers (Cheap Shot, Pounce)
+//   - controlledStun: deliberate on-demand stuns (Kidney Shot, Hammer of Justice,
+//                     Bash, Charge, Feral/Bear Charge)
+//   - randomStun:     proc-style stuns (none represented yet; the safe default)
+// Keeping these separate preserves the core rogue opener flow: Cheap Shot does
+// not diminish the following Kidney Shot, while repeated Kidney Shots (or repeated
+// Hammer of Justice) still diminish within their own category.
+const OPENER_STUNS = new Set(['cheap_shot', 'pounce']);
+const CONTROLLED_STUNS = new Set([
+  'kidney_shot',
+  'hammer_of_justice',
+  'bash',
+  'charge',
+  'bear_charge',
+]);
+
+export function stunDrCategory(abilityId: string): CrowdControlDrCategory {
+  if (OPENER_STUNS.has(abilityId)) return 'openerStun';
+  if (CONTROLLED_STUNS.has(abilityId)) return 'controlledStun';
+  return 'randomStun';
+}
+
+// A stun DR category is any of the three stun buckets above; they all share the
+// stun DR reset window. Used by the duration resolver to pick the reset timer.
+export function isStunDrCategory(category: CrowdControlDrCategory): boolean {
+  return category === 'openerStun' || category === 'controlledStun' || category === 'randomStun';
+}

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -196,7 +196,13 @@ export interface Aura {
   stacks?: number; // sunder armor: applications stack up to the effect's cap
 }
 
-export type CrowdControlDrCategory = 'root' | 'polymorph' | 'fear' | 'stun';
+export type CrowdControlDrCategory =
+  | 'root'
+  | 'polymorph'
+  | 'fear'
+  | 'openerStun'
+  | 'controlledStun'
+  | 'randomStun';
 
 export interface CrowdControlDrState {
   stage: number;

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -196,7 +196,7 @@ export interface Aura {
   stacks?: number; // sunder armor: applications stack up to the effect's cap
 }
 
-export type CrowdControlDrCategory = 'root' | 'polymorph' | 'fear';
+export type CrowdControlDrCategory = 'root' | 'polymorph' | 'fear' | 'stun';
 
 export interface CrowdControlDrState {
   stage: number;

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -195,4 +195,92 @@ describe('PvP control abilities in active duels', () => {
 
     expect(castFear()).toBe(8);
   });
+
+  it('diminishes repeated duel stuns to full, half, quarter, then immune, resetting after 18s', () => {
+    const { sim, aPid, b } = startDuel('paladin', 'warrior', 20);
+
+    // Hammer of Justice at level 20 is rank 2: a 4s instant stun. As with Fear, a
+    // resisted stun applies nothing and does NOT advance diminishing returns, so
+    // retry until it lands to keep the sequence stable against shared-RNG drift.
+    const castStun = () => {
+      let dur: number | null = 0;
+      for (let attempt = 0; attempt < 50 && dur === 0; attempt++) {
+        b.auras = b.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+        const pala = sim.entities.get(aPid)!;
+        pala.gcdRemaining = 0;
+        pala.resource = pala.maxResource;
+        pala.cooldowns.delete('hammer_of_justice');
+        sim.castAbility('hammer_of_justice', aPid);
+        finishCast(sim, aPid);
+        dur = b.auras.find((aura) => aura.id === 'hammer_of_justice_stun')?.duration ?? 0;
+      }
+      return dur;
+    };
+
+    expect(castStun()).toBe(4); // 100%
+    expect(castStun()).toBe(2); // 50%
+    expect(castStun()).toBe(1); // 25%
+
+    // Fourth stun in the window is fully diminished: the target is immune, so no
+    // stun aura lands at all (the chain-stun lock is broken).
+    b.auras = b.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+    const pala = sim.entities.get(aPid)!;
+    pala.gcdRemaining = 0;
+    pala.resource = pala.maxResource;
+    pala.cooldowns.delete('hammer_of_justice');
+    sim.castAbility('hammer_of_justice', aPid);
+    finishCast(sim, aPid);
+    expect(b.auras.some((aura) => aura.id === 'hammer_of_justice_stun')).toBe(false);
+
+    // The category resets after the 18s window, restoring full duration.
+    b.auras = b.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+    for (let i = 0; i < 20 * 19; i++) sim.tick();
+    expect(castStun()).toBe(4);
+  });
+
+  it('does not diminish PvE stuns: a stun on a mob keeps full duration on repeat', () => {
+    // DR is duel/PvP only (player source AND player target). A paladin stunning a
+    // hostile mob must always land the full 4s, no matter how many times in a row.
+    const sim = new Sim({ seed: 7, playerClass: 'paladin' as any, playerName: 'Pala', autoEquip: true });
+    const pid = sim.primaryId;
+    sim.setPlayerLevel(20, pid);
+    const p = sim.entities.get(pid)!;
+    // Find a hostile mob in the world near the player.
+    let mob: Entity | undefined;
+    for (const e of sim.entities.values()) {
+      if (e.kind === 'mob' && e.hostile && e.ownerId === null && !e.dead) {
+        mob = e;
+        break;
+      }
+    }
+    expect(mob).toBeDefined();
+    const m = mob!;
+    m.pos = { ...p.pos, x: p.pos.x + 3 };
+    m.prevPos = { ...m.pos };
+    p.facing = Math.atan2(m.pos.x - p.pos.x, m.pos.z - p.pos.z);
+    sim.targetEntity(m.id, pid);
+
+    const stunMob = () => {
+      m.auras = m.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+      p.gcdRemaining = 0;
+      p.resource = p.maxResource;
+      p.cooldowns.delete('hammer_of_justice');
+      let dur = 0;
+      for (let attempt = 0; attempt < 50 && dur === 0; attempt++) {
+        m.auras = m.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+        p.gcdRemaining = 0;
+        p.resource = p.maxResource;
+        p.cooldowns.delete('hammer_of_justice');
+        sim.castAbility('hammer_of_justice', pid);
+        finishCast(sim, pid);
+        dur = m.auras.find((aura) => aura.id === 'hammer_of_justice_stun')?.duration ?? 0;
+      }
+      return dur;
+    };
+
+    expect(stunMob()).toBe(4);
+    expect(stunMob()).toBe(4);
+    expect(stunMob()).toBe(4);
+    expect(stunMob()).toBe(4);
+  });
 });

--- a/tests/pvp_safety.test.ts
+++ b/tests/pvp_safety.test.ts
@@ -7,7 +7,12 @@ import type { Entity, Vec3 } from '../src/sim/types';
 import { dist2d } from '../src/sim/types';
 
 function twoPlayers(clsA = 'mage', clsB = 'warrior') {
-  const sim = new Sim({ seed: 42, playerClass: clsA as any, playerName: 'Caster', autoEquip: true });
+  const sim = new Sim({
+    seed: 42,
+    playerClass: clsA as any,
+    playerName: 'Caster',
+    autoEquip: true,
+  });
   const aPid = sim.primaryId;
   const bPid = sim.addPlayer(clsB as any, 'Victim', { autoEquip: true });
   const a = sim.entities.get(aPid)!;
@@ -48,7 +53,13 @@ function finishCast(sim: Sim, pid: number) {
 const pos = (e: Entity): Vec3 => ({ ...e.pos });
 
 const hasCc = (e: Entity) =>
-  e.auras.some((au) => au.kind === 'polymorph' || au.kind === 'stun' || au.kind === 'incapacitate' || au.kind === 'root');
+  e.auras.some(
+    (au) =>
+      au.kind === 'polymorph' ||
+      au.kind === 'stun' ||
+      au.kind === 'incapacitate' ||
+      au.kind === 'root',
+  );
 
 describe('PvP safety outside duels (#96)', () => {
   it('a player cannot polymorph another player', () => {
@@ -238,10 +249,48 @@ describe('PvP control abilities in active duels', () => {
     expect(castStun()).toBe(4);
   });
 
+  it('keeps opener and controlled stuns on independent DR chains (#1004)', () => {
+    // Classic-style stun DR is not one bucket: a from-stealth opener (Cheap Shot,
+    // Pounce) must not eat into a controlled stun's chain (Kidney Shot, Hammer of
+    // Justice). Simulate a fully diminished OPENER chain on the target, then prove a
+    // controlled stun still lands at full duration and diminishes only within its
+    // own controlled bucket.
+    const { sim, aPid, b } = startDuel('paladin', 'warrior', 20);
+
+    // Pretend the target already burned its opener-stun chain to immunity.
+    b.ccDr.set('openerStun', { stage: 3, resetAt: sim.time + 18 });
+
+    const castStun = () => {
+      let dur = 0;
+      for (let attempt = 0; attempt < 50 && dur === 0; attempt++) {
+        b.auras = b.auras.filter((aura) => aura.id !== 'hammer_of_justice_stun');
+        const pala = sim.entities.get(aPid)!;
+        pala.gcdRemaining = 0;
+        pala.resource = pala.maxResource;
+        pala.cooldowns.delete('hammer_of_justice');
+        sim.castAbility('hammer_of_justice', aPid);
+        finishCast(sim, aPid);
+        dur = b.auras.find((aura) => aura.id === 'hammer_of_justice_stun')?.duration ?? 0;
+      }
+      return dur;
+    };
+
+    // The controlled stun is unaffected by the spent opener chain: full duration,
+    // then diminishes only within its own controlled bucket.
+    expect(castStun()).toBe(4); // 100%, not diminished by the opener bucket
+    expect(castStun()).toBe(2); // 50%
+    expect(castStun()).toBe(1); // 25%
+  });
+
   it('does not diminish PvE stuns: a stun on a mob keeps full duration on repeat', () => {
     // DR is duel/PvP only (player source AND player target). A paladin stunning a
     // hostile mob must always land the full 4s, no matter how many times in a row.
-    const sim = new Sim({ seed: 7, playerClass: 'paladin' as any, playerName: 'Pala', autoEquip: true });
+    const sim = new Sim({
+      seed: 7,
+      playerClass: 'paladin' as any,
+      playerName: 'Pala',
+      autoEquip: true,
+    });
     const pid = sim.primaryId;
     sim.setPlayerLevel(20, pid);
     const p = sim.entities.get(pid)!;

--- a/tests/stun_dr.test.ts
+++ b/tests/stun_dr.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isStunDrCategory, stunDrCategory } from '../src/sim/stun_dr';
+
+describe('stun DR categories (#1004)', () => {
+  it('classifies from-stealth openers as openerStun', () => {
+    expect(stunDrCategory('cheap_shot')).toBe('openerStun');
+    expect(stunDrCategory('pounce')).toBe('openerStun');
+  });
+
+  it('classifies deliberate on-demand stuns as controlledStun', () => {
+    expect(stunDrCategory('kidney_shot')).toBe('controlledStun');
+    expect(stunDrCategory('hammer_of_justice')).toBe('controlledStun');
+    expect(stunDrCategory('bash')).toBe('controlledStun');
+    expect(stunDrCategory('charge')).toBe('controlledStun');
+    expect(stunDrCategory('bear_charge')).toBe('controlledStun');
+  });
+
+  it('keeps opener and controlled stuns in independent buckets', () => {
+    // The whole point of the split: a rogue opener must not share a bucket with a
+    // controlled stun, so Cheap Shot cannot diminish the following Kidney Shot.
+    expect(stunDrCategory('cheap_shot')).not.toBe(stunDrCategory('kidney_shot'));
+  });
+
+  it('defaults unknown / proc stuns to randomStun', () => {
+    expect(stunDrCategory('some_future_proc_stun')).toBe('randomStun');
+  });
+
+  it('recognises all three stun buckets as stun DR categories', () => {
+    expect(isStunDrCategory('openerStun')).toBe(true);
+    expect(isStunDrCategory('controlledStun')).toBe(true);
+    expect(isStunDrCategory('randomStun')).toBe(true);
+    expect(isStunDrCategory('root')).toBe(false);
+    expect(isStunDrCategory('fear')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Player-cast **stuns had no diminishing returns**, so a duel/arena opponent could be chain-stunned indefinitely. Root, Polymorph, and Fear already diminish in PvP (the `diminishedCrowdControlDuration` path), but every stun apply site set its duration directly, leaving a near-permanent stun-lock as the strongest PvP control in the game.

This adds classic-style stun DR (**100% -> 50% -> 25% -> immune**, resetting **18s** after the last application). Following review feedback from @Rubsey, stuns are **not** one shared bucket: they split into three independent classic categories so a from-stealth opener never eats into a controlled stun's diminishing chain. PvE is unaffected: DR only applies when both source and target are players.

## Stun DR categories
A small pure module `src/sim/stun_dr.ts` classifies each stun ability into one bucket; same-category stuns diminish together, different categories are fully independent:
- **openerStun**: Cheap Shot, Pounce
- **controlledStun**: Kidney Shot, Hammer of Justice, Bash, Charge, Bear/Feral Charge
- **randomStun**: proc-style stuns (none represented yet; the safe default)

So Cheap Shot no longer diminishes a following Kidney Shot, keeping the core rogue opener flow intact, while repeated Kidney Shots (or repeated Hammer of Justice) still diminish within their own bucket.

## Root cause
`diminishedCrowdControlDuration(source, target, category, duration)` covered only `root | polymorph | fear`. The `stun` and `finisherStun` effects in `combat/effect_dispatch.ts` applied `eff.duration` straight onto the aura, never consulting the DR table, so repeated stuns always landed at full length.

## Fix
- `src/sim/stun_dr.ts` (new): `stunDrCategory(abilityId)` maps an ability to `openerStun | controlledStun | randomStun`, plus `isStunDrCategory()`.
- `types.ts`: `CrowdControlDrCategory` replaces `'stun'` with the three stun buckets.
- `sim.ts`: add `PVP_STUN_DR_RESET = 18`; all three stun buckets share it via `isStunDrCategory(category)`, then fall through the existing multiplier path (`[1, 0.5, 0.25]` then `null` = immune), identical to `root`.
- `combat/effect_dispatch.ts`: route both the `stun` and `finisherStun` effects through `ctx.diminishedCrowdControlDuration(p, target, stunDrCategory(ability.id), ...)`, and skip applying the aura when it returns `null` (immune).

PvE/mob/boss stuns (War Stomp, Crushing Blow, Concussive Blow, Nythraxis mechanics) are intentionally left untouched: the DR gate requires a player source AND a player target, so a mob stun always lands at full duration.

## How stun DR resolves
```mermaid
flowchart TD
    A["Player casts a stun on an enemy player"] --> B{Both source and target are players?}
    B -- "No (PvE)" --> P["Full duration applied (DR is PvP only)"]
    B -- "Yes (duel / arena)" --> K{"stunDrCategory(ability.id)"}
    K -- "Cheap Shot, Pounce" --> O["openerStun bucket"]
    K -- "Kidney Shot, Hammer of Justice,<br/>Bash, Charge, Bear Charge" --> C["controlledStun bucket"]
    K -- "proc stuns" --> R["randomStun bucket"]
    O --> O1["100% to 50% to 25% to immune<br/>(18s reset window)"]
    C --> C1["100% to 50% to 25% to immune<br/>(18s reset window)"]
    R --> R1["100% to 50% to 25% to immune<br/>(18s reset window)"]
    O1 -. "independent chain" .- C1
    C1 -. "independent chain" .- R1
```

![Stun DR flow](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-stun-dr/stun_dr.png)

## Tests
- `tests/stun_dr.test.ts` (new): unit coverage of the classifier, including that opener and controlled stuns land in independent buckets and unknown/proc stuns default to `randomStun`.
- `tests/pvp_safety.test.ts`:
  - **Cross-category independence**: a fully diminished opener chain does not reduce a following controlled stun, which still diminishes within its own bucket.
  - **Duel stun DR**: repeated Hammer of Justice (4s rank-2 stun) diminishes 4s -> 2s -> 1s -> immune (no aura), then restores to 4s after the 18s window resets.
  - **PvE no-DR guard**: a player stunning a mob keeps the full 4s on every repeat.

## Validation
- `npx vitest run tests/stun_dr.test.ts tests/pvp_safety.test.ts` (20 passed)
- `npx vitest run tests/architecture.test.ts`
- `npx tsc --noEmit`
- `npm test` (one unrelated flaky timeout in `tests/delves.test.ts`, passes in isolation)
- `npm run build`

No wire/persistence/IWorld surface changes: `ccDr` is server-internal sim state and is not serialized, so no parity golden regen is needed.
