### PR TITLE
Rendering Weapons on Mech skin

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2268,13 +2268,28 @@ async function startOffline(playerClass: PlayerClass, name: string, skin = 0): P
     // / polearm); only the ones this class can wield are granted, so every bag
     // weapon is swappable and the first one auto-equips.
     const TEST_WEAPONS = [
-      'worn_sword', 'redbrook_blade', 'wyrmfang_greatblade', 'highwatch_warblade',
-      'rusty_hatchet', 'drogmars_skullcleaver', 'gorraks_cleaver', 'tunnelkings_spade',
-      'bronzework_mace', 'voss_sanctified_mace', 'bristleback_maul',
-      'keen_dirk', 'skullsplitter_dirk', 'vale_carving_knife',
-      'gravecaller_staff', 'vaels_mist_staff', 'staff_of_the_gravewyrm',
-      'drowned_tide_scepter', 'drownedmoon_scepter', 'palecoil_rod',
-      'fen_reaver_glaive', 'tidereaver_gaff',
+      'worn_sword',
+      'redbrook_blade',
+      'wyrmfang_greatblade',
+      'highwatch_warblade',
+      'rusty_hatchet',
+      'drogmars_skullcleaver',
+      'gorraks_cleaver',
+      'tunnelkings_spade',
+      'bronzework_mace',
+      'voss_sanctified_mace',
+      'bristleback_maul',
+      'keen_dirk',
+      'skullsplitter_dirk',
+      'vale_carving_knife',
+      'gravecaller_staff',
+      'vaels_mist_staff',
+      'staff_of_the_gravewyrm',
+      'drowned_tide_scepter',
+      'drownedmoon_scepter',
+      'palecoil_rod',
+      'fen_reaver_glaive',
+      'tidereaver_gaff',
     ];
     const usable = TEST_WEAPONS.filter((id) => ITEMS[id] && canEquipItem(playerClass, ITEMS[id]));
     for (const id of usable) sim.addItem(id, 1, sim.playerId);

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,8 @@ import { Renderer } from './render/renderer';
 import { navigatorSaveData } from './render/sky';
 import { pathCrossesFence } from './sim/colliders';
 import { ABILITIES, CLASSES } from './sim/content/classes';
+import { ITEMS } from './sim/data';
+import { canEquipItem } from './sim/equipment_rules';
 import { findPlayerPath, resolvePlayerDestination } from './sim/pathfind';
 import { Sim } from './sim/sim';
 import { TAB_NEAR_RADIUS, TAB_QUERY_RADIUS, tabConeHalfAt } from './sim/tab_target';
@@ -2256,6 +2258,28 @@ async function startOffline(playerClass: PlayerClass, name: string, skin = 0): P
     devCommands: import.meta.env.DEV,
   });
   sim.setPlayerSkin(sim.playerId, skin);
+  // Dev convenience: ?mech drops an offline session straight into the Combat Mech
+  // cosmetic body holding a spread of class-usable weapons, to eyeball the held
+  // weapon model on the mech (swap them in the bag to see each one). DEV builds
+  // only (mirrors devCommands gating); inert in production.
+  if (import.meta.env.DEV && new URLSearchParams(location.search).has('mech')) {
+    sim.setPlayerSkin(sim.playerId, 0, 'mech');
+    // One weapon per held-model family (sword / axe / mace / dagger / staff / wand
+    // / polearm); only the ones this class can wield are granted, so every bag
+    // weapon is swappable and the first one auto-equips.
+    const TEST_WEAPONS = [
+      'worn_sword', 'redbrook_blade', 'wyrmfang_greatblade', 'highwatch_warblade',
+      'rusty_hatchet', 'drogmars_skullcleaver', 'gorraks_cleaver', 'tunnelkings_spade',
+      'bronzework_mace', 'voss_sanctified_mace', 'bristleback_maul',
+      'keen_dirk', 'skullsplitter_dirk', 'vale_carving_knife',
+      'gravecaller_staff', 'vaels_mist_staff', 'staff_of_the_gravewyrm',
+      'drowned_tide_scepter', 'drownedmoon_scepter', 'palecoil_rod',
+      'fen_reaver_glaive', 'tidereaver_gaff',
+    ];
+    const usable = TEST_WEAPONS.filter((id) => ITEMS[id] && canEquipItem(playerClass, ITEMS[id]));
+    for (const id of usable) sim.addItem(id, 1, sim.playerId);
+    if (usable[0]) sim.equipItem(usable[0], sim.playerId);
+  }
   // Offline characters are not persisted (a fresh name is typed each session),
   // so the only stable handle is class + name. Keybinds scope to that pair.
   void startGame(sim, sim, null, `offline:${playerClass}:${name}`);

--- a/src/render/characters/index.ts
+++ b/src/render/characters/index.ts
@@ -2,8 +2,8 @@
 // rigs. Asset fetches start at module import (see assets.ts) and register
 // with the preload gate, so createCharacterVisual is synchronous by the time
 // the Renderer constructs views.
-import type { Entity } from '../../sim/types';
-import { visualKeyFor } from './manifest';
+import type { Entity, PlayerClass } from '../../sim/types';
+import { mechHeldWeaponOverride, visualKeyFor } from './manifest';
 import { CharacterVisual } from './visual';
 
 export { CharacterPreview } from './preview';
@@ -17,10 +17,19 @@ export function createCharacterVisual(
 ): CharacterVisual {
   // forms (sheep/bear/cat/travel) are their own models — skins and held weapons
   // only apply to the base body
+  const key = formKey ?? visualKeyFor(e);
+  // The class-agnostic Combat Mech adopts the wearer class's hand layout, so a
+  // rogue-skinned mech dual-wields the equipped weapon in both hands. e.templateId
+  // is the player's class on every host, so this matches offline and online.
+  const weaponOverride =
+    !formKey && key === 'player_mech' && e.kind === 'player'
+      ? mechHeldWeaponOverride(e.templateId as PlayerClass)
+      : null;
   return new CharacterVisual(
-    formKey ?? visualKeyFor(e),
+    key,
     e.color,
     formKey ? 0 : (e.skin ?? 0),
     formKey ? null : e.mainhandItemId,
+    weaponOverride,
   );
 }

--- a/src/render/characters/manifest.ts
+++ b/src/render/characters/manifest.ts
@@ -4,7 +4,7 @@
 
 import { MECH_CHROMAS, type MechChroma } from '../../sim/content/skins';
 import { MOBS } from '../../sim/data';
-import type { Entity } from '../../sim/types';
+import type { Entity, PlayerClass } from '../../sim/types';
 import { ITEM_WEAPON_VARIANTS } from '../../ui/weapon_variants';
 import type { OverheadEmoteId } from '../../world_api';
 
@@ -87,6 +87,11 @@ export interface VisualDef {
    *  applied as a local-space rotation (radians) after the bind transform. */
   weaponFix?: { node: string; rotX?: number; rotY?: number; rotZ?: number }[];
 }
+
+/** The slice of a VisualDef that decides how held weapons attach (which bones, and
+ *  which slots swap to the equipped item). Lets a cosmetic body adopt a different
+ *  class's hand layout without cloning the whole def. */
+export type WeaponLayoutOverride = Pick<VisualDef, 'attach' | 'weaponSlots'>;
 
 // ---------------------------------------------------------------------------
 // Clip sets per source rig family
@@ -447,6 +452,12 @@ export const VISUALS: Record<string, VisualDef> = {
     // baked in from knight.glb (scripts/bake_mech_anims.mjs) — these names now
     // resolve like any other class. Lazy-loaded; see preloadMechAssets().
     clips: kaykit(['1H_Melee_Attack_Chop']),
+    // Class-agnostic cosmetic body, but it still holds the wearer's equipped
+    // mainhand: the shared handslot.r bone carries the grip (the mech reuses the
+    // exact KayKit rig), so weaponSlots swaps attach[0] to the equipped weapon's
+    // model just like every other class. The sword is only the no-weapon default.
+    attach: [{ url: `${WEAPONS}/sword_1handed.glb`, bone: 'handslot.r' }],
+    weaponSlots: [0],
     lazyPreload: true,
   },
 
@@ -914,6 +925,18 @@ export function visualKeyFor(e: Entity): string {
   // npcs — Brother Aldric recurs in every hub under suffixed ids
   if (e.templateId.startsWith('brother_aldric')) return 'npc_aldric';
   return NPC_KEYS[e.templateId] ?? 'npc_villager';
+}
+
+/** Held-weapon layout override for the class-agnostic Combat Mech body. The mech
+ *  keeps its own model and clips but adopts the WEARER class's hand layout, so a
+ *  dual-wield class (the rogue) shows the equipped weapon in BOTH hands on the mech
+ *  (it shares the KayKit handslot.r/.l bones). Non-dual classes return null and keep
+ *  the mech's own single-mainhand default. Host-agnostic: the wearer's class arrives
+ *  as a player entity's templateId, so this applies the same offline and online. */
+export function mechHeldWeaponOverride(cls: PlayerClass): WeaponLayoutOverride | null {
+  const classDef = VISUALS[`player_${cls}`];
+  if (!classDef || (classDef.weaponSlots?.length ?? 0) < 2) return null;
+  return { attach: classDef.attach, weaponSlots: classDef.weaponSlots };
 }
 
 /** Every glb the manifest can reference (for preloading). */

--- a/src/render/characters/preview.ts
+++ b/src/render/characters/preview.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { CLASSES } from '../../sim/data';
 import type { PlayerClass } from '../../sim/types';
 import { trackWebGLContext } from '../context_release';
+import type { WeaponLayoutOverride } from './manifest';
 import { CharacterVisual } from './visual';
 
 const PREVIEW_ANIM_STATE = {
@@ -97,8 +98,14 @@ export class CharacterPreview {
   }
 
   /** Set the active model by raw visual key (e.g. `player_mech` for the cosmetic
-   *  turntable). The asset must already be loaded — callers preload first. */
-  setVisualKey(visualKey: string, weaponItemId: string | null = null): void {
+   *  turntable). The asset must already be loaded — callers preload first.
+   *  `weaponOverride` lets a cosmetic body adopt a class hand layout (rogue mech
+   *  dual-wields), matching the in-world render. */
+  setVisualKey(
+    visualKey: string,
+    weaponItemId: string | null = null,
+    weaponOverride: WeaponLayoutOverride | null = null,
+  ): void {
     // Clean up current visual if it exists
     if (this.currentVisual) {
       this.characterGroup.remove(this.currentVisual.root);
@@ -107,7 +114,13 @@ export class CharacterPreview {
     }
 
     try {
-      this.currentVisual = new CharacterVisual(visualKey, 0xffffff, this.currentSkin, weaponItemId);
+      this.currentVisual = new CharacterVisual(
+        visualKey,
+        0xffffff,
+        this.currentSkin,
+        weaponItemId,
+        weaponOverride,
+      );
       this.characterGroup.add(this.currentVisual.root);
 
       // Reset rotation of group so new character faces forward but holds any user offset if preferred.

--- a/src/render/characters/visual.ts
+++ b/src/render/characters/visual.ts
@@ -22,7 +22,7 @@ import {
   skinTexture,
   tintedFarMaterials,
 } from './assets';
-import type { EmoteClipSpec, VisualDef } from './manifest';
+import type { EmoteClipSpec, VisualDef, WeaponLayoutOverride } from './manifest';
 
 export type { AnimState, BaseState } from './anim_state';
 
@@ -107,9 +107,21 @@ export class CharacterVisual {
   private soulRend = false;
   private bobPhase = Math.random() * Math.PI * 2;
 
-  constructor(key: string, entityColor: number, skinIndex = 0, weaponItemId: string | null = null) {
+  constructor(
+    key: string,
+    entityColor: number,
+    skinIndex = 0,
+    weaponItemId: string | null = null,
+    weaponOverride: WeaponLayoutOverride | null = null,
+  ) {
     const prep = prepareVisual(key);
-    this.def = prep.def;
+    // A cosmetic body (the Combat Mech) keeps its model/clips but can adopt the
+    // wearer class's held-weapon layout (e.g. the rogue dual-wields in both hands).
+    // Override just attach + weaponSlots on a shallow def clone, leaving the rest of
+    // the def (clips/height/tint) intact and never mutating the shared cached def.
+    this.def = weaponOverride
+      ? { ...prep.def, attach: weaponOverride.attach, weaponSlots: weaponOverride.weaponSlots }
+      : prep.def;
     this.key = key;
     this.entityColor = entityColor;
     this.skinIndex = skinIndex;
@@ -119,10 +131,10 @@ export class CharacterVisual {
     // model: yaw/scale/feet normalization wrapper around the skinned clone. The
     // equipped mainhand item (if the class swaps; see VisualDef.weaponSlot) picks
     // the held weapon model, so the visual is born holding the right weapon.
-    this.model = assembleModel(prep.def, weaponItemId);
+    this.model = assembleModel(this.def, weaponItemId);
     applyMaterials(
       this.model,
-      prep.def,
+      this.def,
       entityColor,
       skinTexture(key, skinIndex),
       skinEmissiveTexture(key, skinIndex),

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -22,7 +22,7 @@ import { voice } from '../game/voice';
 import { castBarState } from '../render/cast_bar';
 import { CharacterPreview } from '../render/characters';
 import { preloadMechAssets } from '../render/characters/assets';
-import { skinCount } from '../render/characters/manifest';
+import { mechHeldWeaponOverride, skinCount } from '../render/characters/manifest';
 import {
   onPortraitsReady,
   playerPortraitDataUrl,
@@ -9324,8 +9324,14 @@ export class Hud {
     // Show the player's currently equipped mainhand on the character sheet, so the
     // 3D model reflects gear changes (re-runs on each renderChar after an equip).
     const weapon = this.sim.equipment.mainhand ?? null;
-    if (previewKey) this.charPreview.setVisualKey(previewKey, weapon);
-    else this.charPreview.setClass(cls, weapon);
+    if (previewKey) {
+      // mech is class-agnostic; mirror the wearer class's hand layout (rogue
+      // dual-wields) so the paperdoll matches the in-world render
+      const override = previewKey === 'player_mech' ? mechHeldWeaponOverride(cls) : null;
+      this.charPreview.setVisualKey(previewKey, weapon, override);
+    } else {
+      this.charPreview.setClass(cls, weapon);
+    }
     this.charPreview.setSkin(skin);
   }
 

--- a/tests/held_weapon_models.test.ts
+++ b/tests/held_weapon_models.test.ts
@@ -1,7 +1,11 @@
 import { existsSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import { itemWeaponModelUrl, VISUALS } from '../src/render/characters/manifest';
+import {
+  itemWeaponModelUrl,
+  mechHeldWeaponOverride,
+  VISUALS,
+} from '../src/render/characters/manifest';
 import { ITEM_WEAPON_VARIANTS } from '../src/ui/weapon_variants';
 
 // The per-item held weapon models: each weapon item maps (via the shared
@@ -53,12 +57,13 @@ describe('held weapon models', () => {
   });
 
   // Every player class swaps its held mainhand to the equipped weapon, EXCEPT the
-  // hunter, which keeps its crossbow regardless of the melee weapon equipped.
+  // hunter, which keeps its crossbow regardless of the melee weapon equipped. The
+  // cosmetic Combat Mech (player_mech) is class-agnostic but is included: it still
+  // shows the wearer's equipped mainhand, like every other body.
   it('all player classes swap the mainhand except the hunter', () => {
-    const players = Object.keys(VISUALS).filter(
-      (k) => k.startsWith('player_') && k !== 'player_mech',
-    );
+    const players = Object.keys(VISUALS).filter((k) => k.startsWith('player_'));
     expect(players).toContain('player_hunter');
+    expect(players).toContain('player_mech');
     for (const key of players) {
       const def = VISUALS[key];
       if (key === 'player_hunter') {
@@ -69,5 +74,26 @@ describe('held weapon models', () => {
     }
     // the rogue dual-wields: both hand slots swap so a dagger shows in BOTH hands
     expect(VISUALS.player_rogue.weaponSlots).toEqual([0, 1]);
+  });
+
+  // The class-agnostic Combat Mech adopts the WEARER class's hand layout, so a
+  // rogue wearing the mech still dual-wields (weapon in both hands), while every
+  // single-wield class keeps the mech's own one-hand default (no override).
+  it('the Combat Mech mirrors a dual-wield class so a rogue mech holds both hands', () => {
+    const rogue = mechHeldWeaponOverride('rogue');
+    expect(rogue?.weaponSlots).toEqual([0, 1]);
+    expect(rogue?.attach?.length).toBe(2);
+    for (const cls of [
+      'warrior',
+      'paladin',
+      'hunter',
+      'priest',
+      'mage',
+      'warlock',
+      'shaman',
+      'druid',
+    ] as const) {
+      expect(mechHeldWeaponOverride(cls), `${cls} should not dual-wield on the mech`).toBeNull();
+    }
   });
 });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -14,6 +14,7 @@ vi.mock('../server/db', () => ({
 
 import { saveCharacterState } from '../server/db';
 import { type ClientSession, GameServer, wireEntity } from '../server/game';
+import { mechHeldWeaponOverride, visualKeyFor } from '../src/render/characters/manifest';
 import { ClientWorld } from '../src/net/online';
 import { DELVES } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
@@ -148,6 +149,59 @@ describe('raid lockouts over the wire', () => {
     const client = bareClient(session.pid);
     (client as any).applySnapshot(snap);
     expect(client.raidLockouts()).toEqual([]);
+  });
+});
+
+// The held-weapon-on-the-mech fix is client render, but it depends on three wire
+// fields the server must ship for a player: class (tid), cosmetic body (cat), and
+// equipped mainhand (mh). This drives the REAL server emit (wireEntity) into the
+// REAL client mirror (applySnapshot) and checks the visual layer's inputs, so the
+// mech weapon (and rogue dual-wield) is proven to work online, not just offline.
+describe('Combat Mech held weapon over the wire', () => {
+  it('mirrors class + mech skin + equipped weapon so a rogue mech dual-wields client-side', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'rogue', autoEquip: true });
+    const pid = sim.playerId;
+    sim.setPlayerSkin(pid, 0, 'mech');
+    sim.addItem('keen_dirk', 1, pid);
+    sim.equipItem('keen_dirk', pid);
+    const e = sim.entities.get(pid)!;
+    expect(e.mainhandItemId).toBe('keen_dirk'); // recalcPlayerStats set the held-weapon id
+
+    // server emit
+    const w = wireEntity(e);
+    expect(w.tid).toBe('rogue'); // class drives visualKeyFor + the dual-wield override
+    expect(w.cat).toBe('mech'); // cosmetic body
+    expect(w.mh).toBe('keen_dirk'); // equipped mainhand -> held weapon model
+
+    // client mirror: a DIFFERENT local player seeing this rogue-mech in the world
+    const client = bareClient(pid + 1000);
+    (client as any).applySnapshot({ t: 'snap', ents: [w] });
+    const mirrored = client.entities.get(e.id)!;
+    expect(mirrored.templateId).toBe('rogue');
+    expect(mirrored.skinCatalog).toBe('mech');
+    expect(mirrored.mainhandItemId).toBe('keen_dirk');
+
+    // what the renderer derives from the mirrored entity
+    expect(visualKeyFor(mirrored)).toBe('player_mech');
+    const override = mechHeldWeaponOverride(mirrored.templateId as PlayerClass);
+    expect(override?.weaponSlots).toEqual([0, 1]); // equipped weapon shows in BOTH hands
+  });
+
+  it('keeps a non-dual class (warrior) mech to a single mainhand over the wire', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', autoEquip: true });
+    const pid = sim.playerId;
+    sim.setPlayerSkin(pid, 0, 'mech');
+    sim.addItem('worn_sword', 1, pid);
+    sim.equipItem('worn_sword', pid);
+    const e = sim.entities.get(pid)!;
+
+    const client = bareClient(pid + 1000);
+    (client as any).applySnapshot({ t: 'snap', ents: [wireEntity(e)] });
+    const mirrored = client.entities.get(e.id)!;
+    expect(mirrored.skinCatalog).toBe('mech');
+    expect(mirrored.mainhandItemId).toBe('worn_sword');
+    expect(visualKeyFor(mirrored)).toBe('player_mech');
+    expect(mechHeldWeaponOverride(mirrored.templateId as PlayerClass)).toBeNull();
   });
 });
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -14,8 +14,8 @@ vi.mock('../server/db', () => ({
 
 import { saveCharacterState } from '../server/db';
 import { type ClientSession, GameServer, wireEntity } from '../server/game';
-import { mechHeldWeaponOverride, visualKeyFor } from '../src/render/characters/manifest';
 import { ClientWorld } from '../src/net/online';
+import { mechHeldWeaponOverride, visualKeyFor } from '../src/render/characters/manifest';
 import { DELVES } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
 import { DT, type PlayerClass } from '../src/sim/types';


### PR DESCRIPTION
## What

The Combat Mech cosmetic body rendered empty-handed: unlike every other player class it had no weapon attach points, so `assembleModel` attached nothing and `setWeapon` early-returned. This wires it up so the mech shows the equipped mainhand, and makes it adopt the wearer class's hand layout so a rogue dual-wields in both hands.

## Changes

- `player_mech` now declares an `attach[0]` mainhand + `weaponSlots: [0]`, so the equipped weapon model swaps in. Held weapon matches the inventory icon, same as the other classes. The mech shares the KayKit rig, so the handslot bones and grips resolve identically.
- The mech adopts the wearer class's hand layout via `mechHeldWeaponOverride`: a dual-wield class (rogue) shows the equipped weapon in BOTH hands; single-wield classes keep one mainhand. Threaded through `createCharacterVisual` (live world) and the character-sheet / skin-select paperdoll.
- DEV-only `?mech` offline drop-in: open a local offline session at `/?mech` to spawn wearing the mech with a spread of class-usable weapons (first auto-equipped, the rest swappable in the bag) for quick visual testing. Inert in production.

## Works online

The render path is the shared `createCharacterVisual`, and the wire already carries class (`tid`), cosmetic body (`cat`), and equipped mainhand (`mh`), so behaviour is identical offline and online. Added a server-emit to client-mirror wire round-trip test that proves a rogue-mech arrives with the correct render inputs.

## Tests

- `tests/held_weapon_models.test.ts`: the mech swaps its mainhand like the other classes; the rogue-mech dual-wield override.
- `tests/snapshots.test.ts`: server-to-client wire round trip for a rogue-mech (dual-wield) and a warrior-mech (single mainhand).
- Full suite green (372 files, 3889 passed). tsc clean.
