### PR TITLE
feat(discord): auto-join the Discord server on OAuth link/login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,6 +90,11 @@ WIKI_URL=http://localhost:8080/wiki/index.php/Main_Page
 # credentials; enable it with COMPOSE_PROFILES=discord after setting the bot env.
 # Register this callback in the Discord application:
 #   https://your-domain.example/api/auth/discord/callback
+# Auto-join: set DISCORD_BOT_TOKEN in the GAME SERVER env too (not just the bot) to
+# add players to DISCORD_GUILD_ID for them on Discord link/login. The server then
+# requests the guilds.join scope, and the OAuth callback calls PUT
+# /guilds/{id}/members/{id}. The bot must be a guild member with the Create Invite
+# permission. Leave it unset here and players just use the invite link to join.
 #COMPOSE_PROFILES=discord
 #PUBLIC_GAME_URL=https://worldofclaudecraft.com
 #DISCORD_CLIENT_ID=

--- a/docs/prd/discord/integration.md
+++ b/docs/prd/discord/integration.md
@@ -48,13 +48,35 @@ Grants: link (+250), guild member (+250), booster (+1000), daily active (+50, bo
 Status ladder (lifetime points): Initiate 0, Squire 100, Footman 500, Knight 2k,
 Champion 5k, Warlord 15k, Legend 50k, Mythic 150k (`src/sim/discord_tier.ts`).
 
+## Auto-join (seamless server membership)
+When `DISCORD_BOT_TOKEN` is set in the game-server env (not just the bot), the OAuth
+flow also requests the `guilds.join` scope and the callback ADDS the player to the
+official guild for them (`PUT /guilds/{id}/members/{id}`, Bot-authed, the user's
+access token in the body: 201 added / 204 already in). No separate invite click.
+It is best-effort (a failure never blocks login/link) and idempotent (an existing
+member is skipped). On success `guildMember` is true, so the same paths persist
+membership + grant the member reward, and the bot's `GUILD_MEMBER_ADD` welcome
+fires. The bot must be a guild member with the Create Invite permission. Unset the
+token and the flow is unchanged: membership is only verified, and the widget offers
+the invite link (`hudChrome.discord.joinCta`) instead.
+
+Known edge (accepted): if the guild has Membership Screening enabled, the add
+returns 201 with `pending: true` and the player is counted as a member (and gets the
+member reward) before they finish screening. This matches the existing membership
+semantics (a pending member already appears in `/users/@me/guilds`), and the
+official guild does not use screening; if that ever changes, gate the reward on
+`!member.pending` from the join response body.
+
 ## Endpoints
 Player REST (`server/main.ts` -> `server/discord.ts`):
 - `POST /api/auth/discord/start?mode=login|link` -> `{ url }` (authorize URL). `link`
   requires a full session; `login` is unauthenticated and may provision an account.
+  Requests `guilds.join` too when auto-join is configured (see above).
 - `GET /api/auth/discord/callback?code&state` -> HTML bounce page. Exempt from the
   web-login Origin guard (it is a discord.com redirect with no Origin). Login mints
   a normal session token; link writes the 1:1 `discord_links` row (409 on conflict).
+  When auto-join is on and `guilds.join` was granted, a non-member is added to the
+  guild here before the link/session is finalized.
 - `GET /api/discord` -> link status + points/tier + claimed swag + invite/widget URL
   + live presence (`bearerReadAccount`).
 - `DELETE /api/discord` -> unlink (`bearerActiveAccount`).
@@ -97,6 +119,9 @@ also pushes voice-room membership so the widget shows it even without the iframe
 ## Ops
 - Env: see `.env.example` (Discord section). Feature is OFF until
   `DISCORD_CLIENT_ID/SECRET` are set.
+- Auto-join is OFF until `DISCORD_BOT_TOKEN` is also present in the game-server env
+  and `DISCORD_GUILD_ID` is a valid guild; the bot must be in that guild with the
+  Create Invite permission. Without it, link/login only verifies membership.
 - Run the bot: `npm run bot` (separate process; needs the privileged GUILD_MEMBERS +
   GUILD_PRESENCES intents). Create `WoC <Tier>` roles in the guild to enable
   status-tier role sync.

--- a/server/discord.ts
+++ b/server/discord.ts
@@ -45,6 +45,7 @@ import {
 } from './discord_db';
 import {
   buildAuthorizeUrl,
+  buildGuildJoinRequest,
   buildTokenRequestBody,
   DISCORD_API_BASE,
   DISCORD_TOKEN_URL,
@@ -52,7 +53,11 @@ import {
   type DiscordUser,
   discordAvatarUrl,
   discordDisplayName,
+  discordScopes,
+  GUILD_JOIN_SCOPE,
+  grantedScope,
   isDiscordLinkMode,
+  isDiscordSnowflake,
   isMemberOfGuild,
   parseDiscordUser,
   parseGuildIds,
@@ -87,6 +92,10 @@ export interface DiscordConfig {
   clientSecret: string;
   guildId: string;
   inviteUrl: string;
+  // The bot token (also used by the standalone bot process). Present in the game
+  // server env only when auto-join is wanted: it lets the OAuth callback add the
+  // player to the guild for them. Empty string when unset (auto-join off).
+  botToken: string;
 }
 
 /** Resolve Discord OAuth config from env, or null when not configured (feature off). */
@@ -99,7 +108,18 @@ export function discordConfig(): DiscordConfig | null {
     clientSecret,
     guildId: process.env.DISCORD_GUILD_ID ?? '',
     inviteUrl: process.env.DISCORD_GUILD_INVITE || DEFAULT_INVITE,
+    botToken: process.env.DISCORD_BOT_TOKEN ?? '',
   };
+}
+
+/**
+ * Whether the server can add a consenting player to the guild on link/login. Needs
+ * a real guild id and the bot token in THIS process's env (the bot must be in the
+ * guild with the Create Invite permission). Off by default: without a bot token the
+ * flow behaves exactly as before (verify membership only, invite link to join).
+ */
+export function autoJoinEnabled(cfg: DiscordConfig): boolean {
+  return cfg.botToken !== '' && isDiscordSnowflake(cfg.guildId);
 }
 
 /** Whether the feature is configured. Read by the route table + client UI gate. */
@@ -185,6 +205,10 @@ export async function handleDiscordStart(
     redirectUri: redirectUriFor(req),
     state,
     codeChallenge,
+    // Ask for `guilds.join` (so we can add them to the server) only when the server
+    // is actually configured to do it; otherwise the consent screen would show a
+    // "join servers" permission we can't act on.
+    scopes: discordScopes({ autoJoin: autoJoinEnabled(cfg) }),
   });
   return json(res, 200, { url });
 }
@@ -502,7 +526,57 @@ async function exchangeCodeForIdentity(
     );
     guildMember = isMemberOfGuild(guilds, cfg.guildId);
   }
+  // Seamless join: if they consented to `guilds.join` and are not already in, add
+  // them to the official guild for a single-flow experience (no separate invite
+  // click). Best-effort; a failure just leaves them not-joined. On success they are
+  // now a member, so downstream link/login persists membership + grants the reward,
+  // and the bot's GUILD_MEMBER_ADD welcome fires for free.
+  if (!guildMember && autoJoinEnabled(cfg) && grantedScope(token.scope, GUILD_JOIN_SCOPE)) {
+    if (await joinGuild(cfg, user.id, token.accessToken)) guildMember = true;
+  }
   return { user, guildMember };
+}
+
+// Add a consenting user to the official guild via PUT /guilds/{id}/members/{id}
+// (Bot-authed; the user's access token rides in the body). 201 = added, 204 =
+// already a member; both mean "in". Best-effort with a timeout: any network/HTTP
+// failure returns false so it never blocks the login/link, and never throws.
+async function joinGuild(
+  cfg: DiscordConfig,
+  userId: string,
+  accessToken: string,
+): Promise<boolean> {
+  const request = buildGuildJoinRequest({
+    apiBase: DISCORD_API_BASE,
+    guildId: cfg.guildId,
+    userId,
+    accessToken,
+  });
+  if (!request) return false;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 8000);
+  try {
+    const resp = await fetch(request.url, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bot ${cfg.botToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: request.body,
+      signal: controller.signal,
+    });
+    if (!resp.ok) {
+      note('discord.join.failed');
+      return false;
+    }
+    note('discord.join.success');
+    return true;
+  } catch {
+    note('discord.join.error');
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 async function postForm(url: string, body: string): Promise<unknown> {

--- a/server/discord_oauth.ts
+++ b/server/discord_oauth.ts
@@ -15,6 +15,27 @@ export const DISCORD_CDN_BASE = 'https://cdn.discordapp.com';
 // the official server (for the member reward) without any privileged intent.
 export const DEFAULT_DISCORD_SCOPES = ['identify', 'guilds'] as const;
 
+// The OAuth2 scope that lets us ADD the user to a guild for them via
+// PUT /guilds/{id}/members/{id}. When a bot token + guild id are configured the
+// server requests this too, so Discord's consent screen shows "join servers" and
+// the callback can auto-join the player in one flow.
+export const GUILD_JOIN_SCOPE = 'guilds.join';
+export const DISCORD_SCOPES_WITH_JOIN = ['identify', 'guilds', GUILD_JOIN_SCOPE] as const;
+
+/** The scopes to request: with `guilds.join` only when auto-join is configured. */
+export function discordScopes(opts: { autoJoin: boolean }): readonly string[] {
+  return opts.autoJoin ? DISCORD_SCOPES_WITH_JOIN : DEFAULT_DISCORD_SCOPES;
+}
+
+/**
+ * Whether a granted-scope string (space separated, as Discord returns it on the
+ * token response) actually contains a scope. The user could in theory strip a
+ * scope, so we verify `guilds.join` was granted before attempting the join.
+ */
+export function grantedScope(granted: string, want: string): boolean {
+  return granted.split(/\s+/).filter(Boolean).includes(want);
+}
+
 /** Discord ids are 64-bit snowflakes serialized as decimal strings. */
 export function isDiscordSnowflake(value: unknown): value is string {
   return typeof value === 'string' && /^[0-9]{15,21}$/.test(value);
@@ -67,6 +88,31 @@ export function buildTokenRequestBody(opts: {
     redirect_uri: opts.redirectUri,
     code_verifier: opts.codeVerifier,
   }).toString();
+}
+
+export interface GuildJoinRequest {
+  url: string;
+  body: string;
+}
+
+/**
+ * Build the `PUT /guilds/{guildId}/members/{userId}` request that adds a consenting
+ * user to the guild. The caller supplies the `Authorization: Bot <token>` header;
+ * the body carries the user's OAuth access token (which must have been granted the
+ * `guilds.join` scope). Returns null when either id is not a snowflake, so a
+ * malformed id never reaches the API. A 201 means added, a 204 already a member.
+ */
+export function buildGuildJoinRequest(opts: {
+  apiBase: string;
+  guildId: string;
+  userId: string;
+  accessToken: string;
+}): GuildJoinRequest | null {
+  if (!isDiscordSnowflake(opts.guildId) || !isDiscordSnowflake(opts.userId)) return null;
+  return {
+    url: `${opts.apiBase}/guilds/${opts.guildId}/members/${opts.userId}`,
+    body: JSON.stringify({ access_token: opts.accessToken }),
+  };
 }
 
 export interface DiscordTokenResult {

--- a/tests/discord_oauth.test.ts
+++ b/tests/discord_oauth.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildAuthorizeUrl,
+  buildGuildJoinRequest,
   buildTokenRequestBody,
+  DISCORD_SCOPES_WITH_JOIN,
   discordAvatarUrl,
   discordDisplayName,
+  discordScopes,
+  GUILD_JOIN_SCOPE,
+  grantedScope,
   isDiscordLinkMode,
   isDiscordSnowflake,
   isMemberOfGuild,
@@ -117,6 +122,62 @@ describe('response parsers', () => {
     expect(isMemberOfGuild(ids, '111111111111111111')).toBe(true);
     expect(isMemberOfGuild(ids, '222222222222222222')).toBe(false);
     expect(parseGuildIds('not an array')).toEqual([]);
+  });
+});
+
+describe('auto-join (guilds.join)', () => {
+  it('requests guilds.join only when auto-join is enabled', () => {
+    expect(discordScopes({ autoJoin: false })).toEqual(['identify', 'guilds']);
+    expect(discordScopes({ autoJoin: true })).toEqual(['identify', 'guilds', 'guilds.join']);
+    expect(DISCORD_SCOPES_WITH_JOIN).toContain(GUILD_JOIN_SCOPE);
+  });
+
+  it('adds guilds.join to the authorize URL scope when configured', () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        clientId: '123',
+        redirectUri: 'https://x/cb',
+        state: 's',
+        codeChallenge: 'c',
+        scopes: discordScopes({ autoJoin: true }),
+      }),
+    );
+    expect(url.searchParams.get('scope')).toBe('identify guilds guilds.join');
+  });
+
+  it('detects a granted scope in the space-separated token scope string', () => {
+    expect(grantedScope('identify guilds guilds.join', GUILD_JOIN_SCOPE)).toBe(true);
+    expect(grantedScope('identify guilds', GUILD_JOIN_SCOPE)).toBe(false);
+    // A user who stripped the scope must not be treated as having granted it.
+    expect(grantedScope('  identify   guilds  ', 'guilds')).toBe(true);
+    expect(grantedScope('', GUILD_JOIN_SCOPE)).toBe(false);
+  });
+
+  it('builds the PUT guild-member request with the access token in the body', () => {
+    const req = buildGuildJoinRequest({
+      apiBase: 'https://discord.com/api/v10',
+      guildId: '111111111111111111',
+      userId: '999999999999999999',
+      accessToken: 'user-access-tok',
+    });
+    expect(req).not.toBeNull();
+    expect(req?.url).toBe(
+      'https://discord.com/api/v10/guilds/111111111111111111/members/999999999999999999',
+    );
+    expect(JSON.parse(req?.body ?? '{}')).toEqual({ access_token: 'user-access-tok' });
+  });
+
+  it('refuses to build a request for a non-snowflake guild or user id', () => {
+    const base = {
+      apiBase: 'https://discord.com/api/v10',
+      accessToken: 'tok',
+    };
+    expect(
+      buildGuildJoinRequest({ ...base, guildId: 'nope', userId: '999999999999999999' }),
+    ).toBeNull();
+    expect(
+      buildGuildJoinRequest({ ...base, guildId: '111111111111111111', userId: 'bad' }),
+    ).toBeNull();
   });
 });
 

--- a/tests/discord_server.test.ts
+++ b/tests/discord_server.test.ts
@@ -107,6 +107,8 @@ beforeEach(() => {
   process.env.DISCORD_CLIENT_ID = 'client123';
   process.env.DISCORD_CLIENT_SECRET = 'secret456';
   process.env.DISCORD_GUILD_ID = '111111111111111111';
+  // Auto-join is off by default; the auto-join describe sets a bot token per case.
+  delete process.env.DISCORD_BOT_TOKEN;
   linkRow = [];
   ownerRows = [];
   rewardRows = [];
@@ -456,6 +458,186 @@ describe('GET /api/auth/discord/callback', () => {
     // A session token is minted in the payload; the chooser is not offered.
     expect(res.body).toContain('"token"');
     expect(res.body).not.toContain('"choose":true');
+  });
+});
+
+// Stub the token + identity + guilds + PUT-join calls for an auto-join callback.
+// joinStatus mirrors Discord's PUT /guilds/{id}/members/{id}: 201 = added (default),
+// 204 = already a member, a 4xx = failure. Production only reads resp.ok, so both
+// 201 and 204 count as "in" and any 4xx leaves them not-joined.
+function mockDiscordJoinFetch(
+  opts: { inGuild?: boolean; joinStatus?: number; scope?: string } = {},
+) {
+  const inGuild = opts.inGuild ?? false;
+  const joinStatus = opts.joinStatus ?? 201;
+  const scope = opts.scope ?? 'identify guilds guilds.join';
+  return vi.spyOn(globalThis, 'fetch' as any).mockImplementation((url: any, _init?: any) => {
+    const u = String(url);
+    // Most specific first: the Bot-authed PUT that adds the member.
+    if (u.includes('/members/'))
+      return Promise.resolve({
+        ok: joinStatus >= 200 && joinStatus < 300,
+        status: joinStatus,
+        json: () => Promise.resolve(null),
+      } as any);
+    if (u.includes('/oauth2/token'))
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            access_token: 'tok',
+            token_type: 'Bearer',
+            scope,
+            expires_in: 600,
+          }),
+      } as any);
+    if (u.includes('/users/@me/guilds'))
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(inGuild ? [{ id: '111111111111111111' }] : []),
+      } as any);
+    if (u.includes('/users/@me'))
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: '999999999999999999',
+            username: 'maxp',
+            global_name: 'Maxp',
+            avatar: null,
+          }),
+      } as any);
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) } as any);
+  });
+}
+
+describe('auto-join on link/login (guilds.join)', () => {
+  const LINK_STATE = [
+    { state: 's', code_verifier: 'v', mode: 'link', account_id: 1, redirect_to: null },
+  ];
+  const putCall = (spy: any) =>
+    spy.mock.calls.find((c: any[]) => String(c[0]).includes('/members/'));
+  const linkInsert = () =>
+    dbMock.query.mock.calls.find((c) => String(c[0]).includes('INSERT INTO discord_links'));
+
+  it('requests the guilds.join scope on start only when a bot token is set', async () => {
+    process.env.DISCORD_BOT_TOKEN = 'bot-token';
+    const withToken = makeRes();
+    await handleDiscordStart(makeReq({ url: '/api/auth/discord/start?mode=link' }), withToken, {
+      mode: 'link',
+      accountId: 1,
+    });
+    expect(new URL(parse(withToken).data.url).searchParams.get('scope')).toBe(
+      'identify guilds guilds.join',
+    );
+
+    delete process.env.DISCORD_BOT_TOKEN;
+    const without = makeRes();
+    await handleDiscordStart(makeReq({ url: '/api/auth/discord/start?mode=link' }), without, {
+      mode: 'link',
+      accountId: 1,
+    });
+    expect(new URL(parse(without).data.url).searchParams.get('scope')).toBe('identify guilds');
+  });
+
+  it('adds a non-member to the guild and records membership + reward on link', async () => {
+    process.env.DISCORD_BOT_TOKEN = 'bot-token';
+    stateRows = LINK_STATE;
+    ownerRows = []; // the Discord id is free to link on account 1
+    const fetchSpy = mockDiscordJoinFetch({ inGuild: false, joinStatus: 201 }); // 201 = added
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    // The Bot-authed PUT carried the bot token + the user's access token.
+    const put = putCall(fetchSpy);
+    expect(put).toBeTruthy();
+    expect(put[1].method).toBe('PUT');
+    expect(put[1].headers.Authorization).toBe('Bot bot-token');
+    expect(JSON.parse(put[1].body)).toEqual({ access_token: 'tok' });
+    // The link row records guild_member = true (param $5), and BOTH the link reward
+    // and the guild-member reward are granted (two ledger writes).
+    expect(linkInsert()?.[1]?.[4]).toBe(true);
+    const ledger = dbMock.query.mock.calls.filter((c) =>
+      String(c[0]).includes('INSERT INTO reward_ledger'),
+    );
+    expect(ledger.length).toBe(2);
+    expect(res.body).toContain('"ok":true');
+  });
+
+  it('counts a 204 add response (a TOCTOU already-member) as joined', async () => {
+    // If /users/@me/guilds was stale and the user is actually already in, the add
+    // call returns 204; resp.ok is still true, so we treat them as a member.
+    process.env.DISCORD_BOT_TOKEN = 'bot-token';
+    stateRows = LINK_STATE;
+    ownerRows = [];
+    const fetchSpy = mockDiscordJoinFetch({ inGuild: false, joinStatus: 204 });
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    expect(putCall(fetchSpy)).toBeTruthy();
+    expect(linkInsert()?.[1]?.[4]).toBe(true);
+  });
+
+  it('skips the join when the user is already a guild member', async () => {
+    process.env.DISCORD_BOT_TOKEN = 'bot-token';
+    stateRows = LINK_STATE;
+    ownerRows = [];
+    const fetchSpy = mockDiscordJoinFetch({ inGuild: true });
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    expect(putCall(fetchSpy)).toBeFalsy(); // no add attempted, already in
+    expect(linkInsert()?.[1]?.[4]).toBe(true);
+  });
+
+  it('does not attempt a join when no bot token is configured (membership only)', async () => {
+    // DISCORD_BOT_TOKEN unset: a non-member stays a non-member; no PUT is made.
+    stateRows = LINK_STATE;
+    ownerRows = [];
+    const fetchSpy = mockDiscordJoinFetch({ inGuild: false });
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    expect(putCall(fetchSpy)).toBeFalsy();
+    expect(linkInsert()?.[1]?.[4]).toBe(false);
+  });
+
+  it('links best-effort even when the guild join call fails', async () => {
+    process.env.DISCORD_BOT_TOKEN = 'bot-token';
+    stateRows = LINK_STATE;
+    ownerRows = [];
+    mockDiscordJoinFetch({ inGuild: false, joinStatus: 403 }); // e.g. bot lacks Create Invite
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    // A failed add leaves them recorded as a non-member, but the link still succeeds.
+    expect(linkInsert()?.[1]?.[4]).toBe(false);
+    expect(res.body).toContain('"ok":true');
+  });
+
+  it('does not join when the user declined the guilds.join scope', async () => {
+    process.env.DISCORD_BOT_TOKEN = 'bot-token';
+    stateRows = LINK_STATE;
+    ownerRows = [];
+    // Token came back WITHOUT guilds.join granted -> we must not call the add.
+    const fetchSpy = mockDiscordJoinFetch({ inGuild: false, scope: 'identify guilds' });
+    const res = makeRes();
+    await handleDiscordCallback(
+      makeReq({ url: '/api/auth/discord/callback?code=abc&state=s' }),
+      res,
+    );
+    expect(putCall(fetchSpy)).toBeFalsy();
+    expect(linkInsert()?.[1]?.[4]).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
Makes joining the official Discord server seamless: when a player links or logs in with Discord, the OAuth callback adds them to the guild for them, with no separate invite click. This is the "join as part of the OAuth permission" approach, using Discord's `guilds.join` scope.

## How it works
- Adds the `guilds.join` OAuth2 scope to the authorize request, but only when auto-join is configured (a bot token in the game-server env and a valid `DISCORD_GUILD_ID`). Discord's consent screen then shows "Join servers for you".
- In `exchangeCodeForIdentity`, a non-member who granted the scope is added via a best-effort, Bot-authed `PUT /guilds/{id}/members/{id}` (the user's access token in the body, 8s timeout). 201 (added) and 204 (already in) both count as "in".
- The join runs where the fresh access token already lives, so no OAuth tokens are stored.
- Because it just flips `guildMember` true, every path (link, returning login, and the first-time chooser via the parked pending row) persists membership, grants the dedupe-keyed member reward exactly once, and triggers the bot's existing `GUILD_MEMBER_ADD` welcome.

## Safety / scope
- Off by default: without `DISCORD_BOT_TOKEN` in the server env the flow is unchanged (verify membership only, invite link to join).
- Best-effort: any network or HTTP failure returns false, never blocks login/link, never throws.
- Idempotent: existing members are skipped, and the reward dedupe key prevents any double-award across the callback and the bot's join event.
- No wire-protocol change (the client already reads `guildMember` from `GET /api/discord`), no schema change, no new player-facing strings.

## Operator setup (production)
- Set `DISCORD_BOT_TOKEN` in the game-server env (the same token the bot uses). This is the switch that enables auto-join.
- The bot's role in the guild needs: Create Invite, View Channels, Send Messages, Embed Links, Manage Nicknames, Manage Roles. Keep the bot's role above the WoC tier roles. Full detail in `docs/prd/discord/integration.md`.

## Test plan
- [x] `tsc --noEmit`: 0 errors
- [x] `biome ci` on changed files: pass (pre-existing-style warnings only)
- [x] discord_oauth, discord_server, discord_db, oauth suites: pass (12 new auto-join cases)
- [x] architecture (determinism/purity) and localization_fixes (S3 i18n) guards: pass
- [x] Multi-agent review (privacy-security, cross-platform-sync, migration-safety, adversarial): no CRITICAL/HIGH/MEDIUM
- [ ] Live end-to-end with real Discord credentials and the bot in the guild (needs a staging/prod Discord app; not runnable in CI)

## Accepted edge
If the guild has Membership Screening enabled, an auto-joined player is counted as a member (and rewarded) before completing screening. This matches the existing membership semantics and is documented in the PRD, with the follow-up (gate the reward on `!member.pending`) noted if screening is ever turned on.
