### PR TITLE
[codex] Include Discord bot build script in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ tests
 scripts/*
 !scripts/build_media_manifest.mjs
 !scripts/build_server.mjs
+!scripts/build_bot.mjs
 !scripts/migrate_old_cragmaw_pelt.ts
 !scripts/old_cragmaw_pelt_migration.ts
 !scripts/build_sitemap.mjs

--- a/tests/deploy_discord_bot.test.ts
+++ b/tests/deploy_discord_bot.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const dockerfile = readFileSync('Dockerfile', 'utf8');
+const dockerignore = readFileSync('.dockerignore', 'utf8');
 const compose = readFileSync('docker-compose.yml', 'utf8');
 const composeEnv = (name: string) => `$${`{${name}:-}`}`;
 
@@ -10,6 +11,10 @@ describe('Discord bot deploy container contract', () => {
     expect(dockerfile).toContain('COPY bot ./bot');
     expect(dockerfile).toContain('npm run build:bot');
     expect(dockerfile).toContain('COPY --from=build /app/dist-bot ./dist-bot');
+  });
+
+  it('keeps the Discord bot build script in the Docker build context', () => {
+    expect(dockerignore).toContain('!scripts/build_bot.mjs');
   });
 
   it('runs the Discord bot as a separate compose service', () => {


### PR DESCRIPTION
## Summary
- allow `scripts/build_bot.mjs` through `.dockerignore` so Docker builds can run `npm run build:bot`
- extend the Discord bot deploy contract test to cover the Docker build-context allowlist

## Root Cause
The Dockerfile now runs `npm run build:bot`, but `.dockerignore` ignored `scripts/*` and only allowlisted the older build scripts. On dev, Docker copied `package.json` and `bot/`, but not `scripts/build_bot.mjs`, so the image build failed with `Cannot find module /app/scripts/build_bot.mjs`.

## Validation
- `npm run i18n:gen`
- `git diff --exit-code -- src/ui/i18n.resolved.generated src/admin/i18n.resolved.generated src/ui/i18n.status.summary.json`
- `npm test`
- `npx @biomejs/biome ci --changed --since="origin/release/v0.17.0" --no-errors-on-unmatched`
- `POSTGRES_PASSWORD=test docker compose config --quiet`
- `POSTGRES_PASSWORD=test docker compose --profile discord config --quiet`

## Note
- `POSTGRES_PASSWORD=test docker compose build game` could not run locally because Docker Desktop is not running in this environment (`Docker Desktop is unable to start`).
