### PR TITLE
feat(bot): add Discord bug intake classifier

### DIFF
--- a/bot/intake.ts
+++ b/bot/intake.ts
@@ -1,0 +1,169 @@
+// Pure bug-intake helpers for the Discord bot. V1 keeps message capture and
+// Trello/GitHub writes out of this layer; it only decides whether a single
+// Discord message is worth promoting into short-lived bug intake.
+
+export interface IntakeAttachment {
+  id: string;
+  filename?: string | null;
+  contentType?: string | null;
+  url?: string | null;
+}
+
+export interface IntakeMessage {
+  id: string;
+  channelId: string;
+  authorId: string;
+  authorIsBot?: boolean;
+  webhookId?: string | null;
+  content: string;
+  attachments?: readonly IntakeAttachment[];
+}
+
+export interface IntakeOptions {
+  monitoredChannelIds: ReadonlySet<string>;
+  minCandidateWords?: number;
+}
+
+export type BugIntakeDecision =
+  | {
+      action: 'ignore';
+      reason:
+        | 'bot'
+        | 'webhook'
+        | 'unmonitored-channel'
+        | 'empty'
+        | 'feature-request'
+        | 'low-confidence';
+    }
+  | {
+      action: 'candidate';
+      confidence: 'medium' | 'high';
+      summary: string;
+      evidence: {
+        attachments: number;
+        hasImage: boolean;
+        hasVideo: boolean;
+        hasReproLanguage: boolean;
+        hasErrorLanguage: boolean;
+      };
+      needsMoreInfo: boolean;
+    };
+
+const BUG_PATTERNS: readonly RegExp[] = [
+  /\bbug(?:ged)?\b/i,
+  /\bcrash(?:ed|es|ing)?\b/i,
+  /\berror(?:s)?\b/i,
+  /\bexception\b/i,
+  /\bstuck\b/i,
+  /\bfrozen?\b/i,
+  /\bdisconnect(?:ed|s|ing)?\b/i,
+  /\bdesync(?:ed)?\b/i,
+  /\bexploit\b/i,
+  /\bglitch(?:ed|es|ing)?\b/i,
+  /\bbroken\b/i,
+  /\bnot working\b/i,
+  /\bdoes(?:n'| no)t work\b/i,
+  /\bcan(?:'|no)t\b/i,
+  /\bwrong\b/i,
+  /\bmissing\b/i,
+  /\bclipp(?:ed|ing)\b/i,
+  /\bduplicate(?:d)?\b/i,
+  /\bfail(?:ed|s|ing)?\b/i,
+];
+
+const REPRO_PATTERNS: readonly RegExp[] = [
+  /\bsteps?\b/i,
+  /\brepro(?:duce|duction|s)?\b/i,
+  /\bwhen i\b/i,
+  /\bafter i\b/i,
+  /\bevery time\b/i,
+  /\bonce i\b/i,
+  /\bwhile (?:i|we)\b/i,
+];
+
+const FEATURE_PATTERNS: readonly RegExp[] = [
+  /\bfeature request\b/i,
+  /\bsuggestion\b/i,
+  /\bidea\b/i,
+  /\bwould be (?:cool|nice|great)\b/i,
+  /\bplease add\b/i,
+  /\bcould you add\b/i,
+  /\bcan you add\b/i,
+  /\bi wish\b/i,
+];
+
+const URL_RE = /https?:\/\/\S+/gi;
+const MAX_SUMMARY = 120;
+
+export function classifyBugIntakeMessage(
+  message: IntakeMessage,
+  options: IntakeOptions,
+): BugIntakeDecision {
+  if (message.authorIsBot) return { action: 'ignore', reason: 'bot' };
+  if (message.webhookId) return { action: 'ignore', reason: 'webhook' };
+  if (!options.monitoredChannelIds.has(message.channelId)) {
+    return { action: 'ignore', reason: 'unmonitored-channel' };
+  }
+
+  const content = normalizeMessage(message.content);
+  const attachments = message.attachments ?? [];
+  if (!content && attachments.length === 0) return { action: 'ignore', reason: 'empty' };
+
+  const hasBugLanguage = BUG_PATTERNS.some((re) => re.test(content));
+  const hasReproLanguage = REPRO_PATTERNS.some((re) => re.test(content));
+  const hasFeatureLanguage = FEATURE_PATTERNS.some((re) => re.test(content));
+  const hasImage = attachments.some((a) => isAttachmentType(a, 'image'));
+  const hasVideo = attachments.some((a) => isAttachmentType(a, 'video'));
+  const hasMediaEvidence = hasImage || hasVideo;
+  const wordCount = content ? content.split(/\s+/).length : 0;
+  const minWords = options.minCandidateWords ?? 4;
+
+  if (hasFeatureLanguage && !hasBugLanguage) return { action: 'ignore', reason: 'feature-request' };
+  if (!hasBugLanguage && !hasMediaEvidence) return { action: 'ignore', reason: 'low-confidence' };
+  if (!hasBugLanguage && wordCount < minWords)
+    return { action: 'ignore', reason: 'low-confidence' };
+
+  const hasErrorLanguage = /\b(?:error|exception|stack|console|trace)\b/i.test(content);
+  const confidence =
+    hasBugLanguage && (hasReproLanguage || hasErrorLanguage || hasMediaEvidence)
+      ? 'high'
+      : 'medium';
+
+  return {
+    action: 'candidate',
+    confidence,
+    summary: summarize(content, attachments),
+    evidence: {
+      attachments: attachments.length,
+      hasImage,
+      hasVideo,
+      hasReproLanguage,
+      hasErrorLanguage,
+    },
+    needsMoreInfo: confidence === 'medium' && !hasReproLanguage && !hasMediaEvidence,
+  };
+}
+
+function normalizeMessage(content: string): string {
+  return content.replace(URL_RE, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function summarize(content: string, attachments: readonly IntakeAttachment[]): string {
+  const base = content || attachmentSummary(attachments);
+  return base.length > MAX_SUMMARY ? `${base.slice(0, MAX_SUMMARY - 3).trimEnd()}...` : base;
+}
+
+function attachmentSummary(attachments: readonly IntakeAttachment[]): string {
+  if (attachments.length === 1)
+    return `Attachment: ${attachments[0].filename || attachments[0].id}`;
+  return `${attachments.length} attachments`;
+}
+
+function isAttachmentType(attachment: IntakeAttachment, kind: 'image' | 'video'): boolean {
+  const contentType = attachment.contentType?.toLowerCase() ?? '';
+  if (contentType.startsWith(`${kind}/`)) return true;
+  const filename = attachment.filename?.toLowerCase() ?? '';
+  return kind === 'image'
+    ? /\.(png|jpe?g|gif|webp|avif)$/.test(filename)
+    : /\.(mp4|mov|webm|m4v)$/.test(filename);
+}

--- a/tests/discord_bot.test.ts
+++ b/tests/discord_bot.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { classifyBugIntakeMessage, type IntakeMessage } from '../bot/intake';
 import {
   type ActivityItem,
   allTierRoleNames,
@@ -22,6 +23,14 @@ import {
   voiceMembersForChannel,
 } from '../bot/logic';
 
+const bugMessage = (overrides: Partial<IntakeMessage> = {}): IntakeMessage => ({
+  id: 'm1',
+  channelId: 'bugs',
+  authorId: 'u1',
+  content: 'When I open bags the item tooltip is clipped at the bottom',
+  attachments: [],
+  ...overrides,
+});
 describe('gateway protocol helpers', () => {
   it('requests the privileged member + presence intents', () => {
     // GUILDS(1) | GUILD_MEMBERS(2) | GUILD_VOICE_STATES(128) | GUILD_PRESENCES(256)
@@ -291,5 +300,88 @@ describe('significant-activity cards', () => {
     }) as { allowed_mentions: { users: string[] }; embeds: Array<Record<string, any>> };
     expect(msg.embeds[0].description).toContain('Ghost'); // plain, no mention
     expect(msg.allowed_mentions.users).toEqual(['111']);
+  });
+});
+describe('Discord bug intake classifier', () => {
+  const monitored = new Set(['bugs']);
+
+  it('ignores messages outside monitored bug channels and bot/webhook messages', () => {
+    expect(
+      classifyBugIntakeMessage(bugMessage({ channelId: 'general' }), {
+        monitoredChannelIds: monitored,
+      }),
+    ).toEqual({ action: 'ignore', reason: 'unmonitored-channel' });
+    expect(
+      classifyBugIntakeMessage(bugMessage({ authorIsBot: true }), {
+        monitoredChannelIds: monitored,
+      }),
+    ).toEqual({ action: 'ignore', reason: 'bot' });
+    expect(
+      classifyBugIntakeMessage(bugMessage({ webhookId: 'relay' }), {
+        monitoredChannelIds: monitored,
+      }),
+    ).toEqual({ action: 'ignore', reason: 'webhook' });
+  });
+
+  it('ignores plain chat and feature requests without bug language', () => {
+    expect(
+      classifyBugIntakeMessage(bugMessage({ content: 'anyone running Cragmaw tonight?' }), {
+        monitoredChannelIds: monitored,
+      }),
+    ).toEqual({ action: 'ignore', reason: 'low-confidence' });
+    expect(
+      classifyBugIntakeMessage(bugMessage({ content: 'Feature request: please add mounts' }), {
+        monitoredChannelIds: monitored,
+      }),
+    ).toEqual({ action: 'ignore', reason: 'feature-request' });
+  });
+
+  it('promotes repro-like bug reports with screenshots as high-confidence candidates', () => {
+    const decision = classifyBugIntakeMessage(
+      bugMessage({
+        content:
+          'Every time I queue arena after zoning, the client disconnects with a console error',
+        attachments: [{ id: 'a1', filename: 'disconnect.png', contentType: 'image/png' }],
+      }),
+      { monitoredChannelIds: monitored },
+    );
+    expect(decision).toMatchObject({
+      action: 'candidate',
+      confidence: 'high',
+      evidence: {
+        attachments: 1,
+        hasImage: true,
+        hasVideo: false,
+        hasReproLanguage: true,
+        hasErrorLanguage: true,
+      },
+      needsMoreInfo: false,
+    });
+  });
+
+  it('marks vague bug reports as candidates that need more information', () => {
+    const decision = classifyBugIntakeMessage(
+      bugMessage({ content: 'the market window is broken today' }),
+      { monitoredChannelIds: monitored },
+    );
+    expect(decision).toMatchObject({
+      action: 'candidate',
+      confidence: 'medium',
+      needsMoreInfo: true,
+    });
+  });
+
+  it('keeps summaries short and strips URLs before retention', () => {
+    const decision = classifyBugIntakeMessage(
+      bugMessage({
+        content: `Bug ${'very '.repeat(40)}broken https://example.invalid/private-log`,
+      }),
+      { monitoredChannelIds: monitored },
+    );
+    expect(decision.action).toBe('candidate');
+    if (decision.action === 'candidate') {
+      expect(decision.summary.length).toBeLessThanOrEqual(120);
+      expect(decision.summary).not.toContain('https://');
+    }
   });
 });


### PR DESCRIPTION
﻿## Summary

Adds a pure Discord bug-intake classifier as the first small V1 foundation for the community bug triage bot. The new `bot/intake.ts` module classifies a single Discord message as ignored or a bug candidate using monitored-channel gating, bot/webhook exclusion, bug/repro/error heuristics, media evidence detection, short sanitized summaries, and a `needsMoreInfo` flag for vague reports.

This does not write to Discord, Trello, GitHub, storage, or the live game server. It is intentionally IO-free so later intake/grouping workers can call it without retaining unrelated Discord chatter.

## Related issues

Part of #859.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write bot/intake.ts tests/discord_bot.test.ts` - passed, formatted 2 files.
  - `npx biome lint bot/intake.ts tests/discord_bot.test.ts` - passed with existing warning-only `noExplicitAny` diagnostics in older assertions in `tests/discord_bot.test.ts`.
  - `npm run check:ts` - passed.
  - Wrapped `.browserslistrc` vitest: `npx vitest run tests/discord_bot.test.ts` - passed, 1 file / 27 tests.
  - `npm run build:bot` - passed after rerun outside the Windows sandbox because esbuild was denied directory access by the sandbox.
  - Wrapped `.browserslistrc` `npm run build` - passed with existing Vite/admin dynamic-import, plugin timing, and chunk-size warnings.
- Manual steps: N/A. Pure bot classification logic only; no Discord/Trello/GitHub runtime wiring in this slice.

Full `npm test` was not run for this PR. The focused bot suite, typecheck, bot bundle, and full app build passed.

## Screenshots / recordings

N/A - bot logic only, no player/operator UI change.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
