### PR TITLE
test(sim): lock mana recovery hooks

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -29,6 +29,7 @@
 // (enforced by tests/architecture.test.ts).
 
 import { recalcPlayerStats } from '../entity';
+import { FIVE_SECOND_RULE_THRESHOLD, healthRegenPerTick, manaRegenPerTick } from '../regen';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { type Aura, type AuraKind, CAST_COMPLETE_EPS, DT, type Entity } from '../types';
@@ -61,12 +62,11 @@ export function isRejectedFriendlyNpcAura(aura: Aura): boolean {
 export function updateRegen(ctx: SimContext, p: Entity, _meta: PlayerMeta): void {
   if (ctx.tickCount % 40 !== 0) return; // every 2 seconds (the classic tick)
   if (p.resourceType === 'mana') {
-    if (p.fiveSecondRule >= 5) {
+    if (p.fiveSecondRule >= FIVE_SECOND_RULE_THRESHOLD) {
       // out-of-combat mana regen: faster than before and scales with spirit
       // (gear/level) plus a small flat per-level floor so low-spirit casters
       // still recover at a reasonable pace (#103)
-      const regen = p.stats.spi / 3 + 4 + Math.floor(p.level / 5);
-      p.resource = Math.min(p.maxResource, p.resource + Math.round(regen));
+      p.resource = Math.min(p.maxResource, p.resource + manaRegenPerTick(p.stats.spi, p.level));
     }
   } else if (p.resourceType === 'energy') {
     p.resource = Math.min(p.maxResource, p.resource + 20);
@@ -74,8 +74,7 @@ export function updateRegen(ctx: SimContext, p: Entity, _meta: PlayerMeta): void
     p.resource = Math.max(0, p.resource - 2);
   }
   if (!p.inCombat && p.hp < p.maxHp && !p.eating) {
-    const regen = p.stats.sta * 0.3 + 2;
-    p.hp = Math.min(p.maxHp, p.hp + Math.round(regen));
+    p.hp = Math.min(p.maxHp, p.hp + healthRegenPerTick(p.stats.sta));
   }
   // food and drink tick independently, so both can run at once
   for (const slot of ['eating', 'drinking'] as const) {

--- a/src/sim/regen.ts
+++ b/src/sim/regen.ts
@@ -1,0 +1,21 @@
+// Shared resource-regeneration math. The sim tick and character stat tooltip
+// both use these helpers so #103 tuning stays in one place.
+
+export const FIVE_SECOND_RULE_THRESHOLD = 5;
+export const REGEN_TICKS_PER_5S = 2.5;
+
+export function healthRegenPerTick(sta: number): number {
+  return Math.round(Math.max(0, sta) * 0.3 + 2);
+}
+
+export function manaRegenPerTick(spi: number, level: number): number {
+  return Math.round(Math.max(0, spi) / 3 + 4 + Math.floor(Math.max(0, level) / 5));
+}
+
+export function restingHealthPer5s(sta: number): number {
+  return Math.round(healthRegenPerTick(sta) * REGEN_TICKS_PER_5S);
+}
+
+export function restingManaPer5s(spi: number, level: number): number {
+  return Math.round(manaRegenPerTick(spi, level) * REGEN_TICKS_PER_5S);
+}

--- a/src/sim/social/chat_readouts.ts
+++ b/src/sim/social/chat_readouts.ts
@@ -31,13 +31,13 @@ import {
 import { formatMoney } from '../format_money';
 import { MARKET_MAX_LISTINGS } from '../market';
 import * as petCommands from '../pet/pet_commands';
+import { FIVE_SECOND_RULE_THRESHOLD } from '../regen';
 import { FALL_SAFE_DISTANCE, type PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import { threatEntries } from '../threat';
 import {
   type ArenaFormat,
   type Aura,
-  type AuraKind,
   dist2d,
   type Entity,
   type EquipSlot,
@@ -303,14 +303,13 @@ export function formReadout(e: Entity): string {
 // out-of-combat mana regen only ticks once it reaches FSR_THRESHOLD. Only
 // mana users have meaningful state here — rage/energy classes never spend mana.
 export function manaRegenReadout(e: Entity): string {
-  const FSR_THRESHOLD = 5; // matches the `fiveSecondRule >= 5` gate in updateRegen
   if (e.resourceType !== 'mana') {
     return 'Mana regeneration does not apply to your class.';
   }
-  if (e.fiveSecondRule >= FSR_THRESHOLD) {
+  if (e.fiveSecondRule >= FIVE_SECOND_RULE_THRESHOLD) {
     return 'Your mana is regenerating (out of combat for 5s+).';
   }
-  const resumesIn = Math.ceil(FSR_THRESHOLD - e.fiveSecondRule);
+  const resumesIn = Math.ceil(FIVE_SECOND_RULE_THRESHOLD - e.fiveSecondRule);
   return `Mana regen is paused — resumes in ${resumesIn}s (you spent mana recently).`;
 }
 // Self-only readout of vertical/fall state — surfaces the otherwise-invisible

--- a/src/ui/stat_tooltip.ts
+++ b/src/ui/stat_tooltip.ts
@@ -10,8 +10,11 @@
 // `recalcPlayerStats` in src/sim/entity.ts (armor reduction is imported outright).
 // tests/stat_tooltip.test.ts cross-checks this module against real
 // recalcPlayerStats output so the numbers cannot silently drift.
-import { armorReduction, type PlayerClass, type Stats, type WeaponInfo } from '../sim/types';
 import { CLASSES } from '../sim/data';
+import { restingHealthPer5s, restingManaPer5s } from '../sim/regen';
+import { armorReduction, type PlayerClass, type Stats, type WeaponInfo } from '../sim/types';
+
+export { restingHealthPer5s, restingManaPer5s };
 
 // The unarmed default weapon the sim falls back to (src/sim/entity.ts recalcPlayerStats),
 // so an unarmed character still reads its real fist damage instead of a flat 0.
@@ -28,8 +31,16 @@ export function weaponDps(weapon: WeaponInfo | null | undefined, attackPower: nu
 
 /** The ten cells on the character sheet, in their itemUi.stats.* id form. */
 export type StatId =
-  | 'str' | 'agi' | 'sta' | 'int' | 'spi'
-  | 'armor' | 'attackPower' | 'dps' | 'critChance' | 'dodge';
+  | 'str'
+  | 'agi'
+  | 'sta'
+  | 'int'
+  | 'spi'
+  | 'armor'
+  | 'attackPower'
+  | 'dps'
+  | 'critChance'
+  | 'dodge';
 
 /** A single contribution line. `value` is already in the unit the line displays
  *  (attack power as an integer, percents as a percent number like 1.1, etc.). */
@@ -92,10 +103,6 @@ const AGI_DODGE_PER_POINT = 0.0005; // entity.ts: dodgeChance = 0.05 + s.agi * 0
 const HUNTER_RANGED_AP_PER_AGI = 2; // entity.ts: rangedPower = s.agi * 2 (hunter)
 const INT_SPELLCRIT_PER_POINT = 0.0008; // sim.ts spellCrit(): 0.05 + int * 0.0008
 const AP_PER_DPS = 14; // sim.ts: attackPower / 14 = bonus dps
-// updateRegen (sim.ts) ticks every 2s out of combat; 5s is ~2.5 ticks. The "per
-// 5 sec" framing is the classic MP5/HP5 convention players expect.
-const REGEN_TICKS_PER_5S = 2.5;
-
 /** Mana classes are the only ones Intellect (mana pool) and Spirit (mana regen)
  *  meaningfully serve; rage/energy classes get the "minor benefit" note.
  *
@@ -131,21 +138,6 @@ export function healthFromStamina(sta: number): number {
 export function manaFromIntellect(int: number): number {
   const i = Math.max(0, int);
   return Math.min(i, 20) + Math.max(0, i - 20) * 15;
-}
-
-/** Out-of-combat health regen, expressed per 5 sec (sim.ts updateRegen: hp gains
- *  round(sta * 0.3 + 2) every 2s). Note this game derives health regen from Stamina.
- *  We round the PER-TICK amount first (as the engine does), then scale by 2.5 ticks,
- *  so the displayed figure tracks what the sim actually adds. */
-export function restingHealthPer5s(sta: number): number {
-  return Math.round(Math.round(Math.max(0, sta) * 0.3 + 2) * REGEN_TICKS_PER_5S);
-}
-
-/** Out-of-combat mana regen, per 5 sec (sim.ts updateRegen, five-second rule:
- *  mana gains round(spi / 3 + 4 + floor(level / 5)) every 2s). Per-tick rounded
- *  first to match the engine, then scaled by 2.5 ticks. */
-export function restingManaPer5s(spi: number, level: number): number {
-  return Math.round(Math.round(Math.max(0, spi) / 3 + 4 + Math.floor(level / 5)) * REGEN_TICKS_PER_5S);
 }
 
 /** Build the structured breakdown for one stat cell. Pure: no DOM, no i18n.
@@ -214,7 +206,11 @@ export function buildStatTooltip(stat: StatId, input: StatTooltipInput): StatToo
     case 'armor': {
       isPrimary = false;
       statValue = stats.armor;
-      effects.push({ kind: 'damageReduction', value: armorReduction(stats.armor, level) * 100, level });
+      effects.push({
+        kind: 'damageReduction',
+        value: armorReduction(stats.armor, level) * 100,
+        level,
+      });
       break;
     }
     case 'attackPower': {

--- a/tests/combat_auras.test.ts
+++ b/tests/combat_auras.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../src/sim/combat/auras';
 import { MOBS } from '../src/sim/data';
 import { createMob } from '../src/sim/entity';
+import { manaRegenPerTick } from '../src/sim/regen';
 import type { PlayerMeta } from '../src/sim/sim';
 import { Sim } from '../src/sim/sim';
 import type { Aura, Entity } from '../src/sim/types';
@@ -161,6 +162,23 @@ describe('auras: updateRegen', () => {
     updateRegen(sim.ctx, p, meta);
     expect(p.hp).toBe(hp0);
     expect(p.eating?.remaining).toBe(6); // untouched
+  });
+
+  it('uses the shared spirit and level mana tick formula once the five-second rule is clear', () => {
+    const sim = makeSim();
+    const p = sim.player as AnyEntity;
+    const meta = sim.players.get(p.id) as PlayerMeta;
+    p.resourceType = 'mana';
+    p.maxResource = 500;
+    p.resource = 100;
+    p.stats.spi = 18;
+    p.level = 20;
+    p.fiveSecondRule = 5;
+    sim.tickCount = 40;
+
+    updateRegen(sim.ctx, p, meta);
+
+    expect(p.resource).toBe(100 + manaRegenPerTick(18, 20));
   });
 });
 

--- a/tests/stat_tooltip.test.ts
+++ b/tests/stat_tooltip.test.ts
@@ -1,21 +1,20 @@
 import { describe, expect, it } from 'vitest';
-import { Sim } from '../src/sim/sim';
-import { ALL_CLASSES, armorReduction, type PlayerClass } from '../src/sim/types';
 import { CLASSES } from '../src/sim/content/classes';
 import { ITEMS } from '../src/sim/data';
+import { restingHealthPer5s, restingManaPer5s } from '../src/sim/regen';
+import { Sim } from '../src/sim/sim';
+import { ALL_CLASSES, armorReduction, type PlayerClass } from '../src/sim/types';
 import {
+  agiMeleeApPerPoint,
   buildStatTooltip,
   healthFromStamina,
-  manaFromIntellect,
-  restingHealthPer5s,
-  restingManaPer5s,
   isManaClass,
-  strApPerPoint,
-  agiMeleeApPerPoint,
-  weaponDps,
+  manaFromIntellect,
   type StatEffect,
   type StatId,
   type StatTooltipInput,
+  strApPerPoint,
+  weaponDps,
 } from '../src/ui/stat_tooltip';
 
 // A gear-free, buff-free, talent-free player: autoEquip defaults to false, so the
@@ -40,9 +39,14 @@ function inputFor(cls: PlayerClass, p: ReturnType<typeof freshPlayer>): StatTool
   };
 }
 
-const effect = (effects: StatEffect[], kind: StatEffect['kind']) => effects.find((e) => e.kind === kind);
-const valueOf = (cls: PlayerClass, p: ReturnType<typeof freshPlayer>, stat: StatId, kind: StatEffect['kind']) =>
-  effect(buildStatTooltip(stat, inputFor(cls, p)).effects, kind)?.value;
+const effect = (effects: StatEffect[], kind: StatEffect['kind']) =>
+  effects.find((e) => e.kind === kind);
+const effectValue = (
+  cls: PlayerClass,
+  p: ReturnType<typeof freshPlayer>,
+  stat: StatId,
+  kind: StatEffect['kind'],
+) => effect(buildStatTooltip(stat, inputFor(cls, p)).effects, kind)?.value;
 
 const LEVELS = [1, 10, 20];
 
@@ -51,15 +55,15 @@ describe('stat tooltip math reconciles with recalcPlayerStats', () => {
     for (const level of LEVELS) {
       it(`${cls} L${level}: attack power breakdown sums to entity.attackPower`, () => {
         const p = freshPlayer(cls, level);
-        const strAp = valueOf(cls, p, 'str', 'attackPower') ?? 0;
-        const agiAp = valueOf(cls, p, 'agi', 'attackPower') ?? 0; // present for rogue/hunter only
+        const strAp = effectValue(cls, p, 'str', 'attackPower') ?? 0;
+        const agiAp = effectValue(cls, p, 'agi', 'attackPower') ?? 0; // present for rogue/hunter only
         expect(strAp + agiAp).toBe(p.attackPower);
       });
 
       it(`${cls} L${level}: agility crit/dodge match the 5% base + 0.05%/agi curve`, () => {
         const p = freshPlayer(cls, level);
-        const critPct = valueOf(cls, p, 'agi', 'critPct') ?? 0;
-        const dodgePct = valueOf(cls, p, 'agi', 'dodgePct') ?? 0;
+        const critPct = effectValue(cls, p, 'agi', 'critPct') ?? 0;
+        const dodgePct = effectValue(cls, p, 'agi', 'dodgePct') ?? 0;
         expect(0.05 + critPct / 100).toBeCloseTo(p.critChance, 6);
         expect(0.05 + dodgePct / 100).toBeCloseTo(p.dodgeChance, 6);
       });
@@ -72,9 +76,10 @@ describe('stat tooltip math reconciles with recalcPlayerStats', () => {
         // Players keep their class starting chest even with autoEquip off, so total
         // armor = class growth + that gear's armor + agility*2. Isolate the agi part.
         let gearArmor = 0;
-        for (const id of Object.values(sim.equipment)) gearArmor += (id && ITEMS[id]?.stats?.armor) || 0;
+        for (const id of Object.values(sim.equipment))
+          gearArmor += (id && ITEMS[id]?.stats?.armor) || 0;
         const baseArmor = def.baseStats.armor + def.statsPerLevel.armor * (level - 1);
-        const agiArmor = valueOf(cls, p, 'agi', 'armor') ?? 0;
+        const agiArmor = effectValue(cls, p, 'agi', 'armor') ?? 0;
         expect(agiArmor).toBe(p.stats.armor - baseArmor - gearArmor); // proves the sim adds agi*2
         expect(agiArmor).toBe(p.stats.agi * 2); // proves the tooltip matches
       });
@@ -83,7 +88,7 @@ describe('stat tooltip math reconciles with recalcPlayerStats', () => {
         const p = freshPlayer(cls, level);
         const def = CLASSES[cls];
         const base = def.baseHp + def.hpPerLevel * (level - 1);
-        const maxHealth = valueOf(cls, p, 'sta', 'maxHealth') ?? 0;
+        const maxHealth = effectValue(cls, p, 'sta', 'maxHealth') ?? 0;
         expect(maxHealth).toBe(p.maxHp - base);
         expect(maxHealth).toBe(healthFromStamina(p.stats.sta));
       });
@@ -103,7 +108,7 @@ describe('stat tooltip math reconciles with recalcPlayerStats', () => {
       const p = freshPlayer(cls, 20);
       const def = CLASSES[cls];
       const base = def.baseMana + def.manaPerLevel * (20 - 1);
-      const maxMana = valueOf(cls, p, 'int', 'maxMana') ?? 0;
+      const maxMana = effectValue(cls, p, 'int', 'maxMana') ?? 0;
       expect(maxMana).toBe(p.maxResource - base);
       expect(maxMana).toBe(manaFromIntellect(p.stats.int));
     }
@@ -126,17 +131,30 @@ describe('class-aware effect selection', () => {
   it('Agility melee AP applies only to rogue and hunter', () => {
     expect(agiMeleeApPerPoint('rogue')).toBe(1);
     expect(agiMeleeApPerPoint('hunter')).toBe(1);
-    for (const cls of ['warrior', 'paladin', 'shaman', 'druid', 'mage', 'priest', 'warlock'] as PlayerClass[]) {
+    for (const cls of [
+      'warrior',
+      'paladin',
+      'shaman',
+      'druid',
+      'mage',
+      'priest',
+      'warlock',
+    ] as PlayerClass[]) {
       expect(agiMeleeApPerPoint(cls)).toBe(0);
     }
   });
 
   it('only hunters get a ranged attack power line from Agility', () => {
     const hunter = freshPlayer('hunter', 20);
-    const ranged = effect(buildStatTooltip('agi', inputFor('hunter', hunter)).effects, 'rangedAttackPower');
+    const ranged = effect(
+      buildStatTooltip('agi', inputFor('hunter', hunter)).effects,
+      'rangedAttackPower',
+    );
     expect(ranged?.value).toBe(hunter.stats.agi * 2);
     const warrior = freshPlayer('warrior', 20);
-    expect(effect(buildStatTooltip('agi', inputFor('warrior', warrior)).effects, 'rangedAttackPower')).toBeUndefined();
+    expect(
+      effect(buildStatTooltip('agi', inputFor('warrior', warrior)).effects, 'rangedAttackPower'),
+    ).toBeUndefined();
   });
 
   it('Intellect and Spirit show the minor-benefit note for non-mana classes only', () => {
@@ -229,8 +247,12 @@ describe('weaponDps', () => {
 });
 
 describe('effect wiring reconciles each effect kind with its source', () => {
-  const effVal = (cls: PlayerClass, p: ReturnType<typeof freshPlayer>, stat: StatId, kind: StatEffect['kind']) =>
-    valueOf(cls, p, stat, kind);
+  const effVal = (
+    cls: PlayerClass,
+    p: ReturnType<typeof freshPlayer>,
+    stat: StatId,
+    kind: StatEffect['kind'],
+  ) => effectValue(cls, p, stat, kind);
 
   it('attackPower cell emits dpsFromAp = attackPower / 14', () => {
     const p = freshPlayer('warrior', 20);


### PR DESCRIPTION
﻿## Summary

Part of #103.

This tightens the existing mana-recovery implementation by moving the regen formulas into one shared sim helper:

- Adds `src/sim/regen.ts` as the shared source of truth for health/mana regen ticks and per-5s tooltip estimates.
- Uses the shared mana/health helpers from the actual sim regen tick.
- Uses the same five-second-rule threshold in the `/manaregen` readout.
- Keeps the stat tooltip's MP5/HP5 display wired to the same sim math.
- Adds coverage proving the live regen tick uses the shared spirit + level mana formula.

No player-facing strings changed.

## Related issues

Part of #103

## Type of change

- [ ] Feature: new functionality
- [ ] Bug fix
- [x] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `gh search prs "mana regen" --repo levy-street/world-of-claudecraft --state open --json number,title,url,author` -> `[]`
  - `gh search prs "issue 103" --repo levy-street/world-of-claudecraft --state open --json number,title,url,author` -> `[]`
  - `npx biome check --write src/sim/regen.ts src/sim/combat/auras.ts src/sim/social/chat_readouts.ts src/ui/stat_tooltip.ts tests/combat_auras.test.ts tests/stat_tooltip.test.ts` -> passed; existing `noExplicitAny` warnings remain in `tests/combat_auras.test.ts`.
  - `npx vitest run tests/combat_auras.test.ts tests/stat_tooltip.test.ts tests/manaregen_command.test.ts tests/potion_command.test.ts tests/items.test.ts tests/sim.test.ts` -> passed, 6 files / 275 tests.
  - `npm run check:ts` -> passed.
  - `npm run build:server` -> passed.
  - `npm run build` -> passed using the release-branch `.browserslistrc` comment-stripping workaround; build emitted existing large chunk / ineffective dynamic import warnings.
  - `git diff --check` -> passed.
  - `npx vitest run tests/architecture.test.ts` -> still reproduces the known release-branch failure: `src\world_api\chat.ts value-imports 'OVERHEAD_EMOTE_IDS' from '../sim/types'`.
- Manual steps:
  - Not run. This is a pure sim/helper/stat-tooltip math refactor with no UI layout or interaction changes.

## Screenshots / recordings

N/A - no HUD/window/control layout or visual behavior changed, and no player-facing text changed.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
