### PR TITLE
[codex] Run Discord bot in compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,27 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # Set this to a long random value and mirror it in Ansible secrets.
 #RESTART_COUNTDOWN_SECRET=
 
+# Discord integration. OAuth in the game server is enabled when
+# DISCORD_CLIENT_ID and DISCORD_CLIENT_SECRET are set. The separate bot service
+# is opt-in so local/self-hosted compose stacks keep working without Discord
+# credentials; enable it with COMPOSE_PROFILES=discord after setting the bot env.
+# Register this callback in the Discord application:
+#   https://your-domain.example/api/auth/discord/callback
+#COMPOSE_PROFILES=discord
+#PUBLIC_GAME_URL=https://worldofclaudecraft.com
+#DISCORD_CLIENT_ID=
+#DISCORD_CLIENT_SECRET=
+#DISCORD_GUILD_ID=
+#DISCORD_GUILD_INVITE=https://discord.gg/GjhnUsBtw
+#DISCORD_BOT_TOKEN=
+#DISCORD_BOT_SECRET=
+#DISCORD_VOICE_CHANNEL_ID=
+#DISCORD_WELCOME_CHANNEL_ID=
+#DISCORD_TEST_CHANNEL_ID=
+#DISCORD_RELAY_CHANNEL_ID=
+#DISCORD_ACTIVITY_CHANNEL_ID=
+#DISCORD_SYNC_NICKNAMES=1
+
 # Cloudflare Turnstile SITE key (public) for the login/register widget. NOTE: this
 # is read by the CLIENT and inlined at BUILD time (`vite build`/`npm run build`),
 # NOT at server runtime — it must be present in the build environment, not just on

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm ci --no-audit --no-fund
 COPY .browserslistrc tsconfig.json vite.config.ts index.html admin.html play.html guide.html ./
 COPY src ./src
 COPY server ./server
+COPY bot ./bot
 COPY headless ./headless
 COPY scripts ./scripts
 COPY public ./public
@@ -20,7 +21,7 @@ COPY private ./private
 # Turnstile widget off. Passed through from compose build args.
 ARG VITE_TURNSTILE_SITEKEY=""
 RUN VITE_TURNSTILE_SITEKEY="$VITE_TURNSTILE_SITEKEY" \
-    npm run build && cp -a dist/media ./media-build && rm -rf dist/media && npm run build:server
+    npm run build && cp -a dist/media ./media-build && rm -rf dist/media && npm run build:server && npm run build:bot
 
 FROM node:22-alpine
 WORKDIR /app
@@ -28,6 +29,7 @@ ENV NODE_ENV=production
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/media-build ./media-build
 COPY --from=build /app/dist-server ./dist-server
+COPY --from=build /app/dist-bot ./dist-bot
 RUN mkdir -p /app/dist/media && chown -R node:node /app/dist/media
 EXPOSE 8787
 USER node

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
   # then open http://localhost:8787 — or put a TLS reverse proxy in front
   # for remote hosting (see README).
   game:
+    image: eastbrook-game:${EASTBROOK_IMAGE_TAG:-local}
     build:
       context: .
       args:
@@ -61,11 +62,41 @@ services:
       APPLE_DEVICECHECK_ENV: ${APPLE_DEVICECHECK_ENV:-production}
       # Runtime: protects the loopback-only deploy countdown endpoint.
       RESTART_COUNTDOWN_SECRET: ${RESTART_COUNTDOWN_SECRET:-}
+      # Runtime: Discord OAuth + the secret-gated game <-> Discord bot channel.
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID:-}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET:-}
+      DISCORD_GUILD_ID: ${DISCORD_GUILD_ID:-}
+      DISCORD_GUILD_INVITE: ${DISCORD_GUILD_INVITE:-}
+      DISCORD_BOT_SECRET: ${DISCORD_BOT_SECRET:-}
     # loopback-only: the TLS reverse proxy (Caddy) is the public entrance
     ports:
       - "127.0.0.1:8787:8787"
     volumes:
       - ${EASTBROOK_MEDIA_DIR:-./media-cache}:/app/dist/media
+
+  discord-bot:
+    image: eastbrook-game:${EASTBROOK_IMAGE_TAG:-local}
+    container_name: eastbrook-discord-bot
+    profiles:
+      - discord
+    restart: unless-stopped
+    depends_on:
+      game:
+        condition: service_started
+    environment:
+      GAME_SERVER_URL: http://game:8787
+      PUBLIC_GAME_URL: ${PUBLIC_GAME_URL:-http://localhost:8787}
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID:-}
+      DISCORD_GUILD_ID: ${DISCORD_GUILD_ID:-}
+      DISCORD_BOT_SECRET: ${DISCORD_BOT_SECRET:-}
+      DISCORD_VOICE_CHANNEL_ID: ${DISCORD_VOICE_CHANNEL_ID:-}
+      DISCORD_WELCOME_CHANNEL_ID: ${DISCORD_WELCOME_CHANNEL_ID:-}
+      DISCORD_TEST_CHANNEL_ID: ${DISCORD_TEST_CHANNEL_ID:-}
+      DISCORD_RELAY_CHANNEL_ID: ${DISCORD_RELAY_CHANNEL_ID:-}
+      DISCORD_ACTIVITY_CHANNEL_ID: ${DISCORD_ACTIVITY_CHANNEL_ID:-}
+      DISCORD_SYNC_NICKNAMES: ${DISCORD_SYNC_NICKNAMES:-1}
+    command: ["node", "dist-bot/bot.cjs"]
 
   mediawiki-db:
     image: mariadb:11

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const dockerfile = readFileSync('Dockerfile', 'utf8');
+const compose = readFileSync('docker-compose.yml', 'utf8');
+
+describe('Discord bot deploy container contract', () => {
+  it('builds and ships the bundled Discord bot artifact', () => {
+    expect(dockerfile).toContain('COPY bot ./bot');
+    expect(dockerfile).toContain('npm run build:bot');
+    expect(dockerfile).toContain('COPY --from=build /app/dist-bot ./dist-bot');
+  });
+
+  it('runs the Discord bot as a separate compose service', () => {
+    expect(compose).toContain('discord-bot:');
+    expect(compose).toContain('container_name: eastbrook-discord-bot');
+    expect(compose).toContain('command: ["node", "dist-bot/bot.cjs"]');
+    expect(compose).toContain('GAME_SERVER_URL: http://game:8787');
+    expect(compose).toContain('DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:?Set DISCORD_BOT_TOKEN');
+  });
+
+  it('passes the shared Discord bot secret to the game server', () => {
+    expect(compose).toContain('DISCORD_BOT_SECRET: ${DISCORD_BOT_SECRET:-}');
+  });
+});

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 const dockerfile = readFileSync('Dockerfile', 'utf8');
 const compose = readFileSync('docker-compose.yml', 'utf8');
+const composeEnv = (name: string) => `$${`{${name}:-}`}`;
 
 describe('Discord bot deploy container contract', () => {
   it('builds and ships the bundled Discord bot artifact', () => {
@@ -16,10 +17,10 @@ describe('Discord bot deploy container contract', () => {
     expect(compose).toContain('container_name: eastbrook-discord-bot');
     expect(compose).toContain('command: ["node", "dist-bot/bot.cjs"]');
     expect(compose).toContain('GAME_SERVER_URL: http://game:8787');
-    expect(compose).toContain('DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}');
+    expect(compose).toContain(`DISCORD_BOT_TOKEN: ${composeEnv('DISCORD_BOT_TOKEN')}`);
   });
 
   it('passes the shared Discord bot secret to the game server', () => {
-    expect(compose).toContain('DISCORD_BOT_SECRET: ${DISCORD_BOT_SECRET:-}');
+    expect(compose).toContain(`DISCORD_BOT_SECRET: ${composeEnv('DISCORD_BOT_SECRET')}`);
   });
 });

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -16,7 +16,7 @@ describe('Discord bot deploy container contract', () => {
     expect(compose).toContain('container_name: eastbrook-discord-bot');
     expect(compose).toContain('command: ["node", "dist-bot/bot.cjs"]');
     expect(compose).toContain('GAME_SERVER_URL: http://game:8787');
-    expect(compose).toContain('DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:?Set DISCORD_BOT_TOKEN');
+    expect(compose).toContain('DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}');
   });
 
   it('passes the shared Discord bot secret to the game server', () => {


### PR DESCRIPTION
## Summary
- build and ship the bundled Discord bot artifact in the production image
- add an opt-in `discord-bot` compose service that runs `node dist-bot/bot.cjs` against the game service
- pass Discord OAuth/internal bot env through to the game service and document the required `.env` settings
- add a deploy contract test for the Dockerfile and compose wiring

## Validation
- `npx vitest run tests/deploy_discord_bot.test.ts`
- `POSTGRES_PASSWORD=test docker compose config --quiet`
- `POSTGRES_PASSWORD=test docker compose --profile discord config --quiet`
- `npm run build:bot`
- `npm run build:server`
- `npm run check:ts`

## Note
- `POSTGRES_PASSWORD=test docker compose build game` could not run locally because Docker Desktop is not running in this environment (`Docker Desktop is unable to start`).
