### PR TITLE
[codex] fix browserslist parser on CRLF checkouts

### DIFF
--- a/scripts/browserslist_targets.mjs
+++ b/scripts/browserslist_targets.mjs
@@ -35,7 +35,7 @@ export function parseBrowserslistFloors(text) {
   for (const physicalLine of text.split('\n')) {
     // Strip a '#' comment FIRST, so a comment that happens to contain a comma is
     // not split into a bogus floor entry by the comma handling below.
-    const code = physicalLine.replace(/#.*$/, '');
+    const code = physicalLine.trim().replace(/#.*$/, '');
     for (const raw of code.split(',')) {
       const entry = raw.trim();
       if (!entry) continue;

--- a/tests/browserslist_targets.test.ts
+++ b/tests/browserslist_targets.test.ts
@@ -26,6 +26,11 @@ describe('browserslist floor parser', () => {
     expect(parseBrowserslistFloors(text)).toEqual(['chrome 120', 'safari 17.2']);
   });
 
+  it('ignores comment lines from CRLF checkouts', () => {
+    const text = '# floor\r\nChrome >= 120\r\n# trailing note\r\nFirefox >= 121\r\n';
+    expect(parseBrowserslistFloors(text)).toEqual(['chrome 120', 'firefox 121']);
+  });
+
   it('strips a # comment BEFORE splitting on comma (a comment may contain a comma)', () => {
     // Load-bearing ordering: if comma-split ran first, the text after the comma in the
     // comment would lose its '#' and parse as a bogus floor. This is the exact bug the


### PR DESCRIPTION
## Summary
- Fix the zero-dependency `.browserslistrc` parser on CRLF checkouts by trimming each physical line before stripping `#` comments.
- Add a regression test for CRLF comment lines so Windows checkouts keep loading the shipped browser floors.

## Why
On Windows, `npm run dev` / Vitest startup failed while loading `vite.config.ts` because the parser treated the leading `.browserslistrc` comment as an unsupported floor entry.

## Validation
- `node -e "import('./scripts/browserslist_targets.mjs').then(m=>console.log(JSON.stringify(m.loadBrowserslistFloors('.browserslistrc')))).catch(e=>{console.error(e);process.exit(1)})"`
- `npx biome check scripts\browserslist_targets.mjs tests\browserslist_targets.test.ts`
- `npm test -- tests\browserslist_targets.test.ts`
- `npm run dev -- --host 127.0.0.1 --port 5179` then requested `http://127.0.0.1:5179/play.html` and received HTTP 200
