### PR TITLE
fix(net): carry aura magnitude on the wire so buff/debuff tooltips show real values

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -459,11 +459,21 @@ interface WireAura {
   kind: string;
   rem: number;
   dur: number;
-  // Sent SPARSELY: only a negative-value buff_* aura (a stat-sap) rides the wire (see the
-  // serializer below), the exact case auras_view.isAuraDebuff reads value for. Everything
-  // else (positive buffs, absorb shields, and negative-value non-buff auras like the random
-  // fear angle on an incapacitate) stays off the wire and decodes to 0, exactly as before.
+  // The aura's magnitude, so buff/debuff hover tooltips show the REAL numbers online, exactly
+  // as offline (the descriptor in src/ui/aura_effect.ts reads value per kind: flat stat amount,
+  // slow/haste multiplier, dot/hot per-tick, absorb remaining, ...). Sent RAW (like `dur`, not
+  // round2) so the exact number and its sign survive JSON: round2 could turn a tiny negative
+  // into -0 -> 0 and flip a stat-sap's isAuraDebuff classification. Omitted only when exactly 0,
+  // which decodes back to 0, so value-less auras and an old server are unchanged.
   value?: number;
+  // imbue judgement min/max bonus-damage range (aura_effect imbueRange); only imbue sets these.
+  value2?: number;
+  value3?: number;
+  // dot/hot tick cadence in seconds, so the tooltip's "every N sec" is right online.
+  tickInterval?: number;
+  // damage/heal school for dot/absorb/thorns tooltips. Physical is the client's decode default,
+  // so only a non-physical school needs to ride the wire.
+  school?: string;
   stacks?: number;
   // Remaining charges on a charge-limited aura (Lightning Shield's reflect count). Sent only
   // when defined, so ordinary auras stay off the wire and decode to undefined as before; the
@@ -561,15 +571,20 @@ function dynamicFields(e: Entity): Record<string, unknown> {
         kind: a.kind,
         rem: round2(a.remaining),
         dur: a.duration,
-        // Carry the value ONLY for the exact case the client UI reads it: a negative-value
-        // buff_* aura (a stat-sap), which auras_view.isAuraDebuff classifies as a debuff via
-        // `kind.startsWith('buff_') && value < 0`. Mirroring that predicate keeps the wire in
-        // lockstep with the classification, so a graphics preset can never hide such a debuff
-        // and nothing else (positive buffs, absorb shields, a fear's random facing angle, any
-        // other negative-value non-buff aura) rides the wire or changes online behavior. Sent
-        // RAW (like `dur`, not round2) so the sign the classification keys on survives the
-        // wire exactly: round2 could round a tiny negative to -0, which JSON writes as 0.
-        ...(a.value < 0 && a.kind.startsWith('buff_') ? { value: a.value } : {}),
+        // Carry the aura's magnitude so buff/debuff hover tooltips show the real numbers online,
+        // not 0 (the descriptor in src/ui/aura_effect.ts reads value per kind). Sent RAW (like
+        // `dur`, not round2) so the exact number and its sign survive JSON, keeping a negative
+        // stat-sap's isAuraDebuff classification intact (round2 could turn a tiny negative into
+        // -0 -> 0). Omitted only when exactly 0, which decodes back to 0, so value-less auras and
+        // an old server are unchanged. A hover tooltip magnitude is non-actionable cosmetic text,
+        // so sending it cannot let a graphics preset hide anything (graphics-settings fairness).
+        ...(a.value !== 0 ? { value: a.value } : {}),
+        // imbue judgement min/max range; dot/hot tick cadence; non-physical school. Each rides
+        // only when it carries meaning, so ordinary auras stay lean and decode to their defaults.
+        ...(a.value2 !== undefined ? { value2: a.value2 } : {}),
+        ...(a.value3 !== undefined ? { value3: a.value3 } : {}),
+        ...(a.tickInterval !== undefined ? { tickInterval: a.tickInterval } : {}),
+        ...(a.school !== 'physical' ? { school: a.school } : {}),
         ...(a.stacks && a.stacks > 1 ? { stacks: a.stacks } : {}),
         // Carry the remaining charges only for a charge-limited aura (Lightning Shield), so the
         // buff icon can badge the count online exactly as offline; undefined for every other aura.

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1304,14 +1304,18 @@ export class ClientWorld implements IWorld {
         kind: a.kind,
         remaining: a.rem,
         duration: a.dur,
-        // The wire carries value only for negative-value buff_* stat-saps (sparse,
-        // server/game.ts), so the UI classifies them as debuffs identically to offline; a
-        // missing value (ordinary buffs, absorb, non-buff auras, an old server) decodes to 0
-        // as before. sourceId/school stay simplified (separate pre-existing wire reductions,
-        // not part of this change).
+        // The wire carries the aura magnitude (and imbue range / tick cadence / school) so buff
+        // and debuff hover tooltips show the real numbers online exactly as offline (aura_effect
+        // reads these). A 0/absent value decodes to 0 (value-less auras and an old server are
+        // unchanged), a missing school falls back to the physical default, and imbue range /
+        // tick cadence stay undefined when not sent. sourceId stays simplified (a separate
+        // pre-existing wire reduction, not read by the tooltip).
         value: a.value ?? 0,
+        value2: a.value2,
+        value3: a.value3,
+        tickInterval: a.tickInterval,
         sourceId: 0,
-        school: 'physical' as const,
+        school: a.school ?? 'physical',
         stacks: a.stacks,
         // Mirror the charge count for a charge-limited aura (Lightning Shield); the wire sends it
         // only when defined (server/game.ts), so an ordinary aura or an old server decodes to

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -22,6 +22,8 @@ import { DELVES } from '../src/sim/data';
 import { Sim } from '../src/sim/sim';
 import { type Aura, DT, type PlayerClass } from '../src/sim/types';
 import { terrainHeight } from '../src/sim/world';
+import { absorbTotal } from '../src/ui/absorb_bar';
+import { auraEffectDescriptor } from '../src/ui/aura_effect';
 import { isAuraDebuff } from '../src/ui/auras_view';
 
 const DELTA_KEYS = [
@@ -2162,16 +2164,16 @@ describe('delta-key contract pins (anti-drift)', () => {
   });
 });
 
-// A negative-value buff_* aura (a stat-sap: an intellect-draining curse on buff_int, an
-// attack-power drain on buff_ap) reads as a DEBUFF via auras_view.isAuraDebuff's
-// `value < 0` branch. That branch can only fire online if the wire carries the value. The
-// serializer sends `value` SPARSELY: only when it is negative (the sole case that flips the
-// classification), so an ordinary buff and the positive absorb shield stay off the wire and
-// decode to 0 exactly as before (no absorb-overlay regression; see target_frame.test.ts).
-// The client decode reads `a.value ?? 0`, so an old server that never sends it still decodes
-// to 0 (backward compatible). This drives a real Sim aura through the real serializer
-// (wireEntity) and the real client decode (ClientWorld.applySnapshot).
-describe('aura value over the wire (stat-sap debuff parity)', () => {
+// Buff/debuff hover tooltips read an aura's magnitude (src/ui/aura_effect.ts: flat stat amount,
+// slow/haste multiplier, dot/hot per-tick, absorb remaining, imbue range, ...), so the wire must
+// carry it or the tooltip reads 0 online (the reported "Increases attack power by 0" bug). The
+// serializer now sends `value` whenever it is nonzero (raw, so a negative stat-sap's sign and its
+// isAuraDebuff classification survive), plus value2/value3 (imbue), tickInterval (dot/hot), and a
+// non-physical school. The client decode reads `a.value ?? 0` and `a.school ?? 'physical'`, so a
+// value-0 aura or an old server still decodes to the defaults (backward compatible). This drives a
+// real Sim aura through the real serializer (wireEntity) and the real client decode
+// (ClientWorld.applySnapshot).
+describe('aura magnitude over the wire (buff/debuff tooltip parity)', () => {
   function roundTrip(aura: Aura): { wire: Record<string, unknown>; mirror: Aura } {
     const sim = new Sim({ seed: 1, playerClass: 'warrior', noPlayer: true });
     const pid = sim.addPlayer('warrior', 'Sapped');
@@ -2219,16 +2221,16 @@ describe('aura value over the wire (stat-sap debuff parity)', () => {
     expect(isAuraDebuff(mirror)).toBe(true);
   });
 
-  it('does NOT send a POSITIVE buff value (sparse): a real buff stays a buff in both worlds', () => {
+  it('sends a POSITIVE buff value so its tooltip shows the real magnitude, still a buff in both worlds', () => {
     const buff: Aura = { ...sapInt(40), id: 'arcane_intellect', name: 'Arcane Intellect' };
     const { wire, mirror } = roundTrip(buff);
-    expect('value' in wireAura(wire, 'arcane_intellect')).toBe(false); // omitted on the wire
-    expect(mirror.value).toBe(0); // decodes to 0 (?? 0)
-    expect(isAuraDebuff(buff)).toBe(false);
+    expect(wireAura(wire, 'arcane_intellect').value).toBe(40); // rides the wire now (was omitted)
+    expect(mirror.value).toBe(40); // client mirrors the real magnitude (not the old hardcoded 0)
+    expect(isAuraDebuff(buff)).toBe(false); // positive value -> still a buff, online and off
     expect(isAuraDebuff(mirror)).toBe(false);
   });
 
-  it('does NOT send a POSITIVE absorb value: the shield overlay stays offline-only (no regression)', () => {
+  it('sends a POSITIVE absorb value so the shield overlay and tooltip work online too', () => {
     const shield: Aura = {
       id: 'power_word_shield',
       name: 'Power Word: Shield',
@@ -2240,16 +2242,18 @@ describe('aura value over the wire (stat-sap debuff parity)', () => {
       school: 'holy',
     };
     const { wire, mirror } = roundTrip(shield);
-    expect('value' in wireAura(wire, 'power_word_shield')).toBe(false);
-    // online absorb is still 0, so the shield overlay remains offline-only (target_frame parity).
-    expect(mirror.value).toBe(0);
+    expect(wireAura(wire, 'power_word_shield').value).toBe(250);
+    expect(wireAura(wire, 'power_word_shield').school).toBe('holy'); // non-physical school rides
+    expect(mirror.value).toBe(250); // client mirrors the remaining absorb...
+    expect(mirror.school).toBe('holy');
+    // ...so the unit-frame shield overlay now derives online exactly as offline.
+    expect(absorbTotal([mirror])).toBe(250);
   });
 
-  it('does NOT send a NEGATIVE value for a non-buff_ aura (kind-gated): fear keeps its kind classification', () => {
-    // The emit mirrors isAuraDebuff's value branch (buff_* only), so a negative-value
-    // non-buff aura -- e.g. an incapacitate (fear) carrying a random facing angle that is
-    // negative about half the time -- never ships its value. It stays a debuff via its KIND,
-    // identically in both worlds, and no inert value rides the wire.
+  it('classifies a non-buff_ aura (fear) as a debuff by KIND, not value, across the wire', () => {
+    // An incapacitate (fear) stores a random facing angle in value; it now rides the wire like
+    // any nonzero value, but the incapacitate tooltip reads NO number, so the inert angle is
+    // harmless. Classification stays KIND-based (DEBUFF_AURA_KINDS), identical in both worlds.
     const fear: Aura = {
       id: 'fear',
       name: 'Fear',
@@ -2261,10 +2265,84 @@ describe('aura value over the wire (stat-sap debuff parity)', () => {
       school: 'shadow',
     };
     const { wire, mirror } = roundTrip(fear);
-    expect('value' in wireAura(wire, 'fear')).toBe(false); // negative, but not buff_ -> omitted
-    expect(mirror.value).toBe(0);
+    expect(wireAura(wire, 'fear').value).toBe(-1.5); // nonzero value rides raw (sign preserved)
+    expect(mirror.value).toBe(-1.5);
+    expect(auraEffectDescriptor(fear)?.nums).toBeUndefined(); // incapacitate shows no number
     expect(isAuraDebuff(fear)).toBe(true); // debuff via kind, in both worlds
     expect(isAuraDebuff(mirror)).toBe(true);
+  });
+
+  it('round-trips Aspect of the Hawk so its tooltip shows the real attack power, not 0 (the bug)', () => {
+    // The reported bug: online, Aspect of the Hawk read "Increases attack power by 0" because the
+    // positive buff_ap magnitude never rode the wire. It now does, so offline == online.
+    const hawk: Aura = {
+      id: 'aspect_of_the_hawk',
+      name: 'Aspect of the Hawk',
+      kind: 'buff_ap',
+      remaining: 1800,
+      duration: 1800,
+      value: 20,
+      sourceId: 0,
+      school: 'physical',
+    };
+    const { wire, mirror } = roundTrip(hawk);
+    expect(wireAura(wire, 'aspect_of_the_hawk').value).toBe(20);
+    expect(mirror.value).toBe(20);
+    // end to end: the mirrored aura drives the tooltip descriptor to the real number.
+    const desc = auraEffectDescriptor(mirror);
+    expect(desc?.key).toBe('hudChrome.auraEffect.increase.ap');
+    expect(desc?.nums?.value).toBe(20); // "Increases attack power by 20", never 0
+  });
+
+  it('round-trips a dot magnitude, tick cadence, and non-physical school for its tooltip', () => {
+    const dot: Aura = {
+      id: 'corruption',
+      name: 'Corruption',
+      kind: 'dot',
+      remaining: 12,
+      duration: 12,
+      value: 15,
+      tickInterval: 3,
+      sourceId: 0,
+      school: 'shadow',
+    };
+    const { wire, mirror } = roundTrip(dot);
+    expect(wireAura(wire, 'corruption').value).toBe(15);
+    expect(wireAura(wire, 'corruption').tickInterval).toBe(3);
+    expect(wireAura(wire, 'corruption').school).toBe('shadow');
+    expect(mirror.value).toBe(15);
+    expect(mirror.tickInterval).toBe(3);
+    expect(mirror.school).toBe('shadow');
+    const desc = auraEffectDescriptor(mirror);
+    expect(desc?.key).toBe('hudChrome.auraEffect.dot');
+    expect(desc?.nums?.value).toBe(15);
+    expect(desc?.nums?.interval).toBe(3);
+    expect(desc?.school).toBe('shadow');
+  });
+
+  it('round-trips the imbue judgement range (value2/value3), value omitted when 0', () => {
+    const imbue: Aura = {
+      id: 'holy_might',
+      name: 'Holy Might',
+      kind: 'imbue',
+      remaining: 300,
+      duration: 300,
+      value: 0, // imbue carries its numbers in value2/value3, so value stays 0...
+      value2: 8,
+      value3: 12,
+      sourceId: 0,
+      school: 'holy',
+    };
+    const { wire, mirror } = roundTrip(imbue);
+    expect('value' in wireAura(wire, 'holy_might')).toBe(false); // ...and is omitted (decodes 0)
+    expect(wireAura(wire, 'holy_might').value2).toBe(8);
+    expect(wireAura(wire, 'holy_might').value3).toBe(12);
+    expect(mirror.value2).toBe(8);
+    expect(mirror.value3).toBe(12);
+    const desc = auraEffectDescriptor(mirror);
+    expect(desc?.key).toBe('hudChrome.auraEffect.imbueRange');
+    expect(desc?.nums?.min).toBe(8);
+    expect(desc?.nums?.max).toBe(12);
   });
 
   it('tolerates an old-server wire aura with no value (backward compatible -> 0)', () => {

--- a/tests/target_frame.test.ts
+++ b/tests/target_frame.test.ts
@@ -4,17 +4,14 @@
 // castBarState for the cast bar) plus the inline combo-pip selection with BOTH a
 // Sim-shaped and a faithfully ClientWorld-mirror-shaped target entity.
 //
-// The mirror is NOT a byte copy of the Sim entity: the wire (server/game.ts WireAura)
-// omits the absorb VALUE, and src/net/online.ts reconstructs every aura with
-// `value: 0`. So the absorb SHIELD overlay is an OFFLINE-ONLY visual (online there is
-// no shield data, so the bar is just hp/maxHp). The fields that are
-// divergence-sensitive (the target cast remaining + the combo points) ARE wired and
-// must match. This test models the mirror's value-zeroing faithfully and asserts:
+// The mirror is faithful to src/net/online.ts: the wire (server/game.ts WireAura) now
+// carries the aura magnitude and school, so ClientWorld reconstructs the absorb aura with
+// its real `value` (and non-physical school). The absorb SHIELD overlay therefore derives
+// ONLINE exactly as offline; there is no longer a target-frame divergence. This test asserts:
 //   - the wire-carried frame fields (hp/level/name/resource) render identically,
+//   - the absorb shield fraction matches across hosts (the value is wired now),
 //   - the cast bar (remaining/fill/label) and the combo-pip count match across hosts,
-//   - the absorb shield is the ONE intended divergence (offline shield vs online none),
-// so an offline-only assumption on a wired field cannot ship broken online, and the
-// absorb limitation is documented rather than falsely asserted as identical.
+// so a field the target frame reads renders identically online and offline.
 
 import { describe, expect, it } from 'vitest';
 import { castBarState } from '../src/render/cast_bar';
@@ -84,14 +81,13 @@ function simTarget(over: Partial<TargetState> = {}): Entity {
   } as unknown as Entity;
 }
 
-// Build a ClientWorld-mirror-shaped entity, FAITHFUL to src/net/online.ts: same
-// gameplay fields, but every aura's absorb value is zeroed (the wire omits it) and the
-// mirror carries its own net-bookkeeping extras the derivations must ignore.
+// Build a ClientWorld-mirror-shaped entity, FAITHFUL to src/net/online.ts: same gameplay
+// fields, the aura magnitude/school now survive the wire (so the absorb value is preserved,
+// not zeroed), and the mirror carries its own net-bookkeeping extras the derivations ignore.
 function clientTarget(over: Partial<TargetState> = {}): Entity {
   const s = { ...GAMEPLAY, ...over };
   return {
     ...s,
-    auras: s.auras.map((a) => ({ ...a, value: 0 })),
     netUpdatedAtTick: 9821,
     interpAlpha: 0.5,
     lastWireSeq: 77,
@@ -134,25 +130,23 @@ describe('target frame: Sim-vs-ClientWorld parity', () => {
   it('renders the wire-carried frame fields identically across hosts', () => {
     const fromSim = unitFrameView(targetDescriptor(simTarget()));
     const fromClient = unitFrameView(targetDescriptor(clientTarget()));
-    // Every field that survives the wire is identical; only the absorb overlay (below)
-    // differs, so compare the frame minus its absorb fraction.
-    const { absorbFrac: simAbsorb, absorbOvershield: simOver, ...simRest } = fromSim;
-    const { absorbFrac: cliAbsorb, absorbOvershield: cliOver, ...cliRest } = fromClient;
-    expect(simRest).toEqual(cliRest);
-    expect(simRest.levelText).toBe(BOSS_SKULL_GLYPH); // boss skull, not a number
-    expect(simRest.resClass).toBe('none'); // a target has no resource bar
+    // Every field the frame reads survives the wire now (including the absorb overlay), so
+    // the whole view is identical across hosts.
+    expect(fromClient).toEqual(fromSim);
+    expect(fromSim.levelText).toBe(BOSS_SKULL_GLYPH); // boss skull, not a number
+    expect(fromSim.resClass).toBe('none'); // a target has no resource bar
     // the hostile name color is a pure function of the mirrored `hostile` field:
     expect(targetNameColor(simTarget())).toBe(targetNameColor(clientTarget()));
     expect(targetNameColor(simTarget())).toBe('var(--color-hostile)');
   });
 
-  it('treats the absorb shield as the ONE intended offline-only divergence', () => {
-    // The wire never sends the absorb value (online.ts forces aura.value=0), so the
-    // shield segment shows offline only; this is pre-existing and intended, NOT a bug.
+  it('renders the absorb shield identically across hosts (the value is wired now)', () => {
+    // The wire carries the absorb value (server/game.ts) and online.ts decodes it, so the
+    // shield segment derives online exactly as offline: no target-frame divergence.
     const fromSim = unitFrameView(targetDescriptor(simTarget()));
     const fromClient = unitFrameView(targetDescriptor(clientTarget()));
-    expect(fromSim.absorbFrac).toBeCloseTo((420 + 90) / 600); // 0.85, the offline shield
-    expect(fromClient.absorbFrac).toBeCloseTo(420 / 600); // 0.70, no shield online
+    expect(fromSim.absorbFrac).toBeCloseTo((420 + 90) / 600); // 0.85, the shield...
+    expect(fromClient.absorbFrac).toBeCloseTo((420 + 90) / 600); // ...identical online
   });
 
   it('a dead target renders identically across hosts (no shield, hidden cast)', () => {
@@ -170,7 +164,7 @@ describe('target frame: Sim-vs-ClientWorld parity', () => {
 
   it('the target cast bar (remaining + fill + label) matches across hosts', () => {
     // castingAbility/castTotal/castRemaining/channeling ARE wired, so the cast bar is
-    // identical (the aura-value zeroing does not touch the cast path).
+    // identical across hosts (the cast path is independent of the aura magnitude).
     const fromSim = castBarState(simTarget());
     const fromClient = castBarState(clientTarget());
     expect(fromSim).toEqual(fromClient);


### PR DESCRIPTION
## Problem

Online, buff/debuff hover tooltips showed the wrong magnitude, e.g. **"Increases attack power by 0"** for Aspect of the Hawk (screenshot below). It was not one buff: percent effects (slows, haste) rendered a garbage **"100%"**, DoTs/absorbs read 0, sunders read "by 0 (N stacks)".

## Root cause (online-only)

The tooltip descriptor (`src/ui/aura_effect.ts`) prints exactly what the aura carries. The aura's magnitude was stripped on the server to client wire:

- `server/game.ts` (`dynamicFields`) shipped an aura's `value` **only** for negative-value `buff_*` stat-saps.
- So Aspect of the Hawk (a positive `buff_ap`) and every other value-bearing aura decoded to `0` on the client (`src/net/online.ts`, `value: a.value ?? 0`; `school` was hardcoded `'physical'`, and `value2`/`value3`/`tickInterval` were never read).

Offline (`Sim`) was already correct, so this was an online parity gap across the **whole value-bearing aura family**.

## Fix

Widen the wire to carry the magnitude for all value-bearing auras, then decode it in `ClientWorld`:

- `value` whenever nonzero, sent **raw** (like `dur`) so a stat-sap's sign and its `isAuraDebuff` classification survive JSON.
- `value2`/`value3` (imbue judgement range), `tickInterval` (dot/hot cadence), and a non-physical `school`, each riding only when it carries meaning.
- Backward compatible: an absent `value`/`school` decodes to `0`/`physical` exactly as before.

No `IWorld` or `Sim` change: `Aura.value`/`value2`/`value3`/`tickInterval`/`school` already exist on the shared shape and the offline `Sim` already populates them. This lives entirely at the server-encode + `ClientWorld`-decode seam.

Absorb value now rides too, so the unit-frame **shield overlay** derives online as well as offline (a deliberate parity improvement); `tests/target_frame.test.ts` is updated to assert online/offline parity instead of the old "offline-only" divergence.

## Files

- `server/game.ts` - `WireAura` + `dynamicFields` aura serializer
- `src/net/online.ts` - `ClientWorld` aura decode
- `tests/snapshots.test.ts` - real serializer/decoder round-trips
- `tests/target_frame.test.ts` - absorb-shield parity (was offline-only)

## Notes

- Graphics-settings fairness: unaffected. A hover-tooltip magnitude is non-actionable cosmetic text, and sending more data cannot let a preset hide anything.
- Server authority / anti-cheat: unaffected. Aura magnitudes are already shown offline (the reference) and are classic-authentic; nothing exploitable.
- No new i18n key: the `hudChrome.auraEffect.*` templates and `formatNumber` already exist; the fix just feeds them correct data online.
- The second aura serializer (`server/game.ts` admin online-rows) is operator-only and already sends `value`; no change needed.

## Test plan

- [x] `tests/snapshots.test.ts` - Aspect of the Hawk round-trip (`by 0` becomes `by 20`), positive buff, dot (value + interval + school), imbue (`value2`/`value3`), absorb overlay, negative-sap classification kept, fear kind-classification, old-server backward-compat
- [x] `tests/target_frame.test.ts` - absorb shield now identical across hosts
- [x] Full vitest suite green (6052 passed; the 24 `tests/admin/*` failures are a local `node_modules` symlink quirk, unrelated, green on CI)
- [x] `tsc --noEmit` clean; Biome format clean on changed files
- [ ] Manual online check: log in, cast Aspect of the Hawk, hover the buff, confirm "Increases attack power by 20"