### PR TITLE
feat(sim): rotate vendor surplus stock

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -516,6 +516,7 @@ function identityFields(e: Entity): Record<string, unknown> {
       break;
     }
   }
+  if (e.kind === 'npc' && e.vendorItems.length > 0) out.vi = e.vendorItems;
   if (e.holderTier) out.ht = e.holderTier; // $WOC holder-tier flair (cosmetic)
   if (e.holderBalance) out.hb = Math.round(e.holderBalance); // exact $WOC, for inspect
   if (e.discordTier) out.dt = e.discordTier; // Discord status-tier flair (cosmetic)

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -780,6 +780,11 @@ function blankEntity(id: number): Entity {
     xpValue: 0,
     questIds: [],
     vendorItems: [],
+    vendorBaseItems: [],
+    vendorRotatingItems: [],
+    vendorStockSlots: 1,
+    vendorStockRefreshAt: 0,
+    vendorStockGeneration: 0,
     objectItemId: null,
     dungeonId: null,
     dead: false,
@@ -1242,8 +1247,14 @@ export class ClientWorld implements IWorld {
         e.guild = w.gd ?? '';
         if (e.kind === 'npc') {
           const def = NPCS[e.templateId];
+          const baseItems = def?.vendorItems ? [...def.vendorItems] : [];
           e.questIds = def ? [...def.questIds] : [];
-          e.vendorItems = def?.vendorItems ? [...def.vendorItems] : [];
+          e.vendorBaseItems = baseItems;
+          e.vendorRotatingItems = def?.vendorRotatingItems ? [...def.vendorRotatingItems] : [];
+          e.vendorStockSlots = def?.vendorStockSlots ?? 1;
+          e.vendorItems = Array.isArray(w.vi)
+            ? w.vi.filter((itemId: unknown) => typeof itemId === 'string')
+            : baseItems;
         }
       }
       // interpolation bases: re-anchor at the pose the renderer last drew,

--- a/src/sim/content/items.ts
+++ b/src/sim/content/items.ts
@@ -1217,6 +1217,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 8, max: 14, speed: 2.5 },
     stats: { str: 2 },
     sellValue: 170,
+    buyValue: 1700,
   },
   tradesman_hatchet: {
     id: 'tradesman_hatchet',
@@ -1227,6 +1228,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 7, max: 13, speed: 2.3 },
     stats: { str: 1, sta: 1 },
     sellValue: 160,
+    buyValue: 1600,
   },
   drovers_staff: {
     id: 'drovers_staff',
@@ -1237,6 +1239,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 9, max: 15, speed: 3.0 },
     stats: { int: 3, spi: 2 },
     sellValue: 175,
+    buyValue: 1750,
     requiredClass: MAG,
   },
   caravan_warden_dirk: {
@@ -1248,6 +1251,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 5, max: 9, speed: 1.7, dagger: true },
     stats: { agi: 3 },
     sellValue: 170,
+    buyValue: 1700,
     requiredClass: ROG,
   },
   outrider_brigandine: {
@@ -1259,6 +1263,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 95, str: 1, sta: 2 },
     sellValue: 165,
+    buyValue: 1650,
   },
   caravan_quilted_vest: {
     id: 'caravan_quilted_vest',
@@ -1279,6 +1284,7 @@ export const BASE_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 60, agi: 2, sta: 1 },
     sellValue: 150,
+    buyValue: 1500,
   },
   outrider_legguards: {
     id: 'outrider_legguards',

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -538,6 +538,7 @@ export const ZONE1_NPCS: Record<string, NpcDef> = {
       'minor_healing_potion',
       'minor_mana_potion',
     ],
+    vendorRotatingItems: ['brightwood_venison', 'elixir_of_the_bear'],
     greeting: 'Fresh bread, clean water, fair prices. What can I get you?',
   },
   apothecary_lin: {
@@ -588,6 +589,14 @@ export const ZONE1_NPCS: Record<string, NpcDef> = {
       'tanned_leather_jerkin',
       'hobnail_boots',
       'eastbrook_wool_trousers',
+    ],
+    vendorRotatingItems: [
+      'crossroads_saber',
+      'tradesman_hatchet',
+      'drovers_staff',
+      'caravan_warden_dirk',
+      'outrider_brigandine',
+      'wanderers_chestguard',
     ],
     greeting: 'Mind the sparks, $C. Good steel is the difference between a scar and a grave.',
   },

--- a/src/sim/content/zone2.ts
+++ b/src/sim/content/zone2.ts
@@ -651,6 +651,14 @@ export const ZONE2_NPCS: Record<string, NpcDef> = {
       'fenwalker_boots',
       'reedwoven_trousers',
     ],
+    vendorRotatingItems: [
+      'deacons_cleaver',
+      'staff_of_drowned_prayers',
+      'mistbinder_kris',
+      'drownedguard_breastplate',
+      'fenmist_robe',
+      'eelskin_tunic',
+    ],
     greeting:
       'Dry boots, dry bread, dry powder — at Fenbridge you get two of the three on a good day.',
   },
@@ -1500,6 +1508,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 11, max: 18, speed: 2.4 },
     stats: { str: 4 },
     sellValue: 300,
+    buyValue: 3000,
     requiredClass: WAR,
   },
   staff_of_drowned_prayers: {
@@ -1511,6 +1520,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 12, max: 20, speed: 3.0 },
     stats: { int: 5, spi: 2 },
     sellValue: 300,
+    buyValue: 3000,
     requiredClass: MAG,
   },
   mistbinder_kris: {
@@ -1522,6 +1532,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 7, max: 12, speed: 1.7, dagger: true },
     stats: { agi: 4 },
     sellValue: 300,
+    buyValue: 3000,
     requiredClass: ROG,
   },
   drownedguard_breastplate: {
@@ -1533,6 +1544,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 130, sta: 4 },
     sellValue: 350,
+    buyValue: 3500,
     requiredClass: WAR,
   },
   fenmist_robe: {
@@ -1544,6 +1556,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 45, int: 5, spi: 3 },
     sellValue: 350,
+    buyValue: 3500,
     requiredClass: MAG,
   },
   eelskin_tunic: {
@@ -1555,6 +1568,7 @@ export const ZONE2_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 80, agi: 5 },
     sellValue: 350,
+    buyValue: 3500,
     requiredClass: ROG,
   },
   trollhide_leggings: {

--- a/src/sim/content/zone3.ts
+++ b/src/sim/content/zone3.ts
@@ -889,6 +889,12 @@ export const ZONE3_NPCS: Record<string, NpcDef> = {
       'cragwalker_boots',
       'windguard_leggings',
     ],
+    vendorRotatingItems: [
+      'boneplate_vest',
+      'revenant_silk_robe',
+      'nightwalk_jerkin',
+      'drogmar_warboots',
+    ],
     greeting:
       'Wool, hardtack, and steel-shod boots — Highwatch runs on all three, and I am short of everything.',
   },
@@ -901,6 +907,13 @@ export const ZONE3_NPCS: Record<string, NpcDef> = {
     color: 0x717d7e,
     questIds: [],
     vendorItems: ['highwatch_warblade', 'craghorn_staff', 'icevein_dirk'],
+    vendorRotatingItems: [
+      'zealotsbane_blade',
+      'emberwood_staff',
+      'cultist_flayer',
+      'ironvein_pickblade',
+      'ironvein_lantern_staff',
+    ],
     greeting: 'Forge is hot and the grindstone is turning. If it cuts, I sell it.',
   },
   loremaster_caddis: {
@@ -1900,6 +1913,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 170, sta: 5, str: 3 },
     sellValue: 800,
+    buyValue: 8000,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   revenant_silk_robe: {
@@ -1911,6 +1925,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 60, int: 5, spi: 3 },
     sellValue: 800,
+    buyValue: 8000,
     requiredClass: ['mage', 'priest', 'warlock', 'druid'],
   },
   nightwalk_jerkin: {
@@ -1922,6 +1937,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 105, agi: 6, sta: 2 },
     sellValue: 800,
+    buyValue: 8000,
     requiredClass: ['rogue', 'hunter'],
   },
   zealotsbane_blade: {
@@ -1933,6 +1949,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 18, max: 29, speed: 2.3 },
     stats: { str: 6, sta: 2 },
     sellValue: 900,
+    buyValue: 9000,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   emberwood_staff: {
@@ -1944,6 +1961,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 20, max: 33, speed: 3.0 },
     stats: { int: 6, spi: 2 },
     sellValue: 900,
+    buyValue: 9000,
     requiredClass: ['mage', 'priest', 'warlock', 'druid'],
   },
   cultist_flayer: {
@@ -1955,6 +1973,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 12, max: 19, speed: 1.7, dagger: true },
     stats: { agi: 8 },
     sellValue: 900,
+    buyValue: 9000,
     requiredClass: ['rogue', 'hunter'],
   },
   drogmar_warboots: {
@@ -1966,6 +1985,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     quality: 'uncommon',
     stats: { armor: 85, str: 3, sta: 4 },
     sellValue: 950,
+    buyValue: 9500,
     requiredClass: ['warrior', 'paladin', 'shaman'],
   },
   ironvein_pickblade: {
@@ -1977,6 +1997,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 13, max: 21, speed: 1.8, dagger: true },
     stats: { agi: 7, sta: 2 },
     sellValue: 950,
+    buyValue: 9500,
     requiredClass: ['rogue', 'hunter'],
   },
   ironvein_lantern_staff: {
@@ -1988,6 +2009,7 @@ export const ZONE3_ITEMS: Record<string, ItemDef> = {
     weapon: { min: 19, max: 31, speed: 3.0 },
     stats: { int: 7, spi: 3 },
     sellValue: 950,
+    buyValue: 9500,
     requiredClass: ['mage', 'priest', 'warlock', 'druid'],
   },
   marrowlord_boneboots: {

--- a/src/sim/entity.ts
+++ b/src/sim/entity.ts
@@ -110,6 +110,11 @@ function baseEntity(id: number, pos: Vec3): Entity {
     xpValue: 0,
     questIds: [],
     vendorItems: [],
+    vendorBaseItems: [],
+    vendorRotatingItems: [],
+    vendorStockSlots: 1,
+    vendorStockRefreshAt: 0,
+    vendorStockGeneration: 0,
     objectItemId: null,
     dungeonId: null,
     dead: false,
@@ -436,7 +441,10 @@ export function createNpc(id: number, def: NpcDef, pos: Vec3): Entity {
   e.prevFacing = def.facing;
   e.color = def.color;
   e.questIds = [...def.questIds];
-  e.vendorItems = [...(def.vendorItems ?? [])];
+  e.vendorBaseItems = [...(def.vendorItems ?? [])];
+  e.vendorItems = [...e.vendorBaseItems];
+  e.vendorRotatingItems = [...(def.vendorRotatingItems ?? [])];
+  e.vendorStockSlots = def.vendorStockSlots ?? 1;
   return e;
 }
 

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -189,6 +189,7 @@ import { advancePendingProjectiles, type PendingProjectile } from './projectile_
 import { sanitizeRemovedZone1Content } from './removed_zone1_content';
 import { Rng } from './rng';
 import { persistedResource } from './serialize_resource';
+import { refreshVendorStock, scheduleVendorStockRefresh } from './vendor_stock';
 import { createSimContext, type SimContext, type SimContextHost } from './sim_context';
 import * as chatMod from './social/chat';
 import * as tradeMod from './social/trade';
@@ -937,6 +938,7 @@ export class Sim {
       if (npcDef.dynamic) continue; // spawned on demand by its owning system, not surface-placed
       const safe = this.findSafePos(npcDef.pos.x, npcDef.pos.z, WATER_LEVEL + 0.6);
       const npc = createNpc(this.nextId++, npcDef, this.groundPos(safe.x, safe.z));
+      scheduleVendorStockRefresh(npc, this.time, this.cfg.seed);
       this.addEntity(npc);
       if (npcDef.market) this.market.merchantIds.push(npc.id); // every auctioneer anchors the shared World Market
     }
@@ -2383,6 +2385,9 @@ export class Sim {
         this.updateMob(e);
         updateAuras(this.ctx, e);
       } else if (e.kind === 'npc') {
+        if (refreshVendorStock(e, this.time, this.cfg.seed)) {
+          this.emit({ type: 'vendor', action: 'refresh' });
+        }
         cleanseFriendlyNpcAuras(this.ctx, e);
       } else if (e.kind === 'object') {
         if (!e.lootable) {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1110,6 +1110,10 @@ export interface NpcDef {
   color: number;
   questIds: string[];
   vendorItems?: string[];
+  // Optional local surplus pool. NPCs with this set rotate a small number of
+  // extra goods into their vendor stock on a 15-45 minute sim-clock cadence.
+  vendorRotatingItems?: string[];
+  vendorStockSlots?: number;
   // The Merchant: talking to this NPC opens the player-driven World Market
   // (auction house) instead of a fixed vendor stock.
   market?: boolean;
@@ -1435,6 +1439,11 @@ export interface Entity {
   // npc
   questIds: string[];
   vendorItems: string[];
+  vendorBaseItems: string[];
+  vendorRotatingItems: string[];
+  vendorStockSlots: number;
+  vendorStockRefreshAt: number;
+  vendorStockGeneration: number;
   // object (ground interactable)
   objectItemId: string | null;
   dungeonId: string | null; // set on dungeon door/exit portals
@@ -1576,7 +1585,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'respawn' }
   // itemId names the single item for buy/sell/buyback; it is omitted for the
   // bulk "sell all junk" sweep, which the client treats as a plain refresh signal.
-  | { type: 'vendor'; action: 'buy' | 'sell' | 'buyback'; itemId?: string }
+  | { type: 'vendor'; action: 'buy' | 'sell' | 'buyback' | 'refresh'; itemId?: string }
   // say/yell are delivered only to players in range and carry the speaker's
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is

--- a/src/sim/vendor_stock.ts
+++ b/src/sim/vendor_stock.ts
@@ -1,0 +1,77 @@
+import type { Entity } from './types';
+
+export const VENDOR_STOCK_REFRESH_MIN = 15 * 60;
+export const VENDOR_STOCK_REFRESH_MAX = 45 * 60;
+
+function hashString(input: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function hashUnit(input: string): number {
+  return hashString(input) / 0x100000000;
+}
+
+function vendorKey(e: Entity): string {
+  return e.templateId || String(e.id);
+}
+
+function refreshDelay(seed: number, key: string, generation: number): number {
+  const roll = hashUnit(`${seed}:${key}:${generation}:delay`);
+  return Math.round(
+    VENDOR_STOCK_REFRESH_MIN + roll * (VENDOR_STOCK_REFRESH_MAX - VENDOR_STOCK_REFRESH_MIN),
+  );
+}
+
+function pickRotatingItems(
+  pool: readonly string[],
+  baseItems: readonly string[],
+  slots: number,
+  seed: number,
+  key: string,
+  generation: number,
+): string[] {
+  const base = new Set(baseItems);
+  const candidates = pool.filter((itemId) => !base.has(itemId));
+  const picks: string[] = [];
+  for (let slot = 0; slot < slots && picks.length < candidates.length; slot++) {
+    const available = candidates.filter((itemId) => !picks.includes(itemId));
+    const roll = hashUnit(`${seed}:${key}:${generation}:item:${slot}`);
+    picks.push(available[Math.floor(roll * available.length)]);
+  }
+  return picks;
+}
+
+export function scheduleVendorStockRefresh(e: Entity, now: number, seed: number): boolean {
+  if (e.kind !== 'npc' || e.vendorRotatingItems.length === 0) return false;
+  if (e.vendorStockRefreshAt > now) return false;
+
+  e.vendorStockRefreshAt = now + refreshDelay(seed, vendorKey(e), e.vendorStockGeneration + 1);
+  return true;
+}
+
+export function refreshVendorStock(e: Entity, now: number, seed: number): boolean {
+  if (e.kind !== 'npc' || e.vendorRotatingItems.length === 0) return false;
+  if (e.vendorStockRefreshAt <= 0) scheduleVendorStockRefresh(e, now, seed);
+  if (e.vendorStockRefreshAt > now) return false;
+
+  const generation = e.vendorStockGeneration + 1;
+  const key = vendorKey(e);
+  const slots = Math.max(1, e.vendorStockSlots);
+  const rotating = pickRotatingItems(
+    e.vendorRotatingItems,
+    e.vendorBaseItems,
+    slots,
+    seed,
+    key,
+    generation,
+  );
+  e.vendorItems = [...e.vendorBaseItems, ...rotating];
+  e.vendorStockGeneration = generation;
+  e.vendorStockRefreshAt = now + refreshDelay(seed, key, generation + 1);
+  return true;
+}

--- a/tests/parity/trace.ts
+++ b/tests/parity/trace.ts
@@ -175,6 +175,11 @@ export const ENTITY_EXCLUDE: ReadonlySet<string> = new Set([
   'equippedItems', // render-only mirror for inspect; sim never reads it for gameplay
   'holderTier', // cosmetic wallet flair; sim never reads it
   'holderBalance',
+  'vendorBaseItems', // deterministic vendor-stock bookkeeping; vendorItems carries the offer list
+  'vendorRotatingItems',
+  'vendorStockSlots',
+  'vendorStockRefreshAt',
+  'vendorStockGeneration',
   'stealthed', // derived cache of auras.some(a => a.kind === 'stealth'); auras is sampled
 ]);
 

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -321,6 +321,23 @@ describe('Combat Mech held weapon over the wire', () => {
   });
 });
 
+describe('NPC vendor stock over the wire', () => {
+  it('mirrors rotated vendor items instead of rebuilding static stock client-side', () => {
+    const sim = new Sim({ seed: 7, playerClass: 'warrior', autoEquip: true });
+    const vendor = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes')!;
+    expect(vendor.kind).toBe('npc');
+    vendor.vendorItems = [...vendor.vendorBaseItems, 'brightwood_venison'];
+
+    const wire = wireEntity(vendor);
+    expect(wire.vi).toEqual(vendor.vendorItems);
+
+    const client = bareClient(sim.playerId + 1000);
+    (client as any).applySnapshot({ t: 'snap', ents: [wire] });
+    const mirrored = client.entities.get(vendor.id)!;
+    expect(mirrored.vendorBaseItems).toEqual(vendor.vendorBaseItems);
+    expect(mirrored.vendorItems).toEqual(vendor.vendorItems);
+  });
+});
 describe('combat ratings over the wire', () => {
   it('mirrors Ranged Attack Power so online hunter attack-spell tooltips can scale', () => {
     const sim = new Sim({ seed: 7, playerClass: 'hunter', autoEquip: true });

--- a/tests/vendor_stock.test.ts
+++ b/tests/vendor_stock.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { ITEMS, NPCS } from '../src/sim/data';
+import { createNpc } from '../src/sim/entity';
+import { Sim } from '../src/sim/sim';
+import { DT, type NpcDef } from '../src/sim/types';
+import {
+  refreshVendorStock,
+  scheduleVendorStockRefresh,
+  VENDOR_STOCK_REFRESH_MAX,
+  VENDOR_STOCK_REFRESH_MIN,
+} from '../src/sim/vendor_stock';
+
+function testVendorDef(overrides: Partial<NpcDef> = {}): NpcDef {
+  return {
+    id: 'test_vendor',
+    name: 'Test Vendor',
+    title: 'Provisioner',
+    pos: { x: 0, z: 0 },
+    facing: 0,
+    color: 0xffffff,
+    questIds: [],
+    vendorItems: ['baked_bread'],
+    vendorRotatingItems: ['spring_water', 'roasted_boar', 'tough_jerky'],
+    greeting: 'Hello.',
+    ...overrides,
+  };
+}
+
+describe('rotating vendor stock', () => {
+  it('schedules surplus refreshes on a 15-45 minute sim-clock cadence', () => {
+    const npc = createNpc(99, testVendorDef({ vendorStockSlots: 2 }), { x: 0, y: 0, z: 0 });
+
+    expect(scheduleVendorStockRefresh(npc, 0, 1234)).toBe(true);
+    expect(npc.vendorStockRefreshAt).toBeGreaterThanOrEqual(VENDOR_STOCK_REFRESH_MIN);
+    expect(npc.vendorStockRefreshAt).toBeLessThanOrEqual(VENDOR_STOCK_REFRESH_MAX);
+    expect(npc.vendorItems).toEqual(['baked_bread']);
+
+    expect(refreshVendorStock(npc, npc.vendorStockRefreshAt - 0.01, 1234)).toBe(false);
+    expect(npc.vendorStockGeneration).toBe(0);
+
+    const dueAt = npc.vendorStockRefreshAt;
+    expect(refreshVendorStock(npc, dueAt, 1234)).toBe(true);
+    expect(npc.vendorStockGeneration).toBe(1);
+    expect(npc.vendorItems[0]).toBe('baked_bread');
+    expect(npc.vendorItems).toHaveLength(3);
+    expect(new Set(npc.vendorItems).size).toBe(npc.vendorItems.length);
+    for (const itemId of npc.vendorItems.slice(1)) {
+      expect(npc.vendorRotatingItems).toContain(itemId);
+    }
+    expect(npc.vendorStockRefreshAt).toBeGreaterThanOrEqual(dueAt + VENDOR_STOCK_REFRESH_MIN);
+    expect(npc.vendorStockRefreshAt).toBeLessThanOrEqual(dueAt + VENDOR_STOCK_REFRESH_MAX);
+  });
+
+  it('keeps starting vendor stock stable until the timed refresh is due', () => {
+    const sim = new Sim({ seed: 42, playerClass: 'warrior', autoEquip: true });
+    const wilkes = [...sim.entities.values()].find((e) => e.templateId === 'trader_wilkes');
+
+    expect(wilkes?.kind).toBe('npc');
+    if (wilkes?.kind !== 'npc') throw new Error('trader_wilkes not spawned');
+
+    expect(wilkes.vendorBaseItems).toEqual(NPCS.trader_wilkes.vendorItems);
+    expect(wilkes.vendorItems).toEqual(wilkes.vendorBaseItems);
+    expect(wilkes.vendorStockRefreshAt).toBeGreaterThanOrEqual(VENDOR_STOCK_REFRESH_MIN);
+    expect(wilkes.vendorStockRefreshAt).toBeLessThanOrEqual(VENDOR_STOCK_REFRESH_MAX);
+
+    wilkes.vendorStockRefreshAt = sim.time + DT;
+    const events = sim.tick();
+    const surplus = wilkes.vendorItems.filter((itemId) => !wilkes.vendorBaseItems.includes(itemId));
+    expect(events).toContainEqual({ type: 'vendor', action: 'refresh' });
+    expect(surplus).toHaveLength(1);
+    expect(wilkes.vendorRotatingItems).toContain(surplus[0]);
+    expect(ITEMS[surplus[0]]?.buyValue).toBeGreaterThan(0);
+  });
+
+  it('only rotates items that have vendor buy prices', () => {
+    for (const npc of Object.values(NPCS)) {
+      for (const itemId of npc.vendorRotatingItems ?? []) {
+        expect(ITEMS[itemId]?.buyValue, `${npc.id} rotates unsellable ${itemId}`).toBeGreaterThan(
+          0,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds deterministic rotating surplus stock for NPC vendors on a 15-45 minute sim-clock cadence.
- Keeps each vendor's standing stock stable at spawn, then rotates one extra local upgrade item when its refresh is due.
- Mirrors rotated NPC vendor stock over the online entity wire so clients see the authoritative server offers.
- Adds buy prices for the specific items that can now appear as vendor surplus.

## Related issues

Part of #14

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write server\game.ts src\net\online.ts src\sim\content\items.ts src\sim\content\zone1.ts src\sim\content\zone2.ts src\sim\content\zone3.ts src\sim\entity.ts src\sim\sim.ts src\sim\types.ts src\sim\vendor_stock.ts tests\parity\trace.ts tests\snapshots.test.ts tests\vendor_stock.test.ts` (pass)
  - `npx biome lint server\game.ts src\net\online.ts src\sim\content\items.ts src\sim\content\zone1.ts src\sim\content\zone2.ts src\sim\content\zone3.ts src\sim\entity.ts src\sim\sim.ts src\sim\types.ts src\sim\vendor_stock.ts tests\parity\trace.ts tests\snapshots.test.ts tests\vendor_stock.test.ts --max-diagnostics=20` (exit 0; existing warning noise in `src/net/online.ts` and `tests/snapshots.test.ts`)
  - `npm run check:ts` (pass)
  - `.browserslistrc` comment-clean wrapper + `npx vitest run tests/vendor_stock.test.ts tests/snapshots.test.ts tests/progression.test.ts tests/vendor_view.test.ts` (103 tests passed)
  - `.browserslistrc` comment-clean wrapper + `npx vitest run tests/parity/parity.test.ts --testTimeout=30000` (94 tests passed)
  - `.browserslistrc` comment-clean wrapper + `npm run build` (pass; generated files restored afterward)
- Manual steps: N/A; covered by sim, snapshot, vendor-view/progression, parity, typecheck, and build validation.

## Screenshots / recordings

N/A. This changes vendor stock behavior and online snapshot state, not visual layout or UI styling.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.