### PR TITLE
Fix Paladin Judgement damage talents

### DIFF
--- a/src/sim/combat/effect_dispatch.ts
+++ b/src/sim/combat/effect_dispatch.ts
@@ -244,9 +244,14 @@ export function runEffects(
         p.auras.splice(sealIdx, 1);
         ctx.emit({ type: 'aura', targetId: p.id, name: seal.name, gained: false });
         // Judgement is an instant holy nuke; scale it with Spell Power too.
+        const mods = ctx.playerMods(meta);
+        const judgementMod = mods.abilities[ability.id];
+        const judgementMult = 1 + mods.global.spellDmgPct + (judgementMod?.dmgPct ?? 0);
+        const judgementFlat = judgementMod?.flatDmg ?? 0;
         let dmg =
-          ctx.rng.range(seal.value2 ?? 10, seal.value3 ?? 15) +
-          directHitBonus(p.spellPower, ability, res.castTime);
+          Math.round(
+            ctx.rng.range(seal.value2 ?? 10, seal.value3 ?? 15) * judgementMult + judgementFlat,
+          ) + directHitBonus(p.spellPower, ability, res.castTime);
         const crit = ctx.rng.chance(ctx.spellCrit(p));
         if (crit) dmg *= 1.5;
         ctx.dealDamage(p, target, Math.round(dmg), crit, 'holy', ability.name, 'hit');

--- a/tests/talents.test.ts
+++ b/tests/talents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ClientWorld } from '../src/net/online';
+import { runEffects } from '../src/sim/combat/effect_dispatch';
 import { ABILITIES, abilitiesKnownAt } from '../src/sim/content/classes';
 import {
   computeTalentModifiers,
@@ -19,8 +20,9 @@ import {
   validateAllocation,
   validateTalentTree,
 } from '../src/sim/content/talents';
-import { Sim } from '../src/sim/sim';
-import { ALL_CLASSES, dist2d, MAX_LEVEL } from '../src/sim/types';
+import { type PlayerMeta, Sim } from '../src/sim/sim';
+import type { SimContext } from '../src/sim/sim_context';
+import { ALL_CLASSES, dist2d, type Entity, MAX_LEVEL } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
 import { talentChoiceIconRef, talentNodeIconRef } from '../src/ui/talent_icons';
 
@@ -50,6 +52,43 @@ function nearestMob(sim: Sim) {
 }
 
 const effOf = (k: any, i = 0) => k.effects[i] as any;
+
+function judgementHitAmount(mods: ReturnType<typeof computeTalentModifiers>): number {
+  const judgement = abilitiesKnownAt('paladin', 20, mods).find((k) => k.def.id === 'judgement');
+  if (!judgement) throw new Error('missing Judgement ability');
+  const paladin = {
+    id: 1,
+    spellPower: 0,
+    auras: [
+      {
+        id: 'seal_of_righteousness',
+        name: 'Seal of Righteousness',
+        kind: 'imbue',
+        value2: 100,
+        value3: 100,
+      },
+    ],
+  } as Partial<Entity> as Entity;
+  const target = { id: 2, dead: false } as Partial<Entity> as Entity;
+  const meta = { talentMods: mods, fiestaMods: null } as Partial<PlayerMeta> as PlayerMeta;
+  let amount = 0;
+  const ctx = {
+    rng: { range: () => 100, chance: () => false },
+    breakStealth: () => undefined,
+    emit: () => undefined,
+    error: (_pid: number, text: string) => {
+      throw new Error(text);
+    },
+    playerMods: (m: PlayerMeta) => m.fiestaMods ?? m.talentMods,
+    spellCrit: () => 0,
+    dealDamage: (_source: Entity | null, _target: Entity, damage: number) => {
+      amount = damage;
+    },
+  } as unknown as SimContext;
+
+  runEffects(ctx, paladin, meta, target, judgement);
+  return amount;
+}
 
 describe('talent tree validation (load-time)', () => {
   it('every registered tree is structurally valid', () => {
@@ -350,6 +389,22 @@ describe('precomputed modifiers', () => {
       ),
     ).find((k) => k.def.id === 'seal_of_righteousness')!;
     expect(effOf(seal)).toMatchObject({ bonus: 16, judgeMin: 44, judgeMax: 64 }); // mastery + 2 talent ranks
+  });
+
+  it('applies Judgement damage talents to consumed Seal damage at impact', () => {
+    const base = computeTalentModifiers('paladin', alloc());
+    const holyJudgement = computeTalentModifiers(
+      'paladin',
+      alloc({
+        spec: 'holy',
+        ranks: { holy_choice: 1 },
+        choices: { holy_choice: 'holy_choice_judgement' },
+      }),
+    );
+
+    expect(holyJudgement.abilities.judgement.dmgPct).toBeCloseTo(0.2);
+    expect(judgementHitAmount(base)).toBe(100);
+    expect(judgementHitAmount(holyJudgement)).toBe(120);
   });
 });
 


### PR DESCRIPTION
## Summary
- Apply effective Paladin Judgement damage modifiers when Judgement consumes an active Seal.
- Keep Seal-specific scaling on the Seal aura itself, so Seal of Righteousness talents still snapshot into the Seal and Judgement-specific talents only scale the Judgement impact.
- Add a deterministic combat-effect test for Holy's Judgement of Light modifier: a 100-damage Seal Judgement stays 100 untalented and becomes 120 with the +20% talent.

Fixes #1057

## Testing
- npx biome check --max-diagnostics=10 src\\sim\\combat\\effect_dispatch.ts tests\\talents.test.ts
  - Passed. Biome reports existing warnings in tests/talents.test.ts, but no errors.
- npm run check:ts
  - Passed.
- npx vitest run --config ..\\work\\vitest.node.config.ts tests\\talents.test.ts tests\\social.test.ts
  - Passed: 2 files, 100 tests.

## Notes
- I also attempted the normal 
pm test -- tests\\talents.test.ts tests\\social.test.ts command after allowing the pretest generation step. Pretest completed, but Vitest could not load ite.config.ts on this release branch because .browserslistrc comments are rejected by the current parser. That is the same unrelated Windows/release-branch blocker addressed separately in #1090, so I did not include that fix in this PR.