### PR TITLE
feat(ai): add local dialogue provider scaffold

### DIFF
--- a/src/ai/dialogue.ts
+++ b/src/ai/dialogue.ts
@@ -1,0 +1,103 @@
+export const DEFAULT_DIALOGUE_MAX_WORDS = 45;
+
+export interface DialogueNpcProfile {
+  id: string;
+  name: string;
+  title?: string | null;
+  canonicalGreeting: string;
+  zone?: string | null;
+  questTitles?: readonly string[];
+}
+
+export interface DialoguePlayerProfile {
+  name?: string | null;
+  className?: string | null;
+  level?: number | null;
+}
+
+export interface DialogueRequest {
+  locale: string;
+  languageName?: string | null;
+  npc: DialogueNpcProfile;
+  player?: DialoguePlayerProfile | null;
+  maxWords?: number | null;
+}
+
+export interface DialoguePrompt {
+  system: string;
+  user: string;
+}
+
+export interface DialogueResult {
+  text: string;
+  source: 'static' | 'local-model' | 'server-model';
+  fallback: boolean;
+  model?: string;
+}
+
+export interface DialogueProvider {
+  generateNpcDialogue(request: DialogueRequest, signal?: AbortSignal): Promise<DialogueResult>;
+}
+
+export class StaticDialogueProvider implements DialogueProvider {
+  async generateNpcDialogue(request: DialogueRequest): Promise<DialogueResult> {
+    return staticDialogueResult(request);
+  }
+}
+
+export function staticDialogueResult(request: DialogueRequest): DialogueResult {
+  return {
+    text: cleanOneLine(request.npc.canonicalGreeting),
+    source: 'static',
+    fallback: true,
+  };
+}
+
+export function buildPersonaPrompt(request: DialogueRequest): DialoguePrompt {
+  const npc = request.npc;
+  const maxWords = clampMaxWords(request.maxWords);
+  const language = cleanOneLine(request.languageName || request.locale);
+  const title = cleanOneLine(npc.title ?? '');
+  const zone = cleanOneLine(npc.zone ?? '');
+  const questTitles = (npc.questTitles ?? []).map(cleanOneLine).filter(Boolean);
+  const player = request.player ?? null;
+  const playerLevel = player?.level;
+  const playerBits = [
+    player?.name ? `name: ${cleanOneLine(player.name)}` : null,
+    player?.className ? `class: ${cleanOneLine(player.className)}` : null,
+    typeof playerLevel === 'number' && Number.isFinite(playerLevel)
+      ? `level: ${playerLevel}`
+      : null,
+  ].filter(Boolean);
+
+  const userLines = [
+    `NPC: ${cleanOneLine(npc.name)}${title ? `, ${title}` : ''}`,
+    `Locale: ${request.locale}`,
+    `Reply language: ${language}`,
+    zone ? `Zone: ${zone}` : null,
+    `Canonical greeting: ${cleanOneLine(npc.canonicalGreeting)}`,
+    questTitles.length ? `Known quest topics: ${questTitles.join(', ')}` : null,
+    playerBits.length ? `Player: ${playerBits.join(', ')}` : null,
+    `Limit: ${maxWords} words.`,
+  ].filter((line): line is string => !!line);
+
+  return {
+    system: [
+      'You write optional cosmetic NPC banter for World of ClaudeCraft.',
+      'The deterministic simulation, quest state, rewards, combat, and economy are already decided elsewhere.',
+      'Never invent gameplay facts, rewards, coordinates, account instructions, wallet instructions, secrets, or roadmap promises.',
+      'Keep the canonical greeting true. Add only harmless flavor in the requested language.',
+      'Return one short in-character line, with no markdown and no speaker label.',
+    ].join(' '),
+    user: userLines.join('\n'),
+  };
+}
+
+function clampMaxWords(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_DIALOGUE_MAX_WORDS;
+  return Math.max(12, Math.min(80, Math.trunc(value)));
+}
+
+function cleanOneLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}

--- a/tests/ai_dialogue.test.ts
+++ b/tests/ai_dialogue.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPersonaPrompt,
+  DEFAULT_DIALOGUE_MAX_WORDS,
+  StaticDialogueProvider,
+  staticDialogueResult,
+  type DialogueRequest,
+} from '../src/ai/dialogue';
+
+const baseRequest = (overrides: Partial<DialogueRequest> = {}): DialogueRequest => ({
+  locale: 'en',
+  languageName: 'English',
+  npc: {
+    id: 'marshal_redbrook',
+    name: 'Marshal Redbrook',
+    title: 'Militia Captain',
+    canonicalGreeting: 'Keep your blade close, $C. The Vale is not what it was.',
+    zone: 'Eastbrook Vale',
+    questTitles: ['Greyjaw', 'Bandit Orders'],
+  },
+  player: { name: 'Aldric', className: 'Warrior', level: 12 },
+  ...overrides,
+});
+
+describe('AI dialogue scaffold', () => {
+  it('builds a persona prompt from canonical NPC context without gameplay authority', () => {
+    const prompt = buildPersonaPrompt(baseRequest());
+
+    expect(prompt.system).toContain('optional cosmetic NPC banter');
+    expect(prompt.system).toContain('simulation');
+    expect(prompt.system).toContain('Never invent gameplay facts');
+    expect(prompt.system).toContain('wallet instructions');
+    expect(prompt.system).toContain('no markdown');
+    expect(prompt.user).toContain('NPC: Marshal Redbrook, Militia Captain');
+    expect(prompt.user).toContain('Locale: en');
+    expect(prompt.user).toContain('Reply language: English');
+    expect(prompt.user).toContain('Canonical greeting: Keep your blade close');
+    expect(prompt.user).toContain('Known quest topics: Greyjaw, Bandit Orders');
+    expect(prompt.user).toContain('Player: name: Aldric, class: Warrior, level: 12');
+  });
+
+  it('omits absent optional context and normalizes multi-line canonical text', () => {
+    const prompt = buildPersonaPrompt(
+      baseRequest({
+        languageName: null,
+        npc: {
+          id: 'the_merchant',
+          name: 'The Merchant',
+          canonicalGreeting: 'Fresh stock today.\nNo refunds tomorrow.',
+        },
+        player: null,
+      }),
+    );
+
+    expect(prompt.user).toContain('Reply language: en');
+    expect(prompt.user).toContain('Canonical greeting: Fresh stock today. No refunds tomorrow.');
+    expect(prompt.user).not.toContain('Player:');
+    expect(prompt.user).not.toContain('Known quest topics:');
+    expect(prompt.user).not.toContain('Zone:');
+  });
+
+  it('clamps prompt word budgets to a small dialogue range', () => {
+    expect(buildPersonaPrompt(baseRequest({ maxWords: null })).user).toContain(
+      `Limit: ${DEFAULT_DIALOGUE_MAX_WORDS} words.`,
+    );
+    expect(buildPersonaPrompt(baseRequest({ maxWords: 4 })).user).toContain('Limit: 12 words.');
+    expect(buildPersonaPrompt(baseRequest({ maxWords: 120 })).user).toContain('Limit: 80 words.');
+    expect(buildPersonaPrompt(baseRequest({ maxWords: 23.8 })).user).toContain('Limit: 23 words.');
+  });
+
+  it('returns the canonical greeting through the static fallback provider', async () => {
+    const request = baseRequest({
+      npc: {
+        id: 'scout_maren',
+        name: 'Scout Maren',
+        canonicalGreeting: '  Tracks in the mud.\nEyes in the reeds.  ',
+      },
+    });
+
+    await expect(new StaticDialogueProvider().generateNpcDialogue(request)).resolves.toEqual({
+      text: 'Tracks in the mud. Eyes in the reeds.',
+      source: 'static',
+      fallback: true,
+    });
+    expect(staticDialogueResult(request)).toEqual({
+      text: 'Tracks in the mud. Eyes in the reeds.',
+      source: 'static',
+      fallback: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds the first IO-free scaffold for optional local NPC dialogue from #554.

- Adds `src/ai/dialogue.ts` with a `DialogueProvider` interface, `buildPersonaPrompt()` helper, and `StaticDialogueProvider` fallback.
- Keeps the scaffold presentation-only: it imports nothing from `src/sim`, adds no WebLLM or model dependency, and does not wire generated text into the game yet.
- The prompt builder carries the canonical NPC greeting, locale, player/NPC context, word budget, and safety constraints so future providers can add harmless flavor without claiming gameplay authority.
- Adds focused tests for prompt contents, optional context handling, word-budget clamping, and static fallback output.

## Related issues

Part of #554.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src/ai/dialogue.ts tests/ai_dialogue.test.ts` - passed.
  - `npx biome lint src/ai/dialogue.ts tests/ai_dialogue.test.ts` - passed.
  - `npm run check:ts` - passed.
  - Wrapped `.browserslistrc` vitest: `npx vitest run tests/ai_dialogue.test.ts` - passed, 1 file / 4 tests.
  - Wrapped `.browserslistrc` `npm run build` - passed with existing Vite/admin dynamic-import, plugin timing, and chunk-size warnings.
  - `git diff --cached --check` - passed.
  - Checked changed files for em/en dashes - no matches.
- Manual steps: N/A. Pure scaffold only, no UI or runtime dialogue provider wiring yet.

Known unrelated check result:

- Wrapped `npx vitest run tests/architecture.test.ts tests/ai_dialogue.test.ts` failed in `tests/architecture.test.ts` on the existing `src/world_api/chat.ts` value import of `OVERHEAD_EMOTE_IDS` from `../sim/types`. The new `tests/ai_dialogue.test.ts` portion passed, and this PR does not touch `src/world_api` or `src/sim`.

Full `npm test` was not run for this PR.

## Screenshots / recordings

N/A - pure AI dialogue scaffold, no player/operator UI change.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
