### PR TITLE
feat(sim): add reputation core

### DIFF
--- a/src/sim/content/factions.ts
+++ b/src/sim/content/factions.ts
@@ -1,0 +1,36 @@
+export const REPUTATION_MIN = -42000;
+export const REPUTATION_MAX = 42000;
+
+export const FACTIONS = {
+  eastbrook: {
+    id: 'eastbrook',
+    name: 'Eastbrook',
+    description: 'The people of Eastbrook Vale and the road wardens who keep its farms safe.',
+  },
+} as const;
+
+export type FactionId = keyof typeof FACTIONS;
+export type FactionDef = (typeof FACTIONS)[FactionId];
+
+export const FACTION_ORDER = ['eastbrook'] as const satisfies readonly FactionId[];
+
+export const REPUTATION_STANDINGS = [
+  { name: 'Hostile', min: REPUTATION_MIN },
+  { name: 'Unfriendly', min: -6000 },
+  { name: 'Neutral', min: 0 },
+  { name: 'Friendly', min: 3000 },
+  { name: 'Honored', min: 9000 },
+  { name: 'Revered', min: 21000 },
+  { name: 'Exalted', min: REPUTATION_MAX },
+] as const;
+
+export type ReputationStanding = (typeof REPUTATION_STANDINGS)[number]['name'];
+
+export function reputationStanding(points: number): ReputationStanding {
+  const value = Math.max(REPUTATION_MIN, Math.min(REPUTATION_MAX, Math.floor(points)));
+  let standing: ReputationStanding = 'Hostile';
+  for (const band of REPUTATION_STANDINGS) {
+    if (value >= band.min) standing = band.name;
+  }
+  return standing;
+}

--- a/src/sim/content/zone1.ts
+++ b/src/sim/content/zone1.ts
@@ -637,6 +637,7 @@ export const ZONE1_QUESTS: Record<string, QuestDef> = {
     xpReward: 250,
     copperReward: 75,
     itemRewards: {},
+    reputationReward: { factionId: 'eastbrook', amount: 250 },
   },
   q_greyjaw: {
     id: 'q_greyjaw',

--- a/src/sim/quests/quest_commands.ts
+++ b/src/sim/quests/quest_commands.ts
@@ -26,6 +26,7 @@
 import { QUESTS, questRewardItemId } from '../data';
 import { formatMoney } from '../format_money';
 import { questFallbackGrants } from '../quest_fallback';
+import { grantReputation } from '../reputation';
 import type { PlayerMeta } from '../sim';
 import type { SimContext } from '../sim_context';
 import {
@@ -231,6 +232,21 @@ export function turnInQuestCore(
   const rewardItem = questRewardItemId(quest, meta.cls);
   if (rewardItem) ctx.addItem(rewardItem, 1, meta.entityId);
   ctx.grantXp(quest.xpReward, meta);
+  if (quest.reputationReward) {
+    const rep = grantReputation(
+      meta,
+      quest.reputationReward.factionId,
+      quest.reputationReward.amount,
+    );
+    if (rep) {
+      ctx.emit({
+        type: 'log',
+        text: `Reputation increased with ${rep.factionName} by ${rep.amount}.`,
+        color: '#9ad67a',
+        pid: meta.entityId,
+      });
+    }
+  }
   ctx.emit({ type: 'questDone', questId, pid: meta.entityId });
   ctx.emit({
     type: 'log',

--- a/src/sim/reputation.ts
+++ b/src/sim/reputation.ts
@@ -1,0 +1,33 @@
+import { FACTIONS, REPUTATION_MAX, REPUTATION_MIN, reputationStanding } from './content/factions';
+import type { PlayerMeta } from './sim';
+
+export function normalizeReputation(
+  input: Record<string, number> | undefined,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!input) return out;
+  for (const [factionId, raw] of Object.entries(input)) {
+    if (!FACTIONS[factionId as keyof typeof FACTIONS] || !Number.isFinite(raw)) continue;
+    const value = Math.max(REPUTATION_MIN, Math.min(REPUTATION_MAX, Math.floor(raw)));
+    if (value !== 0) out[factionId] = value;
+  }
+  return out;
+}
+
+export function grantReputation(
+  meta: PlayerMeta,
+  factionId: string,
+  amount: number,
+): { factionName: string; amount: number; total: number; standing: string } | null {
+  const faction = FACTIONS[factionId as keyof typeof FACTIONS];
+  if (!faction || !Number.isFinite(amount)) return null;
+  const delta = Math.floor(amount);
+  if (delta === 0) return null;
+  const before = meta.reputation[factionId] ?? 0;
+  const total = Math.max(REPUTATION_MIN, Math.min(REPUTATION_MAX, before + delta));
+  const applied = total - before;
+  if (applied === 0) return null;
+  if (total === 0) delete meta.reputation[factionId];
+  else meta.reputation[factionId] = total;
+  return { factionName: faction.name, amount: applied, total, standing: reputationStanding(total) };
+}

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -130,6 +130,7 @@ import {
 import { canEquipItem } from './equipment_rules';
 import { fleeSpeed } from './flee_speed';
 import { formatMoney } from './format_money';
+import { normalizeReputation } from './reputation';
 import * as interaction from './interaction';
 import { meetsLevelRequirement } from './item_level_req';
 import * as items from './items';
@@ -646,6 +647,7 @@ export interface PlayerMeta {
   known: ResolvedAbility[];
   questLog: Map<string, QuestProgress>;
   questsDone: Set<string>;
+  reputation: Record<string, number>;
   counters: RewardCounters;
   autoEquip: boolean;
   // sim.time when this character entered the world; powers /played. Session-only
@@ -740,6 +742,7 @@ export interface CharacterState {
   vendorBuyback?: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
   questsDone: string[];
+  reputation?: Record<string, number>;
   // Legacy arenaRating/Wins/Losses are treated as 1v1 data. The explicit
   // 1v1 fields are written by new saves, while old saves fall back cleanly.
   arenaRating?: number;
@@ -1171,6 +1174,7 @@ export class Sim {
       known: [],
       questLog: new Map(),
       questsDone: new Set(),
+      reputation: {},
       counters: freshCounters(),
       autoEquip: opts?.autoEquip ?? false,
       joinedAt: this.time,
@@ -1230,6 +1234,7 @@ export class Sim {
           });
       }
       for (const q of s.questsDone) meta.questsDone.add(q);
+      meta.reputation = normalizeReputation(s.reputation);
       if (s.talents)
         // Revalidate the persisted build against the current rules + level budget
         // before it is baked into the flat mods below. A stored allocation replays
@@ -1408,6 +1413,7 @@ export class Sim {
         state: q.state,
       })),
       questsDone: [...meta.questsDone],
+      reputation: normalizeReputation(meta.reputation),
       arenaRating: meta.arenaRating,
       arenaWins: meta.arenaWins,
       arenaLosses: meta.arenaLosses,

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -408,6 +408,10 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
     ctx.error(r.meta.entityId, readouts.statsReadout(r.meta, r.e));
     return null;
   }
+  if (/^\/(?:reputation|rep|factions?)(?:\s|$)/i.test(raw)) {
+    ctx.error(r.meta.entityId, readouts.reputationReadout(r.meta));
+    return null;
+  }
   if (/^\/(?:buffs?|auras)(?:\s|$)/i.test(raw)) {
     ctx.error(r.meta.entityId, readouts.buffsReadout(r.e));
     return null;
@@ -927,7 +931,7 @@ export function helpLines(): string[] {
     'Chat channels: /s say, /y yell, /general, /p party, /world, /lfg.',
     'Whisper a player with /w <name> <message>, reply with /r.',
     'Other commands: /join <world|lfg>, /roll, /inspect <name>, /follow <name>, /unfollow, /assist <name>, /afk, /dnd, /who.',
-    'Character readouts: /played, /xp, /gold, /stats, /bags, /gear, /abilities, /buffs, /cooldowns, /quest, /completed.',
+    'Character readouts: /played, /xp, /gold, /stats, /reputation, /bags, /gear, /abilities, /buffs, /cooldowns, /quest, /completed.',
     'World readouts: /where, /zones, /nearby, /pois, /graveyard, /dungeons, /arena, /session, /listings, /buyback.',
     'Combat readouts: /target, /targetbuffs, /range, /attack, /casting, /combat, /threat, /consider, /combo, /overpower.',
     'State readouts: /pet, /pettaunt, /speed, /consumable, /potion, /form, /manaregen, /falling, /queued, /savedmana.',

--- a/src/sim/social/chat_readouts.ts
+++ b/src/sim/social/chat_readouts.ts
@@ -12,6 +12,7 @@
 
 import { isDebuffAura } from '../aura_classify';
 import { isRooted } from '../combat/cc';
+import { FACTION_ORDER, FACTIONS, reputationStanding } from '../content/factions';
 import {
   FIRST_TALENT_LEVEL,
   pointsSpent,
@@ -113,6 +114,14 @@ export function zonesReadout(currentZ: number): string {
     return z.id === here.id ? `${line} [you are here]` : line;
   });
   return `Zones (${ZONES.length}): ${parts.join(', ')}.`;
+}
+export function reputationReadout(meta: PlayerMeta): string {
+  const parts = FACTION_ORDER.map((id) => {
+    const faction = FACTIONS[id];
+    const points = meta.reputation[id] ?? 0;
+    return `${faction.name} ${reputationStanding(points)} (${points})`;
+  });
+  return `Reputation: ${parts.join(', ')}.`;
 }
 // Self-only readout of a character's Ashen Coliseum standing. Reads only the
 // persisted PlayerMeta arena fields (no new state). Draws count as neither a

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1256,6 +1256,7 @@ export interface QuestDef {
   xpReward: number;
   copperReward: number;
   itemRewards: Partial<Record<PlayerClass, string>>;
+  reputationReward?: { factionId: string; amount: number };
   requiresQuest?: string; // prerequisite quest id (must be turned in)
   requiredItems?: string[]; // quest items obtained earlier (e.g. a prerequisite reward) that this
   // quest needs; re-granted on accept if the player no longer has them, to avoid a progression block

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -41,6 +41,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     meta.companionUpgrades = { tessa: 2 };
     meta.delveLoreUnlocked = new Set(['lore_1']);
     meta.delveDaily = { date: '2026-06-26', firstClearXp: new Set(['crypt']), markClears: 2 };
+    meta.reputation = { eastbrook: 3250 };
 
     const s1 = sim.serializeCharacter(pid)!;
     const sim2 = makeWorld();
@@ -52,6 +53,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(s2.delveMarks).toBe(17);
     expect(s2.loadouts?.length).toBe(1);
     expect(s2.skinCatalog).toBe('mech');
+    expect(s2.reputation).toEqual({ eastbrook: 3250 });
   });
 
   it('a legacy state missing the post-launch fields loads with sane defaults', () => {
@@ -86,6 +88,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
       'unlockedMilestones',
       'lifetimeXp',
       'restedXp',
+      'reputation',
     ]) {
       delete legacy[key];
     }
@@ -105,6 +108,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(m.loadouts).toEqual([]);
     expect(m.prestigeRank).toBe(0);
     expect(m.restedXp).toBe(0);
+    expect(m.reputation).toEqual({});
     // re-serializing a defaulted character does not throw and fills the new fields.
     expect(() => sim2.serializeCharacter(pid)).not.toThrow();
     expect(sim2.serializeCharacter(pid)!.delveMarks).toBe(0);

--- a/tests/quest_commands.test.ts
+++ b/tests/quest_commands.test.ts
@@ -178,6 +178,7 @@ describe('quest_commands: turnInQuest', () => {
     const ev = sim.drainEvents();
     expect(ev.some((e) => e.type === 'questDone' && (e as any).questId === 'q_wolves')).toBe(true);
     expect(logsTo(ev, pid)).toContain('Quest completed: Wolves at the Door');
+    expect(logsTo(ev, pid)).toContain('Reputation increased with Eastbrook by 250.');
     expect(ev.some((e) => e.type === 'loot' && /^You receive /.test(String((e as any).text)))).toBe(
       true,
     );
@@ -185,6 +186,7 @@ describe('quest_commands: turnInQuest', () => {
     expect(meta.questsDone.has('q_wolves')).toBe(true);
     expect(meta.questLog.has('q_wolves')).toBe(false);
     expect(meta.copper - copperBefore).toBe(QUESTS.q_wolves.copperReward);
+    expect(meta.reputation.eastbrook).toBe(250);
     expect(meta.lifetimeXp).toBeGreaterThan(lifetimeXpBefore);
     expect(meta.counters.questsCompleted).toBe(completedBefore + 1);
   });

--- a/tests/reputation.test.ts
+++ b/tests/reputation.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { REPUTATION_MAX, reputationStanding } from '../src/sim/content/factions';
+import { grantReputation, normalizeReputation } from '../src/sim/reputation';
+import { Sim } from '../src/sim/sim';
+
+describe('reputation standing helpers', () => {
+  it('maps faction points to standing bands', () => {
+    expect(reputationStanding(-42000)).toBe('Hostile');
+    expect(reputationStanding(-1)).toBe('Unfriendly');
+    expect(reputationStanding(0)).toBe('Neutral');
+    expect(reputationStanding(3000)).toBe('Friendly');
+    expect(reputationStanding(9000)).toBe('Honored');
+    expect(reputationStanding(21000)).toBe('Revered');
+    expect(reputationStanding(42000)).toBe('Exalted');
+  });
+
+  it('normalizes persisted faction records', () => {
+    expect(
+      normalizeReputation({
+        eastbrook: 3250.9,
+        unknown: 99,
+        bad: Number.NaN,
+      }),
+    ).toEqual({ eastbrook: 3250 });
+  });
+});
+
+describe('grantReputation', () => {
+  it('ignores unknown factions and clamps known totals', () => {
+    const sim = new Sim({ seed: 11, playerClass: 'warrior' });
+    const meta = sim.meta(sim.playerId);
+    expect(meta).toBeTruthy();
+    if (!meta) return;
+
+    expect(grantReputation(meta, 'unknown', 250)).toBeNull();
+    expect(meta.reputation).toEqual({});
+
+    expect(grantReputation(meta, 'eastbrook', 250)).toEqual({
+      factionName: 'Eastbrook',
+      amount: 250,
+      total: 250,
+      standing: 'Neutral',
+    });
+    expect(meta.reputation.eastbrook).toBe(250);
+
+    const capped = grantReputation(meta, 'eastbrook', REPUTATION_MAX);
+    expect(capped?.total).toBe(REPUTATION_MAX);
+    expect(capped?.amount).toBe(REPUTATION_MAX - 250);
+    expect(meta.reputation.eastbrook).toBe(REPUTATION_MAX);
+  });
+});
+
+describe('/reputation readout', () => {
+  it('reports current faction standings from player meta', () => {
+    const sim = new Sim({ seed: 12, playerClass: 'warrior' });
+    const pid = sim.playerId;
+
+    sim.chat('/reputation', pid);
+    expect(sim.drainEvents()).toContainEqual({
+      type: 'error',
+      text: 'Reputation: Eastbrook Neutral (0).',
+      pid,
+    });
+
+    const meta = sim.meta(pid);
+    expect(meta).toBeTruthy();
+    if (!meta) return;
+    meta.reputation.eastbrook = 3000;
+    sim.chat('/rep', pid);
+    expect(sim.drainEvents()).toContainEqual({
+      type: 'error',
+      text: 'Reputation: Eastbrook Friendly (3000).',
+      pid,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a narrow core reputation system for NPC factions:

- defines an Eastbrook faction registry with standing bands and clamped reputation helpers
- persists per-character reputation records through serialize/load
- grants Eastbrook reputation from the starter Wolves at the Door turn-in
- adds a /reputation slash readout for current standings

This is intentionally core sim/readout scope only; faction UI panels, target-frame standing, kill/opposed faction rewards, and faction-gated vendors are follow-up work.

## Related issues

Part of #450.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\content\factions.ts src\sim\reputation.ts src\sim\types.ts src\sim\content\zone1.ts src\sim\sim.ts src\sim\quests\quest_commands.ts src\sim\social\chat_readouts.ts src\sim\social\chat.ts tests\reputation.test.ts tests\persistence_round_trip.test.ts tests\quest_commands.test.ts`
  - `npx biome lint src\sim\content\factions.ts src\sim\reputation.ts src\sim\types.ts src\sim\content\zone1.ts src\sim\sim.ts src\sim\quests\quest_commands.ts src\sim\social\chat_readouts.ts src\sim\social\chat.ts tests\reputation.test.ts tests\persistence_round_trip.test.ts tests\quest_commands.test.ts` (exits 0; reports existing warnings in touched legacy test files)
  - `npm run check:ts`
  - `npx vitest run tests\reputation.test.ts tests\quest_commands.test.ts tests\persistence_round_trip.test.ts tests\chat.test.ts` (with .browserslistrc comment workaround)
  - `npx vitest run tests\sim_item_i18n.test.ts` (with .browserslistrc comment workaround)
  - `npm run build` (with .browserslistrc comment workaround; passes with existing Vite chunk-size/admin dynamic-import warnings)
  - `git diff --check`
- Manual steps: N/A, core sim/slash command behavior is covered by tests.

Known release-branch caveats: full `npm test` was not run for this focused PR. Prior release-branch blockers observed outside this change include `tests/architecture.test.ts` failing on the existing `src/world_api/chat.ts` value import of `OVERHEAD_EMOTE_IDS`, and parity default 5s timeout needing a longer timeout for `nythraxis_full_pull`.

## Screenshots / recordings

N/A. This adds core sim persistence and a slash readout; no HUD/window/layout/mobile UI changed.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a phone-sized viewport in both portrait and landscape. Touch targets stay at least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.** Every user-facing string is a `t()` key, added to `en` first, then given a real translation in every locale in `supportedLanguages` (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
