### PR TITLE
[codex] Add gathering proficiency tracking

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -2997,6 +2997,7 @@ export class GameServer {
     maybe('drun', this.sim.delveRunWire(anchorSession.pid));
     maybe('dcompanion', this.sim.delveCompanionWire(anchorSession.pid));
     maybe('dmarks', this.sim.delveMarksFor(anchorSession.pid));
+    maybe('gprof', this.sim.gatheringProficienciesFor(anchorSession.pid));
     maybe('dcomp', this.sim.companionUpgradesFor(anchorSession.pid));
     maybe('dclears', this.sim.delveClearsFor(anchorSession.pid));
     maybe('delveDaily', this.sim.delveDailyWire(anchorSession.pid));

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -18,6 +18,11 @@ import { deadTargetSelectable } from '../sim/dead_target';
 import { LEADERBOARD_PAGE_SIZE } from '../sim/leaderboard_page';
 import type { Ante, PickAction } from '../sim/lockpick';
 import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
+import {
+  emptyGatheringProficiencies,
+  type GatheringProficiencies,
+  normalizeGatheringProficiencies,
+} from '../sim/professions/gathering';
 import { computeQuestState, type ResolvedAbility } from '../sim/sim';
 import {
   type Entity,
@@ -802,6 +807,7 @@ export class ClientWorld implements IWorld {
   prestigeRank = 0;
   // Rested XP pool, mirrored from snapshot self.
   restedXp = 0;
+  gatheringProficiencies: GatheringProficiencies = emptyGatheringProficiencies();
   unlockedMilestones: string[] = [];
   // --- IWorldTalents: talents + spec/role + saved loadouts, mirrored from
   // snapshot self (display + staging). ---
@@ -1389,6 +1395,8 @@ export class ClientWorld implements IWorld {
       this.lifetimeXp = s.lxp ?? 0;
       this.restedXp = s.rxp ?? 0;
       this.prestigeRank = s.prk ?? 0;
+      if (s.gprof !== undefined)
+        this.gatheringProficiencies = normalizeGatheringProficiencies(s.gprof);
       if (s.milestones !== undefined) this.unlockedMilestones = s.milestones;
       // IWorldInventory facet (W2) self-decode: copper rides every self-frame (?? 0);
       // inv/buyback/equip are delta-guarded (a missing field keeps the prior mirror).

--- a/src/sim/content/professions.ts
+++ b/src/sim/content/professions.ts
@@ -1,0 +1,13 @@
+export const GATHERING_PROFESSION_IDS = ['mining', 'logging', 'herbalism'] as const;
+
+export type GatheringProfessionId = (typeof GATHERING_PROFESSION_IDS)[number];
+
+export interface GatheringProfessionDef {
+  id: GatheringProfessionId;
+}
+
+export const GATHERING_PROFESSIONS: Record<GatheringProfessionId, GatheringProfessionDef> = {
+  mining: { id: 'mining' },
+  logging: { id: 'logging' },
+  herbalism: { id: 'herbalism' },
+};

--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -1,0 +1,50 @@
+import { GATHERING_PROFESSION_IDS, type GatheringProfessionId } from '../content/professions';
+import type { SimContext } from '../sim_context';
+
+export type GatheringProficiencies = Record<GatheringProfessionId, number>;
+
+export function emptyGatheringProficiencies(): GatheringProficiencies {
+  return {
+    mining: 0,
+    logging: 0,
+    herbalism: 0,
+  };
+}
+
+export function isGatheringProfessionId(value: string): value is GatheringProfessionId {
+  return (GATHERING_PROFESSION_IDS as readonly string[]).includes(value);
+}
+
+export function normalizeGatheringProficiencies(
+  value: Partial<Record<string, number>> | null | undefined,
+): GatheringProficiencies {
+  const out = emptyGatheringProficiencies();
+  if (!value) return out;
+  for (const id of GATHERING_PROFESSION_IDS) {
+    const n = value[id];
+    out[id] = typeof n === 'number' && Number.isFinite(n) ? Math.max(0, Math.floor(n)) : 0;
+  }
+  return out;
+}
+
+export function cloneGatheringProficiencies(value: GatheringProficiencies): GatheringProficiencies {
+  return {
+    mining: value.mining,
+    logging: value.logging,
+    herbalism: value.herbalism,
+  };
+}
+
+export function gainGatheringProficiency(
+  ctx: SimContext,
+  professionId: GatheringProfessionId,
+  amount: number,
+  pid?: number,
+): boolean {
+  const r = ctx.resolve(pid);
+  if (!r || !Number.isFinite(amount) || amount <= 0) return false;
+  const delta = Math.floor(amount);
+  if (delta <= 0) return false;
+  r.meta.gatheringProficiencies[professionId] += delta;
+  return true;
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -49,6 +49,7 @@ import { isSpellResisted } from './combat/spell_resist';
 // moved to social/fiesta.ts with that logic; sim.ts keeps only the type used by
 // the PlayerMeta interface + the power-up catalog the fiestaMatchInfo accessor reads.
 import { type AugmentSpecial, type AugmentTier, POWERUPS_BY_ID } from './content/augments';
+import type { GatheringProfessionId } from './content/professions';
 import {
   classHasSkin,
   EVENT_SKIN_TOKEN_ID,
@@ -170,6 +171,13 @@ import {
 } from './pathfind';
 import * as petAi from './pet/pet_ai';
 import * as petCommands from './pet/pet_commands';
+import {
+  cloneGatheringProficiencies,
+  emptyGatheringProficiencies,
+  type GatheringProficiencies,
+  gainGatheringProficiency as gainGatheringProficiencyImpl,
+  normalizeGatheringProficiencies,
+} from './professions/gathering';
 import {
   applyTalentAllocation,
   deleteTalentLoadout,
@@ -635,6 +643,7 @@ export interface PlayerMeta {
   // Classic Rested XP pool (copper-less XP units). Accrues while resting in an
   // inn, spent to double kill XP. Persisted in CharacterState.
   restedXp: number;
+  gatheringProficiencies: GatheringProficiencies;
   known: ResolvedAbility[];
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;
@@ -722,6 +731,8 @@ export interface CharacterState {
   unlockedMilestones?: string[];
   // Rested XP pool. Optional so pre-rested-XP saves load cleanly (defaults to 0).
   restedXp?: number;
+  // Gathering profession proficiency. Optional so pre-professions saves load cleanly.
+  gatheringProficiencies?: Partial<Record<GatheringProfessionId, number>>;
   copper: number;
   hp: number;
   resource: number;
@@ -1153,6 +1164,7 @@ export class Sim {
       prestigeRank: 0,
       unlockedMilestones: new Set(),
       restedXp: 0,
+      gatheringProficiencies: emptyGatheringProficiencies(),
       known: [],
       questLog: new Map(),
       questsDone: new Set(),
@@ -1200,6 +1212,7 @@ export class Sim {
       meta.lifetimeXp = s.lifetimeXp ?? xpToReachLevel(player.level) + Math.max(0, s.xp);
       meta.prestigeRank = s.prestigeRank ?? 0;
       meta.restedXp = Math.max(0, s.restedXp ?? 0);
+      meta.gatheringProficiencies = normalizeGatheringProficiencies(s.gatheringProficiencies);
       if (s.unlockedMilestones)
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
@@ -1367,6 +1380,7 @@ export class Sim {
       prestigeRank: meta.prestigeRank,
       unlockedMilestones: [...meta.unlockedMilestones],
       restedXp: meta.restedXp,
+      gatheringProficiencies: cloneGatheringProficiencies(meta.gatheringProficiencies),
       copper: meta.copper,
       hp: e.hp,
       // A druid saved while shifted runs on rage/energy with its mana parked in
@@ -1596,6 +1610,9 @@ export class Sim {
   }
   get restedXp(): number {
     return this.primary.restedXp;
+  }
+  get gatheringProficiencies(): GatheringProficiencies {
+    return this.gatheringProficienciesFor(this.primaryId);
   }
   get prestigeRank(): number {
     return this.primary.prestigeRank;
@@ -1965,6 +1982,8 @@ export class Sim {
       countItem: sim.countItem.bind(sim),
       completeQuestForDev: (questId, pid) => completeQuestForDev(sim.ctx, questId, pid),
       completeCurrentQuestsForDev: (pid) => completeCurrentQuestsForDev(sim.ctx, pid),
+      gainGatheringProficiency: (professionId, amount, pid) =>
+        sim.gainGatheringProficiency(professionId, amount, pid),
       // I1 dungeon instancing now lives in instances/dungeons.ts; these route through
       // the same-named Sim delegates (foreign callers use this.X). lockoutNowMs is the
       // shared raid-lockout clock that stays on Sim (N1 also writes through it).
@@ -4467,6 +4486,21 @@ export class Sim {
 
   completeCurrentQuestsForDev(pid?: number): number {
     return completeCurrentQuestsForDev(this.ctx, pid);
+  }
+
+  gainGatheringProficiency(
+    professionId: GatheringProfessionId,
+    amount: number,
+    pid = this.primaryId,
+  ): boolean {
+    return gainGatheringProficiencyImpl(this.ctx, professionId, amount, pid);
+  }
+
+  gatheringProficienciesFor(pid = this.primaryId): GatheringProficiencies {
+    const r = this.resolve(pid);
+    return r
+      ? cloneGatheringProficiencies(r.meta.gatheringProficiencies)
+      : emptyGatheringProficiencies();
   }
 
   // No-op in offline mode

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -12,6 +12,7 @@
 // game/net/DOM/Three, no `Math.random`/`Date.now`), so it runs unchanged in Node,
 // the browser, and the headless RL env (enforced by tests/architecture.test.ts).
 
+import type { GatheringProfessionId } from './content/professions';
 import type { TalentModifiers } from './content/talents';
 import type { DelayedEvent, GroundAoE } from './entity_roster';
 import type { PendingLootRoll } from './loot/loot_roll';
@@ -294,6 +295,11 @@ export interface SimContextCallbacks {
   countItem(itemId: string, pid?: number): number;
   completeQuestForDev(questId: string, pid?: number): boolean;
   completeCurrentQuestsForDev(pid?: number): number;
+  gainGatheringProficiency(
+    professionId: GatheringProfessionId,
+    amount: number,
+    pid?: number,
+  ): boolean;
 
   // T1 player target selection consumes isHostileTo/isFriendlyTo/pvpController/stopFollow;
   // all already on the seam (C4a added the first two + stopFollow, C1 added pvpController)
@@ -767,6 +773,7 @@ export function createSimContext(host: SimContextHost): SimContext {
     countItem: host.countItem,
     completeQuestForDev: host.completeQuestForDev,
     completeCurrentQuestsForDev: host.completeCurrentQuestsForDev,
+    gainGatheringProficiency: host.gainGatheringProficiency,
     addEntity: host.addEntity,
     dropEntity: host.dropEntity,
     rebucket: host.rebucket,

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -9,7 +9,7 @@
 // keep resolving to THIS file, never the sibling directory.
 //
 // ---------------------------------------------------------------------------
-// FACET MAP: the 20 domain facets (each IWorld member assigned exactly once; 142
+// FACET MAP: the 21 domain facets (each IWorld member assigned exactly once; 148
 // total). One interface per file under ./world_api/; aux types travel with their
 // facet. The authoritative member-per-facet split is the W0c parity test.
 //
@@ -22,6 +22,7 @@
 //   cosmetics.ts        IWorldCosmetics      account skins + mech chroma
 //   quests.ts           IWorldQuests         quest log + accept/turn-in/abandon
 //   progression_xp.ts   IWorldProgressionXp  xp/lifetimeXp/prestige/rested/leaderboard
+//   professions.ts      IWorldProfessions    gathering proficiency reads
 //   talents.ts          IWorldTalents        talents, specs, loadouts
 //   pet.ts              IWorldPet            hunter-pet command surface
 //   party.ts            IWorldParty          party/raid + raid-target markers
@@ -36,12 +37,12 @@
 //
 // THREE GATES pin this seam (run before any facet edit):
 //   tests/snapshots.test.ts        (W0a)  selfWireJson <-> applySnapshot round-trip;
-//                                          ALL_DELTA_KEYS (25) + TERSE_TO_IWORLD mapping.
+//                                          ALL_DELTA_KEYS (26) + TERSE_TO_IWORLD mapping.
 //   tests/command_schema.test.ts   (W0b)  COMMAND_NAMES universe; ClientWorld send-set
 //                                          subset-of dispatch-set; DISPATCH_ONLY (7).
-//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (142) present + same-kind on
+//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (148) present + same-kind on
 //                                          Sim + ClientWorld; aggregate == disjoint
-//                                          union of the 20 facets.
+//                                          union of the 21 facets.
 // ---------------------------------------------------------------------------
 
 import type { IWorldChat } from './world_api/chat';
@@ -57,6 +58,7 @@ import type { IWorldLoot } from './world_api/loot';
 import type { IWorldMarket } from './world_api/market';
 import type { IWorldParty } from './world_api/party';
 import type { IWorldPet } from './world_api/pet';
+import type { IWorldProfessions } from './world_api/professions';
 import type { IWorldProgressionXp } from './world_api/progression_xp';
 import type { IWorldQuests } from './world_api/quests';
 import type { IWorldSocialGraph } from './world_api/social_graph';
@@ -91,6 +93,7 @@ export type {
 export type { RaidLockout } from './world_api/dungeons';
 export type { MarketInfo, MarketListingView } from './world_api/market';
 export type { PartyInfo, PartyMemberInfo } from './world_api/party';
+export type { GatheringProficiencies } from './world_api/professions';
 export type { GuildLeaderboardEntry, LeaderboardEntry } from './world_api/progression_xp';
 export type {
   CharacterSearchResult,
@@ -116,6 +119,7 @@ export interface IWorld
     IWorldCosmetics,
     IWorldQuests,
     IWorldProgressionXp,
+    IWorldProfessions,
     IWorldTalents,
     IWorldPet,
     IWorldParty,
@@ -310,6 +314,7 @@ export type WorldFacet =
   | 'IWorldCosmetics'
   | 'IWorldQuests'
   | 'IWorldProgressionXp'
+  | 'IWorldProfessions'
   | 'IWorldTalents'
   | 'IWorldPet'
   | 'IWorldParty'

--- a/src/world_api/professions.ts
+++ b/src/world_api/professions.ts
@@ -1,0 +1,7 @@
+import type { GatheringProficiencies } from '../sim/professions/gathering';
+
+export type { GatheringProficiencies } from '../sim/professions/gathering';
+
+export interface IWorldProfessions {
+  gatheringProficiencies: GatheringProficiencies;
+}

--- a/tests/entity_roster.test.ts
+++ b/tests/entity_roster.test.ts
@@ -175,6 +175,7 @@ function makeCtx() {
     countItem: vi.fn(() => 0),
     completeQuestForDev: vi.fn(() => false),
     completeCurrentQuestsForDev: vi.fn(() => 0),
+    gainGatheringProficiency: vi.fn(() => false),
     lockoutNowMs: vi.fn(() => 0),
     instanceKeyFor: vi.fn(() => 'solo:0'),
     instanceOriginOf: vi.fn(() => ({ x: 0, z: 0 })),

--- a/tests/gathering_proficiency.test.ts
+++ b/tests/gathering_proficiency.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import { GATHERING_PROFESSION_IDS } from '../src/sim/content/professions';
+import { emptyGatheringProficiencies } from '../src/sim/professions/gathering';
+import { Sim } from '../src/sim/sim';
+
+function makeWorld() {
+  return new Sim({ seed: 7, playerClass: 'warrior', noPlayer: true });
+}
+
+describe('gathering profession proficiency', () => {
+  it('starts every gathering profession at zero', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Miner');
+
+    expect(GATHERING_PROFESSION_IDS).toEqual(['mining', 'logging', 'herbalism']);
+    expect(sim.gatheringProficienciesFor(pid)).toEqual(emptyGatheringProficiencies());
+  });
+
+  it('adds proficiency only to the profession and player being granted', () => {
+    const sim = makeWorld();
+    const miner = sim.addPlayer('warrior', 'Miner');
+    const herbalist = sim.addPlayer('druid', 'Herbalist');
+
+    expect(sim.gainGatheringProficiency('mining', 5, miner)).toBe(true);
+    expect(sim.gainGatheringProficiency('mining', 2.9, miner)).toBe(true);
+    expect(sim.gainGatheringProficiency('herbalism', 3, herbalist)).toBe(true);
+
+    expect(sim.gatheringProficienciesFor(miner)).toEqual({
+      mining: 7,
+      logging: 0,
+      herbalism: 0,
+    });
+    expect(sim.gatheringProficienciesFor(herbalist)).toEqual({
+      mining: 0,
+      logging: 0,
+      herbalism: 3,
+    });
+  });
+
+  it('ignores non-positive gains and missing players', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Careful');
+
+    expect(sim.gainGatheringProficiency('logging', 0, pid)).toBe(false);
+    expect(sim.gainGatheringProficiency('logging', -3, pid)).toBe(false);
+    expect(sim.gainGatheringProficiency('logging', Number.NaN, pid)).toBe(false);
+    expect(sim.gainGatheringProficiency('logging', 4, 9999)).toBe(false);
+
+    expect(sim.gatheringProficienciesFor(pid)).toEqual(emptyGatheringProficiencies());
+  });
+
+  it('returns a copy so IWorld readers cannot mutate character state', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Reader');
+    sim.gainGatheringProficiency('mining', 4, pid);
+
+    const view = sim.gatheringProficienciesFor(pid);
+    view.mining = 999;
+
+    expect(sim.gatheringProficienciesFor(pid).mining).toBe(4);
+    expect(sim.gatheringProficiencies.mining).toBe(4);
+  });
+
+  it('persists gathering proficiencies across a serialize and reload round-trip', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'Saver');
+    sim.gainGatheringProficiency('mining', 12, pid);
+    sim.gainGatheringProficiency('logging', 6, pid);
+
+    const state = sim.serializeCharacter(pid);
+    expect(state).not.toBeNull();
+    if (!state) throw new Error('expected serialized character state');
+    expect(state.gatheringProficiencies).toEqual({
+      mining: 12,
+      logging: 6,
+      herbalism: 0,
+    });
+
+    const loaded = makeWorld();
+    const loadedPid = loaded.addPlayer('warrior', 'Saver', { state });
+    expect(loaded.gatheringProficienciesFor(loadedPid)).toEqual({
+      mining: 12,
+      logging: 6,
+      herbalism: 0,
+    });
+  });
+
+  it('loads legacy saves without gathering proficiency as all-zero state', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer('warrior', 'LegacySeed');
+    const state = sim.serializeCharacter(pid);
+    expect(state).not.toBeNull();
+    if (!state) throw new Error('expected serialized character state');
+    const legacy: Record<string, unknown> = { ...state };
+    delete legacy.gatheringProficiencies;
+
+    const loaded = makeWorld();
+    const loadedPid = loaded.addPlayer('warrior', 'Legacy', { state: legacy as never });
+
+    expect(loaded.gatheringProficienciesFor(loadedPid)).toEqual(emptyGatheringProficiencies());
+    expect(loaded.serializeCharacter(loadedPid)?.gatheringProficiencies).toEqual(
+      emptyGatheringProficiencies(),
+    );
+  });
+});

--- a/tests/sim_context.test.ts
+++ b/tests/sim_context.test.ts
@@ -75,6 +75,7 @@ const CALLBACK_KEYS = [
   'countItem',
   'completeQuestForDev',
   'completeCurrentQuestsForDev',
+  'gainGatheringProficiency',
   // E1 entity-roster surface.
   'addEntity',
   'dropEntity',
@@ -311,6 +312,7 @@ function makeFakeHost() {
     countItem: vi.fn(() => 0),
     completeQuestForDev: vi.fn(() => false),
     completeCurrentQuestsForDev: vi.fn(() => 0),
+    gainGatheringProficiency: vi.fn(() => false),
     lockoutNowMs: vi.fn(() => 0),
     instanceKeyFor: vi.fn(() => 'solo:0'),
     instanceOriginOf: vi.fn(() => ({ x: 0, z: 0 })),

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -96,6 +96,7 @@ function bareClient(pid: number): ClientWorld {
   c.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
   c.copper = 0;
   c.xp = 0;
+  c.gatheringProficiencies = { mining: 0, logging: 0, herbalism: 0 };
   c.known = [];
   c.questLog = new Map();
   c.questsDone = new Set();
@@ -321,7 +322,7 @@ describe('delta snapshots', () => {
     const snap = lastSnap(fc.sent);
     expect(snap).not.toBeNull();
     // a fresh session has an empty lastSent, so EVERY maybe() delta key rides the
-    // first snapshot (even the null-valued ones like party/trade); widened to all 25
+    // first snapshot (even the null-valued ones like party/trade); widened to all 26
     for (const key of ALL_DELTA_KEYS) {
       expect(snap.self, `self.${key} missing from first snapshot`).toHaveProperty(key);
     }
@@ -384,7 +385,7 @@ describe('delta snapshots', () => {
     const snap = lastSnap(fc.sent);
     // This single-tick test stays on the decay-safe subset: cds and the timer-backed
     // keys (delve/arena timers, delveDaily) can re-emit after a real sim.tick(), so the
-    // widened all-25 omission is proven by the no-op re-broadcast test instead.
+    // widened all-26 omission is proven by the no-op re-broadcast test instead.
     for (const key of DELTA_KEYS) {
       expect(snap.self, `self.${key} resent although unchanged`).not.toHaveProperty(key);
     }
@@ -711,7 +712,7 @@ describe('delta snapshots', () => {
     joinServer(server, fc2, 2, 'Testb');
     broadcast(server);
     const snapNew = lastSnap(fc2.sent);
-    // a fresh session always receives the full self state: all 25 delta keys
+    // a fresh session always receives the full self state: all 26 delta keys
     for (const key of ALL_DELTA_KEYS) {
       expect(snapNew.self, `self.${key} missing for fresh session`).toHaveProperty(key);
     }
@@ -1758,20 +1759,20 @@ describe('lockpick view rebuilds from events on the online client', () => {
 // ---------------------------------------------------------------------------
 // W0a: full self-snapshot delta round-trip gate.
 //
-// `selfWireJson` (server/game.ts) emits 25 heavy "delta" fields through a
+// `selfWireJson` (server/game.ts) emits 26 heavy "delta" fields through a
 // `maybe(key, value)` closure that ships a key only when its serialized form
 // changed since this session last received it; `applySnapshot` (src/net/
 // online.ts) mirrors each with `if (s.X !== undefined)` (or the inline
 // `s.X ?? e.X` form for `stats`/`weapon`). This is the single most fragile codec
-// in the workstream, so we pin: (a) the exact 25-key set against drift, (b) the
+// in the workstream, so we pin: (a) the exact 26-key set against drift, (b) the
 // terse-key -> IWorld-name rename map, (c) that every dirtied value round-trips
-// onto the correct decode target, and (d) that a no-op re-broadcast omits all 25
+// onto the correct decode target, and (d) that a no-op re-broadcast omits all 26
 // while the prior decoded value is preserved.
 // ---------------------------------------------------------------------------
 
-// The pinned set of the 25 `maybe(...)` delta keys, sorted. Cross-checked below
+// The pinned set of the 26 `maybe(...)` delta keys, sorted. Cross-checked below
 // against the live `maybe(...)` calls scraped from server/game.ts source, so a
-// 26th unregistered delta key reddens this gate.
+// 27th unregistered delta key reddens this gate.
 const ALL_DELTA_KEYS = [
   'arena',
   'buyback',
@@ -1785,6 +1786,7 @@ const ALL_DELTA_KEYS = [
   'drun',
   'duel',
   'equip',
+  'gprof',
   'inv',
   'lockouts',
   'lroll',
@@ -1819,6 +1821,7 @@ const TERSE_TO_IWORLD: Record<string, string> = {
   drun: 'delveRun',
   duel: 'duelInfo',
   equip: 'equipment',
+  gprof: 'gatheringProficiencies',
   inv: 'inventory',
   lockouts: 'selfLockouts',
   lroll: 'lootRollPrompts',
@@ -1840,9 +1843,9 @@ const TERSE_TO_IWORLD: Record<string, string> = {
 // filter without a wall-clock read in test scaffolding.
 const FAR_FUTURE_MS = 8_000_000_000_000;
 
-// Dirty every one of the 25 `maybe()` delta fields with a distinguishable,
+// Dirty every one of the 26 `maybe()` delta fields with a distinguishable,
 // non-default value so the round-trip + no-op-omission assertions are meaningful
-// (a fresh session carries all 25 on snapshot #1 regardless, since lastSent is
+// (a fresh session carries all 26 on snapshot #1 regardless, since lastSent is
 // empty). Most fields are set on their real PlayerMeta/Entity/session source;
 // for the few whose authentic setup is mutually exclusive in one player state we
 // poke the exact source field the encoder reads, per the brief (the gate asserts
@@ -1901,6 +1904,7 @@ function dirtyEveryDeltaField(): {
   meta.lifetimeXp = 555;
   meta.restedXp = 222;
   meta.prestigeRank = 3;
+  meta.gatheringProficiencies.mining = 11;
   meta.delveMarks = 7;
   meta.delveClears = { 'collapsed_reliquary:heroic': 1 };
   meta.companionUpgrades = { companion_tessa: 2 };
@@ -1947,7 +1951,7 @@ function dirtyEveryDeltaField(): {
 }
 
 describe('full self-state snapshot delta fixture', () => {
-  it('carries every one of the 25 dirtied delta keys on the first snapshot', () => {
+  it('carries every one of the 26 dirtied delta keys on the first snapshot', () => {
     const { server, fc } = dirtyEveryDeltaField();
     broadcast(server);
     const snap = lastSnap(fc.sent);
@@ -1982,6 +1986,7 @@ describe('full self-state snapshot delta fixture', () => {
     expect(client.inventory).toEqual([{ itemId: 'baked_bread', count: 3 }]); // inv -> inventory
     expect(client.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]); // buyback -> vendorBuyback
     expect(client.equipment).toMatchObject({ mainhand: 'zealotsbane_blade' }); // equip -> equipment
+    expect(client.gatheringProficiencies).toEqual({ mining: 11, logging: 0, herbalism: 0 }); // gprof -> gatheringProficiencies
     // cosmetics -> accountCosmetics, asserted against the normalized shape (the input
     // is already the normal {completedQuestIds, mechChromaIds} form, see :192-202)
     expect(client.accountCosmetics).toEqual({
@@ -2018,7 +2023,7 @@ describe('full self-state snapshot delta fixture', () => {
     expect(client.activeLoadout).toBe(0);
   });
 
-  it('omits all 25 delta keys on a no-op re-broadcast and preserves the prior mirror', () => {
+  it('omits all 26 delta keys on a no-op re-broadcast and preserves the prior mirror', () => {
     const { server, fc, leader, memberPid } = dirtyEveryDeltaField();
     broadcast(server);
     const client = bareClient(leader.pid);
@@ -2033,7 +2038,7 @@ describe('full self-state snapshot delta fixture', () => {
     const delveRunRef = client.delveRun;
 
     // a second broadcast with NO intervening sim.tick() and no state mutation: the
-    // maybe() closure sees byte-identical JSON for all 25 and omits every one
+    // maybe() closure sees byte-identical JSON for all 26 and omits every one
     fc.sent.length = 0;
     broadcast(server);
     const snap2 = lastSnap(fc.sent);
@@ -2052,14 +2057,15 @@ describe('full self-state snapshot delta fixture', () => {
     expect(client.delveRun).toBe(delveRunRef);
     expect(client.markerFor(memberPid)).toBe(3);
     expect(client.delveMarks).toBe(7);
+    expect(client.gatheringProficiencies).toEqual({ mining: 11, logging: 0, herbalism: 0 });
     expect(client.companionState?.companionId).toBe('companion_tessa');
   });
 });
 
 describe('delta-key contract pins (anti-drift)', () => {
-  it('ALL_DELTA_KEYS contains exactly 25 unique keys in sorted order', () => {
-    expect(ALL_DELTA_KEYS).toHaveLength(25);
-    expect(new Set(ALL_DELTA_KEYS).size).toBe(25);
+  it('ALL_DELTA_KEYS contains exactly 26 unique keys in sorted order', () => {
+    expect(ALL_DELTA_KEYS).toHaveLength(26);
+    expect(new Set(ALL_DELTA_KEYS).size).toBe(26);
     expect([...ALL_DELTA_KEYS]).toEqual([...ALL_DELTA_KEYS].sort());
   });
 
@@ -2071,7 +2077,7 @@ describe('delta-key contract pins (anti-drift)', () => {
     const scraped = new Set<string>();
     for (let m = re.exec(src); m !== null; m = re.exec(src)) scraped.add(m[1]);
     expect(scraped.has('lockouts')).toBe(true); // the multi-line call IS captured
-    expect(scraped.size).toBe(25);
+    expect(scraped.size).toBe(26);
     expect([...scraped].sort()).toEqual([...ALL_DELTA_KEYS].sort());
   });
 
@@ -2087,6 +2093,7 @@ describe('delta-key contract pins (anti-drift)', () => {
       drun: 'delveRun',
       dcompanion: 'companionState',
       dmarks: 'delveMarks',
+      gprof: 'gatheringProficiencies',
       dcomp: 'companionUpgrades',
       dclears: 'delveClears',
     };

--- a/tests/world_api_parity.test.ts
+++ b/tests/world_api_parity.test.ts
@@ -1,6 +1,6 @@
 // W0c: the IWorld structural-parity gate.
 //
-// `IWorld` (src/world_api.ts:341-510, 147 members) is the ONE seam render/ui depend
+// `IWorld` (src/world_api.ts:341-510, 148 members) is the ONE seam render/ui depend
 // on. `tsc` already proves both the offline `Sim` and the online `ClientWorld` satisfy
 // it structurally, but the interface is erased at build: there is NO runtime member
 // list, so nothing catches a present-but-throws stub or a kind flip (method vs read).
@@ -9,7 +9,7 @@
 // IWORLD_MEMBERS below is the hand-maintained member list, the W0c analog of the
 // append-only CALLBACK_KEYS in tests/sim_context.test.ts. It is APPEND-ONLY WITH THE
 // INTERFACE: whenever a future slice adds (or removes/renames) a member on `IWorld`,
-// it lands the matching edit here in the SAME commit. The count pins (147 / 36 / 111)
+// it lands the matching edit here in the SAME commit. The count pins (148 / 37 / 111)
 // plus the sorted-name `toEqual` snapshots (modeled on the anti-loosening exclude-set
 // pin in tests/parity/harness.test.ts:131-162) are what force that: a dropped or
 // renamed member reddens deliberately, never silently.
@@ -49,6 +49,7 @@ import type { IWorldLoot } from '../src/world_api/loot';
 import type { IWorldMarket } from '../src/world_api/market';
 import type { IWorldParty } from '../src/world_api/party';
 import type { IWorldPet } from '../src/world_api/pet';
+import type { IWorldProfessions } from '../src/world_api/professions';
 import type { IWorldProgressionXp } from '../src/world_api/progression_xp';
 import type { IWorldQuests } from '../src/world_api/quests';
 import type { IWorldSocialGraph } from '../src/world_api/social_graph';
@@ -64,8 +65,8 @@ interface IWorldMember {
   readonly kind: IWorldMemberKind;
 }
 
-// The 147 members of `interface IWorld`, in interface order (world_api.ts:342-509).
-// Partition: 36 `data` + 111 `method` (read-returning + command-void + 3 async).
+// The 148 members of `interface IWorld`, in interface order (world_api.ts:342-509).
+// Partition: 37 `data` + 111 `method` (read-returning + command-void + 3 async).
 // biome-ignore lint/suspicious/noExportsInTest: IWORLD_MEMBERS is the W0c pinned structural-parity contract (the authoritative IWorld member list)
 export const IWORLD_MEMBERS = [
   // --- core world / player roster + economy reads (data) ---
@@ -84,6 +85,7 @@ export const IWORLD_MEMBERS = [
   { name: 'prestigeRank', kind: 'data' },
   { name: 'unlockedMilestones', kind: 'data' },
   { name: 'restedXp', kind: 'data' },
+  { name: 'gatheringProficiencies', kind: 'data' },
   { name: 'known', kind: 'data' },
   { name: 'questLog', kind: 'data' },
   { name: 'questsDone', kind: 'data' },
@@ -268,7 +270,7 @@ function withDomStubs<T>(fn: () => T): T {
 }
 
 // A real ClientWorld whose FIELD INITIALIZERS have run (a raw
-// `Object.create(ClientWorld.prototype)` bareClient would be missing all 36 data
+// `Object.create(ClientWorld.prototype)` bareClient would be missing all 37 data
 // props). Pass a non-empty `base` so the ctor builds a `ws://localhost/ws` URL instead
 // of touching `location`; `.close()` clears the stubbed input timer.
 function makeClientWorld(): ClientWorld {
@@ -324,8 +326,8 @@ beforeAll(() => {
 
 describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => {
   it('pins total / data / method counts', () => {
-    expect(IWORLD_MEMBERS.length).toBe(147);
-    expect(DATA_MEMBERS.length).toBe(36);
+    expect(IWORLD_MEMBERS.length).toBe(148);
+    expect(DATA_MEMBERS.length).toBe(37);
     expect(METHOD_MEMBERS.length).toBe(111);
   });
 
@@ -336,7 +338,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
 
   // Sorted-name `toEqual` snapshots: a dropped, renamed, or kind-flipped member reddens
   // these deliberately, forcing a reviewed edit. NOT length-only.
-  it('the full sorted member set is exactly the pinned 147', () => {
+  it('the full sorted member set is exactly the pinned 148', () => {
     expect(IWORLD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -391,6 +393,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'friendAdd',
       'friendRemove',
       'friendlyTabTarget',
+      'gatheringProficiencies',
       'guildAccept',
       'guildCreate',
       'guildDecline',
@@ -488,7 +491,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
     ]);
   });
 
-  it('the sorted data-kind set is exactly the pinned 36', () => {
+  it('the sorted data-kind set is exactly the pinned 37', () => {
     expect(DATA_MEMBERS.map((m) => m.name).sort()).toEqual([
       'accountCosmetics',
       'activeLoadout',
@@ -503,6 +506,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'duelInfo',
       'entities',
       'equipment',
+      'gatheringProficiencies',
       'inventory',
       'known',
       'lifetimeXp',
@@ -687,7 +691,7 @@ describe('membership, not equality: world extras do not fail the gate', () => {
 //       a MISSING name (if the array omits a key, Exclude<> is a non-never union and tsc
 //       fails) -- (1)+(2) together make each array EXACTLY its facet key-set;
 //   (3) the 20 arrays are pairwise DISJOINT (a member filed in two facets reddens);
-//   (4) their union, sorted, equals the pinned 147-name IWORLD_MEMBERS set (a member
+//   (4) their union, sorted, equals the pinned 148-name IWORLD_MEMBERS set (a member
 //       dropped from the split reddens).
 // This is the rigorous form, NOT the tautological `keyof IWorld === keyof (A & B & ...)`
 // (IWorld extends them, so that self-equality proves nothing): it asserts against the
@@ -797,6 +801,13 @@ const FACET_PROGRESSION_XP = [
 ] as const satisfies readonly (keyof IWorldProgressionXp)[];
 type _ExhaustProgressionXp = AssertNever<
   Exclude<keyof IWorldProgressionXp, (typeof FACET_PROGRESSION_XP)[number]>
+>;
+
+const FACET_PROFESSIONS = [
+  'gatheringProficiencies',
+] as const satisfies readonly (keyof IWorldProfessions)[];
+type _ExhaustProfessions = AssertNever<
+  Exclude<keyof IWorldProfessions, (typeof FACET_PROFESSIONS)[number]>
 >;
 
 const FACET_TALENTS = [
@@ -949,6 +960,7 @@ const FACET_MEMBER_ARRAYS: Readonly<Record<string, readonly string[]>> = {
   cosmetics: FACET_COSMETICS,
   quests: FACET_QUESTS,
   progressionXp: FACET_PROGRESSION_XP,
+  professions: FACET_PROFESSIONS,
   talents: FACET_TALENTS,
   pet: FACET_PET,
   party: FACET_PARTY,
@@ -962,9 +974,9 @@ const FACET_MEMBER_ARRAYS: Readonly<Record<string, readonly string[]>> = {
   telemetry: FACET_TELEMETRY,
 };
 
-describe('W1: aggregate IWorld member set equals the disjoint union of the 20 facets', () => {
-  it('pins the facet count at 20', () => {
-    expect(Object.keys(FACET_MEMBER_ARRAYS).length).toBe(20);
+describe('W1: aggregate IWorld member set equals the disjoint union of the 21 facets', () => {
+  it('pins the facet count at 21', () => {
+    expect(Object.keys(FACET_MEMBER_ARRAYS).length).toBe(21);
   });
 
   it('each facet array is non-empty and internally duplicate-free', () => {
@@ -990,10 +1002,10 @@ describe('W1: aggregate IWorld member set equals the disjoint union of the 20 fa
     expect(overlaps, `members filed in more than one facet:\n${overlaps.join('\n')}`).toEqual([]);
   });
 
-  it('the union of the 20 facets equals the pinned 147-member IWORLD_MEMBERS set', () => {
+  it('the union of the 21 facets equals the pinned 148-member IWORLD_MEMBERS set', () => {
     const union = Object.values(FACET_MEMBER_ARRAYS).flatMap((arr) => [...arr]);
-    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(147);
-    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(147);
+    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(148);
+    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(148);
     const sortedUnion = [...union].sort();
     const pinned = IWORLD_MEMBERS.map((m) => m.name).sort();
     expect(sortedUnion).toEqual(pinned);


### PR DESCRIPTION
## Summary

Adds the first gathering professions foundation for Mining, Logging, and Herbalism.

This PR introduces static gathering profession definitions, per-player proficiency state, a deterministic sim-side grant path behind `SimContext`, character JSONB persistence with legacy defaults, and an `IWorld` read surface mirrored through the online self snapshot as `gprof`.

## Related issues

Closes #1119.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx @biomejs/biome check --write server\\game.ts src\\net\\online.ts src\\sim\\sim.ts src\\sim\\sim_context.ts src\\world_api.ts src\\world_api\\professions.ts src\\sim\\content\\professions.ts src\\sim\\professions\\gathering.ts tests\\sim_context.test.ts tests\\snapshots.test.ts tests\\world_api_parity.test.ts tests\\gathering_proficiency.test.ts`
  - `npx @biomejs/biome check --write src\\sim\\professions\\gathering.ts tests\\entity_roster.test.ts`
  - `npx vitest run tests\\gathering_proficiency.test.ts tests\\sim_context.test.ts tests\\entity_roster.test.ts tests\\world_api_parity.test.ts tests\\snapshots.test.ts` (5 files, 262 tests passed)
  - `npx vitest run tests\\persistence_round_trip.test.ts` (1 file, 3 tests passed)
  - `npm run check:ts` (passed)
  - `git diff --check` and `git diff --cached --check` (passed)
- Known release-branch blockers observed:
  - `npx vitest run tests\\architecture.test.ts` still fails on the existing `src\\world_api\\chat.ts value-imports 'OVERHEAD_EMOTE_IDS' from '../sim/types'` issue. This PR did not add a new architecture violation.
  - `npm run lint` still fails repo-wide with 27 errors, 3924 warnings, and 453 infos. The first errors are the existing Biome findings in `headless\\env_server.ts`, `scripts\\*.mjs`, and `mediawiki\\theme\\Common.css`.
  - `npm run build` inside the sandbox fails because esbuild cannot read a parent directory. The escalated build proceeds through i18n, wiki, sitemap, and media manifest generation, then fails at the known `.browserslistrc` Vite config blocker: unsupported comment entry `# CSS engine floor (single source) for the Lightning CSS transformer.` Generated build collateral was restored.
- Manual steps:
  - Verified issue #1119 is open.
  - Verified no open PRs matching #1119 or gathering proficiency before publishing.
  - Verified the branch is based on `origin/release/v0.18.0` at `0c0845c3`.

## Screenshots / recordings

N/A. This PR adds sim, persistence, world API, and snapshot state only. It does not change UI/UX.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.