### PR TITLE
feat(admin): open account details modal from IP association page

### DIFF
--- a/src/admin/pages/IpAssociations.svelte
+++ b/src/admin/pages/IpAssociations.svelte
@@ -9,6 +9,7 @@
   import { localizeAdminError, t } from '../i18n';
   import Badge from '../components/Badge.svelte';
   import AccountIndicators from '../components/AccountIndicators.svelte';
+  import AccountLink from '../components/AccountLink.svelte';
   import IpBlockDialog from '../components/IpBlockDialog.svelte';
   import PageHeader from '../components/PageHeader.svelte';
   import Pager from '../components/Pager.svelte';
@@ -136,7 +137,13 @@
           <section class="ip-account">
             <div class="account-heading">
               <div>
-                <strong>{account.username}</strong>
+                <strong>
+                  <AccountLink
+                    accountId={account.accountId}
+                    label={account.username}
+                    onChanged={() => void refresh()}
+                  />
+                </strong>
                 <span class="hint">{t('ipAssociations.accountId', { id: fmtNumber(account.accountId) })}</span>
                 <AccountIndicators
                   isAdmin={account.isAdmin}

--- a/tests/admin/ip_associations.test.ts
+++ b/tests/admin/ip_associations.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import './_setup';
-import { fireEvent, render, screen, within } from '@testing-library/svelte';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const data = {
@@ -50,7 +50,9 @@ const data = {
 };
 
 let currentData = data;
+const apiGet = vi.fn(async (_path: string) => currentData);
 const apiPost = vi.fn();
+const accountModalOpen = vi.fn();
 
 vi.mock('../../src/admin/api', () => ({
   ApiError: class ApiError extends Error {
@@ -60,11 +62,18 @@ vi.mock('../../src/admin/api', () => ({
       this.status = status;
     }
   },
-  apiGet: vi.fn(async () => currentData),
+  apiGet: (path: string) => apiGet(path),
   apiPost: (...args: unknown[]) => apiPost(...args),
   getToken: () => 'tok',
   getAdminName: () => 'admin',
   clearSession: () => {},
+}));
+
+vi.mock('../../src/admin/account_modal', () => ({
+  getAccountModalController: () => ({
+    open: accountModalOpen,
+    close: vi.fn(),
+  }),
 }));
 
 import { fmtDate } from '../../src/admin/format';
@@ -73,15 +82,22 @@ import IpAssociations from '../../src/admin/pages/IpAssociations.svelte';
 
 beforeEach(() => {
   currentData = data;
+  apiGet.mockClear();
   apiPost.mockReset();
   apiPost.mockResolvedValue({});
+  accountModalOpen.mockReset();
 });
 
 describe('IP associations', () => {
   it('groups one character row per account and identifies every association source', async () => {
     render(IpAssociations, { ip: '203.0.113.7' });
 
-    expect(await screen.findByText('alice')).toBeInTheDocument();
+    const accountLink = await screen.findByRole('button', { name: 'alice' });
+    await fireEvent.click(accountLink);
+    expect(accountModalOpen).toHaveBeenCalledWith(7, expect.any(Function));
+    const onChanged = accountModalOpen.mock.calls[0]?.[1] as (() => void) | undefined;
+    onChanged?.();
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2));
     const title = screen.getByRole('heading', {
       name: t('ipAssociations.title', { ip: '203.0.113.7' }),
     });


### PR DESCRIPTION
## Summary

Make account names clickable in the Shared IPs investigation view.

Clicking an account name now opens the existing account details modal, allowing moderators to inspect the account without leaving the IP associations page.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change

## How was this tested?

- Commands:
  - `npm test`
  - `npm run check:admin`

- Manual steps:
  - Go on admin dashboard / shared IPs
  - click on an IP address
  - click on an account name

## Screenshots / recordings

<img width="1087" height="780" alt="image" src="https://github.com/user-attachments/assets/058a4b43-04f1-4e5c-a943-5f6b1497afaa" />

## Checklist

### Quality

- [x] **Tests pass.** `npm test` is green.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean.
- [x] **Builds succeed.** `npm run build`.

### Cross-platform

- [x] **Tested on desktop and mobile.**
- [x] **Accessible.** Account names use the existing keyboard-operable account link component.

### Localization (i18n)

- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed.
- [x] No generated files were edited manually.