### PR TITLE
[codex] Add professions contracts facet

### DIFF
--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -18,6 +18,7 @@ import { deadTargetSelectable } from '../sim/dead_target';
 import { LEADERBOARD_PAGE_SIZE } from '../sim/leaderboard_page';
 import type { Ante, PickAction } from '../sim/lockpick';
 import { normalizeMoveFacing, sanitizeMoveInput } from '../sim/move_input';
+import { EMPTY_PROFESSIONS_INFO } from '../sim/professions/types';
 import { computeQuestState, type ResolvedAbility } from '../sim/sim';
 import {
   type Entity,
@@ -54,6 +55,7 @@ import {
   type OverheadEmoteId,
   type PartyInfo,
   type PresenceStatus,
+  type ProfessionsInfo,
   type RaidLockout,
   type SocialInfo,
   type TradeInfo,
@@ -1959,6 +1961,9 @@ export class ClientWorld implements IWorld {
   }
   delveShopOffers(delveId: string): DelveShopOfferView[] {
     return resolveDelveShopOffers(delveId, this.delveClears);
+  }
+  professionsInfo(): ProfessionsInfo {
+    return EMPTY_PROFESSIONS_INFO;
   }
   lockpickEngage(objectId: number, ante: Ante): void {
     this.cmd({ cmd: 'lockpick_engage', objectId, ante });

--- a/src/sim/professions/types.ts
+++ b/src/sim/professions/types.ts
@@ -1,0 +1,80 @@
+// Shared professions contracts. Content and mechanics should import these shapes
+// rather than defining parallel skill/craft/recipe/node records.
+
+/** CharacterState JSONB key reserved for persisted profession progress. */
+export const PROFESSIONS_CHARACTER_STATE_KEY = 'professions';
+/** Self-snapshot key reserved for the future professions client mirror. */
+export const PROFESSIONS_SELF_WIRE_KEY = 'professions';
+
+export type ProfessionKind = 'gathering' | 'crafting';
+export type ProfessionSkillId = string;
+export type ProfessionCraftId = string;
+export type ProfessionRecipeId = string;
+export type ProfessionNodeId = string;
+export type ProfessionItemId = string;
+export type ProfessionNodeKind = string;
+export type ProfessionZoneId = string;
+export type ProfessionTier = 'common' | 'uncommon' | 'rare' | 'epic' | 'legendary';
+
+export interface ProfessionItemQuantity {
+  itemId: ProfessionItemId;
+  count: number;
+}
+
+export interface ProfessionSkillRecord {
+  id: ProfessionSkillId;
+  kind: ProfessionKind;
+  nameKey: string;
+  maxRank: number;
+}
+
+export interface ProfessionCraftRecord {
+  id: ProfessionCraftId;
+  skillId: ProfessionSkillId;
+  nameKey: string;
+  unlockRank: number;
+}
+
+export interface ProfessionRecipeRecord {
+  id: ProfessionRecipeId;
+  craftId: ProfessionCraftId;
+  output: ProfessionItemQuantity;
+  inputs: readonly ProfessionItemQuantity[];
+  tier: ProfessionTier;
+  unlockRank: number;
+}
+
+export interface ProfessionNodeRecord {
+  id: ProfessionNodeId;
+  skillId: ProfessionSkillId;
+  zoneId: ProfessionZoneId;
+  kind: ProfessionNodeKind;
+  material: ProfessionItemQuantity;
+  tier: ProfessionTier;
+  respawnSeconds: number;
+}
+
+export interface ProfessionSkillProgress {
+  skillId: ProfessionSkillId;
+  rank: number;
+}
+
+export interface ProfessionsStateSnapshot {
+  skills: readonly ProfessionSkillProgress[];
+}
+
+export interface ProfessionsInfo {
+  skills: readonly ProfessionSkillRecord[];
+  crafts: readonly ProfessionCraftRecord[];
+  recipes: readonly ProfessionRecipeRecord[];
+  nodes: readonly ProfessionNodeRecord[];
+  state: ProfessionsStateSnapshot;
+}
+
+export const EMPTY_PROFESSIONS_INFO: ProfessionsInfo = {
+  skills: [],
+  crafts: [],
+  recipes: [],
+  nodes: [],
+  state: { skills: [] },
+};

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -170,6 +170,7 @@ import {
 } from './pathfind';
 import * as petAi from './pet/pet_ai';
 import * as petCommands from './pet/pet_commands';
+import { EMPTY_PROFESSIONS_INFO, type ProfessionsInfo } from './professions/types';
 import {
   applyTalentAllocation,
   deleteTalentLoadout,
@@ -5684,6 +5685,10 @@ export class Sim {
 
   delveShopOffers(delveId: string): DelveShopOffer[] {
     return this.delveShopOffersFor(delveId, this.primaryId);
+  }
+
+  professionsInfo(): ProfessionsInfo {
+    return EMPTY_PROFESSIONS_INFO;
   }
 
   get delveDaily(): { date: string; firstClearXp: string[]; markClears: number } {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -9,7 +9,7 @@
 // keep resolving to THIS file, never the sibling directory.
 //
 // ---------------------------------------------------------------------------
-// FACET MAP: the 20 domain facets (each IWorld member assigned exactly once; 142
+// FACET MAP: the 21 domain facets (each IWorld member assigned exactly once; 148
 // total). One interface per file under ./world_api/; aux types travel with their
 // facet. The authoritative member-per-facet split is the W0c parity test.
 //
@@ -32,6 +32,7 @@
 //   market.ts           IWorldMarket         World Market browse/list/buy
 //   dungeons.ts         IWorldDungeons       dungeon enter/leave + raid lockouts
 //   delves.ts           IWorldDelves         delve runs, lockpick, companion
+//   professions.ts      IWorldProfessions    profession contracts + read surface
 //   telemetry.ts        IWorldTelemetry      fire-and-forget metrics sink
 //
 // THREE GATES pin this seam (run before any facet edit):
@@ -39,9 +40,9 @@
 //                                          ALL_DELTA_KEYS (25) + TERSE_TO_IWORLD mapping.
 //   tests/command_schema.test.ts   (W0b)  COMMAND_NAMES universe; ClientWorld send-set
 //                                          subset-of dispatch-set; DISPATCH_ONLY (7).
-//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (142) present + same-kind on
+//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (148) present + same-kind on
 //                                          Sim + ClientWorld; aggregate == disjoint
-//                                          union of the 20 facets.
+//                                          union of the 21 facets.
 // ---------------------------------------------------------------------------
 
 import type { IWorldChat } from './world_api/chat';
@@ -57,6 +58,7 @@ import type { IWorldLoot } from './world_api/loot';
 import type { IWorldMarket } from './world_api/market';
 import type { IWorldParty } from './world_api/party';
 import type { IWorldPet } from './world_api/pet';
+import type { IWorldProfessions } from './world_api/professions';
 import type { IWorldProgressionXp } from './world_api/progression_xp';
 import type { IWorldQuests } from './world_api/quests';
 import type { IWorldSocialGraph } from './world_api/social_graph';
@@ -91,6 +93,25 @@ export type {
 export type { RaidLockout } from './world_api/dungeons';
 export type { MarketInfo, MarketListingView } from './world_api/market';
 export type { PartyInfo, PartyMemberInfo } from './world_api/party';
+export type {
+  ProfessionCraftId,
+  ProfessionCraftRecord,
+  ProfessionItemId,
+  ProfessionItemQuantity,
+  ProfessionKind,
+  ProfessionNodeId,
+  ProfessionNodeKind,
+  ProfessionNodeRecord,
+  ProfessionRecipeId,
+  ProfessionRecipeRecord,
+  ProfessionSkillId,
+  ProfessionSkillProgress,
+  ProfessionSkillRecord,
+  ProfessionsInfo,
+  ProfessionsStateSnapshot,
+  ProfessionTier,
+  ProfessionZoneId,
+} from './world_api/professions';
 export type { GuildLeaderboardEntry, LeaderboardEntry } from './world_api/progression_xp';
 export type {
   CharacterSearchResult,
@@ -126,6 +147,7 @@ export interface IWorld
     IWorldMarket,
     IWorldDungeons,
     IWorldDelves,
+    IWorldProfessions,
     IWorldTelemetry {}
 
 // ---------------------------------------------------------------------------
@@ -320,6 +342,7 @@ export type WorldFacet =
   | 'IWorldMarket'
   | 'IWorldDungeons'
   | 'IWorldDelves'
+  | 'IWorldProfessions'
   | 'IWorldTelemetry';
 
 export const COMMAND_FACETS = {

--- a/src/world_api/professions.ts
+++ b/src/world_api/professions.ts
@@ -1,0 +1,25 @@
+import type { ProfessionsInfo } from '../sim/professions/types';
+
+export type {
+  ProfessionCraftId,
+  ProfessionCraftRecord,
+  ProfessionItemId,
+  ProfessionItemQuantity,
+  ProfessionKind,
+  ProfessionNodeId,
+  ProfessionNodeKind,
+  ProfessionNodeRecord,
+  ProfessionRecipeId,
+  ProfessionRecipeRecord,
+  ProfessionSkillId,
+  ProfessionSkillProgress,
+  ProfessionSkillRecord,
+  ProfessionsInfo,
+  ProfessionsStateSnapshot,
+  ProfessionTier,
+  ProfessionZoneId,
+} from '../sim/professions/types';
+
+export interface IWorldProfessions {
+  professionsInfo(): ProfessionsInfo;
+}

--- a/tests/command_facets.test.ts
+++ b/tests/command_facets.test.ts
@@ -266,7 +266,7 @@ describe('command facet tags (W10)', () => {
     expect('leave_crypt' in tags).toBe(false);
   });
 
-  it('does not tag the command-less reads (marketInfo/raidLockouts/delveShopOffers/lockpickState/delveRun/companionState/delveMarks/companionUpgrades/delveDaily)', () => {
+  it('does not tag the command-less reads (marketInfo/raidLockouts/delveShopOffers/lockpickState/delveRun/companionState/delveMarks/companionUpgrades/delveDaily/professionsInfo)', () => {
     for (const read of [
       'marketInfo',
       'raidLockouts',
@@ -277,6 +277,7 @@ describe('command facet tags (W10)', () => {
       'delveMarks',
       'companionUpgrades',
       'delveDaily',
+      'professionsInfo',
     ]) {
       expect(read in tags, `${read} should be untagged (no wire command)`).toBe(false);
     }

--- a/tests/professions_contracts.test.ts
+++ b/tests/professions_contracts.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { ClientWorld } from '../src/net/online';
+import {
+  EMPTY_PROFESSIONS_INFO,
+  PROFESSIONS_CHARACTER_STATE_KEY,
+  PROFESSIONS_SELF_WIRE_KEY,
+} from '../src/sim/professions/types';
+import { Sim } from '../src/sim/sim';
+import type {
+  ProfessionCraftRecord,
+  ProfessionNodeRecord,
+  ProfessionRecipeRecord,
+  ProfessionSkillRecord,
+} from '../src/world_api';
+
+class StubWebSocket {
+  static readonly OPEN = 1;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  readyState = StubWebSocket.OPEN;
+
+  constructor(public readonly url: string) {}
+
+  send(): void {
+    /* no-op */
+  }
+
+  close(): void {
+    /* no-op */
+  }
+}
+
+function makeClientWorld(): ClientWorld {
+  const g = globalThis as Record<string, unknown>;
+  const prevWebSocket = g.WebSocket;
+  const prevWindow = g.window;
+  g.WebSocket = StubWebSocket as unknown;
+  g.window = { setInterval: () => 0, clearInterval: () => undefined };
+  try {
+    const world = new ClientWorld('professions-contract-token', 1, 'warrior', 'http://localhost');
+    world.close();
+    return world;
+  } finally {
+    g.WebSocket = prevWebSocket;
+    g.window = prevWindow;
+  }
+}
+
+describe('professions contracts', () => {
+  it('pins the persistence and self-snapshot key names for downstream slices', () => {
+    expect(PROFESSIONS_CHARACTER_STATE_KEY).toBe('professions');
+    expect(PROFESSIONS_SELF_WIRE_KEY).toBe('professions');
+  });
+
+  it('defines content-as-code records for skills, crafts, recipes, and nodes', () => {
+    const skill = {
+      id: 'mining',
+      kind: 'gathering',
+      nameKey: 'professions.skill.mining',
+      maxRank: 300,
+    } satisfies ProfessionSkillRecord;
+    const craft = {
+      id: 'blacksmithing',
+      skillId: skill.id,
+      nameKey: 'professions.craft.blacksmithing',
+      unlockRank: 1,
+    } satisfies ProfessionCraftRecord;
+    const recipe = {
+      id: 'bronze_sword',
+      craftId: craft.id,
+      output: { itemId: 'bronze_sword', count: 1 },
+      inputs: [{ itemId: 'bronze_bar', count: 2 }],
+      tier: 'common',
+      unlockRank: 25,
+    } satisfies ProfessionRecipeRecord;
+    const node = {
+      id: 'elwynn_copper_01',
+      skillId: skill.id,
+      zoneId: 'zone1',
+      kind: 'ore',
+      material: { itemId: 'copper_ore', count: 1 },
+      tier: 'common',
+      respawnSeconds: 180,
+    } satisfies ProfessionNodeRecord;
+
+    expect({ skill, craft, recipe, node }).toMatchObject({
+      skill: { id: 'mining' },
+      craft: { skillId: 'mining' },
+      recipe: { craftId: 'blacksmithing' },
+      node: { material: { itemId: 'copper_ore' } },
+    });
+  });
+
+  it('exposes the empty professions read surface on Sim and ClientWorld', () => {
+    expect(new Sim({ seed: 1, playerClass: 'warrior' }).professionsInfo()).toEqual(
+      EMPTY_PROFESSIONS_INFO,
+    );
+    expect(makeClientWorld().professionsInfo()).toEqual(EMPTY_PROFESSIONS_INFO);
+  });
+});

--- a/tests/world_api_parity.test.ts
+++ b/tests/world_api_parity.test.ts
@@ -1,6 +1,6 @@
 // W0c: the IWorld structural-parity gate.
 //
-// `IWorld` (src/world_api.ts:341-510, 147 members) is the ONE seam render/ui depend
+// `IWorld` (src/world_api.ts:341-510, 148 members) is the ONE seam render/ui depend
 // on. `tsc` already proves both the offline `Sim` and the online `ClientWorld` satisfy
 // it structurally, but the interface is erased at build: there is NO runtime member
 // list, so nothing catches a present-but-throws stub or a kind flip (method vs read).
@@ -9,7 +9,7 @@
 // IWORLD_MEMBERS below is the hand-maintained member list, the W0c analog of the
 // append-only CALLBACK_KEYS in tests/sim_context.test.ts. It is APPEND-ONLY WITH THE
 // INTERFACE: whenever a future slice adds (or removes/renames) a member on `IWorld`,
-// it lands the matching edit here in the SAME commit. The count pins (147 / 36 / 111)
+// it lands the matching edit here in the SAME commit. The count pins (148 / 36 / 112)
 // plus the sorted-name `toEqual` snapshots (modeled on the anti-loosening exclude-set
 // pin in tests/parity/harness.test.ts:131-162) are what force that: a dropped or
 // renamed member reddens deliberately, never silently.
@@ -34,7 +34,7 @@ import { beforeAll, describe, expect, it } from 'vitest';
 import { ClientWorld } from '../src/net/online';
 import { Sim } from '../src/sim/sim';
 import type { PlayerClass } from '../src/sim/types';
-// The 20 facet interfaces the W1 split produced (src/world_api/<facet>.ts). Imported
+// The 21 facet interfaces the W1 split produced (src/world_api/<facet>.ts). Imported
 // type-only to pin each facet's runtime member array to its interface key-set below.
 import type { IWorldChat } from '../src/world_api/chat';
 import type { IWorldCombat } from '../src/world_api/combat';
@@ -49,6 +49,7 @@ import type { IWorldLoot } from '../src/world_api/loot';
 import type { IWorldMarket } from '../src/world_api/market';
 import type { IWorldParty } from '../src/world_api/party';
 import type { IWorldPet } from '../src/world_api/pet';
+import type { IWorldProfessions } from '../src/world_api/professions';
 import type { IWorldProgressionXp } from '../src/world_api/progression_xp';
 import type { IWorldQuests } from '../src/world_api/quests';
 import type { IWorldSocialGraph } from '../src/world_api/social_graph';
@@ -64,8 +65,8 @@ interface IWorldMember {
   readonly kind: IWorldMemberKind;
 }
 
-// The 147 members of `interface IWorld`, in interface order (world_api.ts:342-509).
-// Partition: 36 `data` + 111 `method` (read-returning + command-void + 3 async).
+// The 148 members of `interface IWorld`, in interface order (world_api.ts:342-509).
+// Partition: 36 `data` + 112 `method` (read-returning + command-void + 3 async).
 // biome-ignore lint/suspicious/noExportsInTest: IWORLD_MEMBERS is the W0c pinned structural-parity contract (the authoritative IWorld member list)
 export const IWORLD_MEMBERS = [
   // --- core world / player roster + economy reads (data) ---
@@ -88,7 +89,7 @@ export const IWORLD_MEMBERS = [
   { name: 'questLog', kind: 'data' },
   { name: 'questsDone', kind: 'data' },
   // --- commands + read-returning methods ---
-  { name: 'questState', kind: 'method' }, // read-returning (1/6)
+  { name: 'questState', kind: 'method' }, // read-returning (1/7)
   { name: 'castAbility', kind: 'method' },
   { name: 'castAbilityBySlot', kind: 'method' },
   { name: 'cancelAura', kind: 'method' },
@@ -101,7 +102,7 @@ export const IWORLD_MEMBERS = [
   { name: 'interact', kind: 'method' },
   { name: 'lootCorpse', kind: 'method' },
   { name: 'submitLootRoll', kind: 'method' },
-  { name: 'activeLootRolls', kind: 'method' }, // read-returning (2/6)
+  { name: 'activeLootRolls', kind: 'method' }, // read-returning (2/7)
   { name: 'pickUpObject', kind: 'method' },
   { name: 'acceptQuest', kind: 'method' },
   { name: 'turnInQuest', kind: 'method' },
@@ -149,7 +150,7 @@ export const IWORLD_MEMBERS = [
   { name: 'moveRaidMember', kind: 'method' },
   { name: 'setPartyLootMaster', kind: 'method' },
   { name: 'assignMasterLoot', kind: 'method' },
-  { name: 'markerFor', kind: 'method' }, // read-returning (3/6)
+  { name: 'markerFor', kind: 'method' }, // read-returning (3/7)
   { name: 'setMarker', kind: 'method' },
   { name: 'clearMarker', kind: 'method' },
   { name: 'tradeRequest', kind: 'method' },
@@ -195,7 +196,7 @@ export const IWORLD_MEMBERS = [
   { name: 'delveInteract', kind: 'method' },
   { name: 'companionUpgrade', kind: 'method' },
   { name: 'delveBuyShopItem', kind: 'method' },
-  { name: 'delveShopOffers', kind: 'method' }, // read-returning (4/6)
+  { name: 'delveShopOffers', kind: 'method' }, // read-returning (4/7)
   { name: 'lockpickState', kind: 'data' },
   { name: 'lockpickEngage', kind: 'method' },
   { name: 'lockpickAction', kind: 'method' },
@@ -206,17 +207,18 @@ export const IWORLD_MEMBERS = [
   { name: 'delveMarks', kind: 'data' },
   { name: 'companionUpgrades', kind: 'data' },
   { name: 'delveDaily', kind: 'data' },
-  { name: 'raidLockouts', kind: 'method' }, // read-returning (5/6)
+  { name: 'raidLockouts', kind: 'method' }, // read-returning (5/7)
   { name: 'leaderboard', kind: 'method' }, // async
   { name: 'guildLeaderboard', kind: 'method' }, // async
   { name: 'prestige', kind: 'method' },
+  { name: 'professionsInfo', kind: 'method' }, // read-returning (7/7)
   // --- talents & specializations (reads + commands) ---
   { name: 'talents', kind: 'data' },
   { name: 'talentSpec', kind: 'data' },
   { name: 'talentRole', kind: 'data' },
   { name: 'loadouts', kind: 'data' },
   { name: 'activeLoadout', kind: 'data' },
-  { name: 'talentPoints', kind: 'method' }, // read-returning (6/6)
+  { name: 'talentPoints', kind: 'method' }, // read-returning (6/7)
   { name: 'applyTalents', kind: 'method' },
   { name: 'respec', kind: 'method' },
   { name: 'setSpec', kind: 'method' },
@@ -324,9 +326,9 @@ beforeAll(() => {
 
 describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => {
   it('pins total / data / method counts', () => {
-    expect(IWORLD_MEMBERS.length).toBe(147);
+    expect(IWORLD_MEMBERS.length).toBe(148);
     expect(DATA_MEMBERS.length).toBe(36);
-    expect(METHOD_MEMBERS.length).toBe(111);
+    expect(METHOD_MEMBERS.length).toBe(112);
   });
 
   it('has no duplicate member names', () => {
@@ -336,7 +338,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
 
   // Sorted-name `toEqual` snapshots: a dropped, renamed, or kind-flipped member reddens
   // these deliberately, forcing a reviewed edit. NOT length-only.
-  it('the full sorted member set is exactly the pinned 147', () => {
+  it('the full sorted member set is exactly the pinned 148', () => {
     expect(IWORLD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -440,6 +442,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'playerId',
       'prestige',
       'prestigeRank',
+      'professionsInfo',
       'questLog',
       'questState',
       'questsDone',
@@ -529,7 +532,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
     ]);
   });
 
-  it('the sorted method-kind set is exactly the pinned 107', () => {
+  it('the sorted method-kind set is exactly the pinned 112', () => {
     expect(METHOD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -609,6 +612,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'pickUpObject',
       'playEmote',
       'prestige',
+      'professionsInfo',
       'questState',
       'raidLockouts',
       'releaseSpirit',
@@ -677,17 +681,17 @@ describe('membership, not equality: world extras do not fail the gate', () => {
   });
 });
 
-// --- W1: aggregate == disjoint union of the 20 facet member sets --------------------
-// After the facet split (W1), `interface IWorld extends` 20 domain facet interfaces
-// (src/world_api/<facet>.ts; the 19 owner-backed facets plus IWorldTelemetry). This
+// --- W1: aggregate == disjoint union of the 21 facet member sets --------------------
+// After the facet split (W1), `interface IWorld extends` 21 domain facet interfaces
+// (src/world_api/<facet>.ts; the 20 owner-backed facets plus IWorldTelemetry). This
 // block proves the split dropped nothing and duplicated nothing:
 //   (1) each facet's runtime name array is pinned to its interface key-set via
 //       `satisfies readonly (keyof IWorldX)[]` (rejects a FOREIGN name at compile time);
 //   (2) a type-level AssertNever<Exclude<keyof IWorldX, array[number]>> per facet rejects
 //       a MISSING name (if the array omits a key, Exclude<> is a non-never union and tsc
 //       fails) -- (1)+(2) together make each array EXACTLY its facet key-set;
-//   (3) the 20 arrays are pairwise DISJOINT (a member filed in two facets reddens);
-//   (4) their union, sorted, equals the pinned 147-name IWORLD_MEMBERS set (a member
+//   (3) the 21 arrays are pairwise DISJOINT (a member filed in two facets reddens);
+//   (4) their union, sorted, equals the pinned 148-name IWORLD_MEMBERS set (a member
 //       dropped from the split reddens).
 // This is the rigorous form, NOT the tautological `keyof IWorld === keyof (A & B & ...)`
 // (IWorld extends them, so that self-equality proves nothing): it asserts against the
@@ -933,12 +937,19 @@ const FACET_DELVES = [
 ] as const satisfies readonly (keyof IWorldDelves)[];
 type _ExhaustDelves = AssertNever<Exclude<keyof IWorldDelves, (typeof FACET_DELVES)[number]>>;
 
+const FACET_PROFESSIONS = [
+  'professionsInfo',
+] as const satisfies readonly (keyof IWorldProfessions)[];
+type _ExhaustProfessions = AssertNever<
+  Exclude<keyof IWorldProfessions, (typeof FACET_PROFESSIONS)[number]>
+>;
+
 const FACET_TELEMETRY = ['reportTelemetry'] as const satisfies readonly (keyof IWorldTelemetry)[];
 type _ExhaustTelemetry = AssertNever<
   Exclude<keyof IWorldTelemetry, (typeof FACET_TELEMETRY)[number]>
 >;
 
-// The 20-facet partition, keyed by facet for legible failure messages.
+// The 21-facet partition, keyed by facet for legible failure messages.
 const FACET_MEMBER_ARRAYS: Readonly<Record<string, readonly string[]>> = {
   entityRoster: FACET_ENTITY_ROSTER,
   combat: FACET_COMBAT,
@@ -959,12 +970,13 @@ const FACET_MEMBER_ARRAYS: Readonly<Record<string, readonly string[]>> = {
   market: FACET_MARKET,
   dungeons: FACET_DUNGEONS,
   delves: FACET_DELVES,
+  professions: FACET_PROFESSIONS,
   telemetry: FACET_TELEMETRY,
 };
 
-describe('W1: aggregate IWorld member set equals the disjoint union of the 20 facets', () => {
-  it('pins the facet count at 20', () => {
-    expect(Object.keys(FACET_MEMBER_ARRAYS).length).toBe(20);
+describe('W1: aggregate IWorld member set equals the disjoint union of the 21 facets', () => {
+  it('pins the facet count at 21', () => {
+    expect(Object.keys(FACET_MEMBER_ARRAYS).length).toBe(21);
   });
 
   it('each facet array is non-empty and internally duplicate-free', () => {
@@ -974,7 +986,7 @@ describe('W1: aggregate IWorld member set equals the disjoint union of the 20 fa
     }
   });
 
-  it('the 20 facet arrays are pairwise disjoint (no member filed in two facets)', () => {
+  it('the 21 facet arrays are pairwise disjoint (no member filed in two facets)', () => {
     const entries = Object.entries(FACET_MEMBER_ARRAYS);
     const overlaps: string[] = [];
     for (let i = 0; i < entries.length; i++) {
@@ -990,10 +1002,10 @@ describe('W1: aggregate IWorld member set equals the disjoint union of the 20 fa
     expect(overlaps, `members filed in more than one facet:\n${overlaps.join('\n')}`).toEqual([]);
   });
 
-  it('the union of the 20 facets equals the pinned 147-member IWORLD_MEMBERS set', () => {
+  it('the union of the 21 facets equals the pinned 148-member IWORLD_MEMBERS set', () => {
     const union = Object.values(FACET_MEMBER_ARRAYS).flatMap((arr) => [...arr]);
-    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(147);
-    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(147);
+    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(148);
+    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(148);
     const sortedUnion = [...union].sort();
     const pinned = IWORLD_MEMBERS.map((m) => m.name).sort();
     expect(sortedUnion).toEqual(pinned);


### PR DESCRIPTION
## Summary

Adds the contracts-first professions foundation for #1164:

- shared content-as-code TypeScript contracts for profession skills, crafts, recipes, nodes, player progress, and the reserved persistence/snapshot keys in `src/sim/professions/types.ts`
- a new `IWorldProfessions` read-only facet with `professionsInfo()` and aggregate `IWorld` wiring
- empty/stub `professionsInfo()` implementations in both `Sim` and `ClientWorld`
- parity/command-facet/contract tests so the new facet remains implemented and command-less until downstream profession slices add real state/content

## Related issues

Part of #1164.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:ts` - passed
  - `npx biome check --write src/net/online.ts src/sim/sim.ts src/world_api.ts src/world_api/professions.ts src/sim/professions/types.ts tests/world_api_parity.test.ts tests/command_facets.test.ts tests/professions_contracts.test.ts` - passed; applied formatting only; remaining diagnostics are existing warnings in broad touched files
  - `npx biome check src/net/online.ts src/sim/sim.ts src/world_api.ts src/world_api/professions.ts src/sim/professions/types.ts tests/world_api_parity.test.ts tests/command_facets.test.ts tests/professions_contracts.test.ts` - passed with existing warnings/infos only
  - `git diff --check` and `git diff --cached --check` - passed
  - `npx vitest run tests/professions_contracts.test.ts tests/world_api_parity.test.ts tests/command_facets.test.ts` - passed with temporary `.browserslistrc` comment-strip workaround; 3 files / 180 tests
  - `npx vitest run tests/command_schema.test.ts` - passed with temporary `.browserslistrc` comment-strip workaround; 1 file / 10 tests
  - `npx vitest run tests/professions_contracts.test.ts tests/world_api_parity.test.ts tests/command_facets.test.ts tests/command_schema.test.ts tests/architecture.test.ts` - new professions tests passed; blocked only by existing release-branch `src/world_api/chat.ts` value import of `OVERHEAD_EMOTE_IDS`; 4 files passed, architecture has 1 known failing test
  - `npm run build` - passed with temporary `.browserslistrc` comment-strip workaround; generated i18n output restored afterward
  - `npm run ci:changed` - blocked by existing release-branch Biome debt: checked 97 files, 93 errors, 676 warnings, 3 infos; first diagnostics were `scripts/malware_scan.mjs:762`, `scripts/profiler/harness.mjs:232`, `tests/chat.test.ts:408`, and `tests/threat.test.ts`
- Manual steps:
  - Verified the branch started from current `origin/release/v0.18.0` (`e0322208f85acb5d7fa9734f148a0dc57ed9f6c9`).
  - Verified issue #1164 is open and no active open PR matched the issue/contracts search before implementation.
  - Confirmed `.browserslistrc` was restored after temporary test/build workarounds.
  - Confirmed build-generated i18n files were restored and not included in this PR.

## Screenshots / recordings

N/A - this is a TypeScript contract / IWorld API surface change with no player- or operator-visible UI/UX changes.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.