### PR TITLE
[codex] Add item-instance inventory model

### DIFF
--- a/docs/professions-item-instances.md
+++ b/docs/professions-item-instances.md
@@ -1,0 +1,20 @@
+# Professions Item Instances
+
+Decision: go, as an additive item-instance payload alongside the existing fungible `{ itemId, count }` inventory slot.
+
+Most items should remain fungible stacks. Professions features that need per-item state can opt a slot into `InvSlot.instance`, which carries the currently known downstream requirements:
+
+- `signer`: the crafter or gatherer identity that signed the item.
+- `effectCharges`: per-effect durability or charge counters for tools and slotted effects.
+- `rolledQuality` / `rolledStats`: non-fungible quality and stat rolls that cannot be represented by a shared item id.
+- `boundTo`: the character identity the item instance is bound to.
+
+The rationale is that tool charge state, signed commissions, and binding workflows all need state that cannot safely live on a global item definition or on a stack keyed only by `itemId`. Keeping the payload optional avoids changing the normal fast path for materials, vendor goods, loot stacks, and other fully fungible items.
+
+Current scope:
+
+- Character save/load preserves the instance payload for inventory and vendor buyback slots.
+- Bag filtering/display treats instanced slots as normal slots so they remain visible to the player.
+- The World Market lists only fungible stacks. Instanced slots are intentionally inert until the market flow has explicit support for escrow, listing, buying, cancelling, and collecting per-instance goods.
+
+Out of scope: crafting-quality rolls that can be represented by distinct rarity-keyed item ids should continue to do that and should not block on item instances.

--- a/src/sim/market.ts
+++ b/src/sim/market.ts
@@ -13,7 +13,14 @@ import { ITEMS } from './data';
 import { formatMoney } from './format_money';
 import type { PlayerMeta } from './sim';
 import type { SimContext } from './sim_context';
-import { dist2d, type Entity, INTERACT_RANGE, type InvSlot } from './types';
+import {
+  cloneInvSlot,
+  dist2d,
+  type Entity,
+  INTERACT_RANGE,
+  type InvSlot,
+  isInstancedInvSlot,
+} from './types';
 
 const MARKET_RANGE = INTERACT_RANGE + 2; // you must stand at the Merchant to deal
 // the /listings readout (still on Sim) reports the seller's count against this cap,
@@ -121,13 +128,39 @@ export class Market {
     return c;
   }
 
+  private marketCollectionSlot(slot: InvSlot): InvSlot {
+    const clone = cloneInvSlot(slot);
+    clone.count = isInstancedInvSlot(clone) ? 1 : Math.max(1, Math.floor(clone.count) || 1);
+    return clone;
+  }
+
+  private fungibleItemCount(meta: PlayerMeta, itemId: string): number {
+    let total = 0;
+    for (const slot of meta.inventory) {
+      if (slot.itemId === itemId && !isInstancedInvSlot(slot)) total += slot.count;
+    }
+    return total;
+  }
+
+  private removeFungibleItem(meta: PlayerMeta, itemId: string, count: number): void {
+    for (let i = meta.inventory.length - 1; i >= 0 && count > 0; i--) {
+      const slot = meta.inventory[i];
+      if (slot.itemId !== itemId || isInstancedInvSlot(slot)) continue;
+      const take = Math.min(slot.count, count);
+      slot.count -= take;
+      count -= take;
+      if (slot.count <= 0) meta.inventory.splice(i, 1);
+    }
+    this.ctx.onInventoryChangedForQuests(meta);
+  }
+
   private mergeMarketCollections(fromKey: string, toKey: string): boolean {
     if (!fromKey || fromKey === toKey) return false;
     const from = this.marketCollections.get(fromKey);
     if (!from) return false;
     const to = this.collectionFor(toKey);
     to.copper += from.copper;
-    to.items.push(...from.items.map((s) => ({ ...s })));
+    to.items.push(...from.items.map(cloneInvSlot));
     this.marketCollections.delete(fromKey);
     return true;
   }
@@ -236,8 +269,15 @@ export class Market {
       return;
     }
     const want = Math.max(1, Math.floor(count));
-    if (this.ctx.countItem(itemId, meta.entityId) < want) {
-      this.ctx.error(meta.entityId, 'You do not have that many to sell.');
+    const marketableCount = this.fungibleItemCount(meta, itemId);
+    if (marketableCount < want) {
+      const totalCount = this.ctx.countItem(itemId, meta.entityId);
+      this.ctx.error(
+        meta.entityId,
+        totalCount >= want
+          ? 'Instanced items cannot be listed on the World Market yet.'
+          : 'You do not have that many to sell.',
+      );
       return;
     }
     const ask = Math.floor(price);
@@ -261,7 +301,7 @@ export class Market {
       );
       return;
     }
-    this.ctx.removeItem(itemId, want, meta.entityId); // escrow
+    this.removeFungibleItem(meta, itemId, want); // escrow
     this.marketListings.push({
       id: this.nextListingId++,
       sellerKey,
@@ -383,7 +423,16 @@ export class Market {
         pid: meta.entityId,
       });
     }
-    for (const s of col.items) this.ctx.addItem(s.itemId, s.count, meta.entityId);
+    let restoredInstancedItem = false;
+    for (const s of col.items) {
+      if (isInstancedInvSlot(s)) {
+        meta.inventory.push(cloneInvSlot(s));
+        restoredInstancedItem = true;
+      } else {
+        this.ctx.addItem(s.itemId, s.count, meta.entityId);
+      }
+    }
+    if (restoredInstancedItem) this.ctx.onInventoryChangedForQuests(meta);
     this.marketCollections.delete(this.marketSellerKey(meta));
   }
 
@@ -461,7 +510,7 @@ export class Market {
       totalCount: matched.length,
       filter: meta.marketFilter,
       collectionCopper: col?.copper ?? 0,
-      collectionItems: col ? col.items.map((s) => ({ ...s })) : [],
+      collectionItems: col ? col.items.map(cloneInvSlot) : [],
       cutPct: Math.round(MARKET_CUT * 100),
       maxListings: MARKET_MAX_LISTINGS,
       myListingCount,
@@ -488,7 +537,7 @@ export class Market {
       collections: [...this.marketCollections.entries()].map(([key, c]) => ({
         key,
         copper: c.copper,
-        items: c.items.map((s) => ({ ...s })),
+        items: c.items.map(cloneInvSlot),
       })),
       nextListingId: this.nextListingId,
     };
@@ -520,7 +569,7 @@ export class Market {
         copper: Math.max(0, Math.floor(c.copper) || 0),
         items: (c.items ?? [])
           .filter((s) => s && ITEMS[s.itemId])
-          .map((s) => ({ itemId: s.itemId, count: Math.max(1, s.count | 0) })),
+          .map((s) => this.marketCollectionSlot(s)),
       });
     }
     const maxId = this.marketListings.reduce((m, l) => Math.max(m, l.id + 1), 1);

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -259,6 +259,7 @@ import {
   angleTo,
   armorReduction,
   type CrowdControlDrCategory,
+  cloneInvSlot,
   DELVE_COMPANION_HEAL_INTERVAL,
   type DelveDef,
   type DelveModuleDef,
@@ -275,6 +276,7 @@ import {
   GCD,
   type InvSlot,
   isConsuming,
+  isInstancedInvSlot,
   isPetClass,
   isQuestTurnInNpc,
   LEASH_DISTANCE,
@@ -1215,8 +1217,8 @@ export class Sim {
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
-      meta.inventory = s.inventory.map((i) => ({ ...i }));
-      meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
+      meta.inventory = s.inventory.map(cloneInvSlot);
+      meta.vendorBuyback = (s.vendorBuyback ?? []).map(cloneInvSlot);
       for (const q of s.questLog) {
         if (q.state !== 'done')
           meta.questLog.set(q.questId, {
@@ -1396,8 +1398,8 @@ export class Sim {
       pos: { x: e.pos.x, z: e.pos.z },
       facing: e.facing,
       equipment: { ...meta.equipment },
-      inventory: meta.inventory.map((i) => ({ ...i })),
-      vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
+      inventory: meta.inventory.map(cloneInvSlot),
+      vendorBuyback: meta.vendorBuyback.map(cloneInvSlot),
       questLog: [...meta.questLog.values()].map((q) => ({
         questId: q.questId,
         counts: [...q.counts],
@@ -4197,7 +4199,7 @@ export class Sim {
     if (!r) return;
     const { meta } = r;
     const def = ITEMS[itemId];
-    const existing = meta.inventory.find((s) => s.itemId === itemId);
+    const existing = meta.inventory.find((s) => s.itemId === itemId && !isInstancedInvSlot(s));
     if (existing) existing.count += count;
     else meta.inventory.push({ itemId, count });
     this.emit({

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -367,11 +367,50 @@ export interface OtherItemDef extends BaseItemDef {
 
 export type ItemDef = ArmorItemDef | WeaponItemDef | OtherItemDef;
 
+export type ItemQuality = NonNullable<BaseItemDef['quality']>;
+
+export interface ItemOwnerRef {
+  characterId?: number;
+  name?: string;
+}
+
+export interface ItemInstancePayload {
+  signer?: ItemOwnerRef;
+  effectCharges?: Record<string, number>;
+  rolledQuality?: ItemQuality;
+  rolledStats?: Partial<Stats>;
+  boundTo?: ItemOwnerRef;
+}
+
 export interface InvSlot {
   itemId: string;
   count: number;
+  instance?: ItemInstancePayload;
 }
 
+export function isInstancedInvSlot(slot: InvSlot): boolean {
+  return slot.instance !== undefined;
+}
+
+export function cloneItemInstancePayload(
+  instance: ItemInstancePayload | undefined,
+): ItemInstancePayload | undefined {
+  if (!instance) return undefined;
+  const clone: ItemInstancePayload = {};
+  if (instance.signer) clone.signer = { ...instance.signer };
+  if (instance.effectCharges) clone.effectCharges = { ...instance.effectCharges };
+  if (instance.rolledQuality) clone.rolledQuality = instance.rolledQuality;
+  if (instance.rolledStats) clone.rolledStats = { ...instance.rolledStats };
+  if (instance.boundTo) clone.boundTo = { ...instance.boundTo };
+  return clone;
+}
+
+export function cloneInvSlot(slot: InvSlot): InvSlot {
+  const clone: InvSlot = { itemId: slot.itemId, count: slot.count };
+  const instance = cloneItemInstancePayload(slot.instance);
+  if (instance) clone.instance = instance;
+  return clone;
+}
 export interface LootSlot extends InvSlot {
   // Quest corpse loot can be personal: each listed player can take one copy.
   personalFor?: number[];

--- a/tests/bags_view.test.ts
+++ b/tests/bags_view.test.ts
@@ -106,6 +106,26 @@ describe('buildBagGrid', () => {
     expect(model.visible.map((s) => s.itemId)).toEqual(['sword', 'potion', 'questItem']);
   });
 
+  it('keeps instanced slots visible in the bag grid', () => {
+    const instanced: InvSlot[] = [
+      {
+        itemId: 'sword',
+        count: 1,
+        instance: {
+          signer: { characterId: 7, name: 'Crafter' },
+          effectCharges: { polish: 2 },
+          rolledQuality: 'rare',
+          rolledStats: { str: 1 },
+          boundTo: { characterId: 9, name: 'Owner' },
+        },
+      },
+    ];
+
+    const model = buildBagGrid(instanced, lookup, DEFAULT_BAG_FILTER);
+
+    expect(model.state).toBe('items');
+    expect(model.visible).toEqual(instanced);
+  });
   it('reuses bag_filter: a category filter narrows the visible rows', () => {
     const weaponsOnly = buildBagGrid(inv, lookup, { ...DEFAULT_BAG_FILTER, category: 'weapon' });
     expect(weaponsOnly.state).toBe('items');

--- a/tests/item_instances.test.ts
+++ b/tests/item_instances.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import type { CharacterState, PlayerMeta } from '../src/sim/sim';
+import { Sim } from '../src/sim/sim';
+import type { Entity, InvSlot, ItemInstancePayload, PlayerClass } from '../src/sim/types';
+import { groundHeight } from '../src/sim/world';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function entityOrThrow(sim: Sim, pid: number): Entity {
+  const entity = sim.entities.get(pid);
+  if (!entity) throw new Error(`missing entity ${pid}`);
+  return entity;
+}
+
+function metaOrThrow(sim: Sim, pid: number): PlayerMeta {
+  const meta = sim.meta(pid);
+  if (!meta) throw new Error(`missing player meta ${pid}`);
+  return meta;
+}
+
+function characterStateOrThrow(sim: Sim, pid: number): CharacterState {
+  const state = sim.serializeCharacter(pid);
+  if (!state) throw new Error(`missing serialized character ${pid}`);
+  return state;
+}
+
+function merchant(sim: Sim): Entity {
+  for (const e of sim.entities.values()) if (e.templateId === 'the_merchant') return e;
+  throw new Error('the Merchant was not spawned');
+}
+
+function standAtMerchant(sim: Sim, pid: number) {
+  const m = merchant(sim);
+  const e = entityOrThrow(sim, pid);
+  e.pos.x = m.pos.x;
+  e.pos.z = m.pos.z;
+  e.pos.y = groundHeight(e.pos.x, e.pos.z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+}
+
+function errorsSince(sim: Sim): string[] {
+  return sim.events.filter((e) => e.type === 'error').map((e) => (e as { text: string }).text);
+}
+
+const TOOL_INSTANCE: ItemInstancePayload = {
+  signer: { characterId: 101, name: 'Mira' },
+  effectCharges: { sharpening: 3, polish: 1 },
+  rolledQuality: 'rare',
+  rolledStats: { str: 2, sta: 1 },
+  boundTo: { characterId: 202, name: 'Saver' },
+};
+
+const PLAYER_CLASS: PlayerClass = 'warrior';
+
+describe('item-instance inventory slots', () => {
+  it('records the additive go decision shape with the professions instance payload', () => {
+    const slot: InvSlot = { itemId: 'worn_sword', count: 1, instance: TOOL_INSTANCE };
+
+    expect(slot).toMatchObject({
+      itemId: 'worn_sword',
+      count: 1,
+      instance: {
+        signer: { characterId: 101, name: 'Mira' },
+        effectCharges: { sharpening: 3, polish: 1 },
+        rolledQuality: 'rare',
+        rolledStats: { str: 2, sta: 1 },
+        boundTo: { characterId: 202, name: 'Saver' },
+      },
+    });
+  });
+
+  it('round-trips instance payloads through character save/load without aliasing', () => {
+    const sim = makeWorld();
+    const pid = sim.addPlayer(PLAYER_CLASS, 'Saver', { characterId: 202 });
+    const meta = metaOrThrow(sim, pid);
+    meta.inventory.push({ itemId: 'worn_sword', count: 1, instance: TOOL_INSTANCE });
+    meta.vendorBuyback.push({
+      itemId: 'wolf_fang',
+      count: 1,
+      instance: { signer: { characterId: 303, name: 'Buyer' }, boundTo: { characterId: 202 } },
+    });
+
+    const saved = characterStateOrThrow(sim, pid);
+    const inventoryInstance = meta.inventory[0]?.instance;
+    const buybackSigner = meta.vendorBuyback[0]?.instance?.signer;
+    if (!inventoryInstance?.effectCharges || !buybackSigner)
+      throw new Error('missing instance data');
+    inventoryInstance.effectCharges.sharpening = 0;
+    buybackSigner.name = 'Mutated';
+
+    const loaded = makeWorld();
+    const loadedPid = loaded.addPlayer(PLAYER_CLASS, 'Saver', { characterId: 202, state: saved });
+    const resaved = characterStateOrThrow(loaded, loadedPid);
+
+    expect(resaved.inventory).toEqual(saved.inventory);
+    expect(resaved.vendorBuyback).toEqual(saved.vendorBuyback);
+    expect(resaved.inventory[0]?.instance?.effectCharges?.sharpening).toBe(3);
+    expect(resaved.vendorBuyback?.[0]?.instance?.signer?.name).toBe('Buyer');
+  });
+
+  it('keeps instanced items inert in the World Market while fungible stacks can list', () => {
+    const sim = makeWorld();
+    const seller = sim.addPlayer(PLAYER_CLASS, 'Seller');
+    standAtMerchant(sim, seller);
+    const meta = metaOrThrow(sim, seller);
+    meta.inventory.push({ itemId: 'wolf_fang', count: 1, instance: TOOL_INSTANCE });
+    sim.events.length = 0;
+
+    sim.marketList('wolf_fang', 1, 100, seller);
+
+    expect(errorsSince(sim)).toEqual(['Instanced items cannot be listed on the World Market yet.']);
+    expect(sim.marketListings.some((l) => !l.house && l.itemId === 'wolf_fang')).toBe(false);
+    expect(meta.inventory).toEqual([{ itemId: 'wolf_fang', count: 1, instance: TOOL_INSTANCE }]);
+
+    sim.addItem('wolf_fang', 2, seller);
+    sim.events.length = 0;
+    sim.marketList('wolf_fang', 2, 100, seller);
+
+    expect(errorsSince(sim)).toEqual([]);
+    expect(
+      sim.marketListings.some((l) => !l.house && l.itemId === 'wolf_fang' && l.count === 2),
+    ).toBe(true);
+    expect(meta.inventory).toEqual([{ itemId: 'wolf_fang', count: 1, instance: TOOL_INSTANCE }]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the additive item-instance model for professions work while keeping normal `{ itemId, count }` stacks as the default fungible path.

This records the go decision in `docs/professions-item-instances.md`, adds optional `InvSlot.instance` metadata for signer, per-effect charges, rolled quality/stats, and bound owner, and deep-clones inventory slots through character save/load boundaries so nested instance payloads do not alias runtime state.

The World Market remains intentionally fungible-only for now: it counts/removes only non-instanced stacks for listing, preserves any collection slots with instance payloads, and reports instanced copies as not listable until #1146 owns per-instance market escrow/listing behavior.

## Related issues

Closes #1165.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:ts` - passed.
  - `npx vitest run tests/item_instances.test.ts tests/bags_view.test.ts tests/bag_filter.test.ts tests/market.test.ts tests/market_view.test.ts tests/persistence_round_trip.test.ts` - passed, 6 files / 69 tests. Run with a temporary `.browserslistrc` comment-strip wrapper because Vite currently rejects comments in that file on this release branch; original bytes restored afterward.
  - `npm run build` - passed with the same temporary `.browserslistrc` wrapper; original bytes restored afterward and generated i18n/status files restored out of the PR. Existing warnings remain: admin i18n ineffective dynamic imports, large chunk warning, plugin timing report.
  - `npx biome ci src/sim/types.ts src/sim/market.ts tests/bags_view.test.ts tests/item_instances.test.ts docs/professions-item-instances.md` - passed for the new/targeted files that are not already carrying branch lint debt.
  - `npx vitest run tests/architecture.test.ts` - blocked by existing release-branch failure: `src/world_api/chat.ts` value-imports `OVERHEAD_EMOTE_IDS` from `../sim/types`.
  - `npx biome ci --changed --no-errors-on-unmatched --colors=off` - blocked by existing release-branch Biome debt: checked 97 files, found 94 errors, 676 warnings, 3 infos. Representative first diagnostics remain in `scripts/malware_scan.mjs:762`, `scripts/profiler/harness.mjs:232`, and `tests/chat.test.ts:408`.
- Manual steps: N/A; this is a sim/model contract change covered by unit tests.

## Screenshots / recordings

N/A. No player-facing UI/UX changed; bag display coverage is via `buildBagGrid` unit tests.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
      Focused/relevant Vitest coverage passed; full `npm test` was not run.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.
      `npm run build` passed; server/env builds not touched.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.