### PR TITLE
fix(ui): heal tooltips scale by Spell Power; fix Lightning Shield {school} placeholder

### DIFF
--- a/src/ui/ability_damage.ts
+++ b/src/ui/ability_damage.ts
@@ -11,8 +11,10 @@ import type { ResolvedAbility } from '../sim/sim';
 import {
   abilityScalingPower,
   channelTickBonus,
+  directHealBonus,
   directHitBonus,
   dotTickBonus,
+  hotTickBonus,
 } from '../sim/spell_scaling';
 import type { AbilityEffect } from '../sim/types';
 
@@ -23,8 +25,9 @@ export interface AbilityScaling {
   attackPower: number;
 }
 
-/** Flat bonus this character adds to ONE displayed hit of `eff` (or, for a DoT, to
- *  its whole `total`), matching combat. 0 when the effect does not scale. */
+/** Flat bonus this character adds to ONE displayed hit of `eff` (or, for a DoT/HoT,
+ *  to its whole `total`), matching combat. Covers damage AND healing (direct heals
+ *  and HoTs scale off Spell Power). 0 when the effect does not scale. */
 export function abilityDamageBonus(
   res: ResolvedAbility,
   eff: AbilityEffect,
@@ -66,6 +69,22 @@ export function abilityDamageBonus(
       // tick, so the total gains per-tick-bonus * tick-count.
       const ticks = eff.interval > 0 ? Math.max(1, eff.duration / eff.interval) : 1;
       return dotTickBonus(power, def, eff.duration, eff.interval) * ticks;
+    }
+    case 'heal':
+      // Heals scale with Spell Power at the direct cast-time coefficient (the
+      // healing mirror of directHitBonus), never the school-dependent `power`.
+      // Match effect_dispatch.ts 'heal'.
+      return directHealBonus(scaling.spellPower, res.castTime);
+    case 'hot': {
+      // A HoT that RIDES a direct heal (Regrowth) does NOT scale its rider: the
+      // direct heal already took the coefficient, so scaling the rider too would
+      // double-dip. Only pure HoTs (Rejuvenation) take it. Match effect_dispatch.ts.
+      const hybridHeal = res.effects.some((e) => e.type === 'heal');
+      if (hybridHeal) return 0;
+      // The tooltip shows the HoT's TOTAL; the sim adds the per-tick bonus to each
+      // tick, so the total gains per-tick-bonus * tick-count.
+      const ticks = eff.interval > 0 ? Math.max(1, eff.duration / eff.interval) : 1;
+      return hotTickBonus(scaling.spellPower, eff.duration, eff.interval) * ticks;
     }
     default:
       return 0;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -2909,7 +2909,7 @@ export class Hud {
   // One-line aura effect summary HTML for the buff/debuff tooltip: the pure descriptor
   // (aura_effect.ts) resolved to localized, esc'd text. Empty when the aura has no
   // descriptor. Injected into the auras view so the i18n-free core never calls t().
-  private auraEffectTooltipHtml(a: AuraEffectInput): string {
+  private auraEffectTooltipHtml(a: AuraEffectInput & { id?: string }): string {
     const effect = auraEffectDescriptor(a);
     if (!effect) return '';
     const values: Record<string, string> = {};
@@ -2918,8 +2918,15 @@ export class Hud {
         values[k] = formatNumber(n, { maximumFractionDigits: 0 });
       }
     }
-    if (effect.school) {
-      values.school = t(`hudChrome.auraEffect.school.${effect.school}` as TranslationKey);
+    // Resolve the {school} placeholder in the dot/absorb/thorns summaries. Prefer
+    // the SOURCE ability's school: it is authoritative and always present
+    // client-side, unlike the aura's own school, which the ability-tooltip call
+    // site omits (only kind+value) and the online wire mirror drops. Without this
+    // a magic reflect like Lightning Shield read a raw "{school}" (ability tooltip)
+    // or the wrong "Physical" (online buff frame) instead of its real school.
+    const school = (a.id ? ABILITIES[a.id]?.school : undefined) ?? effect.school;
+    if (school) {
+      values.school = t(`hudChrome.auraEffect.school.${school}` as TranslationKey);
     }
     return `<div class="tt-effect">${esc(t(effect.key as TranslationKey, values))}</div>`;
   }
@@ -3283,7 +3290,9 @@ export class Hud {
     // Aspect of the Hawk / Fortitude via buffPct) - which the static description can't.
     for (const eff of res.effects) {
       if (eff.type === 'selfBuff' || eff.type === 'buffTarget') {
-        html += this.auraEffectTooltipHtml({ kind: eff.kind, value: eff.value });
+        // Pass the ability id so the effect line can resolve its damage school
+        // (the {school} placeholder in the thorns/dot/absorb summaries).
+        html += this.auraEffectTooltipHtml({ kind: eff.kind, value: eff.value, id: a.id });
       }
     }
     const requirements = abilityRequirementLines(a);
@@ -11076,11 +11085,12 @@ function abilityRequirementLines(def: AbilityDef): string[] {
   return lines;
 }
 
-// Builds the `$d` damage string for an ability tooltip. When `scaling` (the live
-// character's Spell Power / Ranged AP / Attack Power) is given, the BASE damage is
-// shown with the scaling contribution called out as a "(+N)" suffix, e.g.
-// "66 to 74 (+29)", so a caster sees both the base and exactly what their Spell
-// Power adds, and watches it climb as gear changes.
+// Builds the `$d` amount string for an ability tooltip (damage OR healing). When
+// `scaling` (the live character's Spell Power / Ranged AP / Attack Power) is given,
+// the BASE amount is shown with the scaling contribution called out as a "(+N)"
+// suffix, e.g. "66 to 74 (+29)", so a caster or healer sees both the base and
+// exactly what their Spell Power adds, and watches it climb as gear changes.
+// Heals (direct and HoT) scale off Spell Power via abilityDamageBonus.
 function abilityEffectText(res: ResolvedAbility, scaling?: AbilityScaling): string {
   const effects = res.effects;
   // " (+N)" callout for the scaling contribution (Spell Power / Attack Power),
@@ -11132,7 +11142,7 @@ function abilityEffectText(res: ResolvedAbility, scaling?: AbilityScaling): stri
     case 'dot':
       return formatAbilityNumber(secondary.total) + suffix(secondary);
     case 'hot':
-      return formatAbilityNumber(secondary.total);
+      return formatAbilityNumber(secondary.total) + suffix(secondary);
     case 'absorb':
       return formatAbilityNumber(secondary.amount);
     case 'imbue':

--- a/tests/ability_damage.test.ts
+++ b/tests/ability_damage.test.ts
@@ -3,8 +3,10 @@ import { abilitiesKnownAt } from '../src/sim/content/classes';
 import {
   abilityScalingPower,
   channelTickBonus,
+  directHealBonus,
   directHitBonus,
   dotTickBonus,
+  hotTickBonus,
 } from '../src/sim/spell_scaling';
 import { MAX_LEVEL } from '../src/sim/types';
 import { type AbilityScaling, abilityDamageBonus } from '../src/ui/ability_damage';
@@ -78,11 +80,32 @@ describe('abilityDamageBonus (tooltip scaling mirrors combat)', () => {
     expect(abilityDamageBonus(ev, eff, SC)).toBe(Math.round(SC.attackPower / 14));
   });
 
-  it('returns 0 for a heal (heals do not scale in this PR)', () => {
-    const heal = abilitiesKnownAt('priest', MAX_LEVEL).find((k) =>
-      k.effects.some((e) => e.type === 'heal'),
-    )!;
-    const eff = heal.effects.find((e) => e.type === 'heal')!;
-    expect(abilityDamageBonus(heal, eff, SC)).toBe(0);
+  it('a direct heal folds Spell Power at the direct cast-time coefficient', () => {
+    const fh = known('priest', 'flash_heal');
+    const eff = fh.effects.find((e) => e.type === 'heal')!;
+    expect(abilityDamageBonus(fh, eff, SC)).toBe(directHealBonus(SC.spellPower, fh.castTime));
+    expect(abilityDamageBonus(fh, eff, SC)).toBeGreaterThan(0);
+  });
+
+  it('a pure HoT (Rejuvenation) folds Spell Power across all its ticks (the total)', () => {
+    const rej = known('druid', 'rejuvenation');
+    const eff = rej.effects.find((e) => e.type === 'hot')!;
+    if (eff.type !== 'hot') throw new Error('expected hot');
+    const ticks = eff.duration / eff.interval;
+    expect(abilityDamageBonus(rej, eff, SC)).toBe(
+      hotTickBonus(SC.spellPower, eff.duration, eff.interval) * ticks,
+    );
+    expect(abilityDamageBonus(rej, eff, SC)).toBeGreaterThan(0);
+  });
+
+  it('a HoT that rides a direct heal (Regrowth) does not double-scale its rider', () => {
+    const rg = known('druid', 'regrowth');
+    const hot = rg.effects.find((e) => e.type === 'hot')!;
+    // The direct-heal component already took the cast-time coefficient, so the HoT
+    // rider adds no further Spell Power (matches effect_dispatch.ts hybridHeal).
+    expect(abilityDamageBonus(rg, hot, SC)).toBe(0);
+    // ...but the direct-heal component itself still scales.
+    const heal = rg.effects.find((e) => e.type === 'heal')!;
+    expect(abilityDamageBonus(rg, heal, SC)).toBe(directHealBonus(SC.spellPower, rg.castTime));
   });
 });


### PR DESCRIPTION
Two small ability-tooltip accuracy fixes.

## 1. Heal tooltips show their Spell Power contribution `(+N)`
Direct heals and HoTs scale off Spell Power in combat, but their tooltips never showed the `(+N)` contribution that damage abilities do. `abilityDamageBonus` had no `heal`/`hot` case (returned `0`), and `abilityEffectText`'s `hot` branch skipped the suffix entirely (unlike the parallel `dot` branch).

This is the heal half of #1039 (talent tooltip accuracy), which merged with damage scaling only. Added `heal` + `hot` cases mirroring `effect_dispatch.ts` exactly:
- direct heal: `directHealBonus(spellPower, castTime)`
- pure HoT: `hotTickBonus(spellPower, duration, interval) x ticks` for the displayed total
- `0` for a HoT that rides a direct heal (Regrowth), matching the sim's `hybridHeal` double-dip guard

## 2. Lightning Shield reflect line: raw `{school}` placeholder
The reflect line read **"Deals 29 {school} damage to attackers"** (see screenshot in the issue). The ability tooltip appends the aura effect summary passing only `{kind, value}`, so `auraEffectTooltipHtml` had no school to splice into `{school}`.

`auraEffectTooltipHtml` now resolves the school from the **source ability** (authoritative and always present client-side), and the call site passes the ability id. Same fix also corrects the **online buff-frame tooltip**, where the wire mirror drops an aura's school and the reflect read "Physical" instead of "Nature".

## Notes
- Both reuse existing i18n keys (`hudChrome.abilityScaling.bonus`, `hudChrome.auraEffect.school.*`), so no new strings.
- Tests: `ability_damage.test.ts` now covers heal / pure-HoT / hybrid-HoT scaling (replacing the stale "heals do not scale in this PR" test). tsc + biome + architecture green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)