### PR TITLE
fix(game): commit final camera yaw on mouselook release (camera/character snap)

### DIFF
--- a/src/game/mouselook_release.ts
+++ b/src/game/mouselook_release.ts
@@ -1,0 +1,20 @@
+// Classic right-mouse mouselook drives the player's heading: while it is active
+// the per-tick facing intent is set to the camera yaw (camYaw), so the sim facing
+// tracks the camera. Input is sampled at frame rate but facing only commits on a
+// sim tick, so the slice of mouse motion between the last tick and the release is
+// never written: the instant mouselook turns off the facing intent goes null and
+// that final fraction of the turn is dropped. The character then settles back to a
+// facing slightly behind the camera, and moving forward makes the follow camera
+// backtrack to sit behind it, which reads as a snap.
+//
+// This is a single, DOM-free decision: on the FALLING edge of mouselook, commit
+// the current camera yaw one last time so the sim facing ends exactly where the
+// camera ended. It is deliberately scoped to the classic right-mouse mouselook
+// edge; the always-on Mouse Camera mode has its own facing path and is not in play.
+export function mouselookReleaseFacing(
+  prevMouselook: boolean,
+  mouselook: boolean,
+  camYaw: number,
+): number | null {
+  return prevMouselook && !mouselook ? camYaw : null;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import {
   setInterfaceMode,
   useTouchInterface,
 } from './game/mobile_controls';
+import { mouselookReleaseFacing } from './game/mouselook_release';
 import { music } from './game/music';
 import { createPerfMonitor } from './game/perf';
 import { startPerfReporter } from './game/perf_reporter';
@@ -1881,6 +1882,14 @@ async function startGame(
   // eases back to zero so the camera settles in behind the character.
   let lastInterpFacing: number | null = null;
   let wasClickMoving = false;
+  // Tracks classic right-mouse mouselook across frames so its falling edge can
+  // commit the final camera yaw to the player facing (see mouselook_release.ts).
+  let prevMouselook = false;
+  // The release yaw, latched until a sim tick actually commits it. Offline a tick
+  // runs on only ~2/3 of frames (60Hz frames, 20Hz ticks), so committing only on
+  // the release frame would drop the one-shot when release lands on a zero-tick
+  // frame. Held here until consumed, then cleared.
+  let pendingReleaseFacing: number | null = null;
   function updateCamera(frameDt: number, interpFacing: number): void {
     const mi = input.readMoveInput();
     const clickMoving = !!input.clickMoveTarget && !input.suspendMovement && !world.player.dead;
@@ -2109,7 +2118,20 @@ async function startGame(
     const mouselook = input.isMouselookActive() && !world.player.dead;
     const controllerFacing = input.controllerFacingOverride();
     const renderFacing = renderFacingOverride();
-    const movementFacing = !world.player.dead ? (renderFacing ?? controllerFacing) : null;
+    // On the frame mouselook is released, latch the final camera yaw so the player
+    // facing ends exactly where the camera ended; otherwise the last slice of the
+    // turn is dropped and the character lags the camera. The render/controller
+    // overrides take precedence and reclaim the heading, clearing any stale latch.
+    const edgeReleaseFacing = mouselookReleaseFacing(prevMouselook, mouselook, input.camYaw);
+    prevMouselook = mouselook;
+    if (renderFacing !== null || controllerFacing !== null) {
+      pendingReleaseFacing = null;
+    } else if (edgeReleaseFacing !== null) {
+      pendingReleaseFacing = edgeReleaseFacing;
+    }
+    const movementFacing = !world.player.dead
+      ? (renderFacing ?? controllerFacing ?? pendingReleaseFacing)
+      : null;
 
     if (offlineSim) {
       acc += frameDt;
@@ -2136,6 +2158,9 @@ async function startGame(
             events: events.length,
           }),
         );
+        // A tick consumed the latched release facing (movementFacing fed
+        // stepFacing above); drop it so it is not re-applied next frame.
+        pendingReleaseFacing = null;
         acc -= DT;
       }
       const pp = offlineSim.player;
@@ -2177,6 +2202,9 @@ async function startGame(
     const netFacing = movementFacing ?? resolved.facing;
     Object.assign(net.moveInput, resolved.mi);
     net.setMouselookFacing(netFacing);
+    // Online streams facing every frame, so the latched release yaw is consumed
+    // here; drop it so it is not re-applied next frame.
+    pendingReleaseFacing = null;
     if (net.flushInput()) perf.markInputSent(performance.now());
     const echoSamples = net.consumeInputEchoSamples();
     for (const sample of echoSamples) {

--- a/tests/mouselook_release_facing.test.ts
+++ b/tests/mouselook_release_facing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { mouselookReleaseFacing } from '../src/game/mouselook_release';
+
+// Bug: holding right-mouse to rotate the camera, then briefly releasing, left the
+// character a fraction of a turn behind the camera. Facing is only committed to
+// the sim while mouselook is active (facing = camYaw each tick); the final slice
+// of mouse motion since the last tick is dropped the instant mouselook turns off,
+// so the model settles back to a stale facing and the camera later backtracks.
+// The release frame must commit the final camera yaw exactly once.
+describe('mouselookReleaseFacing', () => {
+  it('commits the camera yaw on the mouselook falling edge', () => {
+    expect(mouselookReleaseFacing(true, false, 1.23)).toBe(1.23);
+  });
+
+  it('returns null while mouselook stays engaged', () => {
+    expect(mouselookReleaseFacing(true, true, 1.23)).toBeNull();
+  });
+
+  it('returns null while mouselook stays disengaged', () => {
+    expect(mouselookReleaseFacing(false, false, 1.23)).toBeNull();
+  });
+
+  it('returns null on the rising edge (engaging, not releasing)', () => {
+    expect(mouselookReleaseFacing(false, true, 1.23)).toBeNull();
+  });
+
+  it('passes a negative / wrapped yaw through unchanged on release', () => {
+    expect(mouselookReleaseFacing(true, false, -2.5)).toBe(-2.5);
+  });
+
+  it('commits only on the edge: a held release does not re-fire next frame', () => {
+    // frame N: release edge -> commit
+    expect(mouselookReleaseFacing(true, false, 0.7)).toBe(0.7);
+    // frame N+1: still disengaged -> no further commit (caller keeps prev=false)
+    expect(mouselookReleaseFacing(false, false, 0.7)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

Holding the right mouse button to rotate the camera, then briefly releasing, leaves the character a fraction of a turn behind the camera. Both rotate as intended, but the character stops short of where the camera ended. Then, on the next forward step, the follow camera backtracks to sit behind the character, which reads as a snap. (Holding W while doing a quick RMB flick shows the same snap.)

## Root cause

While classic right-mouse mouselook is active, `resolveMove` commits `facing = input.camYaw` every sim tick, so the player's facing tracks the camera. Input is sampled at frame rate (about 60 Hz) but facing only commits on a 20 Hz sim tick, so the slice of mouse motion between the last tick and the release moment has nowhere to land: the instant mouselook turns off, `movementFacing` and `resolved.facing` both go `null` and that final fraction of the turn is dropped. PR #850's `releaseSelfFacing` then faithfully eases the model back to the sim facing, which is exactly that stale value, so the gap is preserved rather than caused.

```mermaid
sequenceDiagram
    autonumber
    participant ML as mouselook (RMB)
    participant SF as sim player.facing (20Hz)
    participant CAM as follow camera
    ML->>SF: each tick: facing = camYaw
    Note over ML,SF: mouse keeps moving after the last tick
    ML-->>SF: BEFORE: release -> facing intent null,<br/>final slice dropped, facing left behind camera
    CAM->>CAM: forward step -> backtrack behind stale facing (SNAP)
    ML->>SF: AFTER: falling edge -> commit final camYaw once
    CAM->>CAM: aligned, no backtrack, no snap
```

![sequence](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mouselook-release/mouselook_release.png)

## Fix

A small pure module, `src/game/mouselook_release.ts`, returns the camera yaw on the falling edge of mouselook and `null` otherwise. `main.ts` folds it into `movementFacing` **after** the render and controller overrides (`renderFacing ?? controllerFacing ?? pendingReleaseFacing`), so it only fires when nothing else owns the heading.

The yaw is **latched** rather than applied only on the release frame: offline a sim tick runs on only about 2/3 of frames (60 Hz frames, 20 Hz ticks), so a release landing on a zero-tick frame would otherwise drop the one-shot. The latch is cleared once a tick consumes it (offline) or the per-frame input stream sends it (online), and whenever the camera or controller reclaims the heading.

The synthetic trace below (driven by the real edge logic) shows a fast RMB flick: AFTER (green) lands on the camera yaw at release; BEFORE (red) freezes a tick behind it.

![before/after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-mouselook-release/before_after_chart.png)

Scoped deliberately to classic right-mouse mouselook; the always-on Mouse Camera mode has its own facing path and is unchanged.

## Why it is safe

- Presentation/input layer only: no new sim system, no rng, no wire/`IWorld`/i18n change (no S3 guard or locale work). It extends an existing facing intent by one frame.
- Same commit path offline (`offlineSim.player.facing = stepFacing`) and online (`net.setMouselookFacing`), so both hosts align.

## Tests

- `tests/mouselook_release_facing.test.ts` (TDD red -> green): commits only on the falling edge, never while held, engaging, or idle.
- `tsc`, `tests/camera_follow.test.ts`, `tests/facing_smooth.test.ts`, `tests/architecture.test.ts` green; `npm run build` green; `npm run ci:changed` clean.
