### PR TITLE
[codex] Allow Discord bot to boot without dotenv file

### DIFF
--- a/bot/main.ts
+++ b/bot/main.ts
@@ -39,7 +39,11 @@ const RELAY_POLL_MS = 3_000; // how often the bot pulls queued in-game "!" posts
 async function main(): Promise<void> {
   // Load .env (and optional .env.local) into process.env, matching server/db.ts.
   // Existing ambient env wins; missing file is fine (rely on the ambient env).
-  process.loadEnvFile?.();
+  try {
+    process.loadEnvFile?.();
+  } catch {
+    /* no .env */
+  }
   try {
     process.loadEnvFile?.('.env.local');
   } catch {


### PR DESCRIPTION
## Summary
- make the Discord bot tolerate a missing `.env` file in the runtime container
- keep `.env.local` optional as before

## Root Cause
The bot process runs in the production image with Compose-injected environment variables, but no `/app/.env` file. `process.loadEnvFile()` throws when `.env` is missing, so the bot crash-looped on dev before reading the required environment variables from Compose.

## Validation
- `npx vitest run tests/discord_bot.test.ts tests/deploy_discord_bot.test.ts`
- `npm run build:bot`
- `npx @biomejs/biome ci --changed --since="origin/release/v0.17.0" --no-errors-on-unmatched`
