### PR TITLE
[codex] fix keybindings list scrolling

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3490,6 +3490,16 @@
     align-items: start;
     margin-bottom: 8px;
   }
+  .kb-scroll {
+    max-height: max(240px, calc(85vh - 300px));
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding-right: 4px;
+    margin-bottom: 8px;
+  }
+  .kb-scroll .kb-cols {
+    margin-bottom: 0;
+  }
   .kb-col {
     min-width: 0;
   }

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -1365,7 +1365,10 @@ export class OptionsWindow {
       col.appendChild(rows);
       cols.appendChild(col);
     }
-    el.appendChild(cols);
+    const scroll = document.createElement('div');
+    scroll.className = 'kb-scroll';
+    scroll.appendChild(cols);
+    el.appendChild(scroll);
     const reset = document.createElement('button');
     reset.className = 'btn';
     reset.textContent = t('hud.options.resetToDefaults');


### PR DESCRIPTION
## Summary
- Keep the Keybindings title, notes, and footer controls reachable while the binding categories scroll.
- Add a viewport-bounded scroll region around the keybinding grid so the lower Action Bar rows remain accessible in fullscreen and shorter desktop windows.

Fixes #1082

## Validation
- `npx biome check src\ui\options_window.ts src\styles\components.css`
- `npm run check:ts`
