### PR TITLE
fix(ui): make mobile market scrollable

### DIFF
--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -884,25 +884,44 @@
   body.mobile-touch #vendor-window {
     max-height: calc(58vh - 20px);
   }
-  /* The Market carries a tab strip plus the filter selects, which stack to a tall
-     single column on mobile; the vendor's 58vh cap would leave the flex:1 listing
-     body (#market-body) zero height, so it collapsed and could not be scrolled.
-     Give the window the full available height (like #trade-window) so the listing
-     body keeps a usable, touch-scrollable height under the header. */
+  /* The Market carries a tab strip plus filter selects above its tab content. On
+     short landscape phones that header can consume most of the frame, so the
+     whole market window becomes the mobile scroll container. Desktop keeps the
+     nested #market-body scroller defined in components.css. */
   body.mobile-touch #market-window {
+    height: calc(100vh - 20px);
     max-height: calc(100vh - 20px);
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: auto;
+    touch-action: pan-y;
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior: contain;
   }
-  /* Floor the listing body so it keeps a usable, touch-scrollable height even when
-     the subtype filter adds a third stacked row on a short landscape screen. (On a
-     very short viewport the window's overflow:hidden can still clip below this floor,
-     but the body scrolls internally, so it never collapses to the old zero height.) */
+  @supports (height: 100dvh) {
+    body.mobile-touch #market-window {
+      height: calc(100dvh - 20px);
+      max-height: calc(100dvh - 20px);
+    }
+  }
   body.mobile-touch #market-body {
-    min-height: 96px;
+    flex: 0 0 auto;
+    min-height: auto;
+    overflow: visible;
   }
   body.mobile-touch .mkt-filters,
   body.mobile-touch .mkt-filters.has-subtype {
     grid-template-columns: 1fr;
+  }
+  body.mobile-touch .mkt-select.open .mkt-select-menu {
+    position: static;
+    width: auto;
+    margin-top: 4px;
+    max-height: min(236px, calc(100vh - 148px));
+  }
+  @supports (height: 100dvh) {
+    body.mobile-touch .mkt-select.open .mkt-select-menu {
+      max-height: min(236px, calc(100dvh - 148px));
+    }
   }
   body.mobile-touch .mkt-select-btn {
     min-height: 40px;

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -1218,14 +1218,17 @@ describe('client HTML shell', () => {
     expect(componentsCss).toContain(
       '.mkt-page {\n    display: flex;\n    align-items: center;\n    justify-content: space-between;',
     );
-    // On mobile the Market takes the full available height (not the vendor's 58vh
-    // cap) so its tall stacked-filter header cannot squeeze the listing body flat,
-    // and #market-body keeps a min-height floor; the window itself stays
-    // overflow:hidden so #market-body remains the single scroll container.
+    // On mobile the whole Market window scrolls, so stacked filters and long
+    // Browse/Sell/Collect content remain reachable on short landscape screens.
     expect(hudMobileCss).toContain(
-      'body.mobile-touch #market-window {\n    max-height: calc(100vh - 20px);\n    overflow: hidden;',
+      'body.mobile-touch #market-window {\n    height: calc(100vh - 20px);\n    max-height: calc(100vh - 20px);\n    overflow-x: hidden;\n    overflow-y: auto;',
     );
-    expect(hudMobileCss).toContain('body.mobile-touch #market-body {\n    min-height: 96px;');
+    expect(hudMobileCss).toContain(
+      'body.mobile-touch #market-body {\n    flex: 0 0 auto;\n    min-height: auto;\n    overflow: visible;',
+    );
+    expect(hudMobileCss).toContain(
+      'body.mobile-touch .mkt-select.open .mkt-select-menu {\n    position: static;',
+    );
     expect(marketWindowTs).toContain('buildMarketView'); // pagination + filtering delegated to the core
     expect(marketWindowTs).toContain('this.browsePage');
     expect(marketWindowTs).toContain('data-market-page="prev"');


### PR DESCRIPTION
## Summary

Fixes the mobile World Market overflow path so the full Browse, Sell, and Collect content can be reached on short landscape screens.

- Makes the whole mobile `#market-window` the touch scroll container instead of relying on the nested `#market-body` scroller.
- Keeps desktop unchanged: the desktop market still uses the existing `#market-body` internal scroll.
- Lets mobile `#market-body` grow naturally so long tab content contributes to the window scroll height.
- Makes open mobile filter menus render in-flow, so an expanded dropdown no longer floats off the bottom without increasing the scrollable area.
- Updates the client shell regression guard for the new mobile market scroll contract.

## Related issues

Fixes #1051.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests\client_shell.test.ts --config C:\Users\ianca\Documents\Codex\2026-06-30\so\work\vitest.node.config.ts`
    - 1 file passed, 65 tests passed.
  - `npx vitest run tests\client_shell.test.ts tests\market_window.test.ts tests\market_view.test.ts tests\market_filters.test.ts --config C:\Users\ianca\Documents\Codex\2026-06-30\so\work\vitest.node.config.ts`
    - 4 files passed, 99 tests passed.
  - `npx biome lint src\styles\hud.mobile.css tests\client_shell.test.ts`
    - Passed.
  - `npm run check:ts`
    - Passed.
  - `git diff --check`
    - Passed; Git only reported LF-to-CRLF working-copy warnings for the two edited files.
  - `node work\market-scroll-visual-check.mjs`
    - Passed using local Chrome against a fixture loaded with the real project CSS.
    - Verified `#market-window` computed `overflow-y: auto`, accepted scrolling, had `clientHeight=371` and `scrollHeight=2432`, `#market-body` computed `overflow-y: visible`, and the open mobile filter menu computed `position: static`.
  - `npm run build`
    - Blocked after generators/assets by a pre-existing release-branch `.browserslistrc` parser error: `Unsupported .browserslistrc entry (only "Browser >= X" floors are allowed): # CSS engine floor (single source) for the Lightning CSS transformer.`
    - Generated byproducts from the failed build were restored; this PR remains a two-file diff.
  - `npm run lint`
    - Blocked by existing repo-wide Biome diagnostics outside this change: 27 errors, 3905 warnings, 454 infos. Changed-file lint is documented above.
  - Attempted browser-only keyboard navigation test under the Node config:
    - `npx vitest run tests\client_shell.test.ts tests\market_window.test.ts tests\market_view.test.ts tests\market_filters.test.ts tests\browser\keyboard_nav.browser.test.ts --config C:\Users\ianca\Documents\Codex\2026-06-30\so\work\vitest.node.config.ts`
    - The market/shell files passed, but `tests\browser\keyboard_nav.browser.test.ts` failed because that file needs a browser/DOM harness and the Node config has no `document`.
- Manual/visual steps:
  - Rendered a mobile landscape market-window fixture at 852x393 with `body.mobile-touch`, the real `components.css`, and the real `hud.mobile.css`.
  - Included Browse filters, an open subtype dropdown, a search field, and 36 listing rows.
  - Programmatically scrolled the market window to prove the full window is now the scroll container.
  - Captured a local validation screenshot at `C:\Users\ianca\Documents\Codex\2026-06-30\so\work\pr-1051-mobile-market-scroll.png`.

## Screenshots / recordings

Before screenshot: see the issue report image in #1051.

After screenshot captured locally: `C:\Users\ianca\Documents\Codex\2026-06-30\so\work\pr-1051-mobile-market-scroll.png`.

I could not attach a GitHub-hosted image directly through the CLI from this environment, but the screenshot was captured during validation and the computed scroll metrics are listed above.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
