### PR TITLE
fix(ui): reposition market filter dropdowns to stay inside the mobile clip box

### DIFF
--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3216,6 +3216,14 @@
       inset 0 1px 0 #ffffff12;
     z-index: 20;
   }
+  /* Flipped by market_window.ts (positionFilterMenu) when there is more clip-box
+     room above the trigger than below it, e.g. a filter near the bottom of
+     #market-window on mobile: the menu would otherwise render past the window's
+     overflow: hidden clip with no way to scroll to the rest of it. */
+  .mkt-select.open-up .mkt-select-menu {
+    top: auto;
+    bottom: calc(100% + 4px);
+  }
   .mkt-select-option {
     width: 100%;
     display: block;

--- a/src/ui/dropdown_position.ts
+++ b/src/ui/dropdown_position.ts
@@ -1,0 +1,31 @@
+// Pure placement math for a custom dropdown menu that must stay inside a
+// clipping ancestor (overflow: hidden), e.g. the World Market filters inside
+// #market-window on mobile. The menu is CSS position: absolute against its
+// trigger, so a fixed 236px-tall menu can render past the clip boundary with
+// no way to scroll to the rest: the clip box's own scroll region does not
+// grow to include an absolutely positioned descendant. Flip the menu above
+// the trigger and/or shrink it to the actually available space instead.
+
+export interface DropdownPlacementInput {
+  triggerTop: number;
+  triggerBottom: number;
+  containerTop: number;
+  containerBottom: number;
+  preferredMaxHeight: number;
+  gap: number;
+  minHeight: number;
+}
+
+export interface DropdownPlacement {
+  side: 'below' | 'above';
+  maxHeight: number;
+}
+
+export function computeDropdownPlacement(input: DropdownPlacementInput): DropdownPlacement {
+  const spaceBelow = input.containerBottom - input.triggerBottom - input.gap;
+  const spaceAbove = input.triggerTop - input.containerTop - input.gap;
+  const side = spaceAbove > spaceBelow ? 'above' : 'below';
+  const space = side === 'below' ? spaceBelow : spaceAbove;
+  const maxHeight = Math.max(input.minHeight, Math.min(input.preferredMaxHeight, space));
+  return { side, maxHeight };
+}

--- a/src/ui/market_window.ts
+++ b/src/ui/market_window.ts
@@ -18,6 +18,7 @@ import type { EquipSlot } from '../sim/types';
 import type { IWorld } from '../world_api';
 import { markDialogRoot } from './dialog_root';
 import { dropdownKeyNav } from './dropdown_nav';
+import { computeDropdownPlacement } from './dropdown_position';
 import { itemDisplayName } from './entity_i18n';
 import { esc } from './esc';
 import { formatMoney as formatLocalizedMoney, formatNumber, t } from './i18n';
@@ -49,6 +50,15 @@ import { svgIcon } from './ui_icons';
 // shared QUALITY_COLOR map carries the real per-quality hex; this token covers a
 // listing whose item has no quality field, so no raw hex lives in the painter.
 const QUALITY_DEFAULT_COLOR = 'var(--color-quality-default)';
+
+// The filter dropdown's natural size (mirrors .mkt-select-menu's max-height/gap in
+// components.css). #market-window clips with overflow: hidden on mobile, and a menu
+// that renders past that clip has no scroll path to the rest of it, so every open
+// recomputes placement against the window's actual clip box instead of assuming
+// there is always room below the trigger.
+const MKT_MENU_PREFERRED_HEIGHT = 236;
+const MKT_MENU_GAP = 4;
+const MKT_MENU_MIN_HEIGHT = 80;
 
 /**
  * Hud-supplied glue. Composes the shared PainterHostPresentation bag
@@ -205,13 +215,35 @@ export class MarketWindow {
     });
     const closeFilterMenus = () => {
       el.querySelectorAll<HTMLElement>('.mkt-select.open').forEach((menu) => {
-        menu.classList.remove('open');
+        menu.classList.remove('open', 'open-up');
         menu
           .querySelector<HTMLButtonElement>('.mkt-select-btn')
           ?.setAttribute('aria-expanded', 'false');
         const list = menu.querySelector<HTMLElement>('.mkt-select-menu');
-        if (list) list.hidden = true;
+        if (list) {
+          list.hidden = true;
+          list.style.maxHeight = '';
+        }
       });
+    };
+    const positionFilterMenu = (menu: HTMLElement) => {
+      const trigger = menu.querySelector<HTMLButtonElement>('.mkt-select-btn');
+      const list = menu.querySelector<HTMLElement>('.mkt-select-menu');
+      const container = el.querySelector<HTMLElement>('#market-window') ?? el;
+      if (!trigger || !list) return;
+      const t = trigger.getBoundingClientRect();
+      const c = container.getBoundingClientRect();
+      const placement = computeDropdownPlacement({
+        triggerTop: t.top,
+        triggerBottom: t.bottom,
+        containerTop: c.top,
+        containerBottom: c.bottom,
+        preferredMaxHeight: MKT_MENU_PREFERRED_HEIGHT,
+        gap: MKT_MENU_GAP,
+        minHeight: MKT_MENU_MIN_HEIGHT,
+      });
+      menu.classList.toggle('open-up', placement.side === 'above');
+      list.style.maxHeight = `${placement.maxHeight}px`;
     };
     el.querySelectorAll<HTMLButtonElement>('.mkt-select-btn').forEach((button) => {
       button.addEventListener('click', (event) => {
@@ -224,6 +256,7 @@ export class MarketWindow {
         button.setAttribute('aria-expanded', wantOpen ? 'true' : 'false');
         const list = menu.querySelector<HTMLElement>('.mkt-select-menu');
         if (list) list.hidden = !wantOpen;
+        if (wantOpen) positionFilterMenu(menu);
       });
     });
     el.querySelectorAll<HTMLButtonElement>('[data-market-filter-option]').forEach((option) => {
@@ -297,6 +330,7 @@ export class MarketWindow {
             trigger?.setAttribute('aria-expanded', 'true');
             const list = select.querySelector<HTMLElement>('.mkt-select-menu');
             if (list) list.hidden = false;
+            positionFilterMenu(select);
             options[action.index]?.focus();
             break;
           }

--- a/src/ui/market_window.ts
+++ b/src/ui/market_window.ts
@@ -229,15 +229,23 @@ export class MarketWindow {
     const positionFilterMenu = (menu: HTMLElement) => {
       const trigger = menu.querySelector<HTMLButtonElement>('.mkt-select-btn');
       const list = menu.querySelector<HTMLElement>('.mkt-select-menu');
-      const container = el.querySelector<HTMLElement>('#market-window') ?? el;
+      // `el` (deps.root()) already IS #market-window, so there is no separate
+      // container to look up: querySelector('#market-window') on the window
+      // itself never matches its own root and would always fall back to `el`.
       if (!trigger || !list) return;
       const t = trigger.getBoundingClientRect();
-      const c = container.getBoundingClientRect();
+      const c = el.getBoundingClientRect();
+      // #market-window clips at its padding box (overflow: hidden), which sits
+      // inset from the border box measured above by the panel's border width on
+      // each edge; subtract it so the clamp matches the real clip, not the
+      // border-inclusive box.
+      const borderTop = Number.parseFloat(getComputedStyle(el).borderTopWidth) || 0;
+      const borderBottom = Number.parseFloat(getComputedStyle(el).borderBottomWidth) || 0;
       const placement = computeDropdownPlacement({
         triggerTop: t.top,
         triggerBottom: t.bottom,
-        containerTop: c.top,
-        containerBottom: c.bottom,
+        containerTop: c.top + borderTop,
+        containerBottom: c.bottom - borderBottom,
         preferredMaxHeight: MKT_MENU_PREFERRED_HEIGHT,
         gap: MKT_MENU_GAP,
         minHeight: MKT_MENU_MIN_HEIGHT,

--- a/tests/dropdown_position.test.ts
+++ b/tests/dropdown_position.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { computeDropdownPlacement } from '../src/ui/dropdown_position';
+
+describe('computeDropdownPlacement', () => {
+  it('opens below and keeps the full preferred height when there is plenty of room', () => {
+    const placement = computeDropdownPlacement({
+      triggerTop: 100,
+      triggerBottom: 120,
+      containerTop: 0,
+      containerBottom: 600,
+      preferredMaxHeight: 236,
+      gap: 4,
+      minHeight: 80,
+    });
+    expect(placement).toEqual({ side: 'below', maxHeight: 236 });
+  });
+
+  it('shrinks (but stays below) when space below is tight but still the larger side', () => {
+    const placement = computeDropdownPlacement({
+      triggerTop: 250,
+      triggerBottom: 280,
+      containerTop: 0,
+      containerBottom: 330,
+      preferredMaxHeight: 236,
+      gap: 4,
+      minHeight: 40,
+    });
+    // spaceBelow = 330 - 280 - 4 = 46, spaceAbove = 250 - 0 - 4 = 246
+    // spaceBelow < spaceAbove, so it should flip up despite the "still positive" space below.
+    expect(placement.side).toBe('above');
+    expect(placement.maxHeight).toBe(236);
+  });
+
+  it('flips above the trigger when there is more room there, matching the mobile Market clip case', () => {
+    // Reproduces the reported bug: a filter select near the bottom of an
+    // overflow: hidden #market-window, where the menu below would be
+    // majority-clipped with no way to reach it by scrolling.
+    const placement = computeDropdownPlacement({
+      triggerTop: 245,
+      triggerBottom: 277,
+      containerTop: 38,
+      containerBottom: 371,
+      preferredMaxHeight: 236,
+      gap: 4,
+      minHeight: 80,
+    });
+    // spaceBelow = 371 - 277 - 4 = 90, spaceAbove = 245 - 38 - 4 = 203
+    expect(placement.side).toBe('above');
+    expect(placement.maxHeight).toBe(203);
+  });
+
+  it('clamps to minHeight when neither side has enough room', () => {
+    const placement = computeDropdownPlacement({
+      triggerTop: 50,
+      triggerBottom: 60,
+      containerTop: 40,
+      containerBottom: 70,
+      preferredMaxHeight: 236,
+      gap: 4,
+      minHeight: 80,
+    });
+    // spaceBelow = 70 - 60 - 4 = 6, spaceAbove = 50 - 40 - 4 = 6
+    expect(placement.side).toBe('below');
+    expect(placement.maxHeight).toBe(80);
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #1051.

On mobile (landscape), `#market-window` clips with `overflow: hidden` so
`#market-body` can be a fixed-height touch scroller (the fix from #1058). A
filter dropdown (`.mkt-select-menu`) is `position: absolute` against its
trigger, so it does **not** contribute to `#market-body`'s scrollable area.
When a filter select sits near the bottom of the window, the 236px-tall menu
renders mostly past the window's clip boundary with no scroll path to reach
the clipped part, exactly as reported: opening a dropdown pushes content off
screen with no way to get to it.

## Root cause

```mermaid
flowchart TD
    A["#market-window (overflow: hidden)"] --> B["#market-body (overflow-y: auto, in-flow scroller)"]
    A --> C[".mkt-filters (in-flow, outside #market-body)"]
    C --> D[".mkt-select (position: relative)"]
    D --> E[".mkt-select-menu (position: absolute, 236px tall)"]
    E -. "does NOT extend #market-body's scrollHeight" .-> B
    E -. "clipped by #market-window's overflow: hidden" .-> A
    F["Fix: dropdown_position.ts computeDropdownPlacement()"] -. "measures trigger vs #market-window clip box" .-> E
    F -. "flips menu above trigger + clamps max-height" .-> E
```

## Fix

- New pure module `src/ui/dropdown_position.ts` (`computeDropdownPlacement`):
  given the trigger and clip-box rects, decides whether to open the filter
  menu below or above the trigger (picking the side with more room) and
  clamps its `max-height` to what is actually available, so it always stays
  inside the clip box. Unit tested in `tests/dropdown_position.test.ts`.
- `src/ui/market_window.ts`: both places a filter menu opens (mouse click and
  the keyboard listbox `open` action) now call this on open and apply an
  `open-up` class + inline `max-height`.
- `src/styles/components.css`: `.mkt-select.open-up .mkt-select-menu` flips
  the menu to anchor from the bottom instead of the top.
- Desktop is unaffected: `#market-window` has plenty of vertical room there,
  so `computeDropdownPlacement` keeps picking "below" with the full 236px.

## Before / after

Verified with a Puppeteer repro (900x420 landscape-phone touch viewport,
market flooded with 161 listings, Rarity filter opened): before, only ~37%
of the dropdown menu was visible with no way to scroll to the rest; after,
100% of the menu is visible (flipped above the trigger).

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-market-dropdown-1051/before.png) | ![after](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-market-dropdown-1051/after.png) |

The base listing-scroll fix from #1058 (`#market-body` touch-scrolls the
item list itself) was already re-verified green on this branch via
`scripts/market_mobile_scroll_shot.mjs`.

## Testing

- `npx tsc --noEmit`
- `npx vitest run tests/dropdown_position.test.ts tests/architecture.test.ts tests/painter_host.test.ts tests/css_corpus.test.ts tests/css_value_validity.test.ts tests/market_filters.test.ts tests/market.test.ts tests/market_view.test.ts tests/market_window.test.ts tests/save_character_and_market.test.ts` (all green)
- `npx @biomejs/biome check --write` on changed files
- Manual verification via `scripts/market_mobile_scroll_shot.mjs` and a dropdown-clip repro script (Puppeteer, mobile-touch viewport)

Not merging; opening for review per the maintainer's contribution flow.
