### PR TITLE
feat(inventory): add gear set core

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -250,6 +250,9 @@ const HEAVY_SELF_REFRESH_TICKS = 40; // ~2 s backstop; staggered per session so 
 const HEAVY_SELF_CMDS = new Set<string>([
   'equip',
   'unequip_item',
+  'saveGearSet',
+  'equipGearSet',
+  'deleteGearSet',
   'use',
   'discard',
   'buy',
@@ -2278,6 +2281,15 @@ export class GameServer {
           sim.unequipItem(msg.slot as EquipSlot, pid);
         }
         break;
+      case 'saveGearSet':
+        if (typeof msg.name === 'string') sim.saveGearSet(msg.name, pid);
+        break;
+      case 'equipGearSet':
+        if (typeof msg.index === 'number') sim.equipGearSet(Math.floor(msg.index), pid);
+        break;
+      case 'deleteGearSet':
+        if (typeof msg.index === 'number') sim.deleteGearSet(Math.floor(msg.index), pid);
+        break;
       case 'use':
         if (typeof msg.item === 'string') {
           const result = sim.useItem(msg.item, pid);
@@ -3118,6 +3130,7 @@ export class GameServer {
       maybe('inv', meta.inventory);
       maybe('buyback', meta.vendorBuyback);
       maybe('equip', meta.equipment);
+      maybe('gsets', meta.gearSets);
       maybe('cosmetics', anchorSession.accountCosmetics);
       maybe('qlog', [...meta.questLog.values()]);
       maybe('qdone', [...meta.questsDone]);

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -30,6 +30,7 @@ import {
   type MasterLootThreshold,
   type MoveInput,
   type PlayerClass,
+  type SavedGearSet,
   type QuestProgress,
   type QuestState,
   type SimEvent,
@@ -810,6 +811,7 @@ export class ClientWorld implements IWorld {
   inventory: InvSlot[] = [];
   vendorBuyback: InvSlot[] = [];
   equipment: Partial<Record<EquipSlot, string>> = {};
+  gearSets: SavedGearSet[] = [];
   copper = 0;
   // --- IWorldCosmetics: account cosmetics (completed-quest + mech-chroma ids),
   // mirrored from snapshot self. ---
@@ -1432,6 +1434,7 @@ export class ClientWorld implements IWorld {
         this.invChanged = true;
       }
       if (s.equip !== undefined) this.equipment = s.equip;
+      if (s.gsets !== undefined) this.gearSets = s.gsets;
       // IWorldCosmetics facet (W7) self-decode: cosmetics is delta-guarded (a
       // missing field keeps the prior mirror); normalizeAccountCosmetics rebuilds it.
       if (s.cosmetics !== undefined) {
@@ -1673,6 +1676,15 @@ export class ClientWorld implements IWorld {
   }
   unequipItem(slot: EquipSlot): void {
     this.cmd({ cmd: 'unequip_item', slot });
+  }
+  saveGearSet(name: string): void {
+    this.cmd({ cmd: 'saveGearSet', name });
+  }
+  equipGearSet(index: number): void {
+    this.cmd({ cmd: 'equipGearSet', index });
+  }
+  deleteGearSet(index: number): void {
+    this.cmd({ cmd: 'deleteGearSet', index });
   }
   useItem(itemId: string): void {
     this.cmd({ cmd: 'use', item: itemId });

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -28,6 +28,7 @@ import {
   CONSUME_TICKS,
   dist2d,
   type Entity,
+  EQUIP_SLOTS,
   type EquipSlot,
   FISHING_CAST_ID,
   INTERACT_RANGE,
@@ -35,6 +36,8 @@ import {
 } from './types';
 import { vendorStackSize } from './vendor_stack';
 
+export const MAX_GEAR_SETS = 8;
+const GEAR_SET_NAME_MAX = 24;
 const VENDOR_BUYBACK_LIMIT = 12;
 
 export function discardItem(ctx: SimContext, itemId: string, count = 1, pid?: number): void {
@@ -109,6 +112,69 @@ export function unequipItem(ctx: SimContext, slot: EquipSlot, pid?: number): boo
   return true;
 }
 
+function cleanGearSetName(name: string): string {
+  const clean = String(name || '')
+    .trim()
+    .slice(0, GEAR_SET_NAME_MAX);
+  return clean || 'Gear Set';
+}
+
+function cloneGearEquipment(
+  equipment: Partial<Record<EquipSlot, string>>,
+): Partial<Record<EquipSlot, string>> {
+  const out: Partial<Record<EquipSlot, string>> = {};
+  for (const slot of EQUIP_SLOTS) {
+    const itemId = equipment[slot];
+    if (typeof itemId === 'string' && ITEMS[itemId]) out[slot] = itemId;
+  }
+  return out;
+}
+
+export function saveGearSet(ctx: SimContext, name: string, pid?: number): number {
+  const r = ctx.resolve(pid);
+  if (!r) return -1;
+  const clean = cleanGearSetName(name);
+  const saved = { name: clean, equipment: cloneGearEquipment(r.meta.equipment) };
+  const existing = r.meta.gearSets.findIndex((set) => set.name === clean);
+  if (existing >= 0) {
+    r.meta.gearSets[existing] = saved;
+    return existing;
+  }
+  if (r.meta.gearSets.length >= MAX_GEAR_SETS) return -1;
+  r.meta.gearSets.push(saved);
+  return r.meta.gearSets.length - 1;
+}
+
+export function equipGearSet(ctx: SimContext, index: number, pid?: number): boolean {
+  const r = ctx.resolve(pid);
+  if (!r) return false;
+  if (!Number.isInteger(index)) return false;
+  const set = r.meta.gearSets[index];
+  if (!set) return false;
+
+  let changed = false;
+  for (const slot of EQUIP_SLOTS) {
+    const desired = set.equipment[slot];
+    const current = r.meta.equipment[slot];
+    if (desired === current) continue;
+    if (!desired) {
+      changed = unequipItem(ctx, slot, pid) || changed;
+      continue;
+    }
+    if (ctx.countItem(desired, r.meta.entityId) <= 0) continue;
+    const before = r.meta.equipment[slot];
+    equipItem(ctx, desired, pid);
+    changed = changed || r.meta.equipment[slot] !== before;
+  }
+  return changed;
+}
+
+export function deleteGearSet(ctx: SimContext, index: number, pid?: number): boolean {
+  const r = ctx.resolve(pid);
+  if (!r || !Number.isInteger(index) || index < 0 || index >= r.meta.gearSets.length) return false;
+  r.meta.gearSets.splice(index, 1);
+  return true;
+}
 export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseResult | undefined {
   const r = ctx.resolve(pid);
   if (!r) return;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -271,6 +271,7 @@ import {
   DUNGEON_LEASH_DISTANCE,
   dist2d,
   type Entity,
+  EQUIP_SLOTS,
   type EquipSlot,
   type ErrorReason,
   emptyMoveInput,
@@ -296,6 +297,7 @@ import {
   type PlayerClass,
   type QuestProgress,
   type QuestState,
+  type SavedGearSet,
   RUN_SPEED,
   type SimConfig,
   type SimEvent,
@@ -632,6 +634,7 @@ export interface PlayerMeta {
   vendorBuyback: InvSlot[];
   copper: number;
   equipment: PlayerEquipment;
+  gearSets: SavedGearSet[];
   xp: number;
   // Post-cap progression (Max-Level XP Overflow). `lifetimeXp` is the monotonic
   // 64-bit-safe total of all XP ever earned — it keeps growing at the cap and is
@@ -736,6 +739,7 @@ export interface CharacterState {
   pos: { x: number; z: number };
   facing: number;
   equipment: PlayerEquipment;
+  gearSets?: SavedGearSet[];
   inventory: InvSlot[];
   vendorBuyback?: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
@@ -1163,6 +1167,7 @@ export class Sim {
       vendorBuyback: [],
       copper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
+      gearSets: [],
       xp: 0,
       lifetimeXp: 0,
       prestigeRank: 0,
@@ -1219,6 +1224,15 @@ export class Sim {
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
+      meta.gearSets = (s.gearSets ?? []).map((set) => ({
+        name: String(set.name || 'Gear Set').slice(0, 24),
+        equipment: Object.fromEntries(
+          EQUIP_SLOTS.flatMap((slot) => {
+            const itemId = set.equipment?.[slot];
+            return typeof itemId === 'string' && ITEMS[itemId] ? [[slot, itemId]] : [];
+          }),
+        ),
+      }));
       meta.inventory = s.inventory.map((i) => ({ ...i }));
       meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
       for (const q of s.questLog) {
@@ -1400,6 +1414,7 @@ export class Sim {
       pos: { x: e.pos.x, z: e.pos.z },
       facing: e.facing,
       equipment: { ...meta.equipment },
+      gearSets: meta.gearSets.map((set) => ({ name: set.name, equipment: { ...set.equipment } })),
       inventory: meta.inventory.map((i) => ({ ...i })),
       vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
       questLog: [...meta.questLog.values()].map((q) => ({
@@ -1597,6 +1612,9 @@ export class Sim {
   }
   get equipment(): PlayerEquipment {
     return this.primary.equipment;
+  }
+  get gearSets(): SavedGearSet[] {
+    return this.primary.gearSets;
   }
   get copper(): number {
     return this.primary.copper;
@@ -4247,6 +4265,15 @@ export class Sim {
 
   unequipItem(slot: EquipSlot, pid?: number): boolean {
     return items.unequipItem(this.ctx, slot, pid);
+  }
+  saveGearSet(name: string, pid?: number): number {
+    return items.saveGearSet(this.ctx, name, pid);
+  }
+  equipGearSet(index: number, pid?: number): boolean {
+    return items.equipGearSet(this.ctx, index, pid);
+  }
+  deleteGearSet(index: number, pid?: number): boolean {
+    return items.deleteGearSet(this.ctx, index, pid);
   }
 
   private hasFishableWaterAhead(p: Entity): boolean {

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -376,6 +376,10 @@ export interface InvSlot {
   count: number;
 }
 
+export interface SavedGearSet {
+  name: string;
+  equipment: Partial<Record<EquipSlot, string>>;
+}
 export interface LootSlot extends InvSlot {
   // Quest corpse loot can be personal: each listed player can take one copy.
   personalFor?: number[];

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -9,7 +9,7 @@
 // keep resolving to THIS file, never the sibling directory.
 //
 // ---------------------------------------------------------------------------
-// FACET MAP: the 20 domain facets (each IWorld member assigned exactly once; 142
+// FACET MAP: the 20 domain facets (each IWorld member assigned exactly once; 152
 // total). One interface per file under ./world_api/; aux types travel with their
 // facet. The authoritative member-per-facet split is the W0c parity test.
 //
@@ -36,10 +36,10 @@
 //
 // THREE GATES pin this seam (run before any facet edit):
 //   tests/snapshots.test.ts        (W0a)  selfWireJson <-> applySnapshot round-trip;
-//                                          ALL_DELTA_KEYS (25) + TERSE_TO_IWORLD mapping.
+//                                          ALL_DELTA_KEYS (26) + TERSE_TO_IWORLD mapping.
 //   tests/command_schema.test.ts   (W0b)  COMMAND_NAMES universe; ClientWorld send-set
 //                                          subset-of dispatch-set; DISPATCH_ONLY (7).
-//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (142) present + same-kind on
+//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (152) present + same-kind on
 //                                          Sim + ClientWorld; aggregate == disjoint
 //                                          union of the 20 facets.
 // ---------------------------------------------------------------------------
@@ -175,6 +175,9 @@ export const COMMAND_NAMES = [
   'qlinkaccept',
   'equip',
   'unequip_item',
+  'saveGearSet',
+  'equipGearSet',
+  'deleteGearSet',
   'use',
   'discard',
   'buy',
@@ -358,6 +361,18 @@ export const COMMAND_FACETS = {
   saveLoadout: 'IWorldTalents',
   switchLoadout: 'IWorldTalents',
   deleteLoadout: 'IWorldTalents',
+  // IWorldInventory: item, vendor, and saved gear-set commands.
+  equip: 'IWorldInventory',
+  unequip_item: 'IWorldInventory',
+  saveGearSet: 'IWorldInventory',
+  equipGearSet: 'IWorldInventory',
+  deleteGearSet: 'IWorldInventory',
+  use: 'IWorldInventory',
+  discard: 'IWorldInventory',
+  buy: 'IWorldInventory',
+  sell: 'IWorldInventory',
+  buyback: 'IWorldInventory',
+  sell_all_junk: 'IWorldInventory',
   // IWorldCosmetics: skin + mech-chroma equips (snake_case wire strings, by design).
   change_skin: 'IWorldCosmetics',
   claim_event_skin: 'IWorldCosmetics',

--- a/src/world_api/inventory.ts
+++ b/src/world_api/inventory.ts
@@ -1,12 +1,16 @@
-import type { EquipSlot, InvSlot } from '../sim/types';
+import type { EquipSlot, InvSlot, SavedGearSet } from '../sim/types';
 
 export interface IWorldInventory {
   inventory: InvSlot[];
   vendorBuyback: InvSlot[];
   equipment: Partial<Record<EquipSlot, string>>;
+  gearSets: SavedGearSet[];
   copper: number;
   equipItem(itemId: string): void;
   unequipItem(slot: EquipSlot): void;
+  saveGearSet(name: string): void;
+  equipGearSet(index: number): void;
+  deleteGearSet(index: number): void;
   useItem(itemId: string): void;
   discardItem(itemId: string, count?: number): void;
   buyItem(npcId: number, itemId: string): void;

--- a/tests/command_schema.test.ts
+++ b/tests/command_schema.test.ts
@@ -23,8 +23,8 @@ import { COMMAND_NAMES, type CommandName, DISPATCH_ONLY_COMMANDS } from '../src/
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 
 // Verified counts on the current tree (re-derived below; do not hard-code 85/6).
-const EXPECTED_SEND_COUNT = 103;
-const EXPECTED_DISPATCH_COUNT = 112;
+const EXPECTED_SEND_COUNT = 106;
+const EXPECTED_DISPATCH_COUNT = 115;
 const EXPECTED_DISPATCH_ONLY_COUNT = 9;
 
 // The chat sub-channel routing switch (server/game.ts `switch

--- a/tests/items.test.ts
+++ b/tests/items.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import * as items from '../src/sim/items';
 import { Sim } from '../src/sim/sim';
 import type { SimContext } from '../src/sim/sim_context';
-import { type Entity, POTION_COOLDOWN, type SimEvent } from '../src/sim/types';
+import { type Entity, POTION_COOLDOWN, type SavedGearSet, type SimEvent } from '../src/sim/types';
 
 // Direct tests for the extracted inventory/vendor module (W2). They call the module
 // functions with the real SimContext the Sim built in its ctor (the same seam the thin
@@ -28,6 +28,7 @@ function vendorPlayer(sim: Sim, name = 'Aleph') {
       {
         copper: number;
         equipment: Record<string, string>;
+        gearSets: SavedGearSet[];
         vendorBuyback: { itemId: string; count: number }[];
         inventory: { itemId: string; count: number }[];
         pendingSkinRank: number | null;
@@ -87,6 +88,87 @@ describe('items.equipItem / unequipItem', () => {
     expect(meta.equipment.helmet).toBeUndefined();
     expect(sim.countItem('cryptbone_helm', pid)).toBe(1);
     expect(items.unequipItem(ctx, 'legs', pid)).toBe(false);
+  });
+});
+describe('items gear sets', () => {
+  it('saves equipped pieces and restores them from bags', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    sim.addItem('cryptbone_helm', 1, pid);
+    sim.addItem('roadwardens_helm', 1, pid);
+
+    items.equipItem(ctx, 'cryptbone_helm', pid);
+    expect(items.saveGearSet(ctx, '  Tank  ', pid)).toBe(0);
+    expect(meta.gearSets[0].name).toBe('Tank');
+    expect(meta.gearSets[0].equipment.helmet).toBe('cryptbone_helm');
+
+    items.equipItem(ctx, 'roadwardens_helm', pid);
+    expect(meta.equipment.helmet).toBe('roadwardens_helm');
+    expect(sim.countItem('cryptbone_helm', pid)).toBe(1);
+
+    expect(items.equipGearSet(ctx, 0, pid)).toBe(true);
+    expect(meta.equipment.helmet).toBe('cryptbone_helm');
+    expect(sim.countItem('cryptbone_helm', pid)).toBe(0);
+    expect(sim.countItem('roadwardens_helm', pid)).toBe(1);
+  });
+
+  it('restores empty slots captured in a gear set', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    const empty = items.saveGearSet(ctx, 'No Helmet', pid);
+    sim.addItem('cryptbone_helm', 1, pid);
+    items.equipItem(ctx, 'cryptbone_helm', pid);
+
+    expect(items.equipGearSet(ctx, empty, pid)).toBe(true);
+    expect(meta.equipment.helmet).toBeUndefined();
+    expect(sim.countItem('cryptbone_helm', pid)).toBe(1);
+  });
+
+  it('leaves the current slot alone when a saved piece is missing', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    sim.addItem('cryptbone_helm', 1, pid);
+    sim.addItem('roadwardens_helm', 1, pid);
+    items.equipItem(ctx, 'cryptbone_helm', pid);
+    const tank = items.saveGearSet(ctx, 'Tank', pid);
+    items.unequipItem(ctx, 'helmet', pid);
+    sim.removeItem('cryptbone_helm', 1, pid);
+    items.equipItem(ctx, 'roadwardens_helm', pid);
+
+    expect(items.equipGearSet(ctx, tank, pid)).toBe(false);
+    expect(meta.equipment.helmet).toBe('roadwardens_helm');
+  });
+
+  it('caps new gear sets but lets an existing name update in place', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    for (let i = 0; i < items.MAX_GEAR_SETS; i++) {
+      expect(items.saveGearSet(ctx, `Set ${i}`, pid)).toBe(i);
+    }
+    expect(items.saveGearSet(ctx, 'Overflow', pid)).toBe(-1);
+
+    sim.addItem('cryptbone_helm', 1, pid);
+    items.equipItem(ctx, 'cryptbone_helm', pid);
+    expect(items.saveGearSet(ctx, 'Set 0', pid)).toBe(0);
+    expect(meta.gearSets).toHaveLength(items.MAX_GEAR_SETS);
+    expect(meta.gearSets[0].equipment.helmet).toBe('cryptbone_helm');
+  });
+
+  it('deletes a saved gear set by index', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    items.saveGearSet(ctx, 'One', pid);
+    items.saveGearSet(ctx, 'Two', pid);
+
+    expect(items.deleteGearSet(ctx, 0, pid)).toBe(true);
+    expect(meta.gearSets.map((set) => set.name)).toEqual(['Two']);
+    expect(items.deleteGearSet(ctx, Number.NaN, pid)).toBe(false);
+    expect(items.deleteGearSet(ctx, 4, pid)).toBe(false);
   });
 });
 

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -34,6 +34,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     meta.skin = 3;
     meta.skinCatalog = 'mech';
     meta.pendingSkinRank = 'rare';
+    meta.gearSets = [{ name: 'Tank', equipment: { mainhand: 'worn_sword' } }];
     meta.loadouts = [{ name: 'PvP', alloc: meta.talents, bar: [] }];
     meta.activeLoadout = 0;
     meta.delveMarks = 17;
@@ -50,6 +51,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     // spot-check that the rich fields actually survived (not all defaulted to empty).
     expect(s2.arena2v2Rating).toBe(1880);
     expect(s2.delveMarks).toBe(17);
+    expect(s2.gearSets).toEqual([{ name: 'Tank', equipment: { mainhand: 'worn_sword' } }]);
     expect(s2.loadouts?.length).toBe(1);
     expect(s2.skinCatalog).toBe('mech');
   });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -95,6 +95,7 @@ function bareClient(pid: number): ClientWorld {
   c.inventory = [];
   c.vendorBuyback = [];
   c.equipment = {};
+  c.gearSets = [];
   c.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
   c.copper = 0;
   c.xp = 0;
@@ -355,7 +356,7 @@ describe('delta snapshots', () => {
     const snap = lastSnap(fc.sent);
     expect(snap).not.toBeNull();
     // a fresh session has an empty lastSent, so EVERY maybe() delta key rides the
-    // first snapshot (even the null-valued ones like party/trade); widened to all 25
+    // first snapshot (even the null-valued ones like party/trade); widened to all 26
     for (const key of ALL_DELTA_KEYS) {
       expect(snap.self, `self.${key} missing from first snapshot`).toHaveProperty(key);
     }
@@ -768,7 +769,7 @@ describe('delta snapshots', () => {
     joinServer(server, fc2, 2, 'Testb');
     broadcast(server);
     const snapNew = lastSnap(fc2.sent);
-    // a fresh session always receives the full self state: all 25 delta keys
+    // a fresh session always receives the full self state: all 26 delta keys
     for (const key of ALL_DELTA_KEYS) {
       expect(snapNew.self, `self.${key} missing for fresh session`).toHaveProperty(key);
     }
@@ -1815,20 +1816,20 @@ describe('lockpick view rebuilds from events on the online client', () => {
 // ---------------------------------------------------------------------------
 // W0a: full self-snapshot delta round-trip gate.
 //
-// `selfWireJson` (server/game.ts) emits 25 heavy "delta" fields through a
+// `selfWireJson` (server/game.ts) emits 26 heavy "delta" fields through a
 // `maybe(key, value)` closure that ships a key only when its serialized form
 // changed since this session last received it; `applySnapshot` (src/net/
 // online.ts) mirrors each with `if (s.X !== undefined)` (or the inline
 // `s.X ?? e.X` form for `stats`/`weapon`). This is the single most fragile codec
-// in the workstream, so we pin: (a) the exact 25-key set against drift, (b) the
+// in the workstream, so we pin: (a) the exact 26-key set against drift, (b) the
 // terse-key -> IWorld-name rename map, (c) that every dirtied value round-trips
-// onto the correct decode target, and (d) that a no-op re-broadcast omits all 25
+// onto the correct decode target, and (d) that a no-op re-broadcast omits all 26
 // while the prior decoded value is preserved.
 // ---------------------------------------------------------------------------
 
-// The pinned set of the 25 `maybe(...)` delta keys, sorted. Cross-checked below
+// The pinned set of the 26 `maybe(...)` delta keys, sorted. Cross-checked below
 // against the live `maybe(...)` calls scraped from server/game.ts source, so a
-// 26th unregistered delta key reddens this gate.
+// 27th unregistered delta key reddens this gate.
 const ALL_DELTA_KEYS = [
   'arena',
   'buyback',
@@ -1842,6 +1843,7 @@ const ALL_DELTA_KEYS = [
   'drun',
   'duel',
   'equip',
+  'gsets',
   'inv',
   'lockouts',
   'lroll',
@@ -1876,6 +1878,7 @@ const TERSE_TO_IWORLD: Record<string, string> = {
   drun: 'delveRun',
   duel: 'duelInfo',
   equip: 'equipment',
+  gsets: 'gearSets',
   inv: 'inventory',
   lockouts: 'selfLockouts',
   lroll: 'lootRollPrompts',
@@ -1897,9 +1900,9 @@ const TERSE_TO_IWORLD: Record<string, string> = {
 // filter without a wall-clock read in test scaffolding.
 const FAR_FUTURE_MS = 8_000_000_000_000;
 
-// Dirty every one of the 25 `maybe()` delta fields with a distinguishable,
+// Dirty every one of the 26 `maybe()` delta fields with a distinguishable,
 // non-default value so the round-trip + no-op-omission assertions are meaningful
-// (a fresh session carries all 25 on snapshot #1 regardless, since lastSent is
+// (a fresh session carries all 26 on snapshot #1 regardless, since lastSent is
 // empty). Most fields are set on their real PlayerMeta/Entity/session source;
 // for the few whose authentic setup is mutually exclusive in one player state we
 // poke the exact source field the encoder reads, per the brief (the gate asserts
@@ -1949,6 +1952,7 @@ function dirtyEveryDeltaField(): {
 
   // Direct PlayerMeta fields.
   meta.inventory = [{ itemId: 'baked_bread', count: 3 }];
+  meta.gearSets = [{ name: 'Tank', equipment: { mainhand: 'worn_sword' } }];
   meta.vendorBuyback = [{ itemId: 'apprentice_staff', count: 1 }];
   meta.equipment = { ...meta.equipment, mainhand: 'zealotsbane_blade' };
   meta.questLog.set('q_widows', { questId: 'q_widows', counts: [10, 0], state: 'active' });
@@ -2004,7 +2008,7 @@ function dirtyEveryDeltaField(): {
 }
 
 describe('full self-state snapshot delta fixture', () => {
-  it('carries every one of the 25 dirtied delta keys on the first snapshot', () => {
+  it('carries every one of the 26 dirtied delta keys on the first snapshot', () => {
     const { server, fc } = dirtyEveryDeltaField();
     broadcast(server);
     const snap = lastSnap(fc.sent);
@@ -2037,6 +2041,7 @@ describe('full self-state snapshot delta fixture', () => {
 
     // --- fields that decode onto the client ---
     expect(client.inventory).toEqual([{ itemId: 'baked_bread', count: 3 }]); // inv -> inventory
+    expect(client.gearSets).toEqual([{ name: 'Tank', equipment: { mainhand: 'worn_sword' } }]); // gsets -> gearSets
     expect(client.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]); // buyback -> vendorBuyback
     expect(client.equipment).toMatchObject({ mainhand: 'zealotsbane_blade' }); // equip -> equipment
     // cosmetics -> accountCosmetics, asserted against the normalized shape (the input
@@ -2075,7 +2080,7 @@ describe('full self-state snapshot delta fixture', () => {
     expect(client.activeLoadout).toBe(0);
   });
 
-  it('omits all 25 delta keys on a no-op re-broadcast and preserves the prior mirror', () => {
+  it('omits all 26 delta keys on a no-op re-broadcast and preserves the prior mirror', () => {
     const { server, fc, leader, memberPid } = dirtyEveryDeltaField();
     broadcast(server);
     const client = bareClient(leader.pid);
@@ -2090,7 +2095,7 @@ describe('full self-state snapshot delta fixture', () => {
     const delveRunRef = client.delveRun;
 
     // a second broadcast with NO intervening sim.tick() and no state mutation: the
-    // maybe() closure sees byte-identical JSON for all 25 and omits every one
+    // maybe() closure sees byte-identical JSON for all 26 and omits every one
     fc.sent.length = 0;
     broadcast(server);
     const snap2 = lastSnap(fc.sent);
@@ -2114,9 +2119,9 @@ describe('full self-state snapshot delta fixture', () => {
 });
 
 describe('delta-key contract pins (anti-drift)', () => {
-  it('ALL_DELTA_KEYS contains exactly 25 unique keys in sorted order', () => {
-    expect(ALL_DELTA_KEYS).toHaveLength(25);
-    expect(new Set(ALL_DELTA_KEYS).size).toBe(25);
+  it('ALL_DELTA_KEYS contains exactly 26 unique keys in sorted order', () => {
+    expect(ALL_DELTA_KEYS).toHaveLength(26);
+    expect(new Set(ALL_DELTA_KEYS).size).toBe(26);
     expect([...ALL_DELTA_KEYS]).toEqual([...ALL_DELTA_KEYS].sort());
   });
 
@@ -2128,7 +2133,7 @@ describe('delta-key contract pins (anti-drift)', () => {
     const scraped = new Set<string>();
     for (let m = re.exec(src); m !== null; m = re.exec(src)) scraped.add(m[1]);
     expect(scraped.has('lockouts')).toBe(true); // the multi-line call IS captured
-    expect(scraped.size).toBe(25);
+    expect(scraped.size).toBe(26);
     expect([...scraped].sort()).toEqual([...ALL_DELTA_KEYS].sort());
   });
 

--- a/tests/world_api_parity.test.ts
+++ b/tests/world_api_parity.test.ts
@@ -1,6 +1,6 @@
 // W0c: the IWorld structural-parity gate.
 //
-// `IWorld` (src/world_api.ts:341-510, 148 members) is the ONE seam render/ui depend
+// `IWorld` (src/world_api.ts:341-510, 152 members) is the ONE seam render/ui depend
 // on. `tsc` already proves both the offline `Sim` and the online `ClientWorld` satisfy
 // it structurally, but the interface is erased at build: there is NO runtime member
 // list, so nothing catches a present-but-throws stub or a kind flip (method vs read).
@@ -9,7 +9,7 @@
 // IWORLD_MEMBERS below is the hand-maintained member list, the W0c analog of the
 // append-only CALLBACK_KEYS in tests/sim_context.test.ts. It is APPEND-ONLY WITH THE
 // INTERFACE: whenever a future slice adds (or removes/renames) a member on `IWorld`,
-// it lands the matching edit here in the SAME commit. The count pins (148 / 36 / 112)
+// it lands the matching edit here in the SAME commit. The count pins (152 / 37 / 115)
 // plus the sorted-name `toEqual` snapshots (modeled on the anti-loosening exclude-set
 // pin in tests/parity/harness.test.ts:131-162) are what force that: a dropped or
 // renamed member reddens deliberately, never silently.
@@ -64,8 +64,8 @@ interface IWorldMember {
   readonly kind: IWorldMemberKind;
 }
 
-// The 148 members of `interface IWorld`, in interface order (world_api.ts:342-509).
-// Partition: 36 `data` + 112 `method` (read-returning + command-void + 3 async).
+// The 152 members of `interface IWorld`, in interface order (world_api.ts:342-509).
+// Partition: 37 `data` + 115 `method` (read-returning + command-void + 3 async).
 // biome-ignore lint/suspicious/noExportsInTest: IWORLD_MEMBERS is the W0c pinned structural-parity contract (the authoritative IWorld member list)
 export const IWORLD_MEMBERS = [
   // --- core world / player roster + economy reads (data) ---
@@ -77,6 +77,7 @@ export const IWORLD_MEMBERS = [
   { name: 'inventory', kind: 'data' },
   { name: 'vendorBuyback', kind: 'data' },
   { name: 'equipment', kind: 'data' },
+  { name: 'gearSets', kind: 'data' },
   { name: 'accountCosmetics', kind: 'data' },
   { name: 'copper', kind: 'data' },
   { name: 'xp', kind: 'data' },
@@ -110,6 +111,9 @@ export const IWORLD_MEMBERS = [
   { name: 'acceptLinkedQuest', kind: 'method' },
   { name: 'equipItem', kind: 'method' },
   { name: 'unequipItem', kind: 'method' },
+  { name: 'saveGearSet', kind: 'method' },
+  { name: 'equipGearSet', kind: 'method' },
+  { name: 'deleteGearSet', kind: 'method' },
   { name: 'useItem', kind: 'method' },
   { name: 'discardItem', kind: 'method' },
   { name: 'buyItem', kind: 'method' },
@@ -269,7 +273,7 @@ function withDomStubs<T>(fn: () => T): T {
 }
 
 // A real ClientWorld whose FIELD INITIALIZERS have run (a raw
-// `Object.create(ClientWorld.prototype)` bareClient would be missing all 36 data
+// `Object.create(ClientWorld.prototype)` bareClient would be missing all 37 data
 // props). Pass a non-empty `base` so the ctor builds a `ws://localhost/ws` URL instead
 // of touching `location`; `.close()` clears the stubbed input timer.
 function makeClientWorld(): ClientWorld {
@@ -325,9 +329,9 @@ beforeAll(() => {
 
 describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => {
   it('pins total / data / method counts', () => {
-    expect(IWORLD_MEMBERS.length).toBe(148);
-    expect(DATA_MEMBERS.length).toBe(36);
-    expect(METHOD_MEMBERS.length).toBe(112);
+    expect(IWORLD_MEMBERS.length).toBe(152);
+    expect(DATA_MEMBERS.length).toBe(37);
+    expect(METHOD_MEMBERS.length).toBe(115);
   });
 
   it('has no duplicate member names', () => {
@@ -337,7 +341,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
 
   // Sorted-name `toEqual` snapshots: a dropped, renamed, or kind-flipped member reddens
   // these deliberately, forcing a reviewed edit. NOT length-only.
-  it('the full sorted member set is exactly the pinned 148', () => {
+  it('the full sorted member set is exactly the pinned 152', () => {
     expect(IWORLD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -371,6 +375,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'convertPartyToRaid',
       'convertRaidToParty',
       'copper',
+      'deleteGearSet',
       'deleteLoadout',
       'delveBuyShopItem',
       'delveDaily',
@@ -387,12 +392,14 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'enterDelve',
       'enterDungeon',
       'entities',
+      'equipGearSet',
       'equipItem',
       'equipment',
       'feedPet',
       'friendAdd',
       'friendRemove',
       'friendlyTabTarget',
+      'gearSets',
       'guildAccept',
       'guildCreate',
       'guildDecline',
@@ -453,6 +460,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'respec',
       'restedXp',
       'revivePet',
+      'saveGearSet',
       'saveLoadout',
       'searchCharacters',
       'sellAllJunk',
@@ -490,7 +498,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
     ]);
   });
 
-  it('the sorted data-kind set is exactly the pinned 36', () => {
+  it('the sorted data-kind set is exactly the pinned 37', () => {
     expect(DATA_MEMBERS.map((m) => m.name).sort()).toEqual([
       'accountCosmetics',
       'activeLoadout',
@@ -505,6 +513,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'duelInfo',
       'entities',
       'equipment',
+      'gearSets',
       'inventory',
       'known',
       'lifetimeXp',
@@ -531,7 +540,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
     ]);
   });
 
-  it('the sorted method-kind set is exactly the pinned 107', () => {
+  it('the sorted method-kind set is exactly the pinned 115', () => {
     expect(METHOD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -558,6 +567,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'companionUpgrade',
       'convertPartyToRaid',
       'convertRaidToParty',
+      'deleteGearSet',
       'deleteLoadout',
       'delveBuyShopItem',
       'delveInteract',
@@ -569,6 +579,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'duelRequest',
       'enterDelve',
       'enterDungeon',
+      'equipGearSet',
       'equipItem',
       'feedPet',
       'friendAdd',
@@ -619,6 +630,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'reportTelemetry',
       'respec',
       'revivePet',
+      'saveGearSet',
       'saveLoadout',
       'searchCharacters',
       'sellAllJunk',
@@ -690,7 +702,7 @@ describe('membership, not equality: world extras do not fail the gate', () => {
 //       a MISSING name (if the array omits a key, Exclude<> is a non-never union and tsc
 //       fails) -- (1)+(2) together make each array EXACTLY its facet key-set;
 //   (3) the 20 arrays are pairwise DISJOINT (a member filed in two facets reddens);
-//   (4) their union, sorted, equals the pinned 148-name IWORLD_MEMBERS set (a member
+//   (4) their union, sorted, equals the pinned 152-name IWORLD_MEMBERS set (a member
 //       dropped from the split reddens).
 // This is the rigorous form, NOT the tautological `keyof IWorld === keyof (A & B & ...)`
 // (IWorld extends them, so that self-equality proves nothing): it asserts against the
@@ -753,9 +765,13 @@ const FACET_INVENTORY = [
   'inventory',
   'vendorBuyback',
   'equipment',
+  'gearSets',
   'copper',
   'equipItem',
   'unequipItem',
+  'saveGearSet',
+  'equipGearSet',
+  'deleteGearSet',
   'useItem',
   'discardItem',
   'buyItem',
@@ -994,10 +1010,10 @@ describe('W1: aggregate IWorld member set equals the disjoint union of the 20 fa
     expect(overlaps, `members filed in more than one facet:\n${overlaps.join('\n')}`).toEqual([]);
   });
 
-  it('the union of the 20 facets equals the pinned 148-member IWORLD_MEMBERS set', () => {
+  it('the union of the 20 facets equals the pinned 152-member IWORLD_MEMBERS set', () => {
     const union = Object.values(FACET_MEMBER_ARRAYS).flatMap((arr) => [...arr]);
-    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(148);
-    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(148);
+    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(152);
+    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(152);
     const sortedUnion = [...union].sort();
     const pinned = IWORLD_MEMBERS.map((m) => m.name).sort();
     expect(sortedUnion).toEqual(pinned);


### PR DESCRIPTION
## Summary
- Add core saved gear-set support to the sim: save, equip, delete, cap, sanitize, and persist saved equipment snapshots.
- Wire gear sets through the server self-snapshot delta path plus online client command senders/decoding.
- Update IWorld, command, snapshot, inventory, and persistence contract tests for the new backend surface.

## Related issue
Part of #989. This PR intentionally covers the backend/core foundation only; it does not add the Equipment Manager UI.

## Testing
- `npx biome format --write server/game.ts src/net/online.ts src/sim/items.ts src/sim/sim.ts src/sim/types.ts src/world_api.ts src/world_api/inventory.ts tests/command_schema.test.ts tests/items.test.ts tests/persistence_round_trip.test.ts tests/snapshots.test.ts tests/world_api_parity.test.ts`
- `npx biome lint server/game.ts src/net/online.ts src/sim/items.ts src/sim/sim.ts src/sim/types.ts src/world_api.ts src/world_api/inventory.ts tests/command_schema.test.ts tests/items.test.ts tests/persistence_round_trip.test.ts tests/snapshots.test.ts tests/world_api_parity.test.ts --max-diagnostics=40` (exit 0; existing warning noise remains)
- `npm run check:ts`
- `.browserslistrc` comment-clean wrapper + `npx vitest run tests/items.test.ts tests/persistence_round_trip.test.ts tests/snapshots.test.ts tests/command_schema.test.ts tests/command_facets.test.ts tests/world_api_parity.test.ts` (6 files, 292 tests)
- `.browserslistrc` comment-clean wrapper + `npm run build` (passed; existing Vite chunk/dynamic-import warnings)

## Screenshots / recordings
N/A - backend/core inventory support only, no UI change.