### PR TITLE
[codex] Add off-wheel professions spec

### DIFF
--- a/docs/design/off-wheel-professions.md
+++ b/docs/design/off-wheel-professions.md
@@ -1,0 +1,152 @@
+# Off-Wheel Professions Design Spec
+
+Issue: #1150
+Status: exploratory design only
+
+This spec defines a separate profession family for cosmetic, housing, and world-flavor crafts. It is intentionally outside the ten combat-craft wheel used by the core professions system. Nothing here should alter combat output, combat-craft adjacency, opposite-craft drains, combat archetype titles, or material gates.
+
+## Goals
+
+- Give players expressive, social, and housing-focused long-term pursuits that do not increase combat power.
+- Keep non-combat crafts structurally separate from the combat profession wheel so the ten-craft ring remains stable and balanceable.
+- Reuse existing game idioms where possible: vendors, unlock flags, cosmetic catalogs, placement permissions, account/character persistence, and spoiler-safe guide prose.
+- Make each craft useful as a source of identity, decoration, or community trade without becoming required for raids, dungeons, arenas, or leveling.
+
+## Non-Goals
+
+- Do not add these crafts to `src/sim/professions/wheel.ts` or any future combat wheel/adjacency table.
+- Do not add opposite-craft drains, conserved-mass budgeting, or combat archetype title derivation.
+- Do not grant stats, damage, mitigation, healing throughput, resource efficiency, or encounter advantages.
+- Do not create a second gearing treadmill or mandatory raid consumable loop.
+- Do not implement production code as part of this exploratory issue.
+
+## System Boundary
+
+The off-wheel system should be a sibling to combat professions, not a branch of them.
+
+Suggested future module boundary:
+
+```text
+src/sim/professions/
+  wheel.ts                 # combat craft wheel only
+  crafting.ts              # combat craft production only
+  tools.ts                 # combat gathering/tool effects only
+  off_wheel.ts             # non-combat craft progress and unlock reads
+
+src/sim/content/
+  professions.ts           # combat profession content
+  off_wheel_professions.ts # non-combat craft content
+```
+
+If future implementation uses different filenames, preserve the boundary: off-wheel content may read shared item, cosmetic, housing, or achievement primitives, but combat wheel logic must not import off-wheel craft definitions to compute adjacency, drains, or archetypes.
+
+## Craft Families
+
+### Construction
+
+Construction crafts create housing or guild-space objects. They are about place-making rather than character power.
+
+| Craft | Primary Inputs | Outputs | Notes |
+|---|---|---|---|
+| Carpenter | wood, cloth, simple metal fittings | furniture, signs, shelves, practice dummies without combat rewards | Can share gathering inputs with Logging without altering the combat wheel. |
+| Mason | stone, clay, ore byproducts | walls, floors, statues, fountains, memorial plaques | Good sink for stone-like materials that do not fit combat crafting. |
+
+### Tending
+
+Tending crafts are slow, ambient, and collection-oriented.
+
+| Craft | Primary Inputs | Outputs | Notes |
+|---|---|---|---|
+| Shepherd | feed, wool, dyes | rugs, banners, pet-adjacent cosmetics | No combat pets or stat-bearing companions. |
+| Beekeeping | flowers, hives, wax | candles, honey foods with flavor-only presentation, decorative hive props | Any edible output must avoid combat buffs. |
+| Stargazing | observation logs, lenses, charts | star maps, constellation banners, night-sky housing effects | Uses time/place discovery, not kill loops. |
+
+### Cosmetic Arts
+
+Cosmetic crafts customize identity surfaces.
+
+| Craft | Primary Inputs | Outputs | Notes |
+|---|---|---|---|
+| Tattooing | inks, rare pigments | character body markings, account-bound appearance options | Must respect existing cosmetic unlock safety and moderation needs. |
+| Taxidermy | trophy tokens, wood, cloth | mounted creature displays | Trophy eligibility should come from achievements or rare drops, not raw power. |
+| Heraldry | dyes, cloth, metals | tabards, banners, guild crests | Good guild/social feature, no stat-bearing set bonuses. |
+| Instrument-making | wood, strings, metal fittings | playable or emote-triggered instruments | Audio spam controls and local mute settings are required before implementation. |
+| Candlemaking | wax, herbs, dyes | decorative candles, ambience props | Lighting must respect render-budget constraints. |
+
+## Progression Model
+
+Off-wheel progression should be additive and monotonic.
+
+- Each craft tracks its own rank or unlock points independently.
+- Advancement never drains another off-wheel craft and never drains a combat craft.
+- Recipes unlock through use, discovery, vendors, achievements, or reputation.
+- Progress can be character-scoped for craft identity, while some unlocks may become account-wide cosmetics when the output is purely appearance-based.
+- Catch-up can be generous because the system is not combat power.
+
+Recommended rank bands:
+
+| Band | Purpose |
+|---|---|
+| Apprentice | basic recipes from trainers and vendors |
+| Journeyman | zone-themed recipes and simple customization |
+| Artisan | rare cosmetic variants, guild/housing display pieces |
+| Master | prestige appearances, signature props, achievement-linked patterns |
+
+These bands are names for UX and content pacing, not combat rarity gates.
+
+## Economy Rules
+
+- Outputs may be tradable when they are decorations, instruments, or consumable cosmetic kits.
+- Permanent character appearance unlocks should bind on use to prevent accidental loss.
+- Housing or guild-space fixtures may be crafted into items, then placed by a player with permission.
+- Vendor sell values should stay modest so off-wheel crafts cannot become a gold-printing loop.
+- Inputs may overlap with gathering professions, but off-wheel demand must not make combat crafting unaffordable.
+
+## Housing and Placement Rules
+
+Future housing support should be permissioned and server-authoritative.
+
+- Placement requires ownership or a granted role in the destination space.
+- Props have collision and render-budget categories before they can be placed.
+- Large or animated props need stricter caps than small static decorations.
+- Removing a placed object returns it to an owner-controlled inventory or storage, unless an explicit destructive action is confirmed.
+- Public/guild spaces should log placement and removal for moderation.
+
+## UI and Guide Surface
+
+The first production slice should keep UI small:
+
+- trainer/vendor recipe lists
+- craft progress rows
+- recipe detail panel showing cosmetic/housing output
+- placement inventory only once housing exists
+- guide page section explaining that off-wheel crafts are cosmetic and separate from combat professions
+
+Any player-visible UI strings must follow the normal i18n workflow at implementation time. This design doc itself is English-only reference prose under `docs/`.
+
+## Integration Contracts
+
+Future implementation should follow these contracts:
+
+- Combat craft wheel: no import from off-wheel content for adjacency, drains, budget, archetypes, or combat material gates.
+- Items: off-wheel outputs declare a cosmetic, housing, or flavor category and must not carry stat-bearing equipment effects unless those stats already exist independently on a normal item.
+- Cosmetics: permanent appearance unlocks use existing account/character cosmetic safety patterns.
+- Housing: placement is authority-checked server-side and never trusted from the client.
+- Audio: instruments require rate limits, local mute, and proximity rules.
+- Rendering: placed props must declare cost/collision behavior before entering a shared space.
+
+## Acceptance Checklist for Future Implementation
+
+- Off-wheel craft definitions live outside combat wheel content.
+- Tests prove combat wheel craft order, adjacency, and opposite mappings are unchanged when off-wheel crafts are present.
+- At least one craft can unlock or produce a cosmetic/housing output with no combat stat change.
+- Persistence records progress/unlocks without corrupting existing character saves.
+- UI clearly labels the system as cosmetic/housing/non-combat.
+
+## Deferred Questions
+
+- Should off-wheel progress be per-character, account-wide, or mixed by craft?
+- Are player homes, guild halls, or public build plots the first placement target?
+- Which outputs should be tradable after creation, and which should bind on use?
+- Should rare trophy recipes require achievement flags, rare drops, or both?
+- What moderation tools are required before public display props and custom heraldry ship?

--- a/tests/off_wheel_professions_spec.test.ts
+++ b/tests/off_wheel_professions_spec.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const spec = readFileSync('docs/design/off-wheel-professions.md', 'utf8');
+
+describe('off-wheel professions design spec', () => {
+  it('documents the issue 1150 no-combat-wheel boundary', () => {
+    expect(spec).toContain('Issue: #1150');
+    expect(spec).toContain('outside the ten combat-craft wheel');
+    expect(spec).toContain('Do not add these crafts to `src/sim/professions/wheel.ts`');
+    expect(spec).toContain('off_wheel_professions.ts');
+  });
+
+  it('keeps every proposed craft cosmetic, housing, or flavor scoped', () => {
+    for (const craft of [
+      'Carpenter',
+      'Mason',
+      'Shepherd',
+      'Beekeeping',
+      'Stargazing',
+      'Tattooing',
+      'Taxidermy',
+      'Heraldry',
+      'Instrument-making',
+      'Candlemaking',
+    ]) {
+      expect(spec).toContain(craft);
+    }
+    expect(spec).toContain('Do not grant stats, damage, mitigation, healing throughput');
+  });
+});


### PR DESCRIPTION
## Summary

Adds an exploratory design spec for issue #1150 that defines off-wheel professions as a separate, non-combat craft family for cosmetic, housing, and world-flavor progression.

The spec documents the future boundary between combat wheel professions and off-wheel professions, proposes craft families and progression rules, and calls out implementation contracts so future work does not accidentally wire cosmetic/housing crafts into combat adjacency, drains, archetypes, stats, or power rewards.

Also adds a small Vitest guard that keeps the core issue reference, combat-wheel separation, proposed content module name, craft list, and no-combat-stats constraint present in the design spec.

## Related issues

Closes #1150

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - [x] `npx @biomejs/biome check --write docs\design\off-wheel-professions.md tests\off_wheel_professions_spec.test.ts`
  - [x] `npx vitest run tests\off_wheel_professions_spec.test.ts` with temporary `.browserslistrc` comment stripping for the known Vite config parser issue
  - [x] `npm run check:ts`
  - [x] `git diff --check`
  - [x] `git diff --cached --check`
  - [x] `npm run build` with temporary `.browserslistrc` comment stripping; build completed successfully and generated collateral was restored afterward
  - [ ] `npm run build` without workaround currently fails on `release/v0.18.0` before this change is involved: `Unsupported .browserslistrc entry ... # CSS engine floor (single source) for the Lightning CSS transformer.`
  - [ ] `npm run lint` currently fails on existing repo-wide diagnostics: 27 errors, 3929 warnings, 453 infos. First reported files include `headless\env_server.ts`, `scripts\ability_icons_grid_shot.mjs`, `scripts\arena_visual.mjs`, and `mediawiki\theme\Common.css`.
  - [ ] `npm run ci:changed` currently fails on existing changed-baseline diagnostics: 95 errors, 676 warnings, 3 infos. First reported file was `scripts\malware_scan.mjs`; later examples include `tests\chat.test.ts` and `tests\threat.test.ts`.
  - [ ] `npm run security:scan` currently reports existing low-severity findings: high=0, medium=0, low=76, mostly install-script supply-chain flags, dev screenshot "god-mode" comments, and script/test `child_process` usage.
- Manual steps:
  - Reviewed the full staged diff to confirm the PR only adds `docs/design/off-wheel-professions.md` and `tests/off_wheel_professions_spec.test.ts`.
  - Confirmed the spec explicitly says off-wheel professions stay outside the ten combat-craft wheel and do not grant combat stats, damage, mitigation, healing throughput, resource efficiency, or encounter advantages.
  - Confirmed no generated files are staged.

## Screenshots / recordings

N/A. This is a docs/test-only exploratory design spec with no HUD, window, tooltip, mobile control, admin dashboard, or other UI/UX change.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
