### PR TITLE
fix(render): let nameplate clicks target the unit (healer party clicks)

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -83,6 +83,7 @@ import { RenderBudgetGovernor, type RenderBudgetState } from './render_budget';
 import { downscaleDims } from './screenshot';
 import { drapeRingLocalY } from './selection_ring';
 import { buildClouds, buildSky, type SkyView } from './sky';
+import { nearestSloppyPickId, type SloppyPickCandidate } from './sloppy_pick';
 import { shouldRenderStealthGhost } from './stealth';
 import { buildFlaredConeFan, buildRingXZ, drapeConeWorld } from './target_cone_debug';
 import { buildTerrain, type TerrainView } from './terrain';
@@ -731,6 +732,7 @@ export class Renderer {
   private tmpV = new THREE.Vector3();
   private viewCandidates: ViewCandidate[] = [];
   private tmpV2 = new THREE.Vector3();
+  private tmpV3 = new THREE.Vector3();
   // Manual frustum cull for characters. Their skinned meshes keep
   // frustumCulled=false (a skinned mesh's bind-pose bounds don't follow the
   // animated pose, so Three's own cull pops visible rigs out), which means an
@@ -4725,26 +4727,44 @@ export class Renderer {
     // and melee scrums (often hidden behind the player's own model) make
     // precise capsule clicks fiddly. Objects (doors/loot) still need a
     // direct hit; the local player never competes for the click.
+    //
+    // Each candidate is a vertical screen COLUMN from the body midpoint up to
+    // the overhead nameplate anchor (same offset the nameplate uses), so a click
+    // on the floating name (what a healer does to target a party member)
+    // registers on its owner instead of falling outside a body-only radius.
     const SLOPPY_PICK_PX = 26;
-    let bestId: number | null = null;
-    let bestD = SLOPPY_PICK_PX;
+    const candidates: SloppyPickCandidate[] = [];
     for (const [id, v] of this.views) {
       if (id === this.sim.playerId || !v.visual || !v.group.visible) continue;
       const e = this.sim.entities.get(id);
       if (!e || (e.dead && !e.lootable)) continue;
+      // body midpoint anchor (also the in-front-of-camera cull)
       this.tmpV.copy(v.group.position);
       this.tmpV.y += v.height * e.scale * 0.5;
       this.tmpV.project(this.camera);
       if (this.tmpV.z > 1) continue;
-      const sx = (this.tmpV.x * 0.5 + 0.5) * this.viewport.width;
-      const sy = (-this.tmpV.y * 0.5 + 0.5) * this.viewport.height;
-      const d = Math.hypot(sx - clientX, sy - clientY);
-      if (d < bestD) {
-        bestD = d;
-        bestId = id;
+      const midX = (this.tmpV.x * 0.5 + 0.5) * this.viewport.width;
+      const midY = (-this.tmpV.y * 0.5 + 0.5) * this.viewport.height;
+      // Overhead nameplate anchor (matches the nameplate projection offset).
+      // Collapse the column to the body point if the anchor is not safely in
+      // front of the camera: a point behind the near plane projects to bogus
+      // screen coords that could steal an unrelated click (close / first-person
+      // camera puts the head behind the near plane). Same guard the real
+      // nameplate path uses before trusting its projection.
+      this.tmpV2.copy(v.group.position);
+      this.tmpV2.y += v.height * e.scale + 1.0;
+      let topX = midX;
+      let topY = midY;
+      if (isProjectedNameplateAnchorVisible(this.camera, this.tmpV2, this.tmpV3)) {
+        this.tmpV2.project(this.camera);
+        if (this.tmpV2.z <= 1) {
+          topX = (this.tmpV2.x * 0.5 + 0.5) * this.viewport.width;
+          topY = (-this.tmpV2.y * 0.5 + 0.5) * this.viewport.height;
+        }
       }
+      candidates.push({ id, midX, midY, topX, topY });
     }
-    return bestId;
+    return nearestSloppyPickId(clientX, clientY, candidates, SLOPPY_PICK_PX);
   }
 
   // Drop a transient OSRS-style click marker at a world ground point. Called from

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -731,6 +731,11 @@ export class Renderer {
   private baseExposure = 1.12; // tone-mapping exposure at brightness 1.0
   private tmpV = new THREE.Vector3();
   private viewCandidates: ViewCandidate[] = [];
+  // Persistent scratch for the sloppy-pick column build. pick() is also the
+  // per-frame hover-cursor path (updateHoverCursor in main.ts), so a fresh array
+  // here would be per-frame garbage on every cursor-over-empty-ground frame.
+  // Reused like viewCandidates: cleared with .length = 0, grown in place.
+  private sloppyCandidates: SloppyPickCandidate[] = [];
   private tmpV2 = new THREE.Vector3();
   private tmpV3 = new THREE.Vector3();
   // Manual frustum cull for characters. Their skinned meshes keep
@@ -4728,12 +4733,15 @@ export class Renderer {
     // precise capsule clicks fiddly. Objects (doors/loot) still need a
     // direct hit; the local player never competes for the click.
     //
-    // Each candidate is a vertical screen COLUMN from the body midpoint up to
-    // the overhead nameplate anchor (same offset the nameplate uses), so a click
-    // on the floating name (what a healer does to target a party member)
-    // registers on its owner instead of falling outside a body-only radius.
+    // Each candidate is a vertical screen COLUMN from the body midpoint up to an
+    // overhead anchor a touch above the head (the +1.0 the chat-bubble path uses;
+    // slightly higher than the nameplate's own NAMEPLATE_ANCHOR_LIFT of 0.8, which
+    // with the 26px radius just helps the column reach the floating name text).
+    // So a click on the floating name (what a healer does to target a party
+    // member) registers on its owner instead of falling outside a body-only radius.
     const SLOPPY_PICK_PX = 26;
-    const candidates: SloppyPickCandidate[] = [];
+    const candidates = this.sloppyCandidates;
+    candidates.length = 0;
     for (const [id, v] of this.views) {
       if (id === this.sim.playerId || !v.visual || !v.group.visible) continue;
       const e = this.sim.entities.get(id);
@@ -4745,7 +4753,7 @@ export class Renderer {
       if (this.tmpV.z > 1) continue;
       const midX = (this.tmpV.x * 0.5 + 0.5) * this.viewport.width;
       const midY = (-this.tmpV.y * 0.5 + 0.5) * this.viewport.height;
-      // Overhead nameplate anchor (matches the nameplate projection offset).
+      // Overhead anchor (the +1.0 chat-bubble offset, see the note above).
       // Collapse the column to the body point if the anchor is not safely in
       // front of the camera: a point behind the near plane projects to bogus
       // screen coords that could steal an unrelated click (close / first-person

--- a/src/render/sloppy_pick.ts
+++ b/src/render/sloppy_pick.ts
@@ -1,0 +1,66 @@
+// The renderer's forgiving "sloppy pick": when a click misses every clickable
+// capsule, snap to the nearest targetable character within a small screen radius.
+// Extracted as pure screen-space math so it can be reasoned about and unit-tested
+// without a WebGL context.
+//
+// Each character contributes a vertical screen-space COLUMN, not a single point:
+// from the body midpoint (bottom anchor) up to the overhead nameplate (top
+// anchor). The original code measured distance to the body midpoint alone, so
+// clicking the floating name above the head, exactly what a healer does to target
+// a party member, fell outside the radius and selected nobody (or the wrong
+// unit). Measuring to the whole column makes a name click register on its owner.
+
+/**
+ * Shortest pixel distance from a click (px,py) to the segment (ax,ay)-(bx,by),
+ * clamped at the endpoints (so it is a finite segment, not an infinite line).
+ */
+export function distanceToSegmentPx(
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const lenSq = dx * dx + dy * dy;
+  // Degenerate segment (both anchors coincide): plain point distance.
+  const t = lenSq > 0 ? Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / lenSq)) : 0;
+  const cx = ax + t * dx;
+  const cy = ay + t * dy;
+  return Math.hypot(px - cx, py - cy);
+}
+
+export interface SloppyPickCandidate {
+  id: number;
+  // Body midpoint, screen space (the original sloppy-pick anchor).
+  midX: number;
+  midY: number;
+  // Overhead nameplate anchor, screen space.
+  topX: number;
+  topY: number;
+}
+
+/**
+ * Return the id of the nearest candidate whose body-to-nameplate column passes
+ * within `maxPx` of the click, or null if none qualify. The radius is strict
+ * (a click exactly at `maxPx` does not count), matching the prior behaviour.
+ */
+export function nearestSloppyPickId(
+  clickX: number,
+  clickY: number,
+  candidates: readonly SloppyPickCandidate[],
+  maxPx: number,
+): number | null {
+  let bestId: number | null = null;
+  let bestD = maxPx;
+  for (const c of candidates) {
+    const d = distanceToSegmentPx(clickX, clickY, c.midX, c.midY, c.topX, c.topY);
+    if (d < bestD) {
+      bestD = d;
+      bestId = c.id;
+    }
+  }
+  return bestId;
+}

--- a/tests/sloppy_pick.test.ts
+++ b/tests/sloppy_pick.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { distanceToSegmentPx, nearestSloppyPickId } from '../src/render/sloppy_pick';
+
+// Bug: clicking a party member's nameplate (the floating name above the head)
+// did not select the unit. The forgiving "sloppy pick" only measured distance to
+// the body MIDPOINT, but the nameplate floats well above the head, so name clicks
+// fell outside the radius and missed. Anchoring the pick to the whole column from
+// body midpoint up to the nameplate makes clicking the name register.
+describe('distanceToSegmentPx', () => {
+  it('is zero on the segment endpoints', () => {
+    expect(distanceToSegmentPx(0, 0, 0, 0, 0, 10)).toBe(0);
+    expect(distanceToSegmentPx(0, 10, 0, 0, 0, 10)).toBe(0);
+  });
+
+  it('measures perpendicular distance to the column, not the nearest endpoint', () => {
+    // a point beside the middle of a vertical segment
+    expect(distanceToSegmentPx(5, 5, 0, 0, 0, 10)).toBe(5);
+  });
+
+  it('clamps past the ends to the endpoint distance', () => {
+    // above the top endpoint: distance is to the top, not an infinite line
+    expect(distanceToSegmentPx(0, 14, 0, 0, 0, 10)).toBe(4);
+  });
+
+  it('degenerates to point distance when both anchors coincide', () => {
+    expect(distanceToSegmentPx(3, 4, 2, 2, 2, 2)).toBeCloseTo(Math.hypot(1, 2), 6);
+  });
+});
+
+describe('nearestSloppyPickId', () => {
+  const mid = { midX: 100, midY: 200, topX: 100, topY: 140 }; // column from y=140 (name) to y=200 (body)
+
+  it('selects a unit when clicking near its nameplate, well above the body', () => {
+    // click at the name height (y=140); body midpoint is 60px below at y=200
+    const id = nearestSloppyPickId(105, 140, [{ id: 7, ...mid }], 26);
+    expect(id).toBe(7);
+  });
+
+  it('still selects when clicking the body midpoint', () => {
+    expect(nearestSloppyPickId(100, 200, [{ id: 7, ...mid }], 26)).toBe(7);
+  });
+
+  it('returns null when the click is outside the radius of the whole column', () => {
+    expect(nearestSloppyPickId(140, 140, [{ id: 7, ...mid }], 26)).toBeNull();
+  });
+
+  it('picks the nearest column among several overlapping units', () => {
+    const a = { id: 1, midX: 100, midY: 200, topX: 100, topY: 140 };
+    const b = { id: 2, midX: 118, midY: 200, topX: 118, topY: 140 };
+    expect(nearestSloppyPickId(112, 150, [a, b], 26)).toBe(2);
+  });
+
+  it('collapses to point distance when the top anchor equals the mid (guard fallback)', () => {
+    // The renderer collapses the column to the body point when the nameplate
+    // anchor is behind the camera; the pick then behaves like the old body-only
+    // radius rather than trusting a bogus projected top.
+    const c = { id: 9, midX: 100, midY: 200, topX: 100, topY: 200 };
+    expect(nearestSloppyPickId(100, 170, [c], 26)).toBeNull(); // 30px up, no column reach
+    expect(nearestSloppyPickId(100, 178, [c], 26)).toBe(9); // within 26px of the point
+  });
+
+  it('uses a strict radius: a click exactly at the threshold is rejected', () => {
+    expect(nearestSloppyPickId(126, 140, [{ id: 7, ...mid }], 26)).toBeNull();
+    expect(nearestSloppyPickId(125, 140, [{ id: 7, ...mid }], 26)).toBe(7);
+  });
+});


### PR DESCRIPTION
## Problem

Clicking a party member's nameplate (the floating name above their head) often does not select them. For a healer this means missed targets and false heals: the click lands on the name, nothing gets targeted, and the heal goes to whoever was previously selected.

## Root cause

In-world nameplates are visual-only DOM (`pointer-events: none`), so a click on the name falls through to the 3D pick (`renderer.pick`). When the ray misses every clickable capsule, a forgiving "sloppy pick" fallback snaps to the nearest character within 26px. But that fallback measured distance only to the body MIDPOINT. The nameplate floats about a head-height plus 1.0 world units above the body, so a click on the name is well outside the 26px body radius and selects nobody (or, in a scrum, the nearest wrong body).

```mermaid
flowchart TD
    A[Click on party member's name] --> B{Ray hits a clickable capsule?}
    B -- yes --> T[Target that entity]
    B -- no --> C[Sloppy pick fallback]
    C --> D[BEFORE: distance to body MIDPOINT only]
    D --> F[name is far above body -> MISS / false heal]
    C --> G[AFTER: distance to COLUMN body..nameplate]
    G --> T
```

![flow](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-nameplate-click/nameplate_flow.png)

## Fix

Anchor the sloppy pick to the whole vertical screen COLUMN, from the body midpoint up to the overhead nameplate (the same world offset the nameplate projection uses), instead of the body midpoint alone. A click anywhere from the name down to the body now registers on its owner.

The logic is extracted into a pure, unit-tested module `src/render/sloppy_pick.ts` (`distanceToSegmentPx` + `nearestSloppyPickId`); the renderer projects the two screen anchors per candidate and delegates. The radius stays 26px and the nearest column still wins, so overlapping units resolve exactly as before.

![hit area](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-nameplate-click/hitarea.png)

## Why it is safe

- Read-only pick path: `renderer.pick` returns an entity id; no sim / `IWorld` / wire / i18n change.
- Strictly more forgiving in the vertical band only; objects (doors, loot) still need a direct ray hit and the local player never competes for the click, both unchanged.
- Allocation only on click (not per frame), so no hot-path cost.

## Tests

- `tests/sloppy_pick.test.ts` (TDD red -> green): segment-distance math, a name-height click selecting its unit, body-midpoint clicks still working, out-of-radius rejection, nearest-of-overlapping, and the strict 26px boundary.
- `tsc`, `tests/architecture.test.ts` green; `npm run build` green; `npm run ci:changed` clean; pre-push QA floor passes.
