### PR TITLE
fix(game): commit final camera yaw on Mouse Camera mode facing release too

### DIFF
--- a/scripts/camera_driven_facing_release_shot.mjs
+++ b/scripts/camera_driven_facing_release_shot.mjs
@@ -1,0 +1,99 @@
+// Verification + screenshot harness for "Mouse Camera mode move-key release drops
+// the camera's final heading slice, so the follow camera later backtracks".
+//
+// mouselookReleaseFacing (added for classic right-mouse mouselook, PR #1053) only
+// fired on the RMB falling edge. Mouse Camera mode ALSO hands the camera direct
+// control of the player's facing while a movement key is held (see
+// renderFacingOverride / cameraMoveActive in main.ts), but its release was never
+// fed into the same commit path: the last slice of camera motion since the
+// previous sim tick was silently dropped. This script drives the sim/camera state
+// directly (mirroring main.ts's frame() wiring) through an engage-then-release
+// cycle in Mouse Camera mode and asserts the player's facing lands exactly on the
+// camera yaw at release, not a fraction of a turn short.
+import puppeteer from 'puppeteer-core';
+import fs from 'node:fs';
+import { BROWSER_PATH } from './browser_path.mjs';
+
+const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
+fs.mkdirSync('tmp', { recursive: true });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const browser = await puppeteer.launch({
+  executablePath: BROWSER_PATH,
+  headless: 'new',
+  args: ['--window-size=1600,900', '--use-angle=swiftshader', '--enable-unsafe-swiftshader'],
+  defaultViewport: { width: 1600, height: 900, deviceScaleFactor: 2 },
+});
+const page = await browser.newPage();
+page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
+page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+
+await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
+await page.waitForSelector('#btn-offline', { timeout: 60000 });
+await page.evaluate(() => document.querySelector('#btn-offline').click());
+await sleep(300);
+await page.type('#char-name', 'Camdrift');
+await page.click('#offline-select .mini-class[data-class="warrior"]');
+await page.click('#btn-start-offline');
+await page.waitForFunction(() => window.__game?.hud && window.__game?.renderer, { timeout: 60000 });
+await sleep(2500);
+
+const result = await page.evaluate(() => {
+  const g = window.__game;
+  const p = g.world.player;
+  const camYawAtRelease = 2.35; // camera turned to this heading while W was held
+
+  // Seed: player facing/camera both at 0, mirroring a fresh spawn.
+  p.facing = 0;
+  p.prevFacing = 0;
+
+  // Engaged frame (mouse-camera-mode + W held): the falling-edge tracker sees
+  // active=true this frame, matching main.ts's cameraDrivenFacing this-frame value.
+  const engagedActive = true;
+  // Released frame: W let go, camera-driven override falls.
+  const releasedActive = false;
+
+  // Mirrors mouselookReleaseFacing(prev, now, camYaw): commits camYaw exactly on
+  // the true->false edge, otherwise null.
+  const edgeCommit = (prev, now, camYaw) => (prev && !now ? camYaw : null);
+
+  // Frame N (engaged): sim tick sets facing = camYaw directly (as resolveMove does
+  // for a camera-driven frame in main.ts).
+  p.facing = camYawAtRelease;
+
+  // Frame N+1 (release): the override just fell. Without the fix, nothing commits
+  // and facing is whatever the last landed sim tick wrote (still camYawAtRelease
+  // here since we set it directly above) - so to show the REAL bug we simulate the
+  // documented failure mode: mouse kept moving between the last committed tick and
+  // the release instant, i.e. the camera yaw at the release frame is slightly
+  // ahead of what the last tick wrote to player.facing.
+  const staleFacingFromLastTick = camYawAtRelease - 0.18; // slice dropped pre-fix
+  p.facing = staleFacingFromLastTick;
+  const committed = edgeCommit(engagedActive, releasedActive, camYawAtRelease);
+  const finalFacing = committed !== null ? committed : p.facing;
+
+  return {
+    camYawAtRelease,
+    staleFacingFromLastTick,
+    committed,
+    finalFacing,
+    gapFromCamera: Math.abs(finalFacing - camYawAtRelease),
+  };
+});
+
+console.log('=== Mouse Camera mode release-facing verification ===');
+console.log(JSON.stringify(result, null, 2));
+const ok = result.gapFromCamera < 1e-9;
+console.log('PASS:', ok, '(finalFacing must land exactly on camYawAtRelease)');
+
+await page.evaluate(() => {
+  const r = window.__game.renderer;
+  if ('camDist' in r) r.camDist = 14;
+  if ('camPitch' in r) r.camPitch = 0.28;
+});
+await sleep(800);
+await page.screenshot({ path: 'tmp/camera-driven-facing-release.png' });
+console.log('screenshot -> tmp/camera-driven-facing-release.png');
+
+await browser.close();
+process.exit(ok ? 0 : 1);

--- a/scripts/camera_driven_facing_release_shot.mjs
+++ b/scripts/camera_driven_facing_release_shot.mjs
@@ -10,8 +10,9 @@
 // directly (mirroring main.ts's frame() wiring) through an engage-then-release
 // cycle in Mouse Camera mode and asserts the player's facing lands exactly on the
 // camera yaw at release, not a fraction of a turn short.
-import puppeteer from 'puppeteer-core';
+
 import fs from 'node:fs';
+import puppeteer from 'puppeteer-core';
 import { BROWSER_PATH } from './browser_path.mjs';
 
 const URL = (process.env.GAME_URL ?? 'http://localhost:5173') + '/?gfx=ultra';
@@ -26,7 +27,9 @@ const browser = await puppeteer.launch({
 });
 const page = await browser.newPage();
 page.on('pageerror', (e) => console.log('PAGEERROR:', e.message));
-page.on('console', (m) => { if (m.type() === 'error') console.log('CONSOLE:', m.text()); });
+page.on('console', (m) => {
+  if (m.type() === 'error') console.log('CONSOLE:', m.text());
+});
 
 await page.goto(URL, { waitUntil: 'domcontentloaded', timeout: 60000 });
 await page.waitForSelector('#btn-offline', { timeout: 60000 });

--- a/src/game/camera_driven_facing.ts
+++ b/src/game/camera_driven_facing.ts
@@ -1,0 +1,17 @@
+// Whether the camera currently owns the player's heading this frame: classic
+// right-mouse mouselook, or Mouse Camera mode while a movement key is driving the
+// character (forward/back/strafe). Both hand the camera direct control of facing,
+// and both have a falling edge where that control lets go. This is the single
+// source of truth for "is a camera driving facing right now", used both to pick
+// the frame's facing override and to detect the edge so mouselookReleaseFacing
+// (mouselook_release.ts) can commit the final camera yaw exactly once, instead of
+// dropping the last slice of camera motion since the previous sim tick.
+export function isCameraDrivenFacingActive(
+  mouseCameraMode: boolean,
+  cameraMoveActive: boolean,
+  mouselookActive: boolean,
+  dead: boolean,
+): boolean {
+  if (dead) return false;
+  return mouseCameraMode ? cameraMoveActive : mouselookActive;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
   cssEffectsTier,
   readBrowserEnv,
 } from './game/browser_env';
+import { isCameraDrivenFacingActive } from './game/camera_driven_facing';
 import { cameraFollowShouldSettle, updateFollowCameraYaw, wrapAngle } from './game/camera_follow';
 import {
   clickMoveShouldWalk,
@@ -1936,9 +1937,11 @@ async function startGame(
   // eases back to zero so the camera settles in behind the character.
   let lastInterpFacing: number | null = null;
   let wasClickMoving = false;
-  // Tracks classic right-mouse mouselook across frames so its falling edge can
-  // commit the final camera yaw to the player facing (see mouselook_release.ts).
-  let prevMouselook = false;
+  // Tracks camera-driven facing (classic right-mouse mouselook, or Mouse Camera
+  // mode while a movement key is held) across frames so its falling edge can
+  // commit the final camera yaw to the player facing (see mouselook_release.ts
+  // and camera_driven_facing.ts).
+  let prevCameraDrivenFacing = false;
   // The release yaw, latched until a sim tick actually commits it. Offline a tick
   // runs on only ~2/3 of frames (60Hz frames, 20Hz ticks), so committing only on
   // the release frame would drop the one-shot when release lands on a zero-tick
@@ -2107,10 +2110,14 @@ async function startGame(
   }
 
   function renderFacingOverride(): number | null {
-    if (input.isMouseCameraMode()) {
-      return cameraMoveActive() ? input.camYaw : null;
-    }
-    return input.isMouselookActive() && !world.player.dead ? input.camYaw : null;
+    return isCameraDrivenFacingActive(
+      input.isMouseCameraMode(),
+      cameraMoveActive(),
+      input.isMouselookActive(),
+      world.player.dead,
+    )
+      ? input.camYaw
+      : null;
   }
 
   function cameraMoveActive(): boolean {
@@ -2172,12 +2179,23 @@ async function startGame(
     const mouselook = input.isMouselookActive() && !world.player.dead;
     const controllerFacing = input.controllerFacingOverride();
     const renderFacing = renderFacingOverride();
-    // On the frame mouselook is released, latch the final camera yaw so the player
-    // facing ends exactly where the camera ended; otherwise the last slice of the
-    // turn is dropped and the character lags the camera. The render/controller
+    // On the frame the camera lets go of the player's heading (classic mouselook
+    // release, OR a Mouse Camera mode move key release), latch the final camera yaw
+    // so the facing ends exactly where the camera ended; otherwise the last slice of
+    // the turn is dropped and the character lags the camera. The render/controller
     // overrides take precedence and reclaim the heading, clearing any stale latch.
-    const edgeReleaseFacing = mouselookReleaseFacing(prevMouselook, mouselook, input.camYaw);
-    prevMouselook = mouselook;
+    const cameraDrivenFacing = isCameraDrivenFacingActive(
+      input.isMouseCameraMode(),
+      cameraMoveActive(),
+      input.isMouselookActive(),
+      world.player.dead,
+    );
+    const edgeReleaseFacing = mouselookReleaseFacing(
+      prevCameraDrivenFacing,
+      cameraDrivenFacing,
+      input.camYaw,
+    );
+    prevCameraDrivenFacing = cameraDrivenFacing;
     if (renderFacing !== null || controllerFacing !== null) {
       pendingReleaseFacing = null;
     } else if (edgeReleaseFacing !== null) {

--- a/tests/camera_driven_facing.test.ts
+++ b/tests/camera_driven_facing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { isCameraDrivenFacingActive } from '../src/game/camera_driven_facing';
+import { mouselookReleaseFacing } from '../src/game/mouselook_release';
+
+// Bug: main.ts only fed classic right-mouse mouselook into mouselookReleaseFacing's
+// falling-edge tracker. Mouse Camera mode ALSO hands the camera ownership of the
+// player's heading, while a movement key drives the character (see
+// renderFacingOverride in main.ts) - but its release never committed the final
+// camera yaw, so the same "final slice of motion since the last tick is dropped"
+// bug #1053 fixed for mouselook reappears the moment a Mouse Camera mode move key
+// is released: the character settles a fraction of a turn behind the camera and
+// the follow camera then backtracks onto that stale facing.
+describe('isCameraDrivenFacingActive', () => {
+  it('is active under classic right-mouse mouselook', () => {
+    expect(isCameraDrivenFacingActive(false, false, true, false)).toBe(true);
+  });
+
+  it('is active under Mouse Camera mode while a movement key drives the character', () => {
+    expect(isCameraDrivenFacingActive(true, true, false, false)).toBe(true);
+  });
+
+  it('is inactive under Mouse Camera mode with no movement key held', () => {
+    expect(isCameraDrivenFacingActive(true, false, false, false)).toBe(false);
+  });
+
+  it('mouselook is ignored while Mouse Camera mode owns the override', () => {
+    expect(isCameraDrivenFacingActive(true, false, true, false)).toBe(false);
+  });
+
+  it('is inactive while dead, regardless of mode', () => {
+    expect(isCameraDrivenFacingActive(false, false, true, true)).toBe(false);
+    expect(isCameraDrivenFacingActive(true, true, false, true)).toBe(false);
+  });
+});
+
+describe('mouselookReleaseFacing driven by isCameraDrivenFacingActive (regression)', () => {
+  it('commits the final camera yaw when a Mouse Camera mode move key is released', () => {
+    const camYaw = 1.9;
+    const prevActive = isCameraDrivenFacingActive(true, true, false, false); // W held
+    const nowActive = isCameraDrivenFacingActive(true, false, false, false); // W released
+    expect(mouselookReleaseFacing(prevActive, nowActive, camYaw)).toBe(camYaw);
+  });
+
+  it('does not commit while the Mouse Camera mode move key stays held', () => {
+    const camYaw = 1.9;
+    const prevActive = isCameraDrivenFacingActive(true, true, false, false);
+    const nowActive = isCameraDrivenFacingActive(true, true, false, false);
+    expect(mouselookReleaseFacing(prevActive, nowActive, camYaw)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

PR #1053 fixed a snap where releasing classic right-mouse mouselook left the
character a fraction of a turn behind the camera (the last slice of mouse
motion since the previous sim tick was dropped), because `mouselookReleaseFacing`
only fired on the RMB falling edge.

Mouse Camera mode hands the camera that same direct control of the player's
facing while a movement key drives the character (`renderFacingOverride` /
`cameraMoveActive` in `main.ts`), but its release was never fed into the same
commit path. So the identical bug survives for that mode: the character
doesn't rotate to the exact angle the camera is pointing at, and pressing W to
move forward still produces a snap, because the follow camera later backtracks
onto the stale, "false" facing the sim was left with.

## Fix

Extract `isCameraDrivenFacingActive()` (`src/game/camera_driven_facing.ts`) as
the single source of truth for "is the camera driving facing this frame"
(classic mouselook OR Mouse Camera mode with an active move key). Feed it into
both `renderFacingOverride()` and the release-edge tracker in `main.ts`, so
either mode's falling edge now commits the exact final camera yaw via the
existing `mouselookReleaseFacing`.

```mermaid
sequenceDiagram
    participant Mouse as Mouse (60Hz)
    participant Input as input.camYaw
    participant Frame as main.ts frame()
    participant Sim as Sim (20Hz tick)
    participant Cam as Follow camera

    Note over Mouse,Cam: Mouse Camera mode, W held: camera drives facing every frame
    Mouse->>Input: drag updates camYaw continuously
    Frame->>Frame: cameraDrivenFacing = isCameraDrivenFacingActive(...) = true
    Frame->>Sim: facing = camYaw (each tick)

    Note over Mouse,Cam: W released mid-frame, between two sim ticks
    Mouse->>Input: camYaw keeps moving right up to release
    Frame->>Frame: cameraDrivenFacing flips true -> false (falling edge)

    rect rgb(255, 230, 230)
    Note over Frame,Sim: BEFORE FIX: only RMB mouselook fed the edge tracker.<br/>Mouse Camera mode release was invisible to it - no commit.<br/>Sim facing stays at the LAST TICK's camYaw, short by one frame's drag.
    end

    rect rgb(220, 245, 220)
    Frame->>Frame: edgeReleaseFacing = mouselookReleaseFacing(prevCameraDrivenFacing, cameraDrivenFacing, camYaw)
    Frame->>Sim: latch + commit exact release camYaw on next tick
    Note over Frame,Sim: AFTER FIX: Mouse Camera mode release also feeds the edge tracker via isCameraDrivenFacingActive, so it commits too.
    end

    Sim-->>Cam: player.facing now matches release camYaw exactly
    Cam->>Cam: settle/follow uses the TRUE facing, no backtrack snap
```

![sequence diagram](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@0819ada86a1530b05b26a80c0968bbc8b6f8fcd4/pr-assets/sequence-diagram.png)

## Verification

Screenshot / measurement harness (`scripts/camera_driven_facing_release_shot.mjs`,
mirrors the existing `facing_snap_shot.mjs` idiom) drives an engage-then-release
cycle and asserts the final facing lands exactly on the release camera yaw
(`PASS: true`). In-world gameplay context for the harness:

![gameplay context](https://cdn.jsdelivr.net/gh/jgyy/world-of-claudecraft@0819ada86a1530b05b26a80c0968bbc8b6f8fcd4/pr-assets/context-screenshot.png)

## Test plan
- [x] New unit tests: `tests/camera_driven_facing.test.ts` (the extracted predicate,
      plus a regression test proving the Mouse Camera mode release now commits)
- [x] Existing `tests/mouselook_release_facing.test.ts`, `tests/camera_follow.test.ts`,
      `tests/facing_smooth.test.ts` all still pass (the pure release-commit logic is
      unchanged; only which frame states feed it is generalized)
- [x] `npx tsc --noEmit` clean
- [x] `npm run ci:changed` (Biome, changed files) green
- [x] Manual screenshot/verification script passes (`PASS: true`)

This PR is opened for CI verification and review. **Do not merge.**