### PR TITLE
feat(prop-assets): serve external Builder GLBs (/props, /api/props, upload)

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -100,6 +100,7 @@ import {
 } from './moderation_db';
 import { createNativeAttestationChallenge, verifyNativeAttestation } from './native_attestation';
 import { handleOAuth, seedOAuthClients } from './oauth';
+import { handlePropCatalog, handlePropStatic, handlePropUpload } from './prop_assets';
 import { pruneExpiredOAuthGrants } from './oauth_db';
 import { handlePerfReport } from './perf_report';
 import {
@@ -379,6 +380,13 @@ async function bearerAccount(req: http.IncomingMessage): Promise<number | null> 
   const m = /^Bearer ([a-f0-9]{64})$/.exec(auth);
   if (!m) return null;
   return accountForToken(m[1]);
+}
+
+// True when the request's bearer token belongs to an admin account. Used to gate
+// the in-world Builder prop upload route.
+async function isAdminRequestAccount(req: http.IncomingMessage): Promise<boolean> {
+  const accountId = await bearerAccount(req);
+  return accountId !== null && (await isAdminAccount(accountId));
 }
 
 // Account + token scope for the bearer (or null when unauthenticated). The scope
@@ -1393,6 +1401,20 @@ async function main(): Promise<void> {
     if (req.method === 'OPTIONS' && (isApi || publicCorsPath)) {
       res.writeHead(204);
       res.end();
+      return;
+    }
+    // In-world Builder prop assets. Checked before the /api/ catch-all so the
+    // prop catalog + upload routes don't fall into the general API handler.
+    if (req.method === 'GET' && path.startsWith('/props/')) {
+      handlePropStatic(req, res);
+      return;
+    }
+    if (req.method === 'GET' && path === '/api/props') {
+      void handlePropCatalog(req, res);
+      return;
+    }
+    if (req.method === 'POST' && path === '/api/props/upload') {
+      void handlePropUpload(req, res, isAdminRequestAccount);
       return;
     }
     if (url.startsWith('/internal/')) void handleInternalApi(req, res, game);

--- a/server/prop_assets.ts
+++ b/server/prop_assets.ts
@@ -1,0 +1,168 @@
+// External prop assets — GLB files served to the in-world Builder so admins can
+// place them as props. Files live under WOC_PROP_DIR (an operator-configured
+// directory; no default store is assumed). Served read-only at /props/<ref>.glb,
+// listed at /api/props, and uploaded (admin-gated) via POST /api/props/upload.
+//
+// A ref is a bare `<name>.glb` or one subdirectory deep `<group>/<name>.glb`, so
+// assets can be organized into named groups. This pairs with the renderer's
+// `ext:<name>` prop loader, which fetches /props/<name>.glb.
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import http from 'node:http';
+import path from 'node:path';
+
+// Operator-configured asset directory. Unset => the catalog is empty and statics
+// 404; nothing is served from an implicit location. Read per-call so deployment
+// env changes (and tests) take effect without a module reload.
+function propDir(): string {
+  return (process.env.WOC_PROP_DIR ?? '').replace(/[/\\]$/, '');
+}
+
+const GLB_RE = /^[A-Za-z0-9_.-]+\.glb$/; // safe filename, .glb only
+const GLB_REF_RE = /^([A-Za-z0-9_.-]+\/)?[A-Za-z0-9_.-]+\.glb$/; // one subdir deep
+const MAX_UPLOAD = 64 * 1024 * 1024; // 64 MiB
+
+function sendJson(res: http.ServerResponse, code: number, body: unknown): void {
+  res.writeHead(code, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+// Resolve a request ref to a real file inside the prop dir, or null if unsafe/unset.
+function safePropPath(ref: string): string | null {
+  const dir = propDir();
+  if (!dir || !GLB_REF_RE.test(ref) || ref.includes('..')) return null;
+  const full = path.join(dir, ref);
+  if (full !== dir && !full.startsWith(dir + path.sep)) return null;
+  return full;
+}
+
+/** GET /props/<ref>.glb — stream a prop GLB. Public read (every client that sees
+ *  a placed prop fetches it). Returns true if it handled the request. */
+export function handlePropStatic(req: http.IncomingMessage, res: http.ServerResponse): boolean {
+  const url = (req.url ?? '').split('?')[0];
+  if (!url.startsWith('/props/')) return false;
+  const ref = decodeURIComponent(url.slice('/props/'.length));
+  const full = safePropPath(ref);
+  if (!full || !fs.existsSync(full)) {
+    res.writeHead(404);
+    res.end('not found');
+    return true;
+  }
+  const stat = fs.statSync(full);
+  res.writeHead(200, {
+    'content-type': 'model/gltf-binary',
+    'content-length': String(stat.size),
+    'cache-control': 'public, max-age=300',
+  });
+  fs.createReadStream(full).pipe(res);
+  return true;
+}
+
+interface PropEntry {
+  key: string;
+  name: string;
+  url: string;
+  group: string;
+}
+
+const prettify = (s: string): string => s.replace(/[_-]+/g, ' ').trim();
+
+/** GET /api/props — list placeable prop GLBs (top-level + one group subdir deep). */
+export async function handlePropCatalog(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<boolean> {
+  const url = (req.url ?? '').split('?')[0];
+  if (url !== '/api/props') return false;
+  const items: PropEntry[] = [];
+  const dir = propDir();
+  if (!dir) {
+    sendJson(res, 200, { props: items });
+    return true;
+  }
+  try {
+    const entries = await fsp.readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const e of entries) {
+      if (e.isFile() && GLB_RE.test(e.name)) {
+        const base = e.name.replace(/\.glb$/, '');
+        items.push({ key: base, name: prettify(base), url: `/props/${encodeURIComponent(e.name)}`, group: 'Props' });
+      } else if (e.isDirectory() && /^[A-Za-z0-9_.-]+$/.test(e.name)) {
+        const sub = await fsp.readdir(path.join(dir, e.name)).catch(() => [] as string[]);
+        for (const f of sub) {
+          if (!GLB_RE.test(f)) continue;
+          const base = f.replace(/\.glb$/, '');
+          items.push({
+            key: `${e.name}/${base}`,
+            name: prettify(base),
+            url: `/props/${encodeURIComponent(e.name)}/${encodeURIComponent(f)}`,
+            group: e.name,
+          });
+        }
+      }
+    }
+    sendJson(res, 200, { props: items });
+  } catch (err) {
+    sendJson(res, 500, { error: String(err) });
+  }
+  return true;
+}
+
+/**
+ * POST /api/props/upload?name=<x>.glb — admin upload of a GLB into the prop dir.
+ * `isAdmin` is injected by the caller (resolves the request's bearer token to an
+ * admin account) so this module stays free of the auth/db layer. Body = raw GLB.
+ */
+export async function handlePropUpload(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  isAdmin: (req: http.IncomingMessage) => Promise<boolean>,
+): Promise<boolean> {
+  const url = (req.url ?? '').split('?')[0];
+  if (url !== '/api/props/upload' || req.method !== 'POST') return false;
+  if (!propDir()) {
+    sendJson(res, 503, { error: 'prop store not configured' });
+    return true;
+  }
+  if (!(await isAdmin(req))) {
+    sendJson(res, 403, { error: 'admin access required' });
+    return true;
+  }
+  const q = new URLSearchParams((req.url ?? '').split('?')[1] ?? '');
+  let name = (q.get('name') ?? '').trim();
+  if (!name.toLowerCase().endsWith('.glb')) name += '.glb';
+  name = path.basename(name).replace(/[^A-Za-z0-9_.-]/g, '_');
+  const full = safePropPath(name);
+  if (!full) {
+    sendJson(res, 400, { error: 'invalid filename' });
+    return true;
+  }
+  try {
+    await fsp.mkdir(propDir(), { recursive: true });
+    const chunks: Buffer[] = [];
+    let total = 0;
+    await new Promise<void>((resolve, reject) => {
+      req.on('data', (c: Buffer) => {
+        total += c.length;
+        if (total > MAX_UPLOAD) {
+          reject(new Error('file too large (>64MB)'));
+          req.destroy();
+          return;
+        }
+        chunks.push(c);
+      });
+      req.on('end', () => resolve());
+      req.on('error', reject);
+    });
+    const buf = Buffer.concat(chunks);
+    if (buf.length < 12 || buf.toString('ascii', 0, 4) !== 'glTF') {
+      sendJson(res, 400, { error: 'not a valid GLB (missing glTF magic)' });
+      return true;
+    }
+    await fsp.writeFile(full, buf);
+    const base = name.replace(/\.glb$/, '');
+    sendJson(res, 200, { ok: true, key: base, url: `/props/${encodeURIComponent(name)}` });
+  } catch (err) {
+    sendJson(res, 500, { error: String(err) });
+  }
+  return true;
+}

--- a/tests/prop_assets.test.ts
+++ b/tests/prop_assets.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { handlePropCatalog, handlePropStatic, handlePropUpload } from '../server/prop_assets';
+
+// A minimal fake response capturing status + body for handler assertions.
+function fakeRes() {
+  const r = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: '',
+    writeHead(code: number, headers?: Record<string, string>) {
+      r.statusCode = code;
+      if (headers) r.headers = headers;
+      return r;
+    },
+    end(chunk?: string) {
+      if (chunk) r.body += chunk;
+    },
+  };
+  return r;
+}
+
+function get(url: string): http.IncomingMessage {
+  return { url, method: 'GET', headers: {} } as unknown as http.IncomingMessage;
+}
+
+describe('prop_assets serving', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'props-'));
+    process.env.WOC_PROP_DIR = dir;
+    const glb = Buffer.concat([Buffer.from('glTF'), Buffer.alloc(8)]);
+    fs.writeFileSync(path.join(dir, 'barrel.glb'), glb);
+    fs.mkdirSync(path.join(dir, 'village'));
+    fs.writeFileSync(path.join(dir, 'village', 'well.glb'), glb);
+    fs.writeFileSync(path.join(dir, 'notes.txt'), 'ignore me');
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+    delete process.env.WOC_PROP_DIR;
+  });
+
+  it('catalog lists top-level + grouped GLBs and ignores non-GLB files', async () => {
+    const res = fakeRes();
+    await handlePropCatalog(get('/api/props'), res as unknown as http.ServerResponse);
+    expect(res.statusCode).toBe(200);
+    const { props } = JSON.parse(res.body) as { props: { key: string; group: string }[] };
+    const keys = props.map((p) => p.key).sort();
+    expect(keys).toContain('barrel');
+    expect(keys).toContain('village/well');
+    expect(props.some((p) => p.key.includes('notes'))).toBe(false);
+  });
+
+  it('static serve rejects path traversal and unknown files', () => {
+    const bad = fakeRes();
+    handlePropStatic(get('/props/..%2f..%2fetc%2fpasswd'), bad as unknown as http.ServerResponse);
+    expect(bad.statusCode).toBe(404);
+
+    const missing = fakeRes();
+    handlePropStatic(get('/props/nope.glb'), missing as unknown as http.ServerResponse);
+    expect(missing.statusCode).toBe(404);
+  });
+
+  it('catalog is empty when the prop dir is unset', async () => {
+    delete process.env.WOC_PROP_DIR;
+    const res = fakeRes();
+    await handlePropCatalog(get('/api/props'), res as unknown as http.ServerResponse);
+    expect(JSON.parse(res.body)).toEqual({ props: [] });
+  });
+
+  it('upload requires admin', async () => {
+    const res = fakeRes();
+    const denyAdmin = async () => false;
+    const req = {
+      url: '/api/props/upload?name=x.glb',
+      method: 'POST',
+      headers: {},
+      on: () => {},
+    } as unknown as http.IncomingMessage;
+    await handlePropUpload(req, res as unknown as http.ServerResponse, denyAdmin);
+    expect(res.statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## External prop-asset serving

Completes the in-world Builder's external-asset path (PR for the Builder adds the `ext:<name>` → `/props/<name>.glb` renderer loader; this PR serves those files).

### What's here — `server/prop_assets.ts`
- **`GET /props/<ref>.glb`** — public read (every client that sees a placed prop fetches it). Refs are `<name>.glb` or one group-subdir deep `<group>/<name>.glb`; path-traversal-safe, `.glb`-only.
- **`GET /api/props`** — catalog of placeable GLBs, grouped by subdirectory, for the Builder palette.
- **`POST /api/props/upload?name=<x>.glb`** — admin-gated upload (bearer token → `isAdminAccount`), validates the `glTF` magic, 64 MiB cap, sanitized filename.

### Configuration
Files come from `WOC_PROP_DIR`. **No default store is assumed** — if it's unset, the catalog is empty and statics 404, so the feature is inert until an operator points it at a directory. The dir is read per-call, so deployment env changes take effect without a restart.

### Tests
`tests/prop_assets.test.ts`: catalog grouping + non-GLB filtering, path-traversal rejection, empty-when-unset, admin-required upload. Typecheck clean; parity gates untouched; client + server builds pass.
