### PR TITLE
Fix Parchment high-contrast text blur

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -913,6 +913,7 @@ async function startGame(
   const themeStore = new ThemeStore();
   function applyTheme(): void {
     const vars = themeStore.cssVars();
+    document.body.dataset.uiTheme = themeStore.get().preset;
     for (const name of Object.keys(vars))
       document.documentElement.style.setProperty(name, vars[name]);
   }
@@ -7024,7 +7025,9 @@ function fadeOutHomepageMusic(durationMs = 1600): void {
 // (startGame() re-applies via its own ThemeStore once the world loads.)
 (() => {
   try {
-    const vars = new ThemeStore().cssVars();
+    const themeStore = new ThemeStore();
+    const vars = themeStore.cssVars();
+    document.body.dataset.uiTheme = themeStore.get().preset;
     for (const name of Object.keys(vars))
       document.documentElement.style.setProperty(name, vars[name]);
   } catch {

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -2400,6 +2400,13 @@
       1px 1px 2px #000,
       -1px -1px 2px #000;
   }
+  body.high-contrast-text[data-ui-theme="parchment"] .chat-pane div,
+  body.high-contrast-text[data-ui-theme="parchment"] .panel,
+  body.high-contrast-text[data-ui-theme="parchment"] .set-name,
+  body.high-contrast-text[data-ui-theme="parchment"] .tt-stat,
+  body.high-contrast-text[data-ui-theme="parchment"] .tt-desc {
+    text-shadow: none;
+  }
   /* Reduce Motion, drop HUD animations/transitions (mirrors prefers-reduced-motion). */
   body.reduce-motion .fct {
     animation-duration: 0.01ms !important;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -276,6 +276,15 @@ describe('client HTML shell', () => {
     expect(baseCss).toContain('.hud-skip:focus-visible {');
   });
 
+  it('keeps Parchment high-contrast text sharp instead of shadow-blurred', () => {
+    expect(mainTs).toContain('document.body.dataset.uiTheme = themeStore.get().preset;');
+    expect(hudCss).toContain('body.high-contrast-text .tt-desc {');
+    expect(hudCss).toContain('-1px -1px 2px #000;');
+    expect(hudCss).toContain('body.high-contrast-text[data-ui-theme="parchment"] .tt-desc {');
+    expect(hudCss).toContain('body.high-contrast-text[data-ui-theme="parchment"] .panel,');
+    expect(hudCss).toContain('text-shadow: none;');
+  });
+
   it('draws the party focus ring at full strength WITHOUT animating it', () => {
     // A dimmed dead/oor row resets opacity to 1 on keyboard focus so the global outline
     // ring is full, not dimmed. Because .party-frame transitions opacity 0.2s and opacity


### PR DESCRIPTION
## Summary
- Add a data-ui-theme body hook when the saved UI theme is applied on the start screens and in-game HUD.
- Keep the existing High-Contrast Text outline for dark themes, but disable that multi-layer text shadow for Parchment surfaces.
- Add a CSS regression test that pins the body theme hook and the Parchment-specific high-contrast override.

Fixes #1081

## Root cause
High-Contrast Text adds a dark multi-layer 	ext-shadow around HUD text. That works on dark themes, but Parchment already uses dark text on a light panel. The extra shadow creates a smeared halo, making text blurrier instead of more legible.

## Testing
- 
px biome check --max-diagnostics=20 src\\main.ts src\\styles\\hud.css tests\\client_shell.test.ts
  - Passed. Reports existing warnings in src/main.ts; no errors.
- 
pm run check:ts
  - Passed.
- 
px vitest run --config ..\\work\\vitest.node.config.ts tests\\client_shell.test.ts tests\\theme.test.ts tests\\settings.test.ts
  - Passed: 3 files, 102 tests.
- 
pm test -- tests\\client_shell.test.ts tests\\theme.test.ts tests\\settings.test.ts
  - Attempted after allowing the pretest generation step. Pretest completed, then Vitest failed to load ite.config.ts because the current release branch rejects .browserslistrc comments. This is the same unrelated release-branch blocker addressed in #1090, so this PR leaves that fix separate.