### PR TITLE
Stop duel auto attacks on stealthed opponents

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -48,13 +48,19 @@ import { blindMissBonus, isDisarmed, isStunned } from './cc';
 import { baseSwingSpeed } from './form_swing';
 import { applyThornsReaction } from './thorns_charge';
 
+function isHiddenStealthedDuelTarget(ctx: SimContext, attacker: Entity, target: Entity): boolean {
+  if (target.kind !== 'player' || !target.stealthed) return false;
+  const duel = ctx.duelFor(attacker.id);
+  return duel?.state === 'active' && (duel.a === target.id || duel.b === target.id);
+}
+
 export function startAutoAttack(ctx: SimContext, pid?: number): void {
   const r = ctx.resolve(pid);
   if (!r) return;
   const p = r.e;
   if (p.dead) return;
   const t = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
-  if (!t || t.dead || !ctx.isHostileTo(p, t)) {
+  if (!t || t.dead || !ctx.isHostileTo(p, t) || isHiddenStealthedDuelTarget(ctx, p, t)) {
     ctx.error(p.id, 'Invalid attack target.');
     return;
   }
@@ -90,7 +96,7 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
   p.swingTimer = Math.max(0, p.swingTimer - DT);
   if (!p.autoAttack || p.castingAbility) return;
   const t = p.targetId !== null ? ctx.entities.get(p.targetId) : null;
-  if (!t || t.dead || !ctx.isHostileTo(p, t)) {
+  if (!t || t.dead || !ctx.isHostileTo(p, t) || isHiddenStealthedDuelTarget(ctx, p, t)) {
     p.autoAttack = false;
     return;
   }

--- a/tests/duel.test.ts
+++ b/tests/duel.test.ts
@@ -1,14 +1,20 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import type { Aura, Entity } from '../src/sim/types';
+import type { Aura, Entity, PlayerClass } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
 }
 
+function mustEntity(sim: Sim, pid: number): Entity {
+  const e = sim.entities.get(pid);
+  if (!e) throw new Error(`missing entity ${pid}`);
+  return e;
+}
+
 function teleport(sim: Sim, pid: number, x: number, z: number) {
-  const e = sim.entities.get(pid)!;
+  const e = mustEntity(sim, pid);
   e.pos.x = x;
   e.pos.z = z;
   e.pos.y = groundHeight(x, z, sim.cfg.seed);
@@ -19,8 +25,8 @@ function teleport(sim: Sim, pid: number, x: number, z: number) {
 // Start an accepted duel between two adjacent players and run the countdown
 // out so the bout is live.
 function startedDuel(
-  aClass: 'warrior' | 'mage' | 'hunter' | 'warlock' = 'warrior',
-  bClass: 'warrior' | 'mage' | 'hunter' | 'warlock' = 'mage',
+  aClass: PlayerClass = 'warrior',
+  bClass: PlayerClass = 'mage',
 ): { sim: Sim; a: number; b: number } {
   const sim = makeWorld();
   const a = sim.addPlayer(aClass, 'Aleph', { autoEquip: true });
@@ -111,6 +117,41 @@ describe('duel: non-lethal cleanup', () => {
 });
 
 describe('duel: PvP combat affordances', () => {
+  it('stops auto-attacking a duel opponent who enters stealth', () => {
+    const { sim, a, b } = startedDuel('warrior', 'rogue');
+    const attacker = mustEntity(sim, a);
+    const rogue = mustEntity(sim, b);
+    sim.setPlayerLevel(10, b);
+    attacker.targetId = b;
+    attacker.facing = Math.atan2(rogue.pos.x - attacker.pos.x, rogue.pos.z - attacker.pos.z);
+
+    sim.startAutoAttack(a);
+    expect(attacker.autoAttack).toBe(true);
+
+    sim.castAbility('stealth', b);
+    expect(rogue.stealthed).toBe(true);
+    sim.tick();
+
+    expect(attacker.autoAttack).toBe(false);
+    const hpAfterStealth = rogue.hp;
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    expect(rogue.hp).toBe(hpAfterStealth);
+  });
+
+  it('rejects starting auto-attack against a stealthed duel opponent', () => {
+    const { sim, a, b } = startedDuel('warrior', 'rogue');
+    const attacker = mustEntity(sim, a);
+    const rogue = mustEntity(sim, b);
+    sim.setPlayerLevel(10, b);
+    sim.castAbility('stealth', b);
+    expect(rogue.stealthed).toBe(true);
+
+    attacker.targetId = b;
+    sim.startAutoAttack(a);
+
+    expect(attacker.autoAttack).toBe(false);
+  });
+
   it('lets a commanded pet attack an active duel opponent', () => {
     const { sim, a, b } = startedDuel('hunter', 'mage');
     const pet = givePet(sim, a);


### PR DESCRIPTION
## Summary

Stops player auto-attack from continuing against an active duel opponent who has entered stealth. The server already hides stealthed duel opponents from the hostile client, so the sim now also refuses to keep swinging at that hidden opponent.

This also rejects newly starting auto-attack against a stealthed active duel opponent and adds duel regression coverage for both paths.

## Related issues

Fixes #491.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\combat\auto_attack.ts tests\duel.test.ts`
  - `npx biome check --max-diagnostics=40 src\sim\combat\auto_attack.ts tests\duel.test.ts` (passes; existing warnings remain in `tests/duel.test.ts`)
  - `npx vitest run tests\duel.test.ts --config ..\work\vitest.node.config.ts`
  - `npx vitest run tests\interest.test.ts --config ..\work\vitest.node.server.config.ts`
  - `npx vitest run tests\pvp_safety.test.ts tests\combat_auto_attack.test.ts tests\attack_command.test.ts tests\targeting.test.ts --config ..\work\vitest.node.config.ts`
  - `npx vitest run tests\threat.test.ts tests\stealth_render.test.ts tests\sim.test.ts --config ..\work\vitest.node.config.ts`
  - `npm run check:ts`
  - `git diff --check`
- Manual steps:
  - N/A. This is a deterministic sim behavior change covered by regression tests.

`npm test -- tests\duel.test.ts` was also attempted through the project entry point. Inside the sandbox it failed before Vitest because esbuild could not read source directories. Outside the sandbox, generators completed, then Vitest stopped while loading `vite.config.ts` on the known release-branch `.browserslistrc` comment parsing issue: `Unsupported .browserslistrc entry ... # CSS engine floor ...`.

## Screenshots / recordings

N/A. This PR does not change UI/UX.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
