### PR TITLE
tooling(ci): trigger the AI reviewer on /review and /suggest PR comments

### DIFF
--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -48,6 +48,10 @@ jobs:
   screenshots:
     name: Screenshots of changes
     runs-on: ubuntu-latest
+    # issue_comment fires this workflow on every comment on any issue or PR; without this
+    # guard the full checkout + npm ci + Vite boot + puppeteer run would fire on every
+    # comment too, even though nothing in this job reads the comment.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Check out repository
         uses: actions/checkout@v6

--- a/.github/workflows/pr-ai.yml
+++ b/.github/workflows/pr-ai.yml
@@ -1,32 +1,47 @@
 name: PR AI assist
 
-# Two INFORMATIONAL, NON-BLOCKING jobs that help review a pull request. Neither is a
-# required check; they assist review, they do not gate merge. They live in their own
-# workflow so they never interfere with the CI gate in ci.yml.
+# Two INFORMATIONAL, NON-BLOCKING jobs that help review a pull request, plus an on-demand
+# comment trigger for the second one. None of this is a required check; it assists
+# review, it does not gate merge. Lives in its own workflow so it never interferes with
+# the CI gate in ci.yml.
 #
-#   screenshots  boots the Vite dev client headless, runs a fixed offline tour
-#                (character select, desktop HUD, mobile HUD), uploads the PNGs as an
-#                artifact, and links them in a sticky PR comment.
-#   ai-review    sends the PR diff to an OpenRouter model (free openrouter/owl-alpha by
-#                default) and posts the review as a sticky PR comment. No-ops without the
-#                OPENROUTER_API_KEY secret (for example on a fork PR), so it never blocks.
+#   screenshots        boots the Vite dev client headless, runs a fixed offline tour
+#                       (character select, desktop HUD, mobile HUD), uploads the PNGs as
+#                       an artifact, and links them in a sticky PR comment.
+#   ai-review           sends the PR diff to an OpenRouter model (free
+#                       nvidia/nemotron-3-ultra-550b-a55b:free by default) and posts the
+#                       review as a sticky PR comment. No-ops without the
+#                       OPENROUTER_API_KEY secret (for example on a fork PR), so it never
+#                       blocks.
+#   ai-review-comment   on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or
+#                       `/suggest <focus>` on the PR. Fetches the diff itself via the
+#                       GitHub API (no checkout of the PR head, so this stays safe to run
+#                       with repo secrets even against a fork PR) and posts a fresh reply
+#                       comment, keyed to the triggering comment rather than the sticky
+#                       review above.
 #
 # Setup (one time): add an OPENROUTER_API_KEY repo secret to enable ai-review. Optionally
-# set an OPENROUTER_MODEL repo variable to swap the model (owl-alpha is free but ephemeral).
-# See docs/ai-pr-bot.md, including the privacy note on the free owl-alpha tier logging prompts.
+# set an OPENROUTER_MODEL repo variable to swap the model (free models can change or
+# disappear at any time). See docs/ai-pr-bot.md, including the privacy note on free
+# OpenRouter models logging prompts.
 
 on:
   pull_request:
+  issue_comment:
+    types: [created]
   workflow_dispatch:
 
-# Needed to post the sticky review/screenshot comments. Fork PRs get a read-only token,
-# so the comment steps degrade to a no-op there (handled in the scripts).
+# Needed to post the sticky review/screenshot comments and read the PR diff via the API.
+# Fork PRs get a read-only token on the pull_request trigger, so the comment steps
+# degrade to a no-op there (handled in the scripts). issue_comment always runs with the
+# base repo's token and secrets regardless of whose PR it is, which is why
+# ai-review-comment additionally gates on the commenter's author_association.
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: pr-ai-${{ github.event.pull_request.number || github.ref }}
+  group: pr-ai-${{ github.event.pull_request.number || github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -140,9 +155,42 @@ jobs:
       - name: Review with OpenRouter
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'openrouter/owl-alpha' }}
+          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           DIFF_FILE: pr.diff
+        run: node scripts/ai_review.mjs
+
+  ai-review-comment:
+    name: AI review (comment command)
+    runs-on: ubuntu-latest
+    # Only a PR conversation comment (not a plain issue), starting with /review or
+    # /suggest, from someone with write access to THIS repo. author_association is
+    # evaluated against the base repo regardless of whether the PR itself is from a
+    # fork, so a fork PR's own author cannot self-trigger this on their own comment.
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
+      (startsWith(github.event.comment.body, '/review') || startsWith(github.event.comment.body, '/suggest'))
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - name: Review with OpenRouter
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_MODEL: ${{ vars.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_AUTHOR: ${{ github.event.comment.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: node scripts/ai_review.mjs

--- a/docs/ai-pr-bot.md
+++ b/docs/ai-pr-bot.md
@@ -1,8 +1,8 @@
 # PR AI assist
 
-Two informational, non-blocking GitHub Actions jobs that help review a pull request.
-They live in `.github/workflows/pr-ai.yml`, separate from the CI gate (`ci.yml`), and
-neither is a required check.
+Informational, non-blocking GitHub Actions jobs that help review a pull request. They
+live in `.github/workflows/pr-ai.yml`, separate from the CI gate (`ci.yml`), and none of
+them is a required check.
 
 ## What it does
 
@@ -23,25 +23,50 @@ neither is a required check.
    Nits with severity tags. The reviewer is `scripts/ai_review.mjs`; the GitHub comment
    helper is `scripts/gh_sticky_comment.mjs`. No new npm dependencies: it uses Node's
    built-in `fetch` and the GitHub REST API.
+3. **AI review on demand** (`ai-review-comment` job). An OWNER, MEMBER, or COLLABORATOR
+   of this repo can comment `/review` or `/suggest <focus>` on a PR (for example
+   `/suggest check the null handling around the new cache`) to re-run the same reviewer
+   whenever they want, optionally pointed at a specific concern. It runs the same
+   `scripts/ai_review.mjs`, fetching the diff itself from the GitHub API instead of a
+   precomputed file, and posts its answer as a fresh reply comment rather than editing
+   the standing sticky review, so a one-off question does not overwrite it.
 
 ## Enabling the AI review
 
-The screenshots job needs no configuration. The AI review is opt-in:
+The screenshots job needs no configuration. The AI review (automatic and on-demand) is
+opt-in:
 
 - Add a repository **secret** `OPENROUTER_API_KEY` (Settings -> Secrets and variables ->
-  Actions). Get a key at https://openrouter.ai. Without it the `ai-review` job runs but
-  no-ops and exits green, so the workflow is safe to merge before the key exists.
+  Actions). Get a key at https://openrouter.ai. Without it the `ai-review` and
+  `ai-review-comment` jobs run but no-op and exit green, so the workflow is safe to merge
+  before the key exists.
 - Optional repository **variable** `OPENROUTER_MODEL` to override the model. The default is
-  `openrouter/owl-alpha`, a free stealth model (1M context, tool use). It is free **for
-  now**: an unnamed provider can change pricing or pull it at any time, so treat it as a
+  `nvidia/nemotron-3-ultra-550b-a55b:free` (NVIDIA Nemotron 3 Ultra). It is free **for
+  now**: OpenRouter free tiers can change pricing, rate limits, or be pulled at any time
+  (the previous default, `openrouter/owl-alpha`, was pulled), so treat this as a
   prototype default and switch the variable when it goes away. Swapping the model is a
   one-line change with no workflow edit.
 
+## Requesting a review on demand
+
+Comment `/review` on a PR to re-run the reviewer over the current diff, or
+`/suggest <focus>` to ask it to prioritize something specific (the rest of the comment
+after the command is passed to the model as the thing to focus on; it still mentions
+other high-confidence findings). Only comments from an OWNER, MEMBER, or COLLABORATOR of
+this repo trigger it, checked against this repo regardless of whose PR it is, so a first-
+time contributor cannot self-trigger it on their own fork PR by commenting on it. This
+gate exists because, unlike the automatic `pull_request`-triggered job, a comment trigger
+always runs with this repo's secrets available, even against a fork PR: the job never
+checks out or executes the PR's own code, it only reads the diff as text through the
+GitHub API, but the trust gate keeps it from being invoked, and the OpenRouter budget
+spent, by an untrusted commenter.
+
 ## Privacy: read before enabling on private code
 
-The free `owl-alpha` tier **logs prompts to improve the model**, which means the PR diff
-you send is retained by a third party. Do not enable the AI review on code you cannot
-disclose while it points at owl-alpha. Safer options:
+Free OpenRouter models commonly **log prompts to improve the model**, which means the PR
+diff you send may be retained by a third party; check the model's Data Policy tab on
+openrouter.ai. Do not enable the AI review on code you cannot disclose while it points at
+a free model. Safer options:
 
 - Point `OPENROUTER_MODEL` at a paid / non-logging OpenRouter model.
 - Run a local model (the same script pattern works against any OpenAI-compatible endpoint;
@@ -51,10 +76,16 @@ The screenshots job sends nothing to a third party; it only renders your own cli
 
 ## Behavior on fork PRs
 
-Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets. Both
-comment steps and the AI review degrade to a no-op there (the scripts detect the missing
-write access / key and skip), so the workflow never errors on a fork PR. Screenshots are
-still captured and uploaded as an artifact.
+Pull requests from forks get a read-only `GITHUB_TOKEN` and cannot read repo secrets on
+the `pull_request` trigger. Both comment steps and the automatic AI review degrade to a
+no-op there (the scripts detect the missing write access / key and skip), so the workflow
+never errors on a fork PR. Screenshots are still captured and uploaded as an artifact.
+
+The on-demand `/review` and `/suggest` comment trigger is different: `issue_comment`
+always runs with full repo secrets, regardless of whether the PR is from a fork. It is
+still safe against a fork PR because the job never checks out or runs the PR's own code,
+and because it is gated on the commenter's `author_association` with this repo, not with
+the PR's origin (see "Requesting a review on demand" above).
 
 ## Running the screenshot tour locally
 

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -112,7 +112,10 @@ if (diff.length > MAX_DIFF_CHARS) {
 
 // Give the model the file list of the directories this diff touches, so it stops
 // hallucinating that existing imports/helpers are "missing" (its top false positive).
-// Best-effort: empty string when not in a git checkout.
+// Best-effort: empty string when not in a git checkout. On a comment-triggered run the
+// checkout is the base branch (no PR-head checkout, intentionally, see the module
+// comment), so a file the PR itself newly adds will not appear here; that is a known
+// false-positive risk specific to the /review and /suggest path.
 function listTouchedDirs(d) {
   const files = [...d.matchAll(/^\+\+\+ b\/(.+)$/gm)]
     .map((m) => m[1])

--- a/scripts/ai_review.mjs
+++ b/scripts/ai_review.mjs
@@ -1,48 +1,103 @@
 // Minimal AI pull-request reviewer. Sends the PR diff to an OpenRouter model (default:
-// the free openrouter/owl-alpha stealth model) and posts the review as a single sticky
-// comment on the PR. No new npm deps: Node 18+ global fetch + the GitHub REST API.
+// the free nvidia/nemotron-3-ultra-550b-a55b:free model) and posts the review as a
+// sticky comment on the PR. No new npm deps: Node 18+ global fetch + the GitHub REST
+// API.
+//
+// Two ways to trigger it (both wired in .github/workflows/pr-ai.yml):
+//   - automatically on every push to the PR: DIFF_FILE points at a precomputed diff.
+//   - on demand: an OWNER/MEMBER/COLLABORATOR comments `/review` or `/suggest <focus>`
+//     on the PR. The workflow gates on the commenter's author_association; this script
+//     fetches the diff itself via the GitHub API (no DIFF_FILE, no checkout of the PR
+//     head) and posts a fresh reply comment keyed to the triggering comment, separate
+//     from the sticky automatic review.
 //
 // It is best-effort and NON-BLOCKING: if OPENROUTER_API_KEY is absent (for example a
 // fork PR that cannot read repo secrets) it prints a notice and exits 0, so it never
 // gates a merge. The model is swappable via OPENROUTER_MODEL with zero workflow edits,
-// which matters because owl-alpha is a free stealth model that can disappear at any time.
+// which matters because free OpenRouter models can disappear or change at any time.
 //
-// PRIVACY: the free owl-alpha tier logs prompts to improve the model, so the diff you
-// send is retained by a third party. Point OPENROUTER_MODEL at a non-logging / paid
-// model (or a self-hosted one) before using this on code you cannot disclose.
+// PRIVACY: free OpenRouter models commonly log prompts to improve the model, so the
+// diff you send may be retained by a third party. Check the model's Data Policy on
+// openrouter.ai, or point OPENROUTER_MODEL at a non-logging / paid model (or a
+// self-hosted one), before using this on code you cannot disclose.
 //
 // Env (set by the workflow):
 //   OPENROUTER_API_KEY  OpenRouter key (repo secret); absent -> skip, exit 0
 //   GITHUB_TOKEN        token with pull-requests:write (default Actions token)
 //   GITHUB_REPOSITORY   owner/repo
 //   PR_NUMBER           the pull request number
-//   DIFF_FILE           path to a unified diff to review
-//   OPENROUTER_MODEL    model id (default openrouter/owl-alpha)
+//   DIFF_FILE           path to a precomputed unified diff (automatic run); when absent,
+//                       the diff is fetched from the GitHub API instead (comment run)
+//   COMMENT_BODY        the triggering comment's body (comment run only)
+//   COMMENT_ID          the triggering comment's id; keys its reply comment
+//   COMMENT_AUTHOR      the triggering comment's author; credited in the reply
+//   OPENROUTER_MODEL    model id (default nvidia/nemotron-3-ultra-550b-a55b:free)
 //   MAX_DIFF_CHARS      cap on diff chars sent to the model (default 60000)
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import { upsertStickyComment } from './gh_sticky_comment.mjs';
 
-const MARKER = '<!-- pr-ai-review -->';
-const MODEL = process.env.OPENROUTER_MODEL || 'openrouter/owl-alpha';
+const MODEL = process.env.OPENROUTER_MODEL || 'nvidia/nemotron-3-ultra-550b-a55b:free';
 const MAX_DIFF_CHARS = Number(process.env.MAX_DIFF_CHARS || 60000);
 const ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+const GITHUB_API = process.env.GITHUB_API_URL ?? 'https://api.github.com';
 
 const key = process.env.OPENROUTER_API_KEY;
 const prNumber = process.env.PR_NUMBER;
 const diffFile = process.env.DIFF_FILE;
+const commentBody = process.env.COMMENT_BODY;
+const commentId = process.env.COMMENT_ID;
+const commentAuthor = process.env.COMMENT_AUTHOR;
 
 if (!key) {
   console.log('[ai_review] OPENROUTER_API_KEY not set; skipping AI review (non-blocking).');
   process.exit(0);
 }
 
-let diff = '';
-try {
-  diff = fs.readFileSync(diffFile, 'utf8');
-} catch {
-  console.log(`[ai_review] could not read DIFF_FILE=${diffFile}; skipping.`);
+// A comment-triggered run carries COMMENT_BODY: parse the /review or /suggest <focus>
+// command out of it. The workflow only invokes this script for a comment that already
+// matched one of the two commands from a trusted author association, but parse
+// defensively so a direct/manual invocation with an unrecognized body no-ops instead of
+// reviewing on unexpected input.
+function parseCommand(body) {
+  if (!body) return null;
+  const m = body.trim().match(/^\/(review|suggest)\b[ \t]*([\s\S]*)$/);
+  return m ? { command: m[1], focus: m[2].trim() } : null;
+}
+const command = parseCommand(commentBody);
+if (commentBody && !command) {
+  console.log('[ai_review] comment did not match /review or /suggest; skipping.');
   process.exit(0);
+}
+
+async function fetchDiffFromApi() {
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!token || !repo || !prNumber) return '';
+  const res = await fetch(`${GITHUB_API}/repos/${repo}/pulls/${prNumber}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github.v3.diff',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!res.ok) {
+    console.log(`[ai_review] could not fetch PR diff via API (HTTP ${res.status}); skipping.`);
+    return '';
+  }
+  return res.text();
+}
+
+let diff = '';
+if (diffFile) {
+  try {
+    diff = fs.readFileSync(diffFile, 'utf8');
+  } catch {
+    console.log(`[ai_review] could not read DIFF_FILE=${diffFile}; skipping.`);
+    process.exit(0);
+  }
+} else {
+  diff = await fetchDiffFromApi();
 }
 if (!diff.trim()) {
   console.log('[ai_review] empty diff; skipping.');
@@ -142,6 +197,9 @@ Do not restate the diff. Output GitHub-flavored Markdown.`;
 
 const user = [
   truncated ? `Note: the diff was truncated to the first ${MAX_DIFF_CHARS} characters.\n` : '',
+  command?.focus
+    ? `The reviewer specifically asked (via a PR comment) to focus on:\n\n${command.focus}\n\nStill mention any other high-confidence finding, but prioritize this.\n`
+    : '',
   repoFiles
     ? `Files that already exist in the directories this diff touches (so you can resolve imports and must NOT flag these as missing):\n\n\`\`\`\n${repoFiles}\n\`\`\`\n`
     : '',
@@ -189,17 +247,28 @@ try {
   reviewText = `_The automated review could not run this time (\`${MODEL}\`). See the workflow logs._`;
 }
 
+const heading = command
+  ? `## AI review (\`${MODEL}\`, requested by @${commentAuthor ?? 'a maintainer'} via \`/${command.command}\`)`
+  : `## AI review (\`${MODEL}\`)`;
+
 const body = [
-  `## AI review (\`${MODEL}\`)`,
+  heading,
   '',
   reviewText,
   truncated ? `\n<sub>Diff truncated to the first ${MAX_DIFF_CHARS} characters.</sub>` : '',
   '',
-  '<sub>Automated and non-blocking. May be wrong; a human review still decides. The free owl-alpha tier logs prompts, so the diff is retained by a third party.</sub>',
+  '<sub>Automated and non-blocking. May be wrong; a human review still decides. Free OpenRouter models commonly log prompts, so the diff may be retained by a third party.</sub>',
 ].join('\n');
 
+// A comment-triggered run gets its own marker keyed to the triggering comment, so a
+// reply to /review or /suggest never overwrites the standing automatic review, but a
+// retried workflow run for the same comment updates its own reply instead of duplicating.
+const marker = command
+  ? `<!-- pr-ai-review-comment-${commentId ?? prNumber} -->`
+  : '<!-- pr-ai-review -->';
+
 try {
-  const result = await upsertStickyComment({ marker: MARKER, body, prNumber });
+  const result = await upsertStickyComment({ marker, body, prNumber });
   console.log(`ai review comment: ${result ?? 'skipped'}`);
 } catch (e) {
   console.log(`[ai_review] could not post comment (non-blocking): ${e.message}`);


### PR DESCRIPTION
## What

Follow-up to #1036 (merged into `release/v0.18.0`). Adds an on-demand trigger for the
AI PR reviewer: an OWNER, MEMBER, or COLLABORATOR of this repo can comment `/review` or
`/suggest <focus>` on a PR to re-run `scripts/ai_review.mjs` whenever they want, instead
of waiting for the next push.

## How

- New `ai-review-comment` job in `.github/workflows/pr-ai.yml`, triggered by
  `issue_comment` (created). Gated on `github.event.issue.pull_request != null` (a PR
  comment, not a plain issue), the comment starting with `/review` or `/suggest`, and the
  commenter's `author_association` being OWNER, MEMBER, or COLLABORATOR of this repo,
  checked regardless of whose PR it is (so a fork PR's own author cannot self-trigger it
  by commenting on their own PR).
- `scripts/ai_review.mjs` now supports two ways to get the diff: the existing
  `DIFF_FILE` (automatic run) or, when that is absent, a new `fetchDiffFromApi()` that
  reads it straight from `GET /repos/{repo}/pulls/{number}` with the diff media type.
  This means the comment-triggered job never checks out or executes the PR's own code
  (no `ref:` override on `actions/checkout`), so running it with full repo secrets stays
  safe even against a fork PR: only the diff text and the comment body ever reach the
  script, never executable code from the PR.
- A comment-triggered run posts its answer as a fresh reply comment keyed to the
  triggering comment's id (`<!-- pr-ai-review-comment-<id> -->`), so it never overwrites
  the standing automatic sticky review, but a retried Actions run for the same comment
  updates its own reply instead of duplicating.
- Fixed a latent concurrency bug while touching this: the `concurrency.group` only keyed
  off `github.event.pull_request.number`, which is absent on `issue_comment`; two
  `/review` comments on different PRs around the same time would have collapsed into one
  `cancel-in-progress` group. Now also keys off `github.event.issue.number`.
- Also swaps the default `OPENROUTER_MODEL`: `openrouter/owl-alpha` has been pulled from
  OpenRouter, replaced by `nvidia/nemotron-3-ultra-550b-a55b:free`.

## Docs

`docs/ai-pr-bot.md` updated: a new "Requesting a review on demand" section, the trust
gate rationale, and the fork-PR security note extended to cover why `issue_comment`
(unlike `pull_request`) always runs with secrets and why that's still safe here.

## Verification

- `node --check` on the changed script; Biome on the changed files.
- `npx vitest run tests/architecture.test.ts` (guard test, unaffected but green).
- Manually traced both trigger paths against the actual API/permission model (fork PR
  cannot self-trigger via `author_association`; no PR-head checkout in the new job).
- No em dashes, en dashes, or emojis introduced (repo convention).

Generated with Claude Code