### PR TITLE
fix(discord): hide broken Discord avatar images when the CDN load fails

### DIFF
--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -30,6 +30,7 @@ import type { DelveModuleId } from '../sim/delve_layout';
 import type { BiomeId } from '../sim/types';
 import { ALL_CLASSES, type Entity, type SimEvent } from '../sim/types';
 import { groundHeight, WATER_LEVEL, zoneBiomeAt } from '../sim/world';
+import { attachAvatarFallback } from '../ui/avatar_fallback';
 import { tEntity } from '../ui/entity_i18n';
 import type { IWorld } from '../world_api';
 import { isVisuallyDead } from './anim_state';
@@ -3155,6 +3156,10 @@ export class Renderer {
     discordEl.alt = '';
     discordEl.referrerPolicy = 'no-referrer';
     discordEl.style.display = 'none';
+    // The avatar is the one nameplate image sourced from an external URL (Discord's
+    // CDN); if it fails to load, hide it rather than leave the browser's broken-image
+    // placeholder on the plate. Attached once here; the element is reused per entity.
+    attachAvatarFallback(discordEl);
     const nameEl = document.createElement('div');
     nameEl.className = 'np-name';
     nameEl.textContent = e.kind === 'object' ? objectDisplayName(e) : e.name;

--- a/src/ui/avatar_fallback.ts
+++ b/src/ui/avatar_fallback.ts
@@ -1,0 +1,24 @@
+// Guard an external avatar <img> (a Discord CDN profile picture) against a failed
+// load. When the CDN image cannot be fetched (an ad-blocker or privacy extension
+// blocking cdn.discordapp.com, a stale or deleted avatar hash, a transient network
+// error, or a reverse-proxy CSP), the browser paints its own broken-image
+// placeholder in place of the picture: a jarring generic icon on an in-world
+// nameplate or unit frame. Every OTHER image on those surfaces is a locally
+// generated data-URL (tier badge, raid marker) that cannot fail; the linked-Discord
+// avatar is the one external source, so it is the one that needs a fallback.
+//
+// On failure this swaps to a local fallback image when one is given (a generated
+// data-URL badge, which cannot itself fail), otherwise it hides the element so
+// nothing broken shows. The handler attaches once; a fallback that also fails just
+// hides. Safe on a reused element (nameplate) and on a throwaway one (a window that
+// re-renders its innerHTML): the listener lives and dies with the node.
+
+export function attachAvatarFallback(img: HTMLImageElement, fallbackSrc?: string): void {
+  img.addEventListener('error', () => {
+    if (fallbackSrc && img.getAttribute('src') !== fallbackSrc) {
+      img.src = fallbackSrc;
+      return;
+    }
+    img.style.display = 'none';
+  });
+}

--- a/src/ui/discord_widget.ts
+++ b/src/ui/discord_widget.ts
@@ -6,6 +6,7 @@
 // object. It owns no state and never imports Hud. The branching logic lives in
 // the pure view (discord_widget_view.ts); this just paints + wires clicks.
 
+import { attachAvatarFallback } from './avatar_fallback';
 import type {
   DiscordAccountStatus,
   DiscordPresenceState,
@@ -156,6 +157,13 @@ export function renderDiscordWidget(
     `</section>`;
 
   el.innerHTML = `${header}<div class="dc-body">${account}${ladder}${community}</div>`;
+
+  // If the linked Discord avatar fails to load from the CDN, fall back to the
+  // status-tier badge instead of the browser's broken-image placeholder.
+  if (view.mode === 'linked') {
+    const pfp = el.querySelector<HTMLImageElement>('.dc-pfp');
+    if (pfp) attachAvatarFallback(pfp, discordStatusBadgeDataUrl(view.tierIndex));
+  }
 
   // ── wire clicks ────────────────────────────────────────────────────────────
   el.querySelector<HTMLElement>('[data-close]')?.addEventListener('click', () => deps.onClose());

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -113,6 +113,7 @@ import { abilityStartsAutoAttack, hasAutoAttackTarget } from './attack_on_abilit
 import { type AuraEffectInput, auraEffectDescriptor } from './aura_effect';
 import { AurasPainter, type AurasPainterDeps } from './auras_painter';
 import { type AurasDeps, createAurasView } from './auras_view';
+import { attachAvatarFallback } from './avatar_fallback';
 import { BagsWindow } from './bags_window';
 import { CastBarPainter } from './cast_bar_painter';
 import { buildPaperdollView, type PaperdollSlot } from './char_view';
@@ -9975,6 +9976,10 @@ export class Hud {
       parts.push(`<span class="uf-dc-chip rank">${esc(discordStatusDisplayName(tier))}</span>`);
     }
     el.innerHTML = parts.join('');
+    // Hide the external Discord avatar if its CDN image fails to load, so the line
+    // never shows the browser's broken-image placeholder (the nickname stays).
+    const dcAvatar = el.querySelector<HTMLImageElement>('.uf-dc-name img');
+    if (dcAvatar) attachAvatarFallback(dcAvatar);
     el.classList.add('show');
   }
 
@@ -10062,6 +10067,11 @@ export class Hud {
       `<div class="equip-col equip-col-right" id="inspect-equip-right"></div>` +
       `</div></div>`;
     hydratePortraits(el);
+    // If the linked-Discord avatar fails to load from the CDN, fall back to the
+    // status-tier badge (the same image shown when the player has no custom avatar)
+    // instead of the browser's broken-image placeholder.
+    const inspectPfp = el.querySelector<HTMLImageElement>('.inspect-discord-pfp');
+    if (inspectPfp) attachAvatarFallback(inspectPfp, discordStatusBadgeDataUrl(discordTierIdx));
     const view = buildPaperdollView(e.equippedItems, ITEMS);
     const leftCol = el.querySelector('#inspect-equip-left');
     const rightCol = el.querySelector('#inspect-equip-right');

--- a/tests/avatar_fallback.test.ts
+++ b/tests/avatar_fallback.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { attachAvatarFallback } from '../src/ui/avatar_fallback';
+
+// The vitest env has no DOM (this repo models DOM wiring with a hand-rolled fake,
+// see focus_manager.test.ts), so model the minimal HTMLImageElement surface the
+// helper touches: src get/set (mirrored into the src attribute so getAttribute
+// tracks it, like a real element), getAttribute, style.display, and an
+// addEventListener('error') we fire on demand.
+class FakeImg {
+  private handlers: Array<() => void> = [];
+  private attrs: Record<string, string | undefined> = {};
+  style = { display: '' };
+  set src(v: string) {
+    this.attrs.src = v;
+  }
+  get src(): string {
+    return this.attrs.src ?? '';
+  }
+  getAttribute(name: string): string | null {
+    return this.attrs[name] ?? null;
+  }
+  addEventListener(type: string, cb: () => void): void {
+    if (type === 'error') this.handlers.push(cb);
+  }
+  fireError(): void {
+    for (const cb of this.handlers) cb();
+  }
+}
+
+const asImg = (f: FakeImg): HTMLImageElement => f as unknown as HTMLImageElement;
+const CDN = 'https://cdn.discordapp.com/avatars/1/abc.png?size=64';
+const BADGE = 'data:image/png;base64,BADGE';
+
+describe('attachAvatarFallback', () => {
+  it('leaves the image untouched until an error fires', () => {
+    const img = new FakeImg();
+    img.src = CDN;
+    attachAvatarFallback(asImg(img), BADGE);
+    expect(img.src).toBe(CDN);
+    expect(img.style.display).toBe('');
+  });
+
+  it('hides the image when the load fails and no fallback is given', () => {
+    const img = new FakeImg();
+    img.src = CDN;
+    attachAvatarFallback(asImg(img));
+    img.fireError();
+    expect(img.style.display).toBe('none');
+  });
+
+  it('swaps to the fallback source on failure, keeping the image visible', () => {
+    const img = new FakeImg();
+    img.src = CDN;
+    attachAvatarFallback(asImg(img), BADGE);
+    img.fireError();
+    expect(img.src).toBe(BADGE);
+    expect(img.style.display).toBe('');
+  });
+
+  it('hides the image if the fallback source also fails', () => {
+    const img = new FakeImg();
+    img.src = CDN;
+    attachAvatarFallback(asImg(img), BADGE);
+    img.fireError(); // CDN fails -> swap to badge
+    img.fireError(); // badge also fails -> hide
+    expect(img.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Problem

A player's overhead nameplate showed a broken-image placeholder (the generic blue mountain/sun icon) where the linked-Discord profile picture should be:

The linked-Discord avatar is the **only** image on the nameplate / unit-frame surfaces that is fetched from an **external URL** (Discord's CDN, `https://cdn.discordapp.com/avatars/<id>/<hash>.png`). Every other image there (holder-tier badge, raid marker, status-tier badge) is a locally generated `data:` URL that cannot fail to load. The avatar `<img>` had **no `onerror` handling**, so any load failure left the browser's broken-image placeholder painted on the plate.

Failure causes seen in the wild: an ad-blocker or privacy extension blocking `cdn.discordapp.com`, a stale or deleted avatar hash, a transient network error, or a reverse-proxy CSP. (There is no in-repo CSP; this is purely a client-robustness gap.)

The same untreated pattern existed at **four** sites, all fixed here.

## Fix

New helper `src/ui/avatar_fallback.ts`:

```ts
attachAvatarFallback(img, fallbackSrc?) // on 'error': swap to fallbackSrc (a local data-URL badge) if given, else hide the img
```

Wired at the four external-avatar sites:

| Site | File | Behavior on load failure |
|---|---|---|
| Overhead nameplate (the screenshot) | `src/render/renderer.ts` | hide the avatar |
| Target-frame Discord line | `src/ui/hud.ts` (`updateTargetDiscordLine`) | hide, keep the nickname |
| Inspect card | `src/ui/hud.ts` (`openInspect`) | fall back to the status-tier badge |
| Discord window | `src/ui/discord_widget.ts` | fall back to the status-tier badge |

The two "fall back to the status-tier badge" sites reuse the exact image already shown in each surface's existing "player has no custom avatar" branch, so a failed load degrades to the same clean state as no-avatar.

Render/UI only: no sim, wire, i18n, or persistence changes; gameplay-neutral.

## Test plan

- [x] `tests/avatar_fallback.test.ts` (new): hide-on-error, swap-to-fallback, fallback-also-fails, untouched-until-error (node fake-img, matching the repo's DOM-test convention).
- [x] `tsc --noEmit` clean.
- [x] Biome clean on changed files.
- [x] `architecture`, all `discord*` / `nameplate*`, and `hud_perf_budget` suites pass (200 tests).
- [ ] Manual: link Discord, block `cdn.discordapp.com` (or use a deleted avatar), confirm no broken-image icon appears on the nameplate, target frame, inspect card, or Discord window.