### PR TITLE
fix(sim): keep low-level mob spells threatening

### DIFF
--- a/src/sim/combat/spell_resist.ts
+++ b/src/sim/combat/spell_resist.ts
@@ -6,7 +6,7 @@
 // the player cast path (combat/casting_lifecycle.ts) and the pet ranged-spell
 // path (sim.ts) so both label the outcome the same way.
 
-import { spellHitChance } from '../types';
+import { MOB_VS_PLAYER_MAX_MISS, spellHitChance, type Entity } from '../types';
 
 // Probability in [0,1] that a target fully resists a spell from this caster.
 export function spellResistChance(casterLevel: number, targetLevel: number): number {
@@ -23,4 +23,22 @@ export function isSpellResisted(
   targetLevel: number,
 ): boolean {
   return !rng.chance(spellHitChance(casterLevel, targetLevel));
+}
+
+// Entity-aware spell hit for the shared mob/pet ranged-spell path. Player and
+// player-owned pets attacking higher-level mobs keep the full anti-power-level
+// penalty, but hostile wild mobs must still threaten higher-level players/pets.
+export function entitySpellHitChance(caster: Entity, target: Entity): number {
+  const hit = spellHitChance(caster.level, target.level);
+  const hostileWildMob = caster.kind === 'mob' && caster.hostile && caster.ownerId === null;
+  const playerSide = target.kind === 'player' || target.ownerId !== null;
+  return hostileWildMob && playerSide ? Math.max(hit, 1 - MOB_VS_PLAYER_MAX_MISS) : hit;
+}
+
+export function isEntitySpellResisted(
+  rng: { chance(p: number): boolean },
+  caster: Entity,
+  target: Entity,
+): boolean {
+  return !rng.chance(entitySpellHitChance(caster, target));
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -43,7 +43,7 @@ import {
   healingThreat as healingThreatImpl,
   hexOutputMult as hexOutputMultImpl,
 } from './combat/heal';
-import { isSpellResisted } from './combat/spell_resist';
+import { isEntitySpellResisted } from './combat/spell_resist';
 // A3: the augment/power-up content helpers used by the Fiesta match logic
 // (AUGMENTS_BY_ID/AugmentDef/eligibleAugments/POWERUPS/PowerupDef/tierForWave)
 // moved to social/fiesta.ts with that logic; sim.ts keeps only the type used by
@@ -3788,8 +3788,9 @@ export class Sim {
       school: spell.school,
       fx: 'projectile',
     });
-    // Pet spells are resisted, not missed (same semantics as player casts).
-    if (isSpellResisted(this.rng, pet.level, target.level)) {
+    // Mob/pet spells are resisted, not missed. Hostile wild mobs use the entity-aware
+    // helper so lower-level casters still threaten higher-level players and pets.
+    if (isEntitySpellResisted(this.rng, pet, target)) {
       this.emit({
         type: 'damage',
         sourceId: pet.id,

--- a/tests/spell_resist.test.ts
+++ b/tests/spell_resist.test.ts
@@ -6,15 +6,29 @@
 
 import { describe, expect, it } from 'vitest';
 import { castAbility, updateCasting } from '../src/sim/combat/casting_lifecycle';
-import { isSpellResisted, spellResistChance } from '../src/sim/combat/spell_resist';
+import {
+  entitySpellHitChance,
+  isEntitySpellResisted,
+  isSpellResisted,
+  spellResistChance,
+} from '../src/sim/combat/spell_resist';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
 import { advancePendingProjectiles } from '../src/sim/projectile_travel';
 import { Sim } from '../src/sim/sim';
-import { type Entity, type PlayerClass, spellHitChance } from '../src/sim/types';
+import {
+  MOB_VS_PLAYER_MAX_MISS,
+  type Entity,
+  type PlayerClass,
+  spellHitChance,
+} from '../src/sim/types';
 
 type AnySim = Sim & Record<string, any>;
 type AnyEntity = Entity & Record<string, any>;
+
+function entity(over: Partial<Entity>): Entity {
+  return { kind: 'mob', level: 1, hostile: true, ownerId: null, ...over } as unknown as Entity;
+}
 
 describe('spell_resist: pure leaf', () => {
   it('resist chance is the complement of spell-hit chance', () => {
@@ -39,6 +53,44 @@ describe('spell_resist: pure leaf', () => {
     expect(draws).toBe(1);
     expect(landed).toBe(false); // chance(hit)=true means NOT resisted
     expect(isSpellResisted({ chance: () => false }, 5, 5)).toBe(true);
+  });
+  it('caps hostile wild mob spell resists against higher-level players and pets', () => {
+    const mob = entity({ kind: 'mob', level: 1, hostile: true, ownerId: null });
+    const player = entity({ kind: 'player', level: 10, ownerId: null });
+    const pet = entity({ kind: 'mob', level: 10, ownerId: 99 });
+    const playerSideFloor = 1 - MOB_VS_PLAYER_MAX_MISS;
+
+    expect(spellHitChance(mob.level, player.level)).toBeLessThan(playerSideFloor);
+    expect(entitySpellHitChance(mob, player)).toBeCloseTo(playerSideFloor);
+    expect(entitySpellHitChance(mob, pet)).toBeCloseTo(playerSideFloor);
+  });
+
+  it('keeps the full spell penalty for player-owned pets attacking higher-level mobs', () => {
+    const pet = entity({ kind: 'mob', level: 1, hostile: false, ownerId: 99 });
+    const mob = entity({ kind: 'mob', level: 10, hostile: true, ownerId: null });
+
+    expect(entitySpellHitChance(pet, mob)).toBe(spellHitChance(pet.level, mob.level));
+    expect(entitySpellHitChance(pet, mob)).toBeLessThan(1 - MOB_VS_PLAYER_MAX_MISS);
+  });
+
+  it('isEntitySpellResisted draws from the entity-aware hit chance', () => {
+    const mob = entity({ kind: 'mob', level: 1, hostile: true, ownerId: null });
+    const player = entity({ kind: 'player', level: 10, ownerId: null });
+    let seen = 0;
+
+    expect(
+      isEntitySpellResisted(
+        {
+          chance: (p) => {
+            seen = p;
+            return true;
+          },
+        },
+        mob,
+        player,
+      ),
+    ).toBe(false);
+    expect(seen).toBeCloseTo(1 - MOB_VS_PLAYER_MAX_MISS);
   });
 });
 
@@ -109,5 +161,76 @@ describe('spell_resist: cast outcome labeling', () => {
     const dmg = events.filter((e) => e.type === 'damage' && e.targetId === mob.id);
     expect(dmg.some((e) => e.kind === 'miss')).toBe(true);
     expect(dmg.some((e) => e.kind === 'resist')).toBe(false);
+  });
+});
+
+describe('spell_resist: hostile mob spell floor', () => {
+  function rangedCaster(level: number, id: number): AnyEntity {
+    const mob = createMob(id, MOBS.forest_wolf, level, { x: 0, y: 0, z: 0 }) as AnyEntity;
+    mob.hostile = true;
+    mob.ownerId = null;
+    mob.swingTimer = 0;
+    return mob;
+  }
+
+  function ownedPet(level: number, ownerId: number, id: number): AnyEntity {
+    const pet = createMob(id, MOBS.forest_wolf, level, { x: 0, y: 0, z: 0 }) as AnyEntity;
+    pet.hostile = false;
+    pet.ownerId = ownerId;
+    pet.maxHp = 1000;
+    pet.hp = 1000;
+    return pet;
+  }
+
+  it('lets a low-level hostile caster mob land spells on a higher-level player', () => {
+    const { sim, p } = makeSim('mage', 20);
+    const caster = rangedCaster(1, 900700);
+    sim.addEntity(caster);
+    p.maxHp = 1000;
+    p.hp = 1000;
+    let seenHitChance = 0;
+    sim.rng.chance = (chance: number) => {
+      seenHitChance = chance;
+      return chance >= 1 - MOB_VS_PLAYER_MAX_MISS;
+    };
+    sim.rng.range = () => 12;
+
+    sim.ctx.updateRangedPetAttack(caster, p, {
+      name: 'Test Bolt',
+      school: 'shadow',
+      min: 8,
+      max: 10,
+      range: 30,
+      every: 2,
+    });
+
+    expect(seenHitChance).toBeCloseTo(1 - MOB_VS_PLAYER_MAX_MISS);
+    expect(p.hp).toBeLessThan(1000);
+  });
+
+  it('also lets low-level hostile caster mobs threaten player-owned pets', () => {
+    const { sim } = makeSim('hunter', 20);
+    const caster = rangedCaster(1, 900701);
+    const pet = ownedPet(20, sim.playerId, 900702);
+    sim.addEntity(caster);
+    sim.addEntity(pet);
+    let seenHitChance = 0;
+    sim.rng.chance = (chance: number) => {
+      seenHitChance = chance;
+      return chance >= 1 - MOB_VS_PLAYER_MAX_MISS;
+    };
+    sim.rng.range = () => 12;
+
+    sim.ctx.updateRangedPetAttack(caster, pet, {
+      name: 'Test Bolt',
+      school: 'shadow',
+      min: 8,
+      max: 10,
+      range: 30,
+      every: 2,
+    });
+
+    expect(seenHitChance).toBeCloseTo(1 - MOB_VS_PLAYER_MAX_MISS);
+    expect(pet.hp).toBeLessThan(1000);
   });
 });


### PR DESCRIPTION
## Summary

Fixes the ranged spell side of the low-level mob threat floor. Hostile wild mobs now use an entity-aware spell hit helper when casting mob/pet ranged spells at players or player-owned pets, so they keep a meaningful chance to land spells against higher-level player-side targets.

Player-owned pets attacking higher-level mobs still use the full upward level penalty, preserving the anti-power-leveling behavior called out in the issue.

## Related issues

Fixes #1050.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests\spell_resist.test.ts tests\mob_hit_floor.test.ts --config C:\Users\ianca\Documents\Codex\2026-06-30\so\work\vitest.node.config.ts` - 2 files / 14 tests passed.
  - `npx vitest run tests\spell_resist.test.ts tests\mob_hit_floor.test.ts tests\threat.test.ts tests\warlock_pets.test.ts tests\mob_swing.test.ts tests\weakening_hex.test.ts tests\mob_vulnerability.test.ts tests\mob_chill.test.ts --config C:\Users\ianca\Documents\Codex\2026-06-30\so\work\vitest.node.config.ts` - 8 files / 107 tests passed.
  - `npm run check:ts` - passed.
  - `npx biome lint src\sim\combat\spell_resist.ts src\sim\sim.ts tests\spell_resist.test.ts` - passed with existing warnings in `src/sim/sim.ts` and existing `tests/spell_resist.test.ts` test helpers.
  - `git diff --check` - passed, with Git's CRLF normalization warnings only.
  - `npm run lint` - fails on existing repo-wide Biome diagnostics outside this change (`27 errors`, `3905 warnings`, `454 infos`; first examples are in `headless/env_server.ts`, `scripts/*.mjs`, and `mediawiki/theme/Common.css`).
  - `npm run build` - after rerunning outside the sandbox, generators complete but `vite build` fails on the existing `.browserslistrc` parser issue: `Unsupported .browserslistrc entry (only "Browser >= X" floors are allowed): # CSS engine floor (single source) for the Lightning CSS transformer.`
- Manual steps:
  - Reviewed the ranged mob/pet spell path and confirmed the fix only floors hostile wild mob casts against player-side targets.
  - Confirmed player-owned pets attacking higher-level mobs retain the original lower spell-hit chance.

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
