### PR TITLE
fix(render): disambiguate stacked corpse picks

### DIFF
--- a/src/render/pick_resolution.ts
+++ b/src/render/pick_resolution.ts
@@ -1,0 +1,33 @@
+import type { Entity } from '../sim/types';
+
+type PickEntity = Pick<Entity, 'id' | 'kind' | 'dead' | 'lootable'>;
+
+function lootableCorpse(e: PickEntity): boolean {
+  return e.kind === 'mob' && e.dead && e.lootable;
+}
+
+export function resolveDirectPickEntityId(
+  hitEntityIds: readonly number[],
+  entities: Pick<Map<number, PickEntity>, 'get'>,
+  currentTargetId: number | null = null,
+): number | null {
+  const ordered: PickEntity[] = [];
+  const seen = new Set<number>();
+  for (const id of hitEntityIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const e = entities.get(id);
+    if (!e) continue;
+    if (e.kind === 'object' && !e.lootable) return null;
+    if (e.kind === 'mob' && e.dead && !e.lootable) continue;
+    ordered.push(e);
+  }
+  if (ordered.length === 0) return null;
+
+  const corpses = ordered.filter(lootableCorpse);
+  if (lootableCorpse(ordered[0]) && corpses.length > 1 && currentTargetId !== null) {
+    const idx = corpses.findIndex((e) => e.id === currentTargetId);
+    if (idx >= 0) return corpses[(idx + 1) % corpses.length].id;
+  }
+  return ordered[0].id;
+}

--- a/src/render/renderer.ts
+++ b/src/render/renderer.ts
@@ -80,6 +80,7 @@ import {
   nameplateScreenTransform,
 } from './nameplate_projection';
 import { PlacedAssetsView } from './placed_assets';
+import { resolveDirectPickEntityId } from './pick_resolution';
 import { buildComposer, type PostPipeline } from './post';
 import { buildPropMaterialPrewarmGroup, buildProps } from './props';
 import { buildGroundQuestObject } from './quest_objects';
@@ -5189,6 +5190,7 @@ export class Renderer {
     );
     this.raycaster.setFromCamera(ndc, this.camera);
     const hits = this.raycaster.intersectObjects(this.clickTargets, true);
+    const directHitIds: number[] = [];
     for (const hit of hits) {
       let o: THREE.Object3D | null = hit.object;
       while (o) {
@@ -5200,16 +5202,22 @@ export class Renderer {
           const hitView = this.views.get(id);
           if (hitView && !hitView.group.visible) break;
           const e = this.sim.entities.get(id);
-          if (e?.kind === 'object' && !e.lootable) return null;
           // The graveyard angel is hidden from the living, so it must not be
           // click-pickable either (the capsule proxy ignores `visible`): skip it
           // unless the local player is a released spirit.
           if (e?.templateId === 'spirit_healer' && !this.sim.player?.ghost) break;
-          return id;
+          directHitIds.push(id);
+          break;
         }
         o = o.parent;
       }
     }
+    const directPick = resolveDirectPickEntityId(
+      directHitIds,
+      this.sim.entities,
+      this.sim.player.targetId,
+    );
+    if (directHitIds.length > 0) return directPick;
     // Forgiving assist: nothing under the ray, so snap to the nearest
     // targetable character within a small screen radius — chibi proportions
     // and melee scrums (often hidden behind the player's own model) make

--- a/tests/pick_resolution.test.ts
+++ b/tests/pick_resolution.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { resolveDirectPickEntityId } from '../src/render/pick_resolution';
+
+type TestPickEntity = {
+  id: number;
+  kind: 'mob' | 'object' | 'player' | 'npc';
+  dead: boolean;
+  lootable: boolean;
+};
+
+function entities(
+  list: Array<{
+    id: number;
+    kind: TestPickEntity['kind'];
+    dead?: boolean;
+    lootable?: boolean;
+  }>,
+): Map<number, TestPickEntity> {
+  return new Map(
+    list.map((e) => [
+      e.id,
+      {
+        dead: false,
+        lootable: false,
+        ...e,
+      },
+    ]),
+  );
+}
+
+describe('resolveDirectPickEntityId', () => {
+  it('keeps a normal single lootable corpse pick unchanged', () => {
+    const map = entities([{ id: 10, kind: 'mob', dead: true, lootable: true }]);
+    expect(resolveDirectPickEntityId([10], map, 10)).toBe(10);
+  });
+
+  it('skips an already-unlootable corpse to reach a stacked lootable corpse', () => {
+    const map = entities([
+      { id: 10, kind: 'mob', dead: true, lootable: false },
+      { id: 11, kind: 'mob', dead: true, lootable: true },
+    ]);
+    expect(resolveDirectPickEntityId([10, 11], map)).toBe(11);
+  });
+
+  it('cycles to the next lootable corpse in a stacked direct-hit set', () => {
+    const map = entities([
+      { id: 10, kind: 'mob', dead: true, lootable: true },
+      { id: 11, kind: 'mob', dead: true, lootable: true },
+      { id: 12, kind: 'mob', dead: true, lootable: true },
+    ]);
+    expect(resolveDirectPickEntityId([10, 11, 12], map, 10)).toBe(11);
+    expect(resolveDirectPickEntityId([10, 11, 12], map, 11)).toBe(12);
+    expect(resolveDirectPickEntityId([10, 11, 12], map, 12)).toBe(10);
+  });
+
+  it('dedupes repeated child hits before cycling stacked corpses', () => {
+    const map = entities([
+      { id: 10, kind: 'mob', dead: true, lootable: true },
+      { id: 11, kind: 'mob', dead: true, lootable: true },
+    ]);
+    expect(resolveDirectPickEntityId([10, 10, 11], map, 10)).toBe(11);
+  });
+
+  it('does not bypass a non-corpse first hit while cycling corpses', () => {
+    const map = entities([
+      { id: 9, kind: 'mob', dead: false },
+      { id: 10, kind: 'mob', dead: true, lootable: true },
+      { id: 11, kind: 'mob', dead: true, lootable: true },
+    ]);
+    expect(resolveDirectPickEntityId([9, 10, 11], map, 10)).toBe(9);
+  });
+
+  it('preserves unlootable object blocking behavior', () => {
+    const map = entities([
+      { id: 20, kind: 'object', lootable: false },
+      { id: 10, kind: 'mob', dead: true, lootable: true },
+    ]);
+    expect(resolveDirectPickEntityId([20, 10], map)).toBeNull();
+  });
+});


### PR DESCRIPTION
﻿## Summary

- Collect all direct raycast entity hits before resolving a click target.
- Cycle stacked lootable corpses when the currently targeted corpse is clicked again, so repeated clicks can reach every corpse in an overlapping stack.
- Preserve existing single-corpse behavior and unlootable object blocking.

## Related issues

Closes #1257

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\render\pick_resolution.ts tests\pick_resolution.test.ts`
  - `npx biome lint src\render\pick_resolution.ts src\render\renderer.ts tests\pick_resolution.test.ts` (exits 0; existing renderer non-null assertion warnings remain)
  - `.browserslistrc` comment-strip wrapper around `npx vitest run tests\pick_resolution.test.ts tests\sloppy_pick.test.ts tests\interactions.test.ts` (3 files, 26 tests passed)
  - `npm run check:ts`
  - `.browserslistrc` comment-strip wrapper around `npm run build` (passes; existing Vite dynamic-import/chunk/plugin timing warnings remain)
- Manual steps: N/A; covered with focused pick-resolution and existing interaction/sloppy-pick tests.

## Screenshots / recordings

N/A; this is click-target resolution logic with no visible UI design change.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
