### PR TITLE
[codex] Add professions craft ring content

### DIFF
--- a/src/sim/content/professions.ts
+++ b/src/sim/content/professions.ts
@@ -1,0 +1,90 @@
+export type GatheringProfessionId = 'mining' | 'logging' | 'herbalism';
+
+export type ProductionCraftId =
+  | 'weaponcrafting'
+  | 'armorcrafting'
+  | 'engineering'
+  | 'alchemy'
+  | 'cooking'
+  | 'leatherworking'
+  | 'tailoring'
+  | 'inscription'
+  | 'enchanting'
+  | 'jewelcrafting';
+
+export type ProductionCraftPole = 'material' | 'experimental' | 'formal' | 'cross_cutting';
+
+export interface GatheringProfessionDef {
+  readonly id: GatheringProfessionId;
+  readonly name: string;
+}
+
+export interface ProductionCraftDef {
+  readonly id: ProductionCraftId;
+  readonly name: string;
+  readonly pole: ProductionCraftPole;
+}
+
+export const GATHERING_PROFESSION_ORDER = ['mining', 'logging', 'herbalism'] as const;
+
+export const GATHERING_PROFESSIONS: Record<GatheringProfessionId, GatheringProfessionDef> = {
+  mining: { id: 'mining', name: 'Mining' },
+  logging: { id: 'logging', name: 'Logging' },
+  herbalism: { id: 'herbalism', name: 'Herbalism' },
+};
+
+export const PRODUCTION_CRAFT_RING = [
+  'weaponcrafting',
+  'armorcrafting',
+  'engineering',
+  'alchemy',
+  'cooking',
+  'leatherworking',
+  'tailoring',
+  'inscription',
+  'enchanting',
+  'jewelcrafting',
+] as const;
+
+export const PRODUCTION_CRAFTS: Record<ProductionCraftId, ProductionCraftDef> = {
+  weaponcrafting: { id: 'weaponcrafting', name: 'Weaponcrafting', pole: 'material' },
+  armorcrafting: { id: 'armorcrafting', name: 'Armorcrafting', pole: 'material' },
+  engineering: { id: 'engineering', name: 'Engineering', pole: 'experimental' },
+  alchemy: { id: 'alchemy', name: 'Alchemy', pole: 'experimental' },
+  cooking: { id: 'cooking', name: 'Cooking', pole: 'cross_cutting' },
+  leatherworking: { id: 'leatherworking', name: 'Leatherworking', pole: 'material' },
+  tailoring: { id: 'tailoring', name: 'Tailoring', pole: 'material' },
+  inscription: { id: 'inscription', name: 'Inscription', pole: 'formal' },
+  enchanting: { id: 'enchanting', name: 'Enchanting', pole: 'formal' },
+  jewelcrafting: { id: 'jewelcrafting', name: 'Jewelcrafting', pole: 'formal' },
+};
+
+function craftRingIndex(craft: ProductionCraftId): number {
+  const index = PRODUCTION_CRAFT_RING.indexOf(craft);
+  if (index < 0) throw new Error(`Unknown production craft: ${craft}`);
+  return index;
+}
+
+function craftAtRingOffset(craft: ProductionCraftId, offset: number): ProductionCraftId {
+  const index = craftRingIndex(craft);
+  const next =
+    PRODUCTION_CRAFT_RING[
+      (index + offset + PRODUCTION_CRAFT_RING.length) % PRODUCTION_CRAFT_RING.length
+    ];
+  if (!next) throw new Error(`Invalid production craft ring offset: ${craft}, ${offset}`);
+  return next;
+}
+
+export function adjacentProductionCrafts(
+  craft: ProductionCraftId,
+): readonly [ProductionCraftId, ProductionCraftId] {
+  return [craftAtRingOffset(craft, -1), craftAtRingOffset(craft, 1)];
+}
+
+export function oppositeProductionCraft(craft: ProductionCraftId): ProductionCraftId {
+  return craftAtRingOffset(craft, PRODUCTION_CRAFT_RING.length / 2);
+}
+
+export function areAdjacentProductionCrafts(a: ProductionCraftId, b: ProductionCraftId): boolean {
+  return adjacentProductionCrafts(a).includes(b);
+}

--- a/tests/professions_content.test.ts
+++ b/tests/professions_content.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import {
+  adjacentProductionCrafts,
+  areAdjacentProductionCrafts,
+  GATHERING_PROFESSION_ORDER,
+  GATHERING_PROFESSIONS,
+  oppositeProductionCraft,
+  PRODUCTION_CRAFT_RING,
+  PRODUCTION_CRAFTS,
+  type ProductionCraftId,
+  type ProductionCraftPole,
+} from '../src/sim/content/professions';
+
+const EXPECTED_RING: readonly ProductionCraftId[] = [
+  'weaponcrafting',
+  'armorcrafting',
+  'engineering',
+  'alchemy',
+  'cooking',
+  'leatherworking',
+  'tailoring',
+  'inscription',
+  'enchanting',
+  'jewelcrafting',
+];
+
+const EXPECTED_ADJACENCY: Record<
+  ProductionCraftId,
+  readonly [ProductionCraftId, ProductionCraftId]
+> = {
+  weaponcrafting: ['jewelcrafting', 'armorcrafting'],
+  armorcrafting: ['weaponcrafting', 'engineering'],
+  engineering: ['armorcrafting', 'alchemy'],
+  alchemy: ['engineering', 'cooking'],
+  cooking: ['alchemy', 'leatherworking'],
+  leatherworking: ['cooking', 'tailoring'],
+  tailoring: ['leatherworking', 'inscription'],
+  inscription: ['tailoring', 'enchanting'],
+  enchanting: ['inscription', 'jewelcrafting'],
+  jewelcrafting: ['enchanting', 'weaponcrafting'],
+};
+
+const EXPECTED_OPPOSITES: Record<ProductionCraftId, ProductionCraftId> = {
+  weaponcrafting: 'leatherworking',
+  armorcrafting: 'tailoring',
+  engineering: 'inscription',
+  alchemy: 'enchanting',
+  cooking: 'jewelcrafting',
+  leatherworking: 'weaponcrafting',
+  tailoring: 'armorcrafting',
+  inscription: 'engineering',
+  enchanting: 'alchemy',
+  jewelcrafting: 'cooking',
+};
+
+const EXPECTED_POLES: Record<ProductionCraftPole, readonly ProductionCraftId[]> = {
+  material: ['weaponcrafting', 'armorcrafting', 'leatherworking', 'tailoring'],
+  experimental: ['engineering', 'alchemy'],
+  formal: ['inscription', 'enchanting', 'jewelcrafting'],
+  cross_cutting: ['cooking'],
+};
+
+describe('professions content', () => {
+  it('defines the starter gathering professions independently from the craft ring', () => {
+    expect(GATHERING_PROFESSION_ORDER).toEqual(['mining', 'logging', 'herbalism']);
+    expect(Object.keys(GATHERING_PROFESSIONS)).toEqual([...GATHERING_PROFESSION_ORDER]);
+    expect(Object.values(GATHERING_PROFESSIONS).map((profession) => profession.name)).toEqual([
+      'Mining',
+      'Logging',
+      'Herbalism',
+    ]);
+  });
+
+  it('defines the ten production crafts in the fixed ring order', () => {
+    expect(PRODUCTION_CRAFT_RING).toEqual(EXPECTED_RING);
+    expect(Object.keys(PRODUCTION_CRAFTS)).toEqual([...EXPECTED_RING]);
+    expect(new Set(PRODUCTION_CRAFT_RING)).toHaveLength(10);
+  });
+
+  it('derives adjacent crafts from the ring, including wraparound edges', () => {
+    for (const craft of PRODUCTION_CRAFT_RING) {
+      expect(adjacentProductionCrafts(craft)).toEqual(EXPECTED_ADJACENCY[craft]);
+      for (const neighbor of EXPECTED_ADJACENCY[craft]) {
+        expect(areAdjacentProductionCrafts(craft, neighbor)).toBe(true);
+      }
+      expect(areAdjacentProductionCrafts(craft, oppositeProductionCraft(craft))).toBe(false);
+    }
+  });
+
+  it('derives opposite crafts as the craft five positions around the ring', () => {
+    for (const craft of PRODUCTION_CRAFT_RING) {
+      const opposite = oppositeProductionCraft(craft);
+      expect(opposite).toBe(EXPECTED_OPPOSITES[craft]);
+      expect(oppositeProductionCraft(opposite)).toBe(craft);
+    }
+  });
+
+  it('tags every production craft with its pole group', () => {
+    const byPole = PRODUCTION_CRAFT_RING.reduce(
+      (acc, craft) => {
+        acc[PRODUCTION_CRAFTS[craft].pole].push(craft);
+        return acc;
+      },
+      {
+        material: [],
+        experimental: [],
+        formal: [],
+        cross_cutting: [],
+      } as Record<ProductionCraftPole, ProductionCraftId[]>,
+    );
+    expect(byPole).toEqual(EXPECTED_POLES);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the foundational professions content slice for the ten production crafts.

- Adds `src/sim/content/professions.ts` with starter gathering profession ids, the ten production craft ids, craft display names, pole tags, and the fixed craft ring order from #1125.
- Adds pure helper functions for adjacent craft lookup, opposite craft lookup, and adjacency checks.
- Adds focused tests that lock the ring order, wraparound adjacency, opposite pairs, pole grouping, and starter gathering profession list.

## Related issues

Closes #1125.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - [x] `npm run check:ts` passed.
  - [x] `npx biome check --write src\sim\content\professions.ts tests\professions_content.test.ts` passed and formatted the changed files.
  - [x] `npx biome check src\sim\content\professions.ts tests\professions_content.test.ts --max-diagnostics 30` passed.
  - [x] `npx vitest run tests\professions_content.test.ts` passed with the temporary local `.browserslistrc` comment-strip workaround required on this release branch. Result: 1 file passed, 5 tests passed.
  - [ ] `npx vitest run tests\professions_content.test.ts tests\architecture.test.ts` is blocked by an unrelated release-branch architecture failure in `src/world_api/chat.ts`: value import of `OVERHEAD_EMOTE_IDS` from `../sim/types`. The new professions test passed in that run.
  - [x] `git diff --cached --check` passed.
  - [ ] `npm run build` is blocked on the current `release/v0.18.0` branch before Vite builds: `Unsupported .browserslistrc entry (only "Browser >= X" floors are allowed): # CSS engine floor (single source) for the Lightning CSS transformer.`
  - [ ] `npm run lint` is blocked by the existing repo-wide lint backlog: 27 errors, 3924 warnings, 453 infos. First diagnostics are in `headless/env_server.ts`, scripts under `scripts/`, and `mediawiki/theme/Common.css`.
- Manual steps:
  - Compared the implementation against the #1125 issue body and collaborator ring comment: ring order, wraparound edges, and opposite pairs match the issue.

## Screenshots / recordings

N/A. This PR adds pure sim content data and tests only, with no player-visible UI change.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
      Focused content tests pass. Full `npm test` was not run because this release branch currently needs the `.browserslistrc` workaround for Vite/Vitest config loading, and the architecture guard has the unrelated `src/world_api/chat.ts` baseline failure noted above.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.
      `npm run build` is currently blocked by the release-branch `.browserslistrc` comment parsing issue noted above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
      N/A, no UI surface changed.
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).
      N/A, no UI surface changed.

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no currently rendered player-visible strings.
      The craft names are English source content for this new pure data catalog and are not rendered by a UI or emitted from sim/server in this slice.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
      `npm run build` regenerated unrelated outputs before hitting the known blocker; those generated files were restored and are not part of this PR.
