### PR TITLE
tooling(ci): non-blocking PR AI assist (screenshots + OpenRouter owl-alpha review)

### DIFF
--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -36,6 +36,9 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
+        with:
+          # Full history so the diff against the PR base drives change-aware capture.
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -70,10 +73,21 @@ jobs:
             sleep 2
           done
 
+      # Change-aware capture: map the diff to the screens it implies (inventory, world
+      # map, ...). Only on pull_request; otherwise pr_screenshots falls back to the fixed
+      # tour. pr.diff is gitignored.
+      - name: Compute PR diff (for change-aware capture)
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: git diff --no-color "$BASE_SHA" "$HEAD_SHA" > pr.diff || true
+
       - name: Capture screenshots
         env:
           GAME_URL: http://127.0.0.1:5173
           SHOTS_DIR: pr-shots
+          DIFF_FILE: pr.diff
         run: node scripts/pr_screenshots.mjs
 
       - name: Stop the dev client

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -1,0 +1,134 @@
+name: PR AI assist
+
+# Two INFORMATIONAL, NON-BLOCKING jobs that help review a pull request. Neither is a
+# required check; they assist review, they do not gate merge. They live in their own
+# workflow so they never interfere with the CI gate in ci.yml.
+#
+#   screenshots  boots the Vite dev client headless, runs a fixed offline tour
+#                (character select, desktop HUD, mobile HUD), uploads the PNGs as an
+#                artifact, and links them in a sticky PR comment.
+#   ai-review    sends the PR diff to an OpenRouter model (free openrouter/owl-alpha by
+#                default) and posts the review as a sticky PR comment. No-ops without the
+#                OPENROUTER_API_KEY secret (for example on a fork PR), so it never blocks.
+#
+# Setup (one time): add an OPENROUTER_API_KEY repo secret to enable ai-review. Optionally
+# set an OPENROUTER_MODEL repo variable to swap the model (owl-alpha is free but ephemeral).
+# See docs/ai-pr-bot.md, including the privacy note on the free owl-alpha tier logging prompts.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+# Needed to post the sticky review/screenshot comments. Fork PRs get a read-only token,
+# so the comment steps degrade to a no-op there (handled in the scripts).
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-ai-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Screenshots of changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The client imports committed-but-derived i18n tables at boot; regenerate to be safe.
+      - name: Generate i18n artifacts
+        run: npm run i18n:gen
+
+      - name: Resolve a Chrome binary
+        run: |
+          CHROME="$(command -v google-chrome || command -v google-chrome-stable || command -v chromium-browser || command -v chromium || true)"
+          if [ -z "$CHROME" ]; then
+            echo "No system Chrome on PATH; installing a Chrome for Testing build."
+            CHROME="$(npx --yes puppeteer browsers install chrome | awk '{print $NF}')"
+          fi
+          echo "BROWSER_PATH=$CHROME" >> "$GITHUB_ENV"
+          echo "Using browser: $CHROME"
+
+      - name: Start the dev client
+        run: |
+          # strictPort: bind exactly 5173 or fail loudly, never silently bump the port.
+          npm run dev -- --host 127.0.0.1 --port 5173 --strictPort &
+          echo $! > .devpid
+          for i in $(seq 1 60); do
+            curl -sf http://127.0.0.1:5173 >/dev/null && { echo "dev client up"; break; }
+            sleep 2
+          done
+
+      - name: Capture screenshots
+        env:
+          GAME_URL: http://127.0.0.1:5173
+          SHOTS_DIR: pr-shots
+        run: node scripts/pr_screenshots.mjs
+
+      - name: Stop the dev client
+        if: always()
+        run: kill "$(cat .devpid)" 2>/dev/null || true
+
+      - name: Upload screenshots
+        id: upload
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-screenshots
+          path: pr-shots/
+          if-no-files-found: warn
+
+      - name: Comment with screenshot link
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ARTIFACT_URL: ${{ steps.upload.outputs.artifact-url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SHOTS_DIR: pr-shots
+        run: node scripts/pr_comment_shots.mjs
+
+  ai-review:
+    name: AI review (OpenRouter)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Compute PR diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --no-color "$BASE_SHA" "$HEAD_SHA" > pr.diff || true
+          echo "diff bytes: $(wc -c < pr.diff)"
+
+      - name: Review with OpenRouter
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'openrouter/owl-alpha' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          DIFF_FILE: pr.diff
+        run: node scripts/ai_review.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ private/*
 
 # test artifacts & screenshots
 tmp/
+# PR-assist screenshot tour output + its CI-only ephemerals
+pr-shots/
+pr.diff
+.devpid
 .codex-research/
 .codex/
 .playwright-mcp/

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -7,11 +7,17 @@ neither is a required check.
 ## What it does
 
 1. **Screenshots of changes** (`screenshots` job). Boots the Vite dev client headless on
-   a runner (software GL via SwiftShader, no GPU needed), runs a fixed offline tour, and
-   captures PNGs: character select, the desktop HUD in-world, and the mobile-viewport HUD.
-   The frames are uploaded as the `pr-screenshots` artifact and linked from a sticky PR
-   comment. The tour lives in `scripts/pr_screenshots.mjs`; extend it as the canonical set
-   grows (keep it offline and quick).
+   a runner (software GL via SwiftShader, no GPU needed) and captures PNGs of the relevant
+   screens. The frames are uploaded as the `pr-screenshots` artifact and linked from a
+   sticky PR comment. Two modes (`scripts/pr_screenshots.mjs`):
+   - **Change-aware** (when a diff is available): it maps the changed paths to the screens
+     they imply and shoots exactly those, cropped to the relevant region. A change under
+     `src/ui/bags*` captures the inventory window; a change under `src/sim/content/zones*`
+     (or the map/terrain renderer) teleports to a landmark and captures the world map. The
+     target registry (which paths imply which screen, and how to bring it up + clip it)
+     lives in `scripts/pr_shot_targets.mjs`; add coverage with one entry there.
+   - **Fixed tour** (no diff or no matched target): a consistent baseline, character
+     select, desktop HUD, mobile HUD. Keep all recipes offline and quick.
 2. **AI review** (`ai-review` job). Sends the PR diff to an OpenRouter model and posts a
    short review as a sticky PR comment, grouped into Correctness / Invariants / Tests /
    Nits with severity tags. The reviewer is `scripts/ai_review.mjs`; the GitHub comment

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -1,0 +1,62 @@
+# PR AI assist
+
+Two informational, non-blocking GitHub Actions jobs that help review a pull request.
+They live in `.github/workflows/pr-ai.yml`, separate from the CI gate (`ci.yml`), and
+neither is a required check.
+
+## What it does
+
+1. **Screenshots of changes** (`screenshots` job). Boots the Vite dev client headless on
+   a runner (software GL via SwiftShader, no GPU needed), runs a fixed offline tour, and
+   captures PNGs: character select, the desktop HUD in-world, and the mobile-viewport HUD.
+   The frames are uploaded as the `pr-screenshots` artifact and linked from a sticky PR
+   comment. The tour lives in `scripts/pr_screenshots.mjs`; extend it as the canonical set
+   grows (keep it offline and quick).
+2. **AI review** (`ai-review` job). Sends the PR diff to an OpenRouter model and posts a
+   short review as a sticky PR comment, grouped into Correctness / Invariants / Tests /
+   Nits with severity tags. The reviewer is `scripts/ai_review.mjs`; the GitHub comment
+   helper is `scripts/gh_sticky_comment.mjs`. No new npm dependencies: it uses Node's
+   built-in `fetch` and the GitHub REST API.
+
+## Enabling the AI review
+
+The screenshots job needs no configuration. The AI review is opt-in:
+
+- Add a repository **secret** `OPENROUTER_API_KEY` (Settings -> Secrets and variables ->
+  Actions). Get a key at https://openrouter.ai. Without it the `ai-review` job runs but
+  no-ops and exits green, so the workflow is safe to merge before the key exists.
+- Optional repository **variable** `OPENROUTER_MODEL` to override the model. The default is
+  `openrouter/owl-alpha`, a free stealth model (1M context, tool use). It is free **for
+  now**: an unnamed provider can change pricing or pull it at any time, so treat it as a
+  prototype default and switch the variable when it goes away. Swapping the model is a
+  one-line change with no workflow edit.
+
+## Privacy: read before enabling on private code
+
+The free `owl-alpha` tier **logs prompts to improve the model**, which means the PR diff
+you send is retained by a third party. Do not enable the AI review on code you cannot
+disclose while it points at owl-alpha. Safer options:
+
+- Point `OPENROUTER_MODEL` at a paid / non-logging OpenRouter model.
+- Run a local model (the same script pattern works against any OpenAI-compatible endpoint;
+  change `ENDPOINT` in `scripts/ai_review.mjs`).
+
+The screenshots job sends nothing to a third party; it only renders your own client.
+
+## Behavior on fork PRs
+
+Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets. Both
+comment steps and the AI review degrade to a no-op there (the scripts detect the missing
+write access / key and skip), so the workflow never errors on a fork PR. Screenshots are
+still captured and uploaded as an artifact.
+
+## Running the screenshot tour locally
+
+```sh
+npm run dev                       # serves the client on :5173
+BROWSER_PATH=/path/to/chrome \
+  node scripts/pr_screenshots.mjs # writes PNGs into pr-shots/
+```
+
+`BROWSER_PATH` is only needed if no Chrome/Edge/Chromium is on a standard path
+(see `scripts/browser_path.mjs`).

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -19,7 +19,7 @@
 //   DIFF_FILE           path to a unified diff to review
 //   OPENROUTER_MODEL    model id (default openrouter/owl-alpha)
 //   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
@@ -73,7 +73,7 @@ function listTouchedDirs(d) {
   ];
   if (!dirs.length) return '';
   try {
-    const out = execSync(`git ls-files -- ${dirs.map((x) => `'${x}'`).join(' ')}`, {
+    const out = execFileSync('git', ['ls-files', '--', ...dirs], {
       encoding: 'utf8',
       maxBuffer: 8 * 1024 * 1024,
     }).trim();

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -1,0 +1,121 @@
+// Minimal AI pull-request reviewer. Sends the PR diff to an OpenRouter model (default:
+// the free openrouter/owl-alpha stealth model) and posts the review as a single sticky
+// comment on the PR. No new npm deps: Node 18+ global fetch + the GitHub REST API.
+//
+// It is best-effort and NON-BLOCKING: if OPENROUTER_API_KEY is absent (for example a
+// fork PR that cannot read repo secrets) it prints a notice and exits 0, so it never
+// gates a merge. The model is swappable via OPENROUTER_MODEL with zero workflow edits,
+// which matters because owl-alpha is a free stealth model that can disappear at any time.
+//
+// PRIVACY: the free owl-alpha tier logs prompts to improve the model, so the diff you
+// send is retained by a third party. Point OPENROUTER_MODEL at a non-logging / paid
+// model (or a self-hosted one) before using this on code you cannot disclose.
+//
+// Env (set by the workflow):
+//   OPENROUTER_API_KEY  OpenRouter key (repo secret); absent -> skip, exit 0
+//   GITHUB_TOKEN        token with pull-requests:write (default Actions token)
+//   GITHUB_REPOSITORY   owner/repo
+//   PR_NUMBER           the pull request number
+//   DIFF_FILE           path to a unified diff to review
+//   OPENROUTER_MODEL    model id (default openrouter/owl-alpha)
+//   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
+import fs from 'node:fs';
+import { upsertStickyComment } from './gh_sticky_comment.mjs';
+
+const MARKER = '<!-- pr-ai-review -->';
+const MODEL = process.env.OPENROUTER_MODEL || 'openrouter/owl-alpha';
+const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 60000);
+const ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+
+const key = process.env.OPENROUTER_API_KEY;
+const prNumber = process.env.PR_NUMBER;
+const diffFile = process.env.DIFF_FILE;
+
+if (!key) {
+  console.log('[ai_review] OPENROUTER_API_KEY not set; skipping AI review (non-blocking).');
+  process.exit(0);
+}
+
+let diff = '';
+try {
+  diff = fs.readFileSync(diffFile, 'utf8');
+} catch {
+  console.log(`[ai_review] could not read DIFF_FILE=${diffFile}; skipping.`);
+  process.exit(0);
+}
+if (!diff.trim()) {
+  console.log('[ai_review] empty diff; skipping.');
+  process.exit(0);
+}
+
+let truncated = false;
+if (diff.length > MAX_DIFF_CHARS) {
+  diff = diff.slice(0, MAX_DIFF_CHARS);
+  truncated = true;
+}
+
+const system = [
+  'You are a concise senior code reviewer for World of ClaudeCraft, a TypeScript micro-MMO',
+  'and reinforcement-learning environment built on one deterministic 20 Hz simulation core.',
+  'Key invariants to watch for: src/sim/ must stay pure (no DOM/Three/render/ui/net imports);',
+  'all randomness goes through the Rng helper, never Math.random/Date.now/performance.now; the',
+  'server is authoritative and clients never decide outcomes; every player-visible string is a',
+  't() key; no em dashes, en dashes, or emojis anywhere.',
+  'Review ONLY the diff below. Be specific and brief. Group findings under: Correctness,',
+  'Invariants, Tests, Nits. Tag each finding with severity (high/medium/low). If the change',
+  'looks fine, say so in one line. Do not restate the diff. Output GitHub-flavored Markdown.',
+].join(' ');
+
+const user = `${truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n\n` : ''}Unified diff to review:\n\n\`\`\`diff\n${diff}\n\`\`\``;
+
+async function review() {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+      'X-Title': 'WoCC PR review',
+    },
+    body: JSON.stringify({
+      model: MODEL,
+      temperature: 0.2,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: user },
+      ],
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`OpenRouter HTTP ${res.status}: ${(await res.text()).slice(0, 500)}`);
+  }
+  const data = await res.json();
+  const content = data?.choices?.[0]?.message?.content?.trim();
+  if (!content)
+    throw new Error(`OpenRouter returned no content: ${JSON.stringify(data).slice(0, 500)}`);
+  return content;
+}
+
+let reviewText;
+try {
+  reviewText = await review();
+} catch (e) {
+  // Non-blocking: a model/API failure leaves a short note rather than failing the job.
+  console.log(`[ai_review] review failed (non-blocking): ${e.message}`);
+  reviewText = `_The automated review could not run this time (\`${MODEL}\`). See the workflow logs._`;
+}
+
+const body = [
+  `## AI review (\`${MODEL}\`)`,
+  '',
+  reviewText,
+  truncated ? `\n<sub>Diff truncated to the first ${MAX_DIFF_CHARS} characters.</sub>` : '',
+  '',
+  '<sub>Automated and non-blocking. May be wrong; a human review still decides. The free owl-alpha tier logs prompts, so the diff is retained by a third party.</sub>',
+].join('\n');
+
+try {
+  const result = await upsertStickyComment({ marker: MARKER, body, prNumber });
+  console.log(`ai review comment: ${result ?? 'skipped'}`);
+} catch (e) {
+  console.log(`[ai_review] could not post comment (non-blocking): ${e.message}`);
+}

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -19,6 +19,7 @@
 //   DIFF_FILE           path to a unified diff to review
 //   OPENROUTER_MODEL    model id (default openrouter/owl-alpha)
 //   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
@@ -54,19 +55,103 @@ if (diff.length > MAX_DIFF_CHARS) {
   truncated = true;
 }
 
-const system = [
-  'You are a concise senior code reviewer for World of ClaudeCraft, a TypeScript micro-MMO',
-  'and reinforcement-learning environment built on one deterministic 20 Hz simulation core.',
-  'Key invariants to watch for: src/sim/ must stay pure (no DOM/Three/render/ui/net imports);',
-  'all randomness goes through the Rng helper, never Math.random/Date.now/performance.now; the',
-  'server is authoritative and clients never decide outcomes; every player-visible string is a',
-  't() key; no em dashes, en dashes, or emojis anywhere.',
-  'Review ONLY the diff below. Be specific and brief. Group findings under: Correctness,',
-  'Invariants, Tests, Nits. Tag each finding with severity (high/medium/low). If the change',
-  'looks fine, say so in one line. Do not restate the diff. Output GitHub-flavored Markdown.',
-].join(' ');
+// Give the model the file list of the directories this diff touches, so it stops
+// hallucinating that existing imports/helpers are "missing" (its top false positive).
+// Best-effort: empty string when not in a git checkout.
+function listTouchedDirs(d) {
+  const files = [...d.matchAll(/^\+\+\+ b\/(.+)$/gm)]
+    .map((m) => m[1])
+    .filter((p) => p !== '/dev/null');
+  // Map each changed file to its parent dir; drop the repo root so a root-level file
+  // (e.g. .gitignore) does not expand `git ls-files` to the whole tree.
+  const dirs = [
+    ...new Set(
+      files
+        .map((f) => (f.includes('/') ? f.slice(0, f.lastIndexOf('/')) : '.'))
+        .filter((d) => d !== '.'),
+    ),
+  ];
+  if (!dirs.length) return '';
+  try {
+    const out = execSync(`git ls-files -- ${dirs.map((x) => `'${x}'`).join(' ')}`, {
+      encoding: 'utf8',
+      maxBuffer: 8 * 1024 * 1024,
+    }).trim();
+    // Safety cap so a large touched directory cannot blow up the prompt.
+    const lines = out.split('\n');
+    return lines.length > 500
+      ? `${lines.slice(0, 500).join('\n')}\n... (${lines.length - 500} more)`
+      : out;
+  } catch {
+    return '';
+  }
+}
+const repoFiles = listTouchedDirs(diff);
 
-const user = `${truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n\n` : ''}Unified diff to review:\n\n\`\`\`diff\n${diff}\n\`\`\``;
+// Declared dependency names, so the model does not flag an imported package as "missing
+// from package.json" (a false positive it cannot otherwise verify from the diff).
+function declaredDeps() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+    return [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})]
+      .sort()
+      .join(', ');
+  } catch {
+    return '';
+  }
+}
+const deps = declaredDeps();
+
+const system = `You are a precise, skeptical senior code reviewer for World of ClaudeCraft, a TypeScript
+micro-MMO and reinforcement-learning environment built on one deterministic 20 Hz simulation core.
+
+You see ONLY a unified diff plus a list of files that ALREADY EXIST in the repository. Everything
+not shown in the diff already exists and works. Do NOT flag an imported module, helper, or
+referenced file as "missing" or "not in the diff": that is expected. If an import resolves to a path
+in the existing-files list, it is fine. You are also given the list of declared package.json
+dependencies; an import of any listed package is available, so NEVER say a dependency is missing
+from package.json. When you cannot verify something from what you were given, ask a one-line
+question at LOW severity instead of asserting a problem.
+
+Invariant scope, apply LITERALLY and do not generalize beyond it: these rules constrain application
+code under src/ ONLY.
+- src/sim/ stays pure: no DOM/Three/render/ui/net imports; all randomness via the Rng helper, never
+  Math.random / Date.now / performance.now.
+- The server is authoritative; clients never decide outcomes.
+- Every player-visible string rendered by the app is a t() key.
+Code under scripts/, tests/, headless/, and CI YAML under .github/ is Node TOOLING: it is
+English-only, exempt from t(), and may use Math.random / Date.now / child_process freely. NEVER
+raise a t(), Rng, or sim-purity finding against a file outside src/. The "no em dashes, en dashes,
+or emojis" rule applies everywhere.
+
+Severity rubric, use it strictly:
+- high: a real bug, security issue, or src/ invariant violation that WILL break behavior or fail CI
+  AND that you can confirm from the diff alone.
+- medium: likely incorrect or risky, but not certain.
+- low: style, naming, maintainability, or a question.
+If you CANNOT verify a finding from the diff and the provided context, it is AT MOST low and MUST be
+phrased as a one-line question, never high or medium. Do not guess at repository state you were not
+given (CI pins, other files' contents): if you did not see it, do not assert it.
+
+Output rules: prefer FEW high-confidence findings over many. If you are not confident a finding is
+real, OMIT it. Do not pad with generic advice. Only mention missing tests when the diff changes src/
+or server logic that the repo actually tests. Do NOT add your own title or top-level heading (no
+"# ..." or "## AI review"); start directly with the first group. Group findings under Correctness,
+Invariants, Tests, Nits and tag each with its severity. If the change looks fine, say so in one line.
+Do not restate the diff. Output GitHub-flavored Markdown.`;
+
+const user = [
+  truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n` : '',
+  repoFiles
+    ? `Files that already exist in the directories this diff touches (so you can resolve imports and must NOT flag these as missing):\n\n\`\`\`\n${repoFiles}\n\`\`\`\n`
+    : '',
+  deps
+    ? `Declared package.json dependencies (names only); any import of these is available, do NOT flag it as missing:\n\n${deps}\n`
+    : '',
+  `Unified diff to review:\n\n\`\`\`diff\n${diff}\n\`\`\``,
+]
+  .filter(Boolean)
+  .join('\n');
 
 async function review() {
   const res = await fetch(ENDPOINT, {

--- a/scripts/gh_sticky_comment.mjs
+++ b/scripts/gh_sticky_comment.mjs
@@ -1,0 +1,70 @@
+// Shared helper: post or update a single "sticky" comment on a pull request via the
+// GitHub REST API. A sticky comment carries a hidden HTML marker so reruns edit the
+// same comment instead of stacking a new one every push. Used by the PR-assist jobs
+// (ai_review.mjs, pr_comment_shots.mjs). No npm deps: Node 18+ global fetch only.
+//
+// Auth + target come from the standard GitHub Actions environment:
+//   GITHUB_TOKEN       token with pull-requests:write (the default Actions token)
+//   GITHUB_REPOSITORY  owner/repo
+//   GITHUB_API_URL     API base (defaults to https://api.github.com)
+// The PR number is passed in by the caller.
+
+const API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
+
+function ghHeaders(token) {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+// Upsert a sticky comment. Returns 'created' | 'updated', or null when it could not
+// post (no token, no PR number, or a non-write token, e.g. a fork PR). Never throws on
+// a missing token so callers can stay non-blocking; real API errors do throw.
+export async function upsertStickyComment({ marker, body, prNumber, token, repo }) {
+  token = token ?? process.env.GITHUB_TOKEN;
+  repo = repo ?? process.env.GITHUB_REPOSITORY;
+  if (!token || !repo || !prNumber) {
+    console.log('[gh_sticky_comment] missing token/repo/prNumber; skipping comment.');
+    return null;
+  }
+  const fullBody = `${marker}\n${body}`;
+  const headers = ghHeaders(token);
+
+  // Find an existing sticky comment by its marker (first page is plenty for a PR).
+  const listUrl = `${API}/repos/${repo}/issues/${prNumber}/comments?per_page=100`;
+  const listRes = await fetch(listUrl, { headers });
+  if (!listRes.ok) {
+    // A read-only token (fork PR) typically 403s here; degrade gracefully.
+    console.log(`[gh_sticky_comment] cannot list comments (HTTP ${listRes.status}); skipping.`);
+    return null;
+  }
+  const comments = await listRes.json();
+  const existing = comments.find((c) => typeof c.body === 'string' && c.body.includes(marker));
+
+  if (existing) {
+    const res = await fetch(`${API}/repos/${repo}/issues/comments/${existing.id}`, {
+      method: 'PATCH',
+      headers,
+      body: JSON.stringify({ body: fullBody }),
+    });
+    if (!res.ok) throw new Error(`PATCH comment failed: HTTP ${res.status} ${await res.text()}`);
+    return 'updated';
+  }
+
+  const res = await fetch(`${API}/repos/${repo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ body: fullBody }),
+  });
+  if (!res.ok) {
+    if (res.status === 403) {
+      console.log('[gh_sticky_comment] no write access (likely a fork PR); skipping comment.');
+      return null;
+    }
+    throw new Error(`POST comment failed: HTTP ${res.status} ${await res.text()}`);
+  }
+  return 'created';
+}

--- a/scripts/pr_comment_shots.mjs
+++ b/scripts/pr_comment_shots.mjs
@@ -1,0 +1,58 @@
+// Posts (or updates) a sticky PR comment pointing at the screenshot artifact produced
+// by pr_screenshots.mjs. GitHub Actions artifacts are not directly embeddable as images
+// in a comment, so this links the downloadable artifact and lists which frames it holds.
+// Best-effort and non-blocking: it never fails the job.
+//
+// Env (set by the workflow):
+//   GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER   standard Actions context
+//   ARTIFACT_URL   download URL of the uploaded screenshots artifact (optional)
+//   RUN_URL        link to the workflow run (fallback when ARTIFACT_URL is absent)
+//   SHOTS_DIR      directory holding manifest.json (default pr-shots)
+import fs from 'node:fs';
+import { upsertStickyComment } from './gh_sticky_comment.mjs';
+
+const MARKER = '<!-- pr-ai-screenshots -->';
+const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
+const prNumber = process.env.PR_NUMBER;
+
+let manifest = { captured: [], errors: [] };
+try {
+  manifest = JSON.parse(fs.readFileSync(`${OUT}/manifest.json`, 'utf8'));
+} catch {
+  // No manifest means the capture step did not run or produced nothing.
+}
+
+const artifact = process.env.ARTIFACT_URL || process.env.RUN_URL || '';
+const list = manifest.captured.length
+  ? manifest.captured.map((f) => `- \`${f}\``).join('\n')
+  : '_No screenshots were captured for this run._';
+
+const body = [
+  '## Screenshots of this change',
+  '',
+  artifact
+    ? `Download the rendered client screenshots: [**pr-screenshots** artifact](${artifact})`
+    : 'Screenshots were captured but no artifact link was available.',
+  '',
+  '<details><summary>Captured frames</summary>',
+  '',
+  list,
+  '',
+  '</details>',
+  '',
+  manifest.errors?.length
+    ? `<details><summary>Capture notes (${manifest.errors.length})</summary>\n\n\`\`\`\n${manifest.errors.join('\n')}\n\`\`\`\n\n</details>`
+    : '',
+  '',
+  '<sub>Automated, non-blocking. Offline client tour (character select, desktop HUD, mobile HUD).</sub>',
+]
+  .filter((l) => l !== null)
+  .join('\n');
+
+try {
+  const result = await upsertStickyComment({ marker: MARKER, body, prNumber });
+  console.log(`screenshot comment: ${result ?? 'skipped'}`);
+} catch (e) {
+  // Non-blocking: a comment failure must not fail the screenshots job.
+  console.log(`screenshot comment failed (non-blocking): ${e.message}`);
+}

--- a/scripts/pr_screenshots.mjs
+++ b/scripts/pr_screenshots.mjs
@@ -1,27 +1,48 @@
-// Captures a small, curated set of canonical screenshots for a pull request so a
-// reviewer can see what the change looks like in the running client. Offline only:
-// it drives the local Vite dev client (no server, no dev commands) through the shared
-// offline entry flow and writes PNGs into SHOTS_DIR for a CI job to upload.
+// Captures screenshots of a pull request in the running client so a reviewer can see what
+// the change looks like. Offline only: it drives the local Vite dev client (no server, no
+// dev commands) through the shared offline entry flow and writes PNGs into SHOTS_DIR.
 //
-// This is deliberately a FIXED tour (character select, desktop HUD, mobile HUD), not a
-// per-change capture: it gives every PR a consistent "here is the client right now"
-// baseline. Add shots here as the canonical set grows; keep it offline and quick.
+// Two modes:
+//   change-aware  When DIFF_FILE points at a unified diff, it maps the changed paths to the
+//                 screens they imply (see pr_shot_targets.mjs) and shoots exactly those:
+//                 a bag change -> the inventory window, a zone/map change -> the world map.
+//   fixed tour    With no diff (or no matched targets), it falls back to a consistent
+//                 baseline: character select, desktop HUD, mobile HUD.
 //
 // Run locally:  npm run dev   (in another terminal, serves :5173)
-//               BROWSER_PATH=/path/to/chrome node scripts/pr_screenshots.mjs
+//               BROWSER_PATH=/path/to/chrome DIFF_FILE=pr.diff node scripts/pr_screenshots.mjs
 // Env:
 //   GAME_URL    client URL (default http://localhost:5173)
 //   SHOTS_DIR   output directory for PNGs (default pr-shots)
+//   DIFF_FILE   optional unified diff; enables change-aware capture
 //   BROWSER_PATH  Chrome/Edge/Chromium binary (see browser_path.mjs)
-
 import fs from 'node:fs';
 import puppeteer from 'puppeteer-core';
 import { BROWSER_PATH } from './browser_path.mjs';
 import { enterOfflineGame } from './enter_offline_game.mjs';
+import { resolveTargets } from './pr_shot_targets.mjs';
 
 const URL = process.env.GAME_URL ?? 'http://localhost:5173';
 const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
+const DIFF_FILE = process.env.DIFF_FILE;
 fs.mkdirSync(OUT, { recursive: true });
+
+// Resolve change-aware targets from the diff, when one is provided.
+let targets = [];
+if (DIFF_FILE) {
+  try {
+    const diff = fs.readFileSync(DIFF_FILE, 'utf8');
+    const files = [...diff.matchAll(/^\+\+\+ b\/(.+)$/gm)]
+      .map((m) => m[1])
+      .filter((p) => p !== '/dev/null');
+    targets = resolveTargets(files);
+    console.log(
+      `diff: ${files.length} changed file(s) -> targets: ${targets.map((t) => t.key).join(', ') || '(none, using fixed tour)'}`,
+    );
+  } catch (e) {
+    console.log(`could not read DIFF_FILE=${DIFF_FILE}: ${e.message}`);
+  }
+}
 
 const browser = await puppeteer.launch({
   executablePath: BROWSER_PATH,
@@ -34,13 +55,37 @@ const browser = await puppeteer.launch({
 const errors = [];
 const captured = [];
 
-// One guarded shot: a failure in one frame must not lose the others, so the tour
-// always uploads whatever it managed to capture.
-async function shoot(page, name) {
+// One guarded shot: a failure in one frame must not lose the others, so the run always
+// uploads whatever it managed to capture. `clip` is an optional CSS selector; when given
+// and found, the shot is cropped to that element (plus a small margin) instead of full frame.
+async function shoot(page, name, clip) {
   try {
     await new Promise((r) => setTimeout(r, 300));
     const file = `${OUT}/${name}.png`;
-    await page.screenshot({ path: file });
+    let region;
+    if (clip) {
+      region = await page.evaluate((sel) => {
+        const el = document.querySelector(sel);
+        if (!el) return null;
+        const r = el.getBoundingClientRect();
+        return { x: r.x, y: r.y, width: r.width, height: r.height };
+      }, clip);
+    }
+    if (region && region.width > 0 && region.height > 0) {
+      const m = 12;
+      await page.screenshot({
+        path: file,
+        clip: {
+          x: Math.max(0, region.x - m),
+          y: Math.max(0, region.y - m),
+          width: region.width + m * 2,
+          height: region.height + m * 2,
+        },
+      });
+    } else {
+      if (clip) errors.push(`SHOT ${name}: clip '${clip}' not found, captured full frame`);
+      await page.screenshot({ path: file });
+    }
     captured.push(`${name}.png`);
     console.log('shot:', file);
   } catch (e) {
@@ -55,7 +100,26 @@ function watch(page, tag) {
   });
 }
 
-try {
+async function changeAwareTour() {
+  const page = await browser.newPage();
+  watch(page, 'desktop');
+  await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+  await enterOfflineGame(page, { charClass: 'warrior', charName: 'Thorgar', settleMs: 3000 });
+  let i = 1;
+  for (const t of targets) {
+    const idx = String(i).padStart(2, '0');
+    try {
+      const region = await t.capture(page);
+      await shoot(page, `${idx}-${t.key}`, region?.clip);
+    } catch (e) {
+      errors.push(`TARGET ${t.key}: ${e.message}`);
+    }
+    i++;
+  }
+  await page.close();
+}
+
+async function fixedTour() {
   // 1) Character-select landing (desktop): open the offline select so the class cards show.
   const page = await browser.newPage();
   watch(page, 'desktop');
@@ -88,14 +152,22 @@ try {
   } catch (e) {
     errors.push(`MOBILE: ${e.message}`);
   }
+}
+
+try {
+  if (targets.length) await changeAwareTour();
+  else await fixedTour();
 } finally {
   await browser.close();
 }
 
 // Record the manifest so the comment step can list what was captured without re-reading.
-fs.writeFileSync(`${OUT}/manifest.json`, JSON.stringify({ captured, errors }, null, 2));
+fs.writeFileSync(
+  `${OUT}/manifest.json`,
+  JSON.stringify({ mode: targets.length ? 'change-aware' : 'fixed', captured, errors }, null, 2),
+);
 
-if (errors.length) console.log('notes during capture:\n' + errors.join('\n'));
+if (errors.length) console.log(`notes during capture:\n${errors.join('\n')}`);
 console.log(`captured ${captured.length} screenshot(s) into ${OUT}/`);
-// Non-zero only if we got nothing at all, so a partial tour still uploads its frames.
+// Non-zero only if we got nothing at all, so a partial run still uploads its frames.
 process.exit(captured.length > 0 ? 0 : 1);

--- a/scripts/pr_screenshots.mjs
+++ b/scripts/pr_screenshots.mjs
@@ -1,0 +1,101 @@
+// Captures a small, curated set of canonical screenshots for a pull request so a
+// reviewer can see what the change looks like in the running client. Offline only:
+// it drives the local Vite dev client (no server, no dev commands) through the shared
+// offline entry flow and writes PNGs into SHOTS_DIR for a CI job to upload.
+//
+// This is deliberately a FIXED tour (character select, desktop HUD, mobile HUD), not a
+// per-change capture: it gives every PR a consistent "here is the client right now"
+// baseline. Add shots here as the canonical set grows; keep it offline and quick.
+//
+// Run locally:  npm run dev   (in another terminal, serves :5173)
+//               BROWSER_PATH=/path/to/chrome node scripts/pr_screenshots.mjs
+// Env:
+//   GAME_URL    client URL (default http://localhost:5173)
+//   SHOTS_DIR   output directory for PNGs (default pr-shots)
+//   BROWSER_PATH  Chrome/Edge/Chromium binary (see browser_path.mjs)
+
+import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+import { enterOfflineGame } from './enter_offline_game.mjs';
+
+const URL = process.env.GAME_URL ?? 'http://localhost:5173';
+const OUT = process.env.SHOTS_DIR ?? 'pr-shots';
+fs.mkdirSync(OUT, { recursive: true });
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  // Software GL so it runs on a headless CI box with no GPU, matching the other tours.
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900 },
+});
+
+const errors = [];
+const captured = [];
+
+// One guarded shot: a failure in one frame must not lose the others, so the tour
+// always uploads whatever it managed to capture.
+async function shoot(page, name) {
+  try {
+    await new Promise((r) => setTimeout(r, 300));
+    const file = `${OUT}/${name}.png`;
+    await page.screenshot({ path: file });
+    captured.push(`${name}.png`);
+    console.log('shot:', file);
+  } catch (e) {
+    errors.push(`SHOT ${name}: ${e.message}`);
+  }
+}
+
+function watch(page, tag) {
+  page.on('pageerror', (e) => errors.push(`PAGEERROR(${tag}): ${e.message}`));
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`CONSOLE(${tag}): ${m.text()}`);
+  });
+}
+
+try {
+  // 1) Character-select landing (desktop): open the offline select so the class cards show.
+  const page = await browser.newPage();
+  watch(page, 'desktop');
+  await page.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+  await page.evaluate(() => document.querySelector('#btn-offline')?.click());
+  await page
+    .waitForSelector('#offline-select .mini-class', { visible: true, timeout: 15000 })
+    .catch(() => {});
+  await shoot(page, '01-character-select');
+
+  // 2) Desktop HUD in-world.
+  await enterOfflineGame(page, { charClass: 'warrior', charName: 'Thorgar', settleMs: 3000 });
+  await shoot(page, '02-hud-desktop');
+  await page.close();
+
+  // 3) Mobile-viewport HUD (iPhone-class touch viewport).
+  try {
+    const mobile = await browser.newPage();
+    watch(mobile, 'mobile');
+    await mobile.emulate({
+      viewport: { width: 390, height: 844, isMobile: true, hasTouch: true, deviceScaleFactor: 2 },
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    });
+    await mobile.goto(URL, { waitUntil: 'networkidle0', timeout: 60000 });
+    await mobile.evaluate(() => document.body.classList.add('mobile-touch'));
+    await enterOfflineGame(mobile, { charClass: 'mage', charName: 'Aldwin', settleMs: 3000 });
+    await shoot(mobile, '03-hud-mobile');
+    await mobile.close();
+  } catch (e) {
+    errors.push(`MOBILE: ${e.message}`);
+  }
+} finally {
+  await browser.close();
+}
+
+// Record the manifest so the comment step can list what was captured without re-reading.
+fs.writeFileSync(`${OUT}/manifest.json`, JSON.stringify({ captured, errors }, null, 2));
+
+if (errors.length) console.log('notes during capture:\n' + errors.join('\n'));
+console.log(`captured ${captured.length} screenshot(s) into ${OUT}/`);
+// Non-zero only if we got nothing at all, so a partial tour still uploads its frames.
+process.exit(captured.length > 0 ? 0 : 1);

--- a/scripts/pr_shot_targets.mjs
+++ b/scripts/pr_shot_targets.mjs
@@ -1,0 +1,82 @@
+// Change-aware screenshot targets. Each target knows (a) which changed paths imply it
+// (`when`, matched as path substrings) and (b) how to bring that screen up in the running
+// offline client and which region to clip (`capture`). pr_screenshots.mjs maps a diff to
+// the set of targets it implies and shoots exactly those, instead of a fixed tour.
+//
+// Adding coverage is one entry here, not a new script. Keep recipes offline-only (they
+// drive window.__game directly: sim.addItem, hud.toggleBags/toggleMap, sim.player.pos).
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export const TARGETS = [
+  {
+    key: 'inventory',
+    label: 'Inventory / bags',
+    when: ['ui/bags', 'ui/inventory', 'ui/item', 'ui/vendor', 'ui/loot', 'sim/content/items'],
+    // Fill the bags with a spread so the window has content, then open it and clip to #bags.
+    async capture(page) {
+      await page.evaluate(() => {
+        const sim = window.__game?.sim;
+        const ids = [
+          'eastbrook_arming_sword',
+          'apprentice_staff',
+          'cryptbone_helm',
+          'baked_bread',
+          'minor_healing_potion',
+          'minor_mana_potion',
+          'boar_hide',
+          'glade_pelt',
+        ];
+        for (const id of ids) {
+          try {
+            sim?.addItem(id, 1);
+          } catch {}
+        }
+        // Force-hide then toggle so the open is deterministic regardless of prior state
+        // (the same trick the bag_filter screenshot harness uses).
+        const el = document.querySelector('#bags');
+        if (el) el.style.display = 'none';
+        window.__game?.hud?.toggleBags?.();
+      });
+      await wait(700);
+      return { clip: '#bags' };
+    },
+  },
+  {
+    key: 'world-map',
+    label: 'World map / zone',
+    when: [
+      'ui/map',
+      'map_window',
+      'minimap',
+      'sim/content/zones',
+      'sim/zone',
+      'render/terrain',
+      'render/world',
+    ],
+    // Teleport to a known landmark (offline, no dev command), open the world-map window,
+    // and clip to it; fall back to the full frame if the window did not open.
+    async capture(page) {
+      await page.evaluate(() => {
+        const p = window.__game?.sim?.player;
+        if (p?.pos) {
+          p.pos.x = 65; // Boar Meadow, Eastbrook Vale
+          p.pos.z = 0;
+        }
+      });
+      await wait(400);
+      await page.evaluate(() => window.__game?.hud?.toggleMap?.());
+      await wait(600);
+      const open = await page.evaluate(() => {
+        const w = document.querySelector('#map-window');
+        return !!w && getComputedStyle(w).display !== 'none';
+      });
+      return open ? { clip: '#map-window' } : {};
+    },
+  },
+];
+
+// Map a list of changed file paths to the targets they imply (deduped, registry order).
+export function resolveTargets(changedFiles) {
+  return TARGETS.filter((t) => changedFiles.some((f) => t.when.some((w) => f.includes(w))));
+}


### PR DESCRIPTION
## What

Adds two informational, non-blocking GitHub Actions jobs in a new workflow (`.github/workflows/pr-ai.yml`), kept separate from the `ci.yml` gate so they never affect merge.

1. **Screenshots of changes** (`screenshots`): boots the Vite dev client headless (SwiftShader, no GPU), runs a fixed offline tour (character select, desktop HUD, mobile HUD) via the shared `enterOfflineGame` flow, uploads the PNGs as the `pr-screenshots` artifact, and links them from a sticky PR comment. Tour: `scripts/pr_screenshots.mjs`.
2. **AI review** (`ai-review`): sends the PR diff to an OpenRouter model and posts a short review as a sticky PR comment (Correctness / Invariants / Tests / Nits, severity-tagged). Reviewer: `scripts/ai_review.mjs`; sticky-comment helper: `scripts/gh_sticky_comment.mjs`. No new npm dependencies (Node `fetch` + the GitHub REST API).

## Setup

- The screenshots job needs no configuration.
- AI review is opt-in: add an `OPENROUTER_API_KEY` repo secret. Without it the job runs but no-ops and exits green, so this is safe to merge before the key exists.
- Optional `OPENROUTER_MODEL` repo variable to swap the model. Default is `openrouter/owl-alpha`, a free stealth model (1M context, tool use) that is free for now and can be pulled at any time, so it is a prototype default; switching is one variable, no workflow edit.

## Privacy

The free owl-alpha tier logs prompts to improve the model, so the diff sent is retained by a third party. Documented in `docs/ai-pr-bot.md`; point `OPENROUTER_MODEL` at a paid / non-logging or self-hosted model before using it on code you cannot disclose. The screenshots job sends nothing to a third party.

## Fork PRs

Fork PRs get a read-only token and no secrets, so the comment steps and the AI review degrade to a no-op there (handled in the scripts); the workflow never errors. Screenshots are still captured and uploaded as an artifact.

## Verification

- Ran the screenshot tour end to end against a local dev server: 3 frames captured, fully rendered HUD, exit 0.
- Confirmed the graceful paths: missing `OPENROUTER_API_KEY`, empty diff, and missing GitHub token all skip without failing.
- Biome (changed files), `node --check` on all scripts, and YAML validation all pass; no em/en dashes or emojis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)