### PR TITLE
perf(ui): idle-prewarm class ability/aura icons (no mid-game compose stall)

### DIFF
--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -53,6 +53,7 @@ import {
 import type { ZoneDef } from '../sim/data';
 import {
   ABILITIES,
+  abilitiesKnownAt,
   CLASSES,
   COMPANION_UPGRADE_COSTS,
   DELVE_AFFIXES,
@@ -206,6 +207,7 @@ import {
   tOptional,
   tPlural,
 } from './i18n';
+import { abilityIconWarmKeys, type IconWarmKey } from './icon_prewarm';
 import { iconDataUrl, QUALITY_COLOR, raidMarkerDataUrl } from './icons';
 import { itemStatDeltas } from './item_compare';
 import { PICK_ACTION_HOTKEYS } from './lockpick_panel';
@@ -833,6 +835,13 @@ export class Hud {
   // matching canceller; a clearTimeout on an idle id (or vice versa) could cancel
   // an unrelated timer that happens to share the number.
   private mapPrewarmVia: 'idle' | 'timeout' | null = null;
+  // Idle warm-list of the class's ability/aura icons (composed via iconDataUrl so
+  // they are cached before the spellbook/action bar opens or a buff first lands).
+  // No cancellation field: the class never changes mid-session, and a stale idle
+  // callback is a cheap no-op (the warm-list is exhausted).
+  private iconWarmKeys: IconWarmKey[] = [];
+  private iconWarmIdx = 0;
+  private iconWarmHandle = 0;
   // Delve schematic caches: static background (floor/pillars/tombs/dais/exit)
   // keyed by module id, redrawn only when the module changes.
   private delveSchematicBg: HTMLCanvasElement | null = null;
@@ -1313,6 +1322,7 @@ export class Hud {
     const startZoneName = zoneDisplayName(startZone.id);
     this.lastZoneId = startZone.id;
     this.prewarmMapBg(startZone.id); // render the spawn-zone map bg during idle, not on first open
+    this.prewarmAbilityIcons(); // compose the class's ability/aura icons during idle, not on window open / first buff
     this.showBanner(startZoneName);
     this.log(t('hud.core.welcomeZone', { zone: startZoneName }), '#ffd100');
     this.logZoneWelcome(startZone);
@@ -4905,6 +4915,53 @@ export class Hud {
       return;
     }
     this.scheduleMapPrewarm();
+  };
+
+  // Compose the class's ability + aura icons during idle so the spellbook / action
+  // bar (and the first buff/debuff in combat) never pay the synchronous canvas
+  // compose + PNG encode on the main thread mid-game. Mirrors the map-bg idle
+  // prewarm: sliced, idle-deadline-aware, with a setTimeout fallback.
+  private prewarmAbilityIcons(): void {
+    try {
+      const ids = abilitiesKnownAt(this.sim.cfg.playerClass, MAX_LEVEL).map((k) => k.def.id);
+      this.iconWarmKeys = abilityIconWarmKeys(ids);
+      this.iconWarmIdx = 0;
+      this.scheduleIconWarm();
+    } catch {
+      /* best-effort: never block entering the world on a prewarm */
+    }
+  }
+
+  private scheduleIconWarm(): void {
+    if (this.iconWarmIdx >= this.iconWarmKeys.length || this.iconWarmHandle) return;
+    const w = window as typeof window & {
+      requestIdleCallback?: (
+        cb: (d: { timeRemaining(): number }) => void,
+        opts?: { timeout: number },
+      ) => number;
+    };
+    if (w.requestIdleCallback) {
+      this.iconWarmHandle = w.requestIdleCallback(this.pumpIconWarm, { timeout: 4000 });
+    } else {
+      this.iconWarmHandle = window.setTimeout(() => this.pumpIconWarm(), 32);
+    }
+  }
+
+  private pumpIconWarm = (deadline?: { timeRemaining(): number }): void => {
+    this.iconWarmHandle = 0;
+    const ICONS_PER_SLICE = 4; // composing one icon is ~1-2ms; a few fit a frame
+    let n = 0;
+    while (this.iconWarmIdx < this.iconWarmKeys.length) {
+      const { kind, id } = this.iconWarmKeys[this.iconWarmIdx++];
+      try {
+        void iconDataUrl(kind, id); // caches the composited PNG; return discarded
+      } catch {
+        /* skip a missing recipe; the live path falls back the same way */
+      }
+      n++;
+      if (deadline === undefined ? n >= ICONS_PER_SLICE : deadline.timeRemaining() <= 2) break;
+    }
+    if (this.iconWarmIdx < this.iconWarmKeys.length) this.scheduleIconWarm();
   };
 
   // Refresh the minimap clock to the current real local time. Cheap to call

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -4959,7 +4959,12 @@ export class Hud {
         /* skip a missing recipe; the live path falls back the same way */
       }
       n++;
-      if (deadline === undefined ? n >= ICONS_PER_SLICE : deadline.timeRemaining() <= 2) break;
+      // Cap EVERY callback to a small slice, even when the browser hands out a
+      // big idle budget (right after the loading screen it can be tens of ms):
+      // composing the whole warm-list in one callback would block a frame and
+      // stutter. Stop early too if the idle budget runs low. The reschedule paces
+      // the remainder across later idles.
+      if (n >= ICONS_PER_SLICE || (deadline !== undefined && deadline.timeRemaining() <= 2)) break;
     }
     if (this.iconWarmIdx < this.iconWarmKeys.length) this.scheduleIconWarm();
   };

--- a/src/ui/icon_prewarm.ts
+++ b/src/ui/icon_prewarm.ts
@@ -1,0 +1,36 @@
+// Which procedural icons to warm during idle so opening the spellbook / action
+// bar and the first buff/debuff landing in combat never pay the synchronous
+// canvas compose + PNG encode (iconDataUrl) on the main thread mid-game.
+//
+// Pure + host-agnostic (no DOM, no canvas) so it unit-tests directly; the HUD is
+// the thin consumer that iterates these keys through iconDataUrl during idle.
+import type { IconKind } from './icons';
+
+export interface IconWarmKey {
+  kind: IconKind;
+  id: string;
+}
+
+/**
+ * The first icons a player hits: every known ability's ability icon (the action
+ * bar + spellbook on open) and its aura icon (the buff/debuff bar reuses the
+ * ability id when a cast applies an aura - see hud.ts). Deduped so the warmer
+ * never composes the same icon twice, and order-stable so the warm front matches
+ * what the player is most likely to open first.
+ */
+export function abilityIconWarmKeys(abilityIds: readonly string[]): IconWarmKey[] {
+  const keys: IconWarmKey[] = [];
+  const seen = new Set<string>();
+  const push = (kind: IconKind, id: string): void => {
+    if (!id) return;
+    const k = `${kind}|${id}`;
+    if (seen.has(k)) return;
+    seen.add(k);
+    keys.push({ kind, id });
+  };
+  for (const id of abilityIds) {
+    push('ability', id);
+    push('aura', id);
+  }
+  return keys;
+}

--- a/tests/icon_prewarm.test.ts
+++ b/tests/icon_prewarm.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { abilityIconWarmKeys } from '../src/ui/icon_prewarm';
+
+describe('abilityIconWarmKeys', () => {
+  it('warms an ability + aura icon per id, in order', () => {
+    const keys = abilityIconWarmKeys(['heroic_strike', 'rend']);
+    expect(keys).toEqual([
+      { kind: 'ability', id: 'heroic_strike' },
+      { kind: 'aura', id: 'heroic_strike' },
+      { kind: 'ability', id: 'rend' },
+      { kind: 'aura', id: 'rend' },
+    ]);
+  });
+
+  it('dedupes repeated ability ids', () => {
+    const keys = abilityIconWarmKeys(['fireball', 'fireball', 'frostbolt']);
+    expect(keys.filter((k) => k.kind === 'ability').map((k) => k.id)).toEqual([
+      'fireball',
+      'frostbolt',
+    ]);
+    expect(keys).toHaveLength(4);
+  });
+
+  it('skips empty ids and handles an empty list', () => {
+    expect(abilityIconWarmKeys([])).toEqual([]);
+    expect(abilityIconWarmKeys(['', 'shield_bash'])).toEqual([
+      { kind: 'ability', id: 'shield_bash' },
+      { kind: 'aura', id: 'shield_bash' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Idle-prewarm the class's ability/aura icons (kill the on-open compose stall)

Hunting **main-thread blocks that hit mid-game** (not at boot). Found by static analysis:
procedural icons are composed **synchronously on first use** - `iconDataUrl()` draws the
recipe to a canvas and PNG-encodes it (`toDataURL`), both on the main thread, then caches the
result. So the moment you **open the spellbook / action bar**, or the **first time each
buff/debuff lands in combat**, the game composes + encodes every *new* icon at once: a
main-thread stall proportional to the icon count, right in the middle of play.

### Fix
Warm them during idle. After entering the world, enumerate the class's known abilities
(`abilitiesKnownAt`) and compose each ability + aura icon during idle (`requestIdleCallback`,
sliced, with a `setTimeout` fallback) - mirroring the existing **map-bg idle prewarm**. By the
time a window opens or a buff lands the icon is already cached, so nothing composes on the
main thread mid-game.

- **Best-effort + safe**: a failure never blocks entering the world; a stale idle callback is
  a cheap no-op (the warm-list is exhausted); already-cached icons are skipped.
- The warm-list logic is a **pure, unit-tested module** (`src/ui/icon_prewarm.ts`); the HUD is
  the thin consumer.

### Verification
`tsc --noEmit` + `npm run build` + the unit test (3 cases) green. The stall reduction itself
was found statically and is **not yet live-profiled** - the authoring session exhausted the
machine's Chrome-launch capacity. Confirm with `node scripts/profile.mjs combat` (open windows /
fight) before merge; the mechanism (prewarm -> cache hit) is straightforward.

### Context
Part of the same main-thread-stall hunt as the async shader-compile gate (#1015): that covers
GPU program links; this covers the CPU-side canvas compose for icons. Same idea - move
first-use work off the hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
