### PR TITLE
feat(ui): add focus target frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,16 @@
       </div>
     </div>
 
+    <button id="focus-frame" class="unitframe" type="button" aria-label="" title="">
+      <div class="portrait-wrap">
+        <div class="portrait"><canvas id="ff-portrait" width="42" height="42"></canvas></div>
+        <div class="level-chip" id="ff-level"></div>
+      </div>
+      <div class="uf-bars">
+        <div class="uf-name" id="ff-name"></div>
+        <div class="bar hp"><div class="bar-fill" id="ff-hp"></div><div class="bar-absorb" id="ff-absorb"></div><div class="bar-text" id="ff-hp-text"></div></div>
+      </div>
+    </button>
     <div id="party-frames" role="group" data-i18n-aria="hudChrome.unitFrame.partyLabel" aria-label="Your Band"></div>
 
     <div id="buff-bar"></div>

--- a/play.html
+++ b/play.html
@@ -191,6 +191,16 @@
       </div>
     </div>
 
+    <button id="focus-frame" class="unitframe" type="button" aria-label="" title="">
+      <div class="portrait-wrap">
+        <div class="portrait"><canvas id="ff-portrait" width="42" height="42"></canvas></div>
+        <div class="level-chip" id="ff-level"></div>
+      </div>
+      <div class="uf-bars">
+        <div class="uf-name" id="ff-name"></div>
+        <div class="bar hp"><div class="bar-fill" id="ff-hp"></div><div class="bar-absorb" id="ff-absorb"></div><div class="bar-text" id="ff-hp-text"></div></div>
+      </div>
+    </button>
     <div id="party-frames" role="group" data-i18n-aria="hudChrome.unitFrame.partyLabel" aria-label="Your Band"></div>
 
     <div id="buff-bar"></div>

--- a/server/game.ts
+++ b/server/game.ts
@@ -3033,6 +3033,7 @@ export class GameServer {
       combo: p.comboPoints,
       comboTgt: p.comboTargetId,
       target: p.targetId,
+      focus: p.focusTargetId,
       auto: p.autoAttack,
       queued: p.queuedOnSwing,
       ap: p.attackPower,

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -714,6 +714,7 @@ function blankEntity(id: number): Entity {
     moveSpeed: 7,
     hostile: false,
     targetId: null,
+    focusTargetId: null,
     autoAttack: false,
     swingTimer: 0,
     inCombat: false,
@@ -1393,6 +1394,7 @@ export class ClientWorld implements IWorld {
       e.comboPoints = s.combo ?? 0;
       e.comboTargetId = s.comboTgt ?? null;
       e.targetId = s.target ?? null;
+      e.focusTargetId = s.focus ?? null;
       e.autoAttack = !!s.auto;
       e.swingTimer = s.swing ?? e.swingTimer;
       e.queuedOnSwing = s.queued ?? null;

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -40,6 +40,7 @@ function baseEntity(id: number, pos: Vec3): Entity {
     moveSpeed: 7,
     hostile: false,
     targetId: null,
+    focusTargetId: null,
     autoAttack: false,
     swingTimer: 0,
     inCombat: false,

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -280,6 +280,54 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
     return null;
   }
 
+  // "/focus [name]" pins a second unit that survives ordinary retargeting.
+  // With no name it uses the current target, matching classic focus workflows.
+  const focusMatch = /^\/focus(?:\s+([\s\S]+))?$/i.exec(raw);
+  if (focusMatch) {
+    const nameArg = (focusMatch[1] ?? '').trim();
+    let target: Entity | null = null;
+    if (nameArg) {
+      const wanted = nameArg.toLowerCase();
+      const matches: Entity[] = [];
+      for (const e of ctx.entities.values()) {
+        if (e.dead || e.kind === 'object') continue;
+        if (e.name === nameArg) {
+          target = e;
+          break;
+        }
+        if (e.name.toLowerCase() === wanted) matches.push(e);
+      }
+      if (!target) {
+        if (matches.length === 1) target = matches[0];
+        else if (matches.length > 1) {
+          ctx.error(r.meta.entityId, `Several units match '${nameArg}'. Use exact capitalization.`);
+          return null;
+        }
+      }
+      if (!target) {
+        ctx.error(r.meta.entityId, `There is no unit named '${nameArg}'.`);
+        return null;
+      }
+    } else {
+      target = r.e.targetId !== null ? (ctx.entities.get(r.e.targetId) ?? null) : null;
+      if (!target || target.kind === 'object' || target.dead) {
+        ctx.error(r.meta.entityId, 'Target a unit to focus, or use /focus <name>.');
+        return null;
+      }
+    }
+    r.e.focusTargetId = target.id;
+    ctx.error(r.meta.entityId, `Focus set to ${target.name}.`);
+    return null;
+  }
+
+  if (/^\/clearfocus(?:\s|$)/i.test(raw)) {
+    if (r.e.focusTargetId === null) ctx.error(r.meta.entityId, 'You have no focus target.');
+    else {
+      r.e.focusTargetId = null;
+      ctx.error(r.meta.entityId, 'Focus target cleared.');
+    }
+    return null;
+  }
   // "/follow [name]" trails another player; with no name it follows the
   // current target. Movement, combat, casting, re-targeting, or the leader
   // moving out of range all end it (see updateFollowMovement).
@@ -926,7 +974,7 @@ export function helpLines(): string[] {
   return [
     'Chat channels: /s say, /y yell, /general, /p party, /world, /lfg.',
     'Whisper a player with /w <name> <message>, reply with /r.',
-    'Other commands: /join <world|lfg>, /roll, /inspect <name>, /follow <name>, /unfollow, /assist <name>, /afk, /dnd, /who.',
+    'Other commands: /join <world|lfg>, /roll, /inspect <name>, /follow <name>, /unfollow, /focus, /clearfocus, /assist <name>, /afk, /dnd, /who.',
     'Character readouts: /played, /xp, /gold, /stats, /bags, /gear, /abilities, /buffs, /cooldowns, /quest, /completed.',
     'World readouts: /where, /zones, /nearby, /pois, /graveyard, /dungeons, /arena, /session, /listings, /buyback.',
     'Combat readouts: /target, /targetbuffs, /range, /attack, /casting, /combat, /threat, /consider, /combo, /overpower.',

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1344,6 +1344,7 @@ export interface Entity {
   hostile: boolean;
   // combat
   targetId: number | null;
+  focusTargetId: number | null;
   autoAttack: boolean;
   swingTimer: number;
   inCombat: boolean;

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -428,6 +428,50 @@
     display: none;
     z-index: 6;
   }
+  #focus-frame {
+    left: 250px;
+    top: 12px;
+    display: none;
+    z-index: 6;
+    width: 186px;
+    min-height: 52px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    cursor: var(--cursor-point);
+  }
+  #focus-frame .portrait-wrap {
+    width: 48px;
+    height: 48px;
+  }
+  #focus-frame .portrait {
+    width: 44px;
+    height: 44px;
+  }
+  #focus-frame .level-chip {
+    width: 20px;
+    height: 20px;
+    font-size: 10px;
+  }
+  #focus-frame .uf-bars {
+    width: 140px;
+    min-width: 0;
+    padding: 4px 8px 4px 12px;
+  }
+  #focus-frame .uf-name {
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  #focus-frame .bar {
+    height: 12px;
+  }
+  #focus-frame .bar-text {
+    font-size: 9px;
+  }
   .portrait-wrap {
     position: relative;
     width: 64px;
@@ -3314,6 +3358,9 @@
   }
   #party-frames.below-target {
     top: 96px;
+  }
+  #party-frames.below-focus {
+    top: 154px;
   }
   .party-frame {
     --cls: #7fb8ff;

--- a/src/styles/hud.mobile.css
+++ b/src/styles/hud.mobile.css
@@ -724,6 +724,13 @@
     transform: scale(0.82);
     transform-origin: left top;
   }
+  body.mobile-touch #focus-frame {
+    left: max(8px, env(safe-area-inset-left));
+    top: calc(max(8px, env(safe-area-inset-top)) + 126px);
+    transform: scale(0.82);
+    transform-origin: left top;
+    min-height: 40px;
+  }
   body.mobile-touch #party-frames {
     position: fixed;
     left: max(8px, env(safe-area-inset-left));
@@ -737,6 +744,9 @@
   /* party rows are role="button" tap targets (tap to target a member), so they
      must clear the 40x40 mobile touch floor, not the compact desktop
      raid-frame height. Base and landscape both move 30/25px up to 40px; #party-leave too. */
+  body.mobile-touch #party-frames.below-focus {
+    top: calc(max(8px, env(safe-area-inset-top)) + 176px);
+  }
   body.mobile-touch #party-frames .party-frame {
     width: 132px;
     min-height: 40px;
@@ -1844,6 +1854,9 @@
       top: calc(max(6px, env(safe-area-inset-top)) + 100px);
     }
     /* keep the 40x40 touch floor in landscape too (was 25px). */
+    body.mobile-touch #party-frames.below-focus {
+      top: calc(max(6px, env(safe-area-inset-top)) + 138px);
+    }
     body.mobile-touch #party-frames .party-frame {
       width: 118px;
       min-height: 40px;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -743,12 +743,21 @@ export class Hud {
   // writers, exactly as the player frame drives its own absorb node.
   private targetAbsorbEl = $('#tf-absorb');
   private targetDebuffsEl = $('#tf-debuffs');
+  private focusFrameEl = $('#focus-frame');
+  private focusNameEl = $('#ff-name');
+  private focusLevelEl = $('#ff-level');
+  private focusHpEl = $('#ff-hp');
+  private focusHpTextEl = $('#ff-hp-text');
+  private focusPortraitEl = $('#ff-portrait') as unknown as HTMLCanvasElement;
+  private focusAbsorbEl = $('#ff-absorb');
+  private focusFrameVisible = false;
   // The target whose portrait the family painter's repaint gate redraws this frame.
   // The gate fires synchronously inside the targetFramePainter.paint() call below,
   // so this holds the subject for that one call (the old inline block read `target`
   // from its enclosing scope; the gate now lives in the painter, so the redraw
   // closure reads it from here).
   private targetPortraitSubject: Entity | null = null;
+  private focusPortraitSubject: Entity | null = null;
   private comboRowEl = $('#combo-row');
   private castbarEl = $('#castbar');
   private castbarFillEl = this.castbarEl.querySelector('.fill') as HTMLElement;
@@ -1030,6 +1039,7 @@ export class Hud {
     onPortraitsReady(() => {
       this.drawPlayerFramePortrait();
       this.targetFramePainter.invalidatePortrait();
+      this.focusFramePainter.invalidatePortrait();
     });
     const mm = $('#minimap') as unknown as HTMLCanvasElement;
     this.minimapCtx = require2dContext(mm);
@@ -1125,6 +1135,11 @@ export class Hud {
       this.updateClock();
     });
     this.updateClock();
+    $('#focus-frame').addEventListener('click', () => {
+      const focusId = this.sim.player.focusTargetId;
+      const focus = focusId !== null ? this.sim.entities.get(focusId) : null;
+      if (focus && !focus.dead && focus.kind !== 'object') this.sim.targetEntity(focus.id);
+    });
     // classic MMOs: the player interaction menu opens from the target portrait
     $('#target-frame').addEventListener('contextmenu', (ev) => {
       ev.preventDefault();
@@ -2487,6 +2502,21 @@ export class Hud {
       repaintPortrait: () => this.drawTargetPortrait(),
     },
   );
+  private readonly focusFramePainter = new UnitFramePainter(
+    this.writerFacet,
+    {
+      frame: this.focusFrameEl,
+      name: this.focusNameEl,
+      level: this.focusLevelEl,
+      hpFill: this.focusHpEl,
+      hpText: this.focusHpTextEl,
+      absorb: this.focusAbsorbEl,
+    },
+    {
+      shownDisplay: 'flex',
+      repaintPortrait: () => this.drawFocusPortrait(),
+    },
+  );
   // The party frames are N further instances of the unit_frame family, one per
   // member, behind a keyed node pool that replaces the old per-rebuild innerHTML wipe
   // + click/contextmenu re-attach. The pool owns #party-frames; updatePartyFrames
@@ -2873,6 +2903,22 @@ export class Hud {
     }
   }
 
+  private drawFocusPortrait(): void {
+    const focus = this.focusPortraitSubject;
+    if (!focus) return;
+    if (focus.kind === 'player') {
+      this.portraits.drawClass(
+        this.focusPortraitEl,
+        focus.templateId as PlayerClass,
+        focus.skin ?? 0,
+      );
+    } else {
+      this.portraits.drawCrest(
+        this.focusPortraitEl,
+        crestIdForEntity(focus.kind, MOBS[focus.templateId]?.family),
+      );
+    }
+  }
   private itemIcon(item: ItemDef): string {
     const q = item.quality ?? 'common';
     return `<img class="item-icon q-${q}" src="${iconDataUrl('item', item.id)}" alt="" draggable="false">`;
@@ -4557,6 +4603,8 @@ export class Hud {
       }
       this.targetFramePainter.paint(unitFrameView(ABSENT_TARGET_DESCRIPTOR));
     }
+
+    this.updateFocusFrame(p);
 
     // cast bar: the player instance localizes the cast id (castDisplayName), layers
     // the player-only eat/drink overlay (consumeBarState), and clears on hide.
@@ -9840,10 +9888,41 @@ export class Hud {
   // Party frames
   // -------------------------------------------------------------------------
 
+  private updateFocusFrame(p: Entity): void {
+    const focus = p.focusTargetId !== null ? this.sim.entities.get(p.focusTargetId) : null;
+    this.focusFrameVisible = !!focus && !focus.dead && focus.kind !== 'object';
+    if (!this.focusFrameVisible || !focus) {
+      this.focusFramePainter.paint(unitFrameView(ABSENT_TARGET_DESCRIPTOR));
+      this.writerFacet.setAttr(this.focusFrameEl, 'aria-label', '');
+      this.writerFacet.setAttr(this.focusFrameEl, 'title', '');
+      return;
+    }
+    const name = entityDisplayName(focus);
+    this.focusPortraitSubject = focus;
+    this.writerFacet.setAttr(this.focusFrameEl, 'aria-label', name);
+    this.writerFacet.setAttr(this.focusFrameEl, 'title', name);
+    this.focusFramePainter.paint(
+      unitFrameView({
+        present: true,
+        hpFrac: focus.hp / Math.max(1, focus.maxHp),
+        hpText: `${focus.hp} / ${focus.maxHp}`,
+        resourceKind: 'none',
+        resFrac: 0,
+        resText: '',
+        levelText: MOBS[focus.templateId]?.boss ? '??' : String(focus.level),
+        name,
+        portraitKey: `${focus.kind}:${focus.templateId}:${focus.id}:${focus.skin ?? 0}`,
+        absorb: focus,
+        dead: false,
+        outOfRange: false,
+      }),
+    );
+  }
   private updatePartyFrames(): void {
     const target =
       this.sim.player.targetId !== null ? this.sim.entities.get(this.sim.player.targetId) : null;
     this.partyFramesPainter.setBelowTarget(!!target && target.kind !== 'object');
+    this.partyFramesPainter.setBelowFocus(this.focusFrameVisible);
     const info = this.sim.partyInfo;
     if (!info) {
       // Clear only on the transition out of a party (matching the inline `innerHTML

--- a/src/ui/party_frames_painter.ts
+++ b/src/ui/party_frames_painter.ts
@@ -38,6 +38,7 @@ const CLASS_COLOR_PROP = '--cls';
 const COMBAT_CLASS = 'combat';
 // The container class that drops the frames below the target frame.
 const BELOW_TARGET_CLASS = 'below-target';
+const BELOW_FOCUS_CLASS = 'below-focus';
 // Badge visibility: '' reverts to the stylesheet display (shown), 'none' hides. The
 // badges persist in the DOM and only their display toggles, so the icon cue survives
 // forced-colors (where the combat box-shadow is dropped).
@@ -90,6 +91,10 @@ export class PartyFramesPainter {
    *  matching the inline `el.classList.toggle('below-target', ...)`. */
   setBelowTarget(on: boolean): void {
     this.writers.toggleClass(this.container, BELOW_TARGET_CLASS, on);
+  }
+
+  setBelowFocus(on: boolean): void {
+    this.writers.toggleClass(this.container, BELOW_FOCUS_CLASS, on);
   }
 
   /** Set (or clear with null) the leader-only master-loot control. The Hud rebuilds

--- a/src/ui/sim_i18n.ts
+++ b/src/ui/sim_i18n.ts
@@ -4091,6 +4091,23 @@ const RULES: Rule[] = [
     re: /^Your (.+) has improved to Rank (\d+)\.$/,
     build: (m) => tSim('log.abilityRankUp', { name: locAbility(m[1]), rank: m[2] }),
   },
+  // /focus family. Names are user-entered or entity display names; preserve unknown
+  // player text verbatim while localizing known mob names in the success readout.
+  {
+    re: /^Several units match '(.+)'\. Use exact capitalization\.$/,
+    build: (m) => `Several units match '${m[1]}'. Use exact capitalization.`,
+  },
+  {
+    re: /^There is no unit named '(.+)'\.$/,
+    build: (m) => `There is no unit named '${m[1]}'.`,
+  },
+  {
+    re: /^Target a unit to focus, or use \/focus <name>\.$/,
+    build: () => 'Target a unit to focus, or use /focus <name>.',
+  },
+  { re: /^Focus set to (.+)\.$/, build: (m) => `Focus set to ${locMob(m[1])}.` },
+  { re: /^You have no focus target\.$/, build: () => 'You have no focus target.' },
+  { re: /^Focus target cleared\.$/, build: () => 'Focus target cleared.' },
   // /follow family. {name} is another player (a mob name only if it happens to collide).
   {
     re: /^(.+) is too far away to follow\.$/,

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -330,6 +330,16 @@ describe('client HTML shell', () => {
     }
   });
 
+  it('ships a focus frame in BOTH entries and wires it through the HUD painter', () => {
+    for (const entry of [html, playHtml]) {
+      expect(entry).toContain('id="focus-frame" class="unitframe" type="button"');
+      expect(entry).toContain('id="ff-portrait"');
+      expect(entry).toContain('id="ff-hp-text"');
+    }
+    expect(hudTs).toContain("private focusFrameEl = $('#focus-frame');");
+    expect(hudTs).toContain('private readonly focusFramePainter = new UnitFramePainter(');
+    expect(hudTs).toContain("$('#focus-frame').addEventListener('click'");
+  });
   it('labels the party-frames region as a role=group with a localized name in BOTH entries', () => {
     // Each party member is a focusable role="button" named by its visible
     // member text, and labels the #party-frames container as a role="group" via

--- a/tests/focus_target.test.ts
+++ b/tests/focus_target.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { Sim } from '../src/sim/sim';
+import type { Entity, SimEvent } from '../src/sim/types';
+
+function makeWorld() {
+  return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
+}
+
+function liveMob(sim: Sim): Entity {
+  const mob = [...sim.entities.values()].find(
+    (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null,
+  );
+  if (!mob) throw new Error('test needs a live wild mob');
+  return mob;
+}
+
+function errors(events: SimEvent[]): string[] {
+  return events
+    .filter((e): e is Extract<SimEvent, { type: 'error' }> => e.type === 'error')
+    .map((e) => e.text);
+}
+
+describe('/focus command', () => {
+  it('pins the current target as focus and keeps it through normal retargeting', () => {
+    const sim = makeWorld();
+    const playerId = sim.addPlayer('warrior', 'Aleph');
+    const first = liveMob(sim);
+    first.name = 'Focus Wolf';
+    const second = [...sim.entities.values()].find(
+      (e) => e.kind === 'mob' && !e.dead && e.hostile && e.ownerId === null && e.id !== first.id,
+    );
+    if (!second) throw new Error('test needs a second live wild mob');
+
+    sim.targetEntity(first.id, playerId);
+    sim.chat('/focus', playerId);
+    expect(errors(sim.tick())).toContain('Focus set to Focus Wolf.');
+    expect(sim.entities.get(playerId)?.focusTargetId).toBe(first.id);
+
+    sim.targetEntity(second.id, playerId);
+    expect(sim.entities.get(playerId)?.targetId).toBe(second.id);
+    expect(sim.entities.get(playerId)?.focusTargetId).toBe(first.id);
+  });
+
+  it('sets focus by unambiguous unit name and clears it without sending chat', () => {
+    const sim = makeWorld();
+    const playerId = sim.addPlayer('warrior', 'Aleph');
+    const focus = liveMob(sim);
+    focus.name = 'Moonfang';
+
+    sim.chat('/focus moonfang', playerId);
+    let events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    expect(errors(events)).toContain('Focus set to Moonfang.');
+    expect(sim.entities.get(playerId)?.focusTargetId).toBe(focus.id);
+
+    sim.chat('/clearfocus', playerId);
+    events = sim.tick();
+    expect(events.some((e) => e.type === 'chat')).toBe(false);
+    expect(errors(events)).toContain('Focus target cleared.');
+    expect(sim.entities.get(playerId)?.focusTargetId).toBeNull();
+  });
+});

--- a/tests/parity/golden/chat_social.json
+++ b/tests/parity/golden/chat_social.json
@@ -688,7 +688,7 @@
       "time": 0,
       "nextId": 392,
       "state": "d4d9cb7c",
-      "events": "f778074e",
+      "events": "f9f3f587",
       "rng": {
         "draws": 0,
         "digest": "811c9dc5"


### PR DESCRIPTION
## Summary

Adds a focused unit target flow for the HUD:

- `/focus` pins the current live unit target, and `/focus <name>` resolves an exact or unambiguous unit name.
- `/clearfocus` clears the pinned unit.
- The focused unit is synced in online self snapshots as `focus`, rendered as a compact second unit frame, and can be clicked to retarget that unit.
- Party frames shift down when both target/focus frames are visible, including the mobile-touch layout.
- Focus command sim text is registered at the client localization boundary, and the chat-social parity golden is updated for the `/help` command list change.

## Related issues

Part of #930.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src/sim/types.ts src/sim/entity.ts src/net/online.ts server/game.ts src/sim/social/chat.ts src/ui/hud.ts src/ui/party_frames_painter.ts src/ui/sim_i18n.ts src/styles/hud.css src/styles/hud.mobile.css index.html play.html tests/focus_target.test.ts tests/client_shell.test.ts tests/parity/golden/chat_social.json` - passed.
  - `npx biome lint src/sim/types.ts src/sim/entity.ts src/net/online.ts server/game.ts src/sim/social/chat.ts src/ui/hud.ts src/ui/party_frames_painter.ts src/ui/sim_i18n.ts src/styles/hud.css src/styles/hud.mobile.css index.html play.html tests/focus_target.test.ts tests/client_shell.test.ts` - exit-clean; existing warnings remain in `src/net/online.ts` and unrelated `src/ui/hud.ts` lines.
  - `npm run check:ts` - passed.
  - Wrapped `.browserslistrc` focused Vitest: `npx vitest run tests/focus_target.test.ts tests/target_command.test.ts tests/social.test.ts tests/client_shell.test.ts tests/unit_frame.test.ts tests/unit_frame_painter.test.ts tests/party_frames_painter.test.ts` - 7 files, 163 tests passed.
  - Wrapped `.browserslistrc`: `npx vitest run tests/snapshots.test.ts tests/command_schema.test.ts tests/entry_window_parity.test.ts` - 3 files, 88 tests passed.
  - Wrapped `.browserslistrc`: `npx vitest run tests/localization_fixes.test.ts` - 27 passed, 3 skipped.
  - Wrapped `.browserslistrc`: `npx vitest run tests/parity/parity.test.ts -t chat_social` - 2 passed, 92 skipped.
  - Final wrapped `.browserslistrc` targeted pass: 11 passed files, 1 skipped file; 141 passed, 234 skipped.
  - Wrapped `.browserslistrc`: `npm run build` - passed with existing Vite dynamic-import/chunk-size/plugin timing warnings.
  - Wrapped `.browserslistrc`: `npm test` - not fully green on current release branch: 13 failed files, 15 failed tests, 11 skipped. Remaining failures are outside this focus change: `tests/version_sync.test.ts` syntax error, architecture IWorld import guard, i18n ad-hoc Intl guard, i18n determinism/status timeouts, options_window source-text assertion, and several timeout-prone suites (`fiesta`, `fixes`, `loot_master_sim`, `pvp_safety`, `security`, `threat`). The focus localization/parity failures found in an earlier full run were fixed and rechecked with the targeted commands above.
- Manual steps:
  - Started Vite locally with the same temporary `.browserslistrc` cleaning wrapper used for build/tests.
  - Booted an offline character in Chromium via Puppeteer, targeted a nearby mob, ran `/focus`, and verified the focus frame became visible with label `Forest Wolf`, HP text, and `aria-label="Forest Wolf"`.
  - Captured desktop screenshots. A phone-sized screenshot harness hit the app's mobile/orientation boot path before `window.__game` became available; mobile positioning is covered by the source/CSS assertions in `tests/client_shell.test.ts`.

## Screenshots / recordings

Desktop crop:

![Focus frame desktop crop](https://raw.githubusercontent.com/Humpalumps/world-of-claudecraft/codex/pr-assets/pr-assets/focus-target-frame/focus-frame-crop.png)

Desktop full HUD:

![Focus frame desktop full HUD](https://raw.githubusercontent.com/Humpalumps/world-of-claudecraft/codex/pr-assets/pr-assets/focus-target-frame/focus-frame-full.png)

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a phone-sized viewport in both portrait and landscape. Touch targets stay at least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [x] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.** Every user-facing string is a `t()` key, added to `en` first, then given a real translation in every locale in `supportedLanguages` (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [x] Numbers, money, dates, units, and percents go through the i18n formatters (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [x] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.