### PR TITLE
feat(inventory): add personal bank core

### DIFF
--- a/server/game.ts
+++ b/server/game.ts
@@ -250,6 +250,10 @@ const HEAVY_SELF_REFRESH_TICKS = 40; // ~2 s backstop; staggered per session so 
 const HEAVY_SELF_CMDS = new Set<string>([
   'equip',
   'unequip_item',
+  'bank_deposit_item',
+  'bank_withdraw_item',
+  'bank_deposit_copper',
+  'bank_withdraw_copper',
   'use',
   'discard',
   'buy',
@@ -2278,6 +2282,26 @@ export class GameServer {
           sim.unequipItem(msg.slot as EquipSlot, pid);
         }
         break;
+      case 'bank_deposit_item':
+        if (typeof msg.item === 'string') {
+          sim.depositBankItem(msg.item, typeof msg.count === 'number' ? msg.count : undefined, pid);
+        }
+        break;
+      case 'bank_withdraw_item':
+        if (typeof msg.item === 'string') {
+          sim.withdrawBankItem(
+            msg.item,
+            typeof msg.count === 'number' ? msg.count : undefined,
+            pid,
+          );
+        }
+        break;
+      case 'bank_deposit_copper':
+        if (typeof msg.amount === 'number') sim.depositBankCopper(msg.amount, pid);
+        break;
+      case 'bank_withdraw_copper':
+        if (typeof msg.amount === 'number') sim.withdrawBankCopper(msg.amount, pid);
+        break;
       case 'use':
         if (typeof msg.item === 'string') {
           const result = sim.useItem(msg.item, pid);
@@ -3116,6 +3140,8 @@ export class GameServer {
       session.selfHeavyDirty = false;
       session.lastWireRev = meta.wireRev;
       maybe('inv', meta.inventory);
+      maybe('bank', meta.bank);
+      maybe('bankc', meta.bankCopper);
       maybe('buyback', meta.vendorBuyback);
       maybe('equip', meta.equipment);
       maybe('cosmetics', anchorSession.accountCosmetics);

--- a/src/net/online.ts
+++ b/src/net/online.ts
@@ -808,9 +808,11 @@ export class ClientWorld implements IWorld {
   known: ResolvedAbility[] = [];
   realm = '';
   inventory: InvSlot[] = [];
+  bank: InvSlot[] = [];
   vendorBuyback: InvSlot[] = [];
   equipment: Partial<Record<EquipSlot, string>> = {};
   copper = 0;
+  bankCopper = 0;
   // --- IWorldCosmetics: account cosmetics (completed-quest + mech-chroma ids),
   // mirrored from snapshot self. ---
   accountCosmetics: AccountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
@@ -1423,12 +1425,17 @@ export class ClientWorld implements IWorld {
       // Terse keys (inv/buyback/equip/copper) and the per-field guards are unchanged by
       // the move; the offline counterpart is src/sim/items.ts.
       this.copper = s.copper ?? 0;
+      this.bankCopper = s.bankc ?? this.bankCopper;
       if (s.inv !== undefined) {
         this.inventory = s.inv;
         this.invChanged = true;
       }
       if (s.buyback !== undefined) {
         this.vendorBuyback = s.buyback;
+        this.invChanged = true;
+      }
+      if (s.bank !== undefined) {
+        this.bank = s.bank;
         this.invChanged = true;
       }
       if (s.equip !== undefined) this.equipment = s.equip;
@@ -1673,6 +1680,18 @@ export class ClientWorld implements IWorld {
   }
   unequipItem(slot: EquipSlot): void {
     this.cmd({ cmd: 'unequip_item', slot });
+  }
+  depositBankItem(itemId: string, count?: number): void {
+    this.cmd({ cmd: 'bank_deposit_item', item: itemId, count });
+  }
+  withdrawBankItem(itemId: string, count?: number): void {
+    this.cmd({ cmd: 'bank_withdraw_item', item: itemId, count });
+  }
+  depositBankCopper(amount: number): void {
+    this.cmd({ cmd: 'bank_deposit_copper', amount });
+  }
+  withdrawBankCopper(amount: number): void {
+    this.cmd({ cmd: 'bank_withdraw_copper', amount });
   }
   useItem(itemId: string): void {
     this.cmd({ cmd: 'use', item: itemId });

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -59,7 +59,6 @@ export function discardItem(ctx: SimContext, itemId: string, count = 1, pid?: nu
     pid: meta.entityId,
   });
 }
-
 export function equipItem(ctx: SimContext, itemId: string, pid?: number): void {
   const r = ctx.resolve(pid);
   if (!r) return;
@@ -109,6 +108,86 @@ export function unequipItem(ctx: SimContext, slot: EquipSlot, pid?: number): boo
   return true;
 }
 
+function addBankItemSilent(itemId: string, count: number, meta: PlayerMeta): void {
+  const existing = meta.bank.find((s) => s.itemId === itemId);
+  if (existing) existing.count += count;
+  else meta.bank.push({ itemId, count });
+}
+
+function bankAvailable(ctx: SimContext, meta: PlayerMeta, p: Entity): boolean {
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return false;
+  }
+  if (!vendorInRange(ctx, p)) {
+    ctx.error(meta.entityId, 'There is no merchant nearby.');
+    return false;
+  }
+  return true;
+}
+
+export function depositBankItem(ctx: SimContext, itemId: string, count = 1, pid?: number): boolean {
+  const r = ctx.resolve(pid);
+  if (!r) return false;
+  const { meta, e: p } = r;
+  if (!bankAvailable(ctx, meta, p)) return false;
+  const def = ITEMS[itemId];
+  const available = ctx.countItem(itemId, meta.entityId);
+  if (!def || available <= 0) {
+    ctx.error(meta.entityId, "You don't have that item.");
+    return false;
+  }
+  const depositCount = Number.isFinite(count) ? Math.min(Math.floor(count), available) : 0;
+  if (depositCount <= 0) return false;
+  ctx.removeItem(itemId, depositCount, meta.entityId);
+  addBankItemSilent(itemId, depositCount, meta);
+  return true;
+}
+
+export function withdrawBankItem(
+  ctx: SimContext,
+  itemId: string,
+  count = 1,
+  pid?: number,
+): boolean {
+  const r = ctx.resolve(pid);
+  if (!r) return false;
+  const { meta, e: p } = r;
+  if (!bankAvailable(ctx, meta, p)) return false;
+  const slot = meta.bank.find((s) => s.itemId === itemId);
+  if (!ITEMS[itemId] || !slot || slot.count <= 0) return false;
+  const withdrawCount = Number.isFinite(count) ? Math.min(Math.floor(count), slot.count) : 0;
+  if (withdrawCount <= 0) return false;
+  slot.count -= withdrawCount;
+  if (slot.count <= 0) meta.bank = meta.bank.filter((s) => s !== slot);
+  addItemSilent(itemId, withdrawCount, meta);
+  ctx.onInventoryChangedForQuests(meta);
+  return true;
+}
+
+export function depositBankCopper(ctx: SimContext, amount: number, pid?: number): boolean {
+  const r = ctx.resolve(pid);
+  if (!r) return false;
+  const { meta, e: p } = r;
+  if (!bankAvailable(ctx, meta, p)) return false;
+  const deposit = Number.isFinite(amount) ? Math.min(Math.floor(amount), meta.copper) : 0;
+  if (deposit <= 0) return false;
+  meta.copper -= deposit;
+  meta.bankCopper += deposit;
+  return true;
+}
+
+export function withdrawBankCopper(ctx: SimContext, amount: number, pid?: number): boolean {
+  const r = ctx.resolve(pid);
+  if (!r) return false;
+  const { meta, e: p } = r;
+  if (!bankAvailable(ctx, meta, p)) return false;
+  const withdraw = Number.isFinite(amount) ? Math.min(Math.floor(amount), meta.bankCopper) : 0;
+  if (withdraw <= 0) return false;
+  meta.bankCopper -= withdraw;
+  meta.copper += withdraw;
+  return true;
+}
 export function useItem(ctx: SimContext, itemId: string, pid?: number): ItemUseResult | undefined {
   const r = ctx.resolve(pid);
   if (!r) return;

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -629,8 +629,10 @@ export interface PlayerMeta {
   // it every frame. Runtime-only signal, never serialized/persisted.
   wireRev: number;
   inventory: InvSlot[];
+  bank: InvSlot[];
   vendorBuyback: InvSlot[];
   copper: number;
+  bankCopper: number;
   equipment: PlayerEquipment;
   xp: number;
   // Post-cap progression (Max-Level XP Overflow). `lifetimeXp` is the monotonic
@@ -731,12 +733,14 @@ export interface CharacterState {
   // Rested XP pool. Optional so pre-rested-XP saves load cleanly (defaults to 0).
   restedXp?: number;
   copper: number;
+  bankCopper?: number;
   hp: number;
   resource: number;
   pos: { x: number; z: number };
   facing: number;
   equipment: PlayerEquipment;
   inventory: InvSlot[];
+  bank?: InvSlot[];
   vendorBuyback?: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
   questsDone: string[];
@@ -1160,8 +1164,10 @@ export class Sim {
       moveInput: emptyMoveInput(),
       wireRev: 0,
       inventory: [],
+      bank: [],
       vendorBuyback: [],
       copper: 0,
+      bankCopper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
       xp: 0,
       lifetimeXp: 0,
@@ -1218,8 +1224,10 @@ export class Sim {
       if (s.unlockedMilestones)
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
+      meta.bankCopper = Math.max(0, Math.floor(s.bankCopper ?? 0));
       meta.equipment = { ...s.equipment };
       meta.inventory = s.inventory.map((i) => ({ ...i }));
+      meta.bank = (s.bank ?? []).map((i) => ({ ...i }));
       meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
       for (const q of s.questLog) {
         if (q.state !== 'done')
@@ -1387,6 +1395,7 @@ export class Sim {
       unlockedMilestones: [...meta.unlockedMilestones],
       restedXp: meta.restedXp,
       copper: meta.copper,
+      bankCopper: meta.bankCopper,
       hp: e.hp,
       // A druid saved while shifted runs on rage/energy with its mana parked in
       // savedMana; persist the parked mana so reload (always caster form) restores
@@ -1401,6 +1410,7 @@ export class Sim {
       facing: e.facing,
       equipment: { ...meta.equipment },
       inventory: meta.inventory.map((i) => ({ ...i })),
+      bank: meta.bank.map((i) => ({ ...i })),
       vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
       questLog: [...meta.questLog.values()].map((q) => ({
         questId: q.questId,
@@ -1592,6 +1602,9 @@ export class Sim {
   get inventory(): InvSlot[] {
     return this.primary.inventory;
   }
+  get bank(): InvSlot[] {
+    return this.primary.bank;
+  }
   get vendorBuyback(): InvSlot[] {
     return this.primary.vendorBuyback;
   }
@@ -1600,6 +1613,9 @@ export class Sim {
   }
   get copper(): number {
     return this.primary.copper;
+  }
+  get bankCopper(): number {
+    return this.primary.bankCopper;
   }
   set copper(v: number) {
     this.primary.copper = v;
@@ -4247,6 +4263,22 @@ export class Sim {
 
   unequipItem(slot: EquipSlot, pid?: number): boolean {
     return items.unequipItem(this.ctx, slot, pid);
+  }
+
+  depositBankItem(itemId: string, count = 1, pid?: number): boolean {
+    return items.depositBankItem(this.ctx, itemId, count, pid);
+  }
+
+  withdrawBankItem(itemId: string, count = 1, pid?: number): boolean {
+    return items.withdrawBankItem(this.ctx, itemId, count, pid);
+  }
+
+  depositBankCopper(amount: number, pid?: number): boolean {
+    return items.depositBankCopper(this.ctx, amount, pid);
+  }
+
+  withdrawBankCopper(amount: number, pid?: number): boolean {
+    return items.withdrawBankCopper(this.ctx, amount, pid);
   }
 
   private hasFishableWaterAhead(p: Entity): boolean {

--- a/src/world_api.ts
+++ b/src/world_api.ts
@@ -9,7 +9,7 @@
 // keep resolving to THIS file, never the sibling directory.
 //
 // ---------------------------------------------------------------------------
-// FACET MAP: the 20 domain facets (each IWorld member assigned exactly once; 142
+// FACET MAP: the 20 domain facets (each IWorld member assigned exactly once; 154
 // total). One interface per file under ./world_api/; aux types travel with their
 // facet. The authoritative member-per-facet split is the W0c parity test.
 //
@@ -36,10 +36,10 @@
 //
 // THREE GATES pin this seam (run before any facet edit):
 //   tests/snapshots.test.ts        (W0a)  selfWireJson <-> applySnapshot round-trip;
-//                                          ALL_DELTA_KEYS (25) + TERSE_TO_IWORLD mapping.
+//                                          ALL_DELTA_KEYS (27) + TERSE_TO_IWORLD mapping.
 //   tests/command_schema.test.ts   (W0b)  COMMAND_NAMES universe; ClientWorld send-set
 //                                          subset-of dispatch-set; DISPATCH_ONLY (7).
-//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (142) present + same-kind on
+//   tests/world_api_parity.test.ts (W0c)  IWORLD_MEMBERS (154) present + same-kind on
 //                                          Sim + ClientWorld; aggregate == disjoint
 //                                          union of the 20 facets.
 // ---------------------------------------------------------------------------
@@ -267,6 +267,10 @@ export const COMMAND_NAMES = [
   'lockpick_abort',
   'collect_delve_chest_loot',
   'telemetry',
+  'bank_deposit_item',
+  'bank_withdraw_item',
+  'bank_deposit_copper',
+  'bank_withdraw_copper',
 ] as const;
 
 // The union both the send path (`online.ts`) and the dispatch switch
@@ -358,6 +362,11 @@ export const COMMAND_FACETS = {
   saveLoadout: 'IWorldTalents',
   switchLoadout: 'IWorldTalents',
   deleteLoadout: 'IWorldTalents',
+  // IWorldInventory: item, vendor, and personal-bank commands.
+  bank_deposit_item: 'IWorldInventory',
+  bank_withdraw_item: 'IWorldInventory',
+  bank_deposit_copper: 'IWorldInventory',
+  bank_withdraw_copper: 'IWorldInventory',
   // IWorldCosmetics: skin + mech-chroma equips (snake_case wire strings, by design).
   change_skin: 'IWorldCosmetics',
   claim_event_skin: 'IWorldCosmetics',

--- a/src/world_api/inventory.ts
+++ b/src/world_api/inventory.ts
@@ -2,11 +2,17 @@ import type { EquipSlot, InvSlot } from '../sim/types';
 
 export interface IWorldInventory {
   inventory: InvSlot[];
+  bank: InvSlot[];
   vendorBuyback: InvSlot[];
   equipment: Partial<Record<EquipSlot, string>>;
   copper: number;
+  bankCopper: number;
   equipItem(itemId: string): void;
   unequipItem(slot: EquipSlot): void;
+  depositBankItem(itemId: string, count?: number): void;
+  withdrawBankItem(itemId: string, count?: number): void;
+  depositBankCopper(amount: number): void;
+  withdrawBankCopper(amount: number): void;
   useItem(itemId: string): void;
   discardItem(itemId: string, count?: number): void;
   buyItem(npcId: number, itemId: string): void;

--- a/tests/command_schema.test.ts
+++ b/tests/command_schema.test.ts
@@ -23,8 +23,8 @@ import { COMMAND_NAMES, type CommandName, DISPATCH_ONLY_COMMANDS } from '../src/
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 
 // Verified counts on the current tree (re-derived below; do not hard-code 85/6).
-const EXPECTED_SEND_COUNT = 103;
-const EXPECTED_DISPATCH_COUNT = 112;
+const EXPECTED_SEND_COUNT = 107;
+const EXPECTED_DISPATCH_COUNT = 116;
 const EXPECTED_DISPATCH_ONLY_COUNT = 9;
 
 // The chat sub-channel routing switch (server/game.ts `switch

--- a/tests/items.test.ts
+++ b/tests/items.test.ts
@@ -27,8 +27,10 @@ function vendorPlayer(sim: Sim, name = 'Aleph') {
       number,
       {
         copper: number;
+        bankCopper: number;
         equipment: Record<string, string>;
         vendorBuyback: { itemId: string; count: number }[];
+        bank: { itemId: string; count: number }[];
         inventory: { itemId: string; count: number }[];
         pendingSkinRank: number | null;
       }
@@ -87,6 +89,60 @@ describe('items.equipItem / unequipItem', () => {
     expect(meta.equipment.helmet).toBeUndefined();
     expect(sim.countItem('cryptbone_helm', pid)).toBe(1);
     expect(items.unequipItem(ctx, 'legs', pid)).toBe(false);
+  });
+});
+describe('items personal bank', () => {
+  it('moves item stacks between bags and bank without creating quest credit on deposit', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    sim.addItem('wolf_fang', 5, pid);
+    sim.drainEvents();
+
+    expect(items.depositBankItem(ctx, 'wolf_fang', 3, pid)).toBe(true);
+    expect(sim.countItem('wolf_fang', pid)).toBe(2);
+    expect(meta.bank).toEqual([{ itemId: 'wolf_fang', count: 3 }]);
+
+    expect(items.withdrawBankItem(ctx, 'wolf_fang', 2, pid)).toBe(true);
+    expect(sim.countItem('wolf_fang', pid)).toBe(4);
+    expect(meta.bank).toEqual([{ itemId: 'wolf_fang', count: 1 }]);
+
+    expect(items.withdrawBankItem(ctx, 'wolf_fang', 99, pid)).toBe(true);
+    expect(sim.countItem('wolf_fang', pid)).toBe(5);
+    expect(meta.bank).toEqual([]);
+  });
+
+  it('refuses invalid item bank transfers without mutating bags or bank', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    sim.addItem('wolf_fang', 2, pid);
+
+    expect(items.depositBankItem(ctx, 'wolf_fang', Number.NaN, pid)).toBe(false);
+    expect(items.depositBankItem(ctx, 'missing_item', 1, pid)).toBe(false);
+    expect(items.withdrawBankItem(ctx, 'wolf_fang', 1, pid)).toBe(false);
+    expect(sim.countItem('wolf_fang', pid)).toBe(2);
+    expect(meta.bank).toEqual([]);
+  });
+
+  it('moves copper between purse and bank with integer clamping', () => {
+    const sim = makeWorld();
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    meta.copper = 125;
+
+    expect(items.depositBankCopper(ctx, 50.8, pid)).toBe(true);
+    expect(meta.copper).toBe(75);
+    expect(meta.bankCopper).toBe(50);
+
+    expect(items.withdrawBankCopper(ctx, 20.2, pid)).toBe(true);
+    expect(meta.copper).toBe(95);
+    expect(meta.bankCopper).toBe(30);
+
+    expect(items.withdrawBankCopper(ctx, 99, pid)).toBe(true);
+    expect(meta.copper).toBe(125);
+    expect(meta.bankCopper).toBe(0);
+    expect(items.depositBankCopper(ctx, Number.NaN, pid)).toBe(false);
   });
 });
 

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -20,6 +20,8 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     sim.setPlayerLevel(12, pid);
     const meta = sim.meta(pid)!;
     meta.copper = 4242;
+    meta.bankCopper = 777;
+    meta.bank = [{ itemId: 'apprentice_staff', count: 1 }];
     sim.addItem('wolf_fang', 5, pid);
     sim.addItem('baked_bread', 2, pid);
     meta.arenaRating = 1650;
@@ -50,6 +52,8 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     // spot-check that the rich fields actually survived (not all defaulted to empty).
     expect(s2.arena2v2Rating).toBe(1880);
     expect(s2.delveMarks).toBe(17);
+    expect(s2.bankCopper).toBe(777);
+    expect(s2.bank).toEqual([{ itemId: 'apprentice_staff', count: 1 }]);
     expect(s2.loadouts?.length).toBe(1);
     expect(s2.skinCatalog).toBe('mech');
   });

--- a/tests/snapshots.test.ts
+++ b/tests/snapshots.test.ts
@@ -93,10 +93,12 @@ function bareClient(pid: number): ClientWorld {
   c.spectating = null;
   c.moveInput = {};
   c.inventory = [];
+  c.bank = [];
   c.vendorBuyback = [];
   c.equipment = {};
   c.accountCosmetics = { completedQuestIds: [], mechChromaIds: [] };
   c.copper = 0;
+  c.bankCopper = 0;
   c.xp = 0;
   c.known = [];
   c.questLog = new Map();
@@ -355,7 +357,7 @@ describe('delta snapshots', () => {
     const snap = lastSnap(fc.sent);
     expect(snap).not.toBeNull();
     // a fresh session has an empty lastSent, so EVERY maybe() delta key rides the
-    // first snapshot (even the null-valued ones like party/trade); widened to all 25
+    // first snapshot (even the null-valued ones like party/trade); widened to all 27
     for (const key of ALL_DELTA_KEYS) {
       expect(snap.self, `self.${key} missing from first snapshot`).toHaveProperty(key);
     }
@@ -418,7 +420,7 @@ describe('delta snapshots', () => {
     const snap = lastSnap(fc.sent);
     // This single-tick test stays on the decay-safe subset: cds and the timer-backed
     // keys (delve/arena timers, delveDaily) can re-emit after a real sim.tick(), so the
-    // widened all-25 omission is proven by the no-op re-broadcast test instead.
+    // widened all-27 omission is proven by the no-op re-broadcast test instead.
     for (const key of DELTA_KEYS) {
       expect(snap.self, `self.${key} resent although unchanged`).not.toHaveProperty(key);
     }
@@ -768,7 +770,7 @@ describe('delta snapshots', () => {
     joinServer(server, fc2, 2, 'Testb');
     broadcast(server);
     const snapNew = lastSnap(fc2.sent);
-    // a fresh session always receives the full self state: all 25 delta keys
+    // a fresh session always receives the full self state: all 27 delta keys
     for (const key of ALL_DELTA_KEYS) {
       expect(snapNew.self, `self.${key} missing for fresh session`).toHaveProperty(key);
     }
@@ -1815,22 +1817,24 @@ describe('lockpick view rebuilds from events on the online client', () => {
 // ---------------------------------------------------------------------------
 // W0a: full self-snapshot delta round-trip gate.
 //
-// `selfWireJson` (server/game.ts) emits 25 heavy "delta" fields through a
+// `selfWireJson` (server/game.ts) emits 27 heavy "delta" fields through a
 // `maybe(key, value)` closure that ships a key only when its serialized form
 // changed since this session last received it; `applySnapshot` (src/net/
 // online.ts) mirrors each with `if (s.X !== undefined)` (or the inline
 // `s.X ?? e.X` form for `stats`/`weapon`). This is the single most fragile codec
-// in the workstream, so we pin: (a) the exact 25-key set against drift, (b) the
+// in the workstream, so we pin: (a) the exact 27-key set against drift, (b) the
 // terse-key -> IWorld-name rename map, (c) that every dirtied value round-trips
-// onto the correct decode target, and (d) that a no-op re-broadcast omits all 25
+// onto the correct decode target, and (d) that a no-op re-broadcast omits all 27
 // while the prior decoded value is preserved.
 // ---------------------------------------------------------------------------
 
-// The pinned set of the 25 `maybe(...)` delta keys, sorted. Cross-checked below
+// The pinned set of the 27 `maybe(...)` delta keys, sorted. Cross-checked below
 // against the live `maybe(...)` calls scraped from server/game.ts source, so a
-// 26th unregistered delta key reddens this gate.
+// 28th unregistered delta key reddens this gate.
 const ALL_DELTA_KEYS = [
   'arena',
+  'bank',
+  'bankc',
   'buyback',
   'cds',
   'cosmetics',
@@ -1866,6 +1870,8 @@ const ALL_DELTA_KEYS = [
 // keep their name; tal fans out to several members and is asserted directly).
 const TERSE_TO_IWORLD: Record<string, string> = {
   arena: 'arenaInfo',
+  bank: 'bank',
+  bankc: 'bankCopper',
   buyback: 'vendorBuyback',
   cds: 'cooldowns',
   cosmetics: 'accountCosmetics',
@@ -1897,9 +1903,9 @@ const TERSE_TO_IWORLD: Record<string, string> = {
 // filter without a wall-clock read in test scaffolding.
 const FAR_FUTURE_MS = 8_000_000_000_000;
 
-// Dirty every one of the 25 `maybe()` delta fields with a distinguishable,
+// Dirty every one of the 27 `maybe()` delta fields with a distinguishable,
 // non-default value so the round-trip + no-op-omission assertions are meaningful
-// (a fresh session carries all 25 on snapshot #1 regardless, since lastSent is
+// (a fresh session carries all 27 on snapshot #1 regardless, since lastSent is
 // empty). Most fields are set on their real PlayerMeta/Entity/session source;
 // for the few whose authentic setup is mutually exclusive in one player state we
 // poke the exact source field the encoder reads, per the brief (the gate asserts
@@ -1949,6 +1955,8 @@ function dirtyEveryDeltaField(): {
 
   // Direct PlayerMeta fields.
   meta.inventory = [{ itemId: 'baked_bread', count: 3 }];
+  meta.bank = [{ itemId: 'wolf_fang', count: 2 }];
+  meta.bankCopper = 333;
   meta.vendorBuyback = [{ itemId: 'apprentice_staff', count: 1 }];
   meta.equipment = { ...meta.equipment, mainhand: 'zealotsbane_blade' };
   meta.questLog.set('q_widows', { questId: 'q_widows', counts: [10, 0], state: 'active' });
@@ -2004,7 +2012,7 @@ function dirtyEveryDeltaField(): {
 }
 
 describe('full self-state snapshot delta fixture', () => {
-  it('carries every one of the 25 dirtied delta keys on the first snapshot', () => {
+  it('carries every one of the 27 dirtied delta keys on the first snapshot', () => {
     const { server, fc } = dirtyEveryDeltaField();
     broadcast(server);
     const snap = lastSnap(fc.sent);
@@ -2037,6 +2045,8 @@ describe('full self-state snapshot delta fixture', () => {
 
     // --- fields that decode onto the client ---
     expect(client.inventory).toEqual([{ itemId: 'baked_bread', count: 3 }]); // inv -> inventory
+    expect(client.bank).toEqual([{ itemId: 'wolf_fang', count: 2 }]); // bank -> bank
+    expect(client.bankCopper).toBe(333); // bankc -> bankCopper
     expect(client.vendorBuyback).toEqual([{ itemId: 'apprentice_staff', count: 1 }]); // buyback -> vendorBuyback
     expect(client.equipment).toMatchObject({ mainhand: 'zealotsbane_blade' }); // equip -> equipment
     // cosmetics -> accountCosmetics, asserted against the normalized shape (the input
@@ -2075,7 +2085,7 @@ describe('full self-state snapshot delta fixture', () => {
     expect(client.activeLoadout).toBe(0);
   });
 
-  it('omits all 25 delta keys on a no-op re-broadcast and preserves the prior mirror', () => {
+  it('omits all 27 delta keys on a no-op re-broadcast and preserves the prior mirror', () => {
     const { server, fc, leader, memberPid } = dirtyEveryDeltaField();
     broadcast(server);
     const client = bareClient(leader.pid);
@@ -2090,7 +2100,7 @@ describe('full self-state snapshot delta fixture', () => {
     const delveRunRef = client.delveRun;
 
     // a second broadcast with NO intervening sim.tick() and no state mutation: the
-    // maybe() closure sees byte-identical JSON for all 25 and omits every one
+    // maybe() closure sees byte-identical JSON for all 27 and omits every one
     fc.sent.length = 0;
     broadcast(server);
     const snap2 = lastSnap(fc.sent);
@@ -2114,9 +2124,9 @@ describe('full self-state snapshot delta fixture', () => {
 });
 
 describe('delta-key contract pins (anti-drift)', () => {
-  it('ALL_DELTA_KEYS contains exactly 25 unique keys in sorted order', () => {
-    expect(ALL_DELTA_KEYS).toHaveLength(25);
-    expect(new Set(ALL_DELTA_KEYS).size).toBe(25);
+  it('ALL_DELTA_KEYS contains exactly 27 unique keys in sorted order', () => {
+    expect(ALL_DELTA_KEYS).toHaveLength(27);
+    expect(new Set(ALL_DELTA_KEYS).size).toBe(27);
     expect([...ALL_DELTA_KEYS]).toEqual([...ALL_DELTA_KEYS].sort());
   });
 
@@ -2128,7 +2138,7 @@ describe('delta-key contract pins (anti-drift)', () => {
     const scraped = new Set<string>();
     for (let m = re.exec(src); m !== null; m = re.exec(src)) scraped.add(m[1]);
     expect(scraped.has('lockouts')).toBe(true); // the multi-line call IS captured
-    expect(scraped.size).toBe(25);
+    expect(scraped.size).toBe(27);
     expect([...scraped].sort()).toEqual([...ALL_DELTA_KEYS].sort());
   });
 

--- a/tests/world_api_parity.test.ts
+++ b/tests/world_api_parity.test.ts
@@ -1,6 +1,6 @@
 // W0c: the IWorld structural-parity gate.
 //
-// `IWorld` (src/world_api.ts:341-510, 148 members) is the ONE seam render/ui depend
+// `IWorld` (src/world_api.ts:341-510, 154 members) is the ONE seam render/ui depend
 // on. `tsc` already proves both the offline `Sim` and the online `ClientWorld` satisfy
 // it structurally, but the interface is erased at build: there is NO runtime member
 // list, so nothing catches a present-but-throws stub or a kind flip (method vs read).
@@ -9,7 +9,7 @@
 // IWORLD_MEMBERS below is the hand-maintained member list, the W0c analog of the
 // append-only CALLBACK_KEYS in tests/sim_context.test.ts. It is APPEND-ONLY WITH THE
 // INTERFACE: whenever a future slice adds (or removes/renames) a member on `IWorld`,
-// it lands the matching edit here in the SAME commit. The count pins (148 / 36 / 112)
+// it lands the matching edit here in the SAME commit. The count pins (154 / 38 / 116)
 // plus the sorted-name `toEqual` snapshots (modeled on the anti-loosening exclude-set
 // pin in tests/parity/harness.test.ts:131-162) are what force that: a dropped or
 // renamed member reddens deliberately, never silently.
@@ -64,8 +64,8 @@ interface IWorldMember {
   readonly kind: IWorldMemberKind;
 }
 
-// The 148 members of `interface IWorld`, in interface order (world_api.ts:342-509).
-// Partition: 36 `data` + 112 `method` (read-returning + command-void + 3 async).
+// The 154 members of `interface IWorld`, in interface order (world_api.ts:342-509).
+// Partition: 38 `data` + 116 `method` (read-returning + command-void + 3 async).
 // biome-ignore lint/suspicious/noExportsInTest: IWORLD_MEMBERS is the W0c pinned structural-parity contract (the authoritative IWorld member list)
 export const IWORLD_MEMBERS = [
   // --- core world / player roster + economy reads (data) ---
@@ -75,6 +75,8 @@ export const IWORLD_MEMBERS = [
   { name: 'player', kind: 'data' },
   { name: 'moveInput', kind: 'data' },
   { name: 'inventory', kind: 'data' },
+  { name: 'bank', kind: 'data' },
+  { name: 'bankCopper', kind: 'data' },
   { name: 'vendorBuyback', kind: 'data' },
   { name: 'equipment', kind: 'data' },
   { name: 'accountCosmetics', kind: 'data' },
@@ -110,6 +112,10 @@ export const IWORLD_MEMBERS = [
   { name: 'acceptLinkedQuest', kind: 'method' },
   { name: 'equipItem', kind: 'method' },
   { name: 'unequipItem', kind: 'method' },
+  { name: 'depositBankItem', kind: 'method' },
+  { name: 'withdrawBankItem', kind: 'method' },
+  { name: 'depositBankCopper', kind: 'method' },
+  { name: 'withdrawBankCopper', kind: 'method' },
   { name: 'useItem', kind: 'method' },
   { name: 'discardItem', kind: 'method' },
   { name: 'buyItem', kind: 'method' },
@@ -269,7 +275,7 @@ function withDomStubs<T>(fn: () => T): T {
 }
 
 // A real ClientWorld whose FIELD INITIALIZERS have run (a raw
-// `Object.create(ClientWorld.prototype)` bareClient would be missing all 36 data
+// `Object.create(ClientWorld.prototype)` bareClient would be missing all 38 data
 // props). Pass a non-empty `base` so the ctor builds a `ws://localhost/ws` URL instead
 // of touching `location`; `.close()` clears the stubbed input timer.
 function makeClientWorld(): ClientWorld {
@@ -325,9 +331,9 @@ beforeAll(() => {
 
 describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => {
   it('pins total / data / method counts', () => {
-    expect(IWORLD_MEMBERS.length).toBe(148);
-    expect(DATA_MEMBERS.length).toBe(36);
-    expect(METHOD_MEMBERS.length).toBe(112);
+    expect(IWORLD_MEMBERS.length).toBe(154);
+    expect(DATA_MEMBERS.length).toBe(38);
+    expect(METHOD_MEMBERS.length).toBe(116);
   });
 
   it('has no duplicate member names', () => {
@@ -337,7 +343,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
 
   // Sorted-name `toEqual` snapshots: a dropped, renamed, or kind-flipped member reddens
   // these deliberately, forcing a reviewed edit. NOT length-only.
-  it('the full sorted member set is exactly the pinned 148', () => {
+  it('the full sorted member set is exactly the pinned 154', () => {
     expect(IWORLD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -352,6 +358,8 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'arenaQueueJoin',
       'arenaQueueLeave',
       'assignMasterLoot',
+      'bank',
+      'bankCopper',
       'blockAdd',
       'blockRemove',
       'buyBackItem',
@@ -378,6 +386,8 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'delveMarks',
       'delveRun',
       'delveShopOffers',
+      'depositBankCopper',
+      'depositBankItem',
       'devLeaderboard',
       'discardItem',
       'duelAccept',
@@ -486,15 +496,19 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'unlockedMilestones',
       'useItem',
       'vendorBuyback',
+      'withdrawBankCopper',
+      'withdrawBankItem',
       'xp',
     ]);
   });
 
-  it('the sorted data-kind set is exactly the pinned 36', () => {
+  it('the sorted data-kind set is exactly the pinned 38', () => {
     expect(DATA_MEMBERS.map((m) => m.name).sort()).toEqual([
       'accountCosmetics',
       'activeLoadout',
       'arenaInfo',
+      'bank',
+      'bankCopper',
       'cfg',
       'companionState',
       'companionUpgrades',
@@ -531,7 +545,7 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
     ]);
   });
 
-  it('the sorted method-kind set is exactly the pinned 107', () => {
+  it('the sorted method-kind set is exactly the pinned 116', () => {
     expect(METHOD_MEMBERS.map((m) => m.name).sort()).toEqual([
       'abandonPet',
       'abandonQuest',
@@ -562,6 +576,8 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'delveBuyShopItem',
       'delveInteract',
       'delveShopOffers',
+      'depositBankCopper',
+      'depositBankItem',
       'devLeaderboard',
       'discardItem',
       'duelAccept',
@@ -645,6 +661,8 @@ describe('IWORLD_MEMBERS is the pinned IWorld contract (anti-loosening)', () => 
       'unequipItem',
       'unequipMechChroma',
       'useItem',
+      'withdrawBankCopper',
+      'withdrawBankItem',
     ]);
   });
 });
@@ -690,7 +708,7 @@ describe('membership, not equality: world extras do not fail the gate', () => {
 //       a MISSING name (if the array omits a key, Exclude<> is a non-never union and tsc
 //       fails) -- (1)+(2) together make each array EXACTLY its facet key-set;
 //   (3) the 20 arrays are pairwise DISJOINT (a member filed in two facets reddens);
-//   (4) their union, sorted, equals the pinned 148-name IWORLD_MEMBERS set (a member
+//   (4) their union, sorted, equals the pinned 154-name IWORLD_MEMBERS set (a member
 //       dropped from the split reddens).
 // This is the rigorous form, NOT the tautological `keyof IWorld === keyof (A & B & ...)`
 // (IWorld extends them, so that self-equality proves nothing): it asserts against the
@@ -751,11 +769,17 @@ type _ExhaustLoot = AssertNever<Exclude<keyof IWorldLoot, (typeof FACET_LOOT)[nu
 
 const FACET_INVENTORY = [
   'inventory',
+  'bank',
+  'bankCopper',
   'vendorBuyback',
   'equipment',
   'copper',
   'equipItem',
   'unequipItem',
+  'depositBankItem',
+  'withdrawBankItem',
+  'depositBankCopper',
+  'withdrawBankCopper',
   'useItem',
   'discardItem',
   'buyItem',
@@ -994,10 +1018,10 @@ describe('W1: aggregate IWorld member set equals the disjoint union of the 20 fa
     expect(overlaps, `members filed in more than one facet:\n${overlaps.join('\n')}`).toEqual([]);
   });
 
-  it('the union of the 20 facets equals the pinned 148-member IWORLD_MEMBERS set', () => {
+  it('the union of the 20 facets equals the pinned 154-member IWORLD_MEMBERS set', () => {
     const union = Object.values(FACET_MEMBER_ARRAYS).flatMap((arr) => [...arr]);
-    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(148);
-    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(148);
+    expect(union.length, 'union size before dedup (catches a duplicated member)').toBe(154);
+    expect(new Set(union).size, 'union size after dedup (catches a duplicated member)').toBe(154);
     const sortedUnion = [...union].sort();
     const pinned = IWORLD_MEMBERS.map((m) => m.name).sort();
     expect(sortedUnion).toEqual(pinned);


### PR DESCRIPTION
## Summary
- Add persisted per-character bank item and copper storage.
- Add server-authoritative bank deposit/withdraw commands for items and copper, guarded by death state and nearby merchant access as a backend foundation.
- Mirror bank state through self snapshots and the online client, and update command, snapshot, persistence, item, and IWorld parity coverage.

## Related issue
Part of #492. This adds the backend/core storage and wire surface only; banker NPC/window UI remains follow-up work.

## Testing
- `npx biome format --write server/game.ts src/net/online.ts src/sim/items.ts src/sim/sim.ts src/world_api.ts src/world_api/inventory.ts tests/items.test.ts tests/persistence_round_trip.test.ts tests/snapshots.test.ts tests/world_api_parity.test.ts tests/command_schema.test.ts`
- `npx biome lint server/game.ts src/net/online.ts src/sim/items.ts src/sim/sim.ts src/world_api.ts src/world_api/inventory.ts tests/items.test.ts tests/persistence_round_trip.test.ts tests/snapshots.test.ts tests/world_api_parity.test.ts tests/command_schema.test.ts --max-diagnostics=40` (passes; existing warning noise remains)
- `npm run check:ts`
- `.browserslistrc` comment-stripped wrapper: `npx vitest run tests/items.test.ts tests/persistence_round_trip.test.ts tests/snapshots.test.ts tests/command_schema.test.ts tests/command_facets.test.ts tests/world_api_parity.test.ts` (6 files, 292 tests passed)
- `.browserslistrc` comment-stripped wrapper: `npm run build` (passes; existing chunk-size and generated admin locale dynamic-import warnings remain)
- `git diff --check`

## Screenshots / recordings
N/A - backend/core storage and command surface only; no UI changes.