### PR TITLE
fix(python): harden wow env IPC teardown

### DIFF
--- a/python/wow_env.py
+++ b/python/wow_env.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import subprocess
+import threading
+from collections import deque
 from typing import Any
 
 import numpy as np
@@ -39,10 +42,10 @@ class WoWClassicEnv(gym.Env):
     """Single-agent World of Claudecraft environment.
 
     Observation: float32 vector (self, abilities, target, nearby mobs,
-    nearest interactable, quest states). Action: Discrete(23) —
+    nearest interactable, quest states). Action: Discrete(23) --
     movement/turn/strafe/jump, targeting, attack, 10 ability slots,
     interact, stop, eat/drink. Sizes are content-dependent and queried
-    from the env's `info` cmd at startup — never hardcode them.
+    from the env's `info` cmd at startup -- never hardcode them.
     """
 
     metadata = {"render_modes": []}
@@ -57,6 +60,7 @@ class WoWClassicEnv(gym.Env):
         rewards: dict[str, float] | None = None,
         server_path: str | None = None,
         node_binary: str = "node",
+        request_timeout: float = 5.0,
     ) -> None:
         super().__init__()
         self.player_class = player_class
@@ -74,14 +78,19 @@ class WoWClassicEnv(gym.Env):
             raise FileNotFoundError(
                 f"env server bundle not found at {server}. Run `npm run build:env` first."
             )
+        self._request_timeout = request_timeout
+        self._closed = False
+        self._stdout_lines: queue.Queue[str | None] = queue.Queue()
+        self._stderr_tail: deque[str] = deque(maxlen=40)
         self._proc = subprocess.Popen(
             [node_binary, server],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
         )
+        self._start_pipe_readers()
         meta = self._request({"cmd": "info"})
         self._obs_size = int(meta["obs_size"])
         self.action_names: list[str] = list(meta["actions"])
@@ -90,14 +99,84 @@ class WoWClassicEnv(gym.Env):
         self._episode_seed = 0
 
     # ------------------------------------------------------------------
+    def _start_pipe_readers(self) -> None:
+        if self._proc.stdout is not None:
+            threading.Thread(
+                target=self._read_stdout,
+                args=(self._proc.stdout,),
+                name="woc-env-stdout",
+                daemon=True,
+            ).start()
+        if self._proc.stderr is not None:
+            threading.Thread(
+                target=self._read_stderr,
+                args=(self._proc.stderr,),
+                name="woc-env-stderr",
+                daemon=True,
+            ).start()
+
+    def _read_stdout(self, pipe) -> None:
+        try:
+            for line in pipe:
+                self._stdout_lines.put(line)
+        except (OSError, ValueError):
+            pass
+        finally:
+            self._stdout_lines.put(None)
+
+    def _read_stderr(self, pipe) -> None:
+        try:
+            for line in pipe:
+                text = line.rstrip()
+                if text:
+                    self._stderr_tail.append(text)
+        except (OSError, ValueError):
+            pass
+
+    def _stderr_summary(self) -> str:
+        if not self._stderr_tail:
+            return ""
+        return "\nLast env server stderr:\n" + "\n".join(self._stderr_tail)
+
+    def _write_message(self, msg: dict[str, Any]) -> None:
+        stdin = self._proc.stdin
+        if stdin is None:
+            raise RuntimeError("env server stdin is closed" + self._stderr_summary())
+        code = self._proc.poll()
+        if code is not None:
+            raise RuntimeError(f"env server exited with code {code}" + self._stderr_summary())
+        try:
+            stdin.write(json.dumps(msg) + "\n")
+            stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            code = self._proc.poll()
+            exited = f" exited with code {code}" if code is not None else ""
+            raise RuntimeError(f"env server pipe broke{exited}" + self._stderr_summary()) from e
+
     def _request(self, msg: dict[str, Any]) -> dict[str, Any]:
-        assert self._proc.stdin and self._proc.stdout
-        self._proc.stdin.write(json.dumps(msg) + "\n")
-        self._proc.stdin.flush()
-        line = self._proc.stdout.readline()
+        if self._closed:
+            raise RuntimeError("env is closed")
+        self._write_message(msg)
+        try:
+            line = self._stdout_lines.get(timeout=self._request_timeout)
+        except queue.Empty as e:
+            code = self._proc.poll()
+            if code is not None:
+                raise RuntimeError(
+                    f"env server exited with code {code}" + self._stderr_summary()
+                ) from e
+            raise TimeoutError(
+                f"env server did not respond within {self._request_timeout:.1f}s"
+                + self._stderr_summary()
+            ) from e
         if not line:
-            raise RuntimeError("env server died")
-        out = json.loads(line)
+            code = self._proc.poll()
+            exited = f" with code {code}" if code is not None else ""
+            raise RuntimeError(f"env server stdout closed{exited}" + self._stderr_summary())
+        try:
+            out = json.loads(line)
+        except json.JSONDecodeError as e:
+            raise RuntimeError(f"env server sent invalid JSON: {line.strip()}") from e
         if "error" in out:
             raise RuntimeError(f"env server error: {out['error']}")
         return out
@@ -126,12 +205,31 @@ class WoWClassicEnv(gym.Env):
         return obs, float(res["reward"]), bool(res["terminated"]), bool(res["truncated"]), res.get("info", {})
 
     def close(self):
-        if self._proc.poll() is None:
-            try:
-                self._request({"cmd": "close"})
-            except Exception:
-                self._proc.kill()
-        self._proc.wait(timeout=5)
+        if self._closed:
+            return
+        try:
+            if self._proc.poll() is None:
+                try:
+                    self._write_message({"cmd": "close"})
+                except Exception:
+                    pass
+                try:
+                    self._proc.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    self._proc.kill()
+                    try:
+                        self._proc.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        pass
+        finally:
+            self._closed = True
+            for pipe in (self._proc.stdin, self._proc.stdout, self._proc.stderr):
+                if pipe is None:
+                    continue
+                try:
+                    pipe.close()
+                except OSError:
+                    pass
 
 
 def make_env(**kwargs):

--- a/tests/python_wow_env_test.py
+++ b/tests/python_wow_env_test.py
@@ -1,0 +1,133 @@
+import os
+import queue
+import subprocess
+import sys
+import types
+import unittest
+from collections import deque
+
+
+class _Env:
+    def reset(self, *, seed=None):
+        return None
+
+
+class _Box:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class _Discrete:
+    def __init__(self, n):
+        self.n = n
+
+
+gymnasium = types.ModuleType("gymnasium")
+gymnasium.Env = _Env
+gymnasium.spaces = types.SimpleNamespace(Box=_Box, Discrete=_Discrete)
+sys.modules.setdefault("gymnasium", gymnasium)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "python"))
+from wow_env import WoWClassicEnv  # noqa: E402
+
+
+class _Pipe:
+    def __init__(self):
+        self.writes = []
+        self.closed = False
+
+    def write(self, text):
+        self.writes.append(text)
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class _Proc:
+    def __init__(self, poll_value=None, wait_error=None):
+        self.stdin = _Pipe()
+        self.stdout = _Pipe()
+        self.stderr = _Pipe()
+        self._poll_value = poll_value
+        self._wait_error = wait_error
+        self.killed = False
+        self.waits = 0
+
+    def poll(self):
+        return self._poll_value
+
+    def wait(self, timeout=None):
+        self.waits += 1
+        if self._wait_error is not None and self.waits == 1:
+            raise self._wait_error
+        self._poll_value = 0
+        return 0
+
+    def kill(self):
+        self.killed = True
+        self._poll_value = -9
+
+
+def env_for(proc):
+    env = WoWClassicEnv.__new__(WoWClassicEnv)
+    env._proc = proc
+    env._closed = False
+    env._request_timeout = 0.01
+    env._stdout_lines = queue.Queue()
+    env._stderr_tail = deque(maxlen=40)
+    return env
+
+
+class WoWEnvIpcTests(unittest.TestCase):
+    def test_request_times_out_with_stderr_tail_when_child_stays_alive(self):
+        proc = _Proc()
+        env = env_for(proc)
+        env._stderr_tail.append("sim exploded")
+
+        with self.assertRaises(TimeoutError) as ctx:
+            env._request({"cmd": "step", "action": 0})
+
+        self.assertIn("did not respond", str(ctx.exception))
+        self.assertIn("sim exploded", str(ctx.exception))
+        self.assertEqual(proc.stdin.writes, ['{"cmd": "step", "action": 0}\n'])
+
+    def test_request_reports_child_exit_before_writing(self):
+        proc = _Proc(poll_value=7)
+        env = env_for(proc)
+        env._stderr_tail.append("stack trace line")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            env._request({"cmd": "info"})
+
+        self.assertIn("exited with code 7", str(ctx.exception))
+        self.assertIn("stack trace line", str(ctx.exception))
+        self.assertEqual(proc.stdin.writes, [])
+
+    def test_close_does_not_block_on_request_and_kills_stuck_child(self):
+        proc = _Proc(wait_error=subprocess.TimeoutExpired("env", 5))
+        env = env_for(proc)
+
+        env.close()
+
+        self.assertEqual(proc.stdin.writes, ['{"cmd": "close"}\n'])
+        self.assertTrue(proc.killed)
+        self.assertTrue(proc.stdin.closed)
+        self.assertTrue(proc.stdout.closed)
+        self.assertTrue(proc.stderr.closed)
+
+    def test_close_is_idempotent(self):
+        proc = _Proc()
+        env = env_for(proc)
+
+        env.close()
+        env.close()
+
+        self.assertEqual(proc.waits, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Harden the Python `WoWClassicEnv` IPC path so the training wrapper no longer waits forever when the env server stops responding or exits before replying.

- Add a configurable request timeout and background stdout/stderr readers.
- Surface the env server's recent stderr in timeout, exit, and broken-pipe errors.
- Make `close()` idempotent and independent from the request/response path so teardown can kill a stuck child process and close pipes.
- Add Python regression tests for timeout, child-exit, and teardown behavior.

## Related issues

Fixes #150.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `python -m unittest discover -s tests -p "*wow_env_test.py"`
  - `python -m py_compile python\wow_env.py tests\python_wow_env_test.py`
  - `git diff --check`
  - `npm run build:env`
  - `python ..\work\wow_env_smoke.py`
  - `npx vitest run tests\env_protocol.test.ts --config ..\work\vitest.node.config.ts`
  - `npm run check:ts`
  - `npm test -- tests\env_protocol.test.ts` (blocked by existing release-branch `.browserslistrc` parser issue after pretest generation; see note below)
- Manual steps:
  - Ran the Python wrapper against the real built env server bundle; it returned observation shape `(276,)`, `44` available actions, first action `noop`, and closed cleanly.

Known release-branch blocker:

`npm test -- tests\env_protocol.test.ts` runs the pretest generators successfully, then Vitest fails while loading `vite.config.ts` because the release branch parser rejects the `.browserslistrc` comment line `# CSS engine floor (single source) for the Lightning CSS transformer.` The env protocol test itself passes through the direct Node Vitest config command listed above.

## Screenshots / recordings

N/A. This PR changes Python IPC and teardown behavior only; there is no UI/UX change.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
