### PR TITLE
fix(ui): open inspect window from command

### DIFF
--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -270,6 +270,7 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
       return null;
     }
     ctx.error(r.meta.entityId, inspectReadout(target, te));
+    ctx.emit({ type: 'inspect', targetId: te.id, pid: r.meta.entityId });
     return null;
   }
 

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1545,6 +1545,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'milestoneUnlocked'; milestoneId: string }
   | { type: 'learnAbility'; abilityId: string; rank: number }
   | { type: 'loot'; text: string }
+  | { type: 'inspect'; targetId: number }
   | {
       type: 'lootRoll';
       rollId: number;

--- a/src/ui/hud.ts
+++ b/src/ui/hud.ts
@@ -6156,6 +6156,9 @@ export class Hud {
           if ($('#bags').style.display !== 'none') this.renderBags();
           break;
         }
+        case 'inspect':
+          this.openInspect(ev.targetId);
+          break;
         case 'lootRoll': {
           this.showLootRoll(ev);
           break;

--- a/tests/inspect_command.test.ts
+++ b/tests/inspect_command.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { Sim } from '../src/sim/sim';
+import type { SimEvent } from '../src/sim/types';
 
 function makeWorld() {
   return new Sim({ seed: 42, playerClass: 'warrior', noPlayer: true });
@@ -9,27 +10,47 @@ function makeWorld() {
 function inspectReply(sim: Sim, pid: number, text: string): string | undefined {
   sim.chat(text, pid);
   const errs = sim.events.filter(
-    (e): e is Extract<typeof e, { type: 'error' }> => e.type === 'error' && (e as { pid: number }).pid === pid,
+    (e): e is Extract<typeof e, { type: 'error' }> =>
+      e.type === 'error' && (e as { pid: number }).pid === pid,
   );
   return errs.length ? errs[errs.length - 1].text : undefined;
 }
 
+function inspectEvents(sim: Sim, pid: number): Extract<SimEvent, { type: 'inspect' }>[] {
+  return sim.events.filter(
+    (e): e is Extract<SimEvent, { type: 'inspect' }> => e.type === 'inspect' && e.pid === pid,
+  );
+}
+
 describe('/inspect command', () => {
-  it('reports another player\'s level, class, and health', () => {
+  it("reports another player's level, class, and health", () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     const b = sim.addPlayer('mage', 'Bet');
-    const e = sim.entities.get(b)!;
+    const e = sim.entities.get(b);
+    expect(e).toBeDefined();
+    if (!e) throw new Error('missing inspect target entity');
     e.level = 8;
 
     expect(inspectReply(sim, a, '/inspect Bet')).toBe('Bet: Level 8 Mage — HP 100%.');
+  });
+
+  it('emits a personal inspect event for the resolved target', () => {
+    const sim = makeWorld();
+    const a = sim.addPlayer('warrior', 'Aleph');
+    const b = sim.addPlayer('mage', 'Bet');
+
+    expect(inspectReply(sim, a, '/inspect Bet')).toMatch(/^Bet: Level \d+ Mage/);
+    expect(inspectEvents(sim, a)).toEqual([{ type: 'inspect', targetId: b, pid: a }]);
   });
 
   it('shows a partial-health percentage and "dead" for a corpse', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     const b = sim.addPlayer('rogue', 'Gimel');
-    const e = sim.entities.get(b)!;
+    const e = sim.entities.get(b);
+    expect(e).toBeDefined();
+    if (!e) throw new Error('missing inspect target entity');
     e.hp = Math.round(e.maxHp * 0.4);
     expect(inspectReply(sim, a, '/inspect Gimel')).toBe(`Gimel: Level ${e.level} Rogue — HP 40%.`);
 
@@ -49,19 +70,26 @@ describe('/inspect command', () => {
     const a = sim.addPlayer('warrior', 'Aleph');
     sim.addPlayer('mage', 'Bet');
     sim.addPlayer('rogue', 'bet');
-    expect(inspectReply(sim, a, '/inspect BET')).toBe("Several players match 'BET'. Use exact capitalization.");
+    expect(inspectReply(sim, a, '/inspect BET')).toBe(
+      "Several players match 'BET'. Use exact capitalization.",
+    );
+    expect(inspectEvents(sim, a)).toEqual([]);
   });
 
   it('errors when the named player is not online', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
-    expect(inspectReply(sim, a, '/inspect Nobody')).toBe("There is no player named 'Nobody' online.");
+    expect(inspectReply(sim, a, '/inspect Nobody')).toBe(
+      "There is no player named 'Nobody' online.",
+    );
+    expect(inspectEvents(sim, a)).toEqual([]);
   });
 
   it('asks whom to inspect when no name is given', () => {
     const sim = makeWorld();
     const a = sim.addPlayer('warrior', 'Aleph');
     expect(inspectReply(sim, a, '/inspect')).toBe('Inspect whom? Usage: /inspect <name>.');
+    expect(inspectEvents(sim, a)).toEqual([]);
   });
 
   it('supports the /ins and /examine aliases', () => {


### PR DESCRIPTION
## Summary
- Emit a personal `inspect` event after `/inspect`, `/ins`, or `/examine` successfully resolves a player.
- Handle that event in the HUD by opening the existing read-only inspect/profile paperdoll window.
- Keep the legacy one-line chat readout, and add tests that only successful name resolution emits the inspect event.

## Related issue
Part of #747. The inspect window and equipped-gear mirror already exist on `release/v0.19.0`; this wires the slash-command path into that existing window. Target-frame / right-click affordance work remains separate.

## Testing
- `npx biome format --write src/sim/types.ts src/sim/social/chat.ts src/ui/hud.ts tests/inspect_command.test.ts`
- `npx biome lint src/sim/types.ts src/sim/social/chat.ts src/ui/hud.ts tests/inspect_command.test.ts --max-diagnostics=40` (passes; existing `src/ui/hud.ts` master-loot non-null warnings remain)
- `npm run check:ts`
- `.browserslistrc` comment-stripped wrapper: `npx vitest run tests/inspect_command.test.ts tests/inspect_equipment.test.ts` (2 files, 17 tests passed)
- `.browserslistrc` comment-stripped wrapper: `npx vitest run tests/chat.test.ts tests/inspect_command.test.ts tests/inspect_equipment.test.ts` (3 files, 75 tests passed)
- `.browserslistrc` comment-stripped wrapper: `npm run build` (passes; existing chunk-size and generated admin locale dynamic-import warnings remain)
- Local browser verification: offline character `Aleph`, submitted `/inspect Aleph`, and verified `#inspect-window` displayed the profile/paperdoll with equipment rows.
- `git diff --check`

## Screenshots / recordings
Local visual verification completed for the command-opened inspect window. No screenshot is attached to the PR because this reuses the existing inspect window layout rather than changing visual styling.