### PR TITLE
perf(net): fix crowd load-test ceiling + parallelize WS join-path DB reads

### DIFF
--- a/docs/perf/network-crowd-findings.md
+++ b/docs/perf/network-crowd-findings.md
@@ -1,0 +1,47 @@
+# Network / crowd performance: test harness + findings
+
+Work-in-progress. Adds the crowd-load path to the perf profiler (`scripts/profile.mjs
+crowd`) and captures a first pass of real-client crowd measurements. Builds on the
+perf-profiler tooling.
+
+## How to run
+
+```
+ALLOW_DEV_COMMANDS=1 npm run server      # :8787 (bots teleport to cluster)
+npm run dev                              # :5173
+BROWSER_PATH=/path/to/chrome node scripts/profile.mjs crowd --tier high --crowd 50
+```
+
+The `crowd` scenario enters one real online client, then spawns N WS bot clients
+(real REST register + char create + WS auth) clustered around the client, and samples
+client FPS at solo / half-crowd / full-crowd / crowd-while-moving.
+
+## Harness fixes this branch makes (the scenario was broken before)
+
+- **Char names are letters-only** (the server rejects digits). Both the client name
+  (`Pcam<uniq>`) and the bot names (`Pb<uniq>...`) embedded the numeric run stamp, so
+  every Create was silently rejected. Map digits to letters.
+- **Robust online entry.** A fresh account lands on `charcreate-panel` directly (not
+  `charselect`/`realm`), which the old fixed flow never handled. Drive whichever panel
+  appears (realm / charcreate / charselect) until the world loads, tolerating the page
+  navigation that "Enter World" triggers.
+- **Staggered bot joins.** 50 simultaneous WS auth + character-load joins overwhelm the
+  server join path (most time out); join in waves with a gap so the world loop drains
+  each set. Join timeout raised to 20s.
+
+## First findings (RTX 3060 Ti, high tier, offline single-realm dev server)
+
+- Single player baseline: ~85-89 fps.
+- ~21 real players in view: ~65-77 fps, 1% low drops from ~45 to ~33-40. So each nearby
+  player is a real client-side render cost (skinned rig + nameplate), and the 1% lows
+  dip under crowd - the place to optimise client FPS for crowds.
+
+## Open: the ~20-24 connection ceiling
+
+Despite staggering, only ~20-24 bots stay connected (the rest fail with `join timeout`);
+the client then renders ~21. It is NOT the interest scope (players enter at 90yd, the
+bots cluster at 28yd) and NOT an idle-drop (the server only clears stale held input, it
+does not disconnect). It looks like server join-path throughput under the world loop
+(DB character-load concurrency / event-loop contention). Reaching 40-50 connected needs
+a server-side look (DB pool size, join batching). The client-render cost is separately
+measurable and is the FPS-under-crowd lever.

--- a/docs/perf/network-crowd-findings.md
+++ b/docs/perf/network-crowd-findings.md
@@ -25,23 +25,76 @@ client FPS at solo / half-crowd / full-crowd / crowd-while-moving.
   `charselect`/`realm`), which the old fixed flow never handled. Drive whichever panel
   appears (realm / charcreate / charselect) until the world loads, tolerating the page
   navigation that "Enter World" triggers.
-- **Staggered bot joins.** 50 simultaneous WS auth + character-load joins overwhelm the
-  server join path (most time out); join in waves with a gap so the world loop drains
-  each set. Join timeout raised to 20s.
+- **Per-bot `X-Forwarded-For` on the WS upgrade, not only on REST.** This is the fix
+  for the connection ceiling described below. The REST register/create calls already
+  carried a unique XFF per bot; the WebSocket upgrade did not, so every bot's socket
+  resolved to `127.0.0.1` and shared one IP. A loopback source is a trusted XFF setter,
+  so passing the same header on the `new WebSocket(...)` upgrade gives each bot its own
+  apparent IP across the whole join, the way a real crowd of distinct clients does.
+- **Staggered bot joins.** Kept as a courtesy (the bots register/create/join in waves
+  with a gap) so a single run does not thundering-herd the DB pool; it is no longer
+  load-bearing for the ceiling. Join timeout raised to 20s.
 
-## First findings (RTX 3060 Ti, high tier, offline single-realm dev server)
+## Root cause of the old ~20-24 connection ceiling (FIXED)
 
-- Single player baseline: ~85-89 fps.
-- ~21 real players in view: ~65-77 fps, 1% low drops from ~45 to ~33-40. So each nearby
-  player is a real client-side render cost (skinned rig + nameplate), and the 1% lows
-  dip under crowd - the place to optimise client FPS for crowds.
+The ceiling was **not** server join-path throughput, interest scope, or an idle-drop.
+It was the anti-bot **per-IP hard cap** doing its job: `MAX_WS_PER_IP_HARD` (default 20,
+`server/main.ts`). Because the harness only set the per-bot XFF on the REST calls and
+not on the WS upgrade, all bots shared `127.0.0.1`, so the 21st WS connection was
+refused with `close(1008, 'Too many connections from your network')`. The bot then
+waited for a `hello` that never arrived and reported `join timeout`, which read like a
+throughput problem but was a flat policy reject at 20.
 
-## Open: the ~20-24 connection ceiling
+With the XFF now on the WS upgrade (above), each bot is a distinct IP and the cap no
+longer bites, so the crowd scales to the size you ask for. No production behaviour
+changes: the cap is unchanged and still protects real deployments; only the load-test
+harness, which legitimately simulates many distinct clients, now presents distinct IPs.
 
-Despite staggering, only ~20-24 bots stay connected (the rest fail with `join timeout`);
-the client then renders ~21. It is NOT the interest scope (players enter at 90yd, the
-bots cluster at 28yd) and NOT an idle-drop (the server only clears stale held input, it
-does not disconnect). It looks like server join-path throughput under the world loop
-(DB character-load concurrency / event-loop contention). Reaching 40-50 connected needs
-a server-side look (DB pool size, join batching). The client-render cost is separately
-measurable and is the FPS-under-crowd lever.
+## Server join-path optimisation (this branch)
+
+With the ceiling gone, the join path itself is the next lever for a reconnect storm
+(everyone returning after a restart hitting auth at once):
+
+- **Parallelised the auth reads.** `authenticateWebSocket` ran six DB queries strictly
+  in series (token, moderation, character, chat-mute, admin, cosmetics). The five that
+  only depend on the resolved `accountId`/`characterId` now run in one `Promise.all`
+  batch, so a join holds a pool connection for far less wall-clock and a burst drains
+  instead of queueing behind the 10s auth timeout. Error priority (locked > no-character
+  > force-rename > too-many-connections) is preserved.
+- **`PG_POOL_MAX` env knob.** The `pg` pool size (default 10, unchanged) is now
+  env-tunable, so a crowd test or a busy realm can widen it without a code change
+  (`server/db.ts`). Keep the sum across realm processes under the database's
+  `max_connections`.
+
+## Results after the fix (RTX 3060 Ti, high tier, single-realm dev server)
+
+`profile.mjs crowd --tier high --crowd 50`, `PG_POOL_MAX=30`, headed, vsync off. The
+crowd now scales to the requested size: **all 50 bots connect (51 players in scene with
+the real client); zero join failures, zero `1008` rejects, no pool/timeout errors**, vs
+the old ~21 wall.
+
+| scene | players | fps | 1% low | p99 | jank |
+|---|---|---|---|---|---|
+| solo | 1 | 103.9 | 76.1 | 12.3ms | 0% |
+| crowd-25 | 26 | 70.9 | 40.7 | 18.8ms | 0.35% |
+| crowd-50 | 51 | 59.1 | 45.9 | 20.9ms | 0% |
+| crowd-50 moving | 51 | 60.2 | 35.4 | 26.8ms | 1.66% |
+
+The server kept up across the whole run (snapshots sustained 59-60 fps with near-zero
+jank at 51 players, so the 50ms tick budget was not blown). Each nearby player is a real
+client-side render cost (skinned rig + nameplate); that per-player cost is the separate
+FPS-under-crowd lever, and is what the crowd-adaptive character LOD (PR #1013, in the
+release) targets - it is why the 1% low at 51 players (45.9) is actually steadier than
+the old un-LOD'd 21-player run (~33-40).
+
+## How to run a real 40-50 crowd now
+
+```
+npm run db:up                            # Postgres on :5433
+ALLOW_DEV_COMMANDS=1 npm run server      # :8787 (bots teleport to cluster)
+npm run dev                              # :5173
+BROWSER_PATH=/path/to/chrome node scripts/profile.mjs crowd --tier high --crowd 50
+```
+
+`MAX_WS_PER_IP_HARD` no longer needs raising (each bot is a distinct apparent IP). If
+you specifically want to test the per-IP cap itself, set it low and watch the reject.

--- a/scripts/profile.mjs
+++ b/scripts/profile.mjs
@@ -1,0 +1,292 @@
+// Unified game performance profiler CLI (headed, real GPU).
+//
+// Drives the real game through a named scenario and prints rich metrics: FPS +
+// 1%/0.1% lows + frame percentiles + jank, renderer/main-loop phase split, draw
+// calls / triangles / views, and FREEZE ATTRIBUTION (which hitches were shader
+// compiles vs view builds vs long tasks). Supports A/B: save a baseline, re-run
+// after a change, get the diff.
+//
+//   npm run dev                                 # :5173  (always)
+//   ALLOW_DEV_COMMANDS=1 npm run server         # :8787  (only for the crowd scenario)
+//   node scripts/profile.mjs <scenario> [opts]
+//
+// Scenarios:  fps | tour | combat | freeze | tiers | crowd | walk | play
+//   play = walk + RMB camera look + jump + cast every ability (finds first-cast
+//          ability VFX compiles and camera-reveal hitches a plain walk misses)
+// Options:
+//   --tier low|medium|high|ultra   force a tier (default: auto-detect)
+//   --dpr 1|2                       device pixel ratio (default 1)
+//   --mode offline|online          (crowd forces online; others default offline)
+//   --crowd N                      crowd size for the crowd scenario (default 40)
+//   --ms N                         sample window per step (default 4000)
+//   --out file.json                write the full result JSON
+//   --compare baseline.json        diff this run against a saved baseline
+//   --label tag                    label the run
+//   BROWSER_PATH=/path/to/chrome   browser binary
+import fs from 'node:fs';
+import path from 'node:path';
+import { Profiler } from './profiler/harness.mjs';
+import { diffMetrics } from './profiler/metrics.mjs';
+
+function parseArgs(argv) {
+  const a = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t.startsWith('--'))
+      a[t.slice(2)] = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : true;
+    else a._.push(t);
+  }
+  return a;
+}
+const args = parseArgs(process.argv.slice(2));
+const scenario = args._[0] ?? 'fps';
+const TIER = args.tier || undefined;
+const DPR = Number(args.dpr ?? 1);
+const MS = Number(args.ms ?? 4000);
+const CROWD = Number(args.crowd ?? 40);
+
+// Open-world waypoints from the starting region outward (cross-biome traversal).
+const WAYPOINTS = [
+  { x: 0, z: -14, facing: 0, name: 'town' },
+  { x: 0, z: 40, facing: Math.PI, name: 'town-edge' },
+  { x: 30, z: 120, facing: Math.PI, name: 'open-field' },
+  { x: -40, z: 200, facing: Math.PI, name: 'far-north' },
+  { x: 120, z: 80, facing: Math.PI / 2, name: 'east' },
+];
+
+async function scenarioFps(p) {
+  await p.enter({ mode: 'offline', tier: TIER });
+  const out = [];
+  await p.teleport(0, -14, 0);
+  out.push(await p.sample({ ms: MS, label: 'town-idle' }));
+  await p.teleport(0, 60, Math.PI);
+  out.push(await p.sample({ ms: MS, label: 'open-idle' }));
+  await p.teleport(0, 60, Math.PI);
+  await p.setMove({ forward: true });
+  out.push(await p.sample({ ms: MS, label: 'open-run' }));
+  await p.stopMove();
+  return out;
+}
+
+async function scenarioTour(p) {
+  await p.enter({ mode: 'offline', tier: TIER });
+  const out = [];
+  for (const wp of WAYPOINTS) {
+    await p.teleport(wp.x, wp.z, wp.facing);
+    await p.setMove({ forward: true });
+    out.push(await p.sample({ ms: MS, label: `tour-${wp.name}` }));
+    await p.stopMove();
+  }
+  return out;
+}
+
+async function scenarioCombat(p) {
+  await p.enter({ mode: 'offline', tier: TIER });
+  const out = [];
+  // a spot with hostile mobs near the start zone
+  await p.teleport(30, 90, Math.PI);
+  out.push(await p.sample({ ms: 2500, label: 'pre-combat' }));
+  // sample WHILE cycling the action bar so VFX (and first-use shader programs) fire
+  const fire = p.combat({ ms: MS });
+  out.push(await p.sample({ ms: MS, label: 'combat-vfx' }));
+  await fire;
+  return out;
+}
+
+async function scenarioFreeze(p) {
+  await p.enter({ mode: 'offline', tier: TIER });
+  const out = [];
+  // cold traversal into ungenerated terrain - the classic streaming/compile stalls
+  await p.teleport(0, 30, Math.PI);
+  await p.setMove({ forward: true });
+  out.push(await p.sample({ ms: Math.max(MS, 7000), label: 'cold-run' }));
+  await p.stopMove();
+  return out;
+}
+
+async function scenarioTiers(p) {
+  const out = [];
+  for (const tier of ['low', 'medium', 'high', 'ultra']) {
+    await p.enter({ mode: 'offline', tier });
+    await p.teleport(0, 60, Math.PI);
+    await p.setMove({ forward: true });
+    out.push(await p.sample({ ms: MS, label: `tier-${tier}` }));
+    await p.stopMove();
+  }
+  return out;
+}
+
+async function scenarioCrowd(p) {
+  await p.enter({ mode: 'online', tier: TIER });
+  const out = [];
+  out.push(await p.sample({ ms: MS, label: 'solo' }));
+  for (const target of [Math.round(CROWD / 2), CROWD]) {
+    const got = await p.spawnCrowd(target, { radius: 28 });
+    await sleep(3000);
+    out.push(await p.sample({ ms: MS, label: `crowd-${got}` }));
+  }
+  await p.setMove({ forward: true });
+  out.push(await p.sample({ ms: MS, label: 'crowd-run' }));
+  await p.stopMove();
+  return out;
+}
+
+// Walk continuously across the world on foot (no teleports), crossing zones, and
+// collect every freeze with its position + cause as it happens.
+async function scenarioWalk(p) {
+  await p.enter({ mode: TIER && args.mode === 'online' ? 'online' : 'offline', tier: TIER });
+  return [await p.walk({ ms: Number(args.ms ?? 70000), heading: Number(args.heading ?? 0) })];
+}
+
+// Realistic play session: walk + turn the camera (RMB look) + jump + cast every
+// ability. Surfaces first-cast ability VFX compiles and camera-reveal hitches that
+// a straight `walk` (camera fixed forward, no abilities) cannot.
+async function scenarioPlay(p) {
+  await p.enter({ mode: TIER && args.mode === 'online' ? 'online' : 'offline', tier: TIER });
+  return [await p.play({ ms: Number(args.ms ?? 60000), keys: String(args.keys ?? '1234567890') })];
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const SCENARIOS = {
+  fps: scenarioFps,
+  tour: scenarioTour,
+  combat: scenarioCombat,
+  freeze: scenarioFreeze,
+  tiers: scenarioTiers,
+  crowd: scenarioCrowd,
+  walk: scenarioWalk,
+  play: scenarioPlay,
+};
+
+function printWalk(s) {
+  const ev = s.events ?? [];
+  const fz = s.freezes ?? {};
+  console.log(`\n  walked ~${s.distance} units over ${s.trail?.length ?? 0} checkpoints`);
+  console.log(
+    `  total hitches (>=50ms): ${fz.hitchCount ?? 0}  worst ${fz.worstMs ?? 0}ms  by cause: ${JSON.stringify(fz.byCause ?? {})}`,
+  );
+  if (ev.length) {
+    console.log('  freezes as they happened (ms / cause / where):');
+    for (const e of ev)
+      console.log(
+        `    ${String(e.ms).padStart(6)}ms  ${e.cause.padEnd(13)} @ (${e.x}, ${e.z})${e.zone ? ` ${e.zone}` : ''}`,
+      );
+  } else {
+    console.log('  no >=50ms freezes recorded during the walk');
+  }
+  const np = s.newPrograms ?? [];
+  if (np.length) {
+    console.log(`  NEW SHADERS that linked mid-walk (${np.length}):`);
+    for (const k of np) console.log(`    - ${String(k).replace(/\s+/g, ' ').slice(0, 160)}`);
+  }
+  console.log(`  trail: ${(s.trail ?? []).map((t) => `(${t.x},${t.z})`).join(' -> ')}`);
+}
+
+function fmtRow(s) {
+  const f = s.frame ?? {};
+  const z = s.freezes ?? {};
+  const sc = s.scene ?? {};
+  const causes =
+    Object.entries(z.byCause ?? {})
+      .map(([c, n]) => `${c}:${n}`)
+      .join(',') || '-';
+  const kinds =
+    Object.entries(sc.entitiesByKind ?? {})
+      .map(([k, n]) => `${k}:${n}`)
+      .join(' ') || '-';
+  const line1 = [
+    s.label.padEnd(14),
+    `fps ${String(f.fpsMean ?? s.fps).padStart(6)}`,
+    `1%low ${String(f.fpsLow1 ?? '-').padStart(6)}`,
+    `p99 ${String(f.p99Ms ?? s.frameP99).padStart(6)}ms`,
+    `max ${String(f.maxMs ?? s.frameMax).padStart(6)}ms`,
+    `jank ${String(f.jankPct ?? '-').padStart(5)}%`,
+    `sub ${String(s.phaseSubmitMs).padStart(5)}ms`,
+    `hitch[${z.worstMs ?? 0}ms ${causes}]`,
+  ].join('  ');
+  const tris = sc.render ? (sc.render.triangles / 1e6).toFixed(2) : '?';
+  const line2 = `${' '.repeat(14)}  scene: ents ${sc.entityCount ?? s.entities ?? '?'} [${kinds}]  views ${sc.viewCount ?? s.views}  models ${sc.modelCount ?? '?'}  shaders ${sc.programs ?? s.programs}/${sc.shaderVariants ?? '?'}var  tex ${sc.textures ?? '?'}  geo ${sc.geometries ?? '?'}  draws ${sc.render?.calls ?? s.calls}  tris ${tris}M`;
+  const np = s.newPrograms ?? [];
+  const line3 = np.length
+    ? `${' '.repeat(14)}  NEW SHADERS (${np.length}) that linked this window:\n` +
+      np.map((k) => `${' '.repeat(16)}- ${String(k).replace(/\s+/g, ' ').slice(0, 160)}`).join('\n')
+    : '';
+  return [line1, line2, line3].filter(Boolean).join('\n');
+}
+
+async function main() {
+  const run = SCENARIOS[scenario];
+  if (!run) {
+    console.error(`unknown scenario '${scenario}'. one of: ${Object.keys(SCENARIOS).join(', ')}`);
+    process.exit(1);
+  }
+  console.log(
+    `profiler: scenario=${scenario} tier=${TIER ?? 'auto'} dpr=${DPR} ms=${MS} (HEADED, vsync OFF)`,
+  );
+  const p = new Profiler({
+    dpr: DPR,
+    shotDir: typeof args.shot === 'string' ? args.shot : args.shot ? 'tmp/profiler-shots' : null,
+  });
+  let results = [];
+  try {
+    await p.launch();
+    results = await run(p);
+  } finally {
+    await p.close();
+  }
+
+  console.log('\n========== RESULTS ==========');
+  for (const s of results) console.log(fmtRow(s));
+  if (scenario === 'walk' || scenario === 'play') for (const s of results) printWalk(s);
+
+  const payload = {
+    scenario,
+    tier: TIER ?? 'auto',
+    dpr: DPR,
+    label: args.label ?? '',
+    at: new Date().toISOString(),
+    results,
+  };
+  if (args.out) {
+    fs.mkdirSync(path.dirname(args.out) || '.', { recursive: true });
+    fs.writeFileSync(args.out, JSON.stringify(payload, null, 2));
+    console.log(`\nwrote ${args.out}`);
+  }
+
+  if (args.compare) {
+    const base = JSON.parse(fs.readFileSync(args.compare, 'utf8'));
+    console.log(`\n========== A/B vs ${args.compare} ==========`);
+    const byLabel = new Map(base.results.map((r) => [r.label, r]));
+    for (const after of results) {
+      const before = byLabel.get(after.label);
+      if (!before) continue;
+      const a = {
+        fps: after.frame?.fpsMean ?? after.fps,
+        fpsLow1: after.frame?.fpsLow1 ?? 0,
+        p99Ms: after.frame?.p99Ms ?? after.frameP99,
+        calls: after.calls,
+        phaseSubmitMs: after.phaseSubmitMs,
+      };
+      const b = {
+        fps: before.frame?.fpsMean ?? before.fps,
+        fpsLow1: before.frame?.fpsLow1 ?? 0,
+        p99Ms: before.frame?.p99Ms ?? before.frameP99,
+        calls: before.calls,
+        phaseSubmitMs: before.phaseSubmitMs,
+      };
+      const d = diffMetrics(b, a);
+      const cell = (k) =>
+        d[k]
+          ? `${k} ${d[k].before}->${d[k].after} (${d[k].delta > 0 ? '+' : ''}${d[k].pct}% ${d[k].better})`
+          : '';
+      console.log(
+        `${after.label.padEnd(14)} ${cell('fps')}  ${cell('fpsLow1')}  ${cell('p99Ms')}  ${cell('calls')}`,
+      );
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/profiler/CLAUDE.md
+++ b/scripts/profiler/CLAUDE.md
@@ -1,0 +1,42 @@
+<!-- scripts/profiler/ — shared core for the game performance profiler.
+     Node ESM (.mjs), run via scripts/profile.mjs. See scripts/CLAUDE.md. -->
+
+# scripts/profiler/ — performance profiler core
+
+The reusable core behind `scripts/profile.mjs` (the CLI). Built so an MCP server
+can wrap the same `Profiler` later without duplicating logic. Drives the REAL game
+headed on the real GPU (vsync off) and turns a scenario into rich, structured
+metrics. Needs `npm run dev` (:5173); the `crowd` scenario also needs
+`ALLOW_DEV_COMMANDS=1 npm run server` (:8787).
+
+## Files
+- `metrics.mjs` — **pure** metric math (no DOM/puppeteer), unit-tested in
+  `tests/profiler_metrics.test.mjs`:
+  - `frameStats(deltasMs, targetFps)` — mean/median FPS, **1%/0.1% lows**,
+    p50/p95/p99/p99.9/max, stdev (smoothness), jank %, long-frame + stutter counts.
+    The lows are computed from the raw per-frame array, not the perf overlay's
+    pre-summarised percentiles, so they reflect true perceived smoothness.
+  - `attributeFreezes(samples)` — **freeze attribution**: each hitch frame is
+    tagged `shader-compile` (WebGL program count rose), `view-build` (a rig was
+    created), `asset-upload` (texture/geometry streamed to the GPU), `long-task`
+    (JS/GC), or `other`. Turns "a 1.8s hitch" into "it compiled 2 shaders". The
+    sample also reports `newPrograms` (the exact shader cacheKeys that linked
+    during the window) so a residual compile is identifiable - i.e. what to prewarm.
+  - `normalizeReport(report)` — flatten `window.__game.perf.report()` to a stable
+    comparable set. `diffMetrics(before, after)` — A/B delta + better/worse verdict.
+- `harness.mjs` — the `Profiler` class: browser/session lifecycle + scenario
+  primitives (`enter` offline/online, `teleport`, `setMove`, `tour`, `spawnCrowd`
+  /`despawnCrowd`, `combat`, `setTier`, `screenshot`) and the rich `sample({ms})`.
+  `sample` injects a rAF collector (`window.__prof`) that records per-frame
+  `{dt, programs, views, longTaskMs}`, then folds report + `frameStats` +
+  `attributeFreezes`. Online crowds are WS bots with a unique `X-Forwarded-For`
+  per bot to clear the 20/min/IP register limit (load-test only).
+
+## Conventions
+- Reads the world only through `window.__game` (sim/world/renderer/input/perf) +
+  `renderer.webgl.info` / `renderer.views` for the collector. Never mutates sim
+  state beyond dev teleports / movement intent.
+- Keep `metrics.mjs` PURE (it is the tested seam); orchestration/DOM lives in
+  `harness.mjs`. Add a new metric to `metrics.mjs` with a test; add a new scenario
+  to `scripts/profile.mjs` (the `SCENARIOS` map), not here.
+- Node-only deps (`ws`, `puppeteer-core`) like the rest of `scripts/`.

--- a/scripts/profiler/CLAUDE.md
+++ b/scripts/profiler/CLAUDE.md
@@ -30,7 +30,11 @@ metrics. Needs `npm run dev` (:5173); the `crowd` scenario also needs
   `sample` injects a rAF collector (`window.__prof`) that records per-frame
   `{dt, programs, views, longTaskMs}`, then folds report + `frameStats` +
   `attributeFreezes`. Online crowds are WS bots with a unique `X-Forwarded-For`
-  per bot to clear the 20/min/IP register limit (load-test only).
+  per bot on BOTH the REST calls and the WS upgrade (load-test only): the REST XFF
+  clears the 20/min/IP register limit, and the WS XFF clears the per-IP connection
+  cap (`MAX_WS_PER_IP_HARD`). Without the WS XFF every bot shared `127.0.0.1` and
+  the crowd hit a flat 20-connection wall (`close(1008)`), which read as a bogus
+  "join timeout" ceiling.
 
 ## Conventions
 - Reads the world only through `window.__game` (sim/world/renderer/input/perf) +

--- a/scripts/profiler/harness.mjs
+++ b/scripts/profiler/harness.mjs
@@ -1,0 +1,861 @@
+// Profiler core: drives the real game (headed, real GPU, vsync off) and turns a
+// scenario into rich, structured perf metrics. Shared by the CLI today and an
+// MCP server later. Reuses the world hooks on window.__game (sim/world/renderer/
+// input/perf) and, online, spawns WS bot crowds (X-Forwarded-For per bot to clear
+// the 20/min/IP register limit). Pure metric math lives in ./metrics.mjs.
+
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import WebSocket from 'ws';
+import { BROWSER_PATH } from '../browser_path.mjs';
+import { attributeFreezes, frameStats, normalizeReport } from './metrics.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const CLASSES = [
+  'warrior',
+  'paladin',
+  'priest',
+  'mage',
+  'hunter',
+  'rogue',
+  'warlock',
+  'druid',
+  'shaman',
+];
+
+// Injected once per session. A rAF loop records per-frame {dt, programs, views}
+// plus longtasks (so the profiler gets real 1%/0.1% lows + freeze attribution),
+// gathers a live scene inventory (entities by kind, loaded models, shader
+// variants, textures, geometries), and paints an on-screen overlay so the headed
+// window (and every screenshot) shows the live readout.
+const COLLECTOR = `
+window.__prof = {
+  on: false, frames: [], samples: [], _last: 0, _lt: 0, _obs: null, el: null, label: '', _n: 0,
+  _ensureObs() {
+    if (this._obs) return;
+    try {
+      this._obs = new PerformanceObserver((l) => { for (const e of l.getEntries()) this._lt = Math.max(this._lt, e.duration); });
+      this._obs.observe({ entryTypes: ['longtask'] });
+    } catch {}
+  },
+  _ensureOverlay() {
+    if (this.el || typeof document === 'undefined' || !document.body) return;
+    const el = document.createElement('div');
+    el.id = '__prof_overlay';
+    el.style.cssText = 'position:fixed;left:8px;bottom:8px;z-index:2147483647;font:11px/1.4 ui-monospace,monospace;color:#9effa0;background:rgba(0,0,0,.74);padding:7px 9px;border:1px solid #2a6e3a;border-radius:5px;white-space:pre;pointer-events:none;text-shadow:0 1px 1px #000;max-width:46ch';
+    document.body.appendChild(el);
+    this.el = el;
+  },
+  scene() {
+    const g = window.__game; if (!g) return {};
+    const ents = g.world && g.world.entities;
+    const byKind = {};
+    if (ents) for (const e of ents.values()) { const k = e.kind || e.k || 'other'; byKind[k] = (byKind[k] || 0) + 1; }
+    const views = g.renderer && g.renderer.views;
+    const models = {};
+    if (views) for (const v of views.values()) { const k = v.visualKey || 'unknown'; models[k] = (models[k] || 0) + 1; }
+    const info = (g.renderer && g.renderer.webgl && g.renderer.webgl.info) || {};
+    const progs = info.programs || [];
+    const variants = new Set();
+    for (const pr of progs) if (pr && pr.cacheKey) variants.add(pr.cacheKey);
+    const render = info.render || {};
+    const mem = info.memory || {};
+    return {
+      entityCount: ents ? ents.size : 0,
+      entitiesByKind: byKind,
+      viewCount: views ? views.size : 0,
+      modelCount: Object.keys(models).length,
+      models,
+      programs: progs.length,
+      shaderVariants: variants.size,
+      textures: mem.textures || 0,
+      geometries: mem.geometries || 0,
+      render: { calls: render.calls || 0, triangles: render.triangles || 0, points: render.points || 0, lines: render.lines || 0 },
+    };
+  },
+  _rolling() {
+    const r = this.frames.slice(-150);
+    if (!r.length) return { fps: 0, low: 0, max: 0 };
+    const sum = r.reduce((a, b) => a + b, 0);
+    const sorted = r.slice().sort((a, b) => a - b);
+    const k = Math.max(1, Math.ceil(r.length * 0.01));
+    const worst = sorted.slice(sorted.length - k);
+    const lowAvg = worst.reduce((a, b) => a + b, 0) / k;
+    return { fps: 1000 / (sum / r.length), low: lowAvg > 0 ? 1000 / lowAvg : 0, max: sorted[sorted.length - 1] };
+  },
+  _paint() {
+    if (!this.el) return;
+    const sc = this._scene || {};
+    const ro = this._rolling();
+    const kinds = Object.entries(sc.entitiesByKind || {}).map(([k, n]) => k + ':' + n).join(' ');
+    const lastHitch = this.samples.length ? this.samples[this.samples.length - 1] : null;
+    this.el.textContent =
+      'PROFILER  ' + (this.label || '') + '\\n' +
+      'fps ' + ro.fps.toFixed(0) + '  1%low ' + ro.low.toFixed(0) + '  worst ' + ro.max.toFixed(0) + 'ms\\n' +
+      'entities ' + (sc.entityCount || 0) + '  views ' + (sc.viewCount || 0) + '  ' + kinds + '\\n' +
+      'models ' + (sc.modelCount || 0) + '  shaders ' + (sc.programs || 0) + '/' + (sc.shaderVariants || 0) + 'var  tex ' + (sc.textures || 0) + '  geo ' + (sc.geometries || 0) + '\\n' +
+      'draws ' + (sc.render ? sc.render.calls : 0) + '  tris ' + (sc.render ? (sc.render.triangles / 1e6).toFixed(2) : 0) + 'M';
+  },
+  _progKeys() {
+    const g = window.__game;
+    const info = g && g.renderer && g.renderer.webgl && g.renderer.webgl.info;
+    const out = [];
+    if (info && info.programs) for (const pr of info.programs) if (pr && pr.cacheKey) out.push(pr.cacheKey);
+    return out;
+  },
+  start() {
+    this._ensureObs(); this._ensureOverlay();
+    this.frames = []; this.samples = []; this._lt = 0; this.on = true; this._n = 0;
+    this._keys0 = new Set(this._progKeys()); // shader programs present at sample start
+    this._last = performance.now();
+    const loop = () => {
+      if (!this.on) return;
+      const now = performance.now();
+      const dt = now - this._last; this._last = now;
+      const g = window.__game;
+      const info = g && g.renderer && g.renderer.webgl && g.renderer.webgl.info;
+      const programs = info && info.programs ? info.programs.length : 0;
+      const views = g && g.renderer && g.renderer.views ? g.renderer.views.size : 0;
+      const mem = info && info.memory ? info.memory : null;
+      this.frames.push(dt);
+      this.samples.push({ dt, programs, createdViews: views, textures: mem ? mem.textures : 0, geometries: mem ? mem.geometries : 0, longTaskMs: this._lt });
+      this._lt = 0;
+      // scene inventory + overlay are heavier, so refresh ~5x/sec, not per frame
+      if ((this._n++ % 12) === 0) { this._scene = this.scene(); this._paint(); }
+      requestAnimationFrame(loop);
+    };
+    requestAnimationFrame(loop);
+  },
+  stop() {
+    this.on = false; this._scene = this.scene(); this._paint();
+    const k0 = this._keys0 || new Set();
+    const newPrograms = this._progKeys().filter((k) => !k0.has(k)); // shaders that linked during the window
+    return { frames: this.frames.slice(), samples: this.samples.slice(), scene: this._scene, newPrograms };
+  },
+};
+`;
+
+async function api(server, path, body, token, xff) {
+  const res = await fetch(server + path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(xff ? { 'X-Forwarded-For': xff } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: await res.json().catch(() => ({})) };
+}
+
+class Bot {
+  constructor(server, wsBase, uniq, i) {
+    this.server = server;
+    this.wsBase = wsBase;
+    this.i = i;
+    this.cls = CLASSES[i % CLASSES.length];
+    this.level = 1 + ((i * 7) % 40);
+    const li = String(i)
+      .split('')
+      .map((d) => 'abcdefghij'[+d])
+      .join('');
+    // Char names are LETTERS ONLY (server rejects digits); uniq is a numeric stamp.
+    this.name = `Pb${uniq}${li}`.replace(/[0-9]/g, (d) => 'abcdefghij'[+d]);
+    this.uniq = uniq;
+  }
+  async join() {
+    const xff = `172.16.${Math.floor(this.i / 254)}.${(this.i % 254) + 1}`;
+    const reg = await api(
+      this.server,
+      '/api/register',
+      { username: `prof_${this.uniq}_${this.i}`, password: 'hunter22' },
+      undefined,
+      xff,
+    );
+    this.token = reg.body.token;
+    if (!this.token)
+      throw new Error(`register ${this.i}: ${JSON.stringify(reg.body).slice(0, 80)}`);
+    const char = await api(
+      this.server,
+      '/api/characters',
+      { name: this.name, class: this.cls },
+      this.token,
+      xff,
+    );
+    this.charId = char.body.id;
+    if (!this.charId)
+      throw new Error(`charcreate ${this.i}: ${JSON.stringify(char.body).slice(0, 80)}`);
+    await new Promise((resolve, reject) => {
+      this.ws = new WebSocket(`${this.wsBase}/ws`);
+      const to = setTimeout(() => reject(new Error('join timeout')), 20000);
+      this.ws.on('open', () =>
+        this.ws.send(JSON.stringify({ t: 'auth', token: this.token, character: this.charId })),
+      );
+      this.ws.on('message', (data) => {
+        const m = JSON.parse(String(data));
+        if (m.t === 'hello') {
+          clearTimeout(to);
+          resolve();
+        }
+      });
+      this.ws.on('error', reject);
+    });
+  }
+  cmd(p) {
+    this.ws?.send(JSON.stringify({ t: 'cmd', ...p }));
+  }
+  place(x, z, radius) {
+    const a = this.i * 2.39996;
+    const r = radius * Math.sqrt((this.i % 30) / 30);
+    this.cmd({ cmd: 'dev_level', level: this.level });
+    this.cmd({ cmd: 'dev_teleport', x: x + Math.cos(a) * r, z: z + Math.sin(a) * r });
+  }
+  close() {
+    try {
+      this.ws?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export class Profiler {
+  constructor(opts = {}) {
+    this.gameUrl = opts.gameUrl ?? process.env.GAME_URL ?? 'http://localhost:5173';
+    this.server = opts.server ?? process.env.SERVER_URL ?? 'http://localhost:8787';
+    this.wsBase = this.server.replace(/^http/, 'ws');
+    this.width = opts.width ?? 1920;
+    this.height = opts.height ?? 1080;
+    this.dpr = opts.dpr ?? 1;
+    this.targetFps = opts.targetFps ?? 60;
+    this.browserPath = opts.browserPath ?? process.env.BROWSER_PATH ?? BROWSER_PATH;
+    this.shotDir = opts.shotDir ?? process.env.PROF_SHOT ?? null; // screenshot each sample (overlay visible)
+    this.uniq = (process.env.PROF_UNIQ ?? String(Math.floor(performance.now())) + 'x')
+      .replace(/[^a-z0-9]/gi, '')
+      .slice(-6);
+    this.bots = [];
+    this.mode = 'offline';
+  }
+
+  log(...a) {
+    if (!this.quiet) console.log(...a);
+  }
+
+  async launch() {
+    this.browser = await puppeteer.launch({
+      executablePath: this.browserPath,
+      headless: false,
+      protocolTimeout: 180000,
+      args: [
+        `--window-size=${this.width},${this.height + 120}`,
+        '--ignore-gpu-blocklist',
+        '--enable-gpu',
+        '--disable-gpu-vsync',
+        '--disable-frame-rate-limit',
+        '--autoplay-policy=no-user-gesture-required',
+      ],
+    });
+    this.page = await this.browser.newPage();
+    await this.page.setViewport({
+      width: this.width,
+      height: this.height,
+      deviceScaleFactor: this.dpr,
+    });
+    this.page.on('pageerror', (e) => this.log('  [pageerror]', String(e).slice(0, 140)));
+    return this;
+  }
+
+  gfxQs(tier) {
+    return tier ? `&gfx=${tier}` : '';
+  }
+
+  async enter({ mode = 'offline', cls = 'warrior', tier } = {}) {
+    this.mode = mode;
+    const page = this.page;
+    if (mode === 'offline') {
+      await page.goto(`${this.gameUrl}/?perf${this.gfxQs(tier)}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60000,
+      });
+      await page.waitForSelector('#char-name', { timeout: 60000 });
+      await page.$eval('#char-name', (el) => {
+        el.value = 'Probe';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+      await page.$eval(`#offline-select .mini-class[data-class="${cls}"]`, (el) => el.click());
+      await page.$eval('#btn-start-offline', (el) => el.click());
+    } else {
+      const u = `prof_cam_${this.uniq}`;
+      await api(
+        this.server,
+        '/api/register',
+        { username: u, password: 'hunter22' },
+        undefined,
+        '172.31.0.1',
+      );
+      await page.goto(`${this.gameUrl}/?perf${this.gfxQs(tier)}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60000,
+      });
+      await page.waitForFunction(
+        () =>
+          document.querySelector('#btn-online') &&
+          document.querySelector('#login-user') &&
+          document.querySelector('#btn-login'),
+        { timeout: 25000, polling: 200 },
+      );
+      await page.evaluate((u) => {
+        document.querySelector('#btn-online').click();
+        document.querySelector('#login-user').value = u;
+        document.querySelector('#login-pass').value = 'hunter22';
+        document.querySelector('#btn-login').click();
+      }, u);
+      // Char names are LETTERS ONLY (classic rule) - a digit silently rejects Create,
+      // and this.uniq is a numeric timestamp, so map digits to letters.
+      const nm = `Pcam${this.uniq}`.replace(/[0-9]/g, (d) => 'abcdefghij'[+d]);
+      // After login the first panel may be realm-panel, charselect-panel, OR (a fresh
+      // account) charcreate-panel directly. Drive whichever appears until the online
+      // world loads; tolerate the page navigation that "Enter World" triggers.
+      await page.waitForFunction(
+        () =>
+          window.__game?.world?.player ||
+          ['realm-panel', 'charselect-panel', 'charcreate-panel'].includes(
+            document.body.dataset.startPanel,
+          ),
+        { timeout: 25000, polling: 200 },
+      );
+      for (let i = 0; i < 60; i++) {
+        try {
+          if (await page.evaluate(() => !!window.__game?.world?.player)) break;
+          await page.evaluate(
+            (nm, cls) => {
+              const panel = document.body.dataset.startPanel;
+              if (panel === 'realm-panel') {
+                document.querySelector('#realm-panel .realm-row, #realm-panel button')?.click();
+              } else if (panel === 'charcreate-panel') {
+                const n = document.querySelector('#new-char-name');
+                if (n && n.value !== nm) {
+                  n.value = nm;
+                  n.dispatchEvent(new Event('input', { bubbles: true }));
+                }
+                document
+                  .querySelector(`#charcreate-panel .mini-class[data-class="${cls}"]`)
+                  ?.click();
+                document.querySelector('#btn-create-char')?.click();
+              } else if (panel === 'charselect-panel') {
+                const row =
+                  [...document.querySelectorAll('.char-row')].find(
+                    (r) => r.querySelector('.char-name')?.textContent === nm,
+                  ) ?? document.querySelector('.char-row');
+                const btn =
+                  row?.querySelector('.enter-world-btn') ??
+                  document.querySelector('.enter-world-btn');
+                if (btn) btn.click();
+                else document.querySelector('#btn-new-character')?.click();
+              }
+            },
+            nm,
+            cls,
+          );
+        } catch {
+          /* "Enter World" navigated the page; the next poll re-reads window.__game */
+        }
+        await sleep(600);
+      }
+    }
+    await page.waitForFunction(() => window.__game?.world?.player && window.__game?.perf?.report, {
+      timeout: 30000,
+      polling: 300,
+    });
+    await sleep(1500);
+    await page.evaluate(COLLECTOR);
+    this.center = await page.evaluate(() => ({
+      x: window.__game.world.player.pos.x,
+      z: window.__game.world.player.pos.z,
+    }));
+    await this._startGodMode();
+    return this;
+  }
+
+  // Keep the profiled player immortal so a scenario that fights mobs (combat, play)
+  // runs uninterrupted instead of dying, releasing spirit, and teleporting to a
+  // graveyard mid-measurement. Assigning hp does NOT work (the sim re-derives/clamps
+  // it every tick, and a single multi-mob tick can burst past maxHp before any
+  // top-up, which just makes a die/revive FLICKER). Instead redefine `hp` as a getter
+  // that always reads full (maxHp) with a no-op setter: the sim's `hp -= damage`
+  // becomes a no-op and the `hp <= 0` death check can never trip. Applied at enter,
+  // before any combat, so the player simply never dies. Re-asserted at 1 Hz in case
+  // the player entity is swapped (e.g. zone change). Damage DEALT is untouched, so
+  // the combat/cast/VFX load we profile is unchanged.
+  async _startGodMode() {
+    await this.page.evaluate(() => {
+      if (window.__godTimer) return;
+      const apply = () => {
+        try {
+          const w = window.__game && (window.__game.world ?? window.__game.sim);
+          const p = w && w.player;
+          if (!p) return;
+          const d = Object.getOwnPropertyDescriptor(p, 'hp');
+          if (!d || !d.get) {
+            Object.defineProperty(p, 'hp', {
+              configurable: true,
+              enumerable: true,
+              get() {
+                return this.maxHp || 1;
+              },
+              set() {
+                /* immortal: ignore damage writes */
+              },
+            });
+          }
+          if (p.dead) p.dead = false;
+        } catch {
+          /* world not ready / sealed entity */
+        }
+      };
+      apply();
+      window.__godTimer = setInterval(apply, 1000);
+    });
+  }
+
+  async teleport(x, z, facing = 0) {
+    await this.page.evaluate(
+      (x, z, f) => {
+        const p = window.__game.world.player ?? window.__game.sim.player;
+        p.pos.x = x;
+        p.pos.z = z;
+        p.facing = f;
+        window.__game.input.camYaw = f;
+      },
+      x,
+      z,
+      facing,
+    );
+    await sleep(400);
+  }
+
+  async setMove(dir) {
+    await this.page.evaluate((d) => window.__game.input.setTouchMove(d), {
+      forward: false,
+      back: false,
+      strafeLeft: false,
+      strafeRight: false,
+      ...dir,
+    });
+  }
+  async stopMove() {
+    await this.page.evaluate(() => window.__game.input.clearTouchMove());
+  }
+  async look(vec, ms = 1500) {
+    await this.page.evaluate((v) => {
+      window.__game.input.setTouchLook(true);
+      window.__game.input.setTouchLookVector(v);
+    }, vec);
+    await sleep(ms);
+    await this.page.evaluate(() => {
+      window.__game.input.setTouchLookVector({ x: 0, y: 0 });
+      window.__game.input.setTouchLook(false);
+    });
+  }
+
+  async tour(waypoints, { dwellMs = 0 } = {}) {
+    for (const wp of waypoints) {
+      await this.teleport(wp.x, wp.z, wp.facing ?? 0);
+      if (dwellMs) await sleep(dwellMs);
+    }
+  }
+
+  async spawnCrowd(n, { radius = 24 } = {}) {
+    if (this.mode !== 'online') throw new Error('spawnCrowd needs online mode');
+    const c = this.center;
+    const batch = [];
+    for (let i = this.bots.length; i < n; i++)
+      batch.push(new Bot(this.server, this.wsBase, this.uniq, i));
+    // Join in WAVES, not all at once: 50 simultaneous WS auth+character-load joins
+    // overwhelm the server's join path (most time out). Waves let it drain each set.
+    const WAVE = 6;
+    for (let w = 0; w < batch.length; w += WAVE) {
+      await Promise.all(
+        batch.slice(w, w + WAVE).map((b) =>
+          b
+            .join()
+            .then(() => {
+              b.place(c.x, c.z, radius);
+              this.bots.push(b);
+            })
+            .catch((e) => this.log(`  bot ${b.i}: ${String(e).slice(0, 60)}`)),
+        ),
+      );
+      await sleep(2500); // let the world loop drain this wave's joins before the next
+    }
+    for (const b of this.bots) b.place(c.x, c.z, radius);
+    return this.bots.length;
+  }
+  async despawnCrowd() {
+    for (const b of this.bots) b.close();
+    this.bots = [];
+  }
+
+  // Combat / VFX: target the nearest hostile and cycle the action bar so each
+  // ability (and its first-use particle program) fires.
+  async combat({ ms = 6000, keys = '1234567890' } = {}) {
+    await this.page.keyboard.press('Tab');
+    const end = performance.now() + ms;
+    let k = 0;
+    while (performance.now() < end) {
+      await this.page.keyboard.press(keys[k % keys.length]);
+      k++;
+      await sleep(450);
+    }
+  }
+
+  async jump() {
+    await this.page.keyboard.press('Space');
+  }
+
+  // Right-button camera mouselook, the way a player turns to look around. The real
+  // input path reads e.movementX/Y (input.ts) to drive camYaw/camPitch, so we send
+  // PointerEvents WITH movementX set; we also nudge input.camYaw directly so the
+  // sweep is reliable even when a synthetic movementX is dropped. Turning the camera
+  // pulls newly-visible models into the frame, surfacing first-draw shader compiles
+  // and texture/geometry uploads a straight forward walk never points the camera at.
+  async lookSweep({ yaw = 1, frames = 18, dx = 16, dy = 0 } = {}) {
+    await this.page.evaluate(
+      ({ frames, dx, dy, yaw }) =>
+        new Promise((res) => {
+          const cv = document.querySelector('canvas');
+          const r = cv.getBoundingClientRect();
+          const c4 = {
+            clientX: Math.round(r.left + r.width / 2),
+            clientY: Math.round(r.top + r.height / 2),
+          };
+          const mk = (type, extra) =>
+            new PointerEvent(type, {
+              bubbles: true,
+              cancelable: true,
+              pointerId: 1,
+              pointerType: 'mouse',
+              ...c4,
+              ...extra,
+            });
+          cv.dispatchEvent(mk('pointerdown', { button: 2, buttons: 2 }));
+          let i = 0;
+          const step = () => {
+            cv.dispatchEvent(
+              mk('pointermove', { button: -1, buttons: 2, movementX: dx * yaw, movementY: dy }),
+            );
+            try {
+              window.__game.input.camYaw -= 0.06 * yaw;
+              if (dy)
+                window.__game.input.camPitch = Math.min(
+                  1.2,
+                  Math.max(-0.35, window.__game.input.camPitch + dy * 0.004),
+                );
+            } catch {
+              /* input shape differs: the PointerEvent path above still drives it */
+            }
+            if (++i < frames) requestAnimationFrame(step);
+            else {
+              window.dispatchEvent(mk('pointerup', { button: 2, buttons: 0 }));
+              res();
+            }
+          };
+          requestAnimationFrame(step);
+        }),
+      { frames, dx, dy, yaw },
+    );
+  }
+
+  async _pos() {
+    return this.page.evaluate(() => {
+      const g = window.__game;
+      const p = g.world.player ?? g.sim.player;
+      let zone = null;
+      try {
+        zone = (g.world && g.world.zoneName) || (g.sim && g.sim.currentZoneId) || null;
+      } catch {
+        /* ignore */
+      }
+      return { x: p.pos.x, z: p.pos.z, zone };
+    });
+  }
+  async _face(f) {
+    await this.page.evaluate((f) => {
+      const p = window.__game.world.player ?? window.__game.sim.player;
+      p.facing = f;
+      window.__game.input.camYaw = f;
+    }, f);
+  }
+
+  // Acquire the nearest enemy + start auto-attacking via the IWorld API (more
+  // reliable than a Tab keypress, which needs a mob already in tab range): with a
+  // live target + in range, the ability keypresses in `play` actually CAST, so their
+  // first-use VFX shaders compile - the freeze the user hits "especially with abilities".
+  // Acquire a target + start auto-attacking through the IWorld API. NOTE: in the
+  // OFFLINE sim, targeting is driven by the input/screen path and the sim reconciles
+  // the player's target each tick, so neither tabTarget() nor writing targetId from
+  // outside reliably sticks - target-requiring abilities may not fire offline. What
+  // DOES exercise the ability pipeline here: instant/self abilities (buffs, shouts)
+  // fire on the keypress regardless, auto-target kicks in when an attack key is hit
+  // next to a mob, and `play` walks the character through mobs. For exhaustive
+  // targeted-ability coverage run `play` against an online server (`--mode online`),
+  // where the server resolves targeting. Both keep auto-attack on for swing VFX.
+  async _engage() {
+    await this.page.evaluate(() => {
+      const w = window.__game.world ?? window.__game.sim;
+      try {
+        w.tabTarget?.();
+      } catch {
+        /* no enemy in range / offline targeting path differs */
+      }
+      try {
+        w.startAutoAttack?.();
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+
+  // Continuous on-foot traversal of the world (no teleports): walk forward for
+  // `ms`, keeping the collector running the WHOLE time, steering when a collider
+  // stalls progress, and logging every hitch WITH the world position + cause as it
+  // happens. This is the realistic streaming/zone-crossing test a teleport skips.
+  async walk({ ms = 70000, label = 'walk', heading = 0 } = {}) {
+    await this.page.evaluate((l) => {
+      window.__prof.label = l;
+      window.__game.perf.reset();
+      window.__prof.start();
+    }, label);
+    await this._face(heading);
+    await this.setMove({ forward: true });
+    const t0 = performance.now();
+    let facing = heading;
+    let last = await this._pos();
+    let consumed = 0;
+    let stuck = 0;
+    let checkpoint = 0;
+    const events = [];
+    const trail = [];
+    while (performance.now() - t0 < ms) {
+      await sleep(2500);
+      const pos = await this._pos();
+      const moved = Math.hypot(pos.x - last.x, pos.z - last.z);
+      trail.push({
+        x: Math.round(pos.x),
+        z: Math.round(pos.z),
+        moved: Math.round(moved),
+        zone: pos.zone,
+      });
+      if (moved < 2.5) {
+        // stuck on terrain/water: escalate the turn each consecutive stall so it
+        // breaks free instead of hugging the same wall
+        stuck++;
+        facing += 1.7 + stuck * 0.6;
+        await this._face(facing);
+      } else {
+        stuck = 0;
+        // serpentine every ~6 checkpoints so the walk roams across maps, not a line
+        if (++checkpoint % 6 === 0) {
+          facing += (checkpoint % 12 === 0 ? -1 : 1) * 0.9;
+          await this._face(facing);
+        }
+      }
+      last = pos;
+      // drain new collector samples since last check, attribute, log hitches with position
+      const slice = await this.page.evaluate((from) => window.__prof.samples.slice(from), consumed);
+      consumed += slice.length;
+      const fz = attributeFreezes(slice, 8, 50);
+      for (const w of fz.worst) {
+        const e = {
+          ms: w.ms,
+          cause: w.cause,
+          x: Math.round(pos.x),
+          z: Math.round(pos.z),
+          zone: pos.zone,
+        };
+        events.push(e);
+        this.log(
+          `  FREEZE ${String(w.ms).padStart(6)}ms  ${w.cause.padEnd(13)} @ (${e.x}, ${e.z})${pos.zone ? ` ${pos.zone}` : ''}`,
+        );
+      }
+    }
+    await this.stopMove();
+    const raw = await this.page.evaluate(() => ({
+      ...window.__prof.stop(),
+      report: window.__game.perf.report(),
+      entities: window.__game.world.entities.size,
+    }));
+    const norm = normalizeReport(raw.report);
+    norm.entities = raw.entities;
+    let dist = 0;
+    for (let i = 1; i < trail.length; i++) {
+      dist += Math.hypot(trail[i].x - trail[i - 1].x, trail[i].z - trail[i - 1].z);
+    }
+    return {
+      label,
+      mode: this.mode,
+      ...norm,
+      scene: raw.scene ?? null,
+      newPrograms: raw.newPrograms ?? [],
+      frame: frameStats(raw.frames, this.targetFps),
+      freezes: attributeFreezes(raw.samples),
+      trail,
+      events,
+      distance: Math.round(dist),
+    };
+  }
+
+  // A realistic play session: walk while turning the camera (RMB mouselook),
+  // jumping, retargeting, and casting EVERY ability on a short cycle. These are the
+  // inputs a human actually uses and the ones that surface "weird" freezes a plain
+  // walk misses: first-cast ability VFX shader compiles, camera-reveal compiles as
+  // the view turns, and jump/landing hitches. Logs each freeze with position + cause.
+  async play({ ms = 60000, label = 'play', keys = '1234567890' } = {}) {
+    await this.page.evaluate((l) => {
+      window.__prof.label = l;
+      window.__game.perf.reset();
+      window.__prof.start();
+    }, label);
+    await this.setMove({ forward: true });
+    await this._engage(); // acquire nearest enemy + auto-attack so abilities actually fire
+    const t0 = performance.now();
+    let facing = 0,
+      last = await this._pos(),
+      consumed = 0,
+      stuck = 0,
+      checkpoint = 0,
+      k = 0,
+      tick = 0;
+    const events = [];
+    const trail = [];
+    while (performance.now() - t0 < ms) {
+      await this.page.keyboard.press(keys[k++ % keys.length]); // cast the next ability
+      if (tick % 2 === 0) await this.jump();
+      if (tick % 3 === 0)
+        await this.lookSweep({ yaw: tick % 6 === 0 ? 1 : -1, dy: tick % 9 === 0 ? 6 : 0 });
+      if (tick % 4 === 0) await this._engage(); // retarget (mobs die / leave range)
+      tick++;
+      await sleep(850);
+      if (tick % 3 !== 0) continue; // sample position/steer/freezes every 3rd tick (~2.5s)
+      const pos = await this._pos();
+      const moved = Math.hypot(pos.x - last.x, pos.z - last.z);
+      trail.push({
+        x: Math.round(pos.x),
+        z: Math.round(pos.z),
+        moved: Math.round(moved),
+        zone: pos.zone,
+      });
+      if (moved < 2.5) {
+        stuck++;
+        facing += 1.7 + stuck * 0.6;
+        await this._face(facing);
+      } else {
+        stuck = 0;
+        if (++checkpoint % 6 === 0) {
+          facing += (checkpoint % 12 === 0 ? -1 : 1) * 0.9;
+          await this._face(facing);
+        }
+      }
+      last = pos;
+      const slice = await this.page.evaluate((from) => window.__prof.samples.slice(from), consumed);
+      consumed += slice.length;
+      const fz = attributeFreezes(slice, 8, 50);
+      for (const w of fz.worst) {
+        const e = {
+          ms: w.ms,
+          cause: w.cause,
+          x: Math.round(pos.x),
+          z: Math.round(pos.z),
+          zone: pos.zone,
+        };
+        events.push(e);
+        this.log(
+          `  FREEZE ${String(w.ms).padStart(6)}ms  ${w.cause.padEnd(13)} @ (${e.x}, ${e.z})${pos.zone ? ` ${pos.zone}` : ''}`,
+        );
+      }
+    }
+    await this.stopMove();
+    const raw = await this.page.evaluate(() => ({
+      ...window.__prof.stop(),
+      report: window.__game.perf.report(),
+      entities: window.__game.world.entities.size,
+    }));
+    const norm = normalizeReport(raw.report);
+    norm.entities = raw.entities;
+    let dist = 0;
+    for (let i = 1; i < trail.length; i++) {
+      dist += Math.hypot(trail[i].x - trail[i - 1].x, trail[i].z - trail[i - 1].z);
+    }
+    return {
+      label,
+      mode: this.mode,
+      ...norm,
+      scene: raw.scene ?? null,
+      newPrograms: raw.newPrograms ?? [],
+      frame: frameStats(raw.frames, this.targetFps),
+      freezes: attributeFreezes(raw.samples),
+      trail,
+      events,
+      distance: Math.round(dist),
+    };
+  }
+
+  async setTier(tier) {
+    await this.page.evaluate(COLLECTOR); /* re-enter via reload */
+    this.pendingTier = tier;
+    await this.enter({ mode: this.mode, tier });
+  }
+
+  async screenshot(path) {
+    try {
+      await this.page.screenshot({ path });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // The rich measurement: collect raw frames for `ms`, then fold the perf report,
+  // advanced frame stats (1%/0.1% lows, jank, stdev) and freeze attribution.
+  async sample({ ms = 4000, label = 'sample' } = {}) {
+    await this.page.evaluate((label) => {
+      window.__prof.label = label;
+      window.__game.perf.reset();
+      window.__prof.start();
+    }, label);
+    await sleep(ms);
+    const raw = await this.page.evaluate(() => ({
+      ...window.__prof.stop(),
+      report: window.__game.perf.report(),
+      entities: window.__game.world.entities.size,
+    }));
+    const norm = normalizeReport(raw.report);
+    norm.entities = raw.entities;
+    if (this.shotDir) {
+      try {
+        fs.mkdirSync(this.shotDir, { recursive: true });
+      } catch {
+        /* ignore */
+      }
+      await this.screenshot(`${this.shotDir}/${label}.png`);
+    }
+    return {
+      label,
+      mode: this.mode,
+      ...norm,
+      scene: raw.scene ?? null, // entity-by-kind, loaded models, shader variants, tex/geo
+      newPrograms: raw.newPrograms ?? [], // shader cacheKeys that linked during the window
+      frame: frameStats(raw.frames, this.targetFps),
+      freezes: attributeFreezes(raw.samples),
+    };
+  }
+
+  async close() {
+    await this.despawnCrowd();
+    try {
+      await this.browser?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/scripts/profiler/harness.mjs
+++ b/scripts/profiler/harness.mjs
@@ -1,8 +1,9 @@
 // Profiler core: drives the real game (headed, real GPU, vsync off) and turns a
 // scenario into rich, structured perf metrics. Shared by the CLI today and an
 // MCP server later. Reuses the world hooks on window.__game (sim/world/renderer/
-// input/perf) and, online, spawns WS bot crowds (X-Forwarded-For per bot to clear
-// the 20/min/IP register limit). Pure metric math lives in ./metrics.mjs.
+// input/perf) and, online, spawns WS bot crowds (a unique X-Forwarded-For per bot
+// on BOTH the REST calls and the WS upgrade, to clear the 20/min/IP register limit
+// and the per-IP WS connection cap). Pure metric math lives in ./metrics.mjs.
 
 import fs from 'node:fs';
 import puppeteer from 'puppeteer-core';
@@ -186,7 +187,12 @@ class Bot {
     if (!this.charId)
       throw new Error(`charcreate ${this.i}: ${JSON.stringify(char.body).slice(0, 80)}`);
     await new Promise((resolve, reject) => {
-      this.ws = new WebSocket(`${this.wsBase}/ws`);
+      // The WS upgrade needs the SAME per-bot X-Forwarded-For the REST calls use:
+      // without it every bot's socket resolves to 127.0.0.1, so the server's
+      // per-IP hard cap (MAX_WS_PER_IP_HARD, default 20) closes the 21st+ with a
+      // 1008 and the bot then waits forever for `hello` (a "join timeout"). The
+      // header is honoured because a loopback source is a trusted XFF setter.
+      this.ws = new WebSocket(`${this.wsBase}/ws`, { headers: { 'X-Forwarded-For': xff } });
       const to = setTimeout(() => reject(new Error('join timeout')), 20000);
       this.ws.on('open', () =>
         this.ws.send(JSON.stringify({ t: 'auth', token: this.token, character: this.charId })),
@@ -472,8 +478,10 @@ export class Profiler {
     const batch = [];
     for (let i = this.bots.length; i < n; i++)
       batch.push(new Bot(this.server, this.wsBase, this.uniq, i));
-    // Join in WAVES, not all at once: 50 simultaneous WS auth+character-load joins
-    // overwhelm the server's join path (most time out). Waves let it drain each set.
+    // Join in WAVES rather than all at once: a courtesy that keeps a single run
+    // from thundering-herd-ing the DB pool on register/create/auth. It is NOT what
+    // makes the crowd scale (the per-bot WS X-Forwarded-For above is); the wall the
+    // old runs hit was the per-IP connection cap, not join-path throughput.
     const WAVE = 6;
     for (let w = 0; w < batch.length; w += WAVE) {
       await Promise.all(

--- a/scripts/profiler/metrics.mjs
+++ b/scripts/profiler/metrics.mjs
@@ -1,0 +1,223 @@
+// Pure performance-metric math for the profiler. No DOM, no puppeteer - every
+// input is plain data, so it unit-tests directly (tests/profiler_metrics.test.ts)
+// and is shared by the CLI today and an MCP server later.
+
+const round = (v, d = 2) => {
+  if (!Number.isFinite(v)) return 0;
+  const m = 10 ** d;
+  return Math.round(v * m) / m;
+};
+
+/**
+ * State-of-the-art frame-time stats from a raw per-frame duration array (ms).
+ * Beyond mean FPS this reports the percentiles and the gamer-standard 1%/0.1%
+ * lows (the mean of the slowest 1%/0.1% of frames, expressed as FPS) plus jank
+ * and stutter counts - these capture perceived smoothness that an average hides.
+ *
+ * @param deltasMs per-frame durations in milliseconds
+ * @param targetFps the frame budget to judge jank against (default 60)
+ */
+export function frameStats(deltasMs, targetFps = 60) {
+  const d = (deltasMs ?? []).filter((x) => Number.isFinite(x) && x > 0);
+  const n = d.length;
+  if (n === 0) return null;
+  const sorted = [...d].sort((a, b) => a - b);
+  const sum = d.reduce((a, b) => a + b, 0);
+  const mean = sum / n;
+  const variance = d.reduce((a, b) => a + (b - mean) ** 2, 0) / n;
+  const stdev = Math.sqrt(variance);
+  const pctMs = (p) => sorted[Math.min(n - 1, Math.max(0, Math.ceil(p * n) - 1))];
+  // mean of the slowest `frac` of frames -> FPS (the "1% low" / "0.1% low")
+  const lowFps = (frac) => {
+    const k = Math.max(1, Math.ceil(n * frac));
+    const worst = sorted.slice(n - k);
+    const avg = worst.reduce((a, b) => a + b, 0) / k;
+    return avg > 0 ? 1000 / avg : 0;
+  };
+  const budgetMs = 1000 / targetFps;
+  const jank = d.filter((x) => x > budgetMs * 1.5).length; // >1.5x budget = visible hitch
+  const long50 = d.filter((x) => x >= 50).length; // classic "long frame"
+  const stutter100 = d.filter((x) => x >= 100).length; // hard stalls
+  return {
+    frames: n,
+    seconds: round(sum / 1000, 2),
+    fpsMean: round(1000 / mean, 1),
+    fpsMedian: round(1000 / pctMs(0.5), 1),
+    fpsLow1: round(lowFps(0.01), 1), // 1% low (worst 1% of frames)
+    fpsLow01: round(lowFps(0.001), 1), // 0.1% low
+    meanMs: round(mean, 2),
+    p50Ms: round(pctMs(0.5), 2),
+    p95Ms: round(pctMs(0.95), 2),
+    p99Ms: round(pctMs(0.99), 2),
+    p999Ms: round(pctMs(0.999), 2),
+    maxMs: round(sorted[n - 1], 2),
+    stdevMs: round(stdev, 2), // frame-time consistency (lower = smoother)
+    jankPct: round((100 * jank) / n, 2), // % of frames over 1.5x budget
+    long50, // frames >= 50ms
+    stutter100, // frames >= 100ms
+  };
+}
+
+/**
+ * Per-frame freeze attribution. Given per-frame samples that each carry the
+ * cumulative WebGL program (shader) count and created-view count, find the worst
+ * frames and attribute each to a likely cause: a shader program that linked this
+ * frame (compile stall), a character view that was built, or "other" (GC/upload/
+ * CPU). This is what turns "there was a 250ms hitch" into "it compiled 3 shaders".
+ *
+ * @param samples array of { dt, programs, createdViews, longTaskMs? }
+ * @param topN how many worst frames to return
+ */
+export function attributeFreezes(samples, topN = 8, hitchMs = 50) {
+  const s = (samples ?? []).filter((x) => x && Number.isFinite(x.dt));
+  const events = [];
+  for (let i = 1; i < s.length; i++) {
+    const cur = s[i];
+    const prev = s[i - 1];
+    if (cur.dt < hitchMs) continue;
+    const programDelta = Math.max(0, (cur.programs ?? 0) - (prev.programs ?? 0));
+    const viewDelta = Math.max(0, (cur.createdViews ?? 0) - (prev.createdViews ?? 0));
+    const texDelta = Math.max(0, (cur.textures ?? 0) - (prev.textures ?? 0));
+    const geoDelta = Math.max(0, (cur.geometries ?? 0) - (prev.geometries ?? 0));
+    const cause =
+      programDelta > 0
+        ? 'shader-compile' // a WebGL program linked (the worst, fully synchronous)
+        : viewDelta > 0
+          ? 'view-build' // a character rig was instantiated
+          : texDelta > 0 || geoDelta > 0
+            ? 'asset-upload' // texture/geometry streamed to the GPU
+            : cur.longTaskMs
+              ? 'long-task' // a main-thread long task (JS/GC)
+              : 'other';
+    events.push({
+      frame: i,
+      ms: round(cur.dt, 1),
+      programDelta,
+      viewDelta,
+      texDelta,
+      geoDelta,
+      longTaskMs: round(cur.longTaskMs ?? 0, 1),
+      cause,
+    });
+  }
+  events.sort((a, b) => b.ms - a.ms);
+  const byCause = {};
+  for (const e of events) byCause[e.cause] = (byCause[e.cause] ?? 0) + 1;
+  return {
+    hitchCount: events.length,
+    worstMs: events[0]?.ms ?? 0,
+    byCause,
+    worst: events.slice(0, topN),
+  };
+}
+
+/** Flatten a window.__game.perf.report() into a stable, comparable metric set. */
+export function normalizeReport(report) {
+  const r = report ?? {};
+  const w10 = r.windows?.last10s ?? {};
+  const rr = r.renderer ?? {};
+  const fol = rr.foliage ?? {};
+  const budget = rr.renderBudget ?? {};
+  const lt = r.browser?.longTasks ?? {};
+  const mem = r.browser?.memory ?? {};
+  const phase = rr.phaseMs ?? {};
+  const ph = (k) => round(phase[k]?.avg ?? phase[k] ?? 0, 2);
+  const main = r.mainMs ?? {};
+  const mn = (k) => round(main[k]?.avg ?? 0, 2);
+  return {
+    fps: round(r.fps ?? 0, 1),
+    fps10s: round(w10.fps ?? 0, 1),
+    frameP95: round(r.frameMs?.p95 ?? 0, 2),
+    frameP99: round(r.frameMs?.p99 ?? 0, 2),
+    frameMax: round(r.frameMs?.max ?? 0, 2),
+    long50: r.frameMs?.long50 ?? 0,
+    tier: rr.tier ?? '',
+    renderScale: round(rr.effectiveRenderScale ?? 0, 3),
+    calls: rr.calls ?? 0,
+    triangles: rr.triangles ?? 0,
+    programs: rr.programs ?? 0,
+    textures: rr.textures ?? 0,
+    views: rr.views ?? 0,
+    entities: r.entities ?? null,
+    grassTufts: fol.grassVisibleTufts ?? 0,
+    foliageDraws: fol.modelVisibleDraws ?? 0,
+    foliageTris: fol.modelVisibleTriangles ?? 0,
+    phaseEntitiesMs: ph('entities'),
+    phaseWorldMs: ph('world'),
+    phaseSubmitMs: ph('submit'),
+    phaseTotalMs: ph('total'),
+    mainSimMs: mn('sim'),
+    mainRendererMs: mn('renderer'),
+    mainHudMs: mn('hud'),
+    longTaskCount: lt.count ?? 0,
+    longTaskP95: round(lt.p95 ?? 0, 1),
+    longTaskMax: round(lt.max ?? 0, 1),
+    heapUsedMb: round(mem.usedMB ?? 0, 1),
+    heapLimitMb: round(mem.limitMB ?? 0, 1),
+    budgetMode: budget.mode ?? '',
+    budgetReason: budget.reason ?? '',
+    budgetPressure: round(budget.pressure ?? 0, 2),
+    autoGovernor: rr.autoGovernor ?? false,
+  };
+}
+
+const PCT_KEYS = new Set([
+  'fps',
+  'fps10s',
+  'fpsMean',
+  'fpsMedian',
+  'fpsLow1',
+  'fpsLow01',
+  'frameP95',
+  'frameP99',
+  'frameMax',
+  'meanMs',
+  'p95Ms',
+  'p99Ms',
+  'maxMs',
+  'stdevMs',
+  'calls',
+  'triangles',
+  'programs',
+  'views',
+  'foliageDraws',
+  'foliageTris',
+  'phaseSubmitMs',
+  'phaseEntitiesMs',
+  'phaseTotalMs',
+  'mainRendererMs',
+  'heapUsedMb',
+  'long50',
+  'jankPct',
+]);
+
+/**
+ * Diff two flat metric sets (before/after a change). Reports the absolute and
+ * percent delta and a verdict per key (FPS-like keys: up is better; ms/count
+ * keys: down is better), so an A/B run reads at a glance.
+ */
+export function diffMetrics(before, after, keys) {
+  const ks = keys ?? [...new Set([...Object.keys(before ?? {}), ...Object.keys(after ?? {})])];
+  const higherBetter = new Set([
+    'fps',
+    'fps10s',
+    'fpsMean',
+    'fpsMedian',
+    'fpsLow1',
+    'fpsLow01',
+    'renderScale',
+  ]);
+  const out = {};
+  for (const k of ks) {
+    const a = before?.[k];
+    const b = after?.[k];
+    if (typeof a !== 'number' || typeof b !== 'number') continue;
+    const delta = round(b - a, 2);
+    const pct = a !== 0 ? round((100 * (b - a)) / Math.abs(a), 1) : 0;
+    const better = delta === 0 ? 'same' : higherBetter.has(k) === delta > 0 ? 'better' : 'worse';
+    out[k] = { before: a, after: b, delta, pct, better };
+  }
+  return out;
+}
+
+export const profilerMetricsInternals = { round, PCT_KEYS };

--- a/server/db.ts
+++ b/server/db.ts
@@ -34,7 +34,12 @@ export const DATABASE_URL =
     );
   })();
 
-export const pool = new Pool({ connectionString: DATABASE_URL, max: 10 });
+// Pool size defaults to 10 (unchanged), but is env-tunable so a join burst (each
+// WS auth now fires several reads at once) or a crowd load test can widen it
+// without a code change; an operator must keep the sum across realm processes
+// under the database's own max_connections.
+const PG_POOL_MAX = Math.max(1, Number(process.env.PG_POOL_MAX ?? '10') || 10);
+export const pool = new Pool({ connectionString: DATABASE_URL, max: PG_POOL_MAX });
 
 const REALM_SQL_DEFAULT = REALM.replace(/'/g, "''");
 const LIFETIME_XP_EXPR = "((state->>'lifetimeXp')::bigint)";

--- a/server/main.ts
+++ b/server/main.ts
@@ -1445,13 +1445,23 @@ async function main(): Promise<void> {
       ws.close();
       return;
     }
-    const status = await moderationStatusForAccount(accountId);
+    // The remaining account/character reads are independent (each keyed only by
+    // accountId/characterId), so fetch them in one round-trip batch rather than
+    // five sequential awaits: a single join then holds a pool connection for far
+    // less wall-clock, which is what lets a reconnect storm (everyone returning
+    // after a restart) drain instead of piling up behind the 10 s auth timeout.
+    const [status, character, chatMute, isAdmin, accountCosmetics] = await Promise.all([
+      moderationStatusForAccount(accountId),
+      getCharacter(accountId, characterId),
+      chatMuteStatusForAccount(accountId),
+      isAdminAccount(accountId),
+      loadAccountCosmetics(accountId),
+    ]);
     if (status.locked) {
       ws.send(JSON.stringify({ t: 'error', error: status.message }));
       ws.close();
       return;
     }
-    const character = await getCharacter(accountId, characterId);
     if (!character) {
       ws.send(JSON.stringify({ t: 'error', error: 'no such character' }));
       ws.close();
@@ -1467,12 +1477,10 @@ async function main(): Promise<void> {
       ws.close();
       return;
     }
-    const chatMute = await chatMuteStatusForAccount(accountId);
     // Hard per-IP WS connection limit. The soft threshold (composite score evidence)
     // is handled inside game.join(); this guard blocks egregious bot farms before
     // they consume a session slot.
     const ip = requestMetadata(req).ip;
-    const isAdmin = await isAdminAccount(accountId);
     if (
       isConnectionRefused({
         blocked: game.isIpBlocked(ip),
@@ -1484,7 +1492,6 @@ async function main(): Promise<void> {
       ws.close(1008, 'Too many connections from your network');
       return;
     }
-    const accountCosmetics = await loadAccountCosmetics(accountId);
     const result = game.join(
       ws,
       accountId,
@@ -1548,7 +1555,20 @@ async function main(): Promise<void> {
       // attached the permanent message handler. Without this the frames are
       // silently dropped (see ws_buffer.ts).
       const flush = bufferHandshakeMessages(ws);
-      void authenticateWebSocket(ws, String(data), req).finally(flush);
+      // A DB read on the auth path can reject (e.g. the pool is saturated during a
+      // reconnect storm). Without a catch that surfaces as an unhandledRejection and
+      // the socket hangs until the 10 s auth timeout; close it cleanly instead.
+      void authenticateWebSocket(ws, String(data), req)
+        .catch((err) => {
+          console.error('ws auth failed:', err);
+          try {
+            ws.send(JSON.stringify({ t: 'error', error: 'not authenticated' }));
+            ws.close();
+          } catch {
+            /* socket already closing */
+          }
+        })
+        .finally(flush);
     });
   }
 

--- a/tests/profiler_metrics.test.mjs
+++ b/tests/profiler_metrics.test.mjs
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  attributeFreezes,
+  diffMetrics,
+  frameStats,
+  normalizeReport,
+} from '../scripts/profiler/metrics.mjs';
+
+describe('frameStats', () => {
+  it('returns null for empty input', () => {
+    expect(frameStats([])).toBeNull();
+    expect(frameStats(undefined)).toBeNull();
+  });
+
+  it('computes mean FPS and percentiles from frame durations', () => {
+    const steady = Array(100).fill(10); // 100 frames at 10ms => 100 fps
+    const s = frameStats(steady);
+    expect(s.frames).toBe(100);
+    expect(s.fpsMean).toBe(100);
+    expect(s.p95Ms).toBe(10);
+    expect(s.maxMs).toBe(10);
+    expect(s.stdevMs).toBe(0);
+    expect(s.jankPct).toBe(0);
+  });
+
+  it('captures the 1%/0.1% lows that an average hides', () => {
+    // 990 fast frames (8ms) + 10 slow frames (100ms): mean stays high, lows tank.
+    const d = [...Array(990).fill(8), ...Array(10).fill(100)];
+    const s = frameStats(d);
+    expect(s.fpsMean).toBeGreaterThan(80); // average barely dented
+    expect(s.fpsLow1).toBeLessThan(15); // worst 1% ~= 100ms frames => ~10 fps
+    expect(s.long50).toBe(10);
+    expect(s.stutter100).toBe(10);
+    expect(s.maxMs).toBe(100);
+    expect(s.jankPct).toBeGreaterThan(0);
+  });
+
+  it('judges jank against the supplied target budget', () => {
+    const d = Array(100).fill(20); // 20ms = 50fps
+    expect(frameStats(d, 60).jankPct).toBe(0); // 20 < 1.5*16.7
+    expect(frameStats(d, 120).jankPct).toBe(100); // 20 > 1.5*8.3
+  });
+});
+
+describe('attributeFreezes', () => {
+  it('attributes hitches to shader compiles, view builds, or other', () => {
+    const samples = [
+      { dt: 8, programs: 100, createdViews: 0 },
+      { dt: 200, programs: 103, createdViews: 0 }, // +3 programs => shader-compile
+      { dt: 9, programs: 103, createdViews: 0 },
+      { dt: 120, programs: 103, createdViews: 5 }, // +5 views => view-build
+      { dt: 9, programs: 103, createdViews: 5 },
+      { dt: 80, programs: 103, createdViews: 5, longTaskMs: 70 }, // long-task
+      { dt: 70, programs: 103, createdViews: 5 }, // other (GC/upload)
+    ];
+    const a = attributeFreezes(samples, 8, 50);
+    expect(a.hitchCount).toBe(4);
+    expect(a.worstMs).toBe(200);
+    expect(a.byCause['shader-compile']).toBe(1);
+    expect(a.byCause['view-build']).toBe(1);
+    expect(a.byCause['long-task']).toBe(1);
+    expect(a.byCause.other).toBe(1);
+    expect(a.worst[0].cause).toBe('shader-compile');
+  });
+
+  it('tags texture/geometry uploads as asset-upload (not shader-compile)', () => {
+    const samples = [
+      { dt: 8, programs: 50, createdViews: 0, textures: 900, geometries: 500 },
+      { dt: 90, programs: 50, createdViews: 0, textures: 912, geometries: 504 }, // +12 tex => upload
+    ];
+    const a = attributeFreezes(samples, 8, 50);
+    expect(a.byCause['asset-upload']).toBe(1);
+    expect(a.worst[0].texDelta).toBe(12);
+    expect(a.worst[0].geoDelta).toBe(4);
+  });
+
+  it('ignores frames below the hitch threshold', () => {
+    const samples = [
+      { dt: 8, programs: 1 },
+      { dt: 10, programs: 1 },
+      { dt: 12, programs: 1 },
+    ];
+    expect(attributeFreezes(samples, 8, 50).hitchCount).toBe(0);
+  });
+});
+
+describe('normalizeReport', () => {
+  it('flattens a perf report into stable comparable fields', () => {
+    const report = {
+      fps: 72.4,
+      frameMs: { p95: 16.1, p99: 28.6, max: 50, long50: 2 },
+      windows: { last10s: { fps: 73.1 } },
+      mainMs: { sim: { avg: 0.6 }, renderer: { avg: 7 }, hud: { avg: 0.4 } },
+      renderer: {
+        tier: 'high',
+        effectiveRenderScale: 1,
+        calls: 1189,
+        triangles: 4_000_000,
+        programs: 179,
+        views: 63,
+        autoGovernor: true,
+        phaseMs: { entities: { avg: 1 }, submit: { avg: 9.3 }, total: { avg: 10 } },
+        foliage: {
+          grassVisibleTufts: 2700,
+          modelVisibleDraws: 170,
+          modelVisibleTriangles: 2_600_000,
+        },
+        renderBudget: { mode: 'stable', reason: 'stable', pressure: 0.4 },
+      },
+      browser: {
+        longTasks: { count: 1, p95: 60, max: 60 },
+        memory: { usedMB: 300, limitMB: 4096 },
+      },
+    };
+    const m = normalizeReport(report);
+    expect(m.fps).toBe(72.4);
+    expect(m.tier).toBe('high');
+    expect(m.calls).toBe(1189);
+    expect(m.phaseSubmitMs).toBe(9.3);
+    expect(m.mainRendererMs).toBe(7);
+    expect(m.heapUsedMb).toBe(300);
+    expect(m.autoGovernor).toBe(true);
+  });
+});
+
+describe('diffMetrics', () => {
+  it('flags FPS up as better and frame-cost up as worse', () => {
+    const before = { fps: 58.7, frameP95: 32.7, calls: 1344 };
+    const after = { fps: 72.3, frameP95: 17.4, calls: 1189 };
+    const d = diffMetrics(before, after);
+    expect(d.fps.delta).toBeCloseTo(13.6, 1);
+    expect(d.fps.better).toBe('better');
+    expect(d.frameP95.better).toBe('better'); // p95 went down -> better
+    expect(d.calls.better).toBe('better'); // fewer calls -> better
+  });
+
+  it('marks regressions as worse', () => {
+    const d = diffMetrics({ fps: 80 }, { fps: 60 });
+    expect(d.fps.better).toBe('worse');
+    expect(d.fps.delta).toBe(-20);
+  });
+});


### PR DESCRIPTION
## Network / crowd performance: the connection ceiling was misdiagnosed, now fixed

The crowd profiler reported a hard "~20-24 connection ceiling" (bots failing with
`join timeout`), and the first findings guessed at server join-path throughput
(DB concurrency / event-loop contention). That was wrong.

The ceiling is the anti-bot **per-IP hard cap** `MAX_WS_PER_IP_HARD` (default 20).
The harness set a unique `X-Forwarded-For` per bot on the REST calls but **not on
the WS upgrade**, so every bot's socket resolved to `127.0.0.1`, shared one IP, and
the 21st connection was closed with `1008 Too many connections`. The bot then
waited for a `hello` that never came and reported `join timeout`, which read like a
throughput problem but was a flat policy reject at 20.

### Changes
- **Harness (the real fix):** send the same per-bot `X-Forwarded-For` on the WS
  upgrade, not only on REST. Each bot now presents a distinct apparent IP (a
  loopback source is a trusted XFF setter), the way a real crowd of distinct
  clients does, so the load test scales to the size you ask for. No production
  behaviour changes: the cap is unchanged and still protects real deployments.
- **Server, `authenticateWebSocket`:** the six auth DB reads ran strictly in
  series. The five that only depend on the resolved `accountId`/`characterId` now
  run in one `Promise.all` batch (same reject checks, same precedence: locked >
  no-character > force-rename > too-many-connections), so a join holds a pool
  connection for far less wall-clock and a reconnect storm drains instead of
  queueing behind the 10s auth timeout.
- **Server, auth promise `.catch`:** a DB read that rejects under load now closes
  the socket cleanly instead of hanging it until the auth timeout (and no longer
  surfaces as an `unhandledRejection`).
- **Server, `PG_POOL_MAX`:** the `pg` pool size (default 10, unchanged) is now
  env-tunable so a busy realm or a crowd test can widen it without a code change.

### Measured (RTX 3060 Ti, high tier, headed, vsync off, `PG_POOL_MAX=30`)

`node scripts/profile.mjs crowd --tier high --crowd 50`: **all 50 bots connect
(51 players in scene with the real client); zero join failures, zero `1008`
rejects, no pool/timeout errors**, vs the old ~21 wall. Server log clean across the
run.

| scene | players | fps | 1% low | p99 | jank |
|---|---|---|---|---|---|
| solo | 1 | 103.9 | 76.1 | 12.3ms | 0% |
| crowd-25 | 26 | 70.9 | 40.7 | 18.8ms | 0.35% |
| crowd-50 | 51 | 59.1 | 45.9 | 20.9ms | 0% |
| crowd-50 moving | 51 | 60.2 | 35.4 | 26.8ms | 1.66% |

The server kept up (snapshots sustained 59 to 60 fps with near-zero jank at 51
players, so the 50ms tick budget held). The remaining per-player render cost
(skinned rig + nameplate) is the separate FPS-under-crowd lever, which the
crowd-adaptive character LOD (#1013, already in the release) targets.

### Deliberately not done
- `permessage-deflate` compression: it would add CPU on the per-tick send hot path.
  This workload is CPU-bound, not bandwidth-bound, so it is the wrong trade.
- Self-snapshot heavy-field gating (re-stringify avoidance in `selfWireJson`): that
  is the scope of the snapshot-self-perf PR (#891); kept out of here to avoid
  overlap/conflict.

### How to run
```
npm run db:up
ALLOW_DEV_COMMANDS=1 PG_POOL_MAX=30 npm run server
npm run dev
BROWSER_PATH=/path/to/chrome node scripts/profile.mjs crowd --tier high --crowd 50
```
