### PR TITLE
fix(assets): respect base path for public assets

### DIFF
--- a/src/asset_url.ts
+++ b/src/asset_url.ts
@@ -1,0 +1,17 @@
+const EXTERNAL_URL_RE = /^[a-z][a-z\d+\-.]*:/i;
+
+function logicalPublicPath(url: string): string {
+  return url.replace(/^(?:\/+|\.\/)+/, '');
+}
+
+function normalizedBase(base: string): string {
+  if (!base || base === '/') return '/';
+  if (base === '.' || base === './') return './';
+  return base.endsWith('/') ? base : `${base}/`;
+}
+
+export function publicAssetUrl(url: string, base = import.meta.env.BASE_URL): string {
+  if (EXTERNAL_URL_RE.test(url) || url.startsWith('//')) return url;
+  const logical = logicalPublicPath(url);
+  return `${normalizedBase(base)}${logical}`;
+}

--- a/src/game/music.ts
+++ b/src/game/music.ts
@@ -1,3 +1,5 @@
+import { publicAssetUrl } from '../asset_url';
+
 // Procedural adventure soundtrack — no audio files, pure WebAudio synthesis.
 // Eastbrook keeps the original town theme intact. Every other zone pushes
 // harder toward original old-school medieval MMO colors: lute/dulcimer loops,
@@ -25,6 +27,7 @@ const DUNGEON_MUSIC: Record<string, MusicZone> = {
   sunken_bastion: 'dungeon_sunken_bastion',
   gravewyrm_sanctum: 'dungeon_gravewyrm_sanctum',
 };
+const BOSS_TRACK_URL = '/audio/dungeon-boss-fight.mp3';
 
 export function dungeonMusicZoneForDungeon(dungeonId: string): MusicZone {
   return DUNGEON_MUSIC[dungeonId] ?? 'dungeon_hollow_crypt';
@@ -122,7 +125,9 @@ function composeTownEastbrook(): Theme {
     pushNote(ev, b0 + 2, c.root - 24, 1.8, 0.42, 'bass');
     // harp: flowing eighth arpeggio root-3rd-5th-octave and back
     const arp = [t[0], t[1], t[2], t[0] + 12, t[2], t[1], t[0], t[1]];
-    arp.forEach((n, i) => pushNote(ev, b0 + i * 0.5, n, 0.5, 0.34, 'harp'));
+    arp.forEach((n, i) => {
+      pushNote(ev, b0 + i * 0.5, n, 0.5, 0.34, 'harp');
+    });
     // horn counterline in the back half of each section
     if (bar % 8 >= 4) {
       pushNote(ev, b0, c.root - 12, 2, 0.16, 'horn');
@@ -157,11 +162,15 @@ function composeTownEastbrook(): Theme {
 }
 
 function pushRepeated(out: NoteEvent[], startBeat: number, notes: number[], step: number, dur: number, vel: number, inst: Inst): void {
-  notes.forEach((m, i) => pushNote(out, startBeat + i * step, m, dur, vel, inst));
+  notes.forEach((m, i) => {
+    pushNote(out, startBeat + i * step, m, dur, vel, inst);
+  });
 }
 
 function pushDrumHits(out: NoteEvent[], startBeat: number, offsets: number[], inst: Inst, vel: number, midi = 42): void {
-  offsets.forEach((b, i) => pushNote(out, startBeat + b, midi, 0.22, vel * (i % 2 === 0 ? 1 : 0.78), inst));
+  offsets.forEach((b, i) => {
+    pushNote(out, startBeat + b, midi, 0.22, vel * (i % 2 === 0 ? 1 : 0.78), inst);
+  });
 }
 
 function pushPedal(out: NoteEvent[], beat: number, root: number, inst: Inst, vel: number): void {
@@ -323,7 +332,9 @@ function composeLegacyVale(): Theme {
     if (bar % 4 === 1) pushNote(ev, b0 + 2, c.root - 5, 1.8, 0.24, 'bass');
     if (bar % 4 === 3) pushNote(ev, b0 + 2.5, c.root - 10, 1.4, 0.22, 'bass');
     if (bar % 4 === 2) {
-      [t[2], t[0] + 12, t[1] + 12].forEach((n, i) => pushNote(ev, b0 + 1 + i * 0.5, n, 0.5, 0.2, 'harp'));
+      [t[2], t[0] + 12, t[1] + 12].forEach((n, i) => {
+        pushNote(ev, b0 + 1 + i * 0.5, n, 0.5, 0.2, 'harp');
+      });
     }
   });
 
@@ -456,7 +467,9 @@ function composeDungeonFight(
     const ost = opts.doubleTime
       ? [0, 1, 0, 3, 0, 6, 5, 3, 0, 1, 0, 3, 7, 6, 5, 3]
       : [0, 1, 0, 3, 0, 6, 5, 3];
-    ost.forEach((s, i) => pushNote(ev, b0 + i * (opts.doubleTime ? 0.25 : 0.5), figureRoot + s, opts.doubleTime ? 0.18 : 0.28, 0.20, i % 2 === 0 ? 'stacc' : opts.lead));
+    ost.forEach((s, i) => {
+      pushNote(ev, b0 + i * (opts.doubleTime ? 0.25 : 0.5), figureRoot + s, opts.doubleTime ? 0.18 : 0.28, 0.20, i % 2 === 0 ? 'stacc' : opts.lead);
+    });
 
     pushDrumHits(ev, b0, opts.mode === 'crypt' ? [0, 1.5, 2.5, 3.5] : [0, 0.75, 1.5, 2, 2.75, 3.5], 'warDrum', opts.mode === 'wyrm' ? 0.34 : 0.26, 38);
     pushDrumHits(ev, b0, [0.5, 1.25, 2.25, 3.25], 'woodBlock', 0.11, 70);
@@ -521,7 +534,9 @@ function composeCombat(): Theme {
     pushNote(ev, b0 + 3.5, 38, 0.5, 0.3, 'timpani');
     // driving staccato eighths: 1-1-b3-1-5-1-b3-4 in semitones from D3
     const steps = [0, 0, 3, 0, 7, 0, 3, 5];
-    steps.forEach((s, i) => pushNote(ev, b0 + i * 0.5, 50 + s, 0.4, 0.26, 'stacc'));
+    steps.forEach((s, i) => {
+      pushNote(ev, b0 + i * 0.5, 50 + s, 0.4, 0.26, 'stacc');
+    });
     if (bar % 2 === 1) {
       pushNote(ev, b0, 50, 1.6, 0.2, 'horn');
       pushNote(ev, b0 + 0.02, 57, 1.6, 0.16, 'horn');
@@ -1143,7 +1158,7 @@ export class MusicDirector {
   private ensureBossElement(): HTMLAudioElement | null {
     if (this.bossElement) return this.bossElement;
     if (typeof Audio !== 'function') return null;
-    const el = new Audio('/audio/dungeon-boss-fight.mp3');
+    const el = new Audio(publicAssetUrl(BOSS_TRACK_URL));
     el.loop = true;
     el.preload = 'auto';
     this.bossElement = el;
@@ -1154,7 +1169,7 @@ export class MusicDirector {
     const ctx = this.ctx;
     if (!ctx || this.bossBuffer || this.bossLoading || typeof fetch !== 'function') return;
     this.bossLoading = true;
-    void fetch('/audio/dungeon-boss-fight.mp3')
+    void fetch(publicAssetUrl(BOSS_TRACK_URL))
       .then((res) => res.arrayBuffer())
       .then((bytes) => ctx.decodeAudioData(bytes))
       .then((buffer) => {

--- a/src/game/sfx.ts
+++ b/src/game/sfx.ts
@@ -10,6 +10,7 @@
 // and sustained spell casts (cross-faded by gain, never restarted).
 
 import { SFX_CLIPS } from './sfx_manifest.generated';
+import { publicAssetUrl } from '../asset_url';
 
 const SAMPLE_GAIN = 0.85; // base level for sampled clips; sfxVolume multiplies this
 const MAX_VOICES = 24;     // concurrent one-shot sources (frame-budget guard)
@@ -87,7 +88,7 @@ class Sfx {
     if (!ctx) return;
     await Promise.all(Object.entries(SFX_CLIPS).map(async ([key, entry]) => {
       try {
-        const res = await fetch(entry.url);
+        const res = await fetch(publicAssetUrl(entry.url));
         if (!res.ok) return;
         const buf = await ctx.decodeAudioData(await res.arrayBuffer());
         this.buffers.set(key, buf);

--- a/src/game/voice.ts
+++ b/src/game/voice.ts
@@ -8,6 +8,7 @@
 // missing files are silent no-ops, so the game runs fine before any audio exists.
 
 import { VOICE_LINES } from './voice_manifest.generated';
+import { publicAssetUrl } from '../asset_url';
 
 // Voices sit slightly under their slider value so NPC dialogue doesn't overpower
 // the SFX/ambience mix.
@@ -45,11 +46,13 @@ class GameVoice {
     if (!src) return;
     this.stop();
     if (!this.el) this.el = new Audio();
-    this.el.src = src;
+    this.el.src = publicAssetUrl(src);
     this.el.volume = Math.min(1, this.vol * VOICE_BASE_GAIN * (opts?.gain ?? 1));
     // Autoplay restrictions / a missing file reject the promise — ignore, the
     // dialogue text is the source of truth and audio is an enhancement.
-    void this.el.play().catch(() => { /* no-op */ });
+    void this.el.play().catch(() => {
+      /* no-op */
+    });
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@
 // index.html and play.html both bootstrap through this module, so this one import
 // styles both game entries; admin/guide use their own entries and inline CSS.
 import './styles/index.css';
+import { publicAssetUrl } from './asset_url';
 import { syncAppViewport as syncAppViewportShared } from './game/app_viewport';
 import { audio } from './game/audio';
 import {
@@ -7112,7 +7113,7 @@ function wireStartScreens(): void {
 // playing through the loading screen and fades out once the game is on screen.
 function initHomepageMusic(): void {
   if (homepageMusic) return;
-  const el = new Audio('/audio/main-theme.mp3');
+  const el = new Audio(publicAssetUrl('/audio/main-theme.mp3'));
   el.loop = true;
   el.muted = homepageMusicMuted;
   el.preload = 'auto';

--- a/src/render/assets/media.ts
+++ b/src/render/assets/media.ts
@@ -1,11 +1,12 @@
 import { MEDIA_ASSETS } from './manifest.generated';
+import { publicAssetUrl } from '../../asset_url';
 
 function logicalPath(url: string): string {
   return url.replace(/^\/+/, '');
 }
 
-export function assetUrl(url: string): string {
+export function assetUrl(url: string, opts: { base?: string; dev?: boolean } = {}): string {
   const logical = logicalPath(url);
-  if (import.meta.env.DEV) return `/${logical}`;
-  return MEDIA_ASSETS[logical] ?? `/${logical}`;
+  const resolved = (opts.dev ?? import.meta.env.DEV) ? logical : (MEDIA_ASSETS[logical] ?? logical);
+  return publicAssetUrl(resolved, opts.base ?? import.meta.env.BASE_URL);
 }

--- a/src/render/nameplate_painter.ts
+++ b/src/render/nameplate_painter.ts
@@ -17,6 +17,7 @@
 // ui_tier_knobs.nameplateIntervalSec), which the renderer reads, not the painter.
 
 import * as THREE from 'three';
+import { publicAssetUrl } from '../asset_url';
 import { ABILITIES, MOBS, QUESTS } from '../sim/data';
 import { specialRoleColor } from '../sim/discord_roles';
 import { type Entity, isQuestTurnInNpc } from '../sim/types';
@@ -59,7 +60,7 @@ import { type NameplatePlan, nameplatePlanInto, newNameplatePlan } from './namep
 import { FRIENDLY, isFriendlyPet, mobNameColor } from './reaction';
 import type { EntityView } from './renderer';
 
-const emoteIconUrl = (id: string): string => `/ui/emotes/emote-${id}.png`;
+const emoteIconUrl = (id: string): string => publicAssetUrl(`/ui/emotes/emote-${id}.png`);
 
 export interface NameplatePainterDeps {
   /** the per-entity view pool the renderer owns (keyed by entity id) */

--- a/src/ui/emote_icons.ts
+++ b/src/ui/emote_icons.ts
@@ -1,5 +1,6 @@
 import type { OverheadEmoteId } from '../world_api';
+import { publicAssetUrl } from '../asset_url';
 
 export function emoteIconUrl(id: OverheadEmoteId): string {
-  return `/ui/emotes/emote-${id}.png`;
+  return publicAssetUrl(`/ui/emotes/emote-${id}.png`);
 }

--- a/src/ui/icons.ts
+++ b/src/ui/icons.ts
@@ -9,6 +9,7 @@
 // has a proper icon. Results are cached as data URLs.
 
 import { ABILITIES, ITEMS } from '../sim/data';
+import { publicAssetUrl } from '../asset_url';
 import { ITEM_WEAPON_VARIANTS } from './weapon_variants';
 
 export type IconKind = 'ability' | 'item' | 'aura' | 'crest';
@@ -2802,7 +2803,7 @@ const ITEM_ICON_IMAGES = ITEM_WEAPON_VARIANTS;
 /** Static URL of a weapon's rendered thumbnail, or null if it uses a recipe. */
 function weaponIconUrl(id: string): string | null {
   const model = ITEM_ICON_IMAGES[id];
-  return model ? `${WEAPON_ICON_DIR}/${model}.jpg` : null;
+  return model ? publicAssetUrl(`${WEAPON_ICON_DIR}/${model}.jpg`) : null;
 }
 
 // Hand-picked image icons for class abilities, committed as 128px WebP under
@@ -2998,7 +2999,7 @@ export const ABILITY_IMAGE_IDS = new Set<string>([
 export function abilityImageUrl(id: string): string | null {
   if (!ABILITY_IMAGE_IDS.has(id)) return null;
   const cls = ABILITIES[id]?.class;
-  return cls ? `${SKILL_ICON_DIR}/${cls}/${id}.webp` : null;
+  return cls ? publicAssetUrl(`${SKILL_ICON_DIR}/${cls}/${id}.webp`) : null;
 }
 
 const urlCache = new Map<string, string>();

--- a/tests/asset_url.test.ts
+++ b/tests/asset_url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { publicAssetUrl } from '../src/asset_url';
+import { assetUrl } from '../src/render/assets/media';
+
+describe('public asset urls', () => {
+  it('prefixes root-relative public paths with Vite base', () => {
+    expect(publicAssetUrl('/media/foo.glb', '/world-of-claudecraft/')).toBe(
+      '/world-of-claudecraft/media/foo.glb',
+    );
+  });
+
+  it('accepts bases without trailing slash', () => {
+    expect(publicAssetUrl('audio/main-theme.mp3', '/game')).toBe('/game/audio/main-theme.mp3');
+  });
+
+  it('preserves relative base deployments', () => {
+    expect(publicAssetUrl('/ui/emotes/emote-wave.png', './')).toBe('./ui/emotes/emote-wave.png');
+  });
+
+  it('preserves external and inline urls', () => {
+    expect(publicAssetUrl('https://cdn.example.com/a.png', '/game/')).toBe(
+      'https://cdn.example.com/a.png',
+    );
+    expect(publicAssetUrl('//cdn.example.com/a.png', '/game/')).toBe('//cdn.example.com/a.png');
+    expect(publicAssetUrl('data:image/png;base64,abc', '/game/')).toBe('data:image/png;base64,abc');
+    expect(publicAssetUrl('blob:https://example.com/abc', '/game/')).toBe(
+      'blob:https://example.com/abc',
+    );
+  });
+
+  it('resolves media loader dev paths against base', () => {
+    expect(assetUrl('/models/player.glb', { base: '/world-of-claudecraft/', dev: true })).toBe(
+      '/world-of-claudecraft/models/player.glb',
+    );
+  });
+
+  it('resolves media loader fallback paths against base', () => {
+    expect(
+      assetUrl('/models/not-in-manifest.glb', { base: '/world-of-claudecraft/', dev: false }),
+    ).toBe('/world-of-claudecraft/models/not-in-manifest.glb');
+  });
+});


### PR DESCRIPTION
## Summary

- Add a shared `publicAssetUrl()` helper for public-folder assets so runtime URLs are resolved under Vite `BASE_URL` instead of assuming site root.
- Route media manifest URLs, audio clips, homepage/boss music, overhead emotes, and image-backed item/ability icons through that helper.
- Cover root, subpath, relative-base, fallback media, and external URL behavior with focused unit tests.

## Related issues

Closes #1255

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\asset_url.ts src\render\assets\media.ts src\game\sfx.ts src\game\voice.ts src\game\music.ts src\main.ts src\ui\emote_icons.ts src\render\nameplate_painter.ts src\ui\icons.ts tests\asset_url.test.ts`
  - `npx biome lint src\asset_url.ts src\render\assets\media.ts src\game\sfx.ts src\game\voice.ts src\game\music.ts src\main.ts src\ui\emote_icons.ts src\render\nameplate_painter.ts src\ui\icons.ts tests\asset_url.test.ts` (exits 0; existing warnings remain in older files)
  - `npm run check:ts`
  - `.browserslistrc` comment-stripped wrapper around `npx vitest run tests/asset_url.test.ts tests/music.test.ts tests/skill_icons.test.ts tests/aura_icons.test.ts tests/ability_icons.test.ts` (5 files, 24 tests passed; wrapper restored original bytes afterward)
  - `.browserslistrc` comment-stripped wrapper around `npm run build` (passes; wrapper restored original bytes afterward; build emits existing chunk/dynamic-import warnings)
- Manual steps: N/A; no UI/UX behavior changed beyond asset URL resolution.

## Screenshots / recordings

N/A; asset path resolution fix only.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.