### PR TITLE
fix(discord): pass DISCORD_BOT_TOKEN to the game service for auto-join

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,9 @@ services:
       DISCORD_GUILD_ID: ${DISCORD_GUILD_ID:-}
       DISCORD_GUILD_INVITE: ${DISCORD_GUILD_INVITE:-}
       DISCORD_BOT_SECRET: ${DISCORD_BOT_SECRET:-}
+      # Runtime: the game server uses the bot token to auto-join a linking player to
+      # the official guild (guilds.join). Empty disables auto-join (verify-only).
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
     # loopback-only: the TLS reverse proxy (Caddy) is the public entrance
     ports:
       - "127.0.0.1:8787:8787"


### PR DESCRIPTION
## Summary
Follow-up to #1192 (Discord auto-join). The game server reads `DISCORD_BOT_TOKEN` in `discordConfig()` to add a linking player to the guild, but the `game` service in `docker-compose.yml` never forwarded it, only the `discord-bot` service did. So `autoJoinEnabled()` saw an empty token and the game server silently ran verify-only: it never requested the `guilds.join` scope nor called the add-member API, even with `DISCORD_BOT_TOKEN` set in the host `.env`.

This adds the one missing env passthrough on the `game` service, mirroring `discord-bot`.

## Why it was missed
Until auto-join, the game server only needed the shared `DISCORD_BOT_SECRET` (for the game <-> bot internal channel), never the bot token itself, so the compose `game` block was never given `DISCORD_BOT_TOKEN`. #1192 added the code and documented the env requirement but not this compose wiring, which is what actually delivers the value in the deployed topology.

## Change
```diff
       DISCORD_BOT_SECRET: ${DISCORD_BOT_SECRET:-}
+      # Runtime: the game server uses the bot token to auto-join a linking player to
+      # the official guild (guilds.join). Empty disables auto-join (verify-only).
+      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
```

## Local validation (isolated stack, no host ports, dummy env)
- `docker compose build` for the game image: succeeds
- Stack boots healthy: `/api/status` -> `{"ok":true,...}`
- The game container now receives `DISCORD_BOT_TOKEN` (confirmed via `printenv`); it was absent before
- Auto-join is enabled end to end: `POST /api/auth/discord/start` returns `scope = "identify guilds guilds.join"` (was `"identify guilds"` without the token)

## Deploy note
Compose-only, no code or Dockerfile change, so no rebuild is required to activate: pull the change onto a host and `docker compose up -d game` to recreate the game container with the token. Should also forward to `main`.
