### PR TITLE
fix(server): add global inbound WebSocket message rate limit

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -75,6 +75,7 @@ import {
   recordInGameAction,
 } from './moderation_db';
 import { type ModerationHost, ModerationService } from './moderation_service';
+import { consumeMsgToken, createMsgRateBucket, type MsgRateBucketState } from './msg_rate_limit';
 import { nextRaidResetMs } from './raid_reset';
 import { REALM, REALM_PUBLIC_ORIGIN, REALM_RESET_TIME_ZONE } from './realm';
 import { createSerialWriter } from './serial_writer';
@@ -330,6 +331,10 @@ export interface ClientSession {
   chatLastRateError: number;
   chatRateViolations: number;
   chatCooldownUntil: number;
+  // Global inbound-message token bucket (#978): covers every frame (input,
+  // cast, cmd, ...), separate from the chat-only bucket above, so a client
+  // flooding non-chat frames is throttled/kicked instead of processed unconditionally.
+  msgRate: MsgRateBucketState;
   chatMutedUntil: number | null;
   chatMuteReason: string;
   // Hard-word enforcement strike count driving the mute ladder. Account-scoped:
@@ -1468,6 +1473,7 @@ export class GameServer {
       chatLastRateError: 0,
       chatRateViolations: 0,
       chatCooldownUntil: 0,
+      msgRate: createMsgRateBucket(Date.now() / 1000),
       chatMutedUntil: meta.mutedUntil ? new Date(meta.mutedUntil).getTime() : null,
       chatMuteReason: meta.reason ?? '',
       chatStrikes: meta.chatStrikes ?? 0,
@@ -2092,6 +2098,12 @@ export class GameServer {
 
   handleMessage(session: ClientSession, raw: string): void {
     const receivedAtMs = Date.now();
+    const verdict = consumeMsgToken(session.msgRate, receivedAtMs / 1000);
+    if (verdict === 'kick') {
+      void this.kickSession(session, 'rejected by server', 'moderation action');
+      return;
+    }
+    if (verdict === 'drop') return;
     let msg: unknown;
     try {
       msg = JSON.parse(raw);

--- a/server/msg_rate_limit.ts
+++ b/server/msg_rate_limit.ts
@@ -1,0 +1,47 @@
+// Global per-connection inbound WebSocket message rate limit (#978).
+//
+// Only chat had a token bucket (CHAT_RATE_BURST/CHAT_RATE_REFILL_PER_SECOND in
+// game.ts); every other inbound frame (input, cast, cmd, ...) was processed
+// unconditionally, so a client flooding non-chat frames burns server CPU with
+// no throttle or disconnect. This is a SEPARATE, more generous bucket that
+// covers ALL inbound messages so it never throttles legitimate 20 Hz movement
+// input, only genuine floods well above normal traffic.
+//
+// Pure state + functions (no ClientSession/WebSocket import) so the bucket
+// math is unit-testable without a live server.
+
+// Legitimate traffic is at most ~20 input frames/sec plus occasional cast/cmd
+// frames. Burst covers a reconnect catch-up spike; refill comfortably clears
+// that burst while capping sustained throughput well above 20 Hz.
+export const MSG_RATE_BURST = 60;
+export const MSG_RATE_REFILL_PER_SECOND = 40;
+// Consecutive over-budget frames (each already dropped) before the connection
+// is kicked outright, mirroring the chat cooldown-then-kick ladder.
+export const MSG_RATE_VIOLATIONS_FOR_KICK = 200;
+
+export interface MsgRateBucketState {
+  tokens: number;
+  lastRefillSec: number;
+  violations: number;
+}
+
+export function createMsgRateBucket(nowSec: number): MsgRateBucketState {
+  return { tokens: MSG_RATE_BURST, lastRefillSec: nowSec, violations: 0 };
+}
+
+export type MsgRateVerdict = 'allow' | 'drop' | 'kick';
+
+/** Mutates `state` in place and returns whether this message should be processed. */
+export function consumeMsgToken(state: MsgRateBucketState, nowSec: number): MsgRateVerdict {
+  const elapsed = Math.max(0, nowSec - state.lastRefillSec);
+  state.tokens = Math.min(MSG_RATE_BURST, state.tokens + elapsed * MSG_RATE_REFILL_PER_SECOND);
+  state.lastRefillSec = nowSec;
+  if (state.tokens >= 1) {
+    state.tokens -= 1;
+    state.violations = 0;
+    return 'allow';
+  }
+  state.violations++;
+  if (state.violations >= MSG_RATE_VIOLATIONS_FOR_KICK) return 'kick';
+  return 'drop';
+}

--- a/tests/msg_rate_limit.test.ts
+++ b/tests/msg_rate_limit.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  consumeMsgToken,
+  createMsgRateBucket,
+  MSG_RATE_BURST,
+  MSG_RATE_REFILL_PER_SECOND,
+  MSG_RATE_VIOLATIONS_FOR_KICK,
+} from '../server/msg_rate_limit';
+
+describe('msg_rate_limit', () => {
+  it('allows a fresh bucket to spend its full burst', () => {
+    const state = createMsgRateBucket(0);
+    for (let i = 0; i < MSG_RATE_BURST; i++) {
+      expect(consumeMsgToken(state, 0)).toBe('allow');
+    }
+    // burst exhausted, no time elapsed to refill
+    expect(consumeMsgToken(state, 0)).toBe('drop');
+  });
+
+  it('never throttles a sustained legitimate 20 Hz input stream', () => {
+    const state = createMsgRateBucket(0);
+    let now = 0;
+    // drain the initial burst first, as a real connection eventually would
+    for (let i = 0; i < MSG_RATE_BURST; i++) consumeMsgToken(state, now);
+    // steady 20 Hz traffic for 5 simulated seconds
+    for (let i = 0; i < 20 * 5; i++) {
+      now += 1 / 20;
+      expect(consumeMsgToken(state, now)).toBe('allow');
+    }
+  });
+
+  it('refills over time up to the burst cap', () => {
+    const state = createMsgRateBucket(0);
+    for (let i = 0; i < MSG_RATE_BURST; i++) consumeMsgToken(state, 0);
+    expect(consumeMsgToken(state, 0)).toBe('drop');
+    // enough elapsed time to fully refill
+    const later = MSG_RATE_BURST / MSG_RATE_REFILL_PER_SECOND;
+    expect(consumeMsgToken(state, later)).toBe('allow');
+    expect(state.tokens).toBeLessThanOrEqual(MSG_RATE_BURST);
+  });
+
+  it('drops messages once the bucket is empty and no time has passed', () => {
+    const state = createMsgRateBucket(0);
+    for (let i = 0; i < MSG_RATE_BURST; i++) consumeMsgToken(state, 0);
+    for (let i = 0; i < 10; i++) {
+      expect(consumeMsgToken(state, 0)).toBe('drop');
+    }
+  });
+
+  it('kicks a connection that keeps flooding after being dropped', () => {
+    const state = createMsgRateBucket(0);
+    for (let i = 0; i < MSG_RATE_BURST; i++) consumeMsgToken(state, 0);
+    let verdict = 'drop';
+    for (let i = 0; i < MSG_RATE_VIOLATIONS_FOR_KICK; i++) {
+      verdict = consumeMsgToken(state, 0);
+    }
+    expect(verdict).toBe('kick');
+  });
+
+  it('resets the violation counter once a message is allowed again', () => {
+    const state = createMsgRateBucket(0);
+    for (let i = 0; i < MSG_RATE_BURST; i++) consumeMsgToken(state, 0);
+    for (let i = 0; i < MSG_RATE_VIOLATIONS_FOR_KICK - 1; i++) {
+      expect(consumeMsgToken(state, 0)).toBe('drop');
+    }
+    expect(state.violations).toBe(MSG_RATE_VIOLATIONS_FOR_KICK - 1);
+    // enough time passes for one token to refill, resetting the ladder
+    const oneToken = 1 / MSG_RATE_REFILL_PER_SECOND;
+    expect(consumeMsgToken(state, oneToken)).toBe('allow');
+    expect(state.violations).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #978. Only chat had a token bucket (`CHAT_RATE_BURST`/`CHAT_RATE_REFILL_PER_SECOND` in `game.ts`); every other inbound WS frame (`input`, `cast`, `cmd`, ...) was processed unconditionally, so a client flooding non-chat frames caused CPU/DoS pressure with no throttle or disconnect (no state corruption, since GCD/cooldowns still gate actions server-side).

- New pure module `server/msg_rate_limit.ts`: a per-connection token bucket (burst 60, refill 40/s) covering ALL inbound messages, separate from the chat bucket, so it never throttles legitimate 20 Hz movement input, only genuine floods.
- `handleMessage` (`server/game.ts`) now consumes a token per frame before parsing: `drop` silently discards the frame, `kick` disconnects the connection after 200 consecutive over-budget frames (mirrors the existing chat cooldown-then-kick ladder).
- New `ClientSession.msgRate` bucket, initialized alongside the existing chat bucket at session creation.

## Flow

```mermaid
sequenceDiagram
    participant C as Client
    participant H as handleMessage
    participant B as msg_rate_limit bucket
    participant D as dispatchMessage

    C->>H: WS frame (input/cast/cmd/...)
    H->>B: consumeMsgToken(session.msgRate, now)
    alt tokens available
        B-->>H: allow
        H->>D: dispatchMessage(...)
    else bucket empty, under kick threshold
        B-->>H: drop
        H-->>C: frame silently discarded
    else bucket empty, sustained flood (200 consecutive drops)
        B-->>H: kick
        H->>C: kickSession (WS closed)
    end
```

## Test plan
- [x] New `tests/msg_rate_limit.test.ts`: burst exhaustion, sustained 20 Hz traffic never throttled, refill over time, drop-then-kick ladder, violation-counter reset on success.
- [x] `npx tsc --noEmit`
- [x] `npx @biomejs/biome check --write server/game.ts server/msg_rate_limit.ts tests/msg_rate_limit.test.ts`
- [x] `npm test` (full suite green)

Not merging; opening for CI/review.