### PR TITLE
fix(sim): stop food and drink at full

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -81,6 +81,14 @@ export function updateRegen(ctx: SimContext, p: Entity, _meta: PlayerMeta): void
   for (const slot of ['eating', 'drinking'] as const) {
     const c = p[slot];
     if (!c) continue;
+    const restoresHealth = c.hpPer2s > 0;
+    const restoresMana = c.manaPer2s > 0 && p.resourceType === 'mana';
+    const healthFull = !restoresHealth || p.hp >= p.maxHp;
+    const manaFull = !restoresMana || p.resource >= p.maxResource;
+    if (healthFull && manaFull) {
+      p[slot] = null;
+      continue;
+    }
     if (c.hpPer2s > 0 && p.hp < p.maxHp) {
       const heal = Math.min(Math.round(c.hpPer2s * ctx.healingTakenMult(p)), p.maxHp - p.hp);
       p.hp += heal;

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -828,6 +828,30 @@ describe('food, drink, vendor', () => {
     expect(sim.player.drinking).toBe(null);
   });
 
+  it('stops food and drink independently once the relevant bar is full (#15)', () => {
+    const sim = makeSim('mage');
+    sim.addItem('baked_bread', 1);
+    sim.addItem('spring_water', 1);
+    sim.player.hp = sim.player.maxHp;
+    sim.player.resource = 10;
+    sim.player.combatTimer = 99;
+    sim.player.inCombat = false;
+
+    sim.useItem('baked_bread');
+    sim.useItem('spring_water');
+    expect(sim.player.eating).not.toBe(null);
+    expect(sim.player.drinking).not.toBe(null);
+
+    for (let i = 0; i < 20 * 2; i++) sim.tick();
+
+    expect(sim.player.eating).toBe(null);
+    expect(sim.player.drinking).not.toBe(null);
+    expect(sim.player.resource).toBeGreaterThan(10);
+
+    sim.player.resource = sim.player.maxResource;
+    for (let i = 0; i < 20 * 2; i++) sim.tick();
+    expect(sim.player.drinking).toBe(null);
+  });
   it('combat potions restore instantly, work in combat, and share a cooldown (#103)', () => {
     const sim = makeSim('mage');
     sim.addItem('minor_mana_potion', 2);


### PR DESCRIPTION
## Summary

Food and drink consumption now stops independently on the next regen tick once the relevant resource is already full. This prevents a finished meal/drink from continuing to drive the rest/eat/drink state after it has nothing left to restore.

The change is intentionally scoped to the sim regen path: food stops when health is full, drink stops when mana is full, and one can continue while the other has work left.

## Related issues

Part of #15.

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\combat\auras.ts tests\sim.test.ts` - passed
  - `npx biome lint src\sim\combat\auras.ts tests\sim.test.ts` - passed with existing warnings in `tests/sim.test.ts`
  - `npm run check:ts` - passed
  - wrapped `.browserslistrc` command: `npx vitest run tests/sim.test.ts tests/items.test.ts tests/cast_bar.test.ts tests/rest_indicator.test.ts` - passed, 4 files / 129 tests
  - wrapped `.browserslistrc` command: `npx vitest run tests/parity/parity.test.ts tests/parity/coverage.test.ts` - passed, 2 files / 140 tests
  - wrapped `.browserslistrc` command: `npm run build` - passed with existing Vite warnings about admin locale dynamic imports and large chunks
- Manual steps: N/A, sim-only behavior covered by tests.
- Notes: an initial local attempt to run two wrapped commands in parallel failed because both tried to rewrite `.browserslistrc`; the commands were rerun sequentially and passed. Full `npm test` was not run for this focused PR; the release branch still has known unrelated full-suite blockers from current triage.

## Screenshots / recordings

N/A - sim state change only, no UI layout change.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
