### PR TITLE
fix(sim): stop players tunneling through arena walls

### DIFF
--- a/src/sim/combat/auto_attack.ts
+++ b/src/sim/combat/auto_attack.ts
@@ -27,7 +27,7 @@
 // `src/sim`-pure: no DOM/Three, no Math.random/Date.now; all randomness is the shared
 // `ctx.rng` stream, drawn in the exact pre-move positions.
 
-import { CLASSES, MOBS } from '../data';
+import { CLASSES, isArenaPos, MOBS } from '../data';
 import { scheduleProjectile } from '../projectile_travel';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
@@ -112,6 +112,11 @@ export function updatePlayerAutoAttack(ctx: SimContext, p: Entity, meta: PlayerM
     return;
   }
   if (d > MELEE_RANGE) return;
+  // Melee normally skips line of sight (it's always point-blank), but the
+  // arena's thin enclosing walls sit inside MELEE_RANGE: without this a
+  // combatant pressed against a wall could swing through it. See sibling
+  // logic in Sim.abilityNeedsLineOfSight.
+  if (isArenaPos(p.pos.x) && !ctx.hasLineOfSight(p, t)) return;
   ctx.breakGhostWolf(p);
 
   let bonus = 0;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -92,6 +92,7 @@ import {
   GROUND_OBJECTS,
   INSTANCE_SLOT_COUNT,
   ITEMS,
+  isArenaPos,
   isDelvePos,
   MOBS,
   NPCS,
@@ -2967,9 +2968,15 @@ export class Sim {
     cancelCastImpl(this.ctx, p);
   }
 
-  private abilityNeedsLineOfSight(ability: AbilityDef): boolean {
+  private abilityNeedsLineOfSight(ability: AbilityDef, source?: Entity): boolean {
     if (!ability.requiresTarget) return false;
-    return ability.school !== 'physical' || ability.range > MELEE_RANGE;
+    if (ability.school !== 'physical' || ability.range > MELEE_RANGE) return true;
+    // Melee/auto-attack skips line of sight everywhere else (it is always at
+    // point-blank range), but the arena's thin enclosing walls sit well within
+    // MELEE_RANGE: without this, a combatant pressed against a wall can swing
+    // through it at an opponent on the far side. Ranked fairness requires every
+    // attack to respect the same walls movement does inside the pit.
+    return source !== undefined && isArenaPos(source.pos.x);
   }
 
   private hasLineOfSight(source: Entity, target: Entity): boolean {
@@ -2977,7 +2984,7 @@ export class Sim {
   }
 
   private lineOfSightBlocked(source: Entity, target: Entity, ability: AbilityDef): boolean {
-    return this.abilityNeedsLineOfSight(ability) && !this.hasLineOfSight(source, target);
+    return this.abilityNeedsLineOfSight(ability, source) && !this.hasLineOfSight(source, target);
   }
 
   private pushbackCast(p: Entity): void {
@@ -3118,7 +3125,10 @@ export class Sim {
   // `source`. Instantaneous displacement (no aura) walked in small steps so it can
   // be terrain-clamped exactly like a warrior charge — the shove stops at the last
   // safe footing before deep water or a cliff rather than stranding the victim off
-  // the world. Returns the yards actually moved (0 if blocked immediately).
+  // the world. Each step is also collider-swept (resolveMove, the same walker uses)
+  // so a wall (an arena side wall in particular) stops the shove instead of letting
+  // it tunnel through in one coarse hop. Returns the yards actually moved (0 if
+  // blocked immediately).
   private applyKnockback(source: Entity, target: Entity, distance: number): number {
     let dx = target.pos.x - source.pos.x;
     let dz = target.pos.z - source.pos.z;
@@ -3143,17 +3153,21 @@ export class Sim {
       const h1 = groundHeight(nx, nz, this.cfg.seed);
       if (h1 < WATER_LEVEL - SWIM_DEPTH) break; // would land in deep water
       if (h1 > h0 && (h1 - h0) / adv > MAX_CLIMB_SLOPE) break; // would slam into a cliff
-      cx = nx;
-      cz = nz;
+      // resolveMove sweeps cx,cz -> nx,nz against static colliders (walls,
+      // pillars, delve module bounds/doors) in small sub-steps, so a thin wall
+      // stops the shove at its face instead of the coarse 0.5yd hop skipping
+      // over it.
+      const resolved = this.resolveMove(cx, cz, nx, nz, BODY_RADIUS, target);
+      const blocked = Math.hypot(resolved.x - nx, resolved.z - nz) > BODY_RADIUS * 0.25;
+      cx = resolved.x;
+      cz = resolved.z;
       moved += adv;
+      if (blocked) break; // hit a wall: stop the shove here
     }
     if (moved <= 0) return 0;
-    // resolveMovePoint is a no-op wrapper over resolvePosition outside a delve, and
-    // applies the run's module colliders + portcullis doors when target is inside one.
-    const resolved = this.resolveMovePoint(cx, cz, BODY_RADIUS, target);
-    target.pos.x = resolved.x;
-    target.pos.z = resolved.z;
-    target.pos.y = groundHeight(resolved.x, resolved.z, this.cfg.seed);
+    target.pos.x = cx;
+    target.pos.z = cz;
+    target.pos.y = groundHeight(cx, cz, this.cfg.seed);
     target.vy = 0;
     target.onGround = true;
     target.fallStartY = target.pos.y;

--- a/tests/arena.test.ts
+++ b/tests/arena.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { isArenaPos } from '../src/sim/data';
+import { arenaOrigin, isArenaPos } from '../src/sim/data';
+import { DUNGEON_WALL_X } from '../src/sim/dungeon_layout';
 import { eloDelta, Sim } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
 import { groundHeight } from '../src/sim/world';
@@ -670,5 +671,27 @@ describe('arena: class ability target filters', () => {
     sim.castAbility(ability, a);
 
     expect(target.hp).toBeLessThan(startHp);
+  });
+});
+
+describe('arena: enclosing walls', () => {
+  it('melee auto-attack cannot land through the arena side wall', () => {
+    const { sim, a, b } = queueDuo();
+    startBout(sim);
+    const attacker = sim.entities.get(a)!;
+    const target = sim.entities.get(b)!;
+    const slot = sim.arenaMatchFor(a)!.slot ?? 0;
+    const o = arenaOrigin(slot);
+    // attacker just inside the +x wall, target just outside it, close enough
+    // to be within MELEE_RANGE but with the wall between them.
+    teleport(sim, a, o.x + DUNGEON_WALL_X - 1.5, o.z);
+    teleport(sim, b, o.x + DUNGEON_WALL_X + 1.5, o.z);
+    face(sim, a, b);
+    sim.targetEntity(b, a);
+    sim.startAutoAttack(a);
+    const startHp = target.hp;
+    for (let i = 0; i < 20 * 3; i++) sim.tick();
+    // stays toggled on (mirrors the ranged LOS gate) but never lands a swing
+    expect(target.hp).toBe(startHp);
   });
 });

--- a/tests/mob_knockback.test.ts
+++ b/tests/mob_knockback.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
-import { MOBS } from '../src/sim/data';
+import { arenaOrigin, MOBS } from '../src/sim/data';
+import { DUNGEON_WALL_X } from '../src/sim/dungeon_layout';
 import { createMob } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
 
 const SEED = 5150;
 const makeSim = () => new Sim({ seed: SEED, playerClass: 'warrior' });
@@ -14,7 +15,9 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
     const p = sim.entities.get(sim.playerId)!;
     p.gm = true; // an L19 elite would otherwise grind the warrior down mid-loop
     // flat starting ground (Eastbrook town) so the shove isn't terrain-clamped
-    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const tmpl = MOBS.marrowlord_varkas;
     const saved = tmpl.knockback!.chance;
     tmpl.knockback!.chance = 1; // force the proc; misses/dodges still possible
@@ -39,7 +42,9 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
   it('applyKnockback shoves the exact distance over open ground and reports it', () => {
     const sim = makeSim();
     const p = sim.entities.get(sim.playerId)!;
-    p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const mob = createMob(900701, MOBS.marrowlord_varkas, p.level, { x: 0, y: 0, z: 0 });
     const moved = (sim as any).applyKnockback(mob, p, 6);
     expect(moved).toBeGreaterThan(0);
@@ -50,7 +55,10 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
   it('a friendly pet swing (hostile=false) never knocks its target back', () => {
     const sim = makeSim();
     const p = sim.entities.get(sim.playerId)!;
-    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.gm = true;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const tmpl = MOBS.marrowlord_varkas;
     const saved = tmpl.knockback!.chance;
     tmpl.knockback!.chance = 1;
@@ -65,10 +73,35 @@ describe('Knockback on-hit affix (Crushing Sweep)', () => {
     }
   });
 
+  it('a knockback aimed at a thin arena wall cannot tunnel the victim outside the pit', () => {
+    const sim = makeSim();
+    const p = sim.entities.get(sim.playerId)!;
+    // instance-local coordinates near the arena's +x side wall (centreline at
+    // DUNGEON_WALL_X, half-thickness 1): the player stands just inside it.
+    const o = arenaOrigin(0);
+    p.pos.x = o.x + DUNGEON_WALL_X - 1.1;
+    p.pos.z = o.z + 0;
+    p.pos.y = 0;
+    // mob on the far (-x) side of the player so the shove drives it straight
+    // into and, pre-fix, through the wall.
+    const mob = createMob(900704, MOBS.marrowlord_varkas, p.level, {
+      x: o.x + DUNGEON_WALL_X - 5,
+      y: 0,
+      z: o.z,
+    });
+    (sim as any).applyKnockback(mob, p, 8);
+    // the wall's outer face sits at DUNGEON_WALL_X + 1; the victim must never
+    // land past it, no matter how large the shove.
+    expect(p.pos.x).toBeLessThan(o.x + DUNGEON_WALL_X + 1);
+  });
+
   it('a mob without knockback never displaces the player', () => {
     const sim = makeSim();
     const p = sim.entities.get(sim.playerId)!;
-    p.gm = true; p.pos.x = 2; p.pos.z = 0; p.pos.y = 0;
+    p.gm = true;
+    p.pos.x = 2;
+    p.pos.z = 0;
+    p.pos.y = 0;
     const mob = createMob(900703, MOBS.forest_wolf, p.level, { x: 0, y: 0, z: 0 });
     const startGap = dist2d(p.pos, mob.pos);
     for (let i = 0; i < 40; i++) (sim as any).mobSwing(mob, p);


### PR DESCRIPTION
## Problem

Fixes #1085. In ranked arena PvP (The Ashen Coliseum), players can end up on the far side of, or inside, an enclosing wall and keep fighting from a position they should never reach.

## Root cause

Two independent gaps in the arena movement/combat path (`src/sim/`):

1. **On-hit knockback tunnels through thin walls.** `applyKnockback` in `src/sim/sim.ts` stepped the victim outward in 0.5yd hops, checking only terrain height (deep water / cliff slope) per step, then resolved only the *final* landing point with a plain point check (`resolvePosition`). The arena's side walls are only 2yd thick, so a shove aimed across one could cross it entirely between two 0.5yd steps: no intermediate step was ever checked against the wall's collider, and the final point-check happily accepted the far-side landing spot because it wasn't touching the collider anymore.

2. **Melee can swing through a wall.** `abilityNeedsLineOfSight` (and the melee auto-attack path in `src/sim/combat/auto_attack.ts`) never require line of sight for physical abilities/auto-attack at or below `MELEE_RANGE`, since melee is normally point-blank. But the arena's walls sit well inside `MELEE_RANGE`, so a combatant pressed against a wall could already melee an opponent standing on the far side.

```mermaid
sequenceDiagram
    participant M as Mob (source)
    participant P as Player (target)
    participant W as Arena side wall (2yd thick)

    Note over M,P: Before fix
    M->>P: on-hit knockback, 0.5yd steps
    P-->>W: step checks terrain only (water/cliff)
    P->>P: crosses wall in one hop, no collider check mid-step
    P-->>P: final resolvePosition() is a POINT check, already past the wall = accepted
    Note over P: player ends up outside the pit, still swinging

    Note over M,P: After fix
    M->>P: on-hit knockback, 0.5yd steps
    P->>W: each step swept through resolveMove() (same walker as normal movement)
    W-->>P: step blocked at the wall face, shove stops
    Note over P: player stays inside the pit
```

## Fix

- `applyKnockback` now sweeps every 0.5yd step through `resolveMove` (the same collider walker normal player movement already uses), in addition to the existing terrain clamp, and stops the shove the instant a step is deflected by a wall.
- `abilityNeedsLineOfSight` now also requires line of sight when the source is inside the arena (`isArenaPos`), regardless of range/school, so a physical ability pressed against a wall can no longer hit through it.
- The melee auto-attack path in `auto_attack.ts` gets the matching arena-only LOS gate (mirrors the existing ranged auto-attack LOS check).
- Left everywhere else in the world unchanged: melee/physical abilities still skip LOS outside the arena, matching existing balance/feel.

Charge (A* pathfind, already collider-aware) and fear (routed through the normal per-tick swept movement) were checked per the issue's scope and don't have this gap; only the on-hit knockback point-displacement path did.

## Tests

- New: `tests/mob_knockback.test.ts` - "a knockback aimed at a thin arena wall cannot tunnel the victim outside the pit" (reproduces the bug pre-fix, passes post-fix).
- New: `tests/arena.test.ts` - "melee auto-attack cannot land through the arena side wall".
- `npx vitest run tests/mob_knockback.test.ts tests/arena.test.ts tests/sim.test.ts tests/duel.test.ts tests/architecture.test.ts tests/parity/parity.test.ts` - all green, including the golden-trace/rng-draw-order parity gate (no rng draws were added or reordered; the fix is a pure geometric collider sweep).
- `npx tsc --noEmit` - clean.
- `npx @biomejs/biome check` on the changed files - no new errors (pre-existing repo-wide lint warnings only, per this repo's changed-files-only gate).

## Scope

Server-authoritative sim-core fix only (`src/sim/sim.ts`, `src/sim/combat/auto_attack.ts`); no render/UI/client changes needed since the sim is what the server runs authoritatively. Arena matchmaking, Elo, and all non-arena movement/combat are unchanged (the melee LOS gate is scoped strictly to `isArenaPos`).