### PR TITLE
perf(render): FPS-first auto-quality detection (on by default) + high-DPI caps

### DIFF
--- a/scripts/fps_profile.mjs
+++ b/scripts/fps_profile.mjs
@@ -1,0 +1,124 @@
+// Steady-state CPU/GPU frame profiler (headed, real GPU).
+//
+// Boots one tier, runs a sustained forward tour in the open world, then dumps
+// where the frame time goes: the main-loop buckets (sim.tick / renderer.sync /
+// hud.update), the renderer's internal phase split (entities / world /
+// nameplates / submit), and the foliage draw/triangle breakdown. Use it to pick
+// what to optimize, then re-run to confirm the win.
+//
+//   npm run dev   # other terminal
+//   BENCH_TIERS=high node scripts/fps_profile.mjs
+//
+// Env: BENCH_TIER (default auto), BENCH_W/H, BENCH_DPR (1|2), BENCH_RUN_MS.
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const BASE_URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const TIER = process.env.BENCH_TIER ?? 'auto';
+const W = Number(process.env.BENCH_W ?? 1920);
+const H = Number(process.env.BENCH_H ?? 1080);
+const DPR = Number(process.env.BENCH_DPR ?? 1);
+const RUN_MS = Number(process.env.BENCH_RUN_MS ?? 6000);
+const KLASS = process.env.BENCH_CLASS ?? 'warrior';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  console.log(`Profile: tier=${TIER} ${W}x${H} dpr=${DPR} run=${RUN_MS}ms (HEADED, vsync OFF)`);
+  const browser = await puppeteer.launch({
+    executablePath: BROWSER_PATH,
+    headless: false,
+    args: [
+      `--window-size=${W},${H + 120}`,
+      '--ignore-gpu-blocklist',
+      '--enable-gpu',
+      '--disable-gpu-vsync',
+      '--disable-frame-rate-limit',
+      '--autoplay-policy=no-user-gesture-required',
+    ],
+  });
+  const page = await browser.newPage();
+  await page.setViewport({ width: W, height: H, deviceScaleFactor: DPR });
+  const url = TIER === 'auto' ? `${BASE_URL}/?perf` : `${BASE_URL}/?perf&gfx=${TIER}`;
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  await page.waitForSelector('#char-name', { timeout: 60000 });
+  await page.$eval('#char-name', (el) => {
+    el.value = 'ProfileRun';
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await page.$eval(`#offline-select .mini-class[data-class="${KLASS}"]`, (el) => el.click());
+  await page.$eval('#btn-start-offline', (el) => el.click());
+  await page.waitForFunction(
+    () => Boolean(window.__game?.sim?.player && window.__game?.perf?.report),
+    { timeout: 120000 },
+  );
+  await sleep(800);
+
+  // Steady open-world run away from the cold-streaming teleport spike.
+  await page.evaluate(() => {
+    const p = window.__game.sim.player;
+    p.pos.x = 0;
+    p.pos.z = 30;
+    p.facing = Math.PI;
+    window.__game.input.camYaw = Math.PI;
+  });
+  await sleep(800);
+  await page.evaluate(() => window.__game.perf.reset());
+  // BENCH_MOVE=0 holds still (clean steady-state GPU cost, no streaming stalls);
+  // default runs forward (real travel, includes streaming pressure).
+  if (process.env.BENCH_MOVE !== '0') {
+    await page.evaluate(() =>
+      window.__game.input.setTouchMove({
+        forward: true,
+        back: false,
+        strafeLeft: false,
+        strafeRight: false,
+      }),
+    );
+    await sleep(RUN_MS);
+    await page.evaluate(() => window.__game.input.clearTouchMove());
+  } else {
+    await sleep(RUN_MS);
+  }
+
+  const r = await page.evaluate(() => window.__game.perf.report());
+  await browser.close();
+
+  const top = (obj, n = 12) =>
+    Object.entries(obj ?? {})
+      .map(([k, v]) => [k, typeof v === 'object' ? (v.avg ?? v.p95 ?? 0) : v])
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, n);
+
+  const rr = r.renderer ?? {};
+  console.log(
+    `\nfps=${r.fps} 10s=${r.windows?.last10s?.fps}  frameP95=${r.frameMs?.p95}ms p99=${r.frameMs?.p99}ms`,
+  );
+  console.log(
+    `tier=${rr.tier} scale=${rr.effectiveRenderScale} calls=${rr.calls} tris=${rr.triangles} programs=${rr.programs} views=${rr.views}`,
+  );
+  console.log('\nmainMs (avg, top):');
+  for (const [k, v] of top(r.mainMs))
+    console.log(`  ${String(k).padEnd(22)} ${Number(v).toFixed(2)}ms`);
+  console.log('\nrenderer.phaseMs (avg):');
+  for (const [k, v] of top(rr.phaseMs))
+    console.log(
+      `  ${String(k).padEnd(22)} ${typeof v === 'object' ? Number(v.avg ?? 0).toFixed(2) : Number(v).toFixed(2)}ms`,
+    );
+  const f = rr.foliage ?? {};
+  console.log('\nfoliage:');
+  console.log(
+    `  grassVisibleTufts=${f.grassVisibleTufts} modelVisibleDraws=${f.modelVisibleDraws} modelVisibleTriangles=${f.modelVisibleTriangles}`,
+  );
+  console.log(`  modelVisibleByLod=${JSON.stringify(f.modelVisibleByLod)}`);
+  const rb = rr.renderBudget ?? {};
+  console.log(
+    `\nrenderBudget: mode=${rb.mode} reason=${rb.reason} pressure=${rb.pressure} frameMsEma=${rb.frameMsEma} levels=${JSON.stringify(rb.levels)}`,
+  );
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/fps_tier_bench.mjs
+++ b/scripts/fps_tier_bench.mjs
@@ -1,0 +1,226 @@
+// Real-GPU FPS benchmark across graphics tiers (low/medium/high/ultra).
+//
+// Boots the offline world HEADED (so you can watch it and so the real GPU is
+// used, not swiftshader) with vsync + the browser frame-rate limiter DISABLED,
+// so perf.report().fps reflects true GPU throughput instead of the display
+// refresh. Runs a fixed movement tour (town -> open-world run -> cross-zone ->
+// camera spin) per tier and prints a comparison table plus a JSON dump.
+//
+//   npm run dev            # in another terminal (Vite on :5173)
+//   node scripts/fps_tier_bench.mjs
+//
+// Env:
+//   BENCH_TIERS=low,medium,high,ultra   tiers to sweep (default all four)
+//   BENCH_W=1920 BENCH_H=1080           viewport (default 1920x1080)
+//   BENCH_CLASS=warrior                 offline class
+//   BENCH_RUN_MS=6000                   sustained-run sample window per phase
+//   GAME_URL=http://localhost:5173
+//   BROWSER_PATH=/opt/google/chrome/chrome
+import fs from 'node:fs';
+import path from 'node:path';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const BASE_URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const TIERS = (process.env.BENCH_TIERS ?? 'low,medium,high,ultra').split(',').map((s) => s.trim()).filter(Boolean);
+const W = Number(process.env.BENCH_W ?? 1920);
+const H = Number(process.env.BENCH_H ?? 1080);
+const KLASS = process.env.BENCH_CLASS ?? 'warrior';
+const RUN_MS = Number(process.env.BENCH_RUN_MS ?? 6000);
+const SETTLE_MS = Number(process.env.BENCH_SETTLE_MS ?? 700);
+const BOOT_TIMEOUT_MS = Number(process.env.BENCH_BOOT_TIMEOUT_MS ?? 120000);
+const OUT = process.env.BENCH_OUT ?? path.join('tmp', `fps-tier-bench-${new Date().toISOString().replace(/[:.]/g, '-')}.json`);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// A couple of long open-world straightaways from the starting area. Offline we
+// can set the player position directly (no dev commands); the renderer reacts.
+const WAYPOINTS = {
+  townSquare: { x: 0, z: -14, facing: 0 },
+  // north out of the start zone into open biome (foliage/grass heavy)
+  openField: { x: 0, z: 60, facing: Math.PI },
+  // a long push toward a zone boundary to force streaming + biome change
+  farRun: { x: 40, z: 220, facing: Math.PI },
+};
+
+async function bootOffline(page, tier) {
+  // tier 'auto' boots with no ?gfx override so the new FPS-first auto-detection
+  // (gfx_autodetect) and the one-time migration to the Auto preset both run.
+  const url = tier === 'auto' ? `${BASE_URL}/?perf` : `${BASE_URL}/?perf&gfx=${tier}`;
+  await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 });
+  // Start screen -> offline -> pick class -> start.
+  await page.waitForSelector('#char-name', { timeout: 60000 });
+  await page.$eval('#char-name', (el, v) => {
+    el.value = v;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+  }, `Bench${tier[0].toUpperCase()}${tier.slice(1)}`);
+  await page.$eval(`#offline-select .mini-class[data-class="${KLASS}"]`, (el) => el.click());
+  await page.$eval('#btn-start-offline', (el) => el.click());
+  await page.waitForFunction(
+    () => Boolean(window.__game?.sim?.player && window.__game?.perf?.report),
+    { timeout: BOOT_TIMEOUT_MS },
+  );
+  await sleep(SETTLE_MS);
+}
+
+async function teleport(page, wp) {
+  await page.evaluate((wp) => {
+    const g = window.__game;
+    const p = g.sim.player;
+    p.pos.x = wp.x;
+    p.pos.z = wp.z;
+    p.facing = wp.facing;
+    g.input.camYaw = wp.facing;
+  }, wp);
+}
+
+async function runForward(page, ms) {
+  await page.evaluate(() => window.__game.input.setTouchMove({ forward: true, back: false, strafeLeft: false, strafeRight: false }));
+  await sleep(ms);
+  await page.evaluate(() => window.__game.input.clearTouchMove());
+}
+
+async function spinCamera(page, ms) {
+  await page.evaluate(() => {
+    window.__game.input.setTouchLook(true);
+    window.__game.input.setTouchLookVector({ x: 0.9, y: -0.05 });
+  });
+  await sleep(ms);
+  await page.evaluate(() => {
+    window.__game.input.setTouchLookVector({ x: 0, y: 0 });
+    window.__game.input.setTouchLook(false);
+  });
+}
+
+async function resetPerf(page) {
+  await page.evaluate(() => window.__game.perf.reset());
+}
+
+function pick(report) {
+  const r = report ?? {};
+  const w10 = r.windows?.last10s ?? {};
+  const renderer = r.renderer ?? {};
+  const foliage = renderer.foliage ?? {};
+  return {
+    fps: r.fps ?? 0,
+    fps10s: w10.fps ?? 0,
+    frameP50: r.frameMs?.p50 ?? 0,
+    frameP95: r.frameMs?.p95 ?? 0,
+    frameP99: r.frameMs?.p99 ?? 0,
+    frameMax: r.frameMs?.max ?? 0,
+    long50: r.frameMs?.long50 ?? 0,
+    tier: renderer.tier ?? '',
+    renderScale: renderer.effectiveRenderScale ?? 0,
+    calls: renderer.calls ?? 0,
+    triangles: renderer.triangles ?? 0,
+    programs: renderer.programs ?? 0,
+    views: renderer.views ?? 0,
+    grassTufts: foliage.grassVisibleTufts ?? 0,
+    autoGovernor: renderer.autoGovernor ?? false,
+  };
+}
+
+async function sampleWindow(page, label, ms) {
+  await resetPerf(page);
+  await sleep(ms);
+  const report = await page.evaluate(() => window.__game.perf.report());
+  return { label, ...pick(report) };
+}
+
+async function benchTier(browser, tier) {
+  const page = await browser.newPage();
+  await page.setViewport({ width: W, height: H, deviceScaleFactor: 1 });
+  const pageErrors = [];
+  page.on('pageerror', (e) => pageErrors.push(String(e).slice(0, 200)));
+  const phases = [];
+  try {
+    await bootOffline(page, tier);
+
+    // Phase: town (NPCs + props + nameplates), camera still.
+    await teleport(page, WAYPOINTS.townSquare);
+    await sleep(SETTLE_MS);
+    phases.push(await sampleWindow(page, 'town-idle', RUN_MS));
+
+    // Phase: sustained run through the open field (grass/foliage streaming).
+    await teleport(page, WAYPOINTS.openField);
+    await sleep(SETTLE_MS);
+    await resetPerf(page);
+    await runForward(page, RUN_MS);
+    phases.push({ label: 'open-run', ...pick(await page.evaluate(() => window.__game.perf.report())) });
+
+    // Phase: long push toward a zone boundary while running.
+    await teleport(page, WAYPOINTS.farRun);
+    await sleep(SETTLE_MS);
+    await resetPerf(page);
+    await runForward(page, RUN_MS);
+    phases.push({ label: 'far-run', ...pick(await page.evaluate(() => window.__game.perf.report())) });
+
+    // Phase: camera spin in the open field (worst-case visible set churn).
+    await teleport(page, WAYPOINTS.openField);
+    await sleep(SETTLE_MS);
+    await resetPerf(page);
+    await spinCamera(page, RUN_MS);
+    phases.push({ label: 'cam-spin', ...pick(await page.evaluate(() => window.__game.perf.report())) });
+  } catch (err) {
+    pageErrors.push(`FATAL: ${String(err).slice(0, 300)}`);
+  } finally {
+    await page.close();
+  }
+  return { tier, phases, pageErrors };
+}
+
+function fmt(n, w = 7) {
+  return String(typeof n === 'number' ? Math.round(n * 10) / 10 : n).padStart(w);
+}
+
+async function main() {
+  console.log(`FPS tier bench: tiers=[${TIERS.join(', ')}] viewport=${W}x${H} run=${RUN_MS}ms`);
+  console.log(`Browser: ${BROWSER_PATH} (HEADED, vsync OFF)`);
+  const browser = await puppeteer.launch({
+    executablePath: BROWSER_PATH,
+    headless: false,
+    args: [
+      `--window-size=${W},${H + 120}`,
+      '--ignore-gpu-blocklist',
+      '--enable-gpu',
+      '--disable-gpu-vsync',
+      '--disable-frame-rate-limit',
+      '--autoplay-policy=no-user-gesture-required',
+    ],
+  });
+  const results = [];
+  try {
+    for (const tier of TIERS) {
+      console.log(`\n=== Tier: ${tier} ===`);
+      const r = await benchTier(browser, tier);
+      results.push(r);
+      for (const p of r.phases) {
+        console.log(`  ${p.label.padEnd(10)} fps=${fmt(p.fps)} p95=${fmt(p.frameP95)}ms p99=${fmt(p.frameP99)}ms calls=${fmt(p.calls)} tris=${fmt(p.triangles, 9)} grass=${fmt(p.grassTufts)} scale=${fmt(p.renderScale, 5)} gov=${p.autoGovernor}`);
+      }
+      if (r.pageErrors.length) console.log(`  pageErrors: ${r.pageErrors.length} (first: ${r.pageErrors[0]})`);
+    }
+  } finally {
+    await browser.close();
+  }
+
+  // Comparison table: worst-case (min fps / max p95) across phases per tier.
+  console.log('\n========== SUMMARY (worst phase per tier) ==========');
+  console.log('tier     minFps  maxP95  maxP99  maxCalls   maxTris  worstPhase');
+  for (const r of results) {
+    if (!r.phases.length) { console.log(`${r.tier.padEnd(8)}  (no phases - errors)`); continue; }
+    let worst = r.phases[0];
+    for (const p of r.phases) if (p.fps < worst.fps) worst = p;
+    const maxP95 = Math.max(...r.phases.map((p) => p.frameP95));
+    const maxP99 = Math.max(...r.phases.map((p) => p.frameP99));
+    const maxCalls = Math.max(...r.phases.map((p) => p.calls));
+    const maxTris = Math.max(...r.phases.map((p) => p.triangles));
+    console.log(`${r.tier.padEnd(8)} ${fmt(worst.fps)} ${fmt(maxP95)} ${fmt(maxP99)} ${fmt(maxCalls)} ${fmt(maxTris, 9)}  ${worst.label}`);
+  }
+
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify({ viewport: { W, H }, runMs: RUN_MS, tiers: TIERS, results }, null, 2));
+  console.log(`\nWrote ${OUT}`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/src/game/settings.ts
+++ b/src/game/settings.ts
@@ -13,9 +13,14 @@ export const SETTING_RANGES = {
   // SFX by default so dialogue reads over ambient combat noise.
   voiceVolume: { min: 0, max: 1, def: 0.9 },
   brightness: { min: 0.6, max: 1.5, def: 1 },
-  // 1 low, 2 medium, 3 high, 4 ultra, 5 advanced. The renderer reads this
-  // from localStorage during startup because tier choice controls preload.
-  graphicsPreset: { min: 1, max: 5, def: 4 },
+  // 0 auto (default), 1 low, 2 medium, 3 high, 4 ultra, 5 advanced. Auto runs
+  // FPS-first hardware auto-detection (gfx.ts / gfx_autodetect.ts). The renderer
+  // reads this from localStorage during startup because tier choice controls
+  // preload.
+  graphicsPreset: { min: 0, max: 5, def: 0 },
+  // Internal migration marker (never shown in the menu). Bumping GRAPHICS_AUTO_MIGRATION
+  // force-resets every existing player to Auto once, then sticks until they choose.
+  gfxAutoMigration: { min: 0, max: 1_000_000, def: 0 },
   // Adaptive browser-effects tier for the DOM/CSS layer (distinct from the WebGL
   // graphicsPreset above). 0 = Auto: detect the engine (Chromium/WebKit/Gecko),
   // version and desktop-vs-mobile and tone down the most GPU-expensive CSS
@@ -188,13 +193,40 @@ export const BOOL_SETTINGS = {
 
 export type NumericSettingKey = keyof typeof SETTING_RANGES;
 export type BoolSettingKey = keyof typeof BOOL_SETTINGS;
-export type GameSettings = { [K in NumericSettingKey]: number } & { [K in BoolSettingKey]: boolean };
+export type GameSettings = { [K in NumericSettingKey]: number } & {
+  [K in BoolSettingKey]: boolean;
+};
 
-interface Range { min: number; max: number; def: number }
+interface Range {
+  min: number;
+  max: number;
+  def: number;
+}
 
 const STORE_KEY = 'woc_settings';
 const NUMERIC_KEYS = Object.keys(SETTING_RANGES) as NumericSettingKey[];
 const BOOL_KEYS = Object.keys(BOOL_SETTINGS) as BoolSettingKey[];
+
+// One-time graphics migration: when this is greater than a player's stored
+// `gfxAutoMigration`, their graphicsPreset is force-reset to 0 (Auto) once and
+// the marker is advanced, so the rollout reaches everyone (including players who
+// had manually pinned a tier) exactly once, silently. Bump to re-run.
+export const GRAPHICS_AUTO_MIGRATION = 1;
+
+/**
+ * Force a player onto the Auto preset once per migration epoch. Pure + mutating:
+ * returns true when it changed something (so the caller persists). Players who
+ * already ran this epoch are untouched, so a later manual tier choice sticks.
+ */
+export function applyGraphicsAutoMigration(values: {
+  graphicsPreset: number;
+  gfxAutoMigration: number;
+}): boolean {
+  if (values.gfxAutoMigration >= GRAPHICS_AUTO_MIGRATION) return false;
+  values.graphicsPreset = 0;
+  values.gfxAutoMigration = GRAPHICS_AUTO_MIGRATION;
+  return true;
+}
 
 function clampNumeric(key: NumericSettingKey, v: number): number {
   const r = SETTING_RANGES[key];
@@ -217,12 +249,18 @@ export class Settings {
 
   constructor() {
     this.values = this.load();
+    // Roll the whole player base onto Auto once; persist so it never re-fires.
+    if (applyGraphicsAutoMigration(this.values)) this.save();
   }
 
   private load(): GameSettings {
     let stored: unknown = null;
-    try { stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
-    const raw = stored && typeof stored === 'object' ? stored as Record<string, unknown> : {};
+    try {
+      stored = JSON.parse(localStorage.getItem(STORE_KEY) ?? 'null');
+    } catch {
+      /* corrupt */
+    }
+    const raw = stored && typeof stored === 'object' ? (stored as Record<string, unknown>) : {};
     const out = {} as GameSettings;
     for (const key of NUMERIC_KEYS) {
       const v = raw[key];
@@ -236,7 +274,11 @@ export class Settings {
   }
 
   private save(): void {
-    try { localStorage.setItem(STORE_KEY, JSON.stringify(this.values)); } catch { /* storage unavailable */ }
+    try {
+      localStorage.setItem(STORE_KEY, JSON.stringify(this.values));
+    } catch {
+      /* storage unavailable */
+    }
   }
 
   get<K extends keyof GameSettings>(key: K): GameSettings[K] {

--- a/src/main.ts
+++ b/src/main.ts
@@ -70,7 +70,7 @@ import { CharacterPreview } from './render/characters';
 import { skinCount } from './render/characters/manifest';
 import { playerPortraitDataUrl } from './render/characters/portrait';
 import { installWebGLContextRelease } from './render/context_release';
-import { GFX } from './render/gfx';
+import { GFX, persistAutoSample } from './render/gfx';
 import { Renderer } from './render/renderer';
 import { navigatorSaveData } from './render/sky';
 import { pathCrossesFence } from './sim/colliders';
@@ -2237,6 +2237,23 @@ async function startGame(
           tokenProvider: () => api.token,
           characterIdProvider: () => online?.characterId ?? null,
         });
+        // Cross-session Auto memory: while the player is on the Auto preset, record
+        // the running tier's sustained FPS so the next launch can step a struggling
+        // machine down a rung (see gfx_autodetect.resolveAutoTier).
+        if (Math.round(settings.get('graphicsPreset')) === 0) {
+          const recordAutoSample = (): void => {
+            const r = perf.report();
+            const tier = r.renderer?.tier;
+            const fps = r.windows?.last30s?.fps ?? r.fps;
+            if (tier === 'low' || tier === 'medium' || tier === 'high' || tier === 'ultra') {
+              persistAutoSample(tier, fps);
+            }
+          };
+          window.setInterval(recordAutoSample, 20_000);
+          document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') recordAutoSample();
+          });
+        }
         (window as any).__game = {
           sim: world,
           world,

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -343,7 +343,13 @@ function settingsFor(
     // it ~1ms-class on real GPUs; ultra gets full-res Medium
     ao: tier === 'high' || tier === 'ultra',
     msaaSamples: tier === 'high' || tier === 'ultra' ? 4 : 0,
-    pixelRatioCap: tier === 'low' ? 1.48 : tier === 'medium' ? 1.48 : tier === 'high' ? 1.75 : 2.5,
+    // FPS-first DPR caps: the post composer (N8AO + bloom) is the dominant GPU
+    // cost on high/ultra and it scales with pixel count, so a high-DPI panel
+    // (Retina/4K/OS-scaled) is what craters those tiers. Capping the device pixel
+    // ratio lower spends the saved pixels on frame rate. No effect at dpr<=cap
+    // (the desktop-1x majority is untouched); on dpr=2 it renders modestly below
+    // native for a large FPS win. Ultra stays the most generous (manual-only).
+    pixelRatioCap: tier === 'low' ? 1.35 : tier === 'medium' ? 1.42 : tier === 'high' ? 1.5 : 2.0,
     shadowMap: tier === 'low' ? 2048 : tier === 'medium' ? 2560 : 4096,
     standardMaterials: tier === 'medium' || tier === 'high' || tier === 'ultra',
     lowPlus: tier === 'low',

--- a/src/render/gfx.ts
+++ b/src/render/gfx.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { type AutoDetectHints, type RememberedAuto, resolveAutoTier } from './gfx_autodetect';
 
 // Quality tiers: every tier-dependent knob keys off this module instead of
 // scattered LOW_GFX ternaries.
@@ -10,7 +11,8 @@ import * as THREE from 'three';
 //   3. otherwise: persisted graphics preset, with missing values -> ultra
 
 export type GfxTier = 'low' | 'medium' | 'high' | 'ultra';
-export const GFX_CONFIG_VERSION = 14;
+// 15: Auto preset (0) becomes the default + FPS-first hardware auto-detection.
+export const GFX_CONFIG_VERSION = 15;
 
 export const GFX_BUCKET_IDS = [
   'resolution',
@@ -27,7 +29,7 @@ export const GFX_BUCKET_IDS = [
   'ui',
 ] as const;
 
-export type GfxBucketId = typeof GFX_BUCKET_IDS[number];
+export type GfxBucketId = (typeof GFX_BUCKET_IDS)[number];
 export type GfxBucketCost = 'gpu' | 'cpu' | 'mixed';
 
 export interface GfxBucketBand {
@@ -45,11 +47,16 @@ export type GfxBucketLevels = Record<GfxBucketId, number>;
 export interface GfxRuntimeHints {
   search: string;
   deviceMemory?: number;
+  hardwareConcurrency?: number;
   maxTouchPoints: number;
   coarsePointer: boolean;
   narrowViewport: boolean;
+  /** devicePixelRatio; high-DPI panels cost the Auto detector a tier rung. */
+  dpr?: number;
   gpuRenderer?: string;
   graphicsPreset?: number;
+  /** Last-session Auto sample (cross-session step-down); read from localStorage. */
+  rememberedAuto?: RememberedAuto | null;
   terrainDetail?: number;
   foliageDensity?: number;
   effectsQuality?: number;
@@ -100,12 +107,15 @@ export interface GfxRuntimeBudget {
   readonly cooldownSeconds: number;
 }
 
+const PRESET_AUTO = 0;
 const PRESET_LOW = 1;
 const PRESET_MEDIUM = 2;
 const PRESET_HIGH = 3;
 const PRESET_ULTRA = 4;
 const PRESET_ADVANCED = 5;
-const DEFAULT_PRESET = PRESET_ULTRA;
+// Auto is the default: a brand-new player (no persisted preset) is hardware
+// auto-detected (FPS-first) rather than dropped onto ultra blindly.
+const DEFAULT_PRESET = PRESET_AUTO;
 
 export const GFX_BUDGETS: Record<GfxTier, GfxRuntimeBudget> = {
   low: {
@@ -178,7 +188,14 @@ export const GFX_BUCKET_BANDS: Record<GfxTier, GfxBucketBands> = {
     vfx: { min: 0.84, baseline: 1.0, max: 1.0, roi: 0.9, cost: 'mixed', governable: true },
     characters: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
     weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
-    worldStreaming: { min: 0.25, baseline: 0.5, max: 0.68, roi: 0.62, cost: 'cpu', governable: true },
+    worldStreaming: {
+      min: 0.25,
+      baseline: 0.5,
+      max: 0.68,
+      roi: 0.62,
+      cost: 'cpu',
+      governable: true,
+    },
     ui: { min: 0.75, baseline: 0.9, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
   },
   medium: {
@@ -192,7 +209,14 @@ export const GFX_BUCKET_BANDS: Record<GfxTier, GfxBucketBands> = {
     vfx: { min: 0.58, baseline: 0.8, max: 0.9, roi: 0.7, cost: 'mixed', governable: true },
     characters: { min: 0.86, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
     weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
-    worldStreaming: { min: 0.42, baseline: 0.7, max: 0.82, roi: 0.62, cost: 'cpu', governable: true },
+    worldStreaming: {
+      min: 0.42,
+      baseline: 0.7,
+      max: 0.82,
+      roi: 0.62,
+      cost: 'cpu',
+      governable: true,
+    },
     ui: { min: 0.82, baseline: 1.0, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
   },
   high: {
@@ -206,7 +230,14 @@ export const GFX_BUCKET_BANDS: Record<GfxTier, GfxBucketBands> = {
     vfx: { min: 0.68, baseline: 0.92, max: 1.0, roi: 0.7, cost: 'mixed', governable: true },
     characters: { min: 0.9, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
     weapons: { min: 1.0, baseline: 1.0, max: 1.0, roi: 1.0, cost: 'mixed', governable: false },
-    worldStreaming: { min: 0.55, baseline: 0.88, max: 1.0, roi: 0.62, cost: 'cpu', governable: true },
+    worldStreaming: {
+      min: 0.55,
+      baseline: 0.88,
+      max: 1.0,
+      roi: 0.62,
+      cost: 'cpu',
+      governable: true,
+    },
     ui: { min: 0.86, baseline: 1.0, max: 1.0, roi: 0.86, cost: 'cpu', governable: false },
   },
   ultra: {
@@ -242,18 +273,30 @@ function bucketBaselines(bands: GfxBucketBands): GfxBucketLevels {
   };
 }
 
-export function graphicsPresetLabel(value: number | undefined): 'low' | 'medium' | 'high' | 'ultra' | 'advanced' {
+export function graphicsPresetLabel(
+  value: number | undefined,
+): 'auto' | 'low' | 'medium' | 'high' | 'ultra' | 'advanced' {
   switch (Math.round(value ?? DEFAULT_PRESET)) {
-    case PRESET_LOW: return 'low';
-    case PRESET_MEDIUM: return 'medium';
-    case PRESET_HIGH: return 'high';
-    case PRESET_ULTRA: return 'ultra';
-    case PRESET_ADVANCED: return 'advanced';
-    default: return 'low';
+    case PRESET_AUTO:
+      return 'auto';
+    case PRESET_LOW:
+      return 'low';
+    case PRESET_MEDIUM:
+      return 'medium';
+    case PRESET_HIGH:
+      return 'high';
+    case PRESET_ULTRA:
+      return 'ultra';
+    case PRESET_ADVANCED:
+      return 'advanced';
+    default:
+      return 'low';
   }
 }
 
-export function shouldUseAutoGovernor(hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset'>): boolean {
+export function shouldUseAutoGovernor(
+  hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset'>,
+): boolean {
   if (!hints) return false;
   const params = new URLSearchParams(hints.search);
   const override = params.get('governor') ?? params.get('autoGovernor');
@@ -275,7 +318,16 @@ export function configureMaskedDoubleSidedVegetationMaterial<T extends THREE.Mat
 
 function settingsFor(
   tier: GfxTier,
-  hints?: Pick<GfxRuntimeHints, 'search' | 'graphicsPreset' | 'terrainDetail' | 'foliageDensity' | 'effectsQuality' | 'shadowQuality' | 'gpuRenderer'>,
+  hints?: Pick<
+    GfxRuntimeHints,
+    | 'search'
+    | 'graphicsPreset'
+    | 'terrainDetail'
+    | 'foliageDensity'
+    | 'effectsQuality'
+    | 'shadowQuality'
+    | 'gpuRenderer'
+  >,
 ): GfxSettings {
   const bucketBands = GFX_BUCKET_BANDS[tier];
   const weakIntegratedGpu = isWeakIntegratedGpu(hints?.gpuRenderer);
@@ -304,8 +356,10 @@ function settingsFor(
   };
   if (hints?.graphicsPreset === PRESET_ADVANCED) {
     if ((hints.terrainDetail ?? 1) < 0.5) settings = { ...settings, terrainSplat: false };
-    if ((hints.foliageDensity ?? 1) < 0.5) settings = { ...settings, grassRadius: 34, grassStep: 3.8 };
-    if ((hints.effectsQuality ?? 1) < 0.5) settings = { ...settings, composer: false, ao: false, msaaSamples: 0, maxPointLights: 3 };
+    if ((hints.foliageDensity ?? 1) < 0.5)
+      settings = { ...settings, grassRadius: 34, grassStep: 3.8 };
+    if ((hints.effectsQuality ?? 1) < 0.5)
+      settings = { ...settings, composer: false, ao: false, msaaSamples: 0, maxPointLights: 3 };
     if ((hints.shadowQuality ?? 1) < 0.5) settings = { ...settings, shadowMap: 1024 };
   }
   return settings;
@@ -321,7 +375,10 @@ export function forcedTierFromSearch(search: string): GfxTier | null {
 function storedNumericSetting(key: string): number | undefined {
   if (typeof localStorage === 'undefined') return undefined;
   try {
-    const raw = JSON.parse(localStorage.getItem('woc_settings') ?? 'null') as Record<string, unknown> | null;
+    const raw = JSON.parse(localStorage.getItem('woc_settings') ?? 'null') as Record<
+      string,
+      unknown
+    > | null;
     const value = raw && typeof raw === 'object' ? raw[key] : undefined;
     return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
   } catch {
@@ -336,7 +393,9 @@ function probeGpuRenderer(): string | undefined {
     const gl = canvas.getContext('webgl2') ?? canvas.getContext('webgl');
     if (!gl) return undefined;
     const dbg = gl.getExtension('WEBGL_debug_renderer_info');
-    return String(dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER));
+    return String(
+      dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER),
+    );
   } catch {
     return undefined;
   }
@@ -349,19 +408,23 @@ export function urlForcedTier(): GfxTier | null {
 }
 
 function runtimeHints(): GfxRuntimeHints {
-  const nav = typeof navigator !== 'undefined'
-    ? navigator as Navigator & { deviceMemory?: number }
-    : null;
+  const nav =
+    typeof navigator !== 'undefined' ? (navigator as Navigator & { deviceMemory?: number }) : null;
   return {
     search: typeof location !== 'undefined' ? location.search : '',
     deviceMemory: nav?.deviceMemory,
+    hardwareConcurrency: nav?.hardwareConcurrency,
     maxTouchPoints: nav?.maxTouchPoints ?? 0,
-    coarsePointer: typeof matchMedia !== 'undefined' ? matchMedia('(pointer: coarse)').matches : false,
-    narrowViewport: typeof matchMedia !== 'undefined'
-      ? (matchMedia('(max-width: 940px)').matches || matchMedia('(max-height: 760px)').matches)
-      : false,
+    coarsePointer:
+      typeof matchMedia !== 'undefined' ? matchMedia('(pointer: coarse)').matches : false,
+    narrowViewport:
+      typeof matchMedia !== 'undefined'
+        ? matchMedia('(max-width: 940px)').matches || matchMedia('(max-height: 760px)').matches
+        : false,
+    dpr: typeof devicePixelRatio !== 'undefined' ? devicePixelRatio : 1,
     gpuRenderer: probeGpuRenderer(),
     graphicsPreset: storedNumericSetting('graphicsPreset'),
+    rememberedAuto: storedRememberedAuto(),
     terrainDetail: storedNumericSetting('terrainDetail'),
     foliageDensity: storedNumericSetting('foliageDensity'),
     effectsQuality: storedNumericSetting('effectsQuality'),
@@ -369,20 +432,79 @@ function runtimeHints(): GfxRuntimeHints {
   };
 }
 
+// Cross-session Auto memory: the last session's sustained FPS for the tier it
+// actually ran, so resolveAutoTier() can start a struggling machine one rung
+// lower next launch. Stored separately from woc_settings so it never pollutes
+// the player's explicit preferences.
+const AUTOTUNE_KEY = 'woc_gfx_autotune';
+
+function storedRememberedAuto(): RememberedAuto | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = JSON.parse(
+      localStorage.getItem(AUTOTUNE_KEY) ?? 'null',
+    ) as Partial<RememberedAuto> | null;
+    if (!raw || typeof raw !== 'object') return null;
+    const tier = raw.tier;
+    if (tier !== 'low' && tier !== 'medium' && tier !== 'high' && tier !== 'ultra') return null;
+    if (typeof raw.v !== 'number' || typeof raw.fps !== 'number' || !Number.isFinite(raw.fps))
+      return null;
+    return { v: raw.v, tier, fps: raw.fps };
+  } catch {
+    return null;
+  }
+}
+
+/** Persist a sustained-FPS sample for the running Auto tier (called by main.ts). */
+export function persistAutoSample(tier: GfxTier, fps: number): void {
+  if (typeof localStorage === 'undefined' || !Number.isFinite(fps) || fps <= 0) return;
+  try {
+    localStorage.setItem(
+      AUTOTUNE_KEY,
+      JSON.stringify({ v: GFX_CONFIG_VERSION, tier, fps: Math.round(fps) }),
+    );
+  } catch {
+    /* storage unavailable (private mode) */
+  }
+}
+
 export function isConstrainedBrowser(hints: GfxRuntimeHints): boolean {
   if (hints.deviceMemory !== undefined && hints.deviceMemory <= 4) return true;
   return hints.maxTouchPoints > 0 && (hints.coarsePointer || hints.narrowViewport);
+}
+
+/** Map the broad runtime hints onto the Auto detector's explicit input shape. */
+export function autoHintsFrom(hints: GfxRuntimeHints, softwareGl: boolean): AutoDetectHints {
+  return {
+    gpuRenderer: hints.gpuRenderer,
+    deviceMemory: hints.deviceMemory,
+    hardwareConcurrency: hints.hardwareConcurrency,
+    mobile: hints.maxTouchPoints > 0 && (hints.coarsePointer || hints.narrowViewport),
+    dpr: hints.dpr ?? 1,
+    softwareGl,
+  };
 }
 
 export function tierFromHints(hints: GfxRuntimeHints, softwareGl: boolean): GfxTier {
   const forced = forcedTierFromSearch(hints.search);
   if (forced) return forced;
   switch (Math.round(hints.graphicsPreset ?? DEFAULT_PRESET)) {
-    case PRESET_LOW: return 'low';
-    case PRESET_MEDIUM: return 'medium';
-    case PRESET_HIGH: return 'high';
-    case PRESET_ULTRA: return 'ultra';
-    case PRESET_ADVANCED: return 'high';
+    case PRESET_AUTO:
+      return resolveAutoTier(
+        autoHintsFrom(hints, softwareGl),
+        hints.rememberedAuto ?? null,
+        GFX_CONFIG_VERSION,
+      );
+    case PRESET_LOW:
+      return 'low';
+    case PRESET_MEDIUM:
+      return 'medium';
+    case PRESET_HIGH:
+      return 'high';
+    case PRESET_ULTRA:
+      return 'ultra';
+    case PRESET_ADVANCED:
+      return 'high';
   }
   return 'low';
 }
@@ -394,7 +516,9 @@ function rendererName(webgl: THREE.WebGLRenderer): string {
   try {
     const gl = webgl.getContext();
     const dbg = gl.getExtension('WEBGL_debug_renderer_info');
-    return String(dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER));
+    return String(
+      dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER),
+    );
   } catch {
     return '';
   }
@@ -406,7 +530,12 @@ export function isSoftwareGL(webgl: THREE.WebGLRenderer): boolean {
 
 export function isWeakIntegratedGpu(name: string | undefined): boolean {
   const n = name ?? '';
-  return /intel/i.test(n) && /(iris\(tm\) plus graphics 6|iris plus graphics 6|uhd graphics 6|hd graphics 5|hd graphics 6)/i.test(n);
+  return (
+    /intel/i.test(n) &&
+    /(iris\(tm\) plus graphics 6|iris plus graphics 6|uhd graphics 6|hd graphics 5|hd graphics 6)/i.test(
+      n,
+    )
+  );
 }
 
 // Best-guess settings from the URL alone (so module-load consumers see sane
@@ -466,8 +595,11 @@ export function addRimGlow(mat: THREE.Material): void {
   mat.onBeforeCompile = (sh) => {
     sh.uniforms.uRimBoost = sharedUniforms.uRimBoost;
     sh.fragmentShader = sh.fragmentShader
-      .replace('#include <common>', `#include <common>
-      uniform float uRimBoost;`)
+      .replace(
+        '#include <common>',
+        `#include <common>
+      uniform float uRimBoost;`,
+      )
       .replace(
         '#include <emissivemap_fragment>',
         `#include <emissivemap_fragment>
@@ -495,26 +627,26 @@ export function surfaceMat(opts: SurfaceMatOpts): THREE.Material {
   if (cached) return cached;
   const mat = GFX.standardMaterials
     ? new THREE.MeshStandardMaterial({
-      color: opts.color ?? 0xffffff,
-      map: opts.map ?? null,
-      normalMap: opts.normalMap ?? null,
-      roughnessMap: opts.roughnessMap ?? null,
-      aoMap: opts.aoMap ?? null,
-      roughness: opts.roughness ?? 0.85,
-      metalness: opts.metalness ?? 0,
-      flatShading: opts.flatShading ?? false,
-      emissive: opts.emissive ?? 0x000000,
-      emissiveIntensity: opts.emissiveIntensity ?? 1,
-      side: opts.side ?? THREE.FrontSide,
-    })
+        color: opts.color ?? 0xffffff,
+        map: opts.map ?? null,
+        normalMap: opts.normalMap ?? null,
+        roughnessMap: opts.roughnessMap ?? null,
+        aoMap: opts.aoMap ?? null,
+        roughness: opts.roughness ?? 0.85,
+        metalness: opts.metalness ?? 0,
+        flatShading: opts.flatShading ?? false,
+        emissive: opts.emissive ?? 0x000000,
+        emissiveIntensity: opts.emissiveIntensity ?? 1,
+        side: opts.side ?? THREE.FrontSide,
+      })
     : new THREE.MeshLambertMaterial({
-      color: opts.color ?? 0xffffff,
-      map: opts.map ?? null,
-      flatShading: opts.flatShading ?? false,
-      emissive: opts.emissive ?? 0x000000,
-      emissiveIntensity: opts.emissiveIntensity ?? 1,
-      side: opts.side ?? THREE.FrontSide,
-    });
+        color: opts.color ?? 0xffffff,
+        map: opts.map ?? null,
+        flatShading: opts.flatShading ?? false,
+        emissive: opts.emissive ?? 0x000000,
+        emissiveIntensity: opts.emissiveIntensity ?? 1,
+        side: opts.side ?? THREE.FrontSide,
+      });
   if (opts.rim && GFX.standardMaterials) addRimGlow(mat);
   matCache.set(key, mat);
   return mat;

--- a/src/render/gfx_autodetect.ts
+++ b/src/render/gfx_autodetect.ts
@@ -1,0 +1,195 @@
+// First-run graphics auto-detection (the "Auto" quality preset).
+//
+// Pure + host-agnostic: every input is passed in explicitly so the policy is
+// unit-tested without a GL context (see tests/gfx_autodetect.test.ts). gfx.ts
+// is the only consumer; it feeds live runtime hints in and uses the verdict as
+// the boot tier whenever the player is on Auto (graphicsPreset 0).
+//
+// Policy bias: FRAME RATE over visuals (operator decision). The heuristic never
+// auto-picks `ultra` - ultra stays a deliberate manual choice. The adaptive
+// governor (render_budget.ts) then absorbs runtime dips within the chosen tier,
+// and rememberedAutoTier() carries a cross-session step-down so a machine that
+// ran badly last session starts one rung lower next time.
+
+import type { GfxTier } from './gfx';
+
+export interface AutoDetectHints {
+  /** UNMASKED_RENDERER_WEBGL string, e.g. "ANGLE (NVIDIA ... RTX 3060 Ti ...)". */
+  gpuRenderer?: string;
+  /** navigator.deviceMemory (GB), often undefined off Chromium. */
+  deviceMemory?: number;
+  /** navigator.hardwareConcurrency (logical cores). */
+  hardwareConcurrency?: number;
+  /** Phone/tablet-class pointer (coarse pointer or touch-primary). */
+  mobile: boolean;
+  /** devicePixelRatio. High-DPI multiplies pixel cost, so it steps the tier down. */
+  dpr: number;
+  /** SwiftShader/llvmpipe/software path - never a real GPU. */
+  softwareGl: boolean;
+}
+
+export type GpuClass =
+  | 'software'
+  | 'weak'
+  | 'integrated'
+  | 'midDiscrete'
+  | 'strongDiscrete'
+  | 'unknown';
+
+const TIER_ORDER: readonly GfxTier[] = ['low', 'medium', 'high', 'ultra'];
+
+function stepDown(tier: GfxTier, by = 1): GfxTier {
+  const i = TIER_ORDER.indexOf(tier);
+  return TIER_ORDER[Math.max(0, i - by)];
+}
+
+/** Order helper so callers can clamp/compare tiers without re-deriving the order. */
+export function tierRank(tier: GfxTier): number {
+  return TIER_ORDER.indexOf(tier);
+}
+
+export function minTier(a: GfxTier, b: GfxTier): GfxTier {
+  return tierRank(a) <= tierRank(b) ? a : b;
+}
+
+/**
+ * Bucket a WEBGL_debug_renderer_info renderer string into a coarse performance
+ * class. String matching only - deliberately conservative: an unrecognized GPU
+ * lands in `unknown` (treated as a safe middle), and the governor + cross-session
+ * step-down correct any over-estimate.
+ */
+export function classifyGpu(renderer: string | undefined): GpuClass {
+  const r = (renderer ?? '').toLowerCase();
+  if (!r) return 'unknown';
+  if (/swiftshader|llvmpipe|software|microsoft basic render|google.*swiftshader/.test(r)) {
+    return 'software';
+  }
+
+  // Apple Silicon: M1 Pro/Max/Ultra and M2+ are strong; bare M1 is mid-class.
+  if (/apple\s*m[2-9]|apple\s*m1\s*(pro|max|ultra)/.test(r)) return 'strongDiscrete';
+  if (/apple\s*m1/.test(r)) return 'midDiscrete';
+
+  // NVIDIA. RTX 40/50-series and 3070+/2080+ and pro cards are strong; the
+  // xx50/xx60 mainstream and GTX are mid; very old GT/MX are weak.
+  if (/nvidia|geforce|quadro|rtx|gtx/.test(r)) {
+    if (/rtx\s*(40|50|a[2-9]|30[789]|3080|3090|2080|2090)/.test(r)) return 'strongDiscrete';
+    if (/rtx\s*(20|30)|gtx\s*1[6-9]\d{2}|gtx\s*10[6-9]\d|titan/.test(r)) return 'midDiscrete';
+    if (/\b(mx\d{3}|gt\s*\d{3}|gtx\s*9|gtx\s*10[0-5]\d)\b/.test(r)) return 'weak';
+    return 'midDiscrete';
+  }
+
+  // AMD Radeon. RX 6700/7000 and up are strong; RX 5000/6500-6600 mid; Vega/
+  // integrated graphics are integrated-class.
+  if (/radeon|\bamd\b|\brx\s*\d/.test(r)) {
+    if (/rx\s*(6[789]\d{2}|7\d{3})|radeon\s*pro\s*w/.test(r)) return 'strongDiscrete';
+    if (/rx\s*(5\d{3}|6[0-6]\d{2})|rx\s*4\d{2}/.test(r)) return 'midDiscrete';
+    if (/vega|radeon\s*(r[0-9]|hd)/.test(r)) return 'integrated';
+    return 'midDiscrete';
+  }
+
+  // Intel. Arc is a real discrete GPU; Iris Xe is a capable iGPU; older HD/UHD
+  // 5xx/6xx and the Iris Plus 6-series are weak.
+  if (/intel/.test(r)) {
+    if (/\barc\b|arc\s*a\d/.test(r)) return 'midDiscrete';
+    if (/iris\s*xe/.test(r)) return 'integrated';
+    if (
+      /(uhd|hd)\s*graphics\s*[56]|iris\(tm\)\s*plus\s*graphics\s*6|iris\s*plus\s*graphics\s*6/.test(
+        r,
+      )
+    ) {
+      return 'weak';
+    }
+    if (/iris/.test(r)) return 'integrated';
+    return 'weak';
+  }
+
+  // Mobile SoCs (renderer strings often inject "(TM)" between name and number).
+  if (/adreno\D*[67]\d{2}|mali-g[789]\d|apple\s*a1[5-9]/.test(r)) return 'integrated';
+  if (/adreno|mali|powervr|apple\s*a\d/.test(r)) return 'weak';
+
+  return 'unknown';
+}
+
+const CLASS_TIER: Record<GpuClass, GfxTier> = {
+  software: 'low',
+  weak: 'low',
+  integrated: 'medium',
+  midDiscrete: 'high',
+  strongDiscrete: 'high', // FPS-first: cap auto at high; ultra is manual-only.
+  unknown: 'medium', // safe middle; governor + cross-session step-down correct it.
+};
+
+/**
+ * The Auto-preset boot tier. FPS-first: tops out at `high`, drops a rung for
+ * high-DPI and low-memory machines, and forces `low` on phones/software GL.
+ */
+export function recommendAutoTier(h: AutoDetectHints): GfxTier {
+  if (h.softwareGl) return 'low';
+  if (h.mobile) return 'low';
+
+  let tier = CLASS_TIER[classifyGpu(h.gpuRenderer)];
+
+  // High-DPI panels (Retina/4K at dpr>=2) render ~4x the pixels; step one rung
+  // down so the panel does not eat the frame budget. pixelRatioCap + the
+  // governor's render-scale still clamp the rest.
+  if (h.dpr >= 2 && tier !== 'low') tier = stepDown(tier);
+
+  // Memory-starved devices (<=4GB) cannot hold the high-tier texture/shadow
+  // working set; cap at medium, and at low when truly tiny.
+  if (h.deviceMemory !== undefined) {
+    if (h.deviceMemory <= 2) tier = 'low';
+    else if (h.deviceMemory <= 4) tier = minTier(tier, 'medium');
+  }
+
+  // Very low core counts struggle with the CPU-side per-frame work; keep them
+  // off the premium pipeline.
+  if (h.hardwareConcurrency !== undefined && h.hardwareConcurrency <= 2) {
+    tier = minTier(tier, 'medium');
+  }
+
+  return tier;
+}
+
+export interface RememberedAuto {
+  /** GFX_CONFIG_VERSION the sample was taken under; stale versions are ignored. */
+  v: number;
+  /** The Auto tier that was actually running. */
+  tier: GfxTier;
+  /** Sustained FPS observed last session for that tier. */
+  fps: number;
+}
+
+/** FPS-first floor: Auto wants comfortable headroom above 60, not a bare 60. */
+export const AUTO_FPS_FLOOR = 58;
+/** Sustained FPS that justifies stepping a remembered floor back up one rung. */
+export const AUTO_FPS_HEADROOM = 110;
+
+/**
+ * Fold a remembered last-session sample into the heuristic tier. Cross-session
+ * adaptation, deliberately damped so it converges instead of oscillating:
+ * - last session for THIS tier ran below the floor -> start one rung lower;
+ * - last session ran with big headroom AND we were already at/below heuristic
+ *   -> allow one rung back up (never above the heuristic, which is the FPS-first
+ *   ceiling).
+ */
+export function resolveAutoTier(
+  h: AutoDetectHints,
+  remembered: RememberedAuto | null,
+  configVersion: number,
+): GfxTier {
+  const base = recommendAutoTier(h);
+  if (!remembered || remembered.v !== configVersion) return base;
+
+  // Only trust a remembered sample whose tier is at or below the current
+  // heuristic (hardware/DPI unchanged); a higher remembered tier is stale.
+  if (tierRank(remembered.tier) > tierRank(base)) return base;
+
+  if (remembered.fps > 0 && remembered.fps < AUTO_FPS_FLOOR) {
+    return stepDown(remembered.tier);
+  }
+  if (remembered.fps >= AUTO_FPS_HEADROOM && tierRank(remembered.tier) < tierRank(base)) {
+    const up = TIER_ORDER[Math.min(tierRank(base), tierRank(remembered.tier) + 1)];
+    return up;
+  }
+  return minTier(base, remembered.tier);
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -889,6 +889,12 @@ export class Renderer {
       antialias: false,
       powerPreference: 'high-performance',
     });
+    // Drive info.render accounting manually: with the post composer, autoReset
+    // wipes the scene's draw-call/triangle counts on each of its fullscreen
+    // passes, so info ends a frame reading 1 call / 2 triangles (the last quad).
+    // We reset once per frame (in sync, before rendering) so the counters
+    // accumulate the whole frame - scene + shadows + post - on every tier.
+    this.webgl.info.autoReset = false;
     // Release this context promptly on page teardown so repeated logout/login
     // reloads (location.reload) don't exhaust the browser's WebGL context pool.
     trackWebGLContext(this.webgl);
@@ -4130,6 +4136,9 @@ export class Renderer {
       this.camera.position.y += shakeY;
       this.shakeTrauma = Math.max(0, this.shakeTrauma - dt * 1.8);
     }
+    // Reset once here (autoReset is off) so info.render accumulates every pass
+    // of this frame instead of being wiped by the composer's post passes.
+    this.webgl.info.reset();
     if (this.post) this.post.render();
     else this.webgl.render(this.scene, this.camera);
     if (shakeX !== 0 || shakeY !== 0) {

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -13203,6 +13203,7 @@ export class Hud {
       t('hud.options.graphicsQuality'),
       'graphicsPreset',
       [
+        { value: 0, label: t('hud.options.graphicsPresetAuto') },
         { value: 1, label: t('hud.options.graphicsPresetLow') },
         { value: 2, label: t('hud.options.graphicsPresetMedium') },
         { value: 3, label: t('hud.options.graphicsPresetHigh') },

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -1,10 +1,17 @@
-import { describe, expect, it } from 'vitest';
 import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
 import {
   configureMaskedDoubleSidedVegetationMaterial,
-  forcedTierFromSearch, graphicsPresetLabel, isConstrainedBrowser, isWeakIntegratedGpu,
-  shouldUseAutoGovernor, tierFromHints, GFX_BUDGETS, type GfxRuntimeHints,
-  GFX_BUCKET_BANDS, gfxInternalsForTest,
+  forcedTierFromSearch,
+  GFX_BUCKET_BANDS,
+  GFX_BUDGETS,
+  type GfxRuntimeHints,
+  gfxInternalsForTest,
+  graphicsPresetLabel,
+  isConstrainedBrowser,
+  isWeakIntegratedGpu,
+  shouldUseAutoGovernor,
+  tierFromHints,
 } from '../src/render/gfx';
 
 const desktop: GfxRuntimeHints = {
@@ -15,10 +22,13 @@ const desktop: GfxRuntimeHints = {
 };
 
 describe('graphics tier resolution', () => {
-  it('resolves initial renderer startup with no persisted preset to ultra graphics', () => {
+  it('defaults a player with no persisted preset to Auto detection, not ultra', () => {
     expect(desktop.graphicsPreset).toBeUndefined();
-    expect(graphicsPresetLabel(desktop.graphicsPreset)).toBe('ultra');
-    expect(tierFromHints(desktop, false)).toBe('ultra');
+    expect(graphicsPresetLabel(desktop.graphicsPreset)).toBe('auto');
+    // Unknown GPU string resolves to the safe middle; the governor adapts from there.
+    expect(tierFromHints(desktop, false)).toBe('medium');
+    // Software GL forces low even under Auto.
+    expect(tierFromHints(desktop, true)).toBe('low');
   });
 
   it('honors explicit URL tier overrides', () => {
@@ -32,18 +42,28 @@ describe('graphics tier resolution', () => {
 
   it('treats phone-class and low-memory browsers as constrained', () => {
     expect(isConstrainedBrowser({ ...desktop, maxTouchPoints: 1, coarsePointer: true })).toBe(true);
-    expect(isConstrainedBrowser({ ...desktop, maxTouchPoints: 1, narrowViewport: true })).toBe(true);
+    expect(isConstrainedBrowser({ ...desktop, maxTouchPoints: 1, narrowViewport: true })).toBe(
+      true,
+    );
     expect(isConstrainedBrowser({ ...desktop, deviceMemory: 4 })).toBe(true);
     expect(isConstrainedBrowser({ ...desktop, maxTouchPoints: 1 })).toBe(false);
     expect(isConstrainedBrowser(desktop)).toBe(false);
   });
 
-  it('defaults missing presets to ultra while preserving legacy low and forced high', () => {
-    expect(tierFromHints(desktop, false)).toBe('ultra');
-    expect(tierFromHints({ ...desktop, graphicsPreset: 0 }, false)).toBe('low');
-    expect(tierFromHints(desktop, true)).toBe('ultra');
-    expect(tierFromHints({ ...desktop, maxTouchPoints: 1, coarsePointer: true }, false)).toBe('ultra');
-    expect(tierFromHints({ ...desktop, search: '?gfx=high', maxTouchPoints: 1, coarsePointer: true }, false)).toBe('high');
+  it('auto-detects under the default/Auto preset while forced tiers always win', () => {
+    // preset 0 (Auto) auto-detects; unknown desktop GPU -> medium.
+    expect(tierFromHints({ ...desktop, graphicsPreset: 0 }, false)).toBe('medium');
+    // A phone-class pointer forces low under Auto.
+    expect(tierFromHints({ ...desktop, maxTouchPoints: 1, coarsePointer: true }, false)).toBe(
+      'low',
+    );
+    // A URL-forced tier overrides Auto, even on a phone-class device or software GL.
+    expect(
+      tierFromHints(
+        { ...desktop, search: '?gfx=high', maxTouchPoints: 1, coarsePointer: true },
+        false,
+      ),
+    ).toBe('high');
     expect(tierFromHints({ ...desktop, search: '?gfx=ultra' }, true)).toBe('ultra');
   });
 
@@ -57,15 +77,16 @@ describe('graphics tier resolution', () => {
   });
 
   it('labels presets and runs the budget governor unless Ultra or URL-forced', () => {
-    expect(graphicsPresetLabel(undefined)).toBe('ultra');
-    expect(graphicsPresetLabel(0)).toBe('low');
+    expect(graphicsPresetLabel(undefined)).toBe('auto');
+    expect(graphicsPresetLabel(0)).toBe('auto');
     expect(graphicsPresetLabel(1)).toBe('low');
     expect(graphicsPresetLabel(2)).toBe('medium');
     expect(graphicsPresetLabel(3)).toBe('high');
     expect(graphicsPresetLabel(4)).toBe('ultra');
     expect(graphicsPresetLabel(5)).toBe('advanced');
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 0 })).toBe(true);
-    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: undefined })).toBe(false);
+    // No persisted preset is now Auto, so the governor runs by default.
+    expect(shouldUseAutoGovernor({ search: '', graphicsPreset: undefined })).toBe(true);
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 1 })).toBe(true);
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 2 })).toBe(true);
     expect(shouldUseAutoGovernor({ search: '', graphicsPreset: 3 })).toBe(true);
@@ -76,7 +97,9 @@ describe('graphics tier resolution', () => {
     expect(shouldUseAutoGovernor({ search: '?gfx=ultra', graphicsPreset: 0 })).toBe(false);
     expect(shouldUseAutoGovernor({ search: '?gfx=ultra', graphicsPreset: 4 })).toBe(false);
     expect(shouldUseAutoGovernor({ search: '?governor=0', graphicsPreset: 1 })).toBe(false);
-    expect(shouldUseAutoGovernor({ search: '?gfx=ultra&governor=1', graphicsPreset: 0 })).toBe(true);
+    expect(shouldUseAutoGovernor({ search: '?gfx=ultra&governor=1', graphicsPreset: 0 })).toBe(
+      true,
+    );
   });
 
   it('keeps every quality tier bounded by explicit runtime budgets', () => {
@@ -93,20 +116,22 @@ describe('graphics tier resolution', () => {
 
   it('defines tunable bucket bands for every quality tier', () => {
     for (const [tier, bands] of Object.entries(GFX_BUCKET_BANDS)) {
-      expect(Object.keys(bands).sort()).toEqual([
-        'characters',
-        'foliage',
-        'grass',
-        'lighting',
-        'materials',
-        'props',
-        'resolution',
-        'ui',
-        'vfx',
-        'waterSky',
-        'weapons',
-        'worldStreaming',
-      ].sort());
+      expect(Object.keys(bands).sort()).toEqual(
+        [
+          'characters',
+          'foliage',
+          'grass',
+          'lighting',
+          'materials',
+          'props',
+          'resolution',
+          'ui',
+          'vfx',
+          'waterSky',
+          'weapons',
+          'worldStreaming',
+        ].sort(),
+      );
       for (const band of Object.values(bands)) {
         expect(band.min).toBeGreaterThanOrEqual(0);
         expect(band.max).toBeLessThanOrEqual(1);
@@ -162,21 +187,36 @@ describe('graphics tier resolution', () => {
     expect(ultra.msaaSamples).toBe(4);
     expect(ultra.shadowMap).toBe(high.shadowMap);
     expect(ultra.pixelRatioCap).toBeGreaterThan(high.pixelRatioCap);
-    expect(GFX_BUCKET_BANDS.ultra.grass.baseline).toBeGreaterThan(GFX_BUCKET_BANDS.high.grass.baseline);
-    expect(GFX_BUCKET_BANDS.ultra.foliage.baseline).toBeGreaterThan(GFX_BUCKET_BANDS.high.foliage.baseline);
+    expect(GFX_BUCKET_BANDS.ultra.grass.baseline).toBeGreaterThan(
+      GFX_BUCKET_BANDS.high.grass.baseline,
+    );
+    expect(GFX_BUCKET_BANDS.ultra.foliage.baseline).toBeGreaterThan(
+      GFX_BUCKET_BANDS.high.foliage.baseline,
+    );
   });
 
-  it('detects older Intel integrated GPUs without overriding the ultra default', () => {
-    expect(isWeakIntegratedGpu('ANGLE (Intel, ANGLE Metal Renderer: Intel(R) Iris(TM) Plus Graphics 655)')).toBe(true);
+  it('auto-detects older Intel integrated GPUs down to low under Auto', () => {
+    expect(
+      isWeakIntegratedGpu(
+        'ANGLE (Intel, ANGLE Metal Renderer: Intel(R) Iris(TM) Plus Graphics 655)',
+      ),
+    ).toBe(true);
     expect(isWeakIntegratedGpu('ANGLE (Apple, ANGLE Metal Renderer: Apple M2)')).toBe(false);
-    expect(tierFromHints({ ...desktop, gpuRenderer: 'ANGLE (Intel, Intel(R) Iris(TM) Plus Graphics 655)' }, false)).toBe('ultra');
+    expect(
+      tierFromHints(
+        { ...desktop, gpuRenderer: 'ANGLE (Intel, Intel(R) Iris(TM) Plus Graphics 655)' },
+        false,
+      ),
+    ).toBe('low');
   });
 
   it('keeps masked double-sided vegetation off the transparent blended path', () => {
-    const mat = configureMaskedDoubleSidedVegetationMaterial(new THREE.MeshBasicMaterial({
-      alphaTest: 0.3,
-      transparent: true,
-    }));
+    const mat = configureMaskedDoubleSidedVegetationMaterial(
+      new THREE.MeshBasicMaterial({
+        alphaTest: 0.3,
+        transparent: true,
+      }),
+    );
 
     expect(mat.alphaTest).toBe(0.3);
     expect(mat.side).toBe(THREE.DoubleSide);

--- a/tests/gfx.test.ts
+++ b/tests/gfx.test.ts
@@ -187,6 +187,11 @@ describe('graphics tier resolution', () => {
     expect(ultra.msaaSamples).toBe(4);
     expect(ultra.shadowMap).toBe(high.shadowMap);
     expect(ultra.pixelRatioCap).toBeGreaterThan(high.pixelRatioCap);
+    // FPS-first DPR caps: the post composer scales with pixels, so high/ultra are
+    // capped tight enough that a high-DPI panel spends pixels on frame rate.
+    expect(high.pixelRatioCap).toBeLessThanOrEqual(1.5);
+    expect(ultra.pixelRatioCap).toBeLessThanOrEqual(2.0);
+    expect(medium.pixelRatioCap).toBeLessThanOrEqual(1.5);
     expect(GFX_BUCKET_BANDS.ultra.grass.baseline).toBeGreaterThan(
       GFX_BUCKET_BANDS.high.grass.baseline,
     );

--- a/tests/gfx_autodetect.test.ts
+++ b/tests/gfx_autodetect.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AUTO_FPS_FLOOR,
+  AUTO_FPS_HEADROOM,
+  type AutoDetectHints,
+  classifyGpu,
+  minTier,
+  type RememberedAuto,
+  recommendAutoTier,
+  resolveAutoTier,
+  tierRank,
+} from '../src/render/gfx_autodetect';
+
+const base: AutoDetectHints = { mobile: false, dpr: 1, softwareGl: false };
+const angle = (gpu: string) => `ANGLE (${gpu}, OpenGL 4.5.0)`;
+
+describe('classifyGpu', () => {
+  it('flags software renderers', () => {
+    expect(classifyGpu('ANGLE (Google, Vulkan 1.3 (SwiftShader Device))')).toBe('software');
+    expect(classifyGpu('llvmpipe (LLVM 15.0.0, 256 bits)')).toBe('software');
+  });
+
+  it('buckets NVIDIA cards by generation', () => {
+    expect(classifyGpu(angle('NVIDIA GeForce RTX 4070'))).toBe('strongDiscrete');
+    expect(classifyGpu(angle('NVIDIA GeForce RTX 3080'))).toBe('strongDiscrete');
+    expect(classifyGpu(angle('NVIDIA GeForce RTX 3070'))).toBe('strongDiscrete');
+    // The bench machine: 3060 Ti is solid but classed mid (FPS-first caps at high regardless).
+    expect(classifyGpu(angle('NVIDIA GeForce RTX 3060 Ti/PCIe/SSE2'))).toBe('midDiscrete');
+    expect(classifyGpu(angle('NVIDIA GeForce GTX 1650'))).toBe('midDiscrete');
+    expect(classifyGpu(angle('NVIDIA GeForce MX150'))).toBe('weak');
+  });
+
+  it('buckets AMD and Intel parts', () => {
+    expect(classifyGpu(angle('AMD Radeon RX 6700 XT'))).toBe('strongDiscrete');
+    expect(classifyGpu(angle('AMD Radeon RX 5700'))).toBe('midDiscrete');
+    expect(classifyGpu(angle('AMD Radeon Vega 8 Graphics'))).toBe('integrated');
+    expect(classifyGpu(angle('Intel(R) Arc(TM) A770 Graphics'))).toBe('midDiscrete');
+    expect(classifyGpu(angle('Intel(R) Iris(R) Xe Graphics'))).toBe('integrated');
+    expect(classifyGpu(angle('Intel(R) UHD Graphics 620'))).toBe('weak');
+    expect(classifyGpu(angle('Intel(R) Iris(TM) Plus Graphics 655'))).toBe('weak');
+  });
+
+  it('buckets Apple Silicon and mobile SoCs', () => {
+    expect(classifyGpu(angle('Apple M2 Pro'))).toBe('strongDiscrete');
+    expect(classifyGpu(angle('Apple M1 Max'))).toBe('strongDiscrete');
+    expect(classifyGpu(angle('Apple M1'))).toBe('midDiscrete');
+    expect(classifyGpu('Adreno (TM) 730')).toBe('integrated');
+    expect(classifyGpu('Mali-G57')).toBe('weak');
+  });
+
+  it('treats an empty or unrecognized string as unknown', () => {
+    expect(classifyGpu(undefined)).toBe('unknown');
+    expect(classifyGpu('')).toBe('unknown');
+    expect(classifyGpu('Some Future GPU 9999')).toBe('unknown');
+  });
+});
+
+describe('recommendAutoTier (FPS-first, never auto-ultra)', () => {
+  it('maps GPU classes to tiers and never returns ultra', () => {
+    expect(recommendAutoTier({ ...base, gpuRenderer: angle('NVIDIA GeForce RTX 4090') })).toBe(
+      'high',
+    );
+    expect(recommendAutoTier({ ...base, gpuRenderer: angle('NVIDIA GeForce RTX 3060 Ti') })).toBe(
+      'high',
+    );
+    expect(recommendAutoTier({ ...base, gpuRenderer: angle('Intel(R) Iris(R) Xe Graphics') })).toBe(
+      'medium',
+    );
+    expect(recommendAutoTier({ ...base, gpuRenderer: angle('Intel(R) UHD Graphics 620') })).toBe(
+      'low',
+    );
+    expect(recommendAutoTier({ ...base, gpuRenderer: 'SwiftShader', softwareGl: true })).toBe(
+      'low',
+    );
+    expect(recommendAutoTier({ ...base, gpuRenderer: angle('Future GPU') })).toBe('medium');
+  });
+
+  it('forces low on phones and software GL regardless of the named GPU', () => {
+    expect(recommendAutoTier({ ...base, mobile: true, gpuRenderer: angle('Apple M2') })).toBe(
+      'low',
+    );
+    expect(
+      recommendAutoTier({
+        ...base,
+        softwareGl: true,
+        gpuRenderer: angle('NVIDIA GeForce RTX 4090'),
+      }),
+    ).toBe('low');
+  });
+
+  it('steps down one rung on high-DPI panels', () => {
+    expect(
+      recommendAutoTier({ ...base, gpuRenderer: angle('NVIDIA GeForce RTX 4070'), dpr: 2 }),
+    ).toBe('medium');
+    expect(
+      recommendAutoTier({ ...base, gpuRenderer: angle('Intel(R) Iris(R) Xe Graphics'), dpr: 2 }),
+    ).toBe('low');
+  });
+
+  it('caps memory- and core-starved machines', () => {
+    expect(
+      recommendAutoTier({
+        ...base,
+        gpuRenderer: angle('NVIDIA GeForce RTX 4070'),
+        deviceMemory: 4,
+      }),
+    ).toBe('medium');
+    expect(
+      recommendAutoTier({
+        ...base,
+        gpuRenderer: angle('NVIDIA GeForce RTX 4070'),
+        deviceMemory: 2,
+      }),
+    ).toBe('low');
+    expect(
+      recommendAutoTier({
+        ...base,
+        gpuRenderer: angle('NVIDIA GeForce RTX 4070'),
+        hardwareConcurrency: 2,
+      }),
+    ).toBe('medium');
+  });
+});
+
+describe('resolveAutoTier (cross-session step-down/up)', () => {
+  const v = 14;
+  const hints: AutoDetectHints = { ...base, gpuRenderer: angle('NVIDIA GeForce RTX 3060 Ti') }; // heuristic -> high
+
+  it('ignores remembered samples from a different config version', () => {
+    const stale: RememberedAuto = { v: 13, tier: 'low', fps: 20 };
+    expect(resolveAutoTier(hints, stale, v)).toBe('high');
+  });
+
+  it('steps one rung down when last session ran below the floor', () => {
+    const bad: RememberedAuto = { v, tier: 'high', fps: AUTO_FPS_FLOOR - 10 };
+    expect(resolveAutoTier(hints, bad, v)).toBe('medium');
+  });
+
+  it('clamps to a remembered lower floor when the session was merely okay', () => {
+    const okay: RememberedAuto = { v, tier: 'medium', fps: 75 };
+    expect(resolveAutoTier(hints, okay, v)).toBe('medium');
+  });
+
+  it('lets a rung back up only with big headroom, never above the heuristic', () => {
+    const fast: RememberedAuto = { v, tier: 'medium', fps: AUTO_FPS_HEADROOM + 20 };
+    expect(resolveAutoTier(hints, fast, v)).toBe('high');
+    const cap: RememberedAuto = { v, tier: 'high', fps: AUTO_FPS_HEADROOM + 50 };
+    expect(resolveAutoTier(hints, cap, v)).toBe('high'); // never ultra
+  });
+
+  it('discards a remembered tier above the current heuristic as stale hardware', () => {
+    const integrated: AutoDetectHints = {
+      ...base,
+      gpuRenderer: angle('Intel(R) Iris(R) Xe Graphics'),
+    }; // -> medium
+    const stale: RememberedAuto = { v, tier: 'high', fps: 30 };
+    expect(resolveAutoTier(integrated, stale, v)).toBe('medium');
+  });
+});
+
+describe('tier order helpers', () => {
+  it('ranks and mins tiers', () => {
+    expect(tierRank('low')).toBeLessThan(tierRank('medium'));
+    expect(tierRank('high')).toBeLessThan(tierRank('ultra'));
+    expect(minTier('high', 'medium')).toBe('medium');
+    expect(minTier('low', 'ultra')).toBe('low');
+  });
+});

--- a/tests/perf_reporter.test.ts
+++ b/tests/perf_reporter.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { Settings } from '../src/game/settings';
 import type { PerfSnapshot } from '../src/game/perf';
 import { perfReporterInternalsForTest } from '../src/game/perf_reporter';
+import { Settings } from '../src/game/settings';
 
 function installBrowserGlobals(): void {
   const map = new Map<string, string>();
@@ -9,8 +9,12 @@ function installBrowserGlobals(): void {
   (globalThis as any).__APP_BUILD_ID__ = 'testbuild';
   (globalThis as any).localStorage = {
     getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
-    setItem: (k: string, v: string) => { map.set(k, v); },
-    removeItem: (k: string) => { map.delete(k); },
+    setItem: (k: string, v: string) => {
+      map.set(k, v);
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
     clear: () => map.clear(),
   };
   (globalThis as any).location = { search: '?perfScenario=bench_dense_foliage' };
@@ -48,7 +52,14 @@ function qualityBuckets(): NonNullable<PerfSnapshot['renderer']>['qualityBuckets
       vfx: { min: 0.68, baseline: 0.92, max: 1, roi: 0.7, cost: 'mixed', governable: true },
       characters: { min: 0.9, baseline: 1, max: 1, roi: 1, cost: 'mixed', governable: false },
       weapons: { min: 1, baseline: 1, max: 1, roi: 1, cost: 'mixed', governable: false },
-      worldStreaming: { min: 0.55, baseline: 0.88, max: 1, roi: 0.62, cost: 'cpu', governable: true },
+      worldStreaming: {
+        min: 0.55,
+        baseline: 0.88,
+        max: 1,
+        roi: 0.62,
+        cost: 'cpu',
+        governable: true,
+      },
       ui: { min: 0.86, baseline: 1, max: 1, roi: 0.86, cost: 'cpu', governable: false },
     },
     baseline: {
@@ -189,8 +200,18 @@ function snapshot(): PerfSnapshot {
     fps: 60,
     frameMs: { avg: 16.6, p50: 16, p95: 19, p99: 28, max: 52, long50: 1 },
     windows: {
-      last10s: { seconds: 10, frames: 600, fps: 60, frameMs: { avg: 16.6, p50: 16, p95: 18, p99: 24, max: 40, long50: 0 } },
-      last30s: { seconds: 30, frames: 1800, fps: 60, frameMs: { avg: 16.6, p50: 16, p95: 19, p99: 28, max: 52, long50: 1 } },
+      last10s: {
+        seconds: 10,
+        frames: 600,
+        fps: 60,
+        frameMs: { avg: 16.6, p50: 16, p95: 18, p99: 24, max: 40, long50: 0 },
+      },
+      last30s: {
+        seconds: 30,
+        frames: 1800,
+        fps: 60,
+        frameMs: { avg: 16.6, p50: 16, p95: 19, p99: 28, max: 52, long50: 1 },
+      },
     },
     mainMs: { renderer: { count: 1, avg: 5, p95: 5, max: 5 } },
     renderer: {
@@ -302,14 +323,21 @@ function snapshot(): PerfSnapshot {
     },
     browser: {
       longTasks: { count: 2, totalMs: 120, avg: 60, p95: 80, max: 80, lastAge: 1000 },
-      memory: { usedJSHeapSize: 1, totalJSHeapSize: 2, jsHeapSizeLimit: 3, usedMB: 100, limitMB: 4096 },
+      memory: {
+        usedJSHeapSize: 1,
+        totalJSHeapSize: 2,
+        jsHeapSizeLimit: 3,
+        usedMB: 100,
+        limitMB: 4096,
+      },
       visibilityState: 'visible',
     },
     device: {
       dpr: 2,
       viewport: '1440x900',
       mobileTouch: false,
-      userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15',
+      userAgent:
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X) AppleWebKit/605.1.15 Version/17.0 Safari/605.1.15',
       hardwareConcurrency: 12,
       deviceMemory: 8,
       maxTouchPoints: 0,
@@ -322,11 +350,16 @@ beforeEach(() => installBrowserGlobals());
 describe('perf reporter payload', () => {
   it('summarizes renderer performance without copying the full user agent', () => {
     const settings = new Settings();
-    const body = perfReporterInternalsForTest.payloadFromSnapshot(snapshot(), settings, 'sess1', 42)!;
+    const body = perfReporterInternalsForTest.payloadFromSnapshot(
+      snapshot(),
+      settings,
+      'sess1',
+      42,
+    )!;
 
     expect(body.releaseVersion).toBe('0.9.0');
     expect(body.buildId).toBe('testbuild');
-    expect(body.graphicsPreset).toBe('ultra');
+    expect(body.graphicsPreset).toBe('auto'); // fresh Settings now migrates to Auto
     expect(body.graphicsConfigVersion).toBe(14);
     expect(body.gfxTier).toBe('high');
     expect(body.autoGovernor).toBe(true);
@@ -338,12 +371,30 @@ describe('perf reporter payload', () => {
     expect(body.zoneOrScenario).toBe('bench_dense_foliage');
     expect(JSON.stringify(body.rawSummary)).not.toContain('Safari/605');
     expect((body.rawSummary as { graphicsConfigVersion?: number }).graphicsConfigVersion).toBe(14);
-    expect((body.rawSummary as { rendererQualityBuckets?: { levels?: { foliage?: number } } }).rendererQualityBuckets?.levels?.foliage).toBe(1);
-    expect((body.rawSummary as { rendererQualityBuckets?: { levels?: { weapons?: number } } }).rendererQualityBuckets?.levels?.weapons).toBe(1);
-    expect((body.rawSummary as { rendererPrewarmSummary?: { manifestPlanned?: number } }).rendererPrewarmSummary?.manifestPlanned).toBe(14);
-    expect((body.rawSummary as { rendererPrewarmSummary?: { entries?: unknown[] } }).rendererPrewarmSummary?.entries).toHaveLength(2);
-    expect((body.rawSummary as { rendererPrewarm?: { manifestEntries?: unknown[] } }).rendererPrewarm?.manifestEntries).toHaveLength(2);
-    expect((body.rawSummary as { rendererFoliage?: { modelVisibleTrianglesByLod?: { core?: number } } }).rendererFoliage?.modelVisibleTrianglesByLod?.core).toBe(420_000);
+    expect(
+      (body.rawSummary as { rendererQualityBuckets?: { levels?: { foliage?: number } } })
+        .rendererQualityBuckets?.levels?.foliage,
+    ).toBe(1);
+    expect(
+      (body.rawSummary as { rendererQualityBuckets?: { levels?: { weapons?: number } } })
+        .rendererQualityBuckets?.levels?.weapons,
+    ).toBe(1);
+    expect(
+      (body.rawSummary as { rendererPrewarmSummary?: { manifestPlanned?: number } })
+        .rendererPrewarmSummary?.manifestPlanned,
+    ).toBe(14);
+    expect(
+      (body.rawSummary as { rendererPrewarmSummary?: { entries?: unknown[] } })
+        .rendererPrewarmSummary?.entries,
+    ).toHaveLength(2);
+    expect(
+      (body.rawSummary as { rendererPrewarm?: { manifestEntries?: unknown[] } }).rendererPrewarm
+        ?.manifestEntries,
+    ).toHaveLength(2);
+    expect(
+      (body.rawSummary as { rendererFoliage?: { modelVisibleTrianglesByLod?: { core?: number } } })
+        .rendererFoliage?.modelVisibleTrianglesByLod?.core,
+    ).toBe(420_000);
   });
 
   it('keeps local dev trace frames and long-task correlation in raw summary', () => {
@@ -353,101 +404,112 @@ describe('perf reporter payload', () => {
       enabled: true,
       worstFrameLimit: 40,
       minFrameMs: 33,
-      frames: [{
-        atMs: 1200,
-        frameMs: 80,
-        scoreMs: 80,
-        reasons: ['frame-gap'],
-        mainMs: { renderer: 20, hud: 2, events: 0, sim: 0 },
-        renderer: {
-          calls: 200,
-          triangles: 300000,
-          textures: 80,
-          programs: 30,
-          views: 40,
-          renderScale: 1,
-          effectiveRenderScale: 0.9,
-          renderBudget: {
-            enabled: true,
-            mode: 'stable',
-            reason: 'stable',
-            pressure: 0.4,
-            frameMsEma: 16.7,
-            submitMsEma: 1,
-            externalFrameCap: false,
-            stallPressure: 0,
-            recentSubmitStalls: 0,
-            lastSubmitStallMs: 0,
-            stallHoldSeconds: 0,
-            stableSeconds: 0,
-            cooldownSeconds: 0,
-            levels: { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 0.9 },
-            caps: {
-              targetCalls: 330,
-              urgentCalls: 500,
-              targetTriangles: 1100000,
-              urgentTriangles: 1750000,
-              targetGrassTufts: 2850,
-              urgentGrassTufts: 4500,
-              minGrassLevel: 0.6,
-              minFoliageLevel: 0.6,
-              minVfxLevel: 0.68,
-              minLightingLevel: 0.62,
+      frames: [
+        {
+          atMs: 1200,
+          frameMs: 80,
+          scoreMs: 80,
+          reasons: ['frame-gap'],
+          mainMs: { renderer: 20, hud: 2, events: 0, sim: 0 },
+          renderer: {
+            calls: 200,
+            triangles: 300000,
+            textures: 80,
+            programs: 30,
+            views: 40,
+            renderScale: 1,
+            effectiveRenderScale: 0.9,
+            renderBudget: {
+              enabled: true,
+              mode: 'stable',
+              reason: 'stable',
+              pressure: 0.4,
+              frameMsEma: 16.7,
+              submitMsEma: 1,
+              externalFrameCap: false,
+              stallPressure: 0,
+              recentSubmitStalls: 0,
+              lastSubmitStallMs: 0,
+              stallHoldSeconds: 0,
+              stableSeconds: 0,
+              cooldownSeconds: 0,
+              levels: { grass: 1, foliage: 1, vfx: 1, lighting: 1, resolution: 0.9 },
+              caps: {
+                targetCalls: 330,
+                urgentCalls: 500,
+                targetTriangles: 1100000,
+                urgentTriangles: 1750000,
+                targetGrassTufts: 2850,
+                urgentGrassTufts: 4500,
+                minGrassLevel: 0.6,
+                minFoliageLevel: 0.6,
+                minVfxLevel: 0.68,
+                minLightingLevel: 0.62,
+              },
             },
+            qualityBuckets: qualityBuckets(),
+            pixelRatio: 1.5,
+            width: 1440,
+            height: 900,
+            foliage: {
+              modelQuality: 1,
+              modelBuckets: 64,
+              modelVisibleBuckets: 48,
+              modelBucketsByLod: { core: 32, impostor: 12, dressing: 20 },
+              modelVisibleByLod: { core: 24, impostor: 8, dressing: 16 },
+              ...foliageCostStats(),
+              grassEnabled: true,
+              grassQuality: 1,
+              grassActiveRadius: 82,
+              grassChunks: 48,
+              grassReadyChunks: 48,
+              grassVisibleChunks: 42,
+              grassQueuedChunks: 0,
+              grassTufts: 12000,
+              grassVisibleTufts: 9800,
+              grassBuiltChunks: 52,
+              grassDisposedChunks: 4,
+              grassLastBuildMs: 1.2,
+              grassBuildMs: 55,
+              grassCacheLimit: 96,
+            },
+            lastFrame: null,
           },
-          qualityBuckets: qualityBuckets(),
-          pixelRatio: 1.5,
-          width: 1440,
-          height: 900,
-          foliage: {
-            modelQuality: 1,
-            modelBuckets: 64,
-            modelVisibleBuckets: 48,
-            modelBucketsByLod: { core: 32, impostor: 12, dressing: 20 },
-            modelVisibleByLod: { core: 24, impostor: 8, dressing: 16 },
-            ...foliageCostStats(),
-            grassEnabled: true,
-            grassQuality: 1,
-            grassActiveRadius: 82,
-            grassChunks: 48,
-            grassReadyChunks: 48,
-            grassVisibleChunks: 42,
-            grassQueuedChunks: 0,
-            grassTufts: 12000,
-            grassVisibleTufts: 9800,
-            grassBuiltChunks: 52,
-            grassDisposedChunks: 4,
-            grassLastBuildMs: 1.2,
-            grassBuildMs: 55,
-            grassCacheLimit: 96,
+          browser: {
+            longTaskCount: 1,
+            longTaskTotalMs: 70,
+            longTaskLastAgeMs: 15,
+            memoryUsedMb: 100,
           },
-          lastFrame: null,
         },
-        browser: { longTaskCount: 1, longTaskTotalMs: 70, longTaskLastAgeMs: 15, memoryUsedMb: 100 },
-      }],
-      spans: [{
-        atMs: 1190,
-        startMs: 1110,
-        endMs: 1190,
-        durationMs: 80,
-        name: 'renderer.sync',
-        kind: 'external',
-        detail: { views: 42 },
-      }],
-      longTasks: [{
-        startMs: 1100,
-        endMs: 1170,
-        durationMs: 70,
-        name: 'self',
-        entryType: 'longtask',
-        attribution: [],
-        nearestFrameAtMs: 1200,
-        nearestFrameMs: 80,
-        nearestFrameDeltaMs: 65,
-        nearestSpanName: 'renderer.sync',
-        nearestSpanMs: 80,
-        nearestSpanDeltaMs: 0,
-      }],
+      ],
+      spans: [
+        {
+          atMs: 1190,
+          startMs: 1110,
+          endMs: 1190,
+          durationMs: 80,
+          name: 'renderer.sync',
+          kind: 'external',
+          detail: { views: 42 },
+        },
+      ],
+      longTasks: [
+        {
+          startMs: 1100,
+          endMs: 1170,
+          durationMs: 70,
+          name: 'self',
+          entryType: 'longtask',
+          attribution: [],
+          nearestFrameAtMs: 1200,
+          nearestFrameMs: 80,
+          nearestFrameDeltaMs: 65,
+          nearestSpanName: 'renderer.sync',
+          nearestSpanMs: 80,
+          nearestSpanDeltaMs: 0,
+        },
+      ],
     };
 
     const body = perfReporterInternalsForTest.payloadFromSnapshot(snap, settings, 'sess1', 42)!;
@@ -463,9 +525,21 @@ describe('perf reporter payload', () => {
     expect(rawSummary.devTrace.spans[0].name).toBe('renderer.sync');
     expect(rawSummary.devTrace.spans[0].detail?.views).toBe(42);
     expect(rawSummary.devTrace.longTasks[0].nearestFrameMs).toBe(80);
-    expect((body.rawSummary as { rendererFoliage?: { grassVisibleChunks?: number } }).rendererFoliage?.grassVisibleChunks).toBe(42);
-    expect((body.rawSummary as { rendererBudget?: { levels?: { grass?: number } } }).rendererBudget?.levels?.grass).toBe(1);
-    expect((body.rawSummary as { rendererQualityBuckets?: { features?: { windSway?: boolean } } }).rendererQualityBuckets?.features?.windSway).toBe(true);
-    expect((body.rawSummary as { rendererDiagnostics?: { enabled?: boolean } }).rendererDiagnostics?.enabled).toBe(false);
+    expect(
+      (body.rawSummary as { rendererFoliage?: { grassVisibleChunks?: number } }).rendererFoliage
+        ?.grassVisibleChunks,
+    ).toBe(42);
+    expect(
+      (body.rawSummary as { rendererBudget?: { levels?: { grass?: number } } }).rendererBudget
+        ?.levels?.grass,
+    ).toBe(1);
+    expect(
+      (body.rawSummary as { rendererQualityBuckets?: { features?: { windSway?: boolean } } })
+        .rendererQualityBuckets?.features?.windSway,
+    ).toBe(true);
+    expect(
+      (body.rawSummary as { rendererDiagnostics?: { enabled?: boolean } }).rendererDiagnostics
+        ?.enabled,
+    ).toBe(false);
   });
 });

--- a/tests/settings.test.ts
+++ b/tests/settings.test.ts
@@ -1,12 +1,23 @@
 import { beforeEach, describe, expect, it } from 'vitest';
-import { clickMoveButtonLabel, normalizeClickMoveButton, Settings, SETTING_RANGES } from '../src/game/settings';
+import {
+  applyGraphicsAutoMigration,
+  clickMoveButtonLabel,
+  GRAPHICS_AUTO_MIGRATION,
+  normalizeClickMoveButton,
+  SETTING_RANGES,
+  Settings,
+} from '../src/game/settings';
 
 function installStorage(): void {
   const map = new Map<string, string>();
   (globalThis as any).localStorage = {
     getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
-    setItem: (k: string, v: string) => { map.set(k, v); },
-    removeItem: (k: string) => { map.delete(k); },
+    setItem: (k: string, v: string) => {
+      map.set(k, v);
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
     clear: () => map.clear(),
   };
 }
@@ -14,12 +25,38 @@ function installStorage(): void {
 beforeEach(() => installStorage());
 
 describe('Settings', () => {
-  it('defaults fresh sessions and initial logins to the ultra graphics preset', () => {
+  it('defaults fresh sessions to the Auto graphics preset and stamps the migration', () => {
     const s = new Settings();
 
-    expect(localStorage.getItem('woc_settings')).toBeNull();
-    expect(SETTING_RANGES.graphicsPreset.def).toBe(4);
-    expect(s.get('graphicsPreset')).toBe(4);
+    expect(SETTING_RANGES.graphicsPreset.def).toBe(0);
+    expect(s.get('graphicsPreset')).toBe(0);
+    // Constructing Settings runs the one-time Auto migration, which persists.
+    expect(s.get('gfxAutoMigration')).toBe(GRAPHICS_AUTO_MIGRATION);
+    expect(localStorage.getItem('woc_settings')).not.toBeNull();
+  });
+
+  it('force-resets an existing player to Auto exactly once, then respects manual choice', () => {
+    // Pre-migration save: a manually pinned ultra preset, no migration marker.
+    localStorage.setItem('woc_settings', JSON.stringify({ graphicsPreset: 4 }));
+    const s1 = new Settings();
+    expect(s1.get('graphicsPreset')).toBe(0); // forced onto Auto
+    expect(s1.get('gfxAutoMigration')).toBe(GRAPHICS_AUTO_MIGRATION);
+
+    // The player now deliberately picks ultra; it must stick across reloads.
+    s1.set('graphicsPreset', 4);
+    const s2 = new Settings();
+    expect(s2.get('graphicsPreset')).toBe(4);
+  });
+
+  it('applyGraphicsAutoMigration flips to Auto once then stays idempotent', () => {
+    const v = { graphicsPreset: 3, gfxAutoMigration: 0 };
+    expect(applyGraphicsAutoMigration(v)).toBe(true);
+    expect(v.graphicsPreset).toBe(0);
+    expect(v.gfxAutoMigration).toBe(GRAPHICS_AUTO_MIGRATION);
+    expect(applyGraphicsAutoMigration(v)).toBe(false); // already migrated this epoch
+    v.graphicsPreset = 4;
+    expect(applyGraphicsAutoMigration(v)).toBe(false); // a later manual choice is preserved
+    expect(v.graphicsPreset).toBe(4);
   });
 
   it('starts at the documented defaults (camera calmer than the old 1.0)', () => {


### PR DESCRIPTION
## FPS-first auto-quality: a graphics detector that actually works, on by default for everyone

The graphics default was **ultra with the adaptive governor disabled on ultra**, and there was
no real hardware detection: a fresh or weak machine ran the full pipeline with zero runtime
adaptation. The "auto-adjust" players asked for never existed (the earlier attempt was reverted;
its i18n key was the only thing left). This restores it, biased toward frame rate.

Profiled and measured on a real GPU (RTX 3060 Ti, headed Chrome, vsync off) the whole way.

### What changes
- **Real first-run detection (`src/render/gfx_autodetect.ts`, pure + unit-tested).** Classifies
  the GPU renderer string into a perf class and picks the highest tier that should hold a
  comfortable frame rate, **FPS-first**: it never auto-picks `ultra`, steps a rung down for
  high-DPI panels / low memory / few cores, and forces `low` on phones and software GL.
- **`graphicsPreset 0 = Auto` is the new default**, so the adaptive governor (`render_budget.ts`)
  now runs out of the box instead of being disabled on the old ultra default. A cross-session
  memory (`woc_gfx_autotune`) feeds last session's sustained FPS back in, so a struggling machine
  starts a rung lower next launch.
- **Rolled out to everyone once, silently.** A one-time settings migration force-resets every
  existing player (including manually pinned tiers) to Auto, then sticks so a later manual choice
  is preserved. Ultra stays a deliberate manual escape hatch. The Esc menu gains an Auto option.
- **FPS-first device-pixel-ratio caps.** The post composer (N8AO + bloom) is the dominant GPU
  cost on high/ultra and scales with pixel count, so a high-DPI panel is what craters those tiers.
  Lower the caps (high 1.75 to 1.5, ultra 2.5 to 2.0, medium/low lower). No effect on the desktop
  1x majority; on a dpr=2 panel **high measured 102.7 to 121.5 fps (+18%)**.
- **Telemetry fix.** Three's `info.render` autoReset wiped the scene's draw-call/triangle counts
  on each composer post-pass, so high/ultra reported 1 call / 2 triangles. Reset once per frame
  instead, so the in-game perf overlay/reporter report real GPU load on the composer tiers.
- **Tooling:** `scripts/fps_tier_bench.mjs` (headed real-GPU FPS sweep across tiers) and
  `scripts/fps_profile.mjs` (steady-state main-loop / renderer-phase / foliage profiler).

### Measured (RTX 3060 Ti, 1920x1080, vsync off)
| tier | dpr=1 idle | dpr=2 idle |
|---|---|---|
| medium | ~129 | ~119 |
| high | ~117 | ~103 -> **~121** (after the cap) |
| ultra | ~116 | ~65 (manual-only) |

Auto resolves to `high` here with the governor on. The composer (N8AO + bloom) is the GPU cost
that scales with pixels; `medium` (no composer) is the most DPI-robust, which is why the FPS-first
heuristic leans toward it on weaker hardware.

### Notes / follow-ups
- Throughput axis only; the open-world streaming hitches (multi-hundred-ms first-visit spikes) are
  the separate freeze work.
- The `render_budget` submit-stall hold floors foliage/grass for ~8s after a single transient
  travel spike, even at idle, a visible quality dip with no FPS benefit on capable machines. Left
  untouched here (freeze-governor territory); flagged for a follow-up.

### Verification
`tsc --noEmit` clean, `npm run build` green, full Vitest green (one pre-existing `delves.test.ts`
timeout that is load-flaky and passes in isolation, unrelated to these files), biome formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
