### PR TITLE
perf(client): cut per-frame work and GC churn across render, hud, net and input hot paths

### DIFF
--- a/src/game/interactions.ts
+++ b/src/game/interactions.ts
@@ -45,6 +45,29 @@ export function activePvpOpponentIds(
   return ids;
 }
 
+// Re-pick cadence for the hover cursor while the pointer is stationary. A pointer
+// move always re-picks immediately; this only bounds how fast the world can change
+// WHICH entity sits under an unmoving cursor (a walking mob), so the scene raycast
+// stops costing a full intersect pass on every frame of a still mouse.
+export const HOVER_REPICK_MS = 50;
+
+/** Gate for the per-frame hover raycast: pick when the pointer moved, otherwise at
+ *  most every HOVER_REPICK_MS. Pure state machine (caller supplies the clock), so
+ *  it unit-tests without DOM or timers. */
+export class HoverPickGate {
+  private x = Number.NaN;
+  private y = Number.NaN;
+  private nextAt = 0;
+
+  shouldPick(x: number, y: number, nowMs: number): boolean {
+    if (x === this.x && y === this.y && nowMs < this.nextAt) return false;
+    this.x = x;
+    this.y = y;
+    this.nextAt = nowMs + HOVER_REPICK_MS;
+    return true;
+  }
+}
+
 export function isAttackableEntity(
   e: Entity | undefined,
   playerId: number,

--- a/src/game/utc_day.ts
+++ b/src/game/utc_day.ts
@@ -1,0 +1,16 @@
+// The offline sim wants the wall-clock UTC day (delve daily reset) but must not
+// read the clock itself, so the frame loop supplies it. Building the string is a
+// Date allocation plus an ISO serialization; at 60 Hz that is pure churn for a
+// value that changes once a day, so cache it and re-derive at most once a second.
+let cachedDay = '';
+let nextRefreshAtMs = 0;
+
+/** Current UTC day as `YYYY-MM-DD`, recomputed at most once per second. */
+export function currentUtcDay(): string {
+  const now = Date.now();
+  if (now >= nextRefreshAtMs) {
+    cachedDay = new Date(now).toISOString().slice(0, 10);
+    nextRefreshAtMs = now + 1000;
+  }
+  return cachedDay;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,6 +142,7 @@ import {
   t,
   tPlural,
 } from './ui/i18n';
+import { defaultIconPrewarmEntries, prewarmIconCache } from './ui/icon_prewarm';
 import { iconDataUrl } from './ui/icons';
 import { createMetricsSampler } from './ui/perf_metrics_sampler';
 import { PerfOverlay } from './ui/perf_overlay';
@@ -2393,6 +2394,10 @@ async function startGame(
           tokenProvider: () => api.token,
           characterIdProvider: () => online?.characterId ?? null,
         });
+        // Warm the procedural icon cache during idle time so the first
+        // bags/vendor/loot open never pays the compose burst synchronously
+        // (icon_prewarm.ts). Re-entry is a fast no-op: the cache is module-global.
+        prewarmIconCache(defaultIconPrewarmEntries());
         (window as any).__game = {
           sim: world,
           world,

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ import { Input } from './game/input';
 import { InputActivityMeter, installInputActivityTracking } from './game/input_activity';
 import {
   activePvpOpponentIds,
+  HoverPickGate,
   handlePickedEntity,
   hoverCursorKind,
   isAttackableEntity,
@@ -52,6 +53,7 @@ import {
 } from './game/settings';
 import { sfx } from './game/sfx';
 import { resolveUiEffectsProfile } from './game/ui_effects_profile';
+import { currentUtcDay } from './game/utc_day';
 import { voice } from './game/voice';
 import {
   CHAR_SORT_MODES,
@@ -2094,13 +2096,22 @@ async function startGame(
     return ids;
   }
 
+  // The scene raycast is the expensive half of the hover cursor; the gate re-picks
+  // on pointer movement (instantly) or every HOVER_REPICK_MS while stationary. The
+  // cursor KIND below still re-resolves every frame from live entity state, so a
+  // hovered mob dying or turning hostile updates without waiting for a re-pick.
+  const hoverPickGate = new HoverPickGate();
+  let hoverPickedId: number | null = null;
+
   function updateHoverCursor(): void {
     if (!input.hoverActive || input.isDragging() || hud.isModalOpen()) {
       input.setHoverCursor('default');
       return;
     }
-    const id = renderer.pick(input.hoverX, input.hoverY);
-    const entity = id !== null ? world.entities.get(id) : undefined;
+    if (hoverPickGate.shouldPick(input.hoverX, input.hoverY, performance.now())) {
+      hoverPickedId = renderer.pick(input.hoverX, input.hoverY);
+    }
+    const entity = hoverPickedId !== null ? world.entities.get(hoverPickedId) : undefined;
     input.setHoverCursor(
       hoverCursorKind(entity, world.playerId, partyMemberIds(), activePvpOpponentIds(world)),
     );
@@ -2191,7 +2202,7 @@ async function startGame(
       acc += frameDt;
       // Supply the UTC day for the delve daily reset (the sim never reads the wall
       // clock itself, to stay deterministic).
-      offlineSim.utcDay = new Date().toISOString().slice(0, 10);
+      offlineSim.utcDay = currentUtcDay();
       while (acc >= DT) {
         const { mi, facing } = resolveMove(
           mouselook,

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -1330,30 +1330,64 @@ export class ClientWorld implements IWorld {
       // updates the existing Map in place: no per-entity Map churn at 20 Hz
       e.threat.clear();
       if (w.thr) for (const [tid, tv] of w.thr as [number, number][]) e.threat.set(tid, tv);
-      e.auras = (w.auras ?? []).map((a: any) => ({
-        id: a.id,
-        name: a.name,
-        kind: a.kind,
-        remaining: a.rem,
-        duration: a.dur,
-        // The wire carries the aura magnitude (and imbue range / tick cadence / school) so buff
-        // and debuff hover tooltips show the real numbers online exactly as offline (aura_effect
-        // reads these). A 0/absent value decodes to 0 (value-less auras and an old server are
-        // unchanged), a missing school falls back to the physical default, and imbue range /
-        // tick cadence stay undefined when not sent. sourceId stays simplified (a separate
-        // pre-existing wire reduction, not read by the tooltip).
-        value: a.value ?? 0,
-        value2: a.value2,
-        value3: a.value3,
-        tickInterval: a.tickInterval,
-        sourceId: 0,
-        school: a.school ?? 'physical',
-        stacks: a.stacks,
-        // Mirror the charge count for a charge-limited aura (Lightning Shield); the wire sends it
-        // only when defined (server/game.ts), so an ordinary aura or an old server decodes to
-        // undefined and the badge falls back to the stacks path, exactly as before.
-        charges: a.charges,
-      }));
+      // The wire carries the aura magnitude (and imbue range / tick cadence / school) so buff
+      // and debuff hover tooltips show the real numbers online exactly as offline (aura_effect
+      // reads these). A 0/absent value decodes to 0 (value-less auras and an old server are
+      // unchanged), a missing school falls back to the physical default, and imbue range /
+      // tick cadence stay undefined when not sent. sourceId stays simplified (a separate
+      // pre-existing wire reduction, not read by the tooltip).
+      //
+      // Between snapshots the aura SET is usually unchanged (only `rem` ticks down), so when
+      // the incoming ids line up index-for-index with the existing records, update those
+      // records in place: no array + per-aura object allocation per entity at 20 Hz, and the
+      // preserved object identity matches the offline Sim (one live aura object across ticks).
+      // Any composition change (gain/fade/reorder) falls back to the fresh build below.
+      const wireAuras: any[] = w.auras ?? [];
+      let sameAuraShape = e.auras.length === wireAuras.length;
+      if (sameAuraShape) {
+        for (let i = 0; i < wireAuras.length; i++) {
+          if (e.auras[i].id !== wireAuras[i].id) {
+            sameAuraShape = false;
+            break;
+          }
+        }
+      }
+      if (sameAuraShape) {
+        for (let i = 0; i < wireAuras.length; i++) {
+          const a = wireAuras[i];
+          const rec = e.auras[i];
+          rec.name = a.name;
+          rec.kind = a.kind;
+          rec.remaining = a.rem;
+          rec.duration = a.dur;
+          rec.value = a.value ?? 0;
+          rec.value2 = a.value2;
+          rec.value3 = a.value3;
+          rec.tickInterval = a.tickInterval;
+          rec.school = a.school ?? 'physical';
+          rec.stacks = a.stacks;
+          // Mirror the charge count for a charge-limited aura (Lightning Shield); the wire
+          // sends it only when defined (server/game.ts), so an ordinary aura or an old server
+          // decodes to undefined and the badge falls back to the stacks path, exactly as before.
+          rec.charges = a.charges;
+        }
+      } else {
+        e.auras = wireAuras.map((a: any) => ({
+          id: a.id,
+          name: a.name,
+          kind: a.kind,
+          remaining: a.rem,
+          duration: a.dur,
+          value: a.value ?? 0,
+          value2: a.value2,
+          value3: a.value3,
+          tickInterval: a.tickInterval,
+          sourceId: 0,
+          school: a.school ?? 'physical',
+          stacks: a.stacks,
+          charges: a.charges,
+        }));
+      }
       e.loot = w.lootList ?? null;
       return e;
     };

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -877,6 +877,9 @@ export class ClientWorld implements IWorld {
   // entity id -> performance.now() when it first went missing from a snapshot;
   // used for the despawn grace window (anti-flicker), cleared once it returns
   private missingSince = new Map<number, number>();
+  // scratch for applySnapshot's per-message "ids present in this snap" set,
+  // reused across snapshots (20 Hz) instead of allocating a Set per message
+  private wireSeen = new Set<number>();
   // camera follow for keyboard turns applied by the main loop
   pendingFacingDelta = 0;
   connected = false;
@@ -1196,7 +1199,11 @@ export class ClientWorld implements IWorld {
     }
     this.lastSnapAt = now;
 
-    const seen = new Set<number>();
+    // lazy init (not the field initializer alone): tests build bare instances
+    // via Object.create(ClientWorld.prototype), which skips field initializers
+    if (this.wireSeen === undefined) this.wireSeen = new Set();
+    const seen = this.wireSeen;
+    seen.clear();
     const prevSelf = this.entities.get(this.playerId);
     const prevSelfFacing = prevSelf?.facing;
     const prevSelfDead = prevSelf?.dead ?? false;
@@ -1319,7 +1326,10 @@ export class ClientWorld implements IWorld {
       e.petTauntTimer = w.pt ?? 0;
       e.petAutoTaunt = !!w.pa;
       e.petManualTauntPending = false;
-      e.threat = new Map(w.thr ?? []);
+      // same semantics as `new Map(w.thr ?? [])` (absent thr = empty table), but
+      // updates the existing Map in place: no per-entity Map churn at 20 Hz
+      e.threat.clear();
+      if (w.thr) for (const [tid, tv] of w.thr as [number, number][]) e.threat.set(tid, tv);
       e.auras = (w.auras ?? []).map((a: any) => ({
         id: a.id,
         name: a.name,
@@ -1386,8 +1396,12 @@ export class ClientWorld implements IWorld {
       e.resourceType = s.rtype;
       // delta fields: the server omits them while unchanged, so only the
       // snapshots that carry them rebuild the local structures
-      if (s.cds !== undefined)
-        e.cooldowns = new Map(Object.entries(s.cds).map(([k, v]) => [k, Number(v)]));
+      if (s.cds !== undefined) {
+        // in-place rebuild (same result as `new Map(Object.entries(...))`): no
+        // intermediate entry arrays and no Map churn on the 20 Hz self record
+        e.cooldowns.clear();
+        for (const k in s.cds) e.cooldowns.set(k, Number(s.cds[k]));
+      }
       e.gcdRemaining = s.gcd ?? 0;
       e.potionCdRemaining = s.pcd ?? 0;
       e.comboPoints = s.combo ?? 0;

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -677,6 +677,9 @@ export class Renderer {
   camera: THREE.PerspectiveCamera;
   webgl: THREE.WebGLRenderer;
   views = new Map<number, EntityView>();
+  // view groups that own a budgeted point light: exempt from the hidden-view
+  // matrix gate (see the gate pass in sync and the note at registration)
+  private lightOwnerGroups = new WeakSet<THREE.Object3D>();
   nameplateLayer: HTMLDivElement;
   // Travel-form speed-illusion overlay (presentation only; see travel_speed_fx*).
   private travelSpeedFx: TravelSpeedFxPainter;
@@ -915,6 +918,14 @@ export class Renderer {
   ) {
     this.nameplateLayer = nameplateLayer;
     this.travelSpeedFx = new TravelSpeedFxPainter(nameplateLayer);
+    // The scene root sits at identity forever, but with the default
+    // matrixAutoUpdate the root recomposes each frame, which flags
+    // matrixWorldNeedsUpdate and FORCE-cascades a matrixWorld multiply through
+    // every node in the graph (three r165 updateMatrixWorld), defeating both
+    // the static-subtree freeze and the hidden-rig gate below. Freeze the root:
+    // children with auto-update still recompose themselves normally.
+    this.scene.updateMatrix();
+    this.scene.matrixAutoUpdate = false;
     // No default-framebuffer MSAA on any tier: high/ultra get AA from the
     // composer's MSAA HalfFloat target, low is meant to run without AA — and
     // requesting it here would hit software GL (the autodetect can only run
@@ -3241,6 +3252,11 @@ export class Renderer {
         this.viewLights.push(light);
       }
       this.lightRankDirty = true;
+      // A light-owning view is exempt from the hidden-view matrix gate below:
+      // the light-budget rebuild caches light.getWorldPosition, and r165's
+      // updateWorldMatrix does NOT heal through a matrixWorldAutoUpdate=false
+      // ancestor, so a gated group would rank the light at a stale position.
+      this.lightOwnerGroups.add(group);
     }
     this.views.set(e.id, {
       group,
@@ -4172,6 +4188,19 @@ export class Renderer {
     }
     this.lastVisibleRigCount = visibleRigCount;
 
+    // Hidden views skip their whole matrix subtree: three recomposes even
+    // invisible hierarchies, and a distance-culled or off-screen rig is 30-60
+    // nodes of dead per-frame compose+multiply. Re-showing flips the gate back
+    // on, and the next scene update revisits the subtree and recomposes it
+    // from the live position/rotation properties, so nothing renders stale.
+    // (pick() skips hidden views, so a frozen matrix never ghosts a hitbox.
+    // CAUTION: getWorldPosition on a node inside a GATED subtree does not heal
+    // the chain in r165, hence the light-owner exemption; any new world-space
+    // read of a view child must use group.position or exempt the view too.)
+    for (const [, v] of this.views) {
+      v.group.matrixWorldAutoUpdate = v.group.visible || this.lightOwnerGroups.has(v.group);
+    }
+
     // selection ring
     const target = p.targetId !== null ? sim.entities.get(p.targetId) : null;
     if (target) {
@@ -4812,9 +4841,15 @@ export class Renderer {
       let o: THREE.Object3D | null = hit.object;
       while (o) {
         if (o.userData.entityId !== undefined && o.userData.entityId !== this.sim.playerId) {
-          const e = this.sim.entities.get(o.userData.entityId as number);
+          const id = o.userData.entityId as number;
+          // a hidden view is not clickable: the player cannot see it, and its
+          // matrixWorld is frozen while hidden (the rig gate in sync), so a hit
+          // against it would be a ghost hitbox at the hide-time position
+          const hitView = this.views.get(id);
+          if (hitView && !hitView.group.visible) break;
+          const e = this.sim.entities.get(id);
           if (e?.kind === 'object' && !e.lootable) return null;
-          return o.userData.entityId as number;
+          return id;
         }
         o = o.parent;
       }

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -85,6 +85,7 @@ import { downscaleDims } from './screenshot';
 import { drapeRingLocalY } from './selection_ring';
 import { buildClouds, buildSky, type SkyView } from './sky';
 import { nearestSloppyPickId, type SloppyPickCandidate } from './sloppy_pick';
+import { freezeStaticMatrices } from './static_matrix';
 import { shouldRenderStealthGhost } from './stealth';
 import { buildFlaredConeFan, buildRingXZ, drapeConeWorld } from './target_cone_debug';
 import { buildTerrain, type TerrainView } from './terrain';
@@ -1150,10 +1151,14 @@ export class Renderer {
     this.terrainView = buildTerrain(this.sim.cfg.seed);
     setRenderCategory(this.terrainView.group, 'terrain');
     this.scene.add(this.terrainView.group);
+    // Terrain chunks never move after build (the LOD update only toggles
+    // visibility): stop their per-frame matrix recompose (static_matrix.ts).
+    freezeStaticMatrices(this.terrainView.group);
     this.waterView = buildWater(this.sim.cfg.seed);
     for (const mesh of this.waterView.meshes) {
       setRenderCategory(mesh, 'water');
       this.scene.add(mesh);
+      freezeStaticMatrices(mesh); // water animates via uniforms, never transforms
     }
 
     this.foliage = buildFoliage(this.sim.cfg.seed);
@@ -1178,6 +1183,11 @@ export class Renderer {
     this.scene.add(props.group);
     this.flames = props.flames;
     this.fireLights = props.fireLights;
+    // Props are baked into world space at build and their update() only toggles
+    // visibility, so the whole tree is matrix-static, EXCEPT the campfire
+    // flames, whose flicker rescales them every frame: re-enable those.
+    freezeStaticMatrices(props.group);
+    for (const flame of this.flames) flame.matrixAutoUpdate = true;
     // The impact-site light rides the campfire point-light budget so the visible
     // point-light count stays constant as the player travels (constant
     // numPointLights -> materials never recompile for a light-count change).

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -697,6 +697,11 @@ export class Renderer {
   // so sync() can re-drape the ring over the terrain without allocating.
   selectionRingLocalXZ: Float32Array;
   selectionRingDrapeY: Float32Array;
+  // last drape anchor: the drape is a pure function of (x, z, scale), so a
+  // stationary target skips the per-vertex groundHeight resample entirely.
+  private selRingX = Number.NaN;
+  private selRingZ = Number.NaN;
+  private selRingScale = Number.NaN;
   // Dev-only Tab-target cone overlay (enabled via ?targetcone=1 in main.ts).
   // Null until enabled; once built it is re-draped over the terrain in front of
   // the local player every frame. See target_cone_debug.ts.
@@ -3817,13 +3822,29 @@ export class Renderer {
       const e = sim.entities.get(id);
       if (!e) continue;
       // form swaps (polymorph sheep, druid forms) — computed up front because
-      // the shadow gates below must not run the base rig's proxy under a form
-      const polyed = e.auras.some((a) => a.kind === 'polymorph');
-      const bear = !polyed && e.auras.some((a) => a.kind === 'form_bear');
-      const ghostWolf = !polyed && !bear && e.auras.some((a) => a.id === 'ghost_wolf');
-      const cat = !polyed && !bear && (ghostWolf || e.auras.some((a) => a.kind === 'form_cat'));
-      const travel = !polyed && !bear && !cat && e.auras.some((a) => a.kind === 'form_travel');
-      const _stealthed = e.auras.some((a) => a.kind === 'stealth');
+      // the shadow gates below must not run the base rig's proxy under a form.
+      // One pass over the aura list instead of six .some() scans per entity per
+      // frame; the flag combination below preserves the original precedence.
+      let hasPoly = false;
+      let hasBear = false;
+      let hasGhostWolf = false;
+      let hasCatForm = false;
+      let hasTravelForm = false;
+      let hasStealth = false;
+      for (const a of e.auras) {
+        if (a.kind === 'polymorph') hasPoly = true;
+        if (a.kind === 'form_bear') hasBear = true;
+        if (a.id === 'ghost_wolf') hasGhostWolf = true;
+        if (a.kind === 'form_cat') hasCatForm = true;
+        if (a.kind === 'form_travel') hasTravelForm = true;
+        if (a.kind === 'stealth') hasStealth = true;
+      }
+      const polyed = hasPoly;
+      const bear = !polyed && hasBear;
+      const ghostWolf = !polyed && !bear && hasGhostWolf;
+      const cat = !polyed && !bear && (ghostWolf || hasCatForm);
+      const travel = !polyed && !bear && !cat && hasTravelForm;
+      const _stealthed = hasStealth;
       // distance cull: far rigs are invisible specks but cost real draw calls
       const cdx = e.pos.x - p.pos.x,
         cdz = e.pos.z - p.pos.z;
@@ -3915,9 +3936,8 @@ export class Renderer {
         v.group.visible = vis;
         if (v.sparkle && vis) {
           // sub-pixel beyond ~45u but still a full transparent draw each
-          const sdx = e.pos.x - p.pos.x,
-            sdz = e.pos.z - p.pos.z;
-          v.sparkle.visible = sdx * sdx + sdz * sdz < SPARKLE_DRAW_RANGE_SQ;
+          // (d2 is this entity's player distance, computed once above)
+          v.sparkle.visible = d2 < SPARKLE_DRAW_RANGE_SQ;
           const pulse = 0.75 + Math.sin(this.time * 3 + e.id) * 0.25;
           v.sparkle.scale.set(pulse, pulse, 1);
           v.sparkle.material.rotation = this.time * 0.8;
@@ -4149,28 +4169,36 @@ export class Renderer {
       if (tv) {
         const cx = tv.group.position.x;
         const cz = tv.group.position.z;
-        const seed = this.sim.cfg.seed;
         // anchor the reticle to the ground under the unit (a classic decal: it
         // stays grounded even if the target jumps) and drape it over the slope.
-        const gy = groundHeight(cx, cz, seed);
-        this.selectionRing.position.set(cx, gy, cz);
-        this.selectionRing.scale.setScalar(target.scale);
-        const drape = drapeRingLocalY(
-          this.selectionRingLocalXZ,
-          cx,
-          cz,
-          gy,
-          target.scale,
-          0.08,
-          (sx, sz) => groundHeight(sx, sz, seed),
-          this.selectionRingDrapeY,
-        );
-        const ringPos = this.selectionRingMesh.geometry.getAttribute(
-          'position',
-        ) as THREE.BufferAttribute;
-        for (let i = 0; i < drape.length; i++) ringPos.setY(i, drape[i]);
-        ringPos.needsUpdate = true;
-        this.selectionRingTicks.position.y = 0.08; // ticks float just above the footing
+        // The drape is a pure function of (cx, cz, scale) and nothing else writes
+        // the ring's position attribute, so a stationary target reuses last
+        // frame's per-vertex groundHeight samples untouched.
+        if (cx !== this.selRingX || cz !== this.selRingZ || target.scale !== this.selRingScale) {
+          this.selRingX = cx;
+          this.selRingZ = cz;
+          this.selRingScale = target.scale;
+          const seed = this.sim.cfg.seed;
+          const gy = groundHeight(cx, cz, seed);
+          this.selectionRing.position.set(cx, gy, cz);
+          this.selectionRing.scale.setScalar(target.scale);
+          const drape = drapeRingLocalY(
+            this.selectionRingLocalXZ,
+            cx,
+            cz,
+            gy,
+            target.scale,
+            0.08,
+            (sx, sz) => groundHeight(sx, sz, seed),
+            this.selectionRingDrapeY,
+          );
+          const ringPos = this.selectionRingMesh.geometry.getAttribute(
+            'position',
+          ) as THREE.BufferAttribute;
+          for (let i = 0; i < drape.length; i++) ringPos.setY(i, drape[i]);
+          ringPos.needsUpdate = true;
+          this.selectionRingTicks.position.y = 0.08; // ticks float just above the footing
+        }
         this.selectionRingTicks.rotation.y += dt * SELECTION_RING_SPIN; // slow reticle spin
         const ringMat = this.selectionRingMat;
         ringMat.color.setHex(this.isHostileSelectionTarget(target) ? 0xcc2222 : 0xd4af37);

--- a/src/render/static_matrix.ts
+++ b/src/render/static_matrix.ts
@@ -1,0 +1,23 @@
+import type * as THREE from 'three';
+
+// Static-matrix freeze. Three r165 recomposes every Object3D's local matrix and
+// re-multiplies its world matrix EVERY frame while matrixAutoUpdate is true (the
+// default); on this scene that is thousands of never-moving prop/terrain nodes
+// paying real per-frame CPU (updateMatrixWorld + multiplyMatrices dominate the
+// walk profile). Freezing a fully-built static subtree computes its world
+// matrices once and stops the per-frame churn. Children ADDED to a frozen
+// parent later keep their default auto-update and compose against the parent's
+// (already final) matrixWorld, so lazily-streamed content under a frozen root
+// still behaves normally.
+//
+// Contract for callers: only freeze a subtree whose node TRANSFORMS never
+// change after build (visibility toggles, uniform animation, and attribute
+// rewrites are all fine; they do not touch the matrix). Any transform-animated
+// descendant (campfire flames) must be re-enabled by the caller right after
+// the freeze: `node.matrixAutoUpdate = true`.
+export function freezeStaticMatrices(root: THREE.Object3D): void {
+  root.updateMatrixWorld(true);
+  root.traverse((o) => {
+    o.matrixAutoUpdate = false;
+  });
+}

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -20,6 +20,38 @@ function hdr(k: number): number {
   return GFX.composer ? k : 1;
 }
 
+// Per-school projectile colors, cached: a bolt burst used to allocate three
+// THREE.Color per launch. spawn() copies components into the attribute buffers
+// (and update() copies before mutating), never retaining the reference, so the
+// cached instances are effectively immutable. Keyed on GFX.composer so a tier
+// flip rebuilds the HDR-boosted variants.
+const projectileColorCache = new Map<
+  string,
+  { base: THREE.Color; core: THREE.Color; trail: THREE.Color }
+>();
+let projectileColorComposer: boolean | null = null;
+function projectileSchoolColors(school: string): {
+  base: THREE.Color;
+  core: THREE.Color;
+  trail: THREE.Color;
+} {
+  if (projectileColorComposer !== GFX.composer) {
+    projectileColorCache.clear();
+    projectileColorComposer = GFX.composer;
+  }
+  let c = projectileColorCache.get(school);
+  if (!c) {
+    const base = new THREE.Color(SCHOOL_COLORS[school] ?? 0xffffff);
+    c = {
+      base,
+      core: base.clone().multiplyScalar(hdr(2.5)),
+      trail: base.clone().multiplyScalar(hdr(1.4)),
+    };
+    projectileColorCache.set(school, c);
+  }
+  return c;
+}
+
 // ---------------------------------------------------------------------------
 // Sprite atlas: 16 cherry-picked Kenney sprites in a 4x4 grid. Order defines
 // the cell index used by the shader — append only.
@@ -29,26 +61,52 @@ const ATLAS_GRID = 4;
 const ATLAS_CELL = 256;
 
 const SPRITE_FILES = [
-  'light_01', 'light_02', 'flare_01', 'spark_04',
-  'spark_06', 'star_07', 'magic_01', 'magic_04',
-  'twirl_01', 'flame_03', 'fire_01', 'smoke_05',
-  'trace_05', 'slash_02', 'dirt_02', 'circle_05',
+  'light_01',
+  'light_02',
+  'flare_01',
+  'spark_04',
+  'spark_06',
+  'star_07',
+  'magic_01',
+  'magic_04',
+  'twirl_01',
+  'flame_03',
+  'fire_01',
+  'smoke_05',
+  'trace_05',
+  'slash_02',
+  'dirt_02',
+  'circle_05',
 ] as const;
 
 // Named cell indices (keep in sync with SPRITE_FILES order)
 const SPR = {
-  glowSoft: 0, glowCore: 1, flash: 2, sparkle: 3,
-  sparkBurst: 4, star: 5, magicWisp: 6, magicRune: 7,
-  twirl: 8, flame: 9, firePuff: 10, smoke: 11,
-  trace: 12, slash: 13, debris: 14, ring: 15,
+  glowSoft: 0,
+  glowCore: 1,
+  flash: 2,
+  sparkle: 3,
+  sparkBurst: 4,
+  star: 5,
+  magicWisp: 6,
+  magicRune: 7,
+  twirl: 8,
+  flame: 9,
+  firePuff: 10,
+  smoke: 11,
+  trace: 12,
+  slash: 13,
+  debris: 14,
+  ring: 15,
 } as const;
 
 const spriteImages: (TexImageSource | null)[] = SPRITE_FILES.map(() => null);
 for (let i = 0; i < SPRITE_FILES.length; i++) {
-  registerPreload(loadTexture(`/vfx/${SPRITE_FILES[i]}.png`, { srgb: true }).then((tex) => {
-    spriteImages[i] = tex.image as TexImageSource;
-    return tex;
-  }));
+  registerPreload(
+    loadTexture(`/vfx/${SPRITE_FILES[i]}.png`, { srgb: true }).then((tex) => {
+      spriteImages[i] = tex.image as TexImageSource;
+      return tex;
+    }),
+  );
 }
 
 // Compose the atlas once. Any cell whose PNG is unavailable (e.g. unit tests
@@ -69,8 +127,12 @@ function buildAtlasTexture(): THREE.CanvasTexture {
       ctx.drawImage(img as CanvasImageSource, x, y, ATLAS_CELL, ATLAS_CELL);
     } else {
       const g = ctx.createRadialGradient(
-        x + ATLAS_CELL / 2, y + ATLAS_CELL / 2, 2,
-        x + ATLAS_CELL / 2, y + ATLAS_CELL / 2, ATLAS_CELL / 2,
+        x + ATLAS_CELL / 2,
+        y + ATLAS_CELL / 2,
+        2,
+        x + ATLAS_CELL / 2,
+        y + ATLAS_CELL / 2,
+        ATLAS_CELL / 2,
       );
       g.addColorStop(0, 'rgba(255,255,255,1)');
       g.addColorStop(0.4, 'rgba(255,255,255,0.5)');
@@ -137,7 +199,10 @@ export class Vfx {
   private tmpColor = new THREE.Color();
   private quality = 1;
 
-  constructor(scene: THREE.Scene, private anchor: EntityAnchor) {
+  constructor(
+    scene: THREE.Scene,
+    private anchor: EntityAnchor,
+  ) {
     this.pos = new Float32Array(CAPACITY * 3);
     this.vel = new Float32Array(CAPACITY * 3);
     this.col = new Float32Array(CAPACITY * 3);
@@ -232,8 +297,12 @@ export class Vfx {
     for (let i = 0; i < sprites.length; i++) {
       const a = (i / sprites.length) * Math.PI * 2;
       this.spawn(
-        at.x + Math.sin(a) * 1.2, at.y + 0.6 + (i % 4) * 0.25, at.z + Math.cos(a) * 1.2,
-        0, 0, 0,
+        at.x + Math.sin(a) * 1.2,
+        at.y + 0.6 + (i % 4) * 0.25,
+        at.z + Math.cos(a) * 1.2,
+        0,
+        0,
+        0,
         i % 3 === 0 ? 0xffd28a : i % 3 === 1 ? 0x8ed2ff : 0xd98aff,
         0.35 + (i % 4) * 0.08,
         1.0,
@@ -266,17 +335,31 @@ export class Vfx {
   }
 
   private spawn(
-    x: number, y: number, z: number,
-    vx: number, vy: number, vz: number,
-    color: THREE.Color | number, size: number, lifetime: number, gravity = 0,
-    sprite: number = SPR.glowSoft, rot: number = Math.random() * Math.PI * 2,
+    x: number,
+    y: number,
+    z: number,
+    vx: number,
+    vy: number,
+    vz: number,
+    color: THREE.Color | number,
+    size: number,
+    lifetime: number,
+    gravity = 0,
+    sprite: number = SPR.glowSoft,
+    rot: number = Math.random() * Math.PI * 2,
   ): void {
     const i = this.head;
     this.head = (this.head + 1) % CAPACITY;
-    this.pos[i * 3] = x; this.pos[i * 3 + 1] = y; this.pos[i * 3 + 2] = z;
-    this.vel[i * 3] = vx; this.vel[i * 3 + 1] = vy; this.vel[i * 3 + 2] = vz;
+    this.pos[i * 3] = x;
+    this.pos[i * 3 + 1] = y;
+    this.pos[i * 3 + 2] = z;
+    this.vel[i * 3] = vx;
+    this.vel[i * 3 + 1] = vy;
+    this.vel[i * 3 + 2] = vz;
     this.tmpColor.set(color as THREE.ColorRepresentation);
-    this.col[i * 3] = this.tmpColor.r; this.col[i * 3 + 1] = this.tmpColor.g; this.col[i * 3 + 2] = this.tmpColor.b;
+    this.col[i * 3] = this.tmpColor.r;
+    this.col[i * 3 + 1] = this.tmpColor.g;
+    this.col[i * 3 + 2] = this.tmpColor.b;
     this.size[i] = size;
     this.life[i] = lifetime;
     this.maxLife[i] = lifetime;
@@ -293,14 +376,14 @@ export class Vfx {
   projectile(sourceId: number, targetId: number, school: string): void {
     const from = this.anchor(sourceId, 0.62);
     if (!from) return;
-    const color = new THREE.Color(SCHOOL_COLORS[school] ?? 0xffffff);
+    const colors = projectileSchoolColors(school);
     const sprites = projectileSprites(school);
     this.projectiles.push({
       pos: from.clone(),
       targetId,
-      color,
-      coreColor: color.clone().multiplyScalar(hdr(2.5)),
-      trailColor: color.clone().multiplyScalar(hdr(1.4)),
+      color: colors.base,
+      coreColor: colors.core,
+      trailColor: colors.trail,
       speed: 26,
       ttl: 3,
       coreSprite: sprites.core,
@@ -339,12 +422,25 @@ export class Vfx {
       const sp = (2 + Math.random() * 4.5) * power;
       // fire bursts read as flame puffs; everything else as spark showers
       const sprite = isFire
-        ? (i % 3 === 0 ? SPR.firePuff : SPR.flame)
-        : (i % 3 === 0 ? SPR.star : i % 2 === 0 ? SPR.sparkle : SPR.sparkBurst);
+        ? i % 3 === 0
+          ? SPR.firePuff
+          : SPR.flame
+        : i % 3 === 0
+          ? SPR.star
+          : i % 2 === 0
+            ? SPR.sparkle
+            : SPR.sparkBurst;
       this.spawn(
-        at.x, at.y, at.z,
-        Math.sin(a) * sp, up * sp * 0.8, Math.cos(a) * sp,
-        c, 0.34 + Math.random() * 0.3 * power, 0.45 + Math.random() * 0.35, 7,
+        at.x,
+        at.y,
+        at.z,
+        Math.sin(a) * sp,
+        up * sp * 0.8,
+        Math.cos(a) * sp,
+        c,
+        0.34 + Math.random() * 0.3 * power,
+        0.45 + Math.random() * 0.35,
+        7,
         sprite,
       );
     }
@@ -366,7 +462,16 @@ export class Vfx {
       const a = (i / count) * Math.PI * 2;
       const sp = 11 + Math.random() * 3;
       this.spawn(
-        at.x, at.y + 0.25, at.z, Math.sin(a) * sp, 1.2, Math.cos(a) * sp, c, 0.5, 0.55, 6,
+        at.x,
+        at.y + 0.25,
+        at.z,
+        Math.sin(a) * sp,
+        1.2,
+        Math.cos(a) * sp,
+        c,
+        0.5,
+        0.55,
+        6,
         i % 4 === 0 ? SPR.magicRune : SPR.sparkle,
       );
     }
@@ -381,9 +486,16 @@ export class Vfx {
       const a = Math.random() * Math.PI * 2;
       const r = 0.4 + Math.random() * 0.7;
       this.spawn(
-        at.x + Math.sin(a) * r, at.y + Math.random() * 0.4, at.z + Math.cos(a) * r,
-        Math.sin(a) * 0.25, 1.6 + Math.random() * 1.4, Math.cos(a) * 0.25,
-        i % 3 === 0 ? green : gold, 0.3 + Math.random() * 0.25, 0.9 + Math.random() * 0.5, -1.2,
+        at.x + Math.sin(a) * r,
+        at.y + Math.random() * 0.4,
+        at.z + Math.cos(a) * r,
+        Math.sin(a) * 0.25,
+        1.6 + Math.random() * 1.4,
+        Math.cos(a) * 0.25,
+        i % 3 === 0 ? green : gold,
+        0.3 + Math.random() * 0.25,
+        0.9 + Math.random() * 0.5,
+        -1.2,
         i % 2 === 0 ? SPR.star : SPR.sparkle,
       );
     }
@@ -396,9 +508,17 @@ export class Vfx {
     for (let i = 0; i < count; i++) {
       const a = (i / count) * Math.PI * 2;
       this.spawn(
-        at.x + Math.sin(a) * 0.85, at.y + 0.2, at.z + Math.cos(a) * 0.85,
-        -Math.cos(a) * 1.6, 2.1, Math.sin(a) * 1.6,
-        color, 0.3, 0.8, -1.5, SPR.magicWisp,
+        at.x + Math.sin(a) * 0.85,
+        at.y + 0.2,
+        at.z + Math.cos(a) * 0.85,
+        -Math.cos(a) * 1.6,
+        2.1,
+        Math.sin(a) * 1.6,
+        color,
+        0.3,
+        0.8,
+        -1.5,
+        SPR.magicWisp,
       );
     }
   }
@@ -422,9 +542,16 @@ export class Vfx {
       const a = Math.random() * Math.PI * 2;
       const r = 0.3 + Math.random() * 0.9;
       this.spawn(
-        at.x + Math.sin(a) * r, at.y + Math.random() * 0.3, at.z + Math.cos(a) * r,
-        0, 4.5 + Math.random() * 3.5, 0,
-        i % 4 === 0 ? white : gold, 0.42, 1.1 + Math.random() * 0.4, -1,
+        at.x + Math.sin(a) * r,
+        at.y + Math.random() * 0.3,
+        at.z + Math.cos(a) * r,
+        0,
+        4.5 + Math.random() * 3.5,
+        0,
+        i % 4 === 0 ? white : gold,
+        0.42,
+        1.1 + Math.random() * 0.4,
+        -1,
         i % 3 === 0 ? SPR.star : SPR.sparkle,
       );
     }
@@ -438,9 +565,16 @@ export class Vfx {
     const c = SCHOOL_COLORS[school] ?? 0xffffff;
     const a = Math.random() * Math.PI * 2;
     this.spawn(
-      at.x + Math.sin(a) * 0.5, at.y, at.z + Math.cos(a) * 0.5,
-      0, 0.9 + Math.random(), 0,
-      c, 0.26, 0.5, -0.5,
+      at.x + Math.sin(a) * 0.5,
+      at.y,
+      at.z + Math.cos(a) * 0.5,
+      0,
+      0.9 + Math.random(),
+      0,
+      c,
+      0.26,
+      0.5,
+      -0.5,
       school === 'fire' ? SPR.flame : SPR.magicWisp,
     );
   }
@@ -449,9 +583,17 @@ export class Vfx {
     if (!this.emitChance(9, dt)) return;
     const a = Math.random() * Math.PI * 2;
     this.spawn(
-      at.x + Math.sin(a) * 0.5, at.y + 0.55, at.z + Math.cos(a) * 0.5,
-      Math.sin(a) * 1.2, 1.1, Math.cos(a) * 1.2,
-      0xcfe9ff, 0.3, 0.55, 5, SPR.glowSoft,
+      at.x + Math.sin(a) * 0.5,
+      at.y + 0.55,
+      at.z + Math.cos(a) * 0.5,
+      Math.sin(a) * 1.2,
+      1.1,
+      Math.cos(a) * 1.2,
+      0xcfe9ff,
+      0.3,
+      0.55,
+      5,
+      SPR.glowSoft,
     );
   }
 
@@ -460,18 +602,34 @@ export class Vfx {
     if (Math.random() < 0.3) {
       // faint additive smoke puff drifting off the flame tip
       this.spawn(
-        at.x + (Math.random() - 0.5) * 0.3, at.y + 1.0, at.z + (Math.random() - 0.5) * 0.3,
-        (Math.random() - 0.5) * 0.35, 0.8 + Math.random() * 0.5, (Math.random() - 0.5) * 0.35,
-        0x36322e, 0.7 + Math.random() * 0.5, 1.8 + Math.random() * 0.9, -0.25, SPR.smoke,
+        at.x + (Math.random() - 0.5) * 0.3,
+        at.y + 1.0,
+        at.z + (Math.random() - 0.5) * 0.3,
+        (Math.random() - 0.5) * 0.35,
+        0.8 + Math.random() * 0.5,
+        (Math.random() - 0.5) * 0.35,
+        0x36322e,
+        0.7 + Math.random() * 0.5,
+        1.8 + Math.random() * 0.9,
+        -0.25,
+        SPR.smoke,
       );
       return;
     }
     // flame-tongue embers, mostly upright with a little flicker tilt
     this.spawn(
-      at.x + (Math.random() - 0.5) * 0.5, at.y + 0.5, at.z + (Math.random() - 0.5) * 0.5,
-      (Math.random() - 0.5) * 0.5, 1.6 + Math.random() * 1.2, (Math.random() - 0.5) * 0.5,
-      Math.random() < 0.4 ? 0xffd14d : 0xff7a2a, 0.2, 1.0 + Math.random() * 0.6, -0.4,
-      SPR.flame, (Math.random() - 0.5) * 0.6,
+      at.x + (Math.random() - 0.5) * 0.5,
+      at.y + 0.5,
+      at.z + (Math.random() - 0.5) * 0.5,
+      (Math.random() - 0.5) * 0.5,
+      1.6 + Math.random() * 1.2,
+      (Math.random() - 0.5) * 0.5,
+      Math.random() < 0.4 ? 0xffd14d : 0xff7a2a,
+      0.2,
+      1.0 + Math.random() * 0.6,
+      -0.4,
+      SPR.flame,
+      (Math.random() - 0.5) * 0.6,
     );
   }
 
@@ -498,9 +656,16 @@ export class Vfx {
           const a = Math.random() * Math.PI * 2;
           const sp = 2.5 + Math.random() * 4;
           this.spawn(
-            target.x, target.y, target.z,
-            Math.sin(a) * sp, Math.random() * 3, Math.cos(a) * sp,
-            this.tmpColor, 0.44, 0.55, 7,
+            target.x,
+            target.y,
+            target.z,
+            Math.sin(a) * sp,
+            Math.random() * 3,
+            Math.cos(a) * sp,
+            this.tmpColor,
+            0.44,
+            0.55,
+            7,
             k % 2 === 0 ? SPR.sparkle : SPR.sparkBurst,
           );
         }
@@ -513,9 +678,17 @@ export class Vfx {
       this.spawn(pr.pos.x, pr.pos.y, pr.pos.z, 0, 0, 0, pr.coreColor, 1.0, 0.12, 0, pr.coreSprite);
       if (Math.random() < 0.35 + 0.65 * this.quality) {
         this.spawn(
-          pr.pos.x + (Math.random() - 0.5) * 0.25, pr.pos.y + (Math.random() - 0.5) * 0.25, pr.pos.z + (Math.random() - 0.5) * 0.25,
-          (Math.random() - 0.5) * 0.8, 0.4, (Math.random() - 0.5) * 0.8,
-          pr.trailColor, 0.32, 0.6, 1.5, pr.trailSprite,
+          pr.pos.x + (Math.random() - 0.5) * 0.25,
+          pr.pos.y + (Math.random() - 0.5) * 0.25,
+          pr.pos.z + (Math.random() - 0.5) * 0.25,
+          (Math.random() - 0.5) * 0.8,
+          0.4,
+          (Math.random() - 0.5) * 0.8,
+          pr.trailColor,
+          0.32,
+          0.6,
+          1.5,
+          pr.trailSprite,
         );
       }
     }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -2441,6 +2441,7 @@ export class Sim {
   }
 
   private updateLootRolls(): void {
+    if (this.pendingLootRolls.size === 0) return; // skip the defensive copy on the common idle tick
     for (const roll of [...this.pendingLootRolls.values()]) {
       if (roll.expiresAt <= this.time) this.resolveLootRoll(roll);
     }

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -803,6 +803,11 @@ export class Hud {
   private compassMarks = new Map<string, HTMLElement>();
   private compassHeadingEl: HTMLElement | null = null;
   private lastCompassHeading = '';
+  // compassView is a pure function of the player facing, so an unchanged facing
+  // skips the whole rose repositioning pass (and this scratch Set avoids a
+  // per-call allocation on the frames that do reposition)
+  private lastCompassFacing = Number.NaN;
+  private compassVisibleScratch = new Set<string>();
   // Minimap zoom: a multiplier on the minimap's base pixels-per-yard. Discrete
   // presets (see minimap_zoom.ts), persisted to localStorage. 1 = shipped look.
   private minimapZoom = MINIMAP_ZOOM_DEFAULT;
@@ -2926,6 +2931,11 @@ export class Hud {
 
   attachTooltip(el: HTMLElement, html: () => string): void {
     let touchTimer: number | undefined;
+    // tooltip box size, measured once in showAt (right after the content is set)
+    // and reused by every mousemove: the content cannot change between showAt
+    // calls, so re-reading offsetWidth/Height per mousemove only forced a reflow
+    let ttW = 0;
+    let ttH = 0;
     const mobile = () => document.body.classList.contains('mobile-touch');
     const clearTouchTimer = () => {
       if (touchTimer !== undefined) window.clearTimeout(touchTimer);
@@ -2942,10 +2952,10 @@ export class Hud {
       // arrive in visual (zoomed) space, so map x/y into author space (÷ scale)
       // before clamping against the author-space tooltip box + viewport.
       const z = getUiScale();
-      const tw = this.tooltipEl.offsetWidth,
-        th = this.tooltipEl.offsetHeight;
-      this.tooltipEl.style.left = `${Math.max(8, Math.min(window.innerWidth / z - tw - 8, x / z + 14))}px`;
-      this.tooltipEl.style.top = `${Math.max(8, y / z - th - 10)}px`;
+      ttW = this.tooltipEl.offsetWidth;
+      ttH = this.tooltipEl.offsetHeight;
+      this.tooltipEl.style.left = `${Math.max(8, Math.min(window.innerWidth / z - ttW - 8, x / z + 14))}px`;
+      this.tooltipEl.style.top = `${Math.max(8, y / z - ttH - 10)}px`;
     };
     const showNearElement = () => {
       const rect = el.getBoundingClientRect();
@@ -2959,8 +2969,9 @@ export class Hud {
     el.addEventListener('mousemove', (e) => {
       if (mobile()) return;
       const z = getUiScale();
-      const tw = this.tooltipEl.offsetWidth,
-        th = this.tooltipEl.offsetHeight;
+      // reuse the box size measured in showAt: same content, no forced reflow
+      const tw = ttW,
+        th = ttH;
       this.tooltipEl.style.left = `${Math.min(window.innerWidth / z - tw - 8, e.clientX / z + 14)}px`;
       this.tooltipEl.style.top = `${Math.max(8, e.clientY / z - th - 10)}px`;
     });
@@ -4532,9 +4543,11 @@ export class Hud {
           }
         }
         const points = p.comboTargetId === target.id ? p.comboPoints : 0;
-        [...this.comboRowEl.children].forEach((pip, i) => {
-          this.toggleClass(pip as HTMLElement, 'on', i < points);
-        });
+        // indexed walk over the live collection: no per-frame array copy
+        const pips = this.comboRowEl.children;
+        for (let i = 0; i < pips.length; i++) {
+          this.toggleClass(pips[i] as HTMLElement, 'on', i < points);
+        }
       } else {
         this.setDisplay(this.comboRowEl, 'none');
       }
@@ -5529,8 +5542,12 @@ export class Hud {
 
   private updateCompass(): void {
     if (this.compassMarks.size === 0) return;
-    const view = compassView(this.sim.player.facing);
-    const visible = new Set<string>();
+    const facing = this.sim.player.facing;
+    if (facing === this.lastCompassFacing) return; // pure function of facing: nothing can have changed
+    this.lastCompassFacing = facing;
+    const view = compassView(facing);
+    const visible = this.compassVisibleScratch;
+    visible.clear();
     for (const m of view.marks) {
       const el = this.compassMarks.get(m.label);
       if (!el) continue;

--- a/src/ui/icon_prewarm.ts
+++ b/src/ui/icon_prewarm.ts
@@ -11,9 +11,12 @@ import { type IconKind, iconDataUrl } from './icons';
 
 export type IconPrewarmEntry = { kind: IconKind; id: string };
 
-// Icons per slice on the no-deadline (setTimeout) path: ~8 x 3-8ms stays well
-// under one dropped frame while draining a few hundred entries in seconds.
-const ICONS_PER_SLICE = 8;
+// Hard time budget per pump callback. One icon composes in ~3-8ms, so the
+// budget is checked BEFORE each icon (never between batches): a callback can
+// overshoot by at most one icon, not one batch. requestIdleCallback deadlines
+// are estimates; trusting them across a whole batch produced real 60-100ms
+// long tasks in CPU profiles of the first minute of play.
+const SLICE_BUDGET_MS = 6;
 
 /** Every icon the item/ability windows can ask for: the whole item catalog
  *  (bags, vendor, loot, market, quest rewards) plus every ability (action bar,
@@ -38,26 +41,29 @@ type IdleWindow = typeof window & {
  *  failing recipe is skipped rather than aborting the pump. */
 export function prewarmIconCache(
   entries: IconPrewarmEntry[],
-  opts: { warm?: (kind: IconKind, id: string) => void } = {},
+  opts: { warm?: (kind: IconKind, id: string) => void; now?: () => number } = {},
 ): () => void {
   const warm = opts.warm ?? ((kind: IconKind, id: string) => void iconDataUrl(kind, id));
+  const now = opts.now ?? (() => performance.now());
   let next = 0;
   let cancelled = false;
 
   const pump = (deadline?: IdleDeadline): void => {
     if (cancelled) return;
-    do {
-      const end = Math.min(entries.length, next + ICONS_PER_SLICE);
-      for (; next < end; next++) {
-        const entry = entries[next];
-        try {
-          warm(entry.kind, entry.id);
-        } catch {
-          // one bad recipe must not kill the warmer; the icon falls back to
-          // its normal on-demand path (which surfaces the same failure)
-        }
+    const start = now();
+    while (next < entries.length) {
+      // budget checked per ICON: stop when either our own wall-clock budget is
+      // spent or the idle deadline says the frame needs the thread back
+      if (now() - start >= SLICE_BUDGET_MS) break;
+      if (deadline !== undefined && deadline.timeRemaining() <= 3) break;
+      const entry = entries[next++];
+      try {
+        warm(entry.kind, entry.id);
+      } catch {
+        // one bad recipe must not kill the warmer; the icon falls back to
+        // its normal on-demand path (which surfaces the same failure)
       }
-    } while (next < entries.length && deadline !== undefined && deadline.timeRemaining() > 3);
+    }
     if (next < entries.length) schedule();
   };
 

--- a/src/ui/icon_prewarm.ts
+++ b/src/ui/icon_prewarm.ts
@@ -1,0 +1,74 @@
+// Idle-time icon cache warmer. Procedural icons (src/ui/icons.ts) compose a
+// canvas and serialize it with toDataURL on first request, ~3-8ms per unique
+// icon; a first vendor/bags/loot open over a cold cache used to pay that for
+// every visible item at once, a 60-300ms synchronous burst. This walks the
+// likely-needed icon ids during requestIdleCallback slices (setTimeout paced
+// fallback, same pattern as the hud's map prewarm) so the first window open
+// finds the shared urlCache already hot. Purely a cache warmer: rendering is
+// byte-identical with or without it, and it never blocks a frame.
+import { ABILITIES, ITEMS } from '../sim/data';
+import { type IconKind, iconDataUrl } from './icons';
+
+export type IconPrewarmEntry = { kind: IconKind; id: string };
+
+// Icons per slice on the no-deadline (setTimeout) path: ~8 x 3-8ms stays well
+// under one dropped frame while draining a few hundred entries in seconds.
+const ICONS_PER_SLICE = 8;
+
+/** Every icon the item/ability windows can ask for: the whole item catalog
+ *  (bags, vendor, loot, market, quest rewards) plus every ability (action bar,
+ *  spellbook, buff/debuff rows reuse ability art for most auras). Bounded by
+ *  the content tables (a few hundred entries), not by runtime state. */
+export function defaultIconPrewarmEntries(): IconPrewarmEntry[] {
+  const entries: IconPrewarmEntry[] = [];
+  for (const id of Object.keys(ITEMS)) entries.push({ kind: 'item', id });
+  for (const id of Object.keys(ABILITIES)) entries.push({ kind: 'ability', id });
+  return entries;
+}
+
+type IdleDeadline = { timeRemaining(): number };
+type IdleWindow = typeof window & {
+  requestIdleCallback?: (cb: (d: IdleDeadline) => void, opts?: { timeout: number }) => number;
+};
+
+/** Warm the icon data-URL cache for `entries` during idle time. Returns a
+ *  cancel function; cancelling is OPTIONAL (the pump drains a bounded list once
+ *  and self-terminates, and a re-run over a warm cache is a fast no-op), it just
+ *  stops the remaining slices early. `warm` is injectable for tests; a single
+ *  failing recipe is skipped rather than aborting the pump. */
+export function prewarmIconCache(
+  entries: IconPrewarmEntry[],
+  opts: { warm?: (kind: IconKind, id: string) => void } = {},
+): () => void {
+  const warm = opts.warm ?? ((kind: IconKind, id: string) => void iconDataUrl(kind, id));
+  let next = 0;
+  let cancelled = false;
+
+  const pump = (deadline?: IdleDeadline): void => {
+    if (cancelled) return;
+    do {
+      const end = Math.min(entries.length, next + ICONS_PER_SLICE);
+      for (; next < end; next++) {
+        const entry = entries[next];
+        try {
+          warm(entry.kind, entry.id);
+        } catch {
+          // one bad recipe must not kill the warmer; the icon falls back to
+          // its normal on-demand path (which surfaces the same failure)
+        }
+      }
+    } while (next < entries.length && deadline !== undefined && deadline.timeRemaining() > 3);
+    if (next < entries.length) schedule();
+  };
+
+  const schedule = (): void => {
+    const w = window as IdleWindow;
+    if (w.requestIdleCallback) w.requestIdleCallback(pump, { timeout: 2000 });
+    else window.setTimeout(() => pump(), 32);
+  };
+
+  if (entries.length > 0) schedule();
+  return () => {
+    cancelled = true;
+  };
+}

--- a/tests/client_shell.test.ts
+++ b/tests/client_shell.test.ts
@@ -432,7 +432,7 @@ describe('client HTML shell', () => {
     // on the target frame survives (those silently collapse the hot-DOM skip rate).
     expect(hudTs).toContain("this.toggleClass(this.targetFrameEl, 'elite'");
     expect(hudTs).toMatch(/this\.setStyleProp\(\s*this\.targetNameEl,\s*'color',/);
-    expect(hudTs).toContain("this.toggleClass(pip as HTMLElement, 'on', i < points);");
+    expect(hudTs).toContain("this.toggleClass(pips[i] as HTMLElement, 'on', i < points);");
     // The forced-colors hostile cue is a non-color redundant marker on the target
     // name, routed through the same elided toggleClass writer (no raw class write on the
     // per-frame hot path) so it stays write-elided.

--- a/tests/icon_prewarm.test.ts
+++ b/tests/icon_prewarm.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  defaultIconPrewarmEntries,
+  type IconPrewarmEntry,
+  prewarmIconCache,
+} from '../src/ui/icon_prewarm';
+
+type IdleCb = (d: { timeRemaining(): number }) => void;
+
+// Minimal window stub: captures idle callbacks so the test drives the pump by
+// hand (the vitest env is plain Node; jsdom is deliberately not a dependency).
+function stubWindow(): { idleQueue: IdleCb[]; restore: () => void } {
+  const idleQueue: IdleCb[] = [];
+  const fake = {
+    requestIdleCallback: (cb: IdleCb) => {
+      idleQueue.push(cb);
+      return idleQueue.length;
+    },
+    setTimeout: (cb: () => void) => {
+      idleQueue.push(() => cb());
+      return 0;
+    },
+  };
+  const prev = (globalThis as any).window;
+  (globalThis as any).window = fake;
+  return {
+    idleQueue,
+    restore: () => {
+      if (prev === undefined) delete (globalThis as any).window;
+      else (globalThis as any).window = prev;
+    },
+  };
+}
+
+function entries(n: number): IconPrewarmEntry[] {
+  return Array.from({ length: n }, (_, i) => ({ kind: 'item' as const, id: `it${i}` }));
+}
+
+describe('prewarmIconCache', () => {
+  let restore = () => {};
+  afterEach(() => restore());
+
+  it('warms every entry across slices and stops rescheduling when drained', () => {
+    const w = stubWindow();
+    restore = w.restore;
+    const warmed: string[] = [];
+    prewarmIconCache(entries(20), { warm: (_k, id) => warmed.push(id) });
+    // no deadline (undefined) means one bounded slice per callback
+    while (w.idleQueue.length > 0) w.idleQueue.shift()!(undefined as any);
+    expect(warmed).toHaveLength(20);
+    expect(warmed[0]).toBe('it0');
+    expect(warmed[19]).toBe('it19');
+    expect(w.idleQueue).toHaveLength(0); // drained: no further schedule
+  });
+
+  it('uses the idle deadline to run multiple slices in one callback', () => {
+    const w = stubWindow();
+    restore = w.restore;
+    const warmed: string[] = [];
+    prewarmIconCache(entries(30), { warm: (_k, id) => warmed.push(id) });
+    w.idleQueue.shift()!({ timeRemaining: () => 50 }); // generous deadline drains all
+    expect(warmed).toHaveLength(30);
+  });
+
+  it('cancel stops the pump between slices', () => {
+    const w = stubWindow();
+    restore = w.restore;
+    const warmed: string[] = [];
+    const cancel = prewarmIconCache(entries(20), { warm: (_k, id) => warmed.push(id) });
+    w.idleQueue.shift()!(undefined as any); // first slice only
+    const after = warmed.length;
+    expect(after).toBeGreaterThan(0);
+    expect(after).toBeLessThan(20);
+    cancel();
+    while (w.idleQueue.length > 0) w.idleQueue.shift()!(undefined as any);
+    expect(warmed).toHaveLength(after); // nothing warmed after cancel
+  });
+
+  it('a throwing recipe is skipped, not fatal', () => {
+    const w = stubWindow();
+    restore = w.restore;
+    const warmed: string[] = [];
+    prewarmIconCache(entries(3), {
+      warm: (_k, id) => {
+        if (id === 'it1') throw new Error('bad recipe');
+        warmed.push(id);
+      },
+    });
+    while (w.idleQueue.length > 0) w.idleQueue.shift()!(undefined as any);
+    expect(warmed).toEqual(['it0', 'it2']);
+  });
+
+  it('schedules nothing for an empty list', () => {
+    const w = stubWindow();
+    restore = w.restore;
+    prewarmIconCache([], { warm: () => {} });
+    expect(w.idleQueue).toHaveLength(0);
+  });
+});
+
+describe('defaultIconPrewarmEntries', () => {
+  it('covers the item catalog and the ability table', () => {
+    const list = defaultIconPrewarmEntries();
+    expect(list.length).toBeGreaterThan(100);
+    expect(list.some((e) => e.kind === 'item')).toBe(true);
+    expect(list.some((e) => e.kind === 'ability')).toBe(true);
+    for (const e of list) expect(typeof e.id).toBe('string');
+  });
+});

--- a/tests/icon_prewarm.test.ts
+++ b/tests/icon_prewarm.test.ts
@@ -40,12 +40,25 @@ describe('prewarmIconCache', () => {
   let restore = () => {};
   afterEach(() => restore());
 
+  // fake clock: each warm() call costs 2ms, so the 6ms slice budget admits 3
+  // icons per pump before the per-icon check trips
+  function fakeClock(costMs = 2): { now: () => number; tick: () => void } {
+    let t = 0;
+    return { now: () => t, tick: () => (t += costMs) };
+  }
+
   it('warms every entry across slices and stops rescheduling when drained', () => {
     const w = stubWindow();
     restore = w.restore;
+    const clock = fakeClock();
     const warmed: string[] = [];
-    prewarmIconCache(entries(20), { warm: (_k, id) => warmed.push(id) });
-    // no deadline (undefined) means one bounded slice per callback
+    prewarmIconCache(entries(20), {
+      warm: (_k, id) => {
+        warmed.push(id);
+        clock.tick();
+      },
+      now: clock.now,
+    });
     while (w.idleQueue.length > 0) w.idleQueue.shift()!(undefined as any);
     expect(warmed).toHaveLength(20);
     expect(warmed[0]).toBe('it0');
@@ -53,20 +66,55 @@ describe('prewarmIconCache', () => {
     expect(w.idleQueue).toHaveLength(0); // drained: no further schedule
   });
 
-  it('uses the idle deadline to run multiple slices in one callback', () => {
+  it('checks the budget per icon: one pump never exceeds the slice budget', () => {
     const w = stubWindow();
     restore = w.restore;
+    const clock = fakeClock(2);
     const warmed: string[] = [];
-    prewarmIconCache(entries(30), { warm: (_k, id) => warmed.push(id) });
-    w.idleQueue.shift()!({ timeRemaining: () => 50 }); // generous deadline drains all
-    expect(warmed).toHaveLength(30);
+    prewarmIconCache(entries(20), {
+      warm: (_k, id) => {
+        warmed.push(id);
+        clock.tick();
+      },
+      now: clock.now,
+    });
+    // one pump with a GENEROUS idle deadline: the 6ms wall-clock budget must
+    // still stop it after 3 icons (2ms each), not run the whole list
+    w.idleQueue.shift()!({ timeRemaining: () => 50 });
+    expect(warmed).toHaveLength(3);
+  });
+
+  it('yields early when the idle deadline runs out before the budget', () => {
+    const w = stubWindow();
+    restore = w.restore;
+    const clock = fakeClock(1);
+    const warmed: string[] = [];
+    let remaining = 10;
+    prewarmIconCache(entries(30), {
+      warm: (_k, id) => {
+        warmed.push(id);
+        clock.tick();
+        remaining -= 4; // deadline shrinks faster than the 6ms budget
+      },
+      now: clock.now,
+    });
+    w.idleQueue.shift()!({ timeRemaining: () => remaining });
+    expect(warmed).toHaveLength(2); // stopped by timeRemaining() <= 3, not the budget
+    expect(w.idleQueue).toHaveLength(1); // rescheduled for the rest
   });
 
   it('cancel stops the pump between slices', () => {
     const w = stubWindow();
     restore = w.restore;
+    const clock = fakeClock(2);
     const warmed: string[] = [];
-    const cancel = prewarmIconCache(entries(20), { warm: (_k, id) => warmed.push(id) });
+    const cancel = prewarmIconCache(entries(20), {
+      warm: (_k, id) => {
+        warmed.push(id);
+        clock.tick();
+      },
+      now: clock.now,
+    });
     w.idleQueue.shift()!(undefined as any); // first slice only
     const after = warmed.length;
     expect(after).toBeGreaterThan(0);

--- a/tests/interactions.test.ts
+++ b/tests/interactions.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   activePvpOpponentIds,
+  HOVER_REPICK_MS,
+  HoverPickGate,
   handlePickedEntity,
   hoverCursorKind,
   isAttackableEntity,
@@ -272,5 +274,31 @@ describe('handlePickedEntity', () => {
 
     expect(targetId).toBe(2);
     expect(attacks).toBe(1);
+  });
+});
+
+describe('HoverPickGate', () => {
+  it('picks on first call and then throttles a stationary pointer', () => {
+    const gate = new HoverPickGate();
+    expect(gate.shouldPick(10, 20, 1000)).toBe(true);
+    expect(gate.shouldPick(10, 20, 1001)).toBe(false);
+    expect(gate.shouldPick(10, 20, 1000 + HOVER_REPICK_MS - 1)).toBe(false);
+    expect(gate.shouldPick(10, 20, 1000 + HOVER_REPICK_MS)).toBe(true);
+  });
+
+  it('re-picks immediately when the pointer moves', () => {
+    const gate = new HoverPickGate();
+    expect(gate.shouldPick(10, 20, 1000)).toBe(true);
+    expect(gate.shouldPick(11, 20, 1001)).toBe(true); // x moved
+    expect(gate.shouldPick(11, 21, 1002)).toBe(true); // y moved
+    expect(gate.shouldPick(11, 21, 1003)).toBe(false); // stationary again
+  });
+
+  it('a movement re-pick restarts the stationary window', () => {
+    const gate = new HoverPickGate();
+    gate.shouldPick(0, 0, 1000);
+    gate.shouldPick(5, 5, 1030); // move at t=1030 re-picks
+    expect(gate.shouldPick(5, 5, 1030 + HOVER_REPICK_MS - 1)).toBe(false);
+    expect(gate.shouldPick(5, 5, 1030 + HOVER_REPICK_MS)).toBe(true);
   });
 });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -2369,3 +2369,153 @@ describe('aura magnitude over the wire (buff/debuff tooltip parity)', () => {
     expect(mirror.value).toBe(0);
   });
 });
+
+describe('aura decode reuses records across snapshots (allocation fast path)', () => {
+  function wolfWire(sim: Sim, mobId: number): Record<string, unknown> {
+    return JSON.parse(JSON.stringify(wireEntity(sim.entities.get(mobId)!)));
+  }
+
+  function makeMobWithAura(): { sim: Sim; mobId: number } {
+    const sim = new Sim({ seed: 1, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Poker');
+    const mob = [...sim.entities.values()].find((e) => e.kind === 'mob')!;
+    void pid;
+    mob.auras.push({
+      id: 'corruption',
+      name: 'Corruption',
+      kind: 'dot',
+      remaining: 12,
+      duration: 12,
+      value: 15,
+      tickInterval: 3,
+      sourceId: 0,
+      school: 'shadow',
+    });
+    return { sim, mobId: mob.id };
+  }
+
+  it('keeps the same array and record objects while only fields change', () => {
+    const { sim, mobId } = makeMobWithAura();
+    const client = bareClient(999);
+    (client as any).applySnapshot({ t: 'snap', ents: [wolfWire(sim, mobId)] });
+    const firstArr = client.entities.get(mobId)!.auras;
+    const firstRec = firstArr[0];
+    expect(firstRec.remaining).toBe(12);
+
+    // same aura set, only the remaining ticked down: the mirror must update the
+    // SAME objects in place (no per-snapshot churn) with the new field values
+    sim.entities.get(mobId)!.auras[0].remaining = 7.5;
+    (client as any).applySnapshot({ t: 'snap', ents: [wolfWire(sim, mobId)] });
+    const secondArr = client.entities.get(mobId)!.auras;
+    expect(secondArr).toBe(firstArr);
+    expect(secondArr[0]).toBe(firstRec);
+    expect(firstRec.remaining).toBe(7.5);
+    expect(firstRec.value).toBe(15);
+    expect(firstRec.school).toBe('shadow');
+  });
+
+  it('rebuilds the list when the aura composition changes', () => {
+    const { sim, mobId } = makeMobWithAura();
+    const client = bareClient(999);
+    (client as any).applySnapshot({ t: 'snap', ents: [wolfWire(sim, mobId)] });
+    const firstArr = client.entities.get(mobId)!.auras;
+
+    sim.entities.get(mobId)!.auras.push({
+      id: 'venom_bite',
+      name: 'Venom Bite',
+      kind: 'dot',
+      remaining: 6,
+      duration: 6,
+      value: 4,
+      tickInterval: 2,
+      sourceId: 0,
+      school: 'nature',
+    });
+    (client as any).applySnapshot({ t: 'snap', ents: [wolfWire(sim, mobId)] });
+    const secondArr = client.entities.get(mobId)!.auras;
+    expect(secondArr).not.toBe(firstArr); // composition changed: fresh build
+    expect(secondArr.map((a) => a.id)).toEqual(['corruption', 'venom_bite']);
+    expect(secondArr[1].value).toBe(4);
+
+    // and dropping back to one aura rebuilds again (length mismatch path)
+    sim.entities.get(mobId)!.auras.pop();
+    (client as any).applySnapshot({ t: 'snap', ents: [wolfWire(sim, mobId)] });
+    expect(client.entities.get(mobId)!.auras.map((a) => a.id)).toEqual(['corruption']);
+  });
+});
+
+describe('aura decode fast-path guards (composition edge cases)', () => {
+  function client2(sim: Sim, mobId: number) {
+    const client = bareClient(999);
+    const apply = () =>
+      (client as any).applySnapshot({
+        t: 'snap',
+        ents: [JSON.parse(JSON.stringify(wireEntity(sim.entities.get(mobId)!)))],
+      });
+    return { client, apply };
+  }
+
+  function makeMobWithTwoAuras(): { sim: Sim; mobId: number } {
+    const sim = new Sim({ seed: 1, playerClass: 'warrior', noPlayer: true });
+    sim.addPlayer('warrior', 'Poker');
+    const mob = [...sim.entities.values()].find((e) => e.kind === 'mob')!;
+    mob.auras.push(
+      {
+        id: 'corruption',
+        name: 'Corruption',
+        kind: 'dot',
+        remaining: 12,
+        duration: 12,
+        value: 15,
+        sourceId: 0,
+        school: 'shadow',
+      },
+      {
+        id: 'weakness',
+        name: 'Weakness',
+        kind: 'buff_ap',
+        remaining: 9,
+        duration: 9,
+        value: -5,
+        sourceId: 0,
+        school: 'physical',
+      },
+    );
+    return { sim, mobId: mob.id };
+  }
+
+  it('a same-length REORDER rebuilds instead of smearing fields across records', () => {
+    const { sim, mobId } = makeMobWithTwoAuras();
+    const { client, apply } = client2(sim, mobId);
+    apply();
+    const mob = sim.entities.get(mobId)!;
+    // swap the two auras: same ids, same length, different order
+    mob.auras.reverse();
+    apply();
+    const mirrored = client.entities.get(mobId)!.auras;
+    expect(mirrored.map((a) => a.id)).toEqual(['weakness', 'corruption']);
+    // each record carries ITS aura's fields, not the other slot's
+    expect(mirrored[0].value).toBe(-5);
+    expect(mirrored[1].value).toBe(15);
+    expect(mirrored[1].school).toBe('shadow');
+  });
+
+  it('the in-place path clears optional sub-fields the wire stops sending', () => {
+    const { sim, mobId } = makeMobWithTwoAuras();
+    const mob = sim.entities.get(mobId)!;
+    mob.auras[0].stacks = 3;
+    mob.auras[0].value2 = 8;
+    const { client, apply } = client2(sim, mobId);
+    apply();
+    const rec = client.entities.get(mobId)!.auras[0];
+    expect(rec.stacks).toBe(3);
+    expect(rec.value2).toBe(8);
+    // same aura set (fast path), but the optionals dropped off the wire
+    mob.auras[0].stacks = undefined;
+    mob.auras[0].value2 = undefined;
+    apply();
+    expect(client.entities.get(mobId)!.auras[0]).toBe(rec); // fast path taken
+    expect(rec.stacks).toBeUndefined(); // not a stale 3
+    expect(rec.value2).toBeUndefined(); // not a stale 8
+  });
+});

--- a/tests/utc_day.test.ts
+++ b/tests/utc_day.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { currentUtcDay } from '../src/game/utc_day';
+
+describe('currentUtcDay', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the ISO UTC day', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-01T12:34:56Z'));
+    expect(currentUtcDay()).toBe('2026-07-01');
+  });
+
+  it('caches within the refresh window and rolls over across midnight', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-01T23:59:59.700Z'));
+    expect(currentUtcDay()).toBe('2026-07-01');
+    // still inside the 1s cache window: the cached day is served as-is
+    vi.setSystemTime(new Date('2026-07-02T00:00:00.100Z'));
+    expect(currentUtcDay()).toBe('2026-07-01');
+    // past the window: the next read re-derives and sees the new day
+    vi.setSystemTime(new Date('2026-07-02T00:00:00.800Z'));
+    expect(currentUtcDay()).toBe('2026-07-02');
+  });
+});


### PR DESCRIPTION
## Summary

Behavior-preserving, visually identical performance pass over the client hot paths, in two commits: steady-state frame cost + GC churn first, then freeze/hitch sources. Both from four-way audits (renderer, sim tick, HUD per-frame, client loop + net decode) with each candidate verified for exact behavioral equivalence before landing.

## Commit 1: per-frame work and GC churn (32ddbf29)

### Renderer (src/render/renderer.ts)
- Form-swap detection (polymorph / bear / cat / ghost wolf / travel / stealth) collapsed from six per-entity `.some()` scans per frame to one pass; the flag combination preserves the original precedence exactly.
- Loot-sparkle visibility reuses the entity's already-computed squared distance.
- The selection ring's terrain drape (a per-vertex `groundHeight` noise resample, previously every frame) is cached by `(x, z, scale)`; a stationary target skips it entirely. Ring spin, pulse and hostile color still animate per frame.

### Input (src/game/interactions.ts + src/main.ts)
- New `HoverPickGate` (pure, unit-tested): the hover-cursor scene raycast used to run against every rig every frame even with the mouse still. Now it re-picks on any pointer move (instantly) or at most every 50 ms while stationary. The cursor KIND still re-resolves every frame from live entity state.

### Net decode at 20 Hz (src/net/online.ts)
- `applySnapshot` reuses one instance `seen` Set; `threat` and `cooldowns` update in place (delta-guard semantics unchanged, consumers verified to read inline).

### HUD (src/ui/hud.ts)
- Compass early-returns when facing is unchanged (`compassView` is a pure function of facing).
- Combo pips: indexed loop instead of a per-frame array spread (still through the elided `toggleClass` writer).
- Tooltip `mousemove` reuses the box size measured in `showAt` instead of forcing a reflow per event.

### Misc
- `src/game/utc_day.ts` (new): the offline sim's injected `utcDay` string re-derives at most once per second instead of `new Date().toISOString()` per rAF frame.
- `src/sim/sim.ts`: `updateLootRolls` skips the defensive copy on the common empty tick.

## Commit 2: freezes and allocation bursts (a8e3dc4f)

- **Icon cache warmer** (`src/ui/icon_prewarm.ts`, new): the first vendor/bags/loot open paid a synchronous 60-300 ms burst composing every visible item icon (canvas + `toDataURL` per unique icon). The warmer drains the whole item + ability catalog through `requestIdleCallback` slices (8 per slice, `setTimeout` fallback, same pattern as the HUD map prewarm) right after boot, so the shared `urlCache` is hot before any window opens. Purely a cache warmer: rendering is byte-identical.
- **Aura decode fast path** (`src/net/online.ts`): when the wire aura ids line up index-for-index with the existing records (the common case: only `remaining` ticks down between snapshots), the records update in place; no fresh array + object per aura per entity at 20 Hz. Composition changes (gain/fade/reorder/substitution) still rebuild. The preserved object identity matches the offline Sim contract (one live aura object across ticks), so the online mirror is now MORE faithful, not less. A cross-platform-sync review confirmed field-for-field lockstep with the `wireEntity` encoder (12/12 fields MATCH, absence semantics preserved).
- **Per-school projectile color cache** (`src/render/vfx.ts`): three `THREE.Color` allocations per bolt launch eliminated; `spawn()` only copies components, never retains the reference. Keyed on `GFX.composer` so a tier flip rebuilds the HDR variants.

## Deliberately rejected during review
- Aura-derived stat caches (armor/AP/move speed): real cache-invalidation risk for marginal gain.
- Cleave via the spatial grid: changes target iteration order, which shifts rng draw order.
- Reusing the renderer telemetry objects: they escape `sync()` into the perf sample.
- A `stepProjectile` squared-distance compare was applied and then reverted: the architecture reviewer proved it differs from the sqrt compare by 1 ulp at the boundary and it only saved one sqrt per projectile lifetime.

## Verification
- Parity gate (golden traces + rng draw order), `architecture`, `snapshots` (incl. 5 new fast-path pins: identity reuse, field updates, rebuild on gain/shrink, same-length reorder, optional-field clearing), `bandwidth`, `hud_perf_budget`, `painter_host`, `alloc_probe`, `client_shell`, `interactions`, `icon_prewarm`, `utc_day`: all green.
- `tsc --noEmit` clean; Biome error-level clean on changed files.
- QA gate (`qa-checklist`) on both commits: READY, 0 blocking. `architecture-reviewer` and `cross-platform-sync` passes clean (the former drove the projectile revert).
- `npm run perf:prewarm` (prewarm travel bench): all dungeon interiors at +0 program growth; open-world program growth is confined to known waypoints (see follow-ups).
- `npm run perf:tour`: prewarm 4.6 s of the 12 s budget (17/17 steps, 0 failures), HUD hot-write skip rate 98%, FCT burst cap-bounded.
- Browser smoke test on the offline world: loads and plays normally; compass/target/selection ring/tooltips behave identically.
- The 8 full-suite failures observed locally are pre-existing 5 s timeout flakes under load: identical failures reproduce on a clean v0.18.0 checkout on the same machine, and every affected file passes in isolation.

## Follow-up candidates (out of scope here)
- Prewarm coverage gaps surfaced by the travel bench (first-sight shader compiles at `vale.north-edge` +17 programs, `marsh.north-edge` +10, `marsh.entry` +4; benign pop-in on async-compile GPUs, a real stall on sync-compile clients). Extending `prewarmInitialScene` there must be weighed against its 12 s budget.
- Bags/market full DOM rebuild per search keystroke (~75 KB churn); keyed reconciliation like `auras_painter`.
- FCT spawn-shape descriptor memoization for AoE event bursts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)