### PR TITLE
fix(sim): pause natural mana regen in combat

### DIFF
--- a/src/sim/combat/auras.ts
+++ b/src/sim/combat/auras.ts
@@ -61,7 +61,7 @@ export function isRejectedFriendlyNpcAura(aura: Aura): boolean {
 export function updateRegen(ctx: SimContext, p: Entity, _meta: PlayerMeta): void {
   if (ctx.tickCount % 40 !== 0) return; // every 2 seconds (the classic tick)
   if (p.resourceType === 'mana') {
-    if (p.fiveSecondRule >= 5) {
+    if (!p.inCombat && p.fiveSecondRule >= 5) {
       // out-of-combat mana regen: faster than before and scales with spirit
       // (gear/level) plus a small flat per-level floor so low-spirit casters
       // still recover at a reasonable pace (#103)

--- a/src/sim/social/chat_readouts.ts
+++ b/src/sim/social/chat_readouts.ts
@@ -37,7 +37,6 @@ import { threatEntries } from '../threat';
 import {
   type ArenaFormat,
   type Aura,
-  type AuraKind,
   dist2d,
   type Entity,
   type EquipSlot,
@@ -306,6 +305,9 @@ export function manaRegenReadout(e: Entity): string {
   const FSR_THRESHOLD = 5; // matches the `fiveSecondRule >= 5` gate in updateRegen
   if (e.resourceType !== 'mana') {
     return 'Mana regeneration does not apply to your class.';
+  }
+  if (e.inCombat) {
+    return 'Mana regen is paused — leave combat to resume.';
   }
   if (e.fiveSecondRule >= FSR_THRESHOLD) {
     return 'Your mana is regenerating (out of combat for 5s+).';

--- a/tests/combat_auras.test.ts
+++ b/tests/combat_auras.test.ts
@@ -135,6 +135,19 @@ describe('auras: updateAuras expiry / HoT / top guard', () => {
 });
 
 describe('auras: updateRegen', () => {
+  it('keeps natural mana regen paused while in combat', () => {
+    const sim = makeSim();
+    const pid = sim.addPlayer('mage', 'Aleph');
+    const p = sim.entities.get(pid) as AnyEntity;
+    const meta = sim.players.get(pid) as PlayerMeta;
+    p.resource = 0;
+    p.inCombat = true;
+    p.fiveSecondRule = 99;
+    sim.tickCount = 40; // a multiple of 40 so the regen body runs
+    updateRegen(sim.ctx, p, meta);
+    expect(p.resource).toBe(0);
+  });
+
   it('eat heals an out-of-combat player on the 40-tick boundary, decrementing the food', () => {
     const sim = makeSim();
     const p = sim.player as AnyEntity;

--- a/tests/manaregen_command.test.ts
+++ b/tests/manaregen_command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
-import { SimEvent } from '../src/sim/types';
+import type { Entity, SimEvent } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -11,12 +11,18 @@ function errorText(events: SimEvent[]): string | undefined {
   return e?.text;
 }
 
+function entity(sim: Sim, id: number): Entity {
+  const e = sim.entities.get(id);
+  if (!e) throw new Error(`missing entity ${id}`);
+  return e;
+}
+
 describe('/manaregen command', () => {
   it('reports regen active once past the five-second rule', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('mage', 'Aleph');
     sim.tick();
-    const e = sim.entities.get(a)!;
+    const e = entity(sim, a);
     e.fiveSecondRule = 6;
     sim.chat('/manaregen', a);
     expect(errorText(sim.tick())).toBe('Your mana is regenerating (out of combat for 5s+).');
@@ -26,10 +32,23 @@ describe('/manaregen command', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('mage', 'Aleph');
     sim.tick();
-    const e = sim.entities.get(a)!;
+    const e = entity(sim, a);
     e.fiveSecondRule = 2.4; // 5 - 2.4 = 2.6 -> ceil 3
     sim.chat('/5sr', a);
-    expect(errorText(sim.tick())).toBe('Mana regen is paused — resumes in 3s (you spent mana recently).');
+    expect(errorText(sim.tick())).toBe(
+      'Mana regen is paused — resumes in 3s (you spent mana recently).',
+    );
+  });
+
+  it('reports combat as the blocker before the five-second-rule countdown', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('mage', 'Aleph');
+    sim.tick();
+    const e = entity(sim, a);
+    e.inCombat = true;
+    e.fiveSecondRule = 99;
+    sim.chat('/manaregen', a);
+    expect(errorText(sim.tick())).toBe('Mana regen is paused — leave combat to resume.');
   });
 
   it('tells non-mana classes the mechanic does not apply', () => {

--- a/tests/sim.test.ts
+++ b/tests/sim.test.ts
@@ -865,7 +865,7 @@ describe('food, drink, vendor', () => {
     sim.setPlayerLevel(10);
     sim.player.resource = 0;
     sim.player.inCombat = false;
-    sim.player.combatTimer = 0;
+    sim.player.combatTimer = 99;
     sim.player.fiveSecondRule = 99; // out of combat, past the 5s rule
     const spi = sim.player.stats.spi;
     const oldRatePer2s = spi / 4 + 2;


### PR DESCRIPTION
﻿## Summary

- Keep natural mana regeneration paused while the player is in combat.
- Make `/manaregen` report combat as the blocker before showing the five-second-rule countdown.
- Add coverage for the in-combat pause while preserving the existing #103 potion and out-of-combat regen behavior.

## Related issues

Part of #103

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\combat\auras.ts src\sim\social\chat_readouts.ts tests\combat_auras.test.ts tests\manaregen_command.test.ts tests\sim.test.ts`
  - `npx biome lint src\sim\combat\auras.ts src\sim\social\chat_readouts.ts tests\combat_auras.test.ts tests\manaregen_command.test.ts tests\sim.test.ts` (exits 0; existing warning noise remains in broad legacy test files)
  - `.browserslistrc` comment-strip wrapper around `npx vitest run tests\combat_auras.test.ts tests\manaregen_command.test.ts tests\sim.test.ts tests\items.test.ts` (4 files, 123 tests passed)
  - `npm run check:ts`
  - `.browserslistrc` comment-strip wrapper around `npx vitest run tests\parity\harness.test.ts --testTimeout=30000` (1 file, 19 tests passed)
  - `.browserslistrc` comment-strip wrapper around `npm run build` (passes; existing Vite dynamic-import/chunk/plugin timing warnings remain)
- Manual steps: N/A; sim and command behavior covered by focused tests.

## Screenshots / recordings

N/A; this changes sim resource logic and a slash-command text response, not visual UI layout.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR follows existing slash-command readout literal handling and adds no i18n-keyed UI strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
