### PR TITLE
Stop arena knockback from tunneling through walls

### DIFF
--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -3087,8 +3087,8 @@ export class Sim {
   // On-hit knockback: hurl `target` up to `distance` yards straight away from
   // `source`. Instantaneous displacement (no aura) walked in small steps so it can
   // be terrain-clamped exactly like a warrior charge — the shove stops at the last
-  // safe footing before deep water or a cliff rather than stranding the victim off
-  // the world. Returns the yards actually moved (0 if blocked immediately).
+  // safe footing before a wall, deep water, or a cliff rather than
+  // stranding the victim off the world. Returns the yards actually moved (0 if blocked immediately).
   private applyKnockback(source: Entity, target: Entity, distance: number): number {
     let dx = target.pos.x - source.pos.x;
     let dz = target.pos.z - source.pos.z;
@@ -3113,9 +3113,14 @@ export class Sim {
       const h1 = groundHeight(nx, nz, this.cfg.seed);
       if (h1 < WATER_LEVEL - SWIM_DEPTH) break; // would land in deep water
       if (h1 > h0 && (h1 - h0) / adv > MAX_CLIMB_SLOPE) break; // would slam into a cliff
-      cx = nx;
-      cz = nz;
-      moved += adv;
+      const resolved = this.resolveMove(cx, cz, nx, nz, BODY_RADIUS, target);
+      const actual = Math.hypot(resolved.x - cx, resolved.z - cz);
+      if (actual < 1e-4) break;
+      const clipped = Math.hypot(resolved.x - nx, resolved.z - nz) > 1e-3;
+      cx = resolved.x;
+      cz = resolved.z;
+      moved += actual;
+      if (clipped) break;
     }
     if (moved <= 0) return 0;
     // resolveMovePoint is a no-op wrapper over resolvePosition outside a delve, and

--- a/tests/mob_knockback.test.ts
+++ b/tests/mob_knockback.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
-import { MOBS } from '../src/sim/data';
+import { arenaOrigin, MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
 
 const SEED = 5150;
 const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
@@ -14,7 +14,9 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
     const p = sim.entities.get(sim.playerId)!;
     p.gm = true; // an L19 elite would otherwise grind the warrior down mid-loop
     // flat starting ground (Eastbrook town) so the shove isn't terrain-clamped
-    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const tmpl = MOBS.marrowlord_varkas;
     const saved = tmpl.knockback!.chance;
     tmpl.knockback!.chance = 1; // force the proc; misses/dodges still possible
@@ -39,7 +41,9 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
   it('applyKnockback shoves the exact distance over open ground and reports it', () => {
     const sim = makeSim();
     const p = sim.entities.get(sim.playerId)!;
-    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const mob = createMob(900701, MOBS.marrowlord_varkas, p.level, { x: 0, y: 0, z: 0 });
     const moved = (sim as any).applyKnockback(mob, p, 6);
     expect(moved).toBeGreaterThan(0);
@@ -47,10 +51,33 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
     expect(p.pos.x).toBeGreaterThan(2); // displaced along the mob→player axis
   });
 
+  it('applyKnockback cannot tunnel through arena walls', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    const arena = arenaOrigin(0);
+    const wallInnerFaceX = arena.x + 22;
+    p.pos.x = arena.x + 20.5;
+    p.pos.z = arena.z + 2;
+    p.pos.y = 0;
+    const mob = createMob(900704, MOBS.marrowlord_varkas, p.level, {
+      x: arena.x + 18,
+      y: 0,
+      z: arena.z + 2,
+    });
+
+    const moved = (sim as any).applyKnockback(mob, p, 8);
+
+    expect(moved).toBeGreaterThan(0);
+    expect(p.pos.x).toBeLessThan(wallInnerFaceX);
+  });
+
   it('a friendly pet swing (hostile=false) never knocks its target back', () => {
     const sim = makeSim();
     const p = sim.entities.get(sim.playerId)!;
-    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.gm = true;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const tmpl = MOBS.marrowlord_varkas;
     const saved = tmpl.knockback!.chance;
     tmpl.knockback!.chance = 1;
@@ -68,7 +95,10 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
   it('a mob without knockback never displaces the player', () => {
     const sim = makeSim();
     const p = sim.entities.get(sim.playerId)!;
-    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.gm = true;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const mob = createMob(900703, MOBS.forest_wolf, p.level, { x: 0, y: 0, z: 0 });
     const startGap = dist2d(p.pos, mob.pos);
     for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);


### PR DESCRIPTION
## Summary
- Route knockback displacement through swept movement resolution on each step so arena walls and other thin colliders clip the shove instead of only correcting the final landing point.
- Stop knockback at the clipped position and report the actual distance moved.
- Add a regression test proving arena-side knockback no longer lands a player beyond the wall.

## Root cause
`applyKnockback` walked terrain in 0.5 yd increments, but it only called point resolution after choosing the final landing position. A long shove could therefore step from inside the arena to a point already outside the thin wall collider; `resolvePosition` had nothing to push out of because the endpoint was past the wall volume. Using the existing swept `resolveMove` path during each knockback step catches the wall crossing before the target tunnels through.

## Testing
- `npx vitest run tests\mob_knockback.test.ts --config ..\work\vitest.node.config.ts` failed before the fix with `expected 4228.5 to be less than 4222`.
- `npx biome format --write src\sim\sim.ts tests\mob_knockback.test.ts`
- `npx biome check --max-diagnostics=40 src\sim\sim.ts tests\mob_knockback.test.ts` exits 0; remaining output is existing warnings for non-null assertions / `any` usage in these files.
- `npm run check:ts`
- `npx vitest run tests\mob_knockback.test.ts tests\arena.test.ts tests\pathfind.test.ts --config ..\work\vitest.node.config.ts` (3 files / 50 tests)
- `npm test -- tests\mob_knockback.test.ts` was also attempted outside the sandbox after the sandbox blocked esbuild pretest reads. Pretest generation succeeded, then normal Vitest hit the existing release-branch `.browserslistrc` comment parser blocker fixed separately by #1090.

Fixes #1085