### PR TITLE
fix(ui): resync app viewport when opening the options window

### DIFF
--- a/src/game/app_viewport.ts
+++ b/src/game/app_viewport.ts
@@ -1,0 +1,26 @@
+// Keeps the --app-vw/--app-vh custom properties (consumed by #ui's fixed-size,
+// overflow:hidden box) in sync with the true viewport. main.ts wires this to
+// resize/orientation/fullscreenchange; a window that opens on top of #ui can
+// also call it directly so its own size isn't clipped by a stale ancestor box
+// from just before a resize/fullscreen transition settles (see options_window.ts).
+import { useTouchInterface } from './mobile_controls';
+
+export function syncAppViewport(win: Window = window): void {
+  const doc = win.document;
+  const useStableGameViewport =
+    doc.body.classList.contains('game-active') && useTouchInterface(win);
+  const width = Math.max(
+    1,
+    Math.round(
+      useStableGameViewport ? win.innerWidth : (win.visualViewport?.width ?? win.innerWidth),
+    ),
+  );
+  const height = Math.max(
+    1,
+    Math.round(
+      useStableGameViewport ? win.innerHeight : (win.visualViewport?.height ?? win.innerHeight),
+    ),
+  );
+  doc.documentElement.style.setProperty('--app-vw', `${width}px`);
+  doc.documentElement.style.setProperty('--app-vh', `${height}px`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@
 // index.html and play.html both bootstrap through this module, so this one import
 // styles both game entries; admin/guide use their own entries and inline CSS.
 import './styles/index.css';
+import { syncAppViewport as syncAppViewportShared } from './game/app_viewport';
 import { audio } from './game/audio';
 import {
   BROWSER_BODY_CLASSES,
@@ -463,26 +464,7 @@ function syncBuildInfo(): void {
 }
 
 function syncAppViewport(): void {
-  const useStableGameViewport =
-    document.body.classList.contains('game-active') && useTouchInterface();
-  const width = Math.max(
-    1,
-    Math.round(
-      useStableGameViewport
-        ? window.innerWidth
-        : (window.visualViewport?.width ?? window.innerWidth),
-    ),
-  );
-  const height = Math.max(
-    1,
-    Math.round(
-      useStableGameViewport
-        ? window.innerHeight
-        : (window.visualViewport?.height ?? window.innerHeight),
-    ),
-  );
-  document.documentElement.style.setProperty('--app-vw', `${width}px`);
-  document.documentElement.style.setProperty('--app-vh', `${height}px`);
+  syncAppViewportShared();
 }
 
 function preventMobileZoom(): void {

--- a/src/ui/options_window.ts
+++ b/src/ui/options_window.ts
@@ -19,6 +19,7 @@
 // setting value only: it never reads the FPS governor and never defines the
 // effects-quality cutoff (that resolver and per-element tiering live elsewhere).
 
+import { syncAppViewport } from '../game/app_viewport';
 import { audio } from '../game/audio';
 import { GAMEPAD_BUTTON_LABELS, GAMEPAD_NONE } from '../game/gamepad_map';
 import {
@@ -231,6 +232,12 @@ export class OptionsWindow {
       this.close();
       return;
     }
+    // Re-sync --app-vh/--app-vw right before opening: #ui is a fixed,
+    // overflow:hidden box sized from those custom properties, and this window
+    // is one of its children, so a stale value from just before a fullscreen
+    // toggle or resize settles would hard-clip the panel with no visible
+    // scrollbar (the panel's own overflow-y:auto never gets a chance to run).
+    syncAppViewport();
     this.returnFocus = this.deps.captureFocus();
     this.deps.closeOthers();
     this.view = 'main';

--- a/tests/app_viewport.test.ts
+++ b/tests/app_viewport.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { syncAppViewport } from '../src/game/app_viewport';
+
+interface FakeWin {
+  innerWidth: number;
+  innerHeight: number;
+  visualViewport: { width: number; height: number } | undefined;
+  matchMedia: (query: string) => { matches: boolean };
+  document: {
+    body: { classList: { contains: (c: string) => boolean } };
+    documentElement: { style: { setProperty: (name: string, value: string) => void } };
+  };
+}
+
+function fakeWin(opts: {
+  innerWidth: number;
+  innerHeight: number;
+  visualViewport?: { width: number; height: number };
+  gameActive?: boolean;
+  touch?: boolean;
+}): { win: FakeWin; props: Record<string, string> } {
+  const props: Record<string, string> = {};
+  const win: FakeWin = {
+    innerWidth: opts.innerWidth,
+    innerHeight: opts.innerHeight,
+    visualViewport: opts.visualViewport,
+    matchMedia: () => ({ matches: !!opts.touch }),
+    document: {
+      body: {
+        classList: { contains: (c: string) => (c === 'game-active' ? !!opts.gameActive : false) },
+      },
+      documentElement: {
+        style: {
+          setProperty: (name, value) => {
+            props[name] = value;
+          },
+        },
+      },
+    },
+  };
+  return { win, props };
+}
+
+describe('syncAppViewport', () => {
+  it('writes --app-vw/--app-vh from the live viewport', () => {
+    const { win, props } = fakeWin({ innerWidth: 1194, innerHeight: 905 });
+    syncAppViewport(win as unknown as Window);
+    expect(props['--app-vw']).toBe('1194px');
+    expect(props['--app-vh']).toBe('905px');
+  });
+
+  it('prefers visualViewport dimensions off the stable game viewport', () => {
+    const { win, props } = fakeWin({
+      innerWidth: 1194,
+      innerHeight: 905,
+      visualViewport: { width: 1000, height: 700 },
+    });
+    syncAppViewport(win as unknown as Window);
+    expect(props['--app-vw']).toBe('1000px');
+    expect(props['--app-vh']).toBe('700px');
+  });
+
+  it('uses window inner dimensions on the stable (touch, game-active) viewport, ignoring visualViewport', () => {
+    const { win, props } = fakeWin({
+      innerWidth: 1194,
+      innerHeight: 905,
+      visualViewport: { width: 1000, height: 700 },
+      gameActive: true,
+      touch: true,
+    });
+    syncAppViewport(win as unknown as Window);
+    expect(props['--app-vw']).toBe('1194px');
+    expect(props['--app-vh']).toBe('905px');
+  });
+
+  it('rounds fractional visualViewport dimensions and floors at 1px', () => {
+    const { win, props } = fakeWin({
+      innerWidth: 0,
+      innerHeight: 0,
+      visualViewport: { width: 0.4, height: 0.6 },
+    });
+    syncAppViewport(win as unknown as Window);
+    expect(props['--app-vw']).toBe('1px');
+    expect(props['--app-vh']).toBe('1px');
+  });
+});

--- a/tests/options_window.test.ts
+++ b/tests/options_window.test.ts
@@ -154,6 +154,20 @@ describe('options_window: keybind rebind dispatch (cluster 5)', () => {
   });
 });
 
+describe('options_window: viewport resync on open (PR #1118)', () => {
+  it('calls syncAppViewport() before the panel flips to display: block', () => {
+    expect(painter).toContain("import { syncAppViewport } from '../game/app_viewport'");
+    const toggle = painter.slice(painter.indexOf('toggle(): void {'));
+    const toggleEnd = toggle.indexOf('\n  }\n');
+    const body = toggle.slice(0, toggleEnd);
+    const syncIdx = body.indexOf('syncAppViewport()');
+    const displayIdx = body.indexOf("root().style.display = 'block'");
+    expect(syncIdx).toBeGreaterThan(-1);
+    expect(displayIdx).toBeGreaterThan(-1);
+    expect(syncIdx).toBeLessThan(displayIdx);
+  });
+});
+
 describe('options_window: stays a cold window', () => {
   it('exposes no per-frame refresh and is never wired into Hud.update', () => {
     // the painter is open-on-demand only: no refreshIfChanged/update method


### PR DESCRIPTION
## Problem

Fixes #1082.

The keybindings window (and every other Esc > Options sub-panel, since they all
share `#options-menu`) is a child of `#ui`: a `position: fixed` box sized from
the `--app-vw`/`--app-vh` custom properties and clipped with `overflow: hidden`.

```mermaid
flowchart TD
    A["window resize / fullscreenchange"] -->|"immediate + 250ms + 800ms follow-ups"| B["syncAppViewport() writes --app-vh"]
    B --> C["#ui: position:fixed, height:var(--app-vh), overflow:hidden"]
    D["#options-menu (Key Bindings panel)"] -->|"child of"| C
    D -->|"own overflow-y:auto, max-height: calc(85vh - 24px)"| E["panel content scrolls IF it can be seen"]
    F["player opens Options right after a fullscreen toggle"] -.->|"--app-vh still stale (pre-resync)"| C
    C -.->|"clips at the OLD, shorter height BEFORE the panel's own scroll ever runs"| G["lowest Action Bar rows permanently cut off, no visible scrollbar"]
    style F fill:#502,color:#fff
    style G fill:#502,color:#fff
```

Those custom properties refresh on `resize`/`fullscreenchange`, but only on a
timer (immediate + 250ms + 800ms follow-ups in `main.ts`). Opening the options
window inside that short window right after a fullscreen toggle renders the
panel against a stale, shorter `--app-vh`: `#ui` hard-clips the bottom of the
panel *before* the panel's own `overflow-y: auto` ever gets a chance to scroll
it into view, so there is no visible scrollbar and the lowest Action Bar rows
are unreachable, matching the reported behavior.

## Fix

- Extracted the inline `syncAppViewport()` from `main.ts` into a small pure
  module, `src/game/app_viewport.ts` (host-agnostic, Vitest-tested), reused by
  `main.ts` unchanged.
- `OptionsWindow.toggle()` (`src/ui/options_window.ts`) now calls it
  synchronously right before the panel opens, so the panel always renders
  against the true, current viewport regardless of any resize/fullscreen
  timing race. This covers every sub-panel under `#options-menu` (Key
  Bindings, Performance, etc.), per the issue's stated scope.

## Testing

- `tests/app_viewport.test.ts` (new): unit-tests the extracted
  `syncAppViewport` against a hand-rolled fake `Window` (stable-viewport vs.
  `visualViewport` branches, rounding/floor).
- `npx tsc --noEmit`: clean.
- `npx vitest run tests/app_viewport.test.ts tests/options_window.test.ts tests/mobile_controls.test.ts tests/architecture.test.ts tests/client_shell.test.ts`: all green.
- Manual repro via a puppeteer-core script at the exact reported 1194x905
  viewport: opened Key Bindings, scrolled to the bottom with a real mouse-wheel
  event, confirmed the last Action Bar row (23) is fully reachable and the
  panel's built-in scrollbar works end to end.

**Top of the panel:**

![keybindings top](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-kb-fullscreen-scroll/keybinds_top.png)

**Scrolled to the bottom, Action Bar 23 fully reachable:**

![keybindings scrolled to bottom](https://raw.githubusercontent.com/jgyy/world-of-claudecraft/pr-assets-kb-fullscreen-scroll/keybinds_scrolled_bottom.png)

## Scope

Per the issue, this is a fix for `#options-menu` sizing/overflow generally
(the shared `.window`/`#options-menu`/`.kb-wide`/`.perf-wide` CSS was already
correct on its own once the panel is rendered against a fresh viewport; the
gap was the stale `--app-vh` race on open). No CSS changes were needed. Not
merging per instructions; ready for review.
