### PR TITLE
feat(sim): add durability repair core

### DIFF
--- a/src/sim/combat/damage.ts
+++ b/src/sim/combat/damage.ts
@@ -23,6 +23,7 @@
 // (enforced by tests/architecture.test.ts).
 
 import { DELVES, GROUP_XP_BONUS, MOBS } from '../data';
+import { damageEquippedDurability } from '../durability';
 import { recalcPlayerStats } from '../entity';
 import { DAMAGE_IDLE_DESPAWN_MOB_IDS, DAMAGE_IDLE_DESPAWN_SECONDS } from '../entity_roster';
 import type { PlayerMeta } from '../sim';
@@ -495,7 +496,10 @@ export function handleDeath(ctx: SimContext, e: Entity, killer: Entity | null): 
 
   if (e.kind === 'player') {
     const meta = ctx.players.get(e.id);
-    if (meta) meta.counters.deaths++;
+    if (meta) {
+      meta.counters.deaths++;
+      damageEquippedDurability(meta);
+    }
     e.autoAttack = false;
     e.queuedOnSwing = null;
     e.comboPoints = 0;

--- a/src/sim/durability.ts
+++ b/src/sim/durability.ts
@@ -1,0 +1,124 @@
+import { ITEMS } from './data';
+import type { PlayerEquipment } from './entity';
+import type { PlayerMeta } from './sim';
+import { EQUIP_SLOTS, type EquipSlot } from './types';
+
+export type EquipmentDurability = Partial<Record<EquipSlot, number>>;
+
+const SLOT_DURABILITY: Record<EquipSlot, number> = {
+  mainhand: 65,
+  helmet: 55,
+  shoulder: 50,
+  chest: 80,
+  waist: 45,
+  legs: 70,
+  gloves: 45,
+  feet: 55,
+};
+
+const QUALITY_MULT: Record<string, number> = {
+  poor: 0.85,
+  common: 1,
+  uncommon: 1.15,
+  rare: 1.3,
+  epic: 1.5,
+  legendary: 1.8,
+};
+
+export const DEATH_DURABILITY_LOSS = 0.1;
+export const REPAIR_VALUE_MULT = 0.4;
+
+export function maxDurabilityForItem(itemId: string | undefined): number {
+  if (!itemId) return 0;
+  const def = ITEMS[itemId];
+  if (!def?.slot || (def.kind !== 'weapon' && def.kind !== 'armor')) return 0;
+  const mult = QUALITY_MULT[def.quality ?? 'common'] ?? 1;
+  return Math.max(1, Math.round(SLOT_DURABILITY[def.slot] * mult));
+}
+
+export function currentDurabilityForSlot(meta: PlayerMeta, slot: EquipSlot): number {
+  const max = maxDurabilityForItem(meta.equipment[slot]);
+  if (max <= 0) return 0;
+  const raw = meta.equipmentDurability[slot];
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return max;
+  return Math.max(0, Math.min(max, Math.floor(raw)));
+}
+
+export function normalizeEquipmentDurability(
+  equipment: PlayerEquipment,
+  input: EquipmentDurability | undefined,
+): EquipmentDurability {
+  const out: EquipmentDurability = {};
+  for (const slot of EQUIP_SLOTS) {
+    const max = maxDurabilityForItem(equipment[slot]);
+    if (max <= 0) continue;
+    const raw = input?.[slot];
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) continue;
+    const value = Math.max(0, Math.min(max, Math.floor(raw)));
+    if (value < max) out[slot] = value;
+  }
+  return out;
+}
+
+export function resetSlotDurability(meta: PlayerMeta, slot: EquipSlot): void {
+  delete meta.equipmentDurability[slot];
+}
+
+export function damageEquippedDurability(
+  meta: PlayerMeta,
+  lossRatio = DEATH_DURABILITY_LOSS,
+): EquipmentDurability {
+  const changed: EquipmentDurability = {};
+  for (const slot of EQUIP_SLOTS) {
+    const itemId = meta.equipment[slot];
+    const max = maxDurabilityForItem(itemId);
+    if (!itemId || max <= 0) continue;
+    const current = currentDurabilityForSlot(meta, slot);
+    const loss = Math.max(1, Math.ceil(max * lossRatio));
+    const next = Math.max(0, current - loss);
+    if (next < max) meta.equipmentDurability[slot] = next;
+    else delete meta.equipmentDurability[slot];
+    if (next !== current) changed[slot] = next;
+  }
+  return changed;
+}
+
+export function equipmentRepairCost(meta: PlayerMeta): {
+  total: number;
+  slots: EquipmentDurability;
+} {
+  let total = 0;
+  const slots: EquipmentDurability = {};
+  for (const slot of EQUIP_SLOTS) {
+    const itemId = meta.equipment[slot];
+    const def = itemId ? ITEMS[itemId] : undefined;
+    const max = maxDurabilityForItem(itemId);
+    if (!def || max <= 0) continue;
+    const current = currentDurabilityForSlot(meta, slot);
+    const missing = max - current;
+    if (missing <= 0) continue;
+    slots[slot] = current;
+    total += Math.max(1, Math.ceil((missing / max) * def.sellValue * REPAIR_VALUE_MULT));
+  }
+  return { total, slots };
+}
+
+export function repairAllEquipment(meta: PlayerMeta): number {
+  const { total } = equipmentRepairCost(meta);
+  if (total <= 0) return 0;
+  meta.equipmentDurability = {};
+  return total;
+}
+
+export function durabilityReadout(meta: PlayerMeta): string {
+  const parts: string[] = [];
+  for (const slot of EQUIP_SLOTS) {
+    const itemId = meta.equipment[slot];
+    if (!itemId) continue;
+    const max = maxDurabilityForItem(itemId);
+    if (max <= 0) continue;
+    const def = ITEMS[itemId];
+    parts.push(`${def.name} ${currentDurabilityForSlot(meta, slot)}/${max}`);
+  }
+  return parts.length > 0 ? `Durability: ${parts.join(', ')}.` : 'Durability: no equipped gear.';
+}

--- a/src/sim/items.ts
+++ b/src/sim/items.ts
@@ -17,6 +17,7 @@
 // (enforced by tests/architecture.test.ts). This region draws NO rng.
 
 import { ITEMS } from './data';
+import { equipmentRepairCost, repairAllEquipment, resetSlotDurability } from './durability';
 import { recalcPlayerStats } from './entity';
 import { canEquipItem } from './equipment_rules';
 import { formatMoney } from './format_money';
@@ -80,6 +81,7 @@ export function equipItem(ctx: SimContext, itemId: string, pid?: number): void {
   ctx.removeItem(itemId, 1, meta.entityId);
   if (old) addItemSilent(old, 1, meta);
   meta.equipment[slot] = itemId;
+  resetSlotDurability(meta, slot);
   recalcPlayerStats(p, meta.cls, meta.equipment, ctx.playerMods(meta));
   ctx.emit({ type: 'log', text: `Equipped ${def.name}.`, color: '#8f8', pid: meta.entityId });
 }
@@ -94,6 +96,7 @@ export function unequipItem(ctx: SimContext, slot: EquipSlot, pid?: number): boo
   const itemId = meta.equipment[slot];
   if (!itemId) return false;
   delete meta.equipment[slot];
+  resetSlotDurability(meta, slot);
   // addItemSilent (not addItem): returning a piece you already owned to bags is
   // not a fresh acquisition, so it must not fire collect-quest credit. No quest
   // today keys on an unequip, so there is nothing to award here regardless.
@@ -348,6 +351,37 @@ export function sellAllJunk(ctx: SimContext, pid?: number): void {
   ctx.emit({
     type: 'loot',
     text: `Sold ${soldCount} junk item${soldCount === 1 ? '' : 's'} for ${formatMoney(total)}.`,
+    pid: meta.entityId,
+  });
+}
+
+export function repairAll(ctx: SimContext, pid?: number): void {
+  const r = ctx.resolve(pid);
+  if (!r) return;
+  const { meta, e: p } = r;
+  if (p.dead) {
+    ctx.error(meta.entityId, "You can't do that while dead.");
+    return;
+  }
+  if (!vendorInRange(ctx, p)) {
+    ctx.error(meta.entityId, 'There is no merchant nearby.');
+    return;
+  }
+  const { total } = equipmentRepairCost(meta);
+  if (total <= 0) {
+    ctx.error(meta.entityId, 'Your equipment is already fully repaired.');
+    return;
+  }
+  if (meta.copper < total) {
+    ctx.error(meta.entityId, 'Not enough money.');
+    return;
+  }
+  meta.copper -= total;
+  repairAllEquipment(meta);
+  ctx.emit({ type: 'vendor', action: 'repair', pid: meta.entityId });
+  ctx.emit({
+    type: 'loot',
+    text: `Repaired your equipment for ${formatMoney(total)}.`,
     pid: meta.entityId,
   });
 }

--- a/src/sim/sim.ts
+++ b/src/sim/sim.ts
@@ -129,6 +129,7 @@ import {
 } from './entity_roster';
 import { canEquipItem } from './equipment_rules';
 import { fleeSpeed } from './flee_speed';
+import { normalizeEquipmentDurability } from './durability';
 import { formatMoney } from './format_money';
 import * as interaction from './interaction';
 import { meetsLevelRequirement } from './item_level_req';
@@ -632,6 +633,7 @@ export interface PlayerMeta {
   vendorBuyback: InvSlot[];
   copper: number;
   equipment: PlayerEquipment;
+  equipmentDurability: Partial<Record<EquipSlot, number>>;
   xp: number;
   // Post-cap progression (Max-Level XP Overflow). `lifetimeXp` is the monotonic
   // 64-bit-safe total of all XP ever earned — it keeps growing at the cap and is
@@ -736,6 +738,7 @@ export interface CharacterState {
   pos: { x: number; z: number };
   facing: number;
   equipment: PlayerEquipment;
+  equipmentDurability?: Partial<Record<EquipSlot, number>>;
   inventory: InvSlot[];
   vendorBuyback?: InvSlot[];
   questLog: { questId: string; counts: number[]; state: 'active' | 'ready' | 'done' }[];
@@ -1163,6 +1166,7 @@ export class Sim {
       vendorBuyback: [],
       copper: 0,
       equipment: { mainhand: classDef.startWeapon, chest: classDef.startChest },
+      equipmentDurability: {},
       xp: 0,
       lifetimeXp: 0,
       prestigeRank: 0,
@@ -1219,6 +1223,10 @@ export class Sim {
         for (const id of s.unlockedMilestones) meta.unlockedMilestones.add(id);
       meta.copper = s.copper;
       meta.equipment = { ...s.equipment };
+      meta.equipmentDurability = normalizeEquipmentDurability(
+        meta.equipment,
+        s.equipmentDurability,
+      );
       meta.inventory = s.inventory.map((i) => ({ ...i }));
       meta.vendorBuyback = (s.vendorBuyback ?? []).map((i) => ({ ...i }));
       for (const q of s.questLog) {
@@ -1400,6 +1408,7 @@ export class Sim {
       pos: { x: e.pos.x, z: e.pos.z },
       facing: e.facing,
       equipment: { ...meta.equipment },
+      equipmentDurability: normalizeEquipmentDurability(meta.equipment, meta.equipmentDurability),
       inventory: meta.inventory.map((i) => ({ ...i })),
       vendorBuyback: meta.vendorBuyback.map((i) => ({ ...i })),
       questLog: [...meta.questLog.values()].map((q) => ({
@@ -2169,7 +2178,7 @@ export class Sim {
       // already bound above; isRooted/moveSpeedMult/swingIntervalMult are M2 bindings above.)
       setPlayerLevel: sim.setPlayerLevel.bind(sim),
       notice: sim.notice.bind(sim),
-      // L2 inventory/vendor (W2): the four still-on-Sim helpers the moved items.useItem
+      // L2 inventory/vendor (W2): the still-on-Sim helpers the moved items.useItem
       // dispatches to. Late-bound arrows (looked up at call time, not `.bind`d at ctor)
       // so they preserve the pre-move `this.X` dynamic-dispatch semantics, including tests
       // that reassign a Sim method post-construction. startFishing/unlockMechChromaFromItem/
@@ -2179,6 +2188,7 @@ export class Sim {
         sim.unlockMechChromaFromItem(meta, itemId, chromaId),
       openSkinSelect: (meta, catalog, itemId) => sim.openSkinSelect(meta, catalog, itemId),
       isSwimming: (e) => sim.isSwimming(e),
+      repairAll: (pid) => sim.repairAll(pid),
       // Interaction (W3): the moved interaction.interact dispatches into the quest-NPC
       // surface that STAYS on Sim (W4 owns talkToNpc / interactNpcForQuests /
       // isQuestInteractionEntity). Late-bound arrows (call-time lookup, not `.bind`d) so
@@ -4359,6 +4369,10 @@ export class Sim {
 
   buyBackItem(itemId: string, pid?: number): void {
     items.buyBackItem(this.ctx, itemId, pid);
+  }
+
+  repairAll(pid?: number): void {
+    items.repairAll(this.ctx, pid);
   }
 
   private maybeAutoEquip(itemId: string, meta: PlayerMeta): void {

--- a/src/sim/sim_context.ts
+++ b/src/sim/sim_context.ts
@@ -523,7 +523,7 @@ export interface SimContextCallbacks {
   setPlayerLevel(level: number, pid?: number): void;
   notice(pid: number, text: string, color?: string): void;
 
-  // L2 inventory/vendor (src/sim/items.ts): the four helpers the moved useItem
+  // L2 inventory/vendor (src/sim/items.ts): the helpers the moved useItem
   // dispatches to that STAY on Sim (their owning facets are decided later). W2 owns
   // these declarations; each is a thin late-bound delegate to the still-on-Sim method.
   // startFishing's body stays on Sim (fishing facet TBD); unlockMechChromaFromItem /
@@ -538,6 +538,7 @@ export interface SimContextCallbacks {
   ): ItemUseResult | undefined;
   openSkinSelect(meta: PlayerMeta, catalog: SkinCatalog, itemId: string): void;
   isSwimming(e: Entity): boolean;
+  repairAll(pid?: number): void;
 
   // W3 interaction (src/sim/interaction.ts): the moved `interact` dispatcher fans into
   // the quest-NPC surface that STAYS on Sim (W4 owns talkToNpc / interactNpcForQuests /
@@ -876,11 +877,12 @@ export function createSimContext(host: SimContextHost): SimContext {
     // G2 social plumbing passthroughs (hasPendingSocialInvite already bound above; deduped).
     setPlayerLevel: host.setPlayerLevel,
     notice: host.notice,
-    // L2 inventory/vendor (W2): the four still-on-Sim helpers the moved useItem dispatches to.
+    // L2 inventory/vendor (W2): the still-on-Sim helpers the moved useItem dispatches to.
     startFishing: host.startFishing,
     unlockMechChromaFromItem: host.unlockMechChromaFromItem,
     openSkinSelect: host.openSkinSelect,
     isSwimming: host.isSwimming,
+    repairAll: host.repairAll,
     // W3 interaction: the two still-on-Sim quest-NPC delegates the moved interact dispatches to.
     talkToNpc: host.talkToNpc,
     isQuestInteractionEntity: host.isQuestInteractionEntity,

--- a/src/sim/social/chat.ts
+++ b/src/sim/social/chat.ts
@@ -428,6 +428,14 @@ export function chat(ctx: SimContext, text: string, pid?: number): SentChat | nu
     ctx.error(r.meta.entityId, readouts.gearReadout(r.meta));
     return null;
   }
+  if (/^\/(?:durability|dur|condition)(?:\s|$)/i.test(raw)) {
+    ctx.error(r.meta.entityId, readouts.durabilityReadout(r.meta));
+    return null;
+  }
+  if (/^\/(?:repair|repairall)(?:\s|$)/i.test(raw)) {
+    ctx.repairAll(r.meta.entityId);
+    return null;
+  }
   if (/^\/(?:abilities|spells|spellbook)(?:\s|$)/i.test(raw)) {
     ctx.error(r.meta.entityId, readouts.abilitiesReadout(r.meta, r.e));
     return null;
@@ -927,8 +935,8 @@ export function helpLines(): string[] {
     'Chat channels: /s say, /y yell, /general, /p party, /world, /lfg.',
     'Whisper a player with /w <name> <message>, reply with /r.',
     'Other commands: /join <world|lfg>, /roll, /inspect <name>, /follow <name>, /unfollow, /assist <name>, /afk, /dnd, /who.',
-    'Character readouts: /played, /xp, /gold, /stats, /bags, /gear, /abilities, /buffs, /cooldowns, /quest, /completed.',
-    'World readouts: /where, /zones, /nearby, /pois, /graveyard, /dungeons, /arena, /session, /listings, /buyback.',
+    'Character readouts: /played, /xp, /gold, /stats, /bags, /gear, /durability, /abilities, /buffs, /cooldowns, /quest, /completed.',
+    'World readouts: /where, /zones, /nearby, /pois, /graveyard, /dungeons, /arena, /session, /listings, /buyback, /repair.',
     'Combat readouts: /target, /targetbuffs, /range, /attack, /casting, /combat, /threat, /consider, /combo, /overpower.',
     'State readouts: /pet, /pettaunt, /speed, /consumable, /potion, /form, /manaregen, /falling, /queued, /savedmana.',
   ];

--- a/src/sim/social/chat_readouts.ts
+++ b/src/sim/social/chat_readouts.ts
@@ -28,6 +28,7 @@ import {
   ZONES,
   zoneAt,
 } from '../data';
+import { durabilityReadout as durabilityReadoutForMeta } from '../durability';
 import { formatMoney } from '../format_money';
 import { MARKET_MAX_LISTINGS } from '../market';
 import * as petCommands from '../pet/pet_commands';
@@ -125,6 +126,9 @@ export function arenaReadout(meta: PlayerMeta): string {
     return `${label} Rating ${rating} - ${wins} wins, ${losses} losses (${pct}% win rate)`;
   };
   return `Arena: ${part('1v1', meta.arenaRating, meta.arenaWins, meta.arenaLosses)}. ${part('2v2', meta.arena2v2Rating, meta.arena2v2Wins, meta.arena2v2Losses)}.`;
+}
+export function durabilityReadout(meta: PlayerMeta): string {
+  return durabilityReadoutForMeta(meta);
 }
 export function buybackReadout(meta: PlayerMeta): string {
   const slots = meta.vendorBuyback.filter((s) => ITEMS[s.itemId] && s.count > 0);

--- a/src/sim/types.ts
+++ b/src/sim/types.ts
@@ -1576,7 +1576,7 @@ export type SimEvent = { pid?: number } & (
   | { type: 'respawn' }
   // itemId names the single item for buy/sell/buyback; it is omitted for the
   // bulk "sell all junk" sweep, which the client treats as a plain refresh signal.
-  | { type: 'vendor'; action: 'buy' | 'sell' | 'buyback'; itemId?: string }
+  | { type: 'vendor'; action: 'buy' | 'sell' | 'buyback' | 'repair'; itemId?: string }
   // say/yell are delivered only to players in range and carry the speaker's
   // entity id so the client can hang a chat bubble over their head; whisper
   // goes to the target (and echoes to the sender with `to` set); general is

--- a/tests/durability.test.ts
+++ b/tests/durability.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest';
+import {
+  currentDurabilityForSlot,
+  damageEquippedDurability,
+  durabilityReadout,
+  equipmentRepairCost,
+  maxDurabilityForItem,
+  normalizeEquipmentDurability,
+} from '../src/sim/durability';
+import * as items from '../src/sim/items';
+import { Sim } from '../src/sim/sim';
+import type { SimContext } from '../src/sim/sim_context';
+import type { Entity, SimEvent } from '../src/sim/types';
+
+function ctxOf(sim: Sim): SimContext {
+  return (sim as unknown as { ctx: SimContext }).ctx;
+}
+
+function vendorPlayer(sim: Sim) {
+  const pid = sim.addPlayer('warrior', 'Fixit');
+  const anySim = sim as unknown as {
+    entities: Map<number, Entity>;
+    players: Map<
+      number,
+      {
+        copper: number;
+        equipment: Record<string, string>;
+        equipmentDurability: Record<string, number>;
+      }
+    >;
+    rebucket(e: Entity): void;
+  };
+  const merchant = [...anySim.entities.values()].find(
+    (e) =>
+      e.kind === 'npc' && (e as unknown as { templateId?: string }).templateId === 'trader_wilkes',
+  );
+  if (!merchant) throw new Error('merchant not found');
+  const player = anySim.entities.get(pid);
+  if (!player) throw new Error('player not found');
+  player.pos.x = merchant.pos.x + 2;
+  player.pos.z = merchant.pos.z;
+  anySim.rebucket(player);
+  const meta = anySim.players.get(pid);
+  if (!meta) throw new Error('meta not found');
+  return { pid, meta, player };
+}
+
+function eventsOf<T extends SimEvent['type']>(
+  events: SimEvent[],
+  type: T,
+): Extract<SimEvent, { type: T }>[] {
+  return events.filter((e): e is Extract<SimEvent, { type: T }> => e.type === type);
+}
+
+describe('equipment durability helpers', () => {
+  it('treats absent current durability as full and persists only damaged slots', () => {
+    const sim = new Sim({ seed: 1, playerClass: 'warrior' });
+    const meta = sim.meta(sim.playerId);
+    expect(meta).toBeTruthy();
+    if (!meta) return;
+
+    const mainhandMax = maxDurabilityForItem(meta.equipment.mainhand);
+    const chestMax = maxDurabilityForItem(meta.equipment.chest);
+    expect(mainhandMax).toBeGreaterThan(0);
+    expect(chestMax).toBeGreaterThan(0);
+    expect(currentDurabilityForSlot(meta, 'mainhand')).toBe(mainhandMax);
+
+    meta.equipmentDurability = {
+      mainhand: mainhandMax - 3,
+      chest: chestMax,
+      helmet: 12,
+    };
+    expect(normalizeEquipmentDurability(meta.equipment, meta.equipmentDurability)).toEqual({
+      mainhand: mainhandMax - 3,
+    });
+  });
+
+  it('applies deterministic death-style durability loss to equipped gear', () => {
+    const sim = new Sim({ seed: 2, playerClass: 'warrior' });
+    const meta = sim.meta(sim.playerId);
+    expect(meta).toBeTruthy();
+    if (!meta) return;
+
+    const mainhandMax = maxDurabilityForItem(meta.equipment.mainhand);
+    const chestMax = maxDurabilityForItem(meta.equipment.chest);
+    const changed = damageEquippedDurability(meta);
+
+    expect(changed.mainhand).toBe(mainhandMax - Math.ceil(mainhandMax * 0.1));
+    expect(changed.chest).toBe(chestMax - Math.ceil(chestMax * 0.1));
+    expect(meta.equipmentDurability).toEqual(changed);
+  });
+});
+
+describe('vendor repair', () => {
+  it('repairs damaged equipped gear at a nearby merchant and charges the purse', () => {
+    const sim = new Sim({ seed: 3, playerClass: 'warrior', noPlayer: true });
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    const mainhandMax = maxDurabilityForItem(meta.equipment.mainhand);
+    const chestMax = maxDurabilityForItem(meta.equipment.chest);
+    meta.equipmentDurability = { mainhand: mainhandMax - 5, chest: chestMax - 10 };
+    const cost = equipmentRepairCost(meta as never).total;
+    meta.copper = cost;
+
+    items.repairAll(ctx, pid);
+
+    expect(meta.copper).toBe(0);
+    expect(meta.equipmentDurability).toEqual({});
+    const events = sim.drainEvents();
+    expect(events).toContainEqual({ type: 'vendor', action: 'repair', pid });
+    expect(eventsOf(events, 'loot')[0]?.text).toBe(`Repaired your equipment for ${cost}c.`);
+  });
+
+  it('requires a nearby merchant and enough copper', () => {
+    const sim = new Sim({ seed: 4, playerClass: 'warrior', noPlayer: true });
+    const pid = sim.addPlayer('warrior', 'Far');
+    const meta = sim.meta(pid);
+    expect(meta).toBeTruthy();
+    if (!meta) return;
+    const mainhandMax = maxDurabilityForItem(meta.equipment.mainhand);
+    meta.equipmentDurability = { mainhand: mainhandMax - 10 };
+    meta.copper = 1000;
+
+    items.repairAll(ctxOf(sim), pid);
+    expect(eventsOf(sim.drainEvents(), 'error')[0]?.text).toBe('There is no merchant nearby.');
+
+    const near = vendorPlayer(sim);
+    const nearMax = maxDurabilityForItem(near.meta.equipment.mainhand);
+    near.meta.equipmentDurability = { mainhand: nearMax - 10 };
+    near.meta.copper = 0;
+    items.repairAll(ctxOf(sim), near.pid);
+    expect(eventsOf(sim.drainEvents(), 'error')[0]?.text).toBe('Not enough money.');
+  });
+
+  it('routes /durability and /repair through chat commands', () => {
+    const sim = new Sim({ seed: 5, playerClass: 'warrior', noPlayer: true });
+    const { pid, meta } = vendorPlayer(sim);
+    const mainhand = meta.equipment.mainhand;
+    expect(mainhand).toBeTruthy();
+    const mainhandMax = maxDurabilityForItem(mainhand);
+    meta.equipmentDurability = { mainhand: mainhandMax - 7 };
+    const cost = equipmentRepairCost(meta as never).total;
+    meta.copper = cost;
+
+    sim.chat('/durability', pid);
+    expect(eventsOf(sim.drainEvents(), 'error')[0]?.text).toBe(durabilityReadout(meta as never));
+
+    sim.chat('/repair', pid);
+    expect(meta.equipmentDurability).toEqual({});
+    expect(eventsOf(sim.drainEvents(), 'vendor')[0]?.action).toBe('repair');
+  });
+});
+
+describe('equipment durability lifecycle', () => {
+  it('resets a slot when a replacement is equipped or unequipped', () => {
+    const sim = new Sim({ seed: 6, playerClass: 'warrior', noPlayer: true });
+    const { pid, meta } = vendorPlayer(sim);
+    const ctx = ctxOf(sim);
+    sim.addItem('cryptbone_helm', 1, pid);
+    items.equipItem(ctx, 'cryptbone_helm', pid);
+    const helmMax = maxDurabilityForItem('cryptbone_helm');
+    meta.equipmentDurability.helmet = helmMax - 5;
+
+    sim.addItem('roadwardens_helm', 1, pid);
+    items.equipItem(ctx, 'roadwardens_helm', pid);
+    expect(meta.equipmentDurability.helmet).toBeUndefined();
+
+    meta.equipmentDurability.helmet = maxDurabilityForItem('roadwardens_helm') - 5;
+    expect(items.unequipItem(ctx, 'helmet', pid)).toBe(true);
+    expect(meta.equipmentDurability.helmet).toBeUndefined();
+  });
+});

--- a/tests/entity_roster.test.ts
+++ b/tests/entity_roster.test.ts
@@ -287,11 +287,12 @@ function makeCtx() {
     // G2 social plumbing (hasPendingSocialInvite already stubbed above; deduped).
     setPlayerLevel: vi.fn(),
     notice: vi.fn(),
-    // L2 inventory/vendor (W2): the four still-on-Sim helpers the moved useItem dispatches to.
+    // L2 inventory/vendor (W2): the still-on-Sim helpers the moved useItem dispatches to.
     startFishing: vi.fn(),
     unlockMechChromaFromItem: vi.fn(),
     openSkinSelect: vi.fn(),
     isSwimming: vi.fn(() => false),
+    repairAll: vi.fn(),
     // W3 interaction: the two still-on-Sim quest-NPC delegates the moved interact dispatches to.
     talkToNpc: vi.fn(),
     isQuestInteractionEntity: vi.fn(() => false),

--- a/tests/persistence_round_trip.test.ts
+++ b/tests/persistence_round_trip.test.ts
@@ -41,6 +41,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     meta.companionUpgrades = { tessa: 2 };
     meta.delveLoreUnlocked = new Set(['lore_1']);
     meta.delveDaily = { date: '2026-06-26', firstClearXp: new Set(['crypt']), markClears: 2 };
+    meta.equipmentDurability = { mainhand: 20 };
 
     const s1 = sim.serializeCharacter(pid)!;
     const sim2 = makeWorld();
@@ -52,6 +53,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(s2.delveMarks).toBe(17);
     expect(s2.loadouts?.length).toBe(1);
     expect(s2.skinCatalog).toBe('mech');
+    expect(s2.equipmentDurability).toEqual({ mainhand: 20 });
   });
 
   it('a legacy state missing the post-launch fields loads with sane defaults', () => {
@@ -86,6 +88,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
       'unlockedMilestones',
       'lifetimeXp',
       'restedXp',
+      'equipmentDurability',
     ]) {
       delete legacy[key];
     }
@@ -105,6 +108,7 @@ describe('serializeCharacter <-> addPlayer round-trip (G2 persistence)', () => {
     expect(m.loadouts).toEqual([]);
     expect(m.prestigeRank).toBe(0);
     expect(m.restedXp).toBe(0);
+    expect(m.equipmentDurability).toEqual({});
     // re-serializing a defaulted character does not throw and fills the new fields.
     expect(() => sim2.serializeCharacter(pid)).not.toThrow();
     expect(sim2.serializeCharacter(pid)!.delveMarks).toBe(0);

--- a/tests/sim_context.test.ts
+++ b/tests/sim_context.test.ts
@@ -190,11 +190,12 @@ const CALLBACK_KEYS = [
   // G2 social plumbing (hasPendingSocialInvite already listed above; deduped).
   'setPlayerLevel',
   'notice',
-  // L2 inventory/vendor (W2): the four still-on-Sim helpers the moved useItem dispatches to.
+  // L2 inventory/vendor (W2): the still-on-Sim helpers the moved useItem dispatches to.
   'startFishing',
   'unlockMechChromaFromItem',
   'openSkinSelect',
   'isSwimming',
+  'repairAll',
   // W3 interaction: the two still-on-Sim quest-NPC delegates the moved interact dispatches to.
   'talkToNpc',
   'isQuestInteractionEntity',
@@ -420,11 +421,12 @@ function makeFakeHost() {
     // G2 social plumbing (hasPendingSocialInvite already stubbed above; deduped).
     setPlayerLevel: vi.fn(),
     notice: vi.fn(),
-    // L2 inventory/vendor (W2): the four still-on-Sim helpers the moved useItem dispatches to.
+    // L2 inventory/vendor (W2): the still-on-Sim helpers the moved useItem dispatches to.
     startFishing: vi.fn(),
     unlockMechChromaFromItem: vi.fn(),
     openSkinSelect: vi.fn(),
     isSwimming: vi.fn(() => false),
+    repairAll: vi.fn(),
     // W3 interaction: the two still-on-Sim quest-NPC delegates the moved interact dispatches to.
     talkToNpc: vi.fn(),
     isQuestInteractionEntity: vi.fn(() => false),


### PR DESCRIPTION
## Summary

Adds a focused core slice for equipment durability and vendor repair:

- tracks sparse per-slot equipped-gear durability in character state (missing means full)
- applies deterministic 10% equipped-gear durability loss on player death
- resets slot durability when gear is replaced or unequipped
- adds server-authoritative repair-all logic gated by nearby merchants and purse balance
- adds /durability and /repair slash-command access for the core behavior

This intentionally leaves the paperdoll durability bars, vendor-window repair button, broken-item stat suppression, and per-item-instance durability for follow-up work.

## Related issues

Part of #746.

## Type of change

- [x] Feature: new functionality
- [ ] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `npx biome format --write src\sim\durability.ts src\sim\sim.ts src\sim\items.ts src\sim\combat\damage.ts src\sim\sim_context.ts src\sim\social\chat_readouts.ts src\sim\social\chat.ts src\sim\types.ts tests\durability.test.ts tests\persistence_round_trip.test.ts tests\entity_roster.test.ts tests\sim_context.test.ts`
  - `npx biome lint src\sim\durability.ts src\sim\sim.ts src\sim\items.ts src\sim\combat\damage.ts src\sim\sim_context.ts src\sim\social\chat_readouts.ts src\sim\social\chat.ts src\sim\types.ts tests\durability.test.ts tests\persistence_round_trip.test.ts tests\entity_roster.test.ts tests\sim_context.test.ts` (exits 0; reports existing warning noise in legacy touched files)
  - `npm run check:ts`
  - `npx vitest run tests\durability.test.ts tests\items.test.ts tests\persistence_round_trip.test.ts tests\chat.test.ts tests\sim_context.test.ts tests\entity_roster.test.ts` (with .browserslistrc comment workaround)
  - `npx vitest run tests\sim_item_i18n.test.ts` (with .browserslistrc comment workaround)
  - `npm run build` (with .browserslistrc comment workaround; passes with existing Vite chunk-size/admin dynamic-import warnings)
  - `git diff --cached --check`
- Manual steps: N/A; this is core sim persistence/vendor command behavior covered by tests.

Known release-branch caveats: full `npm test` was not run for this focused PR. Prior release-branch blockers observed outside this change include `tests/architecture.test.ts` failing on the existing `src/world_api/chat.ts` value import of `OVERHEAD_EMOTE_IDS`, and parity default 5s timeout needing a longer timeout for `nythraxis_full_pull`.

## Screenshots / recordings

N/A. This PR adds core sim state and slash-command access; it does not change HUD/window/layout/mobile UI.

---

## Checklist

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is TypeScript `strict`).
- [x] **Builds succeed.** `npm run build`, plus `npm run build:server` and `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a phone-sized viewport in both portrait and landscape. Touch targets stay at least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.** Every user-facing string is a `t()` key, added to `en` first, then given a real translation in every locale in `supportedLanguages` (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at the client boundary in this same change, and `npx vitest run tests/localization_fixes.test.ts` passes.
- [ ] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is not enabled in any production path.
- [x] I didn't hand-edit generated files such as `src/render/assets/manifest.generated.ts`. They're regenerated by the build.
