### PR TITLE
fix(discord): match failed-avatar fallback to each surface's no-avatar state

### DIFF
--- a/src/ui/avatar_fallback.ts
+++ b/src/ui/avatar_fallback.ts
@@ -7,16 +7,22 @@
 // generated data-URL (tier badge, raid marker) that cannot fail; the linked-Discord
 // avatar is the one external source, so it is the one that needs a fallback.
 //
-// On failure this swaps to a local fallback image when one is given (a generated
-// data-URL badge, which cannot itself fail), otherwise it hides the element so
-// nothing broken shows. The handler attaches once; a fallback that also fails just
-// hides. Safe on a reused element (nameplate) and on a throwaway one (a window that
-// re-renders its innerHTML): the listener lives and dies with the node.
+// On 'error' this runs `onError(img)` when given, otherwise it hides the element so
+// nothing broken shows. Surfaces that have a local fallback (a generated data-URL
+// badge, which cannot itself fail) pass a callback that reproduces their normal
+// "no avatar" rendering, so a failed load degrades to the same clean state.
+//
+// Safe on a reused element (the pooled nameplate img) and on a throwaway one (a
+// window that re-renders its innerHTML): the listener lives and dies with the node,
+// and the default hide-path cannot loop (a hidden img stops loading).
 
-export function attachAvatarFallback(img: HTMLImageElement, fallbackSrc?: string): void {
+export function attachAvatarFallback(
+  img: HTMLImageElement,
+  onError?: (img: HTMLImageElement) => void,
+): void {
   img.addEventListener('error', () => {
-    if (fallbackSrc && img.getAttribute('src') !== fallbackSrc) {
-      img.src = fallbackSrc;
+    if (onError) {
+      onError(img);
       return;
     }
     img.style.display = 'none';

--- a/src/ui/discord_widget.ts
+++ b/src/ui/discord_widget.ts
@@ -158,11 +158,18 @@ export function renderDiscordWidget(
 
   el.innerHTML = `${header}<div class="dc-body">${account}${ladder}${community}</div>`;
 
-  // If the linked Discord avatar fails to load from the CDN, fall back to the
-  // status-tier badge instead of the browser's broken-image placeholder.
+  // If the linked Discord avatar fails to load from the CDN, degrade to exactly the
+  // no-avatar rendering (a single clean tier badge, replacing the pfp + corner-badge
+  // wrap) instead of the browser's broken-image placeholder.
   if (view.mode === 'linked') {
-    const pfp = el.querySelector<HTMLImageElement>('.dc-pfp');
-    if (pfp) attachAvatarFallback(pfp, discordStatusBadgeDataUrl(view.tierIndex));
+    const wrap = el.querySelector<HTMLElement>('.dc-avatar-wrap');
+    const pfp = wrap?.querySelector<HTMLImageElement>('.dc-pfp');
+    if (wrap && pfp) {
+      const tierIndex = view.tierIndex;
+      attachAvatarFallback(pfp, () => {
+        wrap.outerHTML = `<img class="dc-tier-badge" src="${esc(discordStatusBadgeDataUrl(tierIndex))}" alt="" aria-hidden="true" />`;
+      });
+    }
   }
 
   // ── wire clicks ────────────────────────────────────────────────────────────

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -721,6 +721,9 @@ export class Hud {
   private targetNameEl = $('#tf-name');
   private targetLevelEl = $('#tf-level');
   private targetDiscordEl = $('#tf-discord');
+  // Diff key for the target-frame Discord line, so its per-frame update only rebuilds
+  // innerHTML (and re-attaches the avatar fallback) when the Discord content changes.
+  private targetDiscordSig = '';
   private targetHpEl = $('#tf-hp');
   private targetHpTextEl = $('#tf-hp-text');
   private targetPortraitEl = $('#tf-portrait') as unknown as HTMLCanvasElement;
@@ -9941,10 +9944,19 @@ export class Hud {
     const el = this.targetDiscordEl;
     const tier = target.discordTier ?? 0;
     if (target.kind !== 'player' || (!tier && !target.discordName && !target.discordRole)) {
-      el.classList.remove('show');
-      el.replaceChildren();
+      if (this.targetDiscordSig !== '') {
+        this.targetDiscordSig = '';
+        el.classList.remove('show');
+        el.replaceChildren();
+      }
       return;
     }
+    // This runs every frame the target frame updates; only rebuild when the Discord
+    // content actually changes (else a fresh <img> per frame would re-fetch the
+    // avatar and, on a failing CDN load, flicker between the broken glyph and hidden).
+    const sig = `${tier}|${target.discordName ?? ''}|${target.discordRole ?? ''}|${target.discordAvatar ?? ''}`;
+    if (sig === this.targetDiscordSig) return;
+    this.targetDiscordSig = sig;
     const roleTagLabel = (key: string | undefined): string => {
       switch (key) {
         case 'levyst':
@@ -10067,11 +10079,16 @@ export class Hud {
       `<div class="equip-col equip-col-right" id="inspect-equip-right"></div>` +
       `</div></div>`;
     hydratePortraits(el);
-    // If the linked-Discord avatar fails to load from the CDN, fall back to the
-    // status-tier badge (the same image shown when the player has no custom avatar)
+    // If the linked-Discord avatar fails to load from the CDN, degrade to exactly the
+    // no-avatar rendering (the plain status-tier badge, without the pfp's blue ring)
     // instead of the browser's broken-image placeholder.
     const inspectPfp = el.querySelector<HTMLImageElement>('.inspect-discord-pfp');
-    if (inspectPfp) attachAvatarFallback(inspectPfp, discordStatusBadgeDataUrl(discordTierIdx));
+    if (inspectPfp) {
+      attachAvatarFallback(inspectPfp, (img) => {
+        img.classList.remove('inspect-discord-pfp');
+        img.src = discordStatusBadgeDataUrl(discordTierIdx);
+      });
+    }
     const view = buildPaperdollView(e.equippedItems, ITEMS);
     const leftCol = el.querySelector('#inspect-equip-left');
     const rightCol = el.querySelector('#inspect-equip-right');

--- a/tests/avatar_fallback.test.ts
+++ b/tests/avatar_fallback.test.ts
@@ -3,22 +3,11 @@ import { attachAvatarFallback } from '../src/ui/avatar_fallback';
 
 // The vitest env has no DOM (this repo models DOM wiring with a hand-rolled fake,
 // see focus_manager.test.ts), so model the minimal HTMLImageElement surface the
-// helper touches: src get/set (mirrored into the src attribute so getAttribute
-// tracks it, like a real element), getAttribute, style.display, and an
-// addEventListener('error') we fire on demand.
+// helper touches: style.display and an addEventListener('error') we fire on demand.
 class FakeImg {
   private handlers: Array<() => void> = [];
-  private attrs: Record<string, string | undefined> = {};
+  src = '';
   style = { display: '' };
-  set src(v: string) {
-    this.attrs.src = v;
-  }
-  get src(): string {
-    return this.attrs.src ?? '';
-  }
-  getAttribute(name: string): string | null {
-    return this.attrs[name] ?? null;
-  }
   addEventListener(type: string, cb: () => void): void {
     if (type === 'error') this.handlers.push(cb);
   }
@@ -35,12 +24,12 @@ describe('attachAvatarFallback', () => {
   it('leaves the image untouched until an error fires', () => {
     const img = new FakeImg();
     img.src = CDN;
-    attachAvatarFallback(asImg(img), BADGE);
+    attachAvatarFallback(asImg(img));
     expect(img.src).toBe(CDN);
     expect(img.style.display).toBe('');
   });
 
-  it('hides the image when the load fails and no fallback is given', () => {
+  it('hides the image when the load fails and no handler is given', () => {
     const img = new FakeImg();
     img.src = CDN;
     attachAvatarFallback(asImg(img));
@@ -48,21 +37,17 @@ describe('attachAvatarFallback', () => {
     expect(img.style.display).toBe('none');
   });
 
-  it('swaps to the fallback source on failure, keeping the image visible', () => {
+  it('runs the provided handler on error and does not hide the image itself', () => {
     const img = new FakeImg();
     img.src = CDN;
-    attachAvatarFallback(asImg(img), BADGE);
+    let received: HTMLImageElement | null = null;
+    attachAvatarFallback(asImg(img), (el) => {
+      received = el;
+      el.src = BADGE;
+    });
     img.fireError();
+    expect(received).toBe(asImg(img));
     expect(img.src).toBe(BADGE);
     expect(img.style.display).toBe('');
-  });
-
-  it('hides the image if the fallback source also fails', () => {
-    const img = new FakeImg();
-    img.src = CDN;
-    attachAvatarFallback(asImg(img), BADGE);
-    img.fireError(); // CDN fails -> swap to badge
-    img.fireError(); // badge also fails -> hide
-    expect(img.style.display).toBe('none');
   });
 });


### PR DESCRIPTION
Follow-up polish to #1186 (already merged), from an adversarial review of that fix. All items are cosmetic / robustness refinements on the rare CDN-failure path; #1186 already removes the broken-image placeholder.

## Changes

- **`attachAvatarFallback` now takes an `onError` callback** (default: hide the img), so a surface can reproduce its *exact* "no avatar" rendering on failure instead of only swapping the `<img>` src.
- **Inspect card:** drop the `.inspect-discord-pfp` ring class on fallback, so the badge matches the genuine no-avatar badge (previously it kept a stray Discord-blue border the no-avatar state does not have).
- **Discord window:** replace the whole `.dc-avatar-wrap` with the single clean `.dc-tier-badge`, so a failed avatar no longer renders the tier badge twice (the pfp swap previously left the sibling corner badge in place).
- **Target-frame Discord line:** add a signature diff-guard so it only rebuilds its `innerHTML` when the Discord content changes. This removes a **pre-existing per-frame `innerHTML` rebuild** in the target-frame hot path, and prevents a failing avatar from flickering between the broken glyph and hidden (each frame previously created a fresh visible `<img>`).

## Test plan

- [x] `tests/avatar_fallback.test.ts` updated for the callback form (untouched-until-error, hide-when-no-handler, runs-handler-on-error).
- [x] `tsc --noEmit` clean; Biome clean on changed files.
- [x] `architecture`, all `discord*` / `nameplate*`, and `hud_perf_budget` suites pass (202 tests).
- [ ] Manual: with a linked account and `cdn.discordapp.com` blocked, confirm the inspect card and Discord window show a single clean tier badge, and the target-frame line hides the avatar without flicker.