### PR TITLE
feat(sim): raise concurrent dungeon/delve instance cap to 24

### DIFF
--- a/src/sim/data.ts
+++ b/src/sim/data.ts
@@ -292,7 +292,11 @@ export const ZONE_NAME = ZONE1_ZONE.name;
 // slots stack along z.
 // ---------------------------------------------------------------------------
 
-export const INSTANCE_SLOT_COUNT = 6;
+// Concurrent copies a single dungeon can host. Each slot is a cheap, empty
+// InstanceSlot (no entities, no rng) pre-allocated in the Sim ctor and only
+// populated when a party claims it, so a generous ceiling costs little memory
+// and lets a busy realm keep many leveling groups in the same dungeon at once.
+export const INSTANCE_SLOT_COUNT = 24;
 export const DUNGEON_X_THRESHOLD = 600; // x beyond this = inside an instance
 export const DUNGEON_FLOOR_Y = 0;
 
@@ -377,7 +381,8 @@ export const DELVE_X_MIN = 4800;
 // and the west half is never misclassified as arena. Still >500u clear of ARENA_X.
 const DELVE_WALL_X = 25; // mirror of delve_layout.ts WALL_X (delve side-wall centre)
 export const DELVE_BAND_X_MIN = DELVE_X_MIN - (DELVE_WALL_X + DUNGEON_WALL_HW + 1);
-export const DELVE_SLOT_COUNT = 6;
+// Concurrent copies a single delve can host (mirrors INSTANCE_SLOT_COUNT).
+export const DELVE_SLOT_COUNT = 24;
 export const DELVE_MODULE_GAP = 16;
 export const DELVE_MODULE_Z_START = 8;
 const DELVE_Z0 = -1250;

--- a/tests/delves.test.ts
+++ b/tests/delves.test.ts
@@ -215,6 +215,32 @@ describe('delve registry', () => {
 });
 
 describe('delve lifecycle', () => {
+  it('more than six solo parties can hold their own Collapsed Reliquary run at once', () => {
+    const sim = makeSim();
+    const PARTIES = 8; // was capped at 6 concurrent delve runs before the bump
+    const pids = [sim.playerId];
+    for (let i = 1; i < PARTIES; i++) {
+      pids.push(sim.addPlayer('warrior', `Delver${i}`));
+    }
+
+    for (const pid of pids) {
+      sim.setPlayerLevel(DELVES.collapsed_reliquary.minLevel, pid);
+      sim.drainEvents();
+      sim.enterDelve('collapsed_reliquary', 'normal', pid);
+      const events = sim.drainEvents();
+      expect(
+        events.some((e) => e.type === 'error' && /All instances of .* are busy/.test(e.text ?? '')),
+      ).toBe(false);
+    }
+
+    const claimed = sim.delveRuns.filter(
+      (run) => run.delveId === 'collapsed_reliquary' && run.partyKey !== null,
+    );
+    expect(claimed.length).toBe(PARTIES);
+    // every claimed solo player landed in a distinct run slot (no double-booking)
+    expect(new Set(claimed.map((run) => run.slot)).size).toBe(PARTIES);
+  });
+
   it('enter and leave toggle delve position band', () => {
     const sim = makeSim();
     enterReliquary(sim);

--- a/tests/dungeons.test.ts
+++ b/tests/dungeons.test.ts
@@ -138,6 +138,28 @@ describe('dungeons: empty-instance reset', () => {
   });
 });
 
+describe('dungeons: concurrent-instance capacity', () => {
+  it('more than six solo parties can hold their own Hollow Crypt instance at once', () => {
+    const sim = makeSim();
+    const PARTIES = 8; // was capped at 6 concurrent instances before the bump
+    for (let i = 0; i < PARTIES; i++) {
+      const pid = sim.addPlayer('warrior', `Solo${i}`);
+      sim.drainEvents();
+      enterDungeon(sim.ctx, 'hollow_crypt', pid);
+      const events = sim.drainEvents() as any[];
+      expect(
+        events.some((e) => e.type === 'error' && /All instances of .* are busy/.test(e.text ?? '')),
+      ).toBe(false);
+    }
+    const claimed = (sim.instances as any[]).filter(
+      (i) => i.dungeonId === 'hollow_crypt' && i.partyKey !== null,
+    );
+    expect(claimed.length).toBe(PARTIES);
+    // every claimed party landed in a distinct slot (no double-booking)
+    expect(new Set(claimed.map((i) => i.slot)).size).toBe(PARTIES);
+  });
+});
+
 describe('dungeons: raid lockout gate', () => {
   function attunedRaid(sim: AnySim): number {
     const leader = sim.addPlayer('warrior', 'Lead');


### PR DESCRIPTION
## What

Raise the per-dungeon and per-delve concurrent-instance cap from **6 to 24**
(`INSTANCE_SLOT_COUNT` / `DELVE_SLOT_COUNT` in `src/sim/data.ts`).

## Why

Each dungeon and delve can only host a fixed number of private party instances
at once. On a busy realm, leveling groups running the same low-level dungeon
(Hollow Crypt especially) would fill all 6 slots and the next party hit:

> All instances of &lt;name&gt; are busy. Try again soon.

and was locked out until a slot freed. Six concurrent copies is simply too few
for a populated realm. This was reported while leveling through dungeons.

![before/after capacity](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-raise-instance-cap/assets/instance-capacity.png)

## How it stays safe

Each slot is a cheap, empty `InstanceSlot` pre-allocated in the `Sim`
constructor with **no entities and no rng draws**. Mobs/objects/exit are only
spawned in `claimInstance()` when a party actually enters, and the slot is
reaped 15s after it goes empty.

- **Determinism is unaffected.** Empty slots draw no rng, so the global draw
  order is unchanged; the `tests/parity` golden-trace + draw-order gate stays
  green.
- **No geometry collisions.** Slots stack along **z** inside each dungeon's own
  **x-band**, so a higher count just extends z downfield; it never reaches the
  arena (x=4200) or delve (x&ge;4800) bands.
- **Renderer/collider cost is flat.** Both only ever build the occupied slot
  nearest the player (lazy `builtInteriors` gate / nearest-z search), so the
  extra slots add only a handful of tiny empty objects per dungeon.

```mermaid
flowchart TD
  A["Party walks dungeon door"] --> B{"Party already holds a slot?"}
  B -- yes --> R["Reuse that instance"]
  B -- no --> C{"Any free slot? partyKey == null"}
  C -- "yes (now up to 24)" --> D["claimInstance: spawn mobs + objects + exit"]
  C -- "no (all busy)" --> E["error: All instances busy. Try again soon"]
  D --> F["Party plays the run"]
  R --> F
  F --> G{"Instance empty >= 15s?"}
  G -- yes --> H["freeInstance: despawn, partyKey = null"]
  H --> C
  G -- no --> F
```

(Static render of the same lifecycle:)

![instance lifecycle](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-raise-instance-cap/assets/instance-lifecycle.png)

## Tests

- New capacity regression in `tests/dungeons.test.ts`: eight solo parties each
  claim a distinct Hollow Crypt instance with no "busy" error (would have failed
  at the old cap of 6).
- Green locally: `tests/dungeons.test.ts`, `tests/delves.test.ts`,
  `tests/architecture.test.ts`, the full `tests/parity` suite, `tests/sim.test.ts`,
  `tests/snapshots.test.ts`, `tests/bandwidth.test.ts`, and `tsc --noEmit`.

No i18n change: the "all instances busy" string and its matcher are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
