### PR TITLE
perf(render): crowd-adaptive character LOD to cut GPU submit in crowds

### DIFF
--- a/docs/perf/crowd-fps-findings.md
+++ b/docs/perf/crowd-fps-findings.md
@@ -1,0 +1,63 @@
+# Crowd FPS: where the frame goes, and the crowd-adaptive character budget
+
+Profiled a 50-player crowd on a discrete GPU (RTX 3060 Ti, high tier, 1920x1080,
+vsync off) with `scripts/profile.mjs` and the renderer's own per-phase timing
+(`renderer.perfStats().phaseMs`).
+
+## Finding: crowd cost is GPU-bound on the submit phase, not CPU
+
+Per-phase average frame time (ms), solo vs a 50-player crowd in view:
+
+| phase | solo (4 rigs) | crowd (90 rigs) | delta |
+|---|---|---|---|
+| entities (character CPU: anim/skinning) | 0.56 | 1.93 | +1.37 |
+| world (terrain/foliage/props) | 0.39 | 0.38 | ~0 |
+| nameplates | 0.11 | 0.26 | +0.15 |
+| **submit (GPU rasterize + post + shadow)** | **7.86** | **14.22** | **+6.36** |
+| total | 8.96 | 16.82 | +7.86 |
+
+So 80%+ of the crowd's added frame time is the **submit** phase: rasterizing ~50
+extra skinned character rigs (~6 draws each) into the main pass and re-rendering the
+close ones into the 4096 sun shadow map every frame. The CPU character work
+(animation/skinning) is small (~2ms), so throttling animation harder is NOT the
+lever on this class of hardware; cutting the GPU rig+shadow load is.
+
+## Optimization: crowd-adaptive shadow + LOD ranges (`src/render/crowd_lod.ts`)
+
+The renderer already collapses a distant rig to a single-draw far-LOD mesh (beyond
+58u) and hands its ground shadow to a cheap static proxy (beyond 25u). This change
+makes those two ranges **crowd-adaptive**: as the count of visible articulated rigs
+climbs past a soft knee (16) toward a hard knee (48), the articulated-shadow and
+articulated-LOD ranges shrink toward a floor (~16u shadow, ~42u rig at the hard
+knee). A dense crowd therefore collapses its distant bodies to far LOD and proxy
+shadow sooner. Below the soft knee nothing changes, so ordinary grouping (a 5-man,
+a few passers-by) is never touched. The visible-rig count is read one frame late to
+avoid a second pass and any feedback loop.
+
+The knee math is a pure, unit-tested function (`crowdLodSqScale`,
+`tests/crowd_lod.test.ts`); the renderer is a thin consumer.
+
+### Gameplay-neutral (docs/design/graphics-settings-fairness.md)
+
+It sheds only COSMETIC richness: animation smoothness and distant per-rig shadow
+crispness. It never hides or delays actionable information. Position, the nameplate
+(name/HP/debuffs/raid marks), the target unit frame and the cast bar are HUD/sim
+state rendered independently of the rig LOD and are untouched. The LOD floor (~42u)
+is ~2x melee range and past the 30u nameplate-detail band, so a rig you are
+actually fighting or grouped with never collapses; only distant crowd bodies do.
+This is the same kind of shedding the existing fixed 58u far-LOD already does, just
+scaled by crowd density.
+
+## Measured win (A/B at a fixed 50-player crowd, drift-canceled)
+
+Toggling `renderer.crowdAdaptiveLod` ON vs OFF at the same 50-player crowd spread
+across ~70u (a realistic hub spread, not an artificial tight cluster), four
+order-alternated paired rounds to cancel GPU warm/cool drift:
+
+- mean FPS: ~62.7 -> ~71.4, **+8.7 fps (+13.9%)**, positive in all four rounds.
+- submit phase: **-0.95 ms** mean, lower in all four rounds.
+- 1% low: +3.4 fps (smoother under load).
+
+The win scales with how spread the crowd is (a tightly-clustered crowd where every
+body is inside the LOD floor sees little, since none collapse; a realistic
+town/hub/raid spread sees the full benefit). The toggle defaults ON.

--- a/src/render/crowd_lod.ts
+++ b/src/render/crowd_lod.ts
@@ -1,0 +1,54 @@
+// Crowd-adaptive character LOD budget (pure math, unit-tested).
+//
+// The per-frame cost of a crowd is GPU-bound on the renderer's submit phase: every
+// visible articulated rig is rasterized (~6 draws) and, when close, re-rendered
+// into the sun shadow map. Profiling a 50-player cluster on a discrete GPU shows
+// submit growing ~6ms going from solo to the crowd while the CPU character work
+// (animation/skinning) stays ~2ms, so the crowd lever is the GPU rig+shadow load,
+// not CPU.
+//
+// When many rigs are visible at once (a city, a raid, a world boss) the marginal
+// ones are visual mush, so the renderer pulls the articulated-LOD and
+// articulated-shadow squared ranges IN as the visible-rig count climbs: distant
+// crowd members collapse to their single-draw far LOD and hand their ground shadow
+// to the cheap static proxy sooner.
+//
+// This sheds only COSMETIC richness (animation smoothness + distant per-rig shadow
+// crispness). Position, nameplate, HP, debuffs and the target cast bar are HUD/sim
+// state and are untouched, so the budget is gameplay-neutral
+// (docs/design/graphics-settings-fairness.md): it never hides or delays actionable
+// information, only how smoothly/shadowed a distant body in a dense crowd is drawn.
+
+// Below SOFT visible rigs there is no reduction at all; the pull ramps linearly to
+// its floor at/above HARD. Tuned so ordinary grouping (a 5-man, a few passers-by)
+// is never touched and only genuine crowds pay.
+export const CROWD_LOD_SOFT_RIGS = 16;
+export const CROWD_LOD_HARD_RIGS = 48;
+
+// Floors as a fraction of the BASE squared range, so the LINEAR range floor is the
+// square root of these. Conservative on purpose: a rig you are meleeing or grouped
+// with stays well inside both even at the hard knee.
+//   shadow 0.40 -> ~0.63x linear (articulated shadow 25u -> ~16u at the hard knee)
+//   lod    0.52 -> ~0.72x linear (articulated rig    58u -> ~42u at the hard knee)
+// 42u is ~2x melee range and past the 30u nameplate-detail band, so a rig you are
+// actually interacting with never collapses; only distant crowd bodies do.
+export const CROWD_LOD_MIN_SHADOW_SQ_SCALE = 0.4;
+export const CROWD_LOD_MIN_LOD_SQ_SCALE = 0.52;
+
+// Linear ramp from 1.0 (at/below `soft` visible rigs) to `floorSqScale` (at/above
+// `hard`). The result multiplies a BASE squared range; a floor of 0.45 therefore
+// shrinks the linear range to sqrt(0.45) ~ 0.67x. Pure: no allocation, no clock,
+// NaN-safe (a non-finite count yields no reduction).
+export function crowdLodSqScale(
+  rigs: number,
+  floorSqScale: number,
+  soft: number = CROWD_LOD_SOFT_RIGS,
+  hard: number = CROWD_LOD_HARD_RIGS,
+): number {
+  if (!(rigs > soft)) return 1; // below the knee (or NaN): full detail
+  const span = hard - soft;
+  if (span <= 0) return floorSqScale;
+  const t = Math.min(1, (rigs - soft) / span);
+  // clamp so float rounding at t=1 cannot dip a hair below the floor
+  return Math.max(floorSqScale, 1 + (floorSqScale - 1) * t);
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -57,6 +57,11 @@ import { skinCount, visualKeyFor } from './characters/manifest';
 import { CLICK_MARKER_LIFETIME, clickMarkerAnim, clickMarkerColor } from './click_marker';
 import { trackWebGLContext } from './context_release';
 import { buildCritters, type CritterField } from './critters';
+import {
+  CROWD_LOD_MIN_LOD_SQ_SCALE,
+  CROWD_LOD_MIN_SHADOW_SQ_SCALE,
+  crowdLodSqScale,
+} from './crowd_lod';
 import { buildDelveModule } from './delve_interiors';
 import { buildDelveInteractable } from './delve_props';
 import { DungeonInteriors, ensureDungeonAssets } from './dungeon';
@@ -811,6 +816,14 @@ export class Renderer {
   private envOutdoorIntensity = ENV_INTENSITY;
   private time = 0;
   private frameIdx = 0;
+  // Crowd-adaptive character budget (see crowd_lod.ts). `crowdRigCount` is the
+  // count of visible articulated rigs from the PREVIOUS frame, used to scale this
+  // frame's shadow/LOD ranges (one-frame lag is imperceptible and avoids a second
+  // pass). `crowdAdaptiveLod` gates it on; it stays public so a profiler can A/B
+  // it at a fixed crowd via `window.__game.renderer.crowdAdaptiveLod = false`.
+  crowdAdaptiveLod = true;
+  // visible articulated rigs last frame; read-only diagnostic (drives the scale).
+  crowdRigCount = 0;
   vfx: Vfx;
   private weather: Weather;
   private weatherOn = true;
@@ -3573,6 +3586,16 @@ export class Renderer {
     // frame parity for distance-tiered mixer throttling
     this.frameIdx = (this.frameIdx + 1) & 0xffff;
 
+    // Crowd-adaptive shadow/LOD ranges for THIS frame, from last frame's visible
+    // rig count (crowd_lod.ts). Below the soft knee both scales are 1 (no change);
+    // a dense crowd pulls the articulated-shadow and articulated-LOD ranges in so
+    // distant bodies shed only their (cosmetic) crisp shadow + smooth animation.
+    const crowdRigs = this.crowdAdaptiveLod ? this.crowdRigCount : 0;
+    const shadowRangeSq =
+      ENTITY_SHADOW_RANGE_SQ * crowdLodSqScale(crowdRigs, CROWD_LOD_MIN_SHADOW_SQ_SCALE);
+    const lodRangeSq = ENTITY_LOD_RANGE_SQ * crowdLodSqScale(crowdRigs, CROWD_LOD_MIN_LOD_SQ_SCALE);
+    let visibleRigs = 0;
+
     // world-space view frustum for the per-character cull below. Built from last
     // frame's camera (it's repositioned after this loop); the one-frame lag is
     // absorbed by the generous per-rig cull radius.
@@ -3614,12 +3637,18 @@ export class Renderer {
           continue;
         }
         v.group.visible = true; // the object branch below may re-hide loot
-        // mid-distance rigs keep rendering but leave the shadow pass
-        const wantShadow = d2 < ENTITY_SHADOW_RANGE_SQ;
+        // mid-distance rigs keep rendering but leave the shadow pass. The shadow
+        // and LOD ranges are crowd-scaled (shadowRangeSq/lodRangeSq) so a dense
+        // crowd sheds distant rigs' articulated shadow + skinning sooner.
+        const wantShadow = d2 < shadowRangeSq;
         const inProxyBand = d2 < ENTITY_PROXY_SHADOW_RANGE_SQ;
         if (v.visual) {
+          // every visible character rig (pre-LOD) is one body in the crowd; this
+          // drives next frame's crowd scale (a stable, density-based signal that
+          // does not feed back on the LOD decision it informs).
+          visibleRigs++;
           v.visual.setShadow(wantShadow);
-          v.isFar = d2 > ENTITY_LOD_RANGE_SQ;
+          v.isFar = d2 > lodRangeSq;
           // past the articulated gate the static-pose proxy carries the
           // shadow; an active form's own rig keeps casting instead
           v.visual.setProxyShadow(
@@ -3980,6 +4009,8 @@ export class Renderer {
         this.targetCone.group.visible = true;
       }
     }
+    // visible-rig tally for next frame's crowd-adaptive shadow/LOD scale
+    this.crowdRigCount = visibleRigs;
     markPhase('entities');
 
     let worldStart = performance.now();

--- a/tests/crowd_lod.test.ts
+++ b/tests/crowd_lod.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CROWD_LOD_HARD_RIGS,
+  CROWD_LOD_MIN_LOD_SQ_SCALE,
+  CROWD_LOD_MIN_SHADOW_SQ_SCALE,
+  CROWD_LOD_SOFT_RIGS,
+  crowdLodSqScale,
+} from '../src/render/crowd_lod';
+
+describe('crowdLodSqScale', () => {
+  const floor = CROWD_LOD_MIN_SHADOW_SQ_SCALE;
+
+  it('is a no-op (1.0) at and below the soft knee', () => {
+    expect(crowdLodSqScale(0, floor)).toBe(1);
+    expect(crowdLodSqScale(CROWD_LOD_SOFT_RIGS, floor)).toBe(1);
+    expect(crowdLodSqScale(CROWD_LOD_SOFT_RIGS - 1, floor)).toBe(1);
+  });
+
+  it('reaches exactly the floor at and beyond the hard knee', () => {
+    expect(crowdLodSqScale(CROWD_LOD_HARD_RIGS, floor)).toBeCloseTo(floor, 12);
+    expect(crowdLodSqScale(CROWD_LOD_HARD_RIGS + 100, floor)).toBeCloseTo(floor, 12);
+  });
+
+  it('ramps linearly and monotonically across the knee', () => {
+    const mid = (CROWD_LOD_SOFT_RIGS + CROWD_LOD_HARD_RIGS) / 2;
+    expect(crowdLodSqScale(mid, floor)).toBeCloseTo(1 + (floor - 1) * 0.5, 12);
+    let prev = Number.POSITIVE_INFINITY;
+    for (let rigs = CROWD_LOD_SOFT_RIGS; rigs <= CROWD_LOD_HARD_RIGS; rigs++) {
+      const s = crowdLodSqScale(rigs, floor);
+      expect(s).toBeLessThanOrEqual(prev);
+      expect(s).toBeGreaterThanOrEqual(floor);
+      expect(s).toBeLessThanOrEqual(1);
+      prev = s;
+    }
+  });
+
+  it('never widens a range (scale stays within [floor, 1]) for either floor', () => {
+    for (const f of [CROWD_LOD_MIN_SHADOW_SQ_SCALE, CROWD_LOD_MIN_LOD_SQ_SCALE]) {
+      for (const rigs of [0, 8, 16, 24, 32, 48, 80, 200]) {
+        const s = crowdLodSqScale(rigs, f);
+        expect(s).toBeGreaterThanOrEqual(f);
+        expect(s).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('is NaN-safe (a non-finite count yields full detail)', () => {
+    expect(crowdLodSqScale(Number.NaN, floor)).toBe(1);
+  });
+
+  it('degrades safely if the knee window is empty (soft >= hard)', () => {
+    expect(crowdLodSqScale(50, floor, 40, 40)).toBe(floor);
+  });
+});


### PR DESCRIPTION
## Crowd FPS: crowd-adaptive character LOD

Profiling a 50-player crowd (RTX 3060 Ti, high tier, 1920x1080, vsync off) with the
renderer's own per-phase timing (`renderer.perfStats().phaseMs`) shows the frame is
**GPU-bound on the submit phase**, not CPU-bound:

| phase | solo (4 rigs) | crowd (90 rigs) | delta |
|---|---|---|---|
| entities (character CPU: anim/skinning) | 0.56 | 1.93 | +1.37 |
| world | 0.39 | 0.38 | ~0 |
| nameplates | 0.11 | 0.26 | +0.15 |
| **submit (GPU rasterize + post + shadow)** | **7.86** | **14.22** | **+6.36** |
| total | 8.96 | 16.82 | +7.86 |

80%+ of the crowd's added frame time is **submit**: rasterizing ~50 extra skinned
rigs (~6 draws each) and re-rendering the close ones into the 4096 sun shadow map.
The CPU character work is small, so throttling animation harder is not the lever on
this class of hardware; cutting the GPU rig+shadow load is.

### Change

The renderer already collapses a distant rig to a single-draw far-LOD mesh (beyond
58u) and hands its ground shadow to a cheap static proxy (beyond 25u). This makes
those two ranges **crowd-adaptive**: as the count of visible articulated rigs climbs
from a soft knee (16) to a hard knee (48), the articulated-shadow and
articulated-LOD ranges shrink toward a floor (~16u shadow, ~42u rig). A dense crowd
collapses its distant bodies to far LOD and proxy shadow sooner; below 16 rigs
nothing changes, so ordinary grouping (a 5-man, a few passers-by) is untouched. The
rig count is read one frame late to avoid a second pass and any feedback loop.

The knee math is a pure, unit-tested module (`src/render/crowd_lod.ts` +
`tests/crowd_lod.test.ts`); the renderer is a thin consumer.

### Gameplay-neutral (docs/design/graphics-settings-fairness.md)

It sheds only COSMETIC richness (animation smoothness, distant per-rig shadow
crispness). Position, the nameplate (name/HP/debuffs/raid marks), the target unit
frame, the cast bar, and the click/raycast targeting proxy all render independently
of the rig LOD and are untouched. The ~42u LOD floor is ~2x melee range and past
the nameplate-detail band, so a rig you are fighting or grouped with never
collapses. It is the same shedding the existing fixed 58u far LOD already does, just
scaled by crowd density; it reads a world-density signal, not the FPS governor or a
tier preset. Self is excluded.

### Measured win (A/B at a fixed 50-player crowd, drift-canceled)

Toggling `renderer.crowdAdaptiveLod` ON vs OFF at the same 50-player crowd spread
across ~70u (a realistic hub spread), four order-alternated paired rounds to cancel
GPU warm/cool drift:

- mean FPS ~62.7 -> ~71.4: **+8.7 fps (+13.9%)**, positive in all four rounds.
- submit phase: **-0.95 ms** mean, lower in all four rounds.
- 1% low: +3.4 fps (smoother under load).

The win scales with how spread the crowd is. The budget defaults on;
`renderer.crowdAdaptiveLod` exists for A/B.

### Verification

tsc clean, vite build clean, biome clean on changed files, `tests/crowd_lod.test.ts`
(6) + `tests/render_budget.test.ts` + `tests/architecture.test.ts` green. Render-only
diff: no sim/server/net/IWorld/wire surface touched. Independent fairness review
confirmed gameplay-neutral.
