### PR TITLE
[codex] Add global inbound message rate limit

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -116,6 +116,9 @@ const LEAVE_SAVE_RETRY_MAX_MS = 4000;
 const CHAT_RATE_BURST = 5;
 const CHAT_RATE_REFILL_PER_SECOND = 1 / 3; // sustained 20 messages/minute
 const CHAT_RATE_ERROR_COOLDOWN_SECONDS = 4;
+const INBOUND_MESSAGE_RATE_BURST = 120;
+const INBOUND_MESSAGE_RATE_REFILL_PER_SECOND = 40;
+const INBOUND_MESSAGE_RATE_ERROR_COOLDOWN_SECONDS = 5;
 const CHAT_COOLDOWN_SECONDS = 20;
 const CHAT_RATE_VIOLATIONS_FOR_COOLDOWN = 3;
 const WHO_RESULT_LIMIT = 50;
@@ -319,6 +322,9 @@ export interface ClientSession {
   joinedAt: number;
   dbSessionId: number | null; // play_sessions row, set once the insert lands
   left: boolean; // set in leave(); guards against the open-session insert landing after disconnect
+  inboundMessageTokens: number;
+  inboundMessageLastRefill: number;
+  inboundMessageLastRateError: number;
   chatTokens: number;
   chatLastRefill: number;
   chatLastRateError: number;
@@ -1394,6 +1400,9 @@ export class GameServer {
       joinedAt: Date.now(),
       dbSessionId: null,
       left: false,
+      inboundMessageTokens: INBOUND_MESSAGE_RATE_BURST,
+      inboundMessageLastRefill: Date.now() / 1000,
+      inboundMessageLastRateError: 0,
       chatTokens: CHAT_RATE_BURST,
       chatLastRefill: Date.now() / 1000,
       chatLastRateError: 0,
@@ -2018,6 +2027,7 @@ export class GameServer {
 
   handleMessage(session: ClientSession, raw: string): void {
     const receivedAtMs = Date.now();
+    if (!this.consumeInboundMessageToken(session, receivedAtMs)) return;
     let msg: unknown;
     try {
       msg = JSON.parse(raw);
@@ -2039,6 +2049,30 @@ export class GameServer {
     }
   }
 
+  private consumeInboundMessageToken(session: ClientSession, receivedAtMs: number): boolean {
+    const now = receivedAtMs / 1000;
+    if (now < session.inboundMessageLastRefill) {
+      session.inboundMessageTokens = INBOUND_MESSAGE_RATE_BURST;
+      session.inboundMessageLastRefill = now;
+    }
+    const elapsed = Math.max(0, now - session.inboundMessageLastRefill);
+    if (elapsed > 0) {
+      session.inboundMessageTokens = Math.min(
+        INBOUND_MESSAGE_RATE_BURST,
+        session.inboundMessageTokens + elapsed * INBOUND_MESSAGE_RATE_REFILL_PER_SECOND,
+      );
+      session.inboundMessageLastRefill = now;
+    }
+    if (session.inboundMessageTokens >= 1) {
+      session.inboundMessageTokens -= 1;
+      return true;
+    }
+    if (now - session.inboundMessageLastRateError >= INBOUND_MESSAGE_RATE_ERROR_COOLDOWN_SECONDS) {
+      this.send(session, { t: 'error', error: 'rate limited' });
+      session.inboundMessageLastRateError = now;
+    }
+    return false;
+  }
   private messageCommand(msg: unknown): string {
     if (typeof msg !== 'object' || msg === null || Array.isArray(msg)) return 'unknown';
     const record = msg as Record<string, unknown>;

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -509,6 +509,35 @@ describe('delta snapshots', () => {
     expect(lastSnap(fc.sent).self.ack).toBe(7);
   });
 
+  it('rate limits inbound message floods before processing more input', () => {
+    const now = new Date('2026-01-01T00:00:00Z');
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    session.inboundMessageLastRefill = now.getTime() / 1000;
+    session.inboundMessageLastRateError = 0;
+    fc.sent.length = 0;
+
+    try {
+      for (let seq = 1; seq <= 200; seq++) {
+        server.handleMessage(session, JSON.stringify({ t: 'input', seq, mi: { f: 1 } }));
+      }
+
+      const lastProcessedSeq = session.lastInputSeq;
+      expect(lastProcessedSeq).toBeGreaterThan(0);
+      expect(lastProcessedSeq).toBeLessThan(200);
+
+      server.handleMessage(session, JSON.stringify({ t: 'input', seq: 999, mi: { f: 0 } }));
+      expect(session.lastInputSeq).toBe(lastProcessedSeq);
+      expect(fc.sent).toContainEqual({ t: 'error', error: 'rate limited' });
+
+      vi.advanceTimersByTime(1000);
+      server.handleMessage(session, JSON.stringify({ t: 'input', seq: 1000, mi: { f: 0 } }));
+      expect(session.lastInputSeq).toBe(1000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('turns echoed input acks into client latency samples', () => {
     const client = bareClient(1);
     const first = {


### PR DESCRIPTION
## Summary

Adds a per-session global inbound message token bucket in `GameServer.handleMessage` so floods of non-chat frames are dropped before JSON parsing and command dispatch. The limiter is sized above normal movement cadence (120 burst, 40/sec refill) and rate-limited clients get a throttled `rate limited` error response.

## Related issues

Closes #978

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npm run check:ts`
  - `npx vitest run tests/snapshots.test.ts tests/security.test.ts` (with temporary `.browserslistrc` comment stripping for the known release-branch config-loader issue): 2 files / 121 tests passed
  - `npx vitest run tests/snapshots.test.ts tests/security.test.ts tests/chat_filter.test.ts tests/game_sessions.test.ts tests/architecture.test.ts` (same wrapper): 4 files passed, `tests/architecture.test.ts` failed only on the known release-branch blocker: `src\world_api\chat.ts value-imports 'OVERHEAD_EMOTE_IDS' from '../sim/types'`
  - `npx biome check --write server/game.ts tests/snapshots.test.ts`
  - `npx biome ci server/game.ts tests/snapshots.test.ts --max-diagnostics=80` (passes; reports existing warning-level diagnostics in `tests/snapshots.test.ts`)
  - `git diff --check`
  - `npm run build` (with temporary `.browserslistrc` comment stripping; passes with existing Vite warnings)
  - `npm run build:server` (passes when rerun outside the sandbox; sandboxed attempt failed with filesystem access denied from esbuild)
- Manual steps: N/A, server-only message handling change covered by automated tests.

## Screenshots / recordings

N/A - server-only networking/rate-limit change with no UI/UX surface.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed. Focused/relevant tests pass; full broader run is blocked by the known release-branch architecture failure noted above.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.