### PR TITLE
fix(sim): let low-level mobs threaten player pets

### DIFF
--- a/src/sim/mob/locomotion.ts
+++ b/src/sim/mob/locomotion.ts
@@ -190,9 +190,9 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
       const template = MOBS[mob.templateId];
       let detected: Entity | null = null;
       let detectedD = Infinity;
-      ctx.playerGrid.forEachInRadius(mob.pos.x, mob.pos.z, 25, (e, d2) => {
+      const considerPlayerSideTarget = (e: Entity, d2: number): void => {
         if (e.dead) return;
-        if (isTrivialTo(mob, e)) return;
+        if (e.kind === 'player' && isTrivialTo(mob, e)) return;
         let radius = Math.max(4, Math.min(20, template.aggroRadius + (mob.level - e.level) * 1.5));
         radius *= ctx.delveDetectMult(e);
         // stealthed rogues are harder to detect, relative to observer level
@@ -203,6 +203,13 @@ export function updateMob(ctx: SimContext, mob: Entity): void {
           detected = e;
           detectedD = d;
         }
+      };
+      ctx.playerGrid.forEachInRadius(mob.pos.x, mob.pos.z, 25, considerPlayerSideTarget);
+      ctx.grid.forEachInRadius(mob.pos.x, mob.pos.z, 25, (e, d2) => {
+        if (e.kind !== 'mob' || e.ownerId === null || ctx.isDelveCompanionMob(e)) return;
+        const owner = ctx.entities.get(e.ownerId);
+        if (owner?.kind !== 'player') return;
+        considerPlayerSideTarget(e, d2);
       });
       if (detected) {
         ctx.aggroMob(mob, detected, true);

--- a/tests/low_level_mob_threat.test.ts
+++ b/tests/low_level_mob_threat.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import {
+  meleeMissChance,
+  MOB_VS_PLAYER_MAX_MISS,
+  swingMissChance,
+  type Entity,
+  type SimEvent,
+} from '../src/sim/types';
+import { terrainHeight } from '../src/sim/world';
+
+type TestSim = Sim & {
+  readonly cfg: { seed: number };
+  readonly grid: { update(e: Entity): void };
+  readonly playerGrid: { update(e: Entity): void };
+};
+
+function makeSim(playerClass: 'hunter' | 'warrior' = 'hunter', seed = 42): TestSim {
+  return new Sim({ seed, playerClass, autoEquip: true }) as unknown as TestSim;
+}
+
+function nearestWildMob(sim: Sim, templateId: string, from: Entity = sim.player): Entity {
+  let best: Entity | null = null;
+  let bestD = Infinity;
+  for (const e of sim.entities.values()) {
+    if (e.kind !== 'mob' || e.dead || e.ownerId !== null || e.templateId !== templateId) continue;
+    const dx = e.pos.x - from.pos.x;
+    const dz = e.pos.z - from.pos.z;
+    const d = dx * dx + dz * dz;
+    if (d < bestD) {
+      best = e;
+      bestD = d;
+    }
+  }
+  if (!best) throw new Error(`no wild ${templateId}`);
+  return best;
+}
+
+function teleport(sim: TestSim, e: Entity, x: number, z: number): void {
+  e.pos.x = x;
+  e.pos.z = z;
+  e.pos.y = terrainHeight(x, z, sim.cfg.seed);
+  e.prevPos = { ...e.pos };
+  sim.grid.update(e);
+  if (e.kind === 'player') sim.playerGrid.update(e);
+}
+
+function makeLowLevelThreat(mob: Entity): void {
+  mob.level = 1;
+  mob.weapon = { min: 3, max: 3, speed: 2 };
+  mob.stats.armor = 0;
+  mob.maxHp = 1_000_000;
+  mob.hp = mob.maxHp;
+  mob.aiState = 'idle';
+  mob.aggroTargetId = null;
+  mob.wanderTarget = null;
+  mob.hostile = true;
+}
+
+function syncPetLevel(sim: Sim, owner: Entity): void {
+  (sim as unknown as { syncPetLevel(owner: Entity): void }).syncPetLevel(owner);
+}
+
+function adoptWolf(sim: TestSim): Entity {
+  const pet = nearestWildMob(sim, 'forest_wolf');
+  pet.ownerId = sim.player.id;
+  pet.hostile = false;
+  syncPetLevel(sim, sim.player);
+  pet.petMode = 'defensive';
+  pet.aggroTargetId = null;
+  return pet;
+}
+
+function incomingFrom(events: SimEvent[], source: Entity, target: Entity): number {
+  let total = 0;
+  for (const e of events) {
+    if (
+      e.type === 'damage' &&
+      e.sourceId === source.id &&
+      e.targetId === target.id &&
+      e.kind === 'hit'
+    ) {
+      total += e.amount;
+    }
+  }
+  return total;
+}
+
+describe('low-level mob threat against high-level player-side targets', () => {
+  it('an engaged low-level wild mob still damages a much higher-level player', () => {
+    const sim = makeSim('warrior');
+    sim.setPlayerLevel(20);
+    const player = sim.player;
+    const wolf = nearestWildMob(sim, 'forest_wolf');
+    makeLowLevelThreat(wolf);
+    teleport(sim, player, wolf.pos.x + 2, wolf.pos.z);
+    wolf.aiState = 'attack';
+    wolf.aggroTargetId = player.id;
+    wolf.inCombat = true;
+    wolf.threat.set(player.id, 1);
+
+    const hpBefore = player.hp;
+    let incoming = 0;
+    for (let i = 0; i < 20 * 15 && incoming === 0; i++) {
+      incoming += incomingFrom(sim.tick(), wolf, player);
+    }
+
+    expect(wolf.aggroTargetId).toBe(player.id);
+    expect(incoming).toBeGreaterThan(0);
+    expect(player.hp).toBeLessThan(hpBefore);
+  });
+
+  it('an idle defensive pet is visible to nearby low-level mobs and takes damage', () => {
+    const sim = makeSim('hunter');
+    sim.setPlayerLevel(20);
+    const pet = adoptWolf(sim);
+    const wolf = nearestWildMob(sim, 'forest_wolf', pet);
+    makeLowLevelThreat(wolf);
+    teleport(sim, sim.player, wolf.pos.x + 10, wolf.pos.z);
+    teleport(sim, pet, wolf.pos.x + 3, wolf.pos.z);
+
+    const hpBefore = pet.hp;
+    let incoming = 0;
+    for (let i = 0; i < 20 * 15 && incoming === 0; i++) {
+      incoming += incomingFrom(sim.tick(), wolf, pet);
+    }
+
+    expect(wolf.aggroTargetId).toBe(pet.id);
+    expect(pet.aggroTargetId).toBe(wolf.id);
+    expect(incoming).toBeGreaterThan(0);
+    expect(pet.hp).toBeLessThan(hpBefore);
+    expect(sim.player.inCombat).toBe(true);
+  });
+
+  it('low-level players and pets still keep the full miss penalty against high-level mobs', () => {
+    const highMob = {
+      kind: 'mob',
+      level: 20,
+      hostile: true,
+      ownerId: null,
+    } as Entity;
+    const player = {
+      kind: 'player',
+      level: 1,
+      ownerId: null,
+    } as Entity;
+    const pet = {
+      kind: 'mob',
+      level: 1,
+      hostile: false,
+      ownerId: 99,
+    } as Entity;
+
+    expect(swingMissChance(player, highMob)).toBe(meleeMissChance(player.level, highMob.level));
+    expect(swingMissChance(player, highMob)).toBeGreaterThan(MOB_VS_PLAYER_MAX_MISS);
+    expect(swingMissChance(pet, highMob)).toBe(meleeMissChance(pet.level, highMob.level));
+    expect(swingMissChance(pet, highMob)).toBeGreaterThan(MOB_VS_PLAYER_MAX_MISS);
+  });
+});

--- a/tests/parity/golden/multi_class_heal.json
+++ b/tests/parity/golden/multi_class_heal.json
@@ -1244,7 +1244,7 @@
       "tick": 5,
       "time": 0.25,
       "nextId": 398,
-      "state": "91ab1392",
+      "state": "fce5c6e4",
       "events": "e7cecad5",
       "rng": {
         "draws": 10,
@@ -1255,7 +1255,7 @@
       "tick": 8,
       "time": 0.4,
       "nextId": 398,
-      "state": "7e99b18f",
+      "state": "7090d4a8",
       "events": "e7cecad5",
       "rng": {
         "draws": 10,
@@ -1648,6 +1648,7 @@
           "critChance": 0.05,
           "detonateTimer": "Infinity",
           "dodgeChance": 0.05,
+          "facing": 1.394614,
           "fallStartY": -1.48336,
           "fiveSecondRule": 99,
           "hp": 84,
@@ -1661,7 +1662,7 @@
           "overpowerUntil": -1,
           "ownerId": 393,
           "petMode": "defensive",
-          "petPathCooldown": 0.15,
+          "petPathCooldown": 0.2,
           "pos": {
             "x": 30,
             "y": -1.48336,
@@ -1749,7 +1750,7 @@
             ],
             [
               391,
-              393.5
+              268.5
             ],
             [
               393,
@@ -1809,7 +1810,7 @@
             ],
             [
               391,
-              287.5
+              162.5
             ],
             [
               393,
@@ -1875,7 +1876,7 @@
             ],
             [
               391,
-              287.5
+              162.5
             ],
             [
               394,

--- a/tests/pet_command.test.ts
+++ b/tests/pet_command.test.ts
@@ -88,6 +88,9 @@ describe('/pet command', () => {
     const pet = givePet(sim, a);
     sim.tick();
 
+    const hp = pet.hp;
+    const maxHp = pet.maxHp;
+    const pct = Math.round((hp / maxHp) * 100);
     sim.chat('/pet', a);
     const events = sim.tick();
     // self-only readout: never reaches the chat channel
@@ -95,8 +98,8 @@ describe('/pet command', () => {
     const text = errorText(events)!;
     expect(text).toContain(`Your pet: ${pet.name}`);
     expect(text).toContain(`level ${pet.level}`);
-    expect(text).toContain(`HP ${pet.hp}/${pet.maxHp}`);
-    expect(text).toContain('(100%)');
+    expect(text).toContain(`HP ${hp}/${maxHp}`);
+    expect(text).toContain(`(${pct}%)`);
   });
 
   it('rounds the health percentage from live pet HP', () => {


### PR DESCRIPTION
## Summary

Low-level hostile mobs now notice nearby player-owned combat pets while preserving the existing trivial-con proximity immunity for much higher-level players.

- Keeps player idle-target candidates behind `isTrivialTo(mob, e)`, so low-level mobs still do not proximity-aggro much higher-level players.
- Adds a separate owned-mob scan so nearby player pets can be selected as idle targets, using the same reduced-radius math with a 4 yd minimum.
- Excludes delve companion mobs from the owned-mob scan to avoid changing delve parity behavior.
- Adds focused regression coverage for low-level mobs damaging engaged high-level players, noticing and damaging idle player pets, and preserving miss penalties for low-level players/pets against high-level mobs.
- Updates the intentional parity golden affected by the pet visibility behavior.

## Related issues

Part of #1050.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src/sim/mob/locomotion.ts tests/low_level_mob_threat.test.ts tests/pet_command.test.ts` - passed; formatted 3 files and fixed 1 file.
  - `npx biome lint src/sim/mob/locomotion.ts tests/low_level_mob_threat.test.ts tests/pet_command.test.ts` - passed with 4 existing warning-level non-null assertions in `tests/pet_command.test.ts`.
  - `npm run check:ts` - passed.
  - Wrapped `.browserslistrc` cleanup around `npx vitest run tests/low_level_mob_threat.test.ts tests/mob_hit_floor.test.ts tests/pet_afk_farm.test.ts tests/pet_ai.test.ts tests/threat.test.ts tests/mob_targeting.test.ts tests/trivial_mob_passive.test.ts tests/pet_command.test.ts` - passed, 8 files / 124 tests.
  - Wrapped `.browserslistrc` cleanup around `npx vitest run tests/parity/parity.test.ts tests/parity/coverage.test.ts` - passed, 2 files / 140 tests.
  - Wrapped `.browserslistrc` cleanup around `npm run build` - passed with existing Vite/Rolldown warnings for ineffective dynamic imports, large chunks, and plugin timings.
  - Full `npm test` was attempted before the final `/pet` assertion stabilization and was not fully green due known unrelated release blockers: `tests/version_sync.test.ts` syntax error, architecture import rule failures, i18n ad-hoc `Intl` offenders, several full-suite timeouts, parity `fiesta_powerups` determinism under load, and `options_window` source-text expectations.
- Manual steps: N/A, sim-only behavior covered by automated tests.

## Screenshots / recordings

N/A, sim-only change with no UI/UX surface.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
