### PR TITLE
fix(compose): pass GitHub OAuth env through to the game service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,15 @@ services:
       # Runtime: the game server uses the bot token to auto-join a linking player to
       # the official guild (guilds.join). Empty disables auto-join (verify-only).
       DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      # Runtime: GitHub OAuth for the in-game developer badge. Both id+secret must be
+      # set to enable "Link GitHub"; empty hides it exactly like Discord. GITHUB_REPO
+      # selects which repo's contributor stats back the badge (code default:
+      # levy-street/world-of-claudecraft); GITHUB_TOKEN lifts the GitHub API rate limit
+      # for the contributor + News/Releases fetches. See .env.example.
+      GITHUB_OAUTH_CLIENT_ID: ${GITHUB_OAUTH_CLIENT_ID:-}
+      GITHUB_OAUTH_CLIENT_SECRET: ${GITHUB_OAUTH_CLIENT_SECRET:-}
+      GITHUB_REPO: ${GITHUB_REPO:-}
+      GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     # loopback-only: the TLS reverse proxy (Caddy) is the public entrance
     ports:
       - "127.0.0.1:8787:8787"


### PR DESCRIPTION
## What

Wire the four GitHub environment variables the game server reads into the `game` service `environment:` block in `docker-compose.yml`:

- `GITHUB_OAUTH_CLIENT_ID`
- `GITHUB_OAUTH_CLIENT_SECRET`
- `GITHUB_REPO`
- `GITHUB_TOKEN`

## Why

Docker Compose passes a container **only** the vars listed in its `environment:` block (there is no `env_file:` here). The server reads these from `process.env`:

- `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` in `server/github.ts:47-48`
- `GITHUB_REPO` / `GITHUB_TOKEN` in `server/main.ts:317-318` and `server/github_contributors.ts:27-28`

...but they were never passed through, so inside the container they are always empty. `githubConfig()` returns `null`, which **silently disables the in-game developer-badge / "Link GitHub" flow** (dev-badges, #1086) in every Docker deploy: the UI is hidden and no error is surfaced. `GITHUB_TOKEN` additionally lifts the unauthenticated GitHub API rate limit (60 req/hr/IP) used by the contributor and News/Releases fetches.

The dev-badge feature merged on 2026-07-01, so this affects the current release line.

## Change

Compose-only. All four are optional with empty defaults (`${VAR:-}`), so behavior is unchanged when unset (feature stays hidden, exactly like the Discord OAuth vars alongside it). These keys are **already documented** in `.env.example`, so no doc change is needed.

## Test

- `docker compose config` resolves cleanly with the new keys.
- Verified end-to-end in an isolated stack (`postgres` + `game`): recreating the game container with `GITHUB_OAUTH_CLIENT_ID` set confirmed the value now appears inside the container (`docker exec ... env | grep GITHUB_`), where previously it did not. Server boots clean (`database ready`, listening) and `/`, `/api/realms`, `/guide` all return 200.

## Note (out of scope, for a follow-up)

An env-parity audit of this branch found ~24 other server-read vars similarly missing from compose (accumulated over the last ~3 weeks as features landed), some higher severity than these (e.g. the `EMAIL_API_URL`/`EMAIL_API_KEY`/`EMAIL_FROM` trio silently routes transactional mail to the log instead of sending it; `ANTIBOT_ENFORCE` can never be enabled). Those are deliberately left out of this PR to keep it focused on the GitHub feature, and will be handled separately (ideally with a CI check that fails when the server reads an env var compose does not pass through).