### PR TITLE
Rate-limit inbound websocket messages

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -109,6 +109,8 @@ const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
+const INBOUND_RATE_BURST = 120;
+const INBOUND_RATE_REFILL_PER_SECOND = 40; // safely above the normal 20Hz input stream
 const WHO_RESULT_LIMIT = 50;
 const MAX_ACTIVE_SESSIONS_PER_ACCOUNT = 2;
 const RESTART_COUNTDOWN_TOTAL_SECONDS = 600;
@@ -315,6 +317,9 @@ export interface ClientSession {
   chatLastRateError: number;
   chatRateViolations: number;
   chatCooldownUntil: number;
+  inboundTokens: number;
+  inboundLastRefill: number;
+  inboundRateLimited: boolean;
   chatMutedUntil: number | null;
   chatMuteReason: string;
   // Hard-word enforcement strike count driving the mute ladder. Account-scoped:
@@ -1369,6 +1374,9 @@ export class GameServer {
       chatLastRateError: 0,
       chatRateViolations: 0,
       chatCooldownUntil: 0,
+      inboundTokens: INBOUND_RATE_BURST,
+      inboundLastRefill: Date.now() / 1000,
+      inboundRateLimited: false,
       chatMutedUntil: meta.mutedUntil ? new Date(meta.mutedUntil).getTime() : null,
       chatMuteReason: meta.reason ?? '',
       chatStrikes: meta.chatStrikes ?? 0,
@@ -1987,7 +1995,12 @@ export class GameServer {
   // -------------------------------------------------------------------------
 
   handleMessage(session: ClientSession, raw: string): void {
+    if (session.inboundRateLimited) return;
     const receivedAtMs = Date.now();
+    if (!this.consumeInboundMessageToken(session, receivedAtMs / 1000)) {
+      this.closeRateLimitedSession(session);
+      return;
+    }
     let msg: unknown;
     try {
       msg = JSON.parse(raw);
@@ -2009,6 +2022,32 @@ export class GameServer {
     }
   }
 
+  private consumeInboundMessageToken(session: ClientSession, nowSeconds: number): boolean {
+    const elapsed = Math.max(0, nowSeconds - session.inboundLastRefill);
+    session.inboundTokens = Math.min(
+      INBOUND_RATE_BURST,
+      session.inboundTokens + elapsed * INBOUND_RATE_REFILL_PER_SECOND,
+    );
+    session.inboundLastRefill = nowSeconds;
+    if (session.inboundTokens < 1) {
+      session.inboundRateLimited = true;
+      return false;
+    }
+    session.inboundTokens -= 1;
+    return true;
+  }
+
+  private closeRateLimitedSession(session: ClientSession): void {
+    try {
+      this.send(session, {
+        t: 'error',
+        error: 'Too many messages from this client. Reconnect and slow down.',
+      });
+      session.ws.close(1008, 'Too many messages');
+    } catch {
+      /* socket is already closing/closed */
+    }
+  }
   private messageCommand(msg: unknown): string {
     if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) return 'unknown';
     const record = msg as Record<string, unknown>;

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -41,12 +41,22 @@ const DELTA_KEYS = [
 
 interface FakeClient {
   sent: any[];
+  closed: Array<{ code?: number; reason?: string }>;
   ws: any;
 }
 
 function fakeWs(): FakeClient {
   const sent: any[] = [];
-  return { sent, ws: { readyState: 1, send: (payload: string) => sent.push(JSON.parse(payload)) } };
+  const closed: Array<{ code?: number; reason?: string }> = [];
+  return {
+    sent,
+    closed,
+    ws: {
+      readyState: 1,
+      send: (payload: string) => sent.push(JSON.parse(payload)),
+      close: (code?: number, reason?: string) => closed.push({ code, reason }),
+    },
+  };
 }
 
 function lastSnap(sent: any[]): any {
@@ -484,6 +494,23 @@ describe('delta snapshots', () => {
     fc.sent.length = 0;
     broadcast(server);
     expect(lastSnap(fc.sent).self.ack).toBe(7);
+  });
+  it('rate-limits global inbound message floods before dispatch', () => {
+    fc.sent.length = 0;
+
+    for (let i = 1; i <= 160; i++) {
+      server.handleMessage(session, JSON.stringify({ t: 'input', seq: i, mi: { f: 1 } }));
+    }
+    broadcast(server);
+
+    const snap = lastSnap(fc.sent);
+    expect(snap.self.ack).toBeLessThan(160);
+    expect(session.inboundRateLimited).toBe(true);
+    expect(fc.closed).toContainEqual({ code: 1008, reason: 'Too many messages' });
+    expect(fc.sent).toContainEqual({
+      t: 'error',
+      error: 'Too many messages from this client. Reconnect and slow down.',
+    });
   });
 
   it('turns echoed input acks into client latency samples', () => {


### PR DESCRIPTION
## Summary
- Add a per-session inbound WebSocket token bucket that runs before JSON parsing and message dispatch.
- Close a flooding session with policy code `1008` and a client-visible error once the bucket is exhausted.
- Cover non-chat input floods with a regression test so ordinary chat throttling is no longer the only inbound protection.

## Root cause
Only chat commands had rate limiting. Other authenticated frame types, especially high-frequency `input` frames, went straight through `handleMessage` and `JSON.parse` with no global per-session budget. A tight client loop could therefore force server parse/dispatch work even though sim cooldowns and GCDs still protected gameplay state.

## Testing
- `npx biome format --write server\game.ts tests\snapshots.test.ts`
- `npx biome check --max-diagnostics=40 server\game.ts tests\snapshots.test.ts` exits 0; output is existing warnings in `tests/snapshots.test.ts` (`any` / non-null assertions).
- `npx vitest run tests\snapshots.test.ts tests\security.test.ts --config ..\work\vitest.node.server.config.ts` (2 files / 119 tests)
- `npm run check:ts`
- `npx vitest run tests\ws_buffer.test.ts tests\game_sessions.test.ts tests\chat_log.test.ts --config ..\work\vitest.node.server.config.ts` (3 files / 41 tests)
- `npm test -- tests\snapshots.test.ts` was attempted in the sandbox and failed during esbuild pretest reads with `Access is denied`.
- The same `npm test -- tests\snapshots.test.ts` was attempted outside the sandbox: i18n/wiki pretest generation succeeded, then normal Vitest hit the existing release-branch `.browserslistrc` comment parser blocker fixed separately by #1090.

Fixes #978