### PR TITLE
fix(discord): make the link-Discord CTA banner responsive on phones

### DIFF
--- a/scripts/discord_cta_banner_shot.mjs
+++ b/scripts/discord_cta_banner_shot.mjs
@@ -1,0 +1,91 @@
+// Visual check for the unlinked "Link your Discord" CTA banner across viewports.
+// Renders the REAL banner markup (lifted from index.html) with the REAL CSS rules
+// (lifted from src/styles/index.extra.css) so we exercise the shipped styles, then
+// screenshots a portrait phone, a landscape phone, and a desktop width.
+import { mkdirSync, readFileSync } from 'node:fs';
+import puppeteer from 'puppeteer-core';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+mkdirSync('tmp', { recursive: true });
+
+// Pull just the banner block out of index.html. Terminate on the close button so the
+// capture ends at the banner's own closing </div> and does not spill into the markup
+// that follows it.
+const html = readFileSync('index.html', 'utf8');
+const bannerMatch = html.match(
+  /<div id="discord-cta-banner"[\s\S]*?id="discord-cta-close"[\s\S]*?<\/button>\s*<\/div>/,
+);
+if (!bannerMatch) throw new Error('could not find #discord-cta-banner in index.html');
+// Drop the `hidden` attribute so it renders, and seed the stats text.
+const banner = bannerMatch[0]
+  .replace(' hidden>', '>')
+  .replace(
+    '<span class="dc-cta-stats" id="discord-cta-stats"></span>',
+    '<span class="dc-cta-stats" id="discord-cta-stats">299 online · 1,369 members in the server</span>',
+  );
+
+// Pull the banner CSS (the first banner rule through the trailing media query, which
+// runs to EOF) straight out of index.extra.css so we render the shipped styles.
+const css = readFileSync('src/styles/index.extra.css', 'utf8');
+const fullCss = css.slice(css.indexOf('#discord-cta-banner {'));
+
+const page = `<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+<style>
+* { box-sizing: border-box; }
+html,body { margin:0; background:#15171c; min-height:100vh; font-family: system-ui, sans-serif; }
+.spacer { height: 220px; }
+${fullCss}
+</style></head><body><div class="spacer"></div>${banner}</body></html>`;
+
+// The portrait bug made the banner a tall one-word-per-line column; assert a sane
+// height ceiling and that it never overflows the viewport width.
+const MAX_BANNER_HEIGHT = 160;
+let fail = 0;
+const check = (name, cond, extra = '') => {
+  console.log(`${cond ? 'PASS' : 'FAIL'}  ${name}${extra ? `  ${extra}` : ''}`);
+  if (!cond) fail++;
+};
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--no-sandbox', '--disable-dev-shm-usage', '--use-angle=swiftshader'],
+});
+try {
+  const viewports = [
+    { name: 'portrait-iphone', width: 393, height: 852, touch: true },
+    { name: 'landscape-phone', width: 740, height: 393, touch: true },
+    { name: 'landscape-phone-se', width: 667, height: 375, touch: true },
+    { name: 'desktop', width: 1280, height: 720, touch: false },
+  ];
+  for (const vp of viewports) {
+    const p = await browser.newPage();
+    await p.setViewport({
+      width: vp.width,
+      height: vp.height,
+      deviceScaleFactor: 2,
+      hasTouch: vp.touch,
+      isMobile: vp.touch,
+    });
+    await p.setContent(page, { waitUntil: 'load' });
+    const out = `tmp/discord_cta_${vp.name}.png`;
+    await p.screenshot({ path: out });
+    const box = await p.$eval('#discord-cta-banner', (el) => {
+      const r = el.getBoundingClientRect();
+      return { w: Math.round(r.width), h: Math.round(r.height), right: Math.round(r.right) };
+    });
+    console.log(`${vp.name}: ${out}  banner=${box.w}x${box.h}`);
+    check(`${vp.name} height <= ${MAX_BANNER_HEIGHT}px`, box.h <= MAX_BANNER_HEIGHT, `h=${box.h}`);
+    check(
+      `${vp.name} fits viewport width`,
+      box.right <= vp.width + 1,
+      `right=${box.right}/${vp.width}`,
+    );
+    await p.close();
+  }
+} finally {
+  await browser.close();
+}
+
+process.exit(fail > 0 ? 1 : 0);

--- a/src/styles/index.extra.css
+++ b/src/styles/index.extra.css
@@ -616,7 +616,41 @@
 #discord-cta-banner .dc-cta-x:hover {
   background: #ffffff3a;
 }
-@media (max-width: 560px) {
+/* Phones: the desktop flex row squeezes the title column down to one word per line
+   (the fixed logo/button/dismiss starve it) and the vertically centered button then
+   overlaps it. Re-flow to a grid (logo + title + dismiss on top, the link button
+   full-width below) so the title gets the leftover space and wraps normally, with
+   mobile-floor (>=40px) tap targets. Gated on coarse-pointer too, not just a narrow
+   width, so landscape phones get the same layout (per src/ui/CLAUDE.md). */
+@media (max-width: 560px), (pointer: coarse) {
+  #discord-cta-banner {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "logo text close"
+      "btn  btn  btn";
+    align-items: center;
+    column-gap: 10px;
+    row-gap: 8px;
+    width: min(94vw, 440px);
+  }
+  #discord-cta-banner .dc-cta-logo {
+    grid-area: logo;
+  }
+  #discord-cta-banner .dc-cta-text {
+    grid-area: text;
+  }
+  #discord-cta-banner .dc-cta-x {
+    grid-area: close;
+    align-self: start;
+    width: 40px;
+    height: 40px;
+  }
+  #discord-cta-banner .dc-cta-btn {
+    grid-area: btn;
+    width: 100%;
+    min-height: 40px;
+  }
   #discord-cta-banner .dc-cta-title {
     font-size: 12.5px;
   }


### PR DESCRIPTION
## Problem

On a phone in portrait, the unlinked "Link your Discord" CTA banner renders badly: the title collapses to one word per line, the banner becomes a tall column, and the "Link in one click" button overlaps the text (see the dev-server screenshot in the linked report).

Root cause: the banner is a single flex row (logo, text, button, dismiss) capped at `min(620px, 94vw)`. The fixed-width logo, button, and dismiss starve the text column (which has `min-width: 0`), so at narrow widths the title shrinks to its longest-word width and the vertically centered button lands on top of it.

## Fix

`src/styles/index.extra.css`: re-flow the banner to a CSS grid on phones.

- Row 1: `[logo] [title + stats (1fr)] [dismiss]`; Row 2: the link button full-width.
- The title column now gets the leftover space and wraps to two lines normally.
- Button and dismiss bumped to the `>=40px` mobile tap-target floor (per `src/ui/CLAUDE.md`).
- Gated on `(pointer: coarse)` in addition to `max-width: 560px`, so landscape phones get the same layout (the mobile contract says to gate on pointer capability, not width alone).
- Desktop (fine pointer, wide) is provably untouched: it matches neither media condition and keeps the original one-line row.

Also adds `scripts/discord_cta_banner_shot.mjs`, a puppeteer-core helper that renders the real banner markup + CSS across portrait / landscape / desktop viewports, screenshots them to `tmp/`, and asserts the banner stays within a sane height and inside the viewport (exits non-zero on failure).

## Scope

`index.html`-only banner (not present in `play.html`), so no `play.extra.css` mirror is needed. No new i18n keys (reuses the existing `hudChrome.discord.cta.*`). No sim/server/wire/persistence surface.

## Test plan

- [x] `node scripts/discord_cta_banner_shot.mjs`: portrait 369x112, landscape 440x106, desktop 527x52, all height + width assertions PASS, exit 0.
- [x] Visual check of all three viewports: title wraps to two lines, full-width button, dismiss pinned top-right; desktop unchanged.
- [x] CSS guards green: `css_value_validity`, `css_corpus`, `per_entry_css_wiring`, `styles_extraction`.
- [x] `biome ci` clean on both changed files.
- [ ] Confirm on the dev server in a real portrait phone browser.