### PR TITLE
feat(social): add public guild directory API

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -1018,6 +1018,15 @@ async function handleApi(req: http.IncomingMessage, res: http.ServerResponse): P
       const results = q.trim().length >= 1 ? await searchCharacters(q, 8) : [];
       return json(res, 200, { results });
     }
+    if (req.method === 'GET' && url === '/api/guilds') {
+      if (publicReadRateLimited(req)) return json(res, 429, { error: 'rate limited' });
+      const params = new URLSearchParams((req.url ?? '').split('?')[1] ?? '');
+      const limit = Number(params.get('limit') ?? 50);
+      return json(res, 200, {
+        realm: REALM,
+        guilds: await game.social.guildDirectory(limit),
+      });
+    }
     if (req.method === 'POST' && url === '/api/reports') {
       const accountId = await bearerActiveAccount(req, res);
       if (accountId === null) return;

--- a/server/social.ts
+++ b/server/social.ts
@@ -58,6 +58,14 @@ export interface GuildView {
   members: GuildMemberEntry[];
 }
 
+export interface GuildDirectoryEntry {
+  id: number;
+  name: string;
+  realm: string;
+  memberCount: number;
+  leader: CharInfo | null;
+}
+
 export interface SocialSnapshot {
   friends: FriendEntry[];
   blocks: CharRef[];
@@ -90,6 +98,7 @@ export interface SocialDb {
   removeGuildMember(charId: number): Promise<void>;
   setGuildRank(charId: number, rank: GuildRank): Promise<void>;
   guildMembers(guildId: number): Promise<(CharInfo & { rank: GuildRank })[]>;
+  listGuildDirectory(limit: number): Promise<GuildDirectoryEntry[]>;
 }
 
 export interface SocialActor {
@@ -188,6 +197,12 @@ export class SocialService {
 
   private push(charId: number): void {
     this.tx.pushSnapshot(charId);
+  }
+
+  async guildDirectory(limit = 50): Promise<GuildDirectoryEntry[]> {
+    const fallbackLimit = 50;
+    const n = Number.isFinite(limit) ? Math.trunc(limit) : fallbackLimit;
+    return this.db.listGuildDirectory(Math.max(1, Math.min(100, n || fallbackLimit)));
   }
 
   private err(charId: number, text: string): void {

--- a/server/social_db.ts
+++ b/server/social_db.ts
@@ -4,7 +4,7 @@
 // stored now so cross-realm friends/guilds need no migration later).
 
 import type { Pool } from 'pg';
-import type { CharInfo, CharRef, GuildRank, SocialDb } from './social';
+import type { CharInfo, CharRef, GuildDirectoryEntry, GuildRank, SocialDb } from './social';
 import { REALM } from './realm';
 
 // kept as an alias for the schema's column default; the live realm is REALM
@@ -269,5 +269,42 @@ export class PgSocialDb implements SocialDb {
       [guildId],
     );
     return res.rows;
+  }
+  async listGuildDirectory(limit: number): Promise<GuildDirectoryEntry[]> {
+    const res = await this.pool.query(
+      `SELECT g.id,
+              g.name,
+              g.realm,
+              count(gm.character_id)::int AS member_count,
+              lc.id AS leader_id,
+              lc.name AS leader_name,
+              lc.class AS leader_cls,
+              lc.level AS leader_level,
+              lc.realm AS leader_realm
+         FROM guilds g
+         LEFT JOIN guild_members gm ON gm.guild_id = g.id
+         LEFT JOIN guild_members lgm ON lgm.guild_id = g.id AND lgm.rank = 'leader'
+         LEFT JOIN characters lc ON lc.id = lgm.character_id
+        WHERE g.realm = $1
+        GROUP BY g.id, g.name, g.realm, lc.id, lc.name, lc.class, lc.level, lc.realm
+        ORDER BY count(gm.character_id) DESC, lower(g.name), g.id
+        LIMIT $2`,
+      [REALM, limit],
+    );
+    return res.rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      realm: row.realm,
+      memberCount: row.member_count,
+      leader: row.leader_id === null
+        ? null
+        : {
+            id: row.leader_id,
+            name: row.leader_name,
+            cls: row.leader_cls,
+            level: row.leader_level,
+            realm: row.leader_realm,
+          },
+    }));
   }
 }

--- a/tests/social_system.test.ts
+++ b/tests/social_system.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import {
   SocialService, validateGuildName,
   type CharInfo, type CharRef, type GuildRank, type Presence,
+  type GuildDirectoryEntry,
   type SocialDb, type SocialEvent, type SocialTransport,
 } from '../server/social';
 import { resolveRealm } from '../server/realm';
@@ -78,6 +79,23 @@ class FakeDb implements SocialDb {
     return [...this.members.entries()]
       .filter(([, m]) => m.guildId === guildId)
       .map(([cid, m]) => ({ ...this.chars.get(cid)!, rank: m.rank }));
+  }
+  async listGuildDirectory(limit: number): Promise<GuildDirectoryEntry[]> {
+    return [...this.guilds.entries()]
+      .map(([id, name]) => {
+        const members = [...this.members.entries()].filter(([, m]) => m.guildId === id);
+        const leaderId = members.find(([, m]) => m.rank === 'leader')?.[0];
+        const leader = leaderId === undefined ? null : this.chars.get(leaderId) ?? null;
+        return {
+          id,
+          name,
+          realm: 'Claudemoon',
+          memberCount: members.length,
+          leader,
+        };
+      })
+      .sort((a, b) => b.memberCount - a.memberCount || a.name.localeCompare(b.name) || a.id - b.id)
+      .slice(0, limit);
   }
   guildCount(): number { return this.guilds.size; } // test helper: detect orphaned guilds
 }
@@ -300,6 +318,25 @@ describe('guilds', () => {
     expect(snap.guild?.name).toBe('Iron Vanguard');
     expect(snap.guild?.rank).toBe('leader');
     expect(snap.guild?.members.map((m) => m.name)).toEqual(['Aleph']);
+  });
+
+  it('lists public guild directory entries by size with leader metadata (#110)', async () => {
+    await h.svc.guildCreate(h.actor(1), 'Iron Vanguard');
+    await h.svc.guildCreate(h.actor(3), 'Azure Wardens');
+    await h.svc.guildInvite(h.actor(1), 'Bet');
+    await h.svc.guildAccept(h.actor(2));
+
+    const entries = await h.svc.guildDirectory(1);
+
+    expect(entries).toEqual([
+      {
+        id: 1,
+        name: 'Iron Vanguard',
+        realm: 'Claudemoon',
+        memberCount: 2,
+        leader: { id: 1, name: 'Aleph', cls: 'warrior', level: 10, realm: 'Claudemoon' },
+      },
+    ]);
   });
 
   it('refreshes guildmates\' panels when a member comes online, even non-friends (#100)', async () => {


### PR DESCRIPTION
## Summary

Adds a read-only public guild directory API as a backend foundation for guild discovery in #110.

- Adds `SocialService.guildDirectory()` and `SocialDb.listGuildDirectory()` with a 1-100 result limit clamp.
- Implements the Postgres query for realm-scoped guild listings ordered by member count, then guild name.
- Exposes `GET /api/guilds` with the existing public-read rate limiter.
- Returns each guild's id, name, realm, member count, and Guild Master metadata; request-to-join/recruitment management remains a follow-up slice.

## Related issues

Part of #110.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome lint server/social.ts server/social_db.ts server/main.ts tests/social_system.test.ts` passed (exit 0; existing warnings remain in `server/main.ts` and `tests/social_system.test.ts`).
  - `npm run check:ts` passed.
  - Wrapped `.browserslistrc` around `npx vitest run tests/social_system.test.ts tests/social_frames.test.ts tests/social_view.test.ts tests/social_window.test.ts tests/guild_leaderboard_view.test.ts`: passed, 5 files / 85 tests.
  - `npm run build:server` passed after rerunning outside the sandbox; the first sandboxed attempt hit esbuild `Access is denied` resolving `server/main.ts`.
  - Wrapped `.browserslistrc` around `npm run build`: passed with existing Vite chunk/dynamic-import warnings.
  - Wrapped `.browserslistrc` around `npm test`: completed with existing release-branch failures, 14 failed files / 18 failed tests / 11 skipped. Failures observed in `tests/version_sync.test.ts`, `tests/architecture.test.ts`, `tests/i18n_extra_tables.test.ts`, `tests/options_window.test.ts`, timeout-prone sim/security/account/parity suites, and deterministic parity/fiesta cases; none were in the new guild directory regression.
- Manual steps: N/A, API/service-only change.

## Screenshots / recordings

N/A. Server/API-only change; no UI/UX surface added in this slice.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and `npm run build:env` if I touched those.

Focused tests pass; full `npm test` is not green on the current release branch due the unrelated blockers listed above.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a phone-sized viewport in both portrait and landscape. Touch targets stay at least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and respect for `prefers-reduced-motion` (only if this change adds or edits UI).

N/A: no UI added.

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.** Every user-facing string is a `t()` key, added to `en` first, then given a real translation in every locale in `supportedLanguages` (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
