### PR TITLE
feat(ratelimit): distinct error codes for the per-IP vs per-account limiters

### DIFF
--- a/server/account.ts
+++ b/server/account.ts
@@ -42,7 +42,7 @@ import {
   makeEmailToken,
 } from './email';
 import { json, readBody } from './http_util';
-import { clearAuthFailures, rateLimited, recordAuthFailure } from './ratelimit';
+import { clearAuthFailures, RATE_LIMIT_IP, rateLimited, recordAuthFailure } from './ratelimit';
 import {
   generateRecoveryCodes,
   generateSecret,
@@ -99,7 +99,7 @@ export async function handleAccountChangePassword(
   accountId: number,
   callerToken: string,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const acct = await accountById(accountId);
   if (!acct) return json(res, 404, { error: 'account not found' });
@@ -157,7 +157,7 @@ export async function handleAccountDeactivate(
   accountId: number,
   hooks: AccountGameHooks,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const acct = await accountById(accountId);
   if (!acct) return json(res, 404, { error: 'account not found' });
@@ -191,7 +191,7 @@ export async function handleAccountEmailChange(
   res: http.ServerResponse,
   accountId: number,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const acct = await accountById(accountId);
   if (!acct) return json(res, 404, { error: 'account not found' });
@@ -236,7 +236,7 @@ export async function handleAccountExport(
   res: http.ServerResponse,
   accountId: number,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const bundle = await exportAccountData(accountId);
   if (!bundle) return json(res, 404, { error: 'account not found' });
   const acct = await accountById(accountId);
@@ -256,7 +256,7 @@ export async function handleAccountMarketing(
   res: http.ServerResponse,
   accountId: number,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const optIn = body.optIn === true;
   await setAccountMarketingOptIn(accountId, optIn);
@@ -280,7 +280,7 @@ export async function handleAccount2faSetup(
   res: http.ServerResponse,
   accountId: number,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const acct = await accountById(accountId);
   if (!acct) return json(res, 404, { error: 'account not found' });
@@ -304,7 +304,7 @@ export async function handleAccount2faEnable(
   accountId: number,
   now: number = Date.now(),
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const state = await getTotpState(accountId);
   if (!state) return json(res, 404, { error: 'account not found' });
@@ -328,7 +328,7 @@ export async function handleAccount2faDisable(
   res: http.ServerResponse,
   accountId: number,
 ): Promise<void> {
-  if (rateLimited(req)) return json(res, 429, { error: 'too many attempts, slow down' });
+  if (rateLimited(req)) return json(res, 429, RATE_LIMIT_IP);
   const body = await readBody(req);
   const acct = await accountById(accountId);
   if (!acct) return json(res, 404, { error: 'account not found' });

--- a/server/main.ts
+++ b/server/main.ts
@@ -115,6 +115,8 @@ import {
   cardUploadRateLimited,
   clearAuthFailures,
   publicReadRateLimited,
+  RATE_LIMIT_ACCOUNT,
+  RATE_LIMIT_IP,
   rateLimited,
   recordAuthFailure,
   requestIp,
@@ -614,13 +616,13 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       (url === '/api/register' || url === '/api/login') &&
       rateLimited(req)
     ) {
-      return json(res, 429, { error: 'too many attempts — wait a minute and try again' });
+      return json(res, 429, RATE_LIMIT_IP);
     }
     // Reuse the rate-limit message so a blocked client gets no signal that the
     // block exists. Login is gated separately below, after the account is known,
     // so admins can bypass; registration has no account to check.
     if (req.method === 'POST' && url === '/api/register' && game.isIpBlocked(requestIp(req))) {
-      return json(res, 429, { error: 'too many attempts — wait a minute and try again' });
+      return json(res, 429, RATE_LIMIT_IP);
     }
     if (req.method === 'POST' && url === '/api/register') {
       const body = await readBody(req);
@@ -688,9 +690,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       // Per-account brute-force throttle (#93). The message is identical to a
       // bad-password response so it never reveals whether the account exists.
       if (username && authThrottled(username)) {
-        return json(res, 429, {
-          error: 'too many failed attempts — wait a few minutes and try again',
-        });
+        return json(res, 429, RATE_LIMIT_ACCOUNT);
       }
       const account = username ? await findAccount(username) : null;
       if (!account || !(await verifyPassword(String(body.password ?? ''), account.password_hash))) {
@@ -704,7 +704,7 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       // correct password vs 401 on a wrong one — a small credential-validity tell
       // we accept, since moving the check before the password would lock admins out.
       if (game.isIpBlocked(requestIp(req)) && !(await isAdminAccount(account.id))) {
-        return json(res, 429, { error: 'too many attempts — wait a minute and try again' });
+        return json(res, 429, RATE_LIMIT_IP);
       }
       // Second factor: if 2FA is enabled, the password alone is not enough. With
       // no code supplied we return a challenge (not a token) so the client shows

--- a/server/ratelimit.ts
+++ b/server/ratelimit.ts
@@ -26,6 +26,37 @@ const STRICTEST_RATE_LIMIT = 10;
 
 const attempts = new Map<string, number[]>();
 
+// ---------------------------------------------------------------------------
+// Rate-limit error responses
+//
+// Every 429 a limiter produces carries a stable machine-readable `code` plus an
+// explanatory English message naming WHICH limiter fired and WHY. The client
+// (src/main.ts userFacingApiError) keys off `code` to render the matching
+// localized message, so a per-account lockout no longer shows the per-IP "wait a
+// minute" copy. The English text keeps its historical "too many attempts" /
+// "too many failed attempts" prefix so a client still matching on text (during a
+// deploy where the two sides differ) localizes correctly. Use these constants
+// instead of inlining a 429 body so the code + copy can never drift across the
+// many call sites.
+export const RATE_LIMIT_IP = {
+  // Per-IP sliding-window limiter (rateLimited): more than maxPerMinute requests
+  // from one client IP within WINDOW_MS (60s). Guards login/register and account
+  // ops against floods/spraying from a single source. Clears ~1 min after the
+  // last request from that IP.
+  code: 'rate_limited_ip',
+  error:
+    'too many attempts: too many requests from your network (IP) in a short time. Wait about a minute and try again.',
+} as const;
+export const RATE_LIMIT_ACCOUNT = {
+  // Per-account failed-login throttle (authThrottled): MAX_AUTH_FAILURES wrong
+  // passwords for one username within AUTH_FAIL_WINDOW_MS (15 min), regardless of
+  // source IP. Blunts distributed credential stuffing aimed at one account; a
+  // correct password clears it. Clears ~15 min after the last failed attempt.
+  code: 'rate_limited_account',
+  error:
+    'too many failed attempts: too many failed sign-ins for this account. Wait a few minutes, or reset your password.',
+} as const;
+
 function backstopTargetSize(): number {
   return Math.max(0, MAX_TRACKED_IPS - BACKSTOP_EVICT_BATCH);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,7 @@ import {
 import { createNativeAttestationProof } from './net/native_attestation';
 import {
   Api,
+  ApiError,
   type CharacterSummary,
   ClientWorld,
   isAuthError,
@@ -253,6 +254,14 @@ function saveHomepageMusicMuted(muted: boolean): void {
 }
 
 function userFacingApiError(err: unknown): string {
+  // Prefer the server's stable error CODE over fragile English-text matching, so
+  // the per-account lockout (rate_limited_account) and the per-IP limit
+  // (rate_limited_ip) always get distinct messages even if the wording drifts.
+  // Falls through to the text matchers below for older servers (no code).
+  if (err instanceof ApiError && err.code) {
+    if (err.code === 'rate_limited_account') return tServer('moderation.tooManyFailed');
+    if (err.code === 'rate_limited_ip') return t('errors.api.tooManyAttempts');
+  }
   const text = technicalErrorMessage(err);
   const suspended = text.match(/^This account is suspended until (.+)\.$/);
   if (suspended) return t('errors.api.accountSuspended', { date: suspended[1] });

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -155,6 +155,11 @@ export class ApiError extends Error {
   constructor(
     message: string,
     readonly status: number,
+    // Stable machine-readable error code from the server's JSON body (e.g.
+    // 'rate_limited_ip' vs 'rate_limited_account'), when present. The UI keys off
+    // this instead of fragile error-text matching. Undefined for older servers
+    // or non-JSON failures.
+    readonly code?: string,
   ) {
     super(message);
     this.name = 'ApiError';
@@ -216,7 +221,8 @@ export class Api {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
-    if (!res.ok) throw new ApiError(data.error ?? `request failed (${res.status})`, res.status);
+    if (!res.ok)
+      throw new ApiError(data.error ?? `request failed (${res.status})`, res.status, data.code);
     return data;
   }
 
@@ -225,7 +231,8 @@ export class Api {
       headers: this.token ? { Authorization: `Bearer ${this.token}` } : {},
     });
     const data = await res.json().catch(() => ({}));
-    if (!res.ok) throw new ApiError(data.error ?? `request failed (${res.status})`, res.status);
+    if (!res.ok)
+      throw new ApiError(data.error ?? `request failed (${res.status})`, res.status, data.code);
     return data;
   }
 
@@ -239,7 +246,8 @@ export class Api {
       body: JSON.stringify(body),
     });
     const data = await res.json().catch(() => ({}));
-    if (!res.ok) throw new ApiError(data.error ?? `request failed (${res.status})`, res.status);
+    if (!res.ok)
+      throw new ApiError(data.error ?? `request failed (${res.status})`, res.status, data.code);
     return data;
   }
 
@@ -389,12 +397,15 @@ export class Api {
     const text = await res.text();
     if (!res.ok) {
       let msg = `request failed (${res.status})`;
+      let code: string | undefined;
       try {
-        msg = JSON.parse(text).error ?? msg;
+        const parsed = JSON.parse(text);
+        msg = parsed.error ?? msg;
+        code = parsed.code;
       } catch {
         /* non-JSON error body */
       }
-      throw new ApiError(msg, res.status);
+      throw new ApiError(msg, res.status, code);
     }
     return JSON.parse(text);
   }

--- a/tests/ratelimit_codes.test.ts
+++ b/tests/ratelimit_codes.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  authThrottled,
+  RATE_LIMIT_ACCOUNT,
+  RATE_LIMIT_IP,
+  rateLimited,
+  recordAuthFailure,
+  resetAuthFailures,
+  resetRateLimits,
+} from '../server/ratelimit';
+
+// A fresh, untrusted public IP: 127.0.0.1 / private ranges are treated as our
+// own proxy and resolved via X-Forwarded-For, so tests must drive the limiter
+// from a public address to key on the connection itself.
+function reqFrom(ip: string): any {
+  return { socket: { remoteAddress: ip }, headers: {} };
+}
+
+afterEach(() => {
+  resetRateLimits();
+  resetAuthFailures();
+});
+
+describe('rate-limit error codes', () => {
+  it('exposes distinct, stable codes for the two auth limiters', () => {
+    expect(RATE_LIMIT_IP.code).toBe('rate_limited_ip');
+    expect(RATE_LIMIT_ACCOUNT.code).toBe('rate_limited_account');
+    expect(RATE_LIMIT_IP.code).not.toBe(RATE_LIMIT_ACCOUNT.code);
+  });
+
+  // The client's userFacingApiError keeps a TEXT fallback for older servers /
+  // deploy skew (it matches 'too many attempts' for the IP limit and 'too many
+  // failed attempts' for the account lockout). These prefixes must not drift, and
+  // the IP message must NOT be swallowed by the stricter 'too many failed' arm.
+  it('keeps the English prefixes the client text-fallback matches', () => {
+    const ip = RATE_LIMIT_IP.error.toLowerCase();
+    const acct = RATE_LIMIT_ACCOUNT.error.toLowerCase();
+    expect(ip.startsWith('too many attempts')).toBe(true);
+    expect(acct.startsWith('too many failed attempts')).toBe(true);
+    expect(ip.startsWith('too many failed attempts')).toBe(false);
+  });
+
+  it('per-IP limiter trips after the per-minute ceiling, and is scoped to one IP', () => {
+    const req = reqFrom('203.0.113.50');
+    // Default ceiling is 20/min; the 21st request from the same IP is limited.
+    let limited = false;
+    for (let i = 0; i < 21; i++) limited = rateLimited(req);
+    expect(limited).toBe(true);
+    // A different IP has its own budget (proves it is per-IP, not a shared bucket).
+    expect(rateLimited(reqFrom('198.51.100.9'))).toBe(false);
+  });
+
+  it('per-account throttle trips after repeated failures, independent of IP and account', () => {
+    const user = 'Aelwyn';
+    expect(authThrottled(user)).toBe(false);
+    for (let i = 0; i < 10; i++) recordAuthFailure(user);
+    expect(authThrottled(user)).toBe(true);
+    // A different account is unaffected (proves it is keyed per-account, not per-IP).
+    expect(authThrottled('Someone-Else')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

The login/register rate limiters both surface as a generic "too many attempts" 429, and the client disambiguates them only by **fragile English prefix-matching**:

- The **per-IP** limit (20 req/min, `rateLimited`) and the **per-account** lockout (10 failed sign-ins / 15 min, `authThrottled`) are different things with very different wait times, but a player cannot tell which one they hit.
- The per-account 15-minute lockout renders the per-IP **"wait a minute"** copy, which is misleading.
- The wording had drifted across call sites (`account.ts` "too many attempts, slow down" vs `main.ts` "too many attempts ... wait a minute"), one carrying a stray em dash.
- The 429 body carried no machine-readable `code`, and the client dropped any `code` field, so a future wording change would silently break the client mapping.

## Change

- **`server/ratelimit.ts`**: two centralized 429 bodies, each with a stable `code` and an explanatory message naming which limiter fired and why:
  - `RATE_LIMIT_IP` -> `code: "rate_limited_ip"`
  - `RATE_LIMIT_ACCOUNT` -> `code: "rate_limited_account"`

  Used at every `rateLimited()` / `authThrottled()` site in `main.ts` and `account.ts`, so the code and copy cannot drift again.
- **`src/net/online.ts`**: `ApiError` now captures the server's `code`.
- **`src/main.ts`**: `userFacingApiError` keys off the `code` to pick the right localized message (per-account -> `moderation.tooManyFailed`, per-IP -> `errors.api.tooManyAttempts`), keeping the existing text matchers as a fallback for deploy skew. The English prefixes are preserved so the fallback still works.
- **`tests/ratelimit_codes.test.ts`**: the distinct codes, the text-prefix contract the client fallback relies on, and that each limiter trips independently (per-IP scoped to one IP, per-account scoped to one account).

## Testing

- New `tests/ratelimit_codes.test.ts` + `tests/account_server.test.ts` + `tests/login_parity.test.ts` + `tests/localization_fixes.test.ts` (S3 guard) all pass.
- `npm run check:ts` clean; `biome format` applied; `npm run build:server` bundles.

## Follow-up (separate PR)

The deeper cause behind the original report: the limiter resolves the client IP from `X-Forwarded-For` only and never reads `CF-Connecting-IP`. Behind Cloudflare, if `TRUSTED_PROXY_IPS` does not list Cloudflare's edge ranges, `requestIp()` keys on a shared Cloudflare edge IP, so many users collapse into one bucket and get false-positive rate limits. Worth a separate change (prefer `CF-Connecting-IP` when behind a trusted proxy, and document the `TRUSTED_PROXY_IPS` requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
