### PR TITLE
fix(ui): flip High-Contrast Text halo to match panel lightness

### DIFF
--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -2423,16 +2423,19 @@
   body.compact-chat #chatlog-frame {
     height: 120px;
   }
-  /* High-Contrast Text, thicker dark outline behind HUD labels. */
+  /* High-Contrast Text, thicker outline behind HUD labels. The outline color
+     (--text-outline-color) is theme-aware: it sits on the opposite side of the
+     panel's lightness from the body text, so it sharpens the glyph edge
+     instead of blurring into it on light panels like Parchment. */
   body.high-contrast-text .chat-pane div,
   body.high-contrast-text .panel,
   body.high-contrast-text .set-name,
   body.high-contrast-text .tt-stat,
   body.high-contrast-text .tt-desc {
     text-shadow:
-      0 0 2px #000,
-      1px 1px 2px #000,
-      -1px -1px 2px #000;
+      0 0 2px var(--text-outline-color, #000),
+      1px 1px 2px var(--text-outline-color, #000),
+      -1px -1px 2px var(--text-outline-color, #000);
   }
   /* Reduce Motion, drop HUD animations/transitions (mirrors prefers-reduced-motion). */
   body.reduce-motion .fct {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -65,6 +65,7 @@
     --color-gold: var(--gold);
     --color-accent: var(--gold);
     --color-text-overlay: #f4eede;
+    --text-outline-color: #000000;
     --panel-edge: #08080d;
     --color-text-error: #ff8f85;
     --color-text-success: #7fdc4f;

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -35,13 +35,28 @@ export interface ThemeState {
 
 // Order is the display order of the custom-colour pickers in Options.
 export const THEME_KNOB_ORDER: ThemeKnob[] = [
-  'accent', 'border', 'panel', 'text', 'textMuted', 'hp', 'mana', 'rage', 'energy',
+  'accent',
+  'border',
+  'panel',
+  'text',
+  'textMuted',
+  'hp',
+  'mana',
+  'rage',
+  'energy',
 ];
 
 // i18n sub-keys (under hudChrome.theme.knob.*) for each knob's label.
 export const THEME_KNOB_LABEL_KEY: Record<ThemeKnob, string> = {
-  accent: 'accent', border: 'border', panel: 'panel', text: 'text',
-  textMuted: 'textMuted', hp: 'hp', mana: 'mana', rage: 'rage', energy: 'energy',
+  accent: 'accent',
+  border: 'border',
+  panel: 'panel',
+  text: 'text',
+  textMuted: 'textMuted',
+  hp: 'hp',
+  mana: 'mana',
+  rage: 'rage',
+  energy: 'energy',
 };
 
 export const PRESET_ORDER: PresetId[] = ['classic', 'midnight', 'parchment', 'highContrast'];
@@ -49,24 +64,48 @@ export const PRESET_ORDER: PresetId[] = ['classic', 'midnight', 'parchment', 'hi
 // `classic` reproduces the shipped gold/dark palette; the others are alternates.
 export const THEME_PRESETS: Record<PresetId, ThemeKnobs> = {
   classic: {
-    accent: '#ffd100', border: '#6f5a2a', panel: '#15151f',
-    text: '#f0ebd8', textMuted: '#998d6a',
-    hp: '#1eb838', mana: '#2b7bd4', rage: '#c0392b', energy: '#e4c531',
+    accent: '#ffd100',
+    border: '#6f5a2a',
+    panel: '#15151f',
+    text: '#f0ebd8',
+    textMuted: '#998d6a',
+    hp: '#1eb838',
+    mana: '#2b7bd4',
+    rage: '#c0392b',
+    energy: '#e4c531',
   },
   midnight: {
-    accent: '#8fb8e8', border: '#3a4a66', panel: '#0e1420',
-    text: '#dce6f2', textMuted: '#7f8ca3',
-    hp: '#2ec27e', mana: '#4a90d9', rage: '#d96459', energy: '#e0c84f',
+    accent: '#8fb8e8',
+    border: '#3a4a66',
+    panel: '#0e1420',
+    text: '#dce6f2',
+    textMuted: '#7f8ca3',
+    hp: '#2ec27e',
+    mana: '#4a90d9',
+    rage: '#d96459',
+    energy: '#e0c84f',
   },
   parchment: {
-    accent: '#8a5a1a', border: '#b89a5e', panel: '#ece0c4',
-    text: '#2e2410', textMuted: '#6b5d3e',
-    hp: '#2f8f3a', mana: '#2f6fb0', rage: '#b03a2e', energy: '#a8801f',
+    accent: '#8a5a1a',
+    border: '#b89a5e',
+    panel: '#ece0c4',
+    text: '#2e2410',
+    textMuted: '#6b5d3e',
+    hp: '#2f8f3a',
+    mana: '#2f6fb0',
+    rage: '#b03a2e',
+    energy: '#a8801f',
   },
   highContrast: {
-    accent: '#ffe000', border: '#ffffff', panel: '#000000',
-    text: '#ffffff', textMuted: '#d0d0d0',
-    hp: '#00e000', mana: '#00b0ff', rage: '#ff3030', energy: '#ffe000',
+    accent: '#ffe000',
+    border: '#ffffff',
+    panel: '#000000',
+    text: '#ffffff',
+    textMuted: '#d0d0d0',
+    hp: '#00e000',
+    mana: '#00b0ff',
+    rage: '#ff3030',
+    energy: '#ffe000',
   },
 };
 
@@ -110,7 +149,7 @@ export function mixHex(hex: string, target: string, t: number): string {
 
 function srgbChannel(c: number): number {
   const cs = c / 255;
-  return cs <= 0.03928 ? cs / 12.92 : Math.pow((cs + 0.055) / 1.055, 2.4);
+  return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
 }
 
 /** WCAG relative luminance in [0,1] for a #rrggbb colour. Pure. */
@@ -203,6 +242,12 @@ export function themeCssVars(knobs: ThemeKnobs): Record<string, string> {
   // Overlay text sits over the 3D world (quest tracker), NOT a panel, so it must
   // stay light regardless of preset and lean on its text-shadow for contrast.
   const overlayText = '#f4eede';
+  // High-Contrast Text draws a halo behind HUD labels via text-shadow. A dark
+  // halo sharpens light text against a dark panel, but on a light panel
+  // (Parchment) the body text is already dark, so a dark halo just blurs into
+  // the glyph instead of separating it. The halo needs to sit on the opposite
+  // side of the panel's lightness from the text, so flip it light there.
+  const textOutline = lightPanel ? '#ffffff' : '#000000';
   return {
     '--gold': accent,
     '--gold-dim': accentDim,
@@ -220,6 +265,7 @@ export function themeCssVars(knobs: ThemeKnobs): Record<string, string> {
     '--color-text-light': text,
     '--color-text-muted': textMuted,
     '--color-text-overlay': overlayText,
+    '--text-outline-color': textOutline,
     '--scrollbar-thumb': mixHex(border, '#000000', 0.15),
     '--scrollbar-thumb-hover': border,
     '--scrollbar-border': border,
@@ -264,21 +310,36 @@ export class ThemeStore {
 
   constructor() {
     let raw: unknown = null;
-    try { raw = JSON.parse(localStorage.getItem(THEME_STORE_KEY) ?? 'null'); } catch { /* corrupt */ }
+    try {
+      raw = JSON.parse(localStorage.getItem(THEME_STORE_KEY) ?? 'null');
+    } catch {
+      /* corrupt */
+    }
     this.state = parseTheme(raw);
   }
 
-  get(): ThemeState { return { preset: this.state.preset, custom: { ...this.state.custom } }; }
+  get(): ThemeState {
+    return { preset: this.state.preset, custom: { ...this.state.custom } };
+  }
 
   /** Effective CSS variable map for the current state. */
-  cssVars(): Record<string, string> { return themeCssVars(resolveTheme(this.state)); }
+  cssVars(): Record<string, string> {
+    return themeCssVars(resolveTheme(this.state));
+  }
 
   private save(): void {
-    try { localStorage.setItem(THEME_STORE_KEY, serializeTheme(this.state)); } catch { /* unavailable */ }
+    try {
+      localStorage.setItem(THEME_STORE_KEY, serializeTheme(this.state));
+    } catch {
+      /* unavailable */
+    }
   }
 
   setPreset(preset: PresetId): void {
-    if (PRESET_ORDER.includes(preset)) { this.state.preset = preset; this.save(); }
+    if (PRESET_ORDER.includes(preset)) {
+      this.state.preset = preset;
+      this.save();
+    }
   }
 
   /** Set or (with null) clear one custom knob override. */
@@ -289,5 +350,8 @@ export class ThemeStore {
   }
 
   /** Drop all custom overrides, falling back to the bare preset. */
-  resetCustom(): void { this.state.custom = {}; this.save(); }
+  resetCustom(): void {
+    this.state.custom = {};
+    this.save();
+  }
 }

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import {
-  DEFAULT_THEME,
-  PRESET_ORDER,
-  THEME_KNOB_ORDER,
-  THEME_PRESETS,
   contrastRatio,
+  DEFAULT_THEME,
   ensureReadable,
   isValidHex,
   mixHex,
+  PRESET_ORDER,
   parseTheme,
   relativeLuminance,
   resolveTheme,
   rgba,
   serializeTheme,
+  THEME_KNOB_ORDER,
+  THEME_PRESETS,
   themeCssVars,
 } from '../src/ui/theme';
 
@@ -22,7 +22,7 @@ function wcagContrast(a: string, b: string): number {
   const lum = (hex: string) => {
     const ch = (i: number) => {
       const cs = parseInt(hex.slice(i, i + 2), 16) / 255;
-      return cs <= 0.03928 ? cs / 12.92 : Math.pow((cs + 0.055) / 1.055, 2.4);
+      return cs <= 0.03928 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
     };
     return 0.2126 * ch(1) + 0.7152 * ch(3) + 0.0722 * ch(5);
   };
@@ -104,6 +104,18 @@ describe('theme pure core', () => {
     }
   });
 
+  it('High-Contrast Text outline flips to the opposite side of the panel lightness', () => {
+    for (const id of PRESET_ORDER) {
+      const vars = themeCssVars(resolveTheme({ preset: id, custom: {} }));
+      const panelIsLight = relativeLuminance(vars['--panel-base']) > 0.4;
+      const outlineIsLight = relativeLuminance(vars['--text-outline-color']) > 0.4;
+      // A light panel (Parchment) has dark body text, so the halo must be light
+      // to separate from the glyph instead of blurring into it; a dark panel is
+      // the reverse. Regression test for issue #1081.
+      expect(outlineIsLight, `${id} outline vs panel`).toBe(panelIsLight);
+    }
+  });
+
   it('overlay text token stays light regardless of preset (it floats over the world)', () => {
     for (const id of PRESET_ORDER) {
       const vars = themeCssVars(resolveTheme({ preset: id, custom: {} }));
@@ -114,7 +126,10 @@ describe('theme pure core', () => {
   });
 
   it('custom-override guard repairs a white-on-white text/panel pair', () => {
-    const knobs = resolveTheme({ preset: 'classic', custom: { text: '#ffffff', panel: '#ffffff' } });
+    const knobs = resolveTheme({
+      preset: 'classic',
+      custom: { text: '#ffffff', panel: '#ffffff' },
+    });
     expect(knobs.panel).toBe('#ffffff');
     // text must have been pulled away from white to clear AA on the white panel.
     expect(knobs.text).not.toBe('#ffffff');
@@ -122,7 +137,10 @@ describe('theme pure core', () => {
   });
 
   it('custom-override guard repairs black-on-black too', () => {
-    const knobs = resolveTheme({ preset: 'midnight', custom: { text: '#000000', panel: '#000000' } });
+    const knobs = resolveTheme({
+      preset: 'midnight',
+      custom: { text: '#000000', panel: '#000000' },
+    });
     expect(wcagContrast(knobs.text, knobs.panel)).toBeGreaterThanOrEqual(4.5);
   });
 


### PR DESCRIPTION
## Problem

Fixes #1081. With the Parchment UI theme selected, turning on High-Contrast
Text made body text look blurry instead of sharper.

## Root cause

```mermaid
flowchart LR
  A[body.high-contrast-text rule] -->|text-shadow, 3 black layers| B[HUD label text]
  B --> C{Panel lightness}
  C -->|dark panel: classic/midnight/highContrast| D[light text + black halo\nsharpens edge, good]
  C -->|light panel: parchment| E[dark text + black halo\nhalo blends into glyph, blurs]
```

`src/styles/hud.css` hard-coded a black `text-shadow` halo for the
`high-contrast-text` body class. That sharpens light-on-dark text (Classic,
Midnight, High Contrast presets), but Parchment is a light panel with dark
body text (`src/ui/theme.ts` THEME_PRESETS.parchment: panel `#ece0c4`, text
`#2e2410`), so a black halo behind already-dark glyphs just smears rather
than separating from the background.

## Fix

- `src/ui/theme.ts`: `themeCssVars` now derives `--text-outline-color`
  (white on a light panel, black on a dark panel) alongside the existing
  `isLightPanel` check already used for the accent-contrast repair.
- `src/styles/tokens.css`: seed a `:root` default (`#000000`) for the new
  token.
- `src/styles/hud.css`: the `high-contrast-text` rule now reads
  `var(--text-outline-color, #000)` instead of a literal `#000`.
- `tests/theme.test.ts`: added a regression test asserting the outline
  flips to the opposite lightness of the panel for every preset.

## Scope

Only the High-Contrast Text styling and its interaction with the theme
panel token. No change to theme knobs, presets, or any gameplay-affecting
state; this is a pure cosmetic legibility fix, consistent with the root
CLAUDE.md rule that graphics/accessibility settings must stay
gameplay-neutral.

## Test plan

- [x] `npx tsc --noEmit`
- [x] `npx vitest run tests/theme.test.ts` (14 passed, including the new
      regression test)
- [x] `npx vitest run tests/client_shell.test.ts`
- [x] `npx @biomejs/biome check --write` on all changed files
- [ ] Manual verification: enable Parchment + High-Contrast Text in a live
      browser and confirm crisp text (attempted via a headless Puppeteer
      repro script in this sandboxed environment, but the offline-world
      bootstrap timed out before it could capture a screenshot; the CSS/
      token change is otherwise covered by the new unit test)

Not merging; opening for CI + review.