### PR TITLE
fix(python): harden wow env IPC teardown

### DIFF
--- a/python/test_wow_env.py
+++ b/python/test_wow_env.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import os
+import queue
+import subprocess
+import sys
+import types
+import unittest
+from collections import deque
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.float32 = "float32"
+numpy_stub.asarray = lambda value, dtype=None: value
+sys.modules.setdefault("numpy", numpy_stub)
+
+gym_stub = types.ModuleType("gymnasium")
+
+
+class Env:
+    def reset(self, *, seed=None):
+        self.np_random = types.SimpleNamespace(integers=lambda start, stop: start)
+
+
+class Box:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class Discrete:
+    def __init__(self, value):
+        self.value = value
+
+
+gym_stub.Env = Env
+gym_stub.spaces = types.SimpleNamespace(Box=Box, Discrete=Discrete)
+sys.modules.setdefault("gymnasium", gym_stub)
+
+import wow_env
+
+
+class FakePipe:
+    def __init__(self, broken: bool = False):
+        self.broken = broken
+        self.closed = False
+        self.writes: list[str] = []
+        self.flushed = False
+
+    def write(self, value: str) -> None:
+        if self.broken:
+            raise BrokenPipeError("closed")
+        self.writes.append(value)
+
+    def flush(self) -> None:
+        if self.broken:
+            raise BrokenPipeError("closed")
+        self.flushed = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeProc:
+    def __init__(self, returncode: int | None = None, wait_timeout: bool = False):
+        self.returncode = returncode
+        self.wait_timeout = wait_timeout
+        self.stdin = FakePipe()
+        self.stdout = FakePipe()
+        self.stderr = FakePipe()
+        self.killed = False
+        self.wait_calls: list[float | None] = []
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def kill(self) -> None:
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls.append(timeout)
+        if self.wait_timeout and not self.killed:
+            raise subprocess.TimeoutExpired("node", timeout)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+def make_env(proc: FakeProc, *, stderr: list[str] | None = None, timeout: float = 0.01):
+    env = object.__new__(wow_env.WoWClassicEnv)
+    env._proc = proc
+    env._closed = False
+    env._request_timeout = timeout
+    env._stdout_lines = queue.Queue()
+    env._stderr_tail = deque(stderr or [], maxlen=40)
+    return env
+
+
+class WowEnvIpcTest(unittest.TestCase):
+    def test_request_returns_json_reply(self):
+        proc = FakeProc()
+        env = make_env(proc)
+        env._stdout_lines.put('{"ok": true, "value": 7}\n')
+
+        self.assertEqual(env._request({"cmd": "info"}), {"ok": True, "value": 7})
+        self.assertEqual(json.loads(proc.stdin.writes[0]), {"cmd": "info"})
+        self.assertTrue(proc.stdin.flushed)
+
+    def test_request_timeout_reports_stderr_tail(self):
+        proc = FakeProc()
+        env = make_env(proc, stderr=["stack line", "fatal detail"])
+
+        with self.assertRaisesRegex(RuntimeError, "timed out waiting.*fatal detail"):
+            env._request({"cmd": "step", "action": 1})
+
+    def test_request_reports_exited_server_and_stderr(self):
+        proc = FakeProc(returncode=7)
+        env = make_env(proc, stderr=["boom"])
+
+        with self.assertRaisesRegex(RuntimeError, "exit_code=7.*boom"):
+            env._request({"cmd": "info"})
+        self.assertEqual(proc.stdin.writes, [])
+
+    def test_request_reports_broken_pipe_with_stderr(self):
+        proc = FakeProc()
+        proc.stdin = FakePipe(broken=True)
+        env = make_env(proc, stderr=["pipe broke"])
+
+        with self.assertRaisesRegex(RuntimeError, "pipe broke"):
+            env._request({"cmd": "reset"})
+
+    def test_close_kills_after_wait_timeout_and_closes_pipes(self):
+        proc = FakeProc(wait_timeout=True)
+        env = make_env(proc)
+        env._request = lambda msg: None
+
+        env.close()
+
+        self.assertTrue(proc.killed)
+        self.assertEqual(proc.wait_calls, [5, None])
+        self.assertTrue(proc.stdin.closed)
+        self.assertTrue(proc.stdout.closed)
+        self.assertTrue(proc.stderr.closed)
+        self.assertTrue(env._closed)
+
+    def test_close_kills_when_close_request_fails(self):
+        proc = FakeProc()
+        env = make_env(proc, stderr=["request failed"])
+
+        def fail(_msg: dict[str, Any]) -> None:
+            raise RuntimeError("no reply")
+
+        env._request = fail
+        env.close()
+
+        self.assertTrue(proc.killed)
+        self.assertTrue(proc.stdin.closed)
+        self.assertTrue(proc.stdout.closed)
+        self.assertTrue(proc.stderr.closed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/wow_env.py
+++ b/python/wow_env.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import subprocess
+import threading
+from collections import deque
 from typing import Any
 
 import numpy as np
@@ -57,9 +60,14 @@ class WoWClassicEnv(gym.Env):
         rewards: dict[str, float] | None = None,
         server_path: str | None = None,
         node_binary: str = "node",
+        request_timeout: float = 10.0,
     ) -> None:
         super().__init__()
         self.player_class = player_class
+        self._request_timeout = request_timeout
+        self._stdout_lines: queue.Queue[str | None] = queue.Queue()
+        self._stderr_tail: deque[str] = deque(maxlen=40)
+        self._closed = False
         self._config: dict[str, Any] = {
             "frameSkip": frame_skip,
             "maxSteps": max_steps,
@@ -78,10 +86,11 @@ class WoWClassicEnv(gym.Env):
             [node_binary, server],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
         )
+        self._start_pipe_readers()
         meta = self._request({"cmd": "info"})
         self._obs_size = int(meta["obs_size"])
         self.action_names: list[str] = list(meta["actions"])
@@ -90,13 +99,58 @@ class WoWClassicEnv(gym.Env):
         self._episode_seed = 0
 
     # ------------------------------------------------------------------
+    def _start_pipe_readers(self) -> None:
+        assert self._proc.stdout and self._proc.stderr
+
+        def read_stdout() -> None:
+            try:
+                for line in self._proc.stdout:
+                    self._stdout_lines.put(line)
+            finally:
+                self._stdout_lines.put(None)
+
+        def read_stderr() -> None:
+            for line in self._proc.stderr:
+                stripped = line.strip()
+                if stripped:
+                    self._stderr_tail.append(stripped)
+
+        threading.Thread(target=read_stdout, name="wow-env-stdout", daemon=True).start()
+        threading.Thread(target=read_stderr, name="wow-env-stderr", daemon=True).start()
+
+    def _stderr_summary(self) -> str:
+        if not self._stderr_tail:
+            return ""
+        return " stderr tail: " + " | ".join(self._stderr_tail)
+
+    def _server_failure(self) -> str:
+        code = self._proc.poll()
+        status = "env server exited"
+        if code is not None:
+            status += f" exit_code={code}"
+        return status + self._stderr_summary()
+
     def _request(self, msg: dict[str, Any]) -> dict[str, Any]:
-        assert self._proc.stdin and self._proc.stdout
-        self._proc.stdin.write(json.dumps(msg) + "\n")
-        self._proc.stdin.flush()
-        line = self._proc.stdout.readline()
+        if self._closed:
+            raise RuntimeError("env server is closed")
+        if self._proc.poll() is not None:
+            raise RuntimeError(self._server_failure())
+        if not self._proc.stdin:
+            raise RuntimeError("env server stdin is unavailable")
+        try:
+            self._proc.stdin.write(json.dumps(msg) + "\n")
+            self._proc.stdin.flush()
+        except (BrokenPipeError, OSError) as e:
+            raise RuntimeError(self._server_failure()) from e
+        try:
+            line = self._stdout_lines.get(timeout=self._request_timeout)
+        except queue.Empty as e:
+            raise RuntimeError(
+                f"timed out waiting for env server reply after {self._request_timeout:g}s"
+                + self._stderr_summary()
+            ) from e
         if not line:
-            raise RuntimeError("env server died")
+            raise RuntimeError(self._server_failure())
         out = json.loads(line)
         if "error" in out:
             raise RuntimeError(f"env server error: {out['error']}")
@@ -126,12 +180,31 @@ class WoWClassicEnv(gym.Env):
         return obs, float(res["reward"]), bool(res["terminated"]), bool(res["truncated"]), res.get("info", {})
 
     def close(self):
-        if self._proc.poll() is None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._proc.poll() is None:
+                try:
+                    self._closed = False
+                    self._request({"cmd": "close"})
+                except Exception:
+                    if self._proc.poll() is None:
+                        self._proc.kill()
+                finally:
+                    self._closed = True
             try:
-                self._request({"cmd": "close"})
-            except Exception:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
                 self._proc.kill()
-        self._proc.wait(timeout=5)
+                self._proc.wait()
+        finally:
+            for pipe in (self._proc.stdin, self._proc.stdout, self._proc.stderr):
+                if pipe:
+                    try:
+                        pipe.close()
+                    except OSError:
+                        pass
 
 
 def make_env(**kwargs):


### PR DESCRIPTION
## Summary

- Add a bounded request timeout to the Python Gymnasium client so a silent headless env server can no longer block training forever on `stdout.readline()`.
- Capture and retain the env server stderr tail for timeout, broken-pipe, and exited-process errors.
- Make `close()` idempotent, kill stuck child processes, wait safely, and close all subprocess pipes.
- Add focused stdlib unit coverage for successful replies, timeouts, exited children, broken pipes, and teardown paths.

## Related issues

Closes #150

## Type of change

- [ ] Feature: new functionality
- [x] Bug fix
- [ ] Refactor or performance (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build, CI, or tooling
- [ ] Breaking change (please call it out in the summary)

## How was this tested?

- Commands:
  - `python -m py_compile python\wow_env.py python\test_wow_env.py`
  - `python -m unittest discover -s python -p "test_*.py"`
  - `npx vitest run tests/env_protocol.test.ts`
  - `npm run check:ts`
  - `npm run build:env` (rerun outside the sandbox after esbuild hit the known sandbox access-denied failure)
- Manual steps: N/A; covered by focused unit tests and protocol/build checks.

## Screenshots / recordings

N/A; this changes the Python/headless training client and has no UI surface.

---

## Checklist

Tick the items that apply to your change. It's fine to leave the rest unchecked
or strike them through (`~like this~`) when they don't.

### Quality

- [ ] **Tests pass.** `npm test` is green. I added or updated tests for any
      `sim/` or `server/` behavior I changed.
- [x] **Typecheck passes.** `npx tsc --noEmit` is clean (the project is
      TypeScript `strict`).
- [ ] **Builds succeed.** `npm run build`, plus `npm run build:server` and
      `npm run build:env` if I touched those.

### Cross-platform

- [ ] **Tested on desktop and mobile.** Verified on a desktop and on a
      phone-sized viewport in both portrait and landscape. Touch targets stay at
      least 40x40px and inputs at least 16px font (see `src/ui/CLAUDE.md`).
- [ ] **Accessible.** Keyboard-operable, with visible focus, sensible ARIA, and
      respect for `prefers-reduced-motion` (only if this change adds or edits UI).

### Localization (i18n)

- [ ] **New player-visible strings are translated into every supported locale.**
      Every user-facing string is a `t()` key, added to `en` first, then given a
      real translation in every locale in `supportedLanguages`
      (`src/ui/i18n.ts`). No English placeholders or `// TODO` in other locales.
- [ ] Numbers, money, dates, units, and percents go through the i18n formatters
      (`formatNumber`, `formatMoney`, `formatDateTime`, `Intl`).
- [ ] Player-facing text emitted from `src/sim/` or `server/` is re-localized at
      the client boundary in this same change, and
      `npx vitest run tests/localization_fixes.test.ts` passes.
- [x] N/A. This PR adds no player-visible strings.

### Hygiene

- [x] No secrets, credentials, or `.env` committed, and `ALLOW_DEV_COMMANDS` is
      not enabled in any production path.
- [x] I didn't hand-edit generated files such as
      `src/render/assets/manifest.generated.ts`. They're regenerated by the build.

> **Tip:** commit messages and PR titles use [Conventional Commits](https://www.conventionalcommits.org/)
> with a scope where it fits (`feat(talents): ...`, `fix(net): ...`). It's a
> convention we like, not a requirement. Clear, descriptive messages are what
> matter most.
