### PR TITLE
[codex] Add gathering material rarity roll

### DIFF
--- a/src/sim/professions/gathering.ts
+++ b/src/sim/professions/gathering.ts
@@ -1,0 +1,94 @@
+import type { Rng } from '../rng';
+import type { ItemDef } from '../types';
+
+type ItemQuality = NonNullable<ItemDef['quality']>;
+
+export type GatheringMaterialRarity = Exclude<ItemQuality, 'poor'>;
+
+export type GatheringRarityDistribution = Record<GatheringMaterialRarity, number>;
+
+export const GATHERING_RARITY_PROFICIENCY_CAP = 300;
+
+export const GATHERING_MATERIAL_RARITIES: readonly GatheringMaterialRarity[] = [
+  'common',
+  'uncommon',
+  'rare',
+  'epic',
+  'legendary',
+] as const;
+
+interface RarityBand {
+  proficiency: number;
+  distribution: GatheringRarityDistribution;
+}
+
+export const GATHERING_RARITY_BANDS: readonly RarityBand[] = [
+  {
+    proficiency: 0,
+    distribution: { common: 0.9, uncommon: 0.1, rare: 0, epic: 0, legendary: 0 },
+  },
+  {
+    proficiency: 75,
+    distribution: { common: 0.7, uncommon: 0.24, rare: 0.05, epic: 0.01, legendary: 0 },
+  },
+  {
+    proficiency: 150,
+    distribution: { common: 0.5, uncommon: 0.34, rare: 0.13, epic: 0.025, legendary: 0.005 },
+  },
+  {
+    proficiency: 225,
+    distribution: { common: 0.32, uncommon: 0.38, rare: 0.23, epic: 0.06, legendary: 0.01 },
+  },
+  {
+    proficiency: GATHERING_RARITY_PROFICIENCY_CAP,
+    distribution: { common: 0.2, uncommon: 0.4, rare: 0.28, epic: 0.1, legendary: 0.02 },
+  },
+] as const;
+
+const ROLL_EDGE_EPSILON = 1e-12;
+
+function clampProficiency(proficiency: number): number {
+  if (!Number.isFinite(proficiency)) return 0;
+  return Math.min(GATHERING_RARITY_PROFICIENCY_CAP, Math.max(0, proficiency));
+}
+
+function interpolate(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export function gatheringRarityDistribution(proficiency: number): GatheringRarityDistribution {
+  const p = clampProficiency(proficiency);
+
+  for (let i = 0; i < GATHERING_RARITY_BANDS.length - 1; i++) {
+    const from = GATHERING_RARITY_BANDS[i];
+    const to = GATHERING_RARITY_BANDS[i + 1];
+    if (p < to.proficiency) {
+      const t = (p - from.proficiency) / (to.proficiency - from.proficiency);
+      return {
+        common: interpolate(from.distribution.common, to.distribution.common, t),
+        uncommon: interpolate(from.distribution.uncommon, to.distribution.uncommon, t),
+        rare: interpolate(from.distribution.rare, to.distribution.rare, t),
+        epic: interpolate(from.distribution.epic, to.distribution.epic, t),
+        legendary: interpolate(from.distribution.legendary, to.distribution.legendary, t),
+      };
+    }
+  }
+
+  return GATHERING_RARITY_BANDS[GATHERING_RARITY_BANDS.length - 1].distribution;
+}
+
+export function rollGatheringMaterialRarity(
+  proficiency: number,
+  rng: Pick<Rng, 'next'>,
+): GatheringMaterialRarity {
+  const distribution = gatheringRarityDistribution(proficiency);
+  const roll = rng.next();
+  let cumulative = 0;
+
+  for (const rarity of GATHERING_MATERIAL_RARITIES) {
+    cumulative += distribution[rarity];
+    if (roll + ROLL_EDGE_EPSILON < cumulative) return rarity;
+  }
+
+  return 'legendary';
+}

--- a/tests/gathering_rarity.test.ts
+++ b/tests/gathering_rarity.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GATHERING_MATERIAL_RARITIES,
+  type GatheringMaterialRarity,
+  gatheringRarityDistribution,
+  rollGatheringMaterialRarity,
+} from '../src/sim/professions/gathering';
+import { Rng } from '../src/sim/rng';
+
+function stubRng(value: number): Pick<Rng, 'next'> {
+  return { next: () => value };
+}
+
+function chanceAtLeast(
+  distribution: Record<GatheringMaterialRarity, number>,
+  rarity: GatheringMaterialRarity,
+): number {
+  const start = GATHERING_MATERIAL_RARITIES.indexOf(rarity);
+  return GATHERING_MATERIAL_RARITIES.slice(start).reduce((sum, key) => sum + distribution[key], 0);
+}
+
+describe('professions gathering rarity roll', () => {
+  it('pins the material rarity distribution at key proficiency bands', () => {
+    expect(gatheringRarityDistribution(0)).toEqual({
+      common: 0.9,
+      uncommon: 0.1,
+      rare: 0,
+      epic: 0,
+      legendary: 0,
+    });
+    expect(gatheringRarityDistribution(150)).toEqual({
+      common: 0.5,
+      uncommon: 0.34,
+      rare: 0.13,
+      epic: 0.025,
+      legendary: 0.005,
+    });
+    expect(gatheringRarityDistribution(300)).toEqual({
+      common: 0.2,
+      uncommon: 0.4,
+      rare: 0.28,
+      epic: 0.1,
+      legendary: 0.02,
+    });
+  });
+
+  it('linearly interpolates between bands and clamps out-of-range proficiency', () => {
+    expect(gatheringRarityDistribution(-25)).toEqual(gatheringRarityDistribution(0));
+    expect(gatheringRarityDistribution(Number.NaN)).toEqual(gatheringRarityDistribution(0));
+    expect(gatheringRarityDistribution(999)).toEqual(gatheringRarityDistribution(300));
+
+    const mid = gatheringRarityDistribution(37.5);
+    expect(mid.common).toBeCloseTo(0.8);
+    expect(mid.uncommon).toBeCloseTo(0.17);
+    expect(mid.rare).toBeCloseTo(0.025);
+    expect(mid.epic).toBeCloseTo(0.005);
+    expect(mid.legendary).toBe(0);
+  });
+
+  it('strictly does not lower the chance of any higher rarity as proficiency rises', () => {
+    const thresholds: GatheringMaterialRarity[] = ['uncommon', 'rare', 'epic', 'legendary'];
+    let previous = gatheringRarityDistribution(0);
+
+    for (let proficiency = 15; proficiency <= 300; proficiency += 15) {
+      const next = gatheringRarityDistribution(proficiency);
+      for (const rarity of thresholds) {
+        expect(chanceAtLeast(next, rarity), `${rarity}+ at ${proficiency}`).toBeGreaterThanOrEqual(
+          chanceAtLeast(previous, rarity),
+        );
+      }
+      previous = next;
+    }
+  });
+
+  it('uses one Rng draw to choose the tier from the standard item rarity buckets', () => {
+    let draws = 0;
+    const rng = {
+      next: () => {
+        draws += 1;
+        return 0.5;
+      },
+    };
+
+    expect(rollGatheringMaterialRarity(300, rng)).toBe('uncommon');
+    expect(draws).toBe(1);
+
+    expect(rollGatheringMaterialRarity(300, stubRng(0))).toBe('common');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.19999))).toBe('common');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.2))).toBe('uncommon');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.59999))).toBe('uncommon');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.6))).toBe('rare');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.87999))).toBe('rare');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.88))).toBe('epic');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.97999))).toBe('epic');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.98))).toBe('legendary');
+    expect(rollGatheringMaterialRarity(300, stubRng(0.99999))).toBe('legendary');
+  });
+
+  it('is deterministic with the shared sim Rng stream', () => {
+    const a = new Rng(1122);
+    const b = new Rng(1122);
+    const sequenceA = Array.from({ length: 20 }, () => rollGatheringMaterialRarity(225, a));
+    const sequenceB = Array.from({ length: 20 }, () => rollGatheringMaterialRarity(225, b));
+
+    expect(sequenceA).toEqual(sequenceB);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the pure professions gathering rarity roll foundation from #1122.

- Adds `src/sim/professions/gathering.ts` with a standard item-rarity material distribution for common through legendary materials.
- Scales the chance of higher-rarity material outcomes by gathering proficiency, capped at 300 proficiency.
- Keeps the roll pure and harvest-wiring independent: callers pass a proficiency value plus the shared sim `Rng` stream.
- Excludes `poor` from material outcomes, clamps invalid/out-of-range proficiency, and uses a single deterministic RNG draw per roll.
- Adds focused tests for pinned distributions, interpolation/clamping, monotonic higher-rarity odds, roll thresholds, single-draw behavior, and deterministic replay.

## Related issues

Part of #1122.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx vitest run tests/gathering_rarity.test.ts` - passed, 1 file / 5 tests. Used the existing temporary `.browserslistrc` comment-strip workaround because the current Vite config rejects comment lines before test discovery; `.browserslistrc` was restored and has no diff.
  - `npx vitest run tests/gathering_rarity.test.ts tests/architecture.test.ts` - blocked by an existing release-branch architecture failure unrelated to this PR: `src/world_api/chat.ts` value-imports `OVERHEAD_EMOTE_IDS` from `../sim/types`. The new gathering rarity suite passed inside this run.
  - `npm run check:ts` - passed.
  - `npx biome check src/sim/professions/gathering.ts tests/gathering_rarity.test.ts` - passed.
  - `git diff --cached --check` - passed.
  - `npm run build` - passed with the temporary `.browserslistrc` workaround. Existing build warnings remain for admin i18n dynamic/static imports, large chunks, and plugin timings. Build-generated i18n outputs were restored afterward because this PR adds no strings.
  - `npm run ci:changed` - currently blocked by existing release-branch Biome debt outside this PR: checked 97 files, reported 97 errors / 676 warnings / 3 infos. First diagnostics are in `scripts/malware_scan.mjs:762`, `scripts/profiler/harness.mjs:232`, `tests/chat.test.ts:408`, and `tests/threat.test.ts`.
- Manual steps:
  - Confirmed no active open PR was found for #1122 / gathering material rarity roll before opening this one.
  - Confirmed the final working tree only contains the two intended new files before commit.

## Screenshots / recordings

N/A - this changes pure simulation/domain logic and does not add or change UI/UX.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. Build-generated files were restored after validation.