### PR TITLE
fix(native): require full screen for iOS release

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -32,6 +32,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>

--- a/tests/native_orientation.test.ts
+++ b/tests/native_orientation.test.ts
@@ -13,6 +13,7 @@ describe('native mobile orientation', () => {
 
   it('allows only landscape orientations on iOS and iPadOS', () => {
     const plist = read('ios/App/App/Info.plist');
+    expect(plist).toMatch(/<key>UIRequiresFullScreen<\/key>\s*<true\/>/);
     const orientationBlocks = [
       plist.match(/<key>UISupportedInterfaceOrientations<\/key>\s*<array>([\s\S]*?)<\/array>/),
       plist.match(/<key>UISupportedInterfaceOrientations~ipad<\/key>\s*<array>([\s\S]*?)<\/array>/),


### PR DESCRIPTION
## Summary
- add UIRequiresFullScreen to the iOS plist so the landscape-only iPad build passes App Store orientation validation
- extend the native orientation guard test to require the full-screen plist key

## Test
- npx vitest run tests/native_orientation.test.ts