### PR TITLE
feat(hardcore): opt-in permadeath character mode

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -196,11 +196,14 @@ function initialCharacterState(
   cls: PlayerClass,
   name: string,
   skin: number,
+  hardcore = false,
 ): import('../src/sim/sim').CharacterState {
   const sim = new Sim({ seed: 20061, playerClass: cls, playerName: name });
   sim.setPlayerSkin(sim.playerId, skin);
   const character = sim.serializeCharacter(sim.playerId);
   if (!character) throw new Error('failed to serialize initial character');
+  // Opt-in at creation; never changes for the character's lifetime.
+  if (hardcore) character.hardcore = true;
   return character;
 }
 
@@ -765,13 +768,14 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
           0,
           Math.min(7, Math.floor(typeof body.skin === 'number' ? body.skin : 0)),
         );
+        const hardcore = body.hardcore === true;
         const create = () =>
           createCharacterCapped(
             accountId,
             name,
             body.class,
             10,
-            initialCharacterState(body.class, name, skin),
+            initialCharacterState(body.class, name, skin, hardcore),
           );
         const created = (c: NonNullable<Awaited<ReturnType<typeof createCharacterCapped>>>) =>
           json(res, 200, {

--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -496,6 +496,9 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
   if (e.kind === 'player') {
     const meta = ctx.players.get(e.id);
     if (meta) meta.counters.deaths++;
+    // Hardcore: death is permanent. Mark the character deceased so releaseSpirit
+    // refuses to revive it; the playerDeath event carries the flag for the client.
+    if (meta?.hardcore) meta.deceased = true;
     e.autoAttack = false;
     e.queuedOnSwing = null;
     e.comboPoints = 0;

--- a/src/sim/entity_roster.ts
+++ b/src/sim/entity_roster.ts
@@ -161,6 +161,9 @@ export function releasePlayerSpirit(ctx: SimContext, pid?: number): void {
   if (!r) return;
   const { meta, e: p } = r;
   if (!p.dead) return;
+  // Hardcore permadeath: a deceased hardcore character cannot return from the
+  // graveyard. Its spirit release is a no-op — the body stays dead.
+  if (meta.deceased) return;
   if (ctx.arenaMatches.has(p.id)) return;
   if (isDelvePos(p.pos.x)) {
     releaseSpiritInDelve(ctx, meta.entityId);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -670,6 +670,11 @@ export interface PlayerMeta {
   fiestaRestore: { level: number; xp: number; talents: TalentAllocation } | null;
   loadouts: SavedLoadout[];
   activeLoadout: number; // index into loadouts, or -1 for none
+  // Hardcore mode (opt-in at creation, persisted). A hardcore character that dies
+  // is permanently deceased: it cannot release its spirit back to a graveyard. Both
+  // flags round-trip through CharacterState; absent => a normal (non-hardcore) char.
+  hardcore: boolean;
+  deceased: boolean;
   raidLockouts: Map<string, number>; // dungeon id -> epoch ms expiry
   // Transient presence status. Set by /afk and /dnd, cleared when the player
   // chats again. Session-only — never persisted, so it resets on login.
@@ -738,6 +743,11 @@ export interface CharacterState {
   arena2v2Rating?: number;
   arena2v2Wins?: number;
   arena2v2Losses?: number;
+  // Hardcore mode. Optional so pre-hardcore saves load cleanly (default: normal).
+  // `hardcore` is set at creation and never changes; `deceased` flips true on a
+  // hardcore character's death and locks it out of graveyard respawn.
+  hardcore?: boolean;
+  deceased?: boolean;
   // Talents & Specializations (JSONB; no schema migration). All optional so
   // characters saved before talents existed load cleanly (default: no points spent).
   talents?: TalentAllocation;
@@ -1169,6 +1179,8 @@ export class Sim {
       fiestaRestore: null,
       loadouts: [],
       activeLoadout: -1,
+      hardcore: savedState?.hardcore ?? false,
+      deceased: savedState?.deceased ?? false,
       raidLockouts: new Map(),
       away: null,
       marketFilter: '',
@@ -1380,6 +1392,9 @@ export class Sim {
       arena2v2Rating: meta.arena2v2Rating,
       arena2v2Wins: meta.arena2v2Wins,
       arena2v2Losses: meta.arena2v2Losses,
+      // Hardcore: persist only when set, so non-hardcore saves stay byte-identical.
+      hardcore: meta.hardcore || undefined,
+      deceased: meta.deceased || undefined,
       talents: cloneAllocation(restore ? restore.talents : meta.talents),
       loadouts: meta.loadouts.map((l) => ({
         name: l.name,

--- a/tests/hardcore.test.ts
+++ b/tests/hardcore.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { Sim } from '../src/sim/sim';
+import type { CharacterState } from '../src/sim/sim';
+
+function simWith(state?: Partial<CharacterState>): { sim: Sim; pid: number } {
+  const sim = new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+  // Build a baseline state, fold in the override, and load it as the character.
+  const base = new Sim({ seed: 7, playerClass: 'warrior', playerName: 'HC' });
+  const baseState = base.serializeCharacter(base.playerId)!;
+  const pid = sim.addPlayer('warrior', 'HC', { state: { ...baseState, ...state } });
+  return { sim, pid };
+}
+
+describe('Hardcore mode', () => {
+  it('a hardcore character that dies becomes permanently deceased', () => {
+    const { sim, pid } = simWith({ hardcore: true });
+    const p = sim.entities.get(pid)!;
+    // Drive the death funnel with lethal self-damage (no source).
+    (sim as unknown as { dealDamage: (...a: unknown[]) => void }).dealDamage(
+      p, p, 99999, false, 'physical', null, 'hit',
+    );
+    expect(p.dead).toBe(true);
+
+    // Spirit release must NOT revive a deceased hardcore character.
+    sim.releaseSpirit(pid);
+    expect(sim.entities.get(pid)!.dead).toBe(true);
+
+    // The deceased flag persists across a serialize round-trip.
+    const saved = sim.serializeCharacter(pid)!;
+    expect(saved.hardcore).toBe(true);
+    expect(saved.deceased).toBe(true);
+  });
+
+  it('a normal character revives at the graveyard on spirit release', () => {
+    const { sim, pid } = simWith({ hardcore: false });
+    const p = sim.entities.get(pid)!;
+    (sim as unknown as { dealDamage: (...a: unknown[]) => void }).dealDamage(
+      p, p, 99999, false, 'physical', null, 'hit',
+    );
+    expect(p.dead).toBe(true);
+
+    sim.releaseSpirit(pid);
+    expect(sim.entities.get(pid)!.dead).toBe(false);
+  });
+
+  it('non-hardcore saves stay free of the hardcore/deceased keys', () => {
+    const { sim, pid } = simWith({ hardcore: false });
+    const saved = sim.serializeCharacter(pid)!;
+    expect(saved.hardcore).toBeUndefined();
+    expect(saved.deceased).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Hardcore mode — opt-in permadeath

Adds an optional **hardcore** character mode: a hardcore character that dies is permanently deceased and cannot return from the graveyard. Normal characters are entirely unaffected.

### What's here
- **`CharacterState.hardcore` / `deceased`** — additive JSONB fields (optional, back-compat). They round-trip through `serializeCharacter` ↔ `addPlayer`, and are written **only when set**, so every existing non-hardcore save stays byte-identical.
- **Opt-in at creation** — `POST /characters` accepts `{ hardcore: true }`, threaded through `initialCharacterState`. Hardcore is set once and never changes.
- **Permadeath rule** — on death, a hardcore character is flagged `deceased`; `releasePlayerSpirit` then no-ops for a deceased character, so its body stays dead instead of reviving at the graveyard. The death funnel and normal respawn are otherwise untouched.

### Tests
`tests/hardcore.test.ts`: a hardcore death locks out spirit release and round-trips the flags; a normal character still revives; non-hardcore saves carry neither key. All three parity gates (W0a/W0b/W0c) unchanged and green; client + server builds pass.

### Scope notes
- This PR is the **gameplay rule + persistence + creation opt-in**. Surfacing the hardcore badge / a distinct death screen on the client is a natural follow-up (no new IWorld member here, so the wire/parity surface is untouched).
